### PR TITLE
CNI should invoke ipam release call even if delete endpoint fails

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -320,8 +320,8 @@ func (plugin *netPlugin) Delete(args *cniSkel.CmdArgs) error {
 	// Delete the endpoint.
 	err = plugin.nm.DeleteEndpoint(networkId, endpointId)
 	if err != nil {
-		// Log the error but don't return before releasing address
-		log.Printf("Container Namespace might have been removed. Failed to delete endpoint: %v", err)
+		err = plugin.Errorf("Failed to delete endpoint: %v", err)
+		return err
 	}
 
 	// Call into IPAM plugin to release the endpoint's addresses.
@@ -330,7 +330,7 @@ func (plugin *netPlugin) Delete(args *cniSkel.CmdArgs) error {
 		nwCfg.Ipam.Address = address.IP.String()
 		err = plugin.DelegateDel(nwCfg.Ipam.Type, nwCfg)
 		if err != nil {
-			plugin.Errorf("Failed to release address: %v", err)
+			err = plugin.Errorf("Failed to release address: %v", err)
 			return err
 		}
 	}

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -320,8 +320,8 @@ func (plugin *netPlugin) Delete(args *cniSkel.CmdArgs) error {
 	// Delete the endpoint.
 	err = plugin.nm.DeleteEndpoint(networkId, endpointId)
 	if err != nil {
-		err = plugin.Errorf("Failed to delete endpoint: %v", err)
-		return err
+		// Log the error but don't return before releasing address
+		log.Printf("Container Namespace might have been removed. Failed to delete endpoint: %v", err)
 	}
 
 	// Call into IPAM plugin to release the endpoint's addresses.
@@ -330,8 +330,7 @@ func (plugin *netPlugin) Delete(args *cniSkel.CmdArgs) error {
 		nwCfg.Ipam.Address = address.IP.String()
 		err = plugin.DelegateDel(nwCfg.Ipam.Type, nwCfg)
 		if err != nil {
-			err = plugin.Errorf("Failed to release address: %v", err)
-			return err
+			log.Printf("Failed to release address: %v", err)
 		}
 	}
 

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -330,7 +330,8 @@ func (plugin *netPlugin) Delete(args *cniSkel.CmdArgs) error {
 		nwCfg.Ipam.Address = address.IP.String()
 		err = plugin.DelegateDel(nwCfg.Ipam.Type, nwCfg)
 		if err != nil {
-			log.Printf("Failed to release address: %v", err)
+			plugin.Errorf("Failed to release address: %v", err)
+			return err
 		}
 	}
 

--- a/ipam/pool.go
+++ b/ipam/pool.go
@@ -542,13 +542,13 @@ func (ap *addressPool) releaseAddress(address string, options map[string]string)
 
 	// Fail if an address record with a matching ID is not found.
 	if ar == nil || (id != "" && id != ar.ID) {
-		err = errAddressNotFound
-		return err
+		log.Printf("Address not found. Not Returning error")
+		return nil
 	}
 
 	if !ar.InUse {
-		err = errAddressNotInUse
-		return err
+		log.Printf("Address not in use. Not Returning error")
+		return nil
 	}
 
 	if ar.ID != "" {

--- a/netlink/link.go
+++ b/netlink/link.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/Azure/azure-container-networking/log"
 	"golang.org/x/sys/unix"
 )
 
@@ -146,15 +147,17 @@ func AddLink(link Link) error {
 // DeleteLink deletes a network interface.
 func DeleteLink(name string) error {
 	if name == "" {
-		return fmt.Errorf("Invalid link name")
-	}
-
-	s, err := getSocket()
-	if err != nil {
-		return err
+		log.Printf("[net] Invalid link name. Not returning error")
+		return nil
 	}
 
 	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		log.Printf("[net] Interface not found. Not returning error")
+		return nil
+	}
+
+	s, err := getSocket()
 	if err != nil {
 		return err
 	}

--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -83,7 +83,8 @@ func (nw *network) deleteEndpoint(endpointId string) error {
 	// Look up the endpoint.
 	ep, err := nw.getEndpoint(endpointId)
 	if err != nil {
-		return err
+		log.Printf("[net] Endpoint %v not found. Not Returning error", endpointId)
+		return nil
 	}
 
 	// Call the platform implementation.


### PR DESCRIPTION
This fix makes sure that there is no ip address leak even if delete endpoint(removing veth pair and resources) fails. It assumes container namespace would have been removed already and will invoke ipam release call to release ip address and other resources