### PR TITLE
Log rotation does not respect configured target

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -131,6 +131,7 @@ func (logger *Logger) getLogFileName() string {
 	return logFileName
 }
 
+// todo: handle errors and use atomic file rotation
 // Rotate checks the active log file size and rotates log files if necessary.
 func (logger *Logger) rotate() {
 	// Return if target is not a log file.
@@ -164,7 +165,7 @@ func (logger *Logger) rotate() {
 		}
 
 		// Create a new log file.
-		logger.SetTarget(TargetLogfile)
+		logger.SetTarget(logger.target)
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Log rotation does not respect configured target, causing it to always only log to file after initial rotation. This breaks stdout logging if enabled, once the first rotation takes place.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
