### PR TITLE
chore: consolidating logger package for cns aks swift scenario code

### DIFF
--- a/cns/requestcontroller/kubecontroller/crdtranslator.go
+++ b/cns/requestcontroller/kubecontroller/crdtranslator.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 
 	"github.com/Azure/azure-container-networking/cns"
-	"github.com/Azure/azure-container-networking/log"
+	"github.com/Azure/azure-container-networking/cns/logger"
 	nnc "github.com/Azure/azure-container-networking/nodenetworkconfig/api/v1alpha"
 )
 
@@ -67,9 +67,9 @@ func CRDStatusToNCRequest(crdStatus nnc.NodeNetworkConfigStatus) (cns.CreateNetw
 				NCVersion: ncVersion,
 			}
 			ncRequest.SecondaryIPConfigs[ipAssignment.Name] = secondaryIPConfig
-			log.Debugf("Seconday IP Configs got set, name is %s, config is %v", ipAssignment.Name, secondaryIPConfig)
+			logger.Debugf("Seconday IP Configs got set, name is %s, config is %v", ipAssignment.Name, secondaryIPConfig)
 		}
-		log.Printf("Set NC request info with NetworkContainerid %s, NetworkContainerType %s, NC Version %s",
+		logger.Printf("Set NC request info with NetworkContainerid %s, NetworkContainerType %s, NC Version %s",
 			ncRequest.NetworkContainerid, ncRequest.NetworkContainerType, ncRequest.Version)
 	}
 


### PR DESCRIPTION
Just making logger package consistent for cns aks swift scenario logging.

The command line flag was being honored, I just didnt' realize there were leftover logs on disk from previous containres 

The pipeline shows a failure with goldpinger tests but I ran the same tests with the same CNS dirty version on an underlay in our runners sub and they passed so pretty sure the pipeline one is a flake

![image](https://user-images.githubusercontent.com/35265851/109361236-71a66300-783d-11eb-8846-f5d10c8cb323.png)
 CONFIRMED : it was a flake, this same exact build passed the tests
 https://msazure.visualstudio.com/One/_build/results?buildId=39844247&view=logs&j=c4e47b90-07e0-53db-2983-8e94a4f7f491&t=c4e47b90-07e0-53db-2983-8e94a4f7f491