### PR TITLE
Add dns capabilities to allow for custom dns in Windows

### DIFF
--- a/cni/azure-windows.conflist
+++ b/cni/azure-windows.conflist
@@ -7,7 +7,8 @@
             "mode": "bridge",
             "bridge": "azure0",
             "capabilities": {
-                "portMappings": true
+                "portMappings": true,
+                "dns": true
             },
             "ipam": {
                 "type": "azure-vnet-ipam"

--- a/cni/netconfig.go
+++ b/cni/netconfig.go
@@ -33,7 +33,7 @@ type RuntimeConfig struct {
 	DNS          RuntimeDNSConfig `json:"dns,omitempty"`
 }
 
-// https://github.com/kubernetes/kubernetes/blob/7dbe426b2426458f02339e28d1cc102efdb6eda1/pkg/kubelet/dockershim/network/cni/cni.go#L104
+// https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/dockershim/network/cni/cni.go#L104
 type RuntimeDNSConfig struct {
 	Servers  []string `json:"servers,omitempty"`
 	Searches []string `json:"searches,omitempty"`

--- a/cni/netconfig.go
+++ b/cni/netconfig.go
@@ -28,9 +28,16 @@ type PortMapping struct {
 	Protocol      string `json:"protocol"`
 	HostIp        string `json:"hostIP,omitempty"`
 }
-
 type RuntimeConfig struct {
-	PortMappings []PortMapping `json:"portMappings,omitempty"`
+	PortMappings []PortMapping    `json:"portMappings,omitempty"`
+	DNS          RuntimeDNSConfig `json:"dns,omitempty"`
+}
+
+// https://github.com/kubernetes/kubernetes/blob/7dbe426b2426458f02339e28d1cc102efdb6eda1/pkg/kubelet/dockershim/network/cni/cni.go#L104
+type RuntimeDNSConfig struct {
+	Servers  []string `json:"servers,omitempty"`
+	Searches []string `json:"searches,omitempty"`
+	Options  []string `json:"options,omitempty"`
 }
 
 // NetworkConfig represents Azure CNI plugin network configuration.

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -367,13 +367,10 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 			return err
 		}
 
-		nwDNSInfo := getCustomDNS(nwCfg)
-		if len(nwDNSInfo.Servers) == 0 && nwDNSInfo.Suffix == "" {
-			nwDNSInfo, err = getNetworkDNSSettings(nwCfg, result, k8sNamespace)
-			if err != nil {
-				err = plugin.Errorf("Failed to getDNSSettings: %v", err)
-				return err
-			}
+		nwDNSInfo, err := getNetworkDNSSettings(nwCfg, result, k8sNamespace)
+		if err != nil {
+			err = plugin.Errorf("Failed to getDNSSettings: %v", err)
+			return err
 		}
 
 		log.Printf("[cni-net] nwDNSInfo: %v", nwDNSInfo)
@@ -436,13 +433,10 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 		}
 	}
 
-	epDNSInfo := getCustomDNS(nwCfg)
-	if len(epDNSInfo.Servers) == 0 && epDNSInfo.Suffix == "" {
-		epDNSInfo, err = getEndpointDNSSettings(nwCfg, result, k8sNamespace)
-		if err != nil {
-			err = plugin.Errorf("Failed to getEndpointDNSSettings: %v", err)
-			return err
-		}
+	epDNSInfo, err := getEndpointDNSSettings(nwCfg, result, k8sNamespace)
+	if err != nil {
+		err = plugin.Errorf("Failed to getEndpointDNSSettings: %v", err)
+		return err
 	}
 
 	epInfo = &network.EndpointInfo{

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -367,10 +367,13 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 			return err
 		}
 
-		nwDNSInfo, err := getNetworkDNSSettings(nwCfg, result, k8sNamespace)
-		if err != nil {
-			err = plugin.Errorf("Failed to getDNSSettings: %v", err)
-			return err
+		nwDNSInfo := getCustomDNS(nwCfg)
+		if len(nwDNSInfo.Servers) == 0 && nwDNSInfo.Suffix == "" {
+			nwDNSInfo, err = getNetworkDNSSettings(nwCfg, result, k8sNamespace)
+			if err != nil {
+				err = plugin.Errorf("Failed to getDNSSettings: %v", err)
+				return err
+			}
 		}
 
 		log.Printf("[cni-net] nwDNSInfo: %v", nwDNSInfo)
@@ -433,10 +436,13 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 		}
 	}
 
