### PR TITLE
Make IPVS work with CNI to ensure Service IP reachability from inside Kubernetes Pods

### DIFF
--- a/cni/netconfig.go
+++ b/cni/netconfig.go
@@ -56,7 +56,7 @@ type NetworkConfig struct {
 	EnableSnatOnHost           bool     `json:"enableSnatOnHost,omitempty"`
 	EnableExactMatchForPodName bool     `json:"enableExactMatchForPodName,omitempty"`
 	CNSUrl                     string   `json:"cnsurl,omitempty"`
-	EnableIpvs                 bool     `json:"enableIpvs,omitempty"`
+	DisableIpvs                bool     `json:"disableIpvs,omitempty"`
 	Ipam                       struct {
 		Type          string `json:"type"`
 		Environment   string `json:"environment,omitempty"`

--- a/cni/netconfig.go
+++ b/cni/netconfig.go
@@ -56,6 +56,7 @@ type NetworkConfig struct {
 	EnableSnatOnHost           bool     `json:"enableSnatOnHost,omitempty"`
 	EnableExactMatchForPodName bool     `json:"enableExactMatchForPodName,omitempty"`
 	CNSUrl                     string   `json:"cnsurl,omitempty"`
+	EnableIpvs                 bool     `json:"enableIpvs,omitempty"`
 	Ipam                       struct {
 		Type          string `json:"type"`
 		Environment   string `json:"environment,omitempty"`

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -430,6 +430,7 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 			DNS:              nwDNSInfo,
 			Policies:         policies,
 			NetNs:            args.Netns,
+			EnableIpvs:       nwCfg.EnableIpvs,
 		}
 
 		nwInfo.Options = make(map[string]interface{})

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -430,7 +430,7 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 			DNS:              nwDNSInfo,
 			Policies:         policies,
 			NetNs:            args.Netns,
-			EnableIpvs:       nwCfg.EnableIpvs,
+			DisableIpvs:      nwCfg.DisableIpvs,
 		}
 
 		nwInfo.Options = make(map[string]interface{})

--- a/docs/cni.md
+++ b/docs/cni.md
@@ -48,7 +48,7 @@ Network configuration for CNI plugins is described in JSON format. The default l
   "master": "eth0",
   "bridge": "azure0",
   "logLevel": "info",
-  "enableIpvs": false,
+  "disableIpvs": false,
   "ipam": {
     "type": "azure-vnet-ipam",
     "environment": "azure"
@@ -66,7 +66,7 @@ Network plugin
 * `master`: Name of the host network interface that will be used to connect containers to a VNET. This field is optional. If omitted, the plugin will automatically pick a suitable host network interface. Typically, the primary host interface name is `"Ethernet"` on Windows and `"eth0"` on Linux.
 * `bridge`: Name of the bridge that will be used to connect containers to a VNET. This field is optional. If omitted, the plugin will automatically pick a unique name based on the master interface index.
 * `logLevel`: Log verbosity. Valid values are `info` and `debug`. This field is optional. If omitted, the plugin will log at `info` level.
-* `enableIpvs`: Whether to enable IPVS or not. Enabling this forces packets from container network to go via the host network stack, so that IPVS mappings on the host side are used. This field is optional. If omitted, IPVS is treated as disabled.
+* `disableIpvs`: Whether to hard disable IPVS or not. Setting this to `true` prevents creation of those ebtables entries that ensure packets from container network go via the host network stack. This field is optional (defaults to false).
 
 IPAM plugin
 * `type`: Name of the IPAM plugin. This property should always be set to `azure-vnet-ipam`.

--- a/docs/cni.md
+++ b/docs/cni.md
@@ -48,6 +48,7 @@ Network configuration for CNI plugins is described in JSON format. The default l
   "master": "eth0",
   "bridge": "azure0",
   "logLevel": "info",
+  "enableIpvs": false,
   "ipam": {
     "type": "azure-vnet-ipam",
     "environment": "azure"
@@ -65,6 +66,7 @@ Network plugin
 * `master`: Name of the host network interface that will be used to connect containers to a VNET. This field is optional. If omitted, the plugin will automatically pick a suitable host network interface. Typically, the primary host interface name is `"Ethernet"` on Windows and `"eth0"` on Linux.
 * `bridge`: Name of the bridge that will be used to connect containers to a VNET. This field is optional. If omitted, the plugin will automatically pick a unique name based on the master interface index.
 * `logLevel`: Log verbosity. Valid values are `info` and `debug`. This field is optional. If omitted, the plugin will log at `info` level.
+* `enableIpvs`: Whether to enable IPVS or not. Enabling this forces packets from container network to go via the host network stack, so that IPVS mappings on the host side are used. This field is optional. If omitted, IPVS is treated as disabled.
 
 IPAM plugin
 * `type`: Name of the IPAM plugin. This property should always be set to `azure-vnet-ipam`.

--- a/ebtables/ebtables.go
+++ b/ebtables/ebtables.go
@@ -42,6 +42,15 @@ func SetSnatForInterface(interfaceName string, macAddress net.HardwareAddr, acti
 	return executeShellCommand(command)
 }
 
+// SetBrouteRedirect makes sure that all incoming packets from the specified interface get their MAC addresses modified to bridge mac
+func SetBrouteRedirect(incomingIf string, action string) error {
+	command := fmt.Sprintf(
+		"ebtables -t broute %s BROUTING -i %s -p IPv4 -j redirect --redirect-target ACCEPT",
+		action, incomingIf)
+
+	return executeShellCommand(command)
+}
+
 // SetArpReply sets an ARP reply rule for the given target IP address and MAC address.
 func SetArpReply(ipAddress net.IP, macAddress net.HardwareAddr, action string) error {
 	command := fmt.Sprintf(

--- a/network/bridge_endpointclient_linux.go
+++ b/network/bridge_endpointclient_linux.go
@@ -60,6 +60,13 @@ func (client *LinuxBridgeEndpointClient) AddEndpointRules(epInfo *EndpointInfo) 
 		return err
 	}
 
+	// Add Broute redirect rule for the container interface
+	log.Printf("[net] Enable broute redirect rule for %v", client.hostVethName)
+	if err := ebtables.SetBrouteRedirect(client.hostVethName, ebtables.Append); err != nil {
+		log.Printf("[net] Failed to add broute direct rule for %v: %v", client.hostVethName, err)
+		return err
+	}
+
 	for _, ipAddr := range epInfo.IPAddresses {
 		// Add ARP reply rule.
 		log.Printf("[net] Adding ARP reply rule for IP address %v", ipAddr.String())
@@ -114,6 +121,12 @@ func (client *LinuxBridgeEndpointClient) DeleteEndpointRules(ep *endpoint) {
 				log.Printf("Failed removing arp from vm: %v", err)
 			}
 		}
+	}
+
+	// Delete Broute redirect rule for the container interface
+	log.Printf("[net] Delete broute redirect rule for %v", client.hostVethName)
+	if err := ebtables.SetBrouteRedirect(client.hostVethName, ebtables.Delete); err != nil {
+		log.Printf("[net] Failed to delete broute direct rule for %v: %v", client.hostVethName, err)
 	}
 }
 

--- a/network/bridge_endpointclient_linux.go
+++ b/network/bridge_endpointclient_linux.go
@@ -17,7 +17,7 @@ type LinuxBridgeEndpointClient struct {
 	hostPrimaryMac    net.HardwareAddr
 	containerMac      net.HardwareAddr
 	mode              string
-	ipvsEnabled       bool
+	ipvsDisabled      bool
 }
 
 func NewLinuxBridgeEndpointClient(
@@ -25,7 +25,7 @@ func NewLinuxBridgeEndpointClient(
 	hostVethName string,
 	containerVethName string,
 	mode string,
-	ipvsEnabled bool,
+	ipvsDisabled bool,
 ) *LinuxBridgeEndpointClient {
 
 	client := &LinuxBridgeEndpointClient{
@@ -35,7 +35,7 @@ func NewLinuxBridgeEndpointClient(
 		containerVethName: containerVethName,
 		hostPrimaryMac:    extIf.MacAddress,
 		mode:              mode,
-		ipvsEnabled:       ipvsEnabled,
+		ipvsDisabled:      ipvsDisabled,
 	}
 
 	return client
@@ -64,7 +64,7 @@ func (client *LinuxBridgeEndpointClient) AddEndpointRules(epInfo *EndpointInfo) 
 	}
 
 	// Add Broute redirect rule for the container interface
-	if client.ipvsEnabled {
+	if !client.ipvsDisabled {
 		log.Printf("[net] Enable broute redirect rule for %v", client.hostVethName)
 		if err := ebtables.SetBrouteRedirect(client.hostVethName, ebtables.Append); err != nil {
 			log.Printf("[net] Failed to add broute direct rule for %v: %v", client.hostVethName, err)
@@ -128,7 +128,7 @@ func (client *LinuxBridgeEndpointClient) DeleteEndpointRules(ep *endpoint) {
 		}
 	}
 
-	if client.ipvsEnabled {
+	if !client.ipvsDisabled {
 		// Delete Broute redirect rule for the container interface
 		log.Printf("[net] Delete broute redirect rule for %v", client.hostVethName)
 		if err := ebtables.SetBrouteRedirect(client.hostVethName, ebtables.Delete); err != nil {

--- a/network/endpoint_linux.go
+++ b/network/endpoint_linux.go
@@ -100,7 +100,7 @@ func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
 			localIP)
 	} else if nw.Mode != opModeTransparent {
 		log.Printf("Bridge client")
-		epClient = NewLinuxBridgeEndpointClient(nw.extIf, hostIfName, contIfName, nw.Mode, nw.EnableIpvs)
+		epClient = NewLinuxBridgeEndpointClient(nw.extIf, hostIfName, contIfName, nw.Mode, nw.DisableIpvs)
 	} else {
 		log.Printf("Transparent client")
 		epClient = NewTransparentEndpointClient(nw.extIf, hostIfName, contIfName, nw.Mode)
@@ -229,7 +229,7 @@ func (nw *network) deleteEndpointImpl(ep *endpoint) error {
 		epInfo := ep.getInfo()
 		epClient = NewOVSEndpointClient(nw, epInfo, ep.HostIfName, "", ep.VlanID, ep.LocalIP)
 	} else if nw.Mode != opModeTransparent {
-		epClient = NewLinuxBridgeEndpointClient(nw.extIf, ep.HostIfName, "", nw.Mode, nw.EnableIpvs)
+		epClient = NewLinuxBridgeEndpointClient(nw.extIf, ep.HostIfName, "", nw.Mode, nw.DisableIpvs)
 	} else {
 		epClient = NewTransparentEndpointClient(nw.extIf, ep.HostIfName, "", nw.Mode)
 	}

--- a/network/endpoint_linux.go
+++ b/network/endpoint_linux.go
@@ -100,7 +100,7 @@ func (nw *network) newEndpointImpl(epInfo *EndpointInfo) (*endpoint, error) {
 			localIP)
 	} else if nw.Mode != opModeTransparent {
 		log.Printf("Bridge client")
-		epClient = NewLinuxBridgeEndpointClient(nw.extIf, hostIfName, contIfName, nw.Mode)
+		epClient = NewLinuxBridgeEndpointClient(nw.extIf, hostIfName, contIfName, nw.Mode, nw.EnableIpvs)
 	} else {
 		log.Printf("Transparent client")
 		epClient = NewTransparentEndpointClient(nw.extIf, hostIfName, contIfName, nw.Mode)
@@ -229,7 +229,7 @@ func (nw *network) deleteEndpointImpl(ep *endpoint) error {
 		epInfo := ep.getInfo()
 		epClient = NewOVSEndpointClient(nw, epInfo, ep.HostIfName, "", ep.VlanID, ep.LocalIP)
 	} else if nw.Mode != opModeTransparent {
-		epClient = NewLinuxBridgeEndpointClient(nw.extIf, ep.HostIfName, "", nw.Mode)
+		epClient = NewLinuxBridgeEndpointClient(nw.extIf, ep.HostIfName, "", nw.Mode, nw.EnableIpvs)
 	} else {
 		epClient = NewTransparentEndpointClient(nw.extIf, ep.HostIfName, "", nw.Mode)
 	}

--- a/network/network.go
+++ b/network/network.go
@@ -47,6 +47,7 @@ type network struct {
 	EnableSnatOnHost bool
 	NetNs            string
 	SnatBridgeIP     string
+	EnableIpvs       bool `json:",omitempty"`
 }
 
 // NetworkInfo contains read-only information about a container network.
@@ -61,6 +62,7 @@ type NetworkInfo struct {
 	EnableSnatOnHost bool
 	NetNs            string
 	Options          map[string]interface{}
+	EnableIpvs       bool
 }
 
 // SubnetInfo contains subnet information for a container network.

--- a/network/network.go
+++ b/network/network.go
@@ -47,7 +47,7 @@ type network struct {
 	EnableSnatOnHost bool
 	NetNs            string
 	SnatBridgeIP     string
-	EnableIpvs       bool `json:",omitempty"`
+	DisableIpvs      bool `json:",omitempty"`
 }
 
 // NetworkInfo contains read-only information about a container network.
@@ -62,7 +62,7 @@ type NetworkInfo struct {
 	EnableSnatOnHost bool
 	NetNs            string
 	Options          map[string]interface{}
-	EnableIpvs       bool
+	DisableIpvs      bool
 }
 
 // SubnetInfo contains subnet information for a container network.

--- a/network/network_linux.go
+++ b/network/network_linux.go
@@ -78,6 +78,7 @@ func (nm *networkManager) newNetworkImpl(nwInfo *NetworkInfo, extIf *externalInt
 		VlanId:           vlanid,
 		DNS:              nwInfo.DNS,
 		EnableSnatOnHost: nwInfo.EnableSnatOnHost,
+		EnableIpvs:       nwInfo.EnableIpvs,
 	}
 
 	return nw, nil

--- a/network/network_linux.go
+++ b/network/network_linux.go
@@ -78,7 +78,7 @@ func (nm *networkManager) newNetworkImpl(nwInfo *NetworkInfo, extIf *externalInt
 		VlanId:           vlanid,
 		DNS:              nwInfo.DNS,
 		EnableSnatOnHost: nwInfo.EnableSnatOnHost,
-		EnableIpvs:       nwInfo.EnableIpvs,
+		DisableIpvs:      nwInfo.DisableIpvs,
 	}
 
 	return nw, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR makes packets originating from inside the pod to go via the host stack by setting up / tearing down ebtables broute entries when a container comes up / goes down. Without this, or some other mechanism to force packets to be processed by the host stack, IPVS will not work.

**Which issue this PR fixes**:
Fixes #447 

**Special notes for your reviewer**:
This has been tested to work with both IPVS mode, and the regular iptables mode.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```