### PR TITLE
Remove GetNCVersionURLFmt from NodeInfo contract

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -373,6 +373,5 @@ func (networkContainerRequestPolicy *NetworkContainerRequestPolicies) Validate()
 
 // NodeInfoResponse - Struct to hold the node info response.
 type NodeInfoResponse struct {
-	NetworkContainers  []CreateNetworkContainerRequest
-	GetNCVersionURLFmt string
+	NetworkContainers []CreateNetworkContainerRequest
 }

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -93,7 +93,7 @@ func (service *HTTPRestService) SyncNodeStatus(dncEP, infraVnet, nodeID string, 
 	// check if the version is valid and save it to service state
 	for ncid, nc := range ncsToBeAdded {
 		var (
-			versionURL = fmt.Sprintf(nodeInfoResponse.GetNCVersionURLFmt,
+			versionURL = fmt.Sprintf(nmagentclient.GetNetworkContainerVersionURLFmt,
 				nmagentclient.WireserverIP,
 				nc.PrimaryInterfaceIdentifier,
 				nc.NetworkContainerid,


### PR DESCRIPTION
Remove GetNCVersionURLFmt from NodeInfoResponse api contract

This change removes GetNCVersionURLFmt from the NodeInfoResponse which CNS gets
as a part of SyncNodeStatus in case of managed mode. This data is available with CNS and
should not be needed from DNC.
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
