### PR TITLE
Move E2E's to separate stage

### DIFF
--- a/.pipelines/e2e-job-template.yaml
+++ b/.pipelines/e2e-job-template.yaml
@@ -1,34 +1,40 @@
 parameters:
   name: ""
+  displayName: ""
   pipelineBuildImage: "$(BUILD_IMAGE)"
   clusterDefinition: ""
   clusterDefinitionCniTypeKey: ""
   clusterDefinitionCniBuildOS: ""
   clusterDefinitionCniBuildExt: ""
 
-jobs:
-  - job: ${{ parameters.name }}
-    timeoutInMinutes: 120
-    pool:
-      name: Networking-ContainerNetworking
-      demands: agent.os -equals Linux
-    container:
-      image: ${{ parameters.pipelineBuildImage }}
-    variables:
-      GOPATH: "$(Agent.TempDirectory)/go" # Go workspace path
-      GOBIN: "$(GOPATH)/bin" # Go binaries path
-      modulePath: "$(GOPATH)/src/github.com/Azure/aks-engine"
-      acnPath: "$(GOPATH)/src/github.com/Azure/azure-container-networking"
-      Tag: $[ dependencies.unit_tests.outputs['EnvironmentalVariables.Tag'] ]
-      CommitHash: $[ dependencies.unit_tests.outputs['EnvironmentalVariables.CommitHash'] ]
-      StorageID: $[ dependencies.unit_tests.outputs['EnvironmentalVariables.StorageID'] ]
-      CLEANUP_ON_EXIT: true
-      CLEANUP_IF_FAIL: true
-    steps:
-      - template: e2e-step-template.yaml
-        parameters:
-          name: ${{ parameters.name }}
-          clusterDefinition: ${{ parameters.clusterDefinition }}
-          clusterDefinitionCniTypeKey: ${{ parameters.clusterDefinitionCniTypeKey }}
-          clusterDefinitionCniBuildOS: ${{ parameters.clusterDefinitionCniBuildOS }}
-          clusterDefinitionCniBuildExt: ${{ parameters.clusterDefinitionCniBuildExt }}
+stages:
+  - stage: ${{ parameters.name }}
+    displayName: E2E - ${{ parameters.displayName }}
+    dependsOn: build_and_test
+    jobs:
+      - job: ${{ parameters.name }}
+        displayName: Singletenancy AKS Engine Suite - (${{ parameters.name }})
+        timeoutInMinutes: 120
+        pool:
+          name: Networking-ContainerNetworking
+          demands: agent.os -equals Linux
+        container:
+          image: ${{ parameters.pipelineBuildImage }}
+        variables:
+          GOPATH: "$(Agent.TempDirectory)/go" # Go workspace path
+          GOBIN: "$(GOPATH)/bin" # Go binaries path
+          modulePath: "$(GOPATH)/src/github.com/Azure/aks-engine"
+          acnPath: "$(GOPATH)/src/github.com/Azure/azure-container-networking"
+          Tag: $[ dependencies.unit_tests.outputs['EnvironmentalVariables.Tag'] ]
+          CommitHash: $[ dependencies.unit_tests.outputs['EnvironmentalVariables.CommitHash'] ]
+          StorageID: $[ dependencies.unit_tests.outputs['EnvironmentalVariables.StorageID'] ]
+          CLEANUP_ON_EXIT: true
+          CLEANUP_IF_FAIL: true
+        steps:
+          - template: e2e-step-template.yaml
+            parameters:
+              name: ${{ parameters.name }}
+              clusterDefinition: ${{ parameters.clusterDefinition }}
+              clusterDefinitionCniTypeKey: ${{ parameters.clusterDefinitionCniTypeKey }}
+              clusterDefinitionCniBuildOS: ${{ parameters.clusterDefinitionCniBuildOS }}
+              clusterDefinitionCniBuildExt: ${{ parameters.clusterDefinitionCniBuildExt }}

--- a/.pipelines/e2e-job-template.yaml
+++ b/.pipelines/e2e-job-template.yaml
@@ -25,9 +25,9 @@ stages:
           GOBIN: "$(GOPATH)/bin" # Go binaries path
           modulePath: "$(GOPATH)/src/github.com/Azure/aks-engine"
           acnPath: "$(GOPATH)/src/github.com/Azure/azure-container-networking"
