### PR TITLE
Fix for setting default config values

### DIFF
--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -69,7 +69,7 @@ func ReadConfig() (CNSConfig, error) {
 }
 
 // set telmetry setting defaults
-func setTelemetrySettingDefaults(telemetrySettings TelemetrySettings) {
+func setTelemetrySettingDefaults(telemetrySettings *TelemetrySettings) {
 	if telemetrySettings.RefreshIntervalInSecs == 0 {
 		// set the default refresh interval of metadata thread to 15 seconds
 		telemetrySettings.RefreshIntervalInSecs = 15
@@ -93,5 +93,5 @@ func setTelemetrySettingDefaults(telemetrySettings TelemetrySettings) {
 
 // Set Default values of CNS config if not specified
 func SetCNSConfigDefaults(config *CNSConfig) {
-	setTelemetrySettingDefaults(config.TelemetrySettings)
+	setTelemetrySettingDefaults(&config.TelemetrySettings)
 }

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -224,8 +224,8 @@ func main() {
 		logger.Errorf("[Azure CNS] Error reading cns config: %v", err)
 	}
 
-	logger.Printf("[Azure CNS] Read config :%+v", cnsconfig)
 	configuration.SetCNSConfigDefaults(&cnsconfig)
+	logger.Printf("[Azure CNS] Read config :%+v", cnsconfig)
 
 	disableTelemetry := cnsconfig.TelemetrySettings.DisableAll
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This is the fix for setting default config values. Passed object as pointer instead of value

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```