### PR TITLE
Prevent Namespace Race

### DIFF
--- a/npm/namespace_test.go
+++ b/npm/namespace_test.go
@@ -80,7 +80,7 @@ func TestAddNamespace(t *testing.T) {
 		},
 	}
 
-	if err := npMgr.AddNamespace(nsObj, false); err != nil {
+	if err := npMgr.AddNamespaceWithLock(nsObj); err != nil {
 		t.Errorf("TestAddNamespace @ npMgr.AddNamespace")
 	}
 }
@@ -130,7 +130,7 @@ func TestUpdateNamespace(t *testing.T) {
 		},
 	}
 
-	if err := npMgr.AddNamespace(oldNsObj, false); err != nil {
+	if err := npMgr.AddNamespaceWithLock(oldNsObj); err != nil {
 		t.Errorf("TestUpdateNamespace failed @ npMgr.AddNamespace")
 	}
 
@@ -175,7 +175,7 @@ func TestDeleteNamespace(t *testing.T) {
 		},
 	}
 
-	if err := npMgr.AddNamespace(nsObj, false); err != nil {
+	if err := npMgr.AddNamespaceWithLock(nsObj); err != nil {
 		t.Errorf("TestDeleteNamespace @ npMgr.AddNamespace")
 	}
 

--- a/npm/namespace_test.go
+++ b/npm/namespace_test.go
@@ -80,7 +80,7 @@ func TestAddNamespace(t *testing.T) {
 		},
 	}
 
-	if err := npMgr.AddNamespace(nsObj); err != nil {
+	if err := npMgr.AddNamespace(nsObj, false); err != nil {
 		t.Errorf("TestAddNamespace @ npMgr.AddNamespace")
 	}
 }
@@ -130,7 +130,7 @@ func TestUpdateNamespace(t *testing.T) {
 		},
 	}
 
-	if err := npMgr.AddNamespace(oldNsObj); err != nil {
+	if err := npMgr.AddNamespace(oldNsObj, false); err != nil {
 		t.Errorf("TestUpdateNamespace failed @ npMgr.AddNamespace")
 	}
 
@@ -175,7 +175,7 @@ func TestDeleteNamespace(t *testing.T) {
 		},
 	}
 
-	if err := npMgr.AddNamespace(nsObj); err != nil {
+	if err := npMgr.AddNamespace(nsObj, false); err != nil {
 		t.Errorf("TestDeleteNamespace @ npMgr.AddNamespace")
 	}
 

--- a/npm/npm.go
+++ b/npm/npm.go
@@ -207,7 +207,7 @@ func NewNetworkPolicyManager(clientset *kubernetes.Clientset, informerFactory in
 		// Namespace event handlers
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				npMgr.AddNamespace(obj.(*corev1.Namespace))
+				npMgr.AddNamespace(obj.(*corev1.Namespace), false)
 			},
 			UpdateFunc: func(old, new interface{}) {
 				npMgr.UpdateNamespace(old.(*corev1.Namespace), new.(*corev1.Namespace))

--- a/npm/npm.go
+++ b/npm/npm.go
@@ -217,7 +217,7 @@ func NewNetworkPolicyManager(clientset *kubernetes.Clientset, informerFactory in
 		// Namespace event handlers
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				npMgr.AddNamespace(obj.(*corev1.Namespace), false)
+				npMgr.AddNamespaceWithLock(obj.(*corev1.Namespace))
 			},
 			UpdateFunc: func(old, new interface{}) {
 				npMgr.UpdateNamespace(old.(*corev1.Namespace), new.(*corev1.Namespace))

--- a/npm/nwpolicy.go
+++ b/npm/nwpolicy.go
@@ -49,7 +49,7 @@ func (npMgr *NetworkPolicyManager) AddNetworkPolicy(npObj *networkingv1.NetworkP
 			},
 		}
 		
-		if err = npMgr.AddNamespace(nsObj, true); err != nil {
+		if err = npMgr.AddNamespace(nsObj); err != nil {
 			return err
 		}
 

--- a/npm/nwpolicy_test.go
+++ b/npm/nwpolicy_test.go
@@ -66,7 +66,7 @@ func TestAddNetworkPolicy(t *testing.T) {
 		},
 	}
 
-	if err := npMgr.AddNamespace(nsObj); err != nil {
+	if err := npMgr.AddNamespace(nsObj, false); err != nil {
 		t.Errorf("TestAddNetworkPolicy @ npMgr.AddNamespace")
 	}
 
@@ -177,7 +177,7 @@ func TestUpdateNetworkPolicy(t *testing.T) {
 		},
 	}
 
-	if err := npMgr.AddNamespace(nsObj); err != nil {
+	if err := npMgr.AddNamespace(nsObj, false); err != nil {
 		t.Errorf("TestUpdateNetworkPolicy @ npMgr.AddNamespace")
 	}
 
@@ -289,7 +289,7 @@ func TestDeleteNetworkPolicy(t *testing.T) {
 		},
 	}
 
-	if err := npMgr.AddNamespace(nsObj); err != nil {
+	if err := npMgr.AddNamespace(nsObj, false); err != nil {
 		t.Errorf("TestDeleteNetworkPolicy @ npMgr.AddNamespace")
 	}
 

--- a/npm/nwpolicy_test.go
+++ b/npm/nwpolicy_test.go
@@ -66,7 +66,7 @@ func TestAddNetworkPolicy(t *testing.T) {
 		},
 	}
 
-	if err := npMgr.AddNamespace(nsObj, false); err != nil {
+	if err := npMgr.AddNamespaceWithLock(nsObj); err != nil {
 		t.Errorf("TestAddNetworkPolicy @ npMgr.AddNamespace")
 	}
 
@@ -177,7 +177,7 @@ func TestUpdateNetworkPolicy(t *testing.T) {
 		},
 	}
 
-	if err := npMgr.AddNamespace(nsObj, false); err != nil {
+	if err := npMgr.AddNamespaceWithLock(nsObj); err != nil {
 		t.Errorf("TestUpdateNetworkPolicy @ npMgr.AddNamespace")
 	}
 
@@ -289,7 +289,7 @@ func TestDeleteNetworkPolicy(t *testing.T) {
 		},
 	}
 
-	if err := npMgr.AddNamespace(nsObj, false); err != nil {
+	if err := npMgr.AddNamespaceWithLock(nsObj); err != nil {
 		t.Errorf("TestDeleteNetworkPolicy @ npMgr.AddNamespace")
 	}
 

--- a/npm/pod.go
+++ b/npm/pod.go
@@ -45,7 +45,7 @@ func (npMgr *NetworkPolicyManager) AddPod(podObj *corev1.Pod) error {
 			},
 		}
 		
-		if err = npMgr.AddNamespace(nsObj, true); err != nil {
+		if err = npMgr.AddNamespace(nsObj); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding namespace to npMgr if it doesn't exist. This fixes reboot bug where entries don't get added after failing to append non-existing namespace to all-namespaces.

When NPM reboots, namespace details do not always sync before policies and pods do. In those cases the namespace will need to be added before we proceed with add/update pod/networkpolicy workflow.