### PR TITLE
Fix unnecessary consecutiveAdd for windows(#367).

### DIFF
--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -44,6 +44,15 @@ func handleConsecutiveAdd(args *cniSkel.CmdArgs, endpointId string, nwInfo *netw
 		log.Printf("[net] Found existing endpoint through hcsshim: %+v", hnsEndpoint)
 		log.Printf("[net] Attaching ep %v to container %v", hnsEndpoint.Id, args.ContainerID)
 
+		/*
+		* Return in case of endpoint is already attached and consecutive add call doesn't need to be handled
+		 */
+		endpoint, _ := GetHNSEndpointByID(hnsEndpoint.Id)
+		isAttached, err := endpoint.IsAttached(args.ContainerID)
+		if isAttached {
+			return nil, err
+		}
+
 		err := hcsshim.HotAttachEndpoint(args.ContainerID, hnsEndpoint.Id)
 		if err != nil {
 			log.Printf("[cni-net] Failed to hot attach shared endpoint[%v] to container [%v], err:%v.", hnsEndpoint.Id, args.ContainerID, err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Added endpoint checking logic before calling consecutiveAdd. If endpoint is attached, return directly without calling consecutiveAdd.
When endpoint is attached, it means ADD has been done successfully previously. No consecutiveAdd is needed.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #367 
