### PR TITLE
Fixing windows test failure

### DIFF
--- a/network/monitor_windows.go
+++ b/network/monitor_windows.go
@@ -1,3 +1,7 @@
+package network
+
+import cnms "github.com/Azure/azure-container-networking/cnms/cnmspackage"
+
 func (nm *networkManager) monitorNetworkState(networkMonitor *cnms.NetworkMonitor) error {
 	return nil
 }

--- a/network/monitor_windows.go
+++ b/network/monitor_windows.go
@@ -1,3 +1,3 @@
-func (nm *networkManager) monitorNetworkState() error {
+func (nm *networkManager) monitorNetworkState(networkMonitor *cnms.NetworkMonitor) error {
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixing the windows test build. Did this by rewriting the empty funciton for monitor_windows.go
