### PR TITLE
Generate VethName based on podname and namespace in CNI

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -163,16 +163,23 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 
 	// Parse Pod arguments.
 	podCfg, err := cni.ParseCniArgs(args.Args)
+	if err != nil {
+		log.Printf("Error while parsing CNI Args %v", err)
+		return err
+	}
+
 	k8sNamespace := string(podCfg.K8S_POD_NAMESPACE)
 	if len(k8sNamespace) == 0 {
-		err = plugin.Errorf("No k8s pod namespace provided.")
-		return err
+		errMsg := "Pod Namespace not specified in CNI Args"
+		log.Printf(errMsg)
+		return plugin.Errorf(errMsg)
 	}
 
 	k8sPodName := string(podCfg.K8S_POD_NAME)
 	if len(k8sPodName) == 0 {
-		err = plugin.Errorf("No k8s pod namespace provided.")
-		return err
+		errMsg := "Pod Name not specified in CNI Args"
+		log.Printf(errMsg)
+		return plugin.Errorf(errMsg)
 	}
 
 	// Parse network configuration from stdin.

--- a/network/api.go
+++ b/network/api.go
@@ -17,4 +17,6 @@ var (
 	errEndpointNotFound   = fmt.Errorf("Endpoint not found")
 	errEndpointInUse      = fmt.Errorf("Endpoint is already joined to a sandbox")
 	errEndpointNotInUse   = fmt.Errorf("Endpoint is not joined to a sandbox")
+
+	OptVethName = "vethname"
 )

--- a/network/endpoint_linux.go
+++ b/network/endpoint_linux.go
@@ -6,6 +6,8 @@
 package network
 
 import (
+	"crypto/sha1"
+	"encoding/hex"
 	"fmt"
 	"net"
 
@@ -19,11 +21,17 @@ const (
 	commonInterfacePrefix = "az"
 
 	// Prefix for host virtual network interface names.
-	hostVEthInterfacePrefix = commonInterfacePrefix + "veth"
+	hostVEthInterfacePrefix = commonInterfacePrefix + "v"
 
 	// Prefix for container network interface names.
 	containerInterfacePrefix = "eth"
 )
+
+func generateVethName(key string) string {
+	h := sha1.New()
+	h.Write([]byte(key))
+	return hex.EncodeToString(h.Sum(nil))[:11]
+}
 
 // newEndpointImpl creates a new endpoint in the network.
 func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
@@ -31,16 +39,25 @@ func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
 	var ns *Namespace
 	var ep *endpoint
 	var err error
+	var hostIfName string
+	var contIfName string
 
 	if nw.Endpoints[epInfo.Id] != nil {
-		log.Printf("[net] Endpoint alreday exists.")		
+		log.Printf("[net] Endpoint alreday exists.")
 		err = errEndpointExists
 		return nil, err
 	}
 
-	// Create a veth pair.
-	hostIfName := fmt.Sprintf("%s%s", hostVEthInterfacePrefix, epInfo.Id[:7])
-	contIfName := fmt.Sprintf("%s%s-2", hostVEthInterfacePrefix, epInfo.Id[:7])
+	if _, ok := epInfo.Data[OptVethName]; ok {
+		key := epInfo.Data[OptVethName].(string)
+		vethname := generateVethName(key)
+		hostIfName = fmt.Sprintf("%s%s", hostVEthInterfacePrefix, vethname)
+		contIfName = fmt.Sprintf("%s%s2", hostVEthInterfacePrefix, vethname)
+	} else {
+		// Create a veth pair.
+		hostIfName = fmt.Sprintf("%s%s", hostVEthInterfacePrefix, epInfo.Id[:7])
+		contIfName = fmt.Sprintf("%s%s-2", hostVEthInterfacePrefix, epInfo.Id[:7])
+	}
 
 	log.Printf("[net] Creating veth pair %v %v.", hostIfName, contIfName)
 

--- a/network/endpoint_linux.go
+++ b/network/endpoint_linux.go
@@ -49,12 +49,14 @@ func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
 	}
 
 	if _, ok := epInfo.Data[OptVethName]; ok {
+		log.Printf("Generate veth name based on the key provided")
 		key := epInfo.Data[OptVethName].(string)
 		vethname := generateVethName(key)
 		hostIfName = fmt.Sprintf("%s%s", hostVEthInterfacePrefix, vethname)
 		contIfName = fmt.Sprintf("%s%s2", hostVEthInterfacePrefix, vethname)
 	} else {
 		// Create a veth pair.
+		log.Printf("Generate veth name based on endpoint id")
 		hostIfName = fmt.Sprintf("%s%s", hostVEthInterfacePrefix, epInfo.Id[:7])
 		contIfName = fmt.Sprintf("%s%s-2", hostVEthInterfacePrefix, epInfo.Id[:7])
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Generate VethName based on podname and namespace in CNI. The function will generate hash of the key provided and return first 11 characters of hash. The key is "podname.podnamespace" in CNI.  

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```