### PR TITLE
Fix for unparseable error returned by Azure CNI

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -151,32 +151,34 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 		args.ContainerID, args.Netns, args.IfName, args.Args, args.Path)
 
 	defer func() {
-		if result == nil {
-			result = &cniTypesCurr.Result{}
+		if err == nil {
+			if result == nil {
+				result = &cniTypesCurr.Result{}
+			}
+
+			// Add Interfaces to result.
+			if result == nil {
+				result = &cniTypesCurr.Result{}
+			}
+
+			iface = &cniTypesCurr.Interface{
+				Name: args.IfName,
+			}
+
+			result.Interfaces = append(result.Interfaces, iface)
+
+			addSnatInterface(nwCfg, result)
+
+			// Convert result to the requested CNI version.
+			res, err := result.GetAsVersion(nwCfg.CNIVersion)
+			if err != nil {
+				err = plugin.Error(err)
+			}
+
+			// Output the result to stdout.
+			res.Print()
+			log.Printf("[cni-net] ADD command completed with result:%+v err:%v.", result, err)
 		}
-		
-		// Add Interfaces to result.
-		if result == nil {
-			result = &cniTypesCurr.Result{}
-		}
-
-		iface = &cniTypesCurr.Interface{
-			Name: args.IfName,
-		}
-
-		result.Interfaces = append(result.Interfaces, iface)
-
-		addSnatInterface(nwCfg, result)
-
-		// Convert result to the requested CNI version.
-		res, err := result.GetAsVersion(nwCfg.CNIVersion)
-		if err != nil {
-			err = plugin.Error(err)
-		}
-
-		// Output the result to stdout.
-		res.Print()
-		log.Printf("[cni-net] ADD command completed with result:%+v err:%v.", result, err)
 	}()
 
 	// Parse Pod arguments.

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -171,7 +171,7 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 			plugin.Error(vererr)
 		}
 
-		if err == nil {
+		if err == nil && res != nil {
 			// Output the result to stdout.
 			res.Print()
 		}

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -151,34 +151,32 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 		args.ContainerID, args.Netns, args.IfName, args.Args, args.Path)
 
 	defer func() {
+		// Add Interfaces to result.
+		if result == nil {
+			result = &cniTypesCurr.Result{}
+		}
+
+		iface = &cniTypesCurr.Interface{
+			Name: args.IfName,
+		}
+
+		result.Interfaces = append(result.Interfaces, iface)
+
+		addSnatInterface(nwCfg, result)
+
+		// Convert result to the requested CNI version.
+		res, vererr := result.GetAsVersion(nwCfg.CNIVersion)
+		if vererr != nil {
+			log.Printf("GetAsVersion failed with error %v", vererr)
+			plugin.Error(vererr)
+		}
+
 		if err == nil {
-			if result == nil {
-				result = &cniTypesCurr.Result{}
-			}
-
-			// Add Interfaces to result.
-			if result == nil {
-				result = &cniTypesCurr.Result{}
-			}
-
-			iface = &cniTypesCurr.Interface{
-				Name: args.IfName,
-			}
-
-			result.Interfaces = append(result.Interfaces, iface)
-
-			addSnatInterface(nwCfg, result)
-
-			// Convert result to the requested CNI version.
-			res, err := result.GetAsVersion(nwCfg.CNIVersion)
-			if err != nil {
-				err = plugin.Error(err)
-			}
-
 			// Output the result to stdout.
 			res.Print()
-			log.Printf("[cni-net] ADD command completed with result:%+v err:%v.", result, err)
 		}
+
+		log.Printf("[cni-net] ADD command completed with result:%+v err:%v.", result, err)
 	}()
 
 	// Parse Pod arguments.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
This PR fixes the unparseable error returned by Azure CNI (#195 ). Azure CNI should write result to stdout only in successful case

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```