### PR TITLE
Implement multitenancy for windows

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -283,10 +283,12 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 			resultConsAdd, errConsAdd := handleConsecutiveAdd(args.ContainerID, endpointId, nwInfo, nwCfg)
 			if errConsAdd != nil {
 				log.Printf("handleConsecutiveAdd failed with error %v", errConsAdd)
+				result = resultConsAdd
 				return errConsAdd
 			}
 
 			if resultConsAdd != nil {
+				result = resultConsAdd
 				return nil
 			}
 		}

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -131,6 +131,31 @@ func GetEndpointID(args *cniSkel.CmdArgs) string {
 	return infraEpId
 }
 
+// getPodInfo returns POD info by parsing the CNI args.
+func (plugin *netPlugin) getPodInfo(args string) (string, string, error) {
+	podCfg, err := cni.ParseCniArgs(args)
+	if err != nil {
+		log.Printf("Error while parsing CNI Args %v", err)
+		return "", "", err
+	}
+
+	k8sNamespace := string(podCfg.K8S_POD_NAMESPACE)
+	if len(k8sNamespace) == 0 {
+		errMsg := "Pod Namespace not specified in CNI Args"
+		log.Printf(errMsg)
+		return "", "", plugin.Errorf(errMsg)
+	}
+
+	k8sPodName := string(podCfg.K8S_POD_NAME)
+	if len(k8sPodName) == 0 {
+		errMsg := "Pod Name not specified in CNI Args"
+		log.Printf(errMsg)
+		return "", "", plugin.Errorf(errMsg)
+	}
+
+	return k8sPodName, k8sNamespace, nil
+}
+
 //
 // CNI implementation
 // https://github.com/containernetworking/cni/blob/master/SPEC.md
@@ -192,24 +217,9 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 	}()
 
 	// Parse Pod arguments.
-	podCfg, err := cni.ParseCniArgs(args.Args)
+	k8sPodName, k8sNamespace, err := plugin.getPodInfo(args.Args)
 	if err != nil {
-		log.Printf("Error while parsing CNI Args %v", err)
 		return err
-	}
-
-	k8sNamespace := string(podCfg.K8S_POD_NAMESPACE)
-	if len(k8sNamespace) == 0 {
-		errMsg := "Pod Namespace not specified in CNI Args"
-		log.Printf(errMsg)
-		return plugin.Errorf(errMsg)
-	}
-
-	k8sPodName := string(podCfg.K8S_POD_NAME)
-	if len(k8sPodName) == 0 {
-		errMsg := "Pod Name not specified in CNI Args"
-		log.Printf(errMsg)
-		return plugin.Errorf(errMsg)
 	}
 
 	k8sContainerID := args.ContainerID
@@ -234,10 +244,6 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 		}
 	}
 
