### PR TITLE
Disable Hairpin on host interface

### DIFF
--- a/cni/azure-linux-multitenancy.conflist
+++ b/cni/azure-linux-multitenancy.conflist
@@ -11,6 +11,7 @@
          "podNamespaceForDualNetwork":[],
          "enableExactMatchForPodName": false,
          "enableSnatOnHost":true,
+         "DisableHairpinOnHostInterface": true,
          "ipam":{
             "type":"azure-vnet-ipam"
          },

--- a/cni/azure-linux.conflist
+++ b/cni/azure-linux.conflist
@@ -7,6 +7,7 @@
          "mode":"bridge",
          "bridge":"azure0",
          "ipsToRouteViaHost":["169.254.20.10"],
+         "DisableHairpinOnHostInterface": true,
          "ipam":{
             "type":"azure-vnet-ipam"
          }


### PR DESCRIPTION
In linux disable creating hairpin on host interface as a default setting.
conflist setting can be used to enable it if needed.
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```