### PR TITLE
Adding subnet allocation type "any"

### DIFF
--- a/ipam/api.go
+++ b/ipam/api.go
@@ -30,4 +30,8 @@ var (
 	OptAddressID          = "azure.address.id"
 	OptAddressType        = "azure.address.type"
 	OptAddressTypeGateway = "gateway"
+	OptSubnetAllocType    = "azure.subnet.alloc.type"
+
+	//Subnet alloc type.
+	TypeAny = "any"
 )

--- a/ipam/pool.go
+++ b/ipam/pool.go
@@ -301,12 +301,14 @@ func (as *addressSpace) requestPool(poolId string, subPoolId string, options map
 	} else {
 		// Return any available address pool.
 		ifName := options[OptInterfaceName]
-
+		allocType := options[OptSubnetAllocType]
 		for _, pool := range as.Pools {
 			log.Printf("[ipam] Checking pool %v.", pool.Id)
 
-			// Skip if pool is already in use.
-			if pool.isInUse() {
+			// Skip if pool is already in use or if the pool
+			// is avilable and request is to allocate from
+			// any available pool..
+			if pool.isInUse() && allocType != TypeAny {
 				log.Printf("[ipam] Pool is in use.")
 				continue
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This commit adds an option for subnet allocation type "any". In the current azure ipam code base, if the Subnet option is passed to the ipam plugin, the ipam plugin tries to allocate from within the subnet pool if it is available. If the subnet option is missing, it requests a pool if its available and allocated IP from that pool.  However there is no option to allocate an IP from any available subnet pool.
If the subnet option is not set I expected that Azure ipam plugin would allocate an IP from an existing pool. But it looks like it tries to allocate a new pool from available pools in the metadata server. This would mean on every POD request the ipam pluguin tries to allocate a  pool for the scenario I explain below.

**Why is this needed ?**
If I create a vnet lets say with 172.17.0.0/16 and I create subpools 172.17.1.0/24, 172.17.2.0/24 and create couple of vms , node1 connected to 172.17.1.0/24 and node2 connected to 172.17.2.0/24 and install kubernetes and I also go ahead and deploy a cni plugin like calico and azure ipam plugin. The calico cni config on every node needs to pass in a subnet for the azure ipam plugin because each node is connected to different subnet pool and also for the reason explained above if the subnet is not set.
 In order to do that I will need to add a local cni network config on every node to pass in the subnet for azure ipam plugin to allocate the IP from. But one advantage of azure is that every node has a local configuration already in the local azure metadata server. So adding another local config just for this purpose may be redundant. So I decided to make use of this.
In order to avoid local configs, CNI plugins such as calico can have in their network config an ipam config with ```subnet: 0.0.0.0/24``` and Azure ipam can allocate an IP from any available pool. 


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
Signed-off-by: Abhinandan Prativadi <abhi@docker.com>