### PR TITLE
[NPM] Fixing log noise and removing GetClusterState

### DIFF
--- a/npm/npm.go
+++ b/npm/npm.go
@@ -116,10 +116,16 @@ func (npMgr *NetworkPolicyManager) SendClusterMetrics() {
 
 	for {
 		<-heartbeat
-		clusterState := npMgr.GetClusterState()
-		podCount.Value = float64(clusterState.PodCount)
-		nsCount.Value = float64(clusterState.NsCount)
-		nwPolicyCount.Value = float64(clusterState.NwPolicyCount)
+		npMgr.Lock()
+		podCount.Value = float64(len(npMgr.podMap))
+		//Reducing one to remove all-namespaces ns obj
+		nsCount.Value = float64(len(npMgr.nsMap) - 1)
+		nwPolCount := 0
+		for _, ns := range npMgr.nsMap {
+			nwPolCount = nwPolCount + len(ns.rawNpMap)
+		}
+		nwPolicyCount.Value = float64(nwPolCount)
+		npMgr.Unlock()
 
 		metrics.SendMetric(podCount)
 		metrics.SendMetric(nsCount)

--- a/npm/pod.go
+++ b/npm/pod.go
@@ -126,18 +126,18 @@ func (npMgr *NetworkPolicyManager) UpdatePod(oldPodObj, newPodObj *corev1.Pod) e
 		return nil
 	}
 
+	if isInvalidPodUpdate(oldPodObj, newPodObj) {
+		return nil
+	}
+
 	// today K8s does not allow updating HostNetwork flag for an existing Pod. So NPM can safely
 	// check on the oldPodObj for hostNework value
 	if isHostNetworkPod(oldPodObj) {
 		log.Logf(
-			"POD UPDATING ignored for HostNetwork Pod:\n old pod: [%s/%s/%+v/%s/%s]\n new pod: [%s/%s/%+v/%s/%s]",
+			"POD UPDATING ignored for HostNetwork Pod:\n old pod: [%s/%s/%s]\n new pod: [%s/%s/%s]",
 			oldPodObj.ObjectMeta.Namespace, oldPodObj.ObjectMeta.Name, oldPodObj.Status.PodIP,
 			newPodObj.ObjectMeta.Namespace, newPodObj.ObjectMeta.Name, newPodObj.Status.PodIP,
 		)
-		return nil
-	}
-
-	if isInvalidPodUpdate(oldPodObj, newPodObj) {
 		return nil
 	}
 


### PR DESCRIPTION
For HostNetwork pods on v1.2.2hotfix, we are seeing lots of logs messages for dummy PodUpdate events. This is causing logs to be overwritten fast.