### PR TITLE
Add gateway to NCRequest in CRD Translator

### DIFF
--- a/cns/requestcontroller/kubecontroller/crdtranslator.go
+++ b/cns/requestcontroller/kubecontroller/crdtranslator.go
@@ -46,6 +46,7 @@ func CRDStatusToNCRequest(crdStatus nnc.NodeNetworkConfigStatus) (cns.CreateNetw
 		ipSubnet.IPAddress = ip.String()
 		ipSubnet.PrefixLength = uint8(bits)
 		ncRequest.IPConfiguration.IPSubnet = ipSubnet
+		ncRequest.IPConfiguration.GatewayIPAddress = nc.DefaultGateway
 
 		for _, ipAssignment = range nc.IPAssignments {
 			if ip, ipNet, err = net.ParseCIDR(ipAssignment.IP); err != nil {

--- a/cns/requestcontroller/kubecontroller/crdtranslator_test.go
+++ b/cns/requestcontroller/kubecontroller/crdtranslator_test.go
@@ -14,6 +14,8 @@ const (
 	ipCIDRMaskLength = 32
 	ipNotCIDR        = "10.0.0.1"
 	ipMalformed      = "10.0.0.0.0"
+	defaultGateway   = "10.0.0.2"
+	subnetID         = "subnet1"
 )
 
 func TestStatusToNCRequestMalformedPrimaryIP(t *testing.T) {
@@ -153,6 +155,9 @@ func TestStatusToNCRequestSuccess(t *testing.T) {
 						IP:   ipCIDR,
 					},
 				},
+				SubnetID:       subnetID,
+				DefaultGateway: defaultGateway,
+				Netmask:        "", // Not currently set by DNC Request Controller
 			},
 		},
 	}
@@ -170,6 +175,10 @@ func TestStatusToNCRequestSuccess(t *testing.T) {
 
 	if ncRequest.IPConfiguration.IPSubnet.PrefixLength != uint8(ipCIDRMaskLength) {
 		t.Fatalf("Expected ncRequest's ipconfiguration prefix length to be %v but got %v", ipCIDRMaskLength, ncRequest.IPConfiguration.IPSubnet.PrefixLength)
+	}
+
+	if ncRequest.IPConfiguration.GatewayIPAddress != defaultGateway {
+		t.Fatalf("Expected ncRequest's ipconfiguration gateway to be %s but got %s", defaultGateway, ncRequest.IPConfiguration.GatewayIPAddress)
 	}
 
 	if ncRequest.NetworkContainerid != ncID {


### PR DESCRIPTION
**Reason for Change**:
Fix: add gateway IP address to NC request from CRD status


**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests


**Notes**:
Updated unit test to reflect desired behavior and changed `CRDStatusToNCRequest` to pass that test