### PR TITLE
Fixed initializing store in ipam

### DIFF
--- a/cni/ipam/plugin/main.go
+++ b/cni/ipam/plugin/main.go
@@ -26,10 +26,25 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err := ipamPlugin.Plugin.InitializeKeyValueStore(&config); err != nil {
+		fmt.Printf("Failed to initialize key-value store of ipam plugin, err:%v.\n", err)
+		panic("ipam plugin fatal error")
+	}
+
+	defer func() {
+		if errUninit := ipamPlugin.Plugin.UninitializeKeyValueStore(); errUninit != nil {
+			fmt.Printf("Failed to uninitialize key-value store of ipam plugin, err:%v.\n", err)
+		}
+
+		if recover() != nil {
+			os.Exit(1)
+		}
+	}()
+
 	err = ipamPlugin.Start(&config)
 	if err != nil {
 		fmt.Printf("Failed to start IPAM plugin, err:%v.\n", err)
-		os.Exit(1)
+		panic("ipam plugin fatal error")
 	}
 
 	err = ipamPlugin.Execute(cni.PluginApi(ipamPlugin))
@@ -37,6 +52,6 @@ func main() {
 	ipamPlugin.Stop()
 
 	if err != nil {
-		os.Exit(1)
+		panic("ipam plugin fatal error")
 	}
 }

--- a/cni/network/plugin/main.go
+++ b/cni/network/plugin/main.go
@@ -83,6 +83,12 @@ func main() {
 
 	netPlugin.SetReportManager(reportManager)
 
+	if err = netPlugin.Plugin.InitializeKeyValueStore(&config); err != nil {
+		log.Printf("Failed to initialize key-value store of network plugin, err:%v.\n", err)
+		reportPluginError(reportManager, err)
+		os.Exit(1)
+	}
+
 	defer func() {
 		if errUninit := netPlugin.Plugin.UninitializeKeyValueStore(); errUninit != nil {
 			log.Printf("Failed to uninitialize key-value store of network plugin, err:%v.\n", err)
@@ -92,12 +98,6 @@ func main() {
 			os.Exit(1)
 		}
 	}()
-
-	if err = netPlugin.Plugin.InitializeKeyValueStore(&config); err != nil {
-		log.Printf("Failed to initialize key-value store of network plugin, err:%v.\n", err)
-		reportPluginError(reportManager, err)
-		panic("network plugin fatal error")
-	}
 
 	if err = netPlugin.Start(&config); err != nil {
 		log.Printf("Failed to start network plugin, err:%v.\n", err)

--- a/ipam/manager.go
+++ b/ipam/manager.go
@@ -96,6 +96,7 @@ func (am *addressManager) Uninitialize() {
 func (am *addressManager) restore() error {
 	// Skip if a store is not provided.
 	if am.store == nil {
+		log.Printf("[ipam] ipam store is nil")
 		return nil
 	}
 
@@ -117,6 +118,7 @@ func (am *addressManager) restore() error {
 	err = am.store.Read(storeKey, am)
 	if err != nil {
 		if err == store.ErrKeyNotFound {
+			log.Printf("[ipam] store key not found")
 			return nil
 		} else {
 			log.Printf("[ipam] Failed to restore state, err:%v\n", err)

--- a/network/manager.go
+++ b/network/manager.go
@@ -72,6 +72,7 @@ func (nm *networkManager) Uninitialize() {
 func (nm *networkManager) restore() error {
 	// Skip if a store is not provided.
 	if nm.store == nil {
+		log.Printf("[net] network store is nil")
 		return nil
 	}
 
@@ -83,6 +84,7 @@ func (nm *networkManager) restore() error {
 	err := nm.store.Read(storeKey, nm)
 	if err != nil {
 		if err == store.ErrKeyNotFound {
+			log.Printf("[net] network store key not found")
 			// Considered successful.
 			return nil
 		} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
This PR fixes assigning duplicate ips to pods. The fix is initialize cni ipam store on start.
#181 
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```