-          Tag: $[ dependencies.unit_tests.outputs['EnvironmentalVariables.Tag'] ]
-          CommitHash: $[ dependencies.unit_tests.outputs['EnvironmentalVariables.CommitHash'] ]
-          StorageID: $[ dependencies.unit_tests.outputs['EnvironmentalVariables.StorageID'] ]
+          Tag: $[ stagedependencies.build_and_test.unit_tests.outputs['EnvironmentalVariables.Tag'] ]
+          CommitHash: $[ stagedependencies.build_and_test.unit_tests.outputs['EnvironmentalVariables.CommitHash'] ]
+          StorageID: $[ stagedependencies.build_and_test.unit_tests.outputs['EnvironmentalVariables.StorageID'] ]
           CLEANUP_ON_EXIT: true
           CLEANUP_IF_FAIL: true
         steps:

--- a/.pipelines/e2e-job-template.yaml
+++ b/.pipelines/e2e-job-template.yaml
@@ -8,7 +8,6 @@ parameters:
 
 jobs:
   - job: ${{ parameters.name }}
-    dependsOn: unit_tests
     timeoutInMinutes: 120
     pool:
       name: Networking-ContainerNetworking

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -10,8 +10,10 @@ trigger:
 
 stages:
   - stage: build_and_test
+    displayName: Build and Unit Test
     jobs:
       - job: unit_tests
+        displayName: Unit Tests
         pool:
           name: Networking-ContainerNetworking
           demands: agent.os -equals Linux
@@ -194,6 +196,26 @@ stages:
             displayName: Create artifact storage container
             condition: succeeded()
 
+  - stage: end_to_end_tests
+    displayName: End to End Tests
+    jobs:
+      - job: single_tenancy
+        displayName: Single Tenancy
+        pool:
+          name: Networking-ContainerNetworking
+          demands: agent.os -equals Linux
+
+        container:
+          image: "$(BUILD_IMAGE)" # build image set as variable in pipeline runtime for flexibility
+          options: "--privileged"
+
+        # Go setup for the vmImage:
+        # https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/linux/scripts/installers/go.sh
+        variables:
+          GOBIN: "$(GOPATH)/bin" # Go binaries path
+          GOPATH: "$(System.DefaultWorkingDirectory)/gopath" # Go workspace path
+          modulePath: "$(GOPATH)/src/github.com/Azure/azure-container-networking" # $(build.repository.name)' # Path to the module's code
+
       - template: e2e-job-template.yaml
         parameters:
           name: "ubuntu_16_04_linux_e2e"
@@ -231,8 +253,10 @@ stages:
           clusterDefinitionCniBuildExt: ".zip"
 
   - stage: cleanup
+    displayName: Cleanup
     jobs:
       - job: delete_remote_artifacts
+        displayName: Delete remote artifacts
         pool:
           name: Networking-ContainerNetworking
           demands: agent.os -equals Linux

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -13,7 +13,7 @@ stages:
     displayName: Build and Unit Test
     jobs:
       - job: unit_tests
-        displayName: Unit Tests
+        displayName: CNI, NPM, CNS, CNM
         pool:
           name: Networking-ContainerNetworking
           demands: agent.os -equals Linux
@@ -196,47 +196,53 @@ stages:
             displayName: Create artifact storage container
             condition: succeeded()
 
-  - stage: end_to_end_tests
-    displayName: End to End Tests
-    jobs:
-      - template: e2e-job-template.yaml
-        parameters:
-          name: "ubuntu_16_04_linux_e2e"
-          pipelineBuildImage: "$(BUILD_IMAGE)"
-          clusterDefinition: "cniLinux1604.json"
-          clusterDefinitionCniTypeKey: "azureCNIURLLinux"
-          clusterDefinitionCniBuildOS: "linux"
-          clusterDefinitionCniBuildExt: ".tgz"
+  - template: e2e-job-template.yaml
+    parameters:
+      name: "ubuntu_16_04_linux_e2e"
+      displayName: Ubuntu 16.04
+      pipelineBuildImage: "$(BUILD_IMAGE)"
+      clusterDefinition: "cniLinux1604.json"
+      clusterDefinitionCniTypeKey: "azureCNIURLLinux"
+      clusterDefinitionCniBuildOS: "linux"
+      clusterDefinitionCniBuildExt: ".tgz"
 
