### PR TITLE
Added UT in telemetry code to fix code coverage

### DIFF
--- a/telemetry/cnstelemetry.go
+++ b/telemetry/cnstelemetry.go
@@ -80,6 +80,7 @@ CONNECT:
 			if err == nil {
 				// If write fails, try to re-establish connections as server/client
 				if _, err = telemetryBuffer.Write(report); err != nil {
+					log.Printf("[CNS-Telemetry] Telemetry write failed: %v", err)
 					telemetryBuffer.Cancel()
 					goto CONNECT
 				}

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -176,20 +176,20 @@ func TestCloseTelemetryConnection(t *testing.T) {
 }
 
 func TestServerCloseTelemetryConnection(t *testing.T) {
-	// server telemetrybuffer
+	// create server telemetrybuffer and start server
 	tb = NewTelemetryBuffer(hostAgentUrl)
 	err := tb.StartServer()
 	if err == nil {
 		go tb.BufferAndPushData(0)
 	}
 
-	// client telemetrybuffer
+	// create client telemetrybuffer and connect to server
 	tb1 := NewTelemetryBuffer(hostAgentUrl)
 	if err := tb1.Connect(); err != nil {
 		t.Errorf("connection to telemetry server failed %v", err)
 	}
 
-	// Close server connection
+	// Exit server thread and close server connection
 	tb.Cancel()
 	time.Sleep(300 * time.Millisecond)
 
@@ -199,7 +199,6 @@ func TestServerCloseTelemetryConnection(t *testing.T) {
 
 	// Close client connection
 	tb1.Close()
-
 }
 
 func TestSetReportState(t *testing.T) {

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -228,11 +228,6 @@ func TestClientCloseTelemetryConnection(t *testing.T) {
 		t.Errorf("All connections not closed as expected")
 	}
 
-	b := []byte("tamil")
-	if _, err := tb1.Write(b); err == nil {
-		t.Errorf("write succeeded even after client close")
-	}
-
 	// Exit server thread and close server connection
 	tb.Cancel()
 }

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -186,14 +186,14 @@ func TestServerCloseTelemetryConnection(t *testing.T) {
 	// client telemetrybuffer
 	tb1 := NewTelemetryBuffer(hostAgentUrl)
 	if err := tb1.Connect(); err != nil {
-		fmt.Printf("connection to telemetry server failed %v", err)
+		t.Errorf("connection to telemetry server failed %v", err)
 	}
 
 	// Close server connection
 	tb.Close()
 
 	if len(tb.connections) != 0 {
-		fmt.Printf("server didn't close all connections as expected")
+		t.Errorf("server didn't close all connections as expected")
 	}
 
 	// Close client connection

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -204,7 +204,37 @@ func TestServerCloseTelemetryConnection(t *testing.T) {
 
 	// Close client connection
 	tb1.Close()
+}
 
+func TestClientCloseTelemetryConnection(t *testing.T) {
+	// create server telemetrybuffer and start server
+	tb = NewTelemetryBuffer(hostAgentUrl)
+	err := tb.StartServer()
+	if err == nil {
+		go tb.BufferAndPushData(0)
+	}
+
+	// create client telemetrybuffer and connect to server
+	tb1 := NewTelemetryBuffer(hostAgentUrl)
+	if err := tb1.Connect(); err != nil {
+		t.Errorf("connection to telemetry server failed %v", err)
+	}
+
+	// Close client connection
+	tb1.Close()
+	time.Sleep(300 * time.Millisecond)
+
+	if len(tb.connections) != 0 {
+		t.Errorf("All connections not closed as expected")
+	}
+
+	b := []byte("tamil")
+	if _, err := tb1.Write(b); err == nil {
+		t.Errorf("write succeeded even after client close")
+	}
+
+	// Exit server thread and close server connection
+	tb.Cancel()
 }
 
 func TestSetReportState(t *testing.T) {

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -198,12 +198,13 @@ func TestServerCloseTelemetryConnection(t *testing.T) {
 		t.Errorf("Client couldn't recognise server close")
 	}
 
-	// Close client connection
-	tb1.Close()
-
 	if len(tb.connections) != 0 {
 		t.Errorf("All connections not closed as expected")
 	}
+
+	// Close client connection
+	tb1.Close()
+
 }
 
 func TestSetReportState(t *testing.T) {

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -190,7 +190,8 @@ func TestServerCloseTelemetryConnection(t *testing.T) {
 	}
 
 	// Close server connection
-	tb.Close()
+	tb.Cancel()
+	time.Sleep(300 * time.Millisecond)
 
 	if len(tb.connections) != 0 {
 		t.Errorf("server didn't close all connections as expected")

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -175,6 +175,31 @@ func TestCloseTelemetryConnection(t *testing.T) {
 	}
 }
 
+func TestServerCloseTelemetryConnection(t *testing.T) {
+	// server telemetrybuffer
+	tb = NewTelemetryBuffer(hostAgentUrl)
+	err := tb.StartServer()
+	if err == nil {
+		go tb.BufferAndPushData(0)
+	}
+
+	// client telemetrybuffer
+	tb1 := NewTelemetryBuffer(hostAgentUrl)
+	if err := tb1.Connect(); err != nil {
+		fmt.Printf("connection to telemetry server failed %v", err)
+	}
+
+	// Close server connection
+	tb.Close()
+
+	// Close client connection
+	tb1.Close()
+
+	if len(tb.connections) != 0 {
+		fmt.Printf("server didn't close all connections as expected")
+	}
+}
+
 func TestSetReportState(t *testing.T) {
 	err := reportManager.SetReportState("a.json")
 	if err != nil {

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -193,12 +193,17 @@ func TestServerCloseTelemetryConnection(t *testing.T) {
 	tb.Cancel()
 	time.Sleep(300 * time.Millisecond)
 
-	if len(tb.connections) != 0 {
-		t.Errorf("server didn't close all connections as expected")
+	b := []byte("tamil")
+	if _, err := tb1.Write(b); err == nil {
+		t.Errorf("Client couldn't recognise server close")
 	}
 
 	// Close client connection
 	tb1.Close()
+
+	if len(tb.connections) != 0 {
+		t.Errorf("All connections not closed as expected")
+	}
 }
 
 func TestSetReportState(t *testing.T) {

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -192,12 +192,13 @@ func TestServerCloseTelemetryConnection(t *testing.T) {
 	// Close server connection
 	tb.Close()
 
-	// Close client connection
-	tb1.Close()
-
 	if len(tb.connections) != 0 {
 		fmt.Printf("server didn't close all connections as expected")
 	}
+
+	// Close client connection
+	tb1.Close()
+
 }
 
 func TestSetReportState(t *testing.T) {

--- a/telemetry/telemetrybuffer.go
+++ b/telemetry/telemetrybuffer.go
@@ -127,14 +127,13 @@ func (tb *TelemetryBuffer) StartServer() error {
 								tb.data <- cnsReport
 							}
 						} else {
-							telemetryLogger.Printf("Server closing client connection")
 							var index int
 							var value net.Conn
 							var found bool
 
 							for index, value = range tb.connections {
 								if value == conn {
-									telemetryLogger.Printf("Server closing client connection2")
+									telemetryLogger.Printf("Server closing client connection")
 									conn.Close()
 									found = true
 									break

--- a/telemetry/telemetrybuffer.go
+++ b/telemetry/telemetrybuffer.go
@@ -133,14 +133,23 @@ func (tb *TelemetryBuffer) StartServer() error {
 							}
 						} else {
 							telemetryLogger.Printf("Server closing client connection")
-							for index, value := range tb.connections {
+							var index int
+							var value net.Conn
+							var found bool
+
+							for index, value = range tb.connections {
 								if value == conn {
 									telemetryLogger.Printf("Server closing client connection2")
 									conn.Close()
-									tb.connections = remove(tb.connections, index)
-									return
+									found = true
+									break
 								}
 							}
+
+							if found {
+								tb.connections = remove(tb.connections, index)
+							}
+
 							return
 						}
 					}

--- a/telemetry/telemetrybuffer.go
+++ b/telemetry/telemetrybuffer.go
@@ -78,11 +78,6 @@ func NewTelemetryBuffer(hostReportURL string) *TelemetryBuffer {
 	tb.payload.NPMReports = make([]NPMReport, 0)
 	tb.payload.CNSReports = make([]CNSReport, 0)
 
-	// err := telemetryLogger.SetTarget(log.TargetLogfile)
-	// if err != nil {
-	// 	fmt.Printf("Failed to configure logging: %v\n", err)
-	// }
-
 	return &tb
 }
 

--- a/telemetry/telemetrybuffer.go
+++ b/telemetry/telemetrybuffer.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Azure/azure-container-networking/common"
@@ -52,6 +53,7 @@ type TelemetryBuffer struct {
 	Connected          bool
 	data               chan interface{}
 	cancel             chan bool
+	mutex              sync.Mutex
 }
 
 // Payload object holds the different types of reports
@@ -112,7 +114,9 @@ func (tb *TelemetryBuffer) StartServer() error {
 			// Spawn worker goroutines to communicate with client
 			conn, err := tb.listener.Accept()
 			if err == nil {
+				tb.mutex.Lock()
 				tb.connections = append(tb.connections, conn)
+				tb.mutex.Unlock()
 				go func() {
 					for {
 						reportStr, err := read(conn)
@@ -141,6 +145,9 @@ func (tb *TelemetryBuffer) StartServer() error {
 							var value net.Conn
 							var found bool
 
+							tb.mutex.Lock()
+							defer tb.mutex.Unlock()
+
 							for index, value = range tb.connections {
 								if value == conn {
 									telemetryLogger.Printf("Server closing client connection")
@@ -159,6 +166,7 @@ func (tb *TelemetryBuffer) StartServer() error {
 					}
 				}()
 			} else {
+				telemetryLogger.Printf("Telemetry Server accept error %v", err)
 				return
 			}
 		}
@@ -254,9 +262,12 @@ func (tb *TelemetryBuffer) Close() {
 		tb.listener = nil
 	}
 
+	tb.mutex.Lock()
+	defer tb.mutex.Unlock()
+
 	for _, conn := range tb.connections {
 		if conn != nil {
-			telemetryLogger.Printf("connection close")
+			telemetryLogger.Printf("connection close as server closed")
 			conn.Close()
 		}
 	}

--- a/telemetry/telemetrybuffer.go
+++ b/telemetry/telemetrybuffer.go
@@ -38,7 +38,7 @@ const (
 	cni                       = "CNI"
 )
 
-var telemetryLogger = log.NewLogger(logName, log.LevelInfo, log.TargetStderr)
+var telemetryLogger = log.NewLogger(logName, log.LevelInfo, log.TargetLogfile)
 var payloadSize uint16 = 0
 
 // TelemetryBuffer object
@@ -78,10 +78,10 @@ func NewTelemetryBuffer(hostReportURL string) *TelemetryBuffer {
 	tb.payload.NPMReports = make([]NPMReport, 0)
 	tb.payload.CNSReports = make([]CNSReport, 0)
 
-	err := telemetryLogger.SetTarget(log.TargetLogfile)
-	if err != nil {
-		fmt.Printf("Failed to configure logging: %v\n", err)
-	}
+	// err := telemetryLogger.SetTarget(log.TargetLogfile)
+	// if err != nil {
+	// 	fmt.Printf("Failed to configure logging: %v\n", err)
+	// }
 
 	return &tb
 }
@@ -135,11 +135,13 @@ func (tb *TelemetryBuffer) StartServer() error {
 							telemetryLogger.Printf("Server closing client connection")
 							for index, value := range tb.connections {
 								if value == conn {
+									telemetryLogger.Printf("Server closing client connection2")
 									conn.Close()
 									tb.connections = remove(tb.connections, index)
 									return
 								}
 							}
+							return
 						}
 					}
 				}()

--- a/telemetry/telemetrybuffer.go
+++ b/telemetry/telemetrybuffer.go
@@ -38,7 +38,7 @@ const (
 	cni                       = "CNI"
 )
 
-var telemetryLogger = log.NewLogger(logName, log.LevelInfo, log.TargetLogfile)
+var telemetryLogger = log.NewLogger(logName, log.LevelInfo, log.TargetStderr)
 var payloadSize uint16 = 0
 
 // TelemetryBuffer object
@@ -78,12 +78,22 @@ func NewTelemetryBuffer(hostReportURL string) *TelemetryBuffer {
 	tb.payload.NPMReports = make([]NPMReport, 0)
 	tb.payload.CNSReports = make([]CNSReport, 0)
 
+	err := telemetryLogger.SetTarget(log.TargetLogfile)
+	if err != nil {
+		fmt.Printf("Failed to configure logging: %v\n", err)
+	}
+
 	return &tb
 }
 
 func remove(s []net.Conn, i int) []net.Conn {
-	s[i] = s[len(s)-1]
-	return s[:len(s)-1]
+	if len(s) > 0 && i < len(s) {
+		s[i] = s[len(s)-1]
+		return s[:len(s)-1]
+	}
+
+	telemetryLogger.Printf("tb connections remove failed index %v len %v", i, len(s))
+	return s
 }
 
 // Starts Telemetry server listening on unix domain socket


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
This PR fixes code coverage issue seen by #296 . The PR contains UT for server side closing connection first instead of client.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```