### PR TITLE
Publish/Unpublish Network Containers via CNS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ CNSFILES = \
 	$(wildcard cns/imdsclient/*.go) \
 	$(wildcard cns/ipamclient/*.go) \
 	$(wildcard cns/hnsclient/*.go) \
+	$(wildcard cns/nmagentclient/*.go) \
 	$(wildcard cns/restserver/*.go) \
 	$(wildcard cns/routes/*.go) \
 	$(wildcard cns/service/*.go) \

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -199,7 +199,7 @@ type PublishNetworkContainerRequest struct {
 // PublishNetworkContainerResponse specifies the response to publish network container request.
 type PublishNetworkContainerResponse struct {
 	Response            Response
-	PublishError        error
+	PublishErrorStr     string
 	PublishStatusCode   int
 	PublishResponseBody []byte
 }
@@ -215,7 +215,7 @@ type UnpublishNetworkContainerRequest struct {
 // UnpublishNetworkContainerResponse specifies the response to unpublish network container request.
 type UnpublishNetworkContainerResponse struct {
 	Response              Response
-	UnpublishError        error
+	UnpublishErrorStr     string
 	UnpublishStatusCode   int
 	UnpublishResponseBody []byte
 }

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -189,24 +189,16 @@ type NetworkInterface struct {
 
 // PublishNetworkContainerRequest specifies request to publish network container via NMAgent.
 type PublishNetworkContainerRequest struct {
-	WireSererIP                  string
-	AssociatedInterfaceIP        string
-	NetworkID                    string
-	NetworkContainerID           string
-	AccessToken                  string
-	JoinNetworkURLFmt            string
-	CreateNetworkContainerURLFmt string
-	JoinNetworkURL               string
-	CreateNetworkContainerURL    string
-	//CreateNetworkContainerRequestBody bytes.Buffer
+	NetworkID                         string
+	NetworkContainerID                string
+	JoinNetworkURL                    string
+	CreateNetworkContainerURL         string
 	CreateNetworkContainerRequestBody []byte
 }
 
 // PublishNetworkContainerResponse specifies the response to publish network container request.
 type PublishNetworkContainerResponse struct {
-	Response Response
-	//HttpStatusCode int
-	//HttpResponsePublish http.Response
+	Response            Response
 	PublishStatusCode   int
 	PublishResponseBody []byte
 	PublishError        error

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -1,6 +1,8 @@
 package cns
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
 
 // Container Network Service DNC Contract
 const (
@@ -8,6 +10,8 @@ const (
 	CreateOrUpdateNetworkContainer           = "/network/createorupdatenetworkcontainer"
 	DeleteNetworkContainer                   = "/network/deletenetworkcontainer"
 	GetNetworkContainerStatus                = "/network/getnetworkcontainerstatus"
+	PublishNetworkContainer                  = "/network/publishnetworkcontainer"
+	UnpublishNetworkContainer                = "/network/unpublishnetworkcontainer"
 	GetInterfaceForContainer                 = "/network/getinterfaceforcontainer"
 	GetNetworkContainerByOrchestratorContext = "/network/getnetworkcontainerbyorchestratorcontext"
 	AttachContainerToNetwork                 = "/network/attachcontainertonetwork"
@@ -181,4 +185,29 @@ type DetachContainerFromNetworkResponse struct {
 type NetworkInterface struct {
 	Name      string
 	IPAddress string
+}
+
+// PublishNetworkContainerRequest specifies request to publish network container via NMAgent.
+type PublishNetworkContainerRequest struct {
+	WireSererIP                  string
+	AssociatedInterfaceIP        string
+	NetworkID                    string
+	NetworkContainerID           string
+	AccessToken                  string
+	JoinNetworkURLFmt            string
+	CreateNetworkContainerURLFmt string
+	JoinNetworkURL               string
+	CreateNetworkContainerURL    string
+	//CreateNetworkContainerRequestBody bytes.Buffer
+	CreateNetworkContainerRequestBody []byte
+}
+
+// PublishNetworkContainerResponse specifies the response to publish network container request.
+type PublishNetworkContainerResponse struct {
+	Response Response
+	//HttpStatusCode int
+	//HttpResponsePublish http.Response
+	PublishStatusCode   int
+	PublishResponseBody []byte
+	PublishError        error
 }

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -203,3 +203,19 @@ type PublishNetworkContainerResponse struct {
 	PublishStatusCode   int
 	PublishResponseBody []byte
 }
+
+// UnpublishNetworkContainerRequest specifies request to unpublish network container via NMAgent.
+type UnpublishNetworkContainerRequest struct {
+	NetworkID                 string
+	NetworkContainerID        string
+	JoinNetworkURL            string
+	DeleteNetworkContainerURL string
+}
+
+// UnpublishNetworkContainerResponse specifies the response to unpublish network container request.
+type UnpublishNetworkContainerResponse struct {
+	Response              Response
+	UnpublishError        error
+	UnpublishStatusCode   int
+	UnpublishResponseBody []byte
+}

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -199,7 +199,7 @@ type PublishNetworkContainerRequest struct {
 // PublishNetworkContainerResponse specifies the response to publish network container request.
 type PublishNetworkContainerResponse struct {
 	Response            Response
+	PublishError        error
 	PublishStatusCode   int
 	PublishResponseBody []byte
-	PublishError        error
 }

--- a/cns/nmagentclient/nmagentclient.go
+++ b/cns/nmagentclient/nmagentclient.go
@@ -1,0 +1,84 @@
+package nmagentclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/Azure/azure-container-networking/log"
+)
+
+const (
+	// Http connection timeout duration in milliseconds
+	connectionTimeoutDurationMs = 5000
+	// Response header timeout duration in milliseconds
+	responseHeaderTimeoutDurationMs = 120000
+)
+
+// Creating http client object to be reused instead of creating one every time.
+// This helps make use of the cached tcp connections.
+// Clients are safe for concurrent use by multiple goroutines.
+var httpClient = &http.Client{
+	Transport: &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout: time.Duration(connectionTimeoutDurationMs) * time.Millisecond,
+		}).DialContext,
+		ResponseHeaderTimeout: time.Duration(responseHeaderTimeoutDurationMs) * time.Millisecond,
+	},
+}
+
+// JoinNetwork joins the given network
+func JoinNetwork(
+	networkID string,
+	joinNetworkURL string) (*http.Response, error) {
+	log.Printf("[NMAgentClient] JoinNetwork: %s", networkID)
+
+	// Empty body is required as wireserver cannot handle a post without the body.
+	var body bytes.Buffer
+	json.NewEncoder(&body).Encode("")
+	response, err := httpClient.Post(joinNetworkURL, "application/json", &body)
+
+	if err == nil {
+		defer response.Body.Close()
+	}
+
+	log.Printf("[NMAgentClient][Response] Join network: %s. Response: %+v. Error: %v",
+		networkID, response, err)
+
+	return response, err
+}
+
+// PublishNetworkContainer publishes given network container
+func PublishNetworkContainer(
+	networkContainerID string,
+	createNetworkContainerURL string,
+	requestBodyData []byte) (*http.Response, error) {
+	log.Printf("[NMAgentClient] PublishNetworkContainer NC: %s", networkContainerID)
+
+	requestBody := bytes.NewBuffer(requestBodyData)
+	response, err := httpClient.Post(createNetworkContainerURL, "application/json", requestBody)
+
+	log.Printf("[NMAgentClient][Response] Publish NC: %s. Response: %+v. Error: %v",
+		networkContainerID, response, err)
+
+	return response, err
+}
+
+// UnpublishNetworkContainer unpublishes given network container
+func UnpublishNetworkContainer(
+	networkContainerID string,
+	deleteNetworkContainerURL string) (*http.Response, error) {
+	log.Printf("[NMAgentClient] UnpublishNetworkContainer NC: %s", networkContainerID)
+
+	// Empty body is required as wireserver cannot handle a post without the body.
+	var body bytes.Buffer
+	json.NewEncoder(&body).Encode("")
+	response, err := httpClient.Post(deleteNetworkContainerURL, "application/json", &body)
+
+	log.Printf("[NMAgentClient][Response] Unpublish NC: %s. Response: %+v. Error: %v",
+		networkContainerID, response, err)
+
+	return response, err
+}

--- a/cns/nmagentclient/nmagentclient.go
+++ b/cns/nmagentclient/nmagentclient.go
@@ -3,31 +3,11 @@ package nmagentclient
 import (
 	"bytes"
 	"encoding/json"
-	"net"
 	"net/http"
-	"time"
 
+	"github.com/Azure/azure-container-networking/common"
 	"github.com/Azure/azure-container-networking/log"
 )
-
-const (
-	// Http connection timeout duration in milliseconds
-	connectionTimeoutDurationMs = 5000
-	// Response header timeout duration in milliseconds
-	responseHeaderTimeoutDurationMs = 120000
-)
-
-// Creating http client object to be reused instead of creating one every time.
-// This helps make use of the cached tcp connections.
-// Clients are safe for concurrent use by multiple goroutines.
-var httpClient = &http.Client{
-	Transport: &http.Transport{
-		DialContext: (&net.Dialer{
-			Timeout: time.Duration(connectionTimeoutDurationMs) * time.Millisecond,
-		}).DialContext,
-		ResponseHeaderTimeout: time.Duration(responseHeaderTimeoutDurationMs) * time.Millisecond,
-	},
-}
 
 // JoinNetwork joins the given network
 func JoinNetwork(
@@ -38,7 +18,7 @@ func JoinNetwork(
 	// Empty body is required as wireserver cannot handle a post without the body.
 	var body bytes.Buffer
 	json.NewEncoder(&body).Encode("")
-	response, err := httpClient.Post(joinNetworkURL, "application/json", &body)
+	response, err := common.GetHttpClient().Post(joinNetworkURL, "application/json", &body)
 
 	if err == nil && response.StatusCode == http.StatusOK {
 		defer response.Body.Close()
@@ -58,7 +38,7 @@ func PublishNetworkContainer(
 	log.Printf("[NMAgentClient] PublishNetworkContainer NC: %s", networkContainerID)
 
 	requestBody := bytes.NewBuffer(requestBodyData)
-	response, err := httpClient.Post(createNetworkContainerURL, "application/json", requestBody)
+	response, err := common.GetHttpClient().Post(createNetworkContainerURL, "application/json", requestBody)
 
 	log.Printf("[NMAgentClient][Response] Publish NC: %s. Response: %+v. Error: %v",
 		networkContainerID, response, err)
@@ -75,7 +55,7 @@ func UnpublishNetworkContainer(
 	// Empty body is required as wireserver cannot handle a post without the body.
 	var body bytes.Buffer
 	json.NewEncoder(&body).Encode("")
-	response, err := httpClient.Post(deleteNetworkContainerURL, "application/json", &body)
+	response, err := common.GetHttpClient().Post(deleteNetworkContainerURL, "application/json", &body)
 
 	log.Printf("[NMAgentClient][Response] Unpublish NC: %s. Response: %+v. Error: %v",
 		networkContainerID, response, err)

--- a/cns/nmagentclient/nmagentclient.go
+++ b/cns/nmagentclient/nmagentclient.go
@@ -40,7 +40,7 @@ func JoinNetwork(
 	json.NewEncoder(&body).Encode("")
 	response, err := httpClient.Post(joinNetworkURL, "application/json", &body)
 
-	if err == nil {
+	if err == nil && response.StatusCode == http.StatusOK {
 		defer response.Body.Close()
 	}
 

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -26,6 +26,7 @@ const (
 	InvalidRequest                  = 23
 	NetworkJoinFailed               = 24
 	NetworkContainerPublishFailed   = 25
+	NetworkContainerUnpublishFailed = 26
 	UnexpectedError                 = 99
 )
 

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -24,7 +24,7 @@ const (
 	UnsupportedVerb                 = 21
 	UnsupportedNetworkContainerType = 22
 	InvalidRequest                  = 23
-	NetworkPublishFailed            = 24
+	NetworkJoinFailed               = 24
 	NetworkContainerPublishFailed   = 25
 	UnexpectedError                 = 99
 )

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -24,6 +24,8 @@ const (
 	UnsupportedVerb                 = 21
 	UnsupportedNetworkContainerType = 22
 	InvalidRequest                  = 23
+	NetworkPublishFailed            = 24
+	NetworkContainerPublishFailed   = 25
 	UnexpectedError                 = 99
 )
 

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -1754,11 +1754,11 @@ func (service *HTTPRestService) joinNetwork(
 	networkID string,
 	joinNetworkURL string) (*http.Response, error, error) {
 	var err error
-	unpublishResponse, unPublishErr := nmagentclient.JoinNetwork(
+	unpublishResponse, unpublishErr := nmagentclient.JoinNetwork(
 		networkID,
 		joinNetworkURL)
 
-	if unPublishErr == nil && unpublishResponse.StatusCode == http.StatusOK {
+	if unpublishErr == nil && unpublishResponse.StatusCode == http.StatusOK {
 		// Network joined successfully
 		service.setNetworkStateJoined(networkID)
 		log.Printf("[Azure-CNS] setNetworkStateJoined for network: %s", networkID)
@@ -1766,7 +1766,7 @@ func (service *HTTPRestService) joinNetwork(
 		err = fmt.Errorf("Failed to join network: %s", networkID)
 	}
 
-	return unpublishResponse, unPublishErr, err
+	return unpublishResponse, unpublishErr, err
 }
 
 // Publish Network Container by calling nmagent

--- a/cns/restserver/restserver_test.go
+++ b/cns/restserver/restserver_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/Azure/azure-container-networking/cns"
@@ -66,16 +67,23 @@ var (
 	}
 )
 
+const (
+	nmagentEndpoint = "localhost:9000"
+)
+
 func getInterfaceInfo(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/xml")
 	output, _ := xml.Marshal(hostQueryResponse)
 	w.Write(output)
 }
 
-func getContainerInfo(w http.ResponseWriter, r *http.Request) {
+func nmagentHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(hostQueryForProgrammedVersionResponse))
+
+	if strings.Contains(r.RequestURI, "networkContainers") {
+		w.Write([]byte(hostQueryForProgrammedVersionResponse))
+	}
 }
 
 // Wraps the test run with service setup and teardown.
@@ -109,7 +117,7 @@ func TestMain(m *testing.M) {
 	mux = service.(*HTTPRestService).Listener.GetMux()
 
 	// Setup mock nmagent server
-	u, err := url.Parse("tcp://localhost:9000")
+	u, err := url.Parse("tcp://" + nmagentEndpoint)
 	if err != nil {
 		fmt.Println(err.Error())
 	}
@@ -120,7 +128,7 @@ func TestMain(m *testing.M) {
 	}
 
 	nmAgentServer.AddHandler("/getInterface", getInterfaceInfo)
-	nmAgentServer.AddHandler("machine/plugins/?comp=nmagent&type=NetworkManagement/interfaces/{interface}/networkContainers/{networkContainer}/authenticationToken/{authToken}/api-version/{version}", getContainerInfo)
+	nmAgentServer.AddHandler("/", nmagentHandler)
 
 	err = nmAgentServer.Start(make(chan error, 1))
 	if err != nil {
@@ -133,6 +141,7 @@ func TestMain(m *testing.M) {
 
 	// Cleanup.
 	service.Stop()
+	nmAgentServer.Stop()
 
 	os.Exit(exitCode)
 }
@@ -748,4 +757,87 @@ func TestGetNumOfCPUCores(t *testing.T) {
 	} else {
 		fmt.Printf("getNumberOfCPUCores Responded with %+v\n", numOfCoresResponse)
 	}
+}
+
+func TestPublishNCViaCNS(t *testing.T) {
+	fmt.Println("Test: publishNetworkContainer")
+
+	var (
+		body bytes.Buffer
+		resp cns.PublishNetworkContainerResponse
+	)
+
+	networkID := "vnet1"
+	networkContainerID := "ethWebApp"
+	joinNetworkURL := "http://" + nmagentEndpoint +
+		"/machine/plugins/?comp=nmagent&type=NetworkManagement/joinedVirtualNetworks/" + networkID + "/api-version/1"
+	createNetworkContainerURL := "http://" + nmagentEndpoint +
+		"/machine/plugins/?comp=nmagent&type=NetworkManagement/interfaces/127.0.0.1/networkContainers/" +
+		networkContainerID + "/authenticationToken/dummyauthtoken/api-version/1"
+
+	publishNCRequest := &cns.PublishNetworkContainerRequest{
+		NetworkID:                         networkID,
+		NetworkContainerID:                networkContainerID,
+		JoinNetworkURL:                    joinNetworkURL,
+		CreateNetworkContainerURL:         createNetworkContainerURL,
+		CreateNetworkContainerRequestBody: make([]byte, 0),
+	}
+
+	json.NewEncoder(&body).Encode(publishNCRequest)
+	req, err := http.NewRequest(http.MethodPost, cns.PublishNetworkContainer, &body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	err = decodeResponse(w, &resp)
+	if err != nil || resp.Response.ReturnCode != 0 {
+		t.Errorf("PublishNetworkContainer failed with response %+v Err:%+v", resp, err)
+		t.Fatal(err)
+	}
+
+	fmt.Printf("PublishNetworkContainer succeded with response %+v, raw:%+v\n", resp, w.Body)
+}
+
+func TestUnpublishNCViaCNS(t *testing.T) {
+	fmt.Println("Test: unpublishNetworkContainer")
+
+	var (
+		body bytes.Buffer
+		resp cns.UnpublishNetworkContainerResponse
+	)
+
+	networkID := "vnet1"
+	networkContainerID := "ethWebApp"
+	joinNetworkURL := "http://" + nmagentEndpoint +
+		"/machine/plugins/?comp=nmagent&type=NetworkManagement/joinedVirtualNetworks/" + networkID + "/api-version/1"
+	deleteNetworkContainerURL := "http://" + nmagentEndpoint +
+		"/machine/plugins/?comp=nmagent&type=NetworkManagement/interfaces/127.0.0.1/networkContainers/" +
+		networkContainerID + "/authenticationToken/dummyauthtoken/api-version/1/method/DELETE"
+
+	unpublishNCRequest := &cns.UnpublishNetworkContainerRequest{
+		NetworkID:                 networkID,
+		NetworkContainerID:        networkContainerID,
+		JoinNetworkURL:            joinNetworkURL,
+		DeleteNetworkContainerURL: deleteNetworkContainerURL,
+	}
+
+	json.NewEncoder(&body).Encode(unpublishNCRequest)
+	req, err := http.NewRequest(http.MethodPost, cns.UnpublishNetworkContainer, &body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	err = decodeResponse(w, &resp)
+	if err != nil || resp.Response.ReturnCode != 0 {
+		t.Errorf("UnpublishNetworkContainer failed with response %+v Err:%+v", resp, err)
+		t.Fatal(err)
+	}
+
+	fmt.Printf("UnpublishNetworkContainer succeded with response %+v, raw:%+v\n", resp, w.Body)
 }

--- a/cns/restserver/restserver_test.go
+++ b/cns/restserver/restserver_test.go
@@ -769,11 +769,8 @@ func TestPublishNCViaCNS(t *testing.T) {
 
 	networkID := "vnet1"
 	networkContainerID := "ethWebApp"
-	joinNetworkURL := "http://" + nmagentEndpoint +
-		"/machine/plugins/?comp=nmagent&type=NetworkManagement/joinedVirtualNetworks/" + networkID + "/api-version/1"
-	createNetworkContainerURL := "http://" + nmagentEndpoint +
-		"/machine/plugins/?comp=nmagent&type=NetworkManagement/interfaces/127.0.0.1/networkContainers/" +
-		networkContainerID + "/authenticationToken/dummyauthtoken/api-version/1"
+	joinNetworkURL := "http://" + nmagentEndpoint + "/dummyVnetURL"
+	createNetworkContainerURL := "http://" + nmagentEndpoint + "/networkContainers/dummyNCURL"
 
 	publishNCRequest := &cns.PublishNetworkContainerRequest{
 		NetworkID:                         networkID,
@@ -811,11 +808,8 @@ func TestUnpublishNCViaCNS(t *testing.T) {
 
 	networkID := "vnet1"
 	networkContainerID := "ethWebApp"
-	joinNetworkURL := "http://" + nmagentEndpoint +
-		"/machine/plugins/?comp=nmagent&type=NetworkManagement/joinedVirtualNetworks/" + networkID + "/api-version/1"
-	deleteNetworkContainerURL := "http://" + nmagentEndpoint +
-		"/machine/plugins/?comp=nmagent&type=NetworkManagement/interfaces/127.0.0.1/networkContainers/" +
-		networkContainerID + "/authenticationToken/dummyauthtoken/api-version/1/method/DELETE"
+	joinNetworkURL := "http://" + nmagentEndpoint + "/dummyVnetURL"
+	deleteNetworkContainerURL := "http://" + nmagentEndpoint + "/networkContainers/dummyNCURL"
 
 	unpublishNCRequest := &cns.UnpublishNetworkContainerRequest{
 		NetworkID:                 networkID,

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -152,6 +152,20 @@ var args = acn.ArgumentList{
 		Type:         "bool",
 		DefaultValue: true,
 	},
+	{
+		Name:         acn.OptHttpConnectionTimeout,
+		Shorthand:    acn.OptHttpConnectionTimeoutAlias,
+		Description:  "Set HTTP connection timeout in seconds to be used by http client in CNS",
+		Type:         "int",
+		DefaultValue: "5",
+	},
+	{
+		Name:         acn.OptHttpResponseHeaderTimeout,
+		Shorthand:    acn.OptHttpResponseHeaderTimeoutAlias,
+		Description:  "Set HTTP response header timeout in seconds to be used by http client in CNS",
+		Type:         "int",
+		DefaultValue: "120",
+	},
 }
 
 // Prints description and version information.
@@ -179,6 +193,8 @@ func main() {
 	vers := acn.GetArg(acn.OptVersion).(bool)
 	createDefaultExtNetworkType := acn.GetArg(acn.OptCreateDefaultExtNetworkType).(string)
 	telemetryEnabled := acn.GetArg(acn.OptTelemetry).(bool)
+	httpConnectionTimeout := acn.GetArg(acn.OptHttpConnectionTimeout).(int)
+	httpResponseHeaderTimeout := acn.GetArg(acn.OptHttpResponseHeaderTimeout).(int)
 
 	if vers {
 		printVersion()
@@ -240,6 +256,8 @@ func main() {
 	httpRestService.SetOption(acn.OptNetPluginPath, cniPath)
 	httpRestService.SetOption(acn.OptNetPluginConfigFile, cniConfigFile)
 	httpRestService.SetOption(acn.OptCreateDefaultExtNetworkType, createDefaultExtNetworkType)
+	httpRestService.SetOption(acn.OptHttpConnectionTimeout, httpConnectionTimeout)
+	httpRestService.SetOption(acn.OptHttpResponseHeaderTimeout, httpResponseHeaderTimeout)
 
 	// Create default ext network if commandline option is set
 	if len(strings.TrimSpace(createDefaultExtNetworkType)) > 0 {

--- a/common/config.go
+++ b/common/config.go
@@ -79,4 +79,12 @@ const (
 	// Disable Telemetry
 	OptTelemetry      = "telemetry"
 	OptTelemetryAlias = "dt"
+
+	// HTTP connection timeout
+	OptHttpConnectionTimeout      = "http-connection-timeout"
+	OptHttpConnectionTimeoutAlias = "httpcontimeout"
+
+	// HTTP response header timeout
+	OptHttpResponseHeaderTimeout      = "http-response-header-timeout"
+	OptHttpResponseHeaderTimeoutAlias = "httprespheadertimeout"
 )


### PR DESCRIPTION
Expose 2 APIs to publish and unpublish network containers from CNS.
a.	PublishNetworkContainer
b.	UnpublishNetworkContainer

DNC calls CNS to publish and unpublish the network containers.
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```