### PR TITLE
Dockerfile for cns container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,7 +320,7 @@ ifeq ($(GOOS),linux)
 	docker build \
 	-f cns/aks.Dockerfile \
 	-t $(AZURE_CNS_IMAGE):$(VERSION) \
-	--build-arg CNS_VERSION=$(VERSION) \
+	--build-arg VERSION=$(VERSION) \
 	--build-arg CNS_AI_PATH=$(cnsaipath) \
 	--build-arg CNS_AI_ID=$(CNS_AI_ID) \
 	.

--- a/Makefile
+++ b/Makefile
@@ -313,6 +313,19 @@ ifeq ($(GOOS),linux)
 	docker save $(AZURE_CNS_IMAGE):$(VERSION) | gzip -c > $(CNS_BUILD_DIR)/$(CNS_IMAGE_ARCHIVE_NAME)
 endif
 
+# Build the Azure CNS image for AKS Swift.
+.PHONY: azure-cns-aks-swift-image
+azure-cns-aks-swift-image:
+ifeq ($(GOOS),linux)
+	docker build \
+	-f cns/aks.Dockerfile \
+	-t $(AZURE_CNS_IMAGE):$(VERSION) \
+	--build-arg CNS_VERSION=$(VERSION) \
+	--build-arg CNS_AI_PATH=$(cnsaipath) \
+	--build-arg CNS_AI_ID=$(CNS_AI_ID) \
+	.
+endif
+
 # Publish the Azure NPM image to a Docker registry
 .PHONY: publish-azure-cns-image
 publish-azure-cns-image:

--- a/cns/aks.Dockerfile
+++ b/cns/aks.Dockerfile
@@ -5,7 +5,7 @@ RUN apk --update add ca-certificates
 # Build cns
 FROM golang:1.14-alpine AS builder
 # Build ars
-ARG CNS_VERSION
+ARG VERSION
 ARG CNS_AI_PATH
 ARG CNS_AI_ID
 
@@ -14,8 +14,11 @@ WORKDIR /usr/local/src/cns
 # Copy the source
 COPY . .
 
-# Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o /usr/local/bin/azure-cns -ldflags "-X main.version="$CNS_VERSION" -X "$CNS_AI_PATH"="$CNS_AI_ID" -s -w " cns/service/*.go
+# Build cns
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o /usr/local/bin/azure-cns -ldflags "-X main.version="$VERSION" -X "$CNS_AI_PATH"="$CNS_AI_ID" -s -w " cns/service/*.go
+
+# Build aitelemetry
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o /usr/local/bin/azure-vnet-telemetry -ldflags "-X main.version="$VERSION" -s -w" cni/telemetry/service/*.go
 
 # Copy into final image
 FROM scratch
@@ -23,6 +26,8 @@ COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /usr/local/bin/azure-cns \
 	/usr/local/bin/azure-cns
+COPY --from=builder /usr/local/bin/azure-vnet-telemetry \
+    /usr/local/bin/azure-vnet-telemetry
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 ENTRYPOINT [ "/usr/local/bin/azure-cns" ]

--- a/cns/aks.Dockerfile
+++ b/cns/aks.Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /usr/local/src/cns
 COPY . .
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o /usr/local/bin/azure-cns -ldflags "-X main.version="+$CNS_VERSION+" -X "+$CNS_AI_PATH+"="+$CNS_AI_ID+" -s -w " cns/service/*.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o /usr/local/bin/azure-cns -ldflags "-X main.version="$CNS_VERSION" -X "$CNS_AI_PATH"="$CNS_AI_ID" -s -w " cns/service/*.go
 
 # Copy into final image
 FROM scratch

--- a/cns/aks.Dockerfile
+++ b/cns/aks.Dockerfile
@@ -1,0 +1,29 @@
+# Get a trusted CA cert bundle
+FROM alpine:latest as certs
+RUN apk --update add ca-certificates
+
+# Build cns
+FROM golang:1.14-alpine AS builder
+# Build ars
+ARG CNS_VERSION
+ARG CNS_AI_PATH
+ARG CNS_AI_ID
+
+WORKDIR /usr/local/src/cns
+
+# Copy the source
+COPY . .
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o /usr/local/bin/azure-cns -ldflags "-X main.version="+$CNS_VERSION+" -X "+$CNS_AI_PATH+"="+$CNS_AI_ID+" -s -w " cns/service/*.go
+
+# Copy into final image
+FROM scratch
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /usr/local/bin/azure-cns \
+	/usr/local/bin/azure-cns
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+ENTRYPOINT [ "/usr/local/bin/azure-cns" ]
+EXPOSE 10090


### PR DESCRIPTION
**Reason for Change**:
This PR adds a dockerfile for cns. It is an improvement of the previous dockerfile in terms of best practices of containers.
Mainly, the container only has the binary, and builds the binary as part of the dockerfile, instead of how it was doing it before of copying in a pre-built binary into the dockerfile.

Also this new dockerfile only pulls in the necessary dependencies, wheras the old dockerfile brought many unused dependencies into the image.

I'm thinking we can keep both for now, and eventually remove the old one, as well as update the runner yamls to use the new container.