### PR TITLE
Azure CNI transparent mode as default

### DIFF
--- a/cni/azure-linux.conflist
+++ b/cni/azure-linux.conflist
@@ -4,7 +4,7 @@
    "plugins":[
       {
          "type":"azure-vnet",
-         "mode":"tranparent",
+         "mode":"transparent",
          "bridge":"azure0",
          "ipsToRouteViaHost":["169.254.20.10"],
          "ipam":{

--- a/cni/azure-linux.conflist
+++ b/cni/azure-linux.conflist
@@ -5,7 +5,6 @@
       {
          "type":"azure-vnet",
          "mode":"transparent",
-         "bridge":"azure0",
          "ipsToRouteViaHost":["169.254.20.10"],
          "ipam":{
             "type":"azure-vnet-ipam"

--- a/cni/azure-linux.conflist
+++ b/cni/azure-linux.conflist
@@ -4,7 +4,7 @@
    "plugins":[
       {
          "type":"azure-vnet",
-         "mode":"bridge",
+         "mode":"tranparent",
          "bridge":"azure0",
          "ipsToRouteViaHost":["169.254.20.10"],
          "ipam":{


### PR DESCRIPTION
Azure CNI has been working in bridge mode for single tenancy till date. In bridge mode, a L2 bridge is created, commonly named as "azure0", which acts as a master for the eth0 interface of VM. This bridge gets programmed with the Ip addrs, DNS name servers and other properties from eth0. When a Pod is created, veth pairs for these Pod will have one interface in Pod name space and other one in the pair is attached to L2 bridge. Pod to Pod communication intra-VM occurs through this L2 bridge. Inter-VM Pod-Pod communication requires the packet to come out of bridge, routed to the default gateway assigned in the ip route tables and gets delivered to the destination VM by fabric.

In Transparent mode Azure CNI, there is no L2 bridge and eth0 is not touched by Azure CNI. When a Pod is created, veth pairs of the Pod will have one interface attached to the pod name space and the other one in the pair is attached to the host namespace. Intra VM Pod-Pod communication occurs through IP routes installed by Azure CNI. 

This PR will make "transparent" mode default for Azure CNI. This change affects only **Linux Single tenancy**