### PR TITLE
Create functions for service network state

### DIFF
--- a/cns/api.go
+++ b/cns/api.go
@@ -67,16 +67,16 @@ type CreateHnsNetworkRequest struct {
 // SubnetInfo is assoicated with HNS network and represents a list
 // of subnets available to the network
 type SubnetInfo struct {
-	AddressPrefix  string            `json:",omitempty"`
-	GatewayAddress string            `json:",omitempty"`
+	AddressPrefix  string
+	GatewayAddress string
 	Policies       []json.RawMessage `json:",omitempty"`
 }
 
 // MacPool is assoicated with HNS  network and represents a list
 // of macaddresses available to the network
 type MacPool struct {
-	StartMacAddress string `json:",omitempty"`
-	EndMacAddress   string `json:",omitempty"`
+	StartMacAddress string
+	EndMacAddress   string
 }
 
 // DeleteHnsNetworkRequest describes request to delete the HNS network.


### PR DESCRIPTION
Create get, set and remove functions for service network state
operations. This acquires the service lock inside the functions.
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```