### PR TITLE
[NPM] Periodic Reconciliation of NPM Chain ordering in FORWARD table

### DIFF
--- a/npm/iptm/iptm.go
+++ b/npm/iptm/iptm.go
@@ -54,44 +54,14 @@ func NewIptablesManager() *IptablesManager {
 func (iptMgr *IptablesManager) InitNpmChains() error {
 	log.Logf("Initializing AZURE-NPM chains.")
 
-	if err := iptMgr.AddChain(util.IptablesAzureChain); err != nil {
-		return err
-	}
-
-	// Insert AZURE-NPM chain to FORWARD chain.
-	entry := &IptEntry{
-		Chain: util.IptablesForwardChain,
-		Specs: []string{
-			util.IptablesJumpFlag,
-			util.IptablesAzureChain,
-		},
-	}
-	exists, err := iptMgr.Exists(entry)
+	err := iptMgr.CheckAndAddForwardChain()
 	if err != nil {
-		return err
+		metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to add AZURE-NPM chain to FORWARD chain.")
 	}
 
-	if !exists {
-		// retrieve KUBE-SERVICES index
-		index := "1"
-		iptFilterEntries := exec.Command(util.Iptables, "-t", "filter", "-n", "--list", "FORWARD", "--line-numbers")
-		grep := exec.Command("grep", "KUBE-SERVICES")
-		pipe, _ := iptFilterEntries.StdoutPipe()
-		grep.Stdin = pipe
-		iptFilterEntries.Start()
-		output, err := grep.CombinedOutput()
-		if err == nil && len(output) > 2 {
-			tmpIndex, _ := strconv.Atoi(string(output[0]))
-			index = strconv.Itoa(tmpIndex + 1)
-		}
-		pipe.Close()
-		// position Azure-NPM chain after Kube-Forward and Kube-Service chains if it exists
-		iptMgr.OperationFlag = util.IptablesInsertionFlag
-		entry.Specs = append([]string{index}, entry.Specs...)
-		if _, err = iptMgr.Run(entry); err != nil {
-			metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to add AZURE-NPM chain to FORWARD chain.")
-			return err
-		}
+	entry := &IptEntry{
+		Chain: util.IptablesAzureChain,
+		Specs: []string{},
 	}
 
 	// Create AZURE-NPM-INGRESS-PORT chain.
@@ -102,7 +72,7 @@ func (iptMgr *IptablesManager) InitNpmChains() error {
 	// Append AZURE-NPM-INGRESS-PORT chain to AZURE-NPM chain.
 	entry.Chain = util.IptablesAzureChain
 	entry.Specs = []string{util.IptablesJumpFlag, util.IptablesAzureIngressPortChain}
-	exists, err = iptMgr.Exists(entry)
+	exists, err := iptMgr.Exists(entry)
 	if err != nil {
 		return err
 	}
@@ -437,6 +407,77 @@ func (iptMgr *IptablesManager) InitNpmChains() error {
 	return nil
 }
 
+// CheckAndAddForwardChain initializes and reconciles Azure-NPM chain in right order
+func (iptMgr *IptablesManager) CheckAndAddForwardChain() error {
+
+	// TODO Adding this chain is printing error messages try to clean it up
+	if err := iptMgr.AddChain(util.IptablesAzureChain); err != nil {
+		return err
+	}
+
+	// Insert AZURE-NPM chain to FORWARD chain.
+	entry := &IptEntry{
+		Chain: util.IptablesForwardChain,
+		Specs: []string{
+			util.IptablesJumpFlag,
+			util.IptablesAzureChain,
+		},
+	}
+	exists, err := iptMgr.Exists(entry)
+	if err != nil {
+		return err
+	}
+
+	index := 1
+	// retrieve KUBE-SERVICES index
+	kubeServicesLine, err := iptMgr.GetChainLineNumber(util.IptablesKubeServersChain, util.IptablesForwardChain)
+	if kubeServicesLine > 0 {
+		index = kubeServicesLine + 1
+	}
+	if err != nil {
+		metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to get index of KUBE-SERVICES in FORWARD chain with error: ", err.Error())
+	}
+
+	if !exists {
+		// position Azure-NPM chain after Kube-Forward and Kube-Service chains if it exists
+		iptMgr.OperationFlag = util.IptablesInsertionFlag
+		entry.Specs = append([]string{strconv.Itoa(index)}, entry.Specs...)
+		if _, err = iptMgr.Run(entry); err != nil {
+			metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to add AZURE-NPM chain to FORWARD chain.")
+			return err
+		}
+
+		return nil
+	}
+
+	npmChainLine, err := iptMgr.GetChainLineNumber(util.IptablesAzureChain, util.IptablesForwardChain)
+	if err != nil {
+		metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to get index of AZURE-NPM in FORWARD chain with error: ", err.Error())
+	}
+
+	// Kube-services line number is less than npm chain line number then all good
+	if kubeServicesLine > 0 && npmChainLine == index {
+		return nil
+	}
+
+	// NPM Chain number is less than KUBE-SERVICES then
+	// delete existing NPM chain and add it in the right order
+	iptMgr.OperationFlag = util.IptablesDeletionFlag
+	if _, err = iptMgr.Run(entry); err != nil {
+		metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to add AZURE-NPM chain to FORWARD chain.")
+		return err
+	}
+	iptMgr.OperationFlag = util.IptablesInsertionFlag
+	// Reduce index for deleted AZURE-NPM chain
+	entry.Specs = append([]string{strconv.Itoa(index - 1)}, entry.Specs...)
+	if _, err = iptMgr.Run(entry); err != nil {
+		metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to add AZURE-NPM chain to FORWARD chain.")
+		return err
+	}
+
+	return nil
+}
+
 // UninitNpmChains uninitializes Azure NPM chains in iptables.
 func (iptMgr *IptablesManager) UninitNpmChains() error {
 	IptablesAzureChainList := []string{
@@ -516,6 +557,24 @@ func (iptMgr *IptablesManager) AddChain(chain string) error {
 	}
 
 	return nil
+}
+
+// GetChainLineNumber given a Chain and its parent chain returns line number
+func (iptMgr *IptablesManager) GetChainLineNumber(chain string, parentChain string) (int, error) {
+
+	iptFilterEntries := exec.Command(util.Iptables, "-t", "filter", "-n", "--list", parentChain, "--line-numbers")
+	grep := exec.Command("grep", chain)
+	pipe, _ := iptFilterEntries.StdoutPipe()
+	grep.Stdin = pipe
+	defer pipe.Close()
+	iptFilterEntries.Start()
+	output, err := grep.CombinedOutput()
+	if err == nil && len(output) > 2 {
+		lineNum, _ := strconv.Atoi(string(output[0]))
+		return lineNum, err
+	}
+
+	return 0, err
 }
 
 // DeleteChain deletes a chain from iptables.
@@ -605,7 +664,11 @@ func (iptMgr *IptablesManager) Run(entry *IptEntry) (int, error) {
 	if msg, failed := err.(*exec.ExitError); failed {
 		errCode := msg.Sys().(syscall.WaitStatus).ExitStatus()
 		if errCode > 0 && iptMgr.OperationFlag != util.IptablesCheckFlag {
-			metrics.SendErrorLogAndMetric(util.IptmID, "Error: There was an error running command: [%s %v] Stderr: [%v, %s]", cmdName, strings.Join(cmdArgs, " "), err, strings.TrimSuffix(string(msg.Stderr), "\n"))
+			msgStr := strings.TrimSuffix(string(msg.Stderr), "\n")
+			if strings.Contains(msgStr, "Chain already exists") && iptMgr.OperationFlag == util.IptablesChainCreationFlag {
+				return 0, nil
+			}
+			metrics.SendErrorLogAndMetric(util.IptmID, "Error: There was an error running command: [%s %v] Stderr: [%v, %s]", cmdName, strings.Join(cmdArgs, " "), err, msgStr)
 		}
 
 		return errCode, err

--- a/npm/iptm/iptm.go
+++ b/npm/iptm/iptm.go
@@ -426,7 +426,7 @@ func (iptMgr *IptablesManager) CheckAndAddForwardChain() error {
 
 	index := 1
 	// retrieve KUBE-SERVICES index
-	kubeServicesLine, err := iptMgr.GetChainLineNumber(util.IptablesKubeServersChain, util.IptablesForwardChain)
+	kubeServicesLine, err := iptMgr.GetChainLineNumber(util.IptablesKubeServicesChain, util.IptablesForwardChain)
 	if err != nil {
 		metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to get index of KUBE-SERVICES in FORWARD chain with error: %s", err.Error())
 		return err

--- a/npm/iptm/iptm_test.go
+++ b/npm/iptm/iptm_test.go
@@ -245,7 +245,7 @@ func TestGetChainLineNumber(t *testing.T) {
 		}
 	}()
 
-	if err = iptMgr.AddChain(util.IptablesKubeServersChain); err != nil {
+	if err = iptMgr.AddChain(util.IptablesKubeServicesChain); err != nil {
 		t.Errorf("TestGetChainLineNumber failed @ kube-services chain iptMgr.AddChain error: %s", err.Error())
 	}
 
@@ -254,7 +254,7 @@ func TestGetChainLineNumber(t *testing.T) {
 		Chain: util.IptablesForwardChain,
 		Specs: []string{
 			util.IptablesJumpFlag,
-			util.IptablesKubeServersChain,
+			util.IptablesKubeServicesChain,
 		},
 	}
 

--- a/npm/iptm/iptm_test.go
+++ b/npm/iptm/iptm_test.go
@@ -255,7 +255,7 @@ func TestGetChainLineNumber(t *testing.T) {
 	}
 
 	if kubeExists, err = iptMgr.Exists(entry); err != nil {
-		t.Errorf("TestGetChainLineNumber failed @ kube-services chain iptMgr.Exists")
+		t.Errorf("TestGetChainLineNumber failed @ kube-services chain iptMgr.Exists error: %s", err.Error())
 	}
 
 	entry = &IptEntry{
@@ -267,12 +267,12 @@ func TestGetChainLineNumber(t *testing.T) {
 	}
 
 	if npmExists, err = iptMgr.Exists(entry); err != nil {
-		t.Errorf("TestGetChainLineNumber failed @ azure-npm chain iptMgr.Exists")
+		t.Errorf("TestGetChainLineNumber failed @ azure-npm chain iptMgr.Exists error: %s", err.Error())
 	}
 
 	lineNum, err = iptMgr.GetChainLineNumber(util.IptablesAzureChain, util.IptablesForwardChain)
 	if err != nil {
-		t.Errorf("TestGetChainLineNumber @ initial iptMgr.GetChainLineNumber")
+		t.Errorf("TestGetChainLineNumber @ initial iptMgr.GetChainLineNumber error: %s", err.Error())
 	}
 
 	switch {
@@ -291,7 +291,7 @@ func TestGetChainLineNumber(t *testing.T) {
 	}
 
 	if err = iptMgr.InitNpmChains(); err != nil {
-		t.Errorf("TestGetChainLineNumber @ iptMgr.InitNpmChains")
+		t.Errorf("TestGetChainLineNumber @ iptMgr.InitNpmChains error: %s", err.Error())
 	}
 
 	entry = &IptEntry{
@@ -303,12 +303,12 @@ func TestGetChainLineNumber(t *testing.T) {
 	}
 
 	if npmExists, err = iptMgr.Exists(entry); err != nil {
-		t.Errorf("TestGetChainLineNumber failed @ azure-npm chain iptMgr.Exists")
+		t.Errorf("TestGetChainLineNumber failed @ azure-npm chain iptMgr.Exists error: %s", err.Error())
 	}
 
 	lineNum, err = iptMgr.GetChainLineNumber(util.IptablesAzureChain, util.IptablesForwardChain)
 	if err != nil {
-		t.Errorf("TestGetChainLineNumber @ after Init chains iptMgr.GetChainLineNumber")
+		t.Errorf("TestGetChainLineNumber @ after Init chains iptMgr.GetChainLineNumber error: %s", err.Error())
 	}
 
 	switch {

--- a/npm/iptm/iptm_test.go
+++ b/npm/iptm/iptm_test.go
@@ -245,6 +245,10 @@ func TestGetChainLineNumber(t *testing.T) {
 		}
 	}()
 
+	if err = iptMgr.AddChain(util.IptablesKubeServersChain); err != nil {
+		t.Errorf("TestGetChainLineNumber failed @ kube-services chain iptMgr.AddChain error: %s", err.Error())
+	}
+
 	iptMgr.OperationFlag = util.IptablesCheckFlag
 	entry := &IptEntry{
 		Chain: util.IptablesForwardChain,
@@ -266,9 +270,8 @@ func TestGetChainLineNumber(t *testing.T) {
 		},
 	}
 
-	if npmExists, err = iptMgr.Exists(entry); err != nil {
-		t.Errorf("TestGetChainLineNumber failed @ azure-npm chain iptMgr.Exists error: %s", err.Error())
-	}
+	// Ignore not exists errors
+	npmExists, _ = iptMgr.Exists(entry)
 
 	lineNum, err = iptMgr.GetChainLineNumber(util.IptablesAzureChain, util.IptablesForwardChain)
 	if err != nil {

--- a/npm/iptm/iptm_test.go
+++ b/npm/iptm/iptm_test.go
@@ -225,6 +225,110 @@ func TestRun(t *testing.T) {
 	}
 }
 
+func TestGetChainLineNumber(t *testing.T) {
+	iptMgr := &IptablesManager{}
+
+	var (
+		lineNum    int
+		err        error
+		kubeExists bool
+		npmExists  bool
+	)
+
+	if err = iptMgr.Save(util.IptablesTestConfigFile); err != nil {
+		t.Errorf("TestGetChainLineNumber failed @ iptMgr.Save")
+	}
+
+	defer func() {
+		if err = iptMgr.Restore(util.IptablesTestConfigFile); err != nil {
+			t.Errorf("TestGetChainLineNumber failed @ iptMgr.Restore")
+		}
+	}()
+
+	iptMgr.OperationFlag = util.IptablesCheckFlag
+	entry := &IptEntry{
+		Chain: util.IptablesForwardChain,
+		Specs: []string{
+			util.IptablesJumpFlag,
+			util.IptablesKubeServersChain,
+		},
+	}
+
+	if kubeExists, err = iptMgr.Exists(entry); err != nil {
+		t.Errorf("TestGetChainLineNumber failed @ kube-services chain iptMgr.Exists")
+	}
+
+	entry = &IptEntry{
+		Chain: util.IptablesForwardChain,
+		Specs: []string{
+			util.IptablesJumpFlag,
+			util.IptablesAzureChain,
+		},
+	}
+
+	if npmExists, err = iptMgr.Exists(entry); err != nil {
+		t.Errorf("TestGetChainLineNumber failed @ azure-npm chain iptMgr.Exists")
+	}
+
+	lineNum, err = iptMgr.GetChainLineNumber(util.IptablesAzureChain, util.IptablesForwardChain)
+	if err != nil {
+		t.Errorf("TestGetChainLineNumber @ initial iptMgr.GetChainLineNumber")
+	}
+
+	switch {
+	case (npmExists && kubeExists):
+		if lineNum != 3 {
+			t.Errorf("TestGetChainLineNumber @ initial line number check iptMgr.GetChainLineNumber with npmExists: %t kubeExists: %t", npmExists, kubeExists)
+		}
+	case npmExists:
+		if lineNum == 0 {
+			t.Errorf("TestGetChainLineNumber @ initial line number check iptMgr.GetChainLineNumber with npmExists: %t kubeExists: %t", npmExists, kubeExists)
+		}
+	default:
+		if lineNum != 0 {
+			t.Errorf("TestGetChainLineNumber @ initial line number check iptMgr.GetChainLineNumber with npmExists: %t kubeExists: %t", npmExists, kubeExists)
+		}
+	}
+
+	if err = iptMgr.InitNpmChains(); err != nil {
+		t.Errorf("TestGetChainLineNumber @ iptMgr.InitNpmChains")
+	}
+
+	entry = &IptEntry{
+		Chain: util.IptablesForwardChain,
+		Specs: []string{
+			util.IptablesJumpFlag,
+			util.IptablesAzureChain,
+		},
+	}
+
+	if npmExists, err = iptMgr.Exists(entry); err != nil {
+		t.Errorf("TestGetChainLineNumber failed @ azure-npm chain iptMgr.Exists")
+	}
+
+	lineNum, err = iptMgr.GetChainLineNumber(util.IptablesAzureChain, util.IptablesForwardChain)
+	if err != nil {
+		t.Errorf("TestGetChainLineNumber @ after Init chains iptMgr.GetChainLineNumber")
+	}
+
+	switch {
+	case (npmExists && kubeExists):
+		if lineNum < 2 {
+			t.Errorf("TestGetChainLineNumber @ after Init chains line number check iptMgr.GetChainLineNumber with npmExists: %t kubeExists: %t", npmExists, kubeExists)
+		}
+	case npmExists:
+		if lineNum == 0 {
+			t.Errorf("TestGetChainLineNumber @ after Init chains line number check iptMgr.GetChainLineNumber with npmExists: %t kubeExists: %t", npmExists, kubeExists)
+		}
+	case !npmExists:
+		t.Errorf("TestGetChainLineNumber @ after Init chains line number check iptMgr.GetChainLineNumber with failed to Add chain ")
+	}
+
+	if err = iptMgr.UninitNpmChains(); err != nil {
+		t.Errorf("TestGetChainLineNumber @ iptMgr.UninitNpmChains")
+	}
+}
+
 func TestMain(m *testing.M) {
 	metrics.InitializeAll()
 	iptMgr := NewIptablesManager()

--- a/npm/npm.go
+++ b/npm/npm.go
@@ -35,6 +35,7 @@ const (
 	backupWaitTimeInSeconds       = 60
 	telemetryRetryTimeInSeconds   = 60
 	heartbeatIntervalInMinutes    = 30
+	reconcileChainTimeInMinutes   = 5
 )
 
 // NetworkPolicyManager contains informers for pod, namespace and networkpolicy.
@@ -177,6 +178,7 @@ func (npMgr *NetworkPolicyManager) Start(stopCh <-chan struct{}) error {
 		return fmt.Errorf("Network policy informer failed to sync")
 	}
 
+	go npMgr.reconcileChains()
 	go npMgr.backup()
 
 	return nil
@@ -312,4 +314,17 @@ func NewNetworkPolicyManager(clientset *kubernetes.Clientset, informerFactory in
 	)
 
 	return npMgr
+}
+
+// reconcileChains checks for ordering of AZURE-NPM chain in FORWARD chain periodically.
+func (npMgr *NetworkPolicyManager) reconcileChains() {
+	iptMgr := iptm.NewIptablesManager()
+	var err error
+	for {
+		time.Sleep(reconcileChainTimeInMinutes * time.Minute)
+
+		if err = iptMgr.CheckAndAddForwardChain(); err != nil {
+			metrics.SendErrorLogAndMetric(util.NpmID, "Error: failed to add AZURE-NPM chain to FORWARD chain.")
+		}
+	}
 }

--- a/npm/npm.go
+++ b/npm/npm.go
@@ -317,14 +317,13 @@ func NewNetworkPolicyManager(clientset *kubernetes.Clientset, informerFactory in
 }
 
 // reconcileChains checks for ordering of AZURE-NPM chain in FORWARD chain periodically.
-func (npMgr *NetworkPolicyManager) reconcileChains() {
+func (npMgr *NetworkPolicyManager) reconcileChains() error {
 	iptMgr := iptm.NewIptablesManager()
-	var err error
-	for {
-		time.Sleep(reconcileChainTimeInMinutes * time.Minute)
-
-		if err = iptMgr.CheckAndAddForwardChain(); err != nil {
-			metrics.SendErrorLogAndMetric(util.NpmID, "Error: failed to add AZURE-NPM chain to FORWARD chain.")
+	select {
+	case <-time.After(reconcileChainTimeInMinutes * time.Minute):
+		if err := iptMgr.CheckAndAddForwardChain(); err != nil {
+			return err
 		}
 	}
+	return nil
 }

--- a/npm/pod.go
+++ b/npm/pod.go
@@ -126,18 +126,18 @@ func (npMgr *NetworkPolicyManager) UpdatePod(oldPodObj, newPodObj *corev1.Pod) e
 		return nil
 	}
 
+	if isInvalidPodUpdate(oldPodObj, newPodObj) {
+		return nil
+	}
+
 	// today K8s does not allow updating HostNetwork flag for an existing Pod. So NPM can safely
 	// check on the oldPodObj for hostNework value
 	if isHostNetworkPod(oldPodObj) {
 		log.Logf(
-			"POD UPDATING ignored for HostNetwork Pod:\n old pod: [%s/%s/%+v/%s/%s]\n new pod: [%s/%s/%+v/%s/%s]",
+			"POD UPDATING ignored for HostNetwork Pod:\n old pod: [%s/%s/%s]\n new pod: [%s/%s/%s]",
 			oldPodObj.ObjectMeta.Namespace, oldPodObj.ObjectMeta.Name, oldPodObj.Status.PodIP,
 			newPodObj.ObjectMeta.Namespace, newPodObj.ObjectMeta.Name, newPodObj.Status.PodIP,
 		)
-		return nil
-	}
-
-	if isInvalidPodUpdate(oldPodObj, newPodObj) {
 		return nil
 	}
 

--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -72,6 +72,7 @@ const (
 	IptablesAzureEgressPortChain  string = "AZURE-NPM-EGRESS-PORT"
 	IptablesAzureEgressToChain    string = "AZURE-NPM-EGRESS-TO"
 	IptablesAzureTargetSetsChain  string = "AZURE-NPM-TARGET-SETS"
+	IptablesKubeServersChain      string = "KUBE-SERVICES"
 	IptablesForwardChain          string = "FORWARD"
 	IptablesInputChain            string = "INPUT"
 	// Below chains exists only for before Azure-NPM:v1.0.27

--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -72,7 +72,7 @@ const (
 	IptablesAzureEgressPortChain  string = "AZURE-NPM-EGRESS-PORT"
 	IptablesAzureEgressToChain    string = "AZURE-NPM-EGRESS-TO"
 	IptablesAzureTargetSetsChain  string = "AZURE-NPM-TARGET-SETS"
-	IptablesKubeServersChain      string = "KUBE-SERVICES"
+	IptablesKubeServicesChain     string = "KUBE-SERVICES"
 	IptablesForwardChain          string = "FORWARD"
 	IptablesInputChain            string = "INPUT"
 	// Below chains exists only for before Azure-NPM:v1.0.27


### PR DESCRIPTION
Today, NPM is in a configure and forget state for adding AZURE-NPM chain in FORWARD iptable chain. This change will include running a go routine to periodically (every 5 mins) check the order of AZURE-NPM chain in FORWARD. We can later extend this go routine to check other chains too.