### PR TITLE
Consume ACL for APIPA Endpoint from CreateNC Req

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -231,8 +231,8 @@ type UnpublishNetworkContainerResponse struct {
 	UnpublishResponseBody []byte
 }
 
-// Testing
-type AclPolicyTestSetting struct {
+// ValidAclPolicySetting - Used to validate ACL policy
+type ValidAclPolicySetting struct {
 	Protocols       string `json:","`
 	Action          string `json:","`
 	Direction       string `json:","`
@@ -248,7 +248,7 @@ type AclPolicyTestSetting struct {
 func (networkContainerRequestPolicy *NetworkContainerRequestPolicies) Validate() error {
 	// validate ACL policy
 	if strings.EqualFold(networkContainerRequestPolicy.Type, "ACLPolicy") {
-		var requestedAclPolicy AclPolicyTestSetting
+		var requestedAclPolicy ValidAclPolicySetting
 		if err := json.Unmarshal(networkContainerRequestPolicy.Settings, &requestedAclPolicy); err != nil {
 			return fmt.Errorf("ACL policy failed to pass validation with error: %+v ", err)
 		}

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -248,7 +248,7 @@ type ValidAclPolicySetting struct {
 func (networkContainerRequestPolicy *NetworkContainerRequestPolicies) Validate() error {
 	// validate ACL policy
 	if networkContainerRequestPolicy != nil {
-		if strings.EqualFold(networkContainerRequestPolicy.Type, "ACLPolicy") {
+		if strings.EqualFold(networkContainerRequestPolicy.Type, "ACLPolicy") && strings.EqualFold(networkContainerRequestPolicy.EndpointType, "APIPA") {
 			var requestedAclPolicy ValidAclPolicySetting
 			if err := json.Unmarshal(networkContainerRequestPolicy.Settings, &requestedAclPolicy); err != nil {
 				return fmt.Errorf("ACL policy failed to pass validation with error: %+v ", err)
@@ -259,6 +259,8 @@ func (networkContainerRequestPolicy *NetworkContainerRequestPolicies) Validate()
 			if requestedAclPolicy.Priority == 0 {
 				return fmt.Errorf("Priority field cannot be empty in ACL Policy")
 			}
+		} else {
+			return fmt.Errorf("Only ACL Policies on APIPA endpoint supported")
 		}
 	}
 	return nil

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -241,13 +241,11 @@ func (networkContainerRequestPolicy *NetworkContainerRequestPolicies) Validate()
 		if err := json.Unmarshal(networkContainerRequestPolicy.Settings, &requestedAclPolicy); err != nil {
 			return fmt.Errorf("ACL policy failed to pass validation with error: %+v ", err)
 		}
-		if requestedAclPolicy != nil {
-			if len(strings.TrimSpace(requestedAclPolicy.Action)) == 0 {
-				return fmt.Errorf("Action field cannot be empty in ACL Policy")
-			}
-			if requestedAclPolicy.Priority == 0 {
-				return fmt.Errorf("Priority field cannot be empty in ACL Policy")
-			}
+		if len(strings.TrimSpace(string(requestedAclPolicy.Action))) == 0 {
+			return fmt.Errorf("Action field cannot be empty in ACL Policy")
+		}
+		if requestedAclPolicy.Priority == 0 {
+			return fmt.Errorf("Priority field cannot be empty in ACL Policy")
 		}
 	}
 	return nil

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -2,7 +2,6 @@ package cns
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -76,6 +75,12 @@ type NetworkContainerRequestPolicies struct {
 	Type         string
 	EndpointType string
 	Settings     json.RawMessage
+}
+
+// ConfigureContainerNetworkingRequest - specifies request to attach/detach container to network.
+type ConfigureContainerNetworkingRequest struct {
+	Containerid        string
+	NetworkContainerid string
 }
 
 // KubernetesPodInfo is an OrchestratorContext that holds PodName and PodNamespace.
@@ -230,26 +235,20 @@ type UnpublishNetworkContainerResponse struct {
 
 // Validate - Validates network container request policies
 func (networkContainerRequestPolicy *NetworkContainerRequestPolicies) Validate() error {
-
 	// validate ACL policy
 	if strings.EqualFold(networkContainerRequestPolicy.Type, "ACLPolicy") {
-
 		var requestedAclPolicy hcn.AclPolicySetting
-
 		if err := json.Unmarshal(networkContainerRequestPolicy.Settings, &requestedAclPolicy); err != nil {
-
 			return fmt.Errorf("ACL policy failed to pass validation with error: %+v ", err)
 		}
-
-		if requestedAclPolicy.Action == "" {
-			return errors.New("Action field cannot be empty in ACL Policy")
+		if requestedAclPolicy != nil {
+			if len(strings.TrimSpace(requestedAclPolicy.Action)) == 0 {
+				return fmt.Errorf("Action field cannot be empty in ACL Policy")
+			}
+			if requestedAclPolicy.Priority == 0 {
+				return fmt.Errorf("Priority field cannot be empty in ACL Policy")
+			}
 		}
-
-		if requestedAclPolicy.Priority == 0 {
-			return errors.New("Priority field cannot be empty in ACL Policy")
-		}
-
 	}
-
 	return nil
 }

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-
-	"github.com/Microsoft/hcsshim/hcn"
 )
 
 // Container Network Service DNC Contract
@@ -233,11 +231,24 @@ type UnpublishNetworkContainerResponse struct {
 	UnpublishResponseBody []byte
 }
 
+// Testing
+type AclPolicyTestSetting struct {
+	Protocols       string `json:","`
+	Action          string `json:","`
+	Direction       string `json:","`
+	LocalAddresses  string `json:","`
+	RemoteAddresses string `json:","`
+	LocalPorts      string `json:","`
+	RemotePorts     string `json:","`
+	RuleType        string `json:","`
+	Priority        uint16 `json:","`
+}
+
 // Validate - Validates network container request policies
 func (networkContainerRequestPolicy *NetworkContainerRequestPolicies) Validate() error {
 	// validate ACL policy
 	if strings.EqualFold(networkContainerRequestPolicy.Type, "ACLPolicy") {
-		var requestedAclPolicy hcn.AclPolicySetting
+		var requestedAclPolicy AclPolicyTestSetting
 		if err := json.Unmarshal(networkContainerRequestPolicy.Settings, &requestedAclPolicy); err != nil {
 			return fmt.Errorf("ACL policy failed to pass validation with error: %+v ", err)
 		}

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -67,6 +67,7 @@ type CreateNetworkContainerRequest struct {
 	Routes                     []Route
 	AllowHostToNCCommunication bool
 	AllowNCToHostCommunication bool
+	EndpointPolicies           []NetworkContainerRequestPolicies
 }
 
 // NetworkContainerRequestPolicies - specifies policies associated with create network request

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -253,8 +253,21 @@ func (networkContainerRequestPolicy *NetworkContainerRequestPolicies) Validate()
 			if err := json.Unmarshal(networkContainerRequestPolicy.Settings, &requestedAclPolicy); err != nil {
 				return fmt.Errorf("ACL policy failed to pass validation with error: %+v ", err)
 			}
+			//Deny request if ACL Action is empty
 			if len(strings.TrimSpace(string(requestedAclPolicy.Action))) == 0 {
 				return fmt.Errorf("Action field cannot be empty in ACL Policy")
+			}
+			//Deny request if ACL Action is not Allow or Deny
+			if !strings.EqualFold(requestedAclPolicy.Action, "Allow") && !strings.EqualFold(requestedAclPolicy.Action, "Deny") {
+				return fmt.Errorf("Only Allow or Deny is supported in Action field")
+			}
+			//Deny request if ACL Direction is empty
+			if len(strings.TrimSpace(string(requestedAclPolicy.Direction))) == 0 {
+				return fmt.Errorf("Direction field cannot be empty in ACL Policy")
+			}
+			//Deny request if ACL direction is not In or Out
+			if !strings.EqualFold(requestedAclPolicy.Direction, "In") && !strings.EqualFold(requestedAclPolicy.Direction, "Out") {
+				return fmt.Errorf("Only Allow or Deny is supported in Action field")
 			}
 			if requestedAclPolicy.Priority == 0 {
 				return fmt.Errorf("Priority field cannot be empty in ACL Policy")

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -67,7 +67,6 @@ type CreateNetworkContainerRequest struct {
 	Routes                     []Route
 	AllowHostToNCCommunication bool
 	AllowNCToHostCommunication bool
-	EndpointPolicies           []NetworkContainerRequestPolicies
 }
 
 // NetworkContainerRequestPolicies - specifies policies associated with create network request

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -267,7 +267,7 @@ func (networkContainerRequestPolicy *NetworkContainerRequestPolicies) Validate()
 			}
 			//Deny request if ACL direction is not In or Out
 			if !strings.EqualFold(requestedAclPolicy.Direction, "In") && !strings.EqualFold(requestedAclPolicy.Direction, "Out") {
-				return fmt.Errorf("Only Allow or Deny is supported in Action field")
+				return fmt.Errorf("Only In or Out is supported in Direction field")
 			}
 			if requestedAclPolicy.Priority == 0 {
 				return fmt.Errorf("Priority field cannot be empty in ACL Policy")

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -247,16 +247,18 @@ type ValidAclPolicySetting struct {
 // Validate - Validates network container request policies
 func (networkContainerRequestPolicy *NetworkContainerRequestPolicies) Validate() error {
 	// validate ACL policy
-	if strings.EqualFold(networkContainerRequestPolicy.Type, "ACLPolicy") {
-		var requestedAclPolicy ValidAclPolicySetting
-		if err := json.Unmarshal(networkContainerRequestPolicy.Settings, &requestedAclPolicy); err != nil {
-			return fmt.Errorf("ACL policy failed to pass validation with error: %+v ", err)
-		}
-		if len(strings.TrimSpace(string(requestedAclPolicy.Action))) == 0 {
-			return fmt.Errorf("Action field cannot be empty in ACL Policy")
-		}
-		if requestedAclPolicy.Priority == 0 {
-			return fmt.Errorf("Priority field cannot be empty in ACL Policy")
+	if networkContainerRequestPolicy != nil {
+		if strings.EqualFold(networkContainerRequestPolicy.Type, "ACLPolicy") {
+			var requestedAclPolicy ValidAclPolicySetting
+			if err := json.Unmarshal(networkContainerRequestPolicy.Settings, &requestedAclPolicy); err != nil {
+				return fmt.Errorf("ACL policy failed to pass validation with error: %+v ", err)
+			}
+			if len(strings.TrimSpace(string(requestedAclPolicy.Action))) == 0 {
+				return fmt.Errorf("Action field cannot be empty in ACL Policy")
+			}
+			if requestedAclPolicy.Priority == 0 {
+				return fmt.Errorf("Priority field cannot be empty in ACL Policy")
+			}
 		}
 	}
 	return nil

--- a/cns/hnsclient/hnsclient_linux.go
+++ b/cns/hnsclient/hnsclient_linux.go
@@ -38,7 +38,8 @@ func CreateHostNCApipaEndpoint(
 	networkContainerID string,
 	localIPConfiguration cns.IPConfiguration,
 	allowNCToHostCommunication bool,
-	allowHostToNCCommunication bool) (string, error) {
+	allowHostToNCCommunication bool,
+	ncPolicies []cns.NetworkContainerRequestPolicies) (string, error) {
 	return "", nil
 }
 

--- a/cns/hnsclient/hnsclient_windows.go
+++ b/cns/hnsclient/hnsclient_windows.go
@@ -445,6 +445,14 @@ func configureAclSettingHostNCApipaEndpoint(
 				if err = json.Unmarshal(requestedPolicy.Settings, &requestedAclPolicy); err != nil {
 					return nil, fmt.Errorf("Failed to Unmarshal requested ACL policy: %+v with error: %S", requestedPolicy.Settings, err)
 				}
+				//Using {NetworkContainerIP} as a placeholder to signal using Network Container IP
+				if strings.EqualFold(requestedAclPolicy.LocalAddresses, "{NetworkContainerIP}") {
+					requestedAclPolicy.LocalAddresses = networkContainerApipaIP
+				}
+				//Using {HostApipaIP} as a placeholder to signal using Host Apipa IP
+				if strings.EqualFold(requestedAclPolicy.RemoteAddresses, "{HostApipaIP}") {
+					requestedAclPolicy.RemoteAddresses = hostApipaIP
+				}
 				logger.Printf("ACL Policy requested in NcGoalState %+v", requestedAclPolicy)
 				if err = addAclToEndpointPolicy(requestedAclPolicy, &endpointPolicies); err != nil {
 					return nil, err

--- a/cns/hnsclient/hnsclient_windows.go
+++ b/cns/hnsclient/hnsclient_windows.go
@@ -440,26 +440,18 @@ func configureAclSettingHostNCApipaEndpoint(
 		// Iterate thru the requested endpoint policies where policy type is ACL, endpoint type is APIPA
 		// include the raw json message in the endpoint policies
 		for _, requestedPolicy := range ncRequestedPolicies {
-
 			if strings.EqualFold(requestedPolicy.Type, aclPolicyType) && strings.EqualFold(requestedPolicy.EndpointType, apipaEndpointType) {
-
 				var requestedAclPolicy hcn.AclPolicySetting
-
-				if err := json.Unmarshal(requestedPolicy.Settings, &requestedAclPolicy); err != nil {
-
+				if err = json.Unmarshal(requestedPolicy.Settings, &requestedAclPolicy); err != nil {
 					return nil, fmt.Errorf("Failed to Unmarshal requested ACL policy: %+v with error: %S", requestedPolicy.Settings, err)
 				}
-
-				logger.Printf("ACL Policy requested in NcGoalState %+v ", requestedAclPolicy)
-
+				logger.Printf("ACL Policy requested in NcGoalState %+v", requestedAclPolicy)
 				if err = addAclToEndpointPolicy(requestedAclPolicy, &endpointPolicies); err != nil {
 					return nil, err
 				}
-
 			}
 		}
 	}
-
 	return endpointPolicies, nil
 }
 

--- a/cns/hnsclient/hnsclient_windows.go
+++ b/cns/hnsclient/hnsclient_windows.go
@@ -66,6 +66,12 @@ const (
 
 	// aclPriority200 indicates the ACL priority of 200
 	aclPriority200 = 200
+
+	// aclPolicyType indicates a ACL policy
+	aclPolicyType = "ACLPolicy"
+
+	//signals a APIPA endpoint type
+	apipaEndpointType = "APIPA"
 )
 
 var (
@@ -347,7 +353,8 @@ func configureAclSettingHostNCApipaEndpoint(
 	networkContainerApipaIP string,
 	hostApipaIP string,
 	allowNCToHostCommunication bool,
-	allowHostToNCCommunication bool) ([]hcn.EndpointPolicy, error) {
+	allowHostToNCCommunication bool,
+	ncRequestedPolicies []cns.NetworkContainerRequestPolicies) ([]hcn.EndpointPolicy, error) {
 	var (
 		err              error
 		endpointPolicies []hcn.EndpointPolicy
@@ -426,6 +433,31 @@ func configureAclSettingHostNCApipaEndpoint(
 				return nil, err
 			}
 		}
+
+	}
+
+	if ncRequestedPolicies != nil {
+		// Iterate thru the requested endpoint policies where policy type is ACL, endpoint type is APIPA
+		// include the raw json message in the endpoint policies
+		for _, requestedPolicy := range ncRequestedPolicies {
+
+			if strings.EqualFold(requestedPolicy.Type, aclPolicyType) && strings.EqualFold(requestedPolicy.EndpointType, apipaEndpointType) {
+
+				var requestedAclPolicy hcn.AclPolicySetting
+
+				if err := json.Unmarshal(requestedPolicy.Settings, &requestedAclPolicy); err != nil {
+
+					return nil, fmt.Errorf("Failed to Unmarshal requested ACL policy: %+v with error: %S", requestedPolicy.Settings, err)
+				}
+
+				logger.Printf("ACL Policy requested in NcGoalState %+v ", requestedAclPolicy)
+
+				if err = addAclToEndpointPolicy(requestedAclPolicy, &endpointPolicies); err != nil {
+					return nil, err
+				}
+
+			}
+		}
 	}
 
 	return endpointPolicies, nil
@@ -436,7 +468,8 @@ func configureHostNCApipaEndpoint(
 	networkID string,
 	localIPConfiguration cns.IPConfiguration,
 	allowNCToHostCommunication bool,
-	allowHostToNCCommunication bool) (*hcn.HostComputeEndpoint, error) {
+	allowHostToNCCommunication bool,
+	ncPolicies []cns.NetworkContainerRequestPolicies) (*hcn.HostComputeEndpoint, error) {
 	endpoint := &hcn.HostComputeEndpoint{
 		Name:               endpointName,
 		HostComputeNetwork: networkID,
@@ -455,7 +488,8 @@ func configureHostNCApipaEndpoint(
 		networkContainerApipaIP,
 		hostApipaIP,
 		allowNCToHostCommunication,
-		allowHostToNCCommunication)
+		allowHostToNCCommunication,
+		ncPolicies)
 
 	if err != nil {
 		logger.Errorf("[Azure CNS] Failed to configure ACL for HostNCApipaEndpoint. Error: %v", err)
@@ -490,7 +524,8 @@ func CreateHostNCApipaEndpoint(
 	networkContainerID string,
 	localIPConfiguration cns.IPConfiguration,
 	allowNCToHostCommunication bool,
-	allowHostToNCCommunication bool) (string, error) {
+	allowHostToNCCommunication bool,
+	ncPolicies []cns.NetworkContainerRequestPolicies) (string, error) {
 	var (
 		network      *hcn.HostComputeNetwork
 		endpoint     *hcn.HostComputeEndpoint
@@ -528,7 +563,8 @@ func CreateHostNCApipaEndpoint(
 		network.Id,
 		localIPConfiguration,
 		allowNCToHostCommunication,
-		allowHostToNCCommunication); err != nil {
+		allowHostToNCCommunication,
+		ncPolicies); err != nil {
 		logger.Errorf("[Azure CNS] Failed to configure HostNCApipaEndpoint: %s. Error: %v", endpointName, err)
 		return "", err
 	}

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -1697,7 +1697,8 @@ func (service *HTTPRestService) createHostNCApipaEndpoint(w http.ResponseWriter,
 					req.NetworkContainerID,
 					networkContainerDetails.CreateNetworkContainerRequest.LocalIPConfiguration,
 					networkContainerDetails.CreateNetworkContainerRequest.AllowNCToHostCommunication,
-					networkContainerDetails.CreateNetworkContainerRequest.AllowHostToNCCommunication); err != nil {
+					networkContainerDetails.CreateNetworkContainerRequest.AllowHostToNCCommunication,
+					networkContainerDetails.CreateNetworkContainerRequest.EndpointPolicies); err != nil {
 					returnMessage = fmt.Sprintf("CreateHostNCApipaEndpoint failed with error: %v", err)
 					returnCode = UnexpectedError
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR consumes endpoint policies targeting APIPA endpoints. In the future, we are extending policies to requested by the orchestrator in a extensible way from the Create Network Container Request. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #533 

**Special notes for your reviewer**:

Tested the successful creation of the HostNCApipaEndpoint with the additional policies requested. 
 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```