### PR TITLE
Fix for CNI lock timedout issue.

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -22,8 +22,6 @@ import (
 )
 
 const (
-	// Plugin name.
-	name                = "azure-vnet"
 	dockerNetworkOption = "com.docker.network.generic"
 	opModeTransparent   = "transparent"
 	// Supported IP version. Currently support only IPv4
@@ -45,7 +43,7 @@ type netPlugin struct {
 }
 
 // NewPlugin creates a new netPlugin object.
-func NewPlugin(config *common.PluginConfig) (*netPlugin, error) {
+func NewPlugin(name string, config *common.PluginConfig) (*netPlugin, error) {
 	// Setup base plugin.
 	plugin, err := cni.NewPlugin(name, config.Version)
 	if err != nil {
@@ -101,7 +99,6 @@ func (plugin *netPlugin) Stop() {
 	plugin.nm.Uninitialize()
 	plugin.Uninitialize()
 	log.Printf("[cni-net] Plugin stopped.")
-	log.Close()
 }
 
 // FindMasterInterface returns the name of the master interface.

--- a/common/utils.go
+++ b/common/utils.go
@@ -46,7 +46,7 @@ func LogNetworkInterfaces() {
 
 	for _, iface := range interfaces {
 		addrs, _ := iface.Addrs()
-		log.Printf("[net] Network interface: %+v with IP addresses: %+v", iface, addrs)
+		log.Printf("[net] Network interface: %+v with IP: %+v", iface, addrs)
 	}
 }
 

--- a/network/manager.go
+++ b/network/manager.go
@@ -182,10 +182,7 @@ func (nm *networkManager) restore() error {
 	for _, extIf := range nm.ExternalInterfaces {
 		log.Printf("External Interface %+v", extIf)
 		for _, nw := range extIf.Networks {
-			log.Printf("network %+v", nw)
-			for _, ep := range nw.Endpoints {
-				log.Printf("endpoint %+v", ep)
-			}
+			log.Printf("Number of endpoints: %d", len(nw.Endpoints))
 		}
 	}
 

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -211,6 +211,7 @@ func (reportMgr *ReportManager) SendReport(tb *TelemetryBuffer) error {
 		if err == nil {
 			// If write fails, try to re-establish connections as server/client
 			if _, err = tb.Write(report); err != nil {
+				log.Printf("[Telelmetry] Telelmtry write failed: %v", err)
 				tb.Cancel()
 			}
 		}

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -211,7 +211,6 @@ func (reportMgr *ReportManager) SendReport(tb *TelemetryBuffer) error {
 		if err == nil {
 			// If write fails, try to re-establish connections as server/client
 			if _, err = tb.Write(report); err != nil {
-				log.Printf("[Telelmetry] Telelmtry write failed: %v", err)
 				tb.Cancel()
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
This PR fixes CNI locktimeout issue in linux. If there are multiple cni calls at same time, then all process will try to start telemetry process and eventually endup in undesirable state( cni plugin hangs at telemetry write and lock not released). For this, moved starting telemetry service inside lock code. Fix for #372 
Also moved log setup out of newplugin function to main code.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```