### PR TITLE
Smooth build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,12 @@ else
 all-binaries: azure-cnm-plugin azure-cni-plugin azure-cns
 endif
 
+ifeq ($(GOOS),linux)
 all-images: azure-npm-image
+else 
+all-images: 
+	@echo "Nothing to build. Skip."
+endif
 
 # Clean all build artifacts.
 .PHONY: clean

--- a/build/build-all-containerized.sh
+++ b/build/build-all-containerized.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 
 BUILD_CONTAINER_NAME=acn-builder
-GOOS=$1
-GOARCH=$2
 
 if [ ! "$(docker ps -q -f name=$BUILD_CONTAINER_NAME)" ]; then
     if [ "$(docker ps -aq -f status=exited -f name=$BUILD_CONTAINER_NAME)" ]; then
@@ -10,4 +8,4 @@ if [ ! "$(docker ps -q -f name=$BUILD_CONTAINER_NAME)" ]; then
     fi
 fi
 
-make all-containerized
+GOOS=$1 GOARCH=$2 make all-containerized


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes stale container while in the build process.

**Which issue this PR fixes**

Previously there will be a stale container for failed Jenkins build. This will prevent next build from happening. This PR removes stale container while in the build process.
