### PR TITLE
Simplify AddToSet logic and fix an inconsistency set type creation.

### DIFF
--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -68,6 +68,20 @@ func (ipsMgr *IpsetManager) Exists(key string, val string, kind string) bool {
 	return true
 }
 
+// ExistsSet checks whehter an ipset exists.
+func (ipsMgr *IpsetManager) ExistsSet(setName, kind string) bool {
+    m := ipsMgr.setMap
+    if kind == util.IpsetSetListFlag {
+        m = ipsMgr.listMap
+    }
+
+    if _, exists := m[setName]; !exists {
+        return false
+    }
+
+    return true
+}
+
 func isNsSet(setName string) bool {
 	return !strings.Contains(setName, "-") && !strings.Contains(setName, ":")
 }
@@ -255,8 +269,10 @@ func (ipsMgr *IpsetManager) AddToSet(setName, ip, spec, podUid string) error {
 		return nil
 	}
 
-	if err := ipsMgr.CreateSet(setName, append([]string{util.IpsetNetHashFlag})); err != nil {
-		return err
+	if !ipsMgr.ExistsSet(setName, spec) {
+		if err := ipsMgr.CreateSet(setName, append([]string{spec})); err != nil {
+			return err
+		}
 	}
 	var resultSpec []string
 	if strings.Contains(ip, util.IpsetNomatch) {

--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -68,18 +68,14 @@ func (ipsMgr *IpsetManager) Exists(key string, val string, kind string) bool {
 	return true
 }
 
-// ExistsSet checks whehter an ipset exists.
-func (ipsMgr *IpsetManager) ExistsSet(setName, kind string) bool {
+// SetExists checks whehter an ipset exists.
+func (ipsMgr *IpsetManager) SetExists(setName, kind string) bool {
     m := ipsMgr.setMap
     if kind == util.IpsetSetListFlag {
         m = ipsMgr.listMap
     }
-
-    if _, exists := m[setName]; !exists {
-        return false
-    }
-
-    return true
+    _, exists := m[setName]
+    return exists
 }
 
 func isNsSet(setName string) bool {
@@ -269,7 +265,7 @@ func (ipsMgr *IpsetManager) AddToSet(setName, ip, spec, podUid string) error {
 		return nil
 	}
 
-	if !ipsMgr.ExistsSet(setName, spec) {
+	if !ipsMgr.SetExists(setName, spec) {
 		if err := ipsMgr.CreateSet(setName, append([]string{spec})); err != nil {
 			return err
 		}

--- a/npm/ipsm/ipsm_test.go
+++ b/npm/ipsm/ipsm_test.go
@@ -3,6 +3,7 @@
 package ipsm
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -144,15 +145,24 @@ func TestCreateSet(t *testing.T) {
 		t.Errorf("TestCreateSet failed @ ipsMgr.CreateSet when set maxelem")
 	}
 
+	testSet3Name := "test-set-with-port"
+	spec = append([]string{util.IpsetIPPortHashFlag})
+	if err := ipsMgr.CreateSet(testSet3Name, spec); err != nil {
+		t.Errorf("TestCreateSet failed @ ipsMgr.CreateSet when creating port set")
+	}
+	if err := ipsMgr.AddToSet(testSet3Name, fmt.Sprintf("%s,%s%d", "1.1.1.1", "tcp", 8080), util.IpsetIPPortHashFlag, "0"); err != nil {
+		t.Errorf("AddToSet failed @ ipsMgr.CreateSet when set port")
+	}
+
 	newGaugeVal, err3 := promutil.GetValue(metrics.NumIPSets)
 	newCountVal, err4 := promutil.GetCountValue(metrics.AddIPSetExecTime)
 	testSet1Count, err5 := promutil.GetVecValue(metrics.IPSetInventory, prometheus.Labels{metrics.SetNameLabel: testSet1Name})
 	testSet2Count, err6 := promutil.GetVecValue(metrics.IPSetInventory, prometheus.Labels{metrics.SetNameLabel: testSet2Name})
 	promutil.NotifyIfErrors(t, err1, err2, err3, err4, err5, err6)
-	if newGaugeVal != gaugeVal+2 {
+	if newGaugeVal != gaugeVal+3 {
 		t.Errorf("Change in ipset number didn't register in Prometheus")
 	}
-	if newCountVal != countVal+2 {
+	if newCountVal != countVal+3 {
 		t.Errorf("Execution time didn't register in Prometheus")
 	}
 	if testSet1Count != 0 || testSet2Count != 0 {


### PR DESCRIPTION
fix: an inconsistency set type creation introduced by AddToSet function.

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->NPM created 3 types of ipset. AddToSet will check whether set exist before adding entries. However, previous NPM logic only create 1 type of set in AddToSet function which introduced inconsistency between set type.

**Issue Fixed**:
Simplify logic to create set only when set is not exist for add to set logic.
Fix the inconsistency between set type.

  fix: Bug Fixes 🐞X
- [X ] adds unit tests
