### PR TITLE
Adding AI metrics for NPM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ CNS_BUILD_DIR = $(BUILD_DIR)/cns
 NPM_BUILD_DIR = $(BUILD_DIR)/npm
 NPM_TELEMETRY_DIR = $(NPM_BUILD_DIR)/telemetry
 CNI_AI_ID = 5515a1eb-b2bc-406a-98eb-ba462e6f0411
+NPM_AI_ID = 014c22bd-4107-459e-8475-67909e96edcb
 ACN_PACKAGE_PATH = github.com/Azure/azure-container-networking
 
 # Containerized build parameters.
@@ -180,7 +181,7 @@ $(CNS_BUILD_DIR)/azure-cns$(EXE_EXT): $(CNSFILES)
 # Build the Azure NPM plugin.
 $(NPM_BUILD_DIR)/azure-npm$(EXE_EXT): $(NPMFILES)
 	go build -v -o $(NPM_BUILD_DIR)/azure-vnet-telemetry$(EXE_EXT) -ldflags "-X main.version=$(VERSION) -s -w" $(CNI_TELEMETRY_DIR)/*.go
-	go build -v -o $(NPM_BUILD_DIR)/azure-npm$(EXE_EXT) -ldflags "-X main.version=$(VERSION) -s -w" $(NPM_DIR)/*.go
+	go build -v -o $(NPM_BUILD_DIR)/azure-npm$(EXE_EXT) -ldflags "-X main.version=$(VERSION) -X $(ACN_PACKAGE_PATH)/npm.aiMetadata=$(NPM_AI_ID) -s -w" $(NPM_DIR)/*.go
 
 # Build all binaries in a container.
 .PHONY: all-containerized

--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -6,6 +6,7 @@ ARG NPM_BUILD_DIR
 RUN apt-get update
 RUN apt-get install -y iptables
 RUN apt-get install -y ipset
+RUN apt-get install -y ca-certificates
 
 # Install plugin.
 COPY $NPM_BUILD_DIR/azure-npm /usr/bin

--- a/npm/namespace_test.go
+++ b/npm/namespace_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 
 	"github.com/Azure/azure-container-networking/npm/iptm"
-	"github.com/Azure/azure-container-networking/telemetry"
 
 	"github.com/Azure/azure-container-networking/npm/ipsm"
 	"github.com/Azure/azure-container-networking/npm/util"
@@ -48,10 +47,6 @@ func TestAddNamespace(t *testing.T) {
 	npMgr := &NetworkPolicyManager{
 		nsMap:            make(map[string]*namespace),
 		TelemetryEnabled: false,
-		reportManager: &telemetry.ReportManager{
-			ContentType: telemetry.ContentType,
-			Report:      &telemetry.NPMReport{},
-		},
 	}
 
 	allNs, err := newNs(util.KubeAllNamespacesFlag)
@@ -89,10 +84,6 @@ func TestUpdateNamespace(t *testing.T) {
 	npMgr := &NetworkPolicyManager{
 		nsMap:            make(map[string]*namespace),
 		TelemetryEnabled: false,
-		reportManager: &telemetry.ReportManager{
-			ContentType: telemetry.ContentType,
-			Report:      &telemetry.NPMReport{},
-		},
 	}
 
 	allNs, err := newNs(util.KubeAllNamespacesFlag)
@@ -143,10 +134,6 @@ func TestDeleteNamespace(t *testing.T) {
 	npMgr := &NetworkPolicyManager{
 		nsMap:            make(map[string]*namespace),
 		TelemetryEnabled: false,
-		reportManager: &telemetry.ReportManager{
-			ContentType: telemetry.ContentType,
-			Report:      &telemetry.NPMReport{},
-		},
 	}
 
 	allNs, err := newNs(util.KubeAllNamespacesFlag)

--- a/npm/npm.go
+++ b/npm/npm.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Azure/azure-container-networking/aitelemetry"
 	"github.com/Azure/azure-container-networking/log"
 	"github.com/Azure/azure-container-networking/npm/iptm"
 	"github.com/Azure/azure-container-networking/npm/util"
@@ -22,6 +23,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 )
+
+var aiMetadata string
 
 const (
 	restoreRetryWaitTimeInSeconds = 5
@@ -47,7 +50,7 @@ type NetworkPolicyManager struct {
 	isSafeToCleanUpAzureNpmChain bool
 
 	clusterState  telemetry.ClusterState
-	reportManager *telemetry.ReportManager
+	version    string
 
 	serverVersion    *version.Info
 	TelemetryEnabled bool
@@ -75,6 +78,58 @@ func (npMgr *NetworkPolicyManager) GetClusterState() telemetry.ClusterState {
 	npMgr.clusterState.NwPolicyCount = len(networkpolicies.Items)
 
 	return npMgr.clusterState
+}
+
+// SendAiMetrics :- send NPM metrics using AppInsights
+func (npMgr *NetworkPolicyManager) SendAiMetrics() {
+	var (
+		aiConfig = aitelemetry.AIConfig{
+			AppName:                   util.AzureNpmFlag,
+			AppVersion:                npMgr.version,
+			BatchSize:                 32768,
+			BatchInterval:             30,
+			RefreshTimeout:            15,
+			DebugMode:                 true,
+			GetEnvRetryCount:          5,
+			GetEnvRetryWaitTimeInSecs: 3,
+		}
+		th, err = aitelemetry.NewAITelemetry("", aiMetadata, aiConfig)
+		heartbeat = time.NewTicker(time.Minute * heartbeatIntervalInMinutes).C
+		customDimensions = map[string]string{"ClusterID": util.GetClusterID(npMgr.nodeName),
+												"APIServer": npMgr.serverVersion.String()}
+		podCount = aitelemetry.Metric{
+			Name: "PodCount",
+			CustomDimensions: customDimensions,
+		}
+		nsCount = aitelemetry.Metric{
+			Name: "NsCount",
+			CustomDimensions: customDimensions,
+		}
+		nwPolicyCount = aitelemetry.Metric{
+			Name: "NwPolicyCount",
+			CustomDimensions: customDimensions,
+		}
+	)
+
+	for ; err != nil; {
+		log.Logf("Failed to init AppInsights with err: %+v", err)
+		time.Sleep(time.Minute * 5)
+		th, err = aitelemetry.NewAITelemetry("", aiMetadata, aiConfig)
+	}
+
+	defer th.Close(10)
+
+	for {	
+		<-heartbeat
+		clusterState := npMgr.GetClusterState()
+		podCount.Value = float64(clusterState.PodCount)
+		nsCount.Value = float64(clusterState.NsCount)
+		nwPolicyCount.Value = float64(clusterState.NwPolicyCount)
+
+		th.TrackMetric(podCount)
+		th.TrackMetric(nsCount)
+		th.TrackMetric(nwPolicyCount)
+	}
 }
 
 // restore restores iptables from backup file
@@ -177,17 +232,10 @@ func NewNetworkPolicyManager(clientset *kubernetes.Clientset, informerFactory in
 			NsCount:       0,
 			NwPolicyCount: 0,
 		},
-		reportManager: &telemetry.ReportManager{
-			ContentType: telemetry.ContentType,
-			Report:      &telemetry.NPMReport{},
-		},
+		version: npmVersion,
 		serverVersion:    serverVersion,
 		TelemetryEnabled: true,
 	}
-
-	clusterID := util.GetClusterID(npMgr.nodeName)
-	clusterState := npMgr.GetClusterState()
-	npMgr.reportManager.Report.(*telemetry.NPMReport).GetReport(clusterID, npMgr.nodeName, npmVersion, serverVersion.GitVersion, clusterState)
 
 	allNs, _ := newNs(util.KubeAllNamespacesFlag)
 	npMgr.nsMap[util.KubeAllNamespacesFlag] = allNs

--- a/npm/npm.go
+++ b/npm/npm.go
@@ -93,6 +93,7 @@ func (npMgr *NetworkPolicyManager) SendAiMetrics() {
 			GetEnvRetryCount:          5,
 			GetEnvRetryWaitTimeInSecs: 3,
 		}
+		
 		th, err = aitelemetry.NewAITelemetry("", aiMetadata, aiConfig)
 		heartbeat = time.NewTicker(time.Minute * heartbeatIntervalInMinutes).C
 		customDimensions = map[string]string{"ClusterID": util.GetClusterID(npMgr.nodeName),
@@ -116,6 +117,8 @@ func (npMgr *NetworkPolicyManager) SendAiMetrics() {
 		time.Sleep(time.Minute * 5)
 		th, err = aitelemetry.NewAITelemetry("", aiMetadata, aiConfig)
 	}
+
+	log.Logf("Initialized AppInsights handle")
 
 	defer th.Close(10)
 

--- a/npm/nwpolicy_test.go
+++ b/npm/nwpolicy_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Azure/azure-container-networking/npm/ipsm"
 	"github.com/Azure/azure-container-networking/npm/iptm"
 	"github.com/Azure/azure-container-networking/npm/util"
-	"github.com/Azure/azure-container-networking/telemetry"
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -20,10 +19,6 @@ func TestAddNetworkPolicy(t *testing.T) {
 	npMgr := &NetworkPolicyManager{
 		nsMap:            make(map[string]*namespace),
 		TelemetryEnabled: false,
-		reportManager: &telemetry.ReportManager{
-			ContentType:     telemetry.ContentType,
-			Report:          &telemetry.NPMReport{},
-		},
 	}
 
 	allNs, err := newNs(util.KubeAllNamespacesFlag)
@@ -131,10 +126,6 @@ func TestUpdateNetworkPolicy(t *testing.T) {
 	npMgr := &NetworkPolicyManager{
 		nsMap:            make(map[string]*namespace),
 		TelemetryEnabled: false,
-		reportManager: &telemetry.ReportManager{
-			ContentType:     telemetry.ContentType,
-			Report:          &telemetry.NPMReport{},
-		},
 	}
 
 	allNs, err := newNs(util.KubeAllNamespacesFlag)
@@ -243,10 +234,6 @@ func TestDeleteNetworkPolicy(t *testing.T) {
 	npMgr := &NetworkPolicyManager{
 		nsMap:            make(map[string]*namespace),
 		TelemetryEnabled: false,
-		reportManager: &telemetry.ReportManager{
-			ContentType:     telemetry.ContentType,
-			Report:          &telemetry.NPMReport{},
-		},
 	}
 
 	allNs, err := newNs(util.KubeAllNamespacesFlag)

--- a/npm/plugin/main.go
+++ b/npm/plugin/main.go
@@ -60,6 +60,8 @@ func main() {
 
 	npMgr := npm.NewNetworkPolicyManager(clientset, factory, version)
 
+	go npMgr.SendAiMetrics()
+
 	if err = npMgr.Start(wait.NeverStop); err != nil {
 		log.Logf("npm failed with error %v.", err)
 		panic(err.Error)

--- a/npm/pod_test.go
+++ b/npm/pod_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/Azure/azure-container-networking/npm/ipsm"
 	"github.com/Azure/azure-container-networking/npm/util"
-	"github.com/Azure/azure-container-networking/telemetry"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -39,10 +38,6 @@ func TestAddPod(t *testing.T) {
 	npMgr := &NetworkPolicyManager{
 		nsMap:            make(map[string]*namespace),
 		TelemetryEnabled: false,
-		reportManager: &telemetry.ReportManager{
-			ContentType: telemetry.ContentType,
-			Report:      &telemetry.NPMReport{},
-		},
 	}
 
 	allNs, err := newNs(util.KubeAllNamespacesFlag)
@@ -83,10 +78,6 @@ func TestUpdatePod(t *testing.T) {
 	npMgr := &NetworkPolicyManager{
 		nsMap:            make(map[string]*namespace),
 		TelemetryEnabled: false,
-		reportManager: &telemetry.ReportManager{
-			ContentType: telemetry.ContentType,
-			Report:      &telemetry.NPMReport{},
-		},
 	}
 
 	allNs, err := newNs(util.KubeAllNamespacesFlag)
@@ -145,10 +136,6 @@ func TestDeletePod(t *testing.T) {
 	npMgr := &NetworkPolicyManager{
 		nsMap:            make(map[string]*namespace),
 		TelemetryEnabled: false,
-		reportManager: &telemetry.ReportManager{
-			ContentType: telemetry.ContentType,
-			Report:      &telemetry.NPMReport{},
-		},
 	}
 
 	allNs, err := newNs(util.KubeAllNamespacesFlag)


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding AppInsights metrics for NPM. Pod count, namespace count, and network policy count will be reported on a 30 min heartbeat/interval.