-      - template: e2e-job-template.yaml
-        parameters:
-          name: "ubuntu_18_04_linux_e2e"
-          pipelineBuildImage: "$(BUILD_IMAGE)"
-          clusterDefinition: "cniLinux1804.json"
-          clusterDefinitionCniTypeKey: "azureCNIURLLinux"
-          clusterDefinitionCniBuildOS: "linux"
-          clusterDefinitionCniBuildExt: ".tgz"
+  - template: e2e-job-template.yaml
+    parameters:
+      name: "ubuntu_18_04_linux_e2e"
+      displayName: Ubuntu 18.04
+      pipelineBuildImage: "$(BUILD_IMAGE)"
+      clusterDefinition: "cniLinux1804.json"
+      clusterDefinitionCniTypeKey: "azureCNIURLLinux"
+      clusterDefinitionCniBuildOS: "linux"
+      clusterDefinitionCniBuildExt: ".tgz"
 
-      - template: e2e-job-template.yaml
-        parameters:
-          name: "windows_18_09_e2e"
-          pipelineBuildImage: "$(BUILD_IMAGE)"
-          clusterDefinition: "cniWindows1809.json"
-          clusterDefinitionCniTypeKey: "azureCNIURLWindows"
-          clusterDefinitionCniBuildOS: "windows"
-          clusterDefinitionCniBuildExt: ".zip"
+  - template: e2e-job-template.yaml
+    parameters:
+      name: "windows_18_09_e2e"
+      displayName: "Windows 1809"
+      pipelineBuildImage: "$(BUILD_IMAGE)"
+      clusterDefinition: "cniWindows1809.json"
+      clusterDefinitionCniTypeKey: "azureCNIURLWindows"
+      clusterDefinitionCniBuildOS: "windows"
+      clusterDefinitionCniBuildExt: ".zip"
 
-      - template: e2e-job-template.yaml
-        parameters:
-          name: "windows_19_03_e2e"
-          pipelineBuildImage: "$(BUILD_IMAGE)"
-          clusterDefinition: "cniWindows1903.json"
-          clusterDefinitionCniTypeKey: "azureCNIURLWindows"
-          clusterDefinitionCniBuildOS: "windows"
-          clusterDefinitionCniBuildExt: ".zip"
+  - template: e2e-job-template.yaml
+    parameters:
+      name: "windows_19_03_e2e"
+      displayName: "Windows 1903"
+      pipelineBuildImage: "$(BUILD_IMAGE)"
+      clusterDefinition: "cniWindows1903.json"
+      clusterDefinitionCniTypeKey: "azureCNIURLWindows"
+      clusterDefinitionCniBuildOS: "windows"
+      clusterDefinitionCniBuildExt: ".zip"
 
   - stage: cleanup
     displayName: Cleanup
+    dependsOn:
+      - "ubuntu_16_04_linux_e2e"
+      - "ubuntu_18_04_linux_e2e"
+      - "windows_18_09_e2e"
+      - "windows_19_03_e2e"
     jobs:
       - job: delete_remote_artifacts
         displayName: Delete remote artifacts

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -199,23 +199,6 @@ stages:
   - stage: end_to_end_tests
     displayName: End to End Tests
     jobs:
-      - job: single_tenancy
-        displayName: Single Tenancy
-        pool:
-          name: Networking-ContainerNetworking
-          demands: agent.os -equals Linux
-
-        container:
-          image: "$(BUILD_IMAGE)" # build image set as variable in pipeline runtime for flexibility
-          options: "--privileged"
-
-        # Go setup for the vmImage:
-        # https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/linux/scripts/installers/go.sh
-        variables:
-          GOBIN: "$(GOPATH)/bin" # Go binaries path
-          GOPATH: "$(System.DefaultWorkingDirectory)/gopath" # Go workspace path
-          modulePath: "$(GOPATH)/src/github.com/Azure/azure-container-networking" # $(build.repository.name)' # Path to the module's code
-
       - template: e2e-job-template.yaml
         parameters:
           name: "ubuntu_16_04_linux_e2e"


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

Moving the e2e's to a different stage instead of inside the build and UT's

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
