### PR TITLE
Added GetNetworkContainerByContext Api

### DIFF
--- a/cns/dnccontract.go
+++ b/cns/dnccontract.go
@@ -4,11 +4,12 @@ import "encoding/json"
 
 // Container Network Service DNC Contract
 const (
-	SetOrchestratorType            = "/network/setorchestratortype"
-	CreateOrUpdateNetworkContainer = "/network/createorupdatenetworkcontainer"
-	DeleteNetworkContainer         = "/network/deletenetworkcontainer"
-	GetNetworkContainerStatus      = "/network/getnetworkcontainerstatus"
-	GetInterfaceForContainer       = "/network/getinterfaceforcontainer"
+	SetOrchestratorType                      = "/network/setorchestratortype"
+	CreateOrUpdateNetworkContainer           = "/network/createorupdatenetworkcontainer"
+	DeleteNetworkContainer                   = "/network/deletenetworkcontainer"
+	GetNetworkContainerStatus                = "/network/getnetworkcontainerstatus"
+	GetInterfaceForContainer                 = "/network/getinterfaceforcontainer"
+	GetNetworkContainerByOrchestratorContext = "/network/getnetworkcontainerbyorchestratorcontext"
 )
 
 // NetworkContainer Types
@@ -92,11 +93,16 @@ type GetNetworkContainerStatusResponse struct {
 
 // GetNetworkContainerRequest specifies the details about the request to retrieve a specifc network container.
 type GetNetworkContainerRequest struct {
+	NetworkContainerid  string
+	OrchestratorContext json.RawMessage
 }
 
 // GetNetworkContainerResponse describes the response to retrieve a specifc network container.
 type GetNetworkContainerResponse struct {
-	Response Response
+	IPConfiguration  IPConfiguration
+	Routes           []Route
+	MultiTenancyInfo MultiTenancyInfo
+	Response         Response
 }
 
 // DeleteNetworkContainerRequest specifies the details about the request to delete a specifc network container.

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -20,5 +20,6 @@ const (
 	CallToHostFailed             = 17
 	UnknownContainerID           = 18
 	UnsupportedOrchestratorType  = 19
+	NetworkContainerNotExist     = 20
 	UnexpectedError              = 99
 )

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -20,6 +20,5 @@ const (
 	CallToHostFailed             = 17
 	UnknownContainerID           = 18
 	UnsupportedOrchestratorType  = 19
-	NetworkContainerNotExist     = 20
 	UnexpectedError              = 99
 )

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -978,7 +978,7 @@ func (service *httpRestService) getNetworkContainerResponse(req cns.GetNetworkCo
 		break
 
 	default:
-		getNetworkContainerResponse.Response.ReturnCode = UnexpectedError
+		getNetworkContainerResponse.Response.ReturnCode = UnsupportedOrchestratorType
 		getNetworkContainerResponse.Response.Message = fmt.Sprintf("Invalid orchestrator type %v", service.state.OrchestratorType)
 		return getNetworkContainerResponse
 	}
@@ -991,8 +991,8 @@ func (service *httpRestService) getNetworkContainerResponse(req cns.GetNetworkCo
 		routes = savedReq.Routes
 		encapInfo = savedReq.MultiTenancyInfo
 	} else {
-		getNetworkContainerResponse.Response.ReturnCode = UnexpectedError
-		getNetworkContainerResponse.Response.Message = "Never received call to create this container."
+		getNetworkContainerResponse.Response.ReturnCode = NetworkContainerNotExist
+		getNetworkContainerResponse.Response.Message = "NetworkContainer doesn't exist."
 		return getNetworkContainerResponse
 	}
 

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -991,7 +991,7 @@ func (service *httpRestService) getNetworkContainerResponse(req cns.GetNetworkCo
 		routes = savedReq.Routes
 		encapInfo = savedReq.MultiTenancyInfo
 	} else {
-		getNetworkContainerResponse.Response.ReturnCode = NetworkContainerNotExist
+		getNetworkContainerResponse.Response.ReturnCode = UnknownContainerID
 		getNetworkContainerResponse.Response.Message = "NetworkContainer doesn't exist."
 		return getNetworkContainerResponse
 	}

--- a/cns/restserver/restserver_test.go
+++ b/cns/restserver/restserver_test.go
@@ -277,12 +277,13 @@ func setOrchestratorType(t *testing.T, orchestratorType string) error {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
+
 	var resp cns.Response
 	err = decodeResponse(w, &resp)
 	fmt.Printf("Raw response: %+v", w.Body)
-
 	if err != nil || resp.ReturnCode != 0 {
 		t.Errorf("setOrchestratorType failed with response %+v Err:%+v", resp, err)
 		t.Fatal(err)
@@ -475,6 +476,7 @@ func getInterfaceForContainer(t *testing.T, name string) error {
 
 func TestSetOrchestratorType(t *testing.T) {
 	fmt.Println("Test: TestSetOrchestratorType")
+
 	setEnv(t)
 
 	err := setOrchestratorType(t, cns.Kubernetes)
@@ -487,7 +489,9 @@ func TestSetOrchestratorType(t *testing.T) {
 func TestCreateNetworkContainer(t *testing.T) {
 	// requires more than 30 seconds to run
 	fmt.Println("Test: TestCreateNetworkContainer")
+
 	setEnv(t)
+
 	err := creatOrUpdateNetworkContainerWithName(t, "ethWebApp", "11.0.0.5", "WebApps")
 	if err != nil {
 		t.Errorf("creatOrUpdateWebAppContainerWithName failed Err:%+v", err)
@@ -512,8 +516,10 @@ func TestCreateNetworkContainer(t *testing.T) {
 func TestGetNetworkContainerByOrchestratorContext(t *testing.T) {
 	// requires more than 30 seconds to run
 	fmt.Println("Test: TestGetNetworkContainerByOrchestratorContext")
+
 	setEnv(t)
 	setOrchestratorType(t, cns.Kubernetes)
+
 	err := creatOrUpdateNetworkContainerWithName(t, "ethWebApp", "11.0.0.5", "AzureContainerInstance")
 	if err != nil {
 		t.Errorf("creatOrUpdateNetworkContainerWithName failed Err:%+v", err)
@@ -545,7 +551,9 @@ func TestGetNetworkContainerByOrchestratorContext(t *testing.T) {
 func TestGetNetworkContainerStatus(t *testing.T) {
 	// requires more than 30 seconds to run
 	fmt.Println("Test: TestCreateNetworkContainer")
+
 	setEnv(t)
+
 	err := creatOrUpdateNetworkContainerWithName(t, "ethWebApp", "11.0.0.5", "WebApps")
 	if err != nil {
 		t.Errorf("creatOrUpdateWebAppContainerWithName failed Err:%+v", err)
@@ -571,7 +579,9 @@ func TestGetNetworkContainerStatus(t *testing.T) {
 func TestGetInterfaceForNetworkContainer(t *testing.T) {
 	// requires more than 30 seconds to run
 	fmt.Println("Test: TestCreateNetworkContainer")
+
 	setEnv(t)
+
 	err := creatOrUpdateNetworkContainerWithName(t, "ethWebApp", "11.0.0.5", "WebApps")
 	if err != nil {
 		t.Errorf("creatOrUpdateWebAppContainerWithName failed Err:%+v", err)

--- a/cns/restserver/restserver_test.go
+++ b/cns/restserver/restserver_test.go
@@ -410,6 +410,7 @@ func getNonExistNetworkCotnainerByContext(t *testing.T, name string) error {
 
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
+
 	err = decodeResponse(w, &resp)
 	if err != nil || resp.Response.ReturnCode != UnknownContainerID {
 		t.Errorf("GetNetworkContainerByContext unexpected response %+v Err:%+v", resp, err)

--- a/cns/restserver/restserver_test.go
+++ b/cns/restserver/restserver_test.go
@@ -266,7 +266,35 @@ func TestGetUnhealthyIPAddresses(t *testing.T) {
 	}
 }
 
-func creatOrUpdateWebAppContainerWithName(t *testing.T, name string, ip string) error {
+func setOrchestratorType(t *testing.T, orchestratorType string) error {
+	var body bytes.Buffer
+
+	info := &cns.SetOrchestratorTypeRequest{OrchestratorType: orchestratorType}
+
+	json.NewEncoder(&body).Encode(info)
+
+	req, err := http.NewRequest(http.MethodPost, cns.SetOrchestratorType, &body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	var resp cns.Response
+	err = decodeResponse(w, &resp)
+	fmt.Printf("Raw response: %+v", w.Body)
+
+	if err != nil || resp.ReturnCode != 0 {
+		t.Errorf("setOrchestratorType failed with response %+v Err:%+v", resp, err)
+		t.Fatal(err)
+	} else {
+		fmt.Printf("setOrchestratorType passed with response %+v Err:%+v", resp, err)
+	}
+
+	fmt.Printf("setOrchestratorType succeeded with response %+v\n", resp)
+	return nil
+}
+
+func creatOrUpdateNetworkContainerWithName(t *testing.T, name string, ip string, containerType string) error {
 	var body bytes.Buffer
 	var ipConfig cns.IPConfiguration
 	ipConfig.DNSServers = []string{"8.8.8.8", "8.8.4.4"}
@@ -275,11 +303,14 @@ func creatOrUpdateWebAppContainerWithName(t *testing.T, name string, ip string) 
 	ipSubnet.IPAddress = ip
 	ipSubnet.PrefixLength = 24
 	ipConfig.IPSubnet = ipSubnet
+	podInfo := cns.KubernetesPodInfo{PodName: "testpod", PodNamespace: "testpodnamespace"}
+	context, _ := json.Marshal(podInfo)
 
 	info := &cns.CreateNetworkContainerRequest{
 		Version:                    "0.1",
-		NetworkContainerType:       "WebApps",
+		NetworkContainerType:       containerType,
 		NetworkContainerid:         name,
+		OrchestratorContext:        context,
 		IPConfiguration:            ipConfig,
 		PrimaryInterfaceIdentifier: "11.0.0.7",
 	}
@@ -332,6 +363,33 @@ func deleteNetworkAdapterWithName(t *testing.T, name string) error {
 	}
 
 	fmt.Printf("DeleteNetworkContainer succeded with response %+v\n", resp)
+	return nil
+}
+
+func getNetworkCotnainerByContext(t *testing.T, name string) error {
+	var body bytes.Buffer
+	var resp cns.GetNetworkContainerResponse
+
+	podInfo := cns.KubernetesPodInfo{PodName: "testpod", PodNamespace: "testpodnamespace"}
+	podInfoBytes, err := json.Marshal(podInfo)
+	getReq := &cns.GetNetworkContainerRequest{OrchestratorContext: podInfoBytes}
+
+	json.NewEncoder(&body).Encode(getReq)
+	req, err := http.NewRequest(http.MethodPost, cns.GetNetworkContainerByOrchestratorContext, &body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	err = decodeResponse(w, &resp)
+	if err != nil || resp.Response.ReturnCode != 0 {
+		t.Errorf("GetNetworkContainerByContext failed with response %+v Err:%+v", resp, err)
+		t.Fatal(err)
+	}
+
+	fmt.Printf("**GetNetworkContainerByContext succeded with response %+v, raw:%+v\n", resp, w.Body)
 	return nil
 }
 
@@ -389,19 +447,57 @@ func getInterfaceForContainer(t *testing.T, name string) error {
 	return nil
 }
 
+func TestSetOrchestratorType(t *testing.T) {
+	fmt.Println("Test: TestSetOrchestratorType")
+	setEnv(t)
+
+	err := setOrchestratorType(t, cns.Kubernetes)
+	if err != nil {
+		t.Errorf("setOrchestratorType failed Err:%+v", err)
+		t.Fatal(err)
+	}
+}
+
 func TestCreateNetworkContainer(t *testing.T) {
 	// requires more than 30 seconds to run
 	fmt.Println("Test: TestCreateNetworkContainer")
 	setEnv(t)
-	err := creatOrUpdateWebAppContainerWithName(t, "ethWebApp", "11.0.0.5")
+	err := creatOrUpdateNetworkContainerWithName(t, "ethWebApp", "11.0.0.5", "WebApps")
 	if err != nil {
 		t.Errorf("creatOrUpdateWebAppContainerWithName failed Err:%+v", err)
 		t.Fatal(err)
 	}
 
-	err = creatOrUpdateWebAppContainerWithName(t, "ethWebApp", "11.0.0.6")
+	err = creatOrUpdateNetworkContainerWithName(t, "ethWebApp", "11.0.0.6", "WebApps")
 	if err != nil {
 		t.Errorf("Updating interface failed Err:%+v", err)
+		t.Fatal(err)
+	}
+
+	fmt.Println("Now calling DeleteNetworkContainer")
+
+	err = deleteNetworkAdapterWithName(t, "ethWebApp")
+	if err != nil {
+		t.Errorf("Deleting interface failed Err:%+v", err)
+		t.Fatal(err)
+	}
+}
+
+func TestGetNetworkContainerByOrchestratorContext(t *testing.T) {
+	// requires more than 30 seconds to run
+	fmt.Println("Test: TestGetNetworkContainerByOrchestratorContext")
+	setEnv(t)
+	setOrchestratorType(t, cns.Kubernetes)
+	err := creatOrUpdateNetworkContainerWithName(t, "ethWebApp", "11.0.0.5", "AzureContainerInstance")
+	if err != nil {
+		t.Errorf("creatOrUpdateNetworkContainerWithName failed Err:%+v", err)
+		t.Fatal(err)
+	}
+
+	fmt.Println("Now calling getNetworkCotnainerStatus")
+	err = getNetworkCotnainerByContext(t, "ethWebApp")
+	if err != nil {
+		t.Errorf("TestGetNetworkContainerByOrchestratorContext failed Err:%+v", err)
 		t.Fatal(err)
 	}
 
@@ -418,7 +514,7 @@ func TestGetNetworkContainerStatus(t *testing.T) {
 	// requires more than 30 seconds to run
 	fmt.Println("Test: TestCreateNetworkContainer")
 	setEnv(t)
-	err := creatOrUpdateWebAppContainerWithName(t, "ethWebApp", "11.0.0.5")
+	err := creatOrUpdateNetworkContainerWithName(t, "ethWebApp", "11.0.0.5", "WebApps")
 	if err != nil {
 		t.Errorf("creatOrUpdateWebAppContainerWithName failed Err:%+v", err)
 		t.Fatal(err)
@@ -444,7 +540,7 @@ func TestGetInterfaceForNetworkContainer(t *testing.T) {
 	// requires more than 30 seconds to run
 	fmt.Println("Test: TestCreateNetworkContainer")
 	setEnv(t)
-	err := creatOrUpdateWebAppContainerWithName(t, "ethWebApp", "11.0.0.5")
+	err := creatOrUpdateNetworkContainerWithName(t, "ethWebApp", "11.0.0.5", "WebApps")
 	if err != nil {
 		t.Errorf("creatOrUpdateWebAppContainerWithName failed Err:%+v", err)
 		t.Fatal(err)

--- a/cns/restserver/restserver_test.go
+++ b/cns/restserver/restserver_test.go
@@ -410,7 +410,7 @@ func getNonExistNetworkCotnainerByContext(t *testing.T, name string) error {
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 	err = decodeResponse(w, &resp)
-	if err != nil || resp.Response.ReturnCode != NetworkContainerNotExist {
+	if err != nil || resp.Response.ReturnCode != UnknownContainerID {
 		t.Errorf("GetNetworkContainerByContext unexpected response %+v Err:%+v", resp, err)
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR adds GetNetworkContainerByContext api which retrieves network configuration based on orchestrator context. In case of kuberenetes, the context includes podname and podnamespace.
Also Added corresponding unit tests to validate the basic functionality
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```