### PR TITLE
CNS to start telemetry process and connect to it

### DIFF
--- a/cni/network/plugin/main.go
+++ b/cni/network/plugin/main.go
@@ -22,9 +22,11 @@ import (
 )
 
 const (
-	hostNetAgentURL = "http://168.63.129.16/machine/plugins?comp=netagent&type=cnireport"
-	ipamQueryURL    = "http://168.63.129.16/machine/plugins?comp=nmagent&type=getinterfaceinfov1"
-	pluginName      = "CNI"
+	hostNetAgentURL                 = "http://168.63.129.16/machine/plugins?comp=netagent&type=cnireport"
+	ipamQueryURL                    = "http://168.63.129.16/machine/plugins?comp=nmagent&type=getinterfaceinfov1"
+	pluginName                      = "CNI"
+	telemetryNumRetries             = 5
+	telemetryWaitTimeInMilliseconds = 200
 )
 
 // Version is populated by make during build.
@@ -170,7 +172,7 @@ func main() {
 	}
 
 	tb := telemetry.NewTelemetryBuffer("")
-	tb.ConnectToTelemetryService()
+	tb.ConnectToTelemetryService(telemetryNumRetries, telemetryWaitTimeInMilliseconds)
 	defer tb.Close()
 
 	t := time.Now()

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -143,6 +143,13 @@ var args = acn.ArgumentList{
 		Type:         "string",
 		DefaultValue: platform.K8SNetConfigPath + string(os.PathSeparator) + defaultCNINetworkConfigFileName,
 	},
+	{
+		Name:         acn.OptTelemetry,
+		Shorthand:    acn.OptTelemetryAlias,
+		Description:  "Set to false to disable telemetry",
+		Type:         "bool",
+		DefaultValue: true,
+	},
 }
 
 // Prints description and version information.
@@ -198,7 +205,8 @@ func main() {
 		return
 	}
 
-	if logger := log.GetStd(); logger != nil {
+	// Set-up channel for CNS telemetry if it's enabled (enabled by default)
+	if logger := log.GetStd(); logger != nil && acn.GetArg(acn.OptTelemetry).(bool) {
 		logger.SetChannel(reports)
 	}
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/azure-container-networking/log"
 	"github.com/Azure/azure-container-networking/platform"
 	"github.com/Azure/azure-container-networking/store"
+	"github.com/Azure/azure-container-networking/telemetry"
 )
 
 const (
@@ -168,7 +169,7 @@ func main() {
 	ipamQueryInterval, _ := acn.GetArg(acn.OptIpamQueryInterval).(int)
 	stopcnm = acn.GetArg(acn.OptStopAzureVnet).(bool)
 	vers := acn.GetArg(acn.OptVersion).(bool)
-	// reportToHostInterval := acn.GetArg(acn.OptReportToHostInterval).(int)
+	reportToHostInterval := acn.GetArg(acn.OptReportToHostInterval).(int)
 
 	if vers {
 		printVersion()
@@ -231,10 +232,10 @@ func main() {
 
 	// Start CNS.
 	if httpRestService != nil {
-		// go telemetry.SendCnsTelemetry(reportToHostInterval,
-		// 	reports,
-		// 	httpRestService.(*restserver.HTTPRestService),
-		// 	telemetryStopProcessing)
+		go telemetry.SendCnsTelemetry(reportToHostInterval,
+			reports,
+			httpRestService.(*restserver.HTTPRestService),
+			telemetryStopProcessing)
 		err = httpRestService.Start(&config)
 		if err != nil {
 			log.Errorf("Failed to start CNS, err:%v.\n", err)

--- a/common/config.go
+++ b/common/config.go
@@ -71,4 +71,8 @@ const (
 	// Telemetry config Location
 	OptTelemetryConfigDir      = "telemetry-config-file"
 	OptTelemetryConfigDirAlias = "d"
+
+	// Disable Telemetry
+	OptTelemetry      = "telemetry"
+	OptTelemetryAlias = "dt"
 )

--- a/log/logger.go
+++ b/log/logger.go
@@ -216,7 +216,9 @@ func (logger *Logger) Debugf(format string, args ...interface{}) {
 // Errorf logs a formatted string at info level and sends the string to TelemetryBuffer.
 func (logger *Logger) Errorf(format string, args ...interface{}) {
 	logger.Printf(format, args...)
-	// go func() {
-	// 	logger.reports <- fmt.Sprintf(format, args...)
-	// }()
+	go func() {
+		if logger.reports != nil {
+			logger.reports <- fmt.Sprintf(format, args...)
+		}
+	}()
 }

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -26,9 +26,11 @@ const (
 	NPMTelemetryFile = platform.NPMRuntimePath + "AzureNPMTelemetry.json"
 	// CNITelemetryFile Path.
 	CNITelemetryFile = platform.CNIRuntimePath + "AzureCNITelemetry.json"
-
-	metadataURL = "http://169.254.169.254/metadata/instance?api-version=2017-08-01&format=json"
-	ContentType = "application/json"
+	// ContentType of JSON
+	ContentType                     = "application/json"
+	metadataURL                     = "http://169.254.169.254/metadata/instance?api-version=2017-08-01&format=json"
+	telemetryNumRetries             = 5
+	telemetryWaitTimeInMilliseconds = 200
 )
 
 // OS Details structure.

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -27,10 +27,8 @@ const (
 	// CNITelemetryFile Path.
 	CNITelemetryFile = platform.CNIRuntimePath + "AzureCNITelemetry.json"
 	// ContentType of JSON
-	ContentType                     = "application/json"
-	metadataURL                     = "http://169.254.169.254/metadata/instance?api-version=2017-08-01&format=json"
-	telemetryNumRetries             = 5
-	telemetryWaitTimeInMilliseconds = 200
+	ContentType = "application/json"
+	metadataURL = "http://169.254.169.254/metadata/instance?api-version=2017-08-01&format=json"
 )
 
 // OS Details structure.


### PR DESCRIPTION
**What this PR does / why we need it**:
- Instead of running telemetry buffer (server) on goroutine, we will spawn a separate process.
- Adding an option to disable telemetry when starting CNS (-telemetry=false)