### PR TITLE
[Windows] Keep the network state cleanup behavior unchanged 

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -119,7 +119,7 @@ func (plugin *netPlugin) Start(config *common.PluginConfig) error {
 	common.LogNetworkInterfaces()
 
 	// Initialize network manager.
-	err = plugin.nm.Initialize(config, false)
+	err = plugin.nm.Initialize(config, rehydrateNetworkInfoOnReboot)
 	if err != nil {
 		log.Printf("[cni-net] Failed to initialize network manager, err:%v.", err)
 		return err

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -21,7 +21,8 @@ const (
 )
 
 const (
-	snatConfigFileName = "/tmp/snatConfig"
+	snatConfigFileName           = "/tmp/snatConfig"
+	rehydrateNetworkInfoOnReboot = false
 )
 
 // handleConsecutiveAdd is a dummy function for Linux platform.

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -28,6 +28,10 @@ var (
 	win1903Version = 18362
 )
 
+const (
+	rehydrateNetworkInfoOnReboot = true
+)
+
 /* handleConsecutiveAdd handles consecutive add calls for infrastructure containers on Windows platform.
  * This is a temporary work around for issue #57253 of Kubernetes.
  * We can delete this if statement once they fix it.
@@ -268,7 +272,7 @@ func addIPV6EndpointPolicy(nwInfo network.NetworkInfo) (policy.Policy, error) {
 		return eppolicy, fmt.Errorf("network state doesn't have ipv6 subnet")
 	}
 
-    // Everything should be snat'd except podcidr
+	// Everything should be snat'd except podcidr
 	exceptionList := []string{nwInfo.Subnets[1].Prefix.String()}
 	rawPolicy, _ := json.Marshal(&hcsshim.OutboundNatPolicy{
 		Policy:     hcsshim.Policy{Type: hcsshim.OutboundNat},


### PR DESCRIPTION
A recent change made the operation as no-op.