### PR TITLE
Update npm image version to use the latest v1.0.33

### DIFF
--- a/npm/azure-npm.yaml
+++ b/npm/azure-npm.yaml
@@ -81,7 +81,7 @@ spec:
         kubernetes.io/role: agent
       containers:
         - name: azure-npm
-          image: mcr.microsoft.com/containernetworking/azure-npm:v1.0.30
+          image: mcr.microsoft.com/containernetworking/azure-npm:v1.0.33
           securityContext:
             privileged: true
           env:


### PR DESCRIPTION
**What this PR does / why we need it**:

Update npm image version to use the latest v1.0.33
