### PR TITLE
Fix NPM image libgnutls vulnerability

### DIFF
--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -1,5 +1,5 @@
 # Use a minimal image as a parent image
-FROM ubuntu:focal-20200606
+FROM ubuntu:bionic-20200526
 ARG NPM_BUILD_DIR
 
 # Install dependencies.
@@ -7,9 +7,6 @@ RUN apt-get update
 RUN apt-get install -y iptables
 RUN apt-get install -y ipset
 RUN apt-get install -y ca-certificates
-
-# https://lists.ubuntu.com/archives/ubuntu-security-announce/2020-June/005466.html
-RUN apt-get install -y libgnutls30=3.6.13-2ubuntu1.1
 RUN apt-get upgrade -y
 
 # Install plugin.

--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -1,5 +1,5 @@
 # Use a minimal image as a parent image
-FROM ubuntu:focal
+FROM ubuntu:focal-20200606
 ARG NPM_BUILD_DIR
 
 # Install dependencies.
@@ -7,6 +7,9 @@ RUN apt-get update
 RUN apt-get install -y iptables
 RUN apt-get install -y ipset
 RUN apt-get install -y ca-certificates
+
+# https://lists.ubuntu.com/archives/ubuntu-security-announce/2020-June/005466.html
+RUN apt-get install -y libgnutls30=3.6.13-2ubuntu1.1
 RUN apt-get upgrade -y
 
 # Install plugin.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Lock Azure NPM image to Ubuntu 18 rather than Ubuntu 20, which fixes:
https://lists.ubuntu.com/archives/ubuntu-security-announce/2020-June/005466.html

Also is more in line with current AKS schedule:
https://aka.ms/aks/Ubuntu1804

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```