### PR TITLE
Added resourcegroup and vmid as default dimension in AI metrics

### DIFF
--- a/aitelemetry/telemetrywrapper.go
+++ b/aitelemetry/telemetrywrapper.go
@@ -206,6 +206,7 @@ func (th *telemetryHandle) TrackMetric(metric Metric) {
 		aimetric.Properties[subscriptionIDStr] = th.metadata.SubscriptionID
 		aimetric.Properties[vmNameStr] = th.metadata.VMName
 		aimetric.Properties[versionStr] = th.appVersion
+		aimetric.Properties[resourceGroupStr] = th.metadata.ResourceGroupName
 	}
 
 	// copy custom dimensions

--- a/aitelemetry/telemetrywrapper.go
+++ b/aitelemetry/telemetrywrapper.go
@@ -19,6 +19,7 @@ const (
 	appNameStr          = "AppName"
 	subscriptionIDStr   = "SubscriptionID"
 	vmNameStr           = "VMName"
+	vmIDStr             = "VMID"
 	versionStr          = "AppVersion"
 	azurePublicCloudStr = "AzurePublicCloud"
 	defaultTimeout      = 10
@@ -183,6 +184,7 @@ func (th *telemetryHandle) TrackLog(report Report) {
 		trace.Properties[resourceGroupStr] = th.metadata.ResourceGroupName
 		trace.Properties[vmSizeStr] = th.metadata.VMSize
 		trace.Properties[osVersionStr] = th.metadata.OSVersion
+		trace.Properties[vmIDStr] = th.metadata.VMID
 	}
 
 	// send to appinsights resource
@@ -207,6 +209,7 @@ func (th *telemetryHandle) TrackMetric(metric Metric) {
 		aimetric.Properties[vmNameStr] = th.metadata.VMName
 		aimetric.Properties[versionStr] = th.appVersion
 		aimetric.Properties[resourceGroupStr] = th.metadata.ResourceGroupName
+		aimetric.Properties[vmIDStr] = th.metadata.VMID
 	}
 
 	// copy custom dimensions


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Added resourcegroup as default dimension in AI metrics. Resource group, subid and vmname can uniquely identify a VM else VMID uniquely identifies a VM.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```