### PR TITLE
Set SDNRemoteArpMacAddress regKey for windows multitenancy

### DIFF
--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -1090,14 +1090,18 @@ func (service *HTTPRestService) getNetworkContainerByOrchestratorContext(w http.
 		return
 	}
 
+	// getNetworkContainerByOrchestratorContext gets called for multitenancy and
+	// setting the SDNRemoteArpMacAddress regKey is essential for the multitenancy
+	// to work correctly in case of windows platform. Return if there is an error
+	if err = platform.SetSdnRemoteArpMacAddress(); err != nil {
+		log.Printf("[Azure CNS] SetSdnRemoteArpMacAddress failed with error: %s", err.Error())
+		return
+	}
+
 	getNetworkContainerResponse := service.getNetworkContainerResponse(req)
 	returnCode := getNetworkContainerResponse.Response.ReturnCode
 	err = service.Listener.Encode(w, &getNetworkContainerResponse)
 	log.Response(service.Name, getNetworkContainerResponse, returnCode, ReturnCodeToString(returnCode), err)
-
-	if err = platform.SetSdnRemoteArpMacAddress(); err != nil {
-		log.Printf("[Azure CNS] %s", err.Error())
-	}
 }
 
 func (service *HTTPRestService) deleteNetworkContainer(w http.ResponseWriter, r *http.Request) {

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -1094,6 +1094,10 @@ func (service *HTTPRestService) getNetworkContainerByOrchestratorContext(w http.
 	returnCode := getNetworkContainerResponse.Response.ReturnCode
 	err = service.Listener.Encode(w, &getNetworkContainerResponse)
 	log.Response(service.Name, getNetworkContainerResponse, returnCode, ReturnCodeToString(returnCode), err)
+
+	if err = platform.SetSdnRemoteArpMacAddress(); err != nil {
+		log.Printf("[Azure CNS] %s", err.Error())
+	}
 }
 
 func (service *HTTPRestService) deleteNetworkContainer(w http.ResponseWriter, r *http.Request) {

--- a/platform/os_linux.go
+++ b/platform/os_linux.go
@@ -105,3 +105,9 @@ func KillProcessByName(processName string) error {
 	_, err := ExecuteCommand(cmd)
 	return err
 }
+
+// SetSdnRemoteArpMacAddress sets the regkey for SDNRemoteArpMacAddress needed for multitenancy
+// This operation is specific to windows OS
+func SetSdnRemoteArpMacAddress() error {
+	return nil
+}

--- a/platform/os_windows.go
+++ b/platform/os_windows.go
@@ -164,7 +164,7 @@ func SetSdnRemoteArpMacAddress() error {
 		}
 
 		// Set the reg key if not already set or has incorrect value
-		if result == "" || result != SDNRemoteArpMacAddress {
+		if result != SDNRemoteArpMacAddress {
 			if _, err = executePowershellCommand(SetSdnRemoteArpMacAddressCommand); err != nil {
 				log.Printf("Failed to set SDNRemoteArpMacAddress due to error %s", err.Error())
 				return err

--- a/platform/os_windows.go
+++ b/platform/os_windows.go
@@ -34,7 +34,26 @@ const (
 
 	// DNCRuntimePath is the path where DNC state files are stored.
 	DNCRuntimePath = ""
+
+	// SDNRemoteArpMacAddress is the registry key for the remote arp mac address.
+	// This is set for multitenancy to get arp response from within VM
+	// for vlan tagged arp requests
+	SDNRemoteArpMacAddress = "12-34-56-78-9a-bc"
+
+	// Command to get SDNRemoteArpMacAddress registry key
+	GetSdnRemoteArpMacAddressCommand = "(Get-ItemProperty " +
+		"-Path HKLM:\\SYSTEM\\CurrentControlSet\\Services\\hns\\State -Name SDNRemoteArpMacAddress).SDNRemoteArpMacAddress"
+
+	// Command to set SDNRemoteArpMacAddress registry key
+	SetSdnRemoteArpMacAddressCommand = "Set-ItemProperty " +
+		"-Path HKLM:\\SYSTEM\\CurrentControlSet\\Services\\hns\\State -Name SDNRemoteArpMacAddress -Value \"12-34-56-78-9a-bc\""
+
+	// Command to restart HNS service
+	RestartHnsServiceCommand = "Restart-Service -Name hns"
 )
+
+// Flag to check if sdnRemoteArpMacAddress registry key is set
+var sdnRemoteArpMacAddressSet = false
 
 // GetOSInfo returns OS version information.
 func GetOSInfo() string {
@@ -117,4 +136,49 @@ func ClearNetworkConfiguration() (bool, error) {
 func KillProcessByName(processName string) {
 	cmd := fmt.Sprintf("taskkill /IM %v /F", processName)
 	ExecuteCommand(cmd)
+}
+
+// executePowershellCommand executes powershell command
+func executePowershellCommand(command string) (string, error) {
+	ps, err := exec.LookPath("powershell.exe")
+	if err != nil {
+		return "", fmt.Errorf("Failed to find powershell executable")
+	}
+
+	cmd := exec.Command(ps, command)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.Run()
+
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+// SetSdnRemoteArpMacAddress sets the regkey for SDNRemoteArpMacAddress needed for multitenancy
+func SetSdnRemoteArpMacAddress() error {
+	if sdnRemoteArpMacAddressSet == false {
+		result, err := executePowershellCommand(GetSdnRemoteArpMacAddressCommand)
+		if err != nil {
+			return err
+		}
+
+		// Set the reg key if not already set or has incorrect value
+		if result == "" || result != SDNRemoteArpMacAddress {
+			if _, err = executePowershellCommand(SetSdnRemoteArpMacAddressCommand); err != nil {
+				log.Printf("Failed to set SDNRemoteArpMacAddress due to error %s", err.Error())
+				return err
+			}
+
+			log.Printf("[Azure CNS] SDNRemoteArpMacAddress regKey set successfully. Restarting hns service.")
+			if _, err := executePowershellCommand(RestartHnsServiceCommand); err != nil {
+				log.Printf("Failed to Restart HNS Service due to error %s", err.Error())
+				return err
+			}
+		}
+
+		sdnRemoteArpMacAddressSet = true
+	}
+
+	return nil
 }


### PR DESCRIPTION
SDNRemoteArpMacAddress is the registry key for the remote mac address.
This is needed in case of multitenancy to get arp response from within VM.
This is achieved by setting In-VM arp responder that always responds with
a fake mac address.
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->


**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```