### PR TITLE
Adding/Remove static arp entry for pod IP in VM 

### DIFF
--- a/netlink/link.go
+++ b/netlink/link.go
@@ -390,7 +390,7 @@ func SetLinkHairpin(bridgeName string, on bool) error {
 	return s.sendAndWaitForAck(req)
 }
 
-// SetLinkMaster sets the master (upper) device of a network interface.
+// AddOrRemoveStaticArp sets/removes static arp entry based on mode
 func AddOrRemoveStaticArp(mode int, name string, ipaddr net.IP, mac net.HardwareAddr) error {
 	s, err := getSocket()
 	if err != nil {

--- a/netlink/link.go
+++ b/netlink/link.go
@@ -31,6 +31,11 @@ const (
 	IPVLAN_MODE_MAX
 )
 
+const (
+	ADD = iota
+	REMOVE
+)
+
 // Link represents a network interface.
 type Link interface {
 	Info() *LinkInfo
@@ -381,6 +386,45 @@ func SetLinkHairpin(bridgeName string, on bool) error {
 	attrProtInfo := newAttribute(unix.IFLA_PROTINFO|unix.NLA_F_NESTED, nil)
 	attrProtInfo.addNested(newAttribute(IFLA_BRPORT_MODE, hairpin))
 	req.addPayload(attrProtInfo)
+
+	return s.sendAndWaitForAck(req)
+}
+
+// SetLinkMaster sets the master (upper) device of a network interface.
+func AddOrRemoveStaticArp(mode int, name string, ipaddr net.IP, mac net.HardwareAddr) error {
+	s, err := getSocket()
+	if err != nil {
+		return err
+	}
+
+	var req *message
+	state := 0
+	if mode == ADD {
+		req = newRequest(unix.RTM_NEWNEIGH, unix.NLM_F_CREATE|unix.NLM_F_REPLACE|unix.NLM_F_ACK)
+		state = NUD_PERMANENT
+	} else {
+		req = newRequest(unix.RTM_DELNEIGH, unix.NLM_F_ACK)
+		state = NUD_INCOMPLETE
+	}
+
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		return err
+	}
+
+	msg := neighMsg{
+		Family: uint8(unix.AF_INET),
+		Index:  uint32(iface.Index),
+		State:  uint16(state),
+	}
+	req.addPayload(&msg)
+
+	ipData := ipaddr.To4()
+	dstData := newRtAttr(NDA_DST, ipData)
+	req.addPayload(dstData)
+
+	hwData := newRtAttr(NDA_LLADDR, []byte(mac))
+	req.addPayload(hwData)
 
 	return s.sendAndWaitForAck(req)
 }

--- a/netlink/netlink_test.go
+++ b/netlink/netlink_test.go
@@ -234,3 +234,28 @@ func TestSetLinkHairpin(t *testing.T) {
 		t.Errorf("DeleteLink failed: %+v", err)
 	}
 }
+
+func TestAddRemoveStaticArp(t *testing.T) {
+	_, err := addDummyInterface(ifName)
+	if err != nil {
+		t.Errorf("addDummyInterface failed: %v", err)
+	}
+
+	ip := net.ParseIP("192.168.0.2")
+	mac, _ := net.ParseMAC("aa:b3:4d:5e:e2:4a")
+
+	err = AddOrRemoveStaticArp(ADD, ifName, ip, mac)
+	if err != nil {
+		t.Errorf("ret val %v", err)
+	}
+
+	err = AddOrRemoveStaticArp(REMOVE, ifName, ip, mac)
+	if err != nil {
+		t.Errorf("ret val %v", err)
+	}
+
+	err = DeleteLink(ifName)
+	if err != nil {
+		t.Errorf("DeleteLink failed: %+v", err)
+	}
+}

--- a/network/bridge_endpointclient_linux.go
+++ b/network/bridge_endpointclient_linux.go
@@ -73,11 +73,12 @@ func (client *LinuxBridgeEndpointClient) AddEndpointRules(epInfo *EndpointInfo) 
 			return err
 		}
 
-		log.Printf("[net] Adding static arp for IP address %v and MAC %v in VM", ipAddr.String(), client.containerMac.String())
-		netlink.AddOrRemoveStaticArp(netlink.ADD, client.bridgeName, ipAddr.IP, client.containerMac)
-		if err != nil {
-			log.Printf("Failed setting arp in vm: %v", err)
-			return err
+		if client.mode != opModeTunnel {
+			log.Printf("[net] Adding static arp for IP address %v and MAC %v in VM", ipAddr.String(), client.containerMac.String())
+			netlink.AddOrRemoveStaticArp(netlink.ADD, client.bridgeName, ipAddr.IP, client.containerMac)
+			if err != nil {
+				log.Printf("Failed setting arp in vm: %v", err)
+			}
 		}
 	}
 
@@ -107,10 +108,12 @@ func (client *LinuxBridgeEndpointClient) DeleteEndpointRules(ep *endpoint) {
 			log.Printf("[net] Failed to delete MAC DNAT rule for IP address %v: %v.", ipAddr.String(), err)
 		}
 
-		log.Printf("[net] Removing static arp for IP address %v and MAC %v from VM", ipAddr.String(), ep.MacAddress.String())
-		netlink.AddOrRemoveStaticArp(netlink.REMOVE, client.bridgeName, ipAddr.IP, ep.MacAddress)
-		if err != nil {
-			log.Printf("Failed removing arp from vm: %v", err)
+		if client.mode != opModeTunnel {
+			log.Printf("[net] Removing static arp for IP address %v and MAC %v from VM", ipAddr.String(), ep.MacAddress.String())
+			netlink.AddOrRemoveStaticArp(netlink.REMOVE, client.bridgeName, ipAddr.IP, ep.MacAddress)
+			if err != nil {
+				log.Printf("Failed removing arp from vm: %v", err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
This PR fixes the issues where sometimes packet is getting routed to host instead of pod. Setting static arp entry will prevent vm getting arp responses from host

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```