### PR TITLE
change telemetry to message queue and add npm

### DIFF
--- a/cni/telemetry/Dockerfile
+++ b/cni/telemetry/Dockerfile
@@ -1,0 +1,13 @@
+# Use a minimal image as a parent image
+FROM ubuntu:18.04
+ARG TELEMETRY_BUILD_DIR
+ARG TELEMETRY_CONF_DIR
+
+# Install plugin
+COPY $TELEMETRY_BUILD_DIR/azure-vnet-telemetry /usr/bin
+COPY $TELEMETRY_CONF_DIR/azure-vnet-telemetry.config /usr/bin
+
+WORKDIR /usr/bin
+
+# Run below command by default when the container starts.
+ENTRYPOINT ["/usr/bin/azure-vnet-telemetry", "-d", "/usr/bin"]

--- a/cni/telemetry/service/telemetrymain.go
+++ b/cni/telemetry/service/telemetrymain.go
@@ -106,7 +106,7 @@ func main() {
 		return
 	}
 
-	log.Printf("args %+v", os.Args)
+	log.Logf("args %+v", os.Args)
 
 	if runtime.GOOS == "linux" {
 		configPath = fmt.Sprintf("%s/%s%s", configDirectory, azureVnetTelemetry, configExtension)
@@ -114,25 +114,25 @@ func main() {
 		configPath = fmt.Sprintf("%s\\%s%s", configDirectory, azureVnetTelemetry, configExtension)
 	}
 
-	log.Printf("[Telemetry] Config path: %s", configPath)
+	log.Logf("[Telemetry] Config path: %s", configPath)
 
 	config, err = telemetry.ReadConfigFile(configPath)
 	if err != nil {
-		log.Printf("[Telemetry] Error reading telemetry config: %v", err)
+		log.Logf("[Telemetry] Error reading telemetry config: %v", err)
 	}
 
-	log.Printf("read config returned %+v", config)
+	log.Logf("read config returned %+v", config)
 
 	for {
 		tb = telemetry.NewTelemetryBuffer("")
 
-		log.Printf("[Telemetry] Starting telemetry server")
+		log.Logf("[Telemetry] Starting telemetry server")
 		err = tb.StartServer()
 		if err == nil || tb.FdExists {
 			break
 		}
 
-		log.Printf("[Telemetry] Telemetry service starting failed: %v", err)
+		log.Logf("[Telemetry] Telemetry service starting failed: %v", err)
 		tb.Cleanup(telemetry.FdName)
 		time.Sleep(time.Millisecond * 200)
 	}
@@ -141,7 +141,7 @@ func main() {
 		config.ReportToHostIntervalInSeconds = reportToHostIntervalInSeconds
 	}
 
-	log.Printf("[Telemetry] Report to host for an interval of %d seconds", config.ReportToHostIntervalInSeconds)
+	log.Logf("[Telemetry] Report to host for an interval of %d seconds", config.ReportToHostIntervalInSeconds)
 	tb.BufferAndPushData(config.ReportToHostIntervalInSeconds * time.Second)
 	log.Close()
 }

--- a/log/logger.go
+++ b/log/logger.go
@@ -138,7 +138,7 @@ func (logger *Logger) rotate() {
 	fileName := logger.getLogFileName()
 	fileInfo, err := os.Stat(fileName)
 	if err != nil {
-		logger.Printf("[log] Failed to query log file info %+v.", err)
+		logger.Logf("[log] Failed to query log file info %+v.", err)
 		return
 	}
 
@@ -185,7 +185,7 @@ func (logger *Logger) Response(tag string, response interface{}, returnCode int,
 	}
 }
 
