### PR TITLE
fix: move ipset deletion condition check from DeleteSet to DeleteFromSet.

### DIFF
--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -291,7 +291,9 @@ func (ipsMgr *IpsetManager) DeleteFromSet(setName, ip string) error {
 		return err
 	}
 
-	ipsMgr.DeleteSet(setName)
+	if len(ipsMgr.setMap[setName].elements) == 0 {
+		ipsMgr.DeleteSet(setName)
+	}
 
 	return nil
 }

--- a/npm/ipsm/ipsm_test.go
+++ b/npm/ipsm/ipsm_test.go
@@ -195,7 +195,16 @@ func TestDeleteFromSet(t *testing.T) {
 		t.Errorf("TestDeleteFromSet failed @ ipsMgr.AddToSet")
 	}
 
+	if len(ipsMgr.setMap["test-set"].elements) != 1 {
+		t.Errorf("TestDeleteFromSet failed @ ipsMgr.AddToSet")
+	}
+
 	if err := ipsMgr.DeleteFromSet("test-set", "1.2.3.4"); err != nil {
+		t.Errorf("TestDeleteFromSet failed @ ipsMgr.DeleteFromSet")
+	}
+
+	// After deleting the only entry, "1.2.3.4" from "test-set", "test-set" ipset won't exist
+	if _, exists := ipsMgr.setMap["test-set"]; exists {
 		t.Errorf("TestDeleteFromSet failed @ ipsMgr.DeleteFromSet")
 	}
 }


### PR DESCRIPTION
**Reason for Change**:
Ipset deletion condition check existed in DeleteSet function and got removed from previous PR
https://github.com/Azure/azure-container-networking/pull/582/files#diff-8b67ee9376710a903cde1eac00f06c6aL214
This check is still needed when DeleteFromSet got called. When one pod replica got deleted but there are still other pod replica exsit, we should not delete the whole ipset.

**Issue Fixed**:
Ipset deletion condition check.

- [* ] adds unit tests

