### PR TITLE
Add nc version in SecondaryIPConfig stucture.

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -131,6 +131,7 @@ type IPConfiguration struct {
 // SecondaryIPConfig contains IP info of SecondaryIP
 type SecondaryIPConfig struct {
 	IPAddress string
+	NCVersion int
 }
 
 // IPSubnet contains ip subnet.

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -131,6 +131,7 @@ type IPConfiguration struct {
 // SecondaryIPConfig contains IP info of SecondaryIP
 type SecondaryIPConfig struct {
 	IPAddress string
+	// NCVesion will help in determining whether IP is in pending programming or available when reconciling.
 	NCVersion int
 }
 

--- a/cns/requestcontroller/kubecontroller/crdrequestcontroller_test.go
+++ b/cns/requestcontroller/kubecontroller/crdrequestcontroller_test.go
@@ -592,6 +592,7 @@ func TestInitRequestController(t *testing.T) {
 						},
 					},
 					SubnetAddressSpace: subnetRange,
+					Version:            "1",
 				},
 			},
 		},

--- a/cns/requestcontroller/kubecontroller/crdtranslator.go
+++ b/cns/requestcontroller/kubecontroller/crdtranslator.go
@@ -57,12 +57,16 @@ func CRDStatusToNCRequest(crdStatus nnc.NodeNetworkConfigStatus) (cns.CreateNetw
 			if ip = net.ParseIP(ipAssignment.IP); ip == nil {
 				return ncRequest, fmt.Errorf("Invalid SecondaryIP %s:", ipAssignment.IP)
 			}
-			ncVersion, _ := strconv.Atoi(ncRequest.Version)
-			secondaryIPConfig = cns.SecondaryIPConfig{
-				IPAddress: ip.String(),
-				NCVersion: ncVersion,
+
+			ipConfig, ok := ncRequest.SecondaryIPConfigs[ipAssignment.Name]
+			if !ok || (ok && ipConfig.IPAddress != ip.String()) {
+				ncVersion, _ := strconv.Atoi(ncRequest.Version)
+				secondaryIPConfig = cns.SecondaryIPConfig{
+					IPAddress: ip.String(),
+					NCVersion: ncVersion,
+				}
+				ncRequest.SecondaryIPConfigs[ipAssignment.Name] = secondaryIPConfig
 			}
-			ncRequest.SecondaryIPConfigs[ipAssignment.Name] = secondaryIPConfig
 		}
 	}
 