-// Logf logs a formatted string.
+// logf logs a formatted string.
 func (logger *Logger) logf(format string, args ...interface{}) {
 	if logger.callCount%rotationCheckFrq == 0 {
 		logger.rotate()
@@ -195,27 +195,48 @@ func (logger *Logger) logf(format string, args ...interface{}) {
 	logger.l.Printf(format, args...)
 }
 
-// Printf logs a formatted string at info level.
-func (logger *Logger) Printf(format string, args ...interface{}) {
-	if logger.level >= LevelInfo {
-		logger.mutex.Lock()
-		logger.logf(format, args...)
-		logger.mutex.Unlock()
-	}
+// Logf wraps logf.
+func (logger *Logger) Logf(format string, args ...interface{}) {
+	logger.mutex.Lock()
+	logger.logf(format, args...)
+	logger.mutex.Unlock()
 }
 
-// Debugf logs a formatted string at debug level.
-func (logger *Logger) Debugf(format string, args ...interface{}) {
-	if logger.level >= LevelDebug {
-		logger.mutex.Lock()
-		logger.logf(format, args...)
-		logger.mutex.Unlock()
+// Printf logs a formatted string at info level.
+func (logger *Logger) Printf(format string, args ...interface{}) {
+	if logger.level < LevelInfo {
+		return
 	}
+
+	logger.mutex.Lock()
+	logger.logf(format, args...)
+	logger.mutex.Unlock()
+	go func() {
+		if logger.reports != nil {
+			logger.reports <- fmt.Sprintf(format, args...)
+		}
+	}()
+}
+
+// Debugf logs a formatted string at info level.
+func (logger *Logger) Debugf(format string, args ...interface{}) {
+	if logger.level < LevelDebug {
+		return
+	}
+
+	logger.mutex.Lock()
+	logger.logf(format, args...)
+	logger.mutex.Unlock()
+	go func() {
+		if logger.reports != nil {
+			logger.reports <- fmt.Sprintf(format, args...)
+		}
+	}()
 }
 
 // Errorf logs a formatted string at info level and sends the string to TelemetryBuffer.
 func (logger *Logger) Errorf(format string, args ...interface{}) {
-	logger.Printf(format, args...)
+	logger.Logf(format, args...)
 	go func() {
 		if logger.reports != nil {
 			logger.reports <- fmt.Sprintf(format, args...)

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -22,7 +22,7 @@ func TestLogFileRotatesWhenSizeLimitIsReached(t *testing.T) {
 	l.SetLogFileLimits(512, 2)
 
 	for i := 1; i <= 100; i++ {
-		l.Printf("LogText %v", i)
+		l.Logf("LogText %v", i)
 	}
 
 	l.Close()

--- a/log/stdapi.go
+++ b/log/stdapi.go
@@ -47,6 +47,12 @@ func Response(tag string, response interface{}, returnCode int, returnStr string
 	stdLog.Response(tag, response, returnCode, returnStr, err)
 }
 
+// Logf logs to the local log.
+func Logf(format string, args ...interface{}) {
+	stdLog.Logf(format, args...)
+}
+
+// Printf logs to the local log and send the log through the channel.
 func Printf(format string, args ...interface{}) {
 	stdLog.Printf(format, args...)
 }

--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -1,5 +1,5 @@
 # Use a minimal image as a parent image
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 ARG NPM_BUILD_DIR
 
 # Install dependencies.
@@ -9,6 +9,7 @@ RUN apt-get install -y ipset
 
 # Install plugin.
 COPY $NPM_BUILD_DIR/azure-npm /usr/bin
+
 WORKDIR /usr/bin
 
 # Run the npm command by default when the container starts.

--- a/npm/azure-npm.yaml
+++ b/npm/azure-npm.yaml
@@ -76,7 +76,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
         - name: azure-npm
-          image: containernetworking/azure-npm:v1.0.18
+          image: containernetworking/azure-npm:v1.0.23
           securityContext:
             privileged: true
           env:
@@ -90,6 +90,17 @@ spec:
             mountPath: /run/xtables.lock
           - name: log
             mountPath: /var/log
+          - name: socket-dir
+            mountPath: /var/run
+          - name: tmp
+            mountPath: /tmp
+        - name: azure-vnet-telemetry
+          image: containernetworking/azure-vnet-telemetry:v1.0.23
+          volumeMounts:
+          - name: socket-dir
+            mountPath: /var/run
+          - name: tmp
+            mountPath: /tmp
       hostNetwork: true
       volumes:
       - name: log
@@ -100,4 +111,10 @@ spec:
         hostPath:
           path: /run/xtables.lock
           type: File
+      - name: tmp
+        hostPath:
+          path: /tmp
+          type: Directory
+      - name: socket-dir
+        emptyDir: {}
       serviceAccountName: azure-npm

--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -83,9 +83,9 @@ func (ipsMgr *IpsetManager) CreateList(listName string) error {
 		set:           util.GetHashedName(listName),
 		spec:          util.IpsetSetListFlag,
 	}
-	log.Printf("[Azure-NPM] Creating List: %+v", entry)
+	log.Printf("Creating List: %+v", entry)
 	if _, err := ipsMgr.Run(entry); err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to create ipset list %s.", listName)
+		log.Errorf("Error: failed to create ipset list %s.", listName)
 		return err
 	}
 
@@ -104,11 +104,11 @@ func (ipsMgr *IpsetManager) DeleteList(listName string) error {
 	errCode, err := ipsMgr.Run(entry)
 	if err != nil {
 		if errCode == 1 {
-			log.Printf("[Azure-NPM] Error: Cannot delete list %s as it's being referred or doesn't exist.", listName)
+			log.Printf("Error: Cannot delete list %s as it's being referred or doesn't exist.", listName)
 			return nil
 		}
 
-		log.Errorf("[Azure-NPM] Error: failed to delete ipset %s %+v", listName, entry)
+		log.Errorf("Error: failed to delete ipset %s %+v", listName, entry)
 		return err
 	}
 
@@ -134,7 +134,7 @@ func (ipsMgr *IpsetManager) AddToList(listName string, setName string) error {
 	}
 
 	if _, err := ipsMgr.Run(entry); err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to create ipset rules. rule: %+v", entry)
+		log.Errorf("Error: failed to create ipset rules. rule: %+v", entry)
 		return err
 	}
 
@@ -146,7 +146,7 @@ func (ipsMgr *IpsetManager) AddToList(listName string, setName string) error {
 // DeleteFromList removes an ipset to an ipset list.
 func (ipsMgr *IpsetManager) DeleteFromList(listName string, setName string) error {
 	if _, exists := ipsMgr.listMap[listName]; !exists {
-		log.Printf("[Azure-NPM] ipset list with name %s not found", listName)
+		log.Printf("ipset list with name %s not found", listName)
 		return nil
 	}
 
@@ -164,13 +164,13 @@ func (ipsMgr *IpsetManager) DeleteFromList(listName string, setName string) erro
 	}
 	errCode, err := ipsMgr.Run(entry)
 	if errCode > 1 && err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to delete ipset entry. %+v", entry)
+		log.Errorf("Error: failed to delete ipset entry. %+v", entry)
 		return err
 	}
 
 	if len(ipsMgr.listMap[listName].elements) == 0 {
 		if err := ipsMgr.DeleteList(listName); err != nil {
-			log.Errorf("[Azure-NPM] Error: failed to delete ipset list %s.", listName)
+			log.Errorf("Error: failed to delete ipset list %s.", listName)
 			return err
 		}
 	}
@@ -191,9 +191,9 @@ func (ipsMgr *IpsetManager) CreateSet(setName string) error {
 		set:  util.GetHashedName(setName),
 		spec: util.IpsetNetHashFlag,
 	}
-	log.Printf("[Azure-NPM] Creating Set: %+v", entry)
+	log.Printf("Creating Set: %+v", entry)
 	if _, err := ipsMgr.Run(entry); err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to create ipset.")
+		log.Errorf("Error: failed to create ipset.")
 		return err
 	}
 
@@ -205,7 +205,7 @@ func (ipsMgr *IpsetManager) CreateSet(setName string) error {
 // DeleteSet removes a set from ipset.
 func (ipsMgr *IpsetManager) DeleteSet(setName string) error {
 	if _, exists := ipsMgr.setMap[setName]; !exists {
-		log.Printf("[Azure-NPM] ipset with name %s not found", setName)
+		log.Printf("ipset with name %s not found", setName)
 		return nil
 	}
 
@@ -220,11 +220,11 @@ func (ipsMgr *IpsetManager) DeleteSet(setName string) error {
 	errCode, err := ipsMgr.Run(entry)
 	if err != nil {
 		if errCode == 1 {
-			log.Printf("[Azure-NPM] Cannot delete set %s as it's being referred.", setName)
+			log.Printf("Cannot delete set %s as it's being referred.", setName)
 			return nil
 		}
 
-		log.Errorf("[Azure-NPM] Error: failed to delete ipset %s. Entry: %+v", setName, entry)
+		log.Errorf("Error: failed to delete ipset %s. Entry: %+v", setName, entry)
 		return err
 	}
 
@@ -250,7 +250,7 @@ func (ipsMgr *IpsetManager) AddToSet(setName string, ip string) error {
 	}
 
 	if _, err := ipsMgr.Run(entry); err != nil {
-		log.Printf("[Azure-NPM] Error: failed to create ipset rules. %+v", entry)
+		log.Printf("Error: failed to create ipset rules. %+v", entry)
 		return err
 	}
 
@@ -262,7 +262,7 @@ func (ipsMgr *IpsetManager) AddToSet(setName string, ip string) error {
 // DeleteFromSet removes an ip from an entry in setMap, and delete/update the corresponding ipset.
 func (ipsMgr *IpsetManager) DeleteFromSet(setName string, ip string) error {
 	if _, exists := ipsMgr.setMap[setName]; !exists {
-		log.Printf("[Azure-NPM] ipset with name %s not found", setName)
+		log.Printf("ipset with name %s not found", setName)
 		return nil
 	}
 
@@ -278,7 +278,7 @@ func (ipsMgr *IpsetManager) DeleteFromSet(setName string, ip string) error {
 		spec:          ip,
 	}
 	if _, err := ipsMgr.Run(entry); err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to delete ipset entry. Entry: %+v", entry)
+		log.Errorf("Error: failed to delete ipset entry. Entry: %+v", entry)
 		return err
 	}
 
@@ -293,7 +293,7 @@ func (ipsMgr *IpsetManager) Clean() error {
 		}
 
 		if err := ipsMgr.DeleteSet(setName); err != nil {
-			log.Errorf("[Azure-NPM] Error: failed to clean ipset")
+			log.Errorf("Error: failed to clean ipset")
 			return err
 		}
 	}
@@ -304,7 +304,7 @@ func (ipsMgr *IpsetManager) Clean() error {
 		}
 
 		if err := ipsMgr.DeleteList(listName); err != nil {
-			log.Errorf("[Azure-NPM] Error: failed to clean ipset list")
+			log.Errorf("Error: failed to clean ipset list")
 			return err
 		}
 	}
@@ -318,13 +318,13 @@ func (ipsMgr *IpsetManager) Destroy() error {
 		operationFlag: util.IpsetFlushFlag,
 	}
 	if _, err := ipsMgr.Run(entry); err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to flush ipset")
+		log.Errorf("Error: failed to flush ipset")
 		return err
 	}
 
 	entry.operationFlag = util.IpsetDestroyFlag
 	if _, err := ipsMgr.Run(entry); err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to destroy ipset")
+		log.Errorf("Error: failed to destroy ipset")
 		return err
 	}
 
@@ -342,12 +342,12 @@ func (ipsMgr *IpsetManager) Run(entry *ipsEntry) (int, error) {
 		cmdArgs = append(cmdArgs, entry.spec)
 	}
 
-	log.Printf("[Azure-NPM] Executing ipset command %s %v", cmdName, cmdArgs)
+	log.Printf("Executing ipset command %s %v", cmdName, cmdArgs)
 	_, err := exec.Command(cmdName, cmdArgs...).Output()
 	if msg, failed := err.(*exec.ExitError); failed {
 		errCode := msg.Sys().(syscall.WaitStatus).ExitStatus()
 		if errCode > 1 {
-			log.Errorf("[Azure-NPM] Error: There was an error running command: %s %s Arguments:%v", err, cmdName, cmdArgs)
+			log.Errorf("Error: There was an error running command: %s %s Arguments:%v", err, cmdName, cmdArgs)
 		}
 
 		return errCode, err
@@ -364,7 +364,7 @@ func (ipsMgr *IpsetManager) Save(configFile string) error {
 
 	cmd := exec.Command(util.Ipset, util.IpsetSaveFlag, util.IpsetFileFlag, configFile)
 	if err := cmd.Start(); err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to save ipset to file.")
+		log.Errorf("Error: failed to save ipset to file.")
 		return err
 	}
 	cmd.Wait()
@@ -380,7 +380,7 @@ func (ipsMgr *IpsetManager) Restore(configFile string) error {
 
 	f, err := os.Stat(configFile)
 	if err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to get file %s stat from ipsm.Restore", configFile)
+		log.Errorf("Error: failed to get file %s stat from ipsm.Restore", configFile)
 		return err
 	}
 
@@ -392,7 +392,7 @@ func (ipsMgr *IpsetManager) Restore(configFile string) error {
 
 	cmd := exec.Command(util.Ipset, util.IpsetRestoreFlag, util.IpsetFileFlag, configFile)
 	if err := cmd.Start(); err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to restore ipset from file.")
+		log.Errorf("Error: failed to restore ipset from file.")
 		return err
 	}
 	cmd.Wait()

--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -83,9 +83,9 @@ func (ipsMgr *IpsetManager) CreateList(listName string) error {
 		set:           util.GetHashedName(listName),
 		spec:          util.IpsetSetListFlag,
 	}
-	log.Printf("Creating List: %+v\n", entry)
+	log.Printf("[Azure-NPM] Creating List: %+v", entry)
 	if _, err := ipsMgr.Run(entry); err != nil {
-		log.Printf("Error creating ipset list %s.\n", listName)
+		log.Errorf("[Azure-NPM] Error: failed to create ipset list %s.", listName)
 		return err
 	}
 
@@ -104,12 +104,11 @@ func (ipsMgr *IpsetManager) DeleteList(listName string) error {
 	errCode, err := ipsMgr.Run(entry)
 	if err != nil {
 		if errCode == 1 {
-			log.Printf("Cannot delete list %s as it's being referred or doesn't exist.\n", listName)
+			log.Printf("[Azure-NPM] Error: Cannot delete list %s as it's being referred or doesn't exist.", listName)
 			return nil
 		}
 
-		log.Printf("Error deleting ipset %s", listName)
-		log.Printf("%+v\n", entry)
+		log.Errorf("[Azure-NPM] Error: failed to delete ipset %s %+v", listName, entry)
 		return err
 	}
 
@@ -135,7 +134,7 @@ func (ipsMgr *IpsetManager) AddToList(listName string, setName string) error {
 	}
 
 	if _, err := ipsMgr.Run(entry); err != nil {
-		log.Printf("Error creating ipset rules. rule: %+v", entry)
+		log.Errorf("[Azure-NPM] Error: failed to create ipset rules. rule: %+v", entry)
 		return err
 	}
 
@@ -147,7 +146,7 @@ func (ipsMgr *IpsetManager) AddToList(listName string, setName string) error {
 // DeleteFromList removes an ipset to an ipset list.
 func (ipsMgr *IpsetManager) DeleteFromList(listName string, setName string) error {
 	if _, exists := ipsMgr.listMap[listName]; !exists {
-		log.Printf("ipset list with name %s not found", listName)
+		log.Printf("[Azure-NPM] ipset list with name %s not found", listName)
 		return nil
 	}
 
@@ -165,14 +164,13 @@ func (ipsMgr *IpsetManager) DeleteFromList(listName string, setName string) erro
 	}
 	errCode, err := ipsMgr.Run(entry)
 	if errCode > 1 && err != nil {
-		log.Printf("Error deleting ipset entry.\n")
-		log.Printf("%+v\n", entry)
+		log.Errorf("[Azure-NPM] Error: failed to delete ipset entry. %+v", entry)
 		return err
 	}
 
 	if len(ipsMgr.listMap[listName].elements) == 0 {
 		if err := ipsMgr.DeleteList(listName); err != nil {
-			log.Printf("Error deleting ipset list %s.\n", listName)
+			log.Errorf("[Azure-NPM] Error: failed to delete ipset list %s.", listName)
 			return err
 		}
 	}
@@ -193,9 +191,9 @@ func (ipsMgr *IpsetManager) CreateSet(setName string) error {
 		set:  util.GetHashedName(setName),
 		spec: util.IpsetNetHashFlag,
 	}
-	log.Printf("Creating Set: %+v\n", entry)
+	log.Printf("[Azure-NPM] Creating Set: %+v", entry)
 	if _, err := ipsMgr.Run(entry); err != nil {
-		log.Printf("Error creating ipset.\n")
+		log.Errorf("[Azure-NPM] Error: failed to create ipset.")
 		return err
 	}
 
@@ -207,7 +205,7 @@ func (ipsMgr *IpsetManager) CreateSet(setName string) error {
 // DeleteSet removes a set from ipset.
 func (ipsMgr *IpsetManager) DeleteSet(setName string) error {
 	if _, exists := ipsMgr.setMap[setName]; !exists {
-		log.Printf("ipset with name %s not found", setName)
+		log.Printf("[Azure-NPM] ipset with name %s not found", setName)
 		return nil
 	}
 
@@ -222,11 +220,11 @@ func (ipsMgr *IpsetManager) DeleteSet(setName string) error {
 	errCode, err := ipsMgr.Run(entry)
 	if err != nil {
 		if errCode == 1 {
-			log.Printf("Cannot delete set %s as it's being referred.\n", setName)
+			log.Printf("[Azure-NPM] Cannot delete set %s as it's being referred.", setName)
 			return nil
 		}
 
-		log.Printf("Error deleting ipset %s\n. Entry: %+v", setName, entry)
+		log.Errorf("[Azure-NPM] Error: failed to delete ipset %s. Entry: %+v", setName, entry)
 		return err
 	}
 
@@ -252,8 +250,7 @@ func (ipsMgr *IpsetManager) AddToSet(setName string, ip string) error {
 	}
 
 	if _, err := ipsMgr.Run(entry); err != nil {
-		log.Printf("Error creating ipset rules.\n")
-		log.Printf("rule: %+v\n", entry)
+		log.Printf("[Azure-NPM] Error: failed to create ipset rules. %+v", entry)
 		return err
 	}
 
@@ -265,7 +262,7 @@ func (ipsMgr *IpsetManager) AddToSet(setName string, ip string) error {
 // DeleteFromSet removes an ip from an entry in setMap, and delete/update the corresponding ipset.
 func (ipsMgr *IpsetManager) DeleteFromSet(setName string, ip string) error {
 	if _, exists := ipsMgr.setMap[setName]; !exists {
-		log.Printf("ipset with name %s not found", setName)
+		log.Printf("[Azure-NPM] ipset with name %s not found", setName)
 		return nil
 	}
 
@@ -281,7 +278,7 @@ func (ipsMgr *IpsetManager) DeleteFromSet(setName string, ip string) error {
 		spec:          ip,
 	}
 	if _, err := ipsMgr.Run(entry); err != nil {
-		log.Printf("Error deleting ipset entry.\n Entry: %+v", entry)
+		log.Errorf("[Azure-NPM] Error: failed to delete ipset entry. Entry: %+v", entry)
 		return err
 	}
 
@@ -296,7 +293,7 @@ func (ipsMgr *IpsetManager) Clean() error {
 		}
 
 		if err := ipsMgr.DeleteSet(setName); err != nil {
-			log.Printf("Error cleaning ipset\n")
+			log.Errorf("[Azure-NPM] Error: failed to clean ipset")
 			return err
 		}
 	}
@@ -307,7 +304,7 @@ func (ipsMgr *IpsetManager) Clean() error {
 		}
 
 		if err := ipsMgr.DeleteList(listName); err != nil {
-			log.Printf("Error cleaning ipset list\n")
+			log.Errorf("[Azure-NPM] Error: failed to clean ipset list")
 			return err
 		}
 	}
@@ -321,13 +318,13 @@ func (ipsMgr *IpsetManager) Destroy() error {
 		operationFlag: util.IpsetFlushFlag,
 	}
 	if _, err := ipsMgr.Run(entry); err != nil {
-		log.Printf("Error flushing ipset\n")
+		log.Errorf("[Azure-NPM] Error: failed to flush ipset")
 		return err
 	}
 
 	entry.operationFlag = util.IpsetDestroyFlag
 	if _, err := ipsMgr.Run(entry); err != nil {
-		log.Printf("Error destroying ipset\n")
+		log.Errorf("[Azure-NPM] Error: failed to destroy ipset")
 		return err
 	}
 
@@ -345,13 +342,12 @@ func (ipsMgr *IpsetManager) Run(entry *ipsEntry) (int, error) {
 		cmdArgs = append(cmdArgs, entry.spec)
 	}
 
-	cmdOut, err := exec.Command(cmdName, cmdArgs...).Output()
-	log.Printf("%s\n", string(cmdOut))
-
+	log.Printf("[Azure-NPM] Executing ipset command %s %v", cmdName, cmdArgs)
+	_, err := exec.Command(cmdName, cmdArgs...).Output()
 	if msg, failed := err.(*exec.ExitError); failed {
 		errCode := msg.Sys().(syscall.WaitStatus).ExitStatus()
 		if errCode > 1 {
-			log.Printf("There was an error running command: %s\nArguments:%+v", err, cmdArgs)
+			log.Errorf("[Azure-NPM] Error: There was an error running command: %s %s Arguments:%v", err, cmdName, cmdArgs)
 		}
 
 		return errCode, err
@@ -368,7 +364,7 @@ func (ipsMgr *IpsetManager) Save(configFile string) error {
 
 	cmd := exec.Command(util.Ipset, util.IpsetSaveFlag, util.IpsetFileFlag, configFile)
 	if err := cmd.Start(); err != nil {
-		log.Printf("Error saving ipset to file.\n")
+		log.Errorf("[Azure-NPM] Error: failed to save ipset to file.")
 		return err
 	}
 	cmd.Wait()
@@ -384,7 +380,7 @@ func (ipsMgr *IpsetManager) Restore(configFile string) error {
 
 	f, err := os.Stat(configFile)
 	if err != nil {
-		log.Printf("Error getting file %s stat from ipsm.Restore", configFile)
+		log.Errorf("[Azure-NPM] Error: failed to get file %s stat from ipsm.Restore", configFile)
 		return err
 	}
 
@@ -396,7 +392,7 @@ func (ipsMgr *IpsetManager) Restore(configFile string) error {
 
 	cmd := exec.Command(util.Ipset, util.IpsetRestoreFlag, util.IpsetFileFlag, configFile)
 	if err := cmd.Start(); err != nil {
-		log.Printf("Error restoring ipset from file.\n")
+		log.Errorf("[Azure-NPM] Error: failed to restore ipset from file.")
 		return err
 	}
 	cmd.Wait()

--- a/npm/iptm/iptm.go
+++ b/npm/iptm/iptm.go
@@ -50,7 +50,7 @@ func NewIptablesManager() *IptablesManager {
 
 // InitNpmChains initializes Azure NPM chains in iptables.
 func (iptMgr *IptablesManager) InitNpmChains() error {
-	log.Printf("[Azure-NPM] Initializing AZURE-NPM chains.")
+	log.Printf("Initializing AZURE-NPM chains.")
 
 	if err := iptMgr.AddChain(util.IptablesAzureChain); err != nil {
 		return err
@@ -72,7 +72,7 @@ func (iptMgr *IptablesManager) InitNpmChains() error {
 	if !exists {
 		iptMgr.OperationFlag = util.IptablesInsertionFlag
 		if _, err = iptMgr.Run(entry); err != nil {
-			log.Errorf("[Azure-NPM] Error: failed to add AZURE-NPM chain to FORWARD chain.")
+			log.Errorf("Error: failed to add AZURE-NPM chain to FORWARD chain.")
 			return err
 		}
 	}
@@ -95,7 +95,7 @@ func (iptMgr *IptablesManager) InitNpmChains() error {
 	if !exists {
 		iptMgr.OperationFlag = util.IptablesInsertionFlag
 		if _, err = iptMgr.Run(entry); err != nil {
-			log.Printf("[Azure-NPM] Error: failed to add default allow CONNECTED/RELATED rule to AZURE-NPM chain.")
+			log.Printf("Error: failed to add default allow CONNECTED/RELATED rule to AZURE-NPM chain.")
 			return err
 		}
 	}
@@ -116,7 +116,7 @@ func (iptMgr *IptablesManager) InitNpmChains() error {
 	if !exists {
 		iptMgr.OperationFlag = util.IptablesAppendFlag
 		if _, err := iptMgr.Run(entry); err != nil {
-			log.Errorf("[Azure-NPM] Error: failed to add AZURE-NPM-INGRESS-PORT chain to AZURE-NPM chain.")
+			log.Errorf("Error: failed to add AZURE-NPM-INGRESS-PORT chain to AZURE-NPM chain.")
 			return err
 		}
 	}
@@ -147,7 +147,7 @@ func (iptMgr *IptablesManager) InitNpmChains() error {
 	if !exists {
 		iptMgr.OperationFlag = util.IptablesAppendFlag
 		if _, err := iptMgr.Run(entry); err != nil {
-			log.Errorf("[Azure-NPM] Error: failed to add AZURE-NPM-EGRESS-PORT chain to AZURE-NPM chain.")
+			log.Errorf("Error: failed to add AZURE-NPM-EGRESS-PORT chain to AZURE-NPM chain.")
 			return err
 		}
 	}
@@ -178,7 +178,7 @@ func (iptMgr *IptablesManager) InitNpmChains() error {
 	if !exists {
 		iptMgr.OperationFlag = util.IptablesAppendFlag
 		if _, err := iptMgr.Run(entry); err != nil {
-			log.Errorf("[Azure-NPM] Error: failed to add AZURE-NPM-TARGET-SETS chain to AZURE-NPM chain.")
+			log.Errorf("Error: failed to add AZURE-NPM-TARGET-SETS chain to AZURE-NPM chain.")
 			return err
 		}
 	}
@@ -210,7 +210,7 @@ func (iptMgr *IptablesManager) UninitNpmChains() error {
 	iptMgr.OperationFlag = util.IptablesDeletionFlag
 	errCode, err := iptMgr.Run(entry)
 	if errCode != 1 && err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to remove default rule from FORWARD chain.")
+		log.Errorf("Error: failed to remove default rule from FORWARD chain.")
 		return err
 	}
 
@@ -220,7 +220,7 @@ func (iptMgr *IptablesManager) UninitNpmChains() error {
 			Chain: chain,
 		}
 		if _, err := iptMgr.Run(entry); err != nil {
-			log.Errorf("[Azure-NPM] Error: failed to flush iptables chain %s.", chain)
+			log.Errorf("Error: failed to flush iptables chain %s.", chain)
 		}
 	}
 
@@ -238,12 +238,12 @@ func (iptMgr *IptablesManager) Exists(entry *IptEntry) (bool, error) {
 	iptMgr.OperationFlag = util.IptablesCheckFlag
 	returnCode, err := iptMgr.Run(entry)
 	if err == nil {
-		log.Printf("[Azure-NPM] Rule exists. %+v.", entry)
+		log.Printf("Rule exists. %+v.", entry)
 		return true, nil
 	}
 
 	if returnCode == 1 {
-		log.Printf("[Azure-NPM] Rule doesn't exist. %+v.", entry)
+		log.Printf("Rule doesn't exist. %+v.", entry)
 		return false, nil
 	}
 
@@ -259,11 +259,11 @@ func (iptMgr *IptablesManager) AddChain(chain string) error {
 	errCode, err := iptMgr.Run(entry)
 	if err != nil {
 		if errCode == 1 {
-			log.Printf("[Azure-NPM] Chain already exists %s.", entry.Chain)
+			log.Printf("Chain already exists %s.", entry.Chain)
 			return nil
 		}
 
-		log.Errorf("[Azure-NPM] Error: failed to create iptables chain %s.", entry.Chain)
+		log.Errorf("Error: failed to create iptables chain %s.", entry.Chain)
 		return err
 	}
 
@@ -279,10 +279,10 @@ func (iptMgr *IptablesManager) DeleteChain(chain string) error {
 	errCode, err := iptMgr.Run(entry)
 	if err != nil {
 		if errCode == 1 {
-			log.Printf("[Azure-NPM] Chain doesn't exist %s.", entry.Chain)
+			log.Printf("Chain doesn't exist %s.", entry.Chain)
 			return nil
 		}
-		log.Errorf("[Azure-NPM] Error: failed to delete iptables chain %s.", entry.Chain)
+		log.Errorf("Error: failed to delete iptables chain %s.", entry.Chain)
 		return err
 	}
 
@@ -291,7 +291,7 @@ func (iptMgr *IptablesManager) DeleteChain(chain string) error {
 
 // Add adds a rule in iptables.
 func (iptMgr *IptablesManager) Add(entry *IptEntry) error {
-	log.Printf("[Azure-NPM] Add iptables entry: %+v.", entry)
+	log.Printf("Add iptables entry: %+v.", entry)
 
 	exists, err := iptMgr.Exists(entry)
 	if err != nil {
@@ -304,7 +304,7 @@ func (iptMgr *IptablesManager) Add(entry *IptEntry) error {
 
 	iptMgr.OperationFlag = util.IptablesInsertionFlag
 	if _, err := iptMgr.Run(entry); err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to create iptables rules.")
+		log.Errorf("Error: failed to create iptables rules.")
 		return err
 	}
 
@@ -313,7 +313,7 @@ func (iptMgr *IptablesManager) Add(entry *IptEntry) error {
 
 // Delete removes a rule in iptables.
 func (iptMgr *IptablesManager) Delete(entry *IptEntry) error {
-	log.Printf("[Azure-NPM] Deleting iptables entry: %+v", entry)
+	log.Printf("Deleting iptables entry: %+v", entry)
 
 	exists, err := iptMgr.Exists(entry)
 	if err != nil {
@@ -326,7 +326,7 @@ func (iptMgr *IptablesManager) Delete(entry *IptEntry) error {
 
 	iptMgr.OperationFlag = util.IptablesDeletionFlag
 	if _, err := iptMgr.Run(entry); err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to delete iptables rules.")
+		log.Errorf("Error: failed to delete iptables rules.")
 		return err
 	}
 
@@ -345,13 +345,13 @@ func (iptMgr *IptablesManager) Run(entry *IptEntry) (int, error) {
 	}
 
 	cmdArgs := append([]string{util.IptablesWaitFlag, entry.LockWaitTimeInSeconds, iptMgr.OperationFlag, entry.Chain}, entry.Specs...)
-	log.Printf("[Azure-NPM] Executing iptables command %s %v", cmdName, cmdArgs)
+	log.Printf("Executing iptables command %s %v", cmdName, cmdArgs)
 	_, err := exec.Command(cmdName, cmdArgs...).Output()
 
 	if msg, failed := err.(*exec.ExitError); failed {
 		errCode := msg.Sys().(syscall.WaitStatus).ExitStatus()
 		if errCode > 1 {
-			log.Errorf("[Azure-NPM] Error: There was an error running command: %s %s Arguments:%v", err, cmdName, cmdArgs)
+			log.Errorf("Error: There was an error running command: %s %s Arguments:%v", err, cmdName, cmdArgs)
 		}
 
 		return errCode, err
@@ -373,14 +373,14 @@ func (iptMgr *IptablesManager) Save(configFile string) error {
 
 	defer func(l *os.File) {
 		if err = l.Close(); err != nil {
-			log.Printf("[Azure-NPM] Failed to close iptables locks")
+			log.Printf("Failed to close iptables locks")
 		}
 	}(l)
 
 	// create the config file for writing
 	f, err := os.Create(configFile)
 	if err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to open file: %s.", configFile)
+		log.Errorf("Error: failed to open file: %s.", configFile)
 		return err
 	}
 	defer f.Close()
@@ -388,7 +388,7 @@ func (iptMgr *IptablesManager) Save(configFile string) error {
 	cmd := exec.Command(util.IptablesSave)
 	cmd.Stdout = f
 	if err := cmd.Start(); err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to run iptables-save.")
+		log.Errorf("Error: failed to run iptables-save.")
 		return err
 	}
 	cmd.Wait()
@@ -409,14 +409,14 @@ func (iptMgr *IptablesManager) Restore(configFile string) error {
 
 	defer func(l *os.File) {
 		if err = l.Close(); err != nil {
-			log.Printf("[Azure-NPM] Failed to close iptables locks")
+			log.Printf("Failed to close iptables locks")
 		}
 	}(l)
 
 	// open the config file for reading
 	f, err := os.Open(configFile)
 	if err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to open file: %s.", configFile)
+		log.Errorf("Error: failed to open file: %s.", configFile)
 		return err
 	}
 	defer f.Close()
@@ -424,7 +424,7 @@ func (iptMgr *IptablesManager) Restore(configFile string) error {
 	cmd := exec.Command(util.IptablesRestore)
 	cmd.Stdin = f
 	if err := cmd.Start(); err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to run iptables-restore.")
+		log.Errorf("Error: failed to run iptables-restore.")
 		return err
 	}
 	cmd.Wait()
@@ -447,7 +447,7 @@ func grabIptablesLocks() (*os.File, error) {
 	// Grab 1.6.x style lock.
 	l, err := os.OpenFile(util.IptablesLockFile, os.O_CREATE, 0600)
 	if err != nil {
-		log.Printf("[Azure-NPM] Error: failed to open iptables lock file %s.", util.IptablesLockFile)
+		log.Printf("Error: failed to open iptables lock file %s.", util.IptablesLockFile)
 		return nil, err
 	}
 
@@ -458,7 +458,7 @@ func grabIptablesLocks() (*os.File, error) {
 
 		return true, nil
 	}); err != nil {
-		log.Printf("[Azure-NPM] Error: failed to acquire new iptables lock: %v.", err)
+		log.Printf("Error: failed to acquire new iptables lock: %v.", err)
 		return nil, err
 	}
 

--- a/npm/iptm/iptm.go
+++ b/npm/iptm/iptm.go
@@ -50,7 +50,7 @@ func NewIptablesManager() *IptablesManager {
 
 // InitNpmChains initializes Azure NPM chains in iptables.
 func (iptMgr *IptablesManager) InitNpmChains() error {
-	log.Printf("Initializing AZURE-NPM chains")
+	log.Printf("[Azure-NPM] Initializing AZURE-NPM chains.")
 
 	if err := iptMgr.AddChain(util.IptablesAzureChain); err != nil {
 		return err
@@ -72,7 +72,7 @@ func (iptMgr *IptablesManager) InitNpmChains() error {
 	if !exists {
 		iptMgr.OperationFlag = util.IptablesInsertionFlag
 		if _, err = iptMgr.Run(entry); err != nil {
-			log.Printf("Error adding AZURE-NPM chain to FORWARD chain\n")
+			log.Errorf("[Azure-NPM] Error: failed to add AZURE-NPM chain to FORWARD chain.")
 			return err
 		}
 	}
@@ -95,7 +95,7 @@ func (iptMgr *IptablesManager) InitNpmChains() error {
 	if !exists {
 		iptMgr.OperationFlag = util.IptablesInsertionFlag
 		if _, err = iptMgr.Run(entry); err != nil {
-			log.Printf("Error adding default allow CONNECTED/RELATED rule to AZURE-NPM chain\n")
+			log.Printf("[Azure-NPM] Error: failed to add default allow CONNECTED/RELATED rule to AZURE-NPM chain.")
 			return err
 		}
 	}
@@ -116,7 +116,7 @@ func (iptMgr *IptablesManager) InitNpmChains() error {
 	if !exists {
 		iptMgr.OperationFlag = util.IptablesAppendFlag
 		if _, err := iptMgr.Run(entry); err != nil {
-			log.Printf("Error adding AZURE-NPM-INGRESS-PORT chain to AZURE-NPM chain\n")
+			log.Errorf("[Azure-NPM] Error: failed to add AZURE-NPM-INGRESS-PORT chain to AZURE-NPM chain.")
 			return err
 		}
 	}
@@ -147,7 +147,7 @@ func (iptMgr *IptablesManager) InitNpmChains() error {
 	if !exists {
 		iptMgr.OperationFlag = util.IptablesAppendFlag
 		if _, err := iptMgr.Run(entry); err != nil {
-			log.Printf("Error adding AZURE-NPM-EGRESS-PORT chain to AZURE-NPM chain\n")
+			log.Errorf("[Azure-NPM] Error: failed to add AZURE-NPM-EGRESS-PORT chain to AZURE-NPM chain.")
 			return err
 		}
 	}
@@ -178,7 +178,7 @@ func (iptMgr *IptablesManager) InitNpmChains() error {
 	if !exists {
 		iptMgr.OperationFlag = util.IptablesAppendFlag
 		if _, err := iptMgr.Run(entry); err != nil {
-			log.Printf("Error adding AZURE-NPM-TARGET-SETS chain to AZURE-NPM chain\n")
+			log.Errorf("[Azure-NPM] Error: failed to add AZURE-NPM-TARGET-SETS chain to AZURE-NPM chain.")
 			return err
 		}
 	}
@@ -210,7 +210,7 @@ func (iptMgr *IptablesManager) UninitNpmChains() error {
 	iptMgr.OperationFlag = util.IptablesDeletionFlag
 	errCode, err := iptMgr.Run(entry)
 	if errCode != 1 && err != nil {
-		log.Printf("Error removing default rule from FORWARD chain\n")
+		log.Errorf("[Azure-NPM] Error: failed to remove default rule from FORWARD chain.")
 		return err
 	}
 
@@ -220,7 +220,7 @@ func (iptMgr *IptablesManager) UninitNpmChains() error {
 			Chain: chain,
 		}
 		if _, err := iptMgr.Run(entry); err != nil {
-			log.Printf("Error flushing iptables chain %s\n", chain)
+			log.Errorf("[Azure-NPM] Error: failed to flush iptables chain %s.", chain)
 		}
 	}
 
@@ -238,12 +238,12 @@ func (iptMgr *IptablesManager) Exists(entry *IptEntry) (bool, error) {
 	iptMgr.OperationFlag = util.IptablesCheckFlag
 	returnCode, err := iptMgr.Run(entry)
 	if err == nil {
-		log.Printf("Rule exists. %+v\n", entry)
+		log.Printf("[Azure-NPM] Rule exists. %+v.", entry)
 		return true, nil
 	}
 
 	if returnCode == 1 {
-		log.Printf("Rule doesn't exist. %+v\n", entry)
+		log.Printf("[Azure-NPM] Rule doesn't exist. %+v.", entry)
 		return false, nil
 	}
 
@@ -259,11 +259,11 @@ func (iptMgr *IptablesManager) AddChain(chain string) error {
 	errCode, err := iptMgr.Run(entry)
 	if err != nil {
 		if errCode == 1 {
-			log.Printf("Chain already exists %s\n", entry.Chain)
+			log.Printf("[Azure-NPM] Chain already exists %s.", entry.Chain)
 			return nil
 		}
 
-		log.Printf("Error creating iptables chain %s\n", entry.Chain)
+		log.Errorf("[Azure-NPM] Error: failed to create iptables chain %s.", entry.Chain)
 		return err
 	}
 
@@ -279,10 +279,10 @@ func (iptMgr *IptablesManager) DeleteChain(chain string) error {
 	errCode, err := iptMgr.Run(entry)
 	if err != nil {
 		if errCode == 1 {
-			log.Printf("Chain doesn't exist %s\n", entry.Chain)
+			log.Printf("[Azure-NPM] Chain doesn't exist %s.", entry.Chain)
 			return nil
 		}
-		log.Printf("Error deleting iptables chain %s\n", entry.Chain)
+		log.Errorf("[Azure-NPM] Error: failed to delete iptables chain %s.", entry.Chain)
 		return err
 	}
 
@@ -291,7 +291,7 @@ func (iptMgr *IptablesManager) DeleteChain(chain string) error {
 
 // Add adds a rule in iptables.
 func (iptMgr *IptablesManager) Add(entry *IptEntry) error {
-	log.Printf("Add iptables entry: %+v\n", entry)
+	log.Printf("[Azure-NPM] Add iptables entry: %+v.", entry)
 
 	exists, err := iptMgr.Exists(entry)
 	if err != nil {
@@ -304,7 +304,7 @@ func (iptMgr *IptablesManager) Add(entry *IptEntry) error {
 
 	iptMgr.OperationFlag = util.IptablesInsertionFlag
 	if _, err := iptMgr.Run(entry); err != nil {
-		log.Printf("Error creating iptables rules.\n")
+		log.Errorf("[Azure-NPM] Error: failed to create iptables rules.")
 		return err
 	}
 
@@ -313,7 +313,7 @@ func (iptMgr *IptablesManager) Add(entry *IptEntry) error {
 
 // Delete removes a rule in iptables.
 func (iptMgr *IptablesManager) Delete(entry *IptEntry) error {
-	log.Printf("Deleting iptables entry: %+v\n", entry)
+	log.Printf("[Azure-NPM] Deleting iptables entry: %+v", entry)
 
 	exists, err := iptMgr.Exists(entry)
 	if err != nil {
@@ -326,7 +326,7 @@ func (iptMgr *IptablesManager) Delete(entry *IptEntry) error {
 
 	iptMgr.OperationFlag = util.IptablesDeletionFlag
 	if _, err := iptMgr.Run(entry); err != nil {
-		log.Printf("Error deleting iptables rules.\n")
+		log.Errorf("[Azure-NPM] Error: failed to delete iptables rules.")
 		return err
 	}
 
@@ -335,8 +335,9 @@ func (iptMgr *IptablesManager) Delete(entry *IptEntry) error {
 
 // Run execute an iptables command to update iptables.
 func (iptMgr *IptablesManager) Run(entry *IptEntry) (int, error) {
-	if entry.Command == "" {
-		entry.Command = util.Iptables
+	cmdName := entry.Command
+	if cmdName == "" {
+		cmdName = util.Iptables
 	}
 
 	if entry.LockWaitTimeInSeconds == "" {
@@ -344,13 +345,13 @@ func (iptMgr *IptablesManager) Run(entry *IptEntry) (int, error) {
 	}
 
 	cmdArgs := append([]string{util.IptablesWaitFlag, entry.LockWaitTimeInSeconds, iptMgr.OperationFlag, entry.Chain}, entry.Specs...)
-	cmdOut, err := exec.Command(entry.Command, cmdArgs...).Output()
-	log.Printf("%s\n", string(cmdOut))
+	log.Printf("[Azure-NPM] Executing iptables command %s %v", cmdName, cmdArgs)
+	_, err := exec.Command(cmdName, cmdArgs...).Output()
 
 	if msg, failed := err.(*exec.ExitError); failed {
 		errCode := msg.Sys().(syscall.WaitStatus).ExitStatus()
 		if errCode > 1 {
-			log.Printf("There was an error running command: %s\nArguments:%+v", err, cmdArgs)
+			log.Errorf("[Azure-NPM] Error: There was an error running command: %s %s Arguments:%v", err, cmdName, cmdArgs)
 		}
 
 		return errCode, err
@@ -372,14 +373,14 @@ func (iptMgr *IptablesManager) Save(configFile string) error {
 
 	defer func(l *os.File) {
 		if err = l.Close(); err != nil {
-			log.Printf("Failed to close iptables locks")
+			log.Printf("[Azure-NPM] Failed to close iptables locks")
 		}
 	}(l)
 
 	// create the config file for writing
 	f, err := os.Create(configFile)
 	if err != nil {
-		log.Printf("Error opening file: %s.", configFile)
+		log.Errorf("[Azure-NPM] Error: failed to open file: %s.", configFile)
 		return err
 	}
 	defer f.Close()
@@ -387,7 +388,7 @@ func (iptMgr *IptablesManager) Save(configFile string) error {
 	cmd := exec.Command(util.IptablesSave)
 	cmd.Stdout = f
 	if err := cmd.Start(); err != nil {
-		log.Printf("Error running iptables-save.")
+		log.Errorf("[Azure-NPM] Error: failed to run iptables-save.")
 		return err
 	}
 	cmd.Wait()
@@ -408,14 +409,14 @@ func (iptMgr *IptablesManager) Restore(configFile string) error {
 
 	defer func(l *os.File) {
 		if err = l.Close(); err != nil {
-			log.Printf("Failed to close iptables locks")
+			log.Printf("[Azure-NPM] Failed to close iptables locks")
 		}
 	}(l)
 
 	// open the config file for reading
 	f, err := os.Open(configFile)
 	if err != nil {
-		log.Printf("Error opening file: %s.", configFile)
+		log.Errorf("[Azure-NPM] Error: failed to open file: %s.", configFile)
 		return err
 	}
 	defer f.Close()
@@ -423,7 +424,7 @@ func (iptMgr *IptablesManager) Restore(configFile string) error {
 	cmd := exec.Command(util.IptablesRestore)
 	cmd.Stdin = f
 	if err := cmd.Start(); err != nil {
-		log.Printf("Error running iptables-restore.\n")
+		log.Errorf("[Azure-NPM] Error: failed to run iptables-restore.")
 		return err
 	}
 	cmd.Wait()
@@ -446,7 +447,7 @@ func grabIptablesLocks() (*os.File, error) {
 	// Grab 1.6.x style lock.
 	l, err := os.OpenFile(util.IptablesLockFile, os.O_CREATE, 0600)
 	if err != nil {
-		log.Printf("failed to open iptables lock")
+		log.Printf("[Azure-NPM] Error: failed to open iptables lock file %s.", util.IptablesLockFile)
 		return nil, err
 	}
 
@@ -457,7 +458,7 @@ func grabIptablesLocks() (*os.File, error) {
 
 		return true, nil
 	}); err != nil {
-		log.Printf("failed to acquire new iptables lock: %v", err)
+		log.Printf("[Azure-NPM] Error: failed to acquire new iptables lock: %v.", err)
 		return nil, err
 	}
 

--- a/npm/namespace.go
+++ b/npm/namespace.go
@@ -49,7 +49,7 @@ func (npMgr *NetworkPolicyManager) InitAllNsList() error {
 		}
 
 		if err := allNs.ipsMgr.AddToList(util.KubeAllNamespacesFlag, nsName); err != nil {
-			log.Errorf("[Azure-NPM] Error: failed to add namespace set %s to list %s", nsName, util.KubeAllNamespacesFlag)
+			log.Errorf("Error: failed to add namespace set %s to list %s", nsName, util.KubeAllNamespacesFlag)
 			return err
 		}
 	}
@@ -66,7 +66,7 @@ func (npMgr *NetworkPolicyManager) UninitAllNsList() error {
 		}
 
 		if err := allNs.ipsMgr.DeleteFromList(util.KubeAllNamespacesFlag, nsName); err != nil {
-			log.Errorf("[Azure-NPM] Error: failed to delete namespace set %s from list %s", nsName, util.KubeAllNamespacesFlag)
+			log.Errorf("Error: failed to delete namespace set %s from list %s", nsName, util.KubeAllNamespacesFlag)
 			return err
 		}
 	}
@@ -82,17 +82,17 @@ func (npMgr *NetworkPolicyManager) AddNamespace(nsObj *corev1.Namespace) error {
 	var err error
 
 	nsName, nsNs, nsLabel := nsObj.ObjectMeta.Name, nsObj.ObjectMeta.Namespace, nsObj.ObjectMeta.Labels
-	log.Printf("[Azure-NPM] NAMESPACE CREATING: [%s/%s/%+v]", nsName, nsNs, nsLabel)
+	log.Printf("NAMESPACE CREATING: [%s/%s/%+v]", nsName, nsNs, nsLabel)
 
 	ipsMgr := npMgr.nsMap[util.KubeAllNamespacesFlag].ipsMgr
 	// Create ipset for the namespace.
 	if err = ipsMgr.CreateSet(nsName); err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to create ipset for namespace %s.", nsName)
+		log.Errorf("Error: failed to create ipset for namespace %s.", nsName)
 		return err
 	}
 
 	if err = ipsMgr.AddToList(util.KubeAllNamespacesFlag, nsName); err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to add %s to all-namespace ipset list.", nsName)
+		log.Errorf("Error: failed to add %s to all-namespace ipset list.", nsName)
 		return err
 	}
 
@@ -101,9 +101,9 @@ func (npMgr *NetworkPolicyManager) AddNamespace(nsObj *corev1.Namespace) error {
 	nsLabels := nsObj.ObjectMeta.Labels
 	for nsLabelKey, nsLabelVal := range nsLabels {
 		labelKey := util.GetNsIpsetName(nsLabelKey, nsLabelVal)
-		log.Printf("[Azure-NPM] Adding namespace %s to ipset list %s", nsName, labelKey)
+		log.Printf("Adding namespace %s to ipset list %s", nsName, labelKey)
 		if err = ipsMgr.AddToList(labelKey, nsName); err != nil {
-			log.Errorf("[Azure-NPM] Error: failed to add namespace %s to ipset list %s", nsName, labelKey)
+			log.Errorf("Error: failed to add namespace %s to ipset list %s", nsName, labelKey)
 			return err
 		}
 		labelKeys = append(labelKeys, labelKey)
@@ -111,7 +111,7 @@ func (npMgr *NetworkPolicyManager) AddNamespace(nsObj *corev1.Namespace) error {
 
 	ns, err := newNs(nsName)
 	if err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to create namespace %s", nsName)
+		log.Errorf("Error: failed to create namespace %s", nsName)
 	}
 	npMgr.nsMap[nsName] = ns
 
@@ -125,7 +125,7 @@ func (npMgr *NetworkPolicyManager) UpdateNamespace(oldNsObj *corev1.Namespace, n
 	oldNsName, oldNsNs, oldNsLabel := oldNsObj.ObjectMeta.Name, oldNsObj.ObjectMeta.Namespace, oldNsObj.ObjectMeta.Labels
 	newNsName, newNsNs, newNsLabel := newNsObj.ObjectMeta.Name, newNsObj.ObjectMeta.Namespace, newNsObj.ObjectMeta.Labels
 	log.Printf(
-		"[Azure-NPM] NAMESPACE UPDATING:\n old namespace: [%s/%s/%+v]\n new namespace: [%s/%s/%+v]",
+		"NAMESPACE UPDATING:\n old namespace: [%s/%s/%+v]\n new namespace: [%s/%s/%+v]",
 		oldNsName, oldNsNs, oldNsLabel, newNsName, newNsNs, newNsLabel,
 	)
 
@@ -150,7 +150,7 @@ func (npMgr *NetworkPolicyManager) DeleteNamespace(nsObj *corev1.Namespace) erro
 	var err error
 
 	nsName, nsNs, nsLabel := nsObj.ObjectMeta.Name, nsObj.ObjectMeta.Namespace, nsObj.ObjectMeta.Labels
-	log.Printf("[Azure-NPM] NAMESPACE DELETING: [%s/%s/%+v]", nsName, nsNs, nsLabel)
+	log.Printf("NAMESPACE DELETING: [%s/%s/%+v]", nsName, nsNs, nsLabel)
 
 	_, exists := npMgr.nsMap[nsName]
 	if !exists {
@@ -163,9 +163,9 @@ func (npMgr *NetworkPolicyManager) DeleteNamespace(nsObj *corev1.Namespace) erro
 	nsLabels := nsObj.ObjectMeta.Labels
 	for nsLabelKey, nsLabelVal := range nsLabels {
 		labelKey := util.GetNsIpsetName(nsLabelKey, nsLabelVal)
-		log.Printf("[Azure-NPM] Deleting namespace %s from ipset list %s", nsName, labelKey)
+		log.Printf("Deleting namespace %s from ipset list %s", nsName, labelKey)
 		if err = ipsMgr.DeleteFromList(labelKey, nsName); err != nil {
-			log.Errorf("[Azure-NPM] Error: failed to delete namespace %s from ipset list %s", nsName, labelKey)
+			log.Errorf("Error: failed to delete namespace %s from ipset list %s", nsName, labelKey)
 			return err
 		}
 		labelKeys = append(labelKeys, labelKey)
@@ -173,13 +173,13 @@ func (npMgr *NetworkPolicyManager) DeleteNamespace(nsObj *corev1.Namespace) erro
 
 	// Delete the namespace from all-namespace ipset list.
 	if err = ipsMgr.DeleteFromList(util.KubeAllNamespacesFlag, nsName); err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to delete namespace %s from ipset list %s", nsName, util.KubeAllNamespacesFlag)
+		log.Errorf("Error: failed to delete namespace %s from ipset list %s", nsName, util.KubeAllNamespacesFlag)
 		return err
 	}
 
 	// Delete ipset for the namespace.
 	if err = ipsMgr.DeleteSet(nsName); err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to delete ipset for namespace %s.", nsName)
+		log.Errorf("Error: failed to delete ipset for namespace %s.", nsName)
 		return err
 	}
 

--- a/npm/namespace.go
+++ b/npm/namespace.go
@@ -49,7 +49,7 @@ func (npMgr *NetworkPolicyManager) InitAllNsList() error {
 		}
 
 		if err := allNs.ipsMgr.AddToList(util.KubeAllNamespacesFlag, nsName); err != nil {
-			log.Printf("Error adding namespace set %s to list %s\n", nsName, util.KubeAllNamespacesFlag)
+			log.Errorf("[Azure-NPM] Error: failed to add namespace set %s to list %s", nsName, util.KubeAllNamespacesFlag)
 			return err
 		}
 	}
@@ -66,7 +66,7 @@ func (npMgr *NetworkPolicyManager) UninitAllNsList() error {
 		}
 
 		if err := allNs.ipsMgr.DeleteFromList(util.KubeAllNamespacesFlag, nsName); err != nil {
-			log.Printf("Error deleting namespace set %s from list %s\n", nsName, util.KubeAllNamespacesFlag)
+			log.Errorf("[Azure-NPM] Error: failed to delete namespace set %s from list %s", nsName, util.KubeAllNamespacesFlag)
 			return err
 		}
 	}
@@ -81,24 +81,18 @@ func (npMgr *NetworkPolicyManager) AddNamespace(nsObj *corev1.Namespace) error {
 
 	var err error
 
-	defer func() {
-		if err = npMgr.UpdateAndSendReport(err, util.AddNamespaceEvent); err != nil {
-			log.Printf("Error sending NPM telemetry report")
-		}
-	}()
-
-	nsName, nsNs := nsObj.ObjectMeta.Name, nsObj.ObjectMeta.Namespace
-	log.Printf("NAMESPACE CREATING: %s/%s\n", nsName, nsNs)
+	nsName, nsNs, nsLabel := nsObj.ObjectMeta.Name, nsObj.ObjectMeta.Namespace, nsObj.ObjectMeta.Labels
+	log.Printf("[Azure-NPM] NAMESPACE CREATING: [%s/%s/%+v]", nsName, nsNs, nsLabel)
 
 	ipsMgr := npMgr.nsMap[util.KubeAllNamespacesFlag].ipsMgr
 	// Create ipset for the namespace.
 	if err = ipsMgr.CreateSet(nsName); err != nil {
-		log.Printf("Error creating ipset for namespace %s.\n", nsName)
+		log.Errorf("[Azure-NPM] Error: failed to create ipset for namespace %s.", nsName)
 		return err
 	}
 
 	if err = ipsMgr.AddToList(util.KubeAllNamespacesFlag, nsName); err != nil {
-		log.Printf("Error adding %s to all-namespace ipset list.\n", nsName)
+		log.Errorf("[Azure-NPM] Error: failed to add %s to all-namespace ipset list.", nsName)
 		return err
 	}
 
@@ -107,9 +101,9 @@ func (npMgr *NetworkPolicyManager) AddNamespace(nsObj *corev1.Namespace) error {
 	nsLabels := nsObj.ObjectMeta.Labels
 	for nsLabelKey, nsLabelVal := range nsLabels {
 		labelKey := util.GetNsIpsetName(nsLabelKey, nsLabelVal)
-		log.Printf("Adding namespace %s to ipset list %s\n", nsName, labelKey)
+		log.Printf("[Azure-NPM] Adding namespace %s to ipset list %s", nsName, labelKey)
 		if err = ipsMgr.AddToList(labelKey, nsName); err != nil {
-			log.Printf("Error Adding namespace %s to ipset list %s\n", nsName, labelKey)
+			log.Errorf("[Azure-NPM] Error: failed to add namespace %s to ipset list %s", nsName, labelKey)
 			return err
 		}
 		labelKeys = append(labelKeys, labelKey)
@@ -117,7 +111,7 @@ func (npMgr *NetworkPolicyManager) AddNamespace(nsObj *corev1.Namespace) error {
 
 	ns, err := newNs(nsName)
 	if err != nil {
-		log.Printf("Error creating namespace %s\n", nsName)
+		log.Errorf("[Azure-NPM] Error: failed to create namespace %s", nsName)
 	}
 	npMgr.nsMap[nsName] = ns
 
@@ -128,16 +122,12 @@ func (npMgr *NetworkPolicyManager) AddNamespace(nsObj *corev1.Namespace) error {
 func (npMgr *NetworkPolicyManager) UpdateNamespace(oldNsObj *corev1.Namespace, newNsObj *corev1.Namespace) error {
 	var err error
 
-	defer func() {
-		npMgr.Lock()
-		if err = npMgr.UpdateAndSendReport(err, util.AddNamespaceEvent); err != nil {
-			log.Printf("Error sending NPM telemetry report")
-		}
-		npMgr.Unlock()
-	}()
-
-	oldNsName, newNsName := oldNsObj.ObjectMeta.Name, newNsObj.ObjectMeta.Name
-	log.Printf("NAMESPACE UPDATING. %s/%s", oldNsName, newNsName)
+	oldNsName, oldNsNs, oldNsLabel := oldNsObj.ObjectMeta.Name, oldNsObj.ObjectMeta.Namespace, oldNsObj.ObjectMeta.Labels
+	newNsName, newNsNs, newNsLabel := newNsObj.ObjectMeta.Name, newNsObj.ObjectMeta.Namespace, newNsObj.ObjectMeta.Labels
+	log.Printf(
+		"[Azure-NPM] NAMESPACE UPDATING:\n old namespace: [%s/%s/%+v]\n new namespace: [%s/%s/%+v]",
+		oldNsName, oldNsNs, oldNsLabel, newNsName, newNsNs, newNsLabel,
+	)
 
 	if err = npMgr.DeleteNamespace(oldNsObj); err != nil {
 		return err
@@ -159,14 +149,8 @@ func (npMgr *NetworkPolicyManager) DeleteNamespace(nsObj *corev1.Namespace) erro
 
 	var err error
 
-	defer func() {
-		if err = npMgr.UpdateAndSendReport(err, util.DeleteNamespaceEvent); err != nil {
-			log.Printf("Error sending NPM telemetry report")
-		}
-	}()
-
-	nsName, nsNs := nsObj.ObjectMeta.Name, nsObj.ObjectMeta.Namespace
-	log.Printf("NAMESPACE DELETING: %s/%s\n", nsName, nsNs)
+	nsName, nsNs, nsLabel := nsObj.ObjectMeta.Name, nsObj.ObjectMeta.Namespace, nsObj.ObjectMeta.Labels
+	log.Printf("[Azure-NPM] NAMESPACE DELETING: [%s/%s/%+v]", nsName, nsNs, nsLabel)
 
 	_, exists := npMgr.nsMap[nsName]
 	if !exists {
@@ -179,9 +163,9 @@ func (npMgr *NetworkPolicyManager) DeleteNamespace(nsObj *corev1.Namespace) erro
 	nsLabels := nsObj.ObjectMeta.Labels
 	for nsLabelKey, nsLabelVal := range nsLabels {
 		labelKey := util.GetNsIpsetName(nsLabelKey, nsLabelVal)
-		log.Printf("Deleting namespace %s from ipset list %s\n", nsName, labelKey)
+		log.Printf("[Azure-NPM] Deleting namespace %s from ipset list %s", nsName, labelKey)
 		if err = ipsMgr.DeleteFromList(labelKey, nsName); err != nil {
-			log.Printf("Error deleting namespace %s from ipset list %s\n", nsName, labelKey)
+			log.Errorf("[Azure-NPM] Error: failed to delete namespace %s from ipset list %s", nsName, labelKey)
 			return err
 		}
 		labelKeys = append(labelKeys, labelKey)
@@ -189,13 +173,13 @@ func (npMgr *NetworkPolicyManager) DeleteNamespace(nsObj *corev1.Namespace) erro
 
 	// Delete the namespace from all-namespace ipset list.
 	if err = ipsMgr.DeleteFromList(util.KubeAllNamespacesFlag, nsName); err != nil {
-		log.Printf("Error deleting namespace %s from ipset list %s\n", nsName, util.KubeAllNamespacesFlag)
+		log.Errorf("[Azure-NPM] Error: failed to delete namespace %s from ipset list %s", nsName, util.KubeAllNamespacesFlag)
 		return err
 	}
 
 	// Delete ipset for the namespace.
 	if err = ipsMgr.DeleteSet(nsName); err != nil {
-		log.Printf("Error deleting ipset for namespace %s.\n", nsName)
+		log.Errorf("[Azure-NPM] Error: failed to delete ipset for namespace %s.", nsName)
 		return err
 	}
 

--- a/npm/namespace_test.go
+++ b/npm/namespace_test.go
@@ -48,9 +48,8 @@ func TestAddNamespace(t *testing.T) {
 		nsMap:            make(map[string]*namespace),
 		TelemetryEnabled: false,
 		reportManager: &telemetry.ReportManager{
-			HostNetAgentURL: hostNetAgentURLForNpm,
-			ContentType:     telemetry.ContentType,
-			Report:          &telemetry.NPMReport{},
+			ContentType: telemetry.ContentType,
+			Report:      &telemetry.NPMReport{},
 		},
 	}
 
@@ -90,9 +89,8 @@ func TestUpdateNamespace(t *testing.T) {
 		nsMap:            make(map[string]*namespace),
 		TelemetryEnabled: false,
 		reportManager: &telemetry.ReportManager{
-			HostNetAgentURL: hostNetAgentURLForNpm,
-			ContentType:     telemetry.ContentType,
-			Report:          &telemetry.NPMReport{},
+			ContentType: telemetry.ContentType,
+			Report:      &telemetry.NPMReport{},
 		},
 	}
 
@@ -145,9 +143,8 @@ func TestDeleteNamespace(t *testing.T) {
 		nsMap:            make(map[string]*namespace),
 		TelemetryEnabled: false,
 		reportManager: &telemetry.ReportManager{
-			HostNetAgentURL: hostNetAgentURLForNpm,
-			ContentType:     telemetry.ContentType,
-			Report:          &telemetry.NPMReport{},
+			ContentType: telemetry.ContentType,
+			Report:      &telemetry.NPMReport{},
 		},
 	}
 

--- a/npm/namespace_test.go
+++ b/npm/namespace_test.go
@@ -49,7 +49,7 @@ func TestAddNamespace(t *testing.T) {
 		TelemetryEnabled: false,
 		reportManager: &telemetry.ReportManager{
 			HostNetAgentURL: hostNetAgentURLForNpm,
-			ContentType:     contentType,
+			ContentType:     telemetry.ContentType,
 			Report:          &telemetry.NPMReport{},
 		},
 	}
@@ -91,7 +91,7 @@ func TestUpdateNamespace(t *testing.T) {
 		TelemetryEnabled: false,
 		reportManager: &telemetry.ReportManager{
 			HostNetAgentURL: hostNetAgentURLForNpm,
-			ContentType:     contentType,
+			ContentType:     telemetry.ContentType,
 			Report:          &telemetry.NPMReport{},
 		},
 	}
@@ -146,7 +146,7 @@ func TestDeleteNamespace(t *testing.T) {
 		TelemetryEnabled: false,
 		reportManager: &telemetry.ReportManager{
 			HostNetAgentURL: hostNetAgentURLForNpm,
-			ContentType:     contentType,
+			ContentType:     telemetry.ContentType,
 			Report:          &telemetry.NPMReport{},
 		},
 	}

--- a/npm/npm.go
+++ b/npm/npm.go
@@ -61,17 +61,17 @@ type NetworkPolicyManager struct {
 func (npMgr *NetworkPolicyManager) GetClusterState() telemetry.ClusterState {
 	pods, err := npMgr.clientset.CoreV1().Pods("").List(metav1.ListOptions{})
 	if err != nil {
-		log.Logf("[Azure-NPM] Error: Failed to list pods in GetClusterState")
+		log.Logf("Error: Failed to list pods in GetClusterState")
 	}
 
 	namespaces, err := npMgr.clientset.CoreV1().Namespaces().List(metav1.ListOptions{})
 	if err != nil {
-		log.Logf("[Azure-NPM] Error: Failed to list namespaces in GetClusterState")
+		log.Logf("Error: Failed to list namespaces in GetClusterState")
 	}
 
 	networkpolicies, err := npMgr.clientset.NetworkingV1().NetworkPolicies("").List(metav1.ListOptions{})
 	if err != nil {
-		log.Logf("[Azure-NPM] Error: Failed to list networkpolicies in GetClusterState")
+		log.Logf("Error: Failed to list networkpolicies in GetClusterState")
 	}
 
 	npMgr.clusterState.PodCount = len(pods.Items)
@@ -122,13 +122,13 @@ CONNECT:
 
 		report, err := npMgr.reportManager.ReportToBytes()
 		if err != nil {
-			log.Logf("[Azure-NPM] ReportToBytes failed: %v", err)
+			log.Logf("ReportToBytes failed: %v", err)
 			continue
 		}
 
 		// If write fails, try to re-establish connections as server/client
 		if _, err = tb.Write(report); err != nil {
-			log.Logf("[Azure-NPM] Telemetry write failed: %v", err)
+			log.Logf("Telemetry write failed: %v", err)
 			tb.Close()
 			goto CONNECT
 		}
@@ -147,7 +147,7 @@ func (npMgr *NetworkPolicyManager) restore() {
 		time.Sleep(restoreRetryWaitTimeInSeconds * time.Second)
 	}
 
-	log.Logf("[Azure-NPM] Error: timeout restoring Azure-NPM states")
+	log.Logf("Error: timeout restoring Azure-NPM states")
 	panic(err.Error)
 }
 
@@ -159,7 +159,7 @@ func (npMgr *NetworkPolicyManager) backup() {
 		time.Sleep(backupWaitTimeInSeconds * time.Second)
 
 		if err = iptMgr.Save(util.IptablesConfigFile); err != nil {
-			log.Logf("[Azure-NPM] Error: failed to back up Azure-NPM states")
+			log.Logf("Error: failed to back up Azure-NPM states")
 		}
 	}
 }
@@ -201,13 +201,13 @@ func NewNetworkPolicyManager(clientset *kubernetes.Clientset, informerFactory in
 
 	serverVersion, err := clientset.ServerVersion()
 	if err != nil {
-		log.Logf("[Azure-NPM] Error: failed to retrieving kubernetes version")
+		log.Logf("Error: failed to retrieving kubernetes version")
 		panic(err.Error)
 	}
-	log.Logf("[Azure-NPM] API server version: %+v", serverVersion)
+	log.Logf("API server version: %+v", serverVersion)
 
 	if err = util.SetIsNewNwPolicyVerFlag(serverVersion); err != nil {
-		log.Logf("[Azure-NPM] Error: failed to set IsNewNwPolicyVerFlag")
+		log.Logf("Error: failed to set IsNewNwPolicyVerFlag")
 		panic(err.Error)
 	}
 
@@ -245,7 +245,7 @@ func NewNetworkPolicyManager(clientset *kubernetes.Clientset, informerFactory in
 
 	allNs, err := newNs(util.KubeAllNamespacesFlag)
 	if err != nil {
-		log.Logf("[Azure-NPM] Error: failed to create all-namespace.")
+		log.Logf("Error: failed to create all-namespace.")
 		panic(err.Error)
 	}
 	npMgr.nsMap[util.KubeAllNamespacesFlag] = allNs

--- a/npm/npm.go
+++ b/npm/npm.go
@@ -25,13 +25,16 @@ import (
 )
 
 const (
-	hostNetAgentURLForNpm           = "http://168.63.129.16/machine/plugins?comp=netagent&type=npmreport"
-	contentType                     = "application/json"
-	telemetryRetryWaitTimeInSeconds = 60
-	restoreRetryWaitTimeInSeconds   = 5
-	restoreMaxRetries               = 10
-	backupWaitTimeInSeconds         = 60
+	hostNetAgentURLForNpm         = "http://168.63.129.16/machine/plugins?comp=netagent&type=npmreport"
+	restoreRetryWaitTimeInSeconds = 5
+	restoreMaxRetries             = 10
+	backupWaitTimeInSeconds       = 60
+	telemetryRetryTimeInSeconds   = 60
+	heartbeatIntervalInMinutes    = 30
 )
+
+// reports channel
+var reports = make(chan interface{}, 1000)
 
 // NetworkPolicyManager contains informers for pod, namespace and networkpolicy.
 type NetworkPolicyManager struct {
@@ -58,17 +61,17 @@ type NetworkPolicyManager struct {
 func (npMgr *NetworkPolicyManager) GetClusterState() telemetry.ClusterState {
 	pods, err := npMgr.clientset.CoreV1().Pods("").List(metav1.ListOptions{})
 	if err != nil {
-		log.Printf("Error Listing pods in GetClusterState")
+		log.Logf("[Azure-NPM] Error: Failed to list pods in GetClusterState")
 	}
 
 	namespaces, err := npMgr.clientset.CoreV1().Namespaces().List(metav1.ListOptions{})
 	if err != nil {
-		log.Printf("Error Listing namespaces in GetClusterState")
+		log.Logf("[Azure-NPM] Error: Failed to list namespaces in GetClusterState")
 	}
 
 	networkpolicies, err := npMgr.clientset.NetworkingV1().NetworkPolicies("").List(metav1.ListOptions{})
 	if err != nil {
-		log.Printf("Error Listing networkpolicies in GetClusterState")
+		log.Logf("[Azure-NPM] Error: Failed to list networkpolicies in GetClusterState")
 	}
 
 	npMgr.clusterState.PodCount = len(pods.Items)
@@ -78,31 +81,58 @@ func (npMgr *NetworkPolicyManager) GetClusterState() telemetry.ClusterState {
 	return npMgr.clusterState
 }
 
-// UpdateAndSendReport updates the npm report then send it.
-// This function should only be called when npMgr is locked.
-func (npMgr *NetworkPolicyManager) UpdateAndSendReport(err error, eventMsg string) error {
+// SendNpmTelemetry updates the npm report then send it.
+func (npMgr *NetworkPolicyManager) SendNpmTelemetry() {
 	if !npMgr.TelemetryEnabled {
-		return nil
+		return
 	}
 
-	clusterState := npMgr.GetClusterState()
-	v := reflect.ValueOf(npMgr.reportManager.Report).Elem().FieldByName("ClusterState")
-	if v.CanSet() {
-		v.FieldByName("PodCount").SetInt(int64(clusterState.PodCount))
-		v.FieldByName("NsCount").SetInt(int64(clusterState.NsCount))
-		v.FieldByName("NwPolicyCount").SetInt(int64(clusterState.NwPolicyCount))
+CONNECT:
+	tb := telemetry.NewTelemetryBuffer("")
+	for {
+		tb.TryToConnectToTelemetryService()
+		if tb.Connected {
+			break
+		}
+
+		time.Sleep(time.Second * telemetryRetryTimeInSeconds)
 	}
 
-	reflect.ValueOf(npMgr.reportManager.Report).Elem().FieldByName("EventMessage").SetString(eventMsg)
+	heartbeat := time.NewTicker(time.Minute * heartbeatIntervalInMinutes).C
+	report := npMgr.reportManager.Report
+	for {
+		select {
+		case <-heartbeat:
+			clusterState := npMgr.GetClusterState()
+			v := reflect.ValueOf(report).Elem().FieldByName("ClusterState")
+			if v.CanSet() {
+				v.FieldByName("PodCount").SetInt(int64(clusterState.PodCount))
+				v.FieldByName("NsCount").SetInt(int64(clusterState.NsCount))
+				v.FieldByName("NwPolicyCount").SetInt(int64(clusterState.NwPolicyCount))
+			}
+			reflect.ValueOf(report).Elem().FieldByName("ErrorMessage").SetString("heartbeat")
+		case msg := <-reports:
+			reflect.ValueOf(report).Elem().FieldByName("ErrorMessage").SetString(msg.(string))
+			fmt.Println(msg.(string))
+		}
 
-	if err != nil {
-		reflect.ValueOf(npMgr.reportManager.Report).Elem().FieldByName("EventMessage").SetString(err.Error())
+		reflect.ValueOf(report).Elem().FieldByName("Timestamp").SetString(time.Now().UTC().String())
+		// TODO: Remove below line after the host change is rolled out
+		reflect.ValueOf(report).Elem().FieldByName("EventMessage").SetString(time.Now().UTC().String())
+
+		report, err := npMgr.reportManager.ReportToBytes()
+		if err != nil {
+			log.Logf("[Azure-NPM] ReportToBytes failed: %v", err)
+			continue
+		}
+
+		// If write fails, try to re-establish connections as server/client
+		if _, err = tb.Write(report); err != nil {
+			log.Logf("[Azure-NPM] Telemetry write failed: %v", err)
+			tb.Close()
+			goto CONNECT
+		}
 	}
-
-	var telemetryBuffer *telemetry.TelemetryBuffer
-	connectToTelemetryServer(telemetryBuffer)
-
-	return npMgr.reportManager.SendReport(telemetryBuffer)
 }
 
 // restore restores iptables from backup file
@@ -117,7 +147,7 @@ func (npMgr *NetworkPolicyManager) restore() {
 		time.Sleep(restoreRetryWaitTimeInSeconds * time.Second)
 	}
 
-	log.Printf("Timeout restoring Azure-NPM states")
+	log.Logf("[Azure-NPM] Error: timeout restoring Azure-NPM states")
 	panic(err.Error)
 }
 
@@ -129,7 +159,7 @@ func (npMgr *NetworkPolicyManager) backup() {
 		time.Sleep(backupWaitTimeInSeconds * time.Second)
 
 		if err = iptMgr.Save(util.IptablesConfigFile); err != nil {
-			log.Printf("Error backing up Azure-NPM states")
+			log.Logf("[Azure-NPM] Error: failed to back up Azure-NPM states")
 		}
 	}
 }
@@ -162,51 +192,6 @@ func (npMgr *NetworkPolicyManager) Start(stopCh <-chan struct{}) error {
 	return nil
 }
 
-func connectToTelemetryServer(telemetryBuffer *telemetry.TelemetryBuffer) {
-	for {
-		telemetryBuffer = telemetry.NewTelemetryBuffer("")
-		err := telemetryBuffer.StartServer()
-		if err == nil || telemetryBuffer.FdExists {
-			connErr := telemetryBuffer.Connect()
-			if connErr == nil {
-				break
-			}
-
-			log.Printf("[NPM-Telemetry] Failed to establish telemetry manager connection.")
-			time.Sleep(time.Second * telemetryRetryWaitTimeInSeconds)
-		}
-	}
-}
-
-// RunReportManager starts NPMReportManager and send telemetry periodically.
-func (npMgr *NetworkPolicyManager) RunReportManager() {
-	if !npMgr.TelemetryEnabled {
-		return
-	}
-
-	var telemetryBuffer *telemetry.TelemetryBuffer
-	connectToTelemetryServer(telemetryBuffer)
-
-	go telemetryBuffer.BufferAndPushData(time.Duration(0))
-
-	for {
-		clusterState := npMgr.GetClusterState()
-		v := reflect.ValueOf(npMgr.reportManager.Report).Elem().FieldByName("ClusterState")
-		if v.CanSet() {
-			v.FieldByName("PodCount").SetInt(int64(clusterState.PodCount))
-			v.FieldByName("NsCount").SetInt(int64(clusterState.NsCount))
-			v.FieldByName("NwPolicyCount").SetInt(int64(clusterState.NwPolicyCount))
-		}
-
-		if err := npMgr.reportManager.SendReport(telemetryBuffer); err != nil {
-			log.Printf("[NPM-Telemetry] Error sending NPM telemetry report")
-			connectToTelemetryServer(telemetryBuffer)
-		}
-
-		time.Sleep(5 * time.Minute)
-	}
-}
-
 // NewNetworkPolicyManager creates a NetworkPolicyManager
 func NewNetworkPolicyManager(clientset *kubernetes.Clientset, informerFactory informers.SharedInformerFactory, npmVersion string) *NetworkPolicyManager {
 
@@ -216,13 +201,13 @@ func NewNetworkPolicyManager(clientset *kubernetes.Clientset, informerFactory in
 
 	serverVersion, err := clientset.ServerVersion()
 	if err != nil {
-		log.Printf("Error retrieving server version")
+		log.Logf("[Azure-NPM] Error: failed to retrieving kubernetes version")
 		panic(err.Error)
 	}
-	log.Printf("API server version: %+v", serverVersion)
+	log.Logf("[Azure-NPM] API server version: %+v", serverVersion)
 
 	if err = util.SetIsNewNwPolicyVerFlag(serverVersion); err != nil {
-		log.Printf("Error setting IsNewNwPolicyVerFlag")
+		log.Logf("[Azure-NPM] Error: failed to set IsNewNwPolicyVerFlag")
 		panic(err.Error)
 	}
 
@@ -242,11 +227,16 @@ func NewNetworkPolicyManager(clientset *kubernetes.Clientset, informerFactory in
 		},
 		reportManager: &telemetry.ReportManager{
 			HostNetAgentURL: hostNetAgentURLForNpm,
-			ContentType:     contentType,
+			ContentType:     telemetry.ContentType,
 			Report:          &telemetry.NPMReport{},
 		},
 		serverVersion:    serverVersion,
 		TelemetryEnabled: true,
+	}
+
+	// Set-up channel for Azure-NPM telemetry if it's enabled (enabled by default)
+	if logger := log.GetStd(); logger != nil && npMgr.TelemetryEnabled {
+		logger.SetChannel(reports)
 	}
 
 	clusterID := util.GetClusterID(npMgr.nodeName)
@@ -255,7 +245,7 @@ func NewNetworkPolicyManager(clientset *kubernetes.Clientset, informerFactory in
 
 	allNs, err := newNs(util.KubeAllNamespacesFlag)
 	if err != nil {
-		log.Printf("Error creating all-namespace")
+		log.Logf("[Azure-NPM] Error: failed to create all-namespace.")
 		panic(err.Error)
 	}
 	npMgr.nsMap[util.KubeAllNamespacesFlag] = allNs

--- a/npm/npm.go
+++ b/npm/npm.go
@@ -25,7 +25,6 @@ import (
 )
 
 const (
-	hostNetAgentURLForNpm         = "http://168.63.129.16/machine/plugins?comp=netagent&type=npmreport"
 	restoreRetryWaitTimeInSeconds = 5
 	restoreMaxRetries             = 10
 	backupWaitTimeInSeconds       = 60
@@ -226,9 +225,8 @@ func NewNetworkPolicyManager(clientset *kubernetes.Clientset, informerFactory in
 			NwPolicyCount: 0,
 		},
 		reportManager: &telemetry.ReportManager{
-			HostNetAgentURL: hostNetAgentURLForNpm,
-			ContentType:     telemetry.ContentType,
-			Report:          &telemetry.NPMReport{},
+			ContentType: telemetry.ContentType,
+			Report:      &telemetry.NPMReport{},
 		},
 		serverVersion:    serverVersion,
 		TelemetryEnabled: true,

--- a/npm/nwpolicy.go
+++ b/npm/nwpolicy.go
@@ -15,25 +15,19 @@ func (npMgr *NetworkPolicyManager) AddNetworkPolicy(npObj *networkingv1.NetworkP
 
 	var err error
 
-	defer func() {
-		if err = npMgr.UpdateAndSendReport(err, util.AddNetworkPolicyEvent); err != nil {
-			log.Printf("Error sending NPM telemetry report")
-		}
-	}()
-
 	npNs, npName := npObj.ObjectMeta.Namespace, npObj.ObjectMeta.Name
-	log.Printf("NETWORK POLICY CREATING: %s/%s\n", npNs, npName)
+	log.Printf("[Azure-NPM] NETWORK POLICY CREATING: %v", npObj)
 
 	allNs := npMgr.nsMap[util.KubeAllNamespacesFlag]
 
 	if !npMgr.isAzureNpmChainCreated {
 		if err = allNs.ipsMgr.CreateSet(util.KubeSystemFlag); err != nil {
-			log.Printf("Error initialize kube-system ipset.\n")
+			log.Errorf("[Azure-NPM] Error: failed to initialize kube-system ipset.")
 			return err
 		}
 
 		if err = allNs.iptMgr.InitNpmChains(); err != nil {
-			log.Printf("Error initialize azure-npm chains.\n")
+			log.Errorf("[Azure-NPM] Error: failed to initialize azure-npm chains.")
 			return err
 		}
 
@@ -45,27 +39,27 @@ func (npMgr *NetworkPolicyManager) AddNetworkPolicy(npObj *networkingv1.NetworkP
 	ipsMgr := allNs.ipsMgr
 	for _, set := range podSets {
 		if err = ipsMgr.CreateSet(set); err != nil {
-			log.Printf("Error creating ipset %s-%s\n", npNs, set)
+			log.Errorf("[Azure-NPM] Error: failed to create ipset %s-%s", npNs, set)
 			return err
 		}
 	}
 
 	for _, list := range nsLists {
 		if err = ipsMgr.CreateList(list); err != nil {
-			log.Printf("Error creating ipset list %s-%s\n", npNs, list)
+			log.Errorf("[Azure-NPM] Error: failed to create ipset list %s-%s", npNs, list)
 			return err
 		}
 	}
 
 	if err = npMgr.InitAllNsList(); err != nil {
-		log.Printf("Error initializing all-namespace ipset list.\n")
+		log.Errorf("[Azure-NPM] Error: failed to initialize all-namespace ipset list.")
 		return err
 	}
 
 	iptMgr := allNs.iptMgr
 	for _, iptEntry := range iptEntries {
 		if err = iptMgr.Add(iptEntry); err != nil {
-			log.Printf("Error applying iptables rule\n. Rule: %+v", iptEntry)
+			log.Errorf("[Azure-NPM] Error: failed to apply iptables rule. Rule: %+v", iptEntry)
 			return err
 		}
 	}
@@ -74,7 +68,7 @@ func (npMgr *NetworkPolicyManager) AddNetworkPolicy(npObj *networkingv1.NetworkP
 
 	ns, err := newNs(npNs)
 	if err != nil {
-		log.Printf("Error creating namespace %s\n", npNs)
+		log.Errorf("[Azure-NPM] Error: failed to create namespace %s", npNs)
 	}
 	npMgr.nsMap[npNs] = ns
 
@@ -85,16 +79,7 @@ func (npMgr *NetworkPolicyManager) AddNetworkPolicy(npObj *networkingv1.NetworkP
 func (npMgr *NetworkPolicyManager) UpdateNetworkPolicy(oldNpObj *networkingv1.NetworkPolicy, newNpObj *networkingv1.NetworkPolicy) error {
 	var err error
 
-	defer func() {
-		npMgr.Lock()
-		if err = npMgr.UpdateAndSendReport(err, util.UpdateNetworkPolicyEvent); err != nil {
-			log.Printf("Error sending NPM telemetry report")
-		}
-		npMgr.Unlock()
-	}()
-
-	oldNpNs, oldNpName := oldNpObj.ObjectMeta.Namespace, oldNpObj.ObjectMeta.Name
-	log.Printf("NETWORK POLICY UPDATING: %s/%s\n", oldNpNs, oldNpName)
+	log.Printf("[Azure-NPM] NETWORK POLICY UPDATING:\n old policy:[%v]\n new policy:[%v]", oldNpObj, newNpObj)
 
 	if err = npMgr.DeleteNetworkPolicy(oldNpObj); err != nil {
 		return err
@@ -116,14 +101,8 @@ func (npMgr *NetworkPolicyManager) DeleteNetworkPolicy(npObj *networkingv1.Netwo
 
 	var err error
 
-	defer func() {
-		if err = npMgr.UpdateAndSendReport(err, util.DeleteNetworkPolicyEvent); err != nil {
-			log.Printf("Error sending NPM telemetry report")
-		}
-	}()
-
-	npNs, npName := npObj.ObjectMeta.Namespace, npObj.ObjectMeta.Name
-	log.Printf("NETWORK POLICY DELETING: %s/%s\n", npNs, npName)
+	npName := npObj.ObjectMeta.Name
+	log.Printf("[Azure-NPM] NETWORK POLICY DELETING: %v", npObj)
 
 	allNs := npMgr.nsMap[util.KubeAllNamespacesFlag]
 
@@ -132,7 +111,7 @@ func (npMgr *NetworkPolicyManager) DeleteNetworkPolicy(npObj *networkingv1.Netwo
 	iptMgr := allNs.iptMgr
 	for _, iptEntry := range iptEntries {
 		if err = iptMgr.Delete(iptEntry); err != nil {
-			log.Printf("Error applying iptables rule.\n Rule: %+v", iptEntry)
+			log.Errorf("[Azure-NPM] Error: failed to apply iptables rule. Rule: %+v", iptEntry)
 			return err
 		}
 	}
@@ -141,7 +120,7 @@ func (npMgr *NetworkPolicyManager) DeleteNetworkPolicy(npObj *networkingv1.Netwo
 
 	if len(allNs.npMap) == 0 {
 		if err = iptMgr.UninitNpmChains(); err != nil {
-			log.Printf("Error uninitialize azure-npm chains.\n")
+			log.Errorf("[Azure-NPM] Error: failed to uninitialize azure-npm chains.")
 			return err
 		}
 		npMgr.isAzureNpmChainCreated = false

--- a/npm/nwpolicy.go
+++ b/npm/nwpolicy.go
@@ -16,18 +16,18 @@ func (npMgr *NetworkPolicyManager) AddNetworkPolicy(npObj *networkingv1.NetworkP
 	var err error
 
 	npNs, npName := npObj.ObjectMeta.Namespace, npObj.ObjectMeta.Name
-	log.Printf("[Azure-NPM] NETWORK POLICY CREATING: %v", npObj)
+	log.Printf("NETWORK POLICY CREATING: %v", npObj)
 
 	allNs := npMgr.nsMap[util.KubeAllNamespacesFlag]
 
 	if !npMgr.isAzureNpmChainCreated {
 		if err = allNs.ipsMgr.CreateSet(util.KubeSystemFlag); err != nil {
-			log.Errorf("[Azure-NPM] Error: failed to initialize kube-system ipset.")
+			log.Errorf("Error: failed to initialize kube-system ipset.")
 			return err
 		}
 
 		if err = allNs.iptMgr.InitNpmChains(); err != nil {
-			log.Errorf("[Azure-NPM] Error: failed to initialize azure-npm chains.")
+			log.Errorf("Error: failed to initialize azure-npm chains.")
 			return err
 		}
 
@@ -39,27 +39,27 @@ func (npMgr *NetworkPolicyManager) AddNetworkPolicy(npObj *networkingv1.NetworkP
 	ipsMgr := allNs.ipsMgr
 	for _, set := range podSets {
 		if err = ipsMgr.CreateSet(set); err != nil {
-			log.Errorf("[Azure-NPM] Error: failed to create ipset %s-%s", npNs, set)
+			log.Errorf("Error: failed to create ipset %s-%s", npNs, set)
 			return err
 		}
 	}
 
 	for _, list := range nsLists {
 		if err = ipsMgr.CreateList(list); err != nil {
-			log.Errorf("[Azure-NPM] Error: failed to create ipset list %s-%s", npNs, list)
+			log.Errorf("Error: failed to create ipset list %s-%s", npNs, list)
 			return err
 		}
 	}
 
 	if err = npMgr.InitAllNsList(); err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to initialize all-namespace ipset list.")
+		log.Errorf("Error: failed to initialize all-namespace ipset list.")
 		return err
 	}
 
 	iptMgr := allNs.iptMgr
 	for _, iptEntry := range iptEntries {
 		if err = iptMgr.Add(iptEntry); err != nil {
-			log.Errorf("[Azure-NPM] Error: failed to apply iptables rule. Rule: %+v", iptEntry)
+			log.Errorf("Error: failed to apply iptables rule. Rule: %+v", iptEntry)
 			return err
 		}
 	}
@@ -68,7 +68,7 @@ func (npMgr *NetworkPolicyManager) AddNetworkPolicy(npObj *networkingv1.NetworkP
 
 	ns, err := newNs(npNs)
 	if err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to create namespace %s", npNs)
+		log.Errorf("Error: failed to create namespace %s", npNs)
 	}
 	npMgr.nsMap[npNs] = ns
 
@@ -79,7 +79,7 @@ func (npMgr *NetworkPolicyManager) AddNetworkPolicy(npObj *networkingv1.NetworkP
 func (npMgr *NetworkPolicyManager) UpdateNetworkPolicy(oldNpObj *networkingv1.NetworkPolicy, newNpObj *networkingv1.NetworkPolicy) error {
 	var err error
 
-	log.Printf("[Azure-NPM] NETWORK POLICY UPDATING:\n old policy:[%v]\n new policy:[%v]", oldNpObj, newNpObj)
+	log.Printf("NETWORK POLICY UPDATING:\n old policy:[%v]\n new policy:[%v]", oldNpObj, newNpObj)
 
 	if err = npMgr.DeleteNetworkPolicy(oldNpObj); err != nil {
 		return err
@@ -102,7 +102,7 @@ func (npMgr *NetworkPolicyManager) DeleteNetworkPolicy(npObj *networkingv1.Netwo
 	var err error
 
 	npName := npObj.ObjectMeta.Name
-	log.Printf("[Azure-NPM] NETWORK POLICY DELETING: %v", npObj)
+	log.Printf("NETWORK POLICY DELETING: %v", npObj)
 
 	allNs := npMgr.nsMap[util.KubeAllNamespacesFlag]
 
@@ -111,7 +111,7 @@ func (npMgr *NetworkPolicyManager) DeleteNetworkPolicy(npObj *networkingv1.Netwo
 	iptMgr := allNs.iptMgr
 	for _, iptEntry := range iptEntries {
 		if err = iptMgr.Delete(iptEntry); err != nil {
-			log.Errorf("[Azure-NPM] Error: failed to apply iptables rule. Rule: %+v", iptEntry)
+			log.Errorf("Error: failed to apply iptables rule. Rule: %+v", iptEntry)
 			return err
 		}
 	}
@@ -120,7 +120,7 @@ func (npMgr *NetworkPolicyManager) DeleteNetworkPolicy(npObj *networkingv1.Netwo
 
 	if len(allNs.npMap) == 0 {
 		if err = iptMgr.UninitNpmChains(); err != nil {
-			log.Errorf("[Azure-NPM] Error: failed to uninitialize azure-npm chains.")
+			log.Errorf("Error: failed to uninitialize azure-npm chains.")
 			return err
 		}
 		npMgr.isAzureNpmChainCreated = false

--- a/npm/nwpolicy_test.go
+++ b/npm/nwpolicy_test.go
@@ -22,7 +22,7 @@ func TestAddNetworkPolicy(t *testing.T) {
 		TelemetryEnabled: false,
 		reportManager: &telemetry.ReportManager{
 			HostNetAgentURL: hostNetAgentURLForNpm,
-			ContentType:     contentType,
+			ContentType:     telemetry.ContentType,
 			Report:          &telemetry.NPMReport{},
 		},
 	}
@@ -102,7 +102,7 @@ func TestUpdateNetworkPolicy(t *testing.T) {
 		TelemetryEnabled: false,
 		reportManager: &telemetry.ReportManager{
 			HostNetAgentURL: hostNetAgentURLForNpm,
-			ContentType:     contentType,
+			ContentType:     telemetry.ContentType,
 			Report:          &telemetry.NPMReport{},
 		},
 	}
@@ -210,7 +210,7 @@ func TestDeleteNetworkPolicy(t *testing.T) {
 		TelemetryEnabled: false,
 		reportManager: &telemetry.ReportManager{
 			HostNetAgentURL: hostNetAgentURLForNpm,
-			ContentType:     contentType,
+			ContentType:     telemetry.ContentType,
 			Report:          &telemetry.NPMReport{},
 		},
 	}

--- a/npm/nwpolicy_test.go
+++ b/npm/nwpolicy_test.go
@@ -21,7 +21,6 @@ func TestAddNetworkPolicy(t *testing.T) {
 		nsMap:            make(map[string]*namespace),
 		TelemetryEnabled: false,
 		reportManager: &telemetry.ReportManager{
-			HostNetAgentURL: hostNetAgentURLForNpm,
 			ContentType:     telemetry.ContentType,
 			Report:          &telemetry.NPMReport{},
 		},
@@ -101,7 +100,6 @@ func TestUpdateNetworkPolicy(t *testing.T) {
 		nsMap:            make(map[string]*namespace),
 		TelemetryEnabled: false,
 		reportManager: &telemetry.ReportManager{
-			HostNetAgentURL: hostNetAgentURLForNpm,
 			ContentType:     telemetry.ContentType,
 			Report:          &telemetry.NPMReport{},
 		},
@@ -209,7 +207,6 @@ func TestDeleteNetworkPolicy(t *testing.T) {
 		nsMap:            make(map[string]*namespace),
 		TelemetryEnabled: false,
 		reportManager: &telemetry.ReportManager{
-			HostNetAgentURL: hostNetAgentURLForNpm,
 			ContentType:     telemetry.ContentType,
 			Report:          &telemetry.NPMReport{},
 		},

--- a/npm/parse.go
+++ b/npm/parse.go
@@ -62,7 +62,7 @@ func parseIngress(ns string, targetSets []string, rules []networkingv1.NetworkPo
 
 	// Use hashed string for ipset name to avoid string length limit of ipset.
 	for _, targetSet := range targetSets {
-		log.Printf("Parsing iptables for label %s", targetSet)
+		log.Printf("[Azure-NPM] Parsing iptables for label %s", targetSet)
 
 		hashedTargetSetName := util.GetHashedName(targetSet)
 
@@ -427,7 +427,7 @@ func parseIngress(ns string, targetSets []string, rules []networkingv1.NetworkPo
 		}
 	}
 
-	log.Printf("finished parsing ingress rule")
+	log.Printf("[Azure-NPM] finished parsing ingress rule")
 	return policyRuleSets, policyRuleLists, entries
 }
 
@@ -471,7 +471,7 @@ func parseEgress(ns string, targetSets []string, rules []networkingv1.NetworkPol
 
 	// Use hashed string for ipset name to avoid string length limit of ipset.
 	for _, targetSet := range targetSets {
-		log.Printf("Parsing iptables for label %s", targetSet)
+		log.Printf("[Azure-NPM] Parsing iptables for label %s", targetSet)
 
 		hashedTargetSetName := util.GetHashedName(targetSet)
 
@@ -764,7 +764,7 @@ func parseEgress(ns string, targetSets []string, rules []networkingv1.NetworkPol
 				// Allow traffic from podSelector intersects namespaceSelector
 				// This is only supported in kubernetes version >= 1.11
 				if util.IsNewNwPolicyVerFlag {
-					log.Printf("Kubernetes version > 1.11, parsing podSelector AND namespaceSelector")
+					log.Printf("[Azure-NPM] Kubernetes version > 1.11, parsing podSelector AND namespaceSelector")
 					// allow traffic from all namespaces
 					if len(toRule.NamespaceSelector.MatchLabels) == 0 {
 						nsRuleLists = append(nsRuleLists, util.KubeAllNamespacesFlag)
@@ -837,7 +837,7 @@ func parseEgress(ns string, targetSets []string, rules []networkingv1.NetworkPol
 		}
 	}
 
-	log.Printf("finished parsing ingress rule")
+	log.Printf("[Azure-NPM] finished parsing ingress rule")
 	return policyRuleSets, policyRuleLists, entries
 }
 

--- a/npm/parse.go
+++ b/npm/parse.go
@@ -62,7 +62,7 @@ func parseIngress(ns string, targetSets []string, rules []networkingv1.NetworkPo
 
 	// Use hashed string for ipset name to avoid string length limit of ipset.
 	for _, targetSet := range targetSets {
-		log.Printf("[Azure-NPM] Parsing iptables for label %s", targetSet)
+		log.Printf("Parsing iptables for label %s", targetSet)
 
 		hashedTargetSetName := util.GetHashedName(targetSet)
 
@@ -427,7 +427,7 @@ func parseIngress(ns string, targetSets []string, rules []networkingv1.NetworkPo
 		}
 	}
 
-	log.Printf("[Azure-NPM] finished parsing ingress rule")
+	log.Printf("finished parsing ingress rule")
 	return policyRuleSets, policyRuleLists, entries
 }
 
@@ -471,7 +471,7 @@ func parseEgress(ns string, targetSets []string, rules []networkingv1.NetworkPol
 
 	// Use hashed string for ipset name to avoid string length limit of ipset.
 	for _, targetSet := range targetSets {
-		log.Printf("[Azure-NPM] Parsing iptables for label %s", targetSet)
+		log.Printf("Parsing iptables for label %s", targetSet)
 
 		hashedTargetSetName := util.GetHashedName(targetSet)
 
@@ -764,7 +764,7 @@ func parseEgress(ns string, targetSets []string, rules []networkingv1.NetworkPol
 				// Allow traffic from podSelector intersects namespaceSelector
 				// This is only supported in kubernetes version >= 1.11
 				if util.IsNewNwPolicyVerFlag {
-					log.Printf("[Azure-NPM] Kubernetes version > 1.11, parsing podSelector AND namespaceSelector")
+					log.Printf("Kubernetes version > 1.11, parsing podSelector AND namespaceSelector")
 					// allow traffic from all namespaces
 					if len(toRule.NamespaceSelector.MatchLabels) == 0 {
 						nsRuleLists = append(nsRuleLists, util.KubeAllNamespacesFlag)
@@ -837,7 +837,7 @@ func parseEgress(ns string, targetSets []string, rules []networkingv1.NetworkPol
 		}
 	}
 
-	log.Printf("[Azure-NPM] finished parsing ingress rule")
+	log.Printf("finished parsing ingress rule")
 	return policyRuleSets, policyRuleLists, entries
 }
 

--- a/npm/plugin/main.go
+++ b/npm/plugin/main.go
@@ -14,6 +14,8 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+const waitForTelemetryInSeconds = 60
+
 // Version is populated by make during build.
 var version string
 
@@ -21,7 +23,7 @@ func initLogging() error {
 	log.SetName("azure-npm")
 	log.SetLevel(log.LevelInfo)
 	if err := log.SetTarget(log.TargetLogfile); err != nil {
-		log.Printf("[cni-npm] Failed to configure logging, err:%v.\n", err)
+		log.Logf("[Azure-NPM] Failed to configure logging, err:%v.", err)
 		return err
 	}
 
@@ -33,7 +35,7 @@ func main() {
 
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("[cni-npm] recovered from error: %v", err)
+			log.Logf("[Azure-NPM] recovered from error: %v", err)
 		}
 	}()
 
@@ -50,22 +52,23 @@ func main() {
 	// Creates the clientset
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		log.Printf("[Azure-NPM] clientset creation failed with error %v.\n", err)
+		log.Logf("[Azure-NPM] clientset creation failed with error %v.", err)
 		panic(err.Error())
 	}
 
 	factory := informers.NewSharedInformerFactory(clientset, time.Hour*24)
 
 	npMgr := npm.NewNetworkPolicyManager(clientset, factory, version)
+
+	go npMgr.SendNpmTelemetry()
+
+	time.Sleep(time.Second * waitForTelemetryInSeconds)
+
 	err = npMgr.Start(wait.NeverStop)
 	if err != nil {
-		log.Printf("[Azure-NPM] npm failed with error %v.", err)
+		log.Logf("[Azure-NPM] npm failed with error %v.", err)
 		panic(err.Error)
 	}
-
-	// Disable Azure-NPM telemetry for now since it might throttle wireserver.
-	npMgr.TelemetryEnabled = false
-	go npMgr.RunReportManager()
 
 	select {}
 }

--- a/npm/plugin/main.go
+++ b/npm/plugin/main.go
@@ -23,7 +23,7 @@ func initLogging() error {
 	log.SetName("azure-npm")
 	log.SetLevel(log.LevelInfo)
 	if err := log.SetTarget(log.TargetLogfile); err != nil {
-		log.Logf("[Azure-NPM] Failed to configure logging, err:%v.", err)
+		log.Logf("Failed to configure logging, err:%v.", err)
 		return err
 	}
 
@@ -35,7 +35,7 @@ func main() {
 
 	defer func() {
 		if r := recover(); r != nil {
-			log.Logf("[Azure-NPM] recovered from error: %v", err)
+			log.Logf("recovered from error: %v", err)
 		}
 	}()
 
@@ -52,7 +52,7 @@ func main() {
 	// Creates the clientset
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		log.Logf("[Azure-NPM] clientset creation failed with error %v.", err)
+		log.Logf("clientset creation failed with error %v.", err)
 		panic(err.Error())
 	}
 
@@ -66,7 +66,7 @@ func main() {
 
 	err = npMgr.Start(wait.NeverStop)
 	if err != nil {
-		log.Logf("[Azure-NPM] npm failed with error %v.", err)
+		log.Logf("npm failed with error %v.", err)
 		panic(err.Error)
 	}
 

--- a/npm/pod.go
+++ b/npm/pod.go
@@ -12,9 +12,9 @@ import (
 )
 
 func isValidPod(podObj *corev1.Pod) bool {
-	return podObj.Status.Phase != "Failed" &&
-		podObj.Status.Phase != "Succeeded" &&
-		podObj.Status.Phase != "Unknown" &&
+	return podObj.Status.Phase != corev1.PodPhase(util.KubePodStatusFailedFlag) &&
+		podObj.Status.Phase != corev1.PodPhase(util.KubePodStatusSucceededFlag) &&
+		podObj.Status.Phase != corev1.PodPhase(util.KubePodStatusUnknownFlag) &&
 		len(podObj.Status.PodIP) > 0
 }
 
@@ -33,25 +33,19 @@ func (npMgr *NetworkPolicyManager) AddPod(podObj *corev1.Pod) error {
 
 	var err error
 
-	defer func() {
-		if err = npMgr.UpdateAndSendReport(err, util.AddPodEvent); err != nil {
-			log.Printf("Error sending NPM telemetry report")
-		}
-	}()
-
 	podNs := podObj.ObjectMeta.Namespace
 	podName := podObj.ObjectMeta.Name
 	podNodeName := podObj.Spec.NodeName
 	podLabels := podObj.ObjectMeta.Labels
 	podIP := podObj.Status.PodIP
-	log.Printf("POD CREATING: %s/%s/%s%+v%s\n", podNs, podName, podNodeName, podLabels, podIP)
+	log.Printf("[Azure-NPM] POD CREATING: [%s/%s/%s%+v%s]", podNs, podName, podNodeName, podLabels, podIP)
 
 	// Add the pod to ipset
 	ipsMgr := npMgr.nsMap[util.KubeAllNamespacesFlag].ipsMgr
 	// Add the pod to its namespace's ipset.
-	log.Printf("Adding pod %s to ipset %s\n", podIP, podNs)
+	log.Printf("[Azure-NPM] Adding pod %s to ipset %s", podIP, podNs)
 	if err = ipsMgr.AddToSet(podNs, podIP); err != nil {
-		log.Printf("Error adding pod to namespace ipset.\n")
+		log.Errorf("[Azure-NPM] Error: failed to add pod to namespace ipset.")
 		return err
 	}
 
@@ -64,9 +58,9 @@ func (npMgr *NetworkPolicyManager) AddPod(podObj *corev1.Pod) error {
 		}
 
 		labelKey := util.KubeAllNamespacesFlag + "-" + podLabelKey + ":" + podLabelVal
-		log.Printf("Adding pod %s to ipset %s\n", podIP, labelKey)
+		log.Printf("[Azure-NPM] Adding pod %s to ipset %s", podIP, labelKey)
 		if err = ipsMgr.AddToSet(labelKey, podIP); err != nil {
-			log.Printf("Error adding pod to label ipset.\n")
+			log.Errorf("[Azure-NPM] Error: failed to add pod to label ipset.")
 			return err
 		}
 		labelKeys = append(labelKeys, labelKey)
@@ -74,7 +68,7 @@ func (npMgr *NetworkPolicyManager) AddPod(podObj *corev1.Pod) error {
 
 	ns, err := newNs(podNs)
 	if err != nil {
-		log.Printf("Error creating namespace %s\n", podNs)
+		log.Errorf("[Azure-NPM] Error: failed to create namespace %s", podNs)
 		return err
 	}
 	npMgr.nsMap[podNs] = ns
@@ -90,26 +84,21 @@ func (npMgr *NetworkPolicyManager) UpdatePod(oldPodObj, newPodObj *corev1.Pod) e
 
 	var err error
 
-	defer func() {
-		npMgr.Lock()
-		if err = npMgr.UpdateAndSendReport(err, util.UpdateNamespaceEvent); err != nil {
-			log.Printf("Error sending NPM telemetry report")
-		}
-		npMgr.Unlock()
-	}()
-
 	oldPodObjNs := oldPodObj.ObjectMeta.Namespace
 	oldPodObjName := oldPodObj.ObjectMeta.Name
+	oldPodObjLabel := oldPodObj.ObjectMeta.Labels
 	oldPodObjPhase := oldPodObj.Status.Phase
 	oldPodObjIP := oldPodObj.Status.PodIP
 	newPodObjNs := newPodObj.ObjectMeta.Namespace
 	newPodObjName := newPodObj.ObjectMeta.Name
+	newPodObjLabel := newPodObj.ObjectMeta.Labels
 	newPodObjPhase := newPodObj.Status.Phase
 	newPodObjIP := newPodObj.Status.PodIP
 
 	log.Printf(
-		"POD UPDATING. %s %s %s %s %s %s %s %s\n",
-		oldPodObjNs, oldPodObjName, oldPodObjPhase, oldPodObjIP, newPodObjNs, newPodObjName, newPodObjPhase, newPodObjIP,
+		"[Azure-NPM] POD UPDATING:\n old pod: [%s/%s/%+v/%s/%s]\n new pod: [%s/%s/%+v/%s/%s]",
+		oldPodObjNs, oldPodObjName, oldPodObjLabel, oldPodObjPhase, oldPodObjIP,
+		newPodObjNs, newPodObjName, newPodObjLabel, newPodObjPhase, newPodObjIP,
 	)
 
 	if err = npMgr.DeletePod(oldPodObj); err != nil {
@@ -136,24 +125,18 @@ func (npMgr *NetworkPolicyManager) DeletePod(podObj *corev1.Pod) error {
 
 	var err error
 
-	defer func() {
-		if err = npMgr.UpdateAndSendReport(err, util.DeletePodEvent); err != nil {
-			log.Printf("Error sending NPM telemetry report")
-		}
-	}()
-
 	podNs := podObj.ObjectMeta.Namespace
 	podName := podObj.ObjectMeta.Name
 	podNodeName := podObj.Spec.NodeName
 	podLabels := podObj.ObjectMeta.Labels
 	podIP := podObj.Status.PodIP
-	log.Printf("POD DELETING: %s/%s/%s\n", podNs, podName, podNodeName)
+	log.Printf("[Azure-NPM] POD DELETING: [%s/%s/%s%+v%s]", podNs, podName, podNodeName, podLabels, podIP)
 
 	// Delete pod from ipset
 	ipsMgr := npMgr.nsMap[util.KubeAllNamespacesFlag].ipsMgr
 	// Delete the pod from its namespace's ipset.
 	if err = ipsMgr.DeleteFromSet(podNs, podIP); err != nil {
-		log.Printf("Error deleting pod from namespace ipset.\n")
+		log.Errorf("[Azure-NPM] Error: failed to delete pod from namespace ipset.")
 		return err
 	}
 	// Delete the pod from its label's ipset.
@@ -165,7 +148,7 @@ func (npMgr *NetworkPolicyManager) DeletePod(podObj *corev1.Pod) error {
 
 		labelKey := util.KubeAllNamespacesFlag + "-" + podLabelKey + ":" + podLabelVal
 		if err = ipsMgr.DeleteFromSet(labelKey, podIP); err != nil {
-			log.Printf("Error deleting pod from label ipset.\n")
+			log.Errorf("[Azure-NPM] Error: failed to delete pod from label ipset.")
 			return err
 		}
 	}

--- a/npm/pod.go
+++ b/npm/pod.go
@@ -38,14 +38,14 @@ func (npMgr *NetworkPolicyManager) AddPod(podObj *corev1.Pod) error {
 	podNodeName := podObj.Spec.NodeName
 	podLabels := podObj.ObjectMeta.Labels
 	podIP := podObj.Status.PodIP
-	log.Printf("[Azure-NPM] POD CREATING: [%s/%s/%s%+v%s]", podNs, podName, podNodeName, podLabels, podIP)
+	log.Printf("POD CREATING: [%s/%s/%s%+v%s]", podNs, podName, podNodeName, podLabels, podIP)
 
 	// Add the pod to ipset
 	ipsMgr := npMgr.nsMap[util.KubeAllNamespacesFlag].ipsMgr
 	// Add the pod to its namespace's ipset.
-	log.Printf("[Azure-NPM] Adding pod %s to ipset %s", podIP, podNs)
+	log.Printf("Adding pod %s to ipset %s", podIP, podNs)
 	if err = ipsMgr.AddToSet(podNs, podIP); err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to add pod to namespace ipset.")
+		log.Errorf("Error: failed to add pod to namespace ipset.")
 		return err
 	}
 
@@ -58,9 +58,9 @@ func (npMgr *NetworkPolicyManager) AddPod(podObj *corev1.Pod) error {
 		}
 
 		labelKey := util.KubeAllNamespacesFlag + "-" + podLabelKey + ":" + podLabelVal
-		log.Printf("[Azure-NPM] Adding pod %s to ipset %s", podIP, labelKey)
+		log.Printf("Adding pod %s to ipset %s", podIP, labelKey)
 		if err = ipsMgr.AddToSet(labelKey, podIP); err != nil {
-			log.Errorf("[Azure-NPM] Error: failed to add pod to label ipset.")
+			log.Errorf("Error: failed to add pod to label ipset.")
 			return err
 		}
 		labelKeys = append(labelKeys, labelKey)
@@ -68,7 +68,7 @@ func (npMgr *NetworkPolicyManager) AddPod(podObj *corev1.Pod) error {
 
 	ns, err := newNs(podNs)
 	if err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to create namespace %s", podNs)
+		log.Errorf("Error: failed to create namespace %s", podNs)
 		return err
 	}
 	npMgr.nsMap[podNs] = ns
@@ -96,7 +96,7 @@ func (npMgr *NetworkPolicyManager) UpdatePod(oldPodObj, newPodObj *corev1.Pod) e
 	newPodObjIP := newPodObj.Status.PodIP
 
 	log.Printf(
-		"[Azure-NPM] POD UPDATING:\n old pod: [%s/%s/%+v/%s/%s]\n new pod: [%s/%s/%+v/%s/%s]",
+		"POD UPDATING:\n old pod: [%s/%s/%+v/%s/%s]\n new pod: [%s/%s/%+v/%s/%s]",
 		oldPodObjNs, oldPodObjName, oldPodObjLabel, oldPodObjPhase, oldPodObjIP,
 		newPodObjNs, newPodObjName, newPodObjLabel, newPodObjPhase, newPodObjIP,
 	)
@@ -130,13 +130,13 @@ func (npMgr *NetworkPolicyManager) DeletePod(podObj *corev1.Pod) error {
 	podNodeName := podObj.Spec.NodeName
 	podLabels := podObj.ObjectMeta.Labels
 	podIP := podObj.Status.PodIP
-	log.Printf("[Azure-NPM] POD DELETING: [%s/%s/%s%+v%s]", podNs, podName, podNodeName, podLabels, podIP)
+	log.Printf("POD DELETING: [%s/%s/%s%+v%s]", podNs, podName, podNodeName, podLabels, podIP)
 
 	// Delete pod from ipset
 	ipsMgr := npMgr.nsMap[util.KubeAllNamespacesFlag].ipsMgr
 	// Delete the pod from its namespace's ipset.
 	if err = ipsMgr.DeleteFromSet(podNs, podIP); err != nil {
-		log.Errorf("[Azure-NPM] Error: failed to delete pod from namespace ipset.")
+		log.Errorf("Error: failed to delete pod from namespace ipset.")
 		return err
 	}
 	// Delete the pod from its label's ipset.
@@ -148,7 +148,7 @@ func (npMgr *NetworkPolicyManager) DeletePod(podObj *corev1.Pod) error {
 
 		labelKey := util.KubeAllNamespacesFlag + "-" + podLabelKey + ":" + podLabelVal
 		if err = ipsMgr.DeleteFromSet(labelKey, podIP); err != nil {
-			log.Errorf("[Azure-NPM] Error: failed to delete pod from label ipset.")
+			log.Errorf("Error: failed to delete pod from label ipset.")
 			return err
 		}
 	}

--- a/npm/pod_test.go
+++ b/npm/pod_test.go
@@ -40,9 +40,8 @@ func TestAddPod(t *testing.T) {
 		nsMap:            make(map[string]*namespace),
 		TelemetryEnabled: false,
 		reportManager: &telemetry.ReportManager{
-			HostNetAgentURL: hostNetAgentURLForNpm,
-			ContentType:     telemetry.ContentType,
-			Report:          &telemetry.NPMReport{},
+			ContentType: telemetry.ContentType,
+			Report:      &telemetry.NPMReport{},
 		},
 	}
 
@@ -85,9 +84,8 @@ func TestUpdatePod(t *testing.T) {
 		nsMap:            make(map[string]*namespace),
 		TelemetryEnabled: false,
 		reportManager: &telemetry.ReportManager{
-			HostNetAgentURL: hostNetAgentURLForNpm,
-			ContentType:     telemetry.ContentType,
-			Report:          &telemetry.NPMReport{},
+			ContentType: telemetry.ContentType,
+			Report:      &telemetry.NPMReport{},
 		},
 	}
 
@@ -148,9 +146,8 @@ func TestDeletePod(t *testing.T) {
 		nsMap:            make(map[string]*namespace),
 		TelemetryEnabled: false,
 		reportManager: &telemetry.ReportManager{
-			HostNetAgentURL: hostNetAgentURLForNpm,
-			ContentType:     telemetry.ContentType,
-			Report:          &telemetry.NPMReport{},
+			ContentType: telemetry.ContentType,
+			Report:      &telemetry.NPMReport{},
 		},
 	}
 

--- a/npm/pod_test.go
+++ b/npm/pod_test.go
@@ -41,7 +41,7 @@ func TestAddPod(t *testing.T) {
 		TelemetryEnabled: false,
 		reportManager: &telemetry.ReportManager{
 			HostNetAgentURL: hostNetAgentURLForNpm,
-			ContentType:     contentType,
+			ContentType:     telemetry.ContentType,
 			Report:          &telemetry.NPMReport{},
 		},
 	}
@@ -86,7 +86,7 @@ func TestUpdatePod(t *testing.T) {
 		TelemetryEnabled: false,
 		reportManager: &telemetry.ReportManager{
 			HostNetAgentURL: hostNetAgentURLForNpm,
-			ContentType:     contentType,
+			ContentType:     telemetry.ContentType,
 			Report:          &telemetry.NPMReport{},
 		},
 	}
@@ -149,7 +149,7 @@ func TestDeletePod(t *testing.T) {
 		TelemetryEnabled: false,
 		reportManager: &telemetry.ReportManager{
 			HostNetAgentURL: hostNetAgentURLForNpm,
-			ContentType:     contentType,
+			ContentType:     telemetry.ContentType,
 			Report:          &telemetry.NPMReport{},
 		},
 	}

--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -4,12 +4,15 @@ package util
 
 //kubernetes related constants.
 const (
-	KubeSystemFlag          string = "kube-system"
-	KubePodTemplateHashFlag string = "pod-template-hash"
-	KubeAllPodsFlag         string = "all-pod"
-	KubeAllNamespacesFlag   string = "all-namespace"
-	KubeAppFlag             string = "k8s-app"
-	KubeProxyFlag           string = "kube-proxy"
+	KubeSystemFlag             string = "kube-system"
+	KubePodTemplateHashFlag    string = "pod-template-hash"
+	KubeAllPodsFlag            string = "all-pod"
+	KubeAllNamespacesFlag      string = "all-namespace"
+	KubeAppFlag                string = "k8s-app"
+	KubeProxyFlag              string = "kube-proxy"
+	KubePodStatusFailedFlag    string = "Failed"
+	KubePodStatusSucceededFlag string = "Succeeded"
+	KubePodStatusUnknownFlag   string = "Unknown"
 
 	// The version of k8s that accept "AND" between namespaceSelector and podSelector is "1.11"
 	k8sMajorVerForNewPolicyDef string = "1"

--- a/telemetry/cnstelemetry.go
+++ b/telemetry/cnstelemetry.go
@@ -24,6 +24,8 @@ const (
 	telemetryWaitTimeInMilliseconds = 200
 )
 
+var codeRegex = regexp.MustCompile(`Code:(\w*)`)
+
 // SendCnsTelemetry - handles cns telemetry reports
 func SendCnsTelemetry(reports chan interface{}, service *restserver.HTTPRestService, telemetryStopProcessing chan bool) {
 
@@ -50,7 +52,7 @@ CONNECT:
 			case <-heartbeat:
 				reflect.ValueOf(reportMgr.Report).Elem().FieldByName("EventMessage").SetString("Heartbeat")
 			case msg := <-reports:
-				codeStr := regexp.MustCompile(`Code:(\w*)`).FindString(msg.(string))
+				codeStr := codeRegex.FindString(msg.(string))
 				if len(codeStr) > errorcodePrefix {
 					reflect.ValueOf(reportMgr.Report).Elem().FieldByName("Errorcode").SetString(codeStr[errorcodePrefix:])
 				}
@@ -74,7 +76,7 @@ CONNECT:
 			if err == nil {
 				// If write fails, try to re-establish connections as server/client
 				if _, err = tb.Write(report); err != nil {
-					log.Printf("[CNS-Telemetry] Telemetry write failed: %v", err)
+					log.Logf("[CNS-Telemetry] Telemetry write failed: %v", err)
 					tb.Close()
 					goto CONNECT
 				}

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -156,6 +156,7 @@ type NPMReport struct {
 	ErrorMessage      string
 	EventMessage      string
 	UpTime            string
+	Timestamp         string
 	ClusterState      ClusterState
 	Metadata          Metadata `json:"compute"`
 }
@@ -238,7 +239,7 @@ func (reportMgr *ReportManager) SetReportState(telemetryFile string) error {
 
 	_, err = f.Write(reportBytes)
 	if err != nil {
-		log.Printf("[Telemetry] Error while writing to file %v", err)
+		fmt.Printf("[Telemetry] Error while writing to file %v", err)
 		return fmt.Errorf("[Telemetry] Error while writing to file %v", err)
 	}
 
@@ -251,7 +252,7 @@ func (reportMgr *ReportManager) SetReportState(telemetryFile string) error {
 func (reportMgr *ReportManager) GetReportState(telemetryFile string) bool {
 	// try to set IsNewInstance in report
 	if _, err := os.Stat(telemetryFile); os.IsNotExist(err) {
-		log.Printf("[Telemetry] File not exist %v", telemetryFile)
+		fmt.Printf("[Telemetry] File not exist %v", telemetryFile)
 		reflect.ValueOf(reportMgr.Report).Elem().FieldByName("IsNewInstance").SetBool(true)
 		return false
 	}
@@ -291,7 +292,7 @@ func (report *CNIReport) GetInterfaceDetails(queryUrl string) {
 	if resp.StatusCode != http.StatusOK {
 		errMsg := fmt.Sprintf("Error while getting interface details. http code :%d", resp.StatusCode)
 		report.InterfaceDetails.ErrorMessage = errMsg
-		log.Printf(errMsg)
+		log.Logf(errMsg)
 		return
 	}
 

--- a/telemetry/telemetrybuffer.go
+++ b/telemetry/telemetrybuffer.go
@@ -29,21 +29,22 @@ type TelemetryConfig struct {
 
 // FdName - file descriptor name
 // Delimiter - delimiter for socket reads/writes
-// azureHostReportURL - host net agent url of type payload
-// DefaultInterval - default interval for sending payload to host
+// azureHostReportURL - host net agent url of type buffer
+// DefaultInterval - default interval for sending buffer to host
 // logName - telemetry log name
-// MaxPayloadSize - max payload size in bytes
+// MaxPayloadSize - max buffer size in bytes
 const (
-	FdName                    = "azure-vnet-telemetry"
-	Delimiter                 = '\n'
-	azureHostReportURL        = "http://168.63.129.16/machine/plugins?comp=netagent&type=payload"
-	minInterval               = 10 * time.Second
-	logName                   = "azure-vnet-telemetry"
-	MaxPayloadSize     uint16 = 4096
-	dnc                       = "DNC"
-	cns                       = "CNS"
-	npm                       = "NPM"
-	cni                       = "CNI"
+	FdName             = "azure-vnet-telemetry"
+	Delimiter          = '\n'
+	azureHostReportURL = "http://168.63.129.16/machine/plugins?comp=netagent&type=payload"
+	minInterval        = 10 * time.Second
+	logName            = "azure-vnet-telemetry"
+	MaxPayloadSize     = 4096
+	MaxBufferSize      = 1048576
+	dnc                = "DNC"
+	cns                = "CNS"
+	npm                = "NPM"
+	cni                = "CNI"
 )
 
 var payloadSize uint16 = 0
@@ -54,7 +55,7 @@ type TelemetryBuffer struct {
 	listener           net.Listener
 	connections        []net.Conn
 	azureHostReportURL string
-	payload            Payload
+	buffer             Buffer
 	FdExists           bool
 	Connected          bool
 	data               chan interface{}
@@ -62,8 +63,8 @@ type TelemetryBuffer struct {
 	mutex              sync.Mutex
 }
 
-// Payload object holds the different types of reports
-type Payload struct {
+// Buffer object holds the different types of reports
+type Buffer struct {
 	DNCReports []DNCReport
 	CNIReports []CNIReport
 	NPMReports []NPMReport
@@ -78,13 +79,13 @@ func NewTelemetryBuffer(hostReportURL string) *TelemetryBuffer {
 		tb.azureHostReportURL = azureHostReportURL
 	}
 
-	tb.data = make(chan interface{})
+	tb.data = make(chan interface{}, 1000)
 	tb.cancel = make(chan bool, 1)
 	tb.connections = make([]net.Conn, 0)
-	tb.payload.DNCReports = make([]DNCReport, 0)
-	tb.payload.CNIReports = make([]CNIReport, 0)
-	tb.payload.NPMReports = make([]NPMReport, 0)
-	tb.payload.CNSReports = make([]CNSReport, 0)
+	tb.buffer.DNCReports = make([]DNCReport, 0)
+	tb.buffer.CNIReports = make([]CNIReport, 0)
+	tb.buffer.NPMReports = make([]NPMReport, 0)
+	tb.buffer.CNSReports = make([]CNSReport, 0)
 
 	return &tb
 }
@@ -95,7 +96,7 @@ func remove(s []net.Conn, i int) []net.Conn {
 		return s[:len(s)-1]
 	}
 
-	log.Printf("tb connections remove failed index %v len %v", i, len(s))
+	log.Logf("tb connections remove failed index %v len %v", i, len(s))
 	return s
 }
 
@@ -104,11 +105,11 @@ func (tb *TelemetryBuffer) StartServer() error {
 	err := tb.Listen(FdName)
 	if err != nil {
 		tb.FdExists = strings.Contains(err.Error(), "in use") || strings.Contains(err.Error(), "Access is denied")
-		log.Printf("Listen returns: %v", err.Error())
+		log.Logf("Listen returns: %v", err.Error())
 		return err
 	}
 
-	log.Printf("Telemetry service started")
+	log.Logf("Telemetry service started")
 	// Spawn server goroutine to handle incoming connections
 	go func() {
 		for {
@@ -166,7 +167,7 @@ func (tb *TelemetryBuffer) StartServer() error {
 					}
 				}()
 			} else {
-				log.Printf("Telemetry Server accept error %v", err)
+				log.Logf("Telemetry Server accept error %v", err)
 				return
 			}
 		}
@@ -190,7 +191,7 @@ func (tb *TelemetryBuffer) Connect() error {
 func (tb *TelemetryBuffer) BufferAndPushData(intervalms time.Duration) {
 	defer tb.Close()
 	if !tb.FdExists {
-		log.Printf("[Telemetry] Buffer telemetry data and send it to host")
+		log.Logf("[Telemetry] Buffer telemetry data and send it to host")
 		if intervalms < minInterval {
 			intervalms = minInterval
 		}
@@ -199,23 +200,23 @@ func (tb *TelemetryBuffer) BufferAndPushData(intervalms time.Duration) {
 		for {
 			select {
 			case <-interval:
-				// Send payload to host and clear cache when sent successfully
-				// To-do : if we hit max slice size in payload, write to disk and process the logs on disk on future sends
-				if err := tb.sendToHost(); err == nil {
-					tb.payload.reset()
-				} else {
-					log.Printf("[Telemetry] sending to host failed with error %+v", err)
-				}
+				// Send buffer to host and clear cache when sent successfully
+				// To-do : if we hit max slice size in buffer, write to disk and process the logs on disk on future sends
+				tb.mutex.Lock()
+				tb.sendToHost()
+				tb.mutex.Unlock()
 			case report := <-tb.data:
-				tb.payload.push(report)
+				tb.mutex.Lock()
+				tb.buffer.push(report)
+				tb.mutex.Unlock()
 			case <-tb.cancel:
-				log.Printf("server cancel event")
+				log.Logf("[Telemetry] server cancel event")
 				goto EXIT
 			}
 		}
 	} else {
 		<-tb.cancel
-		log.Printf("Received cancel event")
+		log.Logf("[Telemetry] Received cancel event")
 	}
 
 EXIT:
@@ -256,7 +257,7 @@ func (tb *TelemetryBuffer) Close() {
 	}
 
 	if tb.listener != nil {
-		log.Printf("server close")
+		log.Logf("server close")
 		tb.listener.Close()
 	}
 
@@ -273,13 +274,124 @@ func (tb *TelemetryBuffer) Close() {
 	tb.connections = make([]net.Conn, 0)
 }
 
-// sendToHost - send payload to host
+// sendToHost - send buffer to host
 func (tb *TelemetryBuffer) sendToHost() error {
+	buf := Buffer{
+		DNCReports: make([]DNCReport, 0),
+		CNIReports: make([]CNIReport, 0),
+		NPMReports: make([]NPMReport, 0),
+		CNSReports: make([]CNSReport, 0),
+	}
+	i, payloadSize, maxPayloadSizeReached := 0, 0, false
+	isDNCReportsEmpty, isCNIReportsEmpty, isCNSReportsEmpty, isNPMReportsEmpty := false, false, false, false
+	for {
+		// craft payload in a round-robin manner.
+		switch i % 4 {
+		case 0:
+			reportLen := len(tb.buffer.DNCReports)
+			if reportLen == 0 || isDNCReportsEmpty {
+				isDNCReportsEmpty = true
+				break
+			}
+
+			if reportLen == 1 {
+				isDNCReportsEmpty = true
+			}
+
+			report := tb.buffer.DNCReports[0]
+			if bytes, err := json.Marshal(report); err == nil {
+				payloadSize += len(bytes)
+				if payloadSize > MaxPayloadSize {
+					maxPayloadSizeReached = true
+					break
+				}
+			}
+			buf.DNCReports = append(buf.DNCReports, report)
+			tb.buffer.DNCReports = tb.buffer.DNCReports[1:]
+		case 1:
+			reportLen := len(tb.buffer.CNIReports)
+			if reportLen == 0 || isCNIReportsEmpty {
+				isCNIReportsEmpty = true
+				break
+			}
+
+			if reportLen == 1 {
+				isCNIReportsEmpty = true
+			}
+
+			report := tb.buffer.CNIReports[0]
+			if bytes, err := json.Marshal(report); err == nil {
+				payloadSize += len(bytes)
+				if payloadSize > MaxPayloadSize {
+					maxPayloadSizeReached = true
+					break
+				}
+			}
+			buf.CNIReports = append(buf.CNIReports, report)
+			tb.buffer.CNIReports = tb.buffer.CNIReports[1:]
+		case 2:
+			reportLen := len(tb.buffer.CNSReports)
+			if reportLen == 0 || isCNSReportsEmpty {
+				isCNSReportsEmpty = true
+				break
+			}
+
+			if reportLen == 1 {
+				isCNSReportsEmpty = true
+			}
+
+			report := tb.buffer.CNSReports[0]
+			if bytes, err := json.Marshal(report); err == nil {
+				payloadSize += len(bytes)
+				if payloadSize > MaxPayloadSize {
+					maxPayloadSizeReached = true
+					break
+				}
+			}
+			buf.CNSReports = append(buf.CNSReports, report)
+			tb.buffer.CNSReports = tb.buffer.CNSReports[1:]
+		case 3:
+			reportLen := len(tb.buffer.NPMReports)
+			if reportLen == 0 || isNPMReportsEmpty {
+				isNPMReportsEmpty = true
+				break
+			}
+
+			if reportLen == 1 {
+				isNPMReportsEmpty = true
+			}
+
+			report := tb.buffer.NPMReports[0]
+			if bytes, err := json.Marshal(report); err == nil {
+				payloadSize += len(bytes)
+				if payloadSize > MaxPayloadSize {
+					maxPayloadSizeReached = true
+					break
+				}
+			}
+			buf.NPMReports = append(buf.NPMReports, report)
+			tb.buffer.NPMReports = tb.buffer.NPMReports[1:]
+		}
+
+		if isDNCReportsEmpty && isCNIReportsEmpty && isCNSReportsEmpty && isNPMReportsEmpty {
+			break
+		}
+
+		if maxPayloadSizeReached {
+			break
+		}
+
+		i++
+	}
+
 	httpc := &http.Client{}
 	var body bytes.Buffer
-	log.Printf("Sending payload %+v", tb.payload)
-	json.NewEncoder(&body).Encode(tb.payload)
+	log.Logf("Sending buffer %+v", buf)
+	if err := json.NewEncoder(&body).Encode(buf); err != nil {
+		log.Logf("[Telemetry] Encode buffer error %v", err)
+	}
 	resp, err := httpc.Post(tb.azureHostReportURL, ContentType, &body)
+	log.Logf("[Telemetry] Got response %v", resp)
 	if err != nil {
 		return fmt.Errorf("[Telemetry] HTTP Post returned error %v", err)
 	}
@@ -294,77 +406,48 @@ func (tb *TelemetryBuffer) sendToHost() error {
 }
 
 // push - push the report (x) to corresponding slice
-func (pl *Payload) push(x interface{}) {
+func (buf *Buffer) push(x interface{}) {
 	metadata, err := getHostMetadata()
 	if err != nil {
-		log.Printf("Error getting metadata %v", err)
+		log.Logf("Error getting metadata %v", err)
 	} else {
 		err = saveHostMetadata(metadata)
 		if err != nil {
-			log.Printf("saving host metadata failed with :%v", err)
+			log.Logf("saving host metadata failed with :%v", err)
 		}
 	}
 
-	if notExceeded, reportType := pl.payloadCapNotExceeded(x); notExceeded {
-		switch reportType {
-		case dnc:
-			dncReport := x.(DNCReport)
-			dncReport.Metadata = metadata
-			pl.DNCReports = append(pl.DNCReports, dncReport)
-		case cni:
-			cniReport := x.(CNIReport)
-			cniReport.Metadata = metadata
-			pl.CNIReports = append(pl.CNIReports, cniReport)
-		case npm:
-			npmReport := x.(NPMReport)
-			npmReport.Metadata = metadata
-			pl.NPMReports = append(pl.NPMReports, npmReport)
-		case cns:
-			cnsReport := x.(CNSReport)
-			cnsReport.Metadata = metadata
-			pl.CNSReports = append(pl.CNSReports, cnsReport)
-		}
-	}
-}
-
-// reset - reset payload slices and sets payloadSize to 0
-func (pl *Payload) reset() {
-	pl.DNCReports = nil
-	pl.DNCReports = make([]DNCReport, 0)
-	pl.CNIReports = nil
-	pl.CNIReports = make([]CNIReport, 0)
-	pl.NPMReports = nil
-	pl.NPMReports = make([]NPMReport, 0)
-	pl.CNSReports = nil
-	pl.CNSReports = make([]CNSReport, 0)
-	payloadSize = 0
-}
-
-// payloadCapNotExceeded - Returns whether payload cap will be exceeded as a result of adding the new report; and the report type
-//                         If the cap is not exceeded, we update the payload size here.
-func (pl *Payload) payloadCapNotExceeded(x interface{}) (notExceeded bool, reportType string) {
-	var body bytes.Buffer
 	switch x.(type) {
 	case DNCReport:
-		reportType = dnc
-		json.NewEncoder(&body).Encode(x.(DNCReport))
+		dncReport := x.(DNCReport)
+		dncReport.Metadata = metadata
+		buf.DNCReports = append(buf.DNCReports, dncReport)
 	case CNIReport:
-		reportType = cni
-		json.NewEncoder(&body).Encode(x.(CNIReport))
+		cniReport := x.(CNIReport)
+		cniReport.Metadata = metadata
+		buf.CNIReports = append(buf.CNIReports, cniReport)
 	case NPMReport:
-		reportType = npm
-		json.NewEncoder(&body).Encode(x.(NPMReport))
+		npmReport := x.(NPMReport)
+		npmReport.Metadata = metadata
+		buf.NPMReports = append(buf.NPMReports, npmReport)
 	case CNSReport:
-		reportType = cns
-		json.NewEncoder(&body).Encode(x.(CNSReport))
+		cnsReport := x.(CNSReport)
+		cnsReport.Metadata = metadata
+		buf.CNSReports = append(buf.CNSReports, cnsReport)
 	}
+}
 
-	updatedPayloadSize := uint16(body.Len()) + payloadSize
-	if notExceeded = updatedPayloadSize < MaxPayloadSize && payloadSize < updatedPayloadSize; notExceeded {
-		payloadSize = updatedPayloadSize
-	}
-
-	return
+// reset - reset buffer slices and sets payloadSize to 0
+func (buf *Buffer) reset() {
+	buf.DNCReports = nil
+	buf.DNCReports = make([]DNCReport, 0)
+	buf.CNIReports = nil
+	buf.CNIReports = make([]CNIReport, 0)
+	buf.NPMReports = nil
+	buf.NPMReports = make([]NPMReport, 0)
+	buf.CNSReports = nil
+	buf.CNSReports = make([]CNSReport, 0)
+	payloadSize = 0
 }
 
 // saveHostMetadata - save metadata got from wireserver to json file
@@ -375,7 +458,7 @@ func saveHostMetadata(metadata Metadata) error {
 	}
 
 	if err = ioutil.WriteFile(metadataFile, dataBytes, 0644); err != nil {
-		log.Printf("[Telemetry] Writing metadata to file failed: %v", err)
+		log.Logf("[Telemetry] Writing metadata to file failed: %v", err)
 	}
 
 	return err
@@ -391,7 +474,7 @@ func getHostMetadata() (Metadata, error) {
 		}
 	}
 
-	log.Printf("[Telemetry] Request metadata from wireserver")
+	log.Logf("[Telemetry] Request metadata from wireserver")
 
 	req, err := http.NewRequest("GET", metadataURL, nil)
 	if err != nil {
@@ -438,14 +521,14 @@ func WaitForTelemetrySocket(maxAttempt int, waitTimeInMillisecs time.Duration) {
 func StartTelemetryService(path string, args []string) error {
 	platform.KillProcessByName(TelemetryServiceProcessName)
 
-	log.Printf("[Telemetry] Starting telemetry service process :%v args:%v", path, args)
+	log.Logf("[Telemetry] Starting telemetry service process :%v args:%v", path, args)
 
 	if err := common.StartProcess(path, args); err != nil {
-		log.Printf("[Telemetry] Failed to start telemetry service process :%v", err)
+		log.Logf("[Telemetry] Failed to start telemetry service process :%v", err)
 		return err
 	}
 
-	log.Printf("[Telemetry] Telemetry service started")
+	log.Logf("[Telemetry] Telemetry service started")
 
 	return nil
 }
@@ -456,12 +539,12 @@ func ReadConfigFile(filePath string) (TelemetryConfig, error) {
 
 	b, err := ioutil.ReadFile(filePath)
 	if err != nil {
-		log.Printf("[Telemetry] Failed to read telemetry config: %v", err)
+		log.Logf("[Telemetry] Failed to read telemetry config: %v", err)
 		return config, err
 	}
 
 	if err = json.Unmarshal(b, &config); err != nil {
-		log.Printf("[Telemetry] unmarshal failed with %v", err)
+		log.Logf("[Telemetry] unmarshal failed with %v", err)
 	}
 
 	return config, err
@@ -473,16 +556,27 @@ func (tb *TelemetryBuffer) ConnectToTelemetryService(telemetryNumRetries, teleme
 	args := []string{"-d", dir}
 	for attempt := 0; attempt < 2; attempt++ {
 		if err := tb.Connect(); err != nil {
-			log.Printf("Connection to telemetry socket failed: %v", err)
+			log.Logf("Connection to telemetry socket failed: %v", err)
 			tb.Cleanup(FdName)
 			StartTelemetryService(path, args)
 			WaitForTelemetrySocket(telemetryNumRetries, time.Duration(telemetryWaitTimeInMilliseconds))
 		} else {
 			tb.Connected = true
-			log.Printf("Connected to telemetry service")
+			log.Logf("Connected to telemetry service")
 			return
 		}
 	}
+}
+
+// TryToConnectToTelemetryService - Attempt to connect telemetry process without spawning it if it's not already running.
+func (tb *TelemetryBuffer) TryToConnectToTelemetryService() {
+	if err := tb.Connect(); err != nil {
+		log.Logf("Connection to telemetry socket failed: %v", err)
+		return
+	}
+
+	tb.Connected = true
+	log.Logf("Connected to telemetry service")
 }
 
 func getTelemetryServiceDirectory() (path string, dir string) {
@@ -492,7 +586,7 @@ func getTelemetryServiceDirectory() (path string, dir string) {
 		exDir := filepath.Dir(ex)
 		path = fmt.Sprintf("%v/%v", exDir, TelemetryServiceProcessName)
 		if exists, _ = common.CheckIfFileExists(path); !exists {
-			log.Printf("Skip starting telemetry service as file didn't exist")
+			log.Logf("Skip starting telemetry service as file didn't exist")
 			return
 		}
 		dir = exDir

--- a/telemetry/telemetrybuffer.go
+++ b/telemetry/telemetrybuffer.go
@@ -9,10 +9,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net"
 	"net/http"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -282,7 +284,9 @@ func (tb *TelemetryBuffer) sendToHost() error {
 		NPMReports: make([]NPMReport, 0),
 		CNSReports: make([]CNSReport, 0),
 	}
-	i, payloadSize, maxPayloadSizeReached := 0, 0, false
+
+	seed := rand.NewSource(time.Now().UnixNano())
+	i, payloadSize, maxPayloadSizeReached := rand.New(seed).Intn(reflect.ValueOf(&buf).Elem().NumField()), 0, false
 	isDNCReportsEmpty, isCNIReportsEmpty, isCNSReportsEmpty, isNPMReportsEmpty := false, false, false, false
 	for {
 		// craft payload in a round-robin manner.

--- a/telemetry/telemetrybuffer.go
+++ b/telemetry/telemetrybuffer.go
@@ -84,10 +84,10 @@ func NewTelemetryBuffer(hostReportURL string) *TelemetryBuffer {
 	tb.data = make(chan interface{}, 1000)
 	tb.cancel = make(chan bool, 1)
 	tb.connections = make([]net.Conn, 0)
-	tb.buffer.DNCReports = make([]DNCReport, 0)
-	tb.buffer.CNIReports = make([]CNIReport, 0)
-	tb.buffer.NPMReports = make([]NPMReport, 0)
-	tb.buffer.CNSReports = make([]CNSReport, 0)
+	tb.buffer.DNCReports = make([]DNCReport, 1000)
+	tb.buffer.CNIReports = make([]CNIReport, 1000)
+	tb.buffer.NPMReports = make([]NPMReport, 1000)
+	tb.buffer.CNSReports = make([]CNSReport, 1000)
 
 	return &tb
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR contains:

1. Changing the telemetrybuffer to message queue model. This is because in previous model, a burst of logs will be dropped since the previous buffer only holds up to 4KB. Now, the buffer holds up to 1MB and will send 4KB every 30 seconds in a FIFO order. The payload sent to host is crafted in a round-robin manner so that every component(DNC/CNI/CNS/NPM) will get its chance to send.

2. Enabling Azure-NPM telemetry.

**Special notes for your reviewer**:

Requires a new release after this PR is merged.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
`NONE`