### PR TITLE
IPv6 don't reserve gateway address

### DIFF
--- a/.pipelines/e2e-job-template.yaml
+++ b/.pipelines/e2e-job-template.yaml
@@ -1,6 +1,6 @@
 parameters:
   name: ""
-  pipelineBuildImage: "containernetworking/pipeline-ci:1.0.6"
+  pipelineBuildImage: "$(BUILD_IMAGE)"
   clusterDefinition: ""
   clusterDefinitionCniTypeKey: ""
   clusterDefinitionCniBuildOS: ""

--- a/ipam/ipv6Ipam.go
+++ b/ipam/ipv6Ipam.go
@@ -245,7 +245,7 @@ func retrieveKubernetesPodIPs(node *v1.Node, subnetMaskBitSize string) (*Network
 	}
 
 	// skip the first address, explicitly save all IP's from the given subnet
-	for i := 1; i < len(addresses); i++ {
+	for i := 2; i < len(addresses); i++ {
 		ipaddress := IPAddress{
 			IsPrimary: false,
 			Address:   addresses[i].String(),

--- a/ipam/ipv6Ipam_test.go
+++ b/ipam/ipv6Ipam_test.go
@@ -56,7 +56,6 @@ func TestIPv6Ipam(t *testing.T) {
 					{
 						Prefix: "ace:cab:deca:deed::/126",
 						IPAddresses: []IPAddress{
-							{Address: "ace:cab:deca:deed::1", IsPrimary: false},
 							{Address: "ace:cab:deca:deed::2", IsPrimary: false},
 							{Address: "ace:cab:deca:deed::3", IsPrimary: false},
 						},

--- a/ipam/manager_ipv6Ipam_test.go
+++ b/ipam/manager_ipv6Ipam_test.go
@@ -13,7 +13,6 @@ var (
 
 	// Pools and addresses used by tests.
 	ipv6subnet1 = "ace:cab:deca:deed::" + testSubnetSize
-	ipv6addr1   = "ace:cab:deca:deed::1"
 	ipv6addr2   = "ace:cab:deca:deed::2"
 	ipv6addr3   = "ace:cab:deca:deed::3"
 )
@@ -73,16 +72,6 @@ func TestIPv6GetAddressPoolAndAddress(t *testing.T) {
 		t.Errorf("Mismatched retrieved subnet, expected:%+v, actual %+v", ipv6subnet1, subnet1)
 	}
 
-	// test with no specified address
-	address1, err := am.RequestAddress(LocalDefaultAddressSpaceId, poolID1, ipv6addr1, nil)
-	if err != nil {
-		t.Errorf("RequestAddress failed, err:%v", err)
-	}
-
-	if address1 != ipv6addr1+testSubnetSize {
-		t.Errorf("RequestAddress failed, expected: %v, actual: %v", ipv6addr1+testSubnetSize, address1)
-	}
-
 	// test with a specified address
 	address2, err := am.RequestAddress(LocalDefaultAddressSpaceId, poolID1, ipv6addr2, nil)
 	if err != nil {
@@ -101,12 +90,6 @@ func TestIPv6GetAddressPoolAndAddress(t *testing.T) {
 
 	if address3 != ipv6addr3+testSubnetSize {
 		t.Errorf("RequestAddress failed, expected: %v, actual: %v", ipv6addr3+testSubnetSize, address3)
-	}
-
-	// Release addresses and the pool.
-	err = am.ReleaseAddress(LocalDefaultAddressSpaceId, poolID1, address1, nil)
-	if err != nil {
-		t.Errorf("ReleaseAddress failed, err:%v", err)
 	}
 
 	// Release addresses and the pool.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Don't reserve gateway address in IPv6 IPAM

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```