### PR TITLE
test: stop skipping aks-engine restart test

### DIFF
--- a/.pipelines/e2e-step-template.yaml
+++ b/.pipelines/e2e-step-template.yaml
@@ -88,6 +88,7 @@ steps:
       export CLEANUP_ON_EXIT=true 
       export REGIONS=$(AKS_ENGINE_REGION) 
       export IS_JENKINS=false 
+      export DEBUG_CRASHING_PODS=true
       make test-kubernetes
     name: DeployAKSEngine
     displayName: Run AKS-Engine E2E Tests


### PR DESCRIPTION
**Reason for Change**:
We want to stop skipping the restart test in aks-engine e2e test suite. [code](https://github.com/Azure/aks-engine/blob/c670571cd42c68ecddca9a9379a5a1d3b0cd6a69/test/e2e/kubernetes/kubernetes_test.go#L812)
Can do this by setting `DEBUG_CRASHING_PODS=true` in pipeline

