### PR TITLE
Outbound connectivity from containers

### DIFF
--- a/cnm/plugin.go
+++ b/cnm/plugin.go
@@ -107,7 +107,7 @@ func (plugin *Plugin) DisableDiscovery() {
 
 // ParseOptions returns generic options from a libnetwork request.
 func (plugin *Plugin) ParseOptions(options OptionMap) OptionMap {
-	opt, _ := options[genericData].(OptionMap)
+	opt, _ := options[genericData].(map[string]interface{})
 	return opt
 }
 

--- a/cns/api.go
+++ b/cns/api.go
@@ -35,6 +35,7 @@ type OverlayConfiguration struct {
 type CreateNetworkRequest struct {
 	NetworkName          string
 	OverlayConfiguration OverlayConfiguration
+	Options              map[string]interface{}
 }
 
 // DeleteNetworkRequest describes request to delete the network.

--- a/cns/dockerclient/api.go
+++ b/cns/dockerclient/api.go
@@ -6,6 +6,8 @@ package dockerclient
 const (
 	createNetworkPath  = "/networks/create"
 	inspectNetworkPath = "/networks/"
+
+	OptDisableSnat = "DisableSNAT"
 )
 
 // Config describes subnet/gateway for ipam.
@@ -25,6 +27,7 @@ type NetworkConfiguration struct {
 	Driver   string
 	IPAM     IPAM
 	Internal bool
+	Options  map[string]interface{}
 }
 
 // DockerErrorResponse defines the error response retunred by docker.

--- a/cns/dockerclient/dockerclient.go
+++ b/cns/dockerclient/dockerclient.go
@@ -28,7 +28,7 @@ type DockerClient struct {
 }
 
 func executeShellCommand(command string) error {
-	log.Debugf("[ebtables] %s", command)
+	log.Debugf("[Azure-CNS] %s", command)
 	cmd := exec.Command("sh", "-c", command)
 	err := cmd.Start()
 	if err != nil {

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -5,10 +5,9 @@ package restserver
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"time"
-
-	"net"
 
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/common"
@@ -187,7 +186,7 @@ func (service *httpRestService) createNetwork(w http.ResponseWriter, r *http.Req
 								log.Printf("[Azure CNS] Unable to get routing table from node, %+v.", err.Error())
 							}
 
-							err = dc.CreateNetwork(req.NetworkName)
+							err = dc.CreateNetwork(req.NetworkName, req.Options)
 							if err != nil {
 								returnMessage = fmt.Sprintf("[Azure CNS] Error. CreateNetwork failed %v.", err.Error())
 								returnCode = UnexpectedError


### PR DESCRIPTION
This PR contains support for allowing outbound connectivity from containers by enabling SNAT and by specifying bridge mode from CNS instead of default tunnel mode. The azure-vnet and ipam plugin will also be started as part of CNS