### PR TITLE
feat: include subnet address space in CRD

### DIFF
--- a/cns/requestcontroller/kubecontroller/crdtranslator_test.go
+++ b/cns/requestcontroller/kubecontroller/crdtranslator_test.go
@@ -15,7 +15,7 @@ const (
 	ipNotCIDR        = "10.0.0.1"
 	ipMalformed      = "10.0.0.0.0"
 	defaultGateway   = "10.0.0.2"
-	subnetID         = "subnet1"
+	subnetName       = "subnet1"
 )
 
 func TestStatusToNCRequestMalformedPrimaryIP(t *testing.T) {
@@ -155,9 +155,9 @@ func TestStatusToNCRequestSuccess(t *testing.T) {
 						IP:   ipCIDR,
 					},
 				},
-				SubnetID:       subnetID,
-				DefaultGateway: defaultGateway,
-				Netmask:        "", // Not currently set by DNC Request Controller
+				SubnetName:         subnetName,
+				DefaultGateway:     defaultGateway,
+				SubnetAddressSpace: "", // Not currently set by DNC Request Controller
 			},
 		},
 	}

--- a/nodenetworkconfig/api/v1alpha/nodenetworkconfig.go
+++ b/nodenetworkconfig/api/v1alpha/nodenetworkconfig.go
@@ -66,13 +66,12 @@ type Scaler struct {
 
 // NetworkContainer defines the structure of a Network Container as found in NetworkConfigStatus
 type NetworkContainer struct {
-	ID             string         `json:"id,omitempty"`
-	PrimaryIP      string         `json:"primaryIP,omitempty"`
-	SubnetID       string         `json:"subnetID,omitempty"`
-	IPAssignments  []IPAssignment `json:"iPAssignments,omitempty"`
-	DefaultGateway string         `json:"defaultGateway,omitempty"`
-	// Netmask for the subnet represented by this NC's SubnetID
-	Netmask string `json:"netmask,omitempty"`
+	ID                 string         `json:"id,omitempty"`
+	PrimaryIP          string         `json:"primaryIP,omitempty"`
+	SubnetName         string         `json:"subnetName,omitempty"`
+	IPAssignments      []IPAssignment `json:"iPAssignments,omitempty"`
+	DefaultGateway     string         `json:"defaultGateway,omitempty"`
+	SubnetAddressSpace string         `json:"subnetAddressSpace,omitempty"`
 }
 
 // IPAssignment groups an IP address and Name. Name is a UUID set by the the IP address assigner.

--- a/nodenetworkconfig/manifests/acn.azure.com_nodenetworkconfigs.yaml
+++ b/nodenetworkconfig/manifests/acn.azure.com_nodenetworkconfigs.yaml
@@ -69,12 +69,11 @@ spec:
                     type: array
                   id:
                     type: string
-                  netmask:
-                    description: Netmask for the subnet represented by this NC's SubnetID
-                    type: string
                   primaryIP:
                     type: string
-                  subnetID:
+                  subnetAddressSpace:
+                    type: string
+                  subnetName:
                     type: string
                 type: object
               type: array


### PR DESCRIPTION
feat: include subnet address space in CRD

BREAKING CHANGE: removes `Netmask` from NNC Status because it is now redundant

**Reason for Change**:
Adds subnet address space to CRD status


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
