### PR TITLE
Fixing duplicate UDP/TCP packets being sent from load balancer

### DIFF
--- a/cni/azure-linux.conflist
+++ b/cni/azure-linux.conflist
@@ -6,6 +6,7 @@
          "type":"azure-vnet",
          "mode":"bridge",
          "bridge":"azure0",
+         "disableHairpinOnHostInterface":true,
          "ipsToRouteViaHost":["169.254.20.10"],
          "ipam":{
             "type":"azure-vnet-ipam"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the issue of duplicate packets being sent from UDP and TCP load balancers on a kubernetes cluster using CNI. The change was to add DisableHairpinOnHostInterface:true to the conflist.

**Which issue this PR fixes**
fixes #525 
