### PR TITLE
Prevent storing auth token in CNS state file

### DIFF
--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -125,11 +125,15 @@ func (service *HTTPRestService) saveNetworkContainerGoalState(req cns.CreateNetw
 		hostVersion = "-1"
 	}
 
+	// Remove the auth token before saving the containerStatus to cns json file
+	createNetworkContainerRequest := req
+	createNetworkContainerRequest.AuthorizationToken = ""
+
 	service.state.ContainerStatus[req.NetworkContainerid] =
 		containerstatus{
 			ID:                            req.NetworkContainerid,
 			VMVersion:                     req.Version,
-			CreateNetworkContainerRequest: req,
+			CreateNetworkContainerRequest: createNetworkContainerRequest,
 			HostVersion:                   hostVersion,
 			VfpUpdateComplete:             vfpUpdateComplete}
 


### PR DESCRIPTION
This change prevents the subnet auth token getting saved in the CNS state file.
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
