### PR TITLE
Add pending program status for IPs in CNS.

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -74,6 +74,7 @@ const (
 // CreateNetworkContainerRequest specifies request to create a network container or network isolation boundary.
 type CreateNetworkContainerRequest struct {
 	Version                    string
+	NCVersion                  string
 	NetworkContainerType       string
 	NetworkContainerid         string // Mandatory input.
 	PrimaryInterfaceIdentifier string // Primary CA.

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -61,6 +61,7 @@ const (
 	Available      = "Available"
 	Allocated      = "Allocated"
 	PendingRelease = "PendingRelease"
+	PendingProgram = "PendingProgram"
 )
 
 // ChannelMode :- CNS channel modes

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -58,10 +58,10 @@ const (
 
 // IPConfig States for CNS IPAM
 const (
-	Available      = "Available"
-	Allocated      = "Allocated"
-	PendingRelease = "PendingRelease"
-	PendingProgram = "PendingProgram"
+	Available          = "Available"
+	Allocated          = "Allocated"
+	PendingRelease     = "PendingRelease"
+	PendingProgramming = "PendingProgramming"
 )
 
 // ChannelMode :- CNS channel modes
@@ -74,7 +74,6 @@ const (
 // CreateNetworkContainerRequest specifies request to create a network container or network isolation boundary.
 type CreateNetworkContainerRequest struct {
 	Version                    string
-	NCVersion                  string
 	NetworkContainerType       string
 	NetworkContainerid         string // Mandatory input.
 	PrimaryInterfaceIdentifier string // Primary CA.

--- a/cns/api.go
+++ b/cns/api.go
@@ -37,6 +37,7 @@ type HTTPService interface {
 	SendNCSnapShotPeriodically(int, chan bool)
 	SetNodeOrchestrator(*SetOrchestratorTypeRequest)
 	SyncNodeStatus(string, string, string, json.RawMessage) (int, string)
+	GetPendingProgramIPConfigs() []IPConfigurationStatus
 	GetAvailableIPConfigs() []IPConfigurationStatus
 	GetAllocatedIPConfigs() []IPConfigurationStatus
 	GetPendingReleaseIPConfigs() []IPConfigurationStatus

--- a/cns/fakes/cnsfake.go
+++ b/cns/fakes/cnsfake.go
@@ -83,7 +83,7 @@ func (ipm *IPStateManager) AddIPConfigs(ipconfigs []cns.IPConfigurationStatus) {
 	for i := 0; i < len(ipconfigs); i++ {
 
 		switch {
-		case ipconfigs[i].State == cns.PendingProgram:
+		case ipconfigs[i].State == cns.PendingProgramming:
 			ipm.PendingProgramIPConfigState[ipconfigs[i].ID] = ipconfigs[i]
 		case ipconfigs[i].State == cns.Available:
 			ipm.AvailableIPConfigState[ipconfigs[i].ID] = ipconfigs[i]

--- a/cns/fakes/cnsfake.go
+++ b/cns/fakes/cnsfake.go
@@ -225,6 +225,15 @@ func (fake *HTTPServiceFake) SyncNodeStatus(string, string, string, json.RawMess
 	return 0, ""
 }
 
+func (fake *HTTPServiceFake) GetPendingProgramIPConfigs() []cns.IPConfigurationStatus {
+	ipconfigs := []cns.IPConfigurationStatus{}
+	for _, ipconfig := range fake.IPStateManager.PendingProgramIPConfigState {
+		ipconfigs = append(ipconfigs, ipconfig)
+	}
+
+	return ipconfigs
+}
+
 func (fake *HTTPServiceFake) GetAvailableIPConfigs() []cns.IPConfigurationStatus {
 	ipconfigs := []cns.IPConfigurationStatus{}
 	for _, ipconfig := range fake.IPStateManager.AvailableIPConfigState {

--- a/cns/fakes/cnsfake.go
+++ b/cns/fakes/cnsfake.go
@@ -58,6 +58,7 @@ func (stack *StringStack) Pop() (string, error) {
 }
 
 type IPStateManager struct {
+	PendingProgramIPConfigState map[string]cns.IPConfigurationStatus
 	AvailableIPConfigState      map[string]cns.IPConfigurationStatus
 	AllocatedIPConfigState      map[string]cns.IPConfigurationStatus
 	PendingReleaseIPConfigState map[string]cns.IPConfigurationStatus
@@ -67,6 +68,7 @@ type IPStateManager struct {
 
 func NewIPStateManager() IPStateManager {
 	return IPStateManager{
+		PendingProgramIPConfigState: make(map[string]cns.IPConfigurationStatus),
 		AvailableIPConfigState:      make(map[string]cns.IPConfigurationStatus),
 		AllocatedIPConfigState:      make(map[string]cns.IPConfigurationStatus),
 		PendingReleaseIPConfigState: make(map[string]cns.IPConfigurationStatus),
@@ -81,6 +83,8 @@ func (ipm *IPStateManager) AddIPConfigs(ipconfigs []cns.IPConfigurationStatus) {
 	for i := 0; i < len(ipconfigs); i++ {
 
 		switch {
+		case ipconfigs[i].State == cns.PendingProgram:
+			ipm.PendingProgramIPConfigState[ipconfigs[i].ID] = ipconfigs[i]
 		case ipconfigs[i].State == cns.Available:
 			ipm.AvailableIPConfigState[ipconfigs[i].ID] = ipconfigs[i]
 			ipm.AvailableIPIDStack.Push(ipconfigs[i].ID)

--- a/cns/fakes/imdsclientfake.go
+++ b/cns/fakes/imdsclientfake.go
@@ -47,3 +47,11 @@ func (imdsClient *ImdsClientTest) GetPrimaryInterfaceInfoFromMemory() (*imdsclie
 
 	return imdsClient.GetPrimaryInterfaceInfoFromHost()
 }
+
+// GetNMagentVersion - Mock implementation to return host NMAgent NC version
+// Set it as 0 which is the same as default initial NC version for testing purpose
+func (imdsClient *ImdsClientTest) GetNMagentVersion() int {
+	logger.Printf("[Azure CNS] GetNMagentVersionFromNMAgent")
+
+	return 0
+}

--- a/cns/fakes/imdsclientfake.go
+++ b/cns/fakes/imdsclientfake.go
@@ -21,7 +21,7 @@ func NewFakeImdsClient() *ImdsClientTest {
 	return &ImdsClientTest{}
 }
 
-// GetNetworkContainerInfoFromHost- Mock implementation to return Container version info.
+// GetNetworkContainerInfoFromHost - Mock implementation to return Container version info.
 func (imdsClient *ImdsClientTest) GetNetworkContainerInfoFromHost(networkContainerID string, primaryAddress string, authToken string, apiVersion string) (*imdsclient.ContainerVersion, error) {
 
 	ret := &imdsclient.ContainerVersion{}
@@ -48,10 +48,10 @@ func (imdsClient *ImdsClientTest) GetPrimaryInterfaceInfoFromMemory() (*imdsclie
 	return imdsClient.GetPrimaryInterfaceInfoFromHost()
 }
 
-// GetNMagentVersion - Mock implementation to return host NMAgent NC version
+// GetNetworkContainerInfoFromHostWithoutToken - Mock implementation to return host NMAgent NC version
 // Set it as 0 which is the same as default initial NC version for testing purpose
-func (imdsClient *ImdsClientTest) GetNMagentVersion() int {
-	logger.Printf("[Azure CNS] GetNMagentVersionFromNMAgent")
+func (imdsClient *ImdsClientTest) GetNetworkContainerInfoFromHostWithoutToken() int {
+	logger.Printf("[Azure CNS] get the NC version from NMAgent")
 
 	return 0
 }

--- a/cns/imdsclient/api.go
+++ b/cns/imdsclient/api.go
@@ -74,4 +74,5 @@ type ImdsClientInterface interface {
 	GetNetworkContainerInfoFromHost(networkContainerID string, primaryAddress string, authToken string, apiVersion string) (*ContainerVersion, error)
 	GetPrimaryInterfaceInfoFromHost() (*InterfaceInfo, error)
 	GetPrimaryInterfaceInfoFromMemory() (*InterfaceInfo, error)
+	GetNMagentVersion() int
 }

--- a/cns/imdsclient/api.go
+++ b/cns/imdsclient/api.go
@@ -74,5 +74,5 @@ type ImdsClientInterface interface {
 	GetNetworkContainerInfoFromHost(networkContainerID string, primaryAddress string, authToken string, apiVersion string) (*ContainerVersion, error)
 	GetPrimaryInterfaceInfoFromHost() (*InterfaceInfo, error)
 	GetPrimaryInterfaceInfoFromMemory() (*InterfaceInfo, error)
-	GetNMagentVersion() int
+	GetNetworkContainerInfoFromHostWithoutToken() int
 }

--- a/cns/imdsclient/imdsclient.go
+++ b/cns/imdsclient/imdsclient.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"math"
 	"net/http"
 	"strings"
 
@@ -131,4 +132,12 @@ func (imdsClient *ImdsClient) GetPrimaryInterfaceInfoFromMemory() (*InterfaceInf
 	}
 
 	return iface, err
+}
+
+// GetNMagentVersion is a temp implementation which will be removed once background thread
+// updating host version is ready. Return max integer value to regress current AKS scenario
+func (imdsClient *ImdsClient) GetNMagentVersion() int {
+	logger.Printf("[Azure CNS] GetNMagentVersionFromNMAgent")
+
+	return math.MaxInt64
 }

--- a/cns/imdsclient/imdsclient.go
+++ b/cns/imdsclient/imdsclient.go
@@ -134,9 +134,9 @@ func (imdsClient *ImdsClient) GetPrimaryInterfaceInfoFromMemory() (*InterfaceInf
 	return iface, err
 }
 
-// GetNMagentVersion is a temp implementation which will be removed once background thread
+// GetNetworkContainerInfoFromHostWithoutToken is a temp implementation which will be removed once background thread
 // updating host version is ready. Return max integer value to regress current AKS scenario
-func (imdsClient *ImdsClient) GetNMagentVersion() int {
+func (imdsClient *ImdsClient) GetNetworkContainerInfoFromHostWithoutToken() int {
 	logger.Printf("[Azure CNS] GetNMagentVersionFromNMAgent")
 
 	return math.MaxInt64

--- a/cns/ipampoolmonitor/ipampoolmonitor.go
+++ b/cns/ipampoolmonitor/ipampoolmonitor.go
@@ -64,7 +64,7 @@ func (pm *CNSIPAMPoolMonitor) Start(ctx context.Context, poolMonitorRefreshMilli
 
 func (pm *CNSIPAMPoolMonitor) Reconcile() error {
 	cnsPodIPConfigCount := len(pm.cns.GetPodIPConfigState())
-	pendingProgramCount := len(pm.cns.GetPendingProgramIPConfigs())
+	pendingProgramCount := len(pm.cns.GetPendingProgramIPConfigs()) // TODO: add pending program count to real cns
 	allocatedPodIPCount := len(pm.cns.GetAllocatedIPConfigs())
 	pendingReleaseIPCount := len(pm.cns.GetPendingReleaseIPConfigs())
 	availableIPConfigCount := len(pm.cns.GetAvailableIPConfigs()) // TODO: add pending allocation count to real cns

--- a/cns/ipampoolmonitor/ipampoolmonitor.go
+++ b/cns/ipampoolmonitor/ipampoolmonitor.go
@@ -64,12 +64,14 @@ func (pm *CNSIPAMPoolMonitor) Start(ctx context.Context, poolMonitorRefreshMilli
 
 func (pm *CNSIPAMPoolMonitor) Reconcile() error {
 	cnsPodIPConfigCount := len(pm.cns.GetPodIPConfigState())
+	pendingProgramCount := len(pm.cns.GetPendingProgramIPConfigs())
 	allocatedPodIPCount := len(pm.cns.GetAllocatedIPConfigs())
 	pendingReleaseIPCount := len(pm.cns.GetPendingReleaseIPConfigs())
 	availableIPConfigCount := len(pm.cns.GetAvailableIPConfigs()) // TODO: add pending allocation count to real cns
 	freeIPConfigCount := pm.cachedNNC.Spec.RequestedIPCount - int64(allocatedPodIPCount)
 
-	logger.Printf("[ipam-pool-monitor] Checking pool for resize, Pool Size: %v, Goal Size: %v, BatchSize: %v, MinFree: %v, MaxFree:%v, Allocated: %v, Available: %v, Pending Release: %v, Free: %v", cnsPodIPConfigCount, pm.cachedNNC.Spec.RequestedIPCount, pm.scalarUnits.BatchSize, pm.MinimumFreeIps, pm.MaximumFreeIps, allocatedPodIPCount, availableIPConfigCount, pendingReleaseIPCount, freeIPConfigCount)
+	logger.Printf("[ipam-pool-monitor] Checking pool for resize, Pool Size: %v, Goal Size: %v, BatchSize: %v, MinFree: %v, MaxFree:%v, Allocated: %v, Available: %v, Pending Release: %v, Free: %v, Pending Program: %v",
+		cnsPodIPConfigCount, pm.cachedNNC.Spec.RequestedIPCount, pm.scalarUnits.BatchSize, pm.MinimumFreeIps, pm.MaximumFreeIps, allocatedPodIPCount, availableIPConfigCount, pendingReleaseIPCount, freeIPConfigCount, pendingProgramCount)
 
 	switch {
 	// pod count is increasing

--- a/cns/requestcontroller/kubecontroller/crdtranslator.go
+++ b/cns/requestcontroller/kubecontroller/crdtranslator.go
@@ -36,7 +36,7 @@ func CRDStatusToNCRequest(crdStatus nnc.NodeNetworkConfigStatus) (cns.CreateNetw
 		ncRequest.SecondaryIPConfigs = make(map[string]cns.SecondaryIPConfig)
 		ncRequest.NetworkContainerid = nc.ID
 		ncRequest.NetworkContainerType = cns.Docker
-		ncRequest.NCVersion = nc.Version
+		ncRequest.Version = nc.Version
 
 		if ip = net.ParseIP(nc.PrimaryIP); ip == nil {
 			return ncRequest, fmt.Errorf("Invalid PrimaryIP %s:", nc.PrimaryIP)

--- a/cns/requestcontroller/kubecontroller/crdtranslator.go
+++ b/cns/requestcontroller/kubecontroller/crdtranslator.go
@@ -36,7 +36,7 @@ func CRDStatusToNCRequest(crdStatus nnc.NodeNetworkConfigStatus) (cns.CreateNetw
 		ncRequest.SecondaryIPConfigs = make(map[string]cns.SecondaryIPConfig)
 		ncRequest.NetworkContainerid = nc.ID
 		ncRequest.NetworkContainerType = cns.Docker
-		ncRequest.Version = nc.Version
+		ncRequest.NCVersion = nc.Version
 
 		if ip = net.ParseIP(nc.PrimaryIP); ip == nil {
 			return ncRequest, fmt.Errorf("Invalid PrimaryIP %s:", nc.PrimaryIP)

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -226,11 +226,13 @@ func validateNetworkRequest(t *testing.T, req cns.CreateNetworkContainerRequest)
 	}
 
 	var expectedIPStatus string
-	if containerStatus.VMVersion > containerStatus.HostVersion {
+	// 0 is the default NMAgent version return from fake GetNMagentVersion
+	if containerStatus.VMVersion > "0" {
 		expectedIPStatus = cns.PendingProgramming
 	} else {
 		expectedIPStatus = cns.Available
 	}
+	t.Logf("VMVersion is %s, HostVersion is %s", containerStatus.VMVersion, containerStatus.HostVersion)
 	var alreadyValidated = make(map[string]string)
 	for ipid, ipStatus := range svc.PodIPConfigState {
 		if ipaddress, found := alreadyValidated[ipid]; !found {
@@ -257,7 +259,7 @@ func validateNetworkRequest(t *testing.T, req cns.CreateNetworkContainerRequest)
 					}
 				} else if ipStatus.State != expectedIPStatus {
 					// Todo: Validate for pendingRelease as well
-					t.Fatalf("IPId: %s State is not Available, ipStatus: %+v", ipid, ipStatus)
+					t.Fatalf("IPId: %s State is not as expected, ipStatus is : %+v, expected status is %+v", ipid, ipStatus.State, expectedIPStatus)
 				}
 
 				alreadyValidated[ipid] = ipStatus.IPAddress

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -226,7 +226,7 @@ func validateNetworkRequest(t *testing.T, req cns.CreateNetworkContainerRequest)
 	}
 
 	var expectedIPStatus string
-	// 0 is the default NMAgent version return from fake GetNMagentVersion
+	// 0 is the default NMAgent version return from fake GetNetworkContainerInfoFromHost
 	if containerStatus.VMVersion > "0" {
 		expectedIPStatus = cns.PendingProgramming
 	} else {

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -35,8 +35,17 @@ func TestCreateOrUpdateNetworkContainerInternal(t *testing.T) {
 
 	setEnv(t)
 	setOrchestratorTypeInternal(cns.KubernetesCRD)
+	// NC version set as 0 which is the default initial value.
+	validateCreateOrUpdateNCInternal(t, 2, "0")
+}
 
-	validateCreateOrUpdateNCInternal(t, 2)
+func TestCreateOrUpdateNCWithLargerVersionComparedToNMAgent(t *testing.T) {
+	restartService()
+
+	setEnv(t)
+	setOrchestratorTypeInternal(cns.KubernetesCRD)
+	// NC version set as 1 which is larger than NC version get from mock nmagent.
+	validateCreateOrUpdateNCInternal(t, 2, "1")
 }
 
 func TestReconcileNCWithEmptyState(t *testing.T) {
@@ -69,7 +78,7 @@ func TestReconcileNCWithExistingState(t *testing.T) {
 		secondaryIPConfigs[ipId.String()] = secIpConfig
 		startingIndex++
 	}
-	req := generateNetworkContainerRequest(secondaryIPConfigs, "reconcileNc1")
+	req := generateNetworkContainerRequest(secondaryIPConfigs, "reconcileNc1", "0")
 
 	expectedAllocatedPods := make(map[string]cns.KubernetesPodInfo)
 	expectedAllocatedPods["10.0.0.6"] = cns.KubernetesPodInfo{
@@ -106,7 +115,7 @@ func TestReconcileNCWithSystemPods(t *testing.T) {
 		secondaryIPConfigs[ipId.String()] = secIpConfig
 		startingIndex++
 	}
-	req := generateNetworkContainerRequest(secondaryIPConfigs, uuid.New().String())
+	req := generateNetworkContainerRequest(secondaryIPConfigs, uuid.New().String(), "0")
 
 	expectedAllocatedPods := make(map[string]cns.KubernetesPodInfo)
 	expectedAllocatedPods["10.0.0.6"] = cns.KubernetesPodInfo{
@@ -135,7 +144,7 @@ func setOrchestratorTypeInternal(orchestratorType string) {
 	svc.state.OrchestratorType = orchestratorType
 }
 
-func validateCreateOrUpdateNCInternal(t *testing.T, secondaryIpCount int) {
+func validateCreateOrUpdateNCInternal(t *testing.T, secondaryIpCount int, ncVersion string) {
 	secondaryIPConfigs := make(map[string]cns.SecondaryIPConfig)
 	ncId := "testNc1"
 
@@ -148,7 +157,7 @@ func validateCreateOrUpdateNCInternal(t *testing.T, secondaryIpCount int) {
 		startingIndex++
 	}
 
-	createAndValidateNCRequest(t, secondaryIPConfigs, ncId)
+	createAndValidateNCRequest(t, secondaryIPConfigs, ncId, ncVersion)
 
 	// now Validate Update, add more secondaryIpConfig and it should handle the update
 	fmt.Println("Validate Scaleup")
@@ -160,7 +169,7 @@ func validateCreateOrUpdateNCInternal(t *testing.T, secondaryIpCount int) {
 		startingIndex++
 	}
 
-	createAndValidateNCRequest(t, secondaryIPConfigs, ncId)
+	createAndValidateNCRequest(t, secondaryIPConfigs, ncId, ncVersion)
 
 	// now Scale down, delete 3 ipaddresses from secondaryIpConfig req
 	fmt.Println("Validate Scale down")
@@ -174,7 +183,7 @@ func validateCreateOrUpdateNCInternal(t *testing.T, secondaryIpCount int) {
 		}
 	}
 
-	createAndValidateNCRequest(t, secondaryIPConfigs, ncId)
+	createAndValidateNCRequest(t, secondaryIPConfigs, ncId, ncVersion)
 
 	// Cleanup all SecondaryIps
 	fmt.Println("Validate no SecondaryIpconfigs")
@@ -182,11 +191,11 @@ func validateCreateOrUpdateNCInternal(t *testing.T, secondaryIpCount int) {
 		delete(secondaryIPConfigs, ipid)
 	}
 
-	createAndValidateNCRequest(t, secondaryIPConfigs, ncId)
+	createAndValidateNCRequest(t, secondaryIPConfigs, ncId, ncVersion)
 }
 
-func createAndValidateNCRequest(t *testing.T, secondaryIPConfigs map[string]cns.SecondaryIPConfig, ncId string) {
-	req := generateNetworkContainerRequest(secondaryIPConfigs, ncId)
+func createAndValidateNCRequest(t *testing.T, secondaryIPConfigs map[string]cns.SecondaryIPConfig, ncId, ncVersion string) {
+	req := generateNetworkContainerRequest(secondaryIPConfigs, ncId, ncVersion)
 	returnCode := svc.CreateOrUpdateNetworkContainerInternal(req, fakes.NewFakeScalar(releasePercent, requestPercent, batchSize), fakes.NewFakeNodeNetworkConfigSpec(initPoolSize))
 	if returnCode != 0 {
 		t.Fatalf("Failed to createNetworkContainerRequest, req: %+v, err: %d", req, returnCode)
@@ -216,6 +225,12 @@ func validateNetworkRequest(t *testing.T, req cns.CreateNetworkContainerRequest)
 		t.Fatalf("Failed as Secondary IP count doesnt match in PodIpConfig state, expected:%d, actual %d", len(req.SecondaryIPConfigs), len(svc.PodIPConfigState))
 	}
 
+	var expectedIPStatus string
+	if containerStatus.VMVersion > containerStatus.HostVersion {
+		expectedIPStatus = cns.PendingProgramming
+	} else {
+		expectedIPStatus = cns.Available
+	}
 	var alreadyValidated = make(map[string]string)
 	for ipid, ipStatus := range svc.PodIPConfigState {
 		if ipaddress, found := alreadyValidated[ipid]; !found {
@@ -240,7 +255,7 @@ func validateNetworkRequest(t *testing.T, req cns.CreateNetworkContainerRequest)
 					} else {
 						t.Fatalf("Failed to find podContext for allocated ip: %+v, podinfo :%+v", ipStatus, podInfo)
 					}
-				} else if ipStatus.State != cns.Available {
+				} else if ipStatus.State != expectedIPStatus {
 					// Todo: Validate for pendingRelease as well
 					t.Fatalf("IPId: %s State is not Available, ipStatus: %+v", ipid, ipStatus)
 				}
@@ -256,7 +271,7 @@ func validateNetworkRequest(t *testing.T, req cns.CreateNetworkContainerRequest)
 	}
 }
 
-func generateNetworkContainerRequest(secondaryIps map[string]cns.SecondaryIPConfig, ncId string) cns.CreateNetworkContainerRequest {
+func generateNetworkContainerRequest(secondaryIps map[string]cns.SecondaryIPConfig, ncId string, ncVersion string) cns.CreateNetworkContainerRequest {
 	var ipConfig cns.IPConfiguration
 	ipConfig.DNSServers = dnsservers
 	ipConfig.GatewayIPAddress = gatewayIp
@@ -269,6 +284,7 @@ func generateNetworkContainerRequest(secondaryIps map[string]cns.SecondaryIPConf
 		NetworkContainerType: dockerContainerType,
 		NetworkContainerid:   ncId,
 		IPConfiguration:      ipConfig,
+		Version:              ncVersion,
 	}
 
 	req.SecondaryIPConfigs = make(map[string]cns.SecondaryIPConfig)

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -118,6 +118,15 @@ func (service *HTTPRestService) GetPodIPConfigState() map[string]cns.IPConfigura
 	return service.PodIPConfigState
 }
 
+// GetPendingProgramIPConfigs returns list of IPs which are in pending program status
+func (service *HTTPRestService) GetPendingProgramIPConfigs() []cns.IPConfigurationStatus {
+	service.RLock()
+	defer service.RUnlock()
+	return filterIPConfigMap(service.PodIPConfigState, func(ipconfig cns.IPConfigurationStatus) bool {
+		return ipconfig.State == cns.PendingProgram
+	})
+}
+
 func (service *HTTPRestService) GetAllocatedIPConfigs() []cns.IPConfigurationStatus {
 	service.RLock()
 	defer service.RUnlock()

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -123,7 +123,7 @@ func (service *HTTPRestService) GetPendingProgramIPConfigs() []cns.IPConfigurati
 	service.RLock()
 	defer service.RUnlock()
 	return filterIPConfigMap(service.PodIPConfigState, func(ipconfig cns.IPConfigurationStatus) bool {
-		return ipconfig.State == cns.PendingProgram
+		return ipconfig.State == cns.PendingProgramming
 	})
 }
 

--- a/cns/restserver/ipam_test.go
+++ b/cns/restserver/ipam_test.go
@@ -144,7 +144,7 @@ func UpdatePodIpConfigState(t *testing.T, svc *HTTPRestService, ipconfigs map[st
 		secondaryIPConfigs[ipId] = secIpConfig
 	}
 
-	createAndValidateNCRequest(t, secondaryIPConfigs, testNCID)
+	createAndValidateNCRequest(t, secondaryIPConfigs, testNCID, "0")
 
 	// update ipconfigs to expected state
 	for ipId, ipconfig := range ipconfigs {

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -116,9 +116,7 @@ func (service *HTTPRestService) saveNetworkContainerGoalState(req cns.CreateNetw
 		hostVersion = existingNCStatus.HostVersion
 		existingSecondaryIPConfigs = existingNCStatus.CreateNetworkContainerRequest.SecondaryIPConfigs
 	} else {
-		// Host version is the NC version from NMAgent, set it -2 to indicate no result from NMAgent yet.
-		// Existing NC status will be set as -1 to indicate no version exist yet.
-		// Intentionally set default host version smaller than existing NC version.
+		// Host version is the NC version from NMAgent, set it -1 to indicate no result from NMAgent yet.
 		hostVersion = "-1"
 	}
 

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -112,8 +112,12 @@ func (service *HTTPRestService) saveNetworkContainerGoalState(req cns.CreateNetw
 
 	existingNCStatus, ok := service.state.ContainerStatus[req.NetworkContainerid]
 	var hostVersion string
+	var existingSecondaryIPConfigs map[string]cns.SecondaryIPConfig //uuid is key
+	var existingNCVersion string
 	if ok {
 		hostVersion = existingNCStatus.HostVersion
+		existingSecondaryIPConfigs = existingNCStatus.CreateNetworkContainerRequest.SecondaryIPConfigs
+		existingNCVersion = existingNCStatus.VMVersion
 	}
 
 	service.state.ContainerStatus[req.NetworkContainerid] =
@@ -165,7 +169,7 @@ func (service *HTTPRestService) saveNetworkContainerGoalState(req cns.CreateNetw
 
 		case cns.KubernetesCRD:
 			// Validate and Update the SecondaryIpConfig state
-			returnCode, returnMesage := service.updateIpConfigsStateUntransacted(req, existingNCStatus)
+			returnCode, returnMesage := service.updateIpConfigsStateUntransacted(req, existingSecondaryIPConfigs, existingNCVersion)
 			if returnCode != 0 {
 				return returnCode, returnMesage
 			}
@@ -195,14 +199,14 @@ func (service *HTTPRestService) saveNetworkContainerGoalState(req cns.CreateNetw
 // This func will compute the deltaIpConfigState which needs to be updated (Added or Deleted)
 // from the inmemory map
 // Note: Also this func is an untransacted API as the caller will take a Service lock
-func (service *HTTPRestService) updateIpConfigsStateUntransacted(req cns.CreateNetworkContainerRequest, existingNCStatus containerstatus) (int, string) {
+func (service *HTTPRestService) updateIpConfigsStateUntransacted(req cns.CreateNetworkContainerRequest, existingSecondaryIPConfigs map[string]cns.SecondaryIPConfig, existingNCVersion string) (int, string) {
 	// parse the existingSecondaryIpConfigState to find the deleted Ips
 	newIPConfigs := req.SecondaryIPConfigs
 	var tobeDeletedIpConfigs = make(map[string]cns.SecondaryIPConfig)
 
 	// Populate the ToBeDeleted list, Secondary IPs which doesnt exist in New request anymore.
 	// We will later remove them from the in-memory cache
-	for secondaryIpId, existingIPConfig := range existingNCStatus.CreateNetworkContainerRequest.SecondaryIPConfigs {
+	for secondaryIpId, existingIPConfig := range existingSecondaryIPConfigs {
 		_, exists := newIPConfigs[secondaryIpId]
 		if !exists {
 			// IP got removed in the updated request, add it in tobeDeletedIps
@@ -235,7 +239,7 @@ func (service *HTTPRestService) updateIpConfigsStateUntransacted(req cns.CreateN
 	}
 
 	// Add the newIpConfigs, ignore if ip state is already in the map
-	service.addIPConfigStateUntransacted(req.Version, existingNCStatus, newIPConfigs)
+	service.addIPConfigStateUntransacted(req, existingNCVersion, newIPConfigs)
 
 	return 0, ""
 }
@@ -243,12 +247,13 @@ func (service *HTTPRestService) updateIpConfigsStateUntransacted(req cns.CreateN
 // addIPConfigStateUntransacted adds the IPConfigs to the PodIpConfigState map with Available state
 // If the IP is already added then it will be an idempotent call. Also note, caller will
 // acquire/release the service lock.
-func (service *HTTPRestService) addIPConfigStateUntransacted(version string, existingNCStatus containerstatus, ipconfigs map[string]cns.SecondaryIPConfig) {
+func (service *HTTPRestService) addIPConfigStateUntransacted(req cns.CreateNetworkContainerRequest, existingNCVersionInString string, ipconfigs map[string]cns.SecondaryIPConfig) {
 
 	var newNCVersion int
-	newNCVersion, _ = strconv.Atoi(version)
-	existingNCVersion, _ := strconv.Atoi(existingNCStatus.CreateNetworkContainerRequest.Version)
-	nmAgentNCVersion := getNCVersionFromNMAgent(existingNCStatus.ID)
+	var existingNCVersion int
+	newNCVersion, _ = strconv.Atoi(req.Version)
+	existingNCVersion, _ = strconv.Atoi(existingNCVersionInString)
+	nmAgentNCVersion := getNCVersionFromNMAgent(req.NetworkContainerid)
 
 	if nmAgentNCVersion >= newNCVersion { // add ipconfigs to state
 		for ipId, ipconfig := range ipconfigs {
@@ -259,7 +264,7 @@ func (service *HTTPRestService) addIPConfigStateUntransacted(version string, exi
 
 			// add the new State
 			ipconfigStatus := cns.IPConfigurationStatus{
-				NCID:                existingNCStatus.ID,
+				NCID:                req.NetworkContainerid,
 				ID:                  ipId,
 				IPAddress:           ipconfig.IPAddress,
 				State:               cns.Available,

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -191,13 +191,6 @@ func (service *HTTPRestService) saveNetworkContainerGoalState(req cns.CreateNetw
 		return UnsupportedNetworkContainerType, errMsg
 	}
 
-	service.state.ContainerStatus[req.NetworkContainerid] =
-		containerstatus{
-			ID:                            req.NetworkContainerid,
-			VMVersion:                     req.Version,
-			CreateNetworkContainerRequest: req,
-			HostVersion:                   hostVersion}
-
 	service.saveState()
 	return 0, ""
 }
@@ -254,16 +247,19 @@ func (service *HTTPRestService) updateIpConfigsStateUntransacted(req cns.CreateN
 	// Wait for Ashvin's thread update which querying NMAgent to get latest NC version and save it locally.
 	nmAgentNCVersion := getNCVersionFromNMAgent(req.NetworkContainerid)
 	if nmAgentNCVersion >= newNCVersion {
-		service.addIPConfigStateUntransacted(cns.Available, cns.Available, newIPConfigs)
+		service.addIPConfigStateUntransacted(cns.Available, cns.Available, req.NetworkContainerid, newIPConfigs)
 	} else {
 		if nmAgentNCVersion >= existingNCVersion {
-			service.addIPConfigStateUntransacted(cns.Available, cns.PendingProgramming, newIPConfigs)
+			service.addIPConfigStateUntransacted(cns.Available, cns.PendingProgramming, req.NetworkContainerid, newIPConfigs)
 		} else {
-			service.addIPConfigStateUntransacted(cns.PendingProgramming, cns.PendingProgramming, newIPConfigs)
+			service.addIPConfigStateUntransacted(cns.PendingProgramming, cns.PendingProgramming, req.NetworkContainerid, newIPConfigs)
 		}
 	}
 
-	service.state.ContainerStatus[req.NetworkContainerid].HostVersion = nmAgentNCVersion
+	existingNCStatus, ok := service.state.ContainerStatus[req.NetworkContainerid]
+	if ok {
+		existingNCStatus.HostVersion = strconv.Itoa(nmAgentNCVersion)
+	}
 
 	return 0, ""
 }
@@ -271,7 +267,7 @@ func (service *HTTPRestService) updateIpConfigsStateUntransacted(req cns.CreateN
 // addIPConfigStateUntransacted adds the IPConfigs to the PodIpConfigState map with Available state
 // If the IP is already added then it will be an idempotent call. Also note, caller will
 // acquire/release the service lock.
-func (service *HTTPRestService) addIPConfigStateUntransacted(updatedExistingIPCNSStatus, newIPCNSStatus string, ipconfigs map[string]cns.SecondaryIPConfig) {
+func (service *HTTPRestService) addIPConfigStateUntransacted(updatedExistingIPCNSStatus, newIPCNSStatus, ncId string, ipconfigs map[string]cns.SecondaryIPConfig) {
 	// add ipconfigs to state
 	for ipId, ipconfig := range ipconfigs {
 		if existingPodIpConfigStatus, exists := service.PodIPConfigState[ipId]; exists {
@@ -281,7 +277,7 @@ func (service *HTTPRestService) addIPConfigStateUntransacted(updatedExistingIPCN
 			continue
 		}
 		ipconfigStatus := cns.IPConfigurationStatus{
-			NCID:                req.NetworkContainerid,
+			NCID:                ncId,
 			ID:                  ipId,
 			IPAddress:           ipconfig.IPAddress,
 			State:               newIPCNSStatus,

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -276,6 +276,7 @@ func (service *HTTPRestService) addIPConfigStateUntransacted(updatedExistingIPCN
 			}
 			continue
 		}
+		// add the new State
 		ipconfigStatus := cns.IPConfigurationStatus{
 			NCID:                ncId,
 			ID:                  ipId,

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -234,7 +234,7 @@ func (service *HTTPRestService) updateIpConfigsStateUntransacted(req cns.CreateN
 	nmagentNCVersion, _ := strconv.Atoi(hostVersion)
 
 	// TODO, remove this override when background thread which update nmagent version is ready.
-	nmagentNCVersion = service.imdsClient.GetNMagentVersion()
+	nmagentNCVersion = service.imdsClient.GetNetworkContainerInfoFromHostWithoutToken()
 
 	if nmagentNCVersion >= newNCVersion {
 		service.addIPConfigStateUntransacted(cns.Available, req.NetworkContainerid, newIPConfigs)


### PR DESCRIPTION
*Add pending program status for IPs in CNS.
*Add logic structure of how to update program status.

feat: 
Add logic structure for CNS udpate NC secondary IP to pending program before available

**Reason for Change**:
Pending program is a status to track that IP is available in NC but not in NMAgent side yet. IP is available when NMAgent is also ready. 

**Issue Fixed**:
Prevent CNS allocate pending program IP to pod.
