### PR TITLE
Prevent Namespace Race

### DIFF
--- a/npm/translatePolicy.go
+++ b/npm/translatePolicy.go
@@ -155,13 +155,8 @@ func translateIngress(ns string, targetSelector metav1.LabelSelector, rules []ne
 
 	labelsWithOps, _, _ := parseSelector(&targetSelector)
 	ops, labels := GetOperatorsAndLabels(labelsWithOps)
-	if len(ops) == 1 && len(labels) == 1 {
-		if ops[0] == "" && labels[0] == "" {
-			// targetSelector is empty. Select all pods within the namespace
-			labels[0] = "ns-" + ns
-		}
-	}
 	sets = append(sets, labels...)
+	sets = append(sets, "ns-" + ns)
 
 	targetSelectorIptEntrySpec := craftPartialIptEntrySpecFromOpsAndLabels(ns, ops, labels, util.IptablesDstFlag, false)
 	targetSelectorComment := craftPartialIptablesCommentFromSelector(ns, &targetSelector, false)
@@ -643,13 +638,9 @@ func translateEgress(ns string, targetSelector metav1.LabelSelector, rules []net
 
 	labelsWithOps, _, _ := parseSelector(&targetSelector)
 	ops, labels := GetOperatorsAndLabels(labelsWithOps)
-	if len(ops) == 1 && len(labels) == 1 {
-		if ops[0] == "" && labels[0] == "" {
-			// targetSelector is empty. Select all pods within the namespace
-			labels[0] = "ns-" + ns
-		}
-	}
 	sets = append(sets, labels...)
+	sets = append(sets, "ns-" + ns)
+	
 	targetSelectorIptEntrySpec := craftPartialIptEntrySpecFromOpsAndLabels(ns, ops, labels, util.IptablesSrcFlag, false)
 	targetSelectorComment := craftPartialIptablesCommentFromSelector(ns, &targetSelector, false)
 	for _, rule := range rules {

--- a/npm/translatePolicy_test.go
+++ b/npm/translatePolicy_test.go
@@ -607,6 +607,7 @@ func TestTranslateIngress(t *testing.T) {
 	expectedSets := []string{
 		"context:dev",
 		"testNotIn:frontend",
+		"ns-testnamespace",
 		"app:db",
 		"testIn:frontend",
 		"region:northpole",
@@ -884,6 +885,7 @@ func TestTranslateEgress(t *testing.T) {
 	expectedSets := []string{
 		"context:dev",
 		"testNotIn:frontend",
+		"ns-testnamespace",
 		"app:db",
 		"testIn:frontend",
 		"region:northpole",
@@ -1139,6 +1141,7 @@ func TestTranslatePolicy(t *testing.T) {
 
 	expectedSets = []string{
 		"app:backend",
+		"ns-testnamespace",
 		"app:frontend",
 	}
 	if !reflect.DeepEqual(sets, expectedSets) {
@@ -1263,6 +1266,7 @@ func TestTranslatePolicy(t *testing.T) {
 
 	expectedSets = []string{
 		"app:frontend",
+		"ns-testnamespace",
 	}
 	if !reflect.DeepEqual(sets, expectedSets) {
 		t.Errorf("translatedPolicy failed @ ALLOW-all-TO-app:frontend-FROM-all-namespaces-policy sets comparison")
@@ -1337,6 +1341,7 @@ func TestTranslatePolicy(t *testing.T) {
 
 	expectedSets = []string{
 		"app:frontend",
+		"ns-testnamespace",
 	}
 	if !reflect.DeepEqual(sets, expectedSets) {
 		t.Errorf("translatedPolicy failed @ ALLOW-none-TO-app:frontend-policy sets comparison")
@@ -1521,6 +1526,7 @@ func TestTranslatePolicy(t *testing.T) {
 	sets, lists, iptEntries = translatePolicy(allowAllNsToFrontendPolicy)
 	expectedSets = []string{
 		"app:frontend",
+		"ns-testnamespace",
 	}
 	if !reflect.DeepEqual(sets, expectedSets) {
 		t.Errorf("translatedPolicy failed @ ALLOW-all-namespaces-TO-app:frontend-policy sets comparison")
@@ -1666,6 +1672,7 @@ func TestTranslatePolicy(t *testing.T) {
 
 	expectedSets = []string{
 		"app:frontend",
+		"ns-testnamespace",
 	}
 	if !reflect.DeepEqual(sets, expectedSets) {
 		t.Errorf("translatedPolicy failed @ ALLOW-ns-namespace:dev-AND-!ns-namespace:test0-AND-!ns-namespace:test1-TO-app:frontend-policy sets comparison")
@@ -1827,6 +1834,7 @@ func TestTranslatePolicy(t *testing.T) {
 		"k0",
 		"k1:v0",
 		"k1:v1",
+		"ns-testnamespace",
 	}
 	if !reflect.DeepEqual(sets, expectedSets) {
 		t.Errorf("translatedPolicy failed @ AllOW-ALL-TO-k0-AND-k1:v0-AND-k1:v1-AND-app:frontend-policy sets comparison")
@@ -2031,6 +2039,7 @@ func TestTranslatePolicy(t *testing.T) {
 
 	expectedSets = []string{
 		"app:frontend",
+		"ns-testnamespace",
 		"app:backend",
 	}
 	if !reflect.DeepEqual(sets, expectedSets) {
@@ -2165,6 +2174,7 @@ func TestTranslatePolicy(t *testing.T) {
 
 	expectedSets = []string{
 		"app:backdoor",
+		"ns-dangerous",
 	}
 	if !reflect.DeepEqual(sets, expectedSets) {
 		t.Errorf("translatedPolicy failed @ ALLOW-ALL-TO-app:backdoor-policy sets comparison")
@@ -2251,6 +2261,7 @@ func TestTranslatePolicy(t *testing.T) {
 
 	expectedSets = []string{
 		"app:frontend",
+		"ns-testnamespace",
 		"app:backend",
 	}
 	if !reflect.DeepEqual(sets, expectedSets) {
@@ -2381,6 +2392,7 @@ func TestTranslatePolicy(t *testing.T) {
 	expectedSets = []string{
 		"app:k8s",
 		"team:aks",
+		"ns-acn",
 		"program:cni",
 		"team:acn",
 		"binary:cns",
@@ -2561,6 +2573,7 @@ func TestTranslatePolicy(t *testing.T) {
 
 	expectedSets = []string{
 		"app:backend",
+		"ns-testnamespace",
 	}
 	if !reflect.DeepEqual(sets, expectedSets) {
 		t.Errorf("translatedPolicy failed @ ALLOW-none-FROM-app:backend-policy sets comparison")
@@ -2612,6 +2625,7 @@ func TestTranslatePolicy(t *testing.T) {
 
 	expectedSets = []string{
 		"app:backend",
+		"ns-testnamespace",
 	}
 	if !reflect.DeepEqual(sets, expectedSets) {
 		t.Errorf("translatedPolicy failed @ ALLOW-all-FROM-app:backend-policy sets comparison")
@@ -2752,6 +2766,7 @@ func TestTranslatePolicy(t *testing.T) {
 
 	expectedSets = []string{
 		"app:frontend",
+		"ns-testnamespace",
 	}
 	if !reflect.DeepEqual(sets, expectedSets) {
 		t.Errorf("translatedPolicy failed @ ALLOW-ALL-FROM-app:frontend-TCP-PORT-53-OR-UDP-PORT-53-policy sets comparison")
@@ -2969,6 +2984,7 @@ func TestTranslatePolicy(t *testing.T) {
 
 	expectedSets = []string{
 		"role:db",
+		"ns-default",
 		"role:frontend",
 	}
 	if !reflect.DeepEqual(sets, expectedSets) {
@@ -3303,6 +3319,7 @@ func TestDropPrecedenceOverAllow(t *testing.T) {
 	expectedSets = []string{
 		"app:test",
 		"testIn:pod-A",
+		"ns-default",
 		"testIn:pod-B",
 		"testIn:pod-C",
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Create namespace set if it doesn't exist. This fixes reboot bug where entries don't get added after failing to append non-existing namespace to all-namespaces.

When NPM reboots, namespace details do not always sync before policies and pods do. In those cases the namespace will need to be added before we proceed with add/update pod/networkpolicy workflow.

replaces https://github.com/Azure/azure-container-networking/pull/461

