### PR TITLE
Add secondary IP status update when reconcile.

### DIFF
--- a/cns/restserver/const.go
+++ b/cns/restserver/const.go
@@ -37,6 +37,7 @@ const (
 	UnsupportedOrchestratorContext         = 34
 	NetworkContainerVfpProgramComplete     = 35
 	NetworkContainerVfpProgramCheckSkipped = 36
+	UnsupportedNCVersion                   = 37
 	UnexpectedError                        = 99
 )
 

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -215,11 +215,11 @@ func setOrchestratorTypeInternal(orchestratorType string) {
 func validateCreateOrUpdateNCInternal(t *testing.T, secondaryIpCount int, ncVersion string) {
 	secondaryIPConfigs := make(map[string]cns.SecondaryIPConfig)
 	ncId := "testNc1"
-
+	ncVersionInInt, _ := strconv.Atoi(ncVersion)
 	var startingIndex = 6
 	for i := 0; i < secondaryIpCount; i++ {
 		ipaddress := "10.0.0." + strconv.Itoa(startingIndex)
-		secIpConfig := newSecondaryIPConfig(ipaddress, 0)
+		secIpConfig := newSecondaryIPConfig(ipaddress, ncVersionInInt)
 		ipId := uuid.New()
 		secondaryIPConfigs[ipId.String()] = secIpConfig
 		startingIndex++
@@ -231,7 +231,7 @@ func validateCreateOrUpdateNCInternal(t *testing.T, secondaryIpCount int, ncVers
 	fmt.Println("Validate Scaleup")
 	for i := 0; i < secondaryIpCount; i++ {
 		ipaddress := "10.0.0." + strconv.Itoa(startingIndex)
-		secIpConfig := newSecondaryIPConfig(ipaddress, 1)
+		secIpConfig := newSecondaryIPConfig(ipaddress, ncVersionInInt)
 		ipId := uuid.New()
 		secondaryIPConfigs[ipId.String()] = secIpConfig
 		startingIndex++

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -179,12 +179,6 @@ func (service *HTTPRestService) saveNetworkContainerGoalState(req cns.CreateNetw
 			// Delete first.
 			returnCode, returnMesage := service.deleteIpConfigsStateUntransacted(req, existingSecondaryIPConfigs, hostVersion)
 			// Add new IPs
-			// // TODO, will udpate NC version related variable to int, change it from string to int is a pains
-			//var nmagentNCVersion int
-			// var err error
-			// if nmagentNCVersion, err = strconv.Atoi(hostVersion); err != nil {
-			// 	return UnsupportedNCVersion, fmt.Sprintf("Invalid hostVersion is %s, err:%s", hostVersion, err)
-			// }
 			// TODO, remove this override when background thread which update nmagent version is ready.
 			nmagentNCVersion := service.imdsClient.GetNetworkContainerInfoFromHostWithoutToken()
 			service.addIPConfigStateUntransacted(req.NetworkContainerid, nmagentNCVersion, req.SecondaryIPConfigs, existingSecondaryIPConfigs)

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -122,6 +122,7 @@ func (service *HTTPRestService) saveNetworkContainerGoalState(req cns.CreateNetw
 		vfpUpdateComplete = existingNCStatus.VfpUpdateComplete
 	} else {
 		// Host version is the NC version from NMAgent, set it -1 to indicate no result from NMAgent yet.
+		// TODO, query NMAgent and with aggresive time out and assign latest host version.
 		hostVersion = "-1"
 	}
 
@@ -175,7 +176,19 @@ func (service *HTTPRestService) saveNetworkContainerGoalState(req cns.CreateNetw
 
 		case cns.KubernetesCRD:
 			// Validate and Update the SecondaryIpConfig state
-			returnCode, returnMesage := service.updateIpConfigsStateUntransacted(req, existingSecondaryIPConfigs, hostVersion)
+			// Delete first.
+			returnCode, returnMesage := service.deleteIpConfigsStateUntransacted(req, existingSecondaryIPConfigs, hostVersion)
+			// Add new IPs
+			// // TODO, will udpate NC version related variable to int, change it from string to int is a pains
+			//var nmagentNCVersion int
+			// var err error
+			// if nmagentNCVersion, err = strconv.Atoi(hostVersion); err != nil {
+			// 	return UnsupportedNCVersion, fmt.Sprintf("Invalid hostVersion is %s, err:%s", hostVersion, err)
+			// }
+			// TODO, remove this override when background thread which update nmagent version is ready.
+			nmagentNCVersion := service.imdsClient.GetNetworkContainerInfoFromHostWithoutToken()
+			service.addIPConfigStateUntransacted(req.NetworkContainerid, nmagentNCVersion, req.SecondaryIPConfigs, existingSecondaryIPConfigs)
+
 			if returnCode != 0 {
 				return returnCode, returnMesage
 			}
@@ -195,9 +208,9 @@ func (service *HTTPRestService) saveNetworkContainerGoalState(req cns.CreateNetw
 	return 0, ""
 }
 
-// This func will compute the deltaIpConfigState which needs to be updated (Added or Deleted) from the inmemory map
+// This func will compute the deltaIpConfigState which needs to be deleted from the inmemory map
 // Note: Also this func is an untransacted API as the caller will take a Service lock
-func (service *HTTPRestService) updateIpConfigsStateUntransacted(req cns.CreateNetworkContainerRequest, existingSecondaryIPConfigs map[string]cns.SecondaryIPConfig, hostVersion string) (int, string) {
+func (service *HTTPRestService) deleteIpConfigsStateUntransacted(req cns.CreateNetworkContainerRequest, existingSecondaryIPConfigs map[string]cns.SecondaryIPConfig, hostVersion string) (int, string) {
 	// parse the existingSecondaryIpConfigState to find the deleted Ips
 	newIPConfigs := req.SecondaryIPConfigs
 	var tobeDeletedIpConfigs = make(map[string]cns.SecondaryIPConfig)
@@ -236,25 +249,14 @@ func (service *HTTPRestService) updateIpConfigsStateUntransacted(req cns.CreateN
 		}
 	}
 
-	newNCVersion, _ := strconv.Atoi(req.Version)
-	nmagentNCVersion, _ := strconv.Atoi(hostVersion)
-
-	// TODO, remove this override when background thread which update nmagent version is ready.
-	nmagentNCVersion = service.imdsClient.GetNetworkContainerInfoFromHostWithoutToken()
-
-	if nmagentNCVersion >= newNCVersion {
-		service.addIPConfigStateUntransacted(cns.Available, req.NetworkContainerid, newIPConfigs, existingSecondaryIPConfigs)
-	} else {
-		service.addIPConfigStateUntransacted(cns.PendingProgramming, req.NetworkContainerid, newIPConfigs, existingSecondaryIPConfigs)
-	}
-
 	return 0, ""
 }
 
 // addIPConfigStateUntransacted adds the IPConfigs to the PodIpConfigState map with Available state
 // If the IP is already added then it will be an idempotent call. Also note, caller will
 // acquire/release the service lock.
-func (service *HTTPRestService) addIPConfigStateUntransacted(newIPCNSStatus, ncId string, ipconfigs, existingSecondaryIPConfigs map[string]cns.SecondaryIPConfig) {
+func (service *HTTPRestService) addIPConfigStateUntransacted(ncId string, nmagentNCVersion int, ipconfigs, existingSecondaryIPConfigs map[string]cns.SecondaryIPConfig) {
+	var newIPCNSStatus string
 	// add ipconfigs to state
 	for ipId, ipconfig := range ipconfigs {
 		// New secondary IP configs has new NC version however, CNS don't want to override existing IPs'with new NC version
@@ -266,6 +268,13 @@ func (service *HTTPRestService) addIPConfigStateUntransacted(newIPCNSStatus, ncI
 		logger.Printf("[Azure-Cns] Set IP %s version to %d", ipconfig.IPAddress, ipconfig.NCVersion)
 		if _, exists := service.PodIPConfigState[ipId]; exists {
 			continue
+		}
+		// Using the updated NC version attached with IP to compare with latest nmagent version and determine IP statues.
+		// When reconcile, service.PodIPConfigState doens't exist, rebuild it with the help of NC version attached with IP.
+		if nmagentNCVersion >= ipconfig.NCVersion {
+			newIPCNSStatus = cns.Available
+		} else {
+			newIPCNSStatus = cns.PendingProgramming
 		}
 		// add the new State
 		ipconfigStatus := cns.IPConfigurationStatus{


### PR DESCRIPTION
feat: ad secondary IP status update when reconcile.

**Reason for Change**:
When reconcile, service.PodIPConfigState doesn't exist, rebuild it with the help of NC version attached with IP.

**Issue Fixed**:
Reconcile logic for pending programming IPs.

- [X ] adds unit tests

