### PR TITLE
Change variable name from IP6tables back to Ip6tables.

### DIFF
--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -22,7 +22,7 @@ const (
 //iptables related constants.
 const (
 	Iptables                  string = "iptables"
-	IP6tables                 string = "ip6tables"
+	Ip6tables                 string = "ip6tables"
 	IptablesSave              string = "iptables-save"
 	IptablesRestore           string = "iptables-restore"
 	IptablesConfigFile        string = "/var/log/iptables.conf"


### PR DESCRIPTION
fix: variable name

NMAgent is using npm package. A change in NPM package const variable blocked build. Change variable name back to unblock build.

**Reason for Change**:
NMAgent is using npm package. A change in NPM package const variable blocked build. Change variable name back to unblock build.

**Issue Fixed**:
Build blocking.

 build: Build 🏭

