### PR TITLE
Avoid printing the auth token in CNS log

### DIFF
--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -1819,7 +1820,17 @@ func (service *HTTPRestService) publishNetworkContainer(w http.ResponseWriter, r
 	)
 
 	err = service.Listener.Decode(w, r, &req)
-	logger.Request(service.Name, &req, err)
+
+	// reqCopy creates a copy of incoming request. It doesn't copy the authentication token info
+	// to avoid logging it.
+	reqCopy := cns.PublishNetworkContainerRequest{
+		NetworkID:                 req.NetworkID,
+		NetworkContainerID:        req.NetworkContainerID,
+		JoinNetworkURL:            req.JoinNetworkURL,
+		CreateNetworkContainerURL: strings.Split(req.CreateNetworkContainerURL, "authenticationToken")[0],
+	}
+
+	logger.Request(service.Name, &reqCopy, err)
 	if err != nil {
 		return
 	}
@@ -1902,7 +1913,17 @@ func (service *HTTPRestService) unpublishNetworkContainer(w http.ResponseWriter,
 	)
 
 	err = service.Listener.Decode(w, r, &req)
-	logger.Request(service.Name, &req, err)
+
+	// reqCopy creates a copy of incoming request. It doesn't copy the authentication token info
+	// to avoid logging it.
+	reqCopy := cns.UnpublishNetworkContainerRequest{
+		NetworkID:                 req.NetworkID,
+		NetworkContainerID:        req.NetworkContainerID,
+		JoinNetworkURL:            req.JoinNetworkURL,
+		DeleteNetworkContainerURL: strings.Split(req.DeleteNetworkContainerURL, "authenticationToken")[0],
+	}
+
+	logger.Request(service.Name, &reqCopy, err)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
As DNC makes the call to CNS to publish NC, CNS logs the incoming request.
This prints the auth token. This change removes the auth token from getting
into the logs.
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```