### PR TITLE
CNS option to specify numcpucores for test clusters

### DIFF
--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -1599,7 +1599,13 @@ func (service *HTTPRestService) getNumberOfCPUCores(w http.ResponseWriter, r *ht
 
 	switch r.Method {
 	case "GET":
-		num = runtime.NumCPU()
+		// Use NumCPUCores from commandline option if set
+		numCPUCoresOpt := service.GetOption(acn.OptNumCPUCores).(int)
+		if numCPUCoresOpt > 0 {
+			num = numCPUCoresOpt
+		} else {
+			num = runtime.NumCPU()
+		}
 	default:
 		errMsg = "[Azure-CNS] getNumberOfCPUCores API expects a GET."
 		returnCode = UnsupportedVerb

--- a/cns/restserver/restserver_test.go
+++ b/cns/restserver/restserver_test.go
@@ -727,6 +727,30 @@ func TestGetInterfaceForNetworkContainer(t *testing.T) {
 func TestGetNumOfCPUCores(t *testing.T) {
 	fmt.Println("Test: getNumberOfCPUCores")
 
+	// Test CNS commandline option numcpucores.
+	numcpucores := 100
+
+	// Set the CNS restserver option. This step is needed for test only. When the CNS exe
+	// is run with commandline, CNS main function takes care of this.
+	service.(*HTTPRestService).SetOption(acncommon.OptNumCPUCores, numcpucores)
+	numOfCoresResponse := getNumOfCPUCores(t)
+
+	// Match the returned value with the set value of numcpucores
+	if numcpucores != numOfCoresResponse.NumOfCPUCores {
+		t.Fatal(fmt.Errorf("Mismatch in NumCPUCores. Expected: %d Received: %d",
+			numcpucores, numOfCoresResponse.NumOfCPUCores))
+	}
+
+	fmt.Printf("getNumberOfCPUCores Responded with %+v\n\n", numOfCoresResponse)
+
+	// Test the case where the commandline option is not set. CNS returns the actual CPU count.
+	service.(*HTTPRestService).SetOption(acncommon.OptNumCPUCores, 0)
+	numOfCoresResponse = getNumOfCPUCores(t)
+
+	fmt.Printf("getNumberOfCPUCores Responded with %+v\n\n", numOfCoresResponse)
+}
+
+func getNumOfCPUCores(t *testing.T) cns.NumOfCPUCoresResponse {
 	var (
 		err error
 		req *http.Request
@@ -744,8 +768,8 @@ func TestGetNumOfCPUCores(t *testing.T) {
 
 	err = decodeResponse(w, &numOfCoresResponse)
 	if err != nil || numOfCoresResponse.Response.ReturnCode != 0 {
-		t.Errorf("getNumberOfCPUCores failed with response %+v", numOfCoresResponse)
-	} else {
-		fmt.Printf("getNumberOfCPUCores Responded with %+v\n", numOfCoresResponse)
+		t.Fatal(fmt.Errorf("getNumberOfCPUCores failed with response %+v", numOfCoresResponse))
 	}
+
+	return numOfCoresResponse
 }

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -152,6 +152,13 @@ var args = acn.ArgumentList{
 		Type:         "bool",
 		DefaultValue: true,
 	},
+	{
+		Name:         acn.OptNumCPUCores,
+		Shorthand:    acn.OptNumCPUCoresAlias,
+		Description:  "Set the CPU Core number. This setting should be used in test environment only",
+		Type:         "int",
+		DefaultValue: 0,
+	},
 }
 
 // Prints description and version information.
@@ -179,6 +186,7 @@ func main() {
 	vers := acn.GetArg(acn.OptVersion).(bool)
 	createDefaultExtNetworkType := acn.GetArg(acn.OptCreateDefaultExtNetworkType).(string)
 	telemetryEnabled := acn.GetArg(acn.OptTelemetry).(bool)
+	numCPUCores := acn.GetArg(acn.OptNumCPUCores).(int)
 
 	if vers {
 		printVersion()
@@ -240,6 +248,7 @@ func main() {
 	httpRestService.SetOption(acn.OptNetPluginPath, cniPath)
 	httpRestService.SetOption(acn.OptNetPluginConfigFile, cniConfigFile)
 	httpRestService.SetOption(acn.OptCreateDefaultExtNetworkType, createDefaultExtNetworkType)
+	httpRestService.SetOption(acn.OptNumCPUCores, numCPUCores)
 
 	// Create default ext network if commandline option is set
 	if len(strings.TrimSpace(createDefaultExtNetworkType)) > 0 {

--- a/common/config.go
+++ b/common/config.go
@@ -79,4 +79,8 @@ const (
 	// Disable Telemetry
 	OptTelemetry      = "telemetry"
 	OptTelemetryAlias = "dt"
+
+	// Set the CPU Core number. This setting should be used in test environment only
+	OptNumCPUCores      = "numcpucores"
+	OptNumCPUCoresAlias = "ncpu"
 )


### PR DESCRIPTION
Add CNS option to set numcpucores that CNS uses to enforce per VM NC limit. This is used in test environment only to create test clusters with VMs able to host much more NCs thus removing the dependency on the number of cores in that VM.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```