### PR TITLE
Adds debug commands to CNS binary with debug API

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -22,7 +22,7 @@ const (
 	DetachContainerFromNetwork               = "/network/detachcontainerfromnetwork"
 	RequestIPConfig                          = "/network/requestipconfig"
 	ReleaseIPConfig                          = "/network/releaseipconfig"
-	GetIPAddresses                           = "/network/getipconfigs"
+	GetIPAddresses                           = "/debug/getipaddresses"
 )
 
 // NetworkContainer Prefixes

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -22,6 +22,7 @@ const (
 	DetachContainerFromNetwork               = "/network/detachcontainerfromnetwork"
 	RequestIPConfig                          = "/network/requestipconfig"
 	ReleaseIPConfig                          = "/network/releaseipconfig"
+	GetIPAddresses                           = "/network/getipconfigs"
 )
 
 // NetworkContainer Prefixes
@@ -197,16 +198,6 @@ type GetNetworkContainerResponse struct {
 	AllowNCToHostCommunication bool
 }
 
-type GetIPConfigRequest struct {
-	DesiredIPAddress    string
-	OrchestratorContext json.RawMessage
-}
-
-type GetIPConfigResponse struct {
-	PodIpInfo PodIpInfo
-	Response  Response
-}
-
 // DeleteNetworkContainerRequest specifies the details about the request to delete a specifc network container.
 type PodIpInfo struct {
 	PodIPConfig                     IPSubnet
@@ -219,6 +210,31 @@ type HostIPInfo struct {
 	Gateway   string
 	PrimaryIP string
 	Subnet    string
+}
+
+type IPConfigRequest struct {
+	DesiredIPAddress    string
+	OrchestratorContext json.RawMessage
+}
+
+type IPConfigResponse struct {
+	PodIpInfo PodIpInfo
+	Response  Response
+}
+
+type GetIPAddressesRequest struct {
+	IPConfigStateFilter []string
+}
+
+type GetIPAddressStateResponse struct {
+	IPAddresses []IPAddressState
+	Response    Response
+}
+
+// Only used in the GetIPConfig API to return IP's that match a filter
+type IPAddressState struct {
+	IPAddress string
+	State     string
 }
 
 // DeleteNetworkContainerRequest specifies the details about the request to delete a specifc network container.

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -217,21 +217,25 @@ type IPConfigRequest struct {
 	OrchestratorContext json.RawMessage
 }
 
+// IPConfigResponse is used in CNS IPAM mode as a response to CNI ADD
 type IPConfigResponse struct {
 	PodIpInfo PodIpInfo
 	Response  Response
 }
 
+// GetIPAddressesRequest is used in CNS IPAM mode to get the states of IPConfigs
+// The IPConfigStateFilter is a slice of IP's to fetch from CNS that match those states
 type GetIPAddressesRequest struct {
 	IPConfigStateFilter []string
 }
 
+// GetIPAddressStateResponse is used in CNS IPAM mode as a response to get IP address state
 type GetIPAddressStateResponse struct {
 	IPAddresses []IPAddressState
 	Response    Response
 }
 
-// Only used in the GetIPConfig API to return IP's that match a filter
+// IPAddressState Only used in the GetIPConfig API to return IP's that match a filter
 type IPAddressState struct {
 	IPAddress string
 	State     string

--- a/cns/cnsclient/cli.go
+++ b/cns/cnsclient/cli.go
@@ -16,9 +16,10 @@ var (
 		getArg,
 	}
 
-	getAvailableArg = "Available"
-	getAllocatedArg = "Allocated"
-	getAllArg       = "All"
+	getAvailableArg      = "Available"
+	getAllocatedArg      = "Allocated"
+	getAllArg            = "All"
+	getPendingReleaseArg = "PendingRelease"
 
 	getFlags = []string{
 		getAvailableArg,
@@ -71,33 +72,38 @@ FindIP:
 
 func getCmd(client *CNSClient, arg string) {
 	switch arg {
-	case getAvailableArg:
-		fmt.Println(getAvailableArg)
+	case cns.Available:
 		addr, err := client.GetIPAddressesMatchingStates(cns.Available)
 		if err != nil {
 			fmt.Println(err)
 			return
 		}
-
 		printIPAddresses(addr)
-	case getAllocatedArg:
-		fmt.Println(getAllocatedArg)
+
+	case cns.Allocated:
 		addr, err := client.GetIPAddressesMatchingStates(cns.Allocated)
 		if err != nil {
 			fmt.Println(err)
 			return
 		}
-
 		printIPAddresses(addr)
+
 	case getAllArg:
-		fmt.Println(getAllArg)
-		addr, err := client.GetIPAddressesMatchingStates(cns.Allocated, cns.Available)
+		addr, err := client.GetIPAddressesMatchingStates(cns.Allocated, cns.Available, cns.PendingRelease)
 		if err != nil {
 			fmt.Println(err)
 			return
 		}
-
 		printIPAddresses(addr)
+
+	case cns.PendingRelease:
+		addr, err := client.GetIPAddressesMatchingStates(cns.PendingRelease)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		printIPAddresses(addr)
+
 	default:
 		fmt.Printf("argument supplied for the get cmd, use the '%v' flag", acn.OptDebugCmdAlias)
 	}
@@ -118,6 +124,6 @@ func printIPAddresses(addrSlice []cns.IPAddressState) {
 	})
 
 	for _, addr := range addrSlice {
-		fmt.Printf("%v\n", addr)
+		fmt.Printf("%+v\n", addr)
 	}
 }

--- a/cns/cnsclient/cli.go
+++ b/cns/cnsclient/cli.go
@@ -50,6 +50,7 @@ func getCmd(client *CNSClient, arg string) {
 			fmt.Println(err)
 			return
 		}
+
 		printIPAddresses(addr)
 
 	case getAllocatedArg:
@@ -59,6 +60,7 @@ func getCmd(client *CNSClient, arg string) {
 			fmt.Println(err)
 			return
 		}
+
 		printIPAddresses(addr)
 
 	case getAllArg:
@@ -68,14 +70,14 @@ func getCmd(client *CNSClient, arg string) {
 			fmt.Println(err)
 			return
 		}
+
 		printIPAddresses(addr)
 	default:
-		fmt.Println("argument supplied for the get cmd, use the '%v' flag", acn.OptDebugCmdAlias)
+		fmt.Printf("argument supplied for the get cmd, use the '%v' flag", acn.OptDebugCmdAlias)
 	}
 }
 
 func printIPAddresses(addrSlice []cns.IPAddressState) {
-
 	sort.Slice(addrSlice, func(i, j int) bool {
 		if addrSlice[i].IPAddress < addrSlice[j].IPAddress {
 			return true

--- a/cns/cnsclient/cli.go
+++ b/cns/cnsclient/cli.go
@@ -1,0 +1,92 @@
+package cnsclient
+
+import (
+	"fmt"
+	"net"
+	"sort"
+
+	"github.com/Azure/azure-container-networking/cns"
+	acn "github.com/Azure/azure-container-networking/common"
+)
+
+var (
+	getArg          = "get"
+	getAvailableArg = "Available"
+	getAllocatedArg = "Allocated"
+	getAllArg       = "All"
+
+	releaseArg = "release"
+)
+
+func HandleCNSFlags(cmd, arg string) {
+	var ip net.IP
+
+	interfaces, _ := net.Interfaces()
+	for _, iface := range interfaces {
+		addrs, _ := iface.Addrs()
+		for _, address := range addrs {
+			if ipnet, ok := address.(*net.IPNet); ok && !ipnet.IP.IsLoopback() && ipnet.IP.To4() != nil {
+				ip = ipnet.IP
+			}
+		}
+	}
+
+	cnsurl := "http://" + ip.String() + ":10090"
+	cnsClient, _ := InitCnsClient(cnsurl)
+	switch cmd {
+	case getArg:
+		getCmd(cnsClient, arg)
+	default:
+		fmt.Printf("No debug cmd supplied, options are: %v", getArg)
+	}
+}
+
+func getCmd(client *CNSClient, arg string) {
+	switch arg {
+	case getAvailableArg:
+		fmt.Println(getAvailableArg)
+		addr, err := client.GetIPAddressesMatchingStates(cns.Available)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		printIPAddresses(addr)
+
+	case getAllocatedArg:
+		fmt.Println(getAllocatedArg)
+		addr, err := client.GetIPAddressesMatchingStates(cns.Allocated)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		printIPAddresses(addr)
+
+	case getAllArg:
+		fmt.Println(getAllArg)
+		addr, err := client.GetIPAddressesMatchingStates(cns.Allocated, cns.Available)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		printIPAddresses(addr)
+	default:
+		fmt.Println("argument supplied for the get cmd, use the '%v' flag", acn.OptDebugCmdAlias)
+	}
+}
+
+func printIPAddresses(addrSlice []cns.IPAddressState) {
+
+	sort.Slice(addrSlice, func(i, j int) bool {
+		if addrSlice[i].IPAddress < addrSlice[j].IPAddress {
+			return true
+		}
+		if addrSlice[i].IPAddress > addrSlice[j].IPAddress {
+			return false
+		}
+		return addrSlice[i].IPAddress < addrSlice[j].IPAddress
+	})
+
+	for _, addr := range addrSlice {
+		fmt.Printf("%v\n", addr)
+	}
+}

--- a/cns/cnsclient/cli.go
+++ b/cns/cnsclient/cli.go
@@ -2,7 +2,6 @@ package cnsclient
 
 import (
 	"fmt"
-	"net"
 	"sort"
 	"strings"
 
@@ -20,6 +19,8 @@ const (
 
 	eth0InterfaceName   = "eth0"
 	azure0InterfaceName = "azure0"
+
+	defaultCNSURl = "http://localhost:10090"
 )
 
 var (
@@ -35,29 +36,7 @@ var (
 )
 
 func HandleCNSClientCommands(cmd, arg string) error {
-	var ip net.IP
-
-	// retrieve the primary interface that CNS is listening on
-	interfaces, _ := net.Interfaces()
-FindIP:
-	for _, iface := range interfaces {
-		if iface.Name == eth0InterfaceName || iface.Name == azure0InterfaceName {
-			addrs, _ := iface.Addrs()
-			for _, address := range addrs {
-				if ipnet, ok := address.(*net.IPNet); ok && !ipnet.IP.IsLoopback() && ipnet.IP.To4() != nil {
-					ip = ipnet.IP
-					break FindIP
-				}
-			}
-		}
-	}
-
-	if ip == nil {
-		return fmt.Errorf("Primary IP not found")
-	}
-
-	cnsurl := "http://" + ip.String() + ":10090"
-	cnsClient, err := InitCnsClient(cnsurl)
+	cnsClient, err := InitCnsClient(defaultCNSURl)
 	if err != nil {
 		return err
 	}

--- a/cns/cnsclient/cli.go
+++ b/cns/cnsclient/cli.go
@@ -18,9 +18,10 @@ var (
 	releaseArg = "release"
 )
 
-func HandleCNSFlags(cmd, arg string) {
+func HandleCNSClientCommands(cmd, arg string) {
 	var ip net.IP
 
+	// retrieve the primary interface that CNS is listening on
 	interfaces, _ := net.Interfaces()
 	for _, iface := range interfaces {
 		addrs, _ := iface.Addrs()
@@ -52,7 +53,6 @@ func getCmd(client *CNSClient, arg string) {
 		}
 
 		printIPAddresses(addr)
-
 	case getAllocatedArg:
 		fmt.Println(getAllocatedArg)
 		addr, err := client.GetIPAddressesMatchingStates(cns.Allocated)
@@ -62,7 +62,6 @@ func getCmd(client *CNSClient, arg string) {
 		}
 
 		printIPAddresses(addr)
-
 	case getAllArg:
 		fmt.Println(getAllArg)
 		addr, err := client.GetIPAddressesMatchingStates(cns.Allocated, cns.Available)
@@ -77,14 +76,17 @@ func getCmd(client *CNSClient, arg string) {
 	}
 }
 
+// Sort the addresses based on IP, then write to stdout
 func printIPAddresses(addrSlice []cns.IPAddressState) {
 	sort.Slice(addrSlice, func(i, j int) bool {
 		if addrSlice[i].IPAddress < addrSlice[j].IPAddress {
 			return true
 		}
+
 		if addrSlice[i].IPAddress > addrSlice[j].IPAddress {
 			return false
 		}
+
 		return addrSlice[i].IPAddress < addrSlice[j].IPAddress
 	})
 

--- a/cns/cnsclient/cnsclient.go
+++ b/cns/cnsclient/cnsclient.go
@@ -327,7 +327,10 @@ func (cnsClient *CNSClient) GetIPAddressesMatchingStates(StateFilter ...string) 
 		body bytes.Buffer
 	)
 
-	httpc := &http.Client{}
+	if len(StateFilter) == 0 {
+		return []cns.IPAddressState{}, nil
+	}
+
 	url := cnsClient.connectionURL + cns.GetIPAddresses
 	log.Printf("GetIPAddressesMatchingStates url %v", url)
 
@@ -341,7 +344,7 @@ func (cnsClient *CNSClient) GetIPAddressesMatchingStates(StateFilter ...string) 
 		return resp.IPAddresses, err
 	}
 
-	res, err = httpc.Post(url, contentTypeJSON, &body)
+	res, err = http.Post(url, contentTypeJSON, &body)
 	if err != nil {
 		log.Errorf("[Azure CNSClient] HTTP Post returned error %v", err.Error())
 		return resp.IPAddresses, err

--- a/cns/cnsclient/cnsclient.go
+++ b/cns/cnsclient/cnsclient.go
@@ -209,11 +209,11 @@ func (cnsClient *CNSClient) DeleteHostNCApipaEndpoint(networkContainerID string)
 }
 
 // RequestIPAddress calls the requestIPAddress in CNS
-func (cnsClient *CNSClient) RequestIPAddress(orchestratorContext []byte) (*cns.GetIPConfigResponse, error) {
+func (cnsClient *CNSClient) RequestIPAddress(orchestratorContext []byte) (*cns.IPConfigResponse, error) {
 	var (
 		err      error
 		res      *http.Response
-		response *cns.GetIPConfigResponse
+		response *cns.IPConfigResponse
 	)
 
 	defer func() {
@@ -315,4 +315,56 @@ func (cnsClient *CNSClient) ReleaseIPAddress(orchestratorContext []byte) error {
 	}
 
 	return err
+}
+
+// GetIPAddressesWithStates takes a variadic number of string parameters, to get all IP Addresses matching a number of states
+// usage GetIPAddressesWithStates(cns.Available, cns.Allocated)
+func (cnsClient *CNSClient) GetIPAddressesMatchingStates(StateFilter ...string) ([]cns.IPAddressState, error) {
+	var (
+		resp cns.GetIPAddressStateResponse
+		err  error
+		res  *http.Response
+		body bytes.Buffer
+	)
+
+	httpc := &http.Client{}
+	url := cnsClient.connectionURL + cns.GetIPAddresses
+	log.Printf("GetIPAddressesMatchingStates url %v", url)
+
+	payload := &cns.GetIPAddressesRequest{
+		IPConfigStateFilter: StateFilter,
+	}
+
+	err = json.NewEncoder(&body).Encode(payload)
+	if err != nil {
+		log.Errorf("encoding json failed with %v", err)
+		return resp.IPAddresses, err
+	}
+
+	res, err = httpc.Post(url, contentTypeJSON, &body)
+	if err != nil {
+		log.Errorf("[Azure CNSClient] HTTP Post returned error %v", err.Error())
+		return resp.IPAddresses, err
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		errMsg := fmt.Sprintf("[Azure CNSClient] GetIPAddressesMatchingStates invalid http status code: %v", res.StatusCode)
+		log.Errorf(errMsg)
+		return resp.IPAddresses, fmt.Errorf(errMsg)
+	}
+
+	err = json.NewDecoder(res.Body).Decode(&resp)
+	if err != nil {
+		log.Errorf("[Azure CNSClient] Error received while parsing GetIPAddressesMatchingStates response resp:%v err:%v", res.Body, err.Error())
+		return resp.IPAddresses, err
+	}
+
+	if resp.Response.ReturnCode != 0 {
+		log.Errorf("[Azure CNSClient] GetIPAddressesMatchingStates received error response :%v", resp.Response.Message)
+		return resp.IPAddresses, fmt.Errorf(resp.Response.Message)
+	}
+
+	return resp.IPAddresses, err
 }

--- a/cns/cnsclient/cnsclient.go
+++ b/cns/cnsclient/cnsclient.go
@@ -227,7 +227,7 @@ func (cnsClient *CNSClient) RequestIPAddress(orchestratorContext []byte) (*cns.I
 	httpc := &http.Client{}
 	url := cnsClient.connectionURL + cns.RequestIPConfig
 
-	payload := &cns.GetIPConfigRequest{
+	payload := &cns.IPConfigRequest{
 		OrchestratorContext: orchestratorContext,
 	}
 
@@ -277,7 +277,7 @@ func (cnsClient *CNSClient) ReleaseIPAddress(orchestratorContext []byte) error {
 	url := cnsClient.connectionURL + cns.ReleaseIPConfig
 	log.Printf("ReleaseIPAddress url %v", url)
 
-	payload := &cns.GetIPConfigRequest{
+	payload := &cns.IPConfigRequest{
 		OrchestratorContext: orchestratorContext,
 	}
 

--- a/cns/cnsclient/cnsclient_test.go
+++ b/cns/cnsclient/cnsclient_test.go
@@ -222,4 +222,17 @@ func TestCNSClientRequestAndRelease(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected to not fail when releasing IP reservation found with context: %+v", err)
 	}
+
+	ipaddresses, err = cnsClient.GetIPAddressesMatchingStates(cns.Available)
+	if err != nil {
+		t.Fatalf("Get allocated IP addresses failed %+v", err)
+	}
+
+	if len(ipaddresses) != 1 {
+		t.Fatalf("Number of available IP addresses expected to be 1, actual %+v", ipaddresses)
+	}
+
+	if ipaddresses[0].IPAddress != desiredIpAddress && ipaddresses[0].State != cns.Available {
+		t.Fatalf("Available IP address does not match expected, address state: %+v", ipaddresses)
+	}
 }

--- a/cns/cnsclient/cnsclient_test.go
+++ b/cns/cnsclient/cnsclient_test.go
@@ -223,7 +223,7 @@ func TestCNSClientRequestAndRelease(t *testing.T) {
 		t.Fatalf("Expected to not fail when releasing IP reservation found with context: %+v", err)
 	}
 
-	ipaddresses, err = cnsClient.GetIPAddressesMatchingStates(cns.Available)
+	ipaddresses, err := cnsClient.GetIPAddressesMatchingStates(cns.Available)
 	if err != nil {
 		t.Fatalf("Get allocated IP addresses failed %+v", err)
 	}

--- a/cns/cnsclient/cnsclient_test.go
+++ b/cns/cnsclient/cnsclient_test.go
@@ -71,7 +71,7 @@ func addTestStateToRestServer(t *testing.T, secondaryIps []string) {
 	}
 }
 
-func getIPNetFromResponse(resp *cns.GetIPConfigResponse) (net.IPNet, error) {
+func getIPNetFromResponse(resp *cns.IPConfigResponse) (net.IPNet, error) {
 	var (
 		resultIPnet net.IPNet
 		err         error

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -177,7 +177,7 @@ func (service *HTTPRestService) ReconcileNCState(ncRequest *cns.CreateNetworkCon
 			}
 			jsonContext, _ := json.Marshal(kubernetesPodInfo)
 
-			ipconfigRequest := cns.GetIPConfigRequest{
+			ipconfigRequest := cns.IPConfigRequest{
 				DesiredIPAddress:    secIpConfig.IPAddress,
 				OrchestratorContext: jsonContext,
 			}

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -54,7 +54,6 @@ func (service *HTTPRestService) requestIPConfigHandler(w http.ResponseWriter, r 
 
 func (service *HTTPRestService) releaseIPConfigHandler(w http.ResponseWriter, r *http.Request) {
 	var (
-		podInfo       cns.KubernetesPodInfo
 		req           cns.IPConfigRequest
 		statusCode    int
 		returnMessage string
@@ -171,7 +170,7 @@ func filterIPConfigsWithState(toBeAdded map[string]ipConfigurationStatus, state 
 	for _, v := range toBeAdded {
 		if f(v, state) {
 			ip := cns.IPAddressState{
-				IPAddress: v.IPSubnet.IPAddress,
+				IPAddress: v.IPAddress,
 				State:     v.State,
 			}
 			vsf = append(vsf, ip)

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -17,7 +17,7 @@ import (
 func (service *HTTPRestService) requestIPConfigHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err             error
-		ipconfigRequest cns.GetIPConfigRequest
+		ipconfigRequest cns.IPConfigRequest
 		podIpInfo       cns.PodIpInfo
 		returnCode      int
 		returnMessage   string
@@ -366,7 +366,7 @@ func (service *HTTPRestService) AllocateAnyAvailableIPConfig(podInfo cns.Kuberne
 }
 
 // If IPConfig is already allocated for pod, it returns that else it returns one of the available ipconfigs.
-func requestIPConfigHelper(service *HTTPRestService, req cns.GetIPConfigRequest) (cns.PodIpInfo, error) {
+func requestIPConfigHelper(service *HTTPRestService, req cns.IPConfigRequest) (cns.PodIpInfo, error) {
 	var (
 		podInfo   cns.KubernetesPodInfo
 		podIpInfo cns.PodIpInfo

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -159,7 +159,7 @@ func (service *HTTPRestService) getIPAddressesHandler(w http.ResponseWriter, r *
 	// Get all IPConfigs matching a state, and append to a slice of IPAddressState
 	resp.IPAddresses = make([]cns.IPAddressState, 0)
 	for _, podstate := range req.IPConfigStateFilter {
-		resp.IPAddresses = append(resp.IPAddresses, filterIPConfigsMatchingState(service.PodIPConfigState, podstate, func(ipconfig ipConfigurationStatus, state string) bool {
+		resp.IPAddresses = append(resp.IPAddresses, filterIPConfigsMatchingState(service.PodIPConfigState, podstate, func(ipconfig cns.IPConfigurationStatus, state string) bool {
 			return ipconfig.State == podstate
 		})...)
 	}
@@ -168,7 +168,7 @@ func (service *HTTPRestService) getIPAddressesHandler(w http.ResponseWriter, r *
 }
 
 // filter the ipconfigs in CNS matching a state (Available, Allocated, etc.) and return in a slice
-func filterIPConfigsMatchingState(toBeAdded map[string]ipConfigurationStatus, state string, f func(ipConfigurationStatus, string) bool) []cns.IPAddressState {
+func filterIPConfigsMatchingState(toBeAdded map[string]cns.IPConfigurationStatus, state string, f func(cns.IPConfigurationStatus, string) bool) []cns.IPAddressState {
 	vsf := make([]cns.IPAddressState, 0)
 	for _, v := range toBeAdded {
 		if f(v, state) {
@@ -183,8 +183,8 @@ func filterIPConfigsMatchingState(toBeAdded map[string]ipConfigurationStatus, st
 }
 
 // filter ipconfigs based on predicate
-func filterIPConfigs(toBeAdded map[string]ipConfigurationStatus, f func(ipConfigurationStatus) bool) []ipConfigurationStatus {
-	vsf := make([]ipConfigurationStatus, 0)
+func filterIPConfigs(toBeAdded map[string]cns.IPConfigurationStatus, f func(cns.IPConfigurationStatus) bool) []cns.IPConfigurationStatus {
+	vsf := make([]cns.IPConfigurationStatus, 0)
 	for _, v := range toBeAdded {
 		if f(v) {
 			vsf = append(vsf, v)
@@ -193,7 +193,7 @@ func filterIPConfigs(toBeAdded map[string]ipConfigurationStatus, f func(ipConfig
 	return vsf
 }
 
-func (service *HTTPRestService) GetAllocatedIPConfigs() []ipConfigurationStatus {
+func (service *HTTPRestService) GetAllocatedIPConfigs() []cns.IPConfigurationStatus {
 	service.RLock()
 	defer service.RUnlock()
 	return filterIPConfigMap(service.PodIPConfigState, func(ipconfig cns.IPConfigurationStatus) bool {

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -57,16 +57,10 @@ func (service *HTTPRestService) releaseIPConfigHandler(w http.ResponseWriter, r 
 		req           cns.IPConfigRequest
 		statusCode    int
 		returnMessage string
+		err           error
 	)
 
 	statusCode = UnexpectedError
-
-	err := service.Listener.Decode(w, r, &req)
-	logger.Request(service.Name, &req, err)
-	if err != nil {
-		returnMessage = err.Error()
-		return
-	}
 
 	defer func() {
 		resp := cns.Response{}
@@ -79,6 +73,13 @@ func (service *HTTPRestService) releaseIPConfigHandler(w http.ResponseWriter, r 
 		err = service.Listener.Encode(w, &resp)
 		logger.Response(service.Name, resp, resp.ReturnCode, ReturnCodeToString(resp.ReturnCode), err)
 	}()
+
+	err = service.Listener.Decode(w, r, &req)
+	logger.Request(service.Name, &req, err)
+	if err != nil {
+		returnMessage = err.Error()
+		return
+	}
 
 	podInfo, statusCode, returnMessage := service.validateIpConfigRequest(req)
 
@@ -133,16 +134,10 @@ func (service *HTTPRestService) getIPAddressesHandler(w http.ResponseWriter, r *
 		resp          cns.GetIPAddressStateResponse
 		statusCode    int
 		returnMessage string
+		err           error
 	)
 
 	statusCode = UnexpectedError
-
-	err := service.Listener.Decode(w, r, &req)
-	logger.Request(service.Name, &req, err)
-	if err != nil {
-		returnMessage = err.Error()
-		return
-	}
 
 	defer func() {
 		if err != nil {
@@ -153,6 +148,13 @@ func (service *HTTPRestService) getIPAddressesHandler(w http.ResponseWriter, r *
 		err = service.Listener.Encode(w, &resp)
 		logger.Response(service.Name, resp, resp.Response.ReturnCode, ReturnCodeToString(resp.Response.ReturnCode), err)
 	}()
+
+	err = service.Listener.Decode(w, r, &req)
+	logger.Request(service.Name, &req, err)
+	if err != nil {
+		returnMessage = err.Error()
+		return
+	}
 
 	// Get all IPConfigs matching a state, and append to a slice of IPAddressState
 	resp.IPAddresses = make([]cns.IPAddressState, 0)

--- a/cns/restserver/ipam_test.go
+++ b/cns/restserver/ipam_test.go
@@ -172,7 +172,7 @@ func TestIPAMGetAvailableIPConfig(t *testing.T) {
 	}
 	UpdatePodIpConfigState(t, svc, ipconfigs)
 
-	req := cns.GetIPConfigRequest{}
+	req := cns.IPConfigRequest{}
 	b, _ := json.Marshal(testPod1Info)
 	req.OrchestratorContext = b
 
@@ -207,7 +207,7 @@ func TestIPAMGetNextAvailableIPConfig(t *testing.T) {
 		t.Fatalf("Expected to not fail adding IP's to state: %+v", err)
 	}
 
-	req := cns.GetIPConfigRequest{}
+	req := cns.IPConfigRequest{}
 	b, _ := json.Marshal(testPod2Info)
 	req.OrchestratorContext = b
 
@@ -236,7 +236,7 @@ func TestIPAMGetAlreadyAllocatedIPConfigForSamePod(t *testing.T) {
 		t.Fatalf("Expected to not fail adding IP's to state: %+v", err)
 	}
 
-	req := cns.GetIPConfigRequest{}
+	req := cns.IPConfigRequest{}
 	b, _ := json.Marshal(testPod1Info)
 	req.OrchestratorContext = b
 
@@ -266,7 +266,7 @@ func TestIPAMAttemptToRequestIPNotFoundInPool(t *testing.T) {
 		t.Fatalf("Expected to not fail adding IP's to state: %+v", err)
 	}
 
-	req := cns.GetIPConfigRequest{}
+	req := cns.IPConfigRequest{}
 	b, _ := json.Marshal(testPod2Info)
 	req.OrchestratorContext = b
 	req.DesiredIPAddress = testIP2
@@ -291,7 +291,7 @@ func TestIPAMGetDesiredIPConfigWithSpecfiedIP(t *testing.T) {
 		t.Fatalf("Expected to not fail adding IP's to state: %+v", err)
 	}
 
-	req := cns.GetIPConfigRequest{}
+	req := cns.IPConfigRequest{}
 	b, _ := json.Marshal(testPod1Info)
 	req.OrchestratorContext = b
 	req.DesiredIPAddress = testIP1
@@ -323,7 +323,7 @@ func TestIPAMFailToGetDesiredIPConfigWithAlreadyAllocatedSpecfiedIP(t *testing.T
 	}
 
 	// request the already allocated ip with a new context
-	req := cns.GetIPConfigRequest{}
+	req := cns.IPConfigRequest{}
 	b, _ := json.Marshal(testPod2Info)
 	req.OrchestratorContext = b
 	req.DesiredIPAddress = testIP1
@@ -351,7 +351,7 @@ func TestIPAMFailToGetIPWhenAllIPsAreAllocated(t *testing.T) {
 	}
 
 	// request the already allocated ip with a new context
-	req := cns.GetIPConfigRequest{}
+	req := cns.IPConfigRequest{}
 	b, _ := json.Marshal(testPod3Info)
 	req.OrchestratorContext = b
 
@@ -382,7 +382,7 @@ func TestIPAMRequestThenReleaseThenRequestAgain(t *testing.T) {
 	desiredIpAddress := testIP1
 
 	// Use TestPodInfo2 to request TestIP1, which has already been allocated
-	req := cns.GetIPConfigRequest{}
+	req := cns.IPConfigRequest{}
 	b, _ := json.Marshal(testPod2Info)
 	req.OrchestratorContext = b
 	req.DesiredIPAddress = desiredIpAddress
@@ -399,7 +399,7 @@ func TestIPAMRequestThenReleaseThenRequestAgain(t *testing.T) {
 	}
 
 	// Rerequest
-	req = cns.GetIPConfigRequest{}
+	req = cns.IPConfigRequest{}
 	b, _ = json.Marshal(testPod2Info)
 	req.OrchestratorContext = b
 	req.DesiredIPAddress = desiredIpAddress
@@ -491,7 +491,7 @@ func TestAvailableIPConfigs(t *testing.T) {
 	allocatedIps := svc.GetAllocatedIPConfigs()
 	validateIpState(t, allocatedIps, desiredAllocatedIpConfigs)
 
-	req := cns.GetIPConfigRequest{}
+	req := cns.IPConfigRequest{}
 	b, _ := json.Marshal(testPod1Info)
 	req.OrchestratorContext = b
 	req.DesiredIPAddress = state1.IPAddress

--- a/cns/restserver/ipam_test.go
+++ b/cns/restserver/ipam_test.go
@@ -66,7 +66,7 @@ func NewPodState(ipaddress string, prefixLength uint8, id, ncid, state string) c
 	}
 }
 
-func requestIpAddressAndGetState(t *testing.T, req cns.GetIPConfigRequest) (cns.IPConfigurationStatus, error) {
+func requestIpAddressAndGetState(t *testing.T, req cns.IPConfigRequest) (cns.IPConfigurationStatus, error) {
 	var (
 		podInfo   cns.KubernetesPodInfo
 		ipState   cns.IPConfigurationStatus

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -176,6 +176,7 @@ func (service *HTTPRestService) Start(config *common.ServiceConfig) error {
 	listener.AddHandler(cns.UnpublishNetworkContainer, service.unpublishNetworkContainer)
 	listener.AddHandler(cns.RequestIPConfig, service.requestIPConfigHandler)
 	listener.AddHandler(cns.ReleaseIPConfig, service.releaseIPConfigHandler)
+	listener.AddHandler(cns.GetIPAddresses, service.getIPAddressesHandler)
 
 	// handlers for v0.2
 	listener.AddHandler(cns.V2Prefix+cns.SetEnvironmentPath, service.setEnvironment)

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -625,7 +625,7 @@ func (service *HTTPRestService) SendNCSnapShotPeriodically(ncSnapshotIntervalInM
 	}
 }
 
-func (service *HTTPRestService) validateIpConfigRequest(ipConfigRequest cns.GetIPConfigRequest) (cns.KubernetesPodInfo, int, string) {
+func (service *HTTPRestService) validateIpConfigRequest(ipConfigRequest cns.IPConfigRequest) (cns.KubernetesPodInfo, int, string) {
 	var podInfo cns.KubernetesPodInfo
 
 	if service.state.OrchestratorType != cns.KubernetesCRD {

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Azure/azure-container-networking/cnm/ipam"
 	"github.com/Azure/azure-container-networking/cnm/network"
 	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/cnsclient"
 	"github.com/Azure/azure-container-networking/cns/common"
 	"github.com/Azure/azure-container-networking/cns/configuration"
 	"github.com/Azure/azure-container-networking/cns/hnsclient"
@@ -222,6 +223,20 @@ var args = acn.ArgumentList{
 		Type:         "bool",
 		DefaultValue: false,
 	},
+	{
+		Name:         acn.OptDebugCmd,
+		Shorthand:    acn.OptDebugCmdAlias,
+		Description:  "Debug flag to retrieve IPconfigs, available values: allocated, available, all",
+		Type:         "string",
+		DefaultValue: "",
+	},
+	{
+		Name:         acn.OptDebugArg,
+		Shorthand:    acn.OptDebugArgAlias,
+		Description:  "Argument flag to be paired with the 'debugcmd' flag.",
+		Type:         "string",
+		DefaultValue: "",
+	},
 }
 
 // Prints description and version information.
@@ -294,6 +309,8 @@ func main() {
 	privateEndpoint := acn.GetArg(acn.OptPrivateEndpoint).(string)
 	infravnet := acn.GetArg(acn.OptInfrastructureNetworkID).(string)
 	nodeID := acn.GetArg(acn.OptNodeID).(string)
+	clientDebugCmd := acn.GetArg(acn.OptDebugCmd).(string)
+	clientDebugArg := acn.GetArg(acn.OptDebugArg).(string)
 
 	if vers {
 		printVersion()
@@ -313,6 +330,11 @@ func main() {
 
 	// Create logging provider.
 	logger.InitLogger(name, logLevel, logTarget, logDirectory)
+
+	if clientDebugCmd != "" {
+		cnsclient.HandleCNSFlags(clientDebugCmd, clientDebugArg)
+		os.Exit(0)
+	}
 
 	if !telemetryEnabled {
 		logger.Errorf("[Azure CNS] Cannot disable telemetry via cmdline. Update cns_config.json to disable telemetry.")

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -332,7 +332,7 @@ func main() {
 	logger.InitLogger(name, logLevel, logTarget, logDirectory)
 
 	if clientDebugCmd != "" {
-		cnsclient.HandleCNSFlags(clientDebugCmd, clientDebugArg)
+		cnsclient.HandleCNSClientCommands(clientDebugCmd, clientDebugArg)
 		os.Exit(0)
 	}
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -332,7 +332,11 @@ func main() {
 	logger.InitLogger(name, logLevel, logTarget, logDirectory)
 
 	if clientDebugCmd != "" {
-		cnsclient.HandleCNSClientCommands(clientDebugCmd, clientDebugArg)
+		err := cnsclient.HandleCNSClientCommands(clientDebugCmd, clientDebugArg)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
 		os.Exit(0)
 	}
 

--- a/common/config.go
+++ b/common/config.go
@@ -114,4 +114,12 @@ const (
 	// Managed mode
 	OptManaged      = "managed"
 	OptManagedAlias = "m"
+
+	// Client mode, get allocated ipconfigs
+	OptDebugCmd      = "debugcmd"
+	OptDebugCmdAlias = "cmd"
+
+	// Client mode, get allocated ipconfigs
+	OptDebugArg      = "debugarg"
+	OptDebugArgAlias = "darg"
 )

--- a/common/config.go
+++ b/common/config.go
@@ -115,11 +115,11 @@ const (
 	OptManaged      = "managed"
 	OptManagedAlias = "m"
 
-	// Client mode, get allocated ipconfigs
+	// Client mode, cmd
 	OptDebugCmd      = "debugcmd"
 	OptDebugCmdAlias = "cmd"
 
-	// Client mode, get allocated ipconfigs
+	// Client mode, args for cmd
 	OptDebugArg      = "debugarg"
 	OptDebugArgAlias = "darg"
 )


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Adds a debug API to get IP addresses, options include "Available", "Allocated", and "All".

Usage example:
```bash
$ k exec -it azure-cns-z74hd -- /usr/local/bin/azure-cns -cmd get -darg All
{10.0.0.39 Allocated}
{10.0.0.40 Allocated}
{10.0.0.41 Available}
{10.0.0.42 Allocated}
{10.0.0.43 Available}
{10.0.0.44 Available}
...

$ k exec -it azure-cns-z74hd -- /usr/local/bin/azure-cns -cmd get -darg Allocated
{10.0.0.39 Allocated}
{10.0.0.40 Allocated}
{10.0.0.42 Allocated}
{10.0.0.45 Allocated}
{10.0.0.46 Allocated}
{10.0.0.48 Allocated}
{10.0.0.50 Allocated}
...

$ k exec -it azure-cns-z74hd -- /usr/local/bin/azure-cns -cmd get -darg Available
{10.0.0.41 Available}
{10.0.0.43 Available}
{10.0.0.44 Available}
{10.0.0.47 Available}
{10.0.0.49 Available}
{10.0.0.54 Available}
```



**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
