### PR TITLE
Retry reading DNS servers from global settings

### DIFF
--- a/network/network_linux.go
+++ b/network/network_linux.go
@@ -230,7 +230,13 @@ func saveDnsConfig(extIf *externalInterface) error {
 	dnsInfo, err := readDnsInfo(extIf.Name)
 	if err != nil || len(dnsInfo.Servers) == 0 || dnsInfo.Suffix == "" {
 		log.Printf("[net] Failed to read dns info %+v from interface %v: %v", dnsInfo, extIf.Name, err)
-		return err
+
+		// Retry reading from the global settings
+		dnsInfo, err := readDnsInfo("")
+		if err != nil || len(dnsInfo.Servers) == 0 || dnsInfo.Suffix == "" {
+			log.Printf("[net] Failed also to read dns info %+v from global: %v", dnsInfo, err)
+			return err
+		}
 	}
 
 	extIf.DNSInfo = dnsInfo


### PR DESCRIPTION
In case they are not directly assigned to the interface azure-vnet will
crash if it reads zero DNS servers.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

On Ubuntu 16.04 VM's in Azure, the CNI plugin produces crashes in /var/log/azure-vnet.log because it fails to read any DNS Servers

```
2019/10/03 07:19:34 [6509] [Azure-Utils] systemd-resolve --status eth0
2019/10/03 07:19:34 [6844] [cni] reboot time 2019-10-03 14:15:42 +0000 UTC storeLockFile mod time 2019-10-03 14:19:33.547442591 +0000 UTC
2019/10/03 07:19:35 [6509] [net] console output for above cmd: Link 2 (eth0)
      Current Scopes: none
       LLMNR setting: yes
MulticastDNS setting: no
      DNSSEC setting: no
    DNSSEC supported: no
2019/10/03 07:19:35 [6509] [net] Failed to read dns info {Suffix: Servers:[]} from interface eth0: <nil>
2019/10/03 07:19:35 [6509] [net] Setting link eth0 state down.
2019/10/03 07:19:35 [6509] [net] Setting link eth0 master azure0.
2019/10/03 07:19:35 [6509] [net] Setting link eth0 state up.
2019/10/03 07:19:35 [6509] [net] Setting link azure0 state up.
2019/10/03 07:19:35 [6509] [net] Adding SNAT rule for egress traffic on eth0.
2019/10/03 07:19:35 [6946] [cni] reboot time 2019-10-03 14:15:42 +0000 UTC storeLockFile mod time 2019-10-03 14:19:33.547442591 +0000 UTC
2019/10/03 07:19:35 [6509] [net] Adding ARP reply rule for primary IP address 10.142.0.4.
2019/10/03 07:19:35 [6968] [cni] reboot time 2019-10-03 14:15:42 +0000 UTC storeLockFile mod time 2019-10-03 14:19:33.547442591 +0000 UTC
2019/10/03 07:19:35 [6509] [net] Adding DNAT rule for ingress ARP traffic on interface eth0.
2019/10/03 07:19:35 [6509] [net] Setting link eth0 hairpin on.
2019/10/03 07:19:35 [6509] [net] Adding IP address 10.142.0.4/16 to interface azure0.
2019/10/03 07:19:35 [6509] [net] Adding IP route &{Family:2 Dst:<nil> Src:<nil> Gw:10.142.0.1 Tos:0 Table:254 Protocol:3 Scope:0 Type:1 Flags:0 Priority:0 LinkIndex:4 ILinkIndex:0}.
2019/10/03 07:19:35 [6509] [net] Applying dns config on azure0
2019/10/03 07:19:35 [6509] [net] Connecting interface eth0 completed with err:<nil>.
2019/10/03 07:19:35 [6509] [cni-net] ADD command completed with result:Interfaces:[{Name:eth0 Mac: Sandbox:} {Name:eth0 Mac: Sandbox:}], IP:[{Version:4 Interface:<nil> Address:{IP:10.142.0.22 Mask:ffff0000} Gateway:10.142.0.1}], Routes:[{Dst:{IP:0.0.0.0 Mask:00000000} GW:10.142.0.1}], DNS:{Nameservers:[168.63.129.16] Domain: Search:[] Options:[]} err:<nil>.
2019/10/03 07:19:35 [6509] [cni] Recovered panic: runtime error: index out of range goroutine 1 [running]:
github.com/Azure/azure-container-networking/cni.(*Plugin).Execute.func1(0xc000385e88)
	/var/lib/jenkins/workspace/src/github.com/Azure/azure-container-networking/cni/plugin.go:63 +0xbc
panic(0x7062a0, 0x9dcfe0)
	/var/lib/jenkins/tools/org.jenkinsci.plugins.golang.GolangInstallation/Go_1.11.1/src/runtime/panic.go:513 +0x1b9
github.com/Azure/azure-container-networking/network.applyDnsConfig(0xc0003c0000, 0xc000098cf0, 0x6, 0x1, 0x1)
	/var/lib/jenkins/workspace/src/github.com/Azure/azure-container-networking/network/network_linux.go:272 +0x252
github.com/Azure/azure-container-networking/network.(*networkManager).connectExternalInterface(0xc0000a35e0, 0xc0003c0000, 0xc0000928f0, 0x0, 0x0)
	/var/lib/jenkins/workspace/src/github.com/Azure/azure-container-networking/network/network_linux.go:404 +0xe93
github.com/Azure/azure-container-networking/network.(*networkManager).newNetworkImpl(0xc0000a35e0, 0xc0000928f0, 0xc0003c0000, 0x5, 0xa07e60, 0xc000385301)
	/var/lib/jenkins/workspace/src/github.com/Azure/azure-container-networking/network/network_linux.go:58 +0x179
github.com/Azure/azure-container-networking/network.(*networkManager).newNetwork(0xc0000a35e0, 0xc0000928f0, 0x0, 0x0, 0x0)
	/var/lib/jenkins/workspace/src/github.com/Azure/azure-container-networking/network/network.go:176 +0x1c3
github.com/Azure/azure-container-networking/network.(*networkManager).CreateNetwork(0xc0000a35e0, 0xc0000928f0, 0x0, 0x0)
	/var/lib/jenkins/workspace/src/github.com/Azure/azure-container-networking/network/manager.go:240 +0x84
github.com/Azure/azure-container-networking/cni/network.(*netPlugin).Add(0xc00008e7a0, 0xc00010e460, 0x0, 0x0)
	/var/lib/jenkins/workspace/src/github.com/Azure/azure-container-networking/cni/network/network.go:398 +0x26c6
github.com/Azure/azure-container-networking/cni.PluginApi.Add-fm(0xc00010e460, 0xc000098b00, 0x5)
	/var/lib/jenkins/workspace/src/github.com/Azure/azure-container-networking/cni/plugin.go:81 +0x39
github.com/Azure/azure-container-networking/vendor/github.com/containernetworking/cni/pkg/skel.(*dispatcher).checkVersionAndCall(0xc0000dbd68, 0xc00010e460, 0x7c1da0, 0xc000085980, 0xc0000dbe30, 0x0, 0x5b50f5)
	/var/lib/jenkins/workspace/src/github.com/Azure/azure-container-networking/vendor/github.com/containernetworking/cni/pkg/skel/skel.go:185 +0x185
github.com/Azure/azure-container-networking/vendor/github.com/containernetworking/cni/pkg/skel.(*dispatcher).pluginMain(0xc0000dbd68, 0xc0000dbe30, 0xc0000dbe48, 0xc0000dbe18, 0x7c1da0, 0xc000085980, 0x7bd5a0, 0x7, 0xc0000dbda0)
	/var/lib/jenkins/workspace/src/github.com/Azure/azure-container-networking/vendor/github.com/containernetworking/cni/pkg/skel/skel.go:221 +0x432
github.com/Azure/azure-container-networking/vendor/github.com/containernetworking/cni/pkg/skel.PluginMainWithError(0xc0000dbe30, 0xc0000dbe48, 0xc0000dbe18, 0x7c1da0, 0xc000085980, 0x7bd5a0, 0x7, 0xc00001801c)
	/var/lib/jenkins/workspace/src/github.com/Azure/azure-container-networking/vendor/github.com/containernetworking/cni/pkg/skel/skel.go:286 +0x110
github.com/Azure/azure-container-networking/cni.(*Plugin).Execute(0xc00008e780, 0x7c3a40, 0xc00008e7a0, 0x0, 0x0)
	/var/lib/jenkins/workspace/src/github.com/Azure/azure-container-networking/cni/plugin.go:81 +0x1da
main.main()
	/var/lib/jenkins/workspace/src/github.com/Azure/azure-container-networking/cni/network/plugin/main.go:221 +0x10d3

2019/10/03 07:19:35 [6509] Failed to execute network plugin, err:runtime error: index out of range; goroutine 1 [running]:
github.com/Azure/azure-container-networking/cni.(*Plugin).Execute.func1(0xc000385e88)
	/var/lib/jenkins/workspace/src/github.com/Azure/azure-container-networking/cni/plugin.go:63 +0xbc
panic(0x7062a0, 0x9dcfe0)
	/var/lib/jenkins/tools/org.jenkinsci.plugins.golang.GolangInstallation/Go_1.11.1/src/runtime/panic.go:513 +0x1b9
github.com/Azure/azure-container-networking/network.applyDnsConfig(0xc0003c0000, 0xc000098cf0, 0x6, 0x1, 0x1)
	/var/lib/jenkins/workspace/src/github.com/Azure/azure-container-networking/network/network_linux.go:272 +0x252
github.com/Azure/azure-container-networking/network.(*networkManager).connectExternalInterface(0xc0000a35e0, 0xc0003c0000, 0xc0000928f0, 0x0, 0x0)
	/var/lib/jenkins/workspace/src/github.com/Azure/azure-container-networking/network/network_linux.go:404 +0xe93
github.com/Azure/azure-container-networking/network.(*networkManager).newNetworkImpl(0xc0000a35e0, 0xc0000928f0, 0xc0003c0000, 0x5, 0xa07e60, 0xc000385301)
	/var/lib/jenkins/workspace/src/github.com/Azure/azure-container-networking/network/network_linux.go:58 +0x179
github.com/Azure/azure-container-networking/network.(*networkManager).newNetwork(0xc0000a35e0, 0xc0000928f0, 0x0, 0x0, 0x0)
	/var/lib/jenkins/workspace/src/github.com/Azure/azure-container-networking/network/network.go:176 +0x1c3
github.com/Azure/azure-container-networking/network.(*networkManager).CreateNetwork(0xc0000a35e0, 0xc0000928f0, 0x0, 0x0)
	/var/lib/jenkins/workspace/src/github.com/Azure/azure-container-networking/network/manager.go:240 +0x84
github.com/Azure/azure-container-networking/cni/network.(*netPlugin).Add(0xc00008e7a0, 0xc00010e460, 0x0, 0x0)
	/var/lib/jenkins/workspace/src/github.com/Azure/azure-container-networking/cni/network/network.go:398 +0x26c6
github.com/Azure/azure-container-networking/cni.PluginApi.Add-fm(0xc00010e460, 0xc000098b00, 0x5)
	/var/lib/jenkins/workspace/src/github.com/Azure/azure-container-networking/cni/plugin.go:81 +0x39
github.com/Azure/azure-container-networking/vendor/github.com/containernetworking/cni/pkg/skel.(*dispatcher).checkVersionAndCall(0xc0000dbd68, 0xc00010e460, 0x7c1da0, 0xc000085980, 0xc0000dbe30, 0x0, 0x5b50f5)
	/var/lib/jenkins/workspace/src/github.com/Azure/azure-container-networking/vendor/github.com/containernetworking/cni/pkg/skel/skel.go:185 +0x185
github.com/Azure/azure-container-networking/vendor/github.com/containernetworking/cni/pkg/skel.(*dispatcher).pluginMain(0xc0000dbd68, 0xc0000dbe30, 0xc0000dbe48, 0xc0000dbe18, 0x7c1da0, 0xc000085980, 0x7bd5a0, 0x7, 0xc0000dbda0)
	/var/lib/jenkins/workspace/src/github.com/Azure/azure-container-networking/vendor/github.com/containernetworking/cni/pkg/skel/skel.go:221 +0x432
github.com/Azure/azure-container-networking/vendor/github.com/containernetworking/cni/pkg/skel.PluginMainWithError(0xc0000dbe30, 0xc0000dbe48, 0xc0000dbe18, 0x7c1da0, 0xc000085980, 0x7bd5a0, 0x7, 0xc00001801c)
	/var/lib/jenkins/workspace/src/github.com/Azure/azure-container-networking/vendor/github.com/containernetworking/cni/pkg/skel/skel.go:286 +0x110
github.com/Azure/azure-container-networking/cni.(*Plugin).Execute(0xc00008e780, 0x7c3a40, 0xc00008e7a0, 0x0, 0x0)
	/var/lib/jenkins/workspace/src/github.com/Azure/azure-container-networking/cni/plugin.go:81 +0x1da
main.main()
	/var/lib/jenkins/workspace/src/github.com/Azure/azure-container-networking/cni/network/plugin/main.go:221 +0x10d3
.
2019/10/03 07:19:35 [6509] [cni-net] Plugin stopped.
```

Because it segfaults it does not release the lock for the Address Pool which also made it a bit difficult to debug.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

If `systemd-resolved --status eth0` doesn't yield anything, it will read from `systemd-resolved --status`. This can output the following:

```
Global
         DNS Servers: 10.141.255.254
                      168.63.129.16
          DNS Domain: cm.cluster
                      eth.cluster
                      openstacklocal
                      brightcomputing.com
                      uhgkr1s1qpke1octvmkf41t2ba.ax.internal.cloudapp.net
          DNSSEC NTA: 10.in-addr.arpa
                      16.172.in-addr.arpa
                      168.192.in-addr.arpa
                      17.172.in-addr.arpa
                      18.172.in-addr.arpa
                      19.172.in-addr.arpa
                      20.172.in-addr.arpa
                      21.172.in-addr.arpa
                      22.172.in-addr.arpa
                      23.172.in-addr.arpa
                      24.172.in-addr.arpa
                      25.172.in-addr.arpa
                      26.172.in-addr.arpa
                      27.172.in-addr.arpa
                      28.172.in-addr.arpa
                      29.172.in-addr.arpa
                      30.172.in-addr.arpa
                      31.172.in-addr.arpa
                      corp
                      d.f.ip6.arpa
                      home
                      internal
                      intranet
                      lan
                      local
                      private
                      test

Link 20 (azv7a2d2b02d3c)
      Current Scopes: none
       LLMNR setting: yes
MulticastDNS setting: no
      DNSSEC setting: no
    DNSSEC supported: no

Link 18 (azvcbc1e7b7612)
      Current Scopes: none
       LLMNR setting: yes
MulticastDNS setting: no
      DNSSEC setting: no
    DNSSEC supported: no

Link 16 (azv654bf64fc86)
      Current Scopes: none
       LLMNR setting: yes
MulticastDNS setting: no
      DNSSEC setting: no
    DNSSEC supported: no

Link 14 (azvd18e9a9895f)
      Current Scopes: none
       LLMNR setting: yes
MulticastDNS setting: no
      DNSSEC setting: no
    DNSSEC supported: no

Link 12 (azv9a0a9c87f41)
      Current Scopes: none
       LLMNR setting: yes
MulticastDNS setting: no
      DNSSEC setting: no
    DNSSEC supported: no

Link 10 (azv1c8172e2e49)
      Current Scopes: none
       LLMNR setting: yes
MulticastDNS setting: no
      DNSSEC setting: no
    DNSSEC supported: no

Link 8 (azv4efab29a0da)
      Current Scopes: none
       LLMNR setting: yes
MulticastDNS setting: no
      DNSSEC setting: no
    DNSSEC supported: no

Link 6 (azvfca41c8275e)
      Current Scopes: none
       LLMNR setting: yes
MulticastDNS setting: no
      DNSSEC setting: no
    DNSSEC supported: no

Link 4 (azure0)
      Current Scopes: none
       LLMNR setting: yes
MulticastDNS setting: no
      DNSSEC setting: no
    DNSSEC supported: no

Link 3 (docker0)
      Current Scopes: none
       LLMNR setting: yes
MulticastDNS setting: no
      DNSSEC setting: no
    DNSSEC supported: no

Link 2 (eth0)
      Current Scopes: none
       LLMNR setting: yes
MulticastDNS setting: no
      DNSSEC setting: no
    DNSSEC supported: no
```

I wanted to discuss here first before implementing, but I think a needed change is also to stop parsing for global dns servers once output for specific interfaces begins "^Link"?

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

I don't know what to put here? 

Parse Global DNS Servers setting if interface has no DNS Servers linked via systemd-resolved --status.