### PR TITLE
Cutting out Routes and DNS from EventMessage

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -495,8 +495,8 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 		return err
 	}
 
-	msg := fmt.Sprintf("CNI ADD succeeded : allocated ipaddress %+v, vlanid: %v, podname %v, namespace %v",
-		result, epInfo.Data[network.VlanIDKey], k8sPodName, k8sNamespace)
+	msg := fmt.Sprintf("CNI ADD succeeded : CNI Version %+v, IP:%+v, Interfaces:%+v, vlanid: %v, podname %v, namespace %v",
+		result.CNIVersion, result.IPs, result.Interfaces, epInfo.Data[network.VlanIDKey], k8sPodName, k8sNamespace)
 	plugin.setCNIReportDetails(nwCfg, CNI_ADD, msg)
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Cutting out Routes and DNS from EventMessage because it is cause HostNetAgent crash. This is a temporary/quick resolution to prevent NetAgent crash.
