### PR TITLE
Fix unnecessary consecutiveAdd for windows(#367).

### DIFF
--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -39,6 +39,15 @@ func handleConsecutiveAdd(args *cniSkel.CmdArgs, endpointId string, nwInfo *netw
 		return nil, err
 	}
 
+	/*
+	 * Return in case of endpoint is already attached and consecutive add call doesn't need to be handled
+	 */
+	endpoint, _ := GetHNSEndpointByID(endpointId)
+	isAttached, err := endpoint.IsAttached(args.ContainerID)
+	if isAttached {
+		return nil, err
+	}
+
 	hnsEndpoint, err := hcsshim.GetHNSEndpointByName(endpointId)
 	if hnsEndpoint != nil {
 		log.Printf("[net] Found existing endpoint through hcsshim: %+v", hnsEndpoint)


### PR DESCRIPTION
**What this PR does / why we need it**:
Added endpoint checking logic before calling consecutiveAdd. If endpoint is attached, return directly without calling consecutiveAdd.
When endpoint is attached, it means ADD has been done successfully previously. No consecutiveAdd is needed.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #367 