### PR TITLE
Merge Multiple Network Policies

### DIFF
--- a/npm/iptm/iptm.go
+++ b/npm/iptm/iptm.go
@@ -32,6 +32,7 @@ type IptEntry struct {
 	Chain                 string
 	Flag                  string
 	LockWaitTimeInSeconds string
+	IsJumpEntry           bool
 	Specs                 []string
 }
 
@@ -300,7 +301,11 @@ func (iptMgr *IptablesManager) Add(entry *IptEntry) error {
 		return nil
 	}
 
-	iptMgr.OperationFlag = util.IptablesAppendFlag
+	if entry.IsJumpEntry {
+		iptMgr.OperationFlag = util.IptablesAppendFlag
+	} else {
+		iptMgr.OperationFlag = util.IptablesInsertionFlag
+	}
 	if _, err := iptMgr.Run(entry); err != nil {
 		log.Errorf("Error: failed to create iptables rules.")
 		return err

--- a/npm/translatePolicy_test.go
+++ b/npm/translatePolicy_test.go
@@ -754,7 +754,8 @@ func TestTranslateIngress(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressPortChain,
+			Chain:       util.IptablesAzureIngressPortChain,
+			IsJumpEntry: true,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
@@ -1032,7 +1033,8 @@ func TestTranslateEgress(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureEgressPortChain,
+			Chain:       util.IptablesAzureEgressPortChain,
+			IsJumpEntry: true,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
@@ -1182,7 +1184,8 @@ func TestTranslatePolicy(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressPortChain,
+			Chain:       util.IptablesAzureIngressPortChain,
+			IsJumpEntry: true,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
@@ -1199,7 +1202,8 @@ func TestTranslatePolicy(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressFromChain,
+			Chain:       util.IptablesAzureIngressFromChain,
+			IsJumpEntry: true,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
@@ -1436,7 +1440,8 @@ func TestTranslatePolicy(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressPortChain,
+			Chain:       util.IptablesAzureIngressPortChain,
+			IsJumpEntry: true,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
@@ -1453,7 +1458,8 @@ func TestTranslatePolicy(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressFromChain,
+			Chain:       util.IptablesAzureIngressFromChain,
+			IsJumpEntry: true,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
@@ -1567,7 +1573,8 @@ func TestTranslatePolicy(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressPortChain,
+			Chain:       util.IptablesAzureIngressPortChain,
+			IsJumpEntry: true,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
@@ -1584,7 +1591,8 @@ func TestTranslatePolicy(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressFromChain,
+			Chain:       util.IptablesAzureIngressFromChain,
+			IsJumpEntry: true,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
@@ -1727,7 +1735,8 @@ func TestTranslatePolicy(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressPortChain,
+			Chain:       util.IptablesAzureIngressPortChain,
+			IsJumpEntry: true,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
@@ -1744,7 +1753,8 @@ func TestTranslatePolicy(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressFromChain,
+			Chain:       util.IptablesAzureIngressFromChain,
+			IsJumpEntry: true,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
@@ -1889,7 +1899,8 @@ func TestTranslatePolicy(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressPortChain,
+			Chain:       util.IptablesAzureIngressPortChain,
+			IsJumpEntry: true,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
@@ -1922,7 +1933,8 @@ func TestTranslatePolicy(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressFromChain,
+			Chain:       util.IptablesAzureIngressFromChain,
+			IsJumpEntry: true,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
@@ -2086,7 +2098,8 @@ func TestTranslatePolicy(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressPortChain,
+			Chain:       util.IptablesAzureIngressPortChain,
+			IsJumpEntry: true,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
@@ -2103,7 +2116,8 @@ func TestTranslatePolicy(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressFromChain,
+			Chain:       util.IptablesAzureIngressFromChain,
+			IsJumpEntry: true,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
@@ -2303,7 +2317,8 @@ func TestTranslatePolicy(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressPortChain,
+			Chain:       util.IptablesAzureIngressPortChain,
+			IsJumpEntry: true,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
@@ -2476,7 +2491,8 @@ func TestTranslatePolicy(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressPortChain,
+			Chain:       util.IptablesAzureIngressPortChain,
+			IsJumpEntry: true,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
@@ -2498,7 +2514,8 @@ func TestTranslatePolicy(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressFromChain,
+			Chain:       util.IptablesAzureIngressFromChain,
+			IsJumpEntry: true,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
@@ -2848,7 +2865,8 @@ func TestTranslatePolicy(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureEgressPortChain,
+			Chain:       util.IptablesAzureEgressPortChain,
+			IsJumpEntry: true,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
@@ -2865,7 +2883,8 @@ func TestTranslatePolicy(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureEgressToChain,
+			Chain:       util.IptablesAzureEgressToChain,
+			IsJumpEntry: true,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
@@ -3012,6 +3031,46 @@ func TestTranslatePolicy(t *testing.T) {
 				util.IptablesMatchSetFlag,
 				util.GetHashedName("role:db"),
 				util.IptablesDstFlag,
+				util.IptablesSFlag,
+				"172.17.0.0/16",
+				util.IptablesProtFlag,
+				"TCP",
+				util.IptablesDstPortFlag,
+				"6379",
+				util.IptablesJumpFlag,
+				util.IptablesAccept,
+				util.IptablesModuleFlag,
+				util.IptablesCommentModuleFlag,
+				util.IptablesCommentFlag,
+				"ALLOW-172.17.0.0/16-:-TCP-PORT-6379-TO-role:db",
+			},
+		},
+		&iptm.IptEntry{
+			Chain: util.IptablesAzureIngressFromChain,
+			Specs: []string{
+				util.IptablesSFlag,
+				"172.17.1.0/24",
+				util.IptablesModuleFlag,
+				util.IptablesSetModuleFlag,
+				util.IptablesMatchSetFlag,
+				util.GetHashedName("role:db"),
+				util.IptablesDstFlag,
+				util.IptablesJumpFlag,
+				util.IptablesDrop,
+				util.IptablesModuleFlag,
+				util.IptablesCommentModuleFlag,
+				util.IptablesCommentFlag,
+				"DROP-172.17.1.0/24-TO-role:db",
+			},
+		},
+		&iptm.IptEntry{
+			Chain: util.IptablesAzureIngressPortChain,
+			Specs: []string{
+				util.IptablesModuleFlag,
+				util.IptablesSetModuleFlag,
+				util.IptablesMatchSetFlag,
+				util.GetHashedName("role:db"),
+				util.IptablesDstFlag,
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
 				util.IptablesMatchSetFlag,
@@ -3055,47 +3114,8 @@ func TestTranslatePolicy(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressFromChain,
-			Specs: []string{
-				util.IptablesSFlag,
-				"172.17.1.0/24",
-				util.IptablesModuleFlag,
-				util.IptablesSetModuleFlag,
-				util.IptablesMatchSetFlag,
-				util.GetHashedName("role:db"),
-				util.IptablesDstFlag,
-				util.IptablesJumpFlag,
-				util.IptablesDrop,
-				util.IptablesModuleFlag,
-				util.IptablesCommentModuleFlag,
-				util.IptablesCommentFlag,
-				"DROP-172.17.1.0/24-TO-role:db",
-			},
-		},
-		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressPortChain,
-			Specs: []string{
-				util.IptablesModuleFlag,
-				util.IptablesSetModuleFlag,
-				util.IptablesMatchSetFlag,
-				util.GetHashedName("role:db"),
-				util.IptablesDstFlag,
-				util.IptablesSFlag,
-				"172.17.0.0/16",
-				util.IptablesProtFlag,
-				"TCP",
-				util.IptablesDstPortFlag,
-				"6379",
-				util.IptablesJumpFlag,
-				util.IptablesAccept,
-				util.IptablesModuleFlag,
-				util.IptablesCommentModuleFlag,
-				util.IptablesCommentFlag,
-				"ALLOW-172.17.0.0/16-:-TCP-PORT-6379-TO-role:db",
-			},
-		},
-		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressPortChain,
+			Chain:       util.IptablesAzureIngressPortChain,
+			IsJumpEntry: true,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
@@ -3111,7 +3131,8 @@ func TestTranslatePolicy(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressFromChain,
+			Chain:       util.IptablesAzureIngressFromChain,
+			IsJumpEntry: true,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
@@ -3149,7 +3170,8 @@ func TestTranslatePolicy(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureEgressPortChain,
+			Chain:       util.IptablesAzureEgressPortChain,
+			IsJumpEntry: true,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
@@ -3422,7 +3444,8 @@ func TestDropPrecedenceOverAllow(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressPortChain,
+			Chain:       util.IptablesAzureIngressPortChain,
+			IsJumpEntry: true,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
@@ -3444,7 +3467,8 @@ func TestDropPrecedenceOverAllow(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureIngressFromChain,
+			Chain:       util.IptablesAzureIngressFromChain,
+			IsJumpEntry: true,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
@@ -3491,7 +3515,8 @@ func TestDropPrecedenceOverAllow(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureEgressPortChain,
+			Chain:       util.IptablesAzureEgressPortChain,
+			IsJumpEntry: true,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
@@ -3513,7 +3538,8 @@ func TestDropPrecedenceOverAllow(t *testing.T) {
 			},
 		},
 		&iptm.IptEntry{
-			Chain: util.IptablesAzureEgressToChain,
+			Chain:       util.IptablesAzureEgressToChain,
+			IsJumpEntry: true,
 			Specs: []string{
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,


### PR DESCRIPTION
**What this PR does / why we need it**:
Union between multiple network policies was broken because current implementation only scopes per policy. This PR will prepend all ipt entries except for chain jumps to prioritize the union of allows.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes #465 along with https://github.com/Azure/azure-container-networking/pull/466
