### PR TITLE
Named Ports Support

### DIFF
--- a/npm/azure-npm.yaml
+++ b/npm/azure-npm.yaml
@@ -95,6 +95,8 @@ spec:
             mountPath: /run/xtables.lock
           - name: log
             mountPath: /var/log
+          - name: protocols
+            mountPath: /etc/protocols
       hostNetwork: true
       volumes:
       - name: log
@@ -104,5 +106,9 @@ spec:
       - name: xtables-lock
         hostPath:
           path: /run/xtables.lock
+          type: File
+      - name: protocols
+        hostPath:
+          path: /etc/protocols
           type: File
       serviceAccountName: azure-npm

--- a/npm/ipsm/ipsm_test.go
+++ b/npm/ipsm/ipsm_test.go
@@ -3,8 +3,8 @@
 package ipsm
 
 import (
-	"testing"
 	"os"
+	"testing"
 
 	"github.com/Azure/azure-container-networking/npm/util"
 )
@@ -77,7 +77,7 @@ func TestAddToList(t *testing.T) {
 		}
 	}()
 
-	if err := ipsMgr.CreateSet("test-set"); err != nil {
+	if err := ipsMgr.CreateSet("test-set", util.IpsetNetHashFlag); err != nil {
 		t.Errorf("TestAddToList failed @ ipsMgr.CreateSet")
 	}
 
@@ -98,7 +98,7 @@ func TestDeleteFromList(t *testing.T) {
 		}
 	}()
 
-	if err := ipsMgr.CreateSet("test-set"); err != nil {
+	if err := ipsMgr.CreateSet("test-set", util.IpsetNetHashFlag); err != nil {
 		t.Errorf("TestDeleteFromList failed @ ipsMgr.CreateSet")
 	}
 
@@ -127,7 +127,7 @@ func TestCreateSet(t *testing.T) {
 		}
 	}()
 
-	if err := ipsMgr.CreateSet("test-set"); err != nil {
+	if err := ipsMgr.CreateSet("test-set", util.IpsetNetHashFlag); err != nil {
 		t.Errorf("TestCreateSet failed @ ipsMgr.CreateSet")
 	}
 }
@@ -144,7 +144,7 @@ func TestDeleteSet(t *testing.T) {
 		}
 	}()
 
-	if err := ipsMgr.CreateSet("test-set"); err != nil {
+	if err := ipsMgr.CreateSet("test-set", util.IpsetNetHashFlag); err != nil {
 		t.Errorf("TestDeleteSet failed @ ipsMgr.CreateSet")
 	}
 
@@ -165,7 +165,7 @@ func TestAddToSet(t *testing.T) {
 		}
 	}()
 
-	if err := ipsMgr.AddToSet("test-set", "1.2.3.4"); err != nil {
+	if err := ipsMgr.AddToSet("test-set", "1.2.3.4", util.IpsetNetHashFlag); err != nil {
 		t.Errorf("TestAddToSet failed @ ipsMgr.AddToSet")
 	}
 }
@@ -182,7 +182,7 @@ func TestDeleteFromSet(t *testing.T) {
 		}
 	}()
 
-	if err := ipsMgr.AddToSet("test-set", "1.2.3.4"); err != nil {
+	if err := ipsMgr.AddToSet("test-set", "1.2.3.4", util.IpsetNetHashFlag); err != nil {
 		t.Errorf("TestDeleteFromSet failed @ ipsMgr.AddToSet")
 	}
 
@@ -203,7 +203,7 @@ func TestClean(t *testing.T) {
 		}
 	}()
 
-	if err := ipsMgr.CreateSet("test-set"); err != nil {
+	if err := ipsMgr.CreateSet("test-set", util.IpsetNetHashFlag); err != nil {
 		t.Errorf("TestClean failed @ ipsMgr.CreateSet")
 	}
 
@@ -224,7 +224,7 @@ func TestDestroy(t *testing.T) {
 		}
 	}()
 
