### PR TITLE
Generating EndpointID should not rely on netns in Linux

### DIFF
--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -5,7 +5,6 @@ package network
 
 import (
 	"net"
-	"strings"
 
 	"github.com/Azure/azure-container-networking/log"
 	"github.com/Azure/azure-container-networking/network/policy"
@@ -50,31 +49,6 @@ type RouteInfo struct {
 	Dst     net.IPNet
 	Gw      net.IP
 	DevName string
-}
-
-// ConstructEndpointID constructs endpoint name from netNsPath.
-func ConstructEndpointID(containerID string, netNsPath string, ifName string) (string, string) {
-	infraEpName, workloadEpName := "", ""
-
-	if len(containerID) > 8 {
-		containerID = containerID[:8]
-	}
-
-	if netNsPath != "" {
-		splits := strings.Split(netNsPath, ":")
-		// For workload containers, we extract its linking infrastructure container ID.
-		if len(splits) == 2 {
-			if len(splits[1]) > 8 {
-				splits[1] = splits[1][:8]
-			}
-			infraEpName = splits[1] + "-" + ifName
-			workloadEpName = containerID + "-" + ifName
-		} else {
-			// For infrastructure containers, we just use its container ID.
-			infraEpName = containerID + "-" + ifName
-		}
-	}
-	return infraEpName, workloadEpName
 }
 
 // NewEndpoint creates a new endpoint in the network.
@@ -135,6 +109,8 @@ func (nw *network) deleteEndpoint(endpointId string) error {
 
 // GetEndpoint returns the endpoint with the given ID.
 func (nw *network) getEndpoint(endpointId string) (*endpoint, error) {
+	log.Printf("Trying to retrieve endpoint id %v", endpointId)
+
 	ep := nw.Endpoints[endpointId]
 
 	if ep == nil {

--- a/network/endpoint_linux.go
+++ b/network/endpoint_linux.go
@@ -31,6 +31,19 @@ func generateVethName(key string) string {
 	return hex.EncodeToString(h.Sum(nil))[:11]
 }
 
+func ConstructEndpointID(containerID string, netNsPath string, ifName string) (string, string) {
+	if len(containerID) > 8 {
+		containerID = containerID[:8]
+	} else {
+		log.Printf("Container ID is not greater than 8 ID: %v", containerID)
+		return "", ""
+	}
+
+	infraEpName := containerID + "-" + ifName
+
+	return infraEpName, ""
+}
+
 // newEndpointImpl creates a new endpoint in the network.
 func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
 	var containerIf *net.Interface
@@ -159,7 +172,7 @@ func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
 	// Create the endpoint object.
 	ep = &endpoint{
 		Id:               epInfo.Id,
-		IfName:           contIfName,
+		IfName:           epInfo.IfName,
 		HostIfName:       hostIfName,
 		MacAddress:       containerIf.HardwareAddr,
 		IPAddresses:      epInfo.IPAddresses,

--- a/network/manager.go
+++ b/network/manager.go
@@ -152,6 +152,16 @@ func (nm *networkManager) restore() error {
 	}
 
 	log.Printf("[net] Restored state, %+v\n", nm)
+	for _, extIf := range nm.ExternalInterfaces {
+		log.Printf("External Interface %v", extIf)
+		for _, nw := range extIf.Networks {
+			log.Printf("network %v", nw)
+			for _, ep := range nw.Endpoints {
+				log.Printf("endpoint %v", ep)
+			}
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
This PR fixes leaking IPs if netns is empty. In that case, endpointID is returned empty and call to ipam resource cleanup is not happening

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```