### PR TITLE
Fix NPM Regression & Remove TelemetryBuffer Sidecar

### DIFF
--- a/npm/azure-npm.yaml
+++ b/npm/azure-npm.yaml
@@ -76,7 +76,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
         - name: azure-npm
-          image: mcr.microsoft.com/containernetworking/azure-npm:v1.0.28
+          image: mcr.microsoft.com/containernetworking/azure-npm:v1.0.30
           securityContext:
             privileged: true
           env:
@@ -90,17 +90,6 @@ spec:
             mountPath: /run/xtables.lock
           - name: log
             mountPath: /var/log
-          - name: socket-dir
-            mountPath: /var/run
-          - name: tmp
-            mountPath: /tmp
-        - name: azure-vnet-telemetry
-          image: mcr.microsoft.com/containernetworking/azure-vnet-telemetry:v1.0.28
-          volumeMounts:
-          - name: socket-dir
-            mountPath: /var/run
-          - name: tmp
-            mountPath: /tmp
       hostNetwork: true
       volumes:
       - name: log
@@ -111,10 +100,4 @@ spec:
         hostPath:
           path: /run/xtables.lock
           type: File
-      - name: tmp
-        hostPath:
-          path: /tmp
-          type: Directory
-      - name: socket-dir
-        emptyDir: {}
       serviceAccountName: azure-npm

--- a/npm/iptm/iptm.go
+++ b/npm/iptm/iptm.go
@@ -153,32 +153,6 @@ func (iptMgr *IptablesManager) InitNpmChains() error {
 		return err
 	}
 
-	// Create AZURE-NPM-KUBE-SYSTEM chain.
-	if err := iptMgr.AddChain(util.IptablesAzureKubeSystemChain); err != nil {
-		return err
-	}
-
-	// Append AZURE-NPM-KUBE-SYSTEM chain to AZURE-NPM chain.
-	entry = &IptEntry{
-		Chain: util.IptablesAzureChain,
-		Specs: []string{
-			util.IptablesJumpFlag,
-			util.IptablesAzureKubeSystemChain,
-		},
-	}
-	exists, err = iptMgr.Exists(entry)
-	if err != nil {
-		return err
-	}
-
-	if !exists {
-		iptMgr.OperationFlag = util.IptablesAppendFlag
-		if _, err = iptMgr.Run(entry); err != nil {
-			log.Errorf("Error: failed to add AZURE-NPM-KUBE-SYSTEM chain to AZURE-NPM chain.")
-			return err
-		}
-	}
-
 	// Create AZURE-NPM-TARGET-SETS chain.
 	if err := iptMgr.AddChain(util.IptablesAzureTargetSetsChain); err != nil {
 		return err

--- a/npm/iptm/iptm.go
+++ b/npm/iptm/iptm.go
@@ -101,32 +101,6 @@ func (iptMgr *IptablesManager) InitNpmChains() error {
 		}
 	}
 
