### PR TITLE
Store an identifier in address records to track address requests

### DIFF
--- a/cni/ipam/ipam.go
+++ b/cni/ipam/ipam.go
@@ -178,8 +178,12 @@ func (plugin *ipamPlugin) Add(args *cniSkel.CmdArgs) error {
 		log.Printf("[cni-ipam] Allocated address poolID %v with subnet %v.", poolID, subnet)
 	}
 
+	// Store the endpoint ID in address request.
+	options := make(map[string]string)
+	options[ipam.OptAddressID] = plugin.GetEndpointID(args)
+
 	// Allocate an address for the endpoint.
-	address, err := plugin.am.RequestAddress(nwCfg.Ipam.AddrSpace, nwCfg.Ipam.Subnet, nwCfg.Ipam.Address, nil)
+	address, err := plugin.am.RequestAddress(nwCfg.Ipam.AddrSpace, nwCfg.Ipam.Subnet, nwCfg.Ipam.Address, options)
 	if err != nil {
 		err = plugin.Errorf("Failed to allocate address: %v", err)
 		return err

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -82,16 +82,6 @@ func (plugin *netPlugin) Stop() {
 	log.Printf("[cni-net] Plugin stopped.")
 }
 
-// GetEndpointID returns a unique endpoint ID based on the CNI args.
-func (plugin *netPlugin) getEndpointID(args *cniSkel.CmdArgs) string {
-	containerID := args.ContainerID
-	if len(containerID) > 8 {
-		containerID = containerID[:8]
-	}
-
-	return containerID + "-" + args.IfName
-}
-
 // FindMasterInterface returns the name of the master interface.
 func (plugin *netPlugin) findMasterInterface(nwCfg *cni.NetworkConfig, subnetPrefix *net.IPNet) string {
 	// An explicit master configuration wins. Explicitly specifying a master is
@@ -146,7 +136,7 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 
 	// Initialize values from network config.
 	networkId := nwCfg.Name
-	endpointId := plugin.getEndpointID(args)
+	endpointId := plugin.GetEndpointID(args)
 
 	// Check whether the network already exists.
 	nwInfo, err := plugin.nm.GetNetworkInfo(networkId)
@@ -307,7 +297,7 @@ func (plugin *netPlugin) Delete(args *cniSkel.CmdArgs) error {
 
 	// Initialize values from network config.
 	networkId := nwCfg.Name
-	endpointId := plugin.getEndpointID(args)
+	endpointId := plugin.GetEndpointID(args)
 
 	// Query the network.
 	nwInfo, err := plugin.nm.GetNetworkInfo(networkId)

--- a/cni/plugin.go
+++ b/cni/plugin.go
@@ -139,6 +139,16 @@ func (plugin *Plugin) DelegateDel(pluginName string, nwCfg *NetworkConfig) error
 	return nil
 }
 
+// GetEndpointID returns a unique endpoint ID based on the CNI args.
+func (plugin *Plugin) GetEndpointID(args *cniSkel.CmdArgs) string {
+	containerID := args.ContainerID
+	if len(containerID) > 8 {
+		containerID = containerID[:8]
+	}
+
+	return containerID + "-" + args.IfName
+}
+
 // Error creates and logs a structured CNI error.
 func (plugin *Plugin) Error(err error) *cniTypes.Error {
 	var cniErr *cniTypes.Error

--- a/ipam/api.go
+++ b/ipam/api.go
@@ -27,6 +27,7 @@ var (
 
 	// Options used by AddressManager.
 	OptInterfaceName      = "azure.interface.name"
+	OptAddressID          = "azure.address.id"
 	OptAddressType        = "azure.address.type"
 	OptAddressTypeGateway = "gateway"
 )

--- a/ipam/manager.go
+++ b/ipam/manager.go
@@ -127,6 +127,13 @@ func (am *addressManager) restore() error {
 	for _, as := range am.AddrSpaces {
 		for _, ap := range as.Pools {
 			ap.as = as
+			ap.addrsByID = make(map[string]*addressRecord)
+
+			for _, ar := range ap.Addresses {
+				if ar.ID != "" {
+					ap.addrsByID[ar.ID] = ar
+				}
+			}
 		}
 	}
 

--- a/ipam/pool.go
+++ b/ipam/pool.go
@@ -441,8 +441,11 @@ func (ap *addressPool) requestAddress(address string, options map[string]string)
 			return "", err
 		}
 		if ar.InUse {
-			err = errAddressInUse
-			return "", err
+			// Return the same address if IDs match.
+			if id == "" || id != ar.ID {
+				err = errAddressInUse
+				return "", err
+			}
 		}
 	} else if options[OptAddressType] == OptAddressTypeGateway {
 		// Return the pre-assigned gateway address.
@@ -455,8 +458,8 @@ func (ap *addressPool) requestAddress(address string, options map[string]string)
 		ar = ap.addrsByID[id]
 	}
 
+	// If no address was found, return any available address.
 	if ar == nil {
-		// Return any available address.
 		for _, ar = range ap.Addresses {
 			if !ar.InUse {
 				break

--- a/ipam/pool.go
+++ b/ipam/pool.go
@@ -57,6 +57,7 @@ type addressPool struct {
 	Subnet    net.IPNet
 	Gateway   net.IP
 	Addresses map[string]*addressRecord
+	addrsByID map[string]*addressRecord
 	IsIPv6    bool
 	Priority  int
 	RefCount  int
@@ -73,6 +74,7 @@ type AddressPoolInfo struct {
 
 // Represents an IP address in a pool.
 type addressRecord struct {
+	ID    string
 	Addr  net.IP
 	InUse bool
 	epoch int
@@ -252,6 +254,7 @@ func (as *addressSpace) newAddressPool(ifName string, priority int, subnet *net.
 		Subnet:    *subnet,
 		Gateway:   platform.GenerateAddress(subnet, defaultGatewayHostId),
 		Addresses: make(map[string]*addressRecord),
+		addrsByID: make(map[string]*addressRecord),
 		IsIPv6:    v6,
 		Priority:  priority,
 		epoch:     as.epoch,
@@ -423,22 +426,36 @@ func (ap *addressPool) newAddressRecord(addr *net.IP) (*addressRecord, error) {
 // Requests a new address from the address pool.
 func (ap *addressPool) requestAddress(address string, options map[string]string) (string, error) {
 	var ar *addressRecord
+	var addr *net.IPNet
+	var err error
+	id := options[OptAddressID]
+
+	log.Printf("[ipam] Requesting address with address:%v options:%+v.", address, options)
+	defer func() { log.Printf("[ipam] Address request completed with address:%v err:%v.", addr, err) }()
 
 	if address != "" {
 		// Return the specific address requested.
 		ar = ap.Addresses[address]
 		if ar == nil {
-			return "", errAddressNotFound
+			err = errAddressNotFound
+			return "", err
 		}
 		if ar.InUse {
-			return "", errAddressInUse
+			err = errAddressInUse
+			return "", err
 		}
 	} else if options[OptAddressType] == OptAddressTypeGateway {
 		// Return the pre-assigned gateway address.
 		ar = &addressRecord{
 			Addr: ap.Gateway,
 		}
-	} else {
+		id = ""
+	} else if id != "" {
+		// Return the address with the matching identifier.
+		ar = ap.addrsByID[id]
+	}
+
+	if ar == nil {
 		// Return any available address.
 		for _, ar = range ap.Addresses {
 			if !ar.InUse {
@@ -452,10 +469,15 @@ func (ap *addressPool) requestAddress(address string, options map[string]string)
 		}
 	}
 
+	if id != "" {
+		ap.addrsByID[id] = ar
+	}
+
+	ar.ID = id
 	ar.InUse = true
 
 	// Return address in CIDR notation.
-	addr := net.IPNet{
+	addr = &net.IPNet{
 		IP:   ar.Addr,
 		Mask: ap.Subnet.Mask,
 	}
@@ -465,19 +487,31 @@ func (ap *addressPool) requestAddress(address string, options map[string]string)
 
 // Releases a previously requested address back to its address pool.
 func (ap *addressPool) releaseAddress(address string) error {
+	var err error
+
+	log.Printf("[ipam] Releasing address %v.", address)
+	defer func() { log.Printf("[ipam] Address release completed with err:%v.", err) }()
+
 	ar := ap.Addresses[address]
 	if ar == nil {
 		// Handle pre-assigned addresses.
 		if address == ap.Gateway.String() {
 			return nil
 		}
-		return errAddressNotFound
+		err = errAddressNotFound
+		return err
 	}
 
 	if !ar.InUse {
-		return errAddressNotInUse
+		err = errAddressNotInUse
+		return err
 	}
 
+	if ar.ID != "" {
+		delete(ap.addrsByID, ar.ID)
+	}
+
+	ar.ID = ""
 	ar.InUse = false
 
 	// Delete address record if it is no longer available.


### PR DESCRIPTION
Adds ability to add a generic identifier to each address request. This identifier is associated and persisted with the allocated address. IPAM client can later use the same identifier to request the same address.

This ensures state integrity if the client misbehaves or crashes after an address request succeeds but before the client had a chance to persist its state. Successive calls by the client will not leak addresses as long as it uses the same identifier.

The generic identifier can be set to any string as the client sees fit. This change also updates the CNI IPAM plugin to pass the endpoint ID as the identifier, allowing us to later track which IP address was assigned to which container endpoint.