### PR TITLE
Fixed the #108 issue.

### DIFF
--- a/telemetry/telemetry_linux.go
+++ b/telemetry/telemetry_linux.go
@@ -99,7 +99,9 @@ func (report *Report) GetOSDetails() {
 
 	for i := range linesArr {
 		s := strings.Split(linesArr[i], "=")
-		osInfoArr[s[0]] = strings.TrimSuffix(s[1], "\n")
+		if len(s) = 2 {
+			osInfoArr[s[0]] = strings.TrimSuffix(s[1], "\n")
+		}
 	}
 
 	out, err := exec.Command("uname", "-r").Output()

--- a/telemetry/telemetry_linux.go
+++ b/telemetry/telemetry_linux.go
@@ -99,7 +99,7 @@ func (report *Report) GetOSDetails() {
 
 	for i := range linesArr {
 		s := strings.Split(linesArr[i], "=")
-		if len(s) = 2 {
+		if len(s) == 2 {
 			osInfoArr[s[0]] = strings.TrimSuffix(s[1], "\n")
 		}
 	}

--- a/telemetry/telemetry_linux.go
+++ b/telemetry/telemetry_linux.go
@@ -88,14 +88,19 @@ func (report *Report) GetSystemDetails() {
 
 // This function  creates a report with os details(ostype, version).
 func (report *Report) GetOSDetails() {
-	linesArr, err := ReadFileByLines("/etc/issue")
+	linesArr, err := ReadFileByLines("/etc/os-release")
 	if err != nil || len(linesArr) <= 0 {
 		report.OSDetails = &OSInfo{OSType: runtime.GOOS}
-		report.OSDetails.ErrorMessage = "reading /etc/issue failed with" + err.Error()
+		report.OSDetails.ErrorMessage = "reading /etc/os-release failed with" + err.Error()
 		return
 	}
 
-	osInfoArr := strings.Split(linesArr[0], " ")
+	osInfoArr := make(map[string]string)
+
+	for i := range linesArr {
+		s := strings.Split(linesArr[i], "=")
+		osInfoArr[s[0]] = strings.TrimSuffix(s[1], "\n")
+	}
 
 	out, err := exec.Command("uname", "-r").Output()
 	if err != nil {
@@ -109,8 +114,8 @@ func (report *Report) GetOSDetails() {
 
 	report.OSDetails = &OSInfo{
 		OSType:         runtime.GOOS,
-		OSVersion:      osInfoArr[1],
+		OSVersion:      osInfoArr["VERSION"],
 		KernelVersion:  kernelVersion,
-		OSDistribution: osInfoArr[0],
+		OSDistribution: osInfoArr["ID"],
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Use /etc/os-release instead of /etc/issue as a source for the osInfo because /etc/issue contains completely different lines depending on the linux distributive and fails on the CoreOS.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #108 

**Special notes for your reviewer**:
Split PRs as required
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fixed the osinfo source.
```