### PR TITLE
[fix] IPset fail if set doesn't exist when attempting to add to list

### DIFF
--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -4,6 +4,7 @@
 package ipsm
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"regexp"
@@ -133,8 +134,9 @@ func (ipsMgr *IpsetManager) AddToList(listName string, setName string) error {
 		return nil
 	}
 
+	// ensure set being added to list exists
 	if !ipsMgr.SetExists(setName, util.IpsetSetListFlag) {
-		return nil
+		return fmt.Errorf("Set does not exist [%s] when attempting to add to list [%s]", setName, listName)
 	}
 
 	if ipsMgr.Exists(listName, setName, util.IpsetSetListFlag) {
@@ -269,6 +271,10 @@ func (ipsMgr *IpsetManager) AddToSet(setName, ip, spec, podUid string) error {
 		}
 
 		return nil
+	}
+
+	if ip == "" {
+		return fmt.Errorf("Failed to add IP to set [%s], the ip to be added was empty, spec: %+v", setName, spec)
 	}
 
 	if !ipsMgr.SetExists(setName, spec) {

--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -133,6 +133,10 @@ func (ipsMgr *IpsetManager) AddToList(listName string, setName string) error {
 		return nil
 	}
 
+	if !ipsMgr.SetExists(setName, util.IpsetSetListFlag) {
+		return nil
+	}
+
 	if ipsMgr.Exists(listName, setName, util.IpsetSetListFlag) {
 		return nil
 	}

--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -368,6 +368,16 @@ func (ipsMgr *IpsetManager) DeleteFromSet(setName, ip, podUid string) error {
 		return nil
 	}
 
+	// possible formats
+	//192.168.0.1
+	//192.168.0.1,tcp:25227
+	// todo: handle ip and port with protocol, plus just ip
+	// always guaranteed to have ip, not guaranteed to have port + protocol
+	ipDetails := strings.Split(ip, ",")
+	if len(ipDetails) > 0 && ipDetails[0] == "" {
+		return fmt.Errorf("Failed to add IP to set [%s], the ip to be added was empty", setName)
+	}
+
 	if _, exists := ipsMgr.SetMap[setName].elements[ip]; exists {
 		// in case the IP belongs to a new Pod, then ignore this Delete call as this might be stale
 		cachedPodUid := ipSet.elements[ip]

--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -5,6 +5,7 @@ package ipsm
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"regexp"
@@ -301,6 +302,10 @@ func (ipsMgr *IpsetManager) AddToSet(setName, ip, spec, podUid string) error {
 		return fmt.Errorf("Failed to add IP to set [%s], the ip to be added was empty, spec: %+v", setName, spec)
 	}
 
+	if ipcheck := net.ParseIP(ipDetails[0]); ipcheck == nil {
+		return fmt.Errorf("Failed to parse ip [%s], not a valid ip format, full ip value: [%s]", ipDetails[0], ip)
+	}
+
 	// check if the set exists, ignore the type of the set being added if it exists since the only purpose is to see if it's created or not
 	exists, _ := ipsMgr.SetExists(setName)
 
@@ -324,6 +329,7 @@ func (ipsMgr *IpsetManager) AddToSet(setName, ip, spec, podUid string) error {
 		spec:          resultSpec,
 	}
 
+	// todo: check err handling besides error code, corrupt state possible here
 	if errCode, err := ipsMgr.Run(entry); err != nil && errCode != 1 {
 		metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to create ipset rules. %+v", entry)
 		return err

--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -5,7 +5,6 @@ package ipsm
 
 import (
 	"fmt"
-	"net"
 	"os"
 	"os/exec"
 	"regexp"
@@ -300,10 +299,6 @@ func (ipsMgr *IpsetManager) AddToSet(setName, ip, spec, podUid string) error {
 	ipDetails := strings.Split(ip, ",")
 	if len(ipDetails) > 0 && ipDetails[0] == "" {
 		return fmt.Errorf("Failed to add IP to set [%s], the ip to be added was empty, spec: %+v", setName, spec)
-	}
-
-	if ipcheck := net.ParseIP(ipDetails[0]); ipcheck == nil {
-		return fmt.Errorf("Failed to parse ip [%s], not a valid ip format, full ip value: [%s]", ipDetails[0], ip)
 	}
 
 	// check if the set exists, ignore the type of the set being added if it exists since the only purpose is to see if it's created or not

--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -291,8 +291,13 @@ func (ipsMgr *IpsetManager) AddToSet(setName, ip, spec, podUid string) error {
 		return nil
 	}
 
-	// possible ip values
-	if ip == "" {
+	// possible formats
+	//192.168.0.1
+	//192.168.0.1,tcp:25227
+	// todo: handle ip and port with protocol, plus just ip
+	// always guaranteed to have ip, not guaranteed to have port + protocol
+	ipDetails := strings.Split(ip, ",")
+	if len(ipDetails) > 0 && ipDetails[0] == "" {
 		return fmt.Errorf("Failed to add IP to set [%s], the ip to be added was empty, spec: %+v", setName, spec)
 	}
 

--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -291,6 +291,7 @@ func (ipsMgr *IpsetManager) AddToSet(setName, ip, spec, podUid string) error {
 		return nil
 	}
 
+	// possible ip values
 	if ip == "" {
 		return fmt.Errorf("Failed to add IP to set [%s], the ip to be added was empty, spec: %+v", setName, spec)
 	}
@@ -298,7 +299,7 @@ func (ipsMgr *IpsetManager) AddToSet(setName, ip, spec, podUid string) error {
 	// check if the set exists, ignore the type of the set being added if it exists since the only purpose is to see if it's created or not
 	exists, _ := ipsMgr.SetExists(setName)
 
-	if exists {
+	if !exists {
 		if err := ipsMgr.CreateSet(setName, append([]string{spec})); err != nil {
 			return err
 		}

--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -183,6 +183,27 @@ func (ipsMgr *IpsetManager) AddToList(listName string, setName string) error {
 
 // DeleteFromList removes an ipset to an ipset list.
 func (ipsMgr *IpsetManager) DeleteFromList(listName string, setName string) error {
+
+	//Check if list being added exists in the listmap, if it exists we don't care about the set type
+	exists, _ := ipsMgr.SetExists(setName)
+
+	// if set does not exist, then return because the ipset call will fail due to set not existing
+	if !exists {
+		return fmt.Errorf("Set [%s] does not exist when attempting to delete from list [%s]", setName, listName)
+	}
+
+	//Check if list being added exists in the listmap, if it exists we don't care about the set type
+	exists, listtype := ipsMgr.SetExists(listName)
+
+	// if set does not exist, then return because the ipset call will fail due to set not existing
+	if !exists {
+		return fmt.Errorf("Set [%s] does not exist when attempting to add to list [%s]", setName, listName)
+	}
+
+	if listtype != util.IpsetSetListFlag {
+		return fmt.Errorf("Set [%s] is of the wrong type when attempting to delete list [%s], actual type [%s]", setName, listName, listtype)
+	}
+
 	if _, exists := ipsMgr.ListMap[listName]; !exists {
 		metrics.SendErrorLogAndMetric(util.IpsmID, "ipset list with name %s not found", listName)
 		return nil

--- a/npm/ipsm/ipsm_test.go
+++ b/npm/ipsm/ipsm_test.go
@@ -87,6 +87,10 @@ func TestAddToList(t *testing.T) {
 	if err := ipsMgr.AddToList("test-list", "test-set"); err != nil {
 		t.Errorf("TestAddToList failed @ ipsMgr.AddToList")
 	}
+
+	if err := ipsMgr.AddToList("test-list", "test-set2"); err != nil {
+		t.Errorf("TestAddToList failed @ ipsMgr.AddToList when set doesn't exist")
+	}
 }
 
 func TestDeleteFromList(t *testing.T) {

--- a/npm/ipsm/ipsm_test.go
+++ b/npm/ipsm/ipsm_test.go
@@ -88,7 +88,7 @@ func TestAddToList(t *testing.T) {
 		t.Errorf("TestAddToList failed @ ipsMgr.AddToList")
 	}
 
-	if err := ipsMgr.AddToList("test-list", "test-set2"); err != nil {
+	if err := ipsMgr.AddToList("", ""); err != nil {
 		t.Errorf("TestAddToList failed @ ipsMgr.AddToList when set doesn't exist")
 	}
 }
@@ -291,6 +291,11 @@ func TestAddToSet(t *testing.T) {
 
 	if err := ipsMgr.AddToSet(testSetName, "1.2.3.4/nomatch", util.IpsetNetHashFlag, ""); err != nil {
 		t.Errorf("TestAddToSet with nomatch failed @ ipsMgr.AddToSet")
+	}
+
+	// expect to fail when ip being added is empty
+	if err := ipsMgr.AddToSet(testSetName, "", util.IpsetNetHashFlag, ""); err == nil {
+		t.Errorf("TestAddToSet failed @ ipsMgr.AddToSet when IP is empty")
 	}
 
 	testSetCount, err1 := promutil.GetVecValue(metrics.IPSetInventory, metrics.GetIPSetInventoryLabels(testSetName))

--- a/npm/ipsm/ipsm_test.go
+++ b/npm/ipsm/ipsm_test.go
@@ -199,27 +199,37 @@ func TestCreateSet(t *testing.T) {
 
 	testSet1Name := "test-set"
 	if err := ipsMgr.CreateSet(testSet1Name, []string{util.IpsetNetHashFlag}); err != nil {
-		t.Errorf("TestCreateSet failed @ ipsMgr.CreateSet")
+		t.Fatalf("TestCreateSet failed @ ipsMgr.CreateSet")
 	}
 
 	testSet2Name := "test-set-with-maxelem"
 	spec := append([]string{util.IpsetNetHashFlag, util.IpsetMaxelemName, util.IpsetMaxelemNum})
 	if err := ipsMgr.CreateSet(testSet2Name, spec); err != nil {
-		t.Errorf("TestCreateSet failed @ ipsMgr.CreateSet when set maxelem")
+		t.Fatalf("TestCreateSet failed @ ipsMgr.CreateSet when set maxelem")
 	}
 
 	testSet3Name := "test-set-with-port"
 	spec = append([]string{util.IpsetIPPortHashFlag})
 	if err := ipsMgr.CreateSet(testSet3Name, spec); err != nil {
-		t.Errorf("TestCreateSet failed @ ipsMgr.CreateSet when creating port set")
+		t.Fatalf("TestCreateSet failed @ ipsMgr.CreateSet when creating port set")
 	}
 	if err := ipsMgr.AddToSet(testSet3Name, fmt.Sprintf("%s,%s%d", "1.1.1.1", "tcp", 8080), util.IpsetIPPortHashFlag, "0"); err != nil {
-		t.Errorf("AddToSet failed @ ipsMgr.CreateSet when set port")
+		t.Fatalf("AddToSet failed @ ipsMgr.CreateSet when set port")
 	}
 
 	// should fail when attempting to entry to set with no ip and port/protocol specified
 	if err := ipsMgr.AddToSet(testSet3Name, fmt.Sprintf("%s,%s%d", "", "tcp", 8080), util.IpsetIPPortHashFlag, "0"); err == nil {
-		t.Errorf("Expected AddToSet failed @ ipsMgr.CreateSet when set port specified without ip: %+v", err)
+		t.Fatalf("Expected AddToSet failed @ ipsMgr.CreateSet when set port specified without ip: %+v", err)
+	}
+
+	// should fail when attempting to entry to set with no ip and port/protocol specified
+	if err := ipsMgr.AddToSet(testSet3Name, fmt.Sprintf("%s,", ""), util.IpsetIPPortHashFlag, "0"); err == nil {
+		t.Fatalf("Expected AddToSet failed @ ipsMgr.CreateSet when set no port specified and no ip: %+v", err)
+	}
+
+	// should fail when attempting to entry to set with no ip entry that is passed is not a real ip type
+	if err := ipsMgr.AddToSet(testSet3Name, fmt.Sprintf("%s,", "notarealip"), util.IpsetIPPortHashFlag, "0"); err == nil {
+		t.Fatalf("Expected AddToSet failed @ ipsMgr.CreateSet when invalid ip is supplied: %+v", err)
 	}
 
 	newGaugeVal, err3 := promutil.GetValue(metrics.NumIPSets)
@@ -230,13 +240,13 @@ func TestCreateSet(t *testing.T) {
 	entryCount, err8 := promutil.GetValue(metrics.NumIPSetEntries)
 	promutil.NotifyIfErrors(t, err1, err2, err3, err4, err5, err6, err7, err8)
 	if newGaugeVal != gaugeVal+3 {
-		t.Errorf("Change in ipset number didn't register in Prometheus")
+		t.Fatalf("Change in ipset number didn't register in Prometheus")
 	}
 	if newCountVal != countVal+3 {
-		t.Errorf("Execution time didn't register in Prometheus")
+		t.Fatalf("Execution time didn't register in Prometheus")
 	}
 	if testSet1Count != 0 || testSet2Count != 0 || testSet3Count != 1 || entryCount != 1 {
-		t.Errorf("Prometheus IPSet count has incorrect number of entries")
+		t.Fatalf("Prometheus IPSet count has incorrect number of entries")
 	}
 }
 

--- a/npm/ipsm/ipsm_test.go
+++ b/npm/ipsm/ipsm_test.go
@@ -134,7 +134,17 @@ func TestDeleteFromList(t *testing.T) {
 
 	// Delete set from list and validate set is not in list anymore.
 	if err := ipsMgr.DeleteFromList(listName, setName); err != nil {
-		t.Errorf("TestDeleteFromList failed @ ipsMgr.DeleteFromList")
+		t.Errorf("TestDeleteFromList failed @ ipsMgr.DeleteFromList %v", err)
+	}
+
+	// Delete set from list and validate set is not in list anymore.
+	if err := ipsMgr.DeleteFromList(listName, "nonexistentsetname"); err == nil {
+		t.Errorf("TestDeleteFromList failed @ ipsMgr.DeleteFromList %v", err)
+	}
+
+	// Delete set from list, but list isn't of list type
+	if err := ipsMgr.DeleteFromList(setName, setName); err == nil {
+		t.Errorf("TestDeleteFromList failed @ ipsMgr.DeleteFromList %v", err)
 	}
 
 	entry = &ipsEntry{

--- a/npm/ipsm/ipsm_test.go
+++ b/npm/ipsm/ipsm_test.go
@@ -299,10 +299,30 @@ func TestAddToSet(t *testing.T) {
 		t.Fatalf("TestAddToSet with nomatch failed @ ipsMgr.AddToSet %v", err)
 	}
 
+	if err := ipsMgr.AddToSet(testSetName, fmt.Sprintf("%s,%s:%d", "1.1.1.1", "tcp", 8080), util.IpsetIPPortHashFlag, "0"); err != nil {
+		t.Errorf("AddToSet failed @ ipsMgr.AddToSet when set port: %v", err)
+	}
+
+	if err := ipsMgr.AddToSet(testSetName, fmt.Sprintf("%s,:", "1.1.1.1"), util.IpsetIPPortHashFlag, "0"); err != nil {
+		t.Errorf("AddToSet failed @ ipsMgr.AddToSet when set port is empty: %v", err)
+	}
+
+	if err := ipsMgr.AddToSet(testSetName, fmt.Sprintf("%s,%s:%d", "", "tcp", 8080), util.IpsetIPPortHashFlag, "0"); err == nil {
+		t.Errorf("AddToSet failed @ ipsMgr.AddToSet when port is specified but ip is empty: %v", err)
+	}
+
+	if err := ipsMgr.AddToSet(testSetName, fmt.Sprintf("%s", "1.1.1.1"), util.IpsetIPPortHashFlag, "0"); err != nil {
+		t.Errorf("AddToSet failed @ ipsMgr.AddToSet when only ip is specified: %v", err)
+	}
+
+	if err := ipsMgr.AddToSet(testSetName, fmt.Sprintf(""), util.IpsetIPPortHashFlag, "0"); err == nil {
+		t.Errorf("AddToSet failed @ ipsMgr.AddToSet when no ip is specified: %v", err)
+	}
+
 	testSetCount, err1 := promutil.GetVecValue(metrics.IPSetInventory, metrics.GetIPSetInventoryLabels(testSetName))
 	entryCount, err2 := promutil.GetValue(metrics.NumIPSetEntries)
 	promutil.NotifyIfErrors(t, err1, err2)
-	if testSetCount != 2 || entryCount != 2 {
+	if testSetCount != 5 || entryCount != 5 {
 		t.Fatalf("Prometheus IPSet count has incorrect number of entries, testSetCount %d, entryCount %d", testSetCount, entryCount)
 	}
 }

--- a/npm/ipsm/ipsm_test.go
+++ b/npm/ipsm/ipsm_test.go
@@ -217,6 +217,11 @@ func TestCreateSet(t *testing.T) {
 		t.Errorf("AddToSet failed @ ipsMgr.CreateSet when set port")
 	}
 
+	// should fail when attempting to entry to set with no ip and port/protocol specified
+	if err := ipsMgr.AddToSet(testSet3Name, fmt.Sprintf("%s,%s%d", "", "tcp", 8080), util.IpsetIPPortHashFlag, "0"); err == nil {
+		t.Errorf("Expected AddToSet failed @ ipsMgr.CreateSet when set port specified without ip: %+v", err)
+	}
+
 	newGaugeVal, err3 := promutil.GetValue(metrics.NumIPSets)
 	newCountVal, err4 := promutil.GetCountValue(metrics.AddIPSetExecTime)
 	testSet1Count, err5 := promutil.GetVecValue(metrics.IPSetInventory, metrics.GetIPSetInventoryLabels(testSet1Name))

--- a/npm/ipsm/ipsm_test.go
+++ b/npm/ipsm/ipsm_test.go
@@ -87,10 +87,6 @@ func TestAddToList(t *testing.T) {
 	if err := ipsMgr.AddToList("test-list", "test-set"); err != nil {
 		t.Errorf("TestAddToList failed @ ipsMgr.AddToList")
 	}
-
-	if err := ipsMgr.AddToList("", ""); err != nil {
-		t.Errorf("TestAddToList failed @ ipsMgr.AddToList when set doesn't exist")
-	}
 }
 
 func TestDeleteFromList(t *testing.T) {
@@ -199,37 +195,22 @@ func TestCreateSet(t *testing.T) {
 
 	testSet1Name := "test-set"
 	if err := ipsMgr.CreateSet(testSet1Name, []string{util.IpsetNetHashFlag}); err != nil {
-		t.Fatalf("TestCreateSet failed @ ipsMgr.CreateSet")
+		t.Errorf("TestCreateSet failed @ ipsMgr.CreateSet")
 	}
 
 	testSet2Name := "test-set-with-maxelem"
 	spec := append([]string{util.IpsetNetHashFlag, util.IpsetMaxelemName, util.IpsetMaxelemNum})
 	if err := ipsMgr.CreateSet(testSet2Name, spec); err != nil {
-		t.Fatalf("TestCreateSet failed @ ipsMgr.CreateSet when set maxelem")
+		t.Errorf("TestCreateSet failed @ ipsMgr.CreateSet when set maxelem")
 	}
 
 	testSet3Name := "test-set-with-port"
 	spec = append([]string{util.IpsetIPPortHashFlag})
 	if err := ipsMgr.CreateSet(testSet3Name, spec); err != nil {
-		t.Fatalf("TestCreateSet failed @ ipsMgr.CreateSet when creating port set")
+		t.Errorf("TestCreateSet failed @ ipsMgr.CreateSet when creating port set")
 	}
 	if err := ipsMgr.AddToSet(testSet3Name, fmt.Sprintf("%s,%s%d", "1.1.1.1", "tcp", 8080), util.IpsetIPPortHashFlag, "0"); err != nil {
-		t.Fatalf("AddToSet failed @ ipsMgr.CreateSet when set port")
-	}
-
-	// should fail when attempting to entry to set with no ip and port/protocol specified
-	if err := ipsMgr.AddToSet(testSet3Name, fmt.Sprintf("%s,%s%d", "", "tcp", 8080), util.IpsetIPPortHashFlag, "0"); err == nil {
-		t.Fatalf("Expected AddToSet failed @ ipsMgr.CreateSet when set port specified without ip: %+v", err)
-	}
-
-	// should fail when attempting to entry to set with no ip and port/protocol specified
-	if err := ipsMgr.AddToSet(testSet3Name, fmt.Sprintf("%s,", ""), util.IpsetIPPortHashFlag, "0"); err == nil {
-		t.Fatalf("Expected AddToSet failed @ ipsMgr.CreateSet when set no port specified and no ip: %+v", err)
-	}
-
-	// should fail when attempting to entry to set with no ip entry that is passed is not a real ip type
-	if err := ipsMgr.AddToSet(testSet3Name, fmt.Sprintf("%s,", "notarealip"), util.IpsetIPPortHashFlag, "0"); err == nil {
-		t.Fatalf("Expected AddToSet failed @ ipsMgr.CreateSet when invalid ip is supplied: %+v", err)
+		t.Errorf("AddToSet failed @ ipsMgr.CreateSet when set port")
 	}
 
 	newGaugeVal, err3 := promutil.GetValue(metrics.NumIPSets)
@@ -240,13 +221,13 @@ func TestCreateSet(t *testing.T) {
 	entryCount, err8 := promutil.GetValue(metrics.NumIPSetEntries)
 	promutil.NotifyIfErrors(t, err1, err2, err3, err4, err5, err6, err7, err8)
 	if newGaugeVal != gaugeVal+3 {
-		t.Fatalf("Change in ipset number didn't register in Prometheus")
+		t.Errorf("Change in ipset number didn't register in Prometheus")
 	}
 	if newCountVal != countVal+3 {
-		t.Fatalf("Execution time didn't register in Prometheus")
+		t.Errorf("Execution time didn't register in Prometheus")
 	}
 	if testSet1Count != 0 || testSet2Count != 0 || testSet3Count != 1 || entryCount != 1 {
-		t.Fatalf("Prometheus IPSet count has incorrect number of entries")
+		t.Errorf("Prometheus IPSet count has incorrect number of entries")
 	}
 }
 
@@ -290,34 +271,29 @@ func TestAddToSet(t *testing.T) {
 	metrics.NumIPSetEntries.Set(0)
 	ipsMgr := NewIpsetManager()
 	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
-		t.Errorf("TestAddToSet failed @ ipsMgr.Save")
+		t.Fatalf("TestAddToSet failed @ ipsMgr.Save")
 	}
 
 	defer func() {
 		if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
-			t.Errorf("TestAddToSet failed @ ipsMgr.Restore")
+			t.Fatalf("TestAddToSet failed @ ipsMgr.Restore")
 		}
 	}()
 
 	testSetName := "test-set"
 	if err := ipsMgr.AddToSet(testSetName, "1.2.3.4", util.IpsetNetHashFlag, ""); err != nil {
-		t.Errorf("TestAddToSet failed @ ipsMgr.AddToSet")
+		t.Fatalf("TestAddToSet failed @ ipsMgr.AddToSet")
 	}
 
 	if err := ipsMgr.AddToSet(testSetName, "1.2.3.4/nomatch", util.IpsetNetHashFlag, ""); err != nil {
-		t.Errorf("TestAddToSet with nomatch failed @ ipsMgr.AddToSet")
-	}
-
-	// expect to fail when ip being added is empty
-	if err := ipsMgr.AddToSet(testSetName, "", util.IpsetNetHashFlag, ""); err == nil {
-		t.Errorf("TestAddToSet failed @ ipsMgr.AddToSet when IP is empty")
+		t.Fatalf("TestAddToSet with nomatch failed @ ipsMgr.AddToSet %v", err)
 	}
 
 	testSetCount, err1 := promutil.GetVecValue(metrics.IPSetInventory, metrics.GetIPSetInventoryLabels(testSetName))
 	entryCount, err2 := promutil.GetValue(metrics.NumIPSetEntries)
 	promutil.NotifyIfErrors(t, err1, err2)
 	if testSetCount != 2 || entryCount != 2 {
-		t.Errorf("Prometheus IPSet count has incorrect number of entries")
+		t.Fatalf("Prometheus IPSet count has incorrect number of entries, testSetCount %d, entryCount %d", testSetCount, entryCount)
 	}
 }
 

--- a/npm/namespace_test.go
+++ b/npm/namespace_test.go
@@ -193,15 +193,15 @@ func TestAddNamespaceLabel(t *testing.T) {
 
 	npMgr.Lock()
 	if err := npMgr.AddNamespace(oldNsObj); err != nil {
-		t.Errorf("TestAddNamespaceLabel failed @ npMgr.AddNamespace")
+		t.Fatalf("TestAddNamespaceLabel failed @ npMgr.AddNamespace with err %v", err)
 	}
 
 	if err := npMgr.UpdateNamespace(oldNsObj, newNsObj); err != nil {
-		t.Errorf("TestAddNamespaceLabel failed @ npMgr.UpdateNamespace")
+		t.Fatalf("TestAddNamespaceLabel failed @ npMgr.UpdateNamespace with err %v", err)
 	}
 
-	if !reflect.DeepEqual(npMgr.NsMap["ns-"+newNsObj.Name].LabelsMap, newNsObj.ObjectMeta.Labels) {
-		t.Errorf("TestAddNamespaceLabel failed @ npMgr.nsMap labelMap check")
+	if !reflect.DeepEqual(npMgr.nsMap["ns-"+newNsObj.Name].labelsMap, newNsObj.ObjectMeta.Labels) {
+		t.Fatalf("TestAddNamespaceLabel failed @ npMgr.nsMap labelMap check")
 	}
 
 	npMgr.Unlock()

--- a/npm/namespace_test.go
+++ b/npm/namespace_test.go
@@ -200,7 +200,7 @@ func TestAddNamespaceLabel(t *testing.T) {
 		t.Fatalf("TestAddNamespaceLabel failed @ npMgr.UpdateNamespace with err %v", err)
 	}
 
-	if !reflect.DeepEqual(npMgr.nsMap["ns-"+newNsObj.Name].labelsMap, newNsObj.ObjectMeta.Labels) {
+	if !reflect.DeepEqual(npMgr.NsMap["ns-"+newNsObj.Name].LabelsMap, newNsObj.ObjectMeta.Labels) {
 		t.Fatalf("TestAddNamespaceLabel failed @ npMgr.nsMap labelMap check")
 	}
 

--- a/npm/pod.go
+++ b/npm/pod.go
@@ -177,12 +177,6 @@ func (npMgr *NetworkPolicyManager) AddPod(podObj *corev1.Pod) error {
 		return nil
 	}
 
-	// K8s categorizes Succeeded abd Failed pods be terminated and will not restart them
-	// So NPM will ignorer adding these pods
-	if podObj.Status.Phase == v1.PodSucceeded || podObj.Status.Phase == v1.PodFailed {
-		return nil
-	}
-
 	npmPodObj, podErr := newNpmPod(podObj)
 	if podErr != nil {
 		metrics.SendErrorLogAndMetric(util.PodID, "[AddPod] Error: failed to create namespace %s, %+v with err %v", podObj.ObjectMeta.Name, podObj, podErr)
@@ -203,6 +197,13 @@ func (npMgr *NetworkPolicyManager) AddPod(podObj *corev1.Pod) error {
 	)
 
 	log.Logf("POD CREATING: [%s%s/%s/%s%+v%s]", podUID, podNs, podName, podNodeName, podLabels, podIP)
+
+	// K8s categorizes Succeeded abd Failed pods be terminated and will not restart them
+	// So NPM will ignorer adding these pods
+	if podObj.Status.Phase == v1.PodSucceeded || podObj.Status.Phase == v1.PodFailed {
+		log.Logf("Skipping pod, pod marked as %+v: [%s%s/%s/%s%+v%s]", podObj.Status.Phase, podUID, podNs, podName, podNodeName, podLabels, podIP)
+		return nil
+	}
 
 	if podKey == "" {
 		err = fmt.Errorf("[AddPod] Error: podKey is empty for %s pod in %s with UID %s", podName, podNs, podUID)

--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -115,6 +115,7 @@ const (
 	IPsetCheckListFlag string = "list"
 	IpsetTestFlag      string = "test"
 
+	IpsetSetGenericFlag string = "setgeneric" // not used in ipset commands, used as an internal identifier for nethash/hash:ip,port
 	IpsetSetListFlag    string = "setlist"
 	IpsetNetHashFlag    string = "nethash"
 	IpsetIPPortHashFlag string = "hash:ip,port"


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

This change is to make sure that an ipset exists in npm state, so we don't waste calls to ipset which will fail. Also add check to make sure that when IP being added to set it is nonempty

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
