### PR TITLE
Added iptable default wait lock timeout to 60 seconds

### DIFF
--- a/npm/iptm/iptm.go
+++ b/npm/iptm/iptm.go
@@ -7,10 +7,8 @@ https://github.com/kubernetes/kubernetes/blob/master/pkg/util/iptables
 package iptm
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 	"syscall"
 	"time"
 
@@ -19,6 +17,10 @@ import (
 	"github.com/Azure/azure-container-networking/log"
 	"github.com/Azure/azure-container-networking/npm/util"
 	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	defaultlockWaitTimeInSeconds = "60"
 )
 
 // IptEntry represents an iptables rule.
@@ -337,10 +339,11 @@ func (iptMgr *IptablesManager) Run(entry *IptEntry) (int, error) {
 		entry.Command = util.Iptables
 	}
 
-	waitFlag := fmt.Sprintf("%s %s", util.IptablesWaitFlag, entry.LockWaitTimeInSeconds)
-	waitFlag = strings.TrimSpace(waitFlag)
-	cmdArgs := append([]string{waitFlag, iptMgr.OperationFlag, entry.Chain}, entry.Specs...)
+	if entry.LockWaitTimeInSeconds == "" {
+		entry.LockWaitTimeInSeconds = defaultlockWaitTimeInSeconds
+	}
 
+	cmdArgs := append([]string{util.IptablesWaitFlag, entry.LockWaitTimeInSeconds, iptMgr.OperationFlag, entry.Chain}, entry.Specs...)
 	cmdOut, err := exec.Command(entry.Command, cmdArgs...).Output()
 	log.Printf("%s\n", string(cmdOut))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR changes iptable indefinite wait lock to wait with default timeout as 60 seconds

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```