### PR TITLE
Change version comparison from string to int and add more log in SyncHostNCVersion.

### DIFF
--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -171,6 +171,7 @@ func (service *HTTPRestService) SyncHostNCVersion(ctx context.Context, channelMo
 	}
 	service.RUnlock()
 	if len(hostVersionNeedUpdateNcList) > 0 {
+		logger.Printf("Updating version of the following NC IDs: %v", hostVersionNeedUpdateNcList)
 		ncVersionChannel := make(chan map[string]int)
 		ctxWithTimeout, _ := context.WithTimeout(ctx, syncHostNCTimeoutMilliSec*time.Millisecond)
 		go func() {
@@ -191,8 +192,10 @@ func (service *HTTPRestService) SyncHostNCVersion(ctx context.Context, channelMo
 						if channelMode == cns.CRD {
 							service.MarkIpsAsAvailableUntransacted(ncInfo.ID, newHostNCVersion)
 						}
+						oldHostNCVersion := ncInfo.HostVersion
 						ncInfo.HostVersion = strconv.Itoa(newHostNCVersion)
 						service.state.ContainerStatus[ncID] = ncInfo
+						logger.Printf("Updated NC %s host version from %s to %s", ncID, oldHostNCVersion, ncInfo.HostVersion)
 					}
 				}
 				service.Unlock()


### PR DESCRIPTION
fix: Change version comparison from string to int and as well as the following 3 improvements.
    1. Add more log in SyncHostNCVersion.
    2. Remove unnecessary check for MarkIpsAsAvailable.
    3. Auto formatting.

**Reason for Change**:
Logs are not sufficient enough to debug. 


**Issue Fixed**:
After these logs got added, it will unsure whether host version got updated.
In another word, after log got added, we are clear whether select sentence after channel got executed porperly.
