### PR TITLE
changed vethnaming logic for transparent mode

### DIFF
--- a/network/endpoint_linux.go
+++ b/network/endpoint_linux.go
@@ -68,8 +68,8 @@ func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
 	}
 
 	if _, ok := epInfo.Data[OptVethName]; ok {
-		log.Printf("Generate veth name based on the key provided")
 		key := epInfo.Data[OptVethName].(string)
+		log.Printf("Generate veth name based on the key provided %v", key)
 		vethname := generateVethName(key)
 		hostIfName = fmt.Sprintf("%s%s", hostVEthInterfacePrefix, vethname)
 		contIfName = fmt.Sprintf("%s%s2", hostVEthInterfacePrefix, vethname)
@@ -270,8 +270,18 @@ func deleteRoutes(interfaceName string, routes []RouteInfo) error {
 
 		if route.DevName != "" {
 			devIf, _ := net.InterfaceByName(route.DevName)
+			if devIf == nil {
+				log.Printf("[net] Not deleting route. Interface %v doesn't exist", interfaceName)
+				continue
+			}
+
 			ifIndex = devIf.Index
 		} else {
+			if interfaceIf == nil {
+				log.Printf("[net] Not deleting route. Interface %v doesn't exist", interfaceName)
+				continue
+			}
+
 			ifIndex = interfaceIf.Index
 		}
 

--- a/network/transparent_endpointclient_linux.go
+++ b/network/transparent_endpointclient_linux.go
@@ -52,6 +52,15 @@ func setArpProxy(ifName string) error {
 }
 
 func (client *TransparentEndpointClient) AddEndpoints(epInfo *EndpointInfo) error {
+
+	if _, err := net.InterfaceByName(client.hostVethName); err == nil {
+		log.Printf("Deleting old host veth %v", client.hostVethName)
+		if err = netlink.DeleteLink(client.hostVethName); err != nil {
+			log.Printf("[net] Failed to delete old hostveth %v: %v.", client.hostVethName, err)
+			return err
+		}
+	}
+
 	if err := epcommon.CreateEndpoint(client.hostVethName, client.containerVethName); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
For transparent mode, vethname will be generated based on namespace and podname. Also, it removes old hosveth if that exists.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```