### PR TITLE
Fix egress port iptables rule when no ports are specified

### DIFF
--- a/npm/parse.go
+++ b/npm/parse.go
@@ -423,7 +423,7 @@ func parseEgress(ns string, targetSets []string, rules []networkingv1.NetworkPol
 					util.IptablesSetFlag,
 					util.IptablesMatchSetFlag,
 					hashedTargetSetName,
-					util.IptablesDstFlag,
+					util.IptablesSrcFlag,
 					util.IptablesJumpFlag,
 					util.IptablesAzureEgressToChain,
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR corrects the iptables flag for network policy egress rules when no ports are defined. Without this fix, the rule added to `AZURE-NPM-EGRESS-PORT` (since it checks the `dst` ip instead of `src` ip of the pod) doesn't match and therefore doesn't go to the `AZURE-NPM-EGRESS-TO` table which would allow the traffic.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
None.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```