-	// Initialize values from network config.
-	networkId := nwCfg.Name
-	endpointId := GetEndpointID(args)
-
 	result, cnsNetworkConfig, subnetPrefix, azIpamResult, err = GetMultiTenancyCNIResult(enableInfraVnet, nwCfg, plugin, k8sPodName, k8sNamespace, args.IfName)
 	if err != nil {
 		log.Printf("GetMultiTenancyCNIResult failed with error %v", err)
@@ -252,6 +258,15 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 
 	log.Printf("Result from multitenancy %+v", result)
 
+	// Initialize values from network config.
+	networkId, err := getNetworkName(k8sPodName, k8sNamespace, args.IfName, nwCfg)
+	if err != nil {
+		log.Printf("[cni-net] Failed to extract network name from network config. error: %v", err)
+		return err
+	}
+
+	endpointId := GetEndpointID(args)
+
 	policies := cni.GetPoliciesFromNwCfg(nwCfg.AdditionalArgs)
 
 	// Check whether the network already exists.
@@ -265,13 +280,13 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 		 */
 		epInfo, _ := plugin.nm.GetEndpointInfo(networkId, endpointId)
 		if epInfo != nil {
-			result, err = handleConsecutiveAdd(args.ContainerID, endpointId, nwInfo, nwCfg)
-			if err != nil {
-				log.Printf("handleConsecutiveAdd failed with error %v", err)
-				return err
+			resultConsAdd, errConsAdd := handleConsecutiveAdd(args.ContainerID, endpointId, nwInfo, nwCfg)
+			if errConsAdd != nil {
+				log.Printf("handleConsecutiveAdd failed with error %v", errConsAdd)
+				return errConsAdd
 			}
 
-			if result != nil {
+			if resultConsAdd != nil {
 				return nil
 			}
 		}
@@ -335,11 +350,14 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 		}
 
 		log.Printf("[cni-net] nwDNSInfo: %v", nwDNSInfo)
+		// Update subnet prefix for multi-tenant scenario
+		updateSubnetPrefix(cnsNetworkConfig, &subnetPrefix)
 
 		// Create the network.
 		nwInfo := network.NetworkInfo{
-			Id:   networkId,
-			Mode: nwCfg.Mode,
+			Id:           networkId,
+			Mode:         nwCfg.Mode,
+			MasterIfName: masterIfName,
 			Subnets: []network.SubnetInfo{
 				network.SubnetInfo{
 					Family:  platform.AfINET,
@@ -492,8 +510,18 @@ func (plugin *netPlugin) Get(args *cniSkel.CmdArgs) error {
 
 	log.Printf("[cni-net] Read network configuration %+v.", nwCfg)
 
+	// Parse Pod arguments.
+	k8sPodName, k8sNamespace, err := plugin.getPodInfo(args.Args)
+	if err != nil {
+		return err
+	}
+
 	// Initialize values from network config.
-	networkId := nwCfg.Name
+	networkId, err := getNetworkName(k8sPodName, k8sNamespace, args.IfName, nwCfg)
+	if err != nil {
+		log.Printf("[cni-net] Failed to extract network name from network config. error: %v", err)
+	}
+
 	endpointId := GetEndpointID(args)
 
 	// Query the network.
@@ -552,8 +580,18 @@ func (plugin *netPlugin) Delete(args *cniSkel.CmdArgs) error {
 
 	log.Printf("[cni-net] Read network configuration %+v.", nwCfg)
 
+	// Parse Pod arguments.
+	k8sPodName, k8sNamespace, err := plugin.getPodInfo(args.Args)
+	if err != nil {
+		return err
+	}
+
 	// Initialize values from network config.
-	networkId := nwCfg.Name
+	networkId, err := getNetworkName(k8sPodName, k8sNamespace, args.IfName, nwCfg)
+	if err != nil {
+		log.Printf("[cni-net] Failed to extract network name from network config. error: %v", err)
+	}
+
 	endpointId := GetEndpointID(args)
 
 	// Query the network.

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -108,3 +108,10 @@ func getEndpointDNSSettings(nwCfg *cni.NetworkConfig, result *cniTypesCurr.Resul
 func getPoliciesFromRuntimeCfg(nwCfg *cni.NetworkConfig) []policy.Policy {
 	return nil
 }
+
+func updateSubnetPrefix(cnsNetworkConfig *cns.GetNetworkContainerResponse, subnetPrefix *net.IPNet) {
+}
+
+func getNetworkName(podName, podNs, ifName string, nwCfg *cni.NetworkConfig) (string, error) {
+	return nwCfg.Name, nil
+}

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -73,8 +73,10 @@ func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
 		return nil, err
 	}
 
-	for _, ipAddress := range exceptionList {
-		outBoundNatPolicy.Exceptions = append(outBoundNatPolicy.Exceptions, ipAddress)
+	if exceptionList != nil {
+		for _, ipAddress := range exceptionList {
+			outBoundNatPolicy.Exceptions = append(outBoundNatPolicy.Exceptions, ipAddress)
+		}
 	}
 
 	if epInfo.Data[CnetAddressSpace] != nil {
@@ -85,8 +87,10 @@ func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
 		}
 	}
 
-	serializedOutboundNatPolicy, _ := json.Marshal(outBoundNatPolicy)
-	hnsEndpoint.Policies = append(hnsEndpoint.Policies, serializedOutboundNatPolicy)
+	if outBoundNatPolicy.Exceptions != nil {
+		serializedOutboundNatPolicy, _ := json.Marshal(outBoundNatPolicy)
+		hnsEndpoint.Policies = append(hnsEndpoint.Policies, serializedOutboundNatPolicy)
+	}
 
 	// HNS currently supports only one IP address per endpoint.
 	if epInfo.IPAddresses != nil {

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -77,9 +77,11 @@ func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
 		outBoundNatPolicy.Exceptions = append(outBoundNatPolicy.Exceptions, ipAddress)
 	}
 
-	if cnetAddressSpace := epInfo.Data[CnetAddressSpace].([]string); cnetAddressSpace != nil {
-		for _, ipAddress := range cnetAddressSpace {
-			outBoundNatPolicy.Exceptions = append(outBoundNatPolicy.Exceptions, ipAddress)
+	if epInfo.Data[CnetAddressSpace] != nil {
+		if cnetAddressSpace := epInfo.Data[CnetAddressSpace].([]string); cnetAddressSpace != nil {
+			for _, ipAddress := range cnetAddressSpace {
+				outBoundNatPolicy.Exceptions = append(outBoundNatPolicy.Exceptions, ipAddress)
+			}
 		}
 	}
 

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -44,6 +44,14 @@ func ConstructEndpointID(containerID string, netNsPath string, ifName string) (s
 
 // newEndpointImpl creates a new endpoint in the network.
 func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
+	var vlanid int
+
+	if epInfo.Data != nil {
+		if _, ok := epInfo.Data[VlanIDKey]; ok {
+			vlanid = epInfo.Data[VlanIDKey].(int)
+		}
+	}
+
 	// Get Infrastructure containerID. Handle ADD calls for workload container.
 	var err error
 	infraEpName, _ := ConstructEndpointID(epInfo.ContainerID, epInfo.NetNsPath, epInfo.IfName)
@@ -53,8 +61,30 @@ func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
 		VirtualNetwork: nw.HnsId,
 		DNSSuffix:      epInfo.DNS.Suffix,
 		DNSServerList:  strings.Join(epInfo.DNS.Servers, ","),
-		Policies:       policy.SerializePolicies(policy.EndpointPolicy, epInfo.Policies),
 	}
+
+	// Set outbound NAT policy
+	outBoundNatPolicy := hcsshim.OutboundNatPolicy{}
+	outBoundNatPolicy.Policy.Type = hcsshim.OutboundNat
+
+	exceptionList, err := policy.GetOutBoundNatExceptionList(epInfo.Policies)
+	if err != nil {
+		log.Printf("[net] Failed to parse outbound NAT policy %v", err)
+		return nil, err
+	}
+
+	for _, ipAddress := range exceptionList {
+		outBoundNatPolicy.Exceptions = append(outBoundNatPolicy.Exceptions, ipAddress)
+	}
+
+	if cnetAddressSpace := epInfo.Data[CnetAddressSpace].([]string); cnetAddressSpace != nil {
+		for _, ipAddress := range cnetAddressSpace {
+			outBoundNatPolicy.Exceptions = append(outBoundNatPolicy.Exceptions, ipAddress)
+		}
+	}
+
+	serializedOutboundNatPolicy, _ := json.Marshal(outBoundNatPolicy)
+	hnsEndpoint.Policies = append(hnsEndpoint.Policies, serializedOutboundNatPolicy)
 
 	// HNS currently supports only one IP address per endpoint.
 	if epInfo.IPAddresses != nil {
@@ -96,13 +126,15 @@ func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
 
 	// Create the endpoint object.
 	ep := &endpoint{
-		Id:          infraEpName,
-		HnsId:       hnsResponse.Id,
-		SandboxKey:  epInfo.ContainerID,
-		IfName:      epInfo.IfName,
-		IPAddresses: epInfo.IPAddresses,
-		Gateways:    []net.IP{net.ParseIP(hnsResponse.GatewayAddress)},
-		DNS:         epInfo.DNS,
+		Id:               infraEpName,
+		HnsId:            hnsResponse.Id,
+		SandboxKey:       epInfo.ContainerID,
+		IfName:           epInfo.IfName,
+		IPAddresses:      epInfo.IPAddresses,
+		Gateways:         []net.IP{net.ParseIP(hnsResponse.GatewayAddress)},
+		DNS:              epInfo.DNS,
+		VlanID:           vlanid,
+		EnableSnatOnHost: epInfo.EnableSnatOnHost,
 	}
 
 	for _, route := range epInfo.Routes {

--- a/network/manager.go
+++ b/network/manager.go
@@ -15,8 +15,9 @@ import (
 
 const (
 	// Network store key.
-	storeKey  = "Network"
-	VlanIDKey = "VlanID"
+	storeKey    = "Network"
+	VlanIDKey   = "VlanID"
+	genericData = "com.docker.network.generic"
 )
 
 type NetworkClient interface {

--- a/network/network.go
+++ b/network/network.go
@@ -123,11 +123,10 @@ func (nm *networkManager) findExternalInterfaceBySubnet(subnet string) *external
 }
 
 // FindExternalInterfaceByName finds an external interface by name.
-func (nm *networkManager) findExternalInterfaceByName(name string) *externalInterface {
-	for _, extIf := range nm.ExternalInterfaces {
-		if extIf != nil && extIf.Name == name {
-			return extIf
-		}
+func (nm *networkManager) findExternalInterfaceByName(ifName string) *externalInterface {
+	extIf, exists := nm.ExternalInterfaces[ifName]
+	if exists && extIf != nil {
+		return extIf
 	}
 
 	return nil

--- a/network/network.go
+++ b/network/network.go
@@ -5,6 +5,7 @@ package network
 
 import (
 	"net"
+	"strings"
 
 	"github.com/Azure/azure-container-networking/log"
 	"github.com/Azure/azure-container-networking/network/policy"
@@ -149,8 +150,14 @@ func (nm *networkManager) newNetwork(nwInfo *NetworkInfo) (*network, error) {
 		nwInfo.Mode = opModeDefault
 	}
 
-	// Find the external interface by name.
-	extIf := nm.findExternalInterfaceByName(nwInfo.MasterIfName)
+	// If the master interface name is provided, find the external interface by name
+	// else use subnet to to find the interface
+	var extIf *externalInterface
+	if len(strings.TrimSpace(nwInfo.MasterIfName)) > 0 {
+		extIf = nm.findExternalInterfaceByName(nwInfo.MasterIfName)
+	} else {
+		extIf = nm.findExternalInterfaceBySubnet(nwInfo.Subnets[0].Prefix.String())
+	}
 	if extIf == nil {
 		err = errSubnetNotFound
 		return nil, err

--- a/network/network.go
+++ b/network/network.go
@@ -46,6 +46,7 @@ type network struct {
 
 // NetworkInfo contains read-only information about a container network.
 type NetworkInfo struct {
+	MasterIfName     string
 	Id               string
 	Mode             string
 	Subnets          []SubnetInfo
@@ -121,6 +122,17 @@ func (nm *networkManager) findExternalInterfaceBySubnet(subnet string) *external
 	return nil
 }
 
+// FindExternalInterfaceByName finds an external interface by name.
+func (nm *networkManager) findExternalInterfaceByName(name string) *externalInterface {
+	for _, extIf := range nm.ExternalInterfaces {
+		if extIf != nil && extIf.Name == name {
+			return extIf
+		}
+	}
+
+	return nil
+}
+
 // NewNetwork creates a new container network.
 func (nm *networkManager) newNetwork(nwInfo *NetworkInfo) (*network, error) {
 	var nw *network
@@ -138,8 +150,8 @@ func (nm *networkManager) newNetwork(nwInfo *NetworkInfo) (*network, error) {
 		nwInfo.Mode = opModeDefault
 	}
 
-	// Find the external interface for this subnet.
-	extIf := nm.findExternalInterfaceBySubnet(nwInfo.Subnets[0].Prefix.String())
+	// Find the external interface by name.
+	extIf := nm.findExternalInterfaceByName(nwInfo.MasterIfName)
 	if extIf == nil {
 		err = errSubnetNotFound
 		return nil, err

--- a/network/network_linux.go
+++ b/network/network_linux.go
@@ -21,8 +21,6 @@ const (
 	// Virtual MAC address used by Azure VNET.
 	virtualMacAddress = "12:34:56:78:9a:bc"
 
-	genericData = "com.docker.network.generic"
-
 	SnatBridgeIPKey = "snatBridgeIP"
 
 	LocalIPKey = "localIP"

--- a/network/policy/policy.go
+++ b/network/policy/policy.go
@@ -2,6 +2,13 @@ package policy
 
 import (
 	"encoding/json"
+	"fmt"
+)
+
+const (
+	NetworkPolicy     CNIPolicyType = "NetworkPolicy"
+	EndpointPolicy    CNIPolicyType = "EndpointPolicy"
+	OutBoundNatPolicy CNIPolicyType = "OutBoundNAT"
 )
 
 type CNIPolicyType string
@@ -20,4 +27,32 @@ func SerializePolicies(policyType CNIPolicyType, policies []Policy) []json.RawMe
 		}
 	}
 	return jsonPolicies
+}
+
+// GetOutBoundNatExceptionList returns exception list for outbound nat policy
+func GetOutBoundNatExceptionList(policies []Policy) ([]string, error) {
+	type KVPair struct {
+		Type          CNIPolicyType   `json:"Type"`
+		ExceptionList json.RawMessage `json:"ExceptionList"`
+	}
+
+	for _, policy := range policies {
+		if policy.Type == EndpointPolicy {
+			var data KVPair
+			if err := json.Unmarshal(policy.Data, &data); err != nil {
+				return nil, err
+			}
+
+			if data.Type == OutBoundNatPolicy {
+				var exceptionList []string
+				if err := json.Unmarshal(data.ExceptionList, &exceptionList); err != nil {
+					return nil, err
+				}
+
+				return exceptionList, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("OutBoundNAT policy not set")
 }

--- a/network/policy/policy.go
+++ b/network/policy/policy.go
@@ -2,7 +2,7 @@ package policy
 
 import (
 	"encoding/json"
-	"fmt"
+	"log"
 )
 
 const (
@@ -54,5 +54,6 @@ func GetOutBoundNatExceptionList(policies []Policy) ([]string, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("OutBoundNAT policy not set")
+	log.Printf("OutBoundNAT policy not set.")
+	return nil, nil
 }

--- a/network/policy/policy_windows.go
+++ b/network/policy/policy_windows.go
@@ -1,7 +1,0 @@
-package policy
-
-const (
-	NetworkPolicy     CNIPolicyType = "NetworkPolicy"
-	EndpointPolicy    CNIPolicyType = "EndpointPolicy"
-	OutBoundNatPolicy CNIPolicyType = "OutBoundNatPolicy"
-)


### PR DESCRIPTION
This change allows containers from different vnets to reside in a VM that belongs to a completely different infra-vnet. The isolation is achieved using vlan.
Multitenancy and snatonhost can be enabled using flags in azure conflist file. When multitenancy is enabled, CNI depends on CNS to get the goal state for the network container which includes the allocated IP.