### PR TITLE
test:  stop skipping windows test

### DIFF
--- a/test/e2e/kubernetes/cniWindows1809.json
+++ b/test/e2e/kubernetes/cniWindows1809.json
@@ -32,11 +32,8 @@
          "name": "windowspool2",
          "count": 2,
          "vmSize": "Standard_D2_v2",
-         "availabilityProfile": "AvailabilitySet",
-         "osType": "Windows",
-         "extensions": [{
-            "name": "windows-patches"
-         }]
+        "availabilityProfile": "VirtualMachineScaleSets",
+        "osType": "Windows"
       }],
       "windowsProfile": {
          "adminUsername": "azureuser",

--- a/test/e2e/kubernetes/cniWindows1903.json
+++ b/test/e2e/kubernetes/cniWindows1903.json
@@ -32,11 +32,8 @@
          "name": "windowspool2",
          "count": 2,
          "vmSize": "Standard_D2_v2",
-         "availabilityProfile": "AvailabilitySet",
-         "osType": "Windows",
-         "extensions": [{
-            "name": "windows-patches"
-         }]
+        "availabilityProfile": "VirtualMachineScaleSets",
+        "osType": "Windows"
       }],
       "windowsProfile": {
          "adminUsername": "azureuser",


### PR DESCRIPTION

**Reason for Change**:
A test was being skipped due to our config files listing agent nodes as availability sets instead of vmss's.

**Requirements**:
This test  which makes sure containers come back up correctly after a restart was being skipped because our config files had the agent nodes as availability sets instead of vmss.
https://github.com/Azure/aks-engine/blob/c670571cd42c68ecddca9a9379a5a1d3b0cd6a69/test/e2e/kubernetes/kubernetes_test.go#L2238
![image](https://user-images.githubusercontent.com/35265851/93914610-a117d900-fcbb-11ea-9962-089589dca4ba.png)
![image](https://user-images.githubusercontent.com/35265851/93914554-8e9d9f80-fcbb-11ea-8392-5592c76a3fe0.png)
