### PR TITLE
Limit NPM AI Telemetry Handle Retrievals

### DIFF
--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -7,6 +7,7 @@ COPY $CNS_BUILD_ARCHIVE azure-cns.tgz
 
 # Update and unzip cns archive
 RUN apt-get update && \
+    apt-get install -y ca-certificates && \
     tar -xvzf azure-cns.tgz && \
     rm azure-cns.tgz
 

--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -14,4 +14,4 @@ RUN apt-get update && \
 EXPOSE 10090
 
 # Run the cns command by default when the container starts.
-ENTRYPOINT ["/azure-cns", "-c", "tcp://localhost:10090"]
+ENTRYPOINT ["sh", "-c", "/azure-cns -c tcp://$CNSIpAddress:10090"]


### PR DESCRIPTION
**What this PR does / why we need it**:
- Let npm loop 30 min (1 heartbeat interval) for AI telemetry handle.
- Update ca-certs for CNS image so it may send AI telemetry.