### PR TITLE
Detect reboot for windows and cleanup network config

### DIFF
--- a/ipam/manager.go
+++ b/ipam/manager.go
@@ -110,6 +110,7 @@ func (am *addressManager) restore() error {
 		log.Printf("[ipam] reboot time %v store mod time %v", rebootTime, modTime)
 
 		if err == nil && rebootTime.After(modTime) {
+			log.Printf("[ipam] Detected Reboot")
 			rebooted = true
 		}
 	}

--- a/network/manager.go
+++ b/network/manager.go
@@ -121,7 +121,22 @@ func (nm *networkManager) restore() error {
 		rebootTime, err := platform.GetLastRebootTime()
 		log.Printf("[net] reboot time %v store mod time %v", rebootTime, modTime)
 		if err == nil && rebootTime.After(modTime) {
+			log.Printf("[net] Detected Reboot")
 			rebooted = true
+			if clearNwConfig, err := platform.ClearNetworkConfiguration(); clearNwConfig {
+				if err != nil {
+					log.Printf("[net] Failed to clear network configuration, err:%v\n", err)
+					return err
+				}
+
+				// Clear networkManager contents
+				nm.TimeStamp = time.Time{}
+				for extIfName := range nm.ExternalInterfaces {
+					delete(nm.ExternalInterfaces, extIfName)
+				}
+
+				return nil
+			}
 		}
 	}
 

--- a/platform/os_linux.go
+++ b/platform/os_linux.go
@@ -88,3 +88,9 @@ func SetOutboundSNAT(subnet string) error {
 	}
 	return nil
 }
+
+// ClearNetworkConfiguration clears the azure-vnet.json contents.
+// This will be called only when reboot is detected - This is windows specific
+func ClearNetworkConfiguration() (bool, error) {
+	return false, nil
+}

--- a/platform/os_windows.go
+++ b/platform/os_windows.go
@@ -4,7 +4,13 @@
 package platform
 
 import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
 	"time"
+
+	"github.com/Azure/azure-container-networking/log"
 )
 
 const (
@@ -32,8 +38,60 @@ func GetOSInfo() string {
 
 // GetLastRebootTime returns the last time the system rebooted.
 func GetLastRebootTime() (time.Time, error) {
-	var rebootTime time.Time
-	return rebootTime, nil
+	var systemBootTime string
+	out, err := exec.Command("cmd", "/c", "systeminfo").Output()
+	if err != nil {
+		log.Printf("Failed to query systeminfo, err: %v", err)
+		return time.Time{}.UTC(), err
+	}
+
+	systemInfo := strings.Split(string(out), "\n")
+	for _, systemProperty := range systemInfo {
+		if strings.Contains(systemProperty, "Boot Time") {
+			systemBootTime = strings.TrimSpace(strings.Split(systemProperty, "System Boot Time:")[1])
+		}
+	}
+
+	if len(strings.TrimSpace(systemBootTime)) == 0 {
+		log.Printf("Failed to retrieve boot time from systeminfo")
+		return time.Time{}.UTC(), fmt.Errorf("Failed to retrieve boot time from systeminfo")
+	}
+
+	log.Printf("Boot time: %s", systemBootTime)
+	// The System Boot Time is in the following format "01/02/2006, 03:04:05 PM"
+	// Formulate the Boot Time in the format: "2006-01-02 15:04:05"
+	bootDate := strings.Split(systemBootTime, " ")[0]
+	bootTime := strings.Split(systemBootTime, " ")[1]
+	bootPM := strings.Contains(strings.Split(systemBootTime, " ")[2], "PM")
+
+	month := strings.Split(bootDate, "/")[0]
+	day := strings.Split(bootDate, "/")[1]
+	year := strings.Split(bootDate, "/")[2]
+	year = strings.Trim(year, ",")
+	hour := strings.Split(bootTime, ":")[0]
+	hourInt, _ := strconv.Atoi(hour)
+	min := strings.Split(bootTime, ":")[1]
+	sec := strings.Split(bootTime, ":")[2]
+
+	if bootPM && hourInt < 12 {
+		hourInt += 12
+	} else if !bootPM && hourInt == 12 {
+		hourInt = 0
+	}
+
+	hour = strconv.Itoa(hourInt)
+	systemBootTime = year + "-" + month + "-" + day + " " + hour + ":" + min + ":" + sec
+	log.Printf("Formatted Boot time: %s", systemBootTime)
+
+	// Parse the boot time.
+	layout := "2006-01-02 15:04:05"
+	rebootTime, err := time.ParseInLocation(layout, systemBootTime, time.Local)
+	if err != nil {
+		log.Printf("Failed to parse boot time, err:%v", err)
+		return time.Time{}.UTC(), err
+	}
+
+	return rebootTime.UTC(), nil
 }
 
 func ExecuteCommand(command string) (string, error) {
@@ -42,4 +100,19 @@ func ExecuteCommand(command string) (string, error) {
 
 func SetOutboundSNAT(subnet string) error {
 	return nil
+}
+
+// ClearNetworkConfiguration clears the azure-vnet.json contents.
+// This will be called only when reboot is detected - This is windows specific
+func ClearNetworkConfiguration() (bool, error) {
+	jsonStore := CNIRuntimePath + "azure-vnet.json"
+	log.Printf("Deleting the json store %s", jsonStore)
+	cmd := exec.Command("cmd", "/c", "del", jsonStore)
+
+	if err := cmd.Run(); err != nil {
+		log.Printf("Error deleting the json store %s", jsonStore)
+		return true, err
+	}
+
+	return true, nil
 }


### PR DESCRIPTION
Sometimes issue is seen after reboot when the network config state is not
cleaned up. This change detects reboot and cleans up the network config state.