### PR TITLE
Store fixes; Windows compile

### DIFF
--- a/cni/plugin.go
+++ b/cni/plugin.go
@@ -161,14 +161,14 @@ func (plugin *Plugin) InitializeKeyValueStore(config *common.PluginConfig) error
 		var err error
 		plugin.Store, err = store.NewJsonFileStore(platform.CNIRuntimePath + plugin.Name + ".json")
 		if err != nil {
-			log.Printf("[cni] Failed to create store, err:%v.", err)
+			log.Printf("[cni] Failed to create store: %v.", err)
 			return err
 		}
 	}
 
 	// Acquire store lock.
 	if err := plugin.Store.Lock(true); err != nil {
-		log.Printf("[cni] Timed out on locking store, err:%v.", err)
+		log.Printf("[cni] Failed to lock store: %v.", err)
 		return err
 	}
 
@@ -182,7 +182,7 @@ func (plugin *Plugin) UninitializeKeyValueStore() error {
 	if plugin.Store != nil {
 		err := plugin.Store.Unlock()
 		if err != nil {
-			log.Printf("[cni] Failed to unlock store, err:%v.", err)
+			log.Printf("[cni] Failed to unlock store: %v.", err)
 			return err
 		}
 	}

--- a/netlink/ip.go
+++ b/netlink/ip.go
@@ -1,6 +1,8 @@
 // Copyright 2017 Microsoft. All rights reserved.
 // MIT License
 
+// +build linux
+
 package netlink
 
 import (

--- a/netlink/link.go
+++ b/netlink/link.go
@@ -1,6 +1,8 @@
 // Copyright 2017 Microsoft. All rights reserved.
 // MIT License
 
+// +build linux
+
 package netlink
 
 import (

--- a/netlink/netlink.go
+++ b/netlink/netlink.go
@@ -1,6 +1,8 @@
 // Copyright 2017 Microsoft. All rights reserved.
 // MIT License
 
+// +build linux
+
 package netlink
 
 import (

--- a/netlink/netlink_test.go
+++ b/netlink/netlink_test.go
@@ -1,6 +1,8 @@
 // Copyright 2017 Microsoft. All rights reserved.
 // MIT License
 
+// +build linux
+
 package netlink
 
 import (

--- a/netlink/netlink_windows.go
+++ b/netlink/netlink_windows.go
@@ -1,0 +1,4 @@
+// Copyright 2017 Microsoft. All rights reserved.
+// MIT License
+
+package netlink

--- a/netlink/protocol.go
+++ b/netlink/protocol.go
@@ -1,6 +1,8 @@
 // Copyright 2017 Microsoft. All rights reserved.
 // MIT License
 
+// +build linux
+
 package netlink
 
 import (

--- a/netlink/socket.go
+++ b/netlink/socket.go
@@ -1,6 +1,8 @@
 // Copyright 2017 Microsoft. All rights reserved.
 // MIT License
 
+// +build linux
+
 package netlink
 
 import (

--- a/network/endpoint_linux.go
+++ b/network/endpoint_linux.go
@@ -1,8 +1,6 @@
 // Copyright 2017 Microsoft. All rights reserved.
 // MIT License
 
-// +build linux
-
 package network
 
 import (

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -1,8 +1,6 @@
 // Copyright 2017 Microsoft. All rights reserved.
 // MIT License
 
-// +build windows
-
 package network
 
 import (

--- a/network/epcommon/endpoint_common_windows.go
+++ b/network/epcommon/endpoint_common_windows.go
@@ -1,0 +1,1 @@
+package epcommon

--- a/network/namespace_linux.go
+++ b/network/namespace_linux.go
@@ -1,8 +1,6 @@
 // Copyright 2017 Microsoft. All rights reserved.
 // MIT License
 
-// +build linux
-
 package network
 
 import (

--- a/network/network_linux.go
+++ b/network/network_linux.go
@@ -1,8 +1,6 @@
 // Copyright 2017 Microsoft. All rights reserved.
 // MIT License
 
-// +build linux
-
 package network
 
 import (

--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -1,8 +1,6 @@
 // Copyright 2017 Microsoft. All rights reserved.
 // MIT License
 
-// +build windows
-
 package network
 
 import (

--- a/store/store.go
+++ b/store/store.go
@@ -20,7 +20,9 @@ type KeyValueStore interface {
 
 var (
 	// Errors returned by KeyValueStore methods.
-	ErrKeyNotFound    = fmt.Errorf("Key not found")
-	ErrStoreLocked    = fmt.Errorf("Store is locked")
-	ErrStoreNotLocked = fmt.Errorf("Store is not locked")
+	ErrKeyNotFound                    = fmt.Errorf("key not found")
+	ErrStoreLocked                    = fmt.Errorf("store is already locked")
+	ErrStoreNotLocked                 = fmt.Errorf("store is not locked")
+	ErrTimeoutLockingStore            = fmt.Errorf("timed out locking store")
+	ErrNonBlockingLockIsAlreadyLocked = fmt.Errorf("attempted to perform non-blocking lock on an already locked store")
 )


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Fixes https://github.com/Azure/azure-container-networking/issues/242

- First, the store timeout is woefully low. Bumped to 20 seconds from 2 seconds.
  This appears to fix https://github.com/Azure/azure-container-networking/issues/242#issuecomment-422701838
  IMO, as only test code calls it non-blocked, why even have a block parameter to Lock()?
  IMO also, why a timeout at all? They're always fraught with error and machine timing.

- Presence of a key should be checked using `raw, ok := hvs.data[key]`, not the current nil checked

- ErrKeyNotFound should be returned if the store file does not exist. It shouldn't ignore that error.

- Actually now reports if a timeout occurred correctly, along with non-block lock attempt when already locked.

- Serial pattern abuse in not always closing the lock file.

- Some golang correctness (errors should be lower case)

- go build ./... actually passes on Windows now - various compile errors previously.

- golang pattern conformance `if err:=<test>; err!=nil {....`

- take the mutex in GetModificationTime. Was not thread safe!

- Simplified timeout duration (no need for time.Duration(...))
