### PR TITLE
Add Azure-npm to provide k8s network policy support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,14 @@ CNSFILES = \
 	$(COREFILES) \
 	$(CNMFILES)
 
+NPMFILES = \
+	$(wildcard npm/*.go) \
+	$(wildcard npm/ipsm/*.go) \
+	$(wildcard npm/iptm/*.go) \
+	$(wildcard npm/util/*.go) \
+	$(wildcard npm/plugin/*.go) \
+	$(COREFILES)
+
 # Build defaults.
 GOOS ?= linux
 GOARCH ?= amd64
@@ -48,12 +56,14 @@ CNM_DIR = cnm/plugin
 CNI_NET_DIR = cni/network/plugin
 CNI_IPAM_DIR = cni/ipam/plugin
 CNS_DIR = cns/service
+NPM_DIR = npm/plugin
 OUTPUT_DIR = output
 BUILD_DIR = $(OUTPUT_DIR)/$(GOOS)_$(GOARCH)
 CNM_BUILD_DIR = $(BUILD_DIR)/cnm
 CNI_BUILD_DIR = $(BUILD_DIR)/cni
 CNI_MULTITENANCY_BUILD_DIR = $(BUILD_DIR)/cni-multitenancy
 CNS_BUILD_DIR = $(BUILD_DIR)/cns
+NPM_BUILD_DIR = $(BUILD_DIR)/npm
 
 # Containerized build parameters.
 BUILD_CONTAINER_IMAGE = acn-build
@@ -83,6 +93,10 @@ CNS_ARCHIVE_NAME = azure-cns-$(GOOS)-$(GOARCH)-$(VERSION).$(ARCHIVE_EXT)
 CNM_PLUGIN_IMAGE ?= microsoft/azure-vnet-plugin
 CNM_PLUGIN_ROOTFS = azure-vnet-plugin-rootfs
 
+# Azure network policy manager parameters.
+AZURE_NPM_IMAGE = containernetworking/azure-npm
+AZURE_NPM_VERSION = v0.0.4
+
 VERSION ?= $(shell git describe --tags --always --dirty)
 
 ENSURE_OUTPUT_DIR_EXISTS := $(shell mkdir -p $(OUTPUT_DIR))
@@ -92,8 +106,10 @@ azure-cnm-plugin: $(CNM_BUILD_DIR)/azure-vnet-plugin$(EXE_EXT) cnm-archive
 azure-vnet: $(CNI_BUILD_DIR)/azure-vnet$(EXE_EXT)
 azure-vnet-ipam: $(CNI_BUILD_DIR)/azure-vnet-ipam$(EXE_EXT)
 azure-cni-plugin: azure-vnet azure-vnet-ipam cni-archive
-azure-cns:	$(CNS_BUILD_DIR)/azure-cns$(EXE_EXT) cns-archive 
-all-binaries: azure-cnm-plugin azure-cni-plugin azure-cns
+azure-cns: $(CNS_BUILD_DIR)/azure-cns$(EXE_EXT) cns-archive
+azure-npm: $(NPM_BUILD_DIR)/azure-npm
+
+all-binaries: azure-cnm-plugin azure-cni-plugin azure-cns azure-npm
 
 # Clean all build artifacts.
 .PHONY: clean
@@ -115,6 +131,10 @@ $(CNI_BUILD_DIR)/azure-vnet-ipam$(EXE_EXT): $(CNIFILES)
 # Build the Azure CNS Service.
 $(CNS_BUILD_DIR)/azure-cns$(EXE_EXT): $(CNSFILES)
 	go build -v -o $(CNS_BUILD_DIR)/azure-cns$(EXE_EXT) -ldflags "-X main.version=$(VERSION) -s -w" $(CNS_DIR)/*.go
+
+# Build the Azure NPM plugin.
+$(NPM_BUILD_DIR)/azure-npm: $(NPMFILES)
+	go build -v -o $(NPM_BUILD_DIR)/azure-npm -ldflags "-X main.version=$(VERSION) -s -w" $(NPM_DIR)/*.go
 
 # Build all binaries in a container.
 .PHONY: all-binaries-containerized
@@ -170,6 +190,21 @@ azure-vnet-plugin-image: azure-cnm-plugin
 .PHONY: publish-azure-vnet-plugin-image
 publish-azure-vnet-plugin-image:
 	docker plugin push $(CNM_PLUGIN_IMAGE):$(VERSION)
+
+# Build the Azure NPM image.
+.PHONY: azure-npm-image
+azure-npm-image: azure-npm
+	# Build the plugin image.
+	docker build \
+	-f npm/Dockerfile \
+	-t $(AZURE_NPM_IMAGE):$(AZURE_NPM_VERSION) \
+	--build-arg NPM_BUILD_DIR=$(NPM_BUILD_DIR) \
+	.
+	
+# Publish the Azure NPM image to a Docker registry
+.PHONY: publish-azure-npm-image
+publish-azure-npm-image:
+	docker push $(AZURE_NPM_IMAGE):$(AZURE_NPM_VERSION)
 
 # Create a CNI archive for the target platform.
 .PHONY: cni-archive

--- a/Makefile
+++ b/Makefile
@@ -95,9 +95,9 @@ CNM_PLUGIN_ROOTFS = azure-vnet-plugin-rootfs
 
 # Azure network policy manager parameters.
 AZURE_NPM_IMAGE = containernetworking/azure-npm
-AZURE_NPM_VERSION = v0.0.4
 
 VERSION ?= $(shell git describe --tags --always --dirty)
+AZURE_NPM_VERSION = VERSION
 
 ENSURE_OUTPUT_DIR_EXISTS := $(shell mkdir -p $(OUTPUT_DIR))
 

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -33,7 +33,7 @@ const (
 type netPlugin struct {
 	*cni.Plugin
 	nm            network.NetworkManager
-	reportManager *telemetry.ReportManager
+	reportManager *telemetry.CNIReportManager
 }
 
 // NewPlugin creates a new netPlugin object.
@@ -58,7 +58,7 @@ func NewPlugin(config *common.PluginConfig) (*netPlugin, error) {
 	}, nil
 }
 
-func (plugin *netPlugin) SetReportManager(reportManager *telemetry.ReportManager) {
+func (plugin *netPlugin) SetReportManager(reportManager *telemetry.CNIReportManager) {
 	plugin.reportManager = reportManager
 }
 

--- a/cni/network/plugin/main.go
+++ b/cni/network/plugin/main.go
@@ -24,7 +24,7 @@ const (
 var version string
 
 // If report write succeeded, mark the report flag state to false.
-func markSendReport(reportManager *telemetry.ReportManager) {
+func markSendReport(reportManager *telemetry.CNIReportManager) {
 	if err := reportManager.Report.SetReportState(); err != nil {
 		log.Printf("SetReportState failed due to %v", err)
 		reportManager.Report.ErrorMessage = err.Error()
@@ -36,7 +36,7 @@ func markSendReport(reportManager *telemetry.ReportManager) {
 }
 
 // send error report to hostnetagent if CNI encounters any error.
-func reportPluginError(reportManager *telemetry.ReportManager, err error) {
+func reportPluginError(reportManager *telemetry.CNIReportManager, err error) {
 	log.Printf("Report plugin error")
 	reportManager.GetReport(pluginName, version)
 	reportManager.Report.ErrorMessage = err.Error()
@@ -53,11 +53,13 @@ func main() {
 	var config common.PluginConfig
 	var err error
 	config.Version = version
-	reportManager := &telemetry.ReportManager{
-		HostNetAgentURL: hostNetAgentURL,
-		IpamQueryURL:    ipamQueryURL,
-		ReportType:      reportType,
-		Report:          &telemetry.Report{},
+	reportManager := &telemetry.CNIReportManager{
+		ReportMangager: &telemetry.ReportManager{
+			HostNetAgentURL: hostNetAgentURL,
+			ReportType:      reportType,
+		},
+		IpamQueryURL: ipamQueryURL,
+		Report:       &telemetry.CNIReport{},
 	}
 
 	reportManager.GetReport(pluginName, config.Version)

--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -1,0 +1,15 @@
+# Use a minimal image as a parent image
+FROM ubuntu:16.04
+ARG NPM_BUILD_DIR
+
+# Install dependencies.
+RUN apt-get update
+RUN apt-get install -y iptables
+RUN apt-get install -y ipset
+
+# Install plugin.
+COPY $NPM_BUILD_DIR/azure-npm /usr/bin
+WORKDIR /usr/bin
+
+# Run the npm command by default when the container starts.
+ENTRYPOINT ["/usr/bin/azure-npm"]

--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -69,11 +69,6 @@ func isNsSet(setName string) bool {
 	return !strings.Contains(setName, "-") && !strings.Contains(setName, ":")
 }
 
-// NotReferredByNwPolicy checks if a specific ipset is referred by any network policy.
-func (ipsMgr *IpsetManager) NotReferredByNwPolicy(setName string) bool {
-	return ipsMgr.setMap[setName].referCount == 0
-}
-
 // CreateList creates an ipset list. npm maintains one setlist per namespace label.
 func (ipsMgr *IpsetManager) CreateList(listName string) error {
 	if _, exists := ipsMgr.listMap[listName]; exists {

--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -1,3 +1,5 @@
+// Copyright 2018 Microsoft. All rights reserved.
+// MIT License
 package ipsm
 
 import (

--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -1,0 +1,408 @@
+package ipsm
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"github.com/Azure/azure-container-networking/log"
+	"github.com/Azure/azure-container-networking/npm/util"
+)
+
+type ipsEntry struct {
+	operationFlag string
+	name          string
+	set           string
+	spec          string
+}
+
+// IpsetManager stores ipset states.
+type IpsetManager struct {
+	listMap map[string]*Ipset //tracks all set lists.
+	setMap  map[string]*Ipset //label -> []ip
+}
+
+// Ipset represents one ipset entry.
+type Ipset struct {
+	name       string
+	elements   []string
+	referCount int
+}
+
+// NewIpset creates a new instance for Ipset object.
+func NewIpset(setName string) *Ipset {
+	return &Ipset{
+		name: setName,
+	}
+}
+
+// NewIpsetManager creates a new instance for IpsetManager object.
+func NewIpsetManager() *IpsetManager {
+	return &IpsetManager{
+		listMap: make(map[string]*Ipset),
+		setMap:  make(map[string]*Ipset),
+	}
+}
+
+// Exists checks if an element exists in setMap/listMap.
+func (ipsMgr *IpsetManager) Exists(key string, val string, kind string) bool {
+	m := ipsMgr.setMap
+	if kind == util.IpsetSetListFlag {
+		m = ipsMgr.listMap
+	}
+
+	if _, exists := m[key]; !exists {
+		return false
+	}
+
+	for _, elem := range m[key].elements {
+		if elem == val {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isNsSet(setName string) bool {
+	return !strings.Contains(setName, "-") && !strings.Contains(setName, ":")
+}
+
+// NotReferredByNwPolicy checks if a specific ipset is referred by any network policy.
+func (ipsMgr *IpsetManager) NotReferredByNwPolicy(setName string) bool {
+	return ipsMgr.setMap[setName].referCount == 0
+}
+
+// CreateList creates an ipset list. npm maintains one setlist per namespace label.
+func (ipsMgr *IpsetManager) CreateList(listName string) error {
+	if _, exists := ipsMgr.listMap[listName]; exists {
+		return nil
+	}
+
+	entry := &ipsEntry{
+		name:          listName,
+		operationFlag: util.IpsetCreationFlag,
+		set:           util.GetHashedName(listName),
+		spec:          util.IpsetSetListFlag,
+	}
+	log.Printf("Creating List: %+v\n", entry)
+	if _, err := ipsMgr.Run(entry); err != nil {
+		log.Printf("Error creating ipset list %s.\n", listName)
+		return err
+	}
+
+	ipsMgr.listMap[listName] = NewIpset(listName)
+
+	return nil
+}
+
+// DeleteList removes an ipset list.
+func (ipsMgr *IpsetManager) DeleteList(listName string) error {
+	entry := &ipsEntry{
+		operationFlag: util.IpsetDestroyFlag,
+		set:           util.GetHashedName(listName),
+	}
+
+	errCode, err := ipsMgr.Run(entry)
+	if err != nil {
+		if errCode == 1 {
+			log.Printf("Cannot delete list %s as it's being referred or doesn't exist.\n", listName)
+			return nil
+		}
+
+		log.Printf("Error deleting ipset %s", listName)
+		log.Printf("%+v\n", entry)
+		return err
+	}
+
+	delete(ipsMgr.listMap, listName)
+
+	return nil
+}
+
+// AddToList inserts an ipset to an ipset list.
+func (ipsMgr *IpsetManager) AddToList(listName string, setName string) error {
+	if ipsMgr.Exists(listName, setName, util.IpsetSetListFlag) {
+		return nil
+	}
+
+	if err := ipsMgr.CreateList(listName); err != nil {
+		return err
+	}
+
+	entry := &ipsEntry{
+		operationFlag: util.IpsetAppendFlag,
+		set:           util.GetHashedName(listName),
+		spec:          util.GetHashedName(setName),
+	}
+
+	if _, err := ipsMgr.Run(entry); err != nil {
+		log.Printf("Error creating ipset rules. rule: %+v", entry)
+		return err
+	}
+
+	ipsMgr.listMap[listName].elements = append(ipsMgr.listMap[listName].elements, setName)
+
+	return nil
+}
+
+// DeleteFromList removes an ipset to an ipset list.
+func (ipsMgr *IpsetManager) DeleteFromList(listName string, setName string) error {
+	if _, exists := ipsMgr.listMap[listName]; !exists {
+		log.Printf("ipset list with name %s not found", listName)
+		return nil
+	}
+
+	for i, val := range ipsMgr.listMap[listName].elements {
+		if val == setName {
+			ipsMgr.listMap[listName].elements = append(ipsMgr.listMap[listName].elements[:i], ipsMgr.listMap[listName].elements[i+1:]...)
+		}
+	}
+
+	hashedListName, hashedSetName := util.GetHashedName(listName), util.GetHashedName(setName)
+	entry := &ipsEntry{
+		operationFlag: util.IpsetDeletionFlag,
+		set:           hashedListName,
+		spec:          hashedSetName,
+	}
+	errCode, err := ipsMgr.Run(entry)
+	if errCode > 1 && err != nil {
+		log.Printf("Error deleting ipset entry.\n")
+		log.Printf("%+v\n", entry)
+		return err
+	}
+
+	if len(ipsMgr.listMap[listName].elements) == 0 {
+		if err := ipsMgr.DeleteList(listName); err != nil {
+			log.Printf("Error deleting ipset list %s.\n", listName)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// CreateSet creates an ipset.
+func (ipsMgr *IpsetManager) CreateSet(setName string) error {
+	if _, exists := ipsMgr.setMap[setName]; exists {
+		return nil
+	}
+
+	entry := &ipsEntry{
+		name:          setName,
+		operationFlag: util.IpsetCreationFlag,
+		// Use hashed string for set name to avoid string length limit of ipset.
+		set:  util.GetHashedName(setName),
+		spec: util.IpsetNetHashFlag,
+	}
+	log.Printf("Creating Set: %+v\n", entry)
+	if _, err := ipsMgr.Run(entry); err != nil {
+		log.Printf("Error creating ipset.\n")
+		return err
+	}
+
+	ipsMgr.setMap[setName] = NewIpset(setName)
+
+	return nil
+}
+
+// DeleteSet removes a set from ipset.
+func (ipsMgr *IpsetManager) DeleteSet(setName string) error {
+	if _, exists := ipsMgr.setMap[setName]; !exists {
+		log.Printf("ipset with name %s not found", setName)
+		return nil
+	}
+
+	if len(ipsMgr.setMap[setName].elements) > 0 {
+		return nil
+	}
+
+	entry := &ipsEntry{
+		operationFlag: util.IpsetDestroyFlag,
+		set:           util.GetHashedName(setName),
+	}
+	errCode, err := ipsMgr.Run(entry)
+	if err != nil {
+		if errCode == 1 {
+			log.Printf("Cannot delete set %s as it's being referred.\n", setName)
+			return nil
+		}
+
+		log.Printf("Error deleting ipset %s\n. Entry: %+v", setName, entry)
+		return err
+	}
+
+	delete(ipsMgr.setMap, setName)
+
+	return nil
+}
+
+// AddToSet inserts an ip to an entry in setMap, and creates/updates the corresponding ipset.
+func (ipsMgr *IpsetManager) AddToSet(setName string, ip string) error {
+	if ipsMgr.Exists(setName, ip, util.IpsetNetHashFlag) {
+		return nil
+	}
+
+	if err := ipsMgr.CreateSet(setName); err != nil {
+		return err
+	}
+
+	entry := &ipsEntry{
+		operationFlag: util.IpsetAppendFlag,
+		set:           util.GetHashedName(setName),
+		spec:          ip,
+	}
+
+	if _, err := ipsMgr.Run(entry); err != nil {
+		log.Printf("Error creating ipset rules.\n")
+		log.Printf("rule: %+v\n", entry)
+		return err
+	}
+
+	ipsMgr.setMap[setName].elements = append(ipsMgr.setMap[setName].elements, ip)
+
+	return nil
+}
+
+// DeleteFromSet removes an ip from an entry in setMap, and delete/update the corresponding ipset.
+func (ipsMgr *IpsetManager) DeleteFromSet(setName string, ip string) error {
+	if _, exists := ipsMgr.setMap[setName]; !exists {
+		log.Printf("ipset with name %s not found", setName)
+		return nil
+	}
+
+	for i, val := range ipsMgr.setMap[setName].elements {
+		if val == ip {
+			ipsMgr.setMap[setName].elements = append(ipsMgr.setMap[setName].elements[:i], ipsMgr.setMap[setName].elements[i+1:]...)
+		}
+	}
+
+	entry := &ipsEntry{
+		operationFlag: util.IpsetDeletionFlag,
+		set:           util.GetHashedName(setName),
+		spec:          ip,
+	}
+	if _, err := ipsMgr.Run(entry); err != nil {
+		log.Printf("Error deleting ipset entry.\n Entry: %+v", entry)
+		return err
+	}
+
+	return nil
+}
+
+// Clean removes all the empty sets & lists under the namespace.
+func (ipsMgr *IpsetManager) Clean() error {
+	for setName, set := range ipsMgr.setMap {
+		if len(set.elements) > 0 {
+			continue
+		}
+
+		if err := ipsMgr.DeleteSet(setName); err != nil {
+			log.Printf("Error cleaning ipset\n")
+			return err
+		}
+	}
+
+	for listName, list := range ipsMgr.listMap {
+		if len(list.elements) > 0 {
+			continue
+		}
+
+		if err := ipsMgr.DeleteList(listName); err != nil {
+			log.Printf("Error cleaning ipset list\n")
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Destroy completely cleans ipset.
+func (ipsMgr *IpsetManager) Destroy() error {
+	entry := &ipsEntry{
+		operationFlag: util.IpsetFlushFlag,
+	}
+	if _, err := ipsMgr.Run(entry); err != nil {
+		log.Printf("Error flushing ipset\n")
+		return err
+	}
+
+	entry.operationFlag = util.IpsetDestroyFlag
+	if _, err := ipsMgr.Run(entry); err != nil {
+		log.Printf("Error destroying ipset\n")
+		return err
+	}
+
+	return nil
+}
+
+// Run execute an ipset command to update ipset.
+func (ipsMgr *IpsetManager) Run(entry *ipsEntry) (int, error) {
+	cmdName := util.Ipset
+	cmdArgs := []string{entry.operationFlag, util.IpsetExistFlag}
+	if len(entry.set) > 0 {
+		cmdArgs = append(cmdArgs, entry.set)
+	}
+	if len(entry.spec) > 0 {
+		cmdArgs = append(cmdArgs, entry.spec)
+	}
+
+	cmdOut, err := exec.Command(cmdName, cmdArgs...).Output()
+	log.Printf("%s\n", string(cmdOut))
+
+	if msg, failed := err.(*exec.ExitError); failed {
+		errCode := msg.Sys().(syscall.WaitStatus).ExitStatus()
+		if errCode > 1 {
+			log.Printf("There was an error running command: %s\nArguments:%+v", err, cmdArgs)
+		}
+
+		return errCode, err
+	}
+
+	return 0, nil
+}
+
+// Save saves ipset to file.
+func (ipsMgr *IpsetManager) Save(configFile string) error {
+	if len(configFile) == 0 {
+		configFile = util.IpsetConfigFile
+	}
+
+	cmd := exec.Command(util.Ipset, util.IpsetSaveFlag, util.IpsetFileFlag, configFile)
+	if err := cmd.Start(); err != nil {
+		log.Printf("Error saving ipset to file.\n")
+		return err
+	}
+	cmd.Wait()
+
+	return nil
+}
+
+// Restore restores ipset from file.
+func (ipsMgr *IpsetManager) Restore(configFile string) error {
+	if len(configFile) == 0 {
+		configFile = util.IpsetConfigFile
+	}
+
+	f, err := os.Stat(configFile)
+	if err != nil {
+		log.Printf("Error getting file %s stat from ipsm.Restore", configFile)
+		return err
+	}
+
+	if f.Size() == 0 {
+		if err := ipsMgr.Destroy(); err != nil {
+			return err
+		}
+	}
+
+	cmd := exec.Command(util.Ipset, util.IpsetRestoreFlag, util.IpsetFileFlag, configFile)
+	if err := cmd.Start(); err != nil {
+		log.Printf("Error restoring ipset from file.\n")
+		return err
+	}
+	cmd.Wait()
+
+	return nil
+}

--- a/npm/ipsm/ipsm_test.go
+++ b/npm/ipsm/ipsm_test.go
@@ -1,0 +1,250 @@
+package ipsm
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-container-networking/npm/util"
+)
+
+func TestSave(t *testing.T) {
+	ipsMgr := NewIpsetManager()
+	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
+		t.Errorf("TestSave failed @ ipsMgr.Save")
+	}
+}
+
+func TestRestore(t *testing.T) {
+	ipsMgr := NewIpsetManager()
+	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
+		t.Errorf("TestRestore failed @ ipsMgr.Save")
+	}
+
+	if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
+		t.Errorf("TestRestore failed @ ipsMgr.Restore")
+	}
+}
+
+func TestCreateList(t *testing.T) {
+	ipsMgr := NewIpsetManager()
+	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
+		t.Errorf("TestCreateList failed @ ipsMgr.Save")
+	}
+
+	defer func() {
+		if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
+			t.Errorf("TestCreateList failed @ ipsMgr.Restore")
+		}
+	}()
+
+	if err := ipsMgr.CreateList("test-list"); err != nil {
+		t.Errorf("TestCreateList failed @ ipsMgr.CreateList")
+	}
+}
+
+func TestDeleteList(t *testing.T) {
+	ipsMgr := NewIpsetManager()
+	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
+		t.Errorf("TestDeleteList failed @ ipsMgr.Save")
+	}
+
+	defer func() {
+		if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
+			t.Errorf("TestDeleteList failed @ ipsMgr.Restore")
+		}
+	}()
+
+	if err := ipsMgr.CreateList("test-list"); err != nil {
+		t.Errorf("TestDeleteList failed @ ipsMgr.CreateList")
+	}
+
+	if err := ipsMgr.DeleteList("test-list"); err != nil {
+		t.Errorf("TestDeleteList failed @ ipsMgr.DeleteList")
+	}
+}
+
+func TestAddToList(t *testing.T) {
+	ipsMgr := NewIpsetManager()
+	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
+		t.Errorf("TestAddToList failed @ ipsMgr.Save")
+	}
+
+	defer func() {
+		if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
+			t.Errorf("TestAddToList failed @ ipsMgr.Restore")
+		}
+	}()
+
+	if err := ipsMgr.AddToList("test-list", "test-set"); err != nil {
+		t.Errorf("TestAddToList failed @ ipsMgr.AddToList")
+	}
+}
+
+func TestDeleteFromList(t *testing.T) {
+	ipsMgr := NewIpsetManager()
+	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
+		t.Errorf("TestDeleteFromList failed @ ipsMgr.Save")
+	}
+
+	defer func() {
+		if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
+			t.Errorf("TestDeleteFromList failed @ ipsMgr.Restore")
+		}
+	}()
+
+	if err := ipsMgr.AddToList("test-list", "test-set"); err != nil {
+		t.Errorf("TestDeleteFromList failed @ ipsMgr.AddToList")
+	}
+
+	if err := ipsMgr.DeleteFromList("test-list", "test-set"); err != nil {
+		t.Errorf("TestDeleteFromList failed @ ipsMgr.DeleteFromList")
+	}
+}
+
+func TestCreateSet(t *testing.T) {
+	ipsMgr := NewIpsetManager()
+	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
+		t.Errorf("TestCreateSet failed @ ipsMgr.Save")
+	}
+
+	defer func() {
+		if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
+			t.Errorf("TestCreateSet failed @ ipsMgr.Restore")
+		}
+	}()
+
+	if err := ipsMgr.CreateSet("test-set"); err != nil {
+		t.Errorf("TestCreateSet failed @ ipsMgr.CreateSet")
+	}
+}
+
+func TestDeleteSet(t *testing.T) {
+	ipsMgr := NewIpsetManager()
+	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
+		t.Errorf("TestDeleteSet failed @ ipsMgr.Save")
+	}
+
+	defer func() {
+		if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
+			t.Errorf("TestDeleteSet failed @ ipsMgr.Restore")
+		}
+	}()
+
+	if err := ipsMgr.CreateSet("test-set"); err != nil {
+		t.Errorf("TestDeleteSet failed @ ipsMgr.CreateSet")
+	}
+
+	if err := ipsMgr.DeleteSet("test-set"); err != nil {
+		t.Errorf("TestDeleteSet failed @ ipsMgr.DeleteSet")
+	}
+}
+
+func TestAddToSet(t *testing.T) {
+	ipsMgr := NewIpsetManager()
+	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
+		t.Errorf("TestAddToSet failed @ ipsMgr.Save")
+	}
+
+	defer func() {
+		if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
+			t.Errorf("TestAddToSet failed @ ipsMgr.Restore")
+		}
+	}()
+
+	if err := ipsMgr.AddToSet("test-set", "1.2.3.4"); err != nil {
+		t.Errorf("TestAddToSet failed @ ipsMgr.AddToSet")
+	}
+}
+
+func TestDeleteFromSet(t *testing.T) {
+	ipsMgr := NewIpsetManager()
+	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
+		t.Errorf("TestDeleteFromSet failed @ ipsMgr.Save")
+	}
+
+	defer func() {
+		if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
+			t.Errorf("TestDeleteFromSet failed @ ipsMgr.Restore")
+		}
+	}()
+
+	if err := ipsMgr.AddToSet("test-set", "1.2.3.4"); err != nil {
+		t.Errorf("TestDeleteFromSet failed @ ipsMgr.AddToSet")
+	}
+
+	if err := ipsMgr.DeleteFromSet("test-set", "1.2.3.4"); err != nil {
+		t.Errorf("TestDeleteFromSet failed @ ipsMgr.DeleteFromSet")
+	}
+}
+
+func TestClean(t *testing.T) {
+	ipsMgr := NewIpsetManager()
+	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
+		t.Errorf("TestClean failed @ ipsMgr.Save")
+	}
+
+	defer func() {
+		if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
+			t.Errorf("TestClean failed @ ipsMgr.Restore")
+		}
+	}()
+
+	if err := ipsMgr.CreateSet("test-set"); err != nil {
+		t.Errorf("TestClean failed @ ipsMgr.CreateSet")
+	}
+
+	if err := ipsMgr.Clean(); err != nil {
+		t.Errorf("TestClean failed @ ipsMgr.Clean")
+	}
+}
+
+func TestDestroy(t *testing.T) {
+	ipsMgr := NewIpsetManager()
+	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
+		t.Errorf("TestDestroy failed @ ipsMgr.Save")
+	}
+
+	defer func() {
+		if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
+			t.Errorf("TestDestroy failed @ ipsMgr.Restore")
+		}
+	}()
+
+	if err := ipsMgr.AddToSet("test-set", "1.2.3.4"); err != nil {
+		t.Errorf("TestDestroy failed @ ipsMgr.AddToSet")
+	}
+
+	if err := ipsMgr.Destroy(); err != nil {
+		t.Errorf("TestDestroy failed @ ipsMgr.Destroy")
+	}
+}
+
+func TestRun(t *testing.T) {
+	ipsMgr := NewIpsetManager()
+	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
+		t.Errorf("TestRun failed @ ipsMgr.Save")
+	}
+
+	defer func() {
+		if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
+			t.Errorf("TestRun failed @ ipsMgr.Restore")
+		}
+	}()
+
+	entry := &ipsEntry{
+		operationFlag: util.IpsetCreationFlag,
+		set:           "test-set",
+		spec:          util.IpsetNetHashFlag,
+	}
+	if _, err := ipsMgr.Run(entry); err != nil {
+		t.Errorf("TestRun failed @ ipsMgr.Run")
+	}
+}
+
+func TestMain(m *testing.M) {
+	ipsMgr := NewIpsetManager()
+	ipsMgr.Save(util.IpsetConfigFile)
+
+	m.Run()
+
+	ipsMgr.Restore(util.IpsetConfigFile)
+}

--- a/npm/ipsm/ipsm_test.go
+++ b/npm/ipsm/ipsm_test.go
@@ -1,3 +1,5 @@
+// Copyright 2018 Microsoft. All rights reserved.
+// MIT License
 package ipsm
 
 import (

--- a/npm/iptm/iptm.go
+++ b/npm/iptm/iptm.go
@@ -1,0 +1,420 @@
+package iptm
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/Azure/azure-container-networking/log"
+	"github.com/Azure/azure-container-networking/npm/util"
+)
+
+// IptEntry represents an iptables rule.
+type IptEntry struct {
+	Name       string
+	HashedName string
+	Chain      string
+	Flag       string
+	Specs      []string
+}
+
+// IptablesManager stores iptables entries.
+type IptablesManager struct {
+	OperationFlag string
+}
+
+// NewIptablesManager creates a new instance for IptablesManager object.
+func NewIptablesManager() *IptablesManager {
+	iptMgr := &IptablesManager{
+		OperationFlag: "",
+	}
+
+	return iptMgr
+}
+
+// InitNpmChains initializes Azure NPM chains in iptables.
+func (iptMgr *IptablesManager) InitNpmChains() error {
+	log.Printf("Initializing AZURE-NPM chains")
+
+	if err := iptMgr.AddChain(util.IptablesAzureChain); err != nil {
+		return err
+	}
+
+	// Insert AZURE-NPM chain to FORWARD chain.
+	entry := &IptEntry{
+		Chain: util.IptablesForwardChain,
+		Specs: []string{
+			util.IptablesJumpFlag,
+			util.IptablesAzureChain,
+		},
+	}
+	exists, err := iptMgr.Exists(entry)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		iptMgr.OperationFlag = util.IptablesInsertionFlag
+		if _, err = iptMgr.Run(entry); err != nil {
+			log.Printf("Error adding AZURE-NPM chain to FORWARD chain\n")
+			return err
+		}
+	}
+
+	// Add default allow CONNECTED/RELATED rule to AZURE-NPM chain.
+	entry.Chain = util.IptablesAzureChain
+	entry.Specs = []string{
+		util.IptablesMatchFlag,
+		util.IptablesStateFlag,
+		util.IPtablesMatchStateFlag,
+		util.IptablesRelatedState + "," + util.IptablesEstablishedState,
+		util.IptablesJumpFlag,
+		util.IptablesAccept,
+	}
+	exists, err = iptMgr.Exists(entry)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		iptMgr.OperationFlag = util.IptablesInsertionFlag
+		if _, err = iptMgr.Run(entry); err != nil {
+			log.Printf("Error adding default allow CONNECTED/RELATED rule to AZURE-NPM chain\n")
+			return err
+		}
+	}
+
+	// Add default allow kube-system rules to AZURE-NPM chain.
+	entry.Specs = []string{
+		util.IptablesMatchFlag,
+		util.IptablesSetFlag,
+		util.IptablesMatchSetFlag,
+		util.GetHashedName(util.KubeSystemFlag),
+		util.IptablesDstFlag,
+		util.IptablesJumpFlag,
+		util.IptablesAccept,
+	}
+	exists, err = iptMgr.Exists(entry)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		iptMgr.OperationFlag = util.IptablesAppendFlag
+		if _, err := iptMgr.Run(entry); err != nil {
+			log.Printf("Error adding default allow kube-system rule to AZURE-NPM chain\n")
+			return err
+		}
+	}
+
+	entry.Specs = []string{
+		util.IptablesMatchFlag,
+		util.IptablesSetFlag,
+		util.IptablesMatchSetFlag,
+		util.GetHashedName(util.KubeSystemFlag),
+		util.IptablesSrcFlag,
+		util.IptablesJumpFlag,
+		util.IptablesAccept,
+	}
+	exists, err = iptMgr.Exists(entry)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		iptMgr.OperationFlag = util.IptablesAppendFlag
+		if _, err := iptMgr.Run(entry); err != nil {
+			log.Printf("Error adding default allow kube-system rule to AZURE-NPM chain\n")
+			return err
+		}
+	}
+	// Create AZURE-NPM-INGRESS-PORT chain.
+	if err := iptMgr.AddChain(util.IptablesAzureIngressPortChain); err != nil {
+		return err
+	}
+
+	// Insert AZURE-NPM-INGRESS-PORT chain to AZURE-NPM chain.
+	entry.Chain = util.IptablesAzureChain
+	entry.Specs = []string{util.IptablesJumpFlag, util.IptablesAzureIngressPortChain}
+	exists, err = iptMgr.Exists(entry)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		iptMgr.OperationFlag = util.IptablesAppendFlag
+		if _, err := iptMgr.Run(entry); err != nil {
+			log.Printf("Error adding AZURE-NPM-INGRESS-PORT chain to AZURE-NPM chain\n")
+			return err
+		}
+	}
+
+	// Create AZURE-NPM-INGRESS-FROM chain.
+	if err := iptMgr.AddChain(util.IptablesAzureIngressFromChain); err != nil {
+		return err
+	}
+
+	// Create AZURE-NPM-EGRESS-PORT chain.
+	if err := iptMgr.AddChain(util.IptablesAzureEgressPortChain); err != nil {
+		return err
+	}
+
+	// Insert AZURE-NPM-EGRESS-PORT chain to AZURE-NPM chain.
+	entry.Chain = util.IptablesAzureChain
+	entry.Specs = []string{util.IptablesJumpFlag, util.IptablesAzureEgressPortChain}
+	exists, err = iptMgr.Exists(entry)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		iptMgr.OperationFlag = util.IptablesAppendFlag
+		if _, err := iptMgr.Run(entry); err != nil {
+			log.Printf("Error adding AZURE-NPM-EGRESS-PORT chain to AZURE-NPM chain\n")
+			return err
+		}
+	}
+
+	// Create AZURE-NPM-EGRESS-FROM chain.
+	if err := iptMgr.AddChain(util.IptablesAzureEgressToChain); err != nil {
+		return err
+	}
+
+	// Create AZURE-NPM-TARGET-SETS chain.
+	if err := iptMgr.AddChain(util.IptablesAzureTargetSetsChain); err != nil {
+		return err
+	}
+
+	// Insert AZURE-NPM-TARGET-SETS chain to AZURE-NPM chain.
+	entry.Chain = util.IptablesAzureChain
+	entry.Specs = []string{util.IptablesJumpFlag, util.IptablesAzureTargetSetsChain}
+	exists, err = iptMgr.Exists(entry)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		iptMgr.OperationFlag = util.IptablesAppendFlag
+		if _, err := iptMgr.Run(entry); err != nil {
+			log.Printf("Error adding AZURE-NPM-TARGET-SETS chain to AZURE-NPM chain\n")
+			return err
+		}
+	}
+
+	return nil
+}
+
+// UninitNpmChains uninitializes Azure NPM chains in iptables.
+func (iptMgr *IptablesManager) UninitNpmChains() error {
+	IptablesAzureChainList := []string{
+		util.IptablesAzureChain,
+		util.IptablesAzureIngressPortChain,
+		util.IptablesAzureIngressFromChain,
+		util.IptablesAzureEgressPortChain,
+		util.IptablesAzureEgressToChain,
+		util.IptablesAzureTargetSetsChain,
+	}
+
+	// Remove AZURE-NPM chain from FORWARD chain.
+	entry := &IptEntry{
+		Chain: util.IptablesForwardChain,
+		Specs: []string{
+			util.IptablesJumpFlag,
+			util.IptablesAzureChain,
+		},
+	}
+	iptMgr.OperationFlag = util.IptablesDeletionFlag
+	errCode, err := iptMgr.Run(entry)
+	if errCode != 1 && err != nil {
+		log.Printf("Error removing default rule from FORWARD chain\n")
+		return err
+	}
+
+	iptMgr.OperationFlag = util.IptablesFlushFlag
+	for _, chain := range IptablesAzureChainList {
+		entry := &IptEntry{
+			Chain: chain,
+		}
+		if _, err := iptMgr.Run(entry); err != nil {
+			log.Printf("Error flushing iptables chain %s\n", chain)
+		}
+	}
+
+	for _, chain := range IptablesAzureChainList {
+		if err := iptMgr.DeleteChain(chain); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Exists checks if a rule exists in iptables.
+func (iptMgr *IptablesManager) Exists(entry *IptEntry) (bool, error) {
+	iptMgr.OperationFlag = util.IptablesCheckFlag
+	returnCode, err := iptMgr.Run(entry)
+	if err == nil {
+		log.Printf("Rule exists. %+v\n", entry)
+		return true, nil
+	}
+
+	if returnCode == 1 {
+		log.Printf("Rule doesn't exist. %+v\n", entry)
+		return false, nil
+	}
+
+	return false, err
+}
+
+// AddChain adds a chain to iptables.
+func (iptMgr *IptablesManager) AddChain(chain string) error {
+	entry := &IptEntry{
+		Chain: chain,
+	}
+	iptMgr.OperationFlag = util.IptablesChainCreationFlag
+	errCode, err := iptMgr.Run(entry)
+	if err != nil {
+		if errCode == 1 {
+			log.Printf("Chain already exists %s\n", entry.Chain)
+			return nil
+		}
+
+		log.Printf("Error creating iptables chain %s\n", entry.Chain)
+		return err
+	}
+
+	return nil
+}
+
+// DeleteChain deletes a chain from iptables.
+func (iptMgr *IptablesManager) DeleteChain(chain string) error {
+	entry := &IptEntry{
+		Chain: chain,
+	}
+	iptMgr.OperationFlag = util.IptablesDestroyFlag
+	errCode, err := iptMgr.Run(entry)
+	if err != nil {
+		if errCode == 1 {
+			log.Printf("Chain doesn't exist %s\n", entry.Chain)
+			return nil
+		}
+		log.Printf("Error deleting iptables chain %s\n", entry.Chain)
+		return err
+	}
+
+	return nil
+}
+
+// Add adds a rule in iptables.
+func (iptMgr *IptablesManager) Add(entry *IptEntry) error {
+	log.Printf("Add iptables entry: %+v\n", entry)
+
+	exists, err := iptMgr.Exists(entry)
+	if err != nil {
+		return err
+	}
+
+	if exists {
+		return nil
+	}
+
+	iptMgr.OperationFlag = util.IptablesAppendFlag
+	if _, err := iptMgr.Run(entry); err != nil {
+		log.Printf("Error creating iptables rules.\n")
+		return err
+	}
+
+	return nil
+}
+
+// Delete removes a rule in iptables.
+func (iptMgr *IptablesManager) Delete(entry *IptEntry) error {
+	log.Printf("Deleting iptables entry: %+v\n", entry)
+
+	exists, err := iptMgr.Exists(entry)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		return nil
+	}
+
+	iptMgr.OperationFlag = util.IptablesDeletionFlag
+	if _, err := iptMgr.Run(entry); err != nil {
+		log.Printf("Error deleting iptables rules.\n")
+		return err
+	}
+
+	return nil
+}
+
+// Run execute an iptables command to update iptables.
+func (iptMgr *IptablesManager) Run(entry *IptEntry) (int, error) {
+	cmdName := util.Iptables
+	cmdArgs := append([]string{iptMgr.OperationFlag, entry.Chain}, entry.Specs...)
+
+	cmdOut, err := exec.Command(cmdName, cmdArgs...).Output()
+	log.Printf("%s\n", string(cmdOut))
+
+	if msg, failed := err.(*exec.ExitError); failed {
+		errCode := msg.Sys().(syscall.WaitStatus).ExitStatus()
+		if errCode > 1 {
+			log.Printf("There was an error running command: %s\nArguments:%+v", err, cmdArgs)
+		}
+
+		return errCode, err
+	}
+
+	return 0, nil
+}
+
+// Save saves current iptables configuration to /var/log/iptables.conf
+func (iptMgr *IptablesManager) Save(configFile string) error {
+	if len(configFile) == 0 {
+		configFile = util.IptablesConfigFile
+	}
+
+	// create the config file for writing
+	f, err := os.Create(configFile)
+	if err != nil {
+		log.Printf("Error opening file: %s.", configFile)
+		return err
+	}
+	defer f.Close()
+
+	cmd := exec.Command(util.IptablesSave)
+	cmd.Stdout = f
+	if err := cmd.Start(); err != nil {
+		log.Printf("Error running iptables-save.\n")
+		return err
+	}
+	cmd.Wait()
+
+	return nil
+}
+
+// Restore restores iptables configuration from /var/log/iptables.conf
+func (iptMgr *IptablesManager) Restore(configFile string) error {
+	if len(configFile) == 0 {
+		configFile = util.IptablesConfigFile
+	}
+
+	// open the config file for reading
+	f, err := os.Open(configFile)
+	if err != nil {
+		log.Printf("Error opening file: %s.", configFile)
+		return err
+	}
+	defer f.Close()
+
+	cmd := exec.Command(util.IptablesRestore)
+	cmd.Stdin = f
+	if err := cmd.Start(); err != nil {
+		log.Printf("Error running iptables-restore.\n")
+		return err
+	}
+	cmd.Wait()
+
+	return nil
+}

--- a/npm/iptm/iptm_test.go
+++ b/npm/iptm/iptm_test.go
@@ -1,0 +1,210 @@
+package iptm
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-container-networking/npm/util"
+)
+
+func TestSave(t *testing.T) {
+	iptMgr := &IptablesManager{}
+	if err := iptMgr.Save(util.IptablesTestConfigFile); err != nil {
+		t.Errorf("TestSave failed @ iptMgr.Save")
+	}
+}
+
+func TestRestore(t *testing.T) {
+	iptMgr := &IptablesManager{}
+	if err := iptMgr.Save(util.IptablesTestConfigFile); err != nil {
+		t.Errorf("TestRestore failed @ iptMgr.Save")
+	}
+
+	if err := iptMgr.Restore(util.IptablesTestConfigFile); err != nil {
+		t.Errorf("TestRestore failed @ iptMgr.Restore")
+	}
+}
+
+func TestInitNpmChains(t *testing.T) {
+	iptMgr := &IptablesManager{}
+
+	if err := iptMgr.Save(util.IptablesTestConfigFile); err != nil {
+		t.Errorf("TestInitNpmChains failed @ iptMgr.Save")
+	}
+
+	defer func() {
+		if err := iptMgr.Restore(util.IptablesTestConfigFile); err != nil {
+			t.Errorf("TestInitNpmChains failed @ iptMgr.Restore")
+		}
+	}()
+
+	if err := iptMgr.InitNpmChains(); err != nil {
+		t.Errorf("TestInitNpmChains @ iptMgr.InitNpmChains")
+	}
+}
+
+func TestUninitNpmChains(t *testing.T) {
+	iptMgr := &IptablesManager{}
+
+	if err := iptMgr.Save(util.IptablesTestConfigFile); err != nil {
+		t.Errorf("TestUninitNpmChains failed @ iptMgr.Save")
+	}
+
+	defer func() {
+		if err := iptMgr.Restore(util.IptablesTestConfigFile); err != nil {
+			t.Errorf("TestUninitNpmChains failed @ iptMgr.Restore")
+		}
+	}()
+
+	if err := iptMgr.InitNpmChains(); err != nil {
+		t.Errorf("TestUninitNpmChains @ iptMgr.InitNpmChains")
+	}
+
+	if err := iptMgr.UninitNpmChains(); err != nil {
+		t.Errorf("TestUninitNpmChains @ iptMgr.UninitNpmChains")
+	}
+}
+
+func TestExists(t *testing.T) {
+	iptMgr := &IptablesManager{}
+	if err := iptMgr.Save(util.IptablesTestConfigFile); err != nil {
+		t.Errorf("TestExists failed @ iptMgr.Save")
+	}
+
+	defer func() {
+		if err := iptMgr.Restore(util.IptablesTestConfigFile); err != nil {
+			t.Errorf("TestExists failed @ iptMgr.Restore")
+		}
+	}()
+
+	iptMgr.OperationFlag = util.IptablesCheckFlag
+	entry := &IptEntry{
+		Chain: util.IptablesForwardChain,
+		Specs: []string{
+			util.IptablesJumpFlag,
+			util.IptablesAccept,
+		},
+	}
+	if _, err := iptMgr.Exists(entry); err != nil {
+		t.Errorf("TestExists failed @ iptMgr.Exists")
+	}
+}
+
+func TestAddChain(t *testing.T) {
+	iptMgr := &IptablesManager{}
+	if err := iptMgr.Save(util.IptablesTestConfigFile); err != nil {
+		t.Errorf("TestAddChain failed @ iptMgr.Save")
+	}
+
+	defer func() {
+		if err := iptMgr.Restore(util.IptablesTestConfigFile); err != nil {
+			t.Errorf("TestAddChain failed @ iptMgr.Restore")
+		}
+	}()
+
+	if err := iptMgr.AddChain("TEST-CHAIN"); err != nil {
+		t.Errorf("TestAddChain failed @ iptMgr.AddChain")
+	}
+}
+
+func TestDeleteChain(t *testing.T) {
+	iptMgr := &IptablesManager{}
+	if err := iptMgr.Save(util.IptablesTestConfigFile); err != nil {
+		t.Errorf("TestDeleteChain failed @ iptMgr.Save")
+	}
+
+	defer func() {
+		if err := iptMgr.Restore(util.IptablesTestConfigFile); err != nil {
+			t.Errorf("TestDeleteChain failed @ iptMgr.Restore")
+		}
+	}()
+
+	if err := iptMgr.AddChain("TEST-CHAIN"); err != nil {
+		t.Errorf("TestDeleteChain failed @ iptMgr.AddChain")
+	}
+
+	if err := iptMgr.DeleteChain("TEST-CHAIN"); err != nil {
+		t.Errorf("TestDeleteChain failed @ iptMgr.DeleteChain")
+	}
+}
+
+func TestAdd(t *testing.T) {
+	iptMgr := &IptablesManager{}
+	if err := iptMgr.Save(util.IptablesTestConfigFile); err != nil {
+		t.Errorf("TestAdd failed @ iptMgr.Save")
+	}
+
+	defer func() {
+		if err := iptMgr.Restore(util.IptablesTestConfigFile); err != nil {
+			t.Errorf("TestAdd failed @ iptMgr.Restore")
+		}
+	}()
+
+	entry := &IptEntry{
+		Chain: util.IptablesForwardChain,
+		Specs: []string{
+			util.IptablesJumpFlag,
+			util.IptablesReject,
+		},
+	}
+	if err := iptMgr.Add(entry); err != nil {
+		t.Errorf("TestAdd failed @ iptMgr.Add")
+	}
+}
+
+func TestDelete(t *testing.T) {
+	iptMgr := &IptablesManager{}
+	if err := iptMgr.Save(util.IptablesTestConfigFile); err != nil {
+		t.Errorf("TestDelete failed @ iptMgr.Save")
+	}
+
+	defer func() {
+		if err := iptMgr.Restore(util.IptablesTestConfigFile); err != nil {
+			t.Errorf("TestDelete failed @ iptMgr.Restore")
+		}
+	}()
+
+	entry := &IptEntry{
+		Chain: util.IptablesForwardChain,
+		Specs: []string{
+			util.IptablesJumpFlag,
+			util.IptablesReject,
+		},
+	}
+	if err := iptMgr.Add(entry); err != nil {
+		t.Errorf("TestDelete failed @ iptMgr.Add")
+	}
+
+	if err := iptMgr.Delete(entry); err != nil {
+		t.Errorf("TestDelete failed @ iptMgr.Delete")
+	}
+}
+
+func TestRun(t *testing.T) {
+	iptMgr := &IptablesManager{}
+	if err := iptMgr.Save(util.IptablesTestConfigFile); err != nil {
+		t.Errorf("TestRun failed @ iptMgr.Save")
+	}
+
+	defer func() {
+		if err := iptMgr.Restore(util.IptablesTestConfigFile); err != nil {
+			t.Errorf("TestRun failed @ iptMgr.Restore")
+		}
+	}()
+
+	iptMgr.OperationFlag = util.IptablesChainCreationFlag
+	entry := &IptEntry{
+		Chain: "TEST-CHAIN",
+	}
+	if _, err := iptMgr.Run(entry); err != nil {
+		t.Errorf("TestRun failed @ iptMgr.Run")
+	}
+}
+
+func TestMain(m *testing.M) {
+	iptMgr := NewIptablesManager()
+	iptMgr.Save(util.IptablesConfigFile)
+
+	m.Run()
+
+	iptMgr.Restore(util.IptablesConfigFile)
+}

--- a/npm/namespace.go
+++ b/npm/namespace.go
@@ -1,3 +1,5 @@
+// Copyright 2018 Microsoft. All rights reserved.
+// MIT License
 package npm
 
 import (

--- a/npm/namespace.go
+++ b/npm/namespace.go
@@ -76,7 +76,7 @@ func (npMgr *NetworkPolicyManager) UninitAllNsList() error {
 	return nil
 }
 
-// AddNamespace handles add namespace.
+// AddNamespace handles adding  namespace to ipset.
 func (npMgr *NetworkPolicyManager) AddNamespace(nsObj *corev1.Namespace) error {
 	npMgr.Lock()
 	defer npMgr.Unlock()
@@ -128,7 +128,7 @@ func (npMgr *NetworkPolicyManager) AddNamespace(nsObj *corev1.Namespace) error {
 	return nil
 }
 
-// UpdateNamespace handles update namespace.
+// UpdateNamespace handles updating namespace in ipset.
 func (npMgr *NetworkPolicyManager) UpdateNamespace(oldNsObj *corev1.Namespace, newNsObj *corev1.Namespace) error {
 	var err error
 
@@ -156,7 +156,7 @@ func (npMgr *NetworkPolicyManager) UpdateNamespace(oldNsObj *corev1.Namespace, n
 	return nil
 }
 
-// DeleteNamespace handles delete namespace.
+// DeleteNamespace handles deleting namespace from ipset.
 func (npMgr *NetworkPolicyManager) DeleteNamespace(nsObj *corev1.Namespace) error {
 	npMgr.Lock()
 	defer npMgr.Unlock()

--- a/npm/namespace.go
+++ b/npm/namespace.go
@@ -15,7 +15,7 @@ type namespace struct {
 	name   string
 	setMap map[string]string
 	podMap map[types.UID]*corev1.Pod
-	npMap  map[string]*networkingv1.NetworkPolicy // TODO: Optimize to ordered map.
+	npMap  map[string]*networkingv1.NetworkPolicy
 	ipsMgr *ipsm.IpsetManager
 	iptMgr *iptm.IptablesManager
 }
@@ -90,7 +90,7 @@ func (npMgr *NetworkPolicyManager) AddNamespace(nsObj *corev1.Namespace) error {
 	}()
 
 	nsName, nsNs := nsObj.ObjectMeta.Name, nsObj.ObjectMeta.Namespace
-	log.Printf("NAMESPACE CREATED: %s/%s\n", nsName, nsNs)
+	log.Printf("NAMESPACE CREATING: %s/%s\n", nsName, nsNs)
 
 	ipsMgr := npMgr.nsMap[util.KubeAllNamespacesFlag].ipsMgr
 	// Create ipset for the namespace.
@@ -141,7 +141,7 @@ func (npMgr *NetworkPolicyManager) UpdateNamespace(oldNsObj *corev1.Namespace, n
 	}()
 
 	oldNsName, newNsName := oldNsObj.ObjectMeta.Name, newNsObj.ObjectMeta.Name
-	log.Printf("NAMESPACE UPDATED. %s/%s", oldNsName, newNsName)
+	log.Printf("NAMESPACE UPDATING. %s/%s", oldNsName, newNsName)
 
 	if err = npMgr.DeleteNamespace(oldNsObj); err != nil {
 		return err
@@ -170,7 +170,7 @@ func (npMgr *NetworkPolicyManager) DeleteNamespace(nsObj *corev1.Namespace) erro
 	}()
 
 	nsName, nsNs := nsObj.ObjectMeta.Name, nsObj.ObjectMeta.Namespace
-	log.Printf("NAMESPACE DELETED: %s/%s\n", nsName, nsNs)
+	log.Printf("NAMESPACE DELETING: %s/%s\n", nsName, nsNs)
 
 	_, exists := npMgr.nsMap[nsName]
 	if !exists {

--- a/npm/namespace.go
+++ b/npm/namespace.go
@@ -1,0 +1,177 @@
+package npm
+
+import (
+	"github.com/Azure/azure-container-networking/log"
+	"github.com/Azure/azure-container-networking/npm/ipsm"
+	"github.com/Azure/azure-container-networking/npm/iptm"
+	"github.com/Azure/azure-container-networking/npm/util"
+	"k8s.io/apimachinery/pkg/types"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+type namespace struct {
+	name   string
+	setMap map[string]string
+	podMap map[types.UID]*corev1.Pod
+	npMap  map[string]*networkingv1.NetworkPolicy // TODO: Optimize to ordered map.
+	ipsMgr *ipsm.IpsetManager
+	iptMgr *iptm.IptablesManager
+}
+
+// newNS constructs a new namespace object.
+func newNs(name string) (*namespace, error) {
+	ns := &namespace{
+		name:   name,
+		setMap: make(map[string]string),
+		podMap: make(map[types.UID]*corev1.Pod),
+		npMap:  make(map[string]*networkingv1.NetworkPolicy),
+		ipsMgr: ipsm.NewIpsetManager(),
+		iptMgr: iptm.NewIptablesManager(),
+	}
+
+	return ns, nil
+}
+
+func isSystemNs(nsObj *corev1.Namespace) bool {
+	return nsObj.ObjectMeta.Name == util.KubeSystemFlag
+}
+
+func getNsIpsetName(k, v string) string {
+	return "ns-" + k + ":" + v
+}
+
+// InitAllNsList syncs all-namespace ipset list.
+func (npMgr *NetworkPolicyManager) InitAllNsList() error {
+	allNs := npMgr.nsMap[util.KubeAllNamespacesFlag]
+	for nsName := range npMgr.nsMap {
+		if nsName == util.KubeAllNamespacesFlag {
+			continue
+		}
+
+		if err := allNs.ipsMgr.AddToList(util.KubeAllNamespacesFlag, nsName); err != nil {
+			log.Printf("Error adding namespace set %s to list %s\n", nsName, util.KubeAllNamespacesFlag)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// UninitAllNsList cleans all-namespace ipset list.
+func (npMgr *NetworkPolicyManager) UninitAllNsList() error {
+	allNs := npMgr.nsMap[util.KubeAllNamespacesFlag]
+	for nsName := range npMgr.nsMap {
+		if nsName == util.KubeAllNamespacesFlag {
+			continue
+		}
+
+		if err := allNs.ipsMgr.DeleteFromList(util.KubeAllNamespacesFlag, nsName); err != nil {
+			log.Printf("Error deleting namespace set %s from list %s\n", nsName, util.KubeAllNamespacesFlag)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// AddNamespace handles add namespace.
+func (npMgr *NetworkPolicyManager) AddNamespace(nsObj *corev1.Namespace) error {
+	npMgr.Lock()
+	defer npMgr.Unlock()
+
+	nsName, nsNs := nsObj.ObjectMeta.Name, nsObj.ObjectMeta.Namespace
+	log.Printf("NAMESPACE CREATED: %s/%s\n", nsName, nsNs)
+
+	ipsMgr := npMgr.nsMap[util.KubeAllNamespacesFlag].ipsMgr
+	// Create ipset for the namespace.
+	if err := ipsMgr.CreateSet(nsName); err != nil {
+		log.Printf("Error creating ipset for namespace %s.\n", nsName)
+		return err
+	}
+
+	if err := ipsMgr.AddToList(util.KubeAllNamespacesFlag, nsName); err != nil {
+		log.Printf("Error adding %s to all-namespace ipset list.\n", nsName)
+		return err
+	}
+
+	// Add the namespace to its label's ipset list.
+	var labelKeys []string
+	nsLabels := nsObj.ObjectMeta.Labels
+	for nsLabelKey, nsLabelVal := range nsLabels {
+		labelKey := getNsIpsetName(nsLabelKey, nsLabelVal)
+		log.Printf("Adding namespace %s to ipset list %s\n", nsName, labelKey)
+		if err := ipsMgr.AddToList(labelKey, nsName); err != nil {
+			log.Printf("Error Adding namespace %s to ipset list %s\n", nsName, labelKey)
+			return err
+		}
+		labelKeys = append(labelKeys, labelKey)
+	}
+
+	ns, err := newNs(nsName)
+	if err != nil {
+		log.Printf("Error creating namespace %s\n", nsName)
+	}
+	npMgr.nsMap[nsName] = ns
+
+	return nil
+}
+
+// UpdateNamespace handles update namespace.
+func (npMgr *NetworkPolicyManager) UpdateNamespace(oldNsObj *corev1.Namespace, newNsObj *corev1.Namespace) error {
+	oldNsName, newNsName := oldNsObj.ObjectMeta.Name, newNsObj.ObjectMeta.Name
+	log.Printf("NAMESPACE UPDATED. %s/%s", oldNsName, newNsName)
+
+	npMgr.DeleteNamespace(oldNsObj)
+
+	if newNsObj.ObjectMeta.DeletionTimestamp == nil && newNsObj.ObjectMeta.DeletionGracePeriodSeconds == nil {
+		npMgr.AddNamespace(newNsObj)
+	}
+
+	return nil
+}
+
+// DeleteNamespace handles delete namespace.
+func (npMgr *NetworkPolicyManager) DeleteNamespace(nsObj *corev1.Namespace) error {
+	npMgr.Lock()
+	defer npMgr.Unlock()
+
+	nsName, nsNs := nsObj.ObjectMeta.Name, nsObj.ObjectMeta.Namespace
+	log.Printf("NAMESPACE DELETED: %s/%s\n", nsName, nsNs)
+
+	_, exists := npMgr.nsMap[nsName]
+	if !exists {
+		return nil
+	}
+
+	// Delete the namespace from its label's ipset list.
+	ipsMgr := npMgr.nsMap[util.KubeAllNamespacesFlag].ipsMgr
+	var labelKeys []string
+	nsLabels := nsObj.ObjectMeta.Labels
+	for nsLabelKey, nsLabelVal := range nsLabels {
+		labelKey := getNsIpsetName(nsLabelKey, nsLabelVal)
+		log.Printf("Deleting namespace %s from ipset list %s\n", nsName, labelKey)
+		if err := ipsMgr.DeleteFromList(labelKey, nsName); err != nil {
+			log.Printf("Error deleting namespace %s from ipset list %s\n", nsName, labelKey)
+			return err
+		}
+		labelKeys = append(labelKeys, labelKey)
+	}
+
+	// Delete the namespace from all-namespace ipset list.
+	if err := ipsMgr.DeleteFromList(util.KubeAllNamespacesFlag, nsName); err != nil {
+		log.Printf("Error deleting namespace %s from ipset list %s\n", nsName, util.KubeAllNamespacesFlag)
+		return err
+	}
+
+	// Delete ipset for the namespace.
+	if err := ipsMgr.DeleteSet(nsName); err != nil {
+		log.Printf("Error deleting ipset for namespace %s.\n", nsName)
+		return err
+	}
+
+	delete(npMgr.nsMap, nsName)
+
+	return nil
+}

--- a/npm/namespace_test.go
+++ b/npm/namespace_test.go
@@ -1,3 +1,5 @@
+// Copyright 2018 Microsoft. All rights reserved.
+// MIT License
 package npm
 
 import (

--- a/npm/namespace_test.go
+++ b/npm/namespace_test.go
@@ -1,0 +1,179 @@
+package npm
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-container-networking/npm/iptm"
+
+	"github.com/Azure/azure-container-networking/npm/ipsm"
+	"github.com/Azure/azure-container-networking/npm/util"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestnewNs(t *testing.T) {
+	if _, err := newNs("test"); err != nil {
+		t.Errorf("TestnewNs failed @ newNs")
+	}
+}
+
+func TestAllNsList(t *testing.T) {
+	npMgr := &NetworkPolicyManager{}
+
+	ipsMgr := ipsm.NewIpsetManager()
+	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
+		t.Errorf("TestAllNsList failed @ ipsMgr.Save")
+	}
+
+	defer func() {
+		if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
+			t.Errorf("TestAllNsList failed @ ipsMgr.Restore")
+		}
+	}()
+
+	if err := npMgr.InitAllNsList(); err != nil {
+		t.Errorf("TestAllNsList failed @ InitAllNsList")
+	}
+
+	if err := npMgr.UninitAllNsList(); err != nil {
+		t.Errorf("TestAllNsList failed @ UninitAllNsList")
+	}
+}
+
+func TestAddNamespace(t *testing.T) {
+	npMgr := &NetworkPolicyManager{
+		nsMap: make(map[string]*namespace),
+	}
+
+	allNs, err := newNs(util.KubeAllNamespacesFlag)
+	if err != nil {
+		panic(err.Error)
+	}
+	npMgr.nsMap[util.KubeAllNamespacesFlag] = allNs
+
+	ipsMgr := ipsm.NewIpsetManager()
+	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
+		t.Errorf("TestAddNamespace failed @ ipsMgr.Save")
+	}
+
+	defer func() {
+		if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
+			t.Errorf("TestAddNamespace failed @ ipsMgr.Restore")
+		}
+	}()
+
+	nsObj := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-namespace",
+			Labels: map[string]string{
+				"app": "test-namespace",
+			},
+		},
+	}
+
+	if err := npMgr.AddNamespace(nsObj); err != nil {
+		t.Errorf("TestAddNamespace @ npMgr.AddNamespace")
+	}
+}
+
+func TestUpdateNamespace(t *testing.T) {
+	npMgr := &NetworkPolicyManager{
+		nsMap: make(map[string]*namespace),
+	}
+
+	allNs, err := newNs(util.KubeAllNamespacesFlag)
+	if err != nil {
+		panic(err.Error)
+	}
+	npMgr.nsMap[util.KubeAllNamespacesFlag] = allNs
+
+	ipsMgr := ipsm.NewIpsetManager()
+	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
+		t.Errorf("TestUpdateNamespace failed @ ipsMgr.Save")
+	}
+
+	defer func() {
+		if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
+			t.Errorf("TestUpdateNamespace failed @ ipsMgr.Restore")
+		}
+	}()
+
+	oldNsObj := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "old-test-namespace",
+			Labels: map[string]string{
+				"app": "old-test-namespace",
+			},
+		},
+	}
+
+	newNsObj := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "new-test-namespace",
+			Labels: map[string]string{
+				"app": "new-test-namespace",
+			},
+		},
+	}
+
+	if err := npMgr.AddNamespace(oldNsObj); err != nil {
+		t.Errorf("TestUpdateNamespace failed @ npMgr.AddNamespace")
+	}
+
+	if err := npMgr.UpdateNamespace(oldNsObj, newNsObj); err != nil {
+		t.Errorf("TestUpdateNamespace failed @ npMgr.UpdateNamespace")
+	}
+}
+
+func TestDeleteNamespace(t *testing.T) {
+	npMgr := &NetworkPolicyManager{
+		nsMap: make(map[string]*namespace),
+	}
+
+	allNs, err := newNs(util.KubeAllNamespacesFlag)
+	if err != nil {
+		panic(err.Error)
+	}
+	npMgr.nsMap[util.KubeAllNamespacesFlag] = allNs
+
+	ipsMgr := ipsm.NewIpsetManager()
+	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
+		t.Errorf("TestDeleteNamespace failed @ ipsMgr.Save")
+	}
+
+	defer func() {
+		if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
+			t.Errorf("TestDeleteNamespace failed @ ipsMgr.Restore")
+		}
+	}()
+
+	nsObj := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-namespace",
+			Labels: map[string]string{
+				"app": "test-namespace",
+			},
+		},
+	}
+
+	if err := npMgr.AddNamespace(nsObj); err != nil {
+		t.Errorf("TestDeleteNamespace @ npMgr.AddNamespace")
+	}
+
+	if err := npMgr.DeleteNamespace(nsObj); err != nil {
+		t.Errorf("TestDeleteNamespace @ npMgr.DeleteNamespace")
+	}
+}
+
+func TestMain(m *testing.M) {
+	iptMgr := iptm.NewIptablesManager()
+	iptMgr.Save(util.IptablesConfigFile)
+
+	ipsMgr := ipsm.NewIpsetManager()
+	ipsMgr.Save(util.IpsetConfigFile)
+
+	m.Run()
+
+	iptMgr.Restore(util.IptablesConfigFile)
+	ipsMgr.Restore(util.IpsetConfigFile)
+}

--- a/npm/npm.go
+++ b/npm/npm.go
@@ -1,3 +1,5 @@
+// Copyright 2018 Microsoft. All rights reserved.
+// MIT License
 package npm
 
 import (

--- a/npm/npm.go
+++ b/npm/npm.go
@@ -1,0 +1,124 @@
+package npm
+
+import (
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/Azure/azure-container-networking/npm/util"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	networkinginformers "k8s.io/client-go/informers/networking/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+// NetworkPolicyManager contains informers for pod, namespace and networkpolicy.
+type NetworkPolicyManager struct {
+	sync.Mutex
+	clientset *kubernetes.Clientset
+
+	informerFactory informers.SharedInformerFactory
+	podInformer     coreinformers.PodInformer
+	nsInformer      coreinformers.NamespaceInformer
+	npInformer      networkinginformers.NetworkPolicyInformer
+
+	nodeName               string
+	nsMap                  map[string]*namespace
+	isAzureNpmChainCreated bool
+}
+
+// Run starts shared informers and waits for the shared informer cache to sync.
+func (npMgr *NetworkPolicyManager) Run(stopCh <-chan struct{}) error {
+	// Starts all informers manufactured by npMgr's informerFactory.
+	npMgr.informerFactory.Start(stopCh)
+
+	// Wait for the initial sync of local cache.
+	if !cache.WaitForCacheSync(stopCh, npMgr.podInformer.Informer().HasSynced) {
+		return fmt.Errorf("Pod informer failed to sync")
+	}
+
+	if !cache.WaitForCacheSync(stopCh, npMgr.nsInformer.Informer().HasSynced) {
+		return fmt.Errorf("Namespace informer failed to sync")
+	}
+
+	if !cache.WaitForCacheSync(stopCh, npMgr.npInformer.Informer().HasSynced) {
+		return fmt.Errorf("Namespace informer failed to sync")
+	}
+
+	return nil
+}
+
+// NewNetworkPolicyManager creates a NetworkPolicyManager
+func NewNetworkPolicyManager(clientset *kubernetes.Clientset, informerFactory informers.SharedInformerFactory) *NetworkPolicyManager {
+
+	podInformer := informerFactory.Core().V1().Pods()
+	nsInformer := informerFactory.Core().V1().Namespaces()
+	npInformer := informerFactory.Networking().V1().NetworkPolicies()
+
+	npMgr := &NetworkPolicyManager{
+		clientset:       clientset,
+		informerFactory: informerFactory,
+		podInformer:     podInformer,
+		nsInformer:      nsInformer,
+		npInformer:      npInformer,
+		nodeName:        os.Getenv("HOSTNAME"),
+		nsMap:           make(map[string]*namespace),
+		isAzureNpmChainCreated: false,
+	}
+
+	allNs, err := newNs(util.KubeAllNamespacesFlag)
+	if err != nil {
+		panic(err.Error)
+	}
+	npMgr.nsMap[util.KubeAllNamespacesFlag] = allNs
+
+	podInformer.Informer().AddEventHandler(
+		// Pod event handlers
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				npMgr.AddPod(obj.(*corev1.Pod))
+			},
+			UpdateFunc: func(old, new interface{}) {
+				npMgr.UpdatePod(old.(*corev1.Pod), new.(*corev1.Pod))
+			},
+			DeleteFunc: func(obj interface{}) {
+				npMgr.DeletePod(obj.(*corev1.Pod))
+			},
+		},
+	)
+
+	nsInformer.Informer().AddEventHandler(
+		// Namespace event handlers
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				npMgr.AddNamespace(obj.(*corev1.Namespace))
+			},
+			UpdateFunc: func(old, new interface{}) {
+				npMgr.UpdateNamespace(old.(*corev1.Namespace), new.(*corev1.Namespace))
+			},
+			DeleteFunc: func(obj interface{}) {
+				npMgr.DeleteNamespace(obj.(*corev1.Namespace))
+			},
+		},
+	)
+
+	npInformer.Informer().AddEventHandler(
+		// Network policy event handlers
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				npMgr.AddNetworkPolicy(obj.(*networkingv1.NetworkPolicy))
+			},
+			UpdateFunc: func(old, new interface{}) {
+				npMgr.UpdateNetworkPolicy(old.(*networkingv1.NetworkPolicy), new.(*networkingv1.NetworkPolicy))
+			},
+			DeleteFunc: func(obj interface{}) {
+				npMgr.DeleteNetworkPolicy(obj.(*networkingv1.NetworkPolicy))
+			},
+		},
+	)
+
+	return npMgr
+}

--- a/npm/nwpolicy.go
+++ b/npm/nwpolicy.go
@@ -1,3 +1,5 @@
+// Copyright 2018 Microsoft. All rights reserved.
+// MIT License
 package npm
 
 import (

--- a/npm/nwpolicy.go
+++ b/npm/nwpolicy.go
@@ -6,7 +6,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 )
 
-// AddNetworkPolicy adds network policy.
+// AddNetworkPolicy handles adding network policy to iptables.
 func (npMgr *NetworkPolicyManager) AddNetworkPolicy(npObj *networkingv1.NetworkPolicy) error {
 	npMgr.Lock()
 	defer npMgr.Unlock()
@@ -81,7 +81,7 @@ func (npMgr *NetworkPolicyManager) AddNetworkPolicy(npObj *networkingv1.NetworkP
 	return nil
 }
 
-// UpdateNetworkPolicy updates network policy.
+// UpdateNetworkPolicy handles updateing network policy in iptables.
 func (npMgr *NetworkPolicyManager) UpdateNetworkPolicy(oldNpObj *networkingv1.NetworkPolicy, newNpObj *networkingv1.NetworkPolicy) error {
 	var err error
 
@@ -109,7 +109,7 @@ func (npMgr *NetworkPolicyManager) UpdateNetworkPolicy(oldNpObj *networkingv1.Ne
 	return nil
 }
 
-// DeleteNetworkPolicy deletes network policy.
+// DeleteNetworkPolicy handles deleting network policy from iptables.
 func (npMgr *NetworkPolicyManager) DeleteNetworkPolicy(npObj *networkingv1.NetworkPolicy) error {
 	npMgr.Lock()
 	defer npMgr.Unlock()

--- a/npm/nwpolicy.go
+++ b/npm/nwpolicy.go
@@ -20,7 +20,7 @@ func (npMgr *NetworkPolicyManager) AddNetworkPolicy(npObj *networkingv1.NetworkP
 	}()
 
 	npNs, npName := npObj.ObjectMeta.Namespace, npObj.ObjectMeta.Name
-	log.Printf("NETWORK POLICY CREATED: %s/%s\n", npNs, npName)
+	log.Printf("NETWORK POLICY CREATING: %s/%s\n", npNs, npName)
 
 	allNs := npMgr.nsMap[util.KubeAllNamespacesFlag]
 
@@ -94,7 +94,7 @@ func (npMgr *NetworkPolicyManager) UpdateNetworkPolicy(oldNpObj *networkingv1.Ne
 	}()
 
 	oldNpNs, oldNpName := oldNpObj.ObjectMeta.Namespace, oldNpObj.ObjectMeta.Name
-	log.Printf("NETWORK POLICY UPDATED: %s/%s\n", oldNpNs, oldNpName)
+	log.Printf("NETWORK POLICY UPDATING: %s/%s\n", oldNpNs, oldNpName)
 
 	if err = npMgr.DeleteNetworkPolicy(oldNpObj); err != nil {
 		return err
@@ -123,7 +123,7 @@ func (npMgr *NetworkPolicyManager) DeleteNetworkPolicy(npObj *networkingv1.Netwo
 	}()
 
 	npNs, npName := npObj.ObjectMeta.Namespace, npObj.ObjectMeta.Name
-	log.Printf("NETWORK POLICY DELETED: %s/%s\n", npNs, npName)
+	log.Printf("NETWORK POLICY DELETING: %s/%s\n", npNs, npName)
 
 	allNs := npMgr.nsMap[util.KubeAllNamespacesFlag]
 

--- a/npm/nwpolicy.go
+++ b/npm/nwpolicy.go
@@ -1,0 +1,119 @@
+package npm
+
+import (
+	"github.com/Azure/azure-container-networking/log"
+	"github.com/Azure/azure-container-networking/npm/util"
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+// AddNetworkPolicy adds network policy.
+func (npMgr *NetworkPolicyManager) AddNetworkPolicy(npObj *networkingv1.NetworkPolicy) error {
+	npMgr.Lock()
+	defer npMgr.Unlock()
+
+	npNs, npName := npObj.ObjectMeta.Namespace, npObj.ObjectMeta.Name
+	log.Printf("NETWORK POLICY CREATED: %s/%s\n", npNs, npName)
+
+	allNs := npMgr.nsMap[util.KubeAllNamespacesFlag]
+
+	if !npMgr.isAzureNpmChainCreated {
+		if err := allNs.ipsMgr.CreateSet(util.KubeSystemFlag); err != nil {
+			log.Printf("Error initialize kube-system ipset.\n")
+			return err
+		}
+
+		if err := allNs.iptMgr.InitNpmChains(); err != nil {
+			log.Printf("Error initialize azure-npm chains.\n")
+			return err
+		}
+
+		npMgr.isAzureNpmChainCreated = true
+	}
+
+	podSets, nsLists, iptEntries := parsePolicy(npObj)
+
+	ipsMgr := allNs.ipsMgr
+	for _, set := range podSets {
+		if err := ipsMgr.CreateSet(set); err != nil {
+			log.Printf("Error creating ipset %s-%s\n", npNs, set)
+			return err
+		}
+	}
+
+	for _, list := range nsLists {
+		if err := ipsMgr.CreateList(list); err != nil {
+			log.Printf("Error creating ipset list %s-%s\n", npNs, list)
+			return err
+		}
+	}
+
+	if err := npMgr.InitAllNsList(); err != nil {
+		log.Printf("Error initializing all-namespace ipset list.\n")
+		return err
+	}
+
+	iptMgr := allNs.iptMgr
+	for _, iptEntry := range iptEntries {
+		if err := iptMgr.Add(iptEntry); err != nil {
+			log.Printf("Error applying iptables rule\n. Rule: %+v", iptEntry)
+			return err
+		}
+	}
+
+	allNs.npMap[npName] = npObj
+
+	ns, err := newNs(npNs)
+	if err != nil {
+		log.Printf("Error creating namespace %s\n", npNs)
+	}
+	npMgr.nsMap[npNs] = ns
+
+	return nil
+}
+
+// UpdateNetworkPolicy updates network policy.
+func (npMgr *NetworkPolicyManager) UpdateNetworkPolicy(oldNpObj *networkingv1.NetworkPolicy, newNpObj *networkingv1.NetworkPolicy) error {
+	oldNpNs, oldNpName := oldNpObj.ObjectMeta.Namespace, oldNpObj.ObjectMeta.Name
+	log.Printf("NETWORK POLICY UPDATED: %s/%s\n", oldNpNs, oldNpName)
+
+	npMgr.DeleteNetworkPolicy(oldNpObj)
+
+	if newNpObj.ObjectMeta.DeletionTimestamp == nil && newNpObj.ObjectMeta.DeletionGracePeriodSeconds == nil {
+		npMgr.AddNetworkPolicy(newNpObj)
+	}
+
+	return nil
+}
+
+// DeleteNetworkPolicy deletes network policy.
+func (npMgr *NetworkPolicyManager) DeleteNetworkPolicy(npObj *networkingv1.NetworkPolicy) error {
+	npMgr.Lock()
+	defer npMgr.Unlock()
+
+	npNs, npName := npObj.ObjectMeta.Namespace, npObj.ObjectMeta.Name
+	log.Printf("NETWORK POLICY DELETED: %s/%s\n", npNs, npName)
+
+	allNs := npMgr.nsMap[util.KubeAllNamespacesFlag]
+
+	_, _, iptEntries := parsePolicy(npObj)
+
+	iptMgr := allNs.iptMgr
+	for _, iptEntry := range iptEntries {
+		if err := iptMgr.Delete(iptEntry); err != nil {
+			log.Printf("Error applying iptables rule.\n Rule: %+v", iptEntry)
+			return err
+		}
+	}
+
+	delete(allNs.npMap, npName)
+
+	if len(allNs.npMap) == 0 {
+		if err := iptMgr.UninitNpmChains(); err != nil {
+			log.Printf("Error uninitialize azure-npm chains.\n")
+			return err
+		}
+		npMgr.isAzureNpmChainCreated = false
+	}
+
+	return nil
+}

--- a/npm/nwpolicy_test.go
+++ b/npm/nwpolicy_test.go
@@ -1,3 +1,5 @@
+// Copyright 2018 Microsoft. All rights reserved.
+// MIT License
 package npm
 
 import (

--- a/npm/nwpolicy_test.go
+++ b/npm/nwpolicy_test.go
@@ -1,0 +1,268 @@
+package npm
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-container-networking/npm/ipsm"
+	"github.com/Azure/azure-container-networking/npm/iptm"
+	"github.com/Azure/azure-container-networking/npm/util"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestAddNetworkPolicy(t *testing.T) {
+	npMgr := &NetworkPolicyManager{
+		nsMap: make(map[string]*namespace),
+	}
+
+	allNs, err := newNs(util.KubeAllNamespacesFlag)
+	if err != nil {
+		panic(err.Error)
+	}
+	npMgr.nsMap[util.KubeAllNamespacesFlag] = allNs
+
+	iptMgr := iptm.NewIptablesManager()
+	if err := iptMgr.Save(util.IptablesTestConfigFile); err != nil {
+		t.Errorf("TestAddNetworkPolicy failed @ iptMgr.Save")
+	}
+
+	ipsMgr := ipsm.NewIpsetManager()
+	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
+		t.Errorf("TestAddNetworkPolicy failed @ ipsMgr.Save")
+	}
+
+	defer func() {
+		if err := iptMgr.Restore(util.IptablesTestConfigFile); err != nil {
+			t.Errorf("TestAddNetworkPolicy failed @ iptMgr.Restore")
+		}
+
+		if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
+			t.Errorf("TestAddNetworkPolicy failed @ ipsMgr.Restore")
+		}
+	}()
+
+	nsObj := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-nwpolicy",
+			Labels: map[string]string{
+				"app": "test-namespace",
+			},
+		},
+	}
+
+	if err := npMgr.AddNamespace(nsObj); err != nil {
+		t.Errorf("TestAddNetworkPolicy @ npMgr.AddNamespace")
+	}
+
+	tcp := corev1.ProtocolTCP
+	allow := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "allow-ingress",
+			Namespace: "test-nwpolicy",
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				networkingv1.NetworkPolicyIngressRule{
+					From: []networkingv1.NetworkPolicyPeer{{
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"},
+						},
+					}},
+					Ports: []networkingv1.NetworkPolicyPort{{
+						Protocol: &tcp,
+						Port: &intstr.IntOrString{
+							StrVal: "8000",
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	if err := npMgr.AddNetworkPolicy(allow); err != nil {
+		t.Errorf("TestAddNetworkPolicy failed @ AddNetworkPolicy")
+	}
+}
+
+func TestUpdateNetworkPolicy(t *testing.T) {
+	npMgr := &NetworkPolicyManager{
+		nsMap: make(map[string]*namespace),
+	}
+
+	allNs, err := newNs(util.KubeAllNamespacesFlag)
+	if err != nil {
+		panic(err.Error)
+	}
+	npMgr.nsMap[util.KubeAllNamespacesFlag] = allNs
+
+	iptMgr := iptm.NewIptablesManager()
+	if err := iptMgr.Save(util.IptablesTestConfigFile); err != nil {
+		t.Errorf("UpdateAddNetworkPolicy failed @ iptMgr.Save")
+	}
+
+	ipsMgr := ipsm.NewIpsetManager()
+	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
+		t.Errorf("UpdateAddNetworkPolicy failed @ ipsMgr.Save")
+	}
+
+	defer func() {
+		if err := iptMgr.Restore(util.IptablesTestConfigFile); err != nil {
+			t.Errorf("UpdateAddNetworkPolicy failed @ iptMgr.Restore")
+		}
+
+		if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
+			t.Errorf("UpdateAddNetworkPolicy failed @ ipsMgr.Restore")
+		}
+	}()
+
+	nsObj := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-nwpolicy",
+			Labels: map[string]string{
+				"app": "test-namespace",
+			},
+		},
+	}
+
+	if err := npMgr.AddNamespace(nsObj); err != nil {
+		t.Errorf("TestAddNetworkPolicy @ npMgr.AddNamespace")
+	}
+
+	tcp, udp := corev1.ProtocolTCP, corev1.ProtocolUDP
+	allowIngress := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "allow-ingress",
+			Namespace: "test-nwpolicy",
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				networkingv1.NetworkPolicyIngressRule{
+					From: []networkingv1.NetworkPolicyPeer{{
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"},
+						},
+					}},
+					Ports: []networkingv1.NetworkPolicyPort{{
+						Protocol: &tcp,
+						Port: &intstr.IntOrString{
+							StrVal: "8000",
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	allowEgress := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "allow-egress",
+			Namespace: "test-nwpolicy",
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				networkingv1.NetworkPolicyEgressRule{
+					To: []networkingv1.NetworkPolicyPeer{{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"ns": "test"},
+						},
+					}},
+					Ports: []networkingv1.NetworkPolicyPort{{
+						Protocol: &udp,
+						Port: &intstr.IntOrString{
+							StrVal: "8001",
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	if err := npMgr.AddNetworkPolicy(allowIngress); err != nil {
+		t.Errorf("TestUpdateNetworkPolicy failed @ AddNetworkPolicy")
+	}
+
+	if err := npMgr.UpdateNetworkPolicy(allowIngress, allowEgress); err != nil {
+		t.Errorf("TestUpdateNetworkPolicy failed @ UpdateNetworkPolicy")
+	}
+}
+
+func TestDeleteNetworkPolicy(t *testing.T) {
+	npMgr := &NetworkPolicyManager{
+		nsMap: make(map[string]*namespace),
+	}
+
+	allNs, err := newNs(util.KubeAllNamespacesFlag)
+	if err != nil {
+		panic(err.Error)
+	}
+	npMgr.nsMap[util.KubeAllNamespacesFlag] = allNs
+
+	iptMgr := iptm.NewIptablesManager()
+	if err := iptMgr.Save(util.IptablesTestConfigFile); err != nil {
+		t.Errorf("TestDeleteNetworkPolicy failed @ iptMgr.Save")
+	}
+
+	ipsMgr := ipsm.NewIpsetManager()
+	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
+		t.Errorf("TestDeleteNetworkPolicy failed @ ipsMgr.Save")
+	}
+
+	defer func() {
+		if err := iptMgr.Restore(util.IptablesTestConfigFile); err != nil {
+			t.Errorf("TestDeleteNetworkPolicy failed @ iptMgr.Restore")
+		}
+
+		if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
+			t.Errorf("TestDeleteNetworkPolicy failed @ ipsMgr.Restore")
+		}
+	}()
+
+	nsObj := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-nwpolicy",
+			Labels: map[string]string{
+				"app": "test-namespace",
+			},
+		},
+	}
+
+	if err := npMgr.AddNamespace(nsObj); err != nil {
+		t.Errorf("TestDeleteNetworkPolicy @ npMgr.AddNamespace")
+	}
+
+	tcp := corev1.ProtocolTCP
+	allow := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "allow-ingress",
+			Namespace: "test-nwpolicy",
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				networkingv1.NetworkPolicyIngressRule{
+					From: []networkingv1.NetworkPolicyPeer{{
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"},
+						},
+					}},
+					Ports: []networkingv1.NetworkPolicyPort{{
+						Protocol: &tcp,
+						Port: &intstr.IntOrString{
+							StrVal: "8000",
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	if err := npMgr.AddNetworkPolicy(allow); err != nil {
+		t.Errorf("TestAddNetworkPolicy failed @ AddNetworkPolicy")
+	}
+
+	if err := npMgr.DeleteNetworkPolicy(allow); err != nil {
+		t.Errorf("TestAddNetworkPolicy failed @ DeleteNetworkPolicy")
+	}
+}

--- a/npm/parse.go
+++ b/npm/parse.go
@@ -1,3 +1,5 @@
+// Copyright 2018 Microsoft. All rights reserved.
+// MIT License
 package npm
 
 import (

--- a/npm/parse.go
+++ b/npm/parse.go
@@ -309,7 +309,6 @@ func parseEgress(ns string, targetSets []string, rules []networkingv1.NetworkPol
 		isAppliedToNs = true
 	}
 
-	//TODO: handle IPBlock
 	for _, rule := range rules {
 		for _, portRule := range rule.Ports {
 			protPortPairSlice = append(protPortPairSlice,

--- a/npm/parse.go
+++ b/npm/parse.go
@@ -1,0 +1,667 @@
+package npm
+
+import (
+	"fmt"
+
+	"github.com/Azure/azure-container-networking/log"
+	"github.com/Azure/azure-container-networking/npm/iptm"
+	"github.com/Azure/azure-container-networking/npm/util"
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+// azureNpmPrefix defines prefix for ipset.
+const azureNpmPrefix string = "azure-npm-"
+
+type portsInfo struct {
+	protocol string
+	port     string
+}
+
+func parseIngress(ns string, targetSets []string, rules []networkingv1.NetworkPolicyIngressRule) ([]string, []string, []*iptm.IptEntry) {
+	var (
+		portRuleExists    = false
+		fromRuleExists    = false
+		isAppliedToNs     = false
+		protPortPairSlice []*portsInfo
+		PodNsRuleSets     []string // pod sets listed in Ingress rules.
+		nsRuleLists       []string // namespace sets listed in Ingress rules
+		entries           []*iptm.IptEntry
+		ipblock           *networkingv1.IPBlock
+	)
+
+	if len(targetSets) == 0 {
+		targetSets = append(targetSets, ns)
+		isAppliedToNs = true
+	}
+
+	for _, rule := range rules {
+		for _, portRule := range rule.Ports {
+			protPortPairSlice = append(protPortPairSlice,
+				&portsInfo{
+					protocol: string(*portRule.Protocol),
+					port:     fmt.Sprint(portRule.Port.IntVal),
+				})
+
+			portRuleExists = true
+		}
+
+		for _, fromRule := range rule.From {
+			if fromRule.PodSelector != nil {
+				if len(fromRule.PodSelector.MatchLabels) == 0 {
+					PodNsRuleSets = append(PodNsRuleSets, ns)
+				}
+
+				for podLabelKey, podLabelVal := range fromRule.PodSelector.MatchLabels {
+					PodNsRuleSets = append(PodNsRuleSets, util.KubeAllNamespacesFlag+"-"+podLabelKey+":"+podLabelVal)
+				}
+			}
+
+			if fromRule.NamespaceSelector != nil {
+				if len(fromRule.NamespaceSelector.MatchLabels) == 0 {
+					nsRuleLists = append(nsRuleLists, util.KubeAllNamespacesFlag)
+				}
+
+				for nsLabelKey, nsLabelVal := range fromRule.NamespaceSelector.MatchLabels {
+					nsRuleLists = append(nsRuleLists, "ns-"+nsLabelKey+":"+nsLabelVal)
+				}
+			}
+
+			if fromRule.IPBlock != nil {
+				ipblock = fromRule.IPBlock
+			}
+
+			fromRuleExists = true
+		}
+	}
+
+	if isAppliedToNs {
+		hashedTargetSetName := util.GetHashedName(ns)
+
+		nsDrop := &iptm.IptEntry{
+			Name:       ns,
+			HashedName: hashedTargetSetName,
+			Chain:      util.IptablesAzureTargetSetsChain,
+			Specs: []string{
+				util.IptablesMatchFlag,
+				util.IptablesSetFlag,
+				util.IptablesMatchSetFlag,
+				hashedTargetSetName,
+				util.IptablesDstFlag,
+				util.IptablesJumpFlag,
+				util.IptablesDrop,
+			},
+		}
+		entries = append(entries, nsDrop)
+	}
+
+	// Use hashed string for ipset name to avoid string length limit of ipset.
+	for _, targetSet := range targetSets {
+		log.Printf("Parsing iptables for label %s", targetSet)
+
+		hashedTargetSetName := util.GetHashedName(targetSet)
+
+		if len(rules) == 0 {
+			drop := &iptm.IptEntry{
+				Name:       targetSet,
+				HashedName: hashedTargetSetName,
+				Chain:      util.IptablesAzureIngressPortChain,
+				Specs: []string{
+					util.IptablesMatchFlag,
+					util.IptablesSetFlag,
+					util.IptablesMatchSetFlag,
+					hashedTargetSetName,
+					util.IptablesDstFlag,
+					util.IptablesJumpFlag,
+					util.IptablesDrop,
+				},
+			}
+			entries = append(entries, drop)
+			continue
+		}
+
+		if !portRuleExists && !fromRuleExists {
+			allow := &iptm.IptEntry{
+				Name:       targetSet,
+				HashedName: hashedTargetSetName,
+				Chain:      util.IptablesAzureIngressPortChain,
+				Specs: []string{
+					util.IptablesMatchFlag,
+					util.IptablesSetFlag,
+					util.IptablesMatchSetFlag,
+					hashedTargetSetName,
+					util.IptablesDstFlag,
+					util.IptablesJumpFlag,
+					util.IptablesAccept,
+				},
+			}
+			entries = append(entries, allow)
+			continue
+		}
+
+		if !portRuleExists {
+			entry := &iptm.IptEntry{
+				Name:       targetSet,
+				HashedName: hashedTargetSetName,
+				Chain:      util.IptablesAzureIngressPortChain,
+				Specs: []string{
+					util.IptablesMatchFlag,
+					util.IptablesSetFlag,
+					util.IptablesMatchSetFlag,
+					hashedTargetSetName,
+					util.IptablesDstFlag,
+					util.IptablesJumpFlag,
+					util.IptablesAzureIngressFromChain,
+				},
+			}
+			entries = append(entries, entry)
+		} else {
+			for _, protPortPair := range protPortPairSlice {
+				entry := &iptm.IptEntry{
+					Name:       targetSet,
+					HashedName: hashedTargetSetName,
+					Chain:      util.IptablesAzureIngressPortChain,
+					Specs: []string{
+						util.IptablesProtFlag,
+						protPortPair.protocol,
+						util.IptablesDstPortFlag,
+						protPortPair.port,
+						util.IptablesMatchFlag,
+						util.IptablesSetFlag,
+						util.IptablesMatchSetFlag,
+						hashedTargetSetName,
+						util.IptablesDstFlag,
+						util.IptablesJumpFlag,
+						util.IptablesAzureIngressFromChain,
+					},
+				}
+				entries = append(entries, entry)
+			}
+		}
+
+		if !fromRuleExists {
+			entry := &iptm.IptEntry{
+				Name:       targetSet,
+				HashedName: hashedTargetSetName,
+				Chain:      util.IptablesAzureIngressFromChain,
+				Specs: []string{
+					util.IptablesMatchFlag,
+					util.IptablesSetFlag,
+					util.IptablesMatchSetFlag,
+					hashedTargetSetName,
+					util.IptablesDstFlag,
+					util.IptablesJumpFlag,
+					util.IptablesAccept,
+				},
+			}
+			entries = append(entries, entry)
+			continue
+		}
+
+		if ipblock != nil {
+			// Handle ipblock field of NetworkPolicyPeer
+			if len(ipblock.Except) > 0 {
+				for _, except := range ipblock.Except {
+					entry := &iptm.IptEntry{
+						Chain: util.IptablesAzureIngressFromChain,
+						Specs: []string{
+							util.IptablesMatchFlag,
+							util.IptablesSetFlag,
+							util.IptablesMatchSetFlag,
+							hashedTargetSetName,
+							util.IptablesDstFlag,
+							util.IptablesSFlag,
+							except,
+							util.IptablesJumpFlag,
+							util.IptablesDrop,
+						},
+					}
+					entries = append(entries, entry)
+				}
+			}
+
+			if len(ipblock.CIDR) > 0 {
+				cidrEntry := &iptm.IptEntry{
+					Chain: util.IptablesAzureIngressFromChain,
+					Specs: []string{
+						util.IptablesMatchFlag,
+						util.IptablesSetFlag,
+						util.IptablesMatchSetFlag,
+						hashedTargetSetName,
+						util.IptablesDstFlag,
+						util.IptablesSFlag,
+						ipblock.CIDR,
+						util.IptablesJumpFlag,
+						util.IptablesAccept,
+					},
+				}
+				entries = append(entries, cidrEntry)
+			}
+		}
+
+		// Handle PodSelector field of NetworkPolicyPeer.
+		for _, podRuleSet := range PodNsRuleSets {
+			hashedRuleSetName := util.GetHashedName(podRuleSet)
+			entry := &iptm.IptEntry{
+				Name:       podRuleSet,
+				HashedName: hashedRuleSetName,
+				Chain:      util.IptablesAzureIngressFromChain,
+				Specs: []string{
+					util.IptablesMatchFlag,
+					util.IptablesSetFlag,
+					util.IptablesMatchSetFlag,
+					hashedRuleSetName,
+					util.IptablesSrcFlag,
+					util.IptablesMatchFlag,
+					util.IptablesSetFlag,
+					util.IptablesMatchSetFlag,
+					hashedTargetSetName,
+					util.IptablesDstFlag,
+					util.IptablesJumpFlag,
+					util.IptablesAccept,
+				},
+			}
+			entries = append(entries, entry)
+		}
+
+		// Handle NamespaceSelector field of NetworkPolicyPeer
+		for _, nsRuleSet := range nsRuleLists {
+			hashedRuleSetName := util.GetHashedName(nsRuleSet)
+			entry := &iptm.IptEntry{
+				Name:       nsRuleSet,
+				HashedName: hashedRuleSetName,
+				Chain:      util.IptablesAzureIngressFromChain,
+				Specs: []string{
+					util.IptablesMatchFlag,
+					util.IptablesSetFlag,
+					util.IptablesMatchSetFlag,
+					hashedRuleSetName,
+					util.IptablesSrcFlag,
+					util.IptablesMatchFlag,
+					util.IptablesSetFlag,
+					util.IptablesMatchSetFlag,
+					hashedTargetSetName,
+					util.IptablesDstFlag,
+					util.IptablesJumpFlag,
+					util.IptablesAccept,
+				},
+			}
+			entries = append(entries, entry)
+		}
+	}
+
+	return PodNsRuleSets, nsRuleLists, entries
+}
+
+func parseEgress(ns string, targetSets []string, rules []networkingv1.NetworkPolicyEgressRule) ([]string, []string, []*iptm.IptEntry) {
+	var (
+		portRuleExists    = false
+		toRuleExists      = false
+		isAppliedToNs     = false
+		protPortPairSlice []*portsInfo
+		PodNsRuleSets     []string // pod sets listed in Egress rules.
+		nsRuleLists       []string // namespace sets listed in Egress rules
+		entries           []*iptm.IptEntry
+		ipblock           *networkingv1.IPBlock
+	)
+
+	if len(targetSets) == 0 {
+		targetSets = append(targetSets, ns)
+		isAppliedToNs = true
+	}
+
+	//TODO: handle IPBlock
+	for _, rule := range rules {
+		for _, portRule := range rule.Ports {
+			protPortPairSlice = append(protPortPairSlice,
+				&portsInfo{
+					protocol: string(*portRule.Protocol),
+					port:     fmt.Sprint(portRule.Port.IntVal),
+				})
+
+			portRuleExists = true
+		}
+
+		for _, toRule := range rule.To {
+			if toRule.PodSelector != nil {
+				if len(toRule.PodSelector.MatchLabels) == 0 {
+					PodNsRuleSets = append(PodNsRuleSets, ns)
+				}
+
+				for podLabelKey, podLabelVal := range toRule.PodSelector.MatchLabels {
+					PodNsRuleSets = append(PodNsRuleSets, util.KubeAllNamespacesFlag+"-"+podLabelKey+":"+podLabelVal)
+				}
+			}
+
+			if toRule.NamespaceSelector != nil {
+				if len(toRule.NamespaceSelector.MatchLabels) == 0 {
+					nsRuleLists = append(nsRuleLists, util.KubeAllNamespacesFlag)
+				}
+
+				for nsLabelKey, nsLabelVal := range toRule.NamespaceSelector.MatchLabels {
+					nsRuleLists = append(nsRuleLists, "ns-"+nsLabelKey+":"+nsLabelVal)
+				}
+			}
+
+			if toRule.IPBlock != nil {
+				ipblock = toRule.IPBlock
+			}
+
+			toRuleExists = true
+		}
+	}
+
+	if isAppliedToNs {
+		hashedTargetSetName := util.GetHashedName(ns)
+
+		nsDrop := &iptm.IptEntry{
+			Name:       ns,
+			HashedName: hashedTargetSetName,
+			Chain:      util.IptablesAzureTargetSetsChain,
+			Specs: []string{
+				util.IptablesMatchFlag,
+				util.IptablesSetFlag,
+				util.IptablesMatchSetFlag,
+				hashedTargetSetName,
+				util.IptablesSrcFlag,
+				util.IptablesJumpFlag,
+				util.IptablesDrop,
+			},
+		}
+		entries = append(entries, nsDrop)
+	}
+
+	// Use hashed string for ipset name to avoid string length limit of ipset.
+	for _, targetSet := range targetSets {
+		hashedTargetSetName := util.GetHashedName(targetSet)
+
+		if len(rules) == 0 {
+			drop := &iptm.IptEntry{
+				Name:       targetSet,
+				HashedName: hashedTargetSetName,
+				Chain:      util.IptablesAzureEgressPortChain,
+				Specs: []string{
+					util.IptablesMatchFlag,
+					util.IptablesSetFlag,
+					util.IptablesMatchSetFlag,
+					hashedTargetSetName,
+					util.IptablesSrcFlag,
+					util.IptablesJumpFlag,
+					util.IptablesDrop,
+				},
+			}
+			entries = append(entries, drop)
+			continue
+		}
+
+		if !portRuleExists && !toRuleExists {
+			allow := &iptm.IptEntry{
+				Name:       targetSet,
+				HashedName: hashedTargetSetName,
+				Chain:      util.IptablesAzureEgressPortChain,
+				Specs: []string{
+					util.IptablesMatchFlag,
+					util.IptablesSetFlag,
+					util.IptablesMatchSetFlag,
+					hashedTargetSetName,
+					util.IptablesSrcFlag,
+					util.IptablesJumpFlag,
+					util.IptablesAccept,
+				},
+			}
+			entries = append(entries, allow)
+			continue
+		}
+
+		if !portRuleExists {
+			entry := &iptm.IptEntry{
+				Name:       targetSet,
+				HashedName: hashedTargetSetName,
+				Chain:      util.IptablesAzureEgressPortChain,
+				Specs: []string{
+					util.IptablesMatchFlag,
+					util.IptablesSetFlag,
+					util.IptablesMatchSetFlag,
+					hashedTargetSetName,
+					util.IptablesDstFlag,
+					util.IptablesJumpFlag,
+					util.IptablesAzureEgressToChain,
+				},
+			}
+			entries = append(entries, entry)
+		} else {
+			for _, protPortPair := range protPortPairSlice {
+				entry := &iptm.IptEntry{
+					Name:       targetSet,
+					HashedName: hashedTargetSetName,
+					Chain:      util.IptablesAzureEgressPortChain,
+					Specs: []string{
+						util.IptablesProtFlag,
+						protPortPair.protocol,
+						util.IptablesDstPortFlag,
+						protPortPair.port,
+						util.IptablesMatchFlag,
+						util.IptablesSetFlag,
+						util.IptablesMatchSetFlag,
+						hashedTargetSetName,
+						util.IptablesSrcFlag,
+						util.IptablesJumpFlag,
+						util.IptablesAzureEgressToChain,
+					},
+				}
+				entries = append(entries, entry)
+			}
+		}
+
+		if !toRuleExists {
+			entry := &iptm.IptEntry{
+				Name:       targetSet,
+				HashedName: hashedTargetSetName,
+				Chain:      util.IptablesAzureEgressToChain,
+				Specs: []string{
+					util.IptablesMatchFlag,
+					util.IptablesSetFlag,
+					util.IptablesMatchSetFlag,
+					hashedTargetSetName,
+					util.IptablesDstFlag,
+					util.IptablesJumpFlag,
+					util.IptablesAccept,
+				},
+			}
+			entries = append(entries, entry)
+			continue
+		}
+
+		if ipblock != nil {
+			// Handle ipblock field of NetworkPolicyPeer
+			if len(ipblock.Except) > 0 {
+				for _, except := range ipblock.Except {
+					entry := &iptm.IptEntry{
+						Chain: util.IptablesAzureEgressToChain,
+						Specs: []string{
+							util.IptablesMatchFlag,
+							util.IptablesSetFlag,
+							util.IptablesMatchSetFlag,
+							hashedTargetSetName,
+							util.IptablesSrcFlag,
+							util.IptablesDFlag,
+							except,
+							util.IptablesJumpFlag,
+							util.IptablesDrop,
+						},
+					}
+					entries = append(entries, entry)
+				}
+			}
+
+			if len(ipblock.CIDR) > 0 {
+				cidrEntry := &iptm.IptEntry{
+					Chain: util.IptablesAzureEgressToChain,
+					Specs: []string{
+						util.IptablesMatchFlag,
+						util.IptablesSetFlag,
+						util.IptablesMatchSetFlag,
+						hashedTargetSetName,
+						util.IptablesSrcFlag,
+						util.IptablesDFlag,
+						ipblock.CIDR,
+						util.IptablesJumpFlag,
+						util.IptablesAccept,
+					},
+				}
+				entries = append(entries, cidrEntry)
+			}
+		}
+
+		// Handle PodSelector field of NetworkPolicyPeer.
+		for _, podRuleSet := range PodNsRuleSets {
+			hashedRuleSetName := util.GetHashedName(podRuleSet)
+			entry := &iptm.IptEntry{
+				Name:       podRuleSet,
+				HashedName: hashedRuleSetName,
+				Chain:      util.IptablesAzureEgressToChain,
+				Specs: []string{
+					util.IptablesMatchFlag,
+					util.IptablesSetFlag,
+					util.IptablesMatchSetFlag,
+					hashedTargetSetName,
+					util.IptablesSrcFlag,
+					util.IptablesMatchFlag,
+					util.IptablesSetFlag,
+					util.IptablesMatchSetFlag,
+					hashedRuleSetName,
+					util.IptablesDstFlag,
+					util.IptablesJumpFlag,
+					util.IptablesAccept,
+				},
+			}
+			entries = append(entries, entry)
+		}
+
+		// Handle NamespaceSelector field of NetworkPolicyPeer
+		for _, nsRuleSet := range nsRuleLists {
+			hashedRuleSetName := util.GetHashedName(nsRuleSet)
+			entry := &iptm.IptEntry{
+				Name:       nsRuleSet,
+				HashedName: hashedRuleSetName,
+				Chain:      util.IptablesAzureEgressToChain,
+				Specs: []string{
+					util.IptablesMatchFlag,
+					util.IptablesSetFlag,
+					util.IptablesMatchSetFlag,
+					hashedTargetSetName,
+					util.IptablesSrcFlag,
+					util.IptablesMatchFlag,
+					util.IptablesSetFlag,
+					util.IptablesMatchSetFlag,
+					hashedRuleSetName,
+					util.IptablesDstFlag,
+					util.IptablesJumpFlag,
+					util.IptablesAccept,
+				},
+			}
+			entries = append(entries, entry)
+		}
+	}
+
+	return PodNsRuleSets, nsRuleLists, entries
+}
+
+// Drop all non-whitelisted packets.
+func getDefaultDropEntries(targetSets []string) []*iptm.IptEntry {
+	var entries []*iptm.IptEntry
+
+	for _, targetSet := range targetSets {
+		hashedTargetSetName := util.GetHashedName(targetSet)
+		entry := &iptm.IptEntry{
+			Name:       targetSet,
+			HashedName: hashedTargetSetName,
+			Chain:      util.IptablesAzureTargetSetsChain,
+			Specs: []string{
+				util.IptablesMatchFlag,
+				util.IptablesSetFlag,
+				util.IptablesMatchSetFlag,
+				hashedTargetSetName,
+				util.IptablesSrcFlag,
+				util.IptablesJumpFlag,
+				util.IptablesDrop,
+			},
+		}
+		entries = append(entries, entry)
+
+		entry = &iptm.IptEntry{
+			Name:       targetSet,
+			HashedName: hashedTargetSetName,
+			Chain:      util.IptablesAzureTargetSetsChain,
+			Specs: []string{
+				util.IptablesMatchFlag,
+				util.IptablesSetFlag,
+				util.IptablesMatchSetFlag,
+				hashedTargetSetName,
+				util.IptablesDstFlag,
+				util.IptablesJumpFlag,
+				util.IptablesDrop,
+			},
+		}
+		entries = append(entries, entry)
+	}
+
+	return entries
+}
+
+// ParsePolicy parses network policy.
+func parsePolicy(npObj *networkingv1.NetworkPolicy) ([]string, []string, []*iptm.IptEntry) {
+	var (
+		resultPodSets []string
+		resultNsLists []string
+		affectedSets  []string
+		entries       []*iptm.IptEntry
+	)
+
+	// Get affected pods.
+	npNs, selector := npObj.ObjectMeta.Namespace, npObj.Spec.PodSelector.MatchLabels
+	for podLabelKey, podLabelVal := range selector {
+		affectedSet := util.KubeAllNamespacesFlag + "-" + podLabelKey + ":" + podLabelVal
+		affectedSets = append(affectedSets, affectedSet)
+	}
+
+	if len(npObj.Spec.PolicyTypes) == 0 {
+		ingressPodSets, ingressNsSets, ingressEntries := parseIngress(npNs, affectedSets, npObj.Spec.Ingress)
+		resultPodSets = append(resultPodSets, ingressPodSets...)
+		resultNsLists = append(resultNsLists, ingressNsSets...)
+		entries = append(entries, ingressEntries...)
+
+		egressPodSets, egressNsSets, egressEntries := parseEgress(npNs, affectedSets, npObj.Spec.Egress)
+		resultPodSets = append(resultPodSets, egressPodSets...)
+		resultNsLists = append(resultNsLists, egressNsSets...)
+		entries = append(entries, egressEntries...)
+
+		entries = append(entries, getDefaultDropEntries(affectedSets)...)
+
+		resultPodSets = append(resultPodSets, affectedSets...)
+
+		return util.UniqueStrSlice(resultPodSets), util.UniqueStrSlice(resultNsLists), entries
+	}
+
+	for _, ptype := range npObj.Spec.PolicyTypes {
+		if ptype == networkingv1.PolicyTypeIngress {
+			ingressPodSets, ingressNsSets, ingressEntries := parseIngress(npNs, affectedSets, npObj.Spec.Ingress)
+			resultPodSets = append(resultPodSets, ingressPodSets...)
+			resultNsLists = append(resultNsLists, ingressNsSets...)
+			entries = append(entries, ingressEntries...)
+		}
+
+		if ptype == networkingv1.PolicyTypeEgress {
+			egressPodSets, egressNsSets, egressEntries := parseEgress(npNs, affectedSets, npObj.Spec.Egress)
+			resultPodSets = append(resultPodSets, egressPodSets...)
+			resultNsLists = append(resultNsLists, egressNsSets...)
+			entries = append(entries, egressEntries...)
+		}
+
+		entries = append(entries, getDefaultDropEntries(affectedSets)...)
+	}
+
+	resultPodSets = append(resultPodSets, affectedSets...)
+	resultPodSets = append(resultPodSets, npNs)
+
+	return util.UniqueStrSlice(resultPodSets), util.UniqueStrSlice(resultNsLists), entries
+}

--- a/npm/plugin/main.go
+++ b/npm/plugin/main.go
@@ -12,12 +12,15 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+// Version is populated by make during build.
+var version string
+
 func initLogging() error {
 	log.SetName("azure-npm")
 	log.SetLevel(log.LevelInfo)
 	err := log.SetTarget(log.TargetLogfile)
 	if err != nil {
-		log.Printf("[cni-npm] Failed to configure logging, err:%v.\n", err)
+		log.Printf("[Azure-NPM] Failed to configure logging, err:%v.\n", err)
 		return err
 	}
 
@@ -38,17 +41,20 @@ func main() {
 	// Creates the clientset
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		log.Printf("[cni-npm] clientset creation failed with error %v.\n", err)
+		log.Printf("[Azure-NPM] clientset creation failed with error %v.\n", err)
 		panic(err.Error())
 	}
 
 	factory := informers.NewSharedInformerFactory(clientset, time.Hour*24)
-	npMgr := npm.NewNetworkPolicyManager(clientset, factory)
+
+	npMgr := npm.NewNetworkPolicyManager(clientset, factory, version)
 	err = npMgr.Run(wait.NeverStop)
 	if err != nil {
-		log.Printf("[cni-npm] npm failed with error %v.\n", err)
+		log.Printf("[Azure-NPM] npm failed with error %v.", err)
 		panic(err.Error)
 	}
+
+	go npMgr.RunReportManager()
 
 	select {}
 }

--- a/npm/plugin/main.go
+++ b/npm/plugin/main.go
@@ -1,3 +1,5 @@
+// Copyright 2018 Microsoft. All rights reserved.
+// MIT License
 package main
 
 import (

--- a/npm/plugin/main.go
+++ b/npm/plugin/main.go
@@ -18,9 +18,8 @@ var version string
 func initLogging() error {
 	log.SetName("azure-npm")
 	log.SetLevel(log.LevelInfo)
-	err := log.SetTarget(log.TargetLogfile)
-	if err != nil {
-		log.Printf("[Azure-NPM] Failed to configure logging, err:%v.\n", err)
+	if err := log.SetTarget(log.TargetLogfile); err != nil {
+		log.Printf("[cni-npm] Failed to configure logging, err:%v.\n", err)
 		return err
 	}
 
@@ -28,7 +27,15 @@ func initLogging() error {
 }
 
 func main() {
-	if err := initLogging(); err != nil {
+	var err error
+
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("[cni-npm] recovered from error: %v", err)
+		}
+	}()
+
+	if err = initLogging(); err != nil {
 		panic(err.Error())
 	}
 

--- a/npm/plugin/main.go
+++ b/npm/plugin/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"time"
+
+	"github.com/Azure/azure-container-networking/log"
+	"github.com/Azure/azure-container-networking/npm"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+func initLogging() error {
+	log.SetName("azure-npm")
+	log.SetLevel(log.LevelInfo)
+	err := log.SetTarget(log.TargetLogfile)
+	if err != nil {
+		log.Printf("[cni-npm] Failed to configure logging, err:%v.\n", err)
+		return err
+	}
+
+	return nil
+}
+
+func main() {
+	if err := initLogging(); err != nil {
+		panic(err.Error())
+	}
+
+	// Creates the in-cluster config
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		panic(err.Error())
+	}
+
+	// Creates the clientset
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		log.Printf("[cni-npm] clientset creation failed with error %v.\n", err)
+		panic(err.Error())
+	}
+
+	factory := informers.NewSharedInformerFactory(clientset, time.Hour*24)
+	npMgr := npm.NewNetworkPolicyManager(clientset, factory)
+	err = npMgr.Run(wait.NeverStop)
+	if err != nil {
+		log.Printf("[cni-npm] npm failed with error %v.\n", err)
+		panic(err.Error)
+	}
+
+	select {}
+}

--- a/npm/pod.go
+++ b/npm/pod.go
@@ -1,3 +1,5 @@
+// Copyright 2018 Microsoft. All rights reserved.
+// MIT License
 package npm
 
 import (

--- a/npm/pod.go
+++ b/npm/pod.go
@@ -52,6 +52,7 @@ func (npMgr *NetworkPolicyManager) AddPod(podObj *corev1.Pod) error {
 	log.Printf("Adding pod %s to ipset %s\n", podIP, podNs)
 	if err = ipsMgr.AddToSet(podNs, podIP); err != nil {
 		log.Printf("Error adding pod to namespace ipset.\n")
+		return err
 	}
 
 	// Add the pod to its label's ipset.
@@ -76,6 +77,7 @@ func (npMgr *NetworkPolicyManager) AddPod(podObj *corev1.Pod) error {
 	ns, err := newNs(podNs)
 	if err != nil {
 		log.Printf("Error creating namespace %s\n", podNs)
+		return err
 	}
 	npMgr.nsMap[podNs] = ns
 

--- a/npm/pod.go
+++ b/npm/pod.go
@@ -42,7 +42,7 @@ func (npMgr *NetworkPolicyManager) AddPod(podObj *corev1.Pod) error {
 	podNodeName := podObj.Spec.NodeName
 	podLabels := podObj.ObjectMeta.Labels
 	podIP := podObj.Status.PodIP
-	log.Printf("POD CREATED: %s/%s/%s%+v%s\n", podNs, podName, podNodeName, podLabels, podIP)
+	log.Printf("POD CREATING: %s/%s/%s%+v%s\n", podNs, podName, podNodeName, podLabels, podIP)
 
 	// Add the pod to ipset
 	ipsMgr := npMgr.nsMap[util.KubeAllNamespacesFlag].ipsMgr
@@ -106,7 +106,7 @@ func (npMgr *NetworkPolicyManager) UpdatePod(oldPodObj, newPodObj *corev1.Pod) e
 	newPodObjIP := newPodObj.Status.PodIP
 
 	log.Printf(
-		"POD UPDATED. %s %s %s %s %s %s %s %s\n",
+		"POD UPDATING. %s %s %s %s %s %s %s %s\n",
 		oldPodObjNs, oldPodObjName, oldPodObjPhase, oldPodObjIP, newPodObjNs, newPodObjName, newPodObjPhase, newPodObjIP,
 	)
 
@@ -145,7 +145,7 @@ func (npMgr *NetworkPolicyManager) DeletePod(podObj *corev1.Pod) error {
 	podNodeName := podObj.Spec.NodeName
 	podLabels := podObj.ObjectMeta.Labels
 	podIP := podObj.Status.PodIP
-	log.Printf("POD DELETED: %s/%s/%s\n", podNs, podName, podNodeName)
+	log.Printf("POD DELETING: %s/%s/%s\n", podNs, podName, podNodeName)
 
 	// Delete pod from ipset
 	ipsMgr := npMgr.nsMap[util.KubeAllNamespacesFlag].ipsMgr

--- a/npm/pod.go
+++ b/npm/pod.go
@@ -20,7 +20,7 @@ func isSystemPod(podObj *corev1.Pod) bool {
 	return podObj.ObjectMeta.Namespace == util.KubeSystemFlag
 }
 
-// AddPod handles add pod.
+// AddPod handles adding pod ip to its label's ipset.
 func (npMgr *NetworkPolicyManager) AddPod(podObj *corev1.Pod) error {
 	npMgr.Lock()
 	defer npMgr.Unlock()
@@ -80,7 +80,7 @@ func (npMgr *NetworkPolicyManager) AddPod(podObj *corev1.Pod) error {
 	return nil
 }
 
-// UpdatePod handles update pod.
+// UpdatePod handles updating pod ip in its label's ipset.
 func (npMgr *NetworkPolicyManager) UpdatePod(oldPodObj, newPodObj *corev1.Pod) error {
 	if !isValidPod(newPodObj) {
 		return nil
@@ -123,7 +123,7 @@ func (npMgr *NetworkPolicyManager) UpdatePod(oldPodObj, newPodObj *corev1.Pod) e
 	return nil
 }
 
-// DeletePod handles delete pod.
+// DeletePod handles deleting pod from its label's ipset.
 func (npMgr *NetworkPolicyManager) DeletePod(podObj *corev1.Pod) error {
 	npMgr.Lock()
 	defer npMgr.Unlock()

--- a/npm/pod.go
+++ b/npm/pod.go
@@ -1,0 +1,140 @@
+package npm
+
+import (
+	"strings"
+
+	"github.com/Azure/azure-container-networking/log"
+	"github.com/Azure/azure-container-networking/npm/util"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func isValidPod(podObj *corev1.Pod) bool {
+	return podObj.Status.Phase != "Failed" &&
+		podObj.Status.Phase != "Succeeded" &&
+		podObj.Status.Phase != "Unknown" &&
+		len(podObj.Status.PodIP) > 0
+}
+
+func isSystemPod(podObj *corev1.Pod) bool {
+	return podObj.ObjectMeta.Namespace == util.KubeSystemFlag
+}
+
+// AddPod handles add pod.
+func (npMgr *NetworkPolicyManager) AddPod(podObj *corev1.Pod) error {
+	npMgr.Lock()
+	defer npMgr.Unlock()
+
+	if !isValidPod(podObj) {
+		return nil
+	}
+
+	podNs := podObj.ObjectMeta.Namespace
+	podName := podObj.ObjectMeta.Name
+	podNodeName := podObj.Spec.NodeName
+	podLabels := podObj.ObjectMeta.Labels
+	podIP := podObj.Status.PodIP
+	log.Printf("POD CREATED: %s/%s/%s%+v%s\n", podNs, podName, podNodeName, podLabels, podIP)
+
+	// Add the pod to ipset
+	ipsMgr := npMgr.nsMap[util.KubeAllNamespacesFlag].ipsMgr
+	// Add the pod to its namespace's ipset.
+	log.Printf("Adding pod %s to ipset %s\n", podIP, podNs)
+	if err := ipsMgr.AddToSet(podNs, podIP); err != nil {
+		log.Printf("Error adding pod to namespace ipset.\n")
+	}
+
+	// Add the pod to its label's ipset.
+	var labelKeys []string
+	for podLabelKey, podLabelVal := range podLabels {
+		//Ignore pod-template-hash label.
+		if strings.Contains(podLabelKey, util.KubePodTemplateHashFlag) {
+			continue
+		}
+
+		labelKey := util.KubeAllNamespacesFlag + "-" + podLabelKey + ":" + podLabelVal
+		log.Printf("Adding pod %s to ipset %s\n", podIP, labelKey)
+		if err := ipsMgr.AddToSet(labelKey, podIP); err != nil {
+			log.Printf("Error adding pod to label ipset.\n")
+			return err
+		}
+		labelKeys = append(labelKeys, labelKey)
+	}
+
+	ns, err := newNs(podNs)
+	if err != nil {
+		log.Printf("Error creating namespace %s\n", podNs)
+	}
+	npMgr.nsMap[podNs] = ns
+
+	return nil
+}
+
+// UpdatePod handles update pod.
+func (npMgr *NetworkPolicyManager) UpdatePod(oldPodObj, newPodObj *corev1.Pod) error {
+	if !isValidPod(newPodObj) {
+		return nil
+	}
+
+	oldPodObjNs := oldPodObj.ObjectMeta.Namespace
+	oldPodObjName := oldPodObj.ObjectMeta.Name
+	oldPodObjPhase := oldPodObj.Status.Phase
+	oldPodObjIP := oldPodObj.Status.PodIP
+	newPodObjNs := newPodObj.ObjectMeta.Namespace
+	newPodObjName := newPodObj.ObjectMeta.Name
+	newPodObjPhase := newPodObj.Status.Phase
+	newPodObjIP := newPodObj.Status.PodIP
+
+	log.Printf(
+		"POD UPDATED. %s %s %s %s %s %s %s %s\n",
+		oldPodObjNs, oldPodObjName, oldPodObjPhase, oldPodObjIP, newPodObjNs, newPodObjName, newPodObjPhase, newPodObjIP,
+	)
+
+	npMgr.DeletePod(oldPodObj)
+
+	if newPodObj.ObjectMeta.DeletionTimestamp == nil && newPodObj.ObjectMeta.DeletionGracePeriodSeconds == nil {
+		npMgr.AddPod(newPodObj)
+	}
+
+	return nil
+}
+
+// DeletePod handles delete pod.
+func (npMgr *NetworkPolicyManager) DeletePod(podObj *corev1.Pod) error {
+	npMgr.Lock()
+	defer npMgr.Unlock()
+
+	if !isValidPod(podObj) {
+		return nil
+	}
+
+	podNs := podObj.ObjectMeta.Namespace
+	podName := podObj.ObjectMeta.Name
+	podNodeName := podObj.Spec.NodeName
+	podLabels := podObj.ObjectMeta.Labels
+	podIP := podObj.Status.PodIP
+	log.Printf("POD DELETED: %s/%s/%s\n", podNs, podName, podNodeName)
+
+	// Delete pod from ipset
+	ipsMgr := npMgr.nsMap[util.KubeAllNamespacesFlag].ipsMgr
+	// Delete the pod from its namespace's ipset.
+	if err := ipsMgr.DeleteFromSet(podNs, podIP); err != nil {
+		log.Printf("Error deleting pod from namespace ipset.\n")
+		return err
+	}
+	// Delete the pod from its label's ipset.
+	for podLabelKey, podLabelVal := range podLabels {
+		//Ignore pod-template-hash label.
+		if strings.Contains(podLabelKey, "pod-template-hash") {
+			continue
+		}
+
+		labelKey := util.KubeAllNamespacesFlag + "-" + podLabelKey + ":" + podLabelVal
+		if err := ipsMgr.DeleteFromSet(labelKey, podIP); err != nil {
+			log.Printf("Error deleting pod from label ipset.\n")
+			return err
+		}
+	}
+
+	return nil
+}

--- a/npm/pod_test.go
+++ b/npm/pod_test.go
@@ -1,3 +1,5 @@
+// Copyright 2018 Microsoft. All rights reserved.
+// MIT License
 package npm
 
 import (

--- a/npm/pod_test.go
+++ b/npm/pod_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-container-networking/npm/ipsm"
-
 	"github.com/Azure/azure-container-networking/npm/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/npm/pod_test.go
+++ b/npm/pod_test.go
@@ -1,0 +1,173 @@
+package npm
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-container-networking/npm/ipsm"
+
+	"github.com/Azure/azure-container-networking/npm/util"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestisValidPod(t *testing.T) {
+	podObj := &corev1.Pod{
+		Status: corev1.PodStatus{
+			Phase: "Running",
+			PodIP: "1.2.3.4",
+		},
+	}
+	if ok := isValidPod(podObj); !ok {
+		t.Errorf("TestisValidPod failed @ isValidPod")
+	}
+}
+
+func TestisSystemPod(t *testing.T) {
+	podObj := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: util.KubeSystemFlag,
+		},
+	}
+	if ok := isSystemPod(podObj); !ok {
+		t.Errorf("TestisSystemPod failed @ isSystemPod")
+	}
+}
+
+func TestAddPod(t *testing.T) {
+	npMgr := &NetworkPolicyManager{
+		nsMap: make(map[string]*namespace),
+	}
+
+	allNs, err := newNs(util.KubeAllNamespacesFlag)
+	if err != nil {
+		panic(err.Error)
+	}
+	npMgr.nsMap[util.KubeAllNamespacesFlag] = allNs
+
+	ipsMgr := ipsm.NewIpsetManager()
+	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
+		t.Errorf("TestAddPod failed @ ipsMgr.Save")
+	}
+
+	defer func() {
+		if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
+			t.Errorf("TestAddPod failed @ ipsMgr.Restore")
+		}
+	}()
+
+	podObj := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-pod",
+			Labels: map[string]string{
+				"app": "test-pod",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: "Running",
+			PodIP: "1.2.3.4",
+		},
+	}
+	if err := npMgr.AddPod(podObj); err != nil {
+		t.Errorf("TestAddPod failed @ AddPod")
+	}
+}
+
+func TestUpdatePod(t *testing.T) {
+	npMgr := &NetworkPolicyManager{
+		nsMap: make(map[string]*namespace),
+	}
+
+	allNs, err := newNs(util.KubeAllNamespacesFlag)
+	if err != nil {
+		panic(err.Error)
+	}
+	npMgr.nsMap[util.KubeAllNamespacesFlag] = allNs
+
+	ipsMgr := ipsm.NewIpsetManager()
+	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
+		t.Errorf("TestUpdatePod failed @ ipsMgr.Save")
+	}
+
+	defer func() {
+		if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
+			t.Errorf("TestUpdatePod failed @ ipsMgr.Restore")
+		}
+	}()
+
+	oldPodObj := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "old-test-pod",
+			Labels: map[string]string{
+				"app": "old-test-pod",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: "Running",
+			PodIP: "1.2.3.4",
+		},
+	}
+
+	newPodObj := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "new-test-pod",
+			Labels: map[string]string{
+				"app": "new-test-pod",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: "Running",
+			PodIP: "4.3.2.1",
+		},
+	}
+
+	if err := npMgr.AddPod(oldPodObj); err != nil {
+		t.Errorf("TestUpdatePod failed @ AddPod")
+	}
+
+	if err := npMgr.UpdatePod(oldPodObj, newPodObj); err != nil {
+		t.Errorf("TestUpdatePod failed @ UpdatePod")
+	}
+}
+
+func TestDeletePod(t *testing.T) {
+	npMgr := &NetworkPolicyManager{
+		nsMap: make(map[string]*namespace),
+	}
+
+	allNs, err := newNs(util.KubeAllNamespacesFlag)
+	if err != nil {
+		panic(err.Error)
+	}
+	npMgr.nsMap[util.KubeAllNamespacesFlag] = allNs
+
+	ipsMgr := ipsm.NewIpsetManager()
+	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
+		t.Errorf("TestDeletePod failed @ ipsMgr.Save")
+	}
+
+	defer func() {
+		if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
+			t.Errorf("TestDeletePod failed @ ipsMgr.Restore")
+		}
+	}()
+
+	podObj := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-pod",
+			Labels: map[string]string{
+				"app": "test-pod",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: "Running",
+			PodIP: "1.2.3.4",
+		},
+	}
+	if err := npMgr.AddPod(podObj); err != nil {
+		t.Errorf("TestDeletePod failed @ AddPod")
+	}
+
+	if err := npMgr.DeletePod(podObj); err != nil {
+		t.Errorf("TestDeletePod failed @ DeletePod")
+	}
+}

--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -1,3 +1,5 @@
+// Copyright 2018 Microsoft. All rights reserved.
+// MIT License
 package util
 
 //kubernetes related constants.

--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -68,3 +68,18 @@ const (
 	IpsetNetHashFlag string = "nethash"
 	AzureNpmPrefix   string = "azure-npm-"
 )
+
+//NPM telemetry constants.
+const (
+	AddNamespaceEvent    string = "Add Namespace"
+	UpdateNamespaceEvent string = "Update Namespace"
+	DeleteNamespaceEvent string = "Delete Namespace"
+
+	AddPodEvent    string = "Add Pod"
+	UpdatePodEvent string = "Update Pod"
+	DeletePodEvent string = "Delete Pod"
+
+	AddNetworkPolicyEvent    string = "Add network policy"
+	UpdateNetworkPolicyEvent string = "Update network policy"
+	DeleteNetworkPolicyEvent string = "Delete network policy"
+)

--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -1,0 +1,70 @@
+package util
+
+//kubernetes related constants.
+const (
+	KubeSystemFlag          string = "kube-system"
+	KubePodTemplateHashFlag string = "pod-template-hash"
+	KubeAllPodsFlag         string = "all-pod"
+	KubeAllNamespacesFlag   string = "all-namespace"
+)
+
+//iptables related constants.
+const (
+	Iptables                      string = "iptables"
+	IptablesSave                  string = "iptables-save"
+	IptablesRestore               string = "iptables-restore"
+	IptablesConfigFile            string = "/var/log/iptables.conf"
+	IptablesTestConfigFile        string = "/var/log/iptables-test.conf"
+	IptablesChainCreationFlag     string = "-N"
+	IptablesInsertionFlag         string = "-I"
+	IptablesAppendFlag            string = "-A"
+	IptablesDeletionFlag          string = "-D"
+	IptablesFlushFlag             string = "-F"
+	IptablesCheckFlag             string = "-C"
+	IptablesDestroyFlag           string = "-X"
+	IptablesJumpFlag              string = "-j"
+	IptablesAccept                string = "ACCEPT"
+	IptablesReject                string = "REJECT"
+	IptablesDrop                  string = "DROP"
+	IptablesSrcFlag               string = "src"
+	IptablesDstFlag               string = "dst"
+	IptablesProtFlag              string = "-p"
+	IptablesSFlag                 string = "-s"
+	IptablesDFlag                 string = "-d"
+	IptablesDstPortFlag           string = "--dport"
+	IptablesMatchFlag             string = "-m"
+	IptablesSetFlag               string = "set"
+	IptablesMatchSetFlag          string = "--match-set"
+	IptablesStateFlag             string = "state"
+	IPtablesMatchStateFlag        string = "--state"
+	IptablesRelatedState          string = "RELATED"
+	IptablesEstablishedState      string = "ESTABLISHED"
+	IptablesAzureChain            string = "AZURE-NPM"
+	IptablesAzureIngressPortChain string = "AZURE-NPM-INGRESS-PORT"
+	IptablesAzureIngressFromChain string = "AZURE-NPM-INGRESS-FROM"
+	IptablesAzureEgressPortChain  string = "AZURE-NPM-EGRESS-PORT"
+	IptablesAzureEgressToChain    string = "AZURE-NPM-EGRESS-TO"
+	IptablesAzureTargetSetsChain  string = "AZURE-NPM-TARGET-SETS"
+	IptablesForwardChain          string = "FORWARD"
+)
+
+//ipset related constants.
+const (
+	Ipset               string = "ipset"
+	IpsetSaveFlag       string = "save"
+	IpsetRestoreFlag    string = "restore"
+	IpsetConfigFile     string = "/var/log/ipset.conf"
+	IpsetTestConfigFile string = "/var/log/ipset-test.conf"
+	IpsetCreationFlag   string = "-N"
+	IpsetAppendFlag     string = "-A"
+	IpsetDeletionFlag   string = "-D"
+	IpsetFlushFlag      string = "-F"
+	IpsetDestroyFlag    string = "-X"
+
+	IpsetExistFlag string = "-exist"
+	IpsetFileFlag  string = "-file"
+
+	IpsetSetListFlag string = "setlist"
+	IpsetNetHashFlag string = "nethash"
+	AzureNpmPrefix   string = "azure-npm-"
+)

--- a/npm/util/util.go
+++ b/npm/util/util.go
@@ -1,0 +1,42 @@
+package util
+
+import (
+	"fmt"
+	"hash/fnv"
+)
+
+// Hash hashes a string to another string with length <= 32.
+func Hash(s string) string {
+	h := fnv.New32a()
+	h.Write([]byte(s))
+	return fmt.Sprint(h.Sum32())
+}
+
+// UniqueStrSlice removes duplicate elements from the input string.
+func UniqueStrSlice(s []string) []string {
+	m, unique := map[string]bool{}, []string{}
+	for _, elem := range s {
+		if m[elem] == true {
+			continue
+		}
+
+		m[elem] = true
+		unique = append(unique, elem)
+	}
+
+	return unique
+}
+
+// AppendMap appends new to base.
+func AppendMap(base, new map[string]string) map[string]string {
+	for k, v := range new {
+		base[k] = v
+	}
+
+	return base
+}
+
+// GetHashedName returns hashed ipset name.
+func GetHashedName(name string) string {
+	return AzureNpmPrefix + Hash(name)
+}

--- a/npm/util/util.go
+++ b/npm/util/util.go
@@ -1,3 +1,5 @@
+// Copyright 2018 Microsoft. All rights reserved.
+// MIT License
 package util
 
 import (

--- a/npm/util/util.go
+++ b/npm/util/util.go
@@ -3,7 +3,18 @@ package util
 import (
 	"fmt"
 	"hash/fnv"
+	"strings"
 )
+
+// GetClusterID retrieves cluster ID through node name. (Azure-specific)
+func GetClusterID(nodeName string) string {
+	s := strings.Split(nodeName, "-")
+	if len(s) < 3 {
+		return ""
+	}
+
+	return s[2]
+}
 
 // Hash hashes a string to another string with length <= 32.
 func Hash(s string) string {

--- a/platform/os_linux.go
+++ b/platform/os_linux.go
@@ -18,8 +18,11 @@ const (
 	// CNMRuntimePath is the path where CNM state files are stored.
 	CNMRuntimePath = "/var/lib/azure-network/"
 
-	// CNIRuntimePath is the path where CNM state files are stored.
+	// CNIRuntimePath is the path where CNI state files are stored.
 	CNIRuntimePath = "/var/run/"
+
+	// NPMRuntimePath is the path where NPM logging files are stored.
+	NPMRuntimePath = "/var/run/"
 )
 
 // GetOSInfo returns OS version information.

--- a/platform/os_windows.go
+++ b/platform/os_windows.go
@@ -14,6 +14,9 @@ const (
 
 	// CNIRuntimePath is the path where CNM state files are stored.
 	CNIRuntimePath = ""
+
+	// NPMRuntimePath is the path where NPM state files are stored.
+	NPMRuntimePath = ""
 )
 
 // GetOSInfo returns OS version information.

--- a/telemetry/telemetry_linux.go
+++ b/telemetry/telemetry_linux.go
@@ -60,7 +60,7 @@ func getDiskInfo(path string) (*DiskInfo, error) {
 }
 
 // This function  creates a report with system details(memory, disk, cpu).
-func (report *Report) GetSystemDetails() {
+func (report *CNIReport) GetSystemDetails() {
 	var errMsg string
 	var cpuCount int = 0
 
@@ -87,7 +87,7 @@ func (report *Report) GetSystemDetails() {
 }
 
 // This function  creates a report with os details(ostype, version).
-func (report *Report) GetOSDetails() {
+func (report *CNIReport) GetOSDetails() {
 	linesArr, err := ReadFileByLines("/etc/os-release")
 	if err != nil || len(linesArr) <= 0 {
 		report.OSDetails = &OSInfo{OSType: runtime.GOOS}

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/Azure/azure-container-networking/common"
 )
 
-var reportManager *ReportManager
-var report *Report
+var reportManager *CNIReportManager
+var report *CNIReport
 var ipamQueryUrl = "localhost:3501"
 var hostAgentUrl = "localhost:3500"
 
@@ -66,11 +66,12 @@ func TestMain(m *testing.M) {
 		return
 	}
 
-	reportManager = &ReportManager{}
-	reportManager.HostNetAgentURL = "http://" + hostAgentUrl
+	reportManager = &CNIReportManager{}
+	reportManager.ReportManager = &ReportManager{}
+	reportManager.ReportManager.HostNetAgentURL = "http://" + hostAgentUrl
+	reportManager.ReportManager.ReportType = "application/json"
 	reportManager.IpamQueryURL = "http://" + ipamQueryUrl
-	reportManager.ReportType = "application/json"
-	reportManager.Report = &Report{}
+	reportManager.Report = &CNIReport{}
 	report = reportManager.Report
 	exitCode := m.Run()
 	os.Exit(exitCode)
@@ -83,7 +84,7 @@ func handleIpamQuery(w http.ResponseWriter, r *http.Request) {
 
 func handleCNIReport(rw http.ResponseWriter, req *http.Request) {
 	decoder := json.NewDecoder(req.Body)
-	var t Report
+	var t CNIReport
 	err := decoder.Decode(&t)
 	if err != nil {
 		panic(err)
@@ -138,7 +139,7 @@ func TestSetReportState(t *testing.T) {
 		t.Errorf("SetReportState failed due to %v", err)
 	}
 
-	err = os.Remove(TelemetryFile)
+	err = os.Remove(CNITelemetryFile)
 	if err != nil {
 		t.Errorf("Error removing telemetry file due to %v", err)
 	}

--- a/telemetry/telemetry_windows.go
+++ b/telemetry/telemetry_windows.go
@@ -25,11 +25,11 @@ func getDiskInfo(path string) (*DiskInfo, error) {
 	return nil, nil
 }
 
-func (report *Report) GetSystemDetails() {
+func (report *CNIReport) GetSystemDetails() {
 
 	report.SystemDetails = &SystemInfo{}
 }
 
-func (report *Report) GetOSDetails() {
+func (report *CNIReport) GetOSDetails() {
 	report.OSDetails = &OSInfo{OSType: runtime.GOOS}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds Azure Network Policy Manager, a.k.a, azure-npm, to Azure CNI.
Azure-npm is a Microsoft Azure's fault-tolerant and scalable implementation of [Kubernetes Network Policy plugin](https://kubernetes.io/docs/tasks/administer-cluster/declare-network-policy/).
Azure-npm supports all [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) specified by current version of Kubernetes, and will continue to support future versions.

Azure-npm only supports [Kubernetes v1.8](https://v1-8.docs.kubernetes.io/docs/api-reference/v1.8/) or later, as it requires NetworkPolicy API v1beta1.