### PR TITLE
Exposed a new API to get number of CPU Cores on a Node

### DIFF
--- a/cns/api.go
+++ b/cns/api.go
@@ -18,6 +18,7 @@ const (
 	GetIPAddressUtilizationPath = "/network/ip/utilization"
 	GetUnhealthyIPAddressesPath = "/network/ipaddresses/unhealthy"
 	GetHealthReportPath         = "/network/health"
+	NumberOfCPUCoresPath        = "/network/hostcpucores"
 	V1Prefix                    = "/v0.1"
 	V2Prefix                    = "/v0.2"
 )
@@ -137,6 +138,12 @@ type NodeConfiguration struct {
 type Response struct {
 	ReturnCode int
 	Message    string
+}
+
+// getNumberOfCPUCores describes reponse that returns the host local IP Address.
+type NumOfCPUCoresResponse struct {
+	Response      Response
+	NumOfCPUCores int
 }
 
 // OptionMap describes generic options that can be passed to CNS.

--- a/cns/api.go
+++ b/cns/api.go
@@ -140,7 +140,7 @@ type Response struct {
 	Message    string
 }
 
-// getNumberOfCPUCores describes reponse that returns num of cpu cores present on host.
+// NumOfCPUCoresResponse describes reponse that returns num of cpu cores present on host.
 type NumOfCPUCoresResponse struct {
 	Response      Response
 	NumOfCPUCores int

--- a/cns/api.go
+++ b/cns/api.go
@@ -18,7 +18,7 @@ const (
 	GetIPAddressUtilizationPath = "/network/ip/utilization"
 	GetUnhealthyIPAddressesPath = "/network/ipaddresses/unhealthy"
 	GetHealthReportPath         = "/network/health"
-	NumberOfCPUCoresPath        = "/network/hostcpucores"
+	NumberOfCPUCoresPath        = "/hostcpucores"
 	V1Prefix                    = "/v0.1"
 	V2Prefix                    = "/v0.2"
 )
@@ -140,7 +140,7 @@ type Response struct {
 	Message    string
 }
 
-// getNumberOfCPUCores describes reponse that returns the host local IP Address.
+// getNumberOfCPUCores describes reponse that returns num of cpu cores present on host.
 type NumOfCPUCoresResponse struct {
 	Response      Response
 	NumOfCPUCores int

--- a/cns/api.go
+++ b/cns/api.go
@@ -140,7 +140,7 @@ type Response struct {
 	Message    string
 }
 
-// NumOfCPUCoresResponse describes reponse that returns num of cpu cores present on host.
+// NumOfCPUCoresResponse describes num of cpu cores present on host.
 type NumOfCPUCoresResponse struct {
 	Response      Response
 	NumOfCPUCores int

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -21,6 +21,7 @@ const (
 	UnknownContainerID           = 18
 	UnsupportedOrchestratorType  = 19
 	DockerContainerNotSpecified  = 20
+	UnsupportedVerb              = 21
 	UnexpectedError              = 99
 )
 

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -1583,9 +1583,11 @@ func (service *HTTPRestService) getNumberOfCPUCores(w http.ResponseWriter, r *ht
 	log.Printf("[Azure-CNS] getNumberOfCPUCores")
 	log.Request(service.Name, "getNumberOfCPUCores", nil)
 
-	var num int
-	var returnCode int
-	var errMsg string
+	var (
+		num        int
+		returnCode int
+		errMsg     string
+	)
 
 	switch r.Method {
 	case "GET":

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -1580,22 +1580,22 @@ func (service *HTTPRestService) getNetPluginDetails() *networkcontainers.NetPlug
 // Retrieves the number of logic processors on a node. It will be primarily
 // used to enforce per VM delegated NIC limit by DNC.
 func (service *HTTPRestService) getNumberOfCPUCores(w http.ResponseWriter, r *http.Request) {
-	log.Printf("[Azure CNS] getNumberOfCPUCores")
+	log.Printf("[Azure-CNS] getNumberOfCPUCores")
 	log.Request(service.Name, "getNumberOfCPUCores", nil)
 
-	var num = 0
-	var returnCode = 0
-	var errmsg string
+	var num int
+	var returnCode int
+	var errMsg string
 
 	switch r.Method {
 	case "GET":
 		num = runtime.NumCPU()
 	default:
-		errmsg = "[Azure-CNS] getNumberOfCPUCores API expects a GET."
+		errMsg = "[Azure-CNS] getNumberOfCPUCores API expects a GET."
 		returnCode = UnsupportedVerb
 	}
 
-	resp := cns.Response{ReturnCode: returnCode, Message: errmsg}
+	resp := cns.Response{ReturnCode: returnCode, Message: errMsg}
 	numOfCPUCoresResp := cns.NumOfCPUCoresResponse{
 		Response:      resp,
 		NumOfCPUCores: num,

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"runtime"
 	"sync"
 	"time"
 
@@ -157,6 +158,7 @@ func (service *HTTPRestService) Start(config *common.ServiceConfig) error {
 	listener.AddHandler(cns.DetachContainerFromNetwork, service.detachNetworkContainerFromNetwork)
 	listener.AddHandler(cns.CreateHnsNetworkPath, service.createHnsNetwork)
 	listener.AddHandler(cns.DeleteHnsNetworkPath, service.deleteHnsNetwork)
+	listener.AddHandler(cns.NumberOfCPUCoresPath, service.getNumberOfCPUCores)
 
 	// handlers for v0.2
 	listener.AddHandler(cns.V2Prefix+cns.SetEnvironmentPath, service.setEnvironment)
@@ -177,6 +179,7 @@ func (service *HTTPRestService) Start(config *common.ServiceConfig) error {
 	listener.AddHandler(cns.V2Prefix+cns.DetachContainerFromNetwork, service.detachNetworkContainerFromNetwork)
 	listener.AddHandler(cns.V2Prefix+cns.CreateHnsNetworkPath, service.createHnsNetwork)
 	listener.AddHandler(cns.V2Prefix+cns.DeleteHnsNetworkPath, service.deleteHnsNetwork)
+	listener.AddHandler(cns.V2Prefix+cns.NumberOfCPUCoresPath, service.getNumberOfCPUCores)
 
 	log.Printf("[Azure CNS]  Listening.")
 	return nil
@@ -1572,4 +1575,33 @@ func (service *HTTPRestService) getNetPluginDetails() *networkcontainers.NetPlug
 	pluginBinPath, _ := service.GetOption(acn.OptNetPluginPath).(string)
 	configPath, _ := service.GetOption(acn.OptNetPluginConfigFile).(string)
 	return networkcontainers.NewNetPluginConfiguration(pluginBinPath, configPath)
+}
+
+// Retrieves the number of logic processors on a node. It will be primarily
+// used to enforce per VM delegated NIC limit by DNC.
+func (service *HTTPRestService) getNumberOfCPUCores(w http.ResponseWriter, r *http.Request) {
+	log.Printf("[Azure CNS] getNumberOfCPUCores")
+	log.Request(service.Name, "getNumberOfCPUCores", nil)
+
+	var num = 0
+	var returnCode = 0
+	var errmsg string
+
+	switch r.Method {
+	case "GET":
+		num = runtime.NumCPU()
+	default:
+		errmsg = "[Azure-CNS] getNumberOfCPUCores API expects a GET."
+		returnCode = UnsupportedVerb
+	}
+
+	resp := cns.Response{ReturnCode: returnCode, Message: errmsg}
+	numOfCPUCoresResp := cns.NumOfCPUCoresResponse{
+		Response:      resp,
+		NumOfCPUCores: num,
+	}
+
+	err := service.Listener.Encode(w, &numOfCPUCoresResp)
+
+	log.Response(service.Name, numOfCPUCoresResp, resp.ReturnCode, ReturnCodeToString(resp.ReturnCode), err)
 }

--- a/cns/restserver/restserver_test.go
+++ b/cns/restserver/restserver_test.go
@@ -693,12 +693,15 @@ func TestGetInterfaceForNetworkContainer(t *testing.T) {
 func TestGetNumOfCPUCores(t *testing.T) {
 	fmt.Println("Test: getNumberOfCPUCores")
 
-	req, err := http.NewRequest(http.MethodGet, cns.NumberOfCPUCoresPath, nil)
+	var err error
+	var req *http.Request
+	req, err = http.NewRequest(http.MethodGet, cns.NumberOfCPUCoresPath, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	w := httptest.NewRecorder()
+	var w *httptest.ResponseRecorder
+	w = httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 	var numOfCoresResponse cns.NumOfCPUCoresResponse
 

--- a/cns/restserver/restserver_test.go
+++ b/cns/restserver/restserver_test.go
@@ -693,8 +693,11 @@ func TestGetInterfaceForNetworkContainer(t *testing.T) {
 func TestGetNumOfCPUCores(t *testing.T) {
 	fmt.Println("Test: getNumberOfCPUCores")
 
-	var err error
-	var req *http.Request
+	var (
+		err error
+		req *http.Request
+	)
+
 	req, err = http.NewRequest(http.MethodGet, cns.NumberOfCPUCoresPath, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/cns/restserver/restserver_test.go
+++ b/cns/restserver/restserver_test.go
@@ -689,3 +689,23 @@ func TestGetInterfaceForNetworkContainer(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestGetNumOfCPUCores(t *testing.T) {
+	fmt.Println("Test: getNumberOfCPUCores")
+
+	req, err := http.NewRequest(http.MethodGet, cns.NumberOfCPUCoresPath, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	var numOfCoresResponse cns.NumOfCPUCoresResponse
+
+	err = decodeResponse(w, &numOfCoresResponse)
+	if err != nil || numOfCoresResponse.Response.ReturnCode != 0 {
+		t.Errorf("getNumberOfCPUCores failed with response %+v", numOfCoresResponse)
+	} else {
+		fmt.Printf("getNumberOfCPUCores Responded with %+v\n", numOfCoresResponse)
+	}
+}


### PR DESCRIPTION
Exposed a new API to get number of CPU Cores on a Node. This will be used by DNC eventually to enforce per node NIC limit which is dependent on number of cores.

DNC before allocating a NIC, will get query a node for number of cores and see if the limit ha already been achieved,