### PR TITLE
Update CNS ubuntu version to 20.04

### DIFF
--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -1,5 +1,5 @@
 # Use a minimal image as a parent image
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 ARG CNS_BUILD_ARCHIVE
 
 # Install plugin


### PR DESCRIPTION
fix: repair docker build failure for previous CNS ubuntu version

**Reason for Change**:
Previous 19.10 ubuntu image has issue with apt-get update. Official support for 19.10 also stopped. Updated to official version of 20.04
https://hub.docker.com/_/ubuntu/?tab=tags&page=1&ordering=last_updated


**Issue Fixed**:
docker build failure for ubuntu 19.10 image.


**Requirements**:
None.


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
build: Build 🏭
chore: Maintenance 🔧