### PR TITLE
Add named ports unit test.

### DIFF
--- a/npm/pod_test.go
+++ b/npm/pod_test.go
@@ -70,6 +70,19 @@ func TestAddPod(t *testing.T) {
 			Phase: "Running",
 			PodIP: "1.2.3.4",
 		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				corev1.Container{
+					Ports: []corev1.ContainerPort{
+						corev1.ContainerPort{
+							ContainerPort: 80,
+							Name:          "serve-80",
+							Protocol:      "TCP",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	npMgr.Lock()


### PR DESCRIPTION
fix: add unit test to gate name port features.

**Reason for Change**:
https://github.com/Azure/azure-container-networking/issues/657
Wrong ipset type report by customer when named port got created. This unit test will gate this regression won't happen.

**Issue Fixed**:
https://github.com/Azure/azure-container-networking/issues/657
test: Testing 💚 
- [X ] adds unit tests