### PR TITLE
Added more features in iptm package

### DIFF
--- a/npm/iptm/iptm.go
+++ b/npm/iptm/iptm.go
@@ -7,8 +7,10 @@ https://github.com/kubernetes/kubernetes/blob/master/pkg/util/iptables
 package iptm
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 	"time"
 
@@ -21,11 +23,13 @@ import (
 
 // IptEntry represents an iptables rule.
 type IptEntry struct {
-	Name       string
-	HashedName string
-	Chain      string
-	Flag       string
-	Specs      []string
+	Command               string
+	Name                  string
+	HashedName            string
+	Chain                 string
+	Flag                  string
+	LockWaitTimeInSeconds string
+	Specs                 []string
 }
 
 // IptablesManager stores iptables entries.
@@ -329,10 +333,15 @@ func (iptMgr *IptablesManager) Delete(entry *IptEntry) error {
 
 // Run execute an iptables command to update iptables.
 func (iptMgr *IptablesManager) Run(entry *IptEntry) (int, error) {
-	cmdName := util.Iptables
-	cmdArgs := append([]string{util.IptablesWaitFlag, iptMgr.OperationFlag, entry.Chain}, entry.Specs...)
+	if entry.Command == "" {
+		entry.Command = util.Iptables
+	}
 
-	cmdOut, err := exec.Command(cmdName, cmdArgs...).Output()
+	waitFlag := fmt.Sprintf("%s %s", util.IptablesWaitFlag, entry.LockWaitTimeInSeconds)
+	waitFlag = strings.TrimSpace(waitFlag)
+	cmdArgs := append([]string{waitFlag, iptMgr.OperationFlag, entry.Chain}, entry.Specs...)
+
+	cmdOut, err := exec.Command(entry.Command, cmdArgs...).Output()
 	log.Printf("%s\n", string(cmdOut))
 
 	if msg, failed := err.(*exec.ExitError); failed {

--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -19,6 +19,7 @@ const (
 //iptables related constants.
 const (
 	Iptables                         string = "iptables"
+	Ip6tables                        string = "ip6tables"
 	IptablesSave                     string = "iptables-save"
 	IptablesRestore                  string = "iptables-restore"
 	IptablesConfigFile               string = "/var/log/iptables.conf"
@@ -47,8 +48,11 @@ const (
 	IptablesMatchSetFlag             string = "--match-set"
 	IptablesStateFlag                string = "state"
 	IptablesMatchStateFlag           string = "--state"
+	IptablesMultiportFlag            string = "multiport"
+	IptablesMultiDestportFlag        string = "--dports"
 	IptablesRelatedState             string = "RELATED"
 	IptablesEstablishedState         string = "ESTABLISHED"
+	IptablesFilterTable              string = "filter"
 	IptablesAzureChain               string = "AZURE-NPM"
 	IptablesAzureIngressPortChain    string = "AZURE-NPM-INGRESS-PORT"
 	IptablesAzureIngressFromChain    string = "AZURE-NPM-INGRESS-FROM"
@@ -60,6 +64,7 @@ const (
 	IptablesAzureEgressToPodChain    string = "AZURE-NPM-EGRESS-TO-POD"
 	IptablesAzureTargetSetsChain     string = "AZURE-NPM-TARGET-SETS"
 	IptablesForwardChain             string = "FORWARD"
+	IptablesInputChain               string = "INPUT"
 )
 
 //ipset related constants.


### PR DESCRIPTION
1. ip6table cmd support
2. wiat falg with timeout

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
 This PR adds following support:
1. ip6tables command support without changing function signature
2. Wait flag with timeout parameter
3. Added few more constants to support specific iptable rules

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```