-	if err := ipsMgr.AddToSet("test-set", "1.2.3.4"); err != nil {
+	if err := ipsMgr.AddToSet("test-set", "1.2.3.4", util.IpsetNetHashFlag); err != nil {
 		t.Errorf("TestDestroy failed @ ipsMgr.AddToSet")
 	}
 
@@ -262,6 +262,6 @@ func TestMain(m *testing.M) {
 	exitCode := m.Run()
 
 	ipsMgr.Restore(util.IpsetConfigFile)
-	
+
 	os.Exit(exitCode)
 }

--- a/npm/namespace.go
+++ b/npm/namespace.go
@@ -95,7 +95,7 @@ func (npMgr *NetworkPolicyManager) AddNamespace(nsObj *corev1.Namespace) error {
 
 	ipsMgr := npMgr.nsMap[util.KubeAllNamespacesFlag].ipsMgr
 	// Create ipset for the namespace.
-	if err = ipsMgr.CreateSet(nsName); err != nil {
+	if err = ipsMgr.CreateSet(nsName, util.IpsetNetHashFlag); err != nil {
 		log.Errorf("Error: failed to create ipset for namespace %s.", nsName)
 		return err
 	}

--- a/npm/npm.go
+++ b/npm/npm.go
@@ -250,7 +250,7 @@ func NewNetworkPolicyManager(clientset *kubernetes.Clientset, informerFactory in
 
 	// Create ipset for the namespace.
 	kubeSystemNs := "ns-" + util.KubeSystemFlag
-	if err := allNs.ipsMgr.CreateSet(kubeSystemNs); err != nil {
+	if err := allNs.ipsMgr.CreateSet(kubeSystemNs, util.IpsetNetHashFlag); err != nil {
 		log.Logf("Error: failed to create ipset for namespace %s.", kubeSystemNs)
 	}
 

--- a/npm/nwpolicy.go
+++ b/npm/nwpolicy.go
@@ -49,7 +49,7 @@ func (npMgr *NetworkPolicyManager) AddNetworkPolicy(npObj *networkingv1.NetworkP
 	}
 
 	if !npMgr.isAzureNpmChainCreated {
-		if err = allNs.ipsMgr.CreateSet(util.KubeSystemFlag); err != nil {
+		if err = allNs.ipsMgr.CreateSet(util.KubeSystemFlag, util.IpsetNetHashFlag); err != nil {
 			log.Errorf("Error: failed to initialize kube-system ipset.")
 			return err
 		}
@@ -96,7 +96,7 @@ func (npMgr *NetworkPolicyManager) AddNetworkPolicy(npObj *networkingv1.NetworkP
 	sets, lists, iptEntries = translatePolicy(npObj, ipsMgr)
 	for _, set := range sets {
 		log.Printf("Creating set: %v, hashedSet: %v", set, util.GetHashedName(set))
-		if err = ipsMgr.CreateSet(set); err != nil {
+		if err = ipsMgr.CreateSet(set, util.IpsetNetHashFlag); err != nil {
 			log.Printf("Error creating ipset %s", set)
 			return err
 		}

--- a/npm/nwpolicy_test.go
+++ b/npm/nwpolicy_test.go
@@ -38,7 +38,7 @@ func TestAddNetworkPolicy(t *testing.T) {
 	}
 
 	// Create ns-kube-system set
-	if err := ipsMgr.CreateSet("ns-" + util.KubeSystemFlag); err != nil {
+	if err := ipsMgr.CreateSet("ns-"+util.KubeSystemFlag, util.IpsetNetHashFlag); err != nil {
 		t.Errorf("TestAddNetworkPolicy failed @ ipsMgr.CreateSet, adding kube-system set%+v", err)
 	}
 
@@ -161,7 +161,7 @@ func TestUpdateNetworkPolicy(t *testing.T) {
 	}()
 
 	// Create ns-kube-system set
-	if err := ipsMgr.CreateSet("ns-" + util.KubeSystemFlag); err != nil {
+	if err := ipsMgr.CreateSet("ns-"+util.KubeSystemFlag, util.IpsetNetHashFlag); err != nil {
 		t.Errorf("TestUpdateNetworkPolicy failed @ ipsMgr.CreateSet, adding kube-system set%+v", err)
 	}
 
@@ -273,7 +273,7 @@ func TestDeleteNetworkPolicy(t *testing.T) {
 	}()
 
 	// Create ns-kube-system set
-	if err := ipsMgr.CreateSet("ns-" + util.KubeSystemFlag); err != nil {
+	if err := ipsMgr.CreateSet("ns-"+util.KubeSystemFlag, util.IpsetNetHashFlag); err != nil {
 		t.Errorf("TestDeleteNetworkPolicy failed @ ipsMgr.CreateSet, adding kube-system set%+v", err)
 	}
 

--- a/npm/pod.go
+++ b/npm/pod.go
@@ -25,13 +25,14 @@ func (npMgr *NetworkPolicyManager) AddPod(podObj *corev1.Pod) error {
 	}
 
 	var (
-		err         error
-		podNs       = "ns-" + podObj.ObjectMeta.Namespace
-		podName     = podObj.ObjectMeta.Name
-		podNodeName = podObj.Spec.NodeName
-		podLabels   = podObj.ObjectMeta.Labels
-		podIP       = podObj.Status.PodIP
-		ipsMgr      = npMgr.nsMap[util.KubeAllNamespacesFlag].ipsMgr
+		err           error
+		podNs         = "ns-" + podObj.ObjectMeta.Namespace
+		podName       = podObj.ObjectMeta.Name
+		podNodeName   = podObj.Spec.NodeName
+		podLabels     = podObj.ObjectMeta.Labels
+		podIP         = podObj.Status.PodIP
+		podContainers = podObj.Spec.Containers
+		ipsMgr        = npMgr.nsMap[util.KubeAllNamespacesFlag].ipsMgr
 	)
 
 	log.Printf("POD CREATING: [%s/%s/%s%+v%s]", podNs, podName, podNodeName, podLabels, podIP)
@@ -41,7 +42,6 @@ func (npMgr *NetworkPolicyManager) AddPod(podObj *corev1.Pod) error {
 		log.Printf("Creating set: %v, hashedSet: %v", podNs, util.GetHashedName(podNs))
 		if err = ipsMgr.CreateSet(podNs); err != nil {
 			log.Printf("Error creating ipset %s", podNs)
-			return err
 		}
 	}
 
@@ -49,7 +49,6 @@ func (npMgr *NetworkPolicyManager) AddPod(podObj *corev1.Pod) error {
 	log.Printf("Adding pod %s to ipset %s", podIP, podNs)
 	if err = ipsMgr.AddToSet(podNs, podIP); err != nil {
 		log.Errorf("Error: failed to add pod to namespace ipset.")
-		return err
 	}
 
 	// Add the pod to its label's ipset.
@@ -57,14 +56,21 @@ func (npMgr *NetworkPolicyManager) AddPod(podObj *corev1.Pod) error {
 		log.Printf("Adding pod %s to ipset %s", podIP, podLabelKey)
 		if err = ipsMgr.AddToSet(podLabelKey, podIP); err != nil {
 			log.Errorf("Error: failed to add pod to label ipset.")
-			return err
 		}
 
 		label := podLabelKey + ":" + podLabelVal
 		log.Printf("Adding pod %s to ipset %s", podIP, label)
 		if err = ipsMgr.AddToSet(label, podIP); err != nil {
 			log.Errorf("Error: failed to add pod to label ipset.")
-			return err
+		}
+	}
+
+	// Map named ports
+	for _, container := range podContainers {
+		for _, port := range container.Ports {
+			if port.Name != "" {
+				ipsMgr.AddToPortMap(podIP, port.Name, port.ContainerPort)
+			}
 		}
 	}
 
@@ -98,6 +104,7 @@ func (npMgr *NetworkPolicyManager) UpdatePod(oldPodObj, newPodObj *corev1.Pod) e
 	)
 
 	if err = npMgr.DeletePod(oldPodObj); err != nil {
+		log.Errorf("Error: failed to delete pod during update with error %+v", err)
 		return err
 	}
 
@@ -105,7 +112,7 @@ func (npMgr *NetworkPolicyManager) UpdatePod(oldPodObj, newPodObj *corev1.Pod) e
 	// If the pod transitions back to an active state, then add operation will re establish the updated pod info.
 	if newPodObj.ObjectMeta.DeletionTimestamp == nil && newPodObj.ObjectMeta.DeletionGracePeriodSeconds == nil && newPodObjPhase != v1.PodSucceeded && newPodObjPhase != v1.PodFailed {
 		if err = npMgr.AddPod(newPodObj); err != nil {
-			return err
+			log.Errorf("Error: failed to add pod during update with error %+v", err)
 		}
 	}
 
@@ -133,23 +140,22 @@ func (npMgr *NetworkPolicyManager) DeletePod(podObj *corev1.Pod) error {
 	// Delete the pod from its namespace's ipset.
 	if err = ipsMgr.DeleteFromSet(podNs, podIP); err != nil {
 		log.Errorf("Error: failed to delete pod from namespace ipset.")
-		return err
 	}
 	// Delete the pod from its label's ipset.
 	for podLabelKey, podLabelVal := range podLabels {
 		log.Printf("Deleting pod %s from ipset %s", podIP, podLabelKey)
 		if err = ipsMgr.DeleteFromSet(podLabelKey, podIP); err != nil {
 			log.Errorf("Error: failed to delete pod from label ipset.")
-			return err
 		}
 
 		label := podLabelKey + ":" + podLabelVal
 		log.Printf("Deleting pod %s from ipset %s", podIP, label)
 		if err = ipsMgr.DeleteFromSet(label, podIP); err != nil {
 			log.Errorf("Error: failed to delete pod from label ipset.")
-			return err
 		}
 	}
+	// Delete the named port mapping for pod
+	ipsMgr.DeleteFromPortMap(podIP)
 
 	return nil
 }

--- a/npm/testpolicies/named-port.yaml
+++ b/npm/testpolicies/named-port.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: named-port-ingress-rule
+  namespace: test
+spec:
+  ingress:
+  - ports:
+    - port: serve-80
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app: server
+  policyTypes:
+  - Ingress

--- a/npm/translatePolicy_test.go
+++ b/npm/translatePolicy_test.go
@@ -640,7 +640,7 @@ func TestTranslateIngress(t *testing.T) {
 	}
 
 	util.IsNewNwPolicyVerFlag = true
-	sets, lists, iptEntries := translateIngress(ns, targetSelector, rules, nil)
+	sets, _, lists, iptEntries := translateIngress(ns, targetSelector, rules)
 	expectedSets := []string{
 		"context:dev",
 		"testNotIn:frontend",
@@ -944,7 +944,7 @@ func TestTranslateEgress(t *testing.T) {
 	}
 
 	util.IsNewNwPolicyVerFlag = true
-	sets, lists, iptEntries := translateEgress(ns, targetSelector, rules, nil)
+	sets, _, lists, iptEntries := translateEgress(ns, targetSelector, rules)
 	expectedSets := []string{
 		"context:dev",
 		"testNotIn:frontend",
@@ -1172,7 +1172,7 @@ func TestDenyAllPolicy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(denyAllPolicy, nil)
+	sets, _, lists, iptEntries := translatePolicy(denyAllPolicy)
 
 	expectedSets := []string{"ns-testnamespace"}
 	if !reflect.DeepEqual(sets, expectedSets) {
@@ -1204,7 +1204,7 @@ func TestAllowBackendToFrontend(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sets, lists, iptEntries := translatePolicy(allowBackendToFrontendPolicy, nil)
+	sets, _, lists, iptEntries := translatePolicy(allowBackendToFrontendPolicy)
 
 	expectedSets := []string{
 		"app:backend",
@@ -1342,7 +1342,7 @@ func TestAllowAllToAppFrontend(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(allowToFrontendPolicy, nil)
+	sets, _, lists, iptEntries := translatePolicy(allowToFrontendPolicy)
 
 	expectedSets := []string{
 		"app:frontend",
@@ -1403,7 +1403,7 @@ func TestDenyAllToAppFrontend(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(denyAllToFrontendPolicy, nil)
+	sets, _, lists, iptEntries := translatePolicy(denyAllToFrontendPolicy)
 
 	expectedSets := []string{
 		"app:frontend",
@@ -1439,7 +1439,7 @@ func TestNamespaceToFrontend(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(allowNsTestNamespaceToFrontendPolicy, nil)
+	sets, _, lists, iptEntries := translatePolicy(allowNsTestNamespaceToFrontendPolicy)
 
 	expectedSets := []string{
 		"app:frontend",
@@ -1571,7 +1571,7 @@ func TestAllowAllNamespacesToAppFrontend(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(allowAllNsToFrontendPolicy, nil)
+	sets, _, lists, iptEntries := translatePolicy(allowAllNsToFrontendPolicy)
 	expectedSets := []string{
 		"app:frontend",
 		"ns-testnamespace",
@@ -1704,7 +1704,7 @@ func TestAllowNamespaceDevToAppFrontend(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(allowNsDevToFrontendPolicy, nil)
+	sets, _, lists, iptEntries := translatePolicy(allowNsDevToFrontendPolicy)
 
 	expectedSets := []string{
 		"app:frontend",
@@ -1853,7 +1853,7 @@ func TestAllowAllToK0AndK1AndAppFrontend(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(allowAllToFrontendPolicy, nil)
+	sets, _, lists, iptEntries := translatePolicy(allowAllToFrontendPolicy)
 
 	expectedSets := []string{
 		"app:frontend",
@@ -2054,7 +2054,7 @@ func TestAllowNsDevAndAppBackendToAppFrontend(t *testing.T) {
 	}
 
 	util.IsNewNwPolicyVerFlag = true
-	sets, lists, iptEntries := translatePolicy(allowNsDevAndBackendToFrontendPolicy, nil)
+	sets, _, lists, iptEntries := translatePolicy(allowNsDevAndBackendToFrontendPolicy)
 
 	expectedSets := []string{
 		"app:frontend",
@@ -2195,7 +2195,7 @@ func TestAllowInternalAndExternal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(allowInternalAndExternalPolicy, nil)
+	sets, _, lists, iptEntries := translatePolicy(allowInternalAndExternalPolicy)
 
 	expectedSets := []string{
 		"app:backdoor",
@@ -2256,7 +2256,7 @@ func TestAllowBackendToFrontendPort8000(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(allowBackendToFrontendPort8000Policy, nil)
+	sets, _, lists, iptEntries := translatePolicy(allowBackendToFrontendPort8000Policy)
 
 	expectedSets := []string{
 		"app:frontend",
@@ -2373,7 +2373,7 @@ func TestAllowMultipleLabelsToMultipleLabels(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(allowCniOrCnsToK8sPolicy, nil)
+	sets, _, lists, iptEntries := translatePolicy(allowCniOrCnsToK8sPolicy)
 
 	expectedSets := []string{
 		"app:k8s",
@@ -2581,7 +2581,7 @@ func TestDenyAllFromAppBackend(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(denyAllFromBackendPolicy, nil)
+	sets, _, lists, iptEntries := translatePolicy(denyAllFromBackendPolicy)
 
 	expectedSets := []string{
 		"app:backend",
@@ -2617,7 +2617,7 @@ func TestAllowAllFromAppBackend(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(allowAllEgress, nil)
+	sets, _, lists, iptEntries := translatePolicy(allowAllEgress)
 
 	expectedSets := []string{
 		"app:backend",
@@ -2699,7 +2699,7 @@ func TestDenyAllFromNsUnsafe(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sets, lists, iptEntries := translatePolicy(denyAllFromNsUnsafePolicy, nil)
+	sets, _, lists, iptEntries := translatePolicy(denyAllFromNsUnsafePolicy)
 
 	expectedSets := []string{
 		"ns-unsafe",
@@ -2733,7 +2733,7 @@ func TestAllowAppFrontendToTCPPort53UDPPort53Policy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(allowFrontendToTCPPort53UDPPort53Policy, nil)
+	sets, _, lists, iptEntries := translatePolicy(allowFrontendToTCPPort53UDPPort53Policy)
 
 	expectedSets := []string{
 		"app:frontend",
@@ -2917,7 +2917,7 @@ func TestComplexPolicy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(k8sExamplePolicy, nil)
+	sets, _, lists, iptEntries := translatePolicy(k8sExamplePolicy)
 
 	expectedSets := []string{
 		"role:db",
@@ -3294,7 +3294,7 @@ func TestDropPrecedenceOverAllow(t *testing.T) {
 		},
 	}
 
-	sets, lists, iptEntries := translatePolicy(denyAllPolicy, nil)
+	sets, _, lists, iptEntries := translatePolicy(denyAllPolicy)
 	expectedSets := []string{
 		"ns-default",
 	}
@@ -3311,7 +3311,7 @@ func TestDropPrecedenceOverAllow(t *testing.T) {
 		t.Errorf("expectedLists: %v", expectedLists)
 	}
 
-	sets, lists, finalIptEntries := translatePolicy(allowToPodPolicy, nil)
+	sets, _, lists, finalIptEntries := translatePolicy(allowToPodPolicy)
 	expectedSets = []string{
 		"app:test",
 		"testIn:pod-A",

--- a/npm/translatePolicy_test.go
+++ b/npm/translatePolicy_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/Azure/azure-container-networking/npm/iptm"
 	"github.com/Azure/azure-container-networking/npm/util"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -640,7 +640,7 @@ func TestTranslateIngress(t *testing.T) {
 	}
 
 	util.IsNewNwPolicyVerFlag = true
-	sets, lists, iptEntries := translateIngress(ns, targetSelector, rules)
+	sets, lists, iptEntries := translateIngress(ns, targetSelector, rules, nil)
 	expectedSets := []string{
 		"context:dev",
 		"testNotIn:frontend",
@@ -944,7 +944,7 @@ func TestTranslateEgress(t *testing.T) {
 	}
 
 	util.IsNewNwPolicyVerFlag = true
-	sets, lists, iptEntries := translateEgress(ns, targetSelector, rules)
+	sets, lists, iptEntries := translateEgress(ns, targetSelector, rules, nil)
 	expectedSets := []string{
 		"context:dev",
 		"testNotIn:frontend",
@@ -1172,7 +1172,7 @@ func TestDenyAllPolicy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(denyAllPolicy)
+	sets, lists, iptEntries := translatePolicy(denyAllPolicy, nil)
 
 	expectedSets := []string{"ns-testnamespace"}
 	if !reflect.DeepEqual(sets, expectedSets) {
@@ -1204,7 +1204,7 @@ func TestAllowBackendToFrontend(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sets, lists, iptEntries := translatePolicy(allowBackendToFrontendPolicy)
+	sets, lists, iptEntries := translatePolicy(allowBackendToFrontendPolicy, nil)
 
 	expectedSets := []string{
 		"app:backend",
@@ -1342,7 +1342,7 @@ func TestAllowAllToAppFrontend(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(allowToFrontendPolicy)
+	sets, lists, iptEntries := translatePolicy(allowToFrontendPolicy, nil)
 
 	expectedSets := []string{
 		"app:frontend",
@@ -1403,7 +1403,7 @@ func TestDenyAllToAppFrontend(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(denyAllToFrontendPolicy)
+	sets, lists, iptEntries := translatePolicy(denyAllToFrontendPolicy, nil)
 
 	expectedSets := []string{
 		"app:frontend",
@@ -1439,7 +1439,7 @@ func TestNamespaceToFrontend(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(allowNsTestNamespaceToFrontendPolicy)
+	sets, lists, iptEntries := translatePolicy(allowNsTestNamespaceToFrontendPolicy, nil)
 
 	expectedSets := []string{
 		"app:frontend",
@@ -1571,7 +1571,7 @@ func TestAllowAllNamespacesToAppFrontend(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(allowAllNsToFrontendPolicy)
+	sets, lists, iptEntries := translatePolicy(allowAllNsToFrontendPolicy, nil)
 	expectedSets := []string{
 		"app:frontend",
 		"ns-testnamespace",
@@ -1704,7 +1704,7 @@ func TestAllowNamespaceDevToAppFrontend(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(allowNsDevToFrontendPolicy)
+	sets, lists, iptEntries := translatePolicy(allowNsDevToFrontendPolicy, nil)
 
 	expectedSets := []string{
 		"app:frontend",
@@ -1853,7 +1853,7 @@ func TestAllowAllToK0AndK1AndAppFrontend(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(allowAllToFrontendPolicy)
+	sets, lists, iptEntries := translatePolicy(allowAllToFrontendPolicy, nil)
 
 	expectedSets := []string{
 		"app:frontend",
@@ -2054,7 +2054,7 @@ func TestAllowNsDevAndAppBackendToAppFrontend(t *testing.T) {
 	}
 
 	util.IsNewNwPolicyVerFlag = true
-	sets, lists, iptEntries := translatePolicy(allowNsDevAndBackendToFrontendPolicy)
+	sets, lists, iptEntries := translatePolicy(allowNsDevAndBackendToFrontendPolicy, nil)
 
 	expectedSets := []string{
 		"app:frontend",
@@ -2195,7 +2195,7 @@ func TestAllowInternalAndExternal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(allowInternalAndExternalPolicy)
+	sets, lists, iptEntries := translatePolicy(allowInternalAndExternalPolicy, nil)
 
 	expectedSets := []string{
 		"app:backdoor",
@@ -2256,7 +2256,7 @@ func TestAllowBackendToFrontendPort8000(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(allowBackendToFrontendPort8000Policy)
+	sets, lists, iptEntries := translatePolicy(allowBackendToFrontendPort8000Policy, nil)
 
 	expectedSets := []string{
 		"app:frontend",
@@ -2373,7 +2373,7 @@ func TestAllowMultipleLabelsToMultipleLabels(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(allowCniOrCnsToK8sPolicy)
+	sets, lists, iptEntries := translatePolicy(allowCniOrCnsToK8sPolicy, nil)
 
 	expectedSets := []string{
 		"app:k8s",
@@ -2581,7 +2581,7 @@ func TestDenyAllFromAppBackend(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(denyAllFromBackendPolicy)
+	sets, lists, iptEntries := translatePolicy(denyAllFromBackendPolicy, nil)
 
 	expectedSets := []string{
 		"app:backend",
@@ -2617,7 +2617,7 @@ func TestAllowAllFromAppBackend(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(allowAllEgress)
+	sets, lists, iptEntries := translatePolicy(allowAllEgress, nil)
 
 	expectedSets := []string{
 		"app:backend",
@@ -2699,7 +2699,7 @@ func TestDenyAllFromNsUnsafe(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sets, lists, iptEntries := translatePolicy(denyAllFromNsUnsafePolicy)
+	sets, lists, iptEntries := translatePolicy(denyAllFromNsUnsafePolicy, nil)
 
 	expectedSets := []string{
 		"ns-unsafe",
@@ -2733,7 +2733,7 @@ func TestAllowAppFrontendToTCPPort53UDPPort53Policy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(allowFrontendToTCPPort53UDPPort53Policy)
+	sets, lists, iptEntries := translatePolicy(allowFrontendToTCPPort53UDPPort53Policy, nil)
 
 	expectedSets := []string{
 		"app:frontend",
@@ -2917,7 +2917,7 @@ func TestComplexPolicy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sets, lists, iptEntries := translatePolicy(k8sExamplePolicy)
+	sets, lists, iptEntries := translatePolicy(k8sExamplePolicy, nil)
 
 	expectedSets := []string{
 		"role:db",
@@ -3294,7 +3294,7 @@ func TestDropPrecedenceOverAllow(t *testing.T) {
 		},
 	}
 
-	sets, lists, iptEntries := translatePolicy(denyAllPolicy)
+	sets, lists, iptEntries := translatePolicy(denyAllPolicy, nil)
 	expectedSets := []string{
 		"ns-default",
 	}
@@ -3311,7 +3311,7 @@ func TestDropPrecedenceOverAllow(t *testing.T) {
 		t.Errorf("expectedLists: %v", expectedLists)
 	}
 
-	sets, lists, finalIptEntries := translatePolicy(allowToPodPolicy)
+	sets, lists, finalIptEntries := translatePolicy(allowToPodPolicy, nil)
 	expectedSets = []string{
 		"app:test",
 		"testIn:pod-A",

--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -93,8 +93,12 @@ const (
 	IpsetExistFlag string = "-exist"
 	IpsetFileFlag  string = "-file"
 
-	IpsetSetListFlag string = "setlist"
-	IpsetNetHashFlag string = "nethash"
+	IpsetSetListFlag    string = "setlist"
+	IpsetNetHashFlag    string = "nethash"
+	IpsetIPPortHashFlag string = "hash:ip,port"
+
+	IpsetUDPFlag  string = "udp:"
+	IpsetSCTPFlag string = "sctp:"
 
 	AzureNpmFlag   string = "azure-npm"
 	AzureNpmPrefix string = "azure-npm-"


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding support for named ports in NPM

**Which issue this PR fixes**:
fixes #550 

**Notes for reviewer**
ipset ip+port hash solution

~$ sudo ipset list **azure-npm-671120875**
Name: azure-npm-671120875
Type: hash:ip,port
Revision: 5
Header: family inet hashsize 1024 maxelem 65536
Size in memory: 152
References: 1
Number of entries: 1
Members:
**10.240.0.21,tcp:80**

~$ sudo ipset list **azure-npm-420423296**
Name: azure-npm-420423296
Type: hash:net
Revision: 6
Header: family inet hashsize 1024 maxelem 65536
Size in memory: 472
References: 4
Number of entries: 2
Members:
**10.240.0.21**
10.240.0.66

match-set **azure-npm-420423296** dst match-set azure-npm-1519775445 dst match-set **azure-npm-671120875 dst,dst** _/* ALLOW-ALL-TCP-PORT-**serve-80**-TO-**app:server**-IN-ns-e2e-bqhboou21s78hj9mnud0 */_