### PR TITLE
Remove HNSNetwork's DNS suffix in Windows

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -6,7 +6,6 @@ package network
 import (
 	"fmt"
 	"net"
-	"strings"
 
 	"github.com/Azure/azure-container-networking/cni"
 	"github.com/Azure/azure-container-networking/cns"
@@ -327,6 +326,12 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 			return err
 		}
 
+		nwDnsInfo, err := getNetworkDNSSettings(nwCfg, result, k8sNamespace)
+		if err != nil {
+			err = plugin.Errorf("Failed to getDNSSettings: %v", err)
+			return err
+		}
+
 		// Create the network.
 		nwInfo := network.NetworkInfo{
 			Id:   networkId,
@@ -340,11 +345,8 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 			},
 			BridgeName:       nwCfg.Bridge,
 			EnableSnatOnHost: nwCfg.EnableSnatOnHost,
-			DNS: network.DNSInfo{
-				Servers: nwCfg.DNS.Nameservers,
-				Suffix:  k8sNamespace + "." + strings.Join(nwCfg.DNS.Search, ","),
-			},
-			Policies: policies,
+			DNS:              nwDnsInfo,
+			Policies:         policies,
 		}
 
 		nwInfo.Options = make(map[string]interface{})
@@ -386,6 +388,12 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 		}
 	}
 
+	epDnsInfo, err := getEndpointDNSSettings(nwCfg, result, k8sNamespace)
+	if err != nil {
+		err = plugin.Errorf("Failed to getEndpointDNSSettings: %v", err)
+		return err
+	}
+
 	epInfo = &network.EndpointInfo{
 		Id:               endpointId,
 		ContainerID:      args.ContainerID,
@@ -393,17 +401,10 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 		IfName:           args.IfName,
 		EnableSnatOnHost: nwCfg.EnableSnatOnHost,
 		EnableInfraVnet:  enableInfraVnet,
+		Data:             make(map[string]interface{}),
+		DNS:              epDnsInfo,
+		Policies:         policies,
 	}
-	epInfo.Data = make(map[string]interface{})
-
-	dns, err := getDNSSettings(nwCfg, result, k8sNamespace)
-	if err != nil {
-		log.Printf("Error retrieving dns settings %v", err)
-		return err
-	}
-
-	epInfo.DNS = dns
-	epInfo.Policies = policies
 
 	// Populate addresses.
 	for _, ipconfig := range result.IPs {

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -326,11 +326,13 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 			return err
 		}
 
-		nwDnsInfo, err := getNetworkDNSSettings(nwCfg, result, k8sNamespace)
+		nwDNSInfo, err := getNetworkDNSSettings(nwCfg, result, k8sNamespace)
 		if err != nil {
 			err = plugin.Errorf("Failed to getDNSSettings: %v", err)
 			return err
 		}
+
+		log.Printf("[cni-net] nwDNSInfo: %v", nwDNSInfo)
 
 		// Create the network.
 		nwInfo := network.NetworkInfo{
@@ -345,7 +347,7 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 			},
 			BridgeName:       nwCfg.Bridge,
 			EnableSnatOnHost: nwCfg.EnableSnatOnHost,
-			DNS:              nwDnsInfo,
+			DNS:              nwDNSInfo,
 			Policies:         policies,
 		}
 
@@ -388,7 +390,7 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 		}
 	}
 
-	epDnsInfo, err := getEndpointDNSSettings(nwCfg, result, k8sNamespace)
+	epDNSInfo, err := getEndpointDNSSettings(nwCfg, result, k8sNamespace)
 	if err != nil {
 		err = plugin.Errorf("Failed to getEndpointDNSSettings: %v", err)
 		return err
@@ -402,7 +404,7 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 		EnableSnatOnHost: nwCfg.EnableSnatOnHost,
 		EnableInfraVnet:  enableInfraVnet,
 		Data:             make(map[string]interface{}),
-		DNS:              epDnsInfo,
+		DNS:              epDNSInfo,
 		Policies:         policies,
 	}
 

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -80,20 +80,24 @@ func setupInfraVnetRoutingForMultitenancy(
 	}
 }
 
