### PR TITLE
[NPM] 🐞 {fix} error creating IPsets when same string for ports and labels is used

### DIFF
--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -6,6 +6,7 @@ package ipsm
 import (
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 	"syscall"
 
@@ -70,12 +71,12 @@ func (ipsMgr *IpsetManager) Exists(key string, val string, kind string) bool {
 
 // SetExists checks whehter an ipset exists.
 func (ipsMgr *IpsetManager) SetExists(setName, kind string) bool {
-    m := ipsMgr.setMap
-    if kind == util.IpsetSetListFlag {
-        m = ipsMgr.listMap
-    }
-    _, exists := m[setName]
-    return exists
+	m := ipsMgr.setMap
+	if kind == util.IpsetSetListFlag {
+		m = ipsMgr.listMap
+	}
+	_, exists := m[setName]
+	return exists
 }
 
 func isNsSet(setName string) bool {
@@ -457,6 +458,78 @@ func (ipsMgr *IpsetManager) Restore(configFile string) error {
 	cmd.Wait()
 
 	//TODO based on the set name and number of entries in the config file, update IPSetInventory
+
+	return nil
+}
+
+// DestroyNpmIpsets destroys only ipsets created by NPM
+func (ipsMgr *IpsetManager) DestroyNpmIpsets() error {
+
+	cmdName := util.Ipset
+	cmdArgs := util.IPsetCheckListFlag
+
+	reply, err := exec.Command(cmdName, cmdArgs).Output()
+	if msg, failed := err.(*exec.ExitError); failed {
+		errCode := msg.Sys().(syscall.WaitStatus).ExitStatus()
+		if errCode > 0 {
+			log.Logf("Error: There was an error running command: [%s] Stderr: [%v, %s]", cmdName, err, strings.TrimSuffix(string(msg.Stderr), "\n"))
+			metrics.SendErrorMetric(util.IpsmID, "Error: There was an error running command: [%s] Stderr: [%v, %s]", cmdName, err, strings.TrimSuffix(string(msg.Stderr), "\n"))
+		}
+
+		return err
+	}
+	if reply == nil {
+		log.Logf("Received empty string from ipset list while destroying azure-npm ipsets")
+		return nil
+	}
+
+	log.Logf("Reply from command executed is %s", reply)
+	re := regexp.MustCompile("Name: (azure-npm-\\d+)")
+	ipsetRegexSlice := re.FindAllSubmatch(reply, -1)
+
+	if len(ipsetRegexSlice) == 0 {
+		log.Logf("No Azure-NPM IPsets are found in the Node.")
+		return nil
+	}
+
+	ipsetLists := make([]string, 3)
+	for _, matchedItem := range ipsetRegexSlice {
+		if len(matchedItem) == 2 {
+			itemString := string(matchedItem[1])
+			if strings.Contains(itemString, "azure-npm") {
+				ipsetLists = append(ipsetLists, itemString)
+			}
+		}
+	}
+
+	if len(ipsetLists) == 0 {
+		return nil
+	}
+
+	entry := &ipsEntry{
+		operationFlag: util.IpsetFlushFlag,
+	}
+
+	for _, ipsetName := range ipsetLists {
+		entry := &ipsEntry{
+			operationFlag: util.IpsetFlushFlag,
+			set:           ipsetName,
+		}
+
+		if _, err := ipsMgr.Run(entry); err != nil {
+			metrics.SendErrorMetric(util.IpsmID, "Error: failed to flush ipset %s", ipsetName)
+			log.Logf("Error: failed to flush ipset %s", ipsetName)
+		}
+	}
+
+	for _, ipsetName := range ipsetLists {
+		entry.operationFlag = util.IpsetDestroyFlag
+		entry.set = ipsetName
+		if _, err := ipsMgr.Run(entry); err != nil {
+			metrics.SendErrorMetric(util.IpsmID, "Error: failed to destroy ipset %s", ipsetName)
+			log.Logf("Error: failed to destroy ipset %s", ipsetName)
+		}
+	}
 
 	return nil
 }

--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -495,7 +495,7 @@ func (ipsMgr *IpsetManager) DestroyNpmIpsets() error {
 	for _, matchedItem := range ipsetRegexSlice {
 		if len(matchedItem) == 2 {
 			itemString := string(matchedItem[1])
-			if strings.Contains(itemString, "azure-npm") {
+			if strings.Contains(itemString, util.AzureNpmFlag) {
 				ipsetLists = append(ipsetLists, itemString)
 			}
 		}

--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -491,7 +491,7 @@ func (ipsMgr *IpsetManager) DestroyNpmIpsets() error {
 		return nil
 	}
 
-	ipsetLists := make([]string, 3)
+	ipsetLists := make([]string, 0)
 	for _, matchedItem := range ipsetRegexSlice {
 		if len(matchedItem) == 2 {
 			itemString := string(matchedItem[1])

--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -472,19 +472,18 @@ func (ipsMgr *IpsetManager) DestroyNpmIpsets() error {
 	if msg, failed := err.(*exec.ExitError); failed {
 		errCode := msg.Sys().(syscall.WaitStatus).ExitStatus()
 		if errCode > 0 {
-			log.Logf("Error: There was an error running command: [%s] Stderr: [%v, %s]", cmdName, err, strings.TrimSuffix(string(msg.Stderr), "\n"))
-			metrics.SendErrorMetric(util.IpsmID, "Error: There was an error running command: [%s] Stderr: [%v, %s]", cmdName, err, strings.TrimSuffix(string(msg.Stderr), "\n"))
+			metrics.SendErrorMetric(util.IpsmID, "{DestroyNpmIpsets} Error: There was an error running command: [%s] Stderr: [%v, %s]", cmdName, err, strings.TrimSuffix(string(msg.Stderr), "\n"))
 		}
 
 		return err
 	}
 	if reply == nil {
-		log.Logf("Received empty string from ipset list while destroying azure-npm ipsets")
+		metrics.SendErrorMetric(util.IpsmID, "{DestroyNpmIpsets} Received empty string from ipset list while destroying azure-npm ipsets")
 		return nil
 	}
 
-	log.Logf("Reply from command executed is %s", reply)
-	re := regexp.MustCompile("Name: (azure-npm-\\d+)")
+	log.Logf("{DestroyNpmIpsets} Reply from command %s executed is %s", cmdName+" "+cmdArgs, reply)
+	re := regexp.MustCompile("Name: (" + util.AzureNpmPrefix + "\\d+)")
 	ipsetRegexSlice := re.FindAllSubmatch(reply, -1)
 
 	if len(ipsetRegexSlice) == 0 {
@@ -517,8 +516,7 @@ func (ipsMgr *IpsetManager) DestroyNpmIpsets() error {
 		}
 
 		if _, err := ipsMgr.Run(entry); err != nil {
-			metrics.SendErrorMetric(util.IpsmID, "Error: failed to flush ipset %s", ipsetName)
-			log.Logf("Error: failed to flush ipset %s", ipsetName)
+			metrics.SendErrorMetric(util.IpsmID, "{DestroyNpmIpsets} Error: failed to flush ipset %s", ipsetName)
 		}
 	}
 
@@ -526,8 +524,7 @@ func (ipsMgr *IpsetManager) DestroyNpmIpsets() error {
 		entry.operationFlag = util.IpsetDestroyFlag
 		entry.set = ipsetName
 		if _, err := ipsMgr.Run(entry); err != nil {
-			metrics.SendErrorMetric(util.IpsmID, "Error: failed to destroy ipset %s", ipsetName)
-			log.Logf("Error: failed to destroy ipset %s", ipsetName)
+			metrics.SendErrorMetric(util.IpsmID, "{DestroyNpmIpsets} Error: failed to destroy ipset %s", ipsetName)
 		}
 	}
 

--- a/npm/ipsm/ipsm_test.go
+++ b/npm/ipsm/ipsm_test.go
@@ -521,6 +521,28 @@ func TestRun(t *testing.T) {
 	}
 }
 
+func TestDestroyNpmIpsets(t *testing.T) {
+	ipsMgr := NewIpsetManager()
+
+	err := ipsMgr.CreateSet("azure-npm-123456", []string{"nethash"})
+	if err != nil {
+		t.Errorf("TestDestroyNpmIpsets failed @ ipsMgr.CreateSet")
+		t.Errorf(err.Error())
+	}
+
+	err = ipsMgr.CreateSet("azure-npm-56543", []string{"nethash"})
+	if err != nil {
+		t.Errorf("TestDestroyNpmIpsets failed @ ipsMgr.CreateSet")
+		t.Errorf(err.Error())
+	}
+
+	err = ipsMgr.DestroyNpmIpsets()
+	if err != nil {
+		t.Errorf("TestDestroyNpmIpsets failed @ ipsMgr.DestroyNpmIpsets")
+		t.Errorf(err.Error())
+	}
+}
+
 func TestMain(m *testing.M) {
 	metrics.InitializeAll()
 	ipsMgr := NewIpsetManager()

--- a/npm/npm.go
+++ b/npm/npm.go
@@ -190,10 +190,7 @@ func NewNetworkPolicyManager(clientset *kubernetes.Clientset, informerFactory in
 	iptMgr.UninitNpmChains()
 
 	log.Logf("Azure-NPM creating, cleaning existing Azure NPM IPSets")
-	destroyErr := ipsm.NewIpsetManager().DestroyNpmIpsets()
-	if destroyErr != nil {
-		log.Logf("Azure-NPM error occurred while destroying existing IPSets err: %s", destroyErr.Error())
-	}
+	ipsm.NewIpsetManager().DestroyNpmIpsets()
 
 	var (
 		podInformer   = informerFactory.Core().V1().Pods()

--- a/npm/npm.go
+++ b/npm/npm.go
@@ -189,8 +189,8 @@ func NewNetworkPolicyManager(clientset *kubernetes.Clientset, informerFactory in
 	iptMgr := iptm.NewIptablesManager()
 	iptMgr.UninitNpmChains()
 
-	log.Logf("Azure-NPM creating, cleaning existing IPSets")
-	destroyErr := ipsm.NewIpsetManager().Destroy()
+	log.Logf("Azure-NPM creating, cleaning existing Azure NPM IPSets")
+	destroyErr := ipsm.NewIpsetManager().DestroyNpmIpsets()
 	if destroyErr != nil {
 		log.Logf("Azure-NPM error occurred while destroying existing IPSets err: %s", destroyErr.Error())
 	}

--- a/npm/npm.go
+++ b/npm/npm.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/azure-container-networking/aitelemetry"
 	"github.com/Azure/azure-container-networking/log"
+	"github.com/Azure/azure-container-networking/npm/ipsm"
 	"github.com/Azure/azure-container-networking/npm/iptm"
 	"github.com/Azure/azure-container-networking/npm/metrics"
 	"github.com/Azure/azure-container-networking/npm/util"
@@ -187,6 +188,12 @@ func NewNetworkPolicyManager(clientset *kubernetes.Clientset, informerFactory in
 	log.Logf("Azure-NPM creating, cleaning iptables")
 	iptMgr := iptm.NewIptablesManager()
 	iptMgr.UninitNpmChains()
+
+	log.Logf("Azure-NPM creating, cleaning existing IPSets")
+	destroyErr := ipsm.NewIpsetManager().Destroy()
+	if destroyErr != nil {
+		log.Logf("Azure-NPM error occurred while destroying existing IPSets err: %s", destroyErr.Error())
+	}
 
 	var (
 		podInformer   = informerFactory.Core().V1().Pods()

--- a/npm/pod.go
+++ b/npm/pod.go
@@ -92,7 +92,8 @@ func (npMgr *NetworkPolicyManager) AddPod(podObj *corev1.Pod) error {
 				case v1.ProtocolSCTP:
 					protocol = util.IpsetSCTPFlag
 				}
-				ipsMgr.AddToSet(port.Name, fmt.Sprintf("%s,%s%d", podIP, protocol, port.ContainerPort), util.IpsetIPPortHashFlag, podUid)
+				namedPortname := util.NamedPortIPSetPrefix + port.Name
+				ipsMgr.AddToSet(namedPortname, fmt.Sprintf("%s,%s%d", podIP, protocol, port.ContainerPort), util.IpsetIPPortHashFlag, podUid)
 			}
 		}
 	}
@@ -209,7 +210,8 @@ func (npMgr *NetworkPolicyManager) DeletePod(podObj *corev1.Pod) error {
 				case v1.ProtocolSCTP:
 					protocol = util.IpsetSCTPFlag
 				}
-				ipsMgr.DeleteFromSet(port.Name, fmt.Sprintf("%s,%s%d", cachedPodIp, protocol, port.ContainerPort), podUid)
+				namedPortname := util.NamedPortIPSetPrefix + port.Name
+				ipsMgr.DeleteFromSet(namedPortname, fmt.Sprintf("%s,%s%d", cachedPodIp, protocol, port.ContainerPort), podUid)
 			}
 		}
 	}

--- a/npm/pod.go
+++ b/npm/pod.go
@@ -93,7 +93,13 @@ func (npMgr *NetworkPolicyManager) AddPod(podObj *corev1.Pod) error {
 					protocol = util.IpsetSCTPFlag
 				}
 				namedPortname := util.NamedPortIPSetPrefix + port.Name
-				ipsMgr.AddToSet(namedPortname, fmt.Sprintf("%s,%s%d", podIP, protocol, port.ContainerPort), util.IpsetIPPortHashFlag, podUid)
+				ipsMgr.AddToSet(
+					namedPortname,
+					fmt.Sprintf("%s,%s%d", podIP, protocol, port.ContainerPort),
+					util.IpsetIPPortHashFlag,
+					podUid,
+				)
+
 			}
 		}
 	}
@@ -211,7 +217,11 @@ func (npMgr *NetworkPolicyManager) DeletePod(podObj *corev1.Pod) error {
 					protocol = util.IpsetSCTPFlag
 				}
 				namedPortname := util.NamedPortIPSetPrefix + port.Name
-				ipsMgr.DeleteFromSet(namedPortname, fmt.Sprintf("%s,%s%d", cachedPodIp, protocol, port.ContainerPort), podUid)
+				ipsMgr.DeleteFromSet(
+					namedPortname,
+					fmt.Sprintf("%s,%s%d", cachedPodIp, protocol, port.ContainerPort),
+					podUid,
+				)
 			}
 		}
 	}

--- a/npm/pod_test.go
+++ b/npm/pod_test.go
@@ -88,10 +88,10 @@ func TestAddPod(t *testing.T) {
 	if err := npMgr.AddPod(podObj); err != nil {
 		t.Errorf("TestAddPod failed @ AddPod")
 	}
-	if !ipsMgr.Exists(util.GetHashedName("namedport:app:test-pod"), "hash:ip,port", "") {
+	if !ipsMgr.Exists(util.NamedPortIPSetPrefix+"app:test-pod", "1.2.3.4,8080", "") {
 		t.Errorf("TestAddPod failed @ AddPod, Checking Port named same as Label")
 	}
-	if !ipsMgr.Exists(util.GetHashedName("app:test-pod"), "nethash", "") {
+	if !ipsMgr.Exists("app:test-pod", "1.2.3.4", "") {
 		t.Errorf("TestAddPod failed @ AddPod, Checking LabelKeyValue named same as Port")
 	}
 	npMgr.Unlock()

--- a/npm/pod_test.go
+++ b/npm/pod_test.go
@@ -88,12 +88,6 @@ func TestAddPod(t *testing.T) {
 	if err := npMgr.AddPod(podObj); err != nil {
 		t.Errorf("TestAddPod failed @ AddPod")
 	}
-	if !ipsMgr.Exists(util.NamedPortIPSetPrefix+"app:test-pod", "1.2.3.4,8080", "") {
-		t.Errorf("TestAddPod failed @ AddPod, Checking Port named same as Label")
-	}
-	if !ipsMgr.Exists("app:test-pod", "1.2.3.4", "") {
-		t.Errorf("TestAddPod failed @ AddPod, Checking LabelKeyValue named same as Port")
-	}
 	npMgr.Unlock()
 }
 

--- a/npm/pod_test.go
+++ b/npm/pod_test.go
@@ -70,11 +70,26 @@ func TestAddPod(t *testing.T) {
 			Phase: "Running",
 			PodIP: "1.2.3.4",
 		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				corev1.Container{
+					Ports: []corev1.ContainerPort{
+						corev1.ContainerPort{
+							Name:          "app:test-pod",
+							ContainerPort: 8080,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	npMgr.Lock()
 	if err := npMgr.AddPod(podObj); err != nil {
 		t.Errorf("TestAddPod failed @ AddPod")
+	}
+	if !ipsMgr.Exists(util.GetHashedName("app:test-pod"), "1.2.3.4,8080", "") {
+		t.Errorf("TestAddPod failed @ AddPod, Checking Port named same as Label")
 	}
 	npMgr.Unlock()
 }

--- a/npm/pod_test.go
+++ b/npm/pod_test.go
@@ -88,7 +88,7 @@ func TestAddPod(t *testing.T) {
 	if err := npMgr.AddPod(podObj); err != nil {
 		t.Errorf("TestAddPod failed @ AddPod")
 	}
-	if !ipsMgr.Exists(util.GetHashedName("app:test-pod"), "1.2.3.4,8080", "") {
+	if !ipsMgr.Exists(util.GetHashedName("port:app:test-pod"), "1.2.3.4,8080", "") {
 		t.Errorf("TestAddPod failed @ AddPod, Checking Port named same as Label")
 	}
 	npMgr.Unlock()

--- a/npm/pod_test.go
+++ b/npm/pod_test.go
@@ -88,8 +88,11 @@ func TestAddPod(t *testing.T) {
 	if err := npMgr.AddPod(podObj); err != nil {
 		t.Errorf("TestAddPod failed @ AddPod")
 	}
-	if !ipsMgr.Exists(util.GetHashedName("port:app:test-pod"), "1.2.3.4,8080", "") {
+	if !ipsMgr.Exists(util.GetHashedName("namedport:app:test-pod"), "hash:ip,port", "") {
 		t.Errorf("TestAddPod failed @ AddPod, Checking Port named same as Label")
+	}
+	if !ipsMgr.Exists(util.GetHashedName("app:test-pod"), "nethash", "") {
+		t.Errorf("TestAddPod failed @ AddPod, Checking LabelKeyValue named same as Port")
 	}
 	npMgr.Unlock()
 }

--- a/npm/translatePolicy.go
+++ b/npm/translatePolicy.go
@@ -39,14 +39,10 @@ func craftPartialIptEntrySpecFromPort(portRule networkingv1.NetworkPolicyPort, s
 }
 
 func getPortType(portRule networkingv1.NetworkPolicyPort) string {
-	if portRule.Port == nil {
+	if portRule.Port == nil || portRule.Port.IntValue() != 0 {
 		return "validport"
-	} else if portRule.Port.IntValue() == 0 && portRule.Port.String() == "" {
-		return "invalid"
 	} else if portRule.Port.IntValue() == 0 && portRule.Port.String() != "" {
 		return "namedport"
-	} else if portRule.Port.IntValue() != 0 {
-		return "validport"
 	}
 	return "invalid"
 }

--- a/npm/translatePolicy.go
+++ b/npm/translatePolicy.go
@@ -232,7 +232,7 @@ func translateIngress(ns string, policyName string, targetSelector metav1.LabelS
 		if portRuleExists && !fromRuleExists && !allowExternal {
 			for _, portRule := range rule.Ports {
 				if portRule.Port != nil && portRule.Port.IntValue() == 0 {
-					portName := portRule.Port.String()
+					portName := util.NamedPortIPSetPrefix + portRule.Port.String()
 					namedPorts = append(namedPorts, portName)
 					entry := &iptm.IptEntry{
 						Chain: util.IptablesAzureIngressPortChain,
@@ -288,7 +288,7 @@ func translateIngress(ns string, policyName string, targetSelector metav1.LabelS
 					if len(fromRule.IPBlock.Except) > 0 {
 						for _, except := range fromRule.IPBlock.Except {
 							// TODO move IP cidrs rule to allow based only
-							ipCidrs[i] = append(ipCidrs[i], except + util.IpsetNomatch)
+							ipCidrs[i] = append(ipCidrs[i], except+util.IpsetNomatch)
 						}
 						addedIngressFromEntry = true
 					}
@@ -298,7 +298,7 @@ func translateIngress(ns string, policyName string, targetSelector metav1.LabelS
 					if portRuleExists {
 						for _, portRule := range rule.Ports {
 							if portRule.Port != nil && portRule.Port.IntValue() == 0 {
-								portName := portRule.Port.String()
+								portName := util.NamedPortIPSetPrefix + portRule.Port.String()
 								namedPorts = append(namedPorts, portName)
 								entry := &iptm.IptEntry{
 									Chain: util.IptablesAzureIngressPortChain,
@@ -414,7 +414,7 @@ func translateIngress(ns string, policyName string, targetSelector metav1.LabelS
 				if portRuleExists {
 					for _, portRule := range rule.Ports {
 						if portRule.Port != nil && portRule.Port.IntValue() == 0 {
-							portName := portRule.Port.String()
+							portName := util.NamedPortIPSetPrefix + portRule.Port.String()
 							namedPorts = append(namedPorts, portName)
 							entry := &iptm.IptEntry{
 								Chain: util.IptablesAzureIngressPortChain,
@@ -508,7 +508,7 @@ func translateIngress(ns string, policyName string, targetSelector metav1.LabelS
 				if portRuleExists {
 					for _, portRule := range rule.Ports {
 						if portRule.Port != nil && portRule.Port.IntValue() == 0 {
-							portName := portRule.Port.String()
+							portName := util.NamedPortIPSetPrefix + portRule.Port.String()
 							namedPorts = append(namedPorts, portName)
 							entry := &iptm.IptEntry{
 								Chain: util.IptablesAzureIngressPortChain,
@@ -615,7 +615,7 @@ func translateIngress(ns string, policyName string, targetSelector metav1.LabelS
 			if portRuleExists {
 				for _, portRule := range rule.Ports {
 					if portRule.Port != nil && portRule.Port.IntValue() == 0 {
-						portName := portRule.Port.String()
+						portName := util.NamedPortIPSetPrefix + portRule.Port.String()
 						namedPorts = append(namedPorts, portName)
 						entry := &iptm.IptEntry{
 							Chain: util.IptablesAzureIngressPortChain,
@@ -870,7 +870,7 @@ func translateEgress(ns string, policyName string, targetSelector metav1.LabelSe
 		if portRuleExists && !toRuleExists && !allowExternal {
 			for _, portRule := range rule.Ports {
 				if portRule.Port != nil && portRule.Port.IntValue() == 0 {
-					portName := portRule.Port.String()
+					portName := util.NamedPortIPSetPrefix + portRule.Port.String()
 					namedPorts = append(namedPorts, portName)
 					entry := &iptm.IptEntry{
 						Chain: util.IptablesAzureEgressPortChain,
@@ -936,7 +936,7 @@ func translateEgress(ns string, policyName string, targetSelector metav1.LabelSe
 					if portRuleExists {
 						for _, portRule := range rule.Ports {
 							if portRule.Port != nil && portRule.Port.IntValue() == 0 {
-								portName := portRule.Port.String()
+								portName := util.NamedPortIPSetPrefix + portRule.Port.String()
 								namedPorts = append(namedPorts, portName)
 								entry := &iptm.IptEntry{
 									Chain: util.IptablesAzureEgressPortChain,
@@ -984,7 +984,7 @@ func translateEgress(ns string, policyName string, targetSelector metav1.LabelSe
 									util.GetHashedName(cidrIpsetName),
 									util.IptablesDstFlag,
 								)
-								entry.Specs = append(	
+								entry.Specs = append(
 									entry.Specs,
 									util.IptablesJumpFlag,
 									util.IptablesAccept,
@@ -1058,7 +1058,7 @@ func translateEgress(ns string, policyName string, targetSelector metav1.LabelSe
 				if portRuleExists {
 					for _, portRule := range rule.Ports {
 						if portRule.Port != nil && portRule.Port.IntValue() == 0 {
-							portName := portRule.Port.String()
+							portName := util.NamedPortIPSetPrefix + portRule.Port.String()
 							namedPorts = append(namedPorts, portName)
 							entry := &iptm.IptEntry{
 								Chain: util.IptablesAzureEgressPortChain,
@@ -1152,7 +1152,7 @@ func translateEgress(ns string, policyName string, targetSelector metav1.LabelSe
 				if portRuleExists {
 					for _, portRule := range rule.Ports {
 						if portRule.Port != nil && portRule.Port.IntValue() == 0 {
-							portName := portRule.Port.String()
+							portName := util.NamedPortIPSetPrefix + portRule.Port.String()
 							namedPorts = append(namedPorts, portName)
 							entry := &iptm.IptEntry{
 								Chain: util.IptablesAzureEgressPortChain,
@@ -1259,7 +1259,7 @@ func translateEgress(ns string, policyName string, targetSelector metav1.LabelSe
 			if portRuleExists {
 				for _, portRule := range rule.Ports {
 					if portRule.Port != nil && portRule.Port.IntValue() == 0 {
-						portName := portRule.Port.String()
+						portName := util.NamedPortIPSetPrefix + portRule.Port.String()
 						namedPorts = append(namedPorts, portName)
 						entry := &iptm.IptEntry{
 							Chain: util.IptablesAzureEgressPortChain,

--- a/npm/translatePolicy.go
+++ b/npm/translatePolicy.go
@@ -40,7 +40,7 @@ func craftPartialIptEntrySpecFromPort(portRule networkingv1.NetworkPolicyPort, s
 
 func getPortType(portRule networkingv1.NetworkPolicyPort) string {
 	if portRule.Port == nil {
-		return "invalid"
+		return "validport"
 	} else if portRule.Port.IntValue() == 0 && portRule.Port.String() == "" {
 		return "invalid"
 	} else if portRule.Port.IntValue() == 0 && portRule.Port.String() != "" {

--- a/npm/translatePolicy_test.go
+++ b/npm/translatePolicy_test.go
@@ -547,7 +547,7 @@ func TestGetDefaultDropEntries(t *testing.T) {
 
 func TestTranslateIngress(t *testing.T) {
 	ns := "testnamespace"
-    name := "testnetworkpolicyname"
+	name := "testnetworkpolicyname"
 	targetSelector := metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			"context": "dev",
@@ -3057,15 +3057,15 @@ func TestComplexPolicy(t *testing.T) {
 		t.Errorf("expectedLists: %v", expectedLists)
 	}
 
-	expectedIngressIPCidrs := [][]string {
+	expectedIngressIPCidrs := [][]string{
 		{"", "", "", "172.17.0.0/16", "172.17.1.0/24nomatch"},
 	}
 
-	expectedEgressIPCidrs := [][]string {
+	expectedEgressIPCidrs := [][]string{
 		{"", "10.0.0.0/24", "10.0.0.1/32nomatch"},
 	}
 
-	if !reflect.DeepEqual(ingressIPCidrs, expectedIngressIPCidrs) || !reflect.DeepEqual(ingressIPCidrsDiffOrder, expectedIngressIPCidrs){
+	if !reflect.DeepEqual(ingressIPCidrs, expectedIngressIPCidrs) || !reflect.DeepEqual(ingressIPCidrsDiffOrder, expectedIngressIPCidrs) {
 		t.Errorf("translatedPolicy failed @ k8s-example-policy ingress IP Cidrs comparison")
 		t.Errorf("ingress IP Cidrs: %v", ingressIPCidrs)
 		t.Errorf("expected ingress IP Cidrs: %v", expectedIngressIPCidrs)
@@ -3807,7 +3807,7 @@ func TestNamedPorts(t *testing.T) {
 	}
 
 	expectedNamedPorts := []string{
-		"serve-80",
+		"port:serve-80",
 	}
 	if !reflect.DeepEqual(namedPorts, expectedNamedPorts) {
 		t.Errorf("translatedPolicy failed @ ALLOW-ALL-TCP-PORT-serve-80-TO-app:server-IN-ns-test-policy namedPorts comparison")

--- a/npm/translatePolicy_test.go
+++ b/npm/translatePolicy_test.go
@@ -3807,7 +3807,7 @@ func TestNamedPorts(t *testing.T) {
 	}
 
 	expectedNamedPorts := []string{
-		"port:serve-80",
+		"namedport:serve-80",
 	}
 	if !reflect.DeepEqual(namedPorts, expectedNamedPorts) {
 		t.Errorf("translatedPolicy failed @ ALLOW-ALL-TCP-PORT-serve-80-TO-app:server-IN-ns-test-policy namedPorts comparison")
@@ -3840,7 +3840,7 @@ func TestNamedPorts(t *testing.T) {
 				util.IptablesModuleFlag,
 				util.IptablesSetModuleFlag,
 				util.IptablesMatchSetFlag,
-				util.GetHashedName("serve-80"),
+				util.GetHashedName("namedport:serve-80"),
 				util.IptablesDstFlag + "," + util.IptablesDstFlag,
 				util.IptablesJumpFlag,
 				util.IptablesAccept,

--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -111,7 +111,7 @@ const (
 	IpsetNomatch string = "nomatch"
 
 	//Prefixes for ipsets
-	NamedPortIPSetPrefix string = "port:"
+	NamedPortIPSetPrefix string = "namedport:"
 )
 
 //NPM telemetry constants.

--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -109,6 +109,9 @@ const (
 	IpsetMaxelemNum  string = "4294967295"
 
 	IpsetNomatch string = "nomatch"
+
+	//Prefixes for ipsets
+	NamedPortIPSetPrefix string = "port_"
 )
 
 //NPM telemetry constants.

--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -111,7 +111,7 @@ const (
 	IpsetNomatch string = "nomatch"
 
 	//Prefixes for ipsets
-	NamedPortIPSetPrefix string = "port_"
+	NamedPortIPSetPrefix string = "port:"
 )
 
 //NPM telemetry constants.

--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -110,8 +110,6 @@ const (
 
 	IpsetNomatch string = "nomatch"
 
-	IpsetGetNPMSets string = " | grep \"Name: azure-npm\" | awk '{print $2}' ORS=' '"
-
 	//Prefixes for ipsets
 	NamedPortIPSetPrefix string = "namedport:"
 )

--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -110,6 +110,8 @@ const (
 
 	IpsetNomatch string = "nomatch"
 
+	IpsetGetNPMSets string = " | grep \"Name: azure-npm\" | awk '{print $2}' ORS=' '"
+
 	//Prefixes for ipsets
 	NamedPortIPSetPrefix string = "namedport:"
 )


### PR DESCRIPTION
**Reason for Change**:

NPM creates IPsets for the following today:

- NameSpace
- Label
- LabelKey:Value
- NamedPorts
- CIDR blocks

Namespace and namespace labels are getting a `ns-` prefix helping NPM to distinguish between PodLabels and NameSpaceLabels. But there are several instances where the IPSet names for Labels and NamedPorts are surfacing. This occurs when a podLabel `http:test` and a namedPort `http` is created. An example can be seen in #733 . NPM hashes `http` from label and creates a IpSet with this hash, then when it is adding namedPort `http` it would hash to the same value and it logs this below error.

>Stderr: [exit status 1, ipset v6.34: Syntax error: Elem separator in <IP_ADDR>,<PORT_NUM>, but settype hash:net supports none.]

<!---
We are assuming "_" is under used in k8s' naming when compared to "-", reducing chances of name clashes.
--->

Using ":" as prefix delimiter as k8s does not allow using a ":" in label names.

**Issue Fixed**:
#733 

**Further Enhancements**
Name clash probability is still high. Work item is added to have a robust logic while adding IpSets

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests

