### PR TITLE
Added reservation support in IPAM

### DIFF
--- a/cnm/ipam/ipam.go
+++ b/cnm/ipam/ipam.go
@@ -261,6 +261,8 @@ func (plugin *ipamPlugin) requestAddress(w http.ResponseWriter, r *http.Request)
 		options[ipam.OptAddressType] = ipam.OptAddressTypeGateway
 	}
 
+	options[ipam.OptAddressID] = req.Options[ipam.OptAddressID]
+
 	addr, err := plugin.am.RequestAddress(poolId.AsId, poolId.Subnet, req.Address, options)
 	if err != nil {
 		plugin.SendErrorResponse(w, err)

--- a/cnm/ipam/ipam_test.go
+++ b/cnm/ipam/ipam_test.go
@@ -317,6 +317,7 @@ func TestGetPoolInfo(t *testing.T) {
 	}
 }
 
+// Utility function to request address from IPAM.
 func reqAddrInternal(payload *requestAddressRequest) (string, error) {
 	var body bytes.Buffer
 	var resp requestAddressResponse
@@ -338,6 +339,7 @@ func reqAddrInternal(payload *requestAddressRequest) (string, error) {
 	return resp.Address, nil
 }
 
+// Utility function to release address from IPAM.
 func releaseAddrInternal(payload *releaseAddressRequest) error {
 	var body bytes.Buffer
 	var resp releaseAddressResponse

--- a/ipam/pool.go
+++ b/ipam/pool.go
@@ -456,9 +456,8 @@ func (ap *addressPool) requestAddress(address string, options map[string]string)
 	id := options[OptAddressID]
 
 	if id != "" {
-		// Id exists already. Fetch the address associated with id.
+		// Return the address with the matching identifier.
 		ar = ap.addrsByID[id]
-
 	} else if address != "" {
 		// Return the specific address requested.
 		ar = ap.Addresses[address]
@@ -467,11 +466,8 @@ func (ap *addressPool) requestAddress(address string, options map[string]string)
 			return "", err
 		}
 		if ar.InUse {
-			// Return the same address if IDs match.
-			if id == "" || id != ar.ID {
-				err = errAddressInUse
-				return "", err
-			}
+			err = errAddressInUse
+			return "", err
 		}
 	} else if options[OptAddressType] == OptAddressTypeGateway {
 		// Return the pre-assigned gateway address.


### PR DESCRIPTION
Added reservation id support in IPAM to enable user to tag an ID against IP Address. This will be helpful when IP request transaction is committed in IPAM but the user didn't receive IP Address due to some reason. The user can avail the same address by issuing request address again with the same reservation id 