### PR TITLE
Added support for Ipamclient in Linux in CNS

### DIFF
--- a/cns/ipamclient/ipamclient.go
+++ b/cns/ipamclient/ipamclient.go
@@ -6,8 +6,6 @@ package ipamclient
 import (
 	"bytes"
 	"encoding/json"
-	"net/http"
-
 	"fmt"
 
 	cnmIpam "github.com/Azure/azure-container-networking/cnm/ipam"
@@ -34,20 +32,16 @@ func NewIpamClient(url string) (*IpamClient, error) {
 func (ic *IpamClient) GetAddressSpace() (string, error) {
 	log.Printf("[Azure CNS] GetAddressSpace Request")
 
-	url := ic.connectionURL + cnmIpam.GetAddressSpacesPath
-
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	client, err := getClient(ic.connectionURL)
 	if err != nil {
-		log.Printf("[Azure CNS] Error received while creating http GET request for AddressSpace %v", err.Error())
 		return "", err
 	}
 
-	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	url := ic.connectionURL + cnmIpam.GetAddressSpacesPath
 
-	client := &http.Client{}
-
-	res, err := client.Do(req)
-	if res == nil {
+	res, err := client.Post(url, "application/json", nil)
+	if err != nil {
+		log.Printf("[Azure CNS] HTTP Post returned error %v", err.Error())
 		return "", err
 	}
 
@@ -75,6 +69,11 @@ func (ic *IpamClient) GetPoolID(asID, subnet string) (string, error) {
 	var body bytes.Buffer
 	log.Printf("[Azure CNS] GetPoolID Request")
 
+	client, err := getClient(ic.connectionURL)
+	if err != nil {
+		return "", err
+	}
+
 	url := ic.connectionURL + cnmIpam.RequestPoolPath
 
 	payload := &cnmIpam.RequestPoolRequest{
@@ -84,17 +83,9 @@ func (ic *IpamClient) GetPoolID(asID, subnet string) (string, error) {
 
 	json.NewEncoder(&body).Encode(payload)
 
-	req, err := http.NewRequest(http.MethodGet, url, &body)
+	res, err := client.Post(url, "application/json", &body)
 	if err != nil {
-		log.Printf("[Azure CNS] Error received while creating http GET request for GetPoolID asID: %v poolid: %v err:%v", asID, subnet, err.Error())
-		return "", err
-	}
-	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-
-	client := &http.Client{}
-	res, err := client.Do(req)
-
-	if res == nil {
+		log.Printf("[Azure CNS] HTTP Post returned error %v", err.Error())
 		return "", err
 	}
 
@@ -123,6 +114,11 @@ func (ic *IpamClient) ReserveIPAddress(poolID string, reservationID string) (str
 	var body bytes.Buffer
 	log.Printf("[Azure CNS] ReserveIpAddress")
 
+	client, err := getClient(ic.connectionURL)
+	if err != nil {
+		return "", err
+	}
+
 	url := ic.connectionURL + cnmIpam.RequestAddressPath
 
 	payload := &cnmIpam.RequestAddressRequest{
@@ -133,17 +129,9 @@ func (ic *IpamClient) ReserveIPAddress(poolID string, reservationID string) (str
 	payload.Options[ipam.OptAddressID] = reservationID
 	json.NewEncoder(&body).Encode(payload)
 
-	req, err := http.NewRequest(http.MethodGet, url, &body)
+	res, err := client.Post(url, "application/json", &body)
 	if err != nil {
-		log.Printf("[Azure CNS] Error received while creating http GET request for reserve IP resid: %v poolid: %v err:%v", reservationID, poolID, err.Error())
-		return "", err
-	}
-	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-
-	client := &http.Client{}
-	res, err := client.Do(req)
-
-	if res == nil {
+		log.Printf("[Azure CNS] HTTP Post returned error %v", err.Error())
 		return "", err
 	}
 
@@ -173,6 +161,11 @@ func (ic *IpamClient) ReleaseIPAddress(poolID string, reservationID string) erro
 	var body bytes.Buffer
 	log.Printf("[Azure CNS] ReleaseIpAddress")
 
+	client, err := getClient(ic.connectionURL)
+	if err != nil {
+		return err
+	}
+
 	url := ic.connectionURL + cnmIpam.ReleaseAddressPath
 
 	payload := &cnmIpam.ReleaseAddressRequest{
@@ -185,17 +178,9 @@ func (ic *IpamClient) ReleaseIPAddress(poolID string, reservationID string) erro
 
 	json.NewEncoder(&body).Encode(payload)
 
-	req, err := http.NewRequest(http.MethodGet, url, &body)
+	res, err := client.Post(url, "application/json", &body)
 	if err != nil {
-		log.Printf("[Azure CNS] Error received while creating http GET request for ReleaseIP resid: %v poolid: %v err:%v", reservationID, poolID, err.Error())
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-
-	client := &http.Client{}
-	res, err := client.Do(req)
-
-	if res == nil {
+		log.Printf("[Azure CNS] HTTP Post returned error %v", err.Error())
 		return err
 	}
 
@@ -224,6 +209,10 @@ func (ic *IpamClient) GetIPAddressUtilization(poolID string) (int, int, []string
 	var body bytes.Buffer
 	log.Printf("[Azure CNS] GetIPAddressUtilization")
 
+	client, err := getClient(ic.connectionURL)
+	if err != nil {
+		return 0, 0, nil, err
+	}
 	url := ic.connectionURL + cnmIpam.GetPoolInfoPath
 
 	payload := &cnmIpam.GetPoolInfoRequest{
@@ -232,17 +221,9 @@ func (ic *IpamClient) GetIPAddressUtilization(poolID string) (int, int, []string
 
 	json.NewEncoder(&body).Encode(payload)
 
-	req, err := http.NewRequest(http.MethodGet, url, &body)
+	res, err := client.Post(url, "application/json", &body)
 	if err != nil {
-		log.Printf("[Azure CNS] Error received while creating http GET request for GetIPUtilization poolid: %v err:%v", poolID, err.Error())
-		return 0, 0, nil, err
-	}
-	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-
-	client := &http.Client{}
-	res, err := client.Do(req)
-
-	if res == nil {
+		log.Printf("[Azure CNS] HTTP Post returned error %v", err.Error())
 		return 0, 0, nil, err
 	}
 

--- a/cns/ipamclient/ipamclient_linux.go
+++ b/cns/ipamclient/ipamclient_linux.go
@@ -5,6 +5,38 @@
 
 package ipamclient
 
-const (
-	ipamPluginURL = "unix:///run/docker/plugins/"
+import (
+	"context"
+	"log"
+	"net"
+	"net/http"
 )
+
+const (
+	defaultIpamPluginURL = "http://unix"
+	pluginSockPath       = "/run/docker/plugins/azure-vnet.sock"
+)
+
+//getClient - returns unix http client
+func getClient(url string) (*http.Client, error) {
+	var httpc *http.Client
+	if url == defaultIpamPluginURL {
+		dialContext, err := net.Dial("unix", pluginSockPath)
+		if err != nil {
+			log.Printf("[Azure CNS] Error.Dial context error %v", err.Error())
+			return nil, err
+		}
+
+		httpc = &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+					return dialContext, nil
+				},
+			},
+		}
+	} else {
+		httpc = &http.Client{}
+	}
+
+	return httpc, nil
+}

--- a/cns/ipamclient/ipamclient_windows.go
+++ b/cns/ipamclient/ipamclient_windows.go
@@ -5,6 +5,15 @@
 
 package ipamclient
 
+import (
+	"net/http"
+)
+
 const (
 	defaultIpamPluginURL = "http://localhost:48080"
 )
+
+func getClient(url string) (http.Client, error) {
+	httpc := http.Client{}
+	return httpc, nil
+}

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -332,14 +332,14 @@ func (service *httpRestService) reserveIPAddress(w http.ResponseWriter, r *http.
 
 		addr, err = ic.ReserveIPAddress(poolID, req.ReservationID)
 		if err != nil {
-			returnMessage = fmt.Sprintf("ReserveIpAddress failed with %+v", err.Error())
+			returnMessage = fmt.Sprintf("[Azure CNS] ReserveIpAddress failed with %+v", err.Error())
 			returnCode = AddressUnavailable
 			break
 		}
 
 		addressIP, _, err := net.ParseCIDR(addr)
 		if err != nil {
-			returnMessage = fmt.Sprintf("ParseCIDR failed with %+v", err.Error())
+			returnMessage = fmt.Sprintf("[Azure CNS] ParseCIDR failed with %+v", err.Error())
 			returnCode = UnexpectedError
 			break
 		}
@@ -408,7 +408,7 @@ func (service *httpRestService) releaseIPAddress(w http.ResponseWriter, r *http.
 
 		err = ic.ReleaseIPAddress(poolID, req.ReservationID)
 		if err != nil {
-			returnMessage = fmt.Sprintf("ReleaseIpAddress failed with %+v", err.Error())
+			returnMessage = fmt.Sprintf("[Azure CNS] ReleaseIpAddress failed with %+v", err.Error())
 			returnCode = ReservationNotFound
 		}
 
@@ -521,7 +521,7 @@ func (service *httpRestService) getIPAddressUtilization(w http.ResponseWriter, r
 			returnCode = UnexpectedError
 			break
 		}
-		log.Printf("Capacity %v Available %v UnhealthyAddrs %v", capacity, available, unhealthyAddrs)
+		log.Printf("[Azure CNS] Capacity %v Available %v UnhealthyAddrs %v", capacity, available, unhealthyAddrs)
 
 	default:
 		returnMessage = "[Azure CNS] Error. GetIPUtilization did not receive a GET."
@@ -621,7 +621,7 @@ func (service *httpRestService) getUnhealthyIPAddresses(w http.ResponseWriter, r
 			returnCode = UnexpectedError
 			break
 		}
-		log.Printf("Capacity %v Available %v UnhealthyAddrs %v", capacity, available, unhealthyAddrs)
+		log.Printf("[Azure CNS] Capacity %v Available %v UnhealthyAddrs %v", capacity, available, unhealthyAddrs)
 
 	default:
 		returnMessage = "[Azure CNS] Error. GetUnhealthyIP did not receive a POST."

--- a/cns/routes/routes_linux.go
+++ b/cns/routes/routes_linux.go
@@ -5,16 +5,6 @@
 
 package routes
 
-import (
-	"fmt"
-	"net"
-	"os/exec"
-
-	"strings"
-
-	"github.com/Azure/azure-container-networking/log"
-)
-
 const ()
 
 func getRoutes() ([]Route, error) {


### PR DESCRIPTION
Modified CNS to support ipamclient for both Linux and windows. In Linux ipamclient connects to server via unix domain socket and in windows via tcp socket. Tested the functionality of cns in both Linux and windows.