### PR TITLE
fix(npm/util/util.go): Properly create a semver for comparison

### DIFF
--- a/npm/util/util.go
+++ b/npm/util/util.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"hash/fnv"
 	"os"
-	"strings"
 	"sort"
+	"strings"
 
 	"github.com/Masterminds/semver"
 	"k8s.io/apimachinery/pkg/version"
@@ -98,11 +98,13 @@ func GetHashedName(name string) string {
 // returns -1, 0, 1 if firstVer smaller, equals, bigger than secondVer respectively.
 // returns -2 for error.
 func CompareK8sVer(firstVer *version.Info, secondVer *version.Info) int {
-	v1, err := semver.NewVersion(firstVer.Major+firstVer.Minor)
+	v1str := fmt.Sprintf("%s.%s", firstVer.Major, firstVer.Minor)
+	v1, err := semver.NewVersion(v1str)
 	if err != nil {
 		return -2
 	}
-	v2, err := semver.NewVersion(secondVer.Major+secondVer.Minor)
+	v2str := fmt.Sprintf("%s.%s", secondVer.Major, secondVer.Minor)
+	v2, err := semver.NewVersion(v2str)
 	if err != nil {
 		return -2
 	}

--- a/npm/util/util_test.go
+++ b/npm/util/util_test.go
@@ -1,8 +1,8 @@
 package util
 
 import (
-	"testing"
 	"reflect"
+	"testing"
 
 	"k8s.io/apimachinery/pkg/version"
 )
@@ -15,7 +15,7 @@ func TestSortMap(t *testing.T) {
 	}
 
 	sortedKeys, sortedVals := SortMap(m)
-	
+
 	expectedKeys := []string{
 		"a",
 		"c",
@@ -102,14 +102,28 @@ func TestCompareK8sVer(t *testing.T) {
 		Major: "1",
 		Minor: "14.8-hotfix.20191113",
 	}
-	
+
 	secondVer = &version.Info{
 		Major: "1",
 		Minor: "11",
 	}
-	
+
 	if res := CompareK8sVer(firstVer, secondVer); res != 1 {
 		t.Errorf("TestCompareK8sVer failed @ firstVer > secondVer w/ hotfix tag/pre-release")
+	}
+
+	firstVer = &version.Info{
+		Major: "1",
+		Minor: "11",
+	}
+
+	secondVer = &version.Info{
+		Major: "2",
+		Minor: "1",
+	}
+
+	if res := CompareK8sVer(firstVer, secondVer); res != -1 {
+		t.Errorf("TestCompareK8sVer failed @ firstVer < secondVer w/ 2 major version")
 	}
 }
 


### PR DESCRIPTION
The k8s semver was being created using a concat of the Major+Minor string. This means that a semver comparison of 1.11 vs 2.0-2.9 would alwasy fail as the second semver would only generate a number 20-29. Once a the minor version was increased to 2.10 it would pass correctly as 210 would be greater than 111 if that was the check being considered. This fix properly generates the semver using dot notation - 1.11 vs 111 which makes subsequent comparisons valid. I also added a test for the situation where we are comparing 1.11 vs 2.1

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Fixes comparison for kubernetes versions.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes: https://github.com/Azure/azure-container-networking/issues/494

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```