### PR TITLE
Fix for deleting hostvethpair in transparent mode

### DIFF
--- a/network/transparent_endpointclient_linux.go
+++ b/network/transparent_endpointclient_linux.go
@@ -12,8 +12,8 @@ import (
 
 const (
 	virtualGwIPString = "169.254.1.1/32"
-	defaultGwCidr = "0.0.0.0/0"
-	defaultGw = "0.0.0.0"
+	defaultGwCidr     = "0.0.0.0/0"
+	defaultGw         = "0.0.0.0"
 )
 
 type TransparentEndpointClient struct {
@@ -152,8 +152,8 @@ func (client *TransparentEndpointClient) ConfigureContainerInterfacesAndRoutes(e
 	for _, ipAddr := range epInfo.IPAddresses {
 		_, ipnet, _ := net.ParseCIDR(ipAddr.String())
 		routeInfo := RouteInfo{
-			Dst: *ipnet,
-			Scope: netlink.RT_SCOPE_LINK,
+			Dst:      *ipnet,
+			Scope:    netlink.RT_SCOPE_LINK,
 			Protocol: netlink.RTPROT_KERNEL,
 		}
 		if err := deleteRoutes(client.containerVethName, []RouteInfo{routeInfo}); err != nil {
@@ -165,7 +165,7 @@ func (client *TransparentEndpointClient) ConfigureContainerInterfacesAndRoutes(e
 	//ip route add 169.254.1.1/32 dev eth0
 	virtualGwIP, virtualGwNet, _ := net.ParseCIDR(virtualGwIPString)
 	routeInfo := RouteInfo{
-		Dst: *virtualGwNet,
+		Dst:   *virtualGwNet,
 		Scope: netlink.RT_SCOPE_LINK,
 	}
 	if err := addRoutes(client.containerVethName, []RouteInfo{routeInfo}); err != nil {
@@ -177,7 +177,7 @@ func (client *TransparentEndpointClient) ConfigureContainerInterfacesAndRoutes(e
 	dstIP := net.IPNet{IP: net.ParseIP(defaultGw), Mask: defaultIPNet.Mask}
 	routeInfo = RouteInfo{
 		Dst: dstIP,
-		Gw: virtualGwIP,
+		Gw:  virtualGwIP,
 	}
 	if err := addRoutes(client.containerVethName, []RouteInfo{routeInfo}); err != nil {
 		return err
@@ -189,12 +189,5 @@ func (client *TransparentEndpointClient) ConfigureContainerInterfacesAndRoutes(e
 }
 
 func (client *TransparentEndpointClient) DeleteEndpoints(ep *endpoint) error {
-	log.Printf("[net] Deleting veth pair %v %v.", ep.HostIfName, ep.IfName)
-	err := netlink.DeleteLink(ep.HostIfName)
-	if err != nil {
-		log.Printf("[net] Failed to delete veth pair %v: %v.", ep.HostIfName, err)
-		return err
-	}
-
 	return nil
 }


### PR DESCRIPTION
…pace is deleted

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

The issue is that in transparent mode cni generates the veth pair names based on pod name and namespace. In this case, a new container with the same pod name and namespace called CNI ADD before the old container with the same pod name and namespace call  CNI DEL. Due to this, when the old container issued CNI DEL, it deleted the veth host interface, in turn deleting the eth0(other veth) of the new container.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
