### PR TITLE
Adding CniSucceeded flag to report whether CNI had been run successfully.

### DIFF
--- a/cni/network/plugin/main.go
+++ b/cni/network/plugin/main.go
@@ -60,10 +60,11 @@ func main() {
 		Report:          &telemetry.Report{},
 	}
 
+	reportManager.GetReport(pluginName, config.Version)
+	reportManager.Report.Context = "AzureCNI"
+
 	if !reportManager.Report.GetReportState() {
 		log.Printf("GetReport state file didn't exist. Setting flag to true")
-		reportManager.GetReport(pluginName, config.Version)
-		reportManager.Report.Context = "AzureCNI"
 
 		err = reportManager.SendReport()
 		if err != nil {
@@ -99,14 +100,14 @@ func main() {
 
 	if err != nil {
 		os.Exit(1)
+	}
+
+	// Report CNI successfully finished execution.
+	reportManager.Report.CniSucceeded = true
+	err = reportManager.SendReport()
+	if err != nil {
+		log.Printf("SendReport failed due to %v", err)
 	} else {
-		// Report CNI successfully finished execution.
-		reportManager.Report.CniSucceeded = true
-		err = reportManager.SendReport()
-		if err != nil {
-			log.Printf("SendReport failed due to %v", err)
-		} else {
-			markSendReport(reportManager)
-		}
+		markSendReport(reportManager)
 	}
 }

--- a/cni/network/plugin/main.go
+++ b/cni/network/plugin/main.go
@@ -6,6 +6,8 @@ package main
 import (
 	"os"
 
+	"github.com/Azure/azure-container-networking/cni"
+	"github.com/Azure/azure-container-networking/cni/network"
 	"github.com/Azure/azure-container-networking/common"
 	"github.com/Azure/azure-container-networking/log"
 	"github.com/Azure/azure-container-networking/telemetry"
@@ -71,31 +73,30 @@ func main() {
 		}
 	}
 
-	/*	netPlugin, err := network.NewPlugin(&config)
-		if err != nil {
-			log.Printf("Failed to create network plugin, err:%v.\n", err)
-			reportPluginError(reportManager, err)
-			os.Exit(1)
-		}
+	netPlugin, err := network.NewPlugin(&config)
+	if err != nil {
+		log.Printf("Failed to create network plugin, err:%v.\n", err)
+		reportPluginError(reportManager, err)
+		os.Exit(1)
+	}
 
-		netPlugin.SetReportManager(reportManager)
+	netPlugin.SetReportManager(reportManager)
 
-		err = netPlugin.Start(&config)
-		if err != nil {
-			log.Printf("Failed to start network plugin, err:%v.\n", err)
-			reportPluginError(reportManager, err)
-			os.Exit(1)
-		}
+	err = netPlugin.Start(&config)
+	if err != nil {
+		log.Printf("Failed to start network plugin, err:%v.\n", err)
+		reportPluginError(reportManager, err)
+		os.Exit(1)
+	}
 
-		err = netPlugin.Execute(cni.PluginApi(netPlugin))
-		if err != nil {
-			log.Printf("Failed to execute network plugin, err:%v.\n", err)
-			reportPluginError(reportManager, err)
-		}
+	err = netPlugin.Execute(cni.PluginApi(netPlugin))
+	if err != nil {
+		log.Printf("Failed to execute network plugin, err:%v.\n", err)
+		reportPluginError(reportManager, err)
+	}
 
-		netPlugin.Stop()
-	*/
-	err = nil
+	netPlugin.Stop()
+
 	if err != nil {
 		os.Exit(1)
 	} else {

--- a/cni/network/plugin/main.go
+++ b/cni/network/plugin/main.go
@@ -6,8 +6,6 @@ package main
 import (
 	"os"
 
-	"github.com/Azure/azure-container-networking/cni"
-	"github.com/Azure/azure-container-networking/cni/network"
 	"github.com/Azure/azure-container-networking/common"
 	"github.com/Azure/azure-container-networking/log"
 	"github.com/Azure/azure-container-networking/telemetry"
@@ -73,31 +71,41 @@ func main() {
 		}
 	}
 
-	netPlugin, err := network.NewPlugin(&config)
+	/*	netPlugin, err := network.NewPlugin(&config)
+		if err != nil {
+			log.Printf("Failed to create network plugin, err:%v.\n", err)
+			reportPluginError(reportManager, err)
+			os.Exit(1)
+		}
+
+		netPlugin.SetReportManager(reportManager)
+
+		err = netPlugin.Start(&config)
+		if err != nil {
+			log.Printf("Failed to start network plugin, err:%v.\n", err)
+			reportPluginError(reportManager, err)
+			os.Exit(1)
+		}
+
+		err = netPlugin.Execute(cni.PluginApi(netPlugin))
+		if err != nil {
+			log.Printf("Failed to execute network plugin, err:%v.\n", err)
+			reportPluginError(reportManager, err)
+		}
+
+		netPlugin.Stop()
+	*/
+	err = nil
 	if err != nil {
-		log.Printf("Failed to create network plugin, err:%v.\n", err)
-		reportPluginError(reportManager, err)
 		os.Exit(1)
-	}
-
-	netPlugin.SetReportManager(reportManager)
-
-	err = netPlugin.Start(&config)
-	if err != nil {
-		log.Printf("Failed to start network plugin, err:%v.\n", err)
-		reportPluginError(reportManager, err)
-		os.Exit(1)
-	}
-
-	err = netPlugin.Execute(cni.PluginApi(netPlugin))
-	if err != nil {
-		log.Printf("Failed to execute network plugin, err:%v.\n", err)
-		reportPluginError(reportManager, err)
-	}
-
-	netPlugin.Stop()
-
-	if err != nil {
-		os.Exit(1)
+	} else {
+		// Report CNI successfully finished execution.
+		reportManager.Report.CniSucceeded = true
+		err = reportManager.SendReport()
+		if err != nil {
+			log.Printf("SendReport failed due to %v", err)
+		} else {
+			markSendReport(reportManager)
+		}
 	}
 }

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -149,7 +149,7 @@ func (reportMgr *ReportManager) SendReport() error {
 
 	log.Printf("Going to send Telemetry report to hostnetagent %v", reportMgr.HostNetAgentURL)
 
-	log.Printf(`"Start Flag %v CniSucceeded %t Name %v Version %v ErrorMessage %v vnet %v 
+	log.Printf(`"Start Flag %t CniSucceeded %t Name %v Version %v ErrorMessage %v vnet %v 
 				Context %v SubContext %v"`, reportMgr.Report.StartFlag, reportMgr.Report.CniSucceeded, reportMgr.Report.Name,
 		reportMgr.Report.Version, reportMgr.Report.ErrorMessage, reportMgr.Report.VnetAddressSpace,
 		reportMgr.Report.Context, reportMgr.Report.SubContext)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR adds a CniSucceeded flag as part of the telemetry report set to HostNetAgent.