-	epDNSInfo, err := getEndpointDNSSettings(nwCfg, result, k8sNamespace)
-	if err != nil {
-		err = plugin.Errorf("Failed to getEndpointDNSSettings: %v", err)
-		return err
+	epDNSInfo := getCustomDNS(nwCfg)
+	if len(epDNSInfo.Servers) == 0 && epDNSInfo.Suffix == "" {
+		epDNSInfo, err = getEndpointDNSSettings(nwCfg, result, k8sNamespace)
+		if err != nil {
+			err = plugin.Errorf("Failed to getEndpointDNSSettings: %v", err)
+			return err
+		}
 	}
 
 	epInfo = &network.EndpointInfo{

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -134,6 +134,12 @@ func setupInfraVnetRoutingForMultitenancy(
 func getNetworkDNSSettings(nwCfg *cni.NetworkConfig, result *cniTypesCurr.Result, namespace string) (network.DNSInfo, error) {
 	var nwDNS network.DNSInfo
 
+	// use custom dns if present
+	nwDNS = getCustomDNS(nwCfg)
+	if len(nwDNS.Servers) > 0 || nwDNS.Suffix != "" {
+		return nwDNS, nil
+	}
+
 	if (len(nwCfg.DNS.Search) == 0) != (len(nwCfg.DNS.Nameservers) == 0) {
 		err := fmt.Errorf("Wrong DNS configuration: %+v", nwCfg.DNS)
 		return nwDNS, err
@@ -148,6 +154,12 @@ func getNetworkDNSSettings(nwCfg *cni.NetworkConfig, result *cniTypesCurr.Result
 
 func getEndpointDNSSettings(nwCfg *cni.NetworkConfig, result *cniTypesCurr.Result, namespace string) (network.DNSInfo, error) {
 	var epDNS network.DNSInfo
+
+	// use custom dns if present
+	epDNS = getCustomDNS(nwCfg)
+	if len(epDNS.Servers) > 0 || epDNS.Suffix != "" {
+		return epDNS, nil
+	}
 
 	if (len(nwCfg.DNS.Search) == 0) != (len(nwCfg.DNS.Nameservers) == 0) {
 		err := fmt.Errorf("Wrong DNS configuration: %+v", nwCfg.DNS)
@@ -195,17 +207,14 @@ func getPoliciesFromRuntimeCfg(nwCfg *cni.NetworkConfig) []policy.Policy {
 
 func getCustomDNS(nwCfg *cni.NetworkConfig) network.DNSInfo {
 	log.Printf("[net] RuntimeConfigs: %+v", nwCfg.RuntimeConfig)
-	var epDNS network.DNSInfo
 
 	var search string
 	if len(nwCfg.RuntimeConfig.DNS.Searches) > 0 {
 		search = nwCfg.RuntimeConfig.DNS.Searches[0]
 	}
 
-	epDNS = network.DNSInfo{
+	return network.DNSInfo{
 		Servers: nwCfg.RuntimeConfig.DNS.Servers,
 		Suffix:  search,
 	}
-
-	return epDNS
 }

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -210,7 +210,7 @@ func getCustomDNS(nwCfg *cni.NetworkConfig) network.DNSInfo {
 
 	var search string
 	if len(nwCfg.RuntimeConfig.DNS.Searches) > 0 {
-		search = nwCfg.RuntimeConfig.DNS.Searches[0]
+		search = strings.Join(nwCfg.RuntimeConfig.DNS.Searches, ",")
 	}
 
 	return network.DNSInfo{

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -192,3 +192,20 @@ func getPoliciesFromRuntimeCfg(nwCfg *cni.NetworkConfig) []policy.Policy {
 
 	return policies
 }
+
+func getCustomDNS(nwCfg *cni.NetworkConfig) network.DNSInfo {
+	log.Printf("[net] RuntimeConfigs: %+v", nwCfg.RuntimeConfig)
+	var epDNS network.DNSInfo
+
+	var search string
+	if len(nwCfg.RuntimeConfig.DNS.Searches) > 0 {
+		search = nwCfg.RuntimeConfig.DNS.Searches[0]
+	}
+
+	epDNS = network.DNSInfo{
+		Servers: nwCfg.RuntimeConfig.DNS.Servers,
+		Suffix:  search,
+	}
+
+	return epDNS
+}


### PR DESCRIPTION
Co-authored-by: James Sturtevant <jstur@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Adds dns [capability](https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md) for custom DNS, which is [only used on Windows](https://github.com/kubernetes/kubernetes/blob/7dbe426b2426458f02339e28d1cc102efdb6eda1/pkg/kubelet/dockershim/network/cni/cni.go#L104).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: https://github.com/kubernetes/kubernetes/issues/74541

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add DNS capability for custom DNS on Windows
```