-	// Create AZURE-NPM-KUBE-SYSTEM chain.
-	if err := iptMgr.AddChain(util.IptablesAzureKubeSystemChain); err != nil {
-		return err
-	}
-
-	// Append AZURE-NPM-KUBE-SYSTEM chain to AZURE-NPM chain.
-	entry = &IptEntry{
-		Chain: util.IptablesAzureChain,
-		Specs: []string{
-			util.IptablesJumpFlag,
-			util.IptablesAzureKubeSystemChain,
-		},
-	}
-	exists, err = iptMgr.Exists(entry)
-	if err != nil {
-		return err
-	}
-
-	if !exists {
-		iptMgr.OperationFlag = util.IptablesAppendFlag
-		if _, err = iptMgr.Run(entry); err != nil {
-			log.Errorf("Error: failed to add AZURE-NPM-KUBE-SYSTEM chain to AZURE-NPM chain.")
-			return err
-		}
-	}
-
 	// Create AZURE-NPM-INGRESS-PORT chain.
 	if err := iptMgr.AddChain(util.IptablesAzureIngressPortChain); err != nil {
 		return err
@@ -177,6 +151,32 @@ func (iptMgr *IptablesManager) InitNpmChains() error {
 	// Create AZURE-NPM-EGRESS-TO chain.
 	if err = iptMgr.AddChain(util.IptablesAzureEgressToChain); err != nil {
 		return err
+	}
+
+	// Create AZURE-NPM-KUBE-SYSTEM chain.
+	if err := iptMgr.AddChain(util.IptablesAzureKubeSystemChain); err != nil {
+		return err
+	}
+
+	// Append AZURE-NPM-KUBE-SYSTEM chain to AZURE-NPM chain.
+	entry = &IptEntry{
+		Chain: util.IptablesAzureChain,
+		Specs: []string{
+			util.IptablesJumpFlag,
+			util.IptablesAzureKubeSystemChain,
+		},
+	}
+	exists, err = iptMgr.Exists(entry)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		iptMgr.OperationFlag = util.IptablesAppendFlag
+		if _, err = iptMgr.Run(entry); err != nil {
+			log.Errorf("Error: failed to add AZURE-NPM-KUBE-SYSTEM chain to AZURE-NPM chain.")
+			return err
+		}
 	}
 
 	// Create AZURE-NPM-TARGET-SETS chain.

--- a/npm/plugin/main.go
+++ b/npm/plugin/main.go
@@ -60,8 +60,6 @@ func main() {
 
 	npMgr := npm.NewNetworkPolicyManager(clientset, factory, version)
 
-	go npMgr.SendNpmTelemetry()
-
 	if err = npMgr.Start(wait.NeverStop); err != nil {
 		log.Logf("npm failed with error %v.", err)
 		panic(err.Error)

--- a/npm/plugin/main.go
+++ b/npm/plugin/main.go
@@ -22,7 +22,7 @@ var version string
 func initLogging() error {
 	log.SetName("azure-npm")
 	log.SetLevel(log.LevelInfo)
-	if err := log.SetTarget(log.TargetLogfile); err != nil {
+	if err := log.SetTarget(log.TargetStdOutAndLogFile); err != nil {
 		log.Logf("Failed to configure logging, err:%v.", err)
 		return err
 	}

--- a/npm/translatePolicy_test.go
+++ b/npm/translatePolicy_test.go
@@ -634,33 +634,6 @@ func TestTranslateIngress(t *testing.T) {
 
 	expectedIptEntries := []*iptm.IptEntry{
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressPortChain,
-			Specs: []string{
-				util.IptablesProtFlag,
-				string(v1.ProtocolTCP),
-				util.IptablesDstPortFlag,
-				"6783",
-				util.IptablesModuleFlag,
-				util.IptablesSetModuleFlag,
-				util.IptablesMatchSetFlag,
-				util.GetHashedName("context:dev"),
-				util.IptablesDstFlag,
-				util.IptablesModuleFlag,
-				util.IptablesSetModuleFlag,
-				util.IptablesNotFlag,
-				util.IptablesMatchSetFlag,
-				util.GetHashedName("testNotIn:frontend"),
-				util.IptablesDstFlag,
-				util.IptablesJumpFlag,
-				util.IptablesAzureIngressFromChain,
-				util.IptablesModuleFlag,
-				util.IptablesCommentModuleFlag,
-				util.IptablesCommentFlag,
-				"ALLOW-ALL-TO-TCP-PORT-6783-OF-context:dev-AND-!testNotIn:frontend-TO-JUMP-TO-" +
-					util.IptablesAzureIngressFromChain,
-			},
-		},
-		&iptm.IptEntry{
 			Chain: util.IptablesAzureIngressFromChain,
 			Specs: []string{
 				util.IptablesModuleFlag,
@@ -765,6 +738,33 @@ func TestTranslateIngress(t *testing.T) {
 				util.IptablesCommentModuleFlag,
 				util.IptablesCommentFlag,
 				"ALLOW-ns-planet:earth-AND-ns-keyExists-AND-region:northpole-AND-!k-TO-context:dev-AND-!testNotIn:frontend",
+			},
+		},
+		&iptm.IptEntry{
+			Chain: util.IptablesAzureIngressPortChain,
+			Specs: []string{
+				util.IptablesProtFlag,
+				string(v1.ProtocolTCP),
+				util.IptablesDstPortFlag,
+				"6783",
+				util.IptablesModuleFlag,
+				util.IptablesSetModuleFlag,
+				util.IptablesMatchSetFlag,
+				util.GetHashedName("context:dev"),
+				util.IptablesDstFlag,
+				util.IptablesModuleFlag,
+				util.IptablesSetModuleFlag,
+				util.IptablesNotFlag,
+				util.IptablesMatchSetFlag,
+				util.GetHashedName("testNotIn:frontend"),
+				util.IptablesDstFlag,
+				util.IptablesJumpFlag,
+				util.IptablesAzureIngressFromChain,
+				util.IptablesModuleFlag,
+				util.IptablesCommentModuleFlag,
+				util.IptablesCommentFlag,
+				"ALLOW-ALL-TO-TCP-PORT-6783-OF-context:dev-AND-!testNotIn:frontend-TO-JUMP-TO-" +
+					util.IptablesAzureIngressFromChain,
 			},
 		},
 	}
@@ -904,33 +904,6 @@ func TestTranslateEgress(t *testing.T) {
 
 	expectedIptEntries := []*iptm.IptEntry{
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureEgressPortChain,
-			Specs: []string{
-				util.IptablesProtFlag,
-				string(v1.ProtocolTCP),
-				util.IptablesDstPortFlag,
-				"6783",
-				util.IptablesModuleFlag,
-				util.IptablesSetModuleFlag,
-				util.IptablesMatchSetFlag,
-				util.GetHashedName("context:dev"),
-				util.IptablesSrcFlag,
-				util.IptablesModuleFlag,
-				util.IptablesSetModuleFlag,
-				util.IptablesNotFlag,
-				util.IptablesMatchSetFlag,
-				util.GetHashedName("testNotIn:frontend"),
-				util.IptablesSrcFlag,
-				util.IptablesJumpFlag,
-				util.IptablesAzureEgressToChain,
-				util.IptablesModuleFlag,
-				util.IptablesCommentModuleFlag,
-				util.IptablesCommentFlag,
-				"ALLOW-ALL-FROM-TCP-PORT-6783-OF-context:dev-AND-!testNotIn:frontend-TO-JUMP-TO-" +
-					util.IptablesAzureEgressToChain,
-			},
-		},
-		&iptm.IptEntry{
 			Chain: util.IptablesAzureEgressToChain,
 			Specs: []string{
 				util.IptablesModuleFlag,
@@ -1035,6 +1008,33 @@ func TestTranslateEgress(t *testing.T) {
 				util.IptablesCommentModuleFlag,
 				util.IptablesCommentFlag,
 				"ALLOW-context:dev-AND-!testNotIn:frontend-TO-ns-planet:earth-AND-ns-keyExists-AND-region:northpole-AND-!k",
+			},
+		},
+		&iptm.IptEntry{
+			Chain: util.IptablesAzureEgressPortChain,
+			Specs: []string{
+				util.IptablesProtFlag,
+				string(v1.ProtocolTCP),
+				util.IptablesDstPortFlag,
+				"6783",
+				util.IptablesModuleFlag,
+				util.IptablesSetModuleFlag,
+				util.IptablesMatchSetFlag,
+				util.GetHashedName("context:dev"),
+				util.IptablesSrcFlag,
+				util.IptablesModuleFlag,
+				util.IptablesSetModuleFlag,
+				util.IptablesNotFlag,
+				util.IptablesMatchSetFlag,
+				util.GetHashedName("testNotIn:frontend"),
+				util.IptablesSrcFlag,
+				util.IptablesJumpFlag,
+				util.IptablesAzureEgressToChain,
+				util.IptablesModuleFlag,
+				util.IptablesCommentModuleFlag,
+				util.IptablesCommentFlag,
+				"ALLOW-ALL-FROM-TCP-PORT-6783-OF-context:dev-AND-!testNotIn:frontend-TO-JUMP-TO-" +
+					util.IptablesAzureEgressToChain,
 			},
 		},
 	}
@@ -1152,23 +1152,6 @@ func TestTranslatePolicy(t *testing.T) {
 
 	nonKubeSystemEntries := []*iptm.IptEntry{
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressPortChain,
-			Specs: []string{
-				util.IptablesModuleFlag,
-				util.IptablesSetModuleFlag,
-				util.IptablesMatchSetFlag,
-				util.GetHashedName("app:backend"),
-				util.IptablesDstFlag,
-				util.IptablesJumpFlag,
-				util.IptablesAzureIngressFromChain,
-				util.IptablesModuleFlag,
-				util.IptablesCommentModuleFlag,
-				util.IptablesCommentFlag,
-				"ALLOW-ALL-TO-app:backend-TO-JUMP-TO-" +
-					util.IptablesAzureIngressFromChain,
-			},
-		},
-		&iptm.IptEntry{
 			Chain: util.IptablesAzureIngressFromChain,
 			Specs: []string{
 				util.IptablesModuleFlag,
@@ -1187,6 +1170,23 @@ func TestTranslatePolicy(t *testing.T) {
 				util.IptablesCommentModuleFlag,
 				util.IptablesCommentFlag,
 				"ALLOW-app:frontend-TO-app:backend",
+			},
+		},
+		&iptm.IptEntry{
+			Chain: util.IptablesAzureIngressPortChain,
+			Specs: []string{
+				util.IptablesModuleFlag,
+				util.IptablesSetModuleFlag,
+				util.IptablesMatchSetFlag,
+				util.GetHashedName("app:backend"),
+				util.IptablesDstFlag,
+				util.IptablesJumpFlag,
+				util.IptablesAzureIngressFromChain,
+				util.IptablesModuleFlag,
+				util.IptablesCommentModuleFlag,
+				util.IptablesCommentFlag,
+				"ALLOW-ALL-TO-app:backend-TO-JUMP-TO-" +
+					util.IptablesAzureIngressFromChain,
 			},
 		},
 	}
@@ -1385,23 +1385,6 @@ func TestTranslatePolicy(t *testing.T) {
 
 	nonKubeSystemEntries = []*iptm.IptEntry{
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressPortChain,
-			Specs: []string{
-				util.IptablesModuleFlag,
-				util.IptablesSetModuleFlag,
-				util.IptablesMatchSetFlag,
-				util.GetHashedName("app:frontend"),
-				util.IptablesDstFlag,
-				util.IptablesJumpFlag,
-				util.IptablesAzureIngressFromChain,
-				util.IptablesModuleFlag,
-				util.IptablesCommentModuleFlag,
-				util.IptablesCommentFlag,
-				"ALLOW-ALL-TO-app:frontend-TO-JUMP-TO-" +
-					util.IptablesAzureIngressFromChain,
-			},
-		},
-		&iptm.IptEntry{
 			Chain: util.IptablesAzureIngressFromChain,
 			Specs: []string{
 				util.IptablesModuleFlag,
@@ -1420,6 +1403,23 @@ func TestTranslatePolicy(t *testing.T) {
 				util.IptablesCommentModuleFlag,
 				util.IptablesCommentFlag,
 				"ALLOW-ns-testnamespace-TO-app:frontend",
+			},
+		},
+		&iptm.IptEntry{
+			Chain: util.IptablesAzureIngressPortChain,
+			Specs: []string{
+				util.IptablesModuleFlag,
+				util.IptablesSetModuleFlag,
+				util.IptablesMatchSetFlag,
+				util.GetHashedName("app:frontend"),
+				util.IptablesDstFlag,
+				util.IptablesJumpFlag,
+				util.IptablesAzureIngressFromChain,
+				util.IptablesModuleFlag,
+				util.IptablesCommentModuleFlag,
+				util.IptablesCommentFlag,
+				"ALLOW-ALL-TO-app:frontend-TO-JUMP-TO-" +
+					util.IptablesAzureIngressFromChain,
 			},
 		},
 	}
@@ -1487,23 +1487,6 @@ func TestTranslatePolicy(t *testing.T) {
 
 	nonKubeSystemEntries = []*iptm.IptEntry{
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressPortChain,
-			Specs: []string{
-				util.IptablesModuleFlag,
-				util.IptablesSetModuleFlag,
-				util.IptablesMatchSetFlag,
-				util.GetHashedName("app:frontend"),
-				util.IptablesDstFlag,
-				util.IptablesJumpFlag,
-				util.IptablesAzureIngressFromChain,
-				util.IptablesModuleFlag,
-				util.IptablesCommentModuleFlag,
-				util.IptablesCommentFlag,
-				"ALLOW-ALL-TO-app:frontend-TO-JUMP-TO-" +
-					util.IptablesAzureIngressFromChain,
-			},
-		},
-		&iptm.IptEntry{
 			Chain: util.IptablesAzureIngressFromChain,
 			Specs: []string{
 				util.IptablesModuleFlag,
@@ -1522,6 +1505,23 @@ func TestTranslatePolicy(t *testing.T) {
 				util.IptablesCommentModuleFlag,
 				util.IptablesCommentFlag,
 				"ALLOW-all-namespaces-TO-app:frontend",
+			},
+		},
+		&iptm.IptEntry{
+			Chain: util.IptablesAzureIngressPortChain,
+			Specs: []string{
+				util.IptablesModuleFlag,
+				util.IptablesSetModuleFlag,
+				util.IptablesMatchSetFlag,
+				util.GetHashedName("app:frontend"),
+				util.IptablesDstFlag,
+				util.IptablesJumpFlag,
+				util.IptablesAzureIngressFromChain,
+				util.IptablesModuleFlag,
+				util.IptablesCommentModuleFlag,
+				util.IptablesCommentFlag,
+				"ALLOW-ALL-TO-app:frontend-TO-JUMP-TO-" +
+					util.IptablesAzureIngressFromChain,
 			},
 		},
 	}
@@ -1606,23 +1606,6 @@ func TestTranslatePolicy(t *testing.T) {
 
 	nonKubeSystemEntries = []*iptm.IptEntry{
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressPortChain,
-			Specs: []string{
-				util.IptablesModuleFlag,
-				util.IptablesSetModuleFlag,
-				util.IptablesMatchSetFlag,
-				util.GetHashedName("app:frontend"),
-				util.IptablesDstFlag,
-				util.IptablesJumpFlag,
-				util.IptablesAzureIngressFromChain,
-				util.IptablesModuleFlag,
-				util.IptablesCommentModuleFlag,
-				util.IptablesCommentFlag,
-				"ALLOW-ALL-TO-app:frontend-TO-JUMP-TO-" +
-					util.IptablesAzureIngressFromChain,
-			},
-		},
-		&iptm.IptEntry{
 			Chain: util.IptablesAzureIngressFromChain,
 			Specs: []string{
 				util.IptablesModuleFlag,
@@ -1653,6 +1636,23 @@ func TestTranslatePolicy(t *testing.T) {
 				util.IptablesCommentModuleFlag,
 				util.IptablesCommentFlag,
 				"ALLOW-ns-namespace:dev-AND-ns-!namespace:test0-AND-ns-!namespace:test1-TO-app:frontend",
+			},
+		},
+		&iptm.IptEntry{
+			Chain: util.IptablesAzureIngressPortChain,
+			Specs: []string{
+				util.IptablesModuleFlag,
+				util.IptablesSetModuleFlag,
+				util.IptablesMatchSetFlag,
+				util.GetHashedName("app:frontend"),
+				util.IptablesDstFlag,
+				util.IptablesJumpFlag,
+				util.IptablesAzureIngressFromChain,
+				util.IptablesModuleFlag,
+				util.IptablesCommentModuleFlag,
+				util.IptablesCommentFlag,
+				"ALLOW-ALL-TO-app:frontend-TO-JUMP-TO-" +
+					util.IptablesAzureIngressFromChain,
 			},
 		},
 	}
@@ -1734,39 +1734,6 @@ func TestTranslatePolicy(t *testing.T) {
 	)
 	nonKubeSystemEntries = []*iptm.IptEntry{
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressPortChain,
-			Specs: []string{
-				util.IptablesModuleFlag,
-				util.IptablesSetModuleFlag,
-				util.IptablesMatchSetFlag,
-				util.GetHashedName("app:frontend"),
-				util.IptablesDstFlag,
-				util.IptablesModuleFlag,
-				util.IptablesSetModuleFlag,
-				util.IptablesNotFlag,
-				util.IptablesMatchSetFlag,
-				util.GetHashedName("k0"),
-				util.IptablesDstFlag,
-				util.IptablesModuleFlag,
-				util.IptablesSetModuleFlag,
-				util.IptablesMatchSetFlag,
-				util.GetHashedName("k1:v0"),
-				util.IptablesDstFlag,
-				util.IptablesModuleFlag,
-				util.IptablesSetModuleFlag,
-				util.IptablesMatchSetFlag,
-				util.GetHashedName("k1:v1"),
-				util.IptablesDstFlag,
-				util.IptablesJumpFlag,
-				util.IptablesAzureIngressFromChain,
-				util.IptablesModuleFlag,
-				util.IptablesCommentModuleFlag,
-				util.IptablesCommentFlag,
-				"ALLOW-ALL-TO-app:frontend-AND-!k0-AND-k1:v0-AND-k1:v1-TO-JUMP-TO-" +
-					util.IptablesAzureIngressFromChain,
-			},
-		},
-		&iptm.IptEntry{
 			Chain: util.IptablesAzureIngressFromChain,
 			Specs: []string{
 				util.IptablesModuleFlag,
@@ -1801,6 +1768,39 @@ func TestTranslatePolicy(t *testing.T) {
 				util.IptablesCommentModuleFlag,
 				util.IptablesCommentFlag,
 				"ALLOW-all-namespaces-TO-app:frontend-AND-!k0-AND-k1:v0-AND-k1:v1",
+			},
+		},
+		&iptm.IptEntry{
+			Chain: util.IptablesAzureIngressPortChain,
+			Specs: []string{
+				util.IptablesModuleFlag,
+				util.IptablesSetModuleFlag,
+				util.IptablesMatchSetFlag,
+				util.GetHashedName("app:frontend"),
+				util.IptablesDstFlag,
+				util.IptablesModuleFlag,
+				util.IptablesSetModuleFlag,
+				util.IptablesNotFlag,
+				util.IptablesMatchSetFlag,
+				util.GetHashedName("k0"),
+				util.IptablesDstFlag,
+				util.IptablesModuleFlag,
+				util.IptablesSetModuleFlag,
+				util.IptablesMatchSetFlag,
+				util.GetHashedName("k1:v0"),
+				util.IptablesDstFlag,
+				util.IptablesModuleFlag,
+				util.IptablesSetModuleFlag,
+				util.IptablesMatchSetFlag,
+				util.GetHashedName("k1:v1"),
+				util.IptablesDstFlag,
+				util.IptablesJumpFlag,
+				util.IptablesAzureIngressFromChain,
+				util.IptablesModuleFlag,
+				util.IptablesCommentModuleFlag,
+				util.IptablesCommentFlag,
+				"ALLOW-ALL-TO-app:frontend-AND-!k0-AND-k1:v0-AND-k1:v1-TO-JUMP-TO-" +
+					util.IptablesAzureIngressFromChain,
 			},
 		},
 	}
@@ -1880,23 +1880,6 @@ func TestTranslatePolicy(t *testing.T) {
 	)
 	nonKubeSystemEntries = []*iptm.IptEntry{
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressPortChain,
-			Specs: []string{
-				util.IptablesModuleFlag,
-				util.IptablesSetModuleFlag,
-				util.IptablesMatchSetFlag,
-				util.GetHashedName("app:frontend"),
-				util.IptablesDstFlag,
-				util.IptablesJumpFlag,
-				util.IptablesAzureIngressFromChain,
-				util.IptablesModuleFlag,
-				util.IptablesCommentModuleFlag,
-				util.IptablesCommentFlag,
-				"ALLOW-ALL-TO-app:frontend-TO-JUMP-TO-" +
-					util.IptablesAzureIngressFromChain,
-			},
-		},
-		&iptm.IptEntry{
 			Chain: util.IptablesAzureIngressFromChain,
 			Specs: []string{
 				util.IptablesModuleFlag,
@@ -1920,6 +1903,23 @@ func TestTranslatePolicy(t *testing.T) {
 				util.IptablesCommentModuleFlag,
 				util.IptablesCommentFlag,
 				"ALLOW-ns-ns:dev-AND-app:backend-TO-app:frontend",
+			},
+		},
+		&iptm.IptEntry{
+			Chain: util.IptablesAzureIngressPortChain,
+			Specs: []string{
+				util.IptablesModuleFlag,
+				util.IptablesSetModuleFlag,
+				util.IptablesMatchSetFlag,
+				util.GetHashedName("app:frontend"),
+				util.IptablesDstFlag,
+				util.IptablesJumpFlag,
+				util.IptablesAzureIngressFromChain,
+				util.IptablesModuleFlag,
+				util.IptablesCommentModuleFlag,
+				util.IptablesCommentFlag,
+				"ALLOW-ALL-TO-app:frontend-TO-JUMP-TO-" +
+					util.IptablesAzureIngressFromChain,
 			},
 		},
 	}
@@ -2092,25 +2092,6 @@ func TestTranslatePolicy(t *testing.T) {
 
 	nonKubeSystemEntries = []*iptm.IptEntry{
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressPortChain,
-			Specs: []string{
-				util.IptablesDstPortFlag,
-				"8000",
-				util.IptablesModuleFlag,
-				util.IptablesSetModuleFlag,
-				util.IptablesMatchSetFlag,
-				util.GetHashedName("app:frontend"),
-				util.IptablesDstFlag,
-				util.IptablesJumpFlag,
-				util.IptablesAzureIngressFromChain,
-				util.IptablesModuleFlag,
-				util.IptablesCommentModuleFlag,
-				util.IptablesCommentFlag,
-				"ALLOW-ALL-TO-PORT-8000-OF-app:frontend-TO-JUMP-TO-" +
-					util.IptablesAzureIngressFromChain,
-			},
-		},
-		&iptm.IptEntry{
 			Chain: util.IptablesAzureIngressFromChain,
 			Specs: []string{
 				util.IptablesModuleFlag,
@@ -2129,6 +2110,25 @@ func TestTranslatePolicy(t *testing.T) {
 				util.IptablesCommentModuleFlag,
 				util.IptablesCommentFlag,
 				"ALLOW-app:backend-TO-app:frontend",
+			},
+		},
+		&iptm.IptEntry{
+			Chain: util.IptablesAzureIngressPortChain,
+			Specs: []string{
+				util.IptablesDstPortFlag,
+				"8000",
+				util.IptablesModuleFlag,
+				util.IptablesSetModuleFlag,
+				util.IptablesMatchSetFlag,
+				util.GetHashedName("app:frontend"),
+				util.IptablesDstFlag,
+				util.IptablesJumpFlag,
+				util.IptablesAzureIngressFromChain,
+				util.IptablesModuleFlag,
+				util.IptablesCommentModuleFlag,
+				util.IptablesCommentFlag,
+				"ALLOW-ALL-TO-PORT-8000-OF-app:frontend-TO-JUMP-TO-" +
+					util.IptablesAzureIngressFromChain,
 			},
 		},
 	}
@@ -2215,28 +2215,6 @@ func TestTranslatePolicy(t *testing.T) {
 
 	nonKubeSystemEntries = []*iptm.IptEntry{
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressPortChain,
-			Specs: []string{
-				util.IptablesModuleFlag,
-				util.IptablesSetModuleFlag,
-				util.IptablesMatchSetFlag,
-				util.GetHashedName("app:k8s"),
-				util.IptablesDstFlag,
-				util.IptablesModuleFlag,
-				util.IptablesSetModuleFlag,
-				util.IptablesMatchSetFlag,
-				util.GetHashedName("team:aks"),
-				util.IptablesDstFlag,
-				util.IptablesJumpFlag,
-				util.IptablesAzureIngressFromChain,
-				util.IptablesModuleFlag,
-				util.IptablesCommentModuleFlag,
-				util.IptablesCommentFlag,
-				"ALLOW-ALL-TO-app:k8s-AND-team:aks-TO-JUMP-TO-" +
-					util.IptablesAzureIngressFromChain,
-			},
-		},
-		&iptm.IptEntry{
 			Chain: util.IptablesAzureIngressFromChain,
 			Specs: []string{
 				util.IptablesModuleFlag,
@@ -2296,6 +2274,28 @@ func TestTranslatePolicy(t *testing.T) {
 				util.IptablesCommentModuleFlag,
 				util.IptablesCommentFlag,
 				"ALLOW-binary:cns-AND-group:container-TO-app:k8s-AND-team:aks",
+			},
+		},
+		&iptm.IptEntry{
+			Chain: util.IptablesAzureIngressPortChain,
+			Specs: []string{
+				util.IptablesModuleFlag,
+				util.IptablesSetModuleFlag,
+				util.IptablesMatchSetFlag,
+				util.GetHashedName("app:k8s"),
+				util.IptablesDstFlag,
+				util.IptablesModuleFlag,
+				util.IptablesSetModuleFlag,
+				util.IptablesMatchSetFlag,
+				util.GetHashedName("team:aks"),
+				util.IptablesDstFlag,
+				util.IptablesJumpFlag,
+				util.IptablesAzureIngressFromChain,
+				util.IptablesModuleFlag,
+				util.IptablesCommentModuleFlag,
+				util.IptablesCommentFlag,
+				"ALLOW-ALL-TO-app:k8s-AND-team:aks-TO-JUMP-TO-" +
+					util.IptablesAzureIngressFromChain,
 			},
 		},
 	}
@@ -2600,23 +2600,6 @@ func TestTranslatePolicy(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureEgressPortChain,
-			Specs: []string{
-				util.IptablesModuleFlag,
-				util.IptablesSetModuleFlag,
-				util.IptablesMatchSetFlag,
-				util.GetHashedName("app:frontend"),
-				util.IptablesSrcFlag,
-				util.IptablesJumpFlag,
-				util.IptablesAzureEgressToChain,
-				util.IptablesModuleFlag,
-				util.IptablesCommentModuleFlag,
-				util.IptablesCommentFlag,
-				"ALLOW-ALL-FROM-app:frontend-TO-JUMP-TO-" +
-					util.IptablesAzureEgressToChain,
-			},
-		},
-		&iptm.IptEntry{
 			Chain: util.IptablesAzureEgressToChain,
 			Specs: []string{
 				util.IptablesModuleFlag,
@@ -2636,6 +2619,23 @@ func TestTranslatePolicy(t *testing.T) {
 				util.IptablesCommentFlag,
 				"ALLOW-app:frontend-TO-" +
 					util.KubeAllNamespacesFlag,
+			},
+		},
+		&iptm.IptEntry{
+			Chain: util.IptablesAzureEgressPortChain,
+			Specs: []string{
+				util.IptablesModuleFlag,
+				util.IptablesSetModuleFlag,
+				util.IptablesMatchSetFlag,
+				util.GetHashedName("app:frontend"),
+				util.IptablesSrcFlag,
+				util.IptablesJumpFlag,
+				util.IptablesAzureEgressToChain,
+				util.IptablesModuleFlag,
+				util.IptablesCommentModuleFlag,
+				util.IptablesCommentFlag,
+				"ALLOW-ALL-FROM-app:frontend-TO-JUMP-TO-" +
+					util.IptablesAzureEgressToChain,
 			},
 		},
 	}
@@ -2751,24 +2751,21 @@ func TestTranslatePolicy(t *testing.T) {
 
 	nonKubeSystemEntries = []*iptm.IptEntry{
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressPortChain,
+			Chain: util.IptablesAzureIngressFromChain,
 			Specs: []string{
-				util.IptablesProtFlag,
-				"TCP",
-				util.IptablesDstPortFlag,
-				"6379",
+				util.IptablesSFlag,
+				"172.17.1.0/24",
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
 				util.IptablesMatchSetFlag,
 				util.GetHashedName("role:db"),
 				util.IptablesDstFlag,
 				util.IptablesJumpFlag,
-				util.IptablesAzureIngressFromChain,
+				util.IptablesDrop,
 				util.IptablesModuleFlag,
 				util.IptablesCommentModuleFlag,
 				util.IptablesCommentFlag,
-				"ALLOW-ALL-TO-TCP-PORT-6379-OF-role:db-TO-JUMP-TO-" +
-					util.IptablesAzureIngressFromChain,
+				"DROP-172.17.1.0/24-TO-role:db",
 			},
 		},
 		&iptm.IptEntry{
@@ -2787,24 +2784,6 @@ func TestTranslatePolicy(t *testing.T) {
 				util.IptablesCommentModuleFlag,
 				util.IptablesCommentFlag,
 				"ALLOW-172.17.0.0/16-TO-role:db",
-			},
-		},
-		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressFromChain,
-			Specs: []string{
-				util.IptablesSFlag,
-				"172.17.1.0/24",
-				util.IptablesModuleFlag,
-				util.IptablesSetModuleFlag,
-				util.IptablesMatchSetFlag,
-				util.GetHashedName("role:db"),
-				util.IptablesDstFlag,
-				util.IptablesJumpFlag,
-				util.IptablesDrop,
-				util.IptablesModuleFlag,
-				util.IptablesCommentModuleFlag,
-				util.IptablesCommentFlag,
-				"DROP-172.17.1.0/24-TO-role:db",
 			},
 		},
 		&iptm.IptEntry{
@@ -2850,24 +2829,24 @@ func TestTranslatePolicy(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureEgressPortChain,
+			Chain: util.IptablesAzureIngressPortChain,
 			Specs: []string{
 				util.IptablesProtFlag,
 				"TCP",
 				util.IptablesDstPortFlag,
-				"5978",
+				"6379",
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
 				util.IptablesMatchSetFlag,
 				util.GetHashedName("role:db"),
-				util.IptablesSrcFlag,
+				util.IptablesDstFlag,
 				util.IptablesJumpFlag,
-				util.IptablesAzureEgressToChain,
+				util.IptablesAzureIngressFromChain,
 				util.IptablesModuleFlag,
 				util.IptablesCommentModuleFlag,
 				util.IptablesCommentFlag,
-				"ALLOW-ALL-FROM-TCP-PORT-5978-OF-role:db-TO-JUMP-TO-" +
-					util.IptablesAzureEgressToChain,
+				"ALLOW-ALL-TO-TCP-PORT-6379-OF-role:db-TO-JUMP-TO-" +
+					util.IptablesAzureIngressFromChain,
 			},
 		},
 		&iptm.IptEntry{
@@ -2886,6 +2865,27 @@ func TestTranslatePolicy(t *testing.T) {
 				util.IptablesCommentModuleFlag,
 				util.IptablesCommentFlag,
 				"ALLOW-10.0.0.0/24-FROM-role:db",
+			},
+		},
+		&iptm.IptEntry{
+			Chain: util.IptablesAzureEgressPortChain,
+			Specs: []string{
+				util.IptablesProtFlag,
+				"TCP",
+				util.IptablesDstPortFlag,
+				"5978",
+				util.IptablesModuleFlag,
+				util.IptablesSetModuleFlag,
+				util.IptablesMatchSetFlag,
+				util.GetHashedName("role:db"),
+				util.IptablesSrcFlag,
+				util.IptablesJumpFlag,
+				util.IptablesAzureEgressToChain,
+				util.IptablesModuleFlag,
+				util.IptablesCommentModuleFlag,
+				util.IptablesCommentFlag,
+				"ALLOW-ALL-FROM-TCP-PORT-5978-OF-role:db-TO-JUMP-TO-" +
+					util.IptablesAzureEgressToChain,
 			},
 		},
 	}
@@ -3051,28 +3051,6 @@ func TestAllowPrecedenceOverDeny(t *testing.T) {
 	}
 	nonKubeSystemEntries2 := []*iptm.IptEntry{
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressPortChain,
-			Specs: []string{
-				util.IptablesModuleFlag,
-				util.IptablesSetModuleFlag,
-				util.IptablesMatchSetFlag,
-				util.GetHashedName("app:test"),
-				util.IptablesDstFlag,
-				util.IptablesModuleFlag,
-				util.IptablesSetModuleFlag,
-				util.IptablesMatchSetFlag,
-				util.GetHashedName("testIn:pod-A"),
-				util.IptablesDstFlag,
-				util.IptablesJumpFlag,
-				util.IptablesAzureIngressFromChain,
-				util.IptablesModuleFlag,
-				util.IptablesCommentModuleFlag,
-				util.IptablesCommentFlag,
-				"ALLOW-ALL-TO-app:test-AND-testIn:pod-A-TO-JUMP-TO-" +
-					util.IptablesAzureIngressFromChain,
-			},
-		},
-		&iptm.IptEntry{
 			Chain: util.IptablesAzureIngressFromChain,
 			Specs: []string{
 				util.IptablesModuleFlag,
@@ -3135,25 +3113,25 @@ func TestAllowPrecedenceOverDeny(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureEgressPortChain,
+			Chain: util.IptablesAzureIngressPortChain,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
 				util.IptablesMatchSetFlag,
 				util.GetHashedName("app:test"),
-				util.IptablesSrcFlag,
+				util.IptablesDstFlag,
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
 				util.IptablesMatchSetFlag,
 				util.GetHashedName("testIn:pod-A"),
-				util.IptablesSrcFlag,
+				util.IptablesDstFlag,
 				util.IptablesJumpFlag,
-				util.IptablesAzureEgressToChain,
+				util.IptablesAzureIngressFromChain,
 				util.IptablesModuleFlag,
 				util.IptablesCommentModuleFlag,
 				util.IptablesCommentFlag,
-				"ALLOW-ALL-FROM-app:test-AND-testIn:pod-A-TO-JUMP-TO-" +
-					util.IptablesAzureEgressToChain,
+				"ALLOW-ALL-TO-app:test-AND-testIn:pod-A-TO-JUMP-TO-" +
+					util.IptablesAzureIngressFromChain,
 			},
 		},
 		&iptm.IptEntry{
@@ -3180,6 +3158,28 @@ func TestAllowPrecedenceOverDeny(t *testing.T) {
 				util.IptablesCommentModuleFlag,
 				util.IptablesCommentFlag,
 				"ALLOW-app:test-AND-testIn:pod-A-TO-all-namespaces",
+			},
+		},
+		&iptm.IptEntry{
+			Chain: util.IptablesAzureEgressPortChain,
+			Specs: []string{
+				util.IptablesModuleFlag,
+				util.IptablesSetModuleFlag,
+				util.IptablesMatchSetFlag,
+				util.GetHashedName("app:test"),
+				util.IptablesSrcFlag,
+				util.IptablesModuleFlag,
+				util.IptablesSetModuleFlag,
+				util.IptablesMatchSetFlag,
+				util.GetHashedName("testIn:pod-A"),
+				util.IptablesSrcFlag,
+				util.IptablesJumpFlag,
+				util.IptablesAzureEgressToChain,
+				util.IptablesModuleFlag,
+				util.IptablesCommentModuleFlag,
+				util.IptablesCommentFlag,
+				"ALLOW-ALL-FROM-app:test-AND-testIn:pod-A-TO-JUMP-TO-" +
+					util.IptablesAzureEgressToChain,
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
- give precedence to drop rules (over allow)
- remove telemetry buffer from NPM (removed sidecar as well)
- write logs to stdout (and file) so that we may see logs using 'kubectl logs...'
- remove kube-system chain
- add drop entries in corresponding chain for specific policies (i.e. non ALLOW-ALL* entries)