### PR TITLE
Improve TestDestroy unit test validation to make it not flaky.

### DIFF
--- a/npm/ipsm/ipsm_test.go
+++ b/npm/ipsm/ipsm_test.go
@@ -244,7 +244,7 @@ func TestDeleteSet(t *testing.T) {
 		}
 	}()
 
-	testSetName := "test-set"
+	testSetName := "test-delete-set"
 	if err := ipsMgr.CreateSet(testSetName, append([]string{util.IpsetNetHashFlag})); err != nil {
 		t.Errorf("TestDeleteSet failed @ ipsMgr.CreateSet")
 	}
@@ -350,7 +350,7 @@ func TestDeleteFromSet(t *testing.T) {
 		}
 	}()
 
-	testSetName := "test-set"
+	testSetName := "test-delete-from-set"
 	if err := ipsMgr.AddToSet(testSetName, "1.2.3.4", util.IpsetNetHashFlag, ""); err != nil {
 		t.Errorf("TestDeleteFromSet failed @ ipsMgr.AddToSet")
 	}

--- a/npm/ipsm/ipsm_test.go
+++ b/npm/ipsm/ipsm_test.go
@@ -468,12 +468,21 @@ func TestDestroy(t *testing.T) {
 		}
 	}()
 
-	if err := ipsMgr.AddToSet("test-set", "1.2.3.4", util.IpsetNetHashFlag, ""); err != nil {
+	setName := "test-destroy"
+	testIP := "1.2.3.4"
+	if err := ipsMgr.AddToSet(setName, testIP, util.IpsetNetHashFlag, ""); err != nil {
 		t.Errorf("TestDestroy failed @ ipsMgr.AddToSet")
 	}
 
-	if err := ipsMgr.Destroy(); err != nil {
-		t.Errorf("TestDestroy failed @ ipsMgr.Destroy")
+	// Call Destroy and validate set doesn't exist.
+	ipsMgr.Destroy()
+	entry := &ipsEntry{
+		operationFlag: util.IPsetCheckListFlag,
+		set:           util.GetHashedName(setName),
+	}
+
+	if _, err := ipsMgr.Run(entry); err == nil {
+		t.Errorf("TestDestroy failed @ ipsMgr.Destroy since %s still exist in kernel", setName)
 	}
 }
 


### PR DESCRIPTION
fix: TestDestroy validation
**Reason for Change**:
TestDestroy unit test is flaky sometimes since it can be influenced by other ipsets exist in the system. If there are ipsets got referenced from kernel, flush or destroy won't delete it but return error. TestDestroy validation should changed to validate whether the testing ipset got deleted or not.

**Issue Fixed**:
Flaky unit test.

test: Testing 💚
- [X ] adds unit tests
