### PR TITLE
mark routes_test as windows build

### DIFF
--- a/cns/routes/routes_test.go
+++ b/cns/routes/routes_test.go
@@ -1,6 +1,8 @@
 // Copyright 2017 Microsoft. All rights reserved.
 // MIT License
 
+// +build windows
+
 package routes
 
 import (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
On a linux machine, the go test fails for cns/routes because `cmd` is not found:
```
$ go test github.com/Azure/azure-container-networking/cns/routes
2018/06/08 01:54:56 Test: PutMissingRoutes
2018/06/08 01:54:56 [Azure CNS] Adding missing route: [/C route ADD 159.254.169.254 MASK 255.255.255.255 0.0.0.0 METRIC 12]
2018/06/08 01:54:56 [Azure CNS] Failed to execute add route: [/C route ADD 159.254.169.254 MASK 255.255.255.255 0.0.0.0 METRIC 12]

exec: "cmd": executable file not found in $PATH
2018/06/08 01:54:56 [Azure CNS] Deleting route: [/C route DELETE 159.254.169.254 MASK 255.255.255.255 0.0.0.0 METRIC 12]
2018/06/08 01:54:56 [Azure CNS] Failed to execute delete route: [/C route DELETE 159.254.169.254 MASK 255.255.255.255 0.0.0.0 METRIC 12]

exec: "cmd": executable file not found in $PATH
2018/06/08 01:54:56 [Azure CNS] Nothing available in routing table to push
--- FAIL: TestRestoreMissingRoute (0.00s)
        routes_test.go:71: add route failed exec: "cmd": executable file not found in $PATH
        routes_test.go:87: delete route failed exec: "cmd": executable file not found in $PATH
        routes_test.go:106: unable to restore missing route
FAIL
FAIL    github.com/Azure/azure-container-networking/cns/routes  0.003s
```

This PR will set the test file to only be used on windows builds, so on linux it is skipped:
```
$ go test github.com/Azure/azure-container-networking/cns/routes
?       github.com/Azure/azure-container-networking/cns/routes  [no test files]
```

**Special notes for your reviewer**:

🐳 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
`NONE`