### PR TITLE
Fix saveNCGoalState bug for WebApps containerType

### DIFF
--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -1032,6 +1032,8 @@ func (service *HTTPRestService) saveNetworkContainerGoalState(req cns.CreateNetw
 	case cns.JobObject:
 		fallthrough
 	case cns.COW:
+		fallthrough
+	case cns.WebApps:
 		switch service.state.OrchestratorType {
 		case cns.Kubernetes:
 			fallthrough

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -1044,6 +1044,8 @@ func (service *HTTPRestService) saveNetworkContainerGoalState(req cns.CreateNetw
 		case cns.DBforPostgreSQL:
 			fallthrough
 		case cns.AzureFirstParty:
+			fallthrough
+		case cns.WebApps:
 			var podInfo cns.KubernetesPodInfo
 			err := json.Unmarshal(req.OrchestratorContext, &podInfo)
 			if err != nil {


### PR DESCRIPTION
In case of WebApps the NC goal state gets saved with CNS if the loopback adapter creation is successful. This change fixes the bug where the goal state wasn't getting saved because the condition for WebApps containerType would run into default case and error out.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```