### PR TITLE
Update NPM logs to use Logf instead of Printf

### DIFF
--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -83,7 +83,7 @@ func (ipsMgr *IpsetManager) CreateList(listName string) error {
 		set:           util.GetHashedName(listName),
 		spec:          []string{util.IpsetSetListFlag},
 	}
-	log.Printf("Creating List: %+v", entry)
+	log.Logf("Creating List: %+v", entry)
 	if errCode, err := ipsMgr.Run(entry); err != nil && errCode != 1 {
 		log.Errorf("Error: failed to create ipset list %s.", listName)
 		return err
@@ -148,7 +148,7 @@ func (ipsMgr *IpsetManager) AddToList(listName string, setName string) error {
 // DeleteFromList removes an ipset to an ipset list.
 func (ipsMgr *IpsetManager) DeleteFromList(listName string, setName string) error {
 	if _, exists := ipsMgr.listMap[listName]; !exists {
-		log.Printf("ipset list with name %s not found", listName)
+		log.Logf("ipset list with name %s not found", listName)
 		return nil
 	}
 
@@ -193,7 +193,7 @@ func (ipsMgr *IpsetManager) CreateSet(setName string, spec []string) error {
 		set:  util.GetHashedName(setName),
 		spec: spec,
 	}
-	log.Printf("Creating Set: %+v", entry)
+	log.Logf("Creating Set: %+v", entry)
 	if errCode, err := ipsMgr.Run(entry); err != nil && errCode != 1 {
 		log.Errorf("Error: failed to create ipset.")
 		return err
@@ -207,7 +207,7 @@ func (ipsMgr *IpsetManager) CreateSet(setName string, spec []string) error {
 // DeleteSet removes a set from ipset.
 func (ipsMgr *IpsetManager) DeleteSet(setName string) error {
 	if _, exists := ipsMgr.setMap[setName]; !exists {
-		log.Printf("ipset with name %s not found", setName)
+		log.Logf("ipset with name %s not found", setName)
 		return nil
 	}
 
@@ -254,7 +254,7 @@ func (ipsMgr *IpsetManager) AddToSet(setName, ip, spec string) error {
 	}
 
 	if errCode, err := ipsMgr.Run(entry); err != nil && errCode != 1 {
-		log.Printf("Error: failed to create ipset rules. %+v", entry)
+		log.Logf("Error: failed to create ipset rules. %+v", entry)
 		return err
 	}
 
@@ -266,7 +266,7 @@ func (ipsMgr *IpsetManager) AddToSet(setName, ip, spec string) error {
 // DeleteFromSet removes an ip from an entry in setMap, and delete/update the corresponding ipset.
 func (ipsMgr *IpsetManager) DeleteFromSet(setName, ip string) error {
 	if _, exists := ipsMgr.setMap[setName]; !exists {
-		log.Printf("ipset with name %s not found", setName)
+		log.Logf("ipset with name %s not found", setName)
 		return nil
 	}
 
@@ -348,7 +348,7 @@ func (ipsMgr *IpsetManager) Run(entry *ipsEntry) (int, error) {
 	cmdArgs := append([]string{entry.operationFlag, util.IpsetExistFlag, entry.set}, entry.spec...)
 	cmdArgs = util.DropEmptyFields(cmdArgs)
 
-	log.Printf("Executing ipset command %s %v", cmdName, cmdArgs)
+	log.Logf("Executing ipset command %s %v", cmdName, cmdArgs)
 	_, err := exec.Command(cmdName, cmdArgs...).Output()
 	if msg, failed := err.(*exec.ExitError); failed {
 		errCode := msg.Sys().(syscall.WaitStatus).ExitStatus()

--- a/npm/iptm/iptm.go
+++ b/npm/iptm/iptm.go
@@ -54,7 +54,7 @@ func NewIptablesManager() *IptablesManager {
 
 // InitNpmChains initializes Azure NPM chains in iptables.
 func (iptMgr *IptablesManager) InitNpmChains() error {
-	log.Printf("Initializing AZURE-NPM chains.")
+	log.Logf("Initializing AZURE-NPM chains.")
 
 	if err := iptMgr.AddChain(util.IptablesAzureChain); err != nil {
 		return err
@@ -187,7 +187,7 @@ func (iptMgr *IptablesManager) InitNpmChains() error {
 	if !exists {
 		iptMgr.OperationFlag = util.IptablesAppendFlag
 		if _, err = iptMgr.Run(entry); err != nil {
-			log.Printf("Error: failed to add default allow CONNECTED/RELATED rule to AZURE-NPM chain.")
+			log.Logf("Error: failed to add default allow CONNECTED/RELATED rule to AZURE-NPM chain.")
 			return err
 		}
 	}
@@ -265,7 +265,7 @@ func (iptMgr *IptablesManager) AddChain(chain string) error {
 	errCode, err := iptMgr.Run(entry)
 	if err != nil {
 		if errCode == iptablesErrDoesNotExist {
-			log.Printf("Chain already exists %s.", entry.Chain)
+			log.Logf("Chain already exists %s.", entry.Chain)
 			return nil
 		}
 
@@ -285,7 +285,7 @@ func (iptMgr *IptablesManager) DeleteChain(chain string) error {
 	errCode, err := iptMgr.Run(entry)
 	if err != nil {
 		if errCode == iptablesErrDoesNotExist {
-			log.Printf("Chain doesn't exist %s.", entry.Chain)
+			log.Logf("Chain doesn't exist %s.", entry.Chain)
 			return nil
 		}
 
@@ -298,7 +298,7 @@ func (iptMgr *IptablesManager) DeleteChain(chain string) error {
 
 // Add adds a rule in iptables.
 func (iptMgr *IptablesManager) Add(entry *IptEntry) error {
-	log.Printf("Adding iptables entry: %+v.", entry)
+	log.Logf("Adding iptables entry: %+v.", entry)
 
 	if entry.IsJumpEntry {
 		iptMgr.OperationFlag = util.IptablesAppendFlag
@@ -315,7 +315,7 @@ func (iptMgr *IptablesManager) Add(entry *IptEntry) error {
 
 // Delete removes a rule in iptables.
 func (iptMgr *IptablesManager) Delete(entry *IptEntry) error {
-	log.Printf("Deleting iptables entry: %+v", entry)
+	log.Logf("Deleting iptables entry: %+v", entry)
 
 	exists, err := iptMgr.Exists(entry)
 	if err != nil {
@@ -349,7 +349,7 @@ func (iptMgr *IptablesManager) Run(entry *IptEntry) (int, error) {
 	cmdArgs := append([]string{util.IptablesWaitFlag, entry.LockWaitTimeInSeconds, iptMgr.OperationFlag, entry.Chain}, entry.Specs...)
 
 	if iptMgr.OperationFlag != util.IptablesCheckFlag {
-		log.Printf("Executing iptables command %s %v", cmdName, cmdArgs)
+		log.Logf("Executing iptables command %s %v", cmdName, cmdArgs)
 	}
 
 	_, err := exec.Command(cmdName, cmdArgs...).Output()
@@ -378,7 +378,7 @@ func (iptMgr *IptablesManager) Save(configFile string) error {
 
 	defer func(l *os.File) {
 		if err = l.Close(); err != nil {
-			log.Printf("Failed to close iptables locks")
+			log.Logf("Failed to close iptables locks")
 		}
 	}(l)
 
@@ -414,7 +414,7 @@ func (iptMgr *IptablesManager) Restore(configFile string) error {
 
 	defer func(l *os.File) {
 		if err = l.Close(); err != nil {
-			log.Printf("Failed to close iptables locks")
+			log.Logf("Failed to close iptables locks")
 		}
 	}(l)
 
@@ -452,7 +452,7 @@ func grabIptablesLocks() (*os.File, error) {
 	// Grab 1.6.x style lock.
 	l, err := os.OpenFile(util.IptablesLockFile, os.O_CREATE, 0600)
 	if err != nil {
-		log.Printf("Error: failed to open iptables lock file %s.", util.IptablesLockFile)
+		log.Logf("Error: failed to open iptables lock file %s.", util.IptablesLockFile)
 		return nil, err
 	}
 
@@ -463,7 +463,7 @@ func grabIptablesLocks() (*os.File, error) {
 
 		return true, nil
 	}); err != nil {
-		log.Printf("Error: failed to acquire new iptables lock: %v.", err)
+		log.Logf("Error: failed to acquire new iptables lock: %v.", err)
 		return nil, err
 	}
 

--- a/npm/namespace.go
+++ b/npm/namespace.go
@@ -102,7 +102,7 @@ func (npMgr *NetworkPolicyManager) AddNamespace(nsObj *corev1.Namespace) error {
 	var err error
 
 	nsName, nsLabel := "ns-"+nsObj.ObjectMeta.Name, nsObj.ObjectMeta.Labels
-	log.Printf("NAMESPACE CREATING: [%s/%v]", nsName, nsLabel)
+	log.Logf("NAMESPACE CREATING: [%s/%v]", nsName, nsLabel)
 
 	ipsMgr := npMgr.nsMap[util.KubeAllNamespacesFlag].ipsMgr
 	// Create ipset for the namespace.
@@ -120,14 +120,14 @@ func (npMgr *NetworkPolicyManager) AddNamespace(nsObj *corev1.Namespace) error {
 	nsLabels := nsObj.ObjectMeta.Labels
 	for nsLabelKey, nsLabelVal := range nsLabels {
 		labelKey := "ns-" + nsLabelKey
-		log.Printf("Adding namespace %s to ipset list %s", nsName, labelKey)
+		log.Logf("Adding namespace %s to ipset list %s", nsName, labelKey)
 		if err = ipsMgr.AddToList(labelKey, nsName); err != nil {
 			log.Errorf("Error: failed to add namespace %s to ipset list %s", nsName, labelKey)
 			return err
 		}
 
 		label := "ns-" + nsLabelKey + ":" + nsLabelVal
-		log.Printf("Adding namespace %s to ipset list %s", nsName, label)
+		log.Logf("Adding namespace %s to ipset list %s", nsName, label)
 		if err = ipsMgr.AddToList(label, nsName); err != nil {
 			log.Errorf("Error: failed to add namespace %s to ipset list %s", nsName, label)
 			return err
@@ -152,7 +152,7 @@ func (npMgr *NetworkPolicyManager) UpdateNamespace(oldNsObj *corev1.Namespace, n
 	var err error
 	oldNsNs, oldNsLabel := "ns-"+oldNsObj.ObjectMeta.Name, oldNsObj.ObjectMeta.Labels
 	newNsNs, newNsLabel := "ns-"+newNsObj.ObjectMeta.Name, newNsObj.ObjectMeta.Labels
-	log.Printf(
+	log.Logf(
 		"NAMESPACE UPDATING:\n old namespace: [%s/%v]\n new namespace: [%s/%v]",
 		oldNsNs, oldNsLabel, newNsNs, newNsLabel,
 	)
@@ -175,7 +175,7 @@ func (npMgr *NetworkPolicyManager) DeleteNamespace(nsObj *corev1.Namespace) erro
 	var err error
 
 	nsName, nsLabel := "ns-"+nsObj.ObjectMeta.Name, nsObj.ObjectMeta.Labels
-	log.Printf("NAMESPACE DELETING: [%s/%v]", nsName, nsLabel)
+	log.Logf("NAMESPACE DELETING: [%s/%v]", nsName, nsLabel)
 
 	_, exists := npMgr.nsMap[nsName]
 	if !exists {
@@ -187,14 +187,14 @@ func (npMgr *NetworkPolicyManager) DeleteNamespace(nsObj *corev1.Namespace) erro
 	nsLabels := nsObj.ObjectMeta.Labels
 	for nsLabelKey, nsLabelVal := range nsLabels {
 		labelKey := "ns-" + nsLabelKey
-		log.Printf("Deleting namespace %s from ipset list %s", nsName, labelKey)
+		log.Logf("Deleting namespace %s from ipset list %s", nsName, labelKey)
 		if err = ipsMgr.DeleteFromList(labelKey, nsName); err != nil {
 			log.Errorf("Error: failed to delete namespace %s from ipset list %s", nsName, labelKey)
 			return err
 		}
 
 		label := "ns-" + nsLabelKey + ":" + nsLabelVal
-		log.Printf("Deleting namespace %s from ipset list %s", nsName, label)
+		log.Logf("Deleting namespace %s from ipset list %s", nsName, label)
 		if err = ipsMgr.DeleteFromList(label, nsName); err != nil {
 			log.Errorf("Error: failed to delete namespace %s from ipset list %s", nsName, label)
 			return err

--- a/npm/pod.go
+++ b/npm/pod.go
@@ -50,31 +50,31 @@ func (npMgr *NetworkPolicyManager) AddPod(podObj *corev1.Pod) error {
 		ipsMgr        = npMgr.nsMap[util.KubeAllNamespacesFlag].ipsMgr
 	)
 
-	log.Printf("POD CREATING: [%s/%s/%s%+v%s]", podNs, podName, podNodeName, podLabels, podIP)
+	log.Logf("POD CREATING: [%s/%s/%s%+v%s]", podNs, podName, podNodeName, podLabels, podIP)
 
 	// Add pod namespace if it doesn't exist
 	if _, exists := npMgr.nsMap[podNs]; !exists {
-		log.Printf("Creating set: %v, hashedSet: %v", podNs, util.GetHashedName(podNs))
+		log.Logf("Creating set: %v, hashedSet: %v", podNs, util.GetHashedName(podNs))
 		if err = ipsMgr.CreateSet(podNs, append([]string{util.IpsetNetHashFlag})); err != nil {
-			log.Printf("Error creating ipset %s", podNs)
+			log.Logf("Error creating ipset %s", podNs)
 		}
 	}
 
 	// Add the pod to its namespace's ipset.
-	log.Printf("Adding pod %s to ipset %s", podIP, podNs)
+	log.Logf("Adding pod %s to ipset %s", podIP, podNs)
 	if err = ipsMgr.AddToSet(podNs, podIP, util.IpsetNetHashFlag); err != nil {
 		log.Errorf("Error: failed to add pod to namespace ipset.")
 	}
 
 	// Add the pod to its label's ipset.
 	for podLabelKey, podLabelVal := range podLabels {
-		log.Printf("Adding pod %s to ipset %s", podIP, podLabelKey)
+		log.Logf("Adding pod %s to ipset %s", podIP, podLabelKey)
 		if err = ipsMgr.AddToSet(podLabelKey, podIP, util.IpsetNetHashFlag); err != nil {
 			log.Errorf("Error: failed to add pod to label ipset.")
 		}
 
 		label := podLabelKey + ":" + podLabelVal
-		log.Printf("Adding pod %s to ipset %s", podIP, label)
+		log.Logf("Adding pod %s to ipset %s", podIP, label)
 		if err = ipsMgr.AddToSet(label, podIP, util.IpsetNetHashFlag); err != nil {
 			log.Errorf("Error: failed to add pod to label ipset.")
 		}
@@ -125,7 +125,7 @@ func (npMgr *NetworkPolicyManager) UpdatePod(oldPodObj, newPodObj *corev1.Pod) e
 		newPodObjIP    = newPodObj.Status.PodIP
 	)
 
-	log.Printf(
+	log.Logf(
 		"POD UPDATING:\n old pod: [%s/%s/%+v/%s/%s]\n new pod: [%s/%s/%+v/%s/%s]",
 		oldPodObjNs, oldPodObjName, oldPodObjLabel, oldPodObjPhase, oldPodObjIP,
 		newPodObjNs, newPodObjName, newPodObjLabel, newPodObjPhase, newPodObjIP,
@@ -169,7 +169,7 @@ func (npMgr *NetworkPolicyManager) DeletePod(podObj *corev1.Pod) error {
 		return nil
 	}
 
-	log.Printf("POD DELETING: [%s/%s/%s%+v%s]", podNs, podName, podNodeName, podLabels, podIP)
+	log.Logf("POD DELETING: [%s/%s/%s%+v%s]", podNs, podName, podNodeName, podLabels, podIP)
 
 	// Delete the pod from its namespace's ipset.
 	if err = ipsMgr.DeleteFromSet(podNs, podIP); err != nil {
@@ -178,13 +178,13 @@ func (npMgr *NetworkPolicyManager) DeletePod(podObj *corev1.Pod) error {
 
 	// Delete the pod from its label's ipset.
 	for podLabelKey, podLabelVal := range podLabels {
-		log.Printf("Deleting pod %s from ipset %s", podIP, podLabelKey)
+		log.Logf("Deleting pod %s from ipset %s", podIP, podLabelKey)
 		if err = ipsMgr.DeleteFromSet(podLabelKey, podIP); err != nil {
 			log.Errorf("Error: failed to delete pod from label ipset.")
 		}
 
 		label := podLabelKey + ":" + podLabelVal
-		log.Printf("Deleting pod %s from ipset %s", podIP, label)
+		log.Logf("Deleting pod %s from ipset %s", podIP, label)
 		if err = ipsMgr.DeleteFromSet(label, podIP); err != nil {
 			log.Errorf("Error: failed to delete pod from label ipset.")
 		}

--- a/npm/translatePolicy.go
+++ b/npm/translatePolicy.go
@@ -787,7 +787,7 @@ func translateIngress(ns string, policyName string, targetSelector metav1.LabelS
 		entries = append(entries, entry)
 	}
 
-	log.Printf("finished parsing ingress rule")
+	log.Logf("finished parsing ingress rule")
 	return util.DropEmptyFields(sets), util.DropEmptyFields(namedPorts), util.DropEmptyFields(lists), ipCidrs, entries
 }
 
@@ -802,7 +802,7 @@ func translateEgress(ns string, policyName string, targetSelector metav1.LabelSe
 		addedEgressToEntry, addedPortEntry bool // add drop entry when there are non ALLOW-ALL* rules
 	)
 
-	log.Printf("started parsing egress rule")
+	log.Logf("started parsing egress rule")
 
 	labelsWithOps, _, _ := parseSelector(&targetSelector)
 	ops, labels := GetOperatorsAndLabels(labelsWithOps)
@@ -1430,7 +1430,7 @@ func translateEgress(ns string, policyName string, targetSelector metav1.LabelSe
 		entries = append(entries, entry)
 	}
 
-	log.Printf("finished parsing egress rule")
+	log.Logf("finished parsing egress rule")
 	return util.DropEmptyFields(sets), util.DropEmptyFields(namedPorts), util.DropEmptyFields(lists), ipCidrs, entries
 }
 
@@ -1500,15 +1500,13 @@ func translatePolicy(npObj *networkingv1.NetworkPolicy) ([]string, []string, []s
 		hasIngress, hasEgress bool
 	)
 
-	log.Printf("Translating network policy:\n %+v", npObj)
-
 	defer func() {
-		log.Printf("Finished translatePolicy")
-		log.Printf("sets: %v", resultSets)
-		log.Printf("lists: %v", resultLists)
-		log.Printf("entries: ")
+		log.Logf("Finished translatePolicy")
+		log.Logf("sets: %v", resultSets)
+		log.Logf("lists: %v", resultLists)
+		log.Logf("entries: ")
 		for _, entry := range entries {
-			log.Printf("entry: %+v", entry)
+			log.Logf("entry: %+v", entry)
 		}
 	}()
 
@@ -1574,7 +1572,6 @@ func translatePolicy(npObj *networkingv1.NetworkPolicy) ([]string, []string, []s
 	}
 
 	entries = append(entries, getDefaultDropEntries(npNs, npObj.Spec.PodSelector, hasIngress, hasEgress)...)
-	log.Printf("Translating Policy: %+v", npObj)
 	resultSets, resultLists = util.UniqueStrSlice(resultSets), util.UniqueStrSlice(resultLists)
 
 	return resultSets, resultNamedPorts, resultLists, resultIngressIPCidrs, resultEgressIPCidrs, entries


### PR DESCRIPTION
Update NPM logs to use Logf statements instead of Printf as those are less CPU intensive. Also fixed few logs to avoid printing the old NetworkPolicy objects as that could potentially impact specially for large networkPolicy object. There are log lines when each rule is processed which can be used for debugging.
