### PR TITLE
azure-vnet: Implement GET command

### DIFF
--- a/cni/cni.go
+++ b/cni/cni.go
@@ -11,6 +11,7 @@ const (
 	// CNI commands.
 	Cmd    = "CNI_COMMAND"
 	CmdAdd = "ADD"
+	CmdGet = "GET"
 	CmdDel = "DEL"
 
 	// CNI errors.
@@ -21,10 +22,11 @@ const (
 )
 
 // Supported CNI versions.
-var supportedVersions = []string{"0.1.0", "0.2.0", "0.3.0", "0.3.1"}
+var supportedVersions = []string{"0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0"}
 
 // CNI contract.
 type PluginApi interface {
 	Add(args *cniSkel.CmdArgs) error
+	Get(args *cniSkel.CmdArgs) error
 	Delete(args *cniSkel.CmdArgs) error
 }

--- a/cni/ipam/ipam.go
+++ b/cni/ipam/ipam.go
@@ -250,6 +250,11 @@ func (plugin *ipamPlugin) Add(args *cniSkel.CmdArgs) error {
 	return nil
 }
 
+// Get handles CNI Get commands.
+func (plugin *ipamPlugin) Get(args *cniSkel.CmdArgs) error {
+	return nil
+}
+
 // Delete handles CNI delete commands.
 func (plugin *ipamPlugin) Delete(args *cniSkel.CmdArgs) error {
 	var err error

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -23,12 +23,9 @@ import (
 const (
 	// Plugin name.
 	name = "azure-vnet"
-)
 
-const (
-	// Supported IP version
-	// Currently support only IPv4
-	ipVersion string = "4"
+	// Supported IP version. Currently support only IPv4
+	ipVersion = "4"
 )
 
 // NetPlugin represents the CNI network plugin.
@@ -434,8 +431,12 @@ func (plugin *netPlugin) Get(args *cniSkel.CmdArgs) error {
 			Version:   ipVersion,
 			Interface: &epInfo.IfIndex,
 			Address:   ipAddresses,
-			Gateway:   epInfo.Gateways[0],
 		}
+
+		if epInfo.Gateways != nil {
+			ipConfig.Gateway = epInfo.Gateways[0]
+		}
+
 		result.IPs = append(result.IPs, ipConfig)
 	}
 

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -16,12 +16,19 @@ import (
 	"github.com/Azure/azure-container-networking/telemetry"
 
 	cniSkel "github.com/containernetworking/cni/pkg/skel"
+	cniTypes "github.com/containernetworking/cni/pkg/types"
 	cniTypesCurr "github.com/containernetworking/cni/pkg/types/current"
 )
 
 const (
 	// Plugin name.
 	name = "azure-vnet"
+)
+
+const (
+	// Supported IP version
+	// Currently support only IPv4
+	ipVersion string = "4"
 )
 
 // NetPlugin represents the CNI network plugin.
@@ -358,6 +365,86 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 		err = plugin.Errorf("Failed to create endpoint: %v", err)
 		return err
 	}
+
+	return nil
+}
+
+// Get handles CNI Get commands.
+func (plugin *netPlugin) Get(args *cniSkel.CmdArgs) error {
+	var (
+		result cniTypesCurr.Result
+		err    error
+		nwCfg  *cni.NetworkConfig
+		epInfo *network.EndpointInfo
+		iface  *cniTypesCurr.Interface
+	)
+
+	log.Printf("[cni-net] Processing GET command with args {ContainerID:%v Netns:%v IfName:%v Args:%v Path:%v}.",
+		args.ContainerID, args.Netns, args.IfName, args.Args, args.Path)
+
+	defer func() {
+		// Add Interfaces to result.
+		iface = &cniTypesCurr.Interface{
+			Name: args.IfName,
+		}
+		result.Interfaces = append(result.Interfaces, iface)
+
+		if err == nil {
+			// Convert result to the requested CNI version.
+			res, err := result.GetAsVersion(nwCfg.CNIVersion)
+			if err != nil {
+				err = plugin.Error(err)
+			}
+			// Output the result to stdout.
+			res.Print()
+		}
+
+		log.Printf("[cni-net] GET command completed with result:%+v err:%v.", result, err)
+	}()
+
+	// Parse network configuration from stdin.
+	nwCfg, err = cni.ParseNetworkConfig(args.StdinData)
+	if err != nil {
+		err = plugin.Errorf("Failed to parse network configuration: %v.", err)
+		return err
+	}
+
+	log.Printf("[cni-net] Read network configuration %+v.", nwCfg)
+
+	// Initialize values from network config.
+	networkId := nwCfg.Name
+	endpointId := GetEndpointID(args)
+
+	// Query the network.
+	_, err = plugin.nm.GetNetworkInfo(networkId)
+	if err != nil {
+		plugin.Errorf("Failed to query network: %v", err)
+		return err
+	}
+
+	// Query the endpoint.
+	epInfo, err = plugin.nm.GetEndpointInfo(networkId, endpointId)
+	if err != nil {
+		plugin.Errorf("Failed to query endpoint: %v", err)
+		return err
+	}
+
+	for _, ipAddresses := range epInfo.IPAddresses {
+		ipConfig := &cniTypesCurr.IPConfig{
+			Version:   ipVersion,
+			Interface: &epInfo.IfIndex,
+			Address:   ipAddresses,
+			Gateway:   epInfo.Gateways[0],
+		}
+		result.IPs = append(result.IPs, ipConfig)
+	}
+
+	for _, route := range epInfo.Routes {
+		result.Routes = append(result.Routes, &cniTypes.Route{Dst: route.Dst, GW: route.Gw})
+	}
+
+	result.DNS.Nameservers = epInfo.DNS.Servers
+	result.DNS.Domain = epInfo.DNS.Suffix
 
 	return nil
 }

--- a/cni/network/plugin/main.go
+++ b/cni/network/plugin/main.go
@@ -84,8 +84,7 @@ func main() {
 	netPlugin.SetReportManager(reportManager)
 
 	defer func() {
-		errUninit := netPlugin.Plugin.UninitializeKeyValueStore()
-		if errUninit != nil {
+		if errUninit := netPlugin.Plugin.UninitializeKeyValueStore(); errUninit != nil {
 			log.Printf("Failed to uninitialize key-value store of network plugin, err:%v.\n", err)
 		}
 
@@ -94,23 +93,19 @@ func main() {
 		}
 	}()
 
-	err = netPlugin.Plugin.InitializeKeyValueStore(&config)
-
-	if err != nil {
+	if err = netPlugin.Plugin.InitializeKeyValueStore(&config); err != nil {
 		log.Printf("Failed to initialize key-value store of network plugin, err:%v.\n", err)
 		reportPluginError(reportManager, err)
 		panic("network plugin fatal error")
 	}
 
-	err = netPlugin.Start(&config)
-	if err != nil {
+	if err = netPlugin.Start(&config); err != nil {
 		log.Printf("Failed to start network plugin, err:%v.\n", err)
 		reportPluginError(reportManager, err)
 		panic("network plugin fatal error")
 	}
 
-	err = netPlugin.Execute(cni.PluginApi(netPlugin))
-	if err != nil {
+	if err = netPlugin.Execute(cni.PluginApi(netPlugin)); err != nil {
 		log.Printf("Failed to execute network plugin, err:%v.\n", err)
 		reportPluginError(reportManager, err)
 	}
@@ -123,8 +118,7 @@ func main() {
 
 	// Report CNI successfully finished execution.
 	reportManager.Report.CniSucceeded = true
-	err = reportManager.SendReport()
-	if err != nil {
+	if err = reportManager.SendReport(); err != nil {
 		log.Printf("SendReport failed due to %v", err)
 	} else {
 		markSendReport(reportManager)

--- a/cni/plugin.go
+++ b/cni/plugin.go
@@ -162,16 +162,16 @@ func (plugin *Plugin) InitializeKeyValueStore(config *common.PluginConfig) error
 			log.Printf("[cni] Failed to create store, err:%v.", err)
 			return err
 		}
-
-		// Acquire store lock.
-		err = plugin.Store.Lock(true)
-		if err != nil {
-			log.Printf("[cni] Timed out on locking store, err:%v.", err)
-			return err
-		}
-
-		config.Store = plugin.Store
 	}
+
+	// Acquire store lock.
+	if err := plugin.Store.Lock(true); err != nil {
+		log.Printf("[cni] Timed out on locking store, err:%v.", err)
+		return err
+	}
+
+	config.Store = plugin.Store
+
 	return nil
 }
 
@@ -185,5 +185,6 @@ func (plugin *Plugin) UninitializeKeyValueStore() error {
 		}
 	}
 	plugin.Store = nil
+
 	return nil
 }

--- a/cni/plugin.go
+++ b/cni/plugin.go
@@ -51,37 +51,11 @@ func (plugin *Plugin) Initialize(config *common.PluginConfig) error {
 		log.Printf("[cni] Failed to configure logging, err:%v.\n", err)
 		return err
 	}
-
-	// Initialize store.
-	if plugin.Store == nil {
-		// Create the key value store.
-		var err error
-		plugin.Store, err = store.NewJsonFileStore(platform.CNIRuntimePath + plugin.Name + ".json")
-		if err != nil {
-			log.Printf("[cni] Failed to create store, err:%v.", err)
-			return err
-		}
-
-		// Acquire store lock.
-		err = plugin.Store.Lock(true)
-		if err != nil {
-			log.Printf("[cni] Timed out on locking store, err:%v.", err)
-			return err
-		}
-
-		config.Store = plugin.Store
-	}
-
 	return nil
 }
 
 // Uninitialize uninitializes the plugin.
 func (plugin *Plugin) Uninitialize() {
-	err := plugin.Store.Unlock()
-	if err != nil {
-		log.Printf("[cni] Failed to unlock store, err:%v.", err)
-	}
-
 	plugin.Plugin.Uninitialize()
 }
 
@@ -109,7 +83,7 @@ func (plugin *Plugin) Execute(api PluginApi) (err error) {
 	pluginInfo := cniVers.PluginSupports(supportedVersions...)
 
 	// Parse args and call the appropriate cmd handler.
-	cniErr := cniSkel.PluginMainWithError(api.Add, api.Delete, pluginInfo)
+	cniErr := cniSkel.PluginMainWithError(api.Add, api.Get, api.Delete, pluginInfo)
 	if cniErr != nil {
 		cniErr.Print()
 		return cniErr
@@ -176,4 +150,40 @@ func (plugin *Plugin) Error(err error) *cniTypes.Error {
 // Errorf creates and logs a custom CNI error according to a format specifier.
 func (plugin *Plugin) Errorf(format string, args ...interface{}) *cniTypes.Error {
 	return plugin.Error(fmt.Errorf(format, args...))
+}
+
+// Initialize key-value store
+func (plugin *Plugin) InitializeKeyValueStore(config *common.PluginConfig) error {
+	// Create the key value store.
+	if plugin.Store == nil {
+		var err error
+		plugin.Store, err = store.NewJsonFileStore(platform.CNIRuntimePath + plugin.Name + ".json")
+		if err != nil {
+			log.Printf("[cni] Failed to create store, err:%v.", err)
+			return err
+		}
+
+		// Acquire store lock.
+		err = plugin.Store.Lock(true)
+		if err != nil {
+			log.Printf("[cni] Timed out on locking store, err:%v.", err)
+			return err
+		}
+
+		config.Store = plugin.Store
+	}
+	return nil
+}
+
+// Uninitialize key-value store
+func (plugin *Plugin) UninitializeKeyValueStore() error {
+	if plugin.Store != nil {
+		err := plugin.Store.Unlock()
+		if err != nil {
+			log.Printf("[cni] Failed to unlock store, err:%v.", err)
+			return err
+		}
+	}
+	plugin.Store = nil
+	return nil
 }

--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -21,6 +21,8 @@ type endpoint struct {
 	MacAddress  net.HardwareAddr
 	IPAddresses []net.IPNet
 	Gateways    []net.IP
+	DNS         DNSInfo
+	Routes      []RouteInfo
 }
 
 // EndpointInfo contains read-only information about an endpoint.
@@ -34,6 +36,10 @@ type EndpointInfo struct {
 	DNS         DNSInfo
 	Policies    []policy.Policy
 	Data        map[string]interface{}
+	MacAddress  net.HardwareAddr
+	SandboxKey  string
+	Gateways    []net.IP
+	IfIndex     int
 }
 
 // RouteInfo contains information about an IP route.
@@ -144,6 +150,18 @@ func (ep *endpoint) getInfo() *EndpointInfo {
 		Id:          ep.Id,
 		IPAddresses: ep.IPAddresses,
 		Data:        make(map[string]interface{}),
+		MacAddress:  ep.MacAddress,
+		SandboxKey:  ep.SandboxKey,
+		IfIndex:     0, // Azure CNI supports only one interface
+		DNS:         ep.DNS,
+	}
+
+	for _, route := range ep.Routes {
+		info.Routes = append(info.Routes, route)
+	}
+
+	for _, gw := range ep.Gateways {
+		info.Gateways = append(info.Gateways, gw)
 	}
 
 	// Call the platform implementation.

--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -31,15 +31,15 @@ type EndpointInfo struct {
 	ContainerID string
 	NetNsPath   string
 	IfName      string
+	SandboxKey  string
+	IfIndex     int
+	MacAddress  net.HardwareAddr
+	DNS         DNSInfo
 	IPAddresses []net.IPNet
 	Routes      []RouteInfo
-	DNS         DNSInfo
 	Policies    []policy.Policy
-	Data        map[string]interface{}
-	MacAddress  net.HardwareAddr
-	SandboxKey  string
 	Gateways    []net.IP
-	IfIndex     int
+	Data        map[string]interface{}
 }
 
 // RouteInfo contains information about an IP route.

--- a/network/endpoint_linux.go
+++ b/network/endpoint_linux.go
@@ -222,6 +222,11 @@ func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
 		MacAddress:  containerIf.HardwareAddr,
 		IPAddresses: epInfo.IPAddresses,
 		Gateways:    []net.IP{nw.extIf.IPv4Gateway},
+		DNS:         epInfo.DNS,
+	}
+
+	for _, route := range epInfo.Routes {
+		ep.Routes = append(ep.Routes, route)
 	}
 
 	return ep, nil

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -70,6 +70,11 @@ func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
 		IfName:      epInfo.IfName,
 		IPAddresses: epInfo.IPAddresses,
 		Gateways:    []net.IP{net.ParseIP(hnsResponse.GatewayAddress)},
+		DNS:         epInfo.DNS,
+	}
+
+	for _, route := range epInfo.Routes {
+		ep.Routes = append(ep.Routes, route)
 	}
 
 	ep.MacAddress, _ = net.ParseMAC(hnsResponse.MacAddress)


### PR DESCRIPTION
CNI spec has added a new method : GET which allows the runtime / orchestrator to query the current state of the container networking configuration. This change adds the implementation for the GET method in azure-vnet plugin. The supported version changes to 0.4.0 to support GET API.
This PR fixes #148  