### PR TITLE
Remove overriding host verson when IP already exist.

### DIFF
--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -265,7 +265,6 @@ func (service *HTTPRestService) addIPConfigStateUntransacted(ncId string, hostVe
 		if existingIPConfig, existsInPreviousIPConfig := existingSecondaryIPConfigs[ipId]; existsInPreviousIPConfig {
 			ipconfig.NCVersion = existingIPConfig.NCVersion
 			ipconfigs[ipId] = ipconfig
-			hostVersion = existingIPConfig.NCVersion
 		}
 		logger.Printf("[Azure-Cns] Set IP %s version to %d, programmed host nc version is %d", ipconfig.IPAddress, ipconfig.NCVersion, hostVersion)
 		if _, exists := service.PodIPConfigState[ipId]; exists {


### PR DESCRIPTION
Remove overriding host verson when IP already exist to avoid programming IPs become available after CNS restarts and restore from previous state.

fix: repair a bug when CNS restarts.

**Reason for Change**:
When nmagent nc version api is not ready, host version should always be -1 which indicate CNS can't verify nc version from nmagent side. 
No IP can be assigned since nmagent is not ready.
However, found CNS will assign IPs when restarts and restore from preivous states when nmagent is not ready. It's due to host version override. 

**Issue Fixed**:
Removing unnecessary override of host verson.

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
        fix: Bug Fixes 🐞

**Notes**:
Related logs
```
2021/02/05 17:45:33 [7] [Azure CNS]  Restored state, &{Location: NetworkType: OrchestratorType:KubernetesCRD NodeID: Initialized:false ContainerIDByOrchestratorContext:map[] ContainerStatus:map[f93b7ccd-0818-4b5c-9d63-5c33e2bda2bd:{ID:f93b7ccd-0818-4b5c-9d63-5c33e2bda2bd VMVersion:0 HostVersion:-1 CreateNetworkContainerRequest:{Version:0 NetworkContainerType:Docker NetworkContainerid:f93b7ccd-0818-4b5c-9d63-5c33e2bda2bd PrimaryInterfaceIdentifier: AuthorizationToken: LocalIPConfiguration:{IPSubnet:{IPAddress: PrefixLength:0} DNSServers:[] GatewayIPAddress:} OrchestratorContext:[110 117 108 108] IPConfiguration:{IPSubnet:{IPAddress:10.242.6.153 PrefixLength:16} DNSServers:[] GatewayIPAddress:10.242.0.1} SecondaryIPConfigs:map[071fd777-e1a7-4bd8-a372-93bd4e904427:{IPAddress:10.242.6.154 NCVersion:0} 0ab498e3-af73-4326-8cfe-f4a60b131d39:{IPAddress:10.242.6.163 NCVersion:0} 1c32fd78-ea3b-4a6f-9ff4-6099d420a284:{IPAddress:10.242.6.166 NCVersion:0} 22698d42-dde1-4919-90bf-4ea9fb56686b:{IPAddress:10.242.6.158 NCVersion:0} 5234aa71-1990-481a-a928-fc3d65ef4e7e:{IPAddress:10.242.6.167 NCVersion:0} 54f57ae0-b41e-47de-9250-3b6e886c979a:{IPAddress:10.242.6.168 NCVersion:0} 59e77f4f-8d1a-47fe-a9e3-e24c7883d329:{IPAddress:10.242.6.164 NCVersion:0} 5af6f890-3e3d-49e8-9bcf-01536951fed6:{IPAddress:10.242.6.162 NCVersion:0} 5b61f238-3dd0-41e6-8069-8eb1267aa416:{IPAddress:10.242.6.165 NCVersion:0} 67e55071-284b-4dd8-abbd-de40b24611ed:{IPAddress:10.242.6.155 NCVersion:0} 8b7a7317-4fef-4400-ba99-dd98829eb145:{IPAddress:10.242.6.156 NCVersion:0} 9ab0498a-14c5-4307-b2c5-6693e4213eca:{IPAddress:10.242.6.169 NCVersion:0} 9f8448de-9491-4d71-a6fe-a6f2c4f9cdf8:{IPAddress:10.242.6.159 NCVersion:0} 9fc2722b-f24c-4ccd-9d56-034621c86ccd:{IPAddress:10.242.6.157 NCVersion:0} b4501df4-446f-4b84-8929-ae3964fe0c0d:{IPAddress:10.242.6.161 NCVersion:0} f3d4c579-7f2d-4bf7-92e3-4d8fdfb2132a:{IPAddress:10.242.6.160 NCVersion:0}] MultiTenancyInfo:{EncapType: ID:0} CnetAddressSpace:[] Routes:[] AllowHostToNCCommunication:false AllowNCToHostCommunication:false EndpointPolicies:[]} VfpUpdateComplete:false}] Networks:map[] TimeStamp:2021-02-05 17:32:55.991220253 +0000 UTC joinedNetworks:map[]}

17:32:55 [6] [Azure-Cns] Set IP 10.242.6.154 version to 0, programmed host nc version is -1
None of this call happen
17:45:36 [7] [Azure-Cns] Set IP 10.242.6.160 version to 0, programmed host nc version is 0

17:45:30 [6] [ipam-pool-monitor] Checking pool for resize, Pool Size: 16, Goal Size: 16, BatchSize: 16, MinFree: 8, MaxFree:24, Allocated: 0, Available: 0, Pending Release: 0, Free: 16, Pending Program: 16

17:45:37 [7] [ipam-pool-monitor] Checking pool for resize, Pool Size: 16, Goal Size: 16, BatchSize: 16, MinFree: 8, MaxFree:24, Allocated: 1, Available: 15, Pending Release: 0, Free: 15, Pending Program: 0
```
