### PR TITLE
[NPM] Ignoring hostnetwork pods from being added into Ipsets

### DIFF
--- a/npm/pod.go
+++ b/npm/pod.go
@@ -126,6 +126,17 @@ func (npMgr *NetworkPolicyManager) UpdatePod(oldPodObj, newPodObj *corev1.Pod) e
 		return nil
 	}
 
+	// today K8s does not allow updating HostNetwork flag for an existing Pod. So NPM can safely
+	// check on the oldPodObj for hostNework value
+	if isHostNetworkPod(oldPodObj) {
+		log.Logf(
+			"POD UPDATING ignored for HostNetwork Pod:\n old pod: [%s/%s/%+v/%s/%s]\n new pod: [%s/%s/%+v/%s/%s]",
+			oldPodObj.ObjectMeta.Namespace, oldPodObj.ObjectMeta.Name, oldPodObj.Status.PodIP,
+			newPodObj.ObjectMeta.Namespace, newPodObj.ObjectMeta.Name, newPodObj.Status.PodIP,
+		)
+		return nil
+	}
+
 	if isInvalidPodUpdate(oldPodObj, newPodObj) {
 		return nil
 	}
@@ -149,17 +160,6 @@ func (npMgr *NetworkPolicyManager) UpdatePod(oldPodObj, newPodObj *corev1.Pod) e
 		oldPodObjNs, oldPodObjName, oldPodObjLabel, oldPodObjPhase, oldPodObjIP,
 		newPodObjNs, newPodObjName, newPodObjLabel, newPodObjPhase, newPodObjIP,
 	)
-
-	// today K8s does not allow updating HostNetwork flag for an existing Pod. So NPM can safely
-	// check on the oldPodObj for hostNework value
-	if isHostNetworkPod(oldPodObj) {
-		log.Logf(
-			"POD UPDATING ignored for HostNetwork Pod:\n old pod: [%s/%s/%+v/%s/%s]\n new pod: [%s/%s/%+v/%s/%s]",
-			oldPodObjNs, oldPodObjName, oldPodObjLabel, oldPodObjPhase, oldPodObjIP,
-			newPodObjNs, newPodObjName, newPodObjLabel, newPodObjPhase, newPodObjIP,
-		)
-		return nil
-	}
 
 	// Todo: Update if cached ip and podip changed and it is not a delete event
 


### PR DESCRIPTION
This fix involves ignoring any Add, Update or Delete Pod events for Hostnetwork Pods.