### PR TITLE
Fix Merged Network Policy Deletions

### DIFF
--- a/npm/iptm/iptm.go
+++ b/npm/iptm/iptm.go
@@ -283,15 +283,6 @@ func (iptMgr *IptablesManager) DeleteChain(chain string) error {
 func (iptMgr *IptablesManager) Add(entry *IptEntry) error {
 	log.Printf("Adding iptables entry: %+v.", entry)
 
-	exists, err := iptMgr.Exists(entry)
-	if err != nil {
-		return err
-	}
-
-	if exists {
-		return nil
-	}
-
 	if entry.IsJumpEntry {
 		iptMgr.OperationFlag = util.IptablesAppendFlag
 	} else {

--- a/npm/nwpolicy.go
+++ b/npm/nwpolicy.go
@@ -85,15 +85,14 @@ func (npMgr *NetworkPolicyManager) AddNetworkPolicy(npObj *networkingv1.NetworkP
 	}
 
 	if addedPolicy != nil {
-		sets, lists, iptEntries = translatePolicy(addedPolicy)
 		ns.processedNpMap[hashedSelector] = addedPolicy
 	} else {
-		sets, lists, iptEntries = translatePolicy(npObj)
 		ns.processedNpMap[hashedSelector] = npObj
 	}
 
 	ns.rawNpMap[npObj.ObjectMeta.Name] = npObj
 
+	sets, lists, iptEntries = translatePolicy(npObj)
 	ipsMgr := allNs.ipsMgr
 	for _, set := range sets {
 		log.Printf("Creating set: %v, hashedSet: %v", set, util.GetHashedName(set))

--- a/npm/parsePolicy.go
+++ b/npm/parsePolicy.go
@@ -54,9 +54,8 @@ func addPolicy(old, new *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolic
 	}
 
 	spec := &(addedPolicy.Spec)
-	if len(old.Spec.PolicyTypes) == 1 && old.Spec.PolicyTypes[0] == networkingv1.PolicyTypeEgress &&
-		len(new.Spec.PolicyTypes) == 1 && new.Spec.PolicyTypes[0] == networkingv1.PolicyTypeEgress {
-		spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeEgress}
+	if len(old.Spec.PolicyTypes) == 1 && len(new.Spec.PolicyTypes) == 1 && old.Spec.PolicyTypes[0] == new.Spec.PolicyTypes[0] {
+		spec.PolicyTypes = []networkingv1.PolicyType{new.Spec.PolicyTypes[0]}
 	} else {
 		spec.PolicyTypes = []networkingv1.PolicyType{
 			networkingv1.PolicyTypeIngress,
@@ -126,10 +125,8 @@ func deductPolicy(old, new *networkingv1.NetworkPolicy) (*networkingv1.NetworkPo
 	deductedPolicy.Spec.Ingress = deductedIngress
 	deductedPolicy.Spec.Egress = deductedEgress
 
-	if len(old.Spec.PolicyTypes) == 1 && old.Spec.PolicyTypes[0] == networkingv1.PolicyTypeEgress &&
-		len(new.Spec.PolicyTypes) == 1 && new.Spec.PolicyTypes[0] == networkingv1.PolicyTypeEgress &&
-		len(deductedIngress) == 0 {
-		deductedPolicy.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeEgress}
+	if len(old.Spec.PolicyTypes) == 1 && len(new.Spec.PolicyTypes) == 1 && old.Spec.PolicyTypes[0] == new.Spec.PolicyTypes[0] {
+		deductedPolicy.Spec.PolicyTypes = []networkingv1.PolicyType{new.Spec.PolicyTypes[0]}
 	} else {
 		deductedPolicy.Spec.PolicyTypes = []networkingv1.PolicyType{
 			networkingv1.PolicyTypeIngress,


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix a bug that created a random egress entry when deleting from ingress-centric policy group. Also removing check that prevented adding multiple identical entries in order to prevent deletion of once policy to affect another.