-func getDNSSettings(nwCfg *cni.NetworkConfig, result *cniTypesCurr.Result, namespace string) (network.DNSInfo, error) {
-	var dns network.DNSInfo
+func getNetworkDNSSettings(nwCfg *cni.NetworkConfig, result *cniTypesCurr.Result, namespace string) (network.DNSInfo, error) {
+	var nwDNS network.DNSInfo
 
 	if len(nwCfg.DNS.Nameservers) > 0 {
-		dns = network.DNSInfo{
+		nwDNS = network.DNSInfo{
 			Servers: nwCfg.DNS.Nameservers,
 			Suffix:  nwCfg.DNS.Domain,
 		}
 	} else {
-		dns = network.DNSInfo{
+		nwDNS = network.DNSInfo{
 			Suffix:  result.DNS.Domain,
 			Servers: result.DNS.Nameservers,
 		}
 	}
 
-	return dns, nil
+	return nwDNS, nil
+}
+
+func getEndpointDNSSettings(nwCfg *cni.NetworkConfig, result *cniTypesCurr.Result, namespace string) (network.DNSInfo, error) {
+	return getNetworkDNSSettings(nwCfg, result, namespace)
 }

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -83,25 +83,40 @@ func setupInfraVnetRoutingForMultitenancy(
 	result *cniTypesCurr.Result) {
 }
 
-func getDNSSettings(nwCfg *cni.NetworkConfig, result *cniTypesCurr.Result, namespace string) (network.DNSInfo, error) {
-	var dns network.DNSInfo
+func getNetworkDNSSettings(nwCfg *cni.NetworkConfig, result *cniTypesCurr.Result, namespace string) (network.DNSInfo, error) {
+	var nwDNS network.DNSInfo
 
 	if (len(nwCfg.DNS.Search) == 0) != (len(nwCfg.DNS.Nameservers) == 0) {
 		err := fmt.Errorf("Wrong DNS configuration: %+v", nwCfg.DNS)
-		return dns, err
+		return nwDNS, err
+	}
+
+	nwDNS = network.DNSInfo{
+		Servers: nwCfg.DNS.Nameservers,
+	}
+
+	return nwDNS, nil
+}
+
+func getEndpointDNSSettings(nwCfg *cni.NetworkConfig, result *cniTypesCurr.Result, namespace string) (network.DNSInfo, error) {
+	var epDNS network.DNSInfo
+
+	if (len(nwCfg.DNS.Search) == 0) != (len(nwCfg.DNS.Nameservers) == 0) {
+		err := fmt.Errorf("Wrong DNS configuration: %+v", nwCfg.DNS)
+		return epDNS, err
 	}
 
 	if len(nwCfg.DNS.Search) > 0 {
-		dns = network.DNSInfo{
+		epDNS = network.DNSInfo{
 			Servers: nwCfg.DNS.Nameservers,
 			Suffix:  namespace + "." + strings.Join(nwCfg.DNS.Search, ","),
 		}
 	} else {
-		dns = network.DNSInfo{
+		epDNS = network.DNSInfo{
 			Suffix:  result.DNS.Domain,
 			Servers: result.DNS.Nameservers,
 		}
 	}
 
-	return dns, nil
+	return epDNS, nil
 }

--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -33,7 +33,6 @@ func (nm *networkManager) newNetworkImpl(nwInfo *NetworkInfo, extIf *externalInt
 	hnsNetwork := &hcsshim.HNSNetwork{
 		Name:               nwInfo.Id,
 		NetworkAdapterName: networkAdapterName,
-		DNSSuffix:          nwInfo.DNS.Suffix,
 		DNSServerList:      strings.Join(nwInfo.DNS.Servers, ","),
 		Policies:           policy.SerializePolicies(policy.NetworkPolicy, nwInfo.Policies),
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes HNSNetwork's DNS suffix in Windows. Previously, the HNSNetwork's DNS suffix gets overwritten by newly created HNSEndpoint's DNS suffix. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #245 
