### PR TITLE
Divide hns network

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -288,12 +288,10 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 	}
 
 	endpointId := GetEndpointID(args)
-
 	policies := cni.GetPoliciesFromNwCfg(nwCfg.AdditionalArgs)
 
 	// Check whether the network already exists.
 	nwInfo, nwInfoErr := plugin.nm.GetNetworkInfo(networkId)
-
 	if nwInfoErr == nil {
 		/* Handle consecutive ADD calls for infrastructure containers.
 		 * This is a temporary work around for issue #57253 of Kubernetes.
@@ -318,7 +316,6 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 
 	if nwInfoErr != nil {
 		// Network does not exist.
-
 		log.Printf("[cni-net] Creating network %v.", networkId)
 
 		if !nwCfg.MultiTenancy {
@@ -331,7 +328,6 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 
 			// Derive the subnet prefix from allocated IP address.
 			subnetPrefix = result.IPs[0].Address
-
 			iface := &cniTypesCurr.Interface{Name: args.IfName}
 			result.Interfaces = append(result.Interfaces, iface)
 		}
@@ -375,7 +371,10 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 
 		log.Printf("[cni-net] nwDNSInfo: %v", nwDNSInfo)
 		// Update subnet prefix for multi-tenant scenario
-		updateSubnetPrefix(cnsNetworkConfig, &subnetPrefix)
+		if err = updateSubnetPrefix(cnsNetworkConfig, &subnetPrefix); err != nil {
+			err = plugin.Errorf("Failed to updateSubnetPrefix: %v", err)
+			return err
+		}
 
 		// Create the network.
 		nwInfo := network.NetworkInfo{

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -109,7 +109,8 @@ func getPoliciesFromRuntimeCfg(nwCfg *cni.NetworkConfig) []policy.Policy {
 	return nil
 }
 
-func updateSubnetPrefix(cnsNetworkConfig *cns.GetNetworkContainerResponse, subnetPrefix *net.IPNet) {
+func updateSubnetPrefix(cnsNetworkConfig *cns.GetNetworkContainerResponse, subnetPrefix *net.IPNet) error {
+	return nil
 }
 
 func getNetworkName(podName, podNs, ifName string, nwCfg *cni.NetworkConfig) (string, error) {

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -93,35 +93,43 @@ func setEndpointOptions(cnsNwConfig *cns.GetNetworkContainerResponse, epInfo *ne
 func addSnatInterface(nwCfg *cni.NetworkConfig, result *cniTypesCurr.Result) {
 }
 
-func updateSubnetPrefix(cnsNwConfig *cns.GetNetworkContainerResponse, subnetPrefix *net.IPNet) {
+func updateSubnetPrefix(cnsNwConfig *cns.GetNetworkContainerResponse, subnetPrefix *net.IPNet) error {
 	if cnsNwConfig != nil && cnsNwConfig.MultiTenancyInfo.ID != 0 {
 		ipconfig := cnsNwConfig.IPConfiguration
 		ipAddr := net.ParseIP(ipconfig.IPSubnet.IPAddress)
-
 		if ipAddr.To4() != nil {
-			*subnetPrefix = net.IPNet{IP: ipAddr, Mask: net.CIDRMask(int(ipconfig.IPSubnet.PrefixLength), 32)}
+			*subnetPrefix = net.IPNet{Mask: net.CIDRMask(int(ipconfig.IPSubnet.PrefixLength), 32)}
+		} else if ipAddr.To16() != nil {
+			*subnetPrefix = net.IPNet{Mask: net.CIDRMask(int(ipconfig.IPSubnet.PrefixLength), 128)}
 		} else {
-			*subnetPrefix = net.IPNet{IP: ipAddr, Mask: net.CIDRMask(int(ipconfig.IPSubnet.PrefixLength), 128)}
+			return fmt.Errorf("[cni-net] Failed to get mask from CNS network configuration")
 		}
 
-		subnetPrefix.IP = subnetPrefix.IP.Mask(subnetPrefix.Mask)
+		subnetPrefix.IP = ipAddr.Mask(subnetPrefix.Mask)
 		log.Printf("Updated subnetPrefix: %s", subnetPrefix.String())
 	}
+
+	return nil
 }
 
-func getNetworkName(podName, podNs, ifName string, nwCfg *cni.NetworkConfig) (string, error) {
+func getNetworkName(podName, podNs, ifName string, nwCfg *cni.NetworkConfig) (networkName string, err error) {
+	networkName = nwCfg.Name
 	if nwCfg.MultiTenancy {
 		_, cnsNetworkConfig, _, err := getContainerNetworkConfiguration(nwCfg, podName, podNs, ifName)
 		if err != nil {
 			log.Printf("GetContainerNetworkConfiguration failed for podname %v namespace %v with error %v", podName, podNs, err)
-			return "", err
+		} else {
+			var subnet net.IPNet
+			if err = updateSubnetPrefix(cnsNetworkConfig, &subnet); err == nil {
+				// networkName will look like ~ azure-vlan1-172-28-1-0_24
+				networkName = strings.Replace(subnet.String(), ".", "-", -1)
+				networkName = strings.Replace(networkName, "/", "_", -1)
+				networkName = fmt.Sprintf("%s-vlan%v-%v", nwCfg.Name, cnsNetworkConfig.MultiTenancyInfo.ID, networkName)
+			}
 		}
-
-		networkName := fmt.Sprintf("%s-vlanid%v", nwCfg.Name, cnsNetworkConfig.MultiTenancyInfo.ID)
-		return networkName, nil
 	}
 
-	return nwCfg.Name, nil
+	return
 }
 
 func setupInfraVnetRoutingForMultitenancy(

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -114,6 +114,7 @@ func updateSubnetPrefix(cnsNwConfig *cns.GetNetworkContainerResponse, subnetPref
 
 func getNetworkName(podName, podNs, ifName string, nwCfg *cni.NetworkConfig) (networkName string, err error) {
 	networkName = nwCfg.Name
+	err = nil
 	if nwCfg.MultiTenancy {
 		_, cnsNetworkConfig, _, err := getContainerNetworkConfiguration(nwCfg, podName, podNs, ifName)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of basing HnsNetwork name on vlan, it's now created from subnet + prefix.
This is a temporary workaround until we can add/update HnsNetwork with multiple subnets.
e.g. azure-vlan1 -> azure-vlan1-172-28-1-0_24