### PR TITLE
fix ipamclient failures

### DIFF
--- a/cns/ipamclient/ipamclient.go
+++ b/cns/ipamclient/ipamclient.go
@@ -207,7 +207,7 @@ func (ic *IpamClient) ReleaseIPAddress(poolID string, reservationID string) erro
 
 		return nil
 	}
-	log.Printf("[Azure CNS] ReleaseIP invalid http status code: %v err:%v", res.StatusCode, err.Error())
+	log.Printf("[Azure CNS] ReleaseIP invalid http status code: %v", res.StatusCode)
 	return err
 
 }

--- a/cns/ipamclient/ipamclient_test.go
+++ b/cns/ipamclient/ipamclient_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-container-networking/common"
+	"github.com/Azure/azure-container-networking/cnm/ipam"
 )
 
 var mux *http.ServeMux
@@ -27,11 +28,11 @@ func TestMain(m *testing.M) {
 		fmt.Printf("Failed to create agent, err:%v.\n", err)
 		return
 	}
-	ipamAgent.AddHandler(getAddressSpacesPath, handleIpamAsIDQuery)
-	ipamAgent.AddHandler(requestPoolPath, handlePoolIDQuery)
-	ipamAgent.AddHandler(reserveAddrPath, handleReserveIPQuery)
-	ipamAgent.AddHandler(releaseAddrPath, handleReleaseIPQuery)
-	ipamAgent.AddHandler(getPoolInfoPath, handleIPUtilizationQuery)
+	ipamAgent.AddHandler(ipam.GetAddressSpacesPath, handleIpamAsIDQuery)
+	ipamAgent.AddHandler(ipam.RequestPoolPath, handlePoolIDQuery)
+	ipamAgent.AddHandler(ipam.RequestAddressPath, handleReserveIPQuery)
+	ipamAgent.AddHandler(ipam.ReleasePoolPath, handleReleaseIPQuery)
+	ipamAgent.AddHandler(ipam.GetPoolInfoPath, handleIPUtilizationQuery)
 
 	err = ipamAgent.Start(make(chan error, 1))
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

The `ipamclient_test.go` was using undefined variables.
```
$ go test github.com/Azure/azure-container-networking/cns/ipamclient
# github.com/Azure/azure-container-networking/cns/ipamclient
./ipamclient_test.go:30: undefined: getAddressSpacesPath
./ipamclient_test.go:31: undefined: requestPoolPath
./ipamclient_test.go:32: undefined: reserveAddrPath
./ipamclient_test.go:33: undefined: releaseAddrPath
./ipamclient_test.go:34: undefined: getPoolInfoPath
FAIL    github.com/Azure/azure-container-networking/cns/ipamclient [build failed]
```

This is addressed with the first commit of this PR 8123f3bbc91597cff121956012d42d7ca48a2712

Also, `ipamclient.go` had a nil pointer dereference on non-200 results code responses.
```
$ go test github.com/Azure/azure-container-networking/cns/ipamclient
2018/06/08 04:21:25 [Listener] Started listening on localhost:42424.
2018/06/08 04:21:25 [Azure CNS] GetAddressSpace Request
2018/06/08 04:21:25 [Azure CNS] GetAddressSpace Request
2018/06/08 04:21:25 [Azure CNS] GetPoolID Request
2018/06/08 04:21:25 [Azure CNS] GetAddressSpace Request
2018/06/08 04:21:25 [Azure CNS] GetPoolID Request
2018/06/08 04:21:25 [Azure CNS] ReserveIpAddress
2018/06/08 04:21:25 [Azure CNS] ReserveIpAddress
2018/06/08 04:21:25 [Azure CNS] GetAddressSpace Request
2018/06/08 04:21:25 [Azure CNS] GetPoolID Request
2018/06/08 04:21:25 [Azure CNS] ReserveIpAddress
2018/06/08 04:21:25 [Azure CNS] ReleaseIpAddress
--- FAIL: TestReleaseIP (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x68389c]

goroutine 19 [running]:
testing.tRunner.func1(0xc42017a0d0)
        /usr/local/go/src/testing/testing.go:622 +0x29d
panic(0x6d0d60, 0x890f80)
        /usr/local/go/src/runtime/panic.go:489 +0x2cf
github.com/Azure/azure-container-networking/cns/ipamclient.(*IpamClient).ReleaseIPAddress(0xc420112030, 0xc420112b20, 0xb, 0x7293ad, 0x3, 0x0, 0x0)
        /go/src/github.com/Azure/azure-container-networking/cns/ipamclient/ipamclient.go:210 +0x6bc
github.com/Azure/azure-container-networking/cns/ipamclient.TestReleaseIP(0xc42017a0d0)
        /go/src/github.com/Azure/azure-container-networking/cns/ipamclient/ipamclient_test.go:195 +0x3d1
testing.tRunner(0xc42017a0d0, 0x73c4d0)
        /usr/local/go/src/testing/testing.go:657 +0x96
created by testing.(*T).Run
        /usr/local/go/src/testing/testing.go:697 +0x2ca
FAIL    github.com/Azure/azure-container-networking/cns/ipamclient      0.011s
```

This is addressed with the second commit of this PR c085007d1c804c06fa53592c416b580fa617de7e

So now the tests pass:
```
$ go test github.com/Azure/azure-container-networking/cns/ipamclient
ok      github.com/Azure/azure-container-networking/cns/ipamclient      0.010s
```

**Special notes for your reviewer**:

🐬 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Fix nil pointer dereference on non-200 result code responses for ipamclient ReleaseIPAddress
```