### PR TITLE
Skip HotAttachEp from CNM createEndpoint

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -452,6 +452,7 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 		EnableInfraVnet:    enableInfraVnet,
 		PODName:            k8sPodName,
 		PODNameSpace:       k8sNamespace,
+		SkipHotAttachEp:    false,
 	}
 
 	epPolicies := getPoliciesFromRuntimeCfg(nwCfg)

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -452,7 +452,7 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 		EnableInfraVnet:    enableInfraVnet,
 		PODName:            k8sPodName,
 		PODNameSpace:       k8sNamespace,
-		SkipHotAttachEp:    false,
+		SkipHotAttachEp:    false, // Hot attach at the time of endpoint creation
 	}
 
 	epPolicies := getPoliciesFromRuntimeCfg(nwCfg)

--- a/cnm/network/network.go
+++ b/cnm/network/network.go
@@ -229,8 +229,9 @@ func (plugin *netPlugin) createEndpoint(w http.ResponseWriter, r *http.Request) 
 	}
 
 	epInfo := network.EndpointInfo{
-		Id:          req.EndpointID,
-		IPAddresses: []net.IPNet{*ipv4Address},
+		Id:              req.EndpointID,
+		IPAddresses:     []net.IPNet{*ipv4Address},
+		SkipHotAttachEp: true, // Skip hot attach endpoint as it's done in Join
 	}
 
 	epInfo.Data = make(map[string]interface{})

--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -61,6 +61,7 @@ type EndpointInfo struct {
 	PODNameSpace          string
 	Data                  map[string]interface{}
 	InfraVnetAddressSpace string
+	SkipHotAttachEp       bool
 }
 
 // RouteInfo contains information about an IP route.

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -94,7 +94,10 @@ func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
 		}
 	}()
 
-	if !epInfo.SkipHotAttachEp {
+	if epInfo.SkipHotAttachEp {
+		log.Printf("[net] Skipping attaching the endpoint %v to container %v.",
+			hnsResponse.Id, epInfo.ContainerID)
+	} else {
 		// Attach the endpoint.
 		log.Printf("[net] Attaching endpoint %v to container %v.", hnsResponse.Id, epInfo.ContainerID)
 		err = hcsshim.HotAttachEndpoint(epInfo.ContainerID, hnsResponse.Id)

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -94,12 +94,14 @@ func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
 		}
 	}()
 
-	// Attach the endpoint.
-	log.Printf("[net] Attaching endpoint %v to container %v.", hnsResponse.Id, epInfo.ContainerID)
-	err = hcsshim.HotAttachEndpoint(epInfo.ContainerID, hnsResponse.Id)
-	if err != nil {
-		log.Printf("[net] Failed to attach endpoint: %v.", err)
-		return nil, err
+	if !epInfo.SkipHotAttachEp {
+		// Attach the endpoint.
+		log.Printf("[net] Attaching endpoint %v to container %v.", hnsResponse.Id, epInfo.ContainerID)
+		err = hcsshim.HotAttachEndpoint(epInfo.ContainerID, hnsResponse.Id)
+		if err != nil {
+			log.Printf("[net] Failed to attach endpoint: %v.", err)
+			return nil, err
+		}
 	}
 
 	// Create the endpoint object.


### PR DESCRIPTION
CNM attaches endpoint separately as a part of Join request. This
change avoids the hot attach endpoint operation from CNM create
endpoint. CNI still performs hot attach endpoint as a part of create
endpoint.
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```