### PR TITLE
fix: Pass host gateway to CNI in swift mode

### DIFF
--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -27,12 +27,13 @@ type CNSIPAMInvoker struct {
 }
 
 type IPv4ResultInfo struct {
-	podIPAddress   string
-	ncSubnetPrefix uint8
-	ncPrimaryIP    string
-	gwIPAddress    string
-	hostSubnet     string
-	hostPrimaryIP  string
+	podIPAddress       string
+	ncSubnetPrefix     uint8
+	ncPrimaryIP        string
+	ncGatewayIPAddress string
+	hostSubnet         string
+	hostPrimaryIP      string
+	hostGateway        string
 }
 
 func NewCNSInvoker(podName, namespace string) (*CNSIPAMInvoker, error) {
@@ -61,16 +62,25 @@ func (invoker *CNSIPAMInvoker) Add(nwCfg *cni.NetworkConfig, subnetPrefix *net.I
 	}
 
 	resultIPv4 := IPv4ResultInfo{
-		podIPAddress:   response.PodIpInfo.PodIPConfig.IPAddress,
-		ncSubnetPrefix: response.PodIpInfo.NetworkContainerPrimaryIPConfig.IPSubnet.PrefixLength,
-		ncPrimaryIP:    response.PodIpInfo.NetworkContainerPrimaryIPConfig.IPSubnet.IPAddress,
-		gwIPAddress:    response.PodIpInfo.NetworkContainerPrimaryIPConfig.GatewayIPAddress,
-		hostSubnet:     response.PodIpInfo.HostPrimaryIPInfo.Subnet,
-		hostPrimaryIP:  response.PodIpInfo.HostPrimaryIPInfo.PrimaryIP,
+		podIPAddress:       response.PodIpInfo.PodIPConfig.IPAddress,
+		ncSubnetPrefix:     response.PodIpInfo.NetworkContainerPrimaryIPConfig.IPSubnet.PrefixLength,
+		ncPrimaryIP:        response.PodIpInfo.NetworkContainerPrimaryIPConfig.IPSubnet.IPAddress,
+		ncGatewayIPAddress: response.PodIpInfo.NetworkContainerPrimaryIPConfig.GatewayIPAddress,
+		hostSubnet:         response.PodIpInfo.HostPrimaryIPInfo.Subnet,
+		hostPrimaryIP:      response.PodIpInfo.HostPrimaryIPInfo.PrimaryIP,
+		hostGateway:        response.PodIpInfo.HostPrimaryIPInfo.Gateway,
+	}
+
+	ncgw := net.ParseIP(resultIPv4.ncGatewayIPAddress)
+	if ncgw == nil {
+		return nil, nil, fmt.Errorf("Gateway address %v from response is invalid", resultIPv4.ncGatewayIPAddress)
 	}
 
 	// set the NC Primary IP in options
 	options[network.SNATIPKey] = resultIPv4.ncPrimaryIP
+
+	// set host gateway in options
+	options[network.HostGWKey] = resultIPv4.hostGateway
 
 	log.Printf("Received result %+v for pod %v", resultIPv4, podInfo)
 
@@ -85,7 +95,7 @@ func (invoker *CNSIPAMInvoker) Add(nwCfg *cni.NetworkConfig, subnetPrefix *net.I
 
 func getCNIIPv4Result(info IPv4ResultInfo, subnetPrefix *net.IPNet) (*cniTypesCurr.Result, error) {
 
-	gw := net.ParseIP(info.gwIPAddress)
+	gw := net.ParseIP(info.ncGatewayIPAddress)
 	if gw == nil {
 		return nil, fmt.Errorf("Gateway address %v from response is invalid", gw)
 	}

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -215,6 +215,7 @@ type PodIpInfo struct {
 
 // DeleteNetworkContainerRequest specifies the details about the request to delete a specifc network container.
 type HostIPInfo struct {
+	Gateway   string
 	PrimaryIP string
 	Subnet    string
 }

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -668,6 +668,7 @@ func (service *HTTPRestService) populateIpConfigInfoUntransacted(ipConfigStatus 
 
 	podIpInfo.HostPrimaryIPInfo.PrimaryIP = hostInterfaceInfo.PrimaryIP
 	podIpInfo.HostPrimaryIPInfo.Subnet = hostInterfaceInfo.Subnet
+	podIpInfo.HostPrimaryIPInfo.Gateway = hostInterfaceInfo.Gateway
 
 	return nil
 }

--- a/network/bridge_networkclient_linux.go
+++ b/network/bridge_networkclient_linux.go
@@ -51,7 +51,7 @@ func (client *LinuxBridgeClient) CreateBridge() error {
 func (client *LinuxBridgeClient) AddRoutes(nwInfo *NetworkInfo, interfaceName string) error {
 	if client.nwInfo.IPAMType == AzureCNS {
 
-		// Add snat Rules
+		// fetch the host gateway IP from options
 		gwIP := client.nwInfo.Options[HostGWKey]
 		if gwIP == nil {
 			return fmt.Errorf("Host gateway IP in Options not set")
@@ -62,7 +62,7 @@ func (client *LinuxBridgeClient) AddRoutes(nwInfo *NetworkInfo, interfaceName st
 			return fmt.Errorf("Invalid host gateway IP: %+v", gwIP)
 		}
 
-		// add pod subnet to host
+		// add host gateway as the default gateway for pod IP's
 		devIf, _ := net.InterfaceByName(interfaceName)
 		ifIndex := devIf.Index
 		family := netlink.GetIpAddressFamily(gatewayIP)

--- a/network/bridge_networkclient_linux.go
+++ b/network/bridge_networkclient_linux.go
@@ -52,7 +52,7 @@ func (client *LinuxBridgeClient) AddRoutes(nwInfo *NetworkInfo, interfaceName st
 	if client.nwInfo.IPAMType == AzureCNS {
 
 		// Add snat Rules
-		gwIP := client.nwInfo.Options[SNATIPKey]
+		gwIP := client.nwInfo.Options[HostGWKey]
 		if gwIP == nil {
 			return fmt.Errorf("Host gateway IP in Options not set")
 		}
@@ -61,6 +61,7 @@ func (client *LinuxBridgeClient) AddRoutes(nwInfo *NetworkInfo, interfaceName st
 		if gatewayIP == nil {
 			return fmt.Errorf("Invalid host gateway IP: %+v", gwIP)
 		}
+
 		// add pod subnet to host
 		devIf, _ := net.InterfaceByName(interfaceName)
 		ifIndex := devIf.Index

--- a/network/manager.go
+++ b/network/manager.go
@@ -21,6 +21,7 @@ const (
 	VlanIDKey   = "VlanID"
 	AzureCNS    = "azure-cns"
 	SNATIPKey   = "NCPrimaryIPKey"
+	HostGWKey   = "HostGatewayIP"
 	genericData = "com.docker.network.generic"
 )
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

In swift mode the route for host to pod on other host needs to go via the default gateway, so we add a route to the bridge for the pod subnet to use the host default gateway

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
