### PR TITLE
Increase the log size from 5MB to 16MB

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -37,7 +37,7 @@ const (
 	logFilePerm      = os.FileMode(0664)
 
 	// Log file rotation default limits, in bytes.
-	maxLogFileSize   = 5 * 1024 * 1024
+	maxLogFileSize   = 16 * 1024 * 1024
 	maxLogFileCount  = 8
 	rotationCheckFrq = 8
 )


### PR DESCRIPTION
Change the log file size from 5MB to 16MB to accommodate the logs on busy clusters