### PR TITLE
Throw CNI error - On CNI DEL call, if communication with CNS cannot be established.

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -119,7 +119,7 @@ func (plugin *netPlugin) Start(config *common.PluginConfig) error {
 	common.LogNetworkInterfaces()
 
 	// Initialize network manager.
-	err = plugin.nm.Initialize(config, false)
+	err = plugin.nm.Initialize(config, rehydrateNetworkInfoOnReboot)
 	if err != nil {
 		log.Printf("[cni-net] Failed to initialize network manager, err:%v.", err)
 		return err

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -21,7 +21,8 @@ const (
 )
 
 const (
-	snatConfigFileName = "/tmp/snatConfig"
+	snatConfigFileName           = "/tmp/snatConfig"
+	rehydrateNetworkInfoOnReboot = false
 )
 
 // handleConsecutiveAdd is a dummy function for Linux platform.

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -28,6 +28,10 @@ var (
 	win1903Version = 18362
 )
 
+const (
+	rehydrateNetworkInfoOnReboot = true
+)
+
 /* handleConsecutiveAdd handles consecutive add calls for infrastructure containers on Windows platform.
  * This is a temporary work around for issue #57253 of Kubernetes.
  * We can delete this if statement once they fix it.
@@ -268,7 +272,7 @@ func addIPV6EndpointPolicy(nwInfo network.NetworkInfo) (policy.Policy, error) {
 		return eppolicy, fmt.Errorf("network state doesn't have ipv6 subnet")
 	}
 
-    // Everything should be snat'd except podcidr
+	// Everything should be snat'd except podcidr
 	exceptionList := []string{nwInfo.Subnets[1].Prefix.String()}
 	rawPolicy, _ := json.Marshal(&hcsshim.OutboundNatPolicy{
 		Policy:     hcsshim.Policy{Type: hcsshim.OutboundNat},

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -153,19 +153,33 @@ func updateSubnetPrefix(cnsNwConfig *cns.GetNetworkContainerResponse, subnetPref
 	return nil
 }
 
-func getNetworkName(podName, podNs, ifName string, nwCfg *cni.NetworkConfig) (networkName string, err error) {
+func getNetworkName(podName, podNs, ifName string, nwCfg *cni.NetworkConfig) (string, bool, error) {
+	var (
+		networkName      string
+		err              error
+		isNotFoundErr    bool
+		cnsNetworkConfig *cns.GetNetworkContainerResponse
+	)
+
 	networkName = nwCfg.Name
 	err = nil
+	isNotFoundErr = false
+
 	if nwCfg.MultiTenancy {
 		determineWinVer()
 		if len(strings.TrimSpace(podName)) == 0 || len(strings.TrimSpace(podNs)) == 0 {
 			err = fmt.Errorf("POD info cannot be empty. PodName: %s, PodNamespace: %s", podName, podNs)
-			return
+			return networkName, isNotFoundErr, err
 		}
 
-		_, cnsNetworkConfig, _, err := getContainerNetworkConfiguration(nwCfg, podName, podNs, ifName)
+		_, cnsNetworkConfig, _, isNotFoundErr, err = getContainerNetworkConfiguration(nwCfg, podName, podNs, ifName)
 		if err != nil {
-			log.Printf("GetContainerNetworkConfiguration failed for podname %v namespace %v with error %v", podName, podNs, err)
+			log.Printf(
+				"GetContainerNetworkConfiguration failed for podname %v namespace %v with error %v, isNotFoundErr: %v",
+				podName,
+				podNs,
+				err,
+				isNotFoundErr)
 		} else {
 			var subnet net.IPNet
 			if err = updateSubnetPrefix(cnsNetworkConfig, &subnet); err == nil {
@@ -177,7 +191,7 @@ func getNetworkName(podName, podNs, ifName string, nwCfg *cni.NetworkConfig) (ne
 		}
 	}
 
-	return
+	return networkName, isNotFoundErr, err
 }
 
 func setupInfraVnetRoutingForMultitenancy(


### PR DESCRIPTION
CNI is some cases is unable to talk to CNS. This can happen, CNS crashing or race between start/CNI getting invoked.

Currently if this communication errrs out on DEL calls, CNI will silently ignore the error.  Container runtime assumes everything went fine and deletes the container. But the HNS endpoints are still there on the host result into them being orphaned. If a container with similar configuration is placed on the host , then ADD call will fail with object already exists error.

Please note, CNI DEL are supposed to be idempotent, and should generally handle the resource not found/exist error elegantely without any error. 