### PR TITLE
Adding PortMapping support to Azure cni for Windows (Rebase).

### DIFF
--- a/cni/azure-windows.conflist
+++ b/cni/azure-windows.conflist
@@ -1,43 +1,46 @@
 {
-   "cniVersion":"0.3.0",
-   "name":"azure",
-   "plugins":[
-      {
-         "type":"azure-vnet",
-         "mode":"bridge",
-         "bridge":"azure0",
-         "ipam":{
-            "type":"azure-vnet-ipam"
-         },
-         "dns":{
-            "Nameservers":[
-               "10.0.0.10",
-               "168.63.129.16"
-            ],
-            "Search":[
-               "svc.cluster.local"
-            ]
-         },
-         "AdditionalArgs":[
-            {
-               "Name":"EndpointPolicy",
-               "Value":{
-                  "Type":"OutBoundNAT",
-                  "ExceptionList":[
-                     "10.240.0.0/16",
-                     "10.0.0.0/8"
-                  ]
-               }
+    "cniVersion": "0.3.0",
+    "name": "azure",
+    "plugins": [
+        {
+            "type": "azure-vnet",
+            "mode": "bridge",
+            "bridge": "azure0",
+            "capabilities": {
+                "portMappings": true
             },
-            {
-               "Name":"EndpointPolicy",
-               "Value":{
-                  "Type":"ROUTE",
-                  "DestinationPrefix":"10.0.0.0/8",
-                  "NeedEncap":true
-               }
-            }
-         ]
-      }
-   ]
+            "ipam": {
+                "type": "azure-vnet-ipam"
+            },
+            "dns": {
+                "Nameservers": [
+                    "10.0.0.10",
+                    "168.63.129.16"
+                ],
+                "Search": [
+                    "svc.cluster.local"
+                ]
+            },
+            "AdditionalArgs": [
+                {
+                    "Name": "EndpointPolicy",
+                    "Value": {
+                        "Type": "OutBoundNAT",
+                        "ExceptionList": [
+                            "10.240.0.0/16",
+                            "10.0.0.0/8"
+                        ]
+                    }
+                },
+                {
+                    "Name": "EndpointPolicy",
+                    "Value": {
+                        "Type": "ROUTE",
+                        "DestinationPrefix": "10.0.0.0/8",
+                        "NeedEncap": true
+                    }
+                }
+            ]
+        }
+    ]
 }

--- a/cni/netconfig.go
+++ b/cni/netconfig.go
@@ -22,6 +22,17 @@ type KVPair struct {
 	Value json.RawMessage `json:"value"`
 }
 
+type PortMapping struct {
+	HostPort      int    `json:"hostPort"`
+	ContainerPort int    `json:"containerPort"`
+	Protocol      string `json:"protocol"`
+	HostIp        string `json:"hostIP,omitempty"`
+}
+
+type RuntimeConfig struct {
+	PortMappings []PortMapping `json:"portMappings,omitempty"`
+}
+
 // NetworkConfig represents Azure CNI plugin network configuration.
 type NetworkConfig struct {
 	CNIVersion                 string   `json:"cniVersion"`
@@ -45,7 +56,8 @@ type NetworkConfig struct {
 		Address       string `json:"ipAddress,omitempty"`
 		QueryInterval string `json:"queryInterval,omitempty"`
 	}
-	DNS            cniTypes.DNS `json:"dns"`
+	DNS            cniTypes.DNS  `json:"dns"`
+	RuntimeConfig  RuntimeConfig `json:"runtimeConfig"`
 	AdditionalArgs []KVPair
 }
 

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -407,6 +407,11 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 		DNS:              epDNSInfo,
 		Policies:         policies,
 	}
+	
+	epPolicies := getPoliciesFromRuntimeCfg(nwCfg)
+	for _, epPolicy := range epPolicies {
+		epInfo.Policies = append(epInfo.Policies, epPolicy)
+	}
 
 	// Populate addresses.
 	for _, ipconfig := range result.IPs {

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/log"
 	"github.com/Azure/azure-container-networking/network"
+	"github.com/Azure/azure-container-networking/network/policy"
 	cniTypes "github.com/containernetworking/cni/pkg/types"
 	cniTypesCurr "github.com/containernetworking/cni/pkg/types/current"
 )
@@ -100,4 +101,10 @@ func getNetworkDNSSettings(nwCfg *cni.NetworkConfig, result *cniTypesCurr.Result
 
 func getEndpointDNSSettings(nwCfg *cni.NetworkConfig, result *cniTypesCurr.Result, namespace string) (network.DNSInfo, error) {
 	return getNetworkDNSSettings(nwCfg, result, namespace)
+}
+
+// getPoliciesFromRuntimeCfg returns network policies from network config.
+// getPoliciesFromRuntimeCfg is a dummy function for Linux platform.
+func getPoliciesFromRuntimeCfg(nwCfg *cni.NetworkConfig) []policy.Policy {
+	return nil
 }


### PR DESCRIPTION
Rebase of https://github.com/Azure/azure-container-networking/pull/253

Azure CNI doesn’t program any port mappings. Its not supported in Azure CNI.
Earlier it worked because the port mapping was programmed through NAT network which was added by accident.
