### PR TITLE
HNS v2 Api & Schema support

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -255,22 +255,9 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 	// Check whether the network already exists.
 	nwInfo, nwInfoErr := plugin.nm.GetNetworkInfo(networkId)
 
-	if nwInfoErr == nil {
-		/* Handle consecutive ADD calls for infrastructure containers.
-		* This is a temporary work around for issue #57253 of Kubernetes.
-		* We can delete this if statement once they fix it.
-		* Issue link: https://github.com/kubernetes/kubernetes/issues/57253
-		 */
-		epInfo, _ := plugin.nm.GetEndpointInfo(networkId, endpointId)
-		if epInfo != nil {
-			return nil
-		}
-	}
-
 	// TODO: Remove network creation once the workflow no longer requires it.
 	if nwInfoErr != nil {
 		// Network does not exist.
-
 		log.Printf("[cni-net] Creating network %v.", networkId)
 
 		if !nwCfg.MultiTenancy {

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -263,18 +263,11 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 		 */
 		epInfo, _ := plugin.nm.GetEndpointInfo(networkId, endpointId)
 		if epInfo != nil {
-			result, err = handleConsecutiveAdd(args.ContainerID, endpointId, nwInfo, nwCfg)
-			if err != nil {
-				log.Printf("handleConsecutiveAdd failed with error %v", err)
-				return err
-			}
-
-			if result != nil {
-				return nil
-			}
+			return nil
 		}
 	}
 
+	// TODO: Remove network creation once the workflow no longer requires it.
 	if nwInfoErr != nil {
 		// Network does not exist.
 

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -17,11 +17,6 @@ const (
 	infraInterface = "eth2"
 )
 
-// handleConsecutiveAdd is a dummy function for Linux platform.
-func handleConsecutiveAdd(containerId, endpointId string, nwInfo *network.NetworkInfo, nwCfg *cni.NetworkConfig) (*cniTypesCurr.Result, error) {
-	return nil, nil
-}
-
 func addDefaultRoute(gwIPString string, epInfo *network.EndpointInfo, result *cniTypesCurr.Result) {
 	_, defaultIPNet, _ := net.ParseCIDR("0.0.0.0/0")
 	dstIP := net.IPNet{IP: net.ParseIP("0.0.0.0"), Mask: defaultIPNet.Mask}

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -9,57 +9,11 @@ import (
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/log"
 	"github.com/Azure/azure-container-networking/network"
-	"github.com/Microsoft/hcsshim"
 
 	cniTypes "github.com/containernetworking/cni/pkg/types"
 	cniTypesCurr "github.com/containernetworking/cni/pkg/types/current"
 )
 
-/* handleConsecutiveAdd handles consecutive add calls for infrastructure containers on Windows platform.
- * This is a temporary work around for issue #57253 of Kubernetes.
- * We can delete this if statement once they fix it.
- * Issue link: https://github.com/kubernetes/kubernetes/issues/57253
- */
-func handleConsecutiveAdd(containerId, endpointId string, nwInfo *network.NetworkInfo, nwCfg *cni.NetworkConfig) (*cniTypesCurr.Result, error) {
-	hnsEndpoint, err := hcsshim.GetHNSEndpointByName(endpointId)
-	if hnsEndpoint != nil {
-		log.Printf("[net] Found existing endpoint through hcsshim: %+v", hnsEndpoint)
-		log.Printf("[net] Attaching ep %v to container %v", hnsEndpoint.Id, containerId)
-
-		err := hcsshim.HotAttachEndpoint(containerId, hnsEndpoint.Id)
-		if err != nil {
-			log.Printf("[cni-net] Failed to hot attach shared endpoint[%v] to container [%v], err:%v.", hnsEndpoint.Id, containerId, err)
-			return nil, err
-		}
-
-		// Populate result.
-		address := nwInfo.Subnets[0].Prefix
-		address.IP = hnsEndpoint.IPAddress
-		result := &cniTypesCurr.Result{
-			IPs: []*cniTypesCurr.IPConfig{
-				{
-					Version: "4",
-					Address: address,
-					Gateway: net.ParseIP(hnsEndpoint.GatewayAddress),
-				},
-			},
-			Routes: []*cniTypes.Route{
-				{
-					Dst: net.IPNet{net.IPv4zero, net.IPv4Mask(0, 0, 0, 0)},
-					GW:  net.ParseIP(hnsEndpoint.GatewayAddress),
-				},
-			},
-		}
-
-		// Populate DNS servers.
-		result.DNS.Nameservers = nwCfg.DNS.Nameservers
-
-		return result, nil
-	}
-
-	err = fmt.Errorf("GetHNSEndpointByName for %v returned nil with err %v", endpointId, err)
-	return nil, err
-}
 
 func addDefaultRoute(gwIPString string, epInfo *network.EndpointInfo, result *cniTypesCurr.Result) {
 }

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -2,18 +2,14 @@ package network
 
 import (
 	"fmt"
-	"net"
 	"strings"
 
 	"github.com/Azure/azure-container-networking/cni"
 	"github.com/Azure/azure-container-networking/cns"
-	"github.com/Azure/azure-container-networking/log"
 	"github.com/Azure/azure-container-networking/network"
 
-	cniTypes "github.com/containernetworking/cni/pkg/types"
 	cniTypesCurr "github.com/containernetworking/cni/pkg/types/current"
 )
-
 
 func addDefaultRoute(gwIPString string, epInfo *network.EndpointInfo, result *cniTypesCurr.Result) {
 }

--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Azure/azure-container-networking/log"
 	"github.com/Azure/azure-container-networking/network/policy"
+	"github.com/Microsoft/hcsshim"
 	"github.com/Microsoft/hcsshim/hcn"
 )
 
@@ -23,63 +24,94 @@ func (nm *networkManager) newNetworkImpl(nwInfo *NetworkInfo, extIf *externalInt
 		networkAdapterName = ""
 	}
 
-	hcnPolicies := policy.SerializeHostComputeNetworkPolicies(nwInfo.Policies)
+	/*
+		// TODO: RS5 at release does not process V2 Network Schema, using V1 for now.
+		hcnPolicies := policy.SerializeHostComputeNetworkPolicies(nwInfo.Policies)
 
-	// Create NetworkAdapterName Policy
-	if networkAdapterName != "" {
-		hcnNetAdapterNamePolicy := policy.CreateNetworkAdapterNamePolicySetting(networkAdapterName)
-		hcnPolicies = append(hcnPolicies, hcnNetAdapterNamePolicy)
-	}
+		// Create NetworkAdapterName Policy
+		if networkAdapterName != "" {
+			hcnNetAdapterNamePolicy := policy.CreateNetworkAdapterNamePolicySetting(networkAdapterName)
+			hcnPolicies = append(hcnPolicies, hcnNetAdapterNamePolicy)
+		}
+
+		// Initialize HNS network.
+		hnsNetwork := &hcn.HostComputeNetwork{
+			Name: nwInfo.Id,
+			Ipams: []hcn.Ipam{
+				hcn.Ipam{
+					Type: "Static",
+				},
+			},
+			Dns: hcn.Dns{
+				Suffix:     nwInfo.DNS.Suffix,
+				ServerList: nwInfo.DNS.Servers,
+			},
+			SchemaVersion: hcn.SchemaVersion{
+				Major: 2,
+				Minor: 0,
+			},
+			Policies: hcnPolicies,
+		}
+
+		// Set network mode.
+		switch nwInfo.Mode {
+		case opModeBridge:
+			hnsNetwork.Type = hcn.L2Bridge
+		case opModeTunnel:
+			hnsNetwork.Type = hcn.L2Tunnel
+		default:
+			return nil, errNetworkModeInvalid
+		}
+
+		// Populate subnets.
+		for _, subnet := range nwInfo.Subnets {
+			// Check for nil on address objects.
+			ipAddr := ""
+			if subnet.Prefix.IP != nil && subnet.Prefix.Mask != nil {
+				ipAddr = subnet.Prefix.String()
+			}
+			gwAddr := ""
+			if subnet.Gateway != nil {
+				gwAddr = subnet.Gateway.String()
+			}
+			hnsSubnet := hcn.Subnet{
+				IpAddressPrefix: ipAddr,
+				Routes: []hcn.Route{
+					hcn.Route{
+						NextHop: gwAddr,
+					},
+				},
+			}
+			hnsNetwork.Ipams[0].Subnets = append(hnsNetwork.Ipams[0].Subnets, hnsSubnet)
+		}
+	*/
 
 	// Initialize HNS network.
-	hnsNetwork := &hcn.HostComputeNetwork{
-		Name: nwInfo.Id,
-		Ipams: []hcn.Ipam{
-			hcn.Ipam{
-				Type: "Static",
-			},
-		},
-		Dns: hcn.Dns{
-			Suffix:     nwInfo.DNS.Suffix,
-			ServerList: nwInfo.DNS.Servers,
-		},
-		SchemaVersion: hcn.SchemaVersion{
-			Major: 2,
-			Minor: 0,
-		},
-		Policies: hcnPolicies,
+	hnsNetwork := &hcsshim.HNSNetwork{
+		Name:               nwInfo.Id,
+		NetworkAdapterName: networkAdapterName,
+		DNSServerList:      strings.Join(nwInfo.DNS.Servers, ","),
+		Policies:           policy.SerializePolicies(policy.NetworkPolicy, nwInfo.Policies),
 	}
 
 	// Set network mode.
 	switch nwInfo.Mode {
 	case opModeBridge:
-		hnsNetwork.Type = hcn.L2Bridge
+		hnsNetwork.Type = "l2bridge"
 	case opModeTunnel:
-		hnsNetwork.Type = hcn.L2Tunnel
+		hnsNetwork.Type = "l2tunnel"
 	default:
 		return nil, errNetworkModeInvalid
 	}
 
 	// Populate subnets.
 	for _, subnet := range nwInfo.Subnets {
-		// Check for nil on address objects.
-		ipAddr := ""
-		if subnet.Prefix.IP != nil && subnet.Prefix.Mask != nil {
-			ipAddr = subnet.Prefix.String()
+		hnsSubnet := hcsshim.Subnet{
+			AddressPrefix:  subnet.Prefix.String(),
+			GatewayAddress: subnet.Gateway.String(),
 		}
-		gwAddr := ""
-		if subnet.Gateway != nil {
-			gwAddr = subnet.Gateway.String()
-		}
-		hnsSubnet := hcn.Subnet{
-			IpAddressPrefix: ipAddr,
-			Routes: []hcn.Route{
-				hcn.Route{
-					NextHop: gwAddr,
-				},
-			},
-		}
-		hnsNetwork.Ipams[0].Subnets = append(hnsNetwork.Ipams[0].Subnets, hnsSubnet)
+
+		hnsNetwork.Subnets = append(hnsNetwork.Subnets, hnsSubnet)
 	}
 
 	// Create the HNS network.

--- a/network/policy/policy.go
+++ b/network/policy/policy.go
@@ -2,6 +2,8 @@ package policy
 
 import (
 	"encoding/json"
+
+	"github.com/Microsoft/hcsshim/hcn"
 )
 
 type CNIPolicyType string
@@ -11,13 +13,50 @@ type Policy struct {
 	Data json.RawMessage
 }
 
-// SerializePolicies serializes policies to json.
-func SerializePolicies(policyType CNIPolicyType, policies []Policy) []json.RawMessage {
-	var jsonPolicies []json.RawMessage
+// SerializeHostComputeNetworkPolicies converts Policy objects into HCN Policy objects.
+func SerializeHostComputeNetworkPolicies(policies []Policy) []hcn.NetworkPolicy {
+	var hcnPolicies []hcn.NetworkPolicy
 	for _, policy := range policies {
-		if policy.Type == policyType {
-			jsonPolicies = append(jsonPolicies, policy.Data)
+		if policy.Type == NetworkPolicy {
+			var netPolicy hcn.NetworkPolicy
+			if err := json.Unmarshal([]byte(policy.Data), &netPolicy); err != nil {
+				panic(err)
+			}
+			hcnPolicies = append(hcnPolicies, netPolicy)
 		}
 	}
-	return jsonPolicies
+
+	return hcnPolicies
+}
+
+// SerializeHostComputeEndpointPolicies converts Policy objects into HCN Policy objects.
+func SerializeHostComputeEndpointPolicies(policies []Policy) []hcn.EndpointPolicy {
+	var hcnPolicies []hcn.EndpointPolicy
+	for _, policy := range policies {
+		if policy.Type == EndpointPolicy {
+			var epPolicy hcn.EndpointPolicy
+			if err := json.Unmarshal([]byte(policy.Data), &epPolicy); err != nil {
+				panic(err)
+			}
+			hcnPolicies = append(hcnPolicies, epPolicy)
+		}
+	}
+
+	return hcnPolicies
+}
+
+// CreateNetworkAdapterNamePolicySetting builds a NetAdapterNameNetworkPolicySetting.
+func CreateNetworkAdapterNamePolicySetting(networkAdapterName string) hcn.NetworkPolicy {
+	netAdapterPolicy := hcn.NetAdapterNameNetworkPolicySetting{
+		NetworkAdapterName: networkAdapterName,
+	}
+	policyJSON, err := json.Marshal(netAdapterPolicy)
+	if err != nil {
+		panic(err)
+	}
+
+	return hcn.NetworkPolicy{
+		Type:     hcn.NetAdapterName,
+		Settings: policyJSON,
+	}
 }

--- a/network/policy/policy.go
+++ b/network/policy/policy.go
@@ -13,6 +13,18 @@ type Policy struct {
 	Data json.RawMessage
 }
 
+// TODO: RS5 at release does not process V2 Policy Schema, using V1 for now.
+// SerializePolicies serializes policies to json.
+func SerializePolicies(policyType CNIPolicyType, policies []Policy) []json.RawMessage {
+	var jsonPolicies []json.RawMessage
+	for _, policy := range policies {
+		if policy.Type == policyType {
+			jsonPolicies = append(jsonPolicies, policy.Data)
+		}
+	}
+	return jsonPolicies
+}
+
 // SerializeHostComputeNetworkPolicies converts Policy objects into HCN Policy objects.
 func SerializeHostComputeNetworkPolicies(policies []Policy) []hcn.NetworkPolicy {
 	var hcnPolicies []hcn.NetworkPolicy


### PR DESCRIPTION
Removing workarounds for Issue #57253.
Updating Azure CNI plugin to leverage the HNS v2 support added to HCSShim.
* Uses the HNS v2 Api as well as v2 Schema.