### PR TITLE
Add workaround for windows network creation

### DIFF
--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -8,6 +8,7 @@ package network
 import (
 	"encoding/json"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-container-networking/log"
 	"github.com/Azure/azure-container-networking/network/policy"
@@ -76,6 +77,14 @@ func (nm *networkManager) newNetworkImpl(nwInfo *NetworkInfo, extIf *externalInt
 		Mode:      nwInfo.Mode,
 		Endpoints: make(map[string]*endpoint),
 		extIf:     extIf,
+	}
+
+	globals, err := hcsshim.GetHNSGlobals()
+	if err != nil || globals.Version.Major <= hcsshim.HNSVersion1803.Major {
+		// err would be not nil for windows 1709 & below
+		// Sleep for 10 seconds as a workaround for windows 1803 & below
+		// This is done only when the network is created.
+		time.Sleep(time.Duration(10) * time.Second)
 	}
 
 	return nw, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This is a workaround for windows CNI, where the platform need some delay before cni starts creating endpoint on a newly created network.
The second change is to remove the networkAdapterName
The next change is to use the latest compile with latest CNI

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
This workaround is needed only for 1803 & below
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```