### PR TITLE
CNS Changes to support Host to NC Communication 

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -56,6 +56,7 @@ type CreateNetworkContainerRequest struct {
 	MultiTenancyInfo           MultiTenancyInfo
 	CnetAddressSpace           []IPSubnet // To setup SNAT (should include service endpoint vips).
 	Routes                     []Route
+	AllowHostToNCCommunication bool
 }
 
 // ConfigureContainerNetworkingRequest - specifies request to attach/detach container to network.
@@ -135,6 +136,7 @@ type GetNetworkContainerResponse struct {
 	PrimaryInterfaceIdentifier string
 	LocalIPConfiguration       IPConfiguration
 	Response                   Response
+	AllowHostToNCCommunication bool
 }
 
 // DeleteNetworkContainerRequest specifies the details about the request to delete a specifc network container.

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -1207,6 +1207,7 @@ func (service *HTTPRestService) getNetworkContainerResponse(req cns.GetNetworkCo
 		MultiTenancyInfo:           savedReq.MultiTenancyInfo,
 		PrimaryInterfaceIdentifier: savedReq.PrimaryInterfaceIdentifier,
 		LocalIPConfiguration:       savedReq.LocalIPConfiguration,
+		AllowHostToNCCommunication: savedReq.AllowHostToNCCommunication,
 	}
 
 	return getNetworkContainerResponse


### PR DESCRIPTION
Change basically adds a flag to indicate whether Host to NC Communication is needed or not. If yes, CNI will do the needful, otherswise regular workflow will be executed.