### PR TITLE
Added SetOrchestratorType Api

### DIFF
--- a/client/cnsclient/cnsclient.go
+++ b/client/cnsclient/cnsclient.go
@@ -1,0 +1,84 @@
+package cnsclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/log"
+)
+
+// IpamClient specifies a client to connect to Ipam Plugin.
+type CNSClient struct {
+	connectionURL string
+}
+
+const (
+	defaultCnsURL = "http://localhost:10090"
+)
+
+// NewCnsClient create a new cns client.
+func NewCnsClient(url string) (*CNSClient, error) {
+	if url == "" {
+		url = defaultCnsURL
+	}
+
+	return &CNSClient{
+		connectionURL: url,
+	}, nil
+}
+
+// GetNetworkConfiguration Request to get network config.
+func (cnsClient *CNSClient) GetNetworkConfiguration(podName, podNamespace string) (*cns.GetNetworkContainerResponse, error) {
+	var body bytes.Buffer
+
+	httpc := &http.Client{}
+	url := cnsClient.connectionURL + cns.GetNetworkContainerByOrchestratorContext
+	log.Printf("GetNetworkConfiguration url %v", url)
+
+	podInfo := cns.KubernetesPodInfo{PodName: podName, PodNamespace: podNamespace}
+	podInfoBytes, err := json.Marshal(podInfo)
+	if err != nil {
+		log.Printf("Marshalling azure container instance info failed with %v", err)
+		return nil, err
+	}
+
+	payload := &cns.GetNetworkContainerRequest{
+		OrchestratorContext: podInfoBytes,
+	}
+
+	err = json.NewEncoder(&body).Encode(payload)
+	if err != nil {
+		log.Printf("encoding json failed with %v", err)
+		return nil, err
+	}
+
+	res, err := httpc.Post(url, "application/json", &body)
+	if err != nil {
+		log.Printf("[Azure CNSClient] HTTP Post returned error %v", err.Error())
+		return nil, err
+	}
+
+	if res.StatusCode != 200 {
+		errMsg := fmt.Sprintf("[Azure CNSClient] GetNetworkConfiguration invalid http status code: %v", res.StatusCode)
+		log.Printf(errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+
+	var resp cns.GetNetworkContainerResponse
+
+	err = json.NewDecoder(res.Body).Decode(&resp)
+	if err != nil {
+		log.Printf("[Azure CNSClient] Error received while parsing GetNetworkConfiguration response resp:%v err:%v", res.Body, err.Error())
+		return nil, err
+	}
+
+	if resp.Response.ReturnCode != 0 {
+		log.Printf("[Azure CNSClient] GetNetworkConfiguration received error response :%v", resp.Response.Message)
+		return nil, fmt.Errorf(resp.Response.Message)
+	}
+
+	return &resp, nil
+}

--- a/cni/plugin.go
+++ b/cni/plugin.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/Azure/azure-container-networking/common"
 	"github.com/Azure/azure-container-networking/log"
@@ -166,6 +167,20 @@ func (plugin *Plugin) GetEndpointID(args *cniSkel.CmdArgs) string {
 	}
 
 	return containerID + "-" + args.IfName
+}
+
+func (plugin *Plugin) GetCNIArgs(args string) map[string]interface{} {
+	argsMap := make(map[string]interface{})
+
+	data := strings.Split(args, ";")
+	for _, pair := range data {
+		items := strings.Split(pair, "=")
+		if len(items) > 1 {
+			argsMap[items[0]] = items[1]
+		}
+	}
+
+	return argsMap
 }
 
 // Error creates and logs a structured CNI error.

--- a/cns/dnccontract.go
+++ b/cns/dnccontract.go
@@ -4,11 +4,12 @@ import "encoding/json"
 
 // Container Network Service DNC Contract
 const (
-	SetOrchestratorType            = "/network/setorchestratortype"
-	CreateOrUpdateNetworkContainer = "/network/createorupdatenetworkcontainer"
-	DeleteNetworkContainer         = "/network/deletenetworkcontainer"
-	GetNetworkContainerStatus      = "/network/getnetworkcontainerstatus"
-	GetInterfaceForContainer       = "/network/getinterfaceforcontainer"
+	SetOrchestratorType                      = "/network/setorchestratortype"
+	CreateOrUpdateNetworkContainer           = "/network/createorupdatenetworkcontainer"
+	DeleteNetworkContainer                   = "/network/deletenetworkcontainer"
+	GetNetworkContainerStatus                = "/network/getnetworkcontainerstatus"
+	GetInterfaceForContainer                 = "/network/getinterfaceforcontainer"
+	GetNetworkContainerByOrchestratorContext = "/network/getnetworkcontainerbyorchestratorcontext"
 )
 
 // NetworkContainer Types
@@ -92,11 +93,16 @@ type GetNetworkContainerStatusResponse struct {
 
 // GetNetworkContainerRequest specifies the details about the request to retrieve a specifc network container.
 type GetNetworkContainerRequest struct {
+	NetworkContainerid  string
+	OrchestratorContext json.RawMessage
 }
 
 // GetNetworkContainerResponse describes the response to retrieve a specifc network container.
 type GetNetworkContainerResponse struct {
-	Response Response
+	IPConfiguration  IPConfiguration
+	Routes           []Route
+	MultiTenancyInfo MultiTenancyInfo
+	Response         Response
 }
 
 // DeleteNetworkContainerRequest specifies the details about the request to delete a specifc network container.

--- a/cns/dnccontract.go
+++ b/cns/dnccontract.go
@@ -15,6 +15,7 @@ const (
 // NetworkContainer Types
 const (
 	AzureContainerInstance = "AzureContainerInstance"
+	WebApps                = "WebApps"
 )
 
 // Orchestrator Types

--- a/cns/dnccontract.go
+++ b/cns/dnccontract.go
@@ -4,6 +4,7 @@ import "encoding/json"
 
 // Container Network Service DNC Contract
 const (
+	SetOrchestratorType            = "/network/setorchestratortype"
 	CreateOrUpdateNetworkContainer = "/network/createorupdatenetworkcontainer"
 	DeleteNetworkContainer         = "/network/deletenetworkcontainer"
 	GetNetworkContainerStatus      = "/network/getnetworkcontainerstatus"
@@ -27,17 +28,11 @@ type CreateNetworkContainerRequest struct {
 	NetworkContainerid         string // Mandatory input.
 	PrimaryInterfaceIdentifier string // Primary CA.
 	AuthorizationToken         string
-	OrchestratorInfo           OrchestratorInfo
+	OrchestratorContext        json.RawMessage
 	IPConfiguration            IPConfiguration
 	MultiTenancyInfo           MultiTenancyInfo
 	VnetAddressSpace           []IPSubnet // To setup SNAT (should include service endpoint vips).
 	Routes                     []Route
-}
-
-// OrchestratorInfo contains orchestrator type which is used to cast OrchestratorContext.
-type OrchestratorInfo struct {
-	OrchestratorType    string
-	OrchestratorContext json.RawMessage
 }
 
 // KubernetesPodInfo is an OrchestratorContext that holds PodName and PodNamespace.
@@ -70,6 +65,11 @@ type Route struct {
 	IPAddress        string
 	GatewayIPAddress string
 	InterfaceToUse   string
+}
+
+// SetOrchestratorTypeRequest specifies the orchestrator type for the node.
+type SetOrchestratorTypeRequest struct {
+	OrchestratorType string
 }
 
 // CreateNetworkContainerResponse specifies response of creating a network container.

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -19,5 +19,6 @@ const (
 	NetworkContainerNotSpecified = 16
 	CallToHostFailed             = 17
 	UnknownContainerID           = 18
+	UnsupportedOrchestratorType  = 19
 	UnexpectedError              = 99
 )

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -908,14 +908,12 @@ func (service *httpRestService) createOrUpdateNetworkContainer(w http.ResponseWr
 	case "POST":
 		if req.NetworkContainerType == cns.WebApps {
 			nc := service.networkContainer
-			err := nc.Create(req)
-			if err != nil {
+			if err := nc.Create(req); err != nil {
 				returnMessage = fmt.Sprintf("[Azure CNS] Error. CreateOrUpdateNetworkContainer failed %v", err.Error())
 				returnCode = UnexpectedError
 				break
 			}
 		}
-
 		returnCode, returnMessage = service.saveNetworkContainerGoalState(req)
 
 	default:
@@ -1047,8 +1045,7 @@ func (service *httpRestService) deleteNetworkContainer(w http.ResponseWriter, r 
 
 		if containerStatus.CreateNetworkContainerRequest.NetworkContainerType == cns.WebApps {
 			nc := service.networkContainer
-			err := nc.Delete(req.NetworkContainerid)
-			if err != nil {
+			if err := nc.Delete(req.NetworkContainerid); err != nil {
 				returnMessage = fmt.Sprintf("[Azure CNS] Error. DeleteNetworkContainer failed %v", err.Error())
 				returnCode = UnexpectedError
 				break

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -803,10 +803,11 @@ func (service *httpRestService) restoreState() error {
 
 func (service *httpRestService) setOrchestratorType(w http.ResponseWriter, r *http.Request) {
 	log.Printf("[Azure CNS] setOrchestratorType")
-	var req cns.SetOrchestratorTypeRequest
 
+	var req cns.SetOrchestratorTypeRequest
 	returnMessage := ""
 	returnCode := 0
+
 	err := service.Listener.Decode(w, r, &req)
 	if err != nil {
 		return
@@ -835,13 +836,11 @@ func (service *httpRestService) createOrUpdateNetworkContainer(w http.ResponseWr
 	log.Printf("[Azure CNS] createOrUpdateNetworkContainer")
 
 	var req cns.CreateNetworkContainerRequest
-
 	returnMessage := ""
 	returnCode := 0
+
 	err := service.Listener.Decode(w, r, &req)
-
 	log.Request(service.Name, &req, err)
-
 	if err != nil {
 		return
 	}
@@ -905,13 +904,11 @@ func (service *httpRestService) getNetworkContainer(w http.ResponseWriter, r *ht
 	log.Printf("[Azure CNS] getNetworkContainer")
 
 	var req cns.GetNetworkContainerRequest
-
 	returnMessage := ""
 	returnCode := 0
+
 	err := service.Listener.Decode(w, r, &req)
-
 	log.Request(service.Name, &req, err)
-
 	if err != nil {
 		return
 	}
@@ -932,13 +929,11 @@ func (service *httpRestService) deleteNetworkContainer(w http.ResponseWriter, r 
 	log.Printf("[Azure CNS] deleteNetworkContainer")
 
 	var req cns.DeleteNetworkContainerRequest
-
 	returnMessage := ""
 	returnCode := 0
+
 	err := service.Listener.Decode(w, r, &req)
-
 	log.Request(service.Name, &req, err)
-
 	if err != nil {
 		return
 	}
@@ -987,9 +982,9 @@ func (service *httpRestService) getNetworkContainerStatus(w http.ResponseWriter,
 	var req cns.GetNetworkContainerStatusRequest
 	returnMessage := ""
 	returnCode := 0
+
 	err := service.Listener.Decode(w, r, &req)
 	log.Request(service.Name, &req, err)
-
 	if err != nil {
 		return
 	}
@@ -1050,9 +1045,9 @@ func (service *httpRestService) getInterfaceForContainer(w http.ResponseWriter, 
 	var req cns.GetInterfaceForContainerRequest
 	returnMessage := ""
 	returnCode := 0
+
 	err := service.Listener.Decode(w, r, &req)
 	log.Request(service.Name, &req, err)
-
 	if err != nil {
 		return
 	}

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -94,6 +94,13 @@ var args = acn.ArgumentList{
 		DefaultValue: "",
 	},
 	{
+		Name:         acn.OptStopAzureVnet,
+		Shorthand:    acn.OptStopAzureVnetAlias,
+		Description:  "Start Azure-CNM if flag is true",
+		Type:         "bool",
+		DefaultValue: true,
+	},
+	{
 		Name:         acn.OptVersion,
 		Shorthand:    acn.OptVersionAlias,
 		Description:  "Print version information",
@@ -110,6 +117,7 @@ func printVersion() {
 
 // Main is the entry point for CNS.
 func main() {
+	var stopcnm = false
 	// Initialize and parse command line arguments.
 	acn.ParseArgs(&args, printVersion)
 
@@ -120,6 +128,7 @@ func main() {
 	logTarget := acn.GetArg(acn.OptLogTarget).(int)
 	logDirectory := acn.GetArg(acn.OptLogLocation).(string)
 	ipamQueryInterval, _ := acn.GetArg(acn.OptIpamQueryInterval).(int)
+	stopcnm = acn.GetArg(acn.OptStopAzureVnet).(bool)
 	vers := acn.GetArg(acn.OptVersion).(bool)
 
 	if vers {
@@ -135,54 +144,7 @@ func main() {
 	// Create a channel to receive unhandled errors from CNS.
 	config.ErrChan = make(chan error, 1)
 
-	// Create the key value store.
 	var err error
-	config.Store, err = store.NewJsonFileStore(platform.CNMRuntimePath + name + ".json")
-	if err != nil {
-		fmt.Printf("Failed to create store: %v\n", err)
-		return
-	}
-
-	// Create CNS object.
-	httpRestService, err := restserver.NewHTTPRestService(&config)
-	if err != nil {
-		fmt.Printf("Failed to create CNS object, err:%v.\n", err)
-		return
-	}
-
-	var pluginConfig acn.PluginConfig
-	pluginConfig.Version = version
-
-	// Create a channel to receive unhandled errors from the plugins.
-	pluginConfig.ErrChan = make(chan error, 1)
-
-	// Create network plugin.
-	netPlugin, err := network.NewPlugin(&pluginConfig)
-	if err != nil {
-		fmt.Printf("Failed to create network plugin, err:%v.\n", err)
-		return
-	}
-
-	// Create IPAM plugin.
-	ipamPlugin, err := ipam.NewPlugin(&pluginConfig)
-	if err != nil {
-		fmt.Printf("Failed to create IPAM plugin, err:%v.\n", err)
-		return
-	}
-
-	err = acn.CreateDirectory(platform.CNMRuntimePath)
-	if err != nil {
-		fmt.Printf("Failed to create File Store directory Error:%v", err.Error())
-		return
-	}
-
-	// Create the key value store.
-	pluginConfig.Store, err = store.NewJsonFileStore(platform.CNMRuntimePath + pluginName + ".json")
-	if err != nil {
-		fmt.Printf("Failed to create store: %v\n", err)
-		return
-	}
-
 	// Create logging provider.
 	log.SetName(name)
 	log.SetLevel(logLevel)
@@ -199,6 +161,27 @@ func main() {
 	// Log platform information.
 	log.Printf("Running on %v", platform.GetOSInfo())
 
+	err = acn.CreateDirectory(platform.CNMRuntimePath)
+	if err != nil {
+		fmt.Printf("Failed to create File Store directory Error:%v", err.Error())
+		return
+	}
+
+	// Create the key value store.
+
+	config.Store, err = store.NewJsonFileStore(platform.CNMRuntimePath + name + ".json")
+	if err != nil {
+		fmt.Printf("Failed to create store: %v\n", err)
+		return
+	}
+
+	// Create CNS object.
+	httpRestService, err := restserver.NewHTTPRestService(&config)
+	if err != nil {
+		fmt.Printf("Failed to create CNS object, err:%v.\n", err)
+		return
+	}
+
 	// Set CNS options.
 	httpRestService.SetOption(acn.OptCnsURL, cnsURL)
 
@@ -211,23 +194,50 @@ func main() {
 		}
 	}
 
-	// Set plugin options.
-	netPlugin.SetOption(acn.OptAPIServerURL, url)
+	log.Printf("stop cnm val %t", stopcnm)
+	var netPlugin network.NetPlugin
+	var ipamPlugin ipam.IpamPlugin
 
-	ipamPlugin.SetOption(acn.OptEnvironment, environment)
-	ipamPlugin.SetOption(acn.OptAPIServerURL, url)
-	ipamPlugin.SetOption(acn.OptIpamQueryInterval, ipamQueryInterval)
+	if !stopcnm {
+		var pluginConfig acn.PluginConfig
+		pluginConfig.Version = version
 
-	if netPlugin != nil {
+		// Create a channel to receive unhandled errors from the plugins.
+		pluginConfig.ErrChan = make(chan error, 1)
+
+		// Create network plugin.
+		netPlugin, err = network.NewPlugin(&pluginConfig)
+		if err != nil {
+			fmt.Printf("Failed to create network plugin, err:%v.\n", err)
+			return
+		}
+
+		// Create IPAM plugin.
+		ipamPlugin, err = ipam.NewPlugin(&pluginConfig)
+		if err != nil {
+			fmt.Printf("Failed to create IPAM plugin, err:%v.\n", err)
+			return
+		}
+
+		// Create the key value store.
+		pluginConfig.Store, err = store.NewJsonFileStore(platform.CNMRuntimePath + pluginName + ".json")
+		if err != nil {
+			fmt.Printf("Failed to create store: %v\n", err)
+			return
+		}
+
+		// Set plugin options.
+		netPlugin.SetOption(acn.OptAPIServerURL, url)
 		log.Printf("Start netplugin\n")
 		err = netPlugin.Start(&pluginConfig)
 		if err != nil {
 			fmt.Printf("Failed to start network plugin, err:%v.\n", err)
 			return
 		}
-	}
 
-	if ipamPlugin != nil {
+		ipamPlugin.SetOption(acn.OptEnvironment, environment)
+		ipamPlugin.SetOption(acn.OptAPIServerURL, url)
+		ipamPlugin.SetOption(acn.OptIpamQueryInterval, ipamQueryInterval)
 		err = ipamPlugin.Start(&pluginConfig)
 		if err != nil {
 			fmt.Printf("Failed to start IPAM plugin, err:%v.\n", err)
@@ -252,11 +262,13 @@ func main() {
 		httpRestService.Stop()
 	}
 
-	if netPlugin != nil {
-		netPlugin.Stop()
-	}
+	if !stopcnm {
+		if netPlugin != nil {
+			netPlugin.Stop()
+		}
 
-	if ipamPlugin != nil {
-		ipamPlugin.Stop()
+		if ipamPlugin != nil {
+			ipamPlugin.Stop()
+		}
 	}
 }

--- a/common/config.go
+++ b/common/config.go
@@ -42,6 +42,9 @@ const (
 	OptIpamQueryInterval      = "ipam-query-interval"
 	OptIpamQueryIntervalAlias = "i"
 
+	OptStopAzureVnet      = "stop-azure-cnm"
+	OptStopAzureVnetAlias = "stopcnm"
+
 	// Version.
 	OptVersion      = "version"
 	OptVersionAlias = "v"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR adds setorchestratortype api in CNS so that it will be called once when dnc configures a node
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```