### PR TITLE
Added config option for disabling iptable lock

### DIFF
--- a/cni/netconfig.go
+++ b/cni/netconfig.go
@@ -55,6 +55,7 @@ type NetworkConfig struct {
 	MultiTenancy               bool     `json:"multiTenancy,omitempty"`
 	EnableSnatOnHost           bool     `json:"enableSnatOnHost,omitempty"`
 	EnableExactMatchForPodName bool     `json:"enableExactMatchForPodName,omitempty"`
+	DisableIPTableLock         bool     `json:"disableIPTableLock,omitempty"`
 	CNSUrl                     string   `json:"cnsurl,omitempty"`
 	Ipam                       struct {
 		Type          string `json:"type"`

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -107,10 +107,7 @@ func (plugin *netPlugin) Start(config *common.PluginConfig) error {
 	// Log platform information.
 	log.Printf("[cni-net] Plugin %v version %v.", plugin.Name, plugin.Version)
 	log.Printf("[cni-net] Running on %v", platform.GetOSInfo())
-	out, err := platform.ExecuteCommand("iptables --version")
-	log.Printf("[cni-net] iptable version:%s, err:%v", out, err)
-	out, err = platform.ExecuteCommand("ebtables --version")
-	log.Printf("[cni-net] ebtable version %s, err:%v", out, err)
+	platform.PrintDependencyPackageDetails()
 	common.LogNetworkInterfaces()
 
 	// Initialize network manager.

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/cnsclient"
 	"github.com/Azure/azure-container-networking/common"
+	"github.com/Azure/azure-container-networking/iptables"
 	"github.com/Azure/azure-container-networking/log"
 	"github.com/Azure/azure-container-networking/network"
 	"github.com/Azure/azure-container-networking/platform"
@@ -239,6 +240,7 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 		}
 	}
 
+	iptables.DisableIPTableLock = nwCfg.DisableIPTableLock
 	plugin.setCNIReportDetails(nwCfg, CNI_ADD, "")
 
 	defer func() {
@@ -587,6 +589,8 @@ func (plugin *netPlugin) Get(args *cniSkel.CmdArgs) error {
 
 	log.Printf("[cni-net] Read network configuration %+v.", nwCfg)
 
+	iptables.DisableIPTableLock = nwCfg.DisableIPTableLock
+
 	// Parse Pod arguments.
 	if k8sPodName, k8sNamespace, err = plugin.getPodInfo(args.Args); err != nil {
 		return err
@@ -665,6 +669,7 @@ func (plugin *netPlugin) Delete(args *cniSkel.CmdArgs) error {
 
 	log.Printf("[cni-net] Read network configuration %+v.", nwCfg)
 
+	iptables.DisableIPTableLock = nwCfg.DisableIPTableLock
 	plugin.setCNIReportDetails(nwCfg, CNI_DEL, "")
 
 	// Parse Pod arguments.
@@ -758,6 +763,7 @@ func (plugin *netPlugin) Update(args *cniSkel.CmdArgs) error {
 
 	log.Printf("[cni-net] Read network configuration %+v.", nwCfg)
 
+	iptables.DisableIPTableLock = nwCfg.DisableIPTableLock
 	plugin.setCNIReportDetails(nwCfg, CNI_UPDATE, "")
 
 	defer func() {

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -107,6 +107,10 @@ func (plugin *netPlugin) Start(config *common.PluginConfig) error {
 	// Log platform information.
 	log.Printf("[cni-net] Plugin %v version %v.", plugin.Name, plugin.Version)
 	log.Printf("[cni-net] Running on %v", platform.GetOSInfo())
+	out, err := platform.ExecuteCommand("iptables --version")
+	log.Printf("[cni-net] iptable version:%s, err:%v", out, err)
+	out, err = platform.ExecuteCommand("ebtables --version")
+	log.Printf("[cni-net] ebtable version %s, err:%v", out, err)
 	common.LogNetworkInterfaces()
 
 	// Initialize network manager.

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -55,9 +55,20 @@ const (
 	lockTimeout = 60
 )
 
+var (
+	DisableIPTableLock bool
+)
+
 // Run iptables command
 func runCmd(params string) error {
-	cmd := fmt.Sprintf("%s -w %d %s", iptables, lockTimeout, params)
+	var cmd string
+
+	if DisableIPTableLock {
+		cmd = fmt.Sprintf("%s %s", iptables, params)
+	} else {
+		cmd = fmt.Sprintf("%s -w %d %s", iptables, lockTimeout, params)
+	}
+
 	if _, err := platform.ExecuteCommand(cmd); err != nil {
 		return err
 	}

--- a/platform/os_linux.go
+++ b/platform/os_linux.go
@@ -149,3 +149,12 @@ func GetProcessNameByID(pidstr string) (string, error) {
 
 	return out, nil
 }
+
+func PrintDependencyPackageDetails() {
+	out, err := ExecuteCommand("iptables --version")
+	out = strings.TrimSuffix(out, "\n")
+	log.Printf("[cni-net] iptable version:%s, err:%v", out, err)
+	out, err = ExecuteCommand("ebtables --version")
+	out = strings.TrimSuffix(out, "\n")
+	log.Printf("[cni-net] ebtable version %s, err:%v", out, err)
+}

--- a/platform/os_windows.go
+++ b/platform/os_windows.go
@@ -226,3 +226,6 @@ func GetProcessNameByID(pidstr string) (string, error) {
 
 	return "", fmt.Errorf("Process not found")
 }
+
+func PrintDependencyPackageDetails() {
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Added config option for disabling iptable lock. By default, iptable lock is enabled. If users want to disable iptable lock, they have to set disableIPTableLock field to true in conflist.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```