### PR TITLE
LIFO order for network policies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,9 @@ jobs:
             sudo -E env "PATH=$PATH" go test ./cni/ipam/
             sudo -E env "PATH=$PATH" go test ./cnm/network/
             sudo -E env "PATH=$PATH" go test ./cns/ipamclient/
+            sudo -E env "PATH=$PATH" go test ./npm/iptm/
+            sudo -E env "PATH=$PATH" go test ./npm/ipsm/
+            sudo -E env "PATH=$PATH" go test ./npm/
             #sudo -E env "PATH=$PATH" go test ./cns/restserver/
 workflows:
   version: 2

--- a/npm/iptm/iptm.go
+++ b/npm/iptm/iptm.go
@@ -318,7 +318,7 @@ func (iptMgr *IptablesManager) Add(entry *IptEntry) error {
 		return nil
 	}
 
-	iptMgr.OperationFlag = util.IptablesAppendFlag
+	iptMgr.OperationFlag = util.IptablesInsertionFlag
 	if _, err := iptMgr.Run(entry); err != nil {
 		log.Printf("Error creating iptables rules.\n")
 		return err

--- a/npm/namespace_test.go
+++ b/npm/namespace_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-container-networking/npm/iptm"
+	"github.com/Azure/azure-container-networking/telemetry"
 
 	"github.com/Azure/azure-container-networking/npm/ipsm"
 	"github.com/Azure/azure-container-networking/npm/util"
@@ -45,6 +46,11 @@ func TestAllNsList(t *testing.T) {
 func TestAddNamespace(t *testing.T) {
 	npMgr := &NetworkPolicyManager{
 		nsMap: make(map[string]*namespace),
+		reportManager: &telemetry.ReportManager{
+			HostNetAgentURL: hostNetAgentURLForNpm,
+			ContentType:     contentType,
+			Report:          &telemetry.NPMReport{},
+		},
 	}
 
 	allNs, err := newNs(util.KubeAllNamespacesFlag)
@@ -81,6 +87,11 @@ func TestAddNamespace(t *testing.T) {
 func TestUpdateNamespace(t *testing.T) {
 	npMgr := &NetworkPolicyManager{
 		nsMap: make(map[string]*namespace),
+		reportManager: &telemetry.ReportManager{
+			HostNetAgentURL: hostNetAgentURLForNpm,
+			ContentType:     contentType,
+			Report:          &telemetry.NPMReport{},
+		},
 	}
 
 	allNs, err := newNs(util.KubeAllNamespacesFlag)
@@ -130,6 +141,11 @@ func TestUpdateNamespace(t *testing.T) {
 func TestDeleteNamespace(t *testing.T) {
 	npMgr := &NetworkPolicyManager{
 		nsMap: make(map[string]*namespace),
+		reportManager: &telemetry.ReportManager{
+			HostNetAgentURL: hostNetAgentURLForNpm,
+			ContentType:     contentType,
+			Report:          &telemetry.NPMReport{},
+		},
 	}
 
 	allNs, err := newNs(util.KubeAllNamespacesFlag)

--- a/npm/nwpolicy_test.go
+++ b/npm/nwpolicy_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/azure-container-networking/npm/ipsm"
 	"github.com/Azure/azure-container-networking/npm/iptm"
 	"github.com/Azure/azure-container-networking/npm/util"
+	"github.com/Azure/azure-container-networking/telemetry"
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -18,6 +19,11 @@ import (
 func TestAddNetworkPolicy(t *testing.T) {
 	npMgr := &NetworkPolicyManager{
 		nsMap: make(map[string]*namespace),
+		reportManager: &telemetry.ReportManager{
+			HostNetAgentURL: hostNetAgentURLForNpm,
+			ContentType:     contentType,
+			Report:          &telemetry.NPMReport{},
+		},
 	}
 
 	allNs, err := newNs(util.KubeAllNamespacesFlag)
@@ -92,6 +98,11 @@ func TestAddNetworkPolicy(t *testing.T) {
 func TestUpdateNetworkPolicy(t *testing.T) {
 	npMgr := &NetworkPolicyManager{
 		nsMap: make(map[string]*namespace),
+		reportManager: &telemetry.ReportManager{
+			HostNetAgentURL: hostNetAgentURLForNpm,
+			ContentType:     contentType,
+			Report:          &telemetry.NPMReport{},
+		},
 	}
 
 	allNs, err := newNs(util.KubeAllNamespacesFlag)
@@ -194,6 +205,11 @@ func TestUpdateNetworkPolicy(t *testing.T) {
 func TestDeleteNetworkPolicy(t *testing.T) {
 	npMgr := &NetworkPolicyManager{
 		nsMap: make(map[string]*namespace),
+		reportManager: &telemetry.ReportManager{
+			HostNetAgentURL: hostNetAgentURLForNpm,
+			ContentType:     contentType,
+			Report:          &telemetry.NPMReport{},
+		},
 	}
 
 	allNs, err := newNs(util.KubeAllNamespacesFlag)

--- a/npm/pod_test.go
+++ b/npm/pod_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Azure/azure-container-networking/npm/ipsm"
 	"github.com/Azure/azure-container-networking/npm/util"
+	"github.com/Azure/azure-container-networking/telemetry"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -37,6 +38,11 @@ func TestisSystemPod(t *testing.T) {
 func TestAddPod(t *testing.T) {
 	npMgr := &NetworkPolicyManager{
 		nsMap: make(map[string]*namespace),
+		reportManager: &telemetry.ReportManager{
+			HostNetAgentURL: hostNetAgentURLForNpm,
+			ContentType:     contentType,
+			Report:          &telemetry.NPMReport{},
+		},
 	}
 
 	allNs, err := newNs(util.KubeAllNamespacesFlag)
@@ -76,6 +82,11 @@ func TestAddPod(t *testing.T) {
 func TestUpdatePod(t *testing.T) {
 	npMgr := &NetworkPolicyManager{
 		nsMap: make(map[string]*namespace),
+		reportManager: &telemetry.ReportManager{
+			HostNetAgentURL: hostNetAgentURLForNpm,
+			ContentType:     contentType,
+			Report:          &telemetry.NPMReport{},
+		},
 	}
 
 	allNs, err := newNs(util.KubeAllNamespacesFlag)
@@ -133,6 +144,11 @@ func TestUpdatePod(t *testing.T) {
 func TestDeletePod(t *testing.T) {
 	npMgr := &NetworkPolicyManager{
 		nsMap: make(map[string]*namespace),
+		reportManager: &telemetry.ReportManager{
+			HostNetAgentURL: hostNetAgentURLForNpm,
+			ContentType:     contentType,
+			Report:          &telemetry.NPMReport{},
+		},
 	}
 
 	allNs, err := newNs(util.KubeAllNamespacesFlag)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR:

1. Changes the order of Azure-NPM for applying network policies from FIFO to LIFO.
As per @neumanndaniel suggested, kubernetes administrators/network operators usually apply a deny-all policy then whitelist certain traffic. Without this PR to achieve this, one would have to whitelist all traffic first then apply the deny-all policy. 

2. Adds Azure-NPM to CircleCI config for CI/CD.

**Which issue this PR fixes**: 
Fixes #217

**Special notes for your reviewer**:
This is a change of behavior, not a bug fix.