### PR TITLE
Adding parameter validation to build scripts

### DIFF
--- a/build/build-all-containerized.sh
+++ b/build/build-all-containerized.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+if [[ -z $1 ]] || [[ -z $2 ]]; then
+    echo "Usage: $0 <os> <architecture>"
+    echo "       Example: $0 linux amd64"
+    exit 1
+fi
 
 BUILD_CONTAINER_NAME=acn-builder
 

--- a/build/build-all.sh
+++ b/build/build-all.sh
@@ -1,2 +1,7 @@
 #!/usr/bin/env bash
+if [[ -z $1 ]] || [[ -z $2 ]]; then
+    echo "Usage: $0 <os> <architecture>"
+    echo "       Example: $0 linux amd64"
+    exit 1
+fi
 GOOS=$1 GOARCH=$2 make all-binaries


### PR DESCRIPTION
**What this PR does / why we need it**:

If you run `./build/build-all.sh` or `./build/build-all-containerized.sh`, it will fail:

```none
command-line-arguments
go build -v -o output/_/cni/azure-vnet-ipam.exe -ldflags "-X main.version=v1.0.12-rc3-8-g009ebee-dirty -s -w" cni/ipam/plugin/*.go
github.com/Azure/azure-container-networking/cni/ipam
command-line-arguments
cp cni/azure-.conflist output/_/cni/10-azure.conflist
cp: cannot stat 'cni/azure-.conflist': No such file or directory
Makefile:246: recipe for target 'cni-archive' failed
make: *** [cni-archive] Error 1
Makefile:169: recipe for target 'all-containerized' failed
make: *** [all-containerized] Error 2
```

This fixes it and will show proper usage instead.
