### PR TITLE
Fill in the plugin version in -about- string

### DIFF
--- a/cni/plugin.go
+++ b/cni/plugin.go
@@ -23,6 +23,7 @@ import (
 // Plugin is the parent class for CNI plugins.
 type Plugin struct {
 	*common.Plugin
+	version string
 }
 
 // NewPlugin creates a new CNI plugin.
@@ -34,7 +35,8 @@ func NewPlugin(name, version string) (*Plugin, error) {
 	}
 
 	return &Plugin{
-		Plugin: plugin,
+		Plugin:  plugin,
+		version: version,
 	}, nil
 }
 
@@ -83,7 +85,7 @@ func (plugin *Plugin) Execute(api PluginApi) (err error) {
 	pluginInfo := cniVers.PluginSupports(supportedVersions...)
 
 	// Parse args and call the appropriate cmd handler.
-	cniErr := cniSkel.PluginMainWithError(api.Add, api.Get, api.Delete, pluginInfo)
+	cniErr := cniSkel.PluginMainWithError(api.Add, api.Get, api.Delete, pluginInfo, plugin.version)
 	if cniErr != nil {
 		cniErr.Print()
 		return cniErr


### PR DESCRIPTION
New 'about' string is added by the spec to log the plugin version if CNI_COMMAND is not specified. This change fills that string with the plugin version.