### PR TITLE
Removing execution time metric

### DIFF
--- a/cni/network/plugin/main.go
+++ b/cni/network/plugin/main.go
@@ -11,7 +11,6 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/Azure/azure-container-networking/aitelemetry"
 	"github.com/Azure/azure-container-networking/cni"
 	"github.com/Azure/azure-container-networking/cni/network"
 	"github.com/Azure/azure-container-networking/common"
@@ -141,7 +140,6 @@ func main() {
 	var (
 		config       common.PluginConfig
 		err          error
-		cnimetric    telemetry.AIMetric
 		logDirectory string // This sets empty string i.e. current location
 	)
 
@@ -242,16 +240,6 @@ func main() {
 	}
 
 	executionTimeMs := time.Since(startTime).Milliseconds()
-
-	if cniReport.ErrorMessage != "" || cniReport.EventMessage != "" {
-		cnimetric.Metric = aitelemetry.Metric{
-			Name:             telemetry.CNIExecutimeMetricStr,
-			Value:            float64(executionTimeMs),
-			CustomDimensions: make(map[string]string),
-		}
-		network.SetCustomDimensions(&cnimetric, nil, err)
-		telemetry.SendCNIMetric(&cnimetric, tb)
-	}
 
 	if err != nil {
 		reportPluginError(reportManager, tb, err)

--- a/telemetry/constants.go
+++ b/telemetry/constants.go
@@ -5,7 +5,6 @@ package telemetry
 const (
 
 	// Metric Names
-	CNIExecutimeMetricStr  = "CNIExecutionTimeMs"
 	CNIAddTimeMetricStr    = "CNIAddTimeMs"
 	CNIDelTimeMetricStr    = "CNIDelTimeMs"
 	CNIUpdateTimeMetricStr = "CNIUpdateTimeMs"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to remove the CNIExecutionTimeMs metric from CNI because cni is using too much metrics data and this isn't a very informative metric and is causing lots of data usage from the Application Insights resources for our telemetry.


**Special notes for your reviewer**:
@Tamilmani I tested the changes on an aks-engine cluster and the add and del metrics are unchanged, meaning the add and del metrics still show up in the metrics table in jarvis when adding and deleting pods