### PR TITLE
CNS Debug API to expose PodIpIdByOrchrestratorContext

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -245,14 +245,14 @@ type GetIPAddressStateResponse struct {
 
 // GetIPAddressStatusResponse is used in CNS IPAM mode as a response to get IP address, state and Pod info
 type GetIPAddressStatusResponse struct {
-	IPConfigurationStatus[] IPConfigurationStatus
-	Response Response
+	IPConfigurationStatus []IPConfigurationStatus
+	Response              Response
 }
 
 //GetPodContextResponse is used in CNS Client debug mode to get mapping of Orchestrator Context to Pod IP UUID
 type GetPodContextResponse struct {
 	PodContext map[string]string
-	Response Response
+	Response   Response
 }
 
 // IPAddressState Only used in the GetIPConfig API to return IP's that match a filter

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -23,6 +23,7 @@ const (
 	RequestIPConfig                          = "/network/requestipconfig"
 	ReleaseIPConfig                          = "/network/releaseipconfig"
 	GetIPAddresses                           = "/debug/getipaddresses"
+	GetPodIPOrchestratorContext              = "/debug/getpodcontext"
 )
 
 // NetworkContainer Prefixes
@@ -245,6 +246,12 @@ type GetIPAddressStateResponse struct {
 // GetIPAddressStatusResponse is used in CNS IPAM mode as a response to get IP address, state and Pod info
 type GetIPAddressStatusResponse struct {
 	IPConfigurationStatus[] IPConfigurationStatus
+	Response Response
+}
+
+//GetPodContextResponse is used in CNS Client debug mode to get mapping of Orchestrator Context to Pod IP UUID
+type GetPodContextResponse struct {
+	PodContext map[string]string
 	Response Response
 }
 

--- a/cns/cnsclient/cli.go
+++ b/cns/cnsclient/cli.go
@@ -112,10 +112,10 @@ func getPodCmd(client *CNSClient) error {
 	return nil
 }
 
-func printPodContext(podContext map[string]string){
+func printPodContext(podContext map[string]string) {
 	var i = 1
-	for orchContext,podID := range podContext {
-			fmt.Println(i, " ", orchContext, " : ", podID)
-			i++
+	for orchContext, podID := range podContext {
+		fmt.Println(i, " ", orchContext, " : ", podID)
+		i++
 	}
 }

--- a/cns/cnsclient/cli.go
+++ b/cns/cnsclient/cli.go
@@ -15,6 +15,7 @@ const (
 	getAllocatedArg      = "Allocated"
 	getAllArg            = "All"
 	getPendingReleaseArg = "PendingRelease"
+	getPodCmdArg         = "getPodContexts"
 
 	releaseArg = "release"
 
@@ -28,6 +29,7 @@ const (
 var (
 	availableCmds = []string{
 		getCmdArg,
+		getPodCmdArg,
 	}
 
 	getFlags = []string{
@@ -49,6 +51,8 @@ func HandleCNSClientCommands(cmd, arg string) error {
 	switch {
 	case strings.EqualFold(getCmdArg, cmd):
 		return getCmd(cnsClient, arg)
+	case strings.EqualFold(getPodCmdArg, cmd):
+		return getPodCmd(cnsClient)
 	default:
 		return fmt.Errorf("No debug cmd supplied, options are: %v", getCmdArg)
 	}
@@ -94,5 +98,24 @@ func printIPAddresses(addrSlice []cns.IPConfigurationStatus) {
 
 	for _, addr := range addrSlice {
 		cns.IPConfigurationStatus.String(addr)
+	}
+}
+
+func getPodCmd(client *CNSClient) error {
+
+	resp, err := client.GetPodOrchestratorContext()
+	if err != nil {
+		return err
+	}
+
+	printPodContext(resp)
+	return nil
+}
+
+func printPodContext(podContext map[string]string){
+	var i = 1
+	for orchContext,podID := range podContext {
+			fmt.Println(i, " ", orchContext, " : ", podID)
+			i++
 	}
 }

--- a/cns/cnsclient/cnsclient.go
+++ b/cns/cnsclient/cnsclient.go
@@ -371,36 +371,28 @@ func (cnsClient *CNSClient) GetIPAddressesMatchingStates(StateFilter ...string) 
 
 	return resp.IPConfigurationStatus, err
 }
+
 //GetPodOrchestratorContext calls GetPodIpOrchestratorContext API on CNS
 func (cnsClient *CNSClient) GetPodOrchestratorContext() (map[string]string, error) {
 	var (
 		resp cns.GetPodContextResponse
 		err  error
 		res  *http.Response
-		body bytes.Buffer
 	)
 
 	url := cnsClient.connectionURL + cns.GetPodIPOrchestratorContext
 	log.Printf("GetPodIPOrchestratorContext url %v", url)
 
-	payload := ""
-
-	err = json.NewEncoder(&body).Encode(payload)
+	res, err = http.Get(url)
 	if err != nil {
-		log.Errorf("encoding json failed with %v", err)
-		return resp.PodContext, err
-	}
-
-	res, err = http.Post(url, contentTypeJSON, &body)
-	if err != nil {
-		log.Errorf("[Azure CNSClient] HTTP Post returned error %v", err.Error())
+		log.Errorf("[Azure CNSClient] GetPodIPOrchestratorContext HTTP Get returned error %v", err.Error())
 		return resp.PodContext, err
 	}
 
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		errMsg := fmt.Sprintf("[Azure CNSClient] GetPodContext invalid http status code: %v", res.StatusCode)
+		errMsg := fmt.Sprintf("[Azure CNSClient] GetPodIPOrchestratorContext invalid http status code: %v", res.StatusCode)
 		log.Errorf(errMsg)
 		return resp.PodContext, fmt.Errorf(errMsg)
 	}

--- a/cns/cnsclient/cnsclient.go
+++ b/cns/cnsclient/cnsclient.go
@@ -371,3 +371,50 @@ func (cnsClient *CNSClient) GetIPAddressesMatchingStates(StateFilter ...string) 
 
 	return resp.IPConfigurationStatus, err
 }
+//GetPodOrchestratorContext calls GetPodIpOrchestratorContext API on CNS
+func (cnsClient *CNSClient) GetPodOrchestratorContext() (map[string]string, error) {
+	var (
+		resp cns.GetPodContextResponse
+		err  error
+		res  *http.Response
+		body bytes.Buffer
+	)
+
+	url := cnsClient.connectionURL + cns.GetPodIPOrchestratorContext
+	log.Printf("GetPodIPOrchestratorContext url %v", url)
+
+	payload := ""
+
+	err = json.NewEncoder(&body).Encode(payload)
+	if err != nil {
+		log.Errorf("encoding json failed with %v", err)
+		return resp.PodContext, err
+	}
+
+	res, err = http.Post(url, contentTypeJSON, &body)
+	if err != nil {
+		log.Errorf("[Azure CNSClient] HTTP Post returned error %v", err.Error())
+		return resp.PodContext, err
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		errMsg := fmt.Sprintf("[Azure CNSClient] GetPodContext invalid http status code: %v", res.StatusCode)
+		log.Errorf(errMsg)
+		return resp.PodContext, fmt.Errorf(errMsg)
+	}
+
+	err = json.NewDecoder(res.Body).Decode(&resp)
+	if err != nil {
+		log.Errorf("[Azure CNSClient] Error received while parsing GetPodContext response resp:%v err:%v", res.Body, err.Error())
+		return resp.PodContext, err
+	}
+
+	if resp.Response.ReturnCode != 0 {
+		log.Errorf("[Azure CNSClient] GetPodContext received error response :%v", resp.Response.Message)
+		return resp.PodContext, fmt.Errorf(resp.Response.Message)
+	}
+
+	return resp.PodContext, err
+}

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -100,33 +100,33 @@ func (service *HTTPRestService) MarkIPAsPendingRelease(totalIpsToRelease int) (m
 	defer service.Unlock()
 
 	for uuid, existingIpConfig := range service.PodIPConfigState {
-        if existingIpConfig.State == cns.PendingProgramming {
-        	updatedIpConfig, err := service.updateIPConfigState(uuid, cns.PendingRelease, existingIpConfig.OrchestratorContext)
-        	if err != nil {
-                return nil, err
-            }
+		if existingIpConfig.State == cns.PendingProgramming {
+			updatedIpConfig, err := service.updateIPConfigState(uuid, cns.PendingRelease, existingIpConfig.OrchestratorContext)
+			if err != nil {
+				return nil, err
+			}
 
-            pendingReleasedIps[uuid] = updatedIpConfig
+			pendingReleasedIps[uuid] = updatedIpConfig
 			if len(pendingReleasedIps) == totalIpsToRelease {
 				return pendingReleasedIps, nil
 			}
-    	}
+		}
 	}
-	
-	// if not all expected IPs are set to PendingRelease, then check the Available IPs 
-	for uuid, existingIpConfig := range service.PodIPConfigState {
-        if existingIpConfig.State == cns.Available {
-            updatedIpConfig, err := service.updateIPConfigState(uuid, cns.PendingRelease, existingIpConfig.OrchestratorContext)
-            if err != nil {
-                return nil, err
-            }
 
-            pendingReleasedIps[uuid] = updatedIpConfig
-			
+	// if not all expected IPs are set to PendingRelease, then check the Available IPs
+	for uuid, existingIpConfig := range service.PodIPConfigState {
+		if existingIpConfig.State == cns.Available {
+			updatedIpConfig, err := service.updateIPConfigState(uuid, cns.PendingRelease, existingIpConfig.OrchestratorContext)
+			if err != nil {
+				return nil, err
+			}
+
+			pendingReleasedIps[uuid] = updatedIpConfig
+
 			if len(pendingReleasedIps) == totalIpsToRelease {
 				return pendingReleasedIps, nil
-			}	
-    	} 
+			}
+		}
 	}
 
 	logger.Printf("[MarkIPAsPendingRelease] Set total ips to PendingRelease %d, expected %d", len(pendingReleasedIps), totalIpsToRelease)
@@ -140,9 +140,9 @@ func (service *HTTPRestService) updateIPConfigState(ipId string, updatedState st
 		ipConfig.OrchestratorContext = orchestratorContext
 		service.PodIPConfigState[ipId] = ipConfig
 		return ipConfig, nil
-	} 
-	
-	return  cns.IPConfigurationStatus{}, fmt.Errorf("[updateIPConfigState] Failed to update state %s for the IPConfig. ID %s not found PodIPConfigState", updatedState, ipId)
+	}
+
+	return cns.IPConfigurationStatus{}, fmt.Errorf("[updateIPConfigState] Failed to update state %s for the IPConfig. ID %s not found PodIPConfigState", updatedState, ipId)
 }
 
 // MarkIpsAsAvailableUntransacted will update pending programming IPs to available if NMAgent side's programmed nc version keep up with nc version.
@@ -183,7 +183,6 @@ func (service *HTTPRestService) GetPodIPConfigState() map[string]cns.IPConfigura
 
 func (service *HTTPRestService) getPodIPIDByOrchestratorContexthandler(w http.ResponseWriter, r *http.Request) {
 	var (
-		req           string
 		resp          cns.GetPodContextResponse
 		statusCode    int
 		returnMessage string
@@ -201,12 +200,6 @@ func (service *HTTPRestService) getPodIPIDByOrchestratorContexthandler(w http.Re
 		err = service.Listener.Encode(w, &resp)
 		logger.Response(service.Name, resp, resp.Response.ReturnCode, ReturnCodeToString(resp.Response.ReturnCode), err)
 	}()
-
-	err = service.Listener.Decode(w, r, &req)
-	if err != nil {
-		returnMessage = err.Error()
-		return
-	}
 
 	resp.PodContext = service.GetPodIPIDByOrchestratorContext()
 
@@ -386,7 +379,7 @@ func (service *HTTPRestService) MarkExistingIPsAsPending(pendingIPIDs []string) 
 				return fmt.Errorf("Failed to mark IP [%v] as pending, currently allocated", id)
 			}
 
-            logger.Printf("[MarkExistingIPsAsPending]: Marking IP [%+v] to PendingRelease", ipconfig)
+			logger.Printf("[MarkExistingIPsAsPending]: Marking IP [%+v] to PendingRelease", ipconfig)
 			ipconfig.State = cns.PendingRelease
 			service.PodIPConfigState[id] = ipconfig
 		} else {

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -181,6 +181,44 @@ func (service *HTTPRestService) GetPodIPConfigState() map[string]cns.IPConfigura
 	return service.PodIPConfigState
 }
 
+func (service *HTTPRestService) getPodIPIDByOrchestratorContexthandler(w http.ResponseWriter, r *http.Request) {
+	var (
+		req           string
+		resp          cns.GetPodContextResponse
+		statusCode    int
+		returnMessage string
+		err           error
+	)
+
+	statusCode = UnexpectedError
+
+	defer func() {
+		if err != nil {
+			resp.Response.ReturnCode = statusCode
+			resp.Response.Message = returnMessage
+		}
+
+		err = service.Listener.Encode(w, &resp)
+		logger.Response(service.Name, resp, resp.Response.ReturnCode, ReturnCodeToString(resp.Response.ReturnCode), err)
+	}()
+
+	err = service.Listener.Decode(w, r, &req)
+	if err != nil {
+		returnMessage = err.Error()
+		return
+	}
+
+	resp.PodContext = service.GetPodIPIDByOrchestratorContext()
+
+	return
+}
+
+func (service *HTTPRestService) GetPodIPIDByOrchestratorContext() map[string]string {
+	service.RLock()
+	defer service.RUnlock()
+	return service.PodIPIDByOrchestratorContext
+}
+
 // GetPendingProgramIPConfigs returns list of IPs which are in pending program status
 func (service *HTTPRestService) GetPendingProgramIPConfigs() []cns.IPConfigurationStatus {
 	service.RLock()

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -174,6 +174,7 @@ func (service *HTTPRestService) Init(config *common.ServiceConfig) error {
 	listener.AddHandler(cns.ReleaseIPConfig, service.releaseIPConfigHandler)
 	listener.AddHandler(cns.NmAgentSupportedApisPath, service.nmAgentSupportedApisHandler)
 	listener.AddHandler(cns.GetIPAddresses, service.getIPAddressesHandler)
+	listener.AddHandler(cns.GetPodIPOrchestratorContext, service.getPodIPIDByOrchestratorContexthandler)
 
 	// handlers for v0.2
 	listener.AddHandler(cns.V2Prefix+cns.SetEnvironmentPath, service.setEnvironment)


### PR DESCRIPTION
feat: This API exposes one of the Httpservice struct field to 
display map of OrchestratorContext->PodIpID (UUID) and 
includes debug command getPodContexts for CLI use-case.