--- a/cns/requestcontroller/kubecontroller/crdtranslator.go
+++ b/cns/requestcontroller/kubecontroller/crdtranslator.go
@@ -52,21 +52,17 @@ func CRDStatusToNCRequest(crdStatus nnc.NodeNetworkConfigStatus) (cns.CreateNetw
 		ipSubnet.PrefixLength = uint8(size)
 		ncRequest.IPConfiguration.IPSubnet = ipSubnet
 		ncRequest.IPConfiguration.GatewayIPAddress = nc.DefaultGateway
+		ncVersion, _ := strconv.Atoi(ncRequest.Version)
 
 		for _, ipAssignment = range nc.IPAssignments {
 			if ip = net.ParseIP(ipAssignment.IP); ip == nil {
 				return ncRequest, fmt.Errorf("Invalid SecondaryIP %s:", ipAssignment.IP)
 			}
-
-			ipConfig, ok := ncRequest.SecondaryIPConfigs[ipAssignment.Name]
-			if !ok || (ok && ipConfig.IPAddress != ip.String()) {
-				ncVersion, _ := strconv.Atoi(ncRequest.Version)
-				secondaryIPConfig = cns.SecondaryIPConfig{
-					IPAddress: ip.String(),
-					NCVersion: ncVersion,
-				}
-				ncRequest.SecondaryIPConfigs[ipAssignment.Name] = secondaryIPConfig
+			secondaryIPConfig = cns.SecondaryIPConfig{
+				IPAddress: ip.String(),
+				NCVersion: ncVersion,
 			}
+			ncRequest.SecondaryIPConfigs[ipAssignment.Name] = secondaryIPConfig
 		}
 	}
 

--- a/cns/requestcontroller/kubecontroller/crdtranslator.go
+++ b/cns/requestcontroller/kubecontroller/crdtranslator.go
@@ -52,7 +52,10 @@ func CRDStatusToNCRequest(crdStatus nnc.NodeNetworkConfigStatus) (cns.CreateNetw
 		ipSubnet.PrefixLength = uint8(size)
 		ncRequest.IPConfiguration.IPSubnet = ipSubnet
 		ncRequest.IPConfiguration.GatewayIPAddress = nc.DefaultGateway
-		ncVersion, _ := strconv.Atoi(ncRequest.Version)
+		var ncVersion int
+		if ncVersion, err = strconv.Atoi(ncRequest.Version); err != nil {
+			return ncRequest, fmt.Errorf("Invalid ncRequest.Version is %s in CRD, err:%s", ncRequest.Version, err)
+		}
 
 		for _, ipAssignment = range nc.IPAssignments {
 			if ip = net.ParseIP(ipAssignment.IP); ip == nil {

--- a/cns/requestcontroller/kubecontroller/crdtranslator.go
+++ b/cns/requestcontroller/kubecontroller/crdtranslator.go
@@ -3,6 +3,7 @@ package kubecontroller
 import (
 	"fmt"
 	"net"
+	"strconv"
 
 	"github.com/Azure/azure-container-networking/cns"
 	nnc "github.com/Azure/azure-container-networking/nodenetworkconfig/api/v1alpha"
@@ -56,9 +57,10 @@ func CRDStatusToNCRequest(crdStatus nnc.NodeNetworkConfigStatus) (cns.CreateNetw
 			if ip = net.ParseIP(ipAssignment.IP); ip == nil {
 				return ncRequest, fmt.Errorf("Invalid SecondaryIP %s:", ipAssignment.IP)
 			}
-
+			ncVersion, _ := strconv.Atoi(ncRequest.Version)
 			secondaryIPConfig = cns.SecondaryIPConfig{
 				IPAddress: ip.String(),
+				NCVersion: ncVersion,
 			}
 			ncRequest.SecondaryIPConfigs[ipAssignment.Name] = secondaryIPConfig
 		}

--- a/cns/requestcontroller/kubecontroller/crdtranslator_test.go
+++ b/cns/requestcontroller/kubecontroller/crdtranslator_test.go
@@ -1,6 +1,7 @@
 package kubecontroller
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/Azure/azure-container-networking/cns"
@@ -234,5 +235,10 @@ func TestStatusToNCRequestSuccess(t *testing.T) {
 
 	if secondaryIP.IPAddress != testSecIp1 {
 		t.Fatalf("Expected %v as the secondary IP config but got %v", testSecIp1, secondaryIP.IPAddress)
+	}
+
+	ncVersionInInt, _ := strconv.Atoi(version)
+	if secondaryIP.NCVersion != ncVersionInInt {
+		t.Fatalf("Expected %d as the secondary IP config NC version but got %v", ncVersionInInt, secondaryIP.NCVersion)
 	}
 }

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -61,8 +61,8 @@ func TestCreateAndUpdateNCWithSecondaryIPNCVersion(t *testing.T) {
 	// Build secondaryIPConfig, it will have one item as {IPAddress:"10.0.0.16", NCVersion: 0}
 	ipAddress := "10.0.0.16"
 	secIPConfig := newSecondaryIPConfig(ipAddress, ncVersion)
-	ipID := uuid.New()
-	secondaryIPConfigs[ipID.String()] = secIPConfig
+	ipId := uuid.New()
+	secondaryIPConfigs[ipId.String()] = secIPConfig
 	req := createNCReqInternal(t, secondaryIPConfigs, ncID, strconv.Itoa(ncVersion))
 	validateSecondaryIPsNCVersion(t, req)
 
@@ -72,13 +72,13 @@ func TestCreateAndUpdateNCWithSecondaryIPNCVersion(t *testing.T) {
 	ncVersion++
 	secIPConfig = newSecondaryIPConfig(ipAddress, ncVersion)
 	// "10.0.0.16" will be update to NC version 1 in CRD, reuse the same uuid with it.
-	secondaryIPConfigs[ipID.String()] = secIPConfig
+	secondaryIPConfigs[ipId.String()] = secIPConfig
 
 	// Add {IPAddress:"10.0.0.17", NCVersion: 1} in secondaryIPConfig
 	ipAddress = "10.0.0.17"
 	secIPConfig = newSecondaryIPConfig(ipAddress, ncVersion)
-	ipID = uuid.New()
-	secondaryIPConfigs[ipID.String()] = secIPConfig
+	ipId = uuid.New()
+	secondaryIPConfigs[ipId.String()] = secIPConfig
 	req = createNCReqInternal(t, secondaryIPConfigs, ncID, strconv.Itoa(ncVersion))
 	validateSecondaryIPsNCVersion(t, req)
 }

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -70,7 +70,7 @@ func TestCreateAndUpdateNCWithSecondaryIPNCVersion(t *testing.T) {
 	receivedSecondaryIPConfigs = containerStatus.CreateNetworkContainerRequest.SecondaryIPConfigs
 	for _, secIPConfig := range receivedSecondaryIPConfigs {
 		// Though "10.0.0.16" IP exists in NC version 1, secodanry IP still keep its original NC version 0
-		if secIPConfig.IPAddress != "10.0.0.16" && secIPConfig.NCVersion != 0 {
+		if secIPConfig.IPAddress != "10.0.0.16" || secIPConfig.NCVersion != 0 {
 			t.Fatalf("nc request version is %d, secondary ip %s nc version is %d, expected nc version is 0",
 				ncVersion, secIPConfig.IPAddress, secIPConfig.NCVersion)
 		}
@@ -90,7 +90,8 @@ func TestCreateAndUpdateNCWithSecondaryIPNCVersion(t *testing.T) {
 	ipId = uuid.New()
 	secondaryIPConfigs[ipId.String()] = secIPConfig
 	req = createNCReqInternal(t, secondaryIPConfigs, ncID, strconv.Itoa(ncVersion))
-
+	// Validate secondary IPs' NC version has been updated by NC request
+	receivedSecondaryIPConfigs = containerStatus.CreateNetworkContainerRequest.SecondaryIPConfigs
 	for _, secIPConfig := range receivedSecondaryIPConfigs {
 		// Though "10.0.0.16" IP exists in NC version 1, secodanry IP still keep its original NC version 0
 		if (secIPConfig.IPAddress == "10.0.0.16" && secIPConfig.NCVersion != 0) ||

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -424,20 +424,6 @@ func createNCReqInternal(t *testing.T, secondaryIPConfigs map[string]cns.Seconda
 	return req
 }
 
-func validateSecondaryIPsNCVersion(t *testing.T, req cns.CreateNetworkContainerRequest) {
-	containerStatus := svc.state.ContainerStatus[req.NetworkContainerid]
-	// Validate secondary IPs' NC version has been updated by NC request
-	ncVersion, _ := strconv.Atoi(containerStatus.VMVersion)
-	for _, secIPConfig := range containerStatus.CreateNetworkContainerRequest.SecondaryIPConfigs {
-		// Though "10.0.0.16" IP exists in NC version 1, secodanry IP still keep its original NC version 0
-		if (secIPConfig.IPAddress == "10.0.0.16" && secIPConfig.NCVersion != 0) ||
-			(secIPConfig.IPAddress == "10.0.0.17" && secIPConfig.NCVersion != 1) {
-			t.Fatalf("nc request version is %d, secondary ip %s nc version is %d, expected nc version is 0",
-				ncVersion, secIPConfig.IPAddress, secIPConfig.NCVersion)
-		}
-	}
-}
-
 func restartService() {
 	fmt.Println("Restart Service")
 

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -342,7 +342,12 @@ func validateNCStateAfterReconcile(t *testing.T, ncRequest *cns.CreateNetworkCon
 
 	// validate rest of Secondary IPs in Available state
 	if ncRequest != nil {
+		ncRequestVersion, _ := strconv.Atoi(ncRequest.Version)
 		for secIpId, secIpConfig := range ncRequest.SecondaryIPConfigs {
+			if secIpConfig.NCVersion != ncRequestVersion {
+				t.Fatalf("nc request version is %d, secondary ip %s nc version is %d, they are not equal",
+					ncRequestVersion, secIpConfig.IPAddress, secIpConfig.NCVersion)
+			}
 			if _, exists := expectedAllocatedPods[secIpConfig.IPAddress]; exists {
 				continue
 			}

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -237,9 +237,9 @@ func (service *HTTPRestService) updateIpConfigsStateUntransacted(req cns.CreateN
 	nmagentNCVersion = service.imdsClient.GetNetworkContainerInfoFromHostWithoutToken()
 
 	if nmagentNCVersion >= newNCVersion {
-		service.addIPConfigStateUntransacted(cns.Available, req.NetworkContainerid, newIPConfigs)
+		service.addIPConfigStateUntransacted(cns.Available, req.NetworkContainerid, newIPConfigs, existingSecondaryIPConfigs)
 	} else {
-		service.addIPConfigStateUntransacted(cns.PendingProgramming, req.NetworkContainerid, newIPConfigs)
+		service.addIPConfigStateUntransacted(cns.PendingProgramming, req.NetworkContainerid, newIPConfigs, existingSecondaryIPConfigs)
 	}
 
 	return 0, ""
@@ -248,23 +248,28 @@ func (service *HTTPRestService) updateIpConfigsStateUntransacted(req cns.CreateN
 // addIPConfigStateUntransacted adds the IPConfigs to the PodIpConfigState map with Available state
 // If the IP is already added then it will be an idempotent call. Also note, caller will
 // acquire/release the service lock.
-func (service *HTTPRestService) addIPConfigStateUntransacted(newIPCNSStatus, ncId string, ipconfigs map[string]cns.SecondaryIPConfig) {
+func (service *HTTPRestService) addIPConfigStateUntransacted(newIPCNSStatus, ncId string, ipconfigs, existingSecondaryIPConfigs map[string]cns.SecondaryIPConfig) {
 	// add ipconfigs to state
-	for ipId, ipconfig := range ipconfigs {
-		if _, exists := service.PodIPConfigState[ipId]; exists {
+	for ipID, ipconfig := range ipconfigs {
+		// New secondary IP configs has new NC version however, CNS don't want to override existing IPs'with new NC version
+		// Set it back to previous NC version if IP already exist.
+		if existingIPConfig, existsInPreviousIPConfig := existingSecondaryIPConfigs[ipID]; existsInPreviousIPConfig && existingIPConfig.IPAddress == ipconfig.IPAddress {
+			ipconfig.NCVersion = existingIPConfig.NCVersion
+		}
+		if _, exists := service.PodIPConfigState[ipID]; exists {
 			continue
 		}
 		// add the new State
 		ipconfigStatus := cns.IPConfigurationStatus{
 			NCID:                ncId,
-			ID:                  ipId,
+			ID:                  ipID,
 			IPAddress:           ipconfig.IPAddress,
 			State:               newIPCNSStatus,
 			OrchestratorContext: nil,
 		}
 		logger.Printf("[Azure-Cns] Add IP %s as %s", ipconfig.IPAddress, newIPCNSStatus)
 
-		service.PodIPConfigState[ipId] = ipconfigStatus
+		service.PodIPConfigState[ipID] = ipconfigStatus
 
 		// Todo Update batch API and maintain the count
 	}

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -256,8 +256,8 @@ func (service *HTTPRestService) addIPConfigStateUntransacted(newIPCNSStatus, ncI
 		if existingIPConfig, existsInPreviousIPConfig := existingSecondaryIPConfigs[ipId]; existsInPreviousIPConfig && existingIPConfig.IPAddress == ipconfig.IPAddress {
 			ipconfig.NCVersion = existingIPConfig.NCVersion
 			ipconfigs[ipId] = ipconfig
-			logger.Printf("[Azure-Cns] Set IP %s version from %d back to %d", ipconfig.IPAddress, ipconfig.NCVersion, existingIPConfig.NCVersion)
 		}
+		logger.Printf("[Azure-Cns] Set IP %s version to %d", ipconfig.IPAddress, ipconfig.NCVersion)
 		if _, exists := service.PodIPConfigState[ipId]; exists {
 			continue
 		}

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -253,7 +253,7 @@ func (service *HTTPRestService) addIPConfigStateUntransacted(newIPCNSStatus, ncI
 	for ipId, ipconfig := range ipconfigs {
 		// New secondary IP configs has new NC version however, CNS don't want to override existing IPs'with new NC version
 		// Set it back to previous NC version if IP already exist.
-		if existingIPConfig, existsInPreviousIPConfig := existingSecondaryIPConfigs[ipId]; existsInPreviousIPConfig && existingIPConfig.IPAddress == ipconfig.IPAddress {
+		if existingIPConfig, existsInPreviousIPConfig := existingSecondaryIPConfigs[ipId]; existsInPreviousIPConfig {
 			ipconfig.NCVersion = existingIPConfig.NCVersion
 			ipconfigs[ipId] = ipconfig
 		}

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -255,6 +255,7 @@ func (service *HTTPRestService) addIPConfigStateUntransacted(newIPCNSStatus, ncI
 		// Set it back to previous NC version if IP already exist.
 		if existingIPConfig, existsInPreviousIPConfig := existingSecondaryIPConfigs[ipID]; existsInPreviousIPConfig && existingIPConfig.IPAddress == ipconfig.IPAddress {
 			ipconfig.NCVersion = existingIPConfig.NCVersion
+			ipconfigs[ipID] = ipconfig
 		}
 		if _, exists := service.PodIPConfigState[ipID]; exists {
 			continue


### PR DESCRIPTION
feat: Add NC version in SecondaryIPConfig structure.

**Reason for Change**:
When CNS reconcile, it needs NC version to determine whether an IP should be stay in pending programming or available.

- [X ] adds unit tests