### PR TITLE
Renaming VnetAddressSpace to CnetAddressSpace

### DIFF
--- a/cns/dnccontract.go
+++ b/cns/dnccontract.go
@@ -33,7 +33,7 @@ type CreateNetworkContainerRequest struct {
 	OrchestratorContext        json.RawMessage
 	IPConfiguration            IPConfiguration
 	MultiTenancyInfo           MultiTenancyInfo
-	VnetAddressSpace           []IPSubnet // To setup SNAT (should include service endpoint vips).
+	CnetAddressSpace           []IPSubnet // To setup SNAT (should include service endpoint vips).
 	Routes                     []Route
 }
 
@@ -124,7 +124,7 @@ type GetInterfaceForContainerRequest struct {
 // GetInterfaceForContainerResponse specifies the interface for a given container ID.
 type GetInterfaceForContainerResponse struct {
 	NetworkInterface NetworkInterface
-	VnetAddressSpace []IPSubnet
+	CnetAddressSpace []IPSubnet
 	Response         Response
 }
 

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -1169,12 +1169,12 @@ func (service *httpRestService) getInterfaceForContainer(w http.ResponseWriter, 
 	containerDetails, ok := containerInfo[req.NetworkContainerID]
 	var interfaceName string
 	var ipaddress string
-	var vnetSpace []cns.IPSubnet
+	var cnetSpace []cns.IPSubnet
 
 	if ok {
 		savedReq := containerDetails.CreateNetworkContainerRequest
 		interfaceName = savedReq.NetworkContainerid
-		vnetSpace = savedReq.VnetAddressSpace
+		cnetSpace = savedReq.CnetAddressSpace
 		ipaddress = savedReq.IPConfiguration.IPSubnet.IPAddress // it has to exist
 	} else {
 		returnMessage = "[Azure CNS] Never received call to create this container."
@@ -1191,7 +1191,7 @@ func (service *httpRestService) getInterfaceForContainer(w http.ResponseWriter, 
 	getInterfaceForContainerResponse := cns.GetInterfaceForContainerResponse{
 		Response:         resp,
 		NetworkInterface: cns.NetworkInterface{Name: interfaceName, IPAddress: ipaddress},
-		VnetAddressSpace: vnetSpace,
+		CnetAddressSpace: cnetSpace,
 	}
 
 	err = service.Listener.Encode(w, &getInterfaceForContainerResponse)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Renaming VnetAddressSpace to CnetAddressSpace since all traffic shod be sent to loopback adapter not just Vnet space.