### PR TITLE
Added support for cnm reboot scenario

### DIFF
--- a/cni/plugin.go
+++ b/cni/plugin.go
@@ -56,7 +56,7 @@ func (plugin *Plugin) Initialize(config *common.PluginConfig) error {
 	if plugin.Store == nil {
 		// Create the key value store.
 		var err error
-		plugin.Store, err = store.NewJsonFileStore(platform.RuntimePath + plugin.Name + ".json")
+		plugin.Store, err = store.NewJsonFileStore(platform.CNIRuntimePath + plugin.Name + ".json")
 		if err != nil {
 			log.Printf("[cni] Failed to create store, err:%v.", err)
 			return err

--- a/cnm/plugin/main.go
+++ b/cnm/plugin/main.go
@@ -128,8 +128,14 @@ func main() {
 		return
 	}
 
+	err = common.CreateDirectory(platform.CNMRuntimePath)
+	if err != nil {
+		fmt.Printf("Failed to create File Store directory Error:%v", err.Error())
+		return
+	}
+
 	// Create the key value store.
-	config.Store, err = store.NewJsonFileStore(platform.RuntimePath + name + ".json")
+	config.Store, err = store.NewJsonFileStore(platform.CNMRuntimePath + name + ".json")
 	if err != nil {
 		fmt.Printf("Failed to create store: %v\n", err)
 		return

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -121,7 +121,7 @@ func main() {
 
 	// Create the key value store.
 	var err error
-	config.Store, err = store.NewJsonFileStore(platform.RuntimePath + name + ".json")
+	config.Store, err = store.NewJsonFileStore(platform.CNMRuntimePath + name + ".json")
 	if err != nil {
 		fmt.Printf("Failed to create store: %v\n", err)
 		return
@@ -155,7 +155,7 @@ func main() {
 	}
 
 	// Create the key value store.
-	pluginConfig.Store, err = store.NewJsonFileStore(platform.RuntimePath + pluginName + ".json")
+	pluginConfig.Store, err = store.NewJsonFileStore(platform.CNMRuntimePath + pluginName + ".json")
 	if err != nil {
 		fmt.Printf("Failed to create store: %v\n", err)
 		return

--- a/common/utils.go
+++ b/common/utils.go
@@ -6,6 +6,7 @@ package common
 import (
 	"encoding/xml"
 	"net"
+	"os"
 
 	"github.com/Azure/azure-container-networking/log"
 )
@@ -43,4 +44,28 @@ func LogNetworkInterfaces() {
 		addrs, _ := iface.Addrs()
 		log.Printf("[net] Network interface: %+v with IP addresses: %+v", iface, addrs)
 	}
+}
+
+func CheckIfFileExists(filepath string) (bool, error) {
+	_, err := os.Stat(filepath)
+	if err == nil {
+		return true, nil
+	}
+
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+
+	return true, err
+}
+
+func CreateDirectory(dirPath string) error {
+	var err error
+
+	isExist, _ := CheckIfFileExists(dirPath)
+	if !isExist {
+		err = os.Mkdir(dirPath, os.ModePerm)
+	}
+
+	return err
 }

--- a/ipam/manager.go
+++ b/ipam/manager.go
@@ -100,8 +100,8 @@ func (am *addressManager) restore() error {
 	}
 
 	rebooted := false
-	// After a reboot, all address resources are implicitly released.
-	// Ignore the persisted state if it is older than the last reboot time.
+
+	// Check if the VM is rebooted.
 	modTime, err := am.store.GetModificationTime()
 	if err == nil {
 		log.Printf("[ipam] Store timestamp is %v.", modTime)
@@ -138,7 +138,9 @@ func (am *addressManager) restore() error {
 		}
 	}
 
+	// if rebooted mark the ip as not in use.
 	if rebooted {
+		log.Printf("[ipam] Rehydrating ipam state from persistent store")
 		for _, as := range am.AddrSpaces {
 			for _, ap := range as.Pools {
 				ap.as = as

--- a/ipam/pool.go
+++ b/ipam/pool.go
@@ -484,7 +484,7 @@ func (ap *addressPool) requestAddress(address string, options map[string]string)
 	// If no address was found, return any available address.
 	if ar == nil {
 		for _, ar = range ap.Addresses {
-			if !ar.InUse {
+			if !ar.InUse && ar.ID == "" {
 				break
 			}
 			ar = nil
@@ -497,10 +497,10 @@ func (ap *addressPool) requestAddress(address string, options map[string]string)
 
 	if id != "" {
 		ap.addrsByID[id] = ar
+		ar.ID = id
+	} else {
+		ar.InUse = true
 	}
-
-	ar.ID = id
-	ar.InUse = true
 
 	// Return address in CIDR notation.
 	addr = &net.IPNet{
@@ -551,15 +551,16 @@ func (ap *addressPool) releaseAddress(address string, options map[string]string)
 		return nil
 	}
 
-	if ar.ID != "" {
-		delete(ap.addrsByID, ar.ID)
-	}
-
-	ar.ID = ""
 	ar.InUse = false
+
+	if id != "" && ar.ID == id {
+		delete(ap.addrsByID, ar.ID)
+		ar.ID = ""
+	}
 
 	// Delete address record if it is no longer available.
 	if ar.epoch < ap.as.epoch {
+		log.Printf("Deleting Address record from address pool as metadata doesn't have")
 		delete(ap.Addresses, address)
 	}
 

--- a/ipam/pool.go
+++ b/ipam/pool.go
@@ -560,7 +560,7 @@ func (ap *addressPool) releaseAddress(address string, options map[string]string)
 
 	// Delete address record if it is no longer available.
 	if ar.epoch < ap.as.epoch {
-		log.Printf("Deleting Address record from address pool as metadata doesn't have")
+		log.Printf("Deleting Address record from address pool as metadata doesn't have this address")
 		delete(ap.Addresses, address)
 	}
 

--- a/network/manager.go
+++ b/network/manager.go
@@ -75,21 +75,12 @@ func (nm *networkManager) restore() error {
 		return nil
 	}
 
+	rebooted := false
 	// After a reboot, all address resources are implicitly released.
 	// Ignore the persisted state if it is older than the last reboot time.
-	modTime, err := nm.store.GetModificationTime()
-	if err == nil {
-		log.Printf("[net] Store timestamp is %v.", modTime)
-
-		rebootTime, err := platform.GetLastRebootTime()
-		if err == nil && rebootTime.After(modTime) {
-			log.Printf("[net] Ignoring stale state older than last reboot %v.", rebootTime)
-			return nil
-		}
-	}
 
 	// Read any persisted state.
-	err = nm.store.Read(storeKey, nm)
+	err := nm.store.Read(storeKey, nm)
 	if err != nil {
 		if err == store.ErrKeyNotFound {
 			// Considered successful.
@@ -100,6 +91,17 @@ func (nm *networkManager) restore() error {
 		}
 	}
 
+	modTime, err := nm.store.GetModificationTime()
+	if err == nil {
+		log.Printf("[net] Store timestamp is %v.", modTime)
+
+		rebootTime, err := platform.GetLastRebootTime()
+		if err == nil && rebootTime.After(modTime) {
+			log.Printf("[net] reboot time %v mod time %v", rebootTime, modTime)
+			rebooted = true
+		}
+	}
+
 	// Populate pointers.
 	for _, extIf := range nm.ExternalInterfaces {
 		for _, nw := range extIf.Networks {
@@ -107,8 +109,25 @@ func (nm *networkManager) restore() error {
 		}
 	}
 
-	log.Printf("[net] Restored state, %+v\n", nm)
+	if rebooted {
+		for _, extIf := range nm.ExternalInterfaces {
+			for _, nw := range extIf.Networks {
+				nwInfo, err := nm.GetNetworkInfo(nw.Id)
+				if err != nil {
+					log.Printf("[net] Failed to fetch network info for network %v err %v", nw, err)
+				}
 
+				extIf.BridgeName = ""
+
+				_, err = nm.newNetworkImpl(nwInfo, extIf)
+				if err != nil {
+					log.Printf("[net] Failed to restore network %v", err)
+				}
+			}
+		}
+	}
+
+	log.Printf("[net] Restored state, %+v\n", nm)
 	return nil
 }
 
@@ -204,6 +223,11 @@ func (nm *networkManager) GetNetworkInfo(networkId string) (*NetworkInfo, error)
 	nwInfo := &NetworkInfo{
 		Id:      networkId,
 		Subnets: nw.Subnets,
+		Mode:    nw.Mode,
+	}
+
+	if nw.extIf != nil {
+		nwInfo.BridgeName = nw.extIf.BridgeName
 	}
 
 	return nwInfo, nil

--- a/network/manager.go
+++ b/network/manager.go
@@ -109,19 +109,23 @@ func (nm *networkManager) restore() error {
 		}
 	}
 
+	// if rebooted recreate the network that existed before reboot.
 	if rebooted {
+		log.Printf("[net] Rehydrating network state from persistent store")
 		for _, extIf := range nm.ExternalInterfaces {
 			for _, nw := range extIf.Networks {
 				nwInfo, err := nm.GetNetworkInfo(nw.Id)
 				if err != nil {
-					log.Printf("[net] Failed to fetch network info for network %v err %v", nw, err)
+					log.Printf("[net] Failed to fetch network info for network %v extif %v err %v. This should not happen", nw, extIf, err)
+					return err
 				}
 
 				extIf.BridgeName = ""
 
 				_, err = nm.newNetworkImpl(nwInfo, extIf)
 				if err != nil {
-					log.Printf("[net] Failed to restore network %v", err)
+					log.Printf("[net] Restoring network failed for nwInfo %v extif %v. This should not happen %v", nwInfo, extIf, err)
+					return err
 				}
 			}
 		}

--- a/network/network_linux.go
+++ b/network/network_linux.go
@@ -8,6 +8,7 @@ package network
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/Azure/azure-container-networking/ebtables"
 	"github.com/Azure/azure-container-networking/log"
@@ -118,7 +119,7 @@ func (nm *networkManager) applyIPConfig(extIf *externalInterface, targetIf *net.
 		log.Printf("[net] Adding IP address %v to interface %v.", addr, targetIf.Name)
 
 		err := netlink.AddIpAddress(targetIf.Name, addr.IP, addr)
-		if err != nil {
+		if err != nil && !strings.Contains(strings.ToLower(err.Error()), "file exists") {
 			log.Printf("[net] Failed to add IP address %v: %v.", addr, err)
 			return err
 		}

--- a/platform/os_linux.go
+++ b/platform/os_linux.go
@@ -10,8 +10,12 @@ import (
 )
 
 const (
-	// RuntimePath is the path where runtime files are stored.
-	RuntimePath = "/var/run/"
+
+	// CNMRuntimePath is the path where CNM state files are stored.
+	CNMRuntimePath = "/var/lib/azure-network/"
+
+	// CNIRuntimePath is the path where CNM state files are stored.
+	CNIRuntimePath = "/var/run/"
 
 	// LogPath is the path where log files are stored.
 	LogPath = "/var/log/"

--- a/platform/os_windows.go
+++ b/platform/os_windows.go
@@ -8,8 +8,12 @@ import (
 )
 
 const (
-	// RuntimePath is the path where runtime files are stored.
-	RuntimePath = ""
+
+	// CNMRuntimePath is the path where CNM state files are stored.
+	CNMRuntimePath = ""
+
+	// CNIRuntimePath is the path where CNM state files are stored.
+	CNIRuntimePath = ""
 
 	// LogPath is the path where log files are stored.
 	LogPath = ""

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -93,7 +93,7 @@ type ReportManager struct {
 
 const (
 	// TelemetryFile Path.
-	TelemetryFile = platform.RuntimePath + "AzureCNITelemetry.json"
+	TelemetryFile = platform.CNIRuntimePath + "AzureCNITelemetry.json"
 )
 
 // Read file line by line and return array of lines.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR supports recreating the network that exists before reboot. The CNM will read the state and recreate network if necessary.

**Which issue this PR fixes** #
The issue is that docker remembers the network after reboot but CNM doesn't. This PR will fix that inconsistency and will recreate the network after reboot.
This PR also fixes a bug in reservation id.
If an ip is reserved, it will be marked use by default and the cannot be used with docker run --ip. This PR fixes this issue so that address won't be marked use at the time of reservation.
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```