### PR TITLE
Update tests to use go 1.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,14 +13,14 @@ jobs:
             sudo -E env "PATH=$PATH" apt-get update
             sudo -E env "PATH=$PATH" apt-get install -y ebtables
             sudo -E env "PATH=$PATH" apt-get install -y ipset
-            mkdir -p /home/circleci/go1-10
+            mkdir -p /home/circleci/go1-11
             mkdir --parents /home/circleci/.goproject/src/github.com/Azure/azure-container-networking
-            wget https://storage.googleapis.com/golang/go1.10.2.linux-amd64.tar.gz
-            tar -C /home/circleci/go1-10 -xvf go1.10.2.linux-amd64.tar.gz
-            rm go1.10.2.linux-amd64.tar.gz
+            wget https://storage.googleapis.com/golang/go1.11.1.linux-amd64.tar.gz
+            tar -C /home/circleci/go1-11 -xvf go1.11.1.linux-amd64.tar.gz
+            rm go1.11.1.linux-amd64.tar.gz
             mv * /home/circleci/.goproject/src/github.com/Azure/azure-container-networking
             cd /home/circleci/.goproject/src/github.com/Azure/azure-container-networking
-            export GOROOT='/home/circleci/go1-10/go'
+            export GOROOT='/home/circleci/go1-11/go'
             export GOPATH='/home/circleci/.goproject'
             export PATH=$GOROOT/bin:$PATH
             go get ./...

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.10
+FROM golang:1.11
 
 RUN apt-get update \
  && apt-get install -y zip \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Keeps the codebase using the latest version of Go

