### PR TITLE
Delete container even if NetNs is not specified

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -619,7 +619,7 @@ func (plugin *netPlugin) Delete(args *cniSkel.CmdArgs) error {
 	// Parse Pod arguments.
 	k8sPodName, k8sNamespace, err := plugin.getPodInfo(args.Args)
 	if err != nil {
-		return err
+		log.Printf("[cni-net] Failed to get POD info due to error: %v", err)
 	}
 
 	// Initialize values from network config.

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -116,6 +116,11 @@ func getNetworkName(podName, podNs, ifName string, nwCfg *cni.NetworkConfig) (ne
 	networkName = nwCfg.Name
 	err = nil
 	if nwCfg.MultiTenancy {
+		if len(strings.TrimSpace(podName)) == 0 || len(strings.TrimSpace(podNs)) == 0 {
+			err = fmt.Errorf("POD info cannot be empty. PodName: %s, PodNamespace: %s", podName, podNs)
+			return
+		}
+
 		_, cnsNetworkConfig, _, err := getContainerNetworkConfiguration(nwCfg, podName, podNs, ifName)
 		if err != nil {
 			log.Printf("GetContainerNetworkConfiguration failed for podname %v namespace %v with error %v", podName, podNs, err)


### PR DESCRIPTION
NetNs is an optional argument for deleting the network container.
If not specified, CNI logs the error and proceeds with deleting the
network container. In case of windows multitenancy, pod name
and pod namespace are required and it will return an appropriate
error.