### PR TITLE
CNI gets networkconfig from CNS 

### DIFF
--- a/client/cnsclient/cnsclient.go
+++ b/client/cnsclient/cnsclient.go
@@ -24,6 +24,7 @@ func NewCnsClient(url string) (*CNSClient, error) {
 	if url == "" {
 		url = defaultCnsURL
 	}
+
 	return &CNSClient{
 		connectionURL: url,
 	}, nil

--- a/client/cnsclient/cnsclient.go
+++ b/client/cnsclient/cnsclient.go
@@ -32,8 +32,8 @@ func NewCnsClient(url string) (*CNSClient, error) {
 // GetNetworkConfiguration Request to get network config.
 func (cnsClient *CNSClient) GetNetworkConfiguration(podName, podNamespace string) (*cns.GetNetworkContainerResponse, error) {
 	var body bytes.Buffer
-	httpc := &http.Client{}
 
+	httpc := &http.Client{}
 	url := cnsClient.connectionURL + cns.GetNetworkContainerByOrchestratorContext
 	log.Printf("GetNetworkConfiguration url %v", url)
 
@@ -60,24 +60,24 @@ func (cnsClient *CNSClient) GetNetworkConfiguration(podName, podNamespace string
 		return nil, err
 	}
 
-	if res.StatusCode == 200 {
-		var resp cns.GetNetworkContainerResponse
-		err := json.NewDecoder(res.Body).Decode(&resp)
-		if err != nil {
-			log.Printf("[Azure CNSClient] Error received while parsing GetNetworkConfiguration response resp:%v err:%v", res.Body, err.Error())
-			return nil, err
-		}
-
-		if resp.Response.ReturnCode != 0 {
-			log.Printf("[Azure CNSClient] GetNetworkConfiguration received error response :%v", resp.Response.Message)
-			return nil, fmt.Errorf(resp.Response.Message)
-		}
-
-		return &resp, nil
+	if res.StatusCode != 200 {
+		errMsg := fmt.Sprintf("[Azure CNSClient] GetNetworkConfiguration invalid http status code: %v", res.StatusCode)
+		log.Printf(errMsg)
+		return nil, fmt.Errorf(errMsg)
 	}
 
-	var errMsg string
-	errMsg = fmt.Sprintf(errMsg, "[Azure CNSClient] GetNetworkConfiguration invalid http status code: %v", res.StatusCode)
-	log.Printf(errMsg)
-	return nil, fmt.Errorf(errMsg)
+	var resp cns.GetNetworkContainerResponse
+
+	err = json.NewDecoder(res.Body).Decode(&resp)
+	if err != nil {
+		log.Printf("[Azure CNSClient] Error received while parsing GetNetworkConfiguration response resp:%v err:%v", res.Body, err.Error())
+		return nil, err
+	}
+
+	if resp.Response.ReturnCode != 0 {
+		log.Printf("[Azure CNSClient] GetNetworkConfiguration received error response :%v", resp.Response.Message)
+		return nil, fmt.Errorf(resp.Response.Message)
+	}
+
+	return &resp, nil
 }

--- a/client/cnsclient/cnsclient.go
+++ b/client/cnsclient/cnsclient.go
@@ -1,0 +1,83 @@
+package cnsclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/log"
+)
+
+// IpamClient specifies a client to connect to Ipam Plugin.
+type CNSClient struct {
+	connectionURL string
+}
+
+const (
+	defaultCnsURL = "http://localhost:10090"
+)
+
+// NewCnsClient create a new cns client.
+func NewCnsClient(url string) (*CNSClient, error) {
+	if url == "" {
+		url = defaultCnsURL
+	}
+	return &CNSClient{
+		connectionURL: url,
+	}, nil
+}
+
+// GetNetworkConfiguration Request to get network config.
+func (cnsClient *CNSClient) GetNetworkConfiguration(podName, podNamespace string) (*cns.GetNetworkContainerResponse, error) {
+	var body bytes.Buffer
+	httpc := &http.Client{}
+
+	url := cnsClient.connectionURL + cns.GetNetworkContainerByOrchestratorContext
+	log.Printf("GetNetworkConfiguration url %v", url)
+
+	podInfo := cns.KubernetesPodInfo{PodName: podName, PodNamespace: podNamespace}
+	podInfoBytes, err := json.Marshal(podInfo)
+	if err != nil {
+		log.Printf("Marshalling azure container instance info failed with %v", err)
+		return nil, err
+	}
+
+	payload := &cns.GetNetworkContainerRequest{
+		OrchestratorContext: podInfoBytes,
+	}
+
+	err = json.NewEncoder(&body).Encode(payload)
+	if err != nil {
+		log.Printf("encoding json failed with %v", err)
+		return nil, err
+	}
+
+	res, err := httpc.Post(url, "application/json", &body)
+	if err != nil {
+		log.Printf("[Azure CNSClient] HTTP Post returned error %v", err.Error())
+		return nil, err
+	}
+
+	if res.StatusCode == 200 {
+		var resp cns.GetNetworkContainerResponse
+		err := json.NewDecoder(res.Body).Decode(&resp)
+		if err != nil {
+			log.Printf("[Azure CNSClient] Error received while parsing GetNetworkConfiguration response resp:%v err:%v", res.Body, err.Error())
+			return nil, err
+		}
+
+		if resp.Response.ReturnCode != 0 {
+			log.Printf("[Azure CNSClient] GetNetworkConfiguration received error response :%v", resp.Response.Message)
+			return nil, fmt.Errorf(resp.Response.Message)
+		}
+
+		return &resp, nil
+	}
+
+	var errMsg string
+	errMsg = fmt.Sprintf(errMsg, "[Azure CNSClient] GetNetworkConfiguration invalid http status code: %v", res.StatusCode)
+	log.Printf(errMsg)
+	return nil, fmt.Errorf(errMsg)
+}

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -23,8 +23,8 @@ import (
 const (
 	// Plugin name.
 	name         = "azure-vnet"
-	namespacekey = "K8S_POD_NAMESPACE"
-	podnamekey   = "K8S_POD_NAME"
+	namespaceKey = "K8S_POD_NAMESPACE"
+	podNameKey   = "K8S_POD_NAME"
 )
 
 // NetPlugin represents the CNI network plugin.
@@ -209,7 +209,7 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 		log.Printf("Argsmap %v", argsMap)
 	}
 
-	result, vlanid, err = getContainerNetworkConfiguration(argsMap[namespacekey].(string), argsMap[podnamekey].(string))
+	result, vlanid, err = getContainerNetworkConfiguration(argsMap[namespaceKey].(string), argsMap[podNameKey].(string))
 	if err != nil {
 		log.Printf("SetContainerNetworkConfiguration failed with %v", err)
 	}

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -123,12 +123,10 @@ func (plugin *netPlugin) findMasterInterface(nwCfg *cni.NetworkConfig, subnetPre
 
 func convertToCniResult(networkConfig *cns.GetNetworkContainerResponse) *cniTypesCurr.Result {
 	result := &cniTypesCurr.Result{}
+	resultIpconfig := &cniTypesCurr.IPConfig{}
 
-	log.Printf("Convert IPAddress")
 	ipconfig := networkConfig.IPConfiguration
 	ipAddr := net.ParseIP(ipconfig.IPSubnet.IPAddress)
-
-	resultIpconfig := &cniTypesCurr.IPConfig{}
 
 	if ipAddr.To4() != nil {
 		resultIpconfig.Version = "4"
@@ -164,7 +162,7 @@ func getContainerNetworkConfiguration(namespace string, podName string) (*cniTyp
 		log.Printf("Initializing CNS client error %v", err)
 		return nil, 0, err
 	}
-	log.Printf("Network config request")
+
 	networkConfig, err := cnsClient.GetNetworkConfiguration(podName, namespace)
 	if err != nil {
 		log.Printf("GetNetworkConfiguration failed with %v", err)
@@ -172,6 +170,7 @@ func getContainerNetworkConfiguration(namespace string, podName string) (*cniTyp
 	}
 
 	log.Printf("Network config received from cns %v", networkConfig)
+
 	return convertToCniResult(networkConfig), networkConfig.MultiTenancyInfo.ID, nil
 }
 

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -6,7 +6,9 @@ package network
 import (
 	"net"
 
+	"github.com/Azure/azure-container-networking/client/cnsclient"
 	"github.com/Azure/azure-container-networking/cni"
+	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/common"
 	"github.com/Azure/azure-container-networking/log"
 	"github.com/Azure/azure-container-networking/network"
@@ -14,12 +16,15 @@ import (
 	"github.com/Azure/azure-container-networking/telemetry"
 
 	cniSkel "github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
 	cniTypesCurr "github.com/containernetworking/cni/pkg/types/current"
 )
 
 const (
 	// Plugin name.
-	name = "azure-vnet"
+	name         = "azure-vnet"
+	namespacekey = "K8S_POD_NAMESPACE"
+	podnamekey   = "K8S_POD_NAME"
 )
 
 // NetPlugin represents the CNI network plugin.
@@ -116,6 +121,60 @@ func (plugin *netPlugin) findMasterInterface(nwCfg *cni.NetworkConfig, subnetPre
 	return ""
 }
 
+func convertToCniResult(networkConfig *cns.GetNetworkContainerResponse) *cniTypesCurr.Result {
+	result := &cniTypesCurr.Result{}
+
+	log.Printf("Convert IPAddress")
+	ipconfig := networkConfig.IPConfiguration
+	ipAddr := net.ParseIP(ipconfig.IPSubnet.IPAddress)
+
+	resultIpconfig := &cniTypesCurr.IPConfig{}
+
+	if ipAddr.To4() != nil {
+		resultIpconfig.Version = "4"
+		resultIpconfig.Address = net.IPNet{IP: ipAddr, Mask: net.CIDRMask(int(ipconfig.IPSubnet.PrefixLength), 32)}
+	} else {
+		resultIpconfig.Version = "6"
+		resultIpconfig.Address = net.IPNet{IP: ipAddr, Mask: net.CIDRMask(int(ipconfig.IPSubnet.PrefixLength), 128)}
+	}
+
+	resultIpconfig.Gateway = net.ParseIP(ipconfig.GatewayIPAddress)
+	result.IPs = append(result.IPs, resultIpconfig)
+
+	result.DNS.Nameservers = ipconfig.DNSServers
+
+	if networkConfig.Routes == nil && len(networkConfig.Routes) > 0 {
+		for _, route := range networkConfig.Routes {
+			_, routeIPnet, _ := net.ParseCIDR(route.IPAddress)
+			gwIP := net.ParseIP(route.GatewayIPAddress)
+			result.Routes = append(result.Routes, &types.Route{Dst: *routeIPnet, GW: gwIP})
+		}
+	} else {
+		gwIP := net.ParseIP(networkConfig.IPConfiguration.GatewayIPAddress)
+		dstIP := net.IPNet{IP: net.ParseIP("0.0.0.0"), Mask: resultIpconfig.Address.Mask}
+		result.Routes = append(result.Routes, &types.Route{Dst: dstIP, GW: gwIP})
+	}
+
+	return result
+}
+
+func getContainerNetworkConfiguration(namespace string, podName string) (*cniTypesCurr.Result, int, error) {
+	cnsClient, err := cnsclient.NewCnsClient("")
+	if err != nil {
+		log.Printf("Initializing CNS client error %v", err)
+		return nil, 0, err
+	}
+	log.Printf("Network config request")
+	networkConfig, err := cnsClient.GetNetworkConfiguration(podName, namespace)
+	if err != nil {
+		log.Printf("GetNetworkConfiguration failed with %v", err)
+		return nil, 0, err
+	}
+
+	log.Printf("Network config received from cns %v", networkConfig)
+	return convertToCniResult(networkConfig), networkConfig.MultiTenancyInfo.ID, nil
+}
+
 //
 // CNI implementation
 // https://github.com/containernetworking/cni/blob/master/SPEC.md
@@ -125,6 +184,8 @@ func (plugin *netPlugin) findMasterInterface(nwCfg *cni.NetworkConfig, subnetPre
 func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 	var result *cniTypesCurr.Result
 	var err error
+	var epInfo *network.EndpointInfo
+	var vlanid int
 
 	log.Printf("[cni-net] Processing ADD command with args {ContainerID:%v Netns:%v IfName:%v Args:%v Path:%v}.",
 		args.ContainerID, args.Netns, args.IfName, args.Args, args.Path)
@@ -144,19 +205,42 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 	networkId := nwCfg.Name
 	endpointId := plugin.GetEndpointID(args)
 
+	argsMap := plugin.GetCNIArgs(args.Args)
+	if argsMap != nil {
+		log.Printf("Argsmap %v", argsMap)
+	}
+
+	result, vlanid, err = getContainerNetworkConfiguration(argsMap[namespacekey].(string), argsMap[podnamekey].(string))
+	if err != nil {
+		log.Printf("SetContainerNetworkConfiguration failed with %v", err)
+	}
+
+	epInfo = &network.EndpointInfo{
+		Id:          endpointId,
+		ContainerID: args.ContainerID,
+		NetNsPath:   args.Netns,
+		IfName:      args.IfName,
+	}
+	epInfo.Data = make(map[string]interface{})
+
+	if vlanid != 0 {
+		epInfo.Data["vlanid"] = vlanid
+	}
+
 	// Check whether the network already exists.
 	nwInfo, err := plugin.nm.GetNetworkInfo(networkId)
 	if err != nil {
 		// Network does not exist.
 		log.Printf("[cni-net] Creating network %v.", networkId)
 
-		// Call into IPAM plugin to allocate an address pool for the network.
-		result, err = plugin.DelegateAdd(nwCfg.Ipam.Type, nwCfg)
-		if err != nil {
-			err = plugin.Errorf("Failed to allocate pool: %v", err)
-			return err
+		if result == nil {
+			// Call into IPAM plugin to allocate an address pool for the network.
+			result, err = plugin.DelegateAdd(nwCfg.Ipam.Type, nwCfg)
+			if err != nil {
+				err = plugin.Errorf("Failed to allocate pool: %v", err)
+				return err
+			}
 		}
-
 		// Derive the subnet prefix from allocated IP address.
 		ipconfig := result.IPs[0]
 		subnetPrefix := ipconfig.Address
@@ -211,35 +295,29 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 
 		log.Printf("[cni-net] Created network %v with subnet %v.", networkId, subnetPrefix.String())
 	} else {
-		// Network already exists.
-		subnetPrefix := nwInfo.Subnets[0].Prefix.String()
-		log.Printf("[cni-net] Found network %v with subnet %v.", networkId, subnetPrefix)
+		if result == nil {
+			// Network already exists.
+			subnetPrefix := nwInfo.Subnets[0].Prefix.String()
+			log.Printf("[cni-net] Found network %v with subnet %v.", networkId, subnetPrefix)
 
-		// Call into IPAM plugin to allocate an address for the endpoint.
-		nwCfg.Ipam.Subnet = subnetPrefix
-		result, err = plugin.DelegateAdd(nwCfg.Ipam.Type, nwCfg)
-		if err != nil {
-			err = plugin.Errorf("Failed to allocate address: %v", err)
-			return err
-		}
-
-		ipconfig := result.IPs[0]
-
-		// On failure, call into IPAM plugin to release the address.
-		defer func() {
+			// Call into IPAM plugin to allocate an address for the endpoint.
+			nwCfg.Ipam.Subnet = subnetPrefix
+			result, err = plugin.DelegateAdd(nwCfg.Ipam.Type, nwCfg)
 			if err != nil {
-				nwCfg.Ipam.Address = ipconfig.Address.IP.String()
-				plugin.DelegateDel(nwCfg.Ipam.Type, nwCfg)
+				err = plugin.Errorf("Failed to allocate address: %v", err)
+				return err
 			}
-		}()
-	}
 
-	// Initialize endpoint info.
-	epInfo := &network.EndpointInfo{
-		Id:          endpointId,
-		ContainerID: args.ContainerID,
-		NetNsPath:   args.Netns,
-		IfName:      args.IfName,
+			ipconfig := result.IPs[0]
+
+			// On failure, call into IPAM plugin to release the address.
+			defer func() {
+				if err != nil {
+					nwCfg.Ipam.Address = ipconfig.Address.IP.String()
+					plugin.DelegateDel(nwCfg.Ipam.Type, nwCfg)
+				}
+			}()
+		}
 	}
 
 	// Populate addresses.

--- a/cni/plugin.go
+++ b/cni/plugin.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/Azure/azure-container-networking/common"
 	"github.com/Azure/azure-container-networking/log"
@@ -166,6 +167,20 @@ func (plugin *Plugin) GetEndpointID(args *cniSkel.CmdArgs) string {
 	}
 
 	return containerID + "-" + args.IfName
+}
+
+func (plugin *Plugin) GetCNIArgs(args string) map[string]interface{} {
+	argsMap := make(map[string]interface{})
+
+	data := strings.Split(args, ";")
+	for _, pair := range data {
+		items := strings.Split(pair, "=")
+		if len(items) > 1 {
+			argsMap[items[0]] = items[1]
+		}
+	}
+
+	return argsMap
 }
 
 // Error creates and logs a structured CNI error.

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -20,5 +20,6 @@ const (
 	CallToHostFailed             = 17
 	UnknownContainerID           = 18
 	UnsupportedOrchestratorType  = 19
+	NetworkContainerNotExist     = 20
 	UnexpectedError              = 99
 )

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -20,6 +20,5 @@ const (
 	CallToHostFailed             = 17
 	UnknownContainerID           = 18
 	UnsupportedOrchestratorType  = 19
-	NetworkContainerNotExist     = 20
 	UnexpectedError              = 99
 )

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -228,24 +228,20 @@ func main() {
 
 		// Set plugin options.
 		netPlugin.SetOption(acn.OptAPIServerURL, url)
-		if netPlugin != nil {
-			log.Printf("Start netplugin\n")
-			err = netPlugin.Start(&pluginConfig)
-			if err != nil {
-				fmt.Printf("Failed to start network plugin, err:%v.\n", err)
-				return
-			}
+		log.Printf("Start netplugin\n")
+		err = netPlugin.Start(&pluginConfig)
+		if err != nil {
+			fmt.Printf("Failed to start network plugin, err:%v.\n", err)
+			return
 		}
 
 		ipamPlugin.SetOption(acn.OptEnvironment, environment)
 		ipamPlugin.SetOption(acn.OptAPIServerURL, url)
 		ipamPlugin.SetOption(acn.OptIpamQueryInterval, ipamQueryInterval)
-		if ipamPlugin != nil {
-			err = ipamPlugin.Start(&pluginConfig)
-			if err != nil {
-				fmt.Printf("Failed to start IPAM plugin, err:%v.\n", err)
-				return
-			}
+		err = ipamPlugin.Start(&pluginConfig)
+		if err != nil {
+			fmt.Printf("Failed to start IPAM plugin, err:%v.\n", err)
+			return
 		}
 	}
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -94,6 +94,13 @@ var args = acn.ArgumentList{
 		DefaultValue: "",
 	},
 	{
+		Name:         acn.OptStopAzureVnet,
+		Shorthand:    acn.OptStopAzureVnetAlias,
+		Description:  "Start Azure-CNM if flag is true",
+		Type:         "bool",
+		DefaultValue: true,
+	},
+	{
 		Name:         acn.OptVersion,
 		Shorthand:    acn.OptVersionAlias,
 		Description:  "Print version information",
@@ -110,6 +117,7 @@ func printVersion() {
 
 // Main is the entry point for CNS.
 func main() {
+	var stopcnm = false
 	// Initialize and parse command line arguments.
 	acn.ParseArgs(&args, printVersion)
 
@@ -120,6 +128,7 @@ func main() {
 	logTarget := acn.GetArg(acn.OptLogTarget).(int)
 	logDirectory := acn.GetArg(acn.OptLogLocation).(string)
 	ipamQueryInterval, _ := acn.GetArg(acn.OptIpamQueryInterval).(int)
+	stopcnm = acn.GetArg(acn.OptStopAzureVnet).(bool)
 	vers := acn.GetArg(acn.OptVersion).(bool)
 
 	if vers {
@@ -135,54 +144,7 @@ func main() {
 	// Create a channel to receive unhandled errors from CNS.
 	config.ErrChan = make(chan error, 1)
 
-	// Create the key value store.
 	var err error
-	config.Store, err = store.NewJsonFileStore(platform.CNMRuntimePath + name + ".json")
-	if err != nil {
-		fmt.Printf("Failed to create store: %v\n", err)
-		return
-	}
-
-	// Create CNS object.
-	httpRestService, err := restserver.NewHTTPRestService(&config)
-	if err != nil {
-		fmt.Printf("Failed to create CNS object, err:%v.\n", err)
-		return
-	}
-
-	var pluginConfig acn.PluginConfig
-	pluginConfig.Version = version
-
-	// Create a channel to receive unhandled errors from the plugins.
-	pluginConfig.ErrChan = make(chan error, 1)
-
-	// Create network plugin.
-	netPlugin, err := network.NewPlugin(&pluginConfig)
-	if err != nil {
-		fmt.Printf("Failed to create network plugin, err:%v.\n", err)
-		return
-	}
-
-	// Create IPAM plugin.
-	ipamPlugin, err := ipam.NewPlugin(&pluginConfig)
-	if err != nil {
-		fmt.Printf("Failed to create IPAM plugin, err:%v.\n", err)
-		return
-	}
-
-	err = acn.CreateDirectory(platform.CNMRuntimePath)
-	if err != nil {
-		fmt.Printf("Failed to create File Store directory Error:%v", err.Error())
-		return
-	}
-
-	// Create the key value store.
-	pluginConfig.Store, err = store.NewJsonFileStore(platform.CNMRuntimePath + pluginName + ".json")
-	if err != nil {
-		fmt.Printf("Failed to create store: %v\n", err)
-		return
-	}
-
 	// Create logging provider.
 	log.SetName(name)
 	log.SetLevel(logLevel)
@@ -199,6 +161,27 @@ func main() {
 	// Log platform information.
 	log.Printf("Running on %v", platform.GetOSInfo())
 
+	err = acn.CreateDirectory(platform.CNMRuntimePath)
+	if err != nil {
+		fmt.Printf("Failed to create File Store directory Error:%v", err.Error())
+		return
+	}
+
+	// Create the key value store.
+
+	config.Store, err = store.NewJsonFileStore(platform.CNMRuntimePath + name + ".json")
+	if err != nil {
+		fmt.Printf("Failed to create store: %v\n", err)
+		return
+	}
+
+	// Create CNS object.
+	httpRestService, err := restserver.NewHTTPRestService(&config)
+	if err != nil {
+		fmt.Printf("Failed to create CNS object, err:%v.\n", err)
+		return
+	}
+
 	// Set CNS options.
 	httpRestService.SetOption(acn.OptCnsURL, cnsURL)
 
@@ -211,27 +194,58 @@ func main() {
 		}
 	}
 
-	// Set plugin options.
-	netPlugin.SetOption(acn.OptAPIServerURL, url)
+	log.Printf("stop cnm val %t", stopcnm)
+	var netPlugin network.NetPlugin
+	var ipamPlugin ipam.IpamPlugin
 
-	ipamPlugin.SetOption(acn.OptEnvironment, environment)
-	ipamPlugin.SetOption(acn.OptAPIServerURL, url)
-	ipamPlugin.SetOption(acn.OptIpamQueryInterval, ipamQueryInterval)
+	if !stopcnm {
+		var pluginConfig acn.PluginConfig
+		pluginConfig.Version = version
 
-	if netPlugin != nil {
-		log.Printf("Start netplugin\n")
-		err = netPlugin.Start(&pluginConfig)
+		// Create a channel to receive unhandled errors from the plugins.
+		pluginConfig.ErrChan = make(chan error, 1)
+
+		// Create network plugin.
+		netPlugin, err = network.NewPlugin(&pluginConfig)
 		if err != nil {
-			fmt.Printf("Failed to start network plugin, err:%v.\n", err)
+			fmt.Printf("Failed to create network plugin, err:%v.\n", err)
 			return
 		}
-	}
 
-	if ipamPlugin != nil {
-		err = ipamPlugin.Start(&pluginConfig)
+		// Create IPAM plugin.
+		ipamPlugin, err = ipam.NewPlugin(&pluginConfig)
 		if err != nil {
-			fmt.Printf("Failed to start IPAM plugin, err:%v.\n", err)
+			fmt.Printf("Failed to create IPAM plugin, err:%v.\n", err)
 			return
+		}
+
+		// Create the key value store.
+		pluginConfig.Store, err = store.NewJsonFileStore(platform.CNMRuntimePath + pluginName + ".json")
+		if err != nil {
+			fmt.Printf("Failed to create store: %v\n", err)
+			return
+		}
+
+		// Set plugin options.
+		netPlugin.SetOption(acn.OptAPIServerURL, url)
+		if netPlugin != nil {
+			log.Printf("Start netplugin\n")
+			err = netPlugin.Start(&pluginConfig)
+			if err != nil {
+				fmt.Printf("Failed to start network plugin, err:%v.\n", err)
+				return
+			}
+		}
+
+		ipamPlugin.SetOption(acn.OptEnvironment, environment)
+		ipamPlugin.SetOption(acn.OptAPIServerURL, url)
+		ipamPlugin.SetOption(acn.OptIpamQueryInterval, ipamQueryInterval)
+		if ipamPlugin != nil {
+			err = ipamPlugin.Start(&pluginConfig)
+			if err != nil {
+				fmt.Printf("Failed to start IPAM plugin, err:%v.\n", err)
+				return
+			}
 		}
 	}
 
@@ -252,11 +266,13 @@ func main() {
 		httpRestService.Stop()
 	}
 
-	if netPlugin != nil {
-		netPlugin.Stop()
-	}
+	if !stopcnm {
+		if netPlugin != nil {
+			netPlugin.Stop()
+		}
 
-	if ipamPlugin != nil {
-		ipamPlugin.Stop()
+		if ipamPlugin != nil {
+			ipamPlugin.Stop()
+		}
 	}
 }

--- a/common/config.go
+++ b/common/config.go
@@ -42,6 +42,9 @@ const (
 	OptIpamQueryInterval      = "ipam-query-interval"
 	OptIpamQueryIntervalAlias = "i"
 
+	OptStopAzureVnet      = "stop-azure-cnm"
+	OptStopAzureVnetAlias = "stopcnm"
+
 	// Version.
 	OptVersion      = "version"
 	OptVersionAlias = "v"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR adds support for CNI to query and get network config based on podname and namespace. Also added an option in cns to not to start cnm by default.
 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```