### PR TITLE
Update base image for Azure-NPM and Azure-vnet-telemetry

### DIFF
--- a/cni/telemetry/Dockerfile
+++ b/cni/telemetry/Dockerfile
@@ -1,5 +1,5 @@
 # Use a minimal image as a parent image
-FROM ubuntu:18.04
+FROM ubuntu:19.10
 ARG TELEMETRY_BUILD_DIR
 ARG TELEMETRY_CONF_DIR
 

--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -1,5 +1,5 @@
 # Use a minimal image as a parent image
-FROM ubuntu:18.04
+FROM ubuntu:19.10
 ARG NPM_BUILD_DIR
 
 # Install dependencies.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR updates base image for Azure-NPM and Azure-vnet-telemetry to Ubuntu 19.10.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

This version of Ubuntu fixes a [bzip2 vulnerability](https://lists.ubuntu.com/archives/ubuntu-security-announce/2019-June/004983.html).

**Special notes for your reviewer**:

None

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
None
```