### PR TITLE
Add logging to record CNI_COMMAND value

### DIFF
--- a/cni/network/plugin/main.go
+++ b/cni/network/plugin/main.go
@@ -225,6 +225,10 @@ func main() {
 		panic("network plugin start fatal error")
 	}
 
+	// Check CNI_COMMAD value for logging purposes.
+	cmd := os.Getenv("CNI_COMMAND")
+	log.Errorf("CNI_COMMAND environment variable set to %s", cmd)
+
 	handled, err := handleIfCniUpdate(netPlugin.Update)
 	if handled == true {
 		log.Printf("CNI UPDATE finished.")

--- a/cni/network/plugin/main.go
+++ b/cni/network/plugin/main.go
@@ -225,9 +225,9 @@ func main() {
 		panic("network plugin start fatal error")
 	}
 
-	// Check CNI_COMMAD value for logging purposes.
-	cmd := os.Getenv("CNI_COMMAND")
-	log.Errorf("CNI_COMMAND environment variable set to %s", cmd)
+	// Check CNI_COMMAND value for logging purposes.
+	cniCmd := os.Getenv(cni.Cmd)
+	log.Printf("CNI_COMMAND environment variable set to %s", cniCmd)
 
 	handled, err := handleIfCniUpdate(netPlugin.Update)
 	if handled == true {


### PR DESCRIPTION
We have seen cases where our CNI is getting called for COMMAND with commands other ADD/DEL.

CHECK is only supported for 0.4.0 and above, and current logging gives an impression CNI DID nothing for ADD/DEL calls.