### PR TITLE
Lock update operations to prevent race in between updates.

### DIFF
--- a/npm/namespace.go
+++ b/npm/namespace.go
@@ -55,7 +55,7 @@ func (ns *namespace) policyExists(npObj *networkingv1.NetworkPolicy) bool {
 // InitAllNsList syncs all-namespace ipset list.
 func (npMgr *NetworkPolicyManager) InitAllNsList() error {
 	allNs := npMgr.nsMap[util.KubeAllNamespacesFlag]
-	for ns:= range npMgr.nsMap {
+	for ns := range npMgr.nsMap {
 		if ns == util.KubeAllNamespacesFlag {
 			continue
 		}
@@ -88,12 +88,9 @@ func (npMgr *NetworkPolicyManager) UninitAllNsList() error {
 
 // AddNamespace handles adding namespace to ipset.
 func (npMgr *NetworkPolicyManager) AddNamespace(nsObj *corev1.Namespace) error {
-	npMgr.Lock()
-	defer npMgr.Unlock()
-
 	var err error
 
-	nsName, nsLabel := "ns-" + nsObj.ObjectMeta.Name, nsObj.ObjectMeta.Labels
+	nsName, nsLabel := "ns-"+nsObj.ObjectMeta.Name, nsObj.ObjectMeta.Labels
 	log.Printf("NAMESPACE CREATING: [%s/%v]", nsName, nsLabel)
 
 	ipsMgr := npMgr.nsMap[util.KubeAllNamespacesFlag].ipsMgr
@@ -139,8 +136,8 @@ func (npMgr *NetworkPolicyManager) AddNamespace(nsObj *corev1.Namespace) error {
 func (npMgr *NetworkPolicyManager) UpdateNamespace(oldNsObj *corev1.Namespace, newNsObj *corev1.Namespace) error {
 	var err error
 
-	oldNsNs, oldNsLabel := "ns-" + oldNsObj.ObjectMeta.Name, oldNsObj.ObjectMeta.Labels
-	newNsNs, newNsLabel := "ns-" + newNsObj.ObjectMeta.Name, newNsObj.ObjectMeta.Labels
+	oldNsNs, oldNsLabel := "ns-"+oldNsObj.ObjectMeta.Name, oldNsObj.ObjectMeta.Labels
+	newNsNs, newNsLabel := "ns-"+newNsObj.ObjectMeta.Name, newNsObj.ObjectMeta.Labels
 	log.Printf(
 		"NAMESPACE UPDATING:\n old namespace: [%s/%v]\n new namespace: [%s/%v]",
 		oldNsNs, oldNsLabel, newNsNs, newNsLabel,
@@ -161,12 +158,9 @@ func (npMgr *NetworkPolicyManager) UpdateNamespace(oldNsObj *corev1.Namespace, n
 
 // DeleteNamespace handles deleting namespace from ipset.
 func (npMgr *NetworkPolicyManager) DeleteNamespace(nsObj *corev1.Namespace) error {
-	npMgr.Lock()
-	defer npMgr.Unlock()
-
 	var err error
 
-	nsName, nsLabel := "ns-" + nsObj.ObjectMeta.Name, nsObj.ObjectMeta.Labels
+	nsName, nsLabel := "ns-"+nsObj.ObjectMeta.Name, nsObj.ObjectMeta.Labels
 	log.Printf("NAMESPACE DELETING: [%s/%v]", nsName, nsLabel)
 
 	_, exists := npMgr.nsMap[nsName]

--- a/npm/namespace_test.go
+++ b/npm/namespace_test.go
@@ -3,8 +3,8 @@
 package npm
 
 import (
-	"testing"
 	"os"
+	"testing"
 
 	"github.com/Azure/azure-container-networking/npm/iptm"
 
@@ -75,9 +75,11 @@ func TestAddNamespace(t *testing.T) {
 		},
 	}
 
+	npMgr.Lock()
 	if err := npMgr.AddNamespace(nsObj); err != nil {
 		t.Errorf("TestAddNamespace @ npMgr.AddNamespace")
 	}
+	npMgr.Unlock()
 }
 
 func TestUpdateNamespace(t *testing.T) {
@@ -121,6 +123,7 @@ func TestUpdateNamespace(t *testing.T) {
 		},
 	}
 
+	npMgr.Lock()
 	if err := npMgr.AddNamespace(oldNsObj); err != nil {
 		t.Errorf("TestUpdateNamespace failed @ npMgr.AddNamespace")
 	}
@@ -128,6 +131,7 @@ func TestUpdateNamespace(t *testing.T) {
 	if err := npMgr.UpdateNamespace(oldNsObj, newNsObj); err != nil {
 		t.Errorf("TestUpdateNamespace failed @ npMgr.UpdateNamespace")
 	}
+	npMgr.Unlock()
 }
 
 func TestDeleteNamespace(t *testing.T) {
@@ -162,6 +166,7 @@ func TestDeleteNamespace(t *testing.T) {
 		},
 	}
 
+	npMgr.Lock()
 	if err := npMgr.AddNamespace(nsObj); err != nil {
 		t.Errorf("TestDeleteNamespace @ npMgr.AddNamespace")
 	}
@@ -169,6 +174,7 @@ func TestDeleteNamespace(t *testing.T) {
 	if err := npMgr.DeleteNamespace(nsObj); err != nil {
 		t.Errorf("TestDeleteNamespace @ npMgr.DeleteNamespace")
 	}
+	npMgr.Unlock()
 }
 
 func TestMain(m *testing.M) {

--- a/npm/nwpolicy.go
+++ b/npm/nwpolicy.go
@@ -25,9 +25,6 @@ func (npMgr *NetworkPolicyManager) canCleanUpNpmChains() bool {
 
 // AddNetworkPolicy handles adding network policy to iptables.
 func (npMgr *NetworkPolicyManager) AddNetworkPolicy(npObj *networkingv1.NetworkPolicy) error {
-	npMgr.Lock()
-	defer npMgr.Unlock()
-
 	var (
 		err error
 		ns  *namespace
@@ -140,9 +137,6 @@ func (npMgr *NetworkPolicyManager) UpdateNetworkPolicy(oldNpObj *networkingv1.Ne
 
 // DeleteNetworkPolicy handles deleting network policy from iptables.
 func (npMgr *NetworkPolicyManager) DeleteNetworkPolicy(npObj *networkingv1.NetworkPolicy) error {
-	npMgr.Lock()
-	defer npMgr.Unlock()
-
 	var (
 		err error
 		ns  *namespace

--- a/npm/nwpolicy.go
+++ b/npm/nwpolicy.go
@@ -72,9 +72,7 @@ func (npMgr *NetworkPolicyManager) AddNetworkPolicy(npObj *networkingv1.NetworkP
 			log.Printf("Error adding policy %s to %s", npName, oldPolicy.ObjectMeta.Name)
 		}
 		npMgr.isSafeToCleanUpAzureNpmChain = false
-		npMgr.Unlock()
 		npMgr.DeleteNetworkPolicy(oldPolicy)
-		npMgr.Lock()
 		npMgr.isSafeToCleanUpAzureNpmChain = true
 	} else {
 		ns.processedNpMap[hashedSelector] = npObj

--- a/npm/nwpolicy_test.go
+++ b/npm/nwpolicy_test.go
@@ -61,9 +61,11 @@ func TestAddNetworkPolicy(t *testing.T) {
 		},
 	}
 
+	npMgr.Lock()
 	if err := npMgr.AddNamespace(nsObj); err != nil {
 		t.Errorf("TestAddNetworkPolicy @ npMgr.AddNamespace")
 	}
+	npMgr.Unlock()
 
 	tcp := corev1.ProtocolTCP
 	port8000 := intstr.FromInt(8000)
@@ -172,9 +174,11 @@ func TestUpdateNetworkPolicy(t *testing.T) {
 		},
 	}
 
+	npMgr.Lock()
 	if err := npMgr.AddNamespace(nsObj); err != nil {
 		t.Errorf("TestUpdateNetworkPolicy @ npMgr.AddNamespace")
 	}
+	npMgr.Unlock()
 
 	tcp, udp := corev1.ProtocolTCP, corev1.ProtocolUDP
 	allowIngress := &networkingv1.NetworkPolicy{
@@ -282,9 +286,11 @@ func TestDeleteNetworkPolicy(t *testing.T) {
 		},
 	}
 
+	npMgr.Lock()
 	if err := npMgr.AddNamespace(nsObj); err != nil {
 		t.Errorf("TestDeleteNetworkPolicy @ npMgr.AddNamespace")
 	}
+	npMgr.Unlock()
 
 	tcp := corev1.ProtocolTCP
 	allow := &networkingv1.NetworkPolicy{

--- a/npm/nwpolicy_test.go
+++ b/npm/nwpolicy_test.go
@@ -82,17 +82,19 @@ func TestAddNetworkPolicy(t *testing.T) {
 					}},
 					Ports: []networkingv1.NetworkPolicyPort{{
 						Protocol: &tcp,
-						Port: &port8000,
+						Port:     &port8000,
 					}},
 				},
 			},
 		},
 	}
 
+	npMgr.Lock()
 	if err := npMgr.AddNetworkPolicy(allowIngress); err != nil {
 		t.Errorf("TestAddNetworkPolicy failed @ allowIngress AddNetworkPolicy")
 		t.Errorf("Error: %v", err)
 	}
+	npMgr.Unlock()
 
 	allowEgress := &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -109,17 +111,19 @@ func TestAddNetworkPolicy(t *testing.T) {
 					}},
 					Ports: []networkingv1.NetworkPolicyPort{{
 						Protocol: &tcp,
-						Port: &port8000,
+						Port:     &port8000,
 					}},
 				},
 			},
 		},
 	}
 
+	npMgr.Lock()
 	if err := npMgr.AddNetworkPolicy(allowEgress); err != nil {
 		t.Errorf("TestAddNetworkPolicy failed @ allowEgress AddNetworkPolicy")
 		t.Errorf("Error: %v", err)
 	}
+	npMgr.Unlock()
 }
 
 func TestUpdateNetworkPolicy(t *testing.T) {
@@ -221,6 +225,7 @@ func TestUpdateNetworkPolicy(t *testing.T) {
 		},
 	}
 
+	npMgr.Lock()
 	if err := npMgr.AddNetworkPolicy(allowIngress); err != nil {
 		t.Errorf("TestUpdateNetworkPolicy failed @ AddNetworkPolicy")
 	}
@@ -228,6 +233,7 @@ func TestUpdateNetworkPolicy(t *testing.T) {
 	if err := npMgr.UpdateNetworkPolicy(allowIngress, allowEgress); err != nil {
 		t.Errorf("TestUpdateNetworkPolicy failed @ UpdateNetworkPolicy")
 	}
+	npMgr.Unlock()
 }
 
 func TestDeleteNetworkPolicy(t *testing.T) {
@@ -305,6 +311,7 @@ func TestDeleteNetworkPolicy(t *testing.T) {
 		},
 	}
 
+	npMgr.Lock()
 	if err := npMgr.AddNetworkPolicy(allow); err != nil {
 		t.Errorf("TestAddNetworkPolicy failed @ AddNetworkPolicy")
 	}
@@ -312,4 +319,5 @@ func TestDeleteNetworkPolicy(t *testing.T) {
 	if err := npMgr.DeleteNetworkPolicy(allow); err != nil {
 		t.Errorf("TestDeleteNetworkPolicy failed @ DeleteNetworkPolicy")
 	}
+	npMgr.Unlock()
 }

--- a/npm/pod.go
+++ b/npm/pod.go
@@ -19,9 +19,6 @@ func isSystemPod(podObj *corev1.Pod) bool {
 
 // AddPod handles adding pod ip to its label's ipset.
 func (npMgr *NetworkPolicyManager) AddPod(podObj *corev1.Pod) error {
-	npMgr.Lock()
-	defer npMgr.Unlock()
-
 	if !isValidPod(podObj) {
 		return nil
 	}
@@ -113,9 +110,6 @@ func (npMgr *NetworkPolicyManager) UpdatePod(oldPodObj, newPodObj *corev1.Pod) e
 
 // DeletePod handles deleting pod from its label's ipset.
 func (npMgr *NetworkPolicyManager) DeletePod(podObj *corev1.Pod) error {
-	npMgr.Lock()
-	defer npMgr.Unlock()
-
 	if !isValidPod(podObj) {
 		return nil
 	}

--- a/npm/pod_test.go
+++ b/npm/pod_test.go
@@ -69,9 +69,12 @@ func TestAddPod(t *testing.T) {
 			PodIP: "1.2.3.4",
 		},
 	}
+
+	npMgr.Lock()
 	if err := npMgr.AddPod(podObj); err != nil {
 		t.Errorf("TestAddPod failed @ AddPod")
 	}
+	npMgr.Unlock()
 }
 
 func TestUpdatePod(t *testing.T) {
@@ -123,6 +126,7 @@ func TestUpdatePod(t *testing.T) {
 		},
 	}
 
+	npMgr.Lock()
 	if err := npMgr.AddPod(oldPodObj); err != nil {
 		t.Errorf("TestUpdatePod failed @ AddPod")
 	}
@@ -130,6 +134,7 @@ func TestUpdatePod(t *testing.T) {
 	if err := npMgr.UpdatePod(oldPodObj, newPodObj); err != nil {
 		t.Errorf("TestUpdatePod failed @ UpdatePod")
 	}
+	npMgr.Unlock()
 }
 
 func TestDeletePod(t *testing.T) {
@@ -167,6 +172,8 @@ func TestDeletePod(t *testing.T) {
 			PodIP: "1.2.3.4",
 		},
 	}
+
+	npMgr.Lock()
 	if err := npMgr.AddPod(podObj); err != nil {
 		t.Errorf("TestDeletePod failed @ AddPod")
 	}
@@ -174,4 +181,5 @@ func TestDeletePod(t *testing.T) {
 	if err := npMgr.DeletePod(podObj); err != nil {
 		t.Errorf("TestDeletePod failed @ DeletePod")
 	}
+	npMgr.Unlock()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Update operations should've been locked to prevent a race between other operations.

e.g.

namespace updates
>npm deletes namespace
network policy updates
>npm deletes network policy
>npm adds network policy (fails because namespace was not created yet)
...
>npm add namespace