### PR TITLE
Enable outboundNAT for Windows containers.

### DIFF
--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -51,11 +51,6 @@ func (nw *network) newEndpoint(epInfo *EndpointInfo) (*endpoint, error) {
 		}
 	}()
 
-	if nw.Endpoints[epInfo.Id] != nil {
-		err = errEndpointExists
-		return nil, err
-	}
-
 	// Call the platform implementation.
 	ep, err = nw.newEndpointImpl(epInfo)
 	if err != nil {
@@ -67,6 +62,7 @@ func (nw *network) newEndpoint(epInfo *EndpointInfo) (*endpoint, error) {
 	log.Printf("[net] Created endpoint %+v.", ep)
 
 	return ep, nil
+
 }
 
 // DeleteEndpoint deletes an existing endpoint from the network.

--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -58,11 +58,9 @@ func (nw *network) newEndpoint(epInfo *EndpointInfo) (*endpoint, error) {
 	}
 
 	nw.Endpoints[epInfo.Id] = ep
-
 	log.Printf("[net] Created endpoint %+v.", ep)
 
 	return ep, nil
-
 }
 
 // DeleteEndpoint deletes an existing endpoint from the network.

--- a/network/endpoint_linux.go
+++ b/network/endpoint_linux.go
@@ -32,6 +32,12 @@ func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
 	var ep *endpoint
 	var err error
 
+	if nw.Endpoints[epInfo.Id] != nil {
+		log.Printf("[net] Endpoint alreday exists.")		
+		err = errEndpointExists
+		return nil, err
+	}
+
 	// Create a veth pair.
 	hostIfName := fmt.Sprintf("%s%s", hostVEthInterfacePrefix, epInfo.Id[:7])
 	contIfName := fmt.Sprintf("%s%s-2", hostVEthInterfacePrefix, epInfo.Id[:7])

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -45,15 +45,24 @@ func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
 	}
 	
 	// Get Infrastructure containerID. Ignore ADD calls for workload container.
+
 	infraEpID, isWorkLoad := ConstructEndpointID(epInfo.NetNsPath, epInfo.IfName)
 	log.Printf("[net] infraEpID: %v", infraEpID)
+
 	if isWorkLoad && nw.Endpoints[infraEpID] != nil {
 		log.Printf("[net] Found existing infrastructure endpoint %v", infraEpID)
+		if hnsEndpoint != nil
+		//TODO: attach
 		return nw.Endpoints[infraEpID], nil		
 	}	
+	hnsEndpoint, err := hcsshim.GetHNSEndpointByName(infraEpID)
+	if hnsEndpoint != nil {
+		log.Printf("[net] Found existing endpoint %v", infraEpID)
+		//TODO: attach
+	}
 
 	// Initialize HNS endpoint.
-	hnsEndpoint := &hcsshim.HNSEndpoint{
+	hnsEndpoint = &hcsshim.HNSEndpoint{
 		Name:           epInfo.Id,
 		VirtualNetwork: nw.HnsId,
 		DNSSuffix:      epInfo.DNS.Suffix,

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -14,7 +14,7 @@ import (
 	"github.com/Microsoft/hcsshim"
 )
 
-// ConstructEpname constructs endpoint name from netNsPath.
+// ConstructEpName constructs endpoint name from netNsPath.
 func ConstructEpName(containerID string, netNsPath string, ifName string) string {
 	epName := ""
 	if netNsPath != "" {
@@ -43,6 +43,7 @@ func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
 		log.Printf("[net] Found existing endpoint %v, return immediately.", epInfo.Id)
 		return nw.Endpoints[epInfo.Id], nil
 	}
+
 	// Get Infrastructure containerID. Handle ADD calls for workload container.
 	epName := ConstructEpName(epInfo.ContainerID, epInfo.NetNsPath, epInfo.IfName)
 	log.Printf("[net] infraEpName: %v", epName)

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -44,7 +44,11 @@ func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
 	// Get Infrastructure containerID. Handle ADD calls for workload container.
 	infraEpName, workloadEpName := ConstructEpName(epInfo.ContainerID, epInfo.NetNsPath, epInfo.IfName)
 
-	// Handle consecutive ADD calls for infrastructure containers
+	/* Handle consecutive ADD calls for infrastructure containers.
+	 * This is a temporary work around for issue #57253 of Kubernetes.
+	 * We can delete this if statement once they fix it.
+	 * Issue link: https://github.com/kubernetes/kubernetes/issues/57253
+	 */
 	if workloadEpName == "" {
 		if nw.Endpoints[infraEpName] != nil {
 			log.Printf("[net] Found existing endpoint %v, return immediately.", infraEpName)

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -19,9 +19,11 @@ func ConstructEpName(containerID string, netNsPath string, ifName string) string
 	epName := ""
 	if netNsPath != "" {
 		splits := strings.Split(netNsPath, ":")
+		// For workload containers, we extract its linking infrastructure container ID.
 		if len(splits) == 2 {
 			epName = splits[1]
 		} else {
+		// For infrastructure containers, we just use its container ID.
 			epName = containerID
 		}
 		if len(epName) > 8 {

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -34,10 +34,6 @@ func ConstructEpName(containerID string, netNsPath string, ifName string) string
 
 // newEndpointImpl creates a new endpoint in the network.
 func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
-	// Check if endpoint already exists.
-	log.Printf("[net] Entering newEndpointImpl.")
-	log.Printf("[net] epInfo.Id: %v, epInfo.ContainerID: %v, epInfo.NetNsPath: %v", epInfo.Id, epInfo.ContainerID, epInfo.NetNsPath)
-
 	// Ignore consecutive ADD calls for the same container.
 	if nw.Endpoints[epInfo.Id] != nil {
 		log.Printf("[net] Found existing endpoint %v, return immediately.", epInfo.Id)
@@ -49,7 +45,7 @@ func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
 	log.Printf("[net] infraEpName: %v", epName)
 
 	hnsEndpoint, _ := hcsshim.GetHNSEndpointByName(epName)
-	if hnsEndpoint != nil /*&& hnsEndpoint.VirtualNetwork != nw.HnsId */ {
+	if hnsEndpoint != nil {
 		log.Printf("[net] Found existing endpoint through hcsshim%v", epName)
 		log.Printf("[net] Attaching ep %v to container %v", hnsEndpoint.Id, epInfo.ContainerID)
 		if err := hcsshim.HotAttachEndpoint(epInfo.ContainerID, hnsEndpoint.Id); err != nil {
@@ -67,7 +63,6 @@ func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
 	}
 
 	//enable outbound NAT
-
 	var enableOutBoundNat = json.RawMessage(`{"Type":  "OutBoundNAT"}`)
 	hnsEndpoint.Policies = append(hnsEndpoint.Policies, enableOutBoundNat)
 


### PR DESCRIPTION
**What this PR does / why we need it:**

1. Enable outboundNAT for Windows containers.
2. Handle consecutive ADD calls for the same container. 
3. Handle attach endpoint for workload containers.

**Which issue this PR fixes**

    Related issue: [https://github.com/kubernetes/kubernetes/issues/57253](url)