### PR TITLE
CNI not to rehydrate based on reboot time

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -116,7 +116,7 @@ func (plugin *netPlugin) Start(config *common.PluginConfig) error {
 	common.LogNetworkInterfaces()
 
 	// Initialize network manager.
-	err = plugin.nm.Initialize(config)
+	err = plugin.nm.Initialize(config, false)
 	if err != nil {
 		log.Printf("[cni-net] Failed to initialize network manager, err:%v.", err)
 		return err

--- a/cni/plugin.go
+++ b/cni/plugin.go
@@ -160,19 +160,7 @@ func (plugin *Plugin) InitializeKeyValueStore(config *common.PluginConfig) error
 		}
 
 		// Force unlock the json store if the lock file is left on the node after reboot
-		if lockFileModTime, err := plugin.Store.GetLockFileModificationTime(); err == nil {
-			rebootTime, err := platform.GetLastRebootTime()
-			log.Printf("[cni] reboot time %v storeLockFile mod time %v", rebootTime, lockFileModTime)
-			if err == nil && rebootTime.After(lockFileModTime) {
-				log.Printf("[cni] Detected Reboot")
-
-				if err := plugin.Store.Unlock(true); err != nil {
-					log.Printf("[cni] Failed to force unlock store due to error %v", err)
-				} else {
-					log.Printf("[cni] Force unlocked the store successfully")
-				}
-			}
-		}
+		removeLockFileAfterReboot(plugin)
 	}
 
 	// Acquire store lock.

--- a/cni/plugin_linux.go
+++ b/cni/plugin_linux.go
@@ -1,0 +1,11 @@
+package cni
+
+import (
+	"github.com/Azure/azure-container-networking/log"
+	"github.com/Azure/azure-container-networking/platform"
+)
+
+func removeLockFileAfterReboot(plugin *Plugin) {
+	rebootTime, _ := platform.GetLastRebootTime()
+	log.Printf("[cni] reboot time %v", rebootTime)
+}

--- a/cni/plugin_windows.go
+++ b/cni/plugin_windows.go
@@ -1,0 +1,22 @@
+package cni
+
+import (
+	"github.com/Azure/azure-container-networking/log"
+	"github.com/Azure/azure-container-networking/platform"
+)
+
+func removeLockFileAfterReboot(plugin *Plugin) {
+	if lockFileModTime, err := plugin.Store.GetLockFileModificationTime(); err == nil {
+		rebootTime, err := platform.GetLastRebootTime()
+		log.Printf("[cni] reboot time %v storeLockFile mod time %v", rebootTime, lockFileModTime)
+		if err == nil && rebootTime.After(lockFileModTime) {
+			log.Printf("[cni] Detected Reboot")
+
+			if err := plugin.Store.Unlock(true); err != nil {
+				log.Printf("[cni] Failed to force unlock store due to error %v", err)
+			} else {
+				log.Printf("[cni] Force unlocked the store successfully")
+			}
+		}
+	}
+}

--- a/cnm/network/network.go
+++ b/cnm/network/network.go
@@ -71,7 +71,7 @@ func (plugin *netPlugin) Start(config *common.PluginConfig) error {
 	}
 
 	// Initialize network manager.
-	err = plugin.nm.Initialize(config)
+	err = plugin.nm.Initialize(config, true)
 	if err != nil {
 		log.Printf("[net] Failed to initialize network manager, err:%v.", err)
 		return err

--- a/cnms/service/networkmonitor.go
+++ b/cnms/service/networkmonitor.go
@@ -152,7 +152,7 @@ func main() {
 			return
 		}
 
-		if err := nm.Initialize(&config); err != nil {
+		if err := nm.Initialize(&config, false); err != nil {
 			log.Printf("[monitor] Failed while initializing network manager %+v", err)
 		}
 

--- a/ipam/manager.go
+++ b/ipam/manager.go
@@ -363,6 +363,7 @@ func (am *addressManager) RequestAddress(asId, poolId, address string, options m
 
 	err = am.save()
 	if err != nil {
+		ap.releaseAddress(addr, options)
 		return "", err
 	}
 

--- a/network/manager_test.go
+++ b/network/manager_test.go
@@ -51,7 +51,7 @@ var (
 			Context("When restore is nil", func() {
 				It("Should return nil", func() {
 					nm := &networkManager{}
-					err := nm.restore()
+					err := nm.restore(false)
 					Expect(err).NotTo(HaveOccurred())
 				})
 			})
@@ -63,7 +63,7 @@ var (
 							ReadError: store.ErrKeyNotFound,
 						},
 					}
-					err := nm.restore()
+					err := nm.restore(false)
 					Expect(err).NotTo(HaveOccurred())
 				})
 			})
@@ -75,7 +75,7 @@ var (
 							ReadError: errors.New("error for test"),
 						},
 					}
-					err := nm.restore()
+					err := nm.restore(false)
 					Expect(err).To(HaveOccurred())
 				})
 			})
@@ -91,11 +91,11 @@ var (
 						ExternalInterfaces: map[string]*externalInterface{},
 					}
 					nm.ExternalInterfaces[extIfName] = &externalInterface{
-						Name: extIfName,
+						Name:     extIfName,
 						Networks: map[string]*network{},
 					}
 					nm.ExternalInterfaces[extIfName].Networks[nwId] = &network{}
-					err := nm.restore()
+					err := nm.restore(false)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(nm.ExternalInterfaces[extIfName].Networks[nwId].extIf.Name).To(Equal(extIfName))
 				})
@@ -104,7 +104,7 @@ var (
 
 		Describe("Test save", func() {
 			Context("When store is nil", func() {
-				It("Should return nil", func(){
+				It("Should return nil", func() {
 					nm := &networkManager{}
 					err := nm.save()
 					Expect(err).NotTo(HaveOccurred())
@@ -112,7 +112,7 @@ var (
 				})
 			})
 			Context("When store.Write return error", func() {
-				It("Should raise error", func(){
+				It("Should raise error", func() {
 					nm := &networkManager{
 						store: &testutils.KeyValueStoreMock{
 							WriteError: errors.New("error for test"),
@@ -120,7 +120,8 @@ var (
 					}
 					err := nm.save()
 					Expect(err).To(HaveOccurred())
-					Expect(nm.TimeStamp).NotTo(Equal(time.Time{}))})
+					Expect(nm.TimeStamp).NotTo(Equal(time.Time{}))
+				})
 			})
 		})
 
@@ -198,9 +199,9 @@ var (
 					}
 					nm.ExternalInterfaces[ifName].Networks[nwId] = &network{
 						Endpoints: map[string]*endpoint{
-							"ep1":&endpoint{},
-							"ep2":&endpoint{},
-							"ep3":&endpoint{},
+							"ep1": &endpoint{},
+							"ep2": &endpoint{},
+							"ep3": &endpoint{},
 						},
 					}
 					num := nm.GetNumberOfEndpoints(ifName, nwId)
@@ -220,9 +221,9 @@ var (
 					}
 					nm.ExternalInterfaces[ifName].Networks[nwId] = &network{
 						Endpoints: map[string]*endpoint{
-							"ep1":&endpoint{},
-							"ep2":&endpoint{},
-							"ep3":&endpoint{},
+							"ep1": &endpoint{},
+							"ep2": &endpoint{},
+							"ep3": &endpoint{},
 						},
 					}
 					num := nm.GetNumberOfEndpoints("", nwId)


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
uptime -s returns different values due to clock drift and cni need not rehydrate based on reboot time.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
#639 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
