### PR TITLE
CNS: Do not start CNM by default

### DIFF
--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -111,9 +111,9 @@ var args = acn.ArgumentList{
 		DefaultValue: "",
 	},
 	{
-		Name:         acn.OptStopAzureVnet,
-		Shorthand:    acn.OptStopAzureVnetAlias,
-		Description:  "Stop Azure-CNM if flag is true",
+		Name:         acn.OptStartAzureCNM,
+		Shorthand:    acn.OptStartAzureCNMAlias,
+		Description:  "Start Azure-CNM if flag is set",
 		Type:         "bool",
 		DefaultValue: false,
 	},
@@ -162,7 +162,6 @@ func printVersion() {
 
 // Main is the entry point for CNS.
 func main() {
-	var stopcnm = true
 	// Initialize and parse command line arguments.
 	acn.ParseArgs(&args, printVersion)
 
@@ -176,7 +175,7 @@ func main() {
 	logDirectory := acn.GetArg(acn.OptLogLocation).(string)
 	ipamQueryUrl, _ := acn.GetArg(acn.OptIpamQueryUrl).(string)
 	ipamQueryInterval, _ := acn.GetArg(acn.OptIpamQueryInterval).(int)
-	stopcnm = acn.GetArg(acn.OptStopAzureVnet).(bool)
+	startCNM := acn.GetArg(acn.OptStartAzureCNM).(bool)
 	vers := acn.GetArg(acn.OptVersion).(bool)
 	createDefaultExtNetworkType := acn.GetArg(acn.OptCreateDefaultExtNetworkType).(string)
 	telemetryEnabled := acn.GetArg(acn.OptTelemetry).(bool)
@@ -271,7 +270,7 @@ func main() {
 	var netPlugin network.NetPlugin
 	var ipamPlugin ipam.IpamPlugin
 
-	if !stopcnm {
+	if startCNM {
 		var pluginConfig acn.PluginConfig
 		pluginConfig.Version = version
 
@@ -344,7 +343,7 @@ func main() {
 
 	telemetryStopProcessing <- true
 
-	if !stopcnm {
+	if startCNM {
 		if netPlugin != nil {
 			netPlugin.Stop()
 		}

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -162,7 +162,7 @@ func printVersion() {
 
 // Main is the entry point for CNS.
 func main() {
-	var stopcnm = false
+	var stopcnm = true
 	// Initialize and parse command line arguments.
 	acn.ParseArgs(&args, printVersion)
 

--- a/common/config.go
+++ b/common/config.go
@@ -44,9 +44,9 @@ const (
 	OptIpamQueryInterval      = "ipam-query-interval"
 	OptIpamQueryIntervalAlias = "i"
 
-	// Don't Start CNM
-	OptStopAzureVnet      = "stop-azure-cnm"
-	OptStopAzureVnetAlias = "stopcnm"
+	// Start CNM
+	OptStartAzureCNM      = "start-azure-cnm"
+	OptStartAzureCNMAlias = "startcnm"
 
 	// Interval to send reports to host
 	OptReportToHostInterval      = "report-interval"


### PR DESCRIPTION
CNM starts by default when CNS starts. This change prevents CNM
from starting by default. stopcnm commandline option can be used
to start CNM if needed.
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```