### PR TITLE
write the files in one transaction.

### DIFF
--- a/cni/utils/fileutils.go
+++ b/cni/utils/fileutils.go
@@ -1,16 +1,18 @@
 package utils
 
-// we need to write the file in transaction
+import (
+	"io/ioutil"
+	"os"
+)
+
+// WriteFile provide one way to write the file in one transaction.
 // or when the process crash or the system reboot, we will have one incomplete file.
-func WriteFile(dstFile string, b []byte) {
+func WriteFile(dstFile string, b []byte, perm os.FileMode) error {
+	tempFilePath := fmt.Sprintf("%s.tmp", dstFile)
+	err := ioutil.WriteFile(tempFilePath, b, perm)
+	if err != nil {
+		return err
+	}
 
-	// fp, err := os.OpenFile(snatConfigFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(0664))
-	// 				if err == nil {
-	// 					fp.Write(jsonStr)
-	// 					fp.Close()
-	// 				} else {
-	// 					log.Errorf("[cni-net] failed to save snat settings to %s with error: %+v", snatConfigFile, err)
-	// 				}
+	return os.Rename(tempFilePath, dstFile)
 }
-
-// ioutil.WriteFile(dstFile, filebytes, perm)

--- a/cni/utils/fileutils.go
+++ b/cni/utils/fileutils.go
@@ -1,6 +1,7 @@
 package utils
 
-// we need to write
+// we need to write the file in transaction
+// or when the process crash or the system reboot, we will have one incomplete file.
 func WriteFile(dstFile string, b []byte) {
 
 	// fp, err := os.OpenFile(snatConfigFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(0664))

--- a/cni/utils/fileutils.go
+++ b/cni/utils/fileutils.go
@@ -1,0 +1,15 @@
+package utils
+
+// we need to write
+func WriteFile(dstFile string, b []byte) {
+
+	// fp, err := os.OpenFile(snatConfigFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(0664))
+	// 				if err == nil {
+	// 					fp.Write(jsonStr)
+	// 					fp.Close()
+	// 				} else {
+	// 					log.Errorf("[cni-net] failed to save snat settings to %s with error: %+v", snatConfigFile, err)
+	// 				}
+}
+
+// ioutil.WriteFile(dstFile, filebytes, perm)

--- a/cnm/plugin.go
+++ b/cnm/plugin.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 
+	"github.com/Azure/azure-container-networking/cni/utils"
 	"github.com/Azure/azure-container-networking/common"
 	"github.com/Azure/azure-container-networking/log"
 )
@@ -90,7 +91,7 @@ func (plugin *Plugin) EnableDiscovery() error {
 	// Write the listener URL to the spec file.
 	fileName := path + plugin.Name + ".spec"
 	url := plugin.Listener.URL.String()
-	err := ioutil.WriteFile(fileName, []byte(url), 0644)
+	err := utils.WriteFile(fileName, []byte(url), 0644)
 	return err
 }
 

--- a/hack/acncli/installer/conflist.go
+++ b/hack/acncli/installer/conflist.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	ccn "github.com/Azure/azure-container-networking/cni"
+	"github.com/Azure/azure-container-networking/cni/utils"
 	c "github.com/Azure/azure-container-networking/hack/acncli/api"
 )
 
@@ -96,7 +97,7 @@ func ModifyConflists(conflistpath string, installerConf InstallerConfig, perm os
 	}
 
 	fmt.Printf("🚛 - Installing %v...\n", dstFile)
-	return ioutil.WriteFile(dstFile, filebytes, perm)
+	return utils.WriteFile(dstFile, filebytes, perm)
 }
 
 func PrettyPrint(o interface{}) {

--- a/store/json.go
+++ b/store/json.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Azure/azure-container-networking/cni/utils"
 	"github.com/Azure/azure-container-networking/log"
 )
 
@@ -109,10 +110,7 @@ func (kvs *jsonFileStore) Flush() error {
 
 // Lock-free flush for internal callers.
 func (kvs *jsonFileStore) flush() error {
-	file, err := os.Create(kvs.fileName)
-	if err != nil {
-		return err
-	}
+
 	defer file.Close()
 
 	buf, err := json.MarshalIndent(&kvs.data, "", "\t")
@@ -120,7 +118,7 @@ func (kvs *jsonFileStore) flush() error {
 		return err
 	}
 
-	if _, err := file.Write(buf); err != nil {
+	if _, err := utils.WriteFile(kvs.fileName, buf, 0666); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
our customer(AKS) sometimes meet the issue that the json file is incomplete.
and we need to restart the services in both linux/windows to mitigate the issue.
I think put the file writing into one "transaction" can help our customer resolve that issue.