### PR TITLE
CNM: Use local address space by default if not specified on request

### DIFF
--- a/ipam/manager.go
+++ b/ipam/manager.go
@@ -265,6 +265,9 @@ func (am *addressManager) RequestPool(asId, poolId, subPoolId string, options ma
 
 	am.refreshSource()
 
+	if asId == "" {
+		asId = "local"
+	}
 	as, err := am.getAddressSpace(asId)
 	if err != nil {
 		return "", "", err
@@ -333,6 +336,9 @@ func (am *addressManager) RequestAddress(asId, poolId, address string, options m
 
 	am.refreshSource()
 
+	if asId == "" {
+		asId = "local"
+	}
 	as, err := am.getAddressSpace(asId)
 	if err != nil {
 		return "", err

--- a/ipam/manager.go
+++ b/ipam/manager.go
@@ -293,6 +293,9 @@ func (am *addressManager) ReleasePool(asId string, poolId string) error {
 
 	am.refreshSource()
 
+	if asId == "" {
+		asId = "local"
+	}
 	as, err := am.getAddressSpace(asId)
 	if err != nil {
 		return err
@@ -369,6 +372,9 @@ func (am *addressManager) ReleaseAddress(asId string, poolId string, address str
 
 	am.refreshSource()
 
+	if asId == "" {
+		asId = "local"
+	}
 	as, err := am.getAddressSpace(asId)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
I found out that at least combination of Windows Server, version 1803 + Docker CE 18.03.1-ce does not include address space value to request which it sends to CNM plugin. So we need handle empty value on here.

I tested with command
```
docker network create --driver=azure-vnet --ipam-driver=azure-vnet --subnet=10.10.10.0/24 azure
```

**Special notes for your reviewer**:
I set "local" as default address space because that is the one which  ipam plugin uses on MAS environment.