### PR TITLE
Added ubuntu18 AKS config for e2e test in ubuntu 18

### DIFF
--- a/test/e2e/kubernetes/cniLinux18.json
+++ b/test/e2e/kubernetes/cniLinux18.json
@@ -21,8 +21,8 @@
            "name":"agentpool1",
            "count":3,
            "vmSize":"Standard_D2_v2",
-	   "osType": "Linux",
-	   "distro": "aks-18.04", 
+	       "osType": "Linux",
+	       "distro": "aks-18.04", 
            "availabilityProfile":"AvailabilitySet"
         }
      ],

--- a/test/e2e/kubernetes/cniLinux18.json
+++ b/test/e2e/kubernetes/cniLinux18.json
@@ -1,0 +1,44 @@
+{
+  "apiVersion":"vlabs",
+  "properties":{
+     "orchestratorProfile":{
+        "orchestratorType":"Kubernetes",
+        "orchestratorRelease":"1.11",
+        "kubernetesConfig":{
+           "networkPlugin":"azure",
+           "networkPolicy":"azure",
+           "azureCNIVersion":"",
+           "azureCNIURLLinux":""
+        }
+     },
+     "masterProfile":{
+        "count":1,
+        "dnsPrefix":"cniLinux",
+        "vmSize":"Standard_D2_v2"
+     },
+     "agentPoolProfiles":[
+        {
+           "name":"agentpool1",
+           "count":3,
+           "vmSize":"Standard_D2_v2",
+	   "osType": "Linux",
+	   "distro": "aks-18.04", 
+           "availabilityProfile":"AvailabilitySet"
+        }
+     ],
+     "linuxProfile":{
+        "adminUsername":"azureuser",
+        "ssh":{
+           "publicKeys":[
+              {
+                 "keyData":""
+              }
+           ]
+        }
+     },
+     "servicePrincipalProfile":{
+        "clientId":"",
+        "secret":""
+     }
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Added ubuntu18 AKS config for doing e2e test in ubuntu 18

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```