### PR TITLE
Lock base Dockerfiles to focal-20200606

### DIFF
--- a/.pipelines/Dockerfile
+++ b/.pipelines/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:focal-20200606
 RUN apt-get update && apt-get install -y software-properties-common sudo wget apt-utils apt-transport-https curl lsb-release gnupg jq
 RUN wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
 RUN sudo dpkg -i packages-microsoft-prod.deb

--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -1,5 +1,6 @@
-# Use a minimal image as a parent image
-FROM ubuntu:19.10
+# Use a minimal image as a parent image. 
+# TODO: Use multistage build and use scratch
+FROM ubuntu:focal-20200606
 ARG CNS_BUILD_ARCHIVE
 
 # Install plugin

--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -1,5 +1,5 @@
 # Use a minimal image as a parent image
-FROM ubuntu:focal
+FROM ubuntu:focal-20200606
 ARG NPM_BUILD_DIR
 
 # Install dependencies.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->
**What this PR does / why we need it**:

Lock dockerfiles in NPM, CNS, and Pipeline to use same Docker image. Eventually move CNS to scratch.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```