### PR TITLE
Configurable wireserver endpoint

### DIFF
--- a/cns/configuration/cns_config.json
+++ b/cns/configuration/cns_config.json
@@ -18,5 +18,6 @@
     "UseHTTPS" : false,
     "TLSSubjectName" : "",
     "TLSCertificatePath" : "",
-    "TLSEndpoint" : "localhost:10091"
+    "TLSEndpoint" : "localhost:10091",
+    "WireserverIP": "168.63.129.16"
 }

--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -24,6 +24,7 @@ type CNSConfig struct {
 	TLSSubjectName     string
 	TLSCertificatePath string
 	TLSEndpoint        string
+	WireserverIP       string
 }
 
 type TelemetrySettings struct {

--- a/cns/restserver/api_test.go
+++ b/cns/restserver/api_test.go
@@ -553,6 +553,16 @@ func publishNCViaCNS(t *testing.T,
 	fmt.Printf("PublishNetworkContainer succeded with response %+v, raw:%+v\n", resp, w.Body)
 }
 
+func TestExtractHost(t *testing.T) {
+	joinURL := "http://127.0.0.1:9001/joinedVirtualNetworks/c9b8e695-2de1-11eb-bf54-000d3af666c8/api-version/1"
+
+	host := extractHostFromJoinNetworkURL(joinURL)
+	expected := "127.0.0.1:9001"
+	if host != expected {
+		t.Fatalf("expected host %q, got %q", expected, host)
+	}
+}
+
 func TestUnpublishNCViaCNS(t *testing.T) {
 	fmt.Println("Test: unpublishNetworkContainer")
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -404,6 +404,10 @@ func main() {
 	configuration.SetCNSConfigDefaults(&cnsconfig)
 	logger.Printf("[Azure CNS] Read config :%+v", cnsconfig)
 
+	if cnsconfig.WireserverIP != "" {
+		nmagentclient.WireserverIP = cnsconfig.WireserverIP
+	}
+
 	if cnsconfig.ChannelMode == cns.Managed {
 		config.ChannelMode = cns.Managed
 		privateEndpoint = cnsconfig.ManagedSettings.PrivateEndpoint


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

This PR adds a configuration option for wireserver ip, helpful in cases where we are not in a live environment and need to use mocks for nmagent. It also adds a check in the publish container endpoint to possibly extract the wireserver endpoint from the incoming request; given that the rest of the payload contains urls used to communicate to wireserver, it follows that we should try to use that instead of the internal cns configuration.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests


**Notes**:
