### PR TITLE
fix: pass podinfo to CNS delete

### DIFF
--- a/cns/cnsclient/cnsclient.go
+++ b/cns/cnsclient/cnsclient.go
@@ -218,7 +218,7 @@ func (cnsClient *CNSClient) RequestIPAddress(orchestratorContext []byte) (*cns.G
 	httpc := &http.Client{}
 	url := cnsClient.connectionURL + cns.RequestIPConfig
 
-	payload := &cns.GetNetworkContainerRequest{
+	payload := &cns.GetIPConfigRequest{
 		OrchestratorContext: orchestratorContext,
 	}
 
@@ -268,7 +268,7 @@ func (cnsClient *CNSClient) ReleaseIPAddress(orchestratorContext []byte) error {
 	url := cnsClient.connectionURL + cns.ReleaseIPConfig
 	log.Printf("ReleaseIPAddress url %v", url)
 
-	payload := &cns.GetNetworkContainerRequest{
+	payload := &cns.GetIPConfigRequest{
 		OrchestratorContext: orchestratorContext,
 	}
 

--- a/cns/cnsclient/cnsclient_test.go
+++ b/cns/cnsclient/cnsclient_test.go
@@ -108,11 +108,15 @@ func TestMain(m *testing.M) {
 	defer os.RemoveAll(tmpLogDir)
 	defer os.Remove(tmpFileState.Name())
 
+	logName := "azure-cns.log"
+	fmt.Printf("Test logger file: %v", tmpLogDir+"/"+logName)
+	fmt.Printf("Test state :%v", tmpFileState.Name())
+
 	if err != nil {
 		panic(err)
 	}
 
-	logger.InitLogger("azure-cns.log", 0, 0, tmpLogDir)
+	logger.InitLogger(logName, 0, 0, tmpLogDir+"/")
 	config := common.ServiceConfig{}
 
 	httpRestService, err := restserver.NewHTTPRestService(&config)

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -30,7 +30,7 @@ func (service *HTTPRestService) requestIPConfigHandler(w http.ResponseWriter, r 
 	}
 
 	// retrieve ipconfig from nc
-	returnCode, returnMessage = service.validateIpConfigRequest(ipconfigRequest)
+	_, returnCode, returnMessage = service.validateIpConfigRequest(ipconfigRequest)
 	if returnCode == Success {
 		if ipconfiguration, err = requestIPConfigHelper(service, ipconfigRequest); err != nil {
 			returnCode = FailedToAllocateIpConfig
@@ -54,7 +54,7 @@ func (service *HTTPRestService) requestIPConfigHandler(w http.ResponseWriter, r 
 
 func (service *HTTPRestService) releaseIPConfigHandler(w http.ResponseWriter, r *http.Request) {
 	var (
-		podInfo       cns.KubernetesPodInfo
+		podInfo       *cns.KubernetesPodInfo
 		req           cns.GetIPConfigRequest
 		statusCode    int
 		returnMessage string
@@ -81,9 +81,9 @@ func (service *HTTPRestService) releaseIPConfigHandler(w http.ResponseWriter, r 
 		logger.Response(service.Name, resp, resp.ReturnCode, ReturnCodeToString(resp.ReturnCode), err)
 	}()
 
-	statusCode, returnMessage = service.validateIpConfigRequest(req)
+	podInfo, statusCode, returnMessage = service.validateIpConfigRequest(req)
 
-	if err = service.releaseIPConfig(podInfo); err != nil {
+	if err = service.releaseIPConfig(*podInfo); err != nil {
 		statusCode = NotFound
 		returnMessage = err.Error()
 		return
@@ -146,12 +146,14 @@ func (service *HTTPRestService) releaseIPConfig(podInfo cns.KubernetesPodInfo) e
 	if ipID != "" {
 		if ipconfig, isExist := service.PodIPConfigState[ipID]; isExist {
 			service.setIPConfigAsAvailable(ipconfig, podInfo)
+			logger.Printf("Released IP %+v for pod %+v", ipconfig.IPSubnet, podInfo)
+
 		} else {
 			logger.Errorf("Failed to get release ipconfig. Pod to IPID exists, but IPID to IPConfig doesn't exist, CNS State potentially corrupt")
 			return fmt.Errorf("releaseIPConfig failed. Pod to IPID exists, but IPID to IPConfig doesn't exist, CNS State potentially corrupt")
 		}
 	} else {
-		logger.Printf("SetIPConfigAsAvailable failed to release, no allocation found for pod")
+		logger.Errorf("SetIPConfigAsAvailable failed to release, no allocation found for pod")
 		return nil
 	}
 	return nil

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -54,7 +54,6 @@ func (service *HTTPRestService) requestIPConfigHandler(w http.ResponseWriter, r 
 
 func (service *HTTPRestService) releaseIPConfigHandler(w http.ResponseWriter, r *http.Request) {
 	var (
-		podInfo       *cns.KubernetesPodInfo
 		req           cns.GetIPConfigRequest
 		statusCode    int
 		returnMessage string
@@ -81,9 +80,9 @@ func (service *HTTPRestService) releaseIPConfigHandler(w http.ResponseWriter, r 
 		logger.Response(service.Name, resp, resp.ReturnCode, ReturnCodeToString(resp.ReturnCode), err)
 	}()
 
-	podInfo, statusCode, returnMessage = service.validateIpConfigRequest(req)
+	podInfo, statusCode, returnMessage := service.validateIpConfigRequest(req)
 
-	if err = service.releaseIPConfig(*podInfo); err != nil {
+	if err = service.releaseIPConfig(podInfo); err != nil {
 		statusCode = NotFound
 		returnMessage = err.Error()
 		return

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -622,23 +622,23 @@ func (service *HTTPRestService) SendNCSnapShotPeriodically(ncSnapshotIntervalInM
 	}
 }
 
-func (service *HTTPRestService) validateIpConfigRequest(ipConfigRequest cns.GetIPConfigRequest) (*cns.KubernetesPodInfo, int, string) {
+func (service *HTTPRestService) validateIpConfigRequest(ipConfigRequest cns.GetIPConfigRequest) (cns.KubernetesPodInfo, int, string) {
 	var podInfo cns.KubernetesPodInfo
 
 	if service.state.OrchestratorType != cns.KubernetesCRD {
-		return &podInfo, UnsupportedOrchestratorType, fmt.Sprintf("ReleaseIPConfig API supported only for kubernetes orchestrator")
+		return podInfo, UnsupportedOrchestratorType, fmt.Sprintf("ReleaseIPConfig API supported only for kubernetes orchestrator")
 	}
 
 	if ipConfigRequest.OrchestratorContext == nil {
-		return &podInfo, EmptyOrchestratorContext, fmt.Sprintf("OrchastratorContext is not set in the req: %+v", ipConfigRequest)
+		return podInfo, EmptyOrchestratorContext, fmt.Sprintf("OrchastratorContext is not set in the req: %+v", ipConfigRequest)
 	}
 
 	// retrieve podinfo  from orchestrator context
 	if err := json.Unmarshal(ipConfigRequest.OrchestratorContext, &podInfo); err != nil {
-		return &podInfo, UnsupportedOrchestratorContext, err.Error()
+		return podInfo, UnsupportedOrchestratorContext, err.Error()
 	}
 
-	return &podInfo, Success, ""
+	return podInfo, Success, ""
 }
 
 func (service *HTTPRestService) populateIpConfigInfoFromNCUntransacted(ncId string, ipConfiguration *cns.IPConfiguration) error {

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -622,22 +622,23 @@ func (service *HTTPRestService) SendNCSnapShotPeriodically(ncSnapshotIntervalInM
 	}
 }
 
-func (service *HTTPRestService) validateIpConfigRequest(ipConfigRequest cns.GetIPConfigRequest) (int, string) {
+func (service *HTTPRestService) validateIpConfigRequest(ipConfigRequest cns.GetIPConfigRequest) (*cns.KubernetesPodInfo, int, string) {
+	var podInfo cns.KubernetesPodInfo
+
 	if service.state.OrchestratorType != cns.KubernetesCRD {
-		return UnsupportedOrchestratorType, fmt.Sprintf("ReleaseIPConfig API supported only for kubernetes orchestrator")
+		return &podInfo, UnsupportedOrchestratorType, fmt.Sprintf("ReleaseIPConfig API supported only for kubernetes orchestrator")
 	}
 
 	if ipConfigRequest.OrchestratorContext == nil {
-		return EmptyOrchestratorContext, fmt.Sprintf("OrchastratorContext is not set in the req: %+v", ipConfigRequest)
+		return &podInfo, EmptyOrchestratorContext, fmt.Sprintf("OrchastratorContext is not set in the req: %+v", ipConfigRequest)
 	}
 
 	// retrieve podinfo  from orchestrator context
-	var podInfo cns.KubernetesPodInfo
 	if err := json.Unmarshal(ipConfigRequest.OrchestratorContext, &podInfo); err != nil {
-		return UnsupportedOrchestratorContext, err.Error()
+		return &podInfo, UnsupportedOrchestratorContext, err.Error()
 	}
 
-	return Success, ""
+	return &podInfo, Success, ""
 }
 
 func (service *HTTPRestService) populateIpConfigInfoFromNCUntransacted(ncId string, ipConfiguration *cns.IPConfiguration) error {


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

IPAM delete in CNS was not passing pod info, therefore ID in state was never found

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
