### PR TITLE
[NPM] Supporting Namespace label updates

### DIFF
--- a/npm/namespace.go
+++ b/npm/namespace.go
@@ -17,6 +17,7 @@ import (
 
 type namespace struct {
 	name           string
+	labelsMap      map[string]string
 	setMap         map[string]string
 	podMap         map[types.UID]*corev1.Pod
 	rawNpMap       map[string]*networkingv1.NetworkPolicy
@@ -29,6 +30,7 @@ type namespace struct {
 func newNs(name string) (*namespace, error) {
 	ns := &namespace{
 		name:           name,
+		labelsMap:      make(map[string]string),
 		setMap:         make(map[string]string),
 		podMap:         make(map[types.UID]*corev1.Pod),
 		rawNpMap:       make(map[string]*networkingv1.NetworkPolicy),
@@ -138,6 +140,9 @@ func (npMgr *NetworkPolicyManager) AddNamespace(nsObj *corev1.Namespace) error {
 	if err != nil {
 		log.Errorf("Error: failed to create namespace %s", nsName)
 	}
+
+	// Append all labels to the cache NS obj
+	ns.labelsMap = util.AppendMap(ns.labelsMap, nsLabel)
 	npMgr.nsMap[nsName] = ns
 
 	return nil
@@ -171,17 +176,30 @@ func (npMgr *NetworkPolicyManager) UpdateNamespace(oldNsObj *corev1.Namespace, n
 		return nil
 	}
 
+	// If orignal AddNamespace failed for some reason, then NS will not be found
+	// in nsMap, resulting in retry of ADD.
+	curNsObj, exists := npMgr.nsMap[newNsNs]
+	if !exists {
+		if newNsObj.ObjectMeta.DeletionTimestamp == nil && newNsObj.ObjectMeta.DeletionGracePeriodSeconds == nil {
+			if err = npMgr.AddNamespace(newNsObj); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
 	//if no change in labels then return
-	if reflect.DeepEqual(oldNsLabel, newNsLabel) {
+	if reflect.DeepEqual(curNsObj.labelsMap, newNsLabel) {
 		log.Logf(
-			"NAMESPACE UPDATING:\n nothing to delete or add. old namespace: [%s/%v]\n new namespace: [%s/%v]",
-			oldNsNs, oldNsLabel, newNsNs, newNsLabel,
+			"NAMESPACE UPDATING:\n nothing to delete or add. old namespace: [%s/%v]\n cache namespace: [%s/%v] new namespace: [%s/%v]",
+			oldNsNs, oldNsLabel, curNsObj.name, curNsObj.labelsMap, newNsNs, newNsLabel,
 		)
 		return nil
 	}
 
 	//If the Namespace is not deleted, delete removed labels and create new labels
-	toAddNsLabels, toDeleteNsLabels := util.CompareMapDiff(oldNsLabel, newNsLabel)
+	toAddNsLabels, toDeleteNsLabels := util.CompareMapDiff(curNsObj.labelsMap, newNsLabel)
 
 	// Delete the namespace from its label's ipset list.
 	ipsMgr := npMgr.nsMap[util.KubeAllNamespacesFlag].ipsMgr
@@ -217,6 +235,10 @@ func (npMgr *NetworkPolicyManager) UpdateNamespace(oldNsObj *corev1.Namespace, n
 			return err
 		}
 	}
+
+	// Append all labels to the cache NS obj
+	curNsObj.labelsMap = util.ClearAndAppendMap(curNsObj.labelsMap, newNsLabel)
+	npMgr.nsMap[newNsNs] = curNsObj
 
 	return nil
 }

--- a/npm/namespace_test.go
+++ b/npm/namespace_test.go
@@ -135,6 +135,114 @@ func TestUpdateNamespace(t *testing.T) {
 	npMgr.Unlock()
 }
 
+func TestAddNamespaceLabel(t *testing.T) {
+	npMgr := &NetworkPolicyManager{
+		nsMap:            make(map[string]*namespace),
+		TelemetryEnabled: false,
+	}
+
+	allNs, err := newNs(util.KubeAllNamespacesFlag)
+	if err != nil {
+		panic(err.Error)
+	}
+	npMgr.nsMap[util.KubeAllNamespacesFlag] = allNs
+
+	ipsMgr := ipsm.NewIpsetManager()
+	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
+		t.Errorf("TestAddNamespaceLabel failed @ ipsMgr.Save")
+	}
+
+	defer func() {
+		if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
+			t.Errorf("TestAddNamespaceLabel failed @ ipsMgr.Restore")
+		}
+	}()
+
+	oldNsObj := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "old-test-namespace",
+			Labels: map[string]string{
+				"app": "old-test-namespace",
+			},
+		},
+	}
+
+	newNsObj := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "old-test-namespace",
+			Labels: map[string]string{
+				"app":    "old-test-namespace",
+				"update": "true",
+			},
+		},
+	}
+
+	npMgr.Lock()
+	if err := npMgr.AddNamespace(oldNsObj); err != nil {
+		t.Errorf("TestAddNamespaceLabel failed @ npMgr.AddNamespace")
+	}
+
+	if err := npMgr.UpdateNamespace(oldNsObj, newNsObj); err != nil {
+		t.Errorf("TestAddNamespaceLabel failed @ npMgr.UpdateNamespace")
+	}
+	npMgr.Unlock()
+}
+
+func TestDeleteandUpdateNamespaceLabel(t *testing.T) {
+	npMgr := &NetworkPolicyManager{
+		nsMap:            make(map[string]*namespace),
+		TelemetryEnabled: false,
+	}
+
+	allNs, err := newNs(util.KubeAllNamespacesFlag)
+	if err != nil {
+		panic(err.Error)
+	}
+	npMgr.nsMap[util.KubeAllNamespacesFlag] = allNs
+
+	ipsMgr := ipsm.NewIpsetManager()
+	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
+		t.Errorf("TestDeleteandUpdateNamespaceLabel failed @ ipsMgr.Save")
+	}
+
+	defer func() {
+		if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
+			t.Errorf("TestDeleteandUpdateNamespaceLabel failed @ ipsMgr.Restore")
+		}
+	}()
+
+	oldNsObj := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "old-test-namespace",
+			Labels: map[string]string{
+				"app":    "old-test-namespace",
+				"update": "true",
+				"group":  "test",
+			},
+		},
+	}
+
+	newNsObj := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "old-test-namespace",
+			Labels: map[string]string{
+				"app":    "old-test-namespace",
+				"update": "false",
+			},
+		},
+	}
+
+	npMgr.Lock()
+	if err := npMgr.AddNamespace(oldNsObj); err != nil {
+		t.Errorf("TestDeleteandUpdateNamespaceLabel failed @ npMgr.AddNamespace")
+	}
+
+	if err := npMgr.UpdateNamespace(oldNsObj, newNsObj); err != nil {
+		t.Errorf("TestDeleteandUpdateNamespaceLabel failed @ npMgr.UpdateNamespace")
+	}
+	npMgr.Unlock()
+}
+
 func TestDeleteNamespace(t *testing.T) {
 	npMgr := &NetworkPolicyManager{
 		nsMap:            make(map[string]*namespace),

--- a/npm/namespace_test.go
+++ b/npm/namespace_test.go
@@ -4,6 +4,7 @@ package npm
 
 import (
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/Azure/azure-container-networking/npm/iptm"
@@ -143,7 +144,7 @@ func TestAddNamespaceLabel(t *testing.T) {
 
 	allNs, err := newNs(util.KubeAllNamespacesFlag)
 	if err != nil {
-		panic(err.Error)
+		t.Fatal(err.Error())
 	}
 	npMgr.nsMap[util.KubeAllNamespacesFlag] = allNs
 
@@ -185,6 +186,11 @@ func TestAddNamespaceLabel(t *testing.T) {
 	if err := npMgr.UpdateNamespace(oldNsObj, newNsObj); err != nil {
 		t.Errorf("TestAddNamespaceLabel failed @ npMgr.UpdateNamespace")
 	}
+
+	if !reflect.DeepEqual(npMgr.nsMap["ns-"+newNsObj.Name].labelsMap, newNsObj.ObjectMeta.Labels) {
+		t.Errorf("TestAddNamespaceLabel failed @ npMgr.nsMap labelMap check")
+	}
+
 	npMgr.Unlock()
 }
 
@@ -196,7 +202,7 @@ func TestDeleteandUpdateNamespaceLabel(t *testing.T) {
 
 	allNs, err := newNs(util.KubeAllNamespacesFlag)
 	if err != nil {
-		panic(err.Error)
+		t.Fatal(err.Error())
 	}
 	npMgr.nsMap[util.KubeAllNamespacesFlag] = allNs
 
@@ -240,6 +246,10 @@ func TestDeleteandUpdateNamespaceLabel(t *testing.T) {
 	if err := npMgr.UpdateNamespace(oldNsObj, newNsObj); err != nil {
 		t.Errorf("TestDeleteandUpdateNamespaceLabel failed @ npMgr.UpdateNamespace")
 	}
+
+	if !reflect.DeepEqual(npMgr.nsMap["ns-"+newNsObj.Name].labelsMap, newNsObj.ObjectMeta.Labels) {
+		t.Errorf("TestDeleteandUpdateNamespaceLabel failed @ npMgr.nsMap labelMap check")
+	}
 	npMgr.Unlock()
 }
 
@@ -282,6 +292,10 @@ func TestDeleteNamespace(t *testing.T) {
 
 	if err := npMgr.DeleteNamespace(nsObj); err != nil {
 		t.Errorf("TestDeleteNamespace @ npMgr.DeleteNamespace")
+	}
+
+	if _, exists := npMgr.nsMap["ns-"+nsObj.Name]; exists {
+		t.Errorf("TestDeleteNamespace failed @ npMgr.nsMap check")
 	}
 	npMgr.Unlock()
 }

--- a/npm/util/util.go
+++ b/npm/util/util.go
@@ -7,8 +7,8 @@ import (
 	"hash/fnv"
 	"os"
 	"regexp"
-	"strings"
 	"sort"
+	"strings"
 
 	"github.com/Masterminds/semver"
 	"k8s.io/apimachinery/pkg/version"
@@ -69,6 +69,32 @@ func SortMap(m *map[string]string) ([]string, []string) {
 	return sortedKeys, sortedVals
 }
 
+// CompareMapDiff will compare two maps string[string] and returns
+// missing values in both
+func CompareMapDiff(orig map[string]string, new map[string]string) (map[string]string, map[string]string) {
+	notInOrig := make(map[string]string)
+	notInNew := make(map[string]string)
+
+	for keyOrig, valOrig := range orig {
+		if valNew, ok := new[keyOrig]; ok {
+			if valNew != valOrig {
+				notInNew[keyOrig] = valOrig
+				notInOrig[keyOrig] = valNew
+			}
+		} else {
+			notInNew[keyOrig] = valOrig
+		}
+	}
+
+	for keyNew, valNew := range new {
+		if _, ok := orig[keyNew]; !ok {
+			notInOrig[keyNew] = valNew
+		}
+	}
+
+	return notInOrig, notInNew
+}
+
 // UniqueStrSlice removes duplicate elements from the input string.
 func UniqueStrSlice(s []string) []string {
 	m, unique := map[string]bool{}, []string{}
@@ -106,7 +132,7 @@ func CompareK8sVer(firstVer *version.Info, secondVer *version.Info) int {
 	if len(v1Minor) < 1 {
 		return -2
 	}
-	v1, err := semver.NewVersion(firstVer.Major+"."+v1Minor[0])
+	v1, err := semver.NewVersion(firstVer.Major + "." + v1Minor[0])
 	if err != nil {
 		return -2
 	}
@@ -114,7 +140,7 @@ func CompareK8sVer(firstVer *version.Info, secondVer *version.Info) int {
 	if len(v2Minor) < 1 {
 		return -2
 	}
-	v2, err := semver.NewVersion(secondVer.Major+"."+v2Minor[0])
+	v2, err := semver.NewVersion(secondVer.Major + "." + v2Minor[0])
 	if err != nil {
 		return -2
 	}

--- a/npm/util/util.go
+++ b/npm/util/util.go
@@ -110,6 +110,16 @@ func UniqueStrSlice(s []string) []string {
 	return unique
 }
 
+// ClearAndAppendMap clears base and appends new to base.
+func ClearAndAppendMap(base, new map[string]string) map[string]string {
+	base = make(map[string]string)
+	for k, v := range new {
+		base[k] = v
+	}
+
+	return base
+}
+
 // AppendMap appends new to base.
 func AppendMap(base, new map[string]string) map[string]string {
 	for k, v := range new {


### PR DESCRIPTION
NPM currently deletes all the ipsets when an existing namespace is updated. This fix selectively deletes or adds only the changed labels for an existing Namespace.