### PR TITLE
Improve boot time query on Windows

### DIFF
--- a/platform/os_windows.go
+++ b/platform/os_windows.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/Azure/azure-container-networking/log"
@@ -55,6 +56,7 @@ const (
 
 // Flag to check if sdnRemoteArpMacAddress registry key is set
 var sdnRemoteArpMacAddressSet = false
+var tickCount = syscall.NewLazyDLL("kernel32.dll").NewProc("GetTickCount64")
 
 // GetOSInfo returns OS version information.
 func GetOSInfo() string {
@@ -69,39 +71,11 @@ func GetProcessSupport() error {
 
 // GetLastRebootTime returns the last time the system rebooted.
 func GetLastRebootTime() (time.Time, error) {
-	out, err := exec.Command("cmd", "/c", "wmic os get lastbootuptime").Output()
-	if err != nil {
-		log.Printf("Failed to query wmic os get lastbootuptime, err: %v", err)
+	output, _, err := tickCount.Call()
+	if errno, ok := err.(syscall.Errno); !ok || errno != 0 {
 		return time.Time{}.UTC(), err
 	}
-
-	lastBootupTime := strings.Split(strings.TrimSpace(string(out)), "\n")
-	if strings.TrimSpace(lastBootupTime[0]) != "LastBootUpTime" || len(lastBootupTime) != 2 {
-		log.Printf("Failed to retrieve boot time")
-		return time.Time{}.UTC(), fmt.Errorf("Failed to retrieve boot time with 'wmic os get lastbootuptime'")
-	}
-	systemBootupTime := strings.Split(lastBootupTime[1], ".")[0]
-
-	// The systembootuptime is in the format YYYYMMDDHHMMSS
-	bootYear := systemBootupTime[0:4]
-	bootMonth := systemBootupTime[4:6]
-	bootDay := systemBootupTime[6:8]
-	bootHour := systemBootupTime[8:10]
-	bootMin := systemBootupTime[10:12]
-	bootSec := systemBootupTime[12:14]
-	systemBootTime := bootYear + "-" + bootMonth + "-" + bootDay + " " + bootHour + ":" + bootMin + ":" + bootSec
-
-	log.Printf("Formatted Boot time: %s", systemBootTime)
-
-	// Parse the boot time.
-	layout := "2006-01-02 15:04:05"
-	rebootTime, err := time.ParseInLocation(layout, systemBootTime, time.Local)
-	if err != nil {
-		log.Printf("Failed to parse boot time, err:%v", err)
-		return time.Time{}.UTC(), err
-	}
-
-	return rebootTime.UTC(), nil
+	return time.Now().Add(-time.Duration(output) * time.Millisecond).UTC(), nil
 }
 
 func ExecuteCommand(command string) (string, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Current implementation usually takes about 500ms to finish, the new one costs almost zero. It comes from https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/util/util_windows.go#L119.

I have verified they generate same time value.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 