### PR TITLE
Return Correct Invoke CNI Error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   setup-and-test:
     # docker:
-    # - image: golang:1.10
+    # - image: golang:1.12
     machine:
       image: circleci/classic:latest
     steps:
@@ -15,14 +15,14 @@ jobs:
             sudo -E env "PATH=$PATH" apt-get install -y ipset
             sudo -E env "PATH=$PATH" apt-get install -y python3-dev gcc
             sudo -E env "PATH=$PATH" pip install coverage
-            mkdir -p /home/circleci/go1-10
+            mkdir -p /home/circleci/go1-12
             mkdir --parents /home/circleci/.goproject/src/github.com/Azure/azure-container-networking
-            wget https://storage.googleapis.com/golang/go1.10.2.linux-amd64.tar.gz
-            tar -C /home/circleci/go1-10 -xvf go1.10.2.linux-amd64.tar.gz
-            rm go1.10.2.linux-amd64.tar.gz
+            wget https://storage.googleapis.com/golang/go1.12.6.linux-amd64.tar.gz
+            tar -C /home/circleci/go1-12 -xvf go1.12.6.linux-amd64.tar.gz
+            rm go1.12.6.linux-amd64.tar.gz
             mv * /home/circleci/.goproject/src/github.com/Azure/azure-container-networking
             cd /home/circleci/.goproject/src/github.com/Azure/azure-container-networking
-            export GOROOT='/home/circleci/go1-10/go'
+            export GOROOT='/home/circleci/go1-12/go'
             export GOPATH='/home/circleci/.goproject'
             export PATH=$GOROOT/bin:$PATH
             go get ./...

--- a/cns/networkcontainers/networkcontainers.go
+++ b/cns/networkcontainers/networkcontainers.go
@@ -153,7 +153,7 @@ func pluginErr(err error, output []byte) error {
 		}
 	} else if len(output) > 0 {
 		var cniError cniTypes.Error
-		if err = json.Unmarshal(output, &cniError); err == nil && cniError.Code != 0 {
+		if unmarshalErr := json.Unmarshal(output, &cniError); unmarshalErr == nil && cniError.Code != 0 {
 			return fmt.Errorf("netplugin completed with error: %+v", cniError)
 		}
 	}

--- a/cns/networkcontainers/networkcontainers.go
+++ b/cns/networkcontainers/networkcontainers.go
@@ -152,6 +152,7 @@ func pluginErr(err error, output []byte) error {
 			return &emsg
 		}
 	} else if len(output) > 0 {
+		// If plugin err is nil, we will only return error if we successfully unmarshal Error struct from CNI and Code != 0
 		var cniError cniTypes.Error
 		if unmarshalErr := json.Unmarshal(output, &cniError); unmarshalErr == nil && cniError.Code != 0 {
 			return fmt.Errorf("netplugin completed with error: %+v", cniError)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
- We only want to return an error when CNI prints the Error struct to stdout. If the Error struct doesn't exist then the operation is considered successful.
- Updating Circle CI to use Golang v1.12.6

**Test**
Azure Batch has tested and confirmed that this resolved their problem with unmarshal errors affecting attach network API.