### PR TITLE
Explicitly add content type header.

### DIFF
--- a/common/listener.go
+++ b/common/listener.go
@@ -122,6 +122,8 @@ func (listener *Listener) Decode(w http.ResponseWriter, r *http.Request, request
 
 // Encode encodes and sends a response as JSON payload.
 func (listener *Listener) Encode(w http.ResponseWriter, response interface{}) error {
+	// Set the content type as application json
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	err := json.NewEncoder(w).Encode(response)
 	if err != nil {
 		http.Error(w, "Failed to encode response: "+err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
If CNS Client happen to use a library which checks for the content type before decoding the response ( ex: Python -aiohttp, then reading the response will always fail. 

We are defaulting to "Content-Type: text/plain; charset=utf-8"

As the response is always JSON ended. The fix basically always add the Content-Type header as  "application/json; charset=UTF-8"