### PR TITLE
fix: Add missing CNI invoker delete calls

### DIFF
--- a/.pipelines/e2e-job-template.yaml
+++ b/.pipelines/e2e-job-template.yaml
@@ -28,8 +28,6 @@ stages:
           Tag: $[ stagedependencies.build_and_test.unit_tests.outputs['EnvironmentalVariables.Tag'] ]
           CommitHash: $[ stagedependencies.build_and_test.unit_tests.outputs['EnvironmentalVariables.CommitHash'] ]
           StorageID: $[ stagedependencies.build_and_test.unit_tests.outputs['EnvironmentalVariables.StorageID'] ]
-          CLEANUP_ON_EXIT: true
-          CLEANUP_IF_FAIL: true
         steps:
           - template: e2e-step-template.yaml
             parameters:

--- a/.pipelines/e2e-step-template.yaml
+++ b/.pipelines/e2e-step-template.yaml
@@ -85,7 +85,8 @@ steps:
       export CLIENT_SECRET=$(AKS_ENGINE_CLIENT_SECRET) 
       export TENANT_ID=$(AKS_ENGINE_TENANT_ID) 
       export SUBSCRIPTION_ID=$(AKS_ENGINE_SUBSCRIPTION_ID) 
-      export CLEANUP_ON_EXIT=true 
+      export CLEANUP_ON_EXIT=false
+      export CLEANUP_IF_FAIL=false
       export REGIONS=$(AKS_ENGINE_REGION) 
       export IS_JENKINS=false 
       export DEBUG_CRASHING_PODS=true
@@ -93,3 +94,15 @@ steps:
     name: DeployAKSEngine
     displayName: Run AKS-Engine E2E Tests
     workingDirectory: "$(modulePath)"
+
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: "$(modulePath)/_output"
+      targetFolder: $(Build.ArtifactStagingDirectory)/${{ parameters.name }}
+    condition: always()
+
+  - task: PublishBuildArtifacts@1
+    inputs:
+      artifactName: ${{ parameters.name }}
+      pathtoPublish: "$(Build.ArtifactStagingDirectory)/${{ parameters.name }}"
+    condition: always()

--- a/cni/network/invoker.go
+++ b/cni/network/invoker.go
@@ -16,5 +16,5 @@ type IPAMInvoker interface {
 	Add(nwCfg *cni.NetworkConfig, subnetPrefix *net.IPNet, options map[string]interface{}) (*cniTypesCurr.Result, *cniTypesCurr.Result, error)
 
 	//Delete calls to the invoker source, and returns error. Returning an error here will fail the CNI Delete call.
-	Delete(address net.IPNet, nwCfg *cni.NetworkConfig, options map[string]interface{}) error
+	Delete(address *net.IPNet, nwCfg *cni.NetworkConfig, options map[string]interface{}) error
 }

--- a/cni/network/invoker_azure.go
+++ b/cni/network/invoker_azure.go
@@ -76,7 +76,11 @@ func (invoker *AzureIPAMInvoker) Add(nwCfg *cni.NetworkConfig, subnetPrefix *net
 func (invoker *AzureIPAMInvoker) Delete(address *net.IPNet, nwCfg *cni.NetworkConfig, options map[string]interface{}) error {
 	var err error
 
-	if len(address.IP.To4()) == 4 {
+	if address == nil {
+		if err = invoker.plugin.DelegateDel(nwCfg.Ipam.Type, nwCfg); err != nil {
+			log.Printf("Network not found, attempted to release address with error:  %v", err)
+		}
+	} else if len(address.IP.To4()) == 4 {
 
 		// cleanup pool
 		if options[optReleasePool] == optValPool {
@@ -103,10 +107,6 @@ func (invoker *AzureIPAMInvoker) Delete(address *net.IPNet, nwCfg *cni.NetworkCo
 		if err = invoker.plugin.DelegateDel(nwCfgIpv6.Ipam.Type, &nwCfgIpv6); err != nil {
 			log.Printf("Failed to release ipv6 address: %v", err)
 			err = invoker.plugin.Errorf("Failed to release ipv6 address: %v", err)
-		}
-	} else if address == nil {
-		if err = invoker.plugin.DelegateDel(nwCfg.Ipam.Type, nwCfg); err != nil {
-			log.Printf("Network not found, attempted to release address with error:  %v", err)
 		}
 	} else {
 		err = fmt.Errorf("Address is incorrect, not valid IPv4 or IPv6")

--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -144,7 +144,7 @@ func getCNIIPv4Result(info IPv4ResultInfo, subnetPrefix *net.IPNet) (*cniTypesCu
 }
 
 // Delete calls into the releaseipconfiguration API in CNS
-func (invoker *CNSIPAMInvoker) Delete(address net.IPNet, nwCfg *cni.NetworkConfig, options map[string]interface{}) error {
+func (invoker *CNSIPAMInvoker) Delete(address *net.IPNet, nwCfg *cni.NetworkConfig, options map[string]interface{}) error {
 
 	// Parse Pod arguments.
 	podInfo := cns.KubernetesPodInfo{PodName: invoker.podName, PodNamespace: invoker.podNamespace}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

All add calls and delete calls should be via the invoker interface, this fix is to change DelegateDel's to invoker.Delete, which is required in swift mode

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
