### PR TITLE
Added support for --ipam-query-url command line switch

### DIFF
--- a/cnm/plugin/main.go
+++ b/cnm/plugin/main.go
@@ -76,6 +76,13 @@ var args = common.ArgumentList{
 		DefaultValue: "",
 	},
 	{
+		Name:         common.OptIpamQueryUrl,
+		Shorthand:    common.OptIpamQueryUrlAlias,
+		Description:  "Set the IPAM query URL",
+		Type:         "string",
+		DefaultValue: "",
+	},
+	{
 		Name:         common.OptIpamQueryInterval,
 		Shorthand:    common.OptIpamQueryIntervalAlias,
 		Description:  "Set the IPAM plugin query interval",
@@ -106,6 +113,7 @@ func main() {
 	url := common.GetArg(common.OptAPIServerURL).(string)
 	logLevel := common.GetArg(common.OptLogLevel).(int)
 	logTarget := common.GetArg(common.OptLogTarget).(int)
+	ipamQueryUrl, _ := common.GetArg(common.OptIpamQueryUrl).(string)
 	ipamQueryInterval, _ := common.GetArg(common.OptIpamQueryInterval).(int)
 	vers := common.GetArg(common.OptVersion).(bool)
 
@@ -166,6 +174,7 @@ func main() {
 
 	ipamPlugin.SetOption(common.OptEnvironment, environment)
 	ipamPlugin.SetOption(common.OptAPIServerURL, url)
+	ipamPlugin.SetOption(common.OptIpamQueryUrl, ipamQueryUrl)
 	ipamPlugin.SetOption(common.OptIpamQueryInterval, ipamQueryInterval)
 
 	// Start plugins.

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -80,6 +80,13 @@ var args = acn.ArgumentList{
 		DefaultValue: "",
 	},
 	{
+		Name:         acn.OptIpamQueryUrl,
+		Shorthand:    acn.OptIpamQueryUrlAlias,
+		Description:  "Set the IPAM query URL",
+		Type:         "string",
+		DefaultValue: "",
+	},
+	{
 		Name:         acn.OptIpamQueryInterval,
 		Shorthand:    acn.OptIpamQueryIntervalAlias,
 		Description:  "Set the IPAM plugin query interval",
@@ -119,6 +126,7 @@ func main() {
 	logLevel := acn.GetArg(acn.OptLogLevel).(int)
 	logTarget := acn.GetArg(acn.OptLogTarget).(int)
 	logDirectory := acn.GetArg(acn.OptLogLocation).(string)
+	ipamQueryUrl, _ := acn.GetArg(acn.OptIpamQueryUrl).(string)
 	ipamQueryInterval, _ := acn.GetArg(acn.OptIpamQueryInterval).(int)
 	vers := acn.GetArg(acn.OptVersion).(bool)
 
@@ -216,6 +224,7 @@ func main() {
 
 	ipamPlugin.SetOption(acn.OptEnvironment, environment)
 	ipamPlugin.SetOption(acn.OptAPIServerURL, url)
+	ipamPlugin.SetOption(acn.OptIpamQueryUrl, ipamQueryUrl)
 	ipamPlugin.SetOption(acn.OptIpamQueryInterval, ipamQueryInterval)
 
 	if netPlugin != nil {

--- a/docs/cnm.md
+++ b/docs/cnm.md
@@ -46,8 +46,11 @@ Usage: azure-cnm-plugin [OPTIONS]
 
 Options:
   -e, --environment=azure      Set the operating environment {azure,mas}
-  -l, --log-level=info         Set the logging level {debug,info}
-  -t, --log-target=logfile     Set the logging target {logfile,syslog,stderr}
+  -u, --api-url                Set the API server URL
+  -l, --log-level=info         Set the logging level {info,debug}
+  -t, --log-target=logfile     Set the logging target {syslog,stderr,logfile}
+  -o, --log-location           Set the logging directory
+  -q, --ipam-query-url         Set the IPAM query URL
   -i, --ipam-query-interval    Set the IPAM plugin query interval
   -v, --version                Print version information
   -h, --help                   Print usage information


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for --ipam-query-url command line switch. Without this is not possible to specify IPAM server URL from command line.