### PR TITLE
Change network mode to l2tunnel by default for windows

### DIFF
--- a/cni/azure-windows-multitenancy.conflist
+++ b/cni/azure-windows-multitenancy.conflist
@@ -4,7 +4,7 @@
     "plugins": [
         {
             "type": "azure-vnet",
-            "mode": "bridge",
+            "mode": "tunnel",
             "bridge": "azure0",
             "multiTenancy":true,
             "enableSnatOnHost":true,

--- a/cni/azure-windows.conflist
+++ b/cni/azure-windows.conflist
@@ -4,7 +4,7 @@
     "plugins": [
         {
             "type": "azure-vnet",
-            "mode": "bridge",
+            "mode": "tunnel",
             "bridge": "azure0",
             "capabilities": {
                 "portMappings": true,


### PR DESCRIPTION
Currently the default mode for the network in case of windows is 
l2bridge. Changing it to l2tunnel by default with this change.