### PR TITLE
NPM Version Validation

### DIFF
--- a/npm/util/util.go
+++ b/npm/util/util.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"os"
+	"regexp"
 	"strings"
 	"sort"
 
@@ -15,6 +16,9 @@ import (
 
 // IsNewNwPolicyVerFlag indicates if the current kubernetes version is newer than 1.11 or not
 var IsNewNwPolicyVerFlag = false
+
+// regex to get minor version
+var re = regexp.MustCompile("[0-9]+")
 
 // Exists reports whether the named file or directory exists.
 func Exists(filePath string) bool {
@@ -98,11 +102,15 @@ func GetHashedName(name string) string {
 // returns -1, 0, 1 if firstVer smaller, equals, bigger than secondVer respectively.
 // returns -2 for error.
 func CompareK8sVer(firstVer *version.Info, secondVer *version.Info) int {
-	v1, err := semver.NewVersion(firstVer.Major+firstVer.Minor)
+	minorVers := re.FindAllString(firstVer.Minor, -1)
+	if len(minorVers) < 1 {
+		return -2
+	}
+	v1, err := semver.NewVersion(firstVer.Major+"."+minorVers[0])
 	if err != nil {
 		return -2
 	}
-	v2, err := semver.NewVersion(secondVer.Major+secondVer.Minor)
+	v2, err := semver.NewVersion(secondVer.Major+"."+secondVer.Minor)
 	if err != nil {
 		return -2
 	}

--- a/npm/util/util.go
+++ b/npm/util/util.go
@@ -102,15 +102,19 @@ func GetHashedName(name string) string {
 // returns -1, 0, 1 if firstVer smaller, equals, bigger than secondVer respectively.
 // returns -2 for error.
 func CompareK8sVer(firstVer *version.Info, secondVer *version.Info) int {
-	minorVers := re.FindAllString(firstVer.Minor, -1)
-	if len(minorVers) < 1 {
+	v1Minor := re.FindAllString(firstVer.Minor, -1)
+	if len(v1Minor) < 1 {
 		return -2
 	}
-	v1, err := semver.NewVersion(firstVer.Major+"."+minorVers[0])
+	v1, err := semver.NewVersion(firstVer.Major+"."+v1Minor[0])
 	if err != nil {
 		return -2
 	}
-	v2, err := semver.NewVersion(secondVer.Major+"."+secondVer.Minor)
+	v2Minor := re.FindAllString(secondVer.Minor, -1)
+	if len(v2Minor) < 1 {
+		return -2
+	}
+	v2, err := semver.NewVersion(secondVer.Major+"."+v2Minor[0])
 	if err != nil {
 		return -2
 	}

--- a/npm/util/util_test.go
+++ b/npm/util/util_test.go
@@ -125,6 +125,20 @@ func TestCompareK8sVer(t *testing.T) {
 	if res := CompareK8sVer(firstVer, secondVer); res != 1 {
 		t.Errorf("TestCompareK8sVer failed @ firstVer > secondVer w/ minor+ release")
 	}
+
+	firstVer = &version.Info{
+		Major: "2",
+		Minor: "1",
+	}
+
+	secondVer = &version.Info{
+		Major: "1",
+		Minor: "11",
+	}
+
+	if res := CompareK8sVer(firstVer, secondVer); res != 1 {
+		t.Errorf("TestCompareK8sVer failed @ firstVer > secondVer w/ major version upgrade")
+	}
 }
 
 func TestIsNewNwPolicyVer(t *testing.T) {

--- a/npm/util/util_test.go
+++ b/npm/util/util_test.go
@@ -111,6 +111,20 @@ func TestCompareK8sVer(t *testing.T) {
 	if res := CompareK8sVer(firstVer, secondVer); res != 1 {
 		t.Errorf("TestCompareK8sVer failed @ firstVer > secondVer w/ hotfix tag/pre-release")
 	}
+
+	firstVer = &version.Info{
+		Major: "1",
+		Minor: "14+",
+	}
+	
+	secondVer = &version.Info{
+		Major: "1",
+		Minor: "11",
+	}
+	
+	if res := CompareK8sVer(firstVer, secondVer); res != 1 {
+		t.Errorf("TestCompareK8sVer failed @ firstVer > secondVer w/ minor+ release")
+	}
 }
 
 func TestIsNewNwPolicyVer(t *testing.T) {

--- a/npm/util/util_test.go
+++ b/npm/util/util_test.go
@@ -139,6 +139,20 @@ func TestCompareK8sVer(t *testing.T) {
 	if res := CompareK8sVer(firstVer, secondVer); res != 1 {
 		t.Errorf("TestCompareK8sVer failed @ firstVer > secondVer w/ major version upgrade")
 	}
+
+	firstVer = &version.Info{
+		Major: "1",
+		Minor: "11",
+	}
+
+	secondVer = &version.Info{
+		Major: "2",
+		Minor: "1",
+	}
+
+	if res := CompareK8sVer(firstVer, secondVer); res != -1 {
+		t.Errorf("TestCompareK8sVer failed @ firstVer < secondVer w/ major version upgrade")
+	}
 }
 
 func TestIsNewNwPolicyVer(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
The value of minor was incorrectly assumed to be e.g. 14.8-hotfix.20191113 instead of 14+

Fixes #494