### PR TITLE
cni: Bounds check the ContainerID before using it

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -86,7 +86,13 @@ func (plugin *netPlugin) Stop() {
 
 // GetEndpointID returns a unique endpoint ID based on the CNI args.
 func (plugin *netPlugin) getEndpointID(args *cniSkel.CmdArgs) string {
-	return args.ContainerID[:8] + "-" + args.IfName
+	var containerID string
+	if len(args.ContainerID) >= 8 {
+		containerID = args.ContainerID[:8] + "-" + args.IfName
+	} else {
+		containerID = args.ContainerID + "-" + args.IfName
+	}
+	return containerID
 }
 
 // FindMasterInterface returns the name of the master interface.


### PR DESCRIPTION
Bounds check the ContainerID before using it.
Fixes #58

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>