### PR TITLE
Implement CreateOrUpdateNetworkContainerInternal API. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ CNSFILES = \
 	$(wildcard cns/routes/*.go) \
 	$(wildcard cns/service/*.go) \
 	$(wildcard cns/networkcontainers/*.go) \
+	$(wildcard cns/requestcontroller/*.go) \
+	$(wildcard cns/requestcontroller/kubecontroller/*.go) \
+	$(wildcard cns/requestcontroller/example/*.go) \
 	$(COREFILES) \
 	$(CNMFILES)
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,6 @@ CNSFILES = \
 	$(wildcard cns/networkcontainers/*.go) \
 	$(wildcard cns/requestcontroller/*.go) \
 	$(wildcard cns/requestcontroller/kubecontroller/*.go) \
-	$(wildcard cns/requestcontroller/example/*.go) \
 	$(COREFILES) \
 	$(CNMFILES)
 

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -44,6 +44,8 @@ const (
 	Batch           = "Batch"
 	DBforPostgreSQL = "DBforPostgreSQL"
 	AzureFirstParty = "AzureFirstParty"
+	KubernetesCRD   = "KubernetesCRD"
+	// TODO: Add OrchastratorType as CRD: https://msazure.visualstudio.com/One/_workitems/edit/7711872
 )
 
 // Encap Types
@@ -98,6 +100,7 @@ type KubernetesPodInfo struct {
 }
 
 // GetOrchestratorContext will return the orchestratorcontext as a string
+// TODO - should use a hashed name or can this be PODUid?
 func (podinfo *KubernetesPodInfo) GetOrchestratorContextKey() string {
 	return podinfo.PodName + ":" + podinfo.PodNamespace
 }
@@ -116,15 +119,7 @@ type IPConfiguration struct {
 }
 
 type SecondaryIPConfig struct {
-	IPConfig IPSubnet
-}
-
-type ContainerIPConfigState struct {
-	IPConfig            IPSubnet
-	ID                  string //uuid
-	NCID                string
-	State               string
-	OrchestratorContext json.RawMessage
+	IPSubnet IPSubnet
 }
 
 // IPSubnet contains ip subnet.

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -118,6 +118,7 @@ type IPConfiguration struct {
 	GatewayIPAddress string
 }
 
+// SecondaryIPConfig contains IP info of SecondaryIP
 type SecondaryIPConfig struct {
 	IPSubnet IPSubnet
 }

--- a/cns/cnsclient/cnsclient_test.go
+++ b/cns/cnsclient/cnsclient_test.go
@@ -47,10 +47,7 @@ func addTestStateToRestServer(t *testing.T, secondaryIps []string) {
 				PrefixLength: 32,
 			},
 		}
-		ipId, err := uuid.NewUUID()
-		if err != nil {
-			t.Fatalf("Failed to generate UUID for secondaryipconfig, err:%s", err)
-		}
+		ipId := uuid.New()
 		secondaryIPConfigs[ipId.String()] = secIpConfig
 	}
 

--- a/cns/cnsclient/cnsclient_test.go
+++ b/cns/cnsclient/cnsclient_test.go
@@ -91,7 +91,7 @@ func getIPConfigFromGetNetworkContainerResponse(resp *cns.GetIPConfigResponse) (
 func TestMain(m *testing.M) {
 	var (
 		info = &cns.SetOrchestratorTypeRequest{
-			OrchestratorType: cns.Kubernetes}
+			OrchestratorType: cns.KubernetesCRD}
 		body bytes.Buffer
 		res  *http.Response
 	)
@@ -152,13 +152,13 @@ func TestCNSClientRequestAndRelease(t *testing.T) {
 	podNamespace := "testpodnamespace"
 	desiredIpAddress := "10.0.0.5"
 	ip := net.ParseIP(desiredIpAddress)
-	_, ipnet, _ := net.ParseCIDR("10.0.0.5/24")
+	_, ipnet, _ := net.ParseCIDR("10.0.0.5/32")
 	desired := net.IPNet{
 		IP:   ip,
 		Mask: ipnet.Mask,
 	}
 
-	secondaryIps := make([]string, 1)
+	secondaryIps := make([]string, 0)
 	secondaryIps = append(secondaryIps, desiredIpAddress)
 	cnsClient, _ := InitCnsClient("")
 
@@ -170,10 +170,10 @@ func TestCNSClientRequestAndRelease(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// no IP reservation found with that context, expect fail
+	// no IP reservation found with that context, expect no failure.
 	err = cnsClient.ReleaseIPAddress(orchestratorContext)
-	if err == nil {
-		t.Fatalf("Expected failure to release when no IP reservation found with context: %+v", err)
+	if err != nil {
+		t.Fatalf("Release ip idempotent call failed: %+v", err)
 	}
 
 	// request IP address

--- a/cns/cnsclient/cnsclient_test.go
+++ b/cns/cnsclient/cnsclient_test.go
@@ -144,7 +144,8 @@ func TestMain(m *testing.M) {
 	}
 	fmt.Println(res)
 
-	m.Run()
+	exitCode := m.Run()
+	os.Exit(exitCode)
 }
 
 func TestCNSClientRequestAndRelease(t *testing.T) {

--- a/cns/cnsclient/cnsclient_test.go
+++ b/cns/cnsclient/cnsclient_test.go
@@ -1,35 +1,71 @@
 package cnsclient
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"net"
+	"net/http"
+	"os"
+	"reflect"
 	"strconv"
+	"testing"
 
 	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/common"
+	"github.com/Azure/azure-container-networking/cns/logger"
+	"github.com/Azure/azure-container-networking/cns/restserver"
+	"github.com/Azure/azure-container-networking/log"
+	"github.com/google/uuid"
 )
 
 var (
-	testNCID = "06867cf3-332d-409d-8819-ed70d2c116b0"
-
-	testIP1      = "10.0.0.1"
-	testPod1GUID = "898fb8f1-f93e-4c96-9c31-6b89098949a3"
-	testPod1Info = cns.KubernetesPodInfo{
-		PodName:      "testpod1",
-		PodNamespace: "testpod1namespace",
-	}
+	svc *restserver.HTTPRestService
 )
 
-// func addTestStateToRestServer(svc *restserver.HTTPRestService) {
-// 	// set state as already allocated
-// 	state1, _ := restserver.NewPodStateWithOrchestratorContext(testIP1, 24, testPod1GUID, testNCID, cns.Available, testPod1Info)
-// 	ipconfigs := map[string]cns.SecondaryIPConfig{
-// 		state1.ID: state1,
-// 	}
-// 	nc := cns.CreateNetworkContainerRequest{
-// 		SecondaryIPConfigs: ipconfigs,
-// 	}
+const (
+	primaryIp           = "10.0.0.5"
+	gatewayIp           = "10.0.0.1"
+	dockerContainerType = cns.Docker
+)
 
-// 	svc.CreateOrUpdateNetworkContainerWithSecondaryIPConfigs(nc)
-// }
+func addTestStateToRestServer(t *testing.T, secondaryIps []string) {
+	var ipConfig cns.IPConfiguration
+	ipConfig.DNSServers = []string{"8.8.8.8", "8.8.4.4"}
+	ipConfig.GatewayIPAddress = gatewayIp
+	var ipSubnet cns.IPSubnet
+	ipSubnet.IPAddress = primaryIp
+	ipSubnet.PrefixLength = 32
+	ipConfig.IPSubnet = ipSubnet
+	secondaryIPConfigs := make(map[string]cns.SecondaryIPConfig)
+
+	for _, secIpAddress := range secondaryIps {
+		secIpConfig := cns.SecondaryIPConfig{
+			IPSubnet: cns.IPSubnet{
+				IPAddress:    secIpAddress,
+				PrefixLength: 32,
+			},
+		}
+		ipId, err := uuid.NewUUID()
+		if err != nil {
+			t.Fatalf("Failed to generate UUID for secondaryipconfig, err:%s", err)
+		}
+		secondaryIPConfigs[ipId.String()] = secIpConfig
+	}
+
+	req := cns.CreateNetworkContainerRequest{
+		NetworkContainerType: dockerContainerType,
+		NetworkContainerid:   "testNcId1",
+		IPConfiguration:      ipConfig,
+		SecondaryIPConfigs:   secondaryIPConfigs,
+	}
+
+	returnCode := svc.CreateOrUpdateNetworkContainerInternal(req)
+	if returnCode != 0 {
+		t.Fatalf("Failed to createNetworkContainerRequest, req: %+v, err: %d", req, returnCode)
+	}
+}
 
 func getIPConfigFromGetNetworkContainerResponse(resp *cns.GetIPConfigResponse) (net.IPNet, error) {
 	var (
@@ -52,7 +88,6 @@ func getIPConfigFromGetNetworkContainerResponse(resp *cns.GetIPConfigResponse) (
 	return resultIPnet, err
 }
 
-/*
 func TestMain(m *testing.M) {
 	var (
 		info = &cns.SetOrchestratorTypeRequest{
@@ -80,14 +115,12 @@ func TestMain(m *testing.M) {
 	config := common.ServiceConfig{}
 
 	httpRestService, err := restserver.NewHTTPRestService(&config)
-	svc := httpRestService.(*restserver.HTTPRestService)
+	svc = httpRestService.(*restserver.HTTPRestService)
 	svc.Name = "cns-test-server"
 	if err != nil {
 		logger.Errorf("Failed to create CNS object, err:%v.\n", err)
 		return
 	}
-
-	//addTestStateToRestServer(svc)
 
 	if httpRestService != nil {
 		err = httpRestService.Start(&config)
@@ -117,14 +150,19 @@ func TestMain(m *testing.M) {
 func TestCNSClientRequestAndRelease(t *testing.T) {
 	podName := "testpodname"
 	podNamespace := "testpodnamespace"
-	ip := net.ParseIP("10.0.0.1")
-	_, ipnet, _ := net.ParseCIDR("10.0.0.1/24")
+	desiredIpAddress := "10.0.0.5"
+	ip := net.ParseIP(desiredIpAddress)
+	_, ipnet, _ := net.ParseCIDR("10.0.0.5/24")
 	desired := net.IPNet{
 		IP:   ip,
 		Mask: ipnet.Mask,
 	}
 
+	secondaryIps := make([]string, 1)
+	secondaryIps = append(secondaryIps, desiredIpAddress)
 	cnsClient, _ := InitCnsClient("")
+
+	addTestStateToRestServer(t, secondaryIps)
 
 	podInfo := cns.KubernetesPodInfo{PodName: podName, PodNamespace: podNamespace}
 	orchestratorContext, err := json.Marshal(podInfo)
@@ -156,4 +194,3 @@ func TestCNSClientRequestAndRelease(t *testing.T) {
 		t.Fatalf("Expected to not fail when releasing IP reservation found with context: %+v", err)
 	}
 }
-*/

--- a/cns/cnsclient/httpapi/client.go
+++ b/cns/cnsclient/httpapi/client.go
@@ -12,24 +12,13 @@ type Client struct {
 
 // CreateOrUpdateNC updates cns state
 func (client *Client) CreateOrUpdateNC(ncRequest *cns.CreateNetworkContainerRequest) error {
-	// var (
-	// 	ipConfigsToAdd []*cns.ContainerIPConfigState
-	// )
+	returnCode := client.RestService.CreateOrUpdateNetworkContainerInternal(ncRequest)
 
-	// //Lock to read ipconfigs
-	// client.RestService.Lock()
+	if returnCode != 0 {
+		return false
+	}
 
-	// //Only add ipconfigs that don't exist in cns state already
-	// for _, ipConfig := range ipConfigs {
-	// 	if _, ok := client.RestService.PodIPConfigState[ipConfig.ID]; !ok {
-	// 		ipConfig.State = cns.Available
-	// 		ipConfigsToAdd = append(ipConfigsToAdd, ipConfig)
-	// 	}
-	// }
-
-	// client.RestService.Unlock()
-	// leave empty
-	return nil //client.RestService.AddIPConfigsToState(ipConfigsToAdd)
+	return nil
 }
 
 // InitCNSState initializes cns state

--- a/cns/cnsclient/httpapi/client.go
+++ b/cns/cnsclient/httpapi/client.go
@@ -1,6 +1,8 @@
 package httpapi
 
 import (
+	"fmt"
+
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/restserver"
 )
@@ -12,10 +14,10 @@ type Client struct {
 
 // CreateOrUpdateNC updates cns state
 func (client *Client) CreateOrUpdateNC(ncRequest *cns.CreateNetworkContainerRequest) error {
-	returnCode := client.RestService.CreateOrUpdateNetworkContainerInternal(ncRequest)
+	returnCode := client.RestService.CreateOrUpdateNetworkContainerInternal(*ncRequest)
 
 	if returnCode != 0 {
-		return false
+		return fmt.Errorf("Failed to Create NC request: %+v, errorCode: %d", *ncRequest, returnCode)
 	}
 
 	return nil

--- a/cns/logger/log.go
+++ b/cns/logger/log.go
@@ -84,8 +84,9 @@ func sendTraceInternal(msg string) {
 	Log.th.TrackLog(report)
 }
 
+// also logs in the AI telemetry
 func Printf(format string, args ...interface{}) {
-	Log.logger.Printf(format, args...)
+	Log.logger.Logf(format, args...)
 
 	if Log.th == nil || Log.DisableTraceLogging {
 		return

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -726,6 +726,8 @@ func (service *HTTPRestService) setOrchestratorType(w http.ResponseWriter, r *ht
 			fallthrough
 		case cns.Kubernetes:
 			fallthrough
+		case cns.KubernetesCRD:
+			fallthrough
 		case cns.WebApps:
 			fallthrough
 		case cns.Batch:

--- a/cns/restserver/api_test.go
+++ b/cns/restserver/api_test.go
@@ -106,8 +106,6 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	svc = service.(*HTTPRestService)
-
-	svc := service.(*HTTPRestService)
 	svc.Name = "cns-test-server"
 	if err != nil {
 		logger.Errorf("Failed to create CNS object, err:%v.\n", err)

--- a/cns/restserver/api_test.go
+++ b/cns/restserver/api_test.go
@@ -51,6 +51,7 @@ type xmlDocument struct {
 
 var (
 	service                               HTTPService
+	svc                                   *HTTPRestService
 	mux                                   *http.ServeMux
 	hostQueryForProgrammedVersionResponse = `{"httpStatusCode":"200","networkContainerId":"eab2470f-test-test-test-b3cd316979d5","version":"1"}`
 	hostQueryResponse                     = xmlDocument{
@@ -104,6 +105,7 @@ func TestMain(m *testing.M) {
 		fmt.Printf("Failed to create CNS object %v\n", err)
 		os.Exit(1)
 	}
+	svc = service.(*HTTPRestService)
 
 	svc := service.(*HTTPRestService)
 	svc.Name = "cns-test-server"

--- a/cns/restserver/const.go
+++ b/cns/restserver/const.go
@@ -30,7 +30,7 @@ const (
 	InvalidPrimaryIPConfig          = 27
 	PrimaryCANotSame                = 28
 	InconsistentIPConfigState       = 29
-	InvalidSecndaryIPConfig         = 30
+	InvalidSecondaryIPConfig        = 30
 	UnexpectedError                 = 99
 )
 

--- a/cns/restserver/const.go
+++ b/cns/restserver/const.go
@@ -27,6 +27,9 @@ const (
 	NetworkJoinFailed               = 24
 	NetworkContainerPublishFailed   = 25
 	NetworkContainerUnpublishFailed = 26
+	PrimaryCANotSpecified           = 27
+	PrimaryCANotSame                = 28
+	InconsistentIPConfigState       = 29
 	UnexpectedError                 = 99
 )
 

--- a/cns/restserver/const.go
+++ b/cns/restserver/const.go
@@ -27,9 +27,10 @@ const (
 	NetworkJoinFailed               = 24
 	NetworkContainerPublishFailed   = 25
 	NetworkContainerUnpublishFailed = 26
-	PrimaryCANotSpecified           = 27
+	InvalidPrimaryIPConfig          = 27
 	PrimaryCANotSame                = 28
 	InconsistentIPConfigState       = 29
+	InvalidSecndaryIPConfig         = 30
 	UnexpectedError                 = 99
 )
 

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -47,7 +47,7 @@ func (service *HTTPRestService) CreateOrUpdateNetworkContainerInternal(req cns.C
 		err := validateIPConfig(ipconfig.IPSubnet)
 		if err != nil {
 			logger.Errorf("[Azure CNS] Error. SecondaryIpConfig, Id:%s is invalid, NC Req: %v", ipId, req)
-			return InvalidSecndaryIPConfig
+			return InvalidSecondaryIPConfig
 		}
 	}
 

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -20,7 +20,8 @@ func (service *HTTPRestService) GetPartitionKey() (dncPartitionKey string) {
 	return
 }
 
-func (service *HTTPRestService) CreateOrUpdateNetworkContainer(req cns.CreateNetworkContainerRequest) int {
+// This API will be called by CNS RequestController on CRD update.
+func (service *HTTPRestService) CreateOrUpdateNetworkContainerInternal(req cns.CreateNetworkContainerRequest) int {
 	if req.NetworkContainerid == "" {
 		logger.Errorf("[Azure CNS] Error. NetworkContainerid is empty")
 		return NetworkContainerNotSpecified

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -35,9 +35,20 @@ func (service *HTTPRestService) CreateOrUpdateNetworkContainerInternal(req cns.C
 	}
 
 	// Validate PrimaryCA must never be empty
-	if req.PrimaryInterfaceIdentifier == "" {
-		logger.Errorf("[Azure CNS] Error. PrimaryCA is empty, NCId %s", req.NetworkContainerid)
-		return PrimaryCANotSpecified
+	err := validateIPConfig(req.IPConfiguration.IPSubnet)
+	if err != nil {
+		logger.Errorf("[Azure CNS] Error. PrimaryCA is invalid, NC Req: %v", req)
+		return InvalidPrimaryIPConfig
+	}
+
+	// Validate SecondaryIPConfig
+	for ipId, ipconfig := range req.SecondaryIPConfigs {
+		// Validate Ipconfig
+		err := validateIPConfig(ipconfig.IPSubnet)
+		if err != nil {
+			logger.Errorf("[Azure CNS] Error. SecondaryIpConfig, Id:%s is invalid, NC Req: %v", ipId, req)
+			return InvalidSecndaryIPConfig
+		}
 	}
 
 	// Validate if state exists already

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -3,6 +3,11 @@
 
 package restserver
 
+import (
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/logger"
+)
+
 // This file contains the internal functions called by either HTTP APIs (api.go) or
 // internal APIs (definde in internalapi.go).
 // This will be used internally (say by RequestController in case of AKS)
@@ -13,4 +18,47 @@ func (service *HTTPRestService) GetPartitionKey() (dncPartitionKey string) {
 	dncPartitionKey = service.dncPartitionKey
 	service.RUnlock()
 	return
+}
+
+func (service *HTTPRestService) CreateOrUpdateNetworkContainer(req cns.CreateNetworkContainerRequest) int {
+	if req.NetworkContainerid == "" {
+		logger.Errorf("[Azure CNS] Error. NetworkContainerid is empty")
+		return NetworkContainerNotSpecified
+	}
+
+	// For now only RequestController uses this API which will be initialized only for AKS scenario.
+	// Validate ContainerType is set as Docker
+	if service.state.OrchestratorType != cns.KubernetesCRD {
+		logger.Errorf("[Azure CNS] Error. Unsupported OrchestratorType: %s", service.state.OrchestratorType)
+		return UnsupportedOrchestratorType
+	}
+
+	// Validate PrimaryCA must never be empty
+	if req.PrimaryInterfaceIdentifier == "" {
+		logger.Errorf("[Azure CNS] Error. PrimaryCA is empty, NCId %s", req.NetworkContainerid)
+		return PrimaryCANotSpecified
+	}
+
+	// Validate if state exists already
+	existing, ok := service.getNetworkContainerDetails(cns.SwiftPrefix + req.NetworkContainerid)
+
+	if ok {
+		existingReq := existing.CreateNetworkContainerRequest
+		if existingReq.PrimaryInterfaceIdentifier != req.PrimaryInterfaceIdentifier {
+			logger.Errorf("[Azure CNS] Error. PrimaryCA is not same, NCId %s, old CA %s, new CA %s", req.NetworkContainerid, existingReq.PrimaryInterfaceIdentifier, req.PrimaryInterfaceIdentifier)
+			return PrimaryCANotSame
+		}
+	}
+
+	// This will Create Or Update the NC state.
+	returnCode, returnMessage := service.saveNetworkContainerGoalState(req)
+
+	// If the NC was created successfully, log NC snapshot.
+	if returnCode == 0 {
+		logNCSnapshot(req)
+	} else {
+		logger.Errorf(returnMessage)
+	}
+
+	return returnCode
 }

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -52,7 +52,7 @@ func (service *HTTPRestService) CreateOrUpdateNetworkContainerInternal(req cns.C
 	}
 
 	// Validate if state exists already
-	existing, ok := service.getNetworkContainerDetails(cns.SwiftPrefix + req.NetworkContainerid)
+	existing, ok := service.getNetworkContainerDetails(req.NetworkContainerid)
 
 	if ok {
 		existingReq := existing.CreateNetworkContainerRequest

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -58,7 +58,7 @@ func (service *HTTPRestService) CreateOrUpdateNetworkContainerInternal(req cns.C
 
 	if ok {
 		existingReq := existingNCInfo.CreateNetworkContainerRequest
-		if reflect.DeepEqual(existingReq.IPConfiguration, req.PrimaryInterfaceIdentifier) != true {
+		if reflect.DeepEqual(existingReq.IPConfiguration, req.IPConfiguration) != true {
 			logger.Errorf("[Azure CNS] Error. PrimaryCA is not same, NCId %s, old CA %s, new CA %s", req.NetworkContainerid, existingReq.PrimaryInterfaceIdentifier, req.PrimaryInterfaceIdentifier)
 			return PrimaryCANotSame
 		}

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -1,0 +1,87 @@
+// Copyright 2020 Microsoft. All rights reserved.
+// MIT License
+
+package restserver
+
+import (
+)
+
+// func TestIPAMExpectFailWhenAddingBadIPConfig(t *testing.T) {
+// 	svc := getTestService()
+
+// 	var err error
+
+// 	// set state as already allocated
+// 	state1, _ := NewPodStateWithOrchestratorContext(testIP1, 24, testPod1GUID, testNCID, cns.Available, testPod1Info)
+
+// 	ipconfigs := map[string]IpConfigurationStatus{
+// 		state1.ID: state1,
+// 	}
+
+// 	err = UpdatePodIpConfigState(svc, ipconfigs)
+// 	if err != nil {
+// 		t.Fatalf("Expected to not fail when good ipconfig is added")
+// 	}
+
+// 	// create bad ipconfig
+// 	state2, _ := NewPodStateWithOrchestratorContext("", 24, "", testNCID, cns.Available, testPod1Info)
+
+// 	ipconfigs2 := map[string]IpConfigurationStatus{
+// 		state2.ID: state2,
+// 	}
+
+// 	// add a bad ipconfig
+// 	err = UpdatePodIpConfigState(svc, ipconfigs2)
+// 	if err == nil {
+// 		t.Fatalf("Expected add to fail when bad ipconfig is added.")
+// 	}
+
+// 	// ensure state remains untouched
+// 	if len(svc.PodIPConfigState) != 1 {
+// 		t.Fatalf("Expected bad ipconfig to not be added added.")
+// 	}
+// }
+
+// func TestIPAMExpectStateToNotChangeWhenChangingAllocatedToAvailable(t *testing.T) {
+// 	svc := getTestService()
+// 	// add two ipconfigs, one as available, the other as allocated
+// 	state1, _ := NewPodStateWithOrchestratorContext(testIP1, 24, testPod1GUID, testNCID, cns.Available, testPod1Info)
+// 	state2, _ := NewPodStateWithOrchestratorContext(testIP2, 24, testPod2GUID, testNCID, cns.Allocated, testPod2Info)
+
+// 	ipconfigs := map[string]IpConfigurationStatus{
+// 		state1.ID: state1,
+// 		state2.ID: state2,
+// 	}
+
+// 	err := UpdatePodIpConfigState(svc, ipconfigs)
+// 	if err != nil {
+// 		t.Fatalf("Expected to not fail adding IP's to state: %+v", err)
+// 	}
+
+// 	// create state2 again, but as available
+// 	state2Available, _ := NewPodStateWithOrchestratorContext(testIP2, 24, testPod2GUID, testNCID, cns.Available, testPod2Info)
+
+// 	// add an available and allocated ipconfig
+// 	ipconfigsTest := map[string]IpConfigurationStatus{
+// 		state1.ID: state1,
+// 		state2.ID: state2Available,
+// 	}
+
+// 	// expect to fail overwriting an allocated state with available
+// 	err = UpdatePodIpConfigState(svc, ipconfigsTest)
+// 	if err == nil {
+// 		t.Fatalf("Expected to fail when overwriting an allocated state as available: %+v", err)
+// 	}
+
+// 	// get allocated ipconfigs, should only be one from the inital call, and not 2 from the failed call
+// 	availableIPconfigs := svc.GetAvailableIPConfigs()
+// 	if len(availableIPconfigs) != 1 {
+// 		t.Fatalf("More than expected available IP configs in state")
+// 	}
+
+// 	// get allocated ipconfigs, should only be one from the inital call, and not 0 from the failed call
+// 	allocatedIPconfigs := svc.GetAllocatedIPConfigs()
+// 	if len(allocatedIPconfigs) != 1 {
+// 		t.Fatalf("More than expected allocated IP configs in state")
+// 	}
+// }

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -142,8 +142,8 @@ func validateNetworkRequest(t *testing.T, req cns.CreateNetworkContainerRequest)
 				t.Errorf("PodIpConfigState has stale ipId: %s, config: %+v", ipid, ipStatus)
 				t.Fatal()
 			} else {
-				if ipStatus.IPConfig.IPSubnet != secondaryIpConfig.IPSubnet {
-					t.Errorf("IPId: %s IPSubnet doesnt match: expected %+v, actual: %+v", ipid, secondaryIpConfig.IPSubnet, ipStatus.IPConfig.IPSubnet)
+				if ipStatus.IPSubnet != secondaryIpConfig.IPSubnet {
+					t.Errorf("IPId: %s IPSubnet doesnt match: expected %+v, actual: %+v", ipid, secondaryIpConfig.IPSubnet, ipStatus.IPSubnet)
 					t.Fatal()
 				}
 
@@ -153,12 +153,12 @@ func validateNetworkRequest(t *testing.T, req cns.CreateNetworkContainerRequest)
 					t.Fatal()
 				}
 
-				alreadyValidated[ipid] = ipStatus.IPConfig.IPSubnet.IPAddress
+				alreadyValidated[ipid] = ipStatus.IPSubnet.IPAddress
 			}
 		} else {
 			// if ipaddress is not same, then fail
-			if ipaddress != ipStatus.IPConfig.IPSubnet.IPAddress {
-				t.Errorf("Added the same IP guid :%s with different ipaddress, expected:%s, actual %s", ipid, ipStatus.IPConfig.IPSubnet.IPAddress, ipaddress)
+			if ipaddress != ipStatus.IPSubnet.IPAddress {
+				t.Errorf("Added the same IP guid :%s with different ipaddress, expected:%s, actual %s", ipid, ipStatus.IPSubnet.IPAddress, ipaddress)
 				t.Fatal()
 			}
 		}

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -4,7 +4,134 @@
 package restserver
 
 import (
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/google/uuid"
 )
+
+const (
+	primaryIp = "10.0.0.5"
+	gatewayIp = "10.0.0.1"
+	dockerContainerType = cns.Docker
+)
+
+func TestCreateOrUpdateNetworkContainerInternal(t *testing.T) {
+	// requires more than 30 seconds to run
+	fmt.Println("Test: TestCreateOrUpdateNetworkContainerInternal")
+
+	setEnv(t)
+	setOrchastratorTypeInternal(cns.KubernetesCRD)
+
+	err := createOrUpdateNetworkContainerInternal(t, 2)
+	if err != nil {
+		t.Errorf("Failed to save the goal state for network container of type JobObject "+
+			" due to error: %+v", err)
+		t.Fatal(err)
+	}
+}
+
+func setOrchastratorTypeInternal(orchestratorType string) {
+	fmt.Println("setOrchastratorTypeInternal")
+	svc.state.OrchestratorType = orchestratorType
+}
+
+func createOrUpdateNetworkContainerInternal(t *testing.T, secondaryIpCount int) error {
+	var ipConfig cns.IPConfiguration
+	ipConfig.DNSServers = []string{"8.8.8.8", "8.8.4.4"}
+	ipConfig.GatewayIPAddress = gatewayIp
+	var ipSubnet cns.IPSubnet
+	ipSubnet.IPAddress = primaryIp
+	ipSubnet.PrefixLength = 32
+	ipConfig.IPSubnet = ipSubnet
+	secondaryIPConfigs := make(map[string]cns.SecondaryIPConfig)
+
+	var startingIndex = 6
+	for i := 1; i < secondaryIpCount; i++ {
+		ipaddress := "10.0.0." + string(startingIndex)
+		secIpConfig := newSecondaryIPConfig(ipaddress, 32)
+		ipId, err := uuid.NewUUID()
+
+		if (err != nil) {
+			t.Errorf("Failed to generate UUID for secondaryipconfig, err:%s", err)
+			t.Fatal(err)
+		}
+		secondaryIPConfigs[ipId.String()] = secIpConfig
+		startingIndex++
+	}
+	
+	req := cns.CreateNetworkContainerRequest{
+		NetworkContainerType:       dockerContainerType,
+		NetworkContainerid:         "testNcId1",
+		IPConfiguration:            ipConfig,
+		SecondaryIPConfigs: secondaryIPConfigs,
+	}
+
+	returnCode := svc.CreateOrUpdateNetworkContainerInternal(req)
+	if returnCode != 0 {
+		t.Errorf("Failed to createNetworkContainerRequest, req: %+v, err: %d", req, returnCode)
+		t.Fatal()
+	}
+
+	validateNetworkRequest(t, req)
+
+	return nil
+}
+
+// Validate the networkRequest is persisted.
+func validateNetworkRequest(t *testing.T, req cns.CreateNetworkContainerRequest) {
+	containerStatus := svc.state.ContainerStatus[req.NetworkContainerid]
+
+	if containerStatus.ID != req.NetworkContainerid {
+		t.Errorf("Failed as NCId is not persisted, expected:%s, actual %s", req.NetworkContainerid, containerStatus.ID)
+		t.Fatal()
+	}
+
+	actualReq := containerStatus.CreateNetworkContainerRequest
+	if actualReq.NetworkContainerType != req.NetworkContainerType {
+		t.Errorf("Failed as ContainerTyper doesnt match, expected:%s, actual %s", req.NetworkContainerType, actualReq.NetworkContainerType)
+		t.Fatal()
+	}
+
+    if actualReq.IPConfiguration.IPSubnet.IPAddress != req.IPConfiguration.IPSubnet.IPAddress {
+		t.Errorf("Failed as Primary IPAddress doesnt match, expected:%s, actual %s", req.IPConfiguration.IPSubnet.IPAddress, actualReq.IPConfiguration.IPSubnet.IPAddress)
+		t.Fatal()
+	}
+
+	// Validate Secondary ips are added in the PodMap
+	if len(svc.PodIPConfigState) != len(req.SecondaryIPConfigs) {
+		t.Errorf("Failed as Secondary IP count doesnt match in PodIpConfig state, expected:%d, actual %d", len(req.SecondaryIPConfigs), len(svc.PodIPConfigState))
+		t.Fatal()
+	}
+
+	var alreadyValidated = make(map[string]string)
+	for ipid, ipStatus := range svc.PodIPConfigState {
+		if ipaddress, found := alreadyValidated[ipid]; !found {
+			if secondaryIpConfig, ok := req.SecondaryIPConfigs[ipid]; !ok {
+				t.Errorf("PodIpConfigState has stale ipId: %s, config: %+v", ipid, ipStatus)
+				t.Fatal()
+			} else {
+				if ipStatus.IPConfig.IPSubnet == secondaryIpConfig.IPSubnet {
+					t.Errorf("IPId: %s IPSubnet doesnt match: expected %+v, actual: %+v", ipid, secondaryIpConfig.IPSubnet, ipStatus.IPConfig.IPSubnet)
+					t.Fatal()
+				}
+
+				// Validate IP state
+				
+				alreadyValidated[ipid] = ipStatus.IPConfig.IPSubnet.IPAddress
+			}
+		} else {
+			// if ipaddress is not same, then fail
+			if ipaddress != ipStatus.IPConfig.IPSubnet.IPAddress {
+				t.Errorf("Added the same IP guid :%s with different ipaddress, expected:%s, actual %s", ipid, ipStatus.IPConfig.IPSubnet.IPAddress, ipaddress)
+				t.Fatal()
+			}
+		}
+
+	}
+}
+
 
 // func TestIPAMExpectFailWhenAddingBadIPConfig(t *testing.T) {
 // 	svc := getTestService()

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -24,11 +24,7 @@ func TestCreateOrUpdateNetworkContainerInternal(t *testing.T) {
 	setEnv(t)
 	setOrchestratorTypeInternal(cns.KubernetesCRD)
 
-	err := createOrUpdateNetworkContainerInternal(t, 2)
-	if err != nil {
-		t.Fatalf("Failed to save the goal state for network container of type JobObject "+
-			" due to error: %+v", err)
-	}
+	validateCreateOrUpdateNCInternal(t, 2)
 }
 
 func setOrchestratorTypeInternal(orchestratorType string) {
@@ -36,7 +32,7 @@ func setOrchestratorTypeInternal(orchestratorType string) {
 	svc.state.OrchestratorType = orchestratorType
 }
 
-func createOrUpdateNetworkContainerInternal(t *testing.T, secondaryIpCount int) {
+func validateCreateOrUpdateNCInternal(t *testing.T, secondaryIpCount int) {
 	secondaryIPConfigs := make(map[string]cns.SecondaryIPConfig)
 
 	var startingIndex = 6

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -6,6 +6,7 @@ package restserver
 import (
 	"fmt"
 	"testing"
+	"strconv"
 
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/google/uuid"
@@ -38,18 +39,11 @@ func setOrchastratorTypeInternal(orchestratorType string) {
 }
 
 func createOrUpdateNetworkContainerInternal(t *testing.T, secondaryIpCount int) error {
-	var ipConfig cns.IPConfiguration
-	ipConfig.DNSServers = []string{"8.8.8.8", "8.8.4.4"}
-	ipConfig.GatewayIPAddress = gatewayIp
-	var ipSubnet cns.IPSubnet
-	ipSubnet.IPAddress = primaryIp
-	ipSubnet.PrefixLength = 32
-	ipConfig.IPSubnet = ipSubnet
 	secondaryIPConfigs := make(map[string]cns.SecondaryIPConfig)
 
 	var startingIndex = 6
-	for i := 1; i < secondaryIpCount; i++ {
-		ipaddress := "10.0.0." + string(startingIndex)
+	for i := 0; i < secondaryIpCount; i++ {
+		ipaddress := "10.0.0." + strconv.Itoa(startingIndex)
 		secIpConfig := newSecondaryIPConfig(ipaddress, 32)
 		ipId, err := uuid.NewUUID()
 
@@ -61,22 +55,58 @@ func createOrUpdateNetworkContainerInternal(t *testing.T, secondaryIpCount int) 
 		startingIndex++
 	}
 	
-	req := cns.CreateNetworkContainerRequest{
-		NetworkContainerType:       dockerContainerType,
-		NetworkContainerid:         "testNcId1",
-		IPConfiguration:            ipConfig,
-		SecondaryIPConfigs: secondaryIPConfigs,
+	createAndValidateNCRequest(t, secondaryIPConfigs)
+
+	// now Validate Update, add more secondaryIpConfig and it should handle the update
+	fmt.Println("Validate Scaleup")
+	for i := 0; i < secondaryIpCount; i++ {
+		ipaddress := "10.0.0." + strconv.Itoa(startingIndex)
+		secIpConfig := newSecondaryIPConfig(ipaddress, 32)
+		ipId, err := uuid.NewUUID()
+
+		if (err != nil) {
+			t.Errorf("Failed to generate UUID for secondaryipconfig, err:%s", err)
+			t.Fatal(err)
+		}
+		secondaryIPConfigs[ipId.String()] = secIpConfig
+		startingIndex++
 	}
 
+	createAndValidateNCRequest(t, secondaryIPConfigs)
+
+	// now Scale down, delete 3 ipaddresses from secondaryIpConfig req
+	fmt.Println("Validate Scalesown")
+	var count = 0
+	for ipid, _ := range secondaryIPConfigs {
+		delete(secondaryIPConfigs, ipid)
+		count++
+
+		if count > secondaryIpCount {
+			break
+		}
+	}
+
+	createAndValidateNCRequest(t, secondaryIPConfigs)
+
+	// Cleanup all SecondaryIps
+	fmt.Println("Validate no SecondaryIpconfigs")
+	for ipid, _ := range secondaryIPConfigs {
+		delete(secondaryIPConfigs, ipid)
+	}
+
+	createAndValidateNCRequest(t, secondaryIPConfigs)
+
+	return nil
+}
+
+func createAndValidateNCRequest(t *testing.T, secondaryIPConfigs map[string]cns.SecondaryIPConfig) {
+	req := generateNetworkContainerRequest(secondaryIPConfigs)
 	returnCode := svc.CreateOrUpdateNetworkContainerInternal(req)
 	if returnCode != 0 {
 		t.Errorf("Failed to createNetworkContainerRequest, req: %+v, err: %d", req, returnCode)
 		t.Fatal()
 	}
-
 	validateNetworkRequest(t, req)
-
-	return nil
 }
 
 // Validate the networkRequest is persisted.
@@ -112,13 +142,17 @@ func validateNetworkRequest(t *testing.T, req cns.CreateNetworkContainerRequest)
 				t.Errorf("PodIpConfigState has stale ipId: %s, config: %+v", ipid, ipStatus)
 				t.Fatal()
 			} else {
-				if ipStatus.IPConfig.IPSubnet == secondaryIpConfig.IPSubnet {
+				if ipStatus.IPConfig.IPSubnet != secondaryIpConfig.IPSubnet {
 					t.Errorf("IPId: %s IPSubnet doesnt match: expected %+v, actual: %+v", ipid, secondaryIpConfig.IPSubnet, ipStatus.IPConfig.IPSubnet)
 					t.Fatal()
 				}
 
 				// Validate IP state
-				
+				if ipStatus.State != cns.Available {
+					t.Errorf("IPId: %s State is not Available, ipStatus: %+v", ipid, ipStatus)
+					t.Fatal()
+				}
+
 				alreadyValidated[ipid] = ipStatus.IPConfig.IPSubnet.IPAddress
 			}
 		} else {
@@ -128,87 +162,28 @@ func validateNetworkRequest(t *testing.T, req cns.CreateNetworkContainerRequest)
 				t.Fatal()
 			}
 		}
-
 	}
 }
 
+func generateNetworkContainerRequest(secondaryIps map[string]cns.SecondaryIPConfig) cns.CreateNetworkContainerRequest{
+    var ipConfig cns.IPConfiguration
+	ipConfig.DNSServers = []string{"8.8.8.8", "8.8.4.4"}
+	ipConfig.GatewayIPAddress = gatewayIp
+	var ipSubnet cns.IPSubnet
+	ipSubnet.IPAddress = primaryIp
+	ipSubnet.PrefixLength = 32
+	ipConfig.IPSubnet = ipSubnet
 
-// func TestIPAMExpectFailWhenAddingBadIPConfig(t *testing.T) {
-// 	svc := getTestService()
+	req := cns.CreateNetworkContainerRequest{
+		NetworkContainerType:       dockerContainerType,
+		NetworkContainerid:         "testNcId1",
+		IPConfiguration:            ipConfig,
+	}
 
-// 	var err error
+	req.SecondaryIPConfigs = make(map[string]cns.SecondaryIPConfig)
+	for k, v := range secondaryIps {
+		req.SecondaryIPConfigs[k] = v
+	}
 
-// 	// set state as already allocated
-// 	state1, _ := NewPodStateWithOrchestratorContext(testIP1, 24, testPod1GUID, testNCID, cns.Available, testPod1Info)
-
-// 	ipconfigs := map[string]IpConfigurationStatus{
-// 		state1.ID: state1,
-// 	}
-
-// 	err = UpdatePodIpConfigState(svc, ipconfigs)
-// 	if err != nil {
-// 		t.Fatalf("Expected to not fail when good ipconfig is added")
-// 	}
-
-// 	// create bad ipconfig
-// 	state2, _ := NewPodStateWithOrchestratorContext("", 24, "", testNCID, cns.Available, testPod1Info)
-
-// 	ipconfigs2 := map[string]IpConfigurationStatus{
-// 		state2.ID: state2,
-// 	}
-
-// 	// add a bad ipconfig
-// 	err = UpdatePodIpConfigState(svc, ipconfigs2)
-// 	if err == nil {
-// 		t.Fatalf("Expected add to fail when bad ipconfig is added.")
-// 	}
-
-// 	// ensure state remains untouched
-// 	if len(svc.PodIPConfigState) != 1 {
-// 		t.Fatalf("Expected bad ipconfig to not be added added.")
-// 	}
-// }
-
-// func TestIPAMExpectStateToNotChangeWhenChangingAllocatedToAvailable(t *testing.T) {
-// 	svc := getTestService()
-// 	// add two ipconfigs, one as available, the other as allocated
-// 	state1, _ := NewPodStateWithOrchestratorContext(testIP1, 24, testPod1GUID, testNCID, cns.Available, testPod1Info)
-// 	state2, _ := NewPodStateWithOrchestratorContext(testIP2, 24, testPod2GUID, testNCID, cns.Allocated, testPod2Info)
-
-// 	ipconfigs := map[string]IpConfigurationStatus{
-// 		state1.ID: state1,
-// 		state2.ID: state2,
-// 	}
-
-// 	err := UpdatePodIpConfigState(svc, ipconfigs)
-// 	if err != nil {
-// 		t.Fatalf("Expected to not fail adding IP's to state: %+v", err)
-// 	}
-
-// 	// create state2 again, but as available
-// 	state2Available, _ := NewPodStateWithOrchestratorContext(testIP2, 24, testPod2GUID, testNCID, cns.Available, testPod2Info)
-
-// 	// add an available and allocated ipconfig
-// 	ipconfigsTest := map[string]IpConfigurationStatus{
-// 		state1.ID: state1,
-// 		state2.ID: state2Available,
-// 	}
-
-// 	// expect to fail overwriting an allocated state with available
-// 	err = UpdatePodIpConfigState(svc, ipconfigsTest)
-// 	if err == nil {
-// 		t.Fatalf("Expected to fail when overwriting an allocated state as available: %+v", err)
-// 	}
-
-// 	// get allocated ipconfigs, should only be one from the inital call, and not 2 from the failed call
-// 	availableIPconfigs := svc.GetAvailableIPConfigs()
-// 	if len(availableIPconfigs) != 1 {
-// 		t.Fatalf("More than expected available IP configs in state")
-// 	}
-
-// 	// get allocated ipconfigs, should only be one from the inital call, and not 0 from the failed call
-// 	allocatedIPconfigs := svc.GetAllocatedIPConfigs()
-// 	if len(allocatedIPconfigs) != 1 {
-// 		t.Fatalf("More than expected allocated IP configs in state")
-// 	}
-// }
+	return req
+}

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -39,11 +39,7 @@ func validateCreateOrUpdateNCInternal(t *testing.T, secondaryIpCount int) {
 	for i := 0; i < secondaryIpCount; i++ {
 		ipaddress := "10.0.0." + strconv.Itoa(startingIndex)
 		secIpConfig := newSecondaryIPConfig(ipaddress, 32)
-		ipId, err := uuid.NewUUID()
-
-		if err != nil {
-			t.Fatalf("Failed to generate UUID for secondaryipconfig, err:%s", err)
-		}
+		ipId := uuid.New()
 		secondaryIPConfigs[ipId.String()] = secIpConfig
 		startingIndex++
 	}
@@ -55,11 +51,7 @@ func validateCreateOrUpdateNCInternal(t *testing.T, secondaryIpCount int) {
 	for i := 0; i < secondaryIpCount; i++ {
 		ipaddress := "10.0.0." + strconv.Itoa(startingIndex)
 		secIpConfig := newSecondaryIPConfig(ipaddress, 32)
-		ipId, err := uuid.NewUUID()
-
-		if (err != nil) {
-			t.Fatalf("Failed to generate UUID for secondaryipconfig, err:%s", err)
-		}
+		ipId := uuid.New()
 		secondaryIPConfigs[ipId.String()] = secIpConfig
 		startingIndex++
 	}

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -92,27 +92,27 @@ func (service *HTTPRestService) releaseIPConfigHandler(w http.ResponseWriter, r 
 	return
 }
 
-func (service *HTTPRestService) GetAllocatedIPConfigs() []*ipConfigurationStatus {
+func (service *HTTPRestService) GetAllocatedIPConfigs() []ipConfigurationStatus {
 	service.RLock()
 	defer service.RUnlock()
-	return filterIPConfigMap(service.PodIPConfigState, func(ipconfig *ipConfigurationStatus) bool {
+	return filterIPConfigMap(service.PodIPConfigState, func(ipconfig ipConfigurationStatus) bool {
 		return ipconfig.State == cns.Allocated
 	})
 }
 
-func (service *HTTPRestService) GetAvailableIPConfigs() []*ipConfigurationStatus {
+func (service *HTTPRestService) GetAvailableIPConfigs() []ipConfigurationStatus {
 	service.RLock()
 	defer service.RUnlock()
-	return filterIPConfigMap(service.PodIPConfigState, func(ipconfig *ipConfigurationStatus) bool {
+	return filterIPConfigMap(service.PodIPConfigState, func(ipconfig ipConfigurationStatus) bool {
 		return ipconfig.State == cns.Available
 	})
 }
 
-func filterIPConfigMap(toBeAdded map[string]ipConfigurationStatus, f func(*ipConfigurationStatus) bool) []*ipConfigurationStatus {
-	vsf := make([]*ipConfigurationStatus, 0)
+func filterIPConfigMap(toBeAdded map[string]ipConfigurationStatus, f func(ipConfigurationStatus) bool) []ipConfigurationStatus {
+	vsf := make([]ipConfigurationStatus, 0)
 	for _, v := range toBeAdded {
-		if f(&v) {
-			vsf = append(vsf, &v)
+		if f(v) {
+			vsf = append(vsf, v)
 		}
 	}
 	return vsf

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -4,6 +4,7 @@
 package restserver
 
 import (
+	"encoding/json"
 	"sync"
 	"time"
 
@@ -23,6 +24,7 @@ import (
 // all HTTP APIs - api.go and/or ipam.go
 // APIs for internal consumption - internalapi.go
 // All helper/utility functions - util.go
+// Constants - const.go
 
 var (
 	// Named Lock for accessing different states in httpRestServiceState
@@ -36,9 +38,9 @@ type HTTPRestService struct {
 	imdsClient                   *imdsclient.ImdsClient
 	ipamClient                   *ipamclient.IpamClient
 	networkContainer             *networkcontainers.NetworkContainers
-	PodIPIDByOrchestratorContext map[string]string                     // OrchestratorContext is key and value is Pod IP uuid.
-	PodIPConfigState             map[string]cns.ContainerIPConfigState // seondaryipid(uuid) is key
-	AllocatedIPCount             map[string]allocatedIPCount           // key - ncid
+	PodIPIDByOrchestratorContext map[string]string                // OrchestratorContext is key and value is Pod IP uuid.
+	PodIPConfigState             map[string]IpConfigurationStatus // seondaryipid(uuid) is key
+	AllocatedIPCount             map[string]allocatedIPCount      // key - ncid
 	routingTable                 *routes.RoutingTable
 	store                        store.KeyValueStore
 	state                        *httpRestServiceState
@@ -48,6 +50,16 @@ type HTTPRestService struct {
 
 type allocatedIPCount struct {
 	Count int
+}
+
+// This is used for KubernetesCRD orchastrator Type where NC has multiple ips.
+// This struct captures the state for SecondaryIPs associated to a given NC
+type IpConfigurationStatus struct {
+	NCID                string
+	ID                  string //uuid
+	IPConfig            cns.SecondaryIPConfig
+	State               string
+	OrchestratorContext json.RawMessage
 }
 
 // containerstatus is used to save status of an existing container
@@ -110,7 +122,7 @@ func NewHTTPRestService(config *common.ServiceConfig) (HTTPService, error) {
 	serviceState.joinedNetworks = make(map[string]struct{})
 
 	podIPIDByOrchestratorContext := make(map[string]string)
-	podIPConfigState := make(map[string]cns.ContainerIPConfigState)
+	podIPConfigState := make(map[string]IpConfigurationStatus)
 	allocatedIPCount := make(map[string]allocatedIPCount) // key - ncid
 
 	return &HTTPRestService{

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -39,7 +39,7 @@ type HTTPRestService struct {
 	ipamClient                   *ipamclient.IpamClient
 	networkContainer             *networkcontainers.NetworkContainers
 	PodIPIDByOrchestratorContext map[string]string                // OrchestratorContext is key and value is Pod IP uuid.
-	PodIPConfigState             map[string]IpConfigurationStatus // seondaryipid(uuid) is key
+	PodIPConfigState             map[string]ipConfigurationStatus // seondaryipid(uuid) is key
 	AllocatedIPCount             map[string]allocatedIPCount      // key - ncid
 	routingTable                 *routes.RoutingTable
 	store                        store.KeyValueStore
@@ -54,10 +54,10 @@ type allocatedIPCount struct {
 
 // This is used for KubernetesCRD orchastrator Type where NC has multiple ips.
 // This struct captures the state for SecondaryIPs associated to a given NC
-type IpConfigurationStatus struct {
+type ipConfigurationStatus struct {
 	NCID                string
 	ID                  string //uuid
-	IPConfig            cns.SecondaryIPConfig
+	IPSubnet            cns.IPSubnet
 	State               string
 	OrchestratorContext json.RawMessage
 }
@@ -122,7 +122,7 @@ func NewHTTPRestService(config *common.ServiceConfig) (HTTPService, error) {
 	serviceState.joinedNetworks = make(map[string]struct{})
 
 	podIPIDByOrchestratorContext := make(map[string]string)
-	podIPConfigState := make(map[string]IpConfigurationStatus)
+	podIPConfigState := make(map[string]ipConfigurationStatus)
 	allocatedIPCount := make(map[string]allocatedIPCount) // key - ncid
 
 	return &HTTPRestService{

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -255,7 +255,7 @@ func (service *HTTPRestService) addIPConfigStateUntransacted(ncId string, ipconf
 }
 
 // Todo: call this when request is received
-func validateIPConfig(ipSubnet cns.IPSubnet) error {
+func validateIPSubnet(ipSubnet cns.IPSubnet) error {
 	if ipSubnet.IPAddress == "" {
 		return fmt.Errorf("Failed to add IPConfig to state: %+v, empty IPSubnet.IPAddress", ipSubnet)
 	}
@@ -265,7 +265,7 @@ func validateIPConfig(ipSubnet cns.IPSubnet) error {
 	return nil
 }
 
-// removeToBeDeletedIpsStateUntransacted removes the IPConfis from the PodIpConfigState map
+// removeToBeDeletedIpsStateUntransacted removes IPConfigs from the PodIpConfigState map
 // Caller will acquire/release the service lock.
 func (service *HTTPRestService) removeToBeDeletedIpsStateUntransacted(ipId string, skipValidation bool) (int, string) {
 

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -238,10 +238,10 @@ func (service *HTTPRestService) addIPConfigStateUntransacted(ncId string, ipconf
 		}
 
 		// add the new State
-		ipconfigStatus := IpConfigurationStatus{
+		ipconfigStatus := ipConfigurationStatus{
 			NCID:                ncId,
 			ID:                  ipId,
-			IPConfig:            ipconfig,
+			IPSubnet:            ipconfig.IPSubnet,
 			State:               cns.Available,
 			OrchestratorContext: nil,
 		}
@@ -265,7 +265,7 @@ func validateIPConfig(ipSubnet cns.IPSubnet) error {
 
 //cleanupIpConfigState takes a lock on the service object, and will remove an array of ipconfigs to the CNS Service.
 //Used to add IPConfigs to the CNS pool, specifically in the scenario of rebatching.
-func (service *HTTPRestService) cleanupIpConfigState(ipconfigs []IpConfigurationStatus) error {
+func (service *HTTPRestService) cleanupIpConfigState(ipconfigs []ipConfigurationStatus) error {
 	service.Lock()
 	defer service.Unlock()
 

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -232,13 +232,6 @@ func (service *HTTPRestService) updateIpConfigsStateUntransacted(req cns.CreateN
 func (service *HTTPRestService) addIPConfigStateUntransacted(ncId string, ipconfigs map[string]cns.SecondaryIPConfig) {
 	// add ipconfigs to state
 	for ipId, ipconfig := range ipconfigs {
-		err := validateIPConfig(ipId, ipconfig)
-		if err != nil {
-			// todo panic crash, we have already updated some state until this point,
-			// this validation is required before we process the request
-			logger.Errorf("PanicCrash: SecondaryIPConfig is not valid")
-		}
-
 		// if this IPConfig already exists in the map, then ignore as this is an idempotent state
 		if _, exists := service.PodIPConfigState[ipId]; exists {
 			continue
@@ -260,15 +253,12 @@ func (service *HTTPRestService) addIPConfigStateUntransacted(ncId string, ipconf
 }
 
 // Todo: call this when request is received
-func validateIPConfig(ipId string, ipconfig cns.SecondaryIPConfig) error {
-	if ipId == "" {
-		return fmt.Errorf("Failed to add IPConfig to state: empty IP ID")
+func validateIPConfig(ipSubnet cns.IPSubnet) error {
+	if ipSubnet.IPAddress == "" {
+		return fmt.Errorf("Failed to add IPConfig to state: %+v, empty IPSubnet.IPAddress", ipSubnet)
 	}
-	if ipconfig.IPSubnet.IPAddress == "" {
-		return fmt.Errorf("Failed to add IPConfig to state: %+v, empty IPSubnet.IPAddress", ipconfig)
-	}
-	if ipconfig.IPSubnet.PrefixLength == 0 {
-		return fmt.Errorf("Failed to add IPConfig to state: %+v, empty IPSubnet.PrefixLength", ipconfig)
+	if ipSubnet.PrefixLength == 0 {
+		return fmt.Errorf("Failed to add IPConfig to state: %+v, empty IPSubnet.PrefixLength", ipSubnet)
 	}
 	return nil
 }


### PR DESCRIPTION
Added implementation for CreateOrUpdateNetworkContainerInternal. This will be called by the CNS requestController and it will handle SecondaryIpConfigs update which will add state for new Secondary ips and delete the state for any delta.

