### PR TITLE
Closing response bodies to prevent socket exhaustion.

### DIFF
--- a/cns/dockerclient/dockerclient.go
+++ b/cns/dockerclient/dockerclient.go
@@ -55,6 +55,8 @@ func (dockerClient *DockerClient) NetworkExists(networkName string) error {
 		return err
 	}
 
+	defer res.Body.Close()
+
 	// network exists
 	if res.StatusCode == 200 {
 		log.Debugf("[Azure CNS] Network with name %v already exists. Docker return code: %v", networkName, res.StatusCode)
@@ -122,6 +124,9 @@ func (dockerClient *DockerClient) CreateNetwork(networkName string, nicInfo *imd
 		log.Printf("[Azure CNS] Error received from http Post for docker network create %v", networkName)
 		return err
 	}
+
+	defer res.Body.Close()
+
 	if res.StatusCode != 201 {
 		var createNetworkResponse DockerErrorResponse
 		err = json.NewDecoder(res.Body).Decode(&createNetworkResponse)
@@ -158,6 +163,12 @@ func (dockerClient *DockerClient) DeleteNetwork(networkName string) error {
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	client := &http.Client{}
 	res, err := client.Do(req)
+	if err != nil {
+		log.Printf("[Azure CNS] HTTP Post returned error %v", err.Error())
+		return err
+	}
+
+	defer res.Body.Close()
 
 	// network successfully deleted.
 	if res.StatusCode == 204 {

--- a/cns/imdsclient/imdsclient.go
+++ b/cns/imdsclient/imdsclient.go
@@ -25,6 +25,8 @@ func (imdsClient *ImdsClient) GetNetworkContainerInfoFromHost(networkContainerID
 		return nil, err
 	}
 
+	defer jsonResponse.Body.Close()
+
 	log.Printf("[Azure CNS] Response received from Azure Host for NetworkManagement/interfaces: %v", jsonResponse.Body)
 
 	var response containerVersionJsonResponse
@@ -50,6 +52,8 @@ func (imdsClient *ImdsClient) GetPrimaryInterfaceInfoFromHost() (*InterfaceInfo,
 	if err != nil {
 		return nil, err
 	}
+
+	defer resp.Body.Close()
 
 	log.Printf("[Azure CNS] Response received from NMAgent for get interface details: %v", resp.Body)
 

--- a/cns/ipamclient/ipamclient.go
+++ b/cns/ipamclient/ipamclient.go
@@ -45,6 +45,8 @@ func (ic *IpamClient) GetAddressSpace() (string, error) {
 		return "", err
 	}
 
+	defer res.Body.Close()
+
 	if res.StatusCode == 200 {
 		var resp cnmIpam.GetDefaultAddressSpacesResponse
 		err := json.NewDecoder(res.Body).Decode(&resp)
@@ -88,6 +90,8 @@ func (ic *IpamClient) GetPoolID(asID, subnet string) (string, error) {
 		log.Printf("[Azure CNS] HTTP Post returned error %v", err.Error())
 		return "", err
 	}
+
+	defer res.Body.Close()
 
 	if res.StatusCode == 200 {
 		var resp cnmIpam.RequestPoolResponse
@@ -134,6 +138,8 @@ func (ic *IpamClient) ReserveIPAddress(poolID string, reservationID string) (str
 		log.Printf("[Azure CNS] HTTP Post returned error %v", err.Error())
 		return "", err
 	}
+
+	defer res.Body.Close()
 
 	if res.StatusCode == 200 {
 		var reserveResp cnmIpam.RequestAddressResponse
@@ -184,6 +190,8 @@ func (ic *IpamClient) ReleaseIPAddress(poolID string, reservationID string) erro
 		return err
 	}
 
+	defer res.Body.Close()
+
 	if res.StatusCode == 200 {
 		var releaseResp cnmIpam.ReleaseAddressResponse
 		err := json.NewDecoder(res.Body).Decode(&releaseResp)
@@ -226,6 +234,8 @@ func (ic *IpamClient) GetIPAddressUtilization(poolID string) (int, int, []string
 		log.Printf("[Azure CNS] HTTP Post returned error %v", err.Error())
 		return 0, 0, nil, err
 	}
+
+	defer res.Body.Close()
 
 	if res.StatusCode == 200 {
 		var poolInfoResp cnmIpam.GetPoolInfoResponse

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -165,6 +165,8 @@ func (reportMgr *ReportManager) SendReport() error {
 		return fmt.Errorf("[Azure CNI] HTTP Post returned error %v", err)
 	}
 
+	defer res.Body.Close()
+
 	if res.StatusCode != 200 {
 		if res.StatusCode == 400 {
 			return fmt.Errorf(`"[Azure CNI] HTTP Post returned statuscode %d. 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Closing response bodies to prevent socket exhaustion.