### PR TITLE
Fix typo in CNI install script

### DIFF
--- a/scripts/install-cni-plugin.sh
+++ b/scripts/install-cni-plugin.sh
@@ -48,7 +48,7 @@ printf "done.\n"
 
 # Install azure-vnet CNI network configuration file.
 printf "Installing azure-vnet CNI network configuration file to $CNI_NETCONF_DIR..."
-mv $CNI_BIN_DIR/*.conf $CNI_NETCONF_DIR
+mv $CNI_BIN_DIR/*.conflist $CNI_NETCONF_DIR
 printf "done.\n"
 
 # Install loopback plugin.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Fix typo for clean execution for CNI install script, changed *.conf to *.conflist


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```