### PR TITLE
Added ipam support for overlay network

### DIFF
--- a/cnm/ipam_overlay/ipam.go
+++ b/cnm/ipam_overlay/ipam.go
@@ -1,0 +1,315 @@
+// Copyright 2017 Microsoft. All rights reserved.
+// MIT License
+
+package ipam
+
+import (
+	"net/http"
+
+	"github.com/Azure/azure-container-networking/cnm"
+	cnmIpam "github.com/Azure/azure-container-networking/cnm/ipam"
+	"github.com/Azure/azure-container-networking/common"
+	"github.com/Azure/azure-container-networking/ipam"
+	"github.com/Azure/azure-container-networking/log"
+)
+
+const (
+	// Plugin name.
+	name = "azure-overlay-ipam"
+
+	// Plugin capabilities reported to libnetwork.
+	requiresMACAddress    = false
+	requiresRequestReplay = false
+	networkType           = "overlay"
+)
+
+// IpamPlugin represents a CNM (libnetwork) IPAM plugin.
+type ipamPlugin struct {
+	*cnm.Plugin
+	am ipam.AddressManager
+}
+
+type IpamPlugin interface {
+	common.PluginApi
+}
+
+// NewPlugin creates a new IpamPlugin object.
+func NewPlugin(config *common.PluginConfig) (IpamPlugin, error) {
+	// Setup base plugin.
+	plugin, err := cnm.NewPlugin(name, config.Version, cnmIpam.EndpointType)
+	if err != nil {
+		return nil, err
+	}
+
+	// Setup address manager.
+	am, err := ipam.NewAddressManager()
+	if err != nil {
+		return nil, err
+	}
+
+	config.IpamApi = am
+
+	return &ipamPlugin{
+		Plugin: plugin,
+		am:     am,
+	}, nil
+}
+
+// Start starts the plugin.
+func (plugin *ipamPlugin) Start(config *common.PluginConfig) error {
+	// Initialize base plugin.
+	err := plugin.Initialize(config)
+	if err != nil {
+		log.Printf("[ipam] Failed to initialize base plugin, err:%v.", err)
+		return err
+	}
+
+	// Initialize address manager.
+	err = plugin.am.Initialize(config, plugin.Options)
+	if err != nil {
+		log.Printf("[ipam] Failed to initialize address manager, err:%v.", err)
+		return err
+	}
+
+	// Add protocol handlers.
+	listener := plugin.Listener
+	listener.AddEndpoint(plugin.EndpointType)
+	listener.AddHandler(cnmIpam.GetCapabilitiesPath, plugin.getCapabilities)
+	listener.AddHandler(cnmIpam.GetAddressSpacesPath, plugin.getDefaultAddressSpaces)
+	listener.AddHandler(cnmIpam.RequestPoolPath, plugin.requestPool)
+	listener.AddHandler(cnmIpam.ReleasePoolPath, plugin.releasePool)
+	listener.AddHandler(cnmIpam.GetPoolInfoPath, plugin.getPoolInfo)
+	listener.AddHandler(cnmIpam.RequestAddressPath, plugin.requestAddress)
+	listener.AddHandler(cnmIpam.ReleaseAddressPath, plugin.releaseAddress)
+
+	// Plugin is ready to be discovered.
+	err = plugin.EnableDiscovery()
+	if err != nil {
+		log.Printf("[ipam] Failed to enable discovery: %v.", err)
+		return err
+	}
+
+	log.Printf("[ipam] Plugin started.")
+
+	return nil
+}
+
+// Stop stops the plugin.
+func (plugin *ipamPlugin) Stop() {
+	plugin.DisableDiscovery()
+	plugin.am.Uninitialize()
+	plugin.Uninitialize()
+	log.Printf("[ipam] Plugin stopped.")
+}
+
+//
+// Libnetwork remote IPAM API implementation
+// https://github.com/docker/libnetwork/blob/master/docs/ipam.md
+//
+
+// Handles GetCapabilities requests.
+func (plugin *ipamPlugin) getCapabilities(w http.ResponseWriter, r *http.Request) {
+	var req cnmIpam.GetCapabilitiesRequest
+
+	log.Request(plugin.Name, &req, nil)
+
+	resp := cnmIpam.GetCapabilitiesResponse{
+		RequiresMACAddress:    requiresMACAddress,
+		RequiresRequestReplay: requiresRequestReplay,
+	}
+
+	err := plugin.Listener.Encode(w, &resp)
+
+	log.Response(plugin.Name, &resp, err)
+}
+
+// Handles GetDefaultAddressSpaces requests.
+func (plugin *ipamPlugin) getDefaultAddressSpaces(w http.ResponseWriter, r *http.Request) {
+	var req cnmIpam.GetDefaultAddressSpacesRequest
+	var resp cnmIpam.GetDefaultAddressSpacesResponse
+
+	log.Request(plugin.Name, &req, nil)
+
+	localId, globalId := plugin.am.GetDefaultAddressSpaces()
+
+	resp.LocalDefaultAddressSpace = localId
+	resp.GlobalDefaultAddressSpace = globalId
+
+	err := plugin.Listener.Encode(w, &resp)
+
+	log.Response(plugin.Name, &resp, err)
+}
+
+// Handles RequestPool requests.
+func (plugin *ipamPlugin) requestPool(w http.ResponseWriter, r *http.Request) {
+	var req cnmIpam.RequestPoolRequest
+
+	// Decode request.
+	err := plugin.Listener.Decode(w, r, &req)
+	log.Request(plugin.Name, &req, err)
+	if err != nil {
+		return
+	}
+
+	if req.Options == nil {
+		req.Options = make(map[string]string)
+	}
+
+	req.Options[ipam.OptOverlayNetwork] = networkType
+
+	// Process request.
+	poolId, subnet, err := plugin.am.RequestPool(req.AddressSpace, req.Pool, req.SubPool, req.Options, req.V6)
+	if err != nil {
+		plugin.SendErrorResponse(w, err)
+		return
+	}
+
+	// Encode response.
+	data := make(map[string]string)
+	poolId = ipam.NewAddressPoolId(req.AddressSpace, poolId, "").String()
+	resp := cnmIpam.RequestPoolResponse{PoolID: poolId, Pool: subnet, Data: data}
+
+	err = plugin.Listener.Encode(w, &resp)
+
+	log.Response(plugin.Name, &resp, err)
+}
+
+// Handles ReleasePool requests.
+func (plugin *ipamPlugin) releasePool(w http.ResponseWriter, r *http.Request) {
+	var req cnmIpam.ReleasePoolRequest
+
+	// Decode request.
+	err := plugin.Listener.Decode(w, r, &req)
+	log.Request(plugin.Name, &req, err)
+	if err != nil {
+		return
+	}
+
+	// Process request.
+	poolId, err := ipam.NewAddressPoolIdFromString(req.PoolID)
+	if err != nil {
+		plugin.SendErrorResponse(w, err)
+		return
+	}
+
+	err = plugin.am.ReleasePool(poolId.AsId, poolId.Subnet)
+	if err != nil {
+		plugin.SendErrorResponse(w, err)
+		return
+	}
+
+	// Encode response.
+	resp := cnmIpam.ReleasePoolResponse{}
+
+	err = plugin.Listener.Encode(w, &resp)
+
+	log.Response(plugin.Name, &resp, err)
+}
+
+// Handles GetPoolInfo requests.
+func (plugin *ipamPlugin) getPoolInfo(w http.ResponseWriter, r *http.Request) {
+	var req cnmIpam.GetPoolInfoRequest
+
+	// Decode request.
+	err := plugin.Listener.Decode(w, r, &req)
+	log.Request(plugin.Name, &req, err)
+	if err != nil {
+		return
+	}
+
+	// Process request.
+	poolId, err := ipam.NewAddressPoolIdFromString(req.PoolID)
+	if err != nil {
+		plugin.SendErrorResponse(w, err)
+		return
+	}
+
+	apInfo, err := plugin.am.GetPoolInfo(poolId.AsId, poolId.Subnet)
+	if err != nil {
+		plugin.SendErrorResponse(w, err)
+		return
+	}
+
+	// Encode response.
+	resp := cnmIpam.GetPoolInfoResponse{
+		Capacity:  apInfo.Capacity,
+		Available: apInfo.Available,
+	}
+
+	err = plugin.Listener.Encode(w, &resp)
+
+	log.Response(plugin.Name, &resp, err)
+}
+
+// Handles RequestAddress requests.
+func (plugin *ipamPlugin) requestAddress(w http.ResponseWriter, r *http.Request) {
+	var req cnmIpam.RequestAddressRequest
+
+	// Decode request.
+	err := plugin.Listener.Decode(w, r, &req)
+	log.Request(plugin.Name, &req, err)
+	if err != nil {
+		return
+	}
+
+	// Process request.
+	poolId, err := ipam.NewAddressPoolIdFromString(req.PoolID)
+	if err != nil {
+		plugin.SendErrorResponse(w, err)
+		return
+	}
+
+	// Convert libnetwork IPAM options to core IPAM options.
+	options := make(map[string]string)
+	if req.Options[cnmIpam.OptAddressType] == cnmIpam.OptAddressTypeGateway {
+		options[ipam.OptAddressType] = ipam.OptAddressTypeGateway
+	}
+
+	options[ipam.OptAddressID] = req.Options[ipam.OptAddressID]
+
+	addr, err := plugin.am.RequestAddress(poolId.AsId, poolId.Subnet, req.Address, options)
+	if err != nil {
+		plugin.SendErrorResponse(w, err)
+		return
+	}
+
+	// Encode response.
+	data := make(map[string]string)
+	resp := cnmIpam.RequestAddressResponse{Address: addr, Data: data}
+
+	err = plugin.Listener.Encode(w, &resp)
+
+	log.Response(plugin.Name, &resp, err)
+}
+
+// Handles ReleaseAddress requests.
+func (plugin *ipamPlugin) releaseAddress(w http.ResponseWriter, r *http.Request) {
+	var req cnmIpam.ReleaseAddressRequest
+
+	// Decode request.
+	err := plugin.Listener.Decode(w, r, &req)
+	log.Request(plugin.Name, &req, err)
+	if err != nil {
+		return
+	}
+
+	// Process request.
+	poolId, err := ipam.NewAddressPoolIdFromString(req.PoolID)
+	if err != nil {
+		plugin.SendErrorResponse(w, err)
+		return
+	}
+
+	err = plugin.am.ReleaseAddress(poolId.AsId, poolId.Subnet, req.Address, req.Options)
+	if err != nil {
+		plugin.SendErrorResponse(w, err)
+		return
+	}
+
+	// Encode response.
+	resp := cnmIpam.ReleaseAddressResponse{}
+
+	err = plugin.Listener.Encode(w, &resp)
+
+	log.Response(plugin.Name, &resp, err)
+}

--- a/cnm/ipam_overlay/ipam_test.go
+++ b/cnm/ipam_overlay/ipam_test.go
@@ -1,0 +1,394 @@
+// Copyright 2017 Microsoft. All rights reserved.
+// MIT License
+
+package ipam
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/Azure/azure-container-networking/cnm"
+	cnmIpam "github.com/Azure/azure-container-networking/cnm/ipam"
+	"github.com/Azure/azure-container-networking/common"
+	"github.com/Azure/azure-container-networking/ipam"
+)
+
+var plugin IpamPlugin
+var mux *http.ServeMux
+
+var localAsId string
+var poolId1 string
+var address1 string
+
+// Wraps the test run with plugin setup and teardown.
+func TestMain(m *testing.M) {
+	var config common.PluginConfig
+
+	// Create the plugin.
+	plugin, err := NewPlugin(&config)
+	if err != nil {
+		fmt.Printf("Failed to create IPAM plugin, err:%v.\n", err)
+		return
+	}
+
+	// Configure test mode.
+	plugin.SetOption(common.OptEnvironment, "null")
+	plugin.SetOption(common.OptAPIServerURL, "null")
+
+	// Start the plugin.
+	err = plugin.Start(&config)
+	if err != nil {
+		fmt.Printf("Failed to start IPAM plugin, err:%v.\n", err)
+		return
+	}
+
+	// Get the internal http mux as test hook.
+	mux = plugin.(*ipamPlugin).Listener.GetMux()
+
+	// Run tests.
+	exitCode := m.Run()
+
+	// Cleanup.
+	plugin.Stop()
+
+	os.Exit(exitCode)
+}
+
+// Decodes plugin's responses to test requests.
+func decodeResponse(w *httptest.ResponseRecorder, response interface{}) error {
+	if w.Code != http.StatusOK {
+		return fmt.Errorf("Request failed with HTTP error %s", w.Code)
+	}
+
+	if w.Body == nil {
+		return fmt.Errorf("Response body is empty")
+	}
+
+	return json.NewDecoder(w.Body).Decode(&response)
+}
+
+//
+// Libnetwork remote IPAM API compliance tests
+// https://github.com/docker/libnetwork/blob/master/docs/ipam.md
+//
+
+// Tests Plugin.Activate functionality.
+func TestActivate(t *testing.T) {
+	var resp cnm.ActivateResponse
+
+	req, err := http.NewRequest(http.MethodGet, "/Plugin.Activate", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	err = decodeResponse(w, &resp)
+
+	if err != nil || resp.Err != "" || resp.Implements[0] != "IpamDriver" {
+		t.Errorf("Activate response is invalid %+v", resp)
+	}
+}
+
+// Tests IpamDriver.GetCapabilities functionality.
+func TestGetCapabilities(t *testing.T) {
+	var resp cnmIpam.GetCapabilitiesResponse
+
+	req, err := http.NewRequest(http.MethodGet, cnmIpam.GetCapabilitiesPath, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	err = decodeResponse(w, &resp)
+
+	if err != nil || resp.Err != "" {
+		t.Errorf("GetCapabilities response is invalid %+v", resp)
+	}
+}
+
+// Tests IpamDriver.GetDefaultAddressSpaces functionality.
+func TestGetDefaultAddressSpaces(t *testing.T) {
+	var resp cnmIpam.GetDefaultAddressSpacesResponse
+
+	req, err := http.NewRequest(http.MethodGet, cnmIpam.GetAddressSpacesPath, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	err = decodeResponse(w, &resp)
+
+	if err != nil || resp.Err != "" || resp.LocalDefaultAddressSpace == "" {
+		t.Errorf("GetDefaultAddressSpaces response is invalid %+v", resp)
+	}
+
+	localAsId = resp.LocalDefaultAddressSpace
+}
+
+// Tests IpamDriver.RequestPool functionality.
+func TestRequestPool(t *testing.T) {
+	var body bytes.Buffer
+	var resp cnmIpam.RequestPoolResponse
+
+	payload := &cnmIpam.RequestPoolRequest{
+		AddressSpace: localAsId,
+		Pool:         "11.1.0.0/24",
+	}
+
+	json.NewEncoder(&body).Encode(payload)
+
+	req, err := http.NewRequest(http.MethodGet, cnmIpam.RequestPoolPath, &body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	err = decodeResponse(w, &resp)
+
+	if err != nil || resp.Err != "" {
+		t.Errorf("RequestPool response is invalid %+v", resp)
+	}
+
+	poolId1 = resp.PoolID
+}
+
+// Tests IpamDriver.RequestAddress functionality.
+func TestRequestAddress(t *testing.T) {
+	var body bytes.Buffer
+	var resp cnmIpam.RequestAddressResponse
+
+	payload := &cnmIpam.RequestAddressRequest{
+		PoolID:  poolId1,
+		Address: "",
+		Options: nil,
+	}
+
+	json.NewEncoder(&body).Encode(payload)
+
+	req, err := http.NewRequest(http.MethodGet, cnmIpam.RequestAddressPath, &body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	err = decodeResponse(w, &resp)
+
+	if err != nil || resp.Err != "" {
+		t.Errorf("RequestAddress response is invalid %+v", resp)
+	}
+
+	address, _, _ := net.ParseCIDR(resp.Address)
+	address1 = address.String()
+}
+
+// Tests IpamDriver.ReleaseAddress functionality.
+func TestReleaseAddress(t *testing.T) {
+	var body bytes.Buffer
+	var resp cnmIpam.ReleaseAddressResponse
+
+	payload := &cnmIpam.ReleaseAddressRequest{
+		PoolID:  poolId1,
+		Address: address1,
+	}
+
+	json.NewEncoder(&body).Encode(payload)
+
+	req, err := http.NewRequest(http.MethodGet, cnmIpam.ReleaseAddressPath, &body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	err = decodeResponse(w, &resp)
+
+	if err != nil || resp.Err != "" {
+		t.Errorf("ReleaseAddress response is invalid %+v", resp)
+	}
+}
+
+// Tests IpamDriver.GetPoolInfo functionality.
+func TestGetPoolInfo(t *testing.T) {
+	var body bytes.Buffer
+	var resp cnmIpam.GetPoolInfoResponse
+
+	payload := &cnmIpam.GetPoolInfoRequest{
+		PoolID: poolId1,
+	}
+
+	json.NewEncoder(&body).Encode(payload)
+
+	req, err := http.NewRequest(http.MethodGet, cnmIpam.GetPoolInfoPath, &body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	err = decodeResponse(w, &resp)
+
+	if err != nil || resp.Err != "" {
+		t.Errorf("GetPoolInfo response is invalid %+v", resp)
+	}
+}
+
+// Utility function to request address from IPAM.
+func reqAddrInternal(payload *cnmIpam.RequestAddressRequest) (string, error) {
+	var body bytes.Buffer
+	var resp cnmIpam.RequestAddressResponse
+	json.NewEncoder(&body).Encode(payload)
+
+	req, err := http.NewRequest(http.MethodGet, cnmIpam.RequestAddressPath, &body)
+	if err != nil {
+		return "", err
+	}
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	err = decodeResponse(w, &resp)
+
+	if err != nil {
+		return "", err
+	}
+	return resp.Address, nil
+}
+
+// Utility function to release address from IPAM.
+func releaseAddrInternal(payload *cnmIpam.ReleaseAddressRequest) error {
+	var body bytes.Buffer
+	var resp cnmIpam.ReleaseAddressResponse
+
+	json.NewEncoder(&body).Encode(payload)
+
+	req, err := http.NewRequest(http.MethodGet, cnmIpam.ReleaseAddressPath, &body)
+	if err != nil {
+		return err
+	}
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	err = decodeResponse(w, &resp)
+
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Tests IpamDriver.RequestAddress with id.
+func TestRequestAddressWithID(t *testing.T) {
+	var ipList [2]string
+
+	for i := 0; i < 2; i++ {
+		payload := &cnmIpam.RequestAddressRequest{
+			PoolID:  poolId1,
+			Address: "",
+			Options: make(map[string]string),
+		}
+
+		payload.Options[ipam.OptAddressID] = "id" + strconv.Itoa(i)
+
+		addr1, err := reqAddrInternal(payload)
+		if err != nil {
+			t.Errorf("RequestAddress response is invalid %+v", err)
+		}
+
+		addr2, err := reqAddrInternal(payload)
+		if err != nil {
+			t.Errorf("RequestAddress response is invalid %+v", err)
+		}
+
+		if addr1 != addr2 {
+			t.Errorf("RequestAddress with id %+v doesn't match with retrieved addr %+v ", addr1, addr2)
+		}
+
+		address, _, _ := net.ParseCIDR(addr1)
+		ipList[i] = address.String()
+	}
+
+	for i := 0; i < 2; i++ {
+		payload := &cnmIpam.ReleaseAddressRequest{
+			PoolID:  poolId1,
+			Address: ipList[i],
+		}
+		err := releaseAddrInternal(payload)
+		if err != nil {
+			t.Errorf("ReleaseAddress response is invalid %+v", err)
+		}
+	}
+}
+
+// Tests IpamDriver.ReleaseAddress with id.
+func TestReleaseAddressWithID(t *testing.T) {
+	reqPayload := &cnmIpam.RequestAddressRequest{
+		PoolID:  poolId1,
+		Address: "",
+		Options: make(map[string]string),
+	}
+	reqPayload.Options[ipam.OptAddressID] = "id1"
+
+	_, err := reqAddrInternal(reqPayload)
+	if err != nil {
+		t.Errorf("RequestAddress response is invalid %+v", err)
+	}
+
+	releasePayload := &cnmIpam.ReleaseAddressRequest{
+		PoolID:  poolId1,
+		Address: "",
+		Options: make(map[string]string),
+	}
+	releasePayload.Options[ipam.OptAddressID] = "id1"
+
+	err = releaseAddrInternal(releasePayload)
+
+	if err != nil {
+		t.Errorf("ReleaseAddress response is invalid %+v", err)
+	}
+}
+
+// Tests IpamDriver.ReleasePool functionality.
+func TestReleasePool(t *testing.T) {
+	var body bytes.Buffer
+	var resp cnmIpam.ReleasePoolResponse
+
+	payload := &cnmIpam.ReleasePoolRequest{
+		PoolID: poolId1,
+	}
+
+	json.NewEncoder(&body).Encode(payload)
+
+	req, err := http.NewRequest(http.MethodGet, cnmIpam.ReleasePoolPath, &body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	err = decodeResponse(w, &resp)
+
+	if err != nil || resp.Err != "" {
+		t.Errorf("ReleasePool response is invalid %+v", resp)
+	}
+}

--- a/ipam/api.go
+++ b/ipam/api.go
@@ -30,4 +30,5 @@ var (
 	OptAddressID          = "azure.address.id"
 	OptAddressType        = "azure.address.type"
 	OptAddressTypeGateway = "gateway"
+	OptOverlayNetwork     = "overlay"
 )


### PR DESCRIPTION
Implemented Ipam driver for overlay network. The pools will be created on demand when a request comes for specific subnet. As of now, ipam driver for azure-vnet and overlay cannot be started concurrently. Instead of starting azure source, the overlay ipam driver starts null source to avoid communication with NM Agent.