### PR TITLE
fix: Remove unreadable CNS state file upon CNS service start

### DIFF
--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
 	"testing"
@@ -545,5 +546,8 @@ func restartService() {
 	fmt.Println("Restart Service")
 
 	service.Stop()
-	startService()
+	if err := startService(); err != nil {
+		fmt.Printf("Failed to restart CNS Service. Error: %v", err)
+		os.Exit(1)
+	}
 }

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -132,7 +132,6 @@ func NewHTTPRestService(config *common.ServiceConfig, imdsClientInterface imdscl
 
 // Start starts the CNS listener.
 func (service *HTTPRestService) Start(config *common.ServiceConfig) error {
-
 	err := service.Initialize(config)
 	if err != nil {
 		logger.Errorf("[Azure CNS]  Failed to initialize base service, err:%v.", err)

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -138,12 +138,7 @@ func (service *HTTPRestService) Start(config *common.ServiceConfig) error {
 		return err
 	}
 
-	err = service.restoreState()
-	if err != nil {
-		logger.Errorf("[Azure CNS]  Failed to restore service state, err:%v.", err)
-		return err
-	}
-
+	service.restoreState()
 	err = service.restoreNetworkState()
 	if err != nil {
 		logger.Errorf("[Azure CNS]  Failed to restore network state, err:%v.", err)

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -74,13 +74,13 @@ func (service *HTTPRestService) saveState() error {
 }
 
 // restoreState restores CNS state from persistent store.
-func (service *HTTPRestService) restoreState() error {
+func (service *HTTPRestService) restoreState() {
 	logger.Printf("[Azure CNS] restoreState")
 
 	// Skip if a store is not provided.
 	if service.store == nil {
 		logger.Printf("[Azure CNS]  store not initialized.")
-		return nil
+		return
 	}
 
 	// Read any persisted state.
@@ -94,11 +94,11 @@ func (service *HTTPRestService) restoreState() error {
 			service.store.Remove()
 		}
 
-		return nil
+		return
 	}
 
 	logger.Printf("[Azure CNS]  Restored state, %+v\n", service.state)
-	return nil
+	return
 }
 
 func (service *HTTPRestService) saveNetworkContainerGoalState(req cns.CreateNetworkContainerRequest) (int, string) {

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -89,11 +89,12 @@ func (service *HTTPRestService) restoreState() error {
 		if err == store.ErrKeyNotFound {
 			// Nothing to restore.
 			logger.Printf("[Azure CNS]  No state to restore.\n")
-			return nil
+		} else {
+			logger.Errorf("[Azure CNS]  Failed to restore state, err:%v. Removing azure-cns.json", err)
+			service.store.Remove()
 		}
 
-		logger.Errorf("[Azure CNS]  Failed to restore state, err:%v\n", err)
-		return err
+		return nil
 	}
 
 	logger.Printf("[Azure CNS]  Restored state, %+v\n", service.state)

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -395,7 +395,7 @@ func main() {
 	if !telemetryEnabled {
 		logger.Errorf("[Azure CNS] Cannot disable telemetry via cmdline. Update cns_config.json to disable telemetry.")
 	}
-	
+
 	cnsconfig, err := configuration.ReadConfig()
 	if err != nil {
 		logger.Errorf("[Azure CNS] Error reading cns config: %v", err)

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -395,7 +395,7 @@ func main() {
 	if !telemetryEnabled {
 		logger.Errorf("[Azure CNS] Cannot disable telemetry via cmdline. Update cns_config.json to disable telemetry.")
 	}
-
+	
 	cnsconfig, err := configuration.ReadConfig()
 	if err != nil {
 		logger.Errorf("[Azure CNS] Error reading cns config: %v", err)

--- a/store/json.go
+++ b/store/json.go
@@ -148,7 +148,6 @@ func (kvs *jsonFileStore) flush() error {
 		return fmt.Errorf("temp file close failed with: %v", err)
 	}
 
-	log.Printf("renaming temp file %v to state file", tmpFileName)
 	// atomic replace
 	if err = platform.ReplaceFile(tmpFileName, kvs.fileName); err != nil {
 		return fmt.Errorf("rename temp file to state file failed:%v", err)
@@ -275,4 +274,12 @@ func (kvs *jsonFileStore) GetLockFileModificationTime() (time.Time, error) {
 
 func (kvs *jsonFileStore) GetLockFileName() string {
 	return kvs.fileName + lockExtension
+}
+
+func (kvs *jsonFileStore) Remove() {
+	kvs.Mutex.Lock()
+	if err := os.Remove(kvs.fileName); err != nil {
+		log.Errorf("could not remove file %s. Error: %v", kvs.fileName, err)
+	}
+	kvs.Mutex.Unlock()
 }

--- a/store/store.go
+++ b/store/store.go
@@ -18,6 +18,7 @@ type KeyValueStore interface {
 	GetModificationTime() (time.Time, error)
 	GetLockFileModificationTime() (time.Time, error)
 	GetLockFileName() string
+	Remove()
 }
 
 var (

--- a/testutils/store_mock.go
+++ b/testutils/store_mock.go
@@ -47,3 +47,7 @@ func (store *KeyValueStoreMock) GetLockFileName() string {
 	return ""
 }
 
+func (store *KeyValueStoreMock) Remove() {
+	return
+}
+


### PR DESCRIPTION
This change removes unreadable state file ( azure-cns.json ) while starting the CNS service
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
