### PR TITLE
Exposed IPAM API path and structures as public

### DIFF
--- a/cnm/ipam/api.go
+++ b/cnm/ipam/api.go
@@ -8,13 +8,13 @@ const (
 	EndpointType = "IpamDriver"
 
 	// Libnetwork IPAM plugin remote API paths
-	getCapabilitiesPath  = "/IpamDriver.GetCapabilities"
-	getAddressSpacesPath = "/IpamDriver.GetDefaultAddressSpaces"
-	requestPoolPath      = "/IpamDriver.RequestPool"
-	releasePoolPath      = "/IpamDriver.ReleasePool"
-	getPoolInfoPath      = "/IpamDriver.GetPoolInfo"
-	requestAddressPath   = "/IpamDriver.RequestAddress"
-	releaseAddressPath   = "/IpamDriver.ReleaseAddress"
+	GetCapabilitiesPath  = "/IpamDriver.GetCapabilities"
+	GetAddressSpacesPath = "/IpamDriver.GetDefaultAddressSpaces"
+	RequestPoolPath      = "/IpamDriver.RequestPool"
+	ReleasePoolPath      = "/IpamDriver.ReleasePool"
+	GetPoolInfoPath      = "/IpamDriver.GetPoolInfo"
+	RequestAddressPath   = "/IpamDriver.RequestAddress"
+	ReleaseAddressPath   = "/IpamDriver.ReleaseAddress"
 
 	// Libnetwork IPAM plugin options
 	OptAddressType        = "RequestAddressType"
@@ -22,29 +22,29 @@ const (
 )
 
 // Request sent by libnetwork when querying plugin capabilities.
-type getCapabilitiesRequest struct {
+type GetCapabilitiesRequest struct {
 }
 
 // Response sent by plugin when registering its capabilities with libnetwork.
-type getCapabilitiesResponse struct {
+type GetCapabilitiesResponse struct {
 	Err                   string
 	RequiresMACAddress    bool
 	RequiresRequestReplay bool
 }
 
 // Request sent by libnetwork when querying the default address space names.
-type getDefaultAddressSpacesRequest struct {
+type GetDefaultAddressSpacesRequest struct {
 }
 
 // Response sent by plugin when returning the default address space names.
-type getDefaultAddressSpacesResponse struct {
+type GetDefaultAddressSpacesResponse struct {
 	Err                       string
 	LocalDefaultAddressSpace  string
 	GlobalDefaultAddressSpace string
 }
 
 // Request sent by libnetwork when acquiring a reference to an address pool.
-type requestPoolRequest struct {
+type RequestPoolRequest struct {
 	AddressSpace string
 	Pool         string
 	SubPool      string
@@ -53,7 +53,7 @@ type requestPoolRequest struct {
 }
 
 // Response sent by plugin when an address pool is successfully referenced.
-type requestPoolResponse struct {
+type RequestPoolResponse struct {
 	Err    string
 	PoolID string
 	Pool   string
@@ -61,22 +61,22 @@ type requestPoolResponse struct {
 }
 
 // Request sent by libnetwork when releasing a previously registered address pool.
-type releasePoolRequest struct {
+type ReleasePoolRequest struct {
 	PoolID string
 }
 
 // Response sent by plugin when an address pool is successfully released.
-type releasePoolResponse struct {
+type ReleasePoolResponse struct {
 	Err string
 }
 
 // Request sent when querying address pool information.
-type getPoolInfoRequest struct {
+type GetPoolInfoRequest struct {
 	PoolID string
 }
 
 // Response sent by plugin when returning address pool information.
-type getPoolInfoResponse struct {
+type GetPoolInfoResponse struct {
 	Err                string
 	Capacity           int
 	Available          int
@@ -84,27 +84,27 @@ type getPoolInfoResponse struct {
 }
 
 // Request sent by libnetwork when reserving an address from a pool.
-type requestAddressRequest struct {
+type RequestAddressRequest struct {
 	PoolID  string
 	Address string
 	Options map[string]string
 }
 
 // Response sent by plugin when an address is successfully reserved.
-type requestAddressResponse struct {
+type RequestAddressResponse struct {
 	Err     string
 	Address string
 	Data    map[string]string
 }
 
 // Request sent by libnetwork when releasing an address back to the pool.
-type releaseAddressRequest struct {
+type ReleaseAddressRequest struct {
 	PoolID  string
 	Address string
 	Options map[string]string
 }
 
 // Response sent by plugin when an address is successfully released.
-type releaseAddressResponse struct {
+type ReleaseAddressResponse struct {
 	Err string
 }

--- a/cnm/ipam/ipam.go
+++ b/cnm/ipam/ipam.go
@@ -72,13 +72,13 @@ func (plugin *ipamPlugin) Start(config *common.PluginConfig) error {
 	// Add protocol handlers.
 	listener := plugin.Listener
 	listener.AddEndpoint(plugin.EndpointType)
-	listener.AddHandler(getCapabilitiesPath, plugin.getCapabilities)
-	listener.AddHandler(getAddressSpacesPath, plugin.getDefaultAddressSpaces)
-	listener.AddHandler(requestPoolPath, plugin.requestPool)
-	listener.AddHandler(releasePoolPath, plugin.releasePool)
-	listener.AddHandler(getPoolInfoPath, plugin.getPoolInfo)
-	listener.AddHandler(requestAddressPath, plugin.requestAddress)
-	listener.AddHandler(releaseAddressPath, plugin.releaseAddress)
+	listener.AddHandler(GetCapabilitiesPath, plugin.getCapabilities)
+	listener.AddHandler(GetAddressSpacesPath, plugin.getDefaultAddressSpaces)
+	listener.AddHandler(RequestPoolPath, plugin.requestPool)
+	listener.AddHandler(ReleasePoolPath, plugin.releasePool)
+	listener.AddHandler(GetPoolInfoPath, plugin.getPoolInfo)
+	listener.AddHandler(RequestAddressPath, plugin.requestAddress)
+	listener.AddHandler(ReleaseAddressPath, plugin.releaseAddress)
 
 	// Plugin is ready to be discovered.
 	err = plugin.EnableDiscovery()
@@ -107,11 +107,11 @@ func (plugin *ipamPlugin) Stop() {
 
 // Handles GetCapabilities requests.
 func (plugin *ipamPlugin) getCapabilities(w http.ResponseWriter, r *http.Request) {
-	var req getCapabilitiesRequest
+	var req GetCapabilitiesRequest
 
 	log.Request(plugin.Name, &req, nil)
 
-	resp := getCapabilitiesResponse{
+	resp := GetCapabilitiesResponse{
 		RequiresMACAddress:    requiresMACAddress,
 		RequiresRequestReplay: requiresRequestReplay,
 	}
@@ -123,8 +123,8 @@ func (plugin *ipamPlugin) getCapabilities(w http.ResponseWriter, r *http.Request
 
 // Handles GetDefaultAddressSpaces requests.
 func (plugin *ipamPlugin) getDefaultAddressSpaces(w http.ResponseWriter, r *http.Request) {
-	var req getDefaultAddressSpacesRequest
-	var resp getDefaultAddressSpacesResponse
+	var req GetDefaultAddressSpacesRequest
+	var resp GetDefaultAddressSpacesResponse
 
 	log.Request(plugin.Name, &req, nil)
 
@@ -140,7 +140,7 @@ func (plugin *ipamPlugin) getDefaultAddressSpaces(w http.ResponseWriter, r *http
 
 // Handles RequestPool requests.
 func (plugin *ipamPlugin) requestPool(w http.ResponseWriter, r *http.Request) {
-	var req requestPoolRequest
+	var req RequestPoolRequest
 
 	// Decode request.
 	err := plugin.Listener.Decode(w, r, &req)
@@ -159,7 +159,7 @@ func (plugin *ipamPlugin) requestPool(w http.ResponseWriter, r *http.Request) {
 	// Encode response.
 	data := make(map[string]string)
 	poolId = ipam.NewAddressPoolId(req.AddressSpace, poolId, "").String()
-	resp := requestPoolResponse{PoolID: poolId, Pool: subnet, Data: data}
+	resp := RequestPoolResponse{PoolID: poolId, Pool: subnet, Data: data}
 
 	err = plugin.Listener.Encode(w, &resp)
 
@@ -168,7 +168,7 @@ func (plugin *ipamPlugin) requestPool(w http.ResponseWriter, r *http.Request) {
 
 // Handles ReleasePool requests.
 func (plugin *ipamPlugin) releasePool(w http.ResponseWriter, r *http.Request) {
-	var req releasePoolRequest
+	var req ReleasePoolRequest
 
 	// Decode request.
 	err := plugin.Listener.Decode(w, r, &req)
@@ -191,7 +191,7 @@ func (plugin *ipamPlugin) releasePool(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Encode response.
-	resp := releasePoolResponse{}
+	resp := ReleasePoolResponse{}
 
 	err = plugin.Listener.Encode(w, &resp)
 
@@ -200,7 +200,7 @@ func (plugin *ipamPlugin) releasePool(w http.ResponseWriter, r *http.Request) {
 
 // Handles GetPoolInfo requests.
 func (plugin *ipamPlugin) getPoolInfo(w http.ResponseWriter, r *http.Request) {
-	var req getPoolInfoRequest
+	var req GetPoolInfoRequest
 
 	// Decode request.
 	err := plugin.Listener.Decode(w, r, &req)
@@ -223,7 +223,7 @@ func (plugin *ipamPlugin) getPoolInfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Encode response.
-	resp := getPoolInfoResponse{
+	resp := GetPoolInfoResponse{
 		Capacity:  apInfo.Capacity,
 		Available: apInfo.Available,
 	}
@@ -239,7 +239,7 @@ func (plugin *ipamPlugin) getPoolInfo(w http.ResponseWriter, r *http.Request) {
 
 // Handles RequestAddress requests.
 func (plugin *ipamPlugin) requestAddress(w http.ResponseWriter, r *http.Request) {
-	var req requestAddressRequest
+	var req RequestAddressRequest
 
 	// Decode request.
 	err := plugin.Listener.Decode(w, r, &req)
@@ -271,7 +271,7 @@ func (plugin *ipamPlugin) requestAddress(w http.ResponseWriter, r *http.Request)
 
 	// Encode response.
 	data := make(map[string]string)
-	resp := requestAddressResponse{Address: addr, Data: data}
+	resp := RequestAddressResponse{Address: addr, Data: data}
 
 	err = plugin.Listener.Encode(w, &resp)
 
@@ -280,7 +280,7 @@ func (plugin *ipamPlugin) requestAddress(w http.ResponseWriter, r *http.Request)
 
 // Handles ReleaseAddress requests.
 func (plugin *ipamPlugin) releaseAddress(w http.ResponseWriter, r *http.Request) {
-	var req releaseAddressRequest
+	var req ReleaseAddressRequest
 
 	// Decode request.
 	err := plugin.Listener.Decode(w, r, &req)
@@ -303,7 +303,7 @@ func (plugin *ipamPlugin) releaseAddress(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Encode response.
-	resp := releaseAddressResponse{}
+	resp := ReleaseAddressResponse{}
 
 	err = plugin.Listener.Encode(w, &resp)
 

--- a/cnm/ipam/ipam_test.go
+++ b/cnm/ipam/ipam_test.go
@@ -137,9 +137,9 @@ func TestActivate(t *testing.T) {
 
 // Tests IpamDriver.GetCapabilities functionality.
 func TestGetCapabilities(t *testing.T) {
-	var resp getCapabilitiesResponse
+	var resp GetCapabilitiesResponse
 
-	req, err := http.NewRequest(http.MethodGet, getCapabilitiesPath, nil)
+	req, err := http.NewRequest(http.MethodGet, GetCapabilitiesPath, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,9 +156,9 @@ func TestGetCapabilities(t *testing.T) {
 
 // Tests IpamDriver.GetDefaultAddressSpaces functionality.
 func TestGetDefaultAddressSpaces(t *testing.T) {
-	var resp getDefaultAddressSpacesResponse
+	var resp GetDefaultAddressSpacesResponse
 
-	req, err := http.NewRequest(http.MethodGet, getAddressSpacesPath, nil)
+	req, err := http.NewRequest(http.MethodGet, GetAddressSpacesPath, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,15 +178,15 @@ func TestGetDefaultAddressSpaces(t *testing.T) {
 // Tests IpamDriver.RequestPool functionality.
 func TestRequestPool(t *testing.T) {
 	var body bytes.Buffer
-	var resp requestPoolResponse
+	var resp RequestPoolResponse
 
-	payload := &requestPoolRequest{
+	payload := &RequestPoolRequest{
 		AddressSpace: localAsId,
 	}
 
 	json.NewEncoder(&body).Encode(payload)
 
-	req, err := http.NewRequest(http.MethodGet, requestPoolPath, &body)
+	req, err := http.NewRequest(http.MethodGet, RequestPoolPath, &body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -206,9 +206,9 @@ func TestRequestPool(t *testing.T) {
 // Tests IpamDriver.RequestAddress functionality.
 func TestRequestAddress(t *testing.T) {
 	var body bytes.Buffer
-	var resp requestAddressResponse
+	var resp RequestAddressResponse
 
-	payload := &requestAddressRequest{
+	payload := &RequestAddressRequest{
 		PoolID:  poolId1,
 		Address: "",
 		Options: nil,
@@ -216,7 +216,7 @@ func TestRequestAddress(t *testing.T) {
 
 	json.NewEncoder(&body).Encode(payload)
 
-	req, err := http.NewRequest(http.MethodGet, requestAddressPath, &body)
+	req, err := http.NewRequest(http.MethodGet, RequestAddressPath, &body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -237,16 +237,16 @@ func TestRequestAddress(t *testing.T) {
 // Tests IpamDriver.ReleaseAddress functionality.
 func TestReleaseAddress(t *testing.T) {
 	var body bytes.Buffer
-	var resp releaseAddressResponse
+	var resp ReleaseAddressResponse
 
-	payload := &releaseAddressRequest{
+	payload := &ReleaseAddressRequest{
 		PoolID:  poolId1,
 		Address: address1,
 	}
 
 	json.NewEncoder(&body).Encode(payload)
 
-	req, err := http.NewRequest(http.MethodGet, releaseAddressPath, &body)
+	req, err := http.NewRequest(http.MethodGet, ReleaseAddressPath, &body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -264,15 +264,15 @@ func TestReleaseAddress(t *testing.T) {
 // Tests IpamDriver.ReleasePool functionality.
 func TestReleasePool(t *testing.T) {
 	var body bytes.Buffer
-	var resp releasePoolResponse
+	var resp ReleasePoolResponse
 
-	payload := &releasePoolRequest{
+	payload := &ReleasePoolRequest{
 		PoolID: poolId1,
 	}
 
 	json.NewEncoder(&body).Encode(payload)
 
-	req, err := http.NewRequest(http.MethodGet, releasePoolPath, &body)
+	req, err := http.NewRequest(http.MethodGet, ReleasePoolPath, &body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -290,15 +290,15 @@ func TestReleasePool(t *testing.T) {
 // Tests IpamDriver.GetPoolInfo functionality.
 func TestGetPoolInfo(t *testing.T) {
 	var body bytes.Buffer
-	var resp getPoolInfoResponse
+	var resp GetPoolInfoResponse
 
-	payload := &getPoolInfoRequest{
+	payload := &GetPoolInfoRequest{
 		PoolID: poolId1,
 	}
 
 	json.NewEncoder(&body).Encode(payload)
 
-	req, err := http.NewRequest(http.MethodGet, getPoolInfoPath, &body)
+	req, err := http.NewRequest(http.MethodGet, GetPoolInfoPath, &body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -314,12 +314,12 @@ func TestGetPoolInfo(t *testing.T) {
 }
 
 // Utility function to request address from IPAM.
-func reqAddrInternal(payload *requestAddressRequest) (string, error) {
+func reqAddrInternal(payload *RequestAddressRequest) (string, error) {
 	var body bytes.Buffer
-	var resp requestAddressResponse
+	var resp RequestAddressResponse
 	json.NewEncoder(&body).Encode(payload)
 
-	req, err := http.NewRequest(http.MethodGet, requestAddressPath, &body)
+	req, err := http.NewRequest(http.MethodGet, RequestAddressPath, &body)
 	if err != nil {
 		return "", err
 	}
@@ -336,13 +336,13 @@ func reqAddrInternal(payload *requestAddressRequest) (string, error) {
 }
 
 // Utility function to release address from IPAM.
-func releaseAddrInternal(payload *releaseAddressRequest) error {
+func releaseAddrInternal(payload *ReleaseAddressRequest) error {
 	var body bytes.Buffer
-	var resp releaseAddressResponse
+	var resp ReleaseAddressResponse
 
 	json.NewEncoder(&body).Encode(payload)
 
-	req, err := http.NewRequest(http.MethodGet, releaseAddressPath, &body)
+	req, err := http.NewRequest(http.MethodGet, ReleaseAddressPath, &body)
 	if err != nil {
 		return err
 	}
@@ -363,7 +363,7 @@ func TestRequestAddressWithID(t *testing.T) {
 	var ipList [2]string
 
 	for i := 0; i < 2; i++ {
-		payload := &requestAddressRequest{
+		payload := &RequestAddressRequest{
 			PoolID:  poolId1,
 			Address: "",
 			Options: make(map[string]string),
@@ -390,7 +390,7 @@ func TestRequestAddressWithID(t *testing.T) {
 	}
 
 	for i := 0; i < 2; i++ {
-		payload := &releaseAddressRequest{
+		payload := &ReleaseAddressRequest{
 			PoolID:  poolId1,
 			Address: ipList[i],
 		}
@@ -403,7 +403,7 @@ func TestRequestAddressWithID(t *testing.T) {
 
 // Tests IpamDriver.ReleaseAddress with id.
 func TestReleaseAddressWithID(t *testing.T) {
-	reqPayload := &requestAddressRequest{
+	reqPayload := &RequestAddressRequest{
 		PoolID:  poolId1,
 		Address: "",
 		Options: make(map[string]string),
@@ -415,7 +415,7 @@ func TestReleaseAddressWithID(t *testing.T) {
 		t.Errorf("RequestAddress response is invalid %+v", err)
 	}
 
-	releasePayload := &releaseAddressRequest{
+	releasePayload := &ReleaseAddressRequest{
 		PoolID:  poolId1,
 		Address: "",
 		Options: make(map[string]string),


### PR DESCRIPTION
Made Ipam API path, request and response structures as public so that Ipamclient can make use of those structures and variables without duplicating it. Ipam client can import Ipam package and access those structures and path.