### PR TITLE
Add pid to log

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -57,6 +57,8 @@ type Logger struct {
 	mutex        *sync.Mutex
 }
 
+var pid = os.Getpid()
+
 // NewLogger creates a new Logger.
 func NewLogger(name string, level int, target int) *Logger {
 	var logger Logger
@@ -190,7 +192,7 @@ func (logger *Logger) logf(format string, args ...interface{}) {
 	if logger.callCount%rotationCheckFrq == 0 {
 		logger.rotate()
 	}
-
+	format = fmt.Sprintf("[%v] %s", pid, format)
 	logger.callCount++
 	logger.l.Printf(format, args...)
 }

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -64,10 +64,10 @@ func TestPid(t *testing.T) {
 	defer os.Remove(fn)
 	
 	logBytes, err := ioutil.ReadFile(fn)
-    if err != nil {
-        t.Fatalf("Failed to read log, %v", err)
-    }
-    log := string(logBytes)
+	if err != nil {
+		t.Fatalf("Failed to read log, %v", err)
+	}
+	log := string(logBytes)
 	exptectedLog := fmt.Sprintf("[%v] LogText 1", os.Getpid());
 
 	if  !strings.Contains(log, exptectedLog){

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -4,7 +4,10 @@
 package log
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -47,4 +50,27 @@ func TestLogFileRotatesWhenSizeLimitIsReached(t *testing.T) {
 		t.Errorf("Found the 2nd rotated log file which should have been deleted.")
 	}
 	os.Remove(fn)
+}
+
+func TestPid(t *testing.T) {
+	l := NewLogger(logName, LevelInfo, TargetLogfile)
+	if l == nil {
+		t.Fatalf("Failed to create logger.")
+	}
+
+	l.Printf("LogText %v", 1)
+	l.Close()
+	fn := l.GetLogDirectory() + logName + ".log"
+	defer os.Remove(fn)
+	
+	logBytes, err := ioutil.ReadFile(fn)
+    if err != nil {
+        t.Fatalf("Failed to read log, %v", err)
+    }
+    log := string(logBytes)
+	exptectedLog := fmt.Sprintf("[%v] LogText 1", os.Getpid());
+
+	if  !strings.Contains(log, exptectedLog){
+		t.Fatalf("Unexpected log: %s.", log)
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Each cni request starts a new process, but they share same log file. When multi cni requests received at same time, it is difficult to distinguish logs for each request, add pid to logs will help to better troubleshooting  issue.

**Which issue this PR fixes**
Fixes #354 