### PR TITLE
add k8s pod namespace to dns suffix

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -274,7 +274,7 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 			BridgeName: nwCfg.Bridge,
 			DNS: network.DNSInfo{
 				Servers: nwCfg.DNS.Nameservers,
-				Suffix:  strings.Join(nwCfg.DNS.Search, ","),
+				Suffix:  k8sNamespace + "." + strings.Join(nwCfg.DNS.Search, ","),
 			},
 			Policies: policies,
 		}
@@ -320,7 +320,7 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 	if len(nwCfg.DNS.Search) > 0 {
 		dns = network.DNSInfo{
 			Servers: nwCfg.DNS.Nameservers,
-			Suffix:  strings.Join(nwCfg.DNS.Search, ","),
+			Suffix:  k8sNamespace + "." + strings.Join(nwCfg.DNS.Search, ","),
 		}
 	} else {
 		dns = network.DNSInfo{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds kubernetes pod's namespace to dns suffix on Windows platform so that service name can be resolved by kube-dns.
