### PR TITLE
CNS: Fix IPAM scaler down to handle incremental decrease

### DIFF
--- a/cns/fakes/cnsfake.go
+++ b/cns/fakes/cnsfake.go
@@ -139,9 +139,10 @@ func (ipm *IPStateManager) MarkIPsAsPending(numberOfIPsToMark int) (map[string]c
 	defer func() {
 		// if there was an error, and not all ip's have been freed, restore state
 		if err != nil && len(pendingRelease) != numberOfIPsToMark {
-			for uuid, _ := range pendingRelease {
+			for uuid, ipState := range pendingRelease {
+				ipState.State = cns.Available
 				ipm.AvailableIPIDStack.Push(pendingRelease[uuid].ID)
-				ipm.AvailableIPConfigState[pendingRelease[uuid].ID] = pendingRelease[uuid]
+				ipm.AvailableIPConfigState[pendingRelease[uuid].ID] = ipState
 				delete(ipm.PendingReleaseIPConfigState, pendingRelease[uuid].ID)
 			}
 		}
@@ -154,7 +155,10 @@ func (ipm *IPStateManager) MarkIPsAsPending(numberOfIPsToMark int) (map[string]c
 		}
 
 		// add all pending release to a slice
-		pendingRelease[id] = ipm.AvailableIPConfigState[id]
+		ipConfig := ipm.AvailableIPConfigState[id]
+		ipConfig.State = cns.PendingRelease
+		pendingRelease[id] = ipConfig
+
 		delete(ipm.AvailableIPConfigState, id)
 	}
 


### PR DESCRIPTION
Fix a race condition in IPAM Pool Monitor during Scale down. It currently overwrites the NotInUse list during incremental deletes

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
Fixed a bug in IPAM Pool monitor


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests


**Notes**:
