### PR TITLE
check for network container type

### DIFF
--- a/cns/dnccontract.go
+++ b/cns/dnccontract.go
@@ -15,6 +15,7 @@ const (
 // NetworkContainer Types
 const (
 	AzureContainerInstance = "AzureContainerInstance"
+	WebApps                = "WebApps"
 )
 
 // Orchestrator Types

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -908,14 +908,12 @@ func (service *httpRestService) createOrUpdateNetworkContainer(w http.ResponseWr
 	case "POST":
 		if req.NetworkContainerType == cns.WebApps {
 			nc := service.networkContainer
-			err := nc.Create(req)
-			if err != nil {
+			if err := nc.Create(req); err != nil {
 				returnMessage = fmt.Sprintf("[Azure CNS] Error. CreateOrUpdateNetworkContainer failed %v", err.Error())
 				returnCode = UnexpectedError
 				break
 			}
 		}
-
 		returnCode, returnMessage = service.saveNetworkContainerGoalState(req)
 
 	default:
@@ -1047,8 +1045,7 @@ func (service *httpRestService) deleteNetworkContainer(w http.ResponseWriter, r 
 
 		if containerStatus.CreateNetworkContainerRequest.NetworkContainerType == cns.WebApps {
 			nc := service.networkContainer
-			err := nc.Delete(req.NetworkContainerid)
-			if err != nil {
+			if err := nc.Delete(req.NetworkContainerid); err != nil {
 				returnMessage = fmt.Sprintf("[Azure CNS] Error. DeleteNetworkContainer failed %v", err.Error())
 				returnCode = UnexpectedError
 				break


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Based on the network container type, it will call netagent networkcontainer.exe otherwise it saves the state and exits 
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```