### PR TITLE
Remove hot attach for create endpoint.  Join will hot attach instead

### DIFF
--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -89,7 +89,17 @@ func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
 	}()
 
 	// Attach the endpoint happens on join
-	log.Printf("[net] Skipping Attaching endpoint %v to container %v, as this will happen in NetworkDriver/Join", hnsResponse.Id, epInfo.ContainerID)
+	if len(epInfo.ContainerID) > 0 {
+		log.Printf("[net] Attaching endpoint %v to container %v.", hnsResponse.Id, epInfo.ContainerID)
+		err = hcsshim.HotAttachEndpoint(epInfo.ContainerID, hnsResponse.Id)
+		if err != nil {
+			log.Printf("[net] Failed to attach endpoint: %v.", err)
+			return nil, err
+		}
+	} else {
+		// Attach the endpoint happens on join
+		log.Printf("[net] Skipping Attaching endpoint %v to container %v, as this will happen in NetworkDriver/Join", hnsResponse.Id, epInfo.ContainerID)
+	}
 
 	// Create the endpoint object.
 	ep := &endpoint{

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -88,13 +88,8 @@ func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
 		}
 	}()
 
-	// Attach the endpoint.
-	log.Printf("[net] Attaching endpoint %v to container %v.", hnsResponse.Id, epInfo.ContainerID)
-	err = hcsshim.HotAttachEndpoint(epInfo.ContainerID, hnsResponse.Id)
-	if err != nil {
-		log.Printf("[net] Failed to attach endpoint: %v.", err)
-		return nil, err
-	}
+	// Attach the endpoint happens on join
+	log.Printf("[net] Skipping Attaching endpoint %v to container %v, as this will happen in NetworkDriver/Join", hnsResponse.Id, epInfo.ContainerID)
 
 	// Create the endpoint object.
 	ep := &endpoint{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Hot attach should happen in the join, not in create endpoint.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
https://github.com/Azure/azure-container-networking/issues/235
**Special notes for your reviewer**:
![cnm testing](https://user-images.githubusercontent.com/2498998/45248787-ae2b2080-b2ca-11e8-9500-96c0386368e9.png)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```