### PR TITLE
Fix cni logs

### DIFF
--- a/cni/network/plugin/main.go
+++ b/cni/network/plugin/main.go
@@ -259,10 +259,11 @@ func main() {
 	reflect.ValueOf(reportManager.Report).Elem().FieldByName("CniSucceeded").SetBool(true)
 	reflect.ValueOf(reportManager.Report).Elem().FieldByName("OperationDuration").SetInt(executionTimeMs)
 
-	if err = reportManager.SendReport(tb); err != nil {
-		log.Errorf("SendReport failed due to %v", err)
-	} else {
-		log.Printf("Sending report succeeded")
+	if cniReport.ErrorMessage != "" || cniReport.EventMessage != "" {
+		if err = reportManager.SendReport(tb); err != nil {
+			log.Errorf("SendReport failed due to %v", err)
+		} else {
+			log.Printf("Sending report succeeded")
+		}
 	}
-
 }

--- a/cni/network/plugin/main.go
+++ b/cni/network/plugin/main.go
@@ -242,13 +242,14 @@ func main() {
 	}
 
 	executionTimeMs := time.Since(startTime).Milliseconds()
-	cnimetric.Metric = aitelemetry.Metric{
-		Name:             telemetry.CNIExecutimeMetricStr,
-		Value:            float64(executionTimeMs),
-		CustomDimensions: make(map[string]string),
-	}
-	network.SetCustomDimensions(&cnimetric, nil, err)
+
 	if cniReport.ErrorMessage != "" || cniReport.EventMessage != "" {
+		cnimetric.Metric = aitelemetry.Metric{
+			Name:             telemetry.CNIExecutimeMetricStr,
+			Value:            float64(executionTimeMs),
+			CustomDimensions: make(map[string]string),
+		}
+		network.SetCustomDimensions(&cnimetric, nil, err)
 		telemetry.SendCNIMetric(&cnimetric, tb)
 	}
 

--- a/cni/network/plugin/main.go
+++ b/cni/network/plugin/main.go
@@ -248,7 +248,9 @@ func main() {
 		CustomDimensions: make(map[string]string),
 	}
 	network.SetCustomDimensions(&cnimetric, nil, err)
-	telemetry.SendCNIMetric(&cnimetric, tb)
+	if cniReport.ErrorMessage != "" || cniReport.EventMessage != "" {
+		telemetry.SendCNIMetric(&cnimetric, tb)
+	}
 
 	if err != nil {
 		reportPluginError(reportManager, tb, err)

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,7 @@ github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkg
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=

--- a/go.sum
+++ b/go.sum
@@ -49,7 +49,6 @@ github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkg
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
-github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=

--- a/telemetry/aiwrapper.go
+++ b/telemetry/aiwrapper.go
@@ -47,8 +47,10 @@ func SendAITelemetry(cnireport CNIReport) {
 	var msg string
 	if cnireport.ErrorMessage != "" {
 		msg = cnireport.ErrorMessage
-	} else {
+	} else if cnireport.EventMessage != "" {
 		msg = cnireport.EventMessage
+	} else {
+		return
 	}
 
 	report := aitelemetry.Report{

--- a/telemetry/aiwrapper.go
+++ b/telemetry/aiwrapper.go
@@ -54,7 +54,7 @@ func SendAITelemetry(cnireport CNIReport) {
 	}
 
 	report := aitelemetry.Report{
-		Message:          "CNI:" + msg,
+		Message:          msg,
 		Context:          cnireport.ContainerName,
 		CustomDimensions: make(map[string]string),
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Empty CNI telemetry logs were being sent and cluttering jarvis. This PR disallows empty messages being sent.

**Which issue this PR fixes**
https://msazure.visualstudio.com/One/_workitems/edit/7041879

**Special notes for your reviewer**:
@tamilmani1989 , I tried adding a function in that defer call we were talking about yesterday, but it broke the connectivity of new pods. Opted for this simpler fix of just checking the error and event message for empty instead. 
