### PR TITLE
Adding telemetry to network monitor

### DIFF
--- a/cnms/cnmspackage/api.go
+++ b/cnms/cnmspackage/api.go
@@ -1,6 +1,9 @@
 package cnms
 
+import "github.com/Azure/azure-container-networking/telemetry"
+
 type NetworkMonitor struct {
 	AddRulesToBeValidated    map[string]int
 	DeleteRulesToBeValidated map[string]int
+	CNIReport                *telemetry.CNIReport
 }

--- a/cnms/cnmspackage/monitor2rules_linux.go
+++ b/cnms/cnmspackage/monitor2rules_linux.go
@@ -54,7 +54,7 @@ func (networkMonitor *NetworkMonitor) addRulesNotExistInMap(
 				networkMonitor.CNIReport.OperationType = "EBTableAdd"
 				delete(networkMonitor.AddRulesToBeValidated, rule)
 			} else {
-				log.Printf("[ADD] Found unmatched rule chain %v rule %v itr %d. Giving one more iteration", chain, rule, itr)
+				log.Printf("[ADD] Found unmatched rule chain %v rule %v itr %d. Giving one more iteration.", chain, rule, itr)
 				networkMonitor.AddRulesToBeValidated[rule] = itr + 1
 			}
 		}

--- a/cnms/cnmspackage/monitor2rules_linux.go
+++ b/cnms/cnmspackage/monitor2rules_linux.go
@@ -16,9 +16,9 @@ func (networkMonitor *NetworkMonitor) deleteRulesNotExistInMap(chainRules map[st
 	for rule, chain := range chainRules {
 		if _, ok := stateRules[rule]; !ok {
 			if itr, ok := networkMonitor.DeleteRulesToBeValidated[rule]; ok && itr > 0 {
-				buf := fmt.Sprintf("[monitor] Deleting Ebtable rule as it didn't exist in state for %d iterations chain %v rule %v\n", itr, chain, rule)
+				buf := fmt.Sprintf("[monitor] Deleting Ebtable rule as it didn't exist in state for %d iterations chain %v rule %v", itr, chain, rule)
 				if err := ebtables.SetEbRule(table, action, chain, rule); err != nil {
-					buf = fmt.Sprintf("[monitor] Error while deleting ebtable rule %v\n", err)
+					buf = fmt.Sprintf("[monitor] Error while deleting ebtable rule %v", err)
 				}
 
 				log.Printf(buf)
@@ -44,9 +44,9 @@ func (networkMonitor *NetworkMonitor) addRulesNotExistInMap(
 	for rule, chain := range stateRules {
 		if _, ok := chainRules[rule]; !ok {
 			if itr, ok := networkMonitor.AddRulesToBeValidated[rule]; ok && itr > 0 {
-				buf := fmt.Sprintf("[monitor] Adding Ebtable rule as it existed in state rules but not in current chain rules for %d iterations chain %v rule %v\n", itr, chain, rule)
+				buf := fmt.Sprintf("[monitor] Adding Ebtable rule as it existed in state rules but not in current chain rules for %d iterations chain %v rule %v", itr, chain, rule)
 				if err := ebtables.SetEbRule(table, action, chain, rule); err != nil {
-					buf = fmt.Sprintf("[monitor] Error while adding ebtable rule %v\n", err)
+					buf = fmt.Sprintf("[monitor] Error while adding ebtable rule %v", err)
 				}
 
 				log.Printf(buf)

--- a/cnms/cnmspackage/monitor2rules_linux.go
+++ b/cnms/cnmspackage/monitor2rules_linux.go
@@ -54,7 +54,7 @@ func (networkMonitor *NetworkMonitor) addRulesNotExistInMap(
 				networkMonitor.CNIReport.OperationType = "EBTableAdd"
 				delete(networkMonitor.AddRulesToBeValidated, rule)
 			} else {
-				log.Printf("[ADD] Found unmatched rule chain %v rule %v itr %d. Giving one more iteration.", chain, rule, itr)
+				log.Printf("[ADD] Found unmatched rule chain %v rule %v itr %d. Giving one more iteration", chain, rule, itr)
 				networkMonitor.AddRulesToBeValidated[rule] = itr + 1
 			}
 		}

--- a/cnms/cnmspackage/monitor2rules_linux.go
+++ b/cnms/cnmspackage/monitor2rules_linux.go
@@ -1,6 +1,8 @@
 package cnms
 
 import (
+	"fmt"
+
 	"github.com/Azure/azure-container-networking/ebtables"
 	"github.com/Azure/azure-container-networking/log"
 )
@@ -14,11 +16,14 @@ func (networkMonitor *NetworkMonitor) deleteRulesNotExistInMap(chainRules map[st
 	for rule, chain := range chainRules {
 		if _, ok := stateRules[rule]; !ok {
 			if itr, ok := networkMonitor.DeleteRulesToBeValidated[rule]; ok && itr > 0 {
-				log.Printf("[monitor] Deleting Ebtable rule as it didn't exist in state for %d iterations chain %v rule %v", itr, chain, rule)
+				buf := fmt.Sprintf("[monitor] Deleting Ebtable rule as it didn't exist in state for %d iterations chain %v rule %v\n", itr, chain, rule)
 				if err := ebtables.SetEbRule(table, action, chain, rule); err != nil {
-					log.Printf("[monitor] Error while deleting ebtable rule %v", err)
+					buf = fmt.Sprintf("[monitor] Error while deleting ebtable rule %v\n", err)
 				}
 
+				log.Printf(buf)
+				networkMonitor.CNIReport.ErrorMessage = buf
+				networkMonitor.CNIReport.OperationType = "EBTableDelete"
 				delete(networkMonitor.DeleteRulesToBeValidated, rule)
 			} else {
 				log.Printf("[DELETE] Found unmatched rule chain %v rule %v itr %d. Giving one more iteration.", chain, rule, itr)
@@ -39,11 +44,14 @@ func (networkMonitor *NetworkMonitor) addRulesNotExistInMap(
 	for rule, chain := range stateRules {
 		if _, ok := chainRules[rule]; !ok {
 			if itr, ok := networkMonitor.AddRulesToBeValidated[rule]; ok && itr > 0 {
-				log.Printf("[monitor] Adding Ebtable rule as it existed in state rules but not in current chain rules for %d iterations chain %v rule %v", itr, chain, rule)
+				buf := fmt.Sprintf("[monitor] Adding Ebtable rule as it existed in state rules but not in current chain rules for %d iterations chain %v rule %v\n", itr, chain, rule)
 				if err := ebtables.SetEbRule(table, action, chain, rule); err != nil {
-					log.Printf("[monitor] Error while adding ebtable rule %v", err)
+					buf = fmt.Sprintf("[monitor] Error while adding ebtable rule %v\n", err)
 				}
 
+				log.Printf(buf)
+				networkMonitor.CNIReport.ErrorMessage = buf
+				networkMonitor.CNIReport.OperationType = "EBTableAdd"
 				delete(networkMonitor.AddRulesToBeValidated, rule)
 			} else {
 				log.Printf("[ADD] Found unmatched rule chain %v rule %v itr %d. Giving one more iteration", chain, rule, itr)

--- a/cnms/service/networkmonitor_test.go
+++ b/cnms/service/networkmonitor_test.go
@@ -6,6 +6,7 @@ import (
 
 	cnms "github.com/Azure/azure-container-networking/cnms/cnmspackage"
 	"github.com/Azure/azure-container-networking/ebtables"
+	"github.com/Azure/azure-container-networking/telemetry"
 )
 
 const (
@@ -35,9 +36,23 @@ func addStateRulesToMap() map[string]string {
 }
 
 func TestAddMissingRule(t *testing.T) {
+	reportManager := &telemetry.ReportManager{
+		ContentType: telemetry.ContentType,
+		Report: &telemetry.CNIReport{
+			Context:          "AzureCNINetworkMonitor",
+			Version:          version,
+			SystemDetails:    telemetry.SystemInfo{},
+			InterfaceDetails: telemetry.InterfaceInfo{},
+			BridgeDetails:    telemetry.BridgeInfo{},
+		},
+	}
+
+	reportManager.Report.(*telemetry.CNIReport).GetOSDetails()
+
 	netMonitor := &cnms.NetworkMonitor{
 		AddRulesToBeValidated:    make(map[string]int),
 		DeleteRulesToBeValidated: make(map[string]int),
+		CNIReport:                reportManager.Report.(*telemetry.CNIReport),
 	}
 
 	currentStateRulesMap := addStateRulesToMap()
@@ -75,9 +90,23 @@ func TestAddMissingRule(t *testing.T) {
 }
 
 func TestDeleteInvalidRule(t *testing.T) {
+	reportManager := &telemetry.ReportManager{
+		ContentType: telemetry.ContentType,
+		Report: &telemetry.CNIReport{
+			Context:          "AzureCNINetworkMonitor",
+			Version:          version,
+			SystemDetails:    telemetry.SystemInfo{},
+			InterfaceDetails: telemetry.InterfaceInfo{},
+			BridgeDetails:    telemetry.BridgeInfo{},
+		},
+	}
+
+	reportManager.Report.(*telemetry.CNIReport).GetOSDetails()
+
 	netMonitor := &cnms.NetworkMonitor{
 		AddRulesToBeValidated:    make(map[string]int),
 		DeleteRulesToBeValidated: make(map[string]int),
+		CNIReport:                reportManager.Report.(*telemetry.CNIReport),
 	}
 
 	currentStateRulesMap := addStateRulesToMap()

--- a/cnms/service/networkmonitor_test.go
+++ b/cnms/service/networkmonitor_test.go
@@ -36,23 +36,10 @@ func addStateRulesToMap() map[string]string {
 }
 
 func TestAddMissingRule(t *testing.T) {
-	reportManager := &telemetry.ReportManager{
-		ContentType: telemetry.ContentType,
-		Report: &telemetry.CNIReport{
-			Context:          "AzureCNINetworkMonitor",
-			Version:          version,
-			SystemDetails:    telemetry.SystemInfo{},
-			InterfaceDetails: telemetry.InterfaceInfo{},
-			BridgeDetails:    telemetry.BridgeInfo{},
-		},
-	}
-
-	reportManager.Report.(*telemetry.CNIReport).GetOSDetails()
-
 	netMonitor := &cnms.NetworkMonitor{
 		AddRulesToBeValidated:    make(map[string]int),
 		DeleteRulesToBeValidated: make(map[string]int),
-		CNIReport:                reportManager.Report.(*telemetry.CNIReport),
+		CNIReport:                &telemetry.CNIReport{},
 	}
 
 	currentStateRulesMap := addStateRulesToMap()
@@ -90,23 +77,10 @@ func TestAddMissingRule(t *testing.T) {
 }
 
 func TestDeleteInvalidRule(t *testing.T) {
-	reportManager := &telemetry.ReportManager{
-		ContentType: telemetry.ContentType,
-		Report: &telemetry.CNIReport{
-			Context:          "AzureCNINetworkMonitor",
-			Version:          version,
-			SystemDetails:    telemetry.SystemInfo{},
-			InterfaceDetails: telemetry.InterfaceInfo{},
-			BridgeDetails:    telemetry.BridgeInfo{},
-		},
-	}
-
-	reportManager.Report.(*telemetry.CNIReport).GetOSDetails()
-
 	netMonitor := &cnms.NetworkMonitor{
 		AddRulesToBeValidated:    make(map[string]int),
 		DeleteRulesToBeValidated: make(map[string]int),
-		CNIReport:                reportManager.Report.(*telemetry.CNIReport),
+		CNIReport:                &telemetry.CNIReport{},
 	}
 
 	currentStateRulesMap := addStateRulesToMap()


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds telemetry capabilities to network monitoring of Eb rules.
It reports discrepancies to telemetry pipeline which can be viewed in jarvis.

**Testing**
To see the test logs go to this jarvis [link](https://jarvis-west.dc.ad.msft.net/E85E6F5A)


**Which issue this PR fixes**
Adaptation of [this](https://github.com/tamilmani1989/azure-container-networking/tree/netmon_telemetry) branch