### PR TITLE
Config option to not enable hairpin on host interface

### DIFF
--- a/cni/netconfig.go
+++ b/cni/netconfig.go
@@ -42,22 +42,23 @@ type RuntimeDNSConfig struct {
 
 // NetworkConfig represents Azure CNI plugin network configuration.
 type NetworkConfig struct {
-	CNIVersion                 string   `json:"cniVersion"`
-	Name                       string   `json:"name"`
-	Type                       string   `json:"type"`
-	Mode                       string   `json:"mode"`
-	Master                     string   `json:"master"`
-	Bridge                     string   `json:"bridge,omitempty"`
-	LogLevel                   string   `json:"logLevel,omitempty"`
-	LogTarget                  string   `json:"logTarget,omitempty"`
-	InfraVnetAddressSpace      string   `json:"infraVnetAddressSpace,omitempty"`
-	PodNamespaceForDualNetwork []string `json:"podNamespaceForDualNetwork,omitempty"`
-	MultiTenancy               bool     `json:"multiTenancy,omitempty"`
-	EnableSnatOnHost           bool     `json:"enableSnatOnHost,omitempty"`
-	EnableExactMatchForPodName bool     `json:"enableExactMatchForPodName,omitempty"`
-	DisableIPTableLock         bool     `json:"disableIPTableLock,omitempty"`
-	CNSUrl                     string   `json:"cnsurl,omitempty"`
-	Ipam                       struct {
+	CNIVersion                    string   `json:"cniVersion"`
+	Name                          string   `json:"name"`
+	Type                          string   `json:"type"`
+	Mode                          string   `json:"mode"`
+	Master                        string   `json:"master"`
+	Bridge                        string   `json:"bridge,omitempty"`
+	LogLevel                      string   `json:"logLevel,omitempty"`
+	LogTarget                     string   `json:"logTarget,omitempty"`
+	InfraVnetAddressSpace         string   `json:"infraVnetAddressSpace,omitempty"`
+	PodNamespaceForDualNetwork    []string `json:"podNamespaceForDualNetwork,omitempty"`
+	MultiTenancy                  bool     `json:"multiTenancy,omitempty"`
+	EnableSnatOnHost              bool     `json:"enableSnatOnHost,omitempty"`
+	EnableExactMatchForPodName    bool     `json:"enableExactMatchForPodName,omitempty"`
+	DisableHairpinOnHostInterface bool     `json:"disableHairpinOnHostInterface,omitempty"`
+	DisableIPTableLock            bool     `json:"disableIPTableLock,omitempty"`
+	CNSUrl                        string   `json:"cnsurl,omitempty"`
+	Ipam                          struct {
 		Type          string `json:"type"`
 		Environment   string `json:"environment,omitempty"`
 		AddrSpace     string `json:"addressSpace,omitempty"`

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -428,11 +428,12 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 					Gateway: gateway,
 				},
 			},
-			BridgeName:       nwCfg.Bridge,
-			EnableSnatOnHost: nwCfg.EnableSnatOnHost,
-			DNS:              nwDNSInfo,
-			Policies:         policies,
-			NetNs:            args.Netns,
+			BridgeName:                    nwCfg.Bridge,
+			EnableSnatOnHost:              nwCfg.EnableSnatOnHost,
+			DNS:                           nwDNSInfo,
+			Policies:                      policies,
+			NetNs:                         args.Netns,
+			DisableHairpinOnHostInterface: nwCfg.DisableHairpinOnHostInterface,
 		}
 
 		nwInfo.Options = make(map[string]interface{})

--- a/network/network.go
+++ b/network/network.go
@@ -51,16 +51,17 @@ type network struct {
 
 // NetworkInfo contains read-only information about a container network.
 type NetworkInfo struct {
-	MasterIfName     string
-	Id               string
-	Mode             string
-	Subnets          []SubnetInfo
-	DNS              DNSInfo
-	Policies         []policy.Policy
-	BridgeName       string
-	EnableSnatOnHost bool
-	NetNs            string
-	Options          map[string]interface{}
+	MasterIfName                  string
+	Id                            string
+	Mode                          string
+	Subnets                       []SubnetInfo
+	DNS                           DNSInfo
+	Policies                      []policy.Policy
+	BridgeName                    string
+	EnableSnatOnHost              bool
+	NetNs                         string
+	Options                       map[string]interface{}
+	DisableHairpinOnHostInterface bool
 }
 
 // SubnetInfo contains subnet information for a container network.

--- a/network/network_linux.go
+++ b/network/network_linux.go
@@ -391,9 +391,11 @@ func (nm *networkManager) connectExternalInterface(extIf *externalInterface, nwI
 	}
 
 	// External interface hairpin on.
-	log.Printf("[net] Setting link %v hairpin on.", hostIf.Name)
-	if err := networkClient.SetHairpinOnHostInterface(true); err != nil {
-		return err
+	if !nwInfo.DisableHairpinOnHostInterface {
+		log.Printf("[net] Setting link %v hairpin on.", hostIf.Name)
+		if err := networkClient.SetHairpinOnHostInterface(true); err != nil {
+			return err
+		}
 	}
 
 	// Apply IP configuration to the bridge for host traffic.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Adds an option to not enable Hairpin on the host interface. 
Setting hairpin on the host interface creates a problem when the upstream network devices have STP enabled. This prevents the CNI to be used on bare-metal hosts.

Note:

1. The default behavior of CNI is left as-is. Only a optional parameter is added for scenarios where enabling hairpin on host doesn't work.
2. Hairpin will still be enabled on all the virtual interfaces, so a pod will still be able to connect itself via its ServiceIP.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```