### PR TITLE
removed reservation id inclusion from CNI

### DIFF
--- a/cni/ipam/ipam.go
+++ b/cni/ipam/ipam.go
@@ -178,12 +178,8 @@ func (plugin *ipamPlugin) Add(args *cniSkel.CmdArgs) error {
 		log.Printf("[cni-ipam] Allocated address poolID %v with subnet %v.", poolID, subnet)
 	}
 
-	// Store the endpoint ID in address request.
-	options := make(map[string]string)
-	options[ipam.OptAddressID] = plugin.GetEndpointID(args)
-
 	// Allocate an address for the endpoint.
-	address, err := plugin.am.RequestAddress(nwCfg.Ipam.AddrSpace, nwCfg.Ipam.Subnet, nwCfg.Ipam.Address, options)
+	address, err := plugin.am.RequestAddress(nwCfg.Ipam.AddrSpace, nwCfg.Ipam.Subnet, nwCfg.Ipam.Address, nil)
 	if err != nil {
 		err = plugin.Errorf("Failed to allocate address: %v", err)
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR removes setting reservation id by default in CNI. Because this is conflicting with the support added for reboot scenario in this PR #98 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```