### PR TITLE
Add kernel status checking in unit test for TestDeleteFromList.

### DIFF
--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -92,6 +92,8 @@ const (
 
 	IpsetExistFlag string = "-exist"
 	IpsetFileFlag  string = "-file"
+	IPsetCheckListFlag string = "list"
+	IpsetTestFlag  string = "test"
 
 	IpsetSetListFlag    string = "setlist"
 	IpsetNetHashFlag    string = "nethash"


### PR DESCRIPTION
test: kernel status checking in unit test for TestDeleteFromList. 

**Reason for Change**:
Previous unit test only check whether error happens when calling DeleteFromList. Add logic to check whether the kernel status match what we expect.
If it works properly, then more kernel status checking will be added in unit test. 

- [X ] adds unit tests
