### PR TITLE
Fixed #108 CoreOS osInfo

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.8.1
+FROM golang:1.9.4
 
 RUN apt-get update && apt-get install -y zip
 

--- a/cni/cni.go
+++ b/cni/cni.go
@@ -11,7 +11,7 @@ const (
 	// CNI commands.
 	Cmd    = "CNI_COMMAND"
 	CmdAdd = "ADD"
-	CmdAdd = "GET"
+	CmdGet = "GET"
 	CmdDel = "DEL"
 
 	// CNI errors.

--- a/cni/cni.go
+++ b/cni/cni.go
@@ -11,6 +11,7 @@ const (
 	// CNI commands.
 	Cmd    = "CNI_COMMAND"
 	CmdAdd = "ADD"
+	CmdAdd = "GET"
 	CmdDel = "DEL"
 
 	// CNI errors.
@@ -26,5 +27,6 @@ var supportedVersions = []string{"0.1.0", "0.2.0", "0.3.0", "0.3.1"}
 // CNI contract.
 type PluginApi interface {
 	Add(args *cniSkel.CmdArgs) error
+	Get(args *cniSkel.CmdArgs) error
 	Delete(args *cniSkel.CmdArgs) error
 }

--- a/cni/ipam/ipam.go
+++ b/cni/ipam/ipam.go
@@ -250,6 +250,11 @@ func (plugin *ipamPlugin) Add(args *cniSkel.CmdArgs) error {
 	return nil
 }
 
+// Get handles CNI get commands.
+func (plugin *ipamPlugin) Get(args *cniSkel.CmdArgs) error {
+	return nil
+}
+
 // Delete handles CNI delete commands.
 func (plugin *ipamPlugin) Delete(args *cniSkel.CmdArgs) error {
 	var err error

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -362,6 +362,11 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 	return nil
 }
 
+// Get handles CNI get commands.
+func (plugin *netPlugin) Get(args *cniSkel.CmdArgs) error {
+	return nil
+}
+
 // Delete handles CNI delete commands.
 func (plugin *netPlugin) Delete(args *cniSkel.CmdArgs) error {
 	var err error

--- a/cni/plugin.go
+++ b/cni/plugin.go
@@ -109,7 +109,7 @@ func (plugin *Plugin) Execute(api PluginApi) (err error) {
 	pluginInfo := cniVers.PluginSupports(supportedVersions...)
 
 	// Parse args and call the appropriate cmd handler.
-	cniErr := cniSkel.PluginMainWithError(api.Add, api.Delete, pluginInfo)
+	cniErr := cniSkel.PluginMainWithError(api.Add, api.Add, api.Delete, pluginInfo)
 	if cniErr != nil {
 		cniErr.Print()
 		return cniErr

--- a/cni/plugin.go
+++ b/cni/plugin.go
@@ -109,7 +109,7 @@ func (plugin *Plugin) Execute(api PluginApi) (err error) {
 	pluginInfo := cniVers.PluginSupports(supportedVersions...)
 
 	// Parse args and call the appropriate cmd handler.
-	cniErr := cniSkel.PluginMainWithError(api.Add, api.Add, api.Delete, pluginInfo)
+	cniErr := cniSkel.PluginMainWithError(api.Add, api.Get, api.Delete, pluginInfo)
 	if cniErr != nil {
 		cniErr.Print()
 		return cniErr

--- a/telemetry/telemetry_linux.go
+++ b/telemetry/telemetry_linux.go
@@ -98,9 +98,9 @@ func (report *Report) GetOSDetails() {
 	osInfoArr := make(map[string]string)
 	
 	for i := range linesArr {
-                s := strings.Split(linesArr[i], "=")
-                osInfoArr[s[0]] = strings.TrimSuffix(s[1], "\n")
-        }
+		s := strings.Split(linesArr[i], "=")
+		osInfoArr[s[0]] = strings.TrimSuffix(s[1], "\n")
+	}
 
 	out, err := exec.Command("uname", "-r").Output()
 	if err != nil {

--- a/telemetry/telemetry_linux.go
+++ b/telemetry/telemetry_linux.go
@@ -98,9 +98,9 @@ func (report *Report) GetOSDetails() {
 	osInfoArr := make(map[string]string)
 	
 	for i := range linesArr {
-        s := strings.Split(linesArr[i], "=")
-        osInfoArr[s[0]] = strings.TrimSuffix(s[1], "\n")
-    }
+                s := strings.Split(linesArr[i], "=")
+                osInfoArr[s[0]] = strings.TrimSuffix(s[1], "\n")
+        }
 
 	out, err := exec.Command("uname", "-r").Output()
 	if err != nil {

--- a/telemetry/telemetry_linux.go
+++ b/telemetry/telemetry_linux.go
@@ -88,14 +88,19 @@ func (report *Report) GetSystemDetails() {
 
 // This function  creates a report with os details(ostype, version).
 func (report *Report) GetOSDetails() {
-	linesArr, err := ReadFileByLines("/etc/issue")
+	linesArr, err := ReadFileByLines("/etc/os-release")
 	if err != nil || len(linesArr) <= 0 {
 		report.OSDetails = &OSInfo{OSType: runtime.GOOS}
-		report.OSDetails.ErrorMessage = "reading /etc/issue failed with" + err.Error()
+		report.OSDetails.ErrorMessage = "reading /etc/os-release failed with" + err.Error()
 		return
 	}
 
-	osInfoArr := strings.Split(linesArr[0], " ")
+	osInfoArr := make(map[string]string)
+	
+	for i := range linesArr {
+        s := strings.Split(linesArr[i], "=")
+        osInfoArr[s[0]] = strings.TrimSuffix(s[1], "\n")
+    }
 
 	out, err := exec.Command("uname", "-r").Output()
 	if err != nil {
@@ -109,8 +114,8 @@ func (report *Report) GetOSDetails() {
 
 	report.OSDetails = &OSInfo{
 		OSType:         runtime.GOOS,
-		OSVersion:      osInfoArr[1],
+		OSVersion:      osInfoArr["VERSION"],
 		KernelVersion:  kernelVersion,
-		OSDistribution: osInfoArr[0],
+		OSDistribution: osInfoArr["ID"],
 	}
 }

--- a/telemetry/telemetry_linux.go
+++ b/telemetry/telemetry_linux.go
@@ -96,7 +96,7 @@ func (report *Report) GetOSDetails() {
 	}
 
 	osInfoArr := make(map[string]string)
-	
+
 	for i := range linesArr {
 		s := strings.Split(linesArr[i], "=")
 		osInfoArr[s[0]] = strings.TrimSuffix(s[1], "\n")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #108 

**Special notes for your reviewer**:
Could you please at least build it and upload artifacts somewhere? Because this problem blocks me and I can't build it myself because of https://github.com/Azure/azure-container-networking/issues/148
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note: 
Use /etc/os-release instead of /etc/issue as a source for the osInfo because /etc/issue contains completely different lines depending on the linux distributive and fails on the CoreOS
```