### PR TITLE
Add prefixlength from SubnetAddressRange

### DIFF
--- a/cns/requestcontroller/kubecontroller/crdrequestcontroller_test.go
+++ b/cns/requestcontroller/kubecontroller/crdrequestcontroller_test.go
@@ -23,7 +23,7 @@ const (
 	existingNNCName      = "nodenetconfig_1"
 	existingPodName      = "pod_1"
 	hostNetworkPodName   = "pod_hostNet"
-	allocatedPodIP       = "10.0.0.1/32"
+	allocatedPodIP       = "10.0.0.2"
 	allocatedUUID        = "539970a2-c2dd-11ea-b3de-0242ac130004"
 	allocatedUUID2       = "01a5dd00-cd5d-11ea-87d0-0242ac130003"
 	networkContainerID   = "24fcd232-0364-41b0-8027-6e6ef9aeabc6"
@@ -31,7 +31,8 @@ const (
 	nonexistingNNCName   = "nodenetconfig_nonexisting"
 	nonexistingPodName   = "pod_nonexisting"
 	nonexistingNamespace = "namespace_nonexisting"
-	ncPrimaryIP          = "10.0.0.1/32"
+	ncPrimaryIP          = "10.0.0.1"
+	subnetRange          = "10.0.0.0/24"
 )
 
 // MockAPI is a mock of kubernete's API server
@@ -607,6 +608,7 @@ func TestInitRequestController(t *testing.T) {
 							IP:   allocatedPodIP,
 						},
 					},
+					SubnetAddressSpace: subnetRange,
 				},
 			},
 		},

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -145,7 +145,7 @@ func (service *HTTPRestService) releaseIPConfig(podInfo cns.KubernetesPodInfo) e
 	if ipID != "" {
 		if ipconfig, isExist := service.PodIPConfigState[ipID]; isExist {
 			service.setIPConfigAsAvailable(ipconfig, podInfo)
-			logger.Printf("Released IP %+v for pod %+v", ipconfig.IPSubnet, podInfo)
+			logger.Printf("Released IP %+v for pod %+v", ipconfig.IPAddress, podInfo)
 
 		} else {
 			logger.Errorf("Failed to get release ipconfig. Pod to IPID exists, but IPID to IPConfig doesn't exist, CNS State potentially corrupt")

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -643,21 +643,23 @@ func (service *HTTPRestService) validateIpConfigRequest(ipConfigRequest cns.GetI
 
 func (service *HTTPRestService) populateIpConfigInfoUntransacted(ipConfigStatus ipConfigurationStatus, ipConfiguration *cns.IPConfiguration) error {
 	var (
-		ncStatus containerstatus
-		exists   bool
+		ncStatus               containerstatus
+		exists                 bool
+		primaryIpConfiguration cns.IPConfiguration
 	)
 
 	if ncStatus, exists = service.state.ContainerStatus[ipConfigStatus.NCID]; !exists {
 		return fmt.Errorf("Failed to get NC Configuration for NcId: %s", ipConfigStatus.NCID)
 	}
 
-	ipConfiguration.DNSServers = ncStatus.CreateNetworkContainerRequest.IPConfiguration.DNSServers
-	ipConfiguration.GatewayIPAddress = ncStatus.CreateNetworkContainerRequest.IPConfiguration.GatewayIPAddress
+	primaryIpConfiguration = ncStatus.CreateNetworkContainerRequest.IPConfiguration
 
-	// TODO: This will be changed soon, and prefix length will be set as Subnetprefix length
+	ipConfiguration.DNSServers = primaryIpConfiguration.DNSServers
+	ipConfiguration.GatewayIPAddress = primaryIpConfiguration.GatewayIPAddress
+
 	ipConfiguration.IPSubnet = cns.IPSubnet{
 		IPAddress:    ipConfigStatus.IPAddress,
-		PrefixLength: 32,
+		PrefixLength: primaryIpConfiguration.IPSubnet.PrefixLength,
 	}
 	return nil
 }


### PR DESCRIPTION
Persist the prefix length of PrimaryIPConfiguration from SubnetAddressRange. Note, since SecondaryIPs are also allocated form same range, no need to persist the length with every secondary ip. That will be populated from primaryIP while passing info to CNI