### PR TITLE
Add NC version in nnc CRD. Populate NC version info from nnc CRD to N…

### DIFF
--- a/cns/requestcontroller/kubecontroller/crdtranslator.go
+++ b/cns/requestcontroller/kubecontroller/crdtranslator.go
@@ -36,6 +36,7 @@ func CRDStatusToNCRequest(crdStatus nnc.NodeNetworkConfigStatus) (cns.CreateNetw
 		ncRequest.SecondaryIPConfigs = make(map[string]cns.SecondaryIPConfig)
 		ncRequest.NetworkContainerid = nc.ID
 		ncRequest.NetworkContainerType = cns.Docker
+		ncRequest.Version = nc.Version
 
 		if ip = net.ParseIP(nc.PrimaryIP); ip == nil {
 			return ncRequest, fmt.Errorf("Invalid PrimaryIP %s:", nc.PrimaryIP)

--- a/cns/requestcontroller/kubecontroller/crdtranslator_test.go
+++ b/cns/requestcontroller/kubecontroller/crdtranslator_test.go
@@ -17,6 +17,7 @@ const (
 	subnetAddressSpace = "10.0.0.0/24"
 	subnetPrefixLen    = 24
 	testSecIp1         = "10.0.0.2"
+	version            = "1"
 )
 
 func TestStatusToNCRequestMalformedPrimaryIP(t *testing.T) {
@@ -193,6 +194,7 @@ func TestStatusToNCRequestSuccess(t *testing.T) {
 				SubnetName:         subnetName,
 				DefaultGateway:     defaultGateway,
 				SubnetAddressSpace: subnetAddressSpace,
+				Version:            version,
 			},
 		},
 	}

--- a/nodenetworkconfig/api/v1alpha/nodenetworkconfig.go
+++ b/nodenetworkconfig/api/v1alpha/nodenetworkconfig.go
@@ -72,6 +72,7 @@ type NetworkContainer struct {
 	IPAssignments      []IPAssignment `json:"iPAssignments,omitempty"`
 	DefaultGateway     string         `json:"defaultGateway,omitempty"`
 	SubnetAddressSpace string         `json:"subnetAddressSpace,omitempty"`
+	Version            string         `json:"version,omitempty"`
 }
 
 // IPAssignment groups an IP address and Name. Name is a UUID set by the the IP address assigner.

--- a/nodenetworkconfig/manifests/acn.azure.com_nodenetworkconfigs.yaml
+++ b/nodenetworkconfig/manifests/acn.azure.com_nodenetworkconfigs.yaml
@@ -75,6 +75,8 @@ spec:
                     type: string
                   subnetName:
                     type: string
+                  version:
+                    type: string
                 type: object
               type: array
             scaler:


### PR DESCRIPTION
feat: add NC version in nnc CRD and populate it to NC request.

**Reason for Change**:
It's a prerequisite for IP classification feature. In IP classification feature, CNS will validate IPs through comparing NC version between its local file, nnc CRD and NMAgent to determine whether its available or still pending programming. 
