### PR TITLE
Add CNS IPAM check to not change state

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -69,6 +69,7 @@ type CreateNetworkContainerRequest struct {
 	LocalIPConfiguration       IPConfiguration
 	OrchestratorContext        json.RawMessage
 	IPConfiguration            IPConfiguration
+	SecondaryIPConfigs         map[string]ContainerIPConfigState //uuid is key
 	MultiTenancyInfo           MultiTenancyInfo
 	CnetAddressSpace           []IPSubnet // To setup SNAT (should include service endpoint vips).
 	Routes                     []Route

--- a/cns/cnsclient/cnsclient_test.go
+++ b/cns/cnsclient/cnsclient_test.go
@@ -33,10 +33,14 @@ var (
 func addTestStateToRestServer(svc *restserver.HTTPRestService) {
 	// set state as already allocated
 	state1, _ := restserver.NewPodStateWithOrchestratorContext(testIP1, 24, testPod1GUID, testNCID, cns.Available, testPod1Info)
-	ipconfigs := []*cns.ContainerIPConfigState{
-		state1,
+	ipconfigs := map[string]cns.ContainerIPConfigState{
+		state1.ID: state1,
 	}
-	svc.AddIPConfigsToState(ipconfigs)
+	nc := cns.CreateNetworkContainerRequest{
+		SecondaryIPConfigs: ipconfigs,
+	}
+
+	svc.CreateOrUpdateNetworkContainerWithSecondaryIPConfigs(nc)
 }
 
 func getIPConfigFromGetNetworkContainerResponse(resp *cns.GetIPConfigResponse) (net.IPNet, error) {

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -19,10 +19,10 @@ func newIPConfig(ipAddress string, prefixLength uint8) cns.IPSubnet {
 	}
 }
 
-func NewPodState(ipaddress string, prefixLength uint8, id, ncid, state string) *cns.ContainerIPConfigState {
+func NewPodState(ipaddress string, prefixLength uint8, id, ncid, state string) cns.ContainerIPConfigState {
 	ipconfig := newIPConfig(ipaddress, prefixLength)
 
-	return &cns.ContainerIPConfigState{
+	return cns.ContainerIPConfigState{
 		IPConfig: ipconfig,
 		ID:       id,
 		NCID:     ncid,
@@ -30,10 +30,10 @@ func NewPodState(ipaddress string, prefixLength uint8, id, ncid, state string) *
 	}
 }
 
-func NewPodStateWithOrchestratorContext(ipaddress string, prefixLength uint8, id, ncid, state string, orchestratorContext cns.KubernetesPodInfo) (*cns.ContainerIPConfigState, error) {
+func NewPodStateWithOrchestratorContext(ipaddress string, prefixLength uint8, id, ncid, state string, orchestratorContext cns.KubernetesPodInfo) (cns.ContainerIPConfigState, error) {
 	ipconfig := newIPConfig(ipaddress, prefixLength)
 	b, err := json.Marshal(orchestratorContext)
-	return &cns.ContainerIPConfigState{
+	return cns.ContainerIPConfigState{
 		IPConfig:            ipconfig,
 		ID:                  id,
 		NCID:                ncid,
@@ -47,7 +47,7 @@ func (service *HTTPRestService) requestIPConfigHandler(w http.ResponseWriter, r 
 	var (
 		err             error
 		ipconfigRequest cns.GetIPConfigRequest
-		ipState         *cns.ContainerIPConfigState
+		ipState         cns.ContainerIPConfigState
 		returnCode      int
 		returnMessage   string
 	)
@@ -122,7 +122,7 @@ func (service *HTTPRestService) releaseIPConfigHandler(w http.ResponseWriter, r 
 	return
 }
 
-func validateIPConfig(ipconfig *cns.ContainerIPConfigState) error {
+func validateIPConfig(ipconfig cns.ContainerIPConfigState) error {
 	if ipconfig.ID == "" {
 		return fmt.Errorf("Failed to add IPConfig to state: %+v, empty ID", ipconfig)
 	}
@@ -138,14 +138,19 @@ func validateIPConfig(ipconfig *cns.ContainerIPConfigState) error {
 	return nil
 }
 
+func (service *HTTPRestService) CreateOrUpdateNetworkContainerWithSecondaryIPConfigs(nc cns.CreateNetworkContainerRequest) error {
+	return service.addIPConfigsToState(nc.SecondaryIPConfigs)
+}
+
 //AddIPConfigsToState takes a lock on the service object, and will add an array of ipconfigs to the CNS Service.
 //Used to add IPConfigs to the CNS pool, specifically in the scenario of rebatching.
-func (service *HTTPRestService) AddIPConfigsToState(ipconfigs []*cns.ContainerIPConfigState) error {
+func (service *HTTPRestService) addIPConfigsToState(ipconfigs map[string]cns.ContainerIPConfigState) error {
 	var (
 		err      error
-		index    int
-		ipconfig *cns.ContainerIPConfigState
+		ipconfig cns.ContainerIPConfigState
 	)
+
+	addedIPconfigs := make([]cns.ContainerIPConfigState, 0)
 
 	service.Lock()
 
@@ -153,14 +158,14 @@ func (service *HTTPRestService) AddIPConfigsToState(ipconfigs []*cns.ContainerIP
 		service.Unlock()
 
 		if err != nil {
-			if removeErr := service.RemoveIPConfigsFromState(ipconfigs[0:index]); removeErr != nil {
+			if removeErr := service.removeIPConfigsFromState(addedIPconfigs); removeErr != nil {
 				logger.Printf("Failed remove IPConfig after AddIpConfigs: %v", removeErr)
 			}
 		}
 	}()
 
 	// ensure the ipconfigs we are not attempting to overwrite existing ipconfig state
-	existingIPConfigs := filterIPConfigSlice(ipconfigs, func(ipconfig *cns.ContainerIPConfigState) bool {
+	existingIPConfigs := filterIPConfigMap(ipconfigs, func(ipconfig *cns.ContainerIPConfigState) bool {
 		existingIPConfig, exists := service.PodIPConfigState[ipconfig.ID]
 		if exists && existingIPConfig.State != ipconfig.State {
 			return true
@@ -172,12 +177,13 @@ func (service *HTTPRestService) AddIPConfigsToState(ipconfigs []*cns.ContainerIP
 	}
 
 	// add ipconfigs to state
-	for index, ipconfig = range ipconfigs {
+	for _, ipconfig = range ipconfigs {
 		if err = validateIPConfig(ipconfig); err != nil {
 			return err
 		}
 
 		service.PodIPConfigState[ipconfig.ID] = ipconfig
+		addedIPconfigs = append(addedIPconfigs, ipconfig)
 
 		if ipconfig.State == cns.Allocated {
 			var podInfo cns.KubernetesPodInfo
@@ -188,25 +194,16 @@ func (service *HTTPRestService) AddIPConfigsToState(ipconfigs []*cns.ContainerIP
 
 			service.PodIPIDByOrchestratorContext[podInfo.GetOrchestratorContextKey()] = ipconfig.ID
 		}
+
 	}
 	return err
 }
 
-func filterIPConfigSlice(vs []*cns.ContainerIPConfigState, f func(*cns.ContainerIPConfigState) bool) []*cns.ContainerIPConfigState {
+func filterIPConfigMap(toBeAdded map[string]cns.ContainerIPConfigState, f func(*cns.ContainerIPConfigState) bool) []*cns.ContainerIPConfigState {
 	vsf := make([]*cns.ContainerIPConfigState, 0)
-	for _, v := range vs {
-		if f(v) {
-			vsf = append(vsf, v)
-		}
-	}
-	return vsf
-}
-
-func filterIPConfigMap(vs map[string]*cns.ContainerIPConfigState, f func(*cns.ContainerIPConfigState) bool) []*cns.ContainerIPConfigState {
-	vsf := make([]*cns.ContainerIPConfigState, 0)
-	for _, v := range vs {
-		if f(v) {
-			vsf = append(vsf, v)
+	for _, v := range toBeAdded {
+		if f(&v) {
+			vsf = append(vsf, &v)
 		}
 	}
 	return vsf
@@ -230,7 +227,7 @@ func (service *HTTPRestService) GetAvailableIPConfigs() []*cns.ContainerIPConfig
 
 //RemoveIPConfigsFromState takes a lock on the service object, and will remove an array of ipconfigs to the CNS Service.
 //Used to add IPConfigs to the CNS pool, specifically in the scenario of rebatching.
-func (service *HTTPRestService) RemoveIPConfigsFromState(ipconfigs []*cns.ContainerIPConfigState) error {
+func (service *HTTPRestService) removeIPConfigsFromState(ipconfigs []cns.ContainerIPConfigState) error {
 	service.Lock()
 	defer service.Unlock()
 
@@ -250,7 +247,7 @@ func (service *HTTPRestService) RemoveIPConfigsFromState(ipconfigs []*cns.Contai
 }
 
 //SetIPConfigAsAllocated takes a lock of the service, and sets the ipconfig in the CNS state as allocated, does not take a lock
-func (service *HTTPRestService) setIPConfigAsAllocated(ipconfig *cns.ContainerIPConfigState, podInfo cns.KubernetesPodInfo, marshalledOrchestratorContext json.RawMessage) *cns.ContainerIPConfigState {
+func (service *HTTPRestService) setIPConfigAsAllocated(ipconfig cns.ContainerIPConfigState, podInfo cns.KubernetesPodInfo, marshalledOrchestratorContext json.RawMessage) cns.ContainerIPConfigState {
 	ipconfig.State = cns.Allocated
 	ipconfig.OrchestratorContext = marshalledOrchestratorContext
 	service.PodIPIDByOrchestratorContext[podInfo.GetOrchestratorContextKey()] = ipconfig.ID
@@ -259,7 +256,7 @@ func (service *HTTPRestService) setIPConfigAsAllocated(ipconfig *cns.ContainerIP
 }
 
 //SetIPConfigAsAllocated and sets the ipconfig in the CNS state as allocated, does not take a lock
-func (service *HTTPRestService) setIPConfigAsAvailable(ipconfig *cns.ContainerIPConfigState, podInfo cns.KubernetesPodInfo) *cns.ContainerIPConfigState {
+func (service *HTTPRestService) setIPConfigAsAvailable(ipconfig cns.ContainerIPConfigState, podInfo cns.KubernetesPodInfo) cns.ContainerIPConfigState {
 	ipconfig.State = cns.Available
 	ipconfig.OrchestratorContext = nil
 	service.PodIPConfigState[ipconfig.ID] = ipconfig
@@ -287,9 +284,9 @@ func (service *HTTPRestService) ReleaseIPConfig(podInfo cns.KubernetesPodInfo) e
 	return nil
 }
 
-func (service *HTTPRestService) GetExistingIPConfig(podInfo cns.KubernetesPodInfo) (*cns.ContainerIPConfigState, bool, error) {
+func (service *HTTPRestService) GetExistingIPConfig(podInfo cns.KubernetesPodInfo) (cns.ContainerIPConfigState, bool, error) {
 	var (
-		ipState *cns.ContainerIPConfigState
+		ipState cns.ContainerIPConfigState
 		isExist bool
 	)
 
@@ -308,8 +305,8 @@ func (service *HTTPRestService) GetExistingIPConfig(podInfo cns.KubernetesPodInf
 	return ipState, isExist, nil
 }
 
-func (service *HTTPRestService) AllocateDesiredIPConfig(podInfo cns.KubernetesPodInfo, desiredIPAddress string, orchestratorContext json.RawMessage) (*cns.ContainerIPConfigState, error) {
-	var ipState *cns.ContainerIPConfigState
+func (service *HTTPRestService) AllocateDesiredIPConfig(podInfo cns.KubernetesPodInfo, desiredIPAddress string, orchestratorContext json.RawMessage) (cns.ContainerIPConfigState, error) {
+	var ipState cns.ContainerIPConfigState
 
 	service.Lock()
 	defer service.Unlock()
@@ -325,8 +322,8 @@ func (service *HTTPRestService) AllocateDesiredIPConfig(podInfo cns.KubernetesPo
 	return ipState, fmt.Errorf("Requested IP not found in pool")
 }
 
-func (service *HTTPRestService) AllocateAnyAvailableIPConfig(podInfo cns.KubernetesPodInfo, orchestratorContext json.RawMessage) (*cns.ContainerIPConfigState, error) {
-	var ipState *cns.ContainerIPConfigState
+func (service *HTTPRestService) AllocateAnyAvailableIPConfig(podInfo cns.KubernetesPodInfo, orchestratorContext json.RawMessage) (cns.ContainerIPConfigState, error) {
+	var ipState cns.ContainerIPConfigState
 
 	service.Lock()
 	defer service.Unlock()
@@ -340,10 +337,10 @@ func (service *HTTPRestService) AllocateAnyAvailableIPConfig(podInfo cns.Kuberne
 }
 
 // If IPConfig is already allocated for pod, it returns that else it returns one of the available ipconfigs.
-func requestIPConfigHelper(service *HTTPRestService, req cns.GetIPConfigRequest) (*cns.ContainerIPConfigState, error) {
+func requestIPConfigHelper(service *HTTPRestService, req cns.GetIPConfigRequest) (cns.ContainerIPConfigState, error) {
 	var (
 		podInfo cns.KubernetesPodInfo
-		ipState *cns.ContainerIPConfigState
+		ipState cns.ContainerIPConfigState
 		isExist bool
 		err     error
 	)

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -194,7 +194,6 @@ func (service *HTTPRestService) addIPConfigsToState(ipconfigs map[string]cns.Con
 
 			service.PodIPIDByOrchestratorContext[podInfo.GetOrchestratorContextKey()] = ipconfig.ID
 		}
-
 	}
 	return err
 }

--- a/cns/restserver/ipam_test.go
+++ b/cns/restserver/ipam_test.go
@@ -375,3 +375,48 @@ func TestIPAMAllocateIPIdempotency(t *testing.T) {
 		t.Fatalf("Expected to not fail adding IP's to state: %+v", err)
 	}
 }
+
+func TestIPAMAddAvailableToAllocated(t *testing.T) {
+	svc := getTestService()
+	// add two ipconfigs, one as available, the other as allocated
+	state1, _ := NewPodStateWithOrchestratorContext(testIP1, 24, testPod1GUID, testNCID, cns.Available, testPod1Info)
+	state2, _ := NewPodStateWithOrchestratorContext(testIP2, 24, testPod2GUID, testNCID, cns.Allocated, testPod2Info)
+
+	// add an available and allocated ipconfig
+	ipconfigs := []*cns.ContainerIPConfigState{
+		state1,
+		state2,
+	}
+
+	err := svc.AddIPConfigsToState(ipconfigs)
+	if err != nil {
+		t.Fatalf("Expected to not fail adding IP's to state: %+v", err)
+	}
+
+	// create state2 again, but as available
+	state2Available, _ := NewPodStateWithOrchestratorContext(testIP2, 24, testPod2GUID, testNCID, cns.Available, testPod2Info)
+
+	// add an available and allocated ipconfig
+	ipconfigsTest := []*cns.ContainerIPConfigState{
+		state1,
+		state2Available,
+	}
+
+	// expect to fail overwriting an allocated state with available
+	err = svc.AddIPConfigsToState(ipconfigsTest)
+	if err == nil {
+		t.Fatalf("Expected to fail when overwriting an allocated state as available: %+v", err)
+	}
+
+	// get allocated ipconfigs, should only be one from the inital call, and not 2 from the failed call
+	availableIPconfigs := svc.GetAvailableIPConfigs()
+	if len(availableIPconfigs) != 1 {
+		t.Fatalf("More than expected available IP configs in state")
+	}
+
+	// get allocated ipconfigs, should only be one from the inital call, and not 0 from the failed call
+	allocatedIPconfigs := svc.GetAllocatedIPConfigs()
+	if len(allocatedIPconfigs) != 1 {
+		t.Fatalf("More than expected allocated IP configs in state")
+	}
+}

--- a/cns/restserver/ipam_test.go
+++ b/cns/restserver/ipam_test.go
@@ -438,7 +438,7 @@ func TestIPAMAllocateIPIdempotency(t *testing.T) {
 	}
 }
 
-func TestIPAMAddAvailableToAllocated(t *testing.T) {
+func TestIPAMExpectStateToNotChangeWhenChangingAllocatedToAvailable(t *testing.T) {
 	svc := getTestService()
 	// add two ipconfigs, one as available, the other as allocated
 	state1, _ := NewPodStateWithOrchestratorContext(testIP1, 24, testPod1GUID, testNCID, cns.Available, testPod1Info)

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -52,9 +52,9 @@ type HTTPRestService struct {
 	imdsClient                   *imdsclient.ImdsClient
 	ipamClient                   *ipamclient.IpamClient
 	networkContainer             *networkcontainers.NetworkContainers
-	PodIPIDByOrchestratorContext map[string]string                      // OrchestratorContext is key and value is Pod IP uuid.
-	PodIPConfigState             map[string]*cns.ContainerIPConfigState // seondaryipid(uuid) is key
-	AllocatedIPCount             map[string]allocatedIPCount            // key - ncid
+	PodIPIDByOrchestratorContext map[string]string                     // OrchestratorContext is key and value is Pod IP uuid.
+	PodIPConfigState             map[string]cns.ContainerIPConfigState // seondaryipid(uuid) is key
+	AllocatedIPCount             map[string]allocatedIPCount           // key - ncid
 	routingTable                 *routes.RoutingTable
 	store                        store.KeyValueStore
 	state                        *httpRestServiceState
@@ -126,7 +126,7 @@ func NewHTTPRestService(config *common.ServiceConfig) (HTTPService, error) {
 	serviceState.joinedNetworks = make(map[string]struct{})
 
 	podIPIDByOrchestratorContext := make(map[string]string)
-	podIPConfigState := make(map[string]*cns.ContainerIPConfigState)
+	podIPConfigState := make(map[string]cns.ContainerIPConfigState)
 	allocatedIPCount := make(map[string]allocatedIPCount) // key - ncid
 
 	return &HTTPRestService{


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

Adding an IPConfig to CNS IPAM could overwrite an existing IPConfig state. Now blocks the scenario AddIPConfig changing state from Allocated to any other state

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ x] adds unit tests


**Notes**:
