### PR TITLE
Filter out hostVnic, which would otherwise fail during network creation

### DIFF
--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -25,10 +25,15 @@ type route interface{}
 
 // NewNetworkImpl creates a new container network.
 func (nm *networkManager) newNetworkImpl(nwInfo *NetworkInfo, extIf *externalInterface) (*network, error) {
+	networkAdapterName := extIf.Name
+	// FixMe: Find a better way to check if a nic that is selected is not part of a vSwitch
+	if strings.HasPrefix(networkAdapterName, "vEthernet") {
+		networkAdapterName = ""
+	}
 	// Initialize HNS network.
 	hnsNetwork := &hcsshim.HNSNetwork{
 		Name:               nwInfo.Id,
-		NetworkAdapterName: extIf.Name,
+		NetworkAdapterName: networkAdapterName,
 		DNSSuffix:          nwInfo.DNS.Suffix,
 		DNSServerList:      strings.Join(nwInfo.DNS.Servers, ","),
 		Policies:           policy.SerializePolicies(policy.NetworkPolicy, nwInfo.Policies),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
If the network adapter name that is passed to the HNS is a hostVnic, the network creation would fail. Rather passing an empty adapter would attempt to create the network using an existing external vSwitch

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```