### PR TITLE
cns_removePrefixLengthFromSecondaryIpconfig

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -127,7 +127,7 @@ type IPConfiguration struct {
 
 // SecondaryIPConfig contains IP info of SecondaryIP
 type SecondaryIPConfig struct {
-	IPSubnet IPSubnet
+	IPAddress string
 }
 
 // IPSubnet contains ip subnet.

--- a/cns/cnsclient/cnsclient_test.go
+++ b/cns/cnsclient/cnsclient_test.go
@@ -46,9 +46,7 @@ func addTestStateToRestServer(t *testing.T, secondaryIps []string) {
 
 	for _, secIpAddress := range secondaryIps {
 		secIpConfig := cns.SecondaryIPConfig{
-			IPSubnet: cns.IPSubnet{
-				IPAddress:    secIpAddress,
-				PrefixLength: 32,
+			IPAddress: secIpAddress,
 			},
 		}
 		ipId := uuid.New()

--- a/cns/cnsclient/cnsclient_test.go
+++ b/cns/cnsclient/cnsclient_test.go
@@ -47,7 +47,6 @@ func addTestStateToRestServer(t *testing.T, secondaryIps []string) {
 	for _, secIpAddress := range secondaryIps {
 		secIpConfig := cns.SecondaryIPConfig{
 			IPAddress: secIpAddress,
-			},
 		}
 		ipId := uuid.New()
 		secondaryIPConfigs[ipId.String()] = secIpConfig

--- a/cns/requestcontroller/kubecontroller/crdrequestcontroller_test.go
+++ b/cns/requestcontroller/kubecontroller/crdrequestcontroller_test.go
@@ -366,17 +366,11 @@ func TestUpdateSpecOnNonExistingNodeNetConfig(t *testing.T) {
 	logger.InitLogger("Azure CNS RequestController", 0, 0, "")
 
 	ipConfig1 := cns.SecondaryIPConfig{
-		IPSubnet: cns.IPSubnet{
-			IPAddress:    "10.0.0.1",
-			PrefixLength: 32,
-		},
+		IPAddress: "10.0.0.1",
 	}
 
 	ipConfig2 := cns.SecondaryIPConfig{
-		IPSubnet: cns.IPSubnet{
-			IPAddress:    "10.0.0.2",
-			PrefixLength: 32,
-		},
+		IPAddress: "10.0.0.2",
 	}
 
 	secondaryIPConfigs := map[string]cns.SecondaryIPConfig{
@@ -421,17 +415,11 @@ func TestUpdateSpecOnExistingNodeNetConfig(t *testing.T) {
 	logger.InitLogger("Azure CNS RequestController", 0, 0, "")
 
 	ipConfig1 := cns.SecondaryIPConfig{
-		IPSubnet: cns.IPSubnet{
-			IPAddress:    "10.0.0.1",
-			PrefixLength: 32,
-		},
+		IPAddress: "10.0.0.1",
 	}
 
 	ipConfig2 := cns.SecondaryIPConfig{
-		IPSubnet: cns.IPSubnet{
-			IPAddress:    "10.0.0.2",
-			PrefixLength: 32,
-		},
+		IPAddress: "10.0.0.2",
 	}
 
 	secondaryIPConfigs := map[string]cns.SecondaryIPConfig{

--- a/cns/requestcontroller/kubecontroller/crdtranslator.go
+++ b/cns/requestcontroller/kubecontroller/crdtranslator.go
@@ -37,7 +37,8 @@ func CRDStatusToNCRequest(crdStatus nnc.NodeNetworkConfigStatus) (cns.CreateNetw
 		ncRequest.NetworkContainerid = nc.ID
 		ncRequest.NetworkContainerType = cns.Docker
 
-		// Convert "10.0.0.1/32" into "10.0.0.1" and 32
+		// Convert "10.0.0.1/32" into "10.0.0.1" and prefix length
+		// Todo, this will be changed soon and only ipaddress will be passed
 		if ip, ipNet, err = net.ParseCIDR(nc.PrimaryIP); err != nil {
 			return ncRequest, err
 		}
@@ -49,16 +50,12 @@ func CRDStatusToNCRequest(crdStatus nnc.NodeNetworkConfigStatus) (cns.CreateNetw
 		ncRequest.IPConfiguration.GatewayIPAddress = nc.DefaultGateway
 
 		for _, ipAssignment = range nc.IPAssignments {
-			if ip, ipNet, err = net.ParseCIDR(ipAssignment.IP); err != nil {
+			if ip, _, err = net.ParseCIDR(ipAssignment.IP); err != nil {
 				return ncRequest, err
 			}
 
-			_, bits = ipNet.Mask.Size()
-
-			ipSubnet.IPAddress = ip.String()
-			ipSubnet.PrefixLength = uint8(bits)
 			secondaryIPConfig = cns.SecondaryIPConfig{
-				IPSubnet: ipSubnet,
+				IPAddress: ip.String(),
 			}
 			ncRequest.SecondaryIPConfigs[ipAssignment.Name] = secondaryIPConfig
 		}

--- a/cns/requestcontroller/kubecontroller/crdtranslator_test.go
+++ b/cns/requestcontroller/kubecontroller/crdtranslator_test.go
@@ -195,12 +195,8 @@ func TestStatusToNCRequestSuccess(t *testing.T) {
 		t.Fatalf("Expected there to be a secondary ip with the key %v but found nothing", allocatedUUID)
 	}
 
-	if secondaryIP.IPSubnet.IPAddress != ipCIDRString {
-		t.Fatalf("Expected %v as the secondary IP config but got %v", ipCIDRString, secondaryIP.IPSubnet.IPAddress)
-	}
-
-	if secondaryIP.IPSubnet.PrefixLength != ipCIDRMaskLength {
-		t.Fatalf("Expected %v as the prefix length for the secondary IP config but got %v", ipCIDRMaskLength, secondaryIP.IPSubnet.PrefixLength)
+	if secondaryIP.IPAddress != ipCIDRString {
+		t.Fatalf("Expected %v as the secondary IP config but got %v", ipCIDRString, secondaryIP.IPAddress)
 	}
 }
 
@@ -233,10 +229,7 @@ func TestSecondaryIPsToCRDSpecSuccess(t *testing.T) {
 
 	secondaryIPs = map[string]cns.SecondaryIPConfig{
 		allocatedUUID: {
-			IPSubnet: cns.IPSubnet{
-				IPAddress:    ipCIDRString,
-				PrefixLength: ipCIDRMaskLength,
-			},
+			IPAddress: ipCIDRString,
 		},
 	}
 

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -58,7 +58,7 @@ func TestReconcileNCWithExistingState(t *testing.T) {
 	var startingIndex = 6
 	for i := 0; i < 4; i++ {
 		ipaddress := "10.0.0." + strconv.Itoa(startingIndex)
-		secIpConfig := newSecondaryIPConfig(ipaddress, 32)
+		secIpConfig := newSecondaryIPConfig(ipaddress)
 		ipId := uuid.New()
 		secondaryIPConfigs[ipId.String()] = secIpConfig
 		startingIndex++
@@ -95,7 +95,7 @@ func TestReconcileNCWithSystemPods(t *testing.T) {
 	var startingIndex = 6
 	for i := 0; i < 4; i++ {
 		ipaddress := "10.0.0." + strconv.Itoa(startingIndex)
-		secIpConfig := newSecondaryIPConfig(ipaddress, 32)
+		secIpConfig := newSecondaryIPConfig(ipaddress)
 		ipId := uuid.New()
 		secondaryIPConfigs[ipId.String()] = secIpConfig
 		startingIndex++
@@ -136,7 +136,7 @@ func validateCreateOrUpdateNCInternal(t *testing.T, secondaryIpCount int) {
 	var startingIndex = 6
 	for i := 0; i < secondaryIpCount; i++ {
 		ipaddress := "10.0.0." + strconv.Itoa(startingIndex)
-		secIpConfig := newSecondaryIPConfig(ipaddress, 32)
+		secIpConfig := newSecondaryIPConfig(ipaddress)
 		ipId := uuid.New()
 		secondaryIPConfigs[ipId.String()] = secIpConfig
 		startingIndex++
@@ -148,7 +148,7 @@ func validateCreateOrUpdateNCInternal(t *testing.T, secondaryIpCount int) {
 	fmt.Println("Validate Scaleup")
 	for i := 0; i < secondaryIpCount; i++ {
 		ipaddress := "10.0.0." + strconv.Itoa(startingIndex)
-		secIpConfig := newSecondaryIPConfig(ipaddress, 32)
+		secIpConfig := newSecondaryIPConfig(ipaddress)
 		ipId := uuid.New()
 		secondaryIPConfigs[ipId.String()] = secIpConfig
 		startingIndex++
@@ -216,8 +216,8 @@ func validateNetworkRequest(t *testing.T, req cns.CreateNetworkContainerRequest)
 			if secondaryIpConfig, ok := req.SecondaryIPConfigs[ipid]; !ok {
 				t.Fatalf("PodIpConfigState has stale ipId: %s, config: %+v", ipid, ipStatus)
 			} else {
-				if ipStatus.IPSubnet != secondaryIpConfig.IPSubnet {
-					t.Fatalf("IPId: %s IPSubnet doesnt match: expected %+v, actual: %+v", ipid, secondaryIpConfig.IPSubnet, ipStatus.IPSubnet)
+				if ipStatus.IPAddress != secondaryIpConfig.IPAddress {
+					t.Fatalf("IPId: %s IPSubnet doesnt match: expected %+v, actual: %+v", ipid, secondaryIpConfig.IPAddress, ipStatus.IPAddress)
 				}
 
 				// Validate IP state
@@ -239,12 +239,12 @@ func validateNetworkRequest(t *testing.T, req cns.CreateNetworkContainerRequest)
 					t.Fatalf("IPId: %s State is not Available, ipStatus: %+v", ipid, ipStatus)
 				}
 
-				alreadyValidated[ipid] = ipStatus.IPSubnet.IPAddress
+				alreadyValidated[ipid] = ipStatus.IPAddress
 			}
 		} else {
 			// if ipaddress is not same, then fail
-			if ipaddress != ipStatus.IPSubnet.IPAddress {
-				t.Fatalf("Added the same IP guid :%s with different ipaddress, expected:%s, actual %s", ipid, ipStatus.IPSubnet.IPAddress, ipaddress)
+			if ipaddress != ipStatus.IPAddress {
+				t.Fatalf("Added the same IP guid :%s with different ipaddress, expected:%s, actual %s", ipid, ipStatus.IPAddress, ipaddress)
 			}
 		}
 	}
@@ -298,7 +298,7 @@ func validateNCStateAfterReconcile(t *testing.T, ncRequest *cns.CreateNetworkCon
 		}
 
 		// Validate if IPAddress matches
-		if ipConfigstate.IPSubnet.IPAddress != ipaddress {
+		if ipConfigstate.IPAddress != ipaddress {
 			t.Fatalf("IpAddress %s is not same, for Pod: %+v, actual ipState: %+v", ipaddress, podInfo, ipConfigstate)
 		}
 
@@ -319,7 +319,7 @@ func validateNCStateAfterReconcile(t *testing.T, ncRequest *cns.CreateNetworkCon
 	// validate rest of Secondary IPs in Available state
 	if ncRequest != nil {
 		for secIpId, secIpConfig := range ncRequest.SecondaryIPConfigs {
-			if _, exists := expectedAllocatedPods[secIpConfig.IPSubnet.IPAddress]; exists {
+			if _, exists := expectedAllocatedPods[secIpConfig.IPAddress]; exists {
 				continue
 			}
 

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -59,7 +59,7 @@ type allocatedIPCount struct {
 type ipConfigurationStatus struct {
 	NCID                string
 	ID                  string //uuid
-	IPSubnet            cns.IPSubnet
+	IPAddress           string
 	State               string
 	OrchestratorContext json.RawMessage
 }


### PR DESCRIPTION
Removed PrefixLength from SecondaryIPConfig struct. We dont need to populate /32 in this struct. When CNI request for SecondaryIPconfig, then add Subnet range prefix length it the IP CIDR format.