### PR TITLE
Locking loggers in case of multi-threaded apps.

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"sync"
 )
 
 // Log level
@@ -50,6 +51,7 @@ type Logger struct {
 	maxFileCount int
 	callCount    int
 	directory    string
+	mutex        *sync.Mutex
 }
 
 // NewLogger creates a new Logger.
@@ -63,6 +65,7 @@ func NewLogger(name string, level int, target int) *Logger {
 	logger.maxFileSize = maxLogFileSize
 	logger.maxFileCount = maxLogFileCount
 	logger.directory = ""
+	logger.mutex = &sync.Mutex{}
 
 	return &logger
 }
@@ -185,13 +188,17 @@ func (logger *Logger) logf(format string, args ...interface{}) {
 // Printf logs a formatted string at info level.
 func (logger *Logger) Printf(format string, args ...interface{}) {
 	if logger.level >= LevelInfo {
+		logger.mutex.Lock()
 		logger.logf(format, args...)
+		logger.mutex.Unlock()
 	}
 }
 
 // Debugf logs a formatted string at debug level.
 func (logger *Logger) Debugf(format string, args ...interface{}) {
 	if logger.level >= LevelDebug {
+		logger.mutex.Lock()
 		logger.logf(format, args...)
+		logger.mutex.Unlock()
 	}
 }

--- a/log/stdapi.go
+++ b/log/stdapi.go
@@ -4,9 +4,9 @@
 package log
 
 // Standard logger is a pre-defined logger for convenience.
-var stdLog *Logger = NewLogger("azure-container-networking", LevelInfo, TargetStderr)
+var stdLog = NewLogger("azure-container-networking", LevelInfo, TargetStderr)
 
-// Helper functions for the standard logger.
+// GetStd - Helper functions for the standard logger.
 func GetStd() *Logger {
 	return stdLog
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This should prevent issues when multiple threads are using the same logger instance.