### PR TITLE
Add nc version in SecondaryIPConfig structure.

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -130,6 +130,7 @@ type IPConfiguration struct {
 // SecondaryIPConfig contains IP info of SecondaryIP
 type SecondaryIPConfig struct {
 	IPAddress string
+	NCVersion int
 }
 
 // IPSubnet contains ip subnet.

--- a/cns/requestcontroller/kubecontroller/crdtranslator.go
+++ b/cns/requestcontroller/kubecontroller/crdtranslator.go
@@ -57,12 +57,16 @@ func CRDStatusToNCRequest(crdStatus nnc.NodeNetworkConfigStatus) (cns.CreateNetw
 			if ip = net.ParseIP(ipAssignment.IP); ip == nil {
 				return ncRequest, fmt.Errorf("Invalid SecondaryIP %s:", ipAssignment.IP)
 			}
-			ncVersion, _ := strconv.Atoi(ncRequest.Version)
-			secondaryIPConfig = cns.SecondaryIPConfig{
-				IPAddress: ip.String(),
-				NCVersion: ncVersion,
+
+			ipConfig, ok := ncRequest.SecondaryIPConfigs[ipAssignment.Name]
+			if !ok || (ok && ipConfig.IPAddress != ip.String()) {
+				ncVersion, _ := strconv.Atoi(ncRequest.Version)
+				secondaryIPConfig = cns.SecondaryIPConfig{
+					IPAddress: ip.String(),
+					NCVersion: ncVersion,
+				}
+				ncRequest.SecondaryIPConfigs[ipAssignment.Name] = secondaryIPConfig
 			}
-			ncRequest.SecondaryIPConfigs[ipAssignment.Name] = secondaryIPConfig
 		}
 	}
 

--- a/cns/requestcontroller/kubecontroller/crdtranslator.go
+++ b/cns/requestcontroller/kubecontroller/crdtranslator.go
@@ -3,6 +3,7 @@ package kubecontroller
 import (
 	"fmt"
 	"net"
+	"strconv"
 
 	"github.com/Azure/azure-container-networking/cns"
 	nnc "github.com/Azure/azure-container-networking/nodenetworkconfig/api/v1alpha"
@@ -56,9 +57,10 @@ func CRDStatusToNCRequest(crdStatus nnc.NodeNetworkConfigStatus) (cns.CreateNetw
 			if ip = net.ParseIP(ipAssignment.IP); ip == nil {
 				return ncRequest, fmt.Errorf("Invalid SecondaryIP %s:", ipAssignment.IP)
 			}
-
+			ncVersion, _ := strconv.Atoi(ncRequest.Version)
 			secondaryIPConfig = cns.SecondaryIPConfig{
 				IPAddress: ip.String(),
+				NCVersion: ncVersion,
 			}
 			ncRequest.SecondaryIPConfigs[ipAssignment.Name] = secondaryIPConfig
 		}

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -324,7 +324,12 @@ func validateNCStateAfterReconcile(t *testing.T, ncRequest *cns.CreateNetworkCon
 
 	// validate rest of Secondary IPs in Available state
 	if ncRequest != nil {
+		ncRequestVersion, _ := strconv.Atoi(ncRequest.Version)
 		for secIpId, secIpConfig := range ncRequest.SecondaryIPConfigs {
+			if secIpConfig.NCVersion != ncRequestVersion {
+				t.Fatalf("nc request version is %d, secondary ip %s nc version is %d, they are not equal",
+					ncRequestVersion, secIpConfig.IPAddress, secIpConfig.NCVersion)
+			}
 			if _, exists := expectedAllocatedPods[secIpConfig.IPAddress]; exists {
 				continue
 			}


### PR DESCRIPTION
feat: Add NC version in SecondaryIPConfig structure.

**Reason for Change**:
When CNS reconcile, it needs NC version to determine whether an IP should be stay in pending programming or available.

- [X ] adds unit tests
