### PR TITLE
Cleanup old networks and lock files after detecting reboot

### DIFF
--- a/ipam/manager.go
+++ b/ipam/manager.go
@@ -105,7 +105,6 @@ func (am *addressManager) restore() error {
 	// Check if the VM is rebooted.
 	modTime, err := am.store.GetModificationTime()
 	if err == nil {
-
 		rebootTime, err := platform.GetLastRebootTime()
 		log.Printf("[ipam] reboot time %v store mod time %v", rebootTime, modTime)
 
@@ -147,6 +146,7 @@ func (am *addressManager) restore() error {
 		for _, as := range am.AddrSpaces {
 			for _, ap := range as.Pools {
 				ap.as = as
+				ap.RefCount = 0
 
 				for _, ar := range ap.Addresses {
 					ar.InUse = false

--- a/network/manager.go
+++ b/network/manager.go
@@ -129,6 +129,14 @@ func (nm *networkManager) restore() error {
 					return err
 				}
 
+				// Delete the networks left behind after reboot
+				for _, extIf := range nm.ExternalInterfaces {
+					for _, nw := range extIf.Networks {
+						log.Printf("[net] Deleting the network %s on reboot\n", nw.Id)
+						nm.deleteNetwork(nw.Id)
+					}
+				}
+
 				// Clear networkManager contents
 				nm.TimeStamp = time.Time{}
 				for extIfName := range nm.ExternalInterfaces {

--- a/platform/os_windows.go
+++ b/platform/os_windows.go
@@ -65,7 +65,15 @@ func GetLastRebootTime() (time.Time, error) {
 	bootPM := strings.Contains(strings.Split(systemBootTime, " ")[2], "PM")
 
 	month := strings.Split(bootDate, "/")[0]
+	if len(month) < 2 {
+		month = "0" + month
+	}
+
 	day := strings.Split(bootDate, "/")[1]
+	if len(day) < 2 {
+		day = "0" + day
+	}
+
 	year := strings.Split(bootDate, "/")[2]
 	year = strings.Trim(year, ",")
 	hour := strings.Split(bootTime, ":")[0]

--- a/store/json_test.go
+++ b/store/json_test.go
@@ -185,7 +185,7 @@ func TestLockingStoreGivesExclusiveAccess(t *testing.T) {
 	}
 
 	// Unlock the first store.
-	err = kvs.Unlock()
+	err = kvs.Unlock(false)
 	if err != nil {
 		t.Errorf("Failed to unlock first store: %v", err)
 	}
@@ -198,7 +198,7 @@ func TestLockingStoreGivesExclusiveAccess(t *testing.T) {
 	}
 
 	// Unlock the second store.
-	err = kvs2.Unlock()
+	err = kvs2.Unlock(false)
 	if err != nil {
 		t.Errorf("Failed to unlock second store: %v", err)
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -14,8 +14,9 @@ type KeyValueStore interface {
 	Write(key string, value interface{}) error
 	Flush() error
 	Lock(block bool) error
-	Unlock() error
+	Unlock(forceUnlock bool) error
 	GetModificationTime() (time.Time, error)
+	GetLockFileModificationTime() (time.Time, error)
 }
 
 var (


### PR DESCRIPTION
After detecting reboot, old networks need to be deleted along with
lock files left behind on the VM.