### PR TITLE
Added options in release address to support release address with id

### DIFF
--- a/cnm/ipam/api.go
+++ b/cnm/ipam/api.go
@@ -95,6 +95,7 @@ type requestAddressResponse struct {
 type releaseAddressRequest struct {
 	PoolID  string
 	Address string
+	Options map[string]string
 }
 
 // Response sent by plugin when an address is successfully released.

--- a/cnm/ipam/ipam.go
+++ b/cnm/ipam/ipam.go
@@ -296,7 +296,10 @@ func (plugin *ipamPlugin) releaseAddress(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	err = plugin.am.ReleaseAddress(poolId.AsId, poolId.Subnet, req.Address)
+	options := make(map[string]string)
+	options[ipam.OptAddressID] = req.Options[ipam.OptAddressID]
+
+	err = plugin.am.ReleaseAddress(poolId.AsId, poolId.Subnet, req.Address, options)
 	if err != nil {
 		plugin.SendErrorResponse(w, err)
 		return

--- a/cnm/ipam/ipam.go
+++ b/cnm/ipam/ipam.go
@@ -296,10 +296,7 @@ func (plugin *ipamPlugin) releaseAddress(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	options := make(map[string]string)
-	options[ipam.OptAddressID] = req.Options[ipam.OptAddressID]
-
-	err = plugin.am.ReleaseAddress(poolId.AsId, poolId.Subnet, req.Address, options)
+	err = plugin.am.ReleaseAddress(poolId.AsId, poolId.Subnet, req.Address, req.Options)
 	if err != nil {
 		plugin.SendErrorResponse(w, err)
 		return

--- a/cnm/ipam/ipam_test.go
+++ b/cnm/ipam/ipam_test.go
@@ -405,3 +405,32 @@ func TestRequestAddressWithID(t *testing.T) {
 		}
 	}
 }
+
+// Tests IpamDriver.ReleaseAddress with reservation id.
+func TestReleaseAddressWithID(t *testing.T) {
+
+	reqPayload := &requestAddressRequest{
+		PoolID:  poolId1,
+		Address: "",
+		Options: make(map[string]string),
+	}
+	reqPayload.Options[ipam.OptAddressID] = "reserve0"
+
+	_, err := reqAddrInternal(reqPayload)
+	if err != nil {
+		t.Errorf("RequestAddress with id  response is invalid %+v", err)
+	}
+
+	releasePayload := &releaseAddressRequest{
+		PoolID:  poolId1,
+		Address: "",
+		Options: make(map[string]string),
+	}
+	releasePayload.Options[ipam.OptAddressID] = "reserve0"
+
+	err = releaseAddrInternal(releasePayload)
+
+	if err != nil {
+		t.Errorf("ReleaseAddress with id  response is invalid %+v", err)
+	}
+}

--- a/cnm/ipam/ipam_test.go
+++ b/cnm/ipam/ipam_test.go
@@ -362,7 +362,7 @@ func releaseAddrInternal(payload *releaseAddressRequest) error {
 	return nil
 }
 
-// Tests IpamDriver.RequestAddress with reservation id.
+// Tests IpamDriver.RequestAddress with id.
 func TestRequestAddressWithID(t *testing.T) {
 	var ipList [2]string
 
@@ -374,16 +374,16 @@ func TestRequestAddressWithID(t *testing.T) {
 			Options: make(map[string]string),
 		}
 
-		payload.Options[ipam.OptAddressID] = "reserve" + strconv.Itoa(i)
+		payload.Options[ipam.OptAddressID] = "id" + strconv.Itoa(i)
 
 		addr1, err := reqAddrInternal(payload)
 		if err != nil {
-			t.Errorf("RequestAddress with id  response is invalid %+v", err)
+			t.Errorf("RequestAddress response is invalid %+v", err)
 		}
 
 		addr2, err := reqAddrInternal(payload)
 		if err != nil {
-			t.Errorf("RequestAddress with id  response is invalid %+v", err)
+			t.Errorf("RequestAddress response is invalid %+v", err)
 		}
 
 		if addr1 != addr2 {
@@ -406,19 +406,18 @@ func TestRequestAddressWithID(t *testing.T) {
 	}
 }
 
-// Tests IpamDriver.ReleaseAddress with reservation id.
+// Tests IpamDriver.ReleaseAddress with id.
 func TestReleaseAddressWithID(t *testing.T) {
-
 	reqPayload := &requestAddressRequest{
 		PoolID:  poolId1,
 		Address: "",
 		Options: make(map[string]string),
 	}
-	reqPayload.Options[ipam.OptAddressID] = "reserve0"
+	reqPayload.Options[ipam.OptAddressID] = "id1"
 
 	_, err := reqAddrInternal(reqPayload)
 	if err != nil {
-		t.Errorf("RequestAddress with id  response is invalid %+v", err)
+		t.Errorf("RequestAddress response is invalid %+v", err)
 	}
 
 	releasePayload := &releaseAddressRequest{
@@ -426,11 +425,11 @@ func TestReleaseAddressWithID(t *testing.T) {
 		Address: "",
 		Options: make(map[string]string),
 	}
-	releasePayload.Options[ipam.OptAddressID] = "reserve0"
+	releasePayload.Options[ipam.OptAddressID] = "id1"
 
 	err = releaseAddrInternal(releasePayload)
 
 	if err != nil {
-		t.Errorf("ReleaseAddress with id  response is invalid %+v", err)
+		t.Errorf("ReleaseAddress response is invalid %+v", err)
 	}
 }

--- a/ipam/manager.go
+++ b/ipam/manager.go
@@ -44,7 +44,7 @@ type AddressManager interface {
 	GetPoolInfo(asId, poolId string) (*AddressPoolInfo, error)
 
 	RequestAddress(asId, poolId, address string, options map[string]string) (string, error)
-	ReleaseAddress(asId, poolId, address string) error
+	ReleaseAddress(asId, poolId, address string, options map[string]string) error
 }
 
 // AddressConfigSource configures the address pools managed by AddressManager.
@@ -342,7 +342,7 @@ func (am *addressManager) RequestAddress(asId, poolId, address string, options m
 }
 
 // ReleaseAddress releases a previously reserved address.
-func (am *addressManager) ReleaseAddress(asId string, poolId string, address string) error {
+func (am *addressManager) ReleaseAddress(asId string, poolId string, address string, options map[string]string) error {
 	am.Lock()
 	defer am.Unlock()
 
@@ -358,7 +358,7 @@ func (am *addressManager) ReleaseAddress(asId string, poolId string, address str
 		return err
 	}
 
-	err = ap.releaseAddress(address)
+	err = ap.releaseAddress(address, options)
 	if err != nil {
 		return err
 	}

--- a/ipam/pool.go
+++ b/ipam/pool.go
@@ -513,30 +513,34 @@ func (ap *addressPool) requestAddress(address string, options map[string]string)
 
 // Releases a previously requested address back to its address pool.
 func (ap *addressPool) releaseAddress(address string, options map[string]string) error {
+	var ar *addressRecord
+	var id string
 	var err error
 
-	log.Printf("[ipam] Releasing address %v.", address)
+	log.Printf("[ipam] Releasing address %v options:%+v.", address, options)
 	defer func() { log.Printf("[ipam] Address release completed with err:%v.", err) }()
 
-	ar := ap.Addresses[address]
-	if ar == nil {
-		id := options[OptAddressID]
-		// Handle pre-assigned addresses.
-		if address == ap.Gateway.String() {
+	if options != nil {
+		id = options[OptAddressID]
+	}
+
+	if address != "" {
+		// Release the specific address.
+		ar = ap.Addresses[address]
+
+		// Release the pre-assigned gateway address.
+		if ar == nil && address == ap.Gateway.String() {
 			return nil
-		} else if id != "" {
-			// Get address associated with id.
-			ar = ap.addrsByID[id]
-			if ar == nil {
-				err = errAddressNotFound
-				return err
-			}
-			address = ar.Addr.String()
-			log.Printf("[ipam] Releasing the address %v associated with id %v", address, id)
-		} else {
-			err = errAddressNotFound
-			return err
 		}
+	} else if id != "" {
+		// Release the address with the matching ID.
+		ar = ap.addrsByID[id]
+		log.Printf("[ipam] Releasing address %v.", ar.Addr.String())
+	}
+
+	if ar == nil {
+		err = errAddressNotFound
+		return err
 	}
 
 	if !ar.InUse {


### PR DESCRIPTION
The option field allows the user to release the address by specifying reservation id alone. The id to address mapping will be handled by ReleaseAddress function.