### PR TITLE
Fix bug for returned error from CNI

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -523,12 +523,14 @@ func (plugin *netPlugin) Get(args *cniSkel.CmdArgs) error {
 		}
 		result.Interfaces = append(result.Interfaces, iface)
 
-		if err == nil {
-			// Convert result to the requested CNI version.
-			res, err := result.GetAsVersion(nwCfg.CNIVersion)
-			if err != nil {
-				err = plugin.Error(err)
-			}
+		// Convert result to the requested CNI version.
+		res, vererr := result.GetAsVersion(nwCfg.CNIVersion)
+		if vererr != nil {
+			log.Printf("GetAsVersion failed with error %v", vererr)
+			plugin.Error(vererr)
+		}
+
+		if err == nil && res != nil {
 			// Output the result to stdout.
 			res.Print()
 		}
@@ -537,8 +539,7 @@ func (plugin *netPlugin) Get(args *cniSkel.CmdArgs) error {
 	}()
 
 	// Parse network configuration from stdin.
-	nwCfg, err = cni.ParseNetworkConfig(args.StdinData)
-	if err != nil {
+	if nwCfg, err = cni.ParseNetworkConfig(args.StdinData); err != nil {
 		err = plugin.Errorf("Failed to parse network configuration: %v.", err)
 		return err
 	}
@@ -546,29 +547,27 @@ func (plugin *netPlugin) Get(args *cniSkel.CmdArgs) error {
 	log.Printf("[cni-net] Read network configuration %+v.", nwCfg)
 
 	// Parse Pod arguments.
-	k8sPodName, k8sNamespace, err := plugin.getPodInfo(args.Args)
-	if err != nil {
+	var k8sPodName, k8sNamespace string
+	if k8sPodName, k8sNamespace, err = plugin.getPodInfo(args.Args); err != nil {
 		return err
 	}
 
 	// Initialize values from network config.
-	networkId, err := getNetworkName(k8sPodName, k8sNamespace, args.IfName, nwCfg)
-	if err != nil {
+	var networkId string
+	if networkId, err = getNetworkName(k8sPodName, k8sNamespace, args.IfName, nwCfg); err != nil {
 		log.Printf("[cni-net] Failed to extract network name from network config. error: %v", err)
 	}
 
 	endpointId := GetEndpointID(args)
 
 	// Query the network.
-	_, err = plugin.nm.GetNetworkInfo(networkId)
-	if err != nil {
+	if _, err = plugin.nm.GetNetworkInfo(networkId); err != nil {
 		plugin.Errorf("Failed to query network: %v", err)
 		return err
 	}
 
 	// Query the endpoint.
-	epInfo, err = plugin.nm.GetEndpointInfo(networkId, endpointId)
-	if err != nil {
+	if epInfo, err = plugin.nm.GetEndpointInfo(networkId, endpointId); err != nil {
 		plugin.Errorf("Failed to query endpoint: %v", err)
 		return err
 	}
@@ -696,8 +695,7 @@ func (plugin *netPlugin) Update(args *cniSkel.CmdArgs) error {
 		args.Netns, args.Args, args.Path)
 
 	// Parse network configuration from stdin.
-	nwCfg, err = cni.ParseNetworkConfig(args.StdinData)
-	if err != nil {
+	if nwCfg, err = cni.ParseNetworkConfig(args.StdinData); err != nil {
 		err = plugin.Errorf("Failed to parse network configuration: %v.", err)
 		return err
 	}
@@ -727,9 +725,9 @@ func (plugin *netPlugin) Update(args *cniSkel.CmdArgs) error {
 	}()
 
 	// Parse Pod arguments.
-	podCfg, err := cni.ParseCniArgs(args.Args)
-	if err != nil {
-		log.Printf("Error while parsing CNI Args during UPDATE %v", err)
+	var podCfg *cni.K8SPodEnvArgs
+	if podCfg, err = cni.ParseCniArgs(args.Args); err != nil {
+		log.Printf("[cni-net] Error while parsing CNI Args during UPDATE %v", err)
 		return err
 	}
 
@@ -751,8 +749,7 @@ func (plugin *netPlugin) Update(args *cniSkel.CmdArgs) error {
 	networkID := nwCfg.Name
 
 	// Query the network.
-	_, err = plugin.nm.GetNetworkInfo(networkID)
-	if err != nil {
+	if _, err = plugin.nm.GetNetworkInfo(networkID); err != nil {
 		errMsg := fmt.Sprintf("Failed to query network during CNI UPDATE: %v", err)
 		log.Printf(errMsg)
 		return plugin.Errorf(errMsg)
@@ -764,14 +761,14 @@ func (plugin *netPlugin) Update(args *cniSkel.CmdArgs) error {
 	if err != nil {
 		plugin.Errorf("Failed to retrieve target endpoint for CNI UPDATE [name=%v, namespace=%v]: %v", k8sPodName, k8sNamespace, err)
 		return err
-	} else {
-		log.Printf("Retrieved existing endpoint from state that may get update: %+v", existingEpInfo)
 	}
+
+	log.Printf("Retrieved existing endpoint from state that may get update: %+v", existingEpInfo)
 
 	// now query CNS to get the target routes that should be there in the networknamespace (as a result of update)
 	log.Printf("Going to collect target routes for [name=%v, namespace=%v] from CNS.", k8sPodName, k8sNamespace)
-	cnsClient, err := cnsclient.NewCnsClient(nwCfg.CNSUrl)
-	if err != nil {
+	var cnsClient *cnsclient.CNSClient
+	if cnsClient, err = cnsclient.NewCnsClient(nwCfg.CNSUrl); err != nil {
 		log.Printf("Initializing CNS client error in CNI Update%v", err)
 		log.Printf(err.Error())
 		return plugin.Errorf(err.Error())
@@ -779,14 +776,14 @@ func (plugin *netPlugin) Update(args *cniSkel.CmdArgs) error {
 
 	// create struct with info for target POD
 	podInfo := cns.KubernetesPodInfo{PodName: k8sPodName, PodNamespace: k8sNamespace}
-	orchestratorContext, err := json.Marshal(podInfo)
-	if err != nil {
+	var []byte orchestratorContext
+	if orchestratorContext, err = json.Marshal(podInfo); err != nil {
 		log.Printf("Marshalling KubernetesPodInfo failed with %v", err)
 		return plugin.Errorf(err.Error())
 	}
 
-	targetNetworkConfig, err := cnsClient.GetNetworkConfiguration(orchestratorContext)
-	if err != nil {
+	var targetNetworkConfig *cns.GetNetworkContainerResponse
+	if targetNetworkConfig, err = cnsClient.GetNetworkConfiguration(orchestratorContext); err != nil {
 		log.Printf("GetNetworkConfiguration failed with %v", err)
 		return plugin.Errorf(err.Error())
 	}
@@ -831,8 +828,7 @@ func (plugin *netPlugin) Update(args *cniSkel.CmdArgs) error {
 
 	// Update the endpoint.
 	log.Printf("Now updating existing endpoint %v with targetNetworkConfig %+v.", existingEpInfo.Id, targetNetworkConfig)
-	err = plugin.nm.UpdateEndpoint(networkID, existingEpInfo, targetEpInfo)
-	if err != nil {
+	if err = plugin.nm.UpdateEndpoint(networkID, existingEpInfo, targetEpInfo); err != nil {
 		err = plugin.Errorf("Failed to update endpoint: %v", err)
 		return err
 	}

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -776,7 +776,7 @@ func (plugin *netPlugin) Update(args *cniSkel.CmdArgs) error {
 
 	// create struct with info for target POD
 	podInfo := cns.KubernetesPodInfo{PodName: k8sPodName, PodNamespace: k8sNamespace}
-	var []byte orchestratorContext
+	var orchestratorContext []byte
 	if orchestratorContext, err = json.Marshal(podInfo); err != nil {
 		log.Printf("Marshalling KubernetesPodInfo failed with %v", err)
 		return plugin.Errorf(err.Error())


### PR DESCRIPTION
Variable err is overwritten in CNI functions - ADD, DEL, GET and UPDATE.
This causes the functions to return nil error even though there is
a valid error. This changes fixes the bug and returns the correct
error from CNI functions.