### PR TITLE
Fix for the github acsengine issue #176

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -148,6 +148,10 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 		args.ContainerID, args.Netns, args.IfName, args.Args, args.Path)
 
 	defer func() {
+		if result == nil {
+			result = &cniTypesCurr.Result{}
+		}
+		
 		// Add Interfaces to result.
 		iface = &cniTypesCurr.Interface{
 			Name: args.IfName,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
This PR fixes the CNI plugin crash when error returned in some cases. The issue was raised in acs-engine #176 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```