### PR TITLE
[DO NOT MERGE] Update npm image to version 32 for testing purpose.

### DIFF
--- a/npm/azure-npm.yaml
+++ b/npm/azure-npm.yaml
@@ -81,7 +81,7 @@ spec:
         kubernetes.io/role: agent
       containers:
         - name: azure-npm
-          image: mcr.microsoft.com/containernetworking/azure-npm:v1.0.30
+          image: mcr.microsoft.com/containernetworking/azure-npm:v1.0.32
           securityContext:
             privileged: true
           env:


### PR DESCRIPTION
This is a testing PR for this one 
https://github.com/Azure/azure-container-networking/pull/521
If we update npm image to version 33, it can't pass one of the aks e2e test. This testing PR update to 32. The purpose is to test whether the aks test is flaky or 33 is not ready.