### PR TITLE
Fix unnecessary consecutiveAdd for windows

### DIFF
--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -39,6 +39,15 @@ func handleConsecutiveAdd(args *cniSkel.CmdArgs, endpointId string, nwInfo *netw
 		return nil, err
 	}
 
+	/*
+	 * Return in case of endpoint is already attached and consecutive add call doesn't need to be handled
+	 */
+	endpoint, _ := GetHNSEndpointByID(endpointId)
+	isAttached, err := endpoint.IsAttached(args.ContainerID)
+	if isAttached {
+		return nil, err
+	}
+
 	hnsEndpoint, err := hcsshim.GetHNSEndpointByName(endpointId)
 	if hnsEndpoint != nil {
 		log.Printf("[net] Found existing endpoint through hcsshim: %+v", hnsEndpoint)

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -42,12 +42,11 @@ func handleConsecutiveAdd(args *cniSkel.CmdArgs, endpointId string, nwInfo *netw
 	hnsEndpoint, err := hcsshim.GetHNSEndpointByName(endpointId)
 	if hnsEndpoint != nil {
 		log.Printf("[net] Found existing endpoint through hcsshim: %+v", hnsEndpoint)
-		log.Printf("[net] Attaching ep %v to container %v", hnsEndpoint.Id, args.ContainerID)
-
 		endpoint, _ := hcsshim.GetHNSEndpointByID(hnsEndpoint.Id)
 		isAttached, _ := endpoint.IsAttached(args.ContainerID)
-		// Attach endpoint if it's not attached yet. If attached, populate result directly should be good enough.
+		// Attach endpoint if it's not attached yet.
 		if !isAttached {
+			log.Printf("[net] Attaching ep %v to container %v", hnsEndpoint.Id, args.ContainerID)
 			err := hcsshim.HotAttachEndpoint(args.ContainerID, hnsEndpoint.Id)
 			if err != nil {
 				log.Printf("[cni-net] Failed to hot attach shared endpoint[%v] to container [%v], err:%v.", hnsEndpoint.Id, args.ContainerID, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Added endpoint checking logic before calling consecutiveAdd. If endpoint is attached, return directly without calling consecutiveAdd. 
When endpoint is attached, it means ADD has been done successfully previously. No consecutiveAdd is needed. 

**Which issue this PR fixes**
fixes #367