### PR TITLE
[CNS] Debug - Expose In-memory data from HTTPRestService

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -24,7 +24,7 @@ const (
 	ReleaseIPConfig                          = "/network/releaseipconfig"
 	GetIPAddresses                           = "/debug/getipaddresses"
 	GetPodIPOrchestratorContext              = "/debug/getpodcontext"
-	GetHTTPRestStruct                        = "/debug/gethttpreststruct"
+	GetHTTPRestData                          = "/debug/getrestdata"
 )
 
 // NetworkContainer Prefixes

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -24,6 +24,7 @@ const (
 	ReleaseIPConfig                          = "/network/releaseipconfig"
 	GetIPAddresses                           = "/debug/getipaddresses"
 	GetPodIPOrchestratorContext              = "/debug/getpodcontext"
+	GetHTTPRestStruct                        = "/debug/gethttpreststruct"
 )
 
 // NetworkContainer Prefixes

--- a/cns/api.go
+++ b/cns/api.go
@@ -180,8 +180,10 @@ type IPAMPoolMonitor interface {
 
 //struct to expose state values for IPAMPoolMonitor struct
 type IpamPoolMonitorStateSnapshot struct {
-	MinimumFreeIps int64
-	MaximumFreeIps int64
+	MinimumFreeIps           int64
+	MaximumFreeIps           int64
+	UpdatingIpsNotInUseCount int
+	CachedNNC                nnc.NodeNetworkConfig
 }
 
 // Response describes generic response from CNS.

--- a/cns/api.go
+++ b/cns/api.go
@@ -175,6 +175,13 @@ type NodeConfiguration struct {
 type IPAMPoolMonitor interface {
 	Start(ctx context.Context, poolMonitorRefreshMilliseconds int) error
 	Update(scalar nnc.Scaler, spec nnc.NodeNetworkConfigSpec) error
+	GetStateSnapshot() IpamPoolMonitorStateSnapshot
+}
+
+//struct to expose state values for IPAMPoolMonitor struct
+type IpamPoolMonitorStateSnapshot struct {
+	MinimumFreeIps int64
+	MaximumFreeIps int64
 }
 
 // Response describes generic response from CNS.

--- a/cns/cnsclient/cli.go
+++ b/cns/cnsclient/cli.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/restserver"
 )
 
 const (
@@ -15,7 +16,11 @@ const (
 	getAllocatedArg      = "Allocated"
 	getAllArg            = "All"
 	getPendingReleaseArg = "PendingRelease"
+<<<<<<< HEAD
 	getPodCmdArg         = "getPodContexts"
+=======
+	getInMemoryData      = "getInMemory"
+>>>>>>> da5071c ([CNS] Debug API to expose In-Memory Data HTTPRestService)
 
 	releaseArg = "release"
 
@@ -29,7 +34,11 @@ const (
 var (
 	availableCmds = []string{
 		getCmdArg,
+<<<<<<< HEAD
 		getPodCmdArg,
+=======
+		getInMemoryData,
+>>>>>>> da5071c ([CNS] Debug API to expose In-Memory Data HTTPRestService)
 	}
 
 	getFlags = []string{
@@ -51,8 +60,13 @@ func HandleCNSClientCommands(cmd, arg string) error {
 	switch {
 	case strings.EqualFold(getCmdArg, cmd):
 		return getCmd(cnsClient, arg)
+<<<<<<< HEAD
 	case strings.EqualFold(getPodCmdArg, cmd):
 		return getPodCmd(cnsClient)
+=======
+	case strings.EqualFold(getInMemoryData, cmd):
+		return getInMemory(cnsClient)
+>>>>>>> da5071c ([CNS] Debug API to expose In-Memory Data HTTPRestService)
 	default:
 		return fmt.Errorf("No debug cmd supplied, options are: %v", getCmdArg)
 	}
@@ -101,13 +115,20 @@ func printIPAddresses(addrSlice []cns.IPConfigurationStatus) {
 	}
 }
 
+<<<<<<< HEAD
 func getPodCmd(client *CNSClient) error {
 
 	resp, err := client.GetPodOrchestratorContext()
+=======
+func getInMemory(client *CNSClient) error {
+
+	inmemoryData, err := client.GetHTTPServiceData()
+>>>>>>> da5071c ([CNS] Debug API to expose In-Memory Data HTTPRestService)
 	if err != nil {
 		return err
 	}
 
+<<<<<<< HEAD
 	printPodContext(resp)
 	return nil
 }
@@ -118,4 +139,14 @@ func printPodContext(podContext map[string]string) {
 		fmt.Println(i, " ", orchContext, " : ", podID)
 		i++
 	}
+=======
+	printInMemoryStruct(inmemoryData.HttpRestServiceData)
+	return nil
+}
+
+func printInMemoryStruct(data restserver.HttpRestServiceData) {
+	fmt.Println("PodIPIDByOrchestratorContext: ", data.PodIPIDByOrchestratorContext)
+	fmt.Println("PodIPConfigState: ", data.PodIPConfigState)
+	fmt.Println("IPAMPoolMonitor: ", data.IPAMPoolMonitor)
+>>>>>>> da5071c ([CNS] Debug API to expose In-Memory Data HTTPRestService)
 }

--- a/cns/cnsclient/cli.go
+++ b/cns/cnsclient/cli.go
@@ -16,11 +16,8 @@ const (
 	getAllocatedArg      = "Allocated"
 	getAllArg            = "All"
 	getPendingReleaseArg = "PendingRelease"
-<<<<<<< HEAD
 	getPodCmdArg         = "getPodContexts"
-=======
 	getInMemoryData      = "getInMemory"
->>>>>>> da5071c ([CNS] Debug API to expose In-Memory Data HTTPRestService)
 
 	releaseArg = "release"
 
@@ -34,11 +31,8 @@ const (
 var (
 	availableCmds = []string{
 		getCmdArg,
-<<<<<<< HEAD
 		getPodCmdArg,
-=======
 		getInMemoryData,
->>>>>>> da5071c ([CNS] Debug API to expose In-Memory Data HTTPRestService)
 	}
 
 	getFlags = []string{
@@ -60,13 +54,10 @@ func HandleCNSClientCommands(cmd, arg string) error {
 	switch {
 	case strings.EqualFold(getCmdArg, cmd):
 		return getCmd(cnsClient, arg)
-<<<<<<< HEAD
 	case strings.EqualFold(getPodCmdArg, cmd):
 		return getPodCmd(cnsClient)
-=======
 	case strings.EqualFold(getInMemoryData, cmd):
 		return getInMemory(cnsClient)
->>>>>>> da5071c ([CNS] Debug API to expose In-Memory Data HTTPRestService)
 	default:
 		return fmt.Errorf("No debug cmd supplied, options are: %v", getCmdArg)
 	}
@@ -115,20 +106,13 @@ func printIPAddresses(addrSlice []cns.IPConfigurationStatus) {
 	}
 }
 
-<<<<<<< HEAD
 func getPodCmd(client *CNSClient) error {
 
 	resp, err := client.GetPodOrchestratorContext()
-=======
-func getInMemory(client *CNSClient) error {
-
-	inmemoryData, err := client.GetHTTPServiceData()
->>>>>>> da5071c ([CNS] Debug API to expose In-Memory Data HTTPRestService)
 	if err != nil {
 		return err
 	}
 
-<<<<<<< HEAD
 	printPodContext(resp)
 	return nil
 }
@@ -139,7 +123,15 @@ func printPodContext(podContext map[string]string) {
 		fmt.Println(i, " ", orchContext, " : ", podID)
 		i++
 	}
-=======
+}
+
+func getInMemory(client *CNSClient) error {
+
+	inmemoryData, err := client.GetHTTPServiceData()
+	if err != nil {
+		return err
+	}
+
 	printInMemoryStruct(inmemoryData.HttpRestServiceData)
 	return nil
 }
@@ -148,5 +140,4 @@ func printInMemoryStruct(data restserver.HttpRestServiceData) {
 	fmt.Println("PodIPIDByOrchestratorContext: ", data.PodIPIDByOrchestratorContext)
 	fmt.Println("PodIPConfigState: ", data.PodIPConfigState)
 	fmt.Println("IPAMPoolMonitor: ", data.IPAMPoolMonitor)
->>>>>>> da5071c ([CNS] Debug API to expose In-Memory Data HTTPRestService)
 }

--- a/cns/cnsclient/cnsclient.go
+++ b/cns/cnsclient/cnsclient.go
@@ -410,3 +410,42 @@ func (cnsClient *CNSClient) GetPodOrchestratorContext() (map[string]string, erro
 
 	return resp.PodContext, err
 }
+
+//GetHTTPServiceData gets all public in-memory struct details for debugging purpose
+func (cnsClient *CNSClient) GetHTTPServiceData() (restserver.GetHTTPServiceDataResponse, error) {
+	var (
+		resp restserver.GetHTTPServiceDataResponse
+		err  error
+		res  *http.Response
+	)
+
+	url := cnsClient.connectionURL + cns.GetHTTPRestData
+	log.Printf("GetHTTPServiceStruct url %v", url)
+
+	res, err = http.Get(url)
+	if err != nil {
+		log.Errorf("[Azure CNSClient] HTTP Get returned error %v", err.Error())
+		return resp, err
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		errMsg := fmt.Sprintf("[Azure CNSClient] GetHTTPServiceStruct invalid http status code: %v", res.StatusCode)
+		log.Errorf(errMsg)
+		return resp, fmt.Errorf(errMsg)
+	}
+
+	err = json.NewDecoder(res.Body).Decode(&resp)
+	if err != nil {
+		log.Errorf("[Azure CNSClient] Error received while parsing GetHTTPServiceStruct response resp:%v err:%v", res.Body, err.Error())
+		return resp, err
+	}
+
+	if resp.Response.ReturnCode != 0 {
+		log.Errorf("[Azure CNSClient] GetTTPServiceStruct received error response :%v", resp.Response.Message)
+		return resp, fmt.Errorf(resp.Response.Message)
+	}
+
+	return resp, err
+}

--- a/cns/cnsclient/cnsclient_test.go
+++ b/cns/cnsclient/cnsclient_test.go
@@ -129,7 +129,7 @@ func TestMain(m *testing.M) {
 	httpRestService, err := restserver.NewHTTPRestService(&config, fakes.NewFakeImdsClient(), fakes.NewFakeNMAgentClient())
 	svc = httpRestService.(*restserver.HTTPRestService)
 	svc.Name = "cns-test-server"
-	svc.IPAMPoolMonitor = fakes.NewIPAMPoolMonitorFake()
+	svc.IPAMPoolMonitor = &fakes.IPAMPoolMonitorFake{FakeMinimumIps: 10, FakeMaximumIps: 20}
 
 	if err != nil {
 		logger.Errorf("Failed to create CNS object, err:%v.\n", err)

--- a/cns/fakes/ipampoolmonitorfake.go
+++ b/cns/fakes/ipampoolmonitorfake.go
@@ -3,10 +3,15 @@ package fakes
 import (
 	"context"
 
+	"github.com/Azure/azure-container-networking/cns"
+
 	nnc "github.com/Azure/azure-container-networking/nodenetworkconfig/api/v1alpha"
 )
 
-type IPAMPoolMonitorFake struct{}
+type IPAMPoolMonitorFake struct {
+	FakeMinimumIps int
+	FakeMaximumIps int
+}
 
 func NewIPAMPoolMonitorFake() *IPAMPoolMonitorFake {
 	return &IPAMPoolMonitorFake{}
@@ -22,4 +27,11 @@ func (ipm *IPAMPoolMonitorFake) Update(scalar nnc.Scaler, spec nnc.NodeNetworkCo
 
 func (ipm *IPAMPoolMonitorFake) Reconcile() error {
 	return nil
+}
+
+func (ipm *IPAMPoolMonitorFake) GetStateSnapshot() cns.IpamPoolMonitorStateSnapshot {
+	return cns.IpamPoolMonitorStateSnapshot{
+		MinimumFreeIps: int64(ipm.FakeMinimumIps),
+		MaximumFreeIps: int64(ipm.FakeMaximumIps),
+	}
 }

--- a/cns/fakes/ipampoolmonitorfake.go
+++ b/cns/fakes/ipampoolmonitorfake.go
@@ -9,8 +9,10 @@ import (
 )
 
 type IPAMPoolMonitorFake struct {
-	FakeMinimumIps int
-	FakeMaximumIps int
+	FakeMinimumIps       int
+	FakeMaximumIps       int
+	FakeIpsNotInUseCount int
+	FakecachedNNC        nnc.NodeNetworkConfig
 }
 
 func NewIPAMPoolMonitorFake() *IPAMPoolMonitorFake {
@@ -31,7 +33,9 @@ func (ipm *IPAMPoolMonitorFake) Reconcile() error {
 
 func (ipm *IPAMPoolMonitorFake) GetStateSnapshot() cns.IpamPoolMonitorStateSnapshot {
 	return cns.IpamPoolMonitorStateSnapshot{
-		MinimumFreeIps: int64(ipm.FakeMinimumIps),
-		MaximumFreeIps: int64(ipm.FakeMaximumIps),
+		MinimumFreeIps:           int64(ipm.FakeMinimumIps),
+		MaximumFreeIps:           int64(ipm.FakeMaximumIps),
+		UpdatingIpsNotInUseCount: ipm.FakeIpsNotInUseCount,
+		CachedNNC:                ipm.FakecachedNNC,
 	}
 }

--- a/cns/ipampoolmonitor/ipampoolmonitor.go
+++ b/cns/ipampoolmonitor/ipampoolmonitor.go
@@ -71,7 +71,6 @@ func (pm *CNSIPAMPoolMonitor) Reconcile() error {
 	pendingReleaseIPCount := len(pm.httpService.GetPendingReleaseIPConfigs())
 	availableIPConfigCount := len(pm.httpService.GetAvailableIPConfigs()) // TODO: add pending allocation count to real cns
 	freeIPConfigCount := pm.cachedNNC.Spec.RequestedIPCount - int64(allocatedPodIPCount)
-
 	msg := fmt.Sprintf("[ipam-pool-monitor] Pool Size: %v, Goal Size: %v, BatchSize: %v, MinFree: %v, MaxFree:%v, Allocated: %v, Available: %v, Pending Release: %v, Free: %v, Pending Program: %v",
 		cnsPodIPConfigCount, pm.cachedNNC.Spec.RequestedIPCount, pm.scalarUnits.BatchSize, pm.MinimumFreeIps, pm.MaximumFreeIps, allocatedPodIPCount, availableIPConfigCount, pendingReleaseIPCount, freeIPConfigCount, pendingProgramCount)
 
@@ -248,4 +247,15 @@ func (pm *CNSIPAMPoolMonitor) Update(scalar nnc.Scaler, spec nnc.NodeNetworkConf
 		pm.cachedNNC.Spec, pm.MinimumFreeIps, pm.MaximumFreeIps)
 
 	return nil
+}
+
+//this function sets the values for state in IPAMPoolMonitor Struct
+func (pm *CNSIPAMPoolMonitor) GetStateSnapshot() cns.IpamPoolMonitorStateSnapshot{
+	defer pm.mu.Unlock()
+	pm.mu.Lock()
+
+	return cns.IpamPoolMonitorStateSnapshot {
+		MinimumFreeIps: pm.MinimumFreeIps,
+		MaximumFreeIps: pm.MaximumFreeIps,
+	}
 }

--- a/cns/ipampoolmonitor/ipampoolmonitor.go
+++ b/cns/ipampoolmonitor/ipampoolmonitor.go
@@ -15,9 +15,9 @@ import (
 type CNSIPAMPoolMonitor struct {
 	pendingRelease bool
 
-	cachedNNC   nnc.NodeNetworkConfig
+	cachedNNC                nnc.NodeNetworkConfig
 	updatingIpsNotInUseCount int
-	scalarUnits nnc.Scaler
+	scalarUnits              nnc.Scaler
 
 	httpService    cns.HTTPService
 	rc             requestcontroller.RequestController
@@ -30,9 +30,9 @@ type CNSIPAMPoolMonitor struct {
 func NewCNSIPAMPoolMonitor(httpService cns.HTTPService, rc requestcontroller.RequestController) *CNSIPAMPoolMonitor {
 	logger.Printf("NewCNSIPAMPoolMonitor: Create IPAM Pool Monitor")
 	return &CNSIPAMPoolMonitor{
-		pendingRelease:				false,
-		httpService:        		httpService,
-		rc:             			rc,
+		pendingRelease: false,
+		httpService:    httpService,
+		rc:             rc,
 	}
 }
 
@@ -201,7 +201,6 @@ func (pm *CNSIPAMPoolMonitor) cleanPendingRelease() error {
 
 	logger.Printf("[ipam-pool-monitor] cleanPendingRelease: UpdateCRDSpec succeeded for spec %+v", tempNNCSpec)
 
-
 	// save the updated state to cachedSpec
 	pm.cachedNNC.Spec = tempNNCSpec
 	pm.pendingRelease = false
@@ -250,12 +249,14 @@ func (pm *CNSIPAMPoolMonitor) Update(scalar nnc.Scaler, spec nnc.NodeNetworkConf
 }
 
 //this function sets the values for state in IPAMPoolMonitor Struct
-func (pm *CNSIPAMPoolMonitor) GetStateSnapshot() cns.IpamPoolMonitorStateSnapshot{
-	defer pm.mu.Unlock()
+func (pm *CNSIPAMPoolMonitor) GetStateSnapshot() cns.IpamPoolMonitorStateSnapshot {
 	pm.mu.Lock()
+	defer pm.mu.Unlock()
 
-	return cns.IpamPoolMonitorStateSnapshot {
-		MinimumFreeIps: pm.MinimumFreeIps,
-		MaximumFreeIps: pm.MaximumFreeIps,
+	return cns.IpamPoolMonitorStateSnapshot{
+		MinimumFreeIps:           pm.MinimumFreeIps,
+		MaximumFreeIps:           pm.MaximumFreeIps,
+		UpdatingIpsNotInUseCount: pm.updatingIpsNotInUseCount,
+		CachedNNC:                pm.cachedNNC,
 	}
 }

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -52,6 +52,24 @@ type HTTPRestService struct {
 	dncPartitionKey string
 }
 
+type GetHTTPResponse struct {
+	HttpStruct HttpStruct
+	Response   Response
+}
+
+//define struct here
+type HttpStruct struct {
+	PodIPIDByOrchestratorContext map[string]string                    // OrchestratorContext is key and value is Pod IP uuid.
+	PodIPConfigState             map[string]cns.IPConfigurationStatus // seondaryipid(uuid) is key
+	AllocatedIPCount             map[string]allocatedIPCount          // key - ncid
+	//IPAMPoolMonitor              cns.IPAMPoolMonitor
+
+}
+type Response struct {
+	ReturnCode int
+	Message    string
+}
+
 type allocatedIPCount struct {
 	Count int
 }


### PR DESCRIPTION
Feat:  [CNS] Debug API to expose In-Memory Data HTTPRestService 
This commit has following changes - 
1. Removed AllocatedIPCount field from HTTPRestService struct in restserver.go as it is not used in project.
2. Added debug command getInMemory and API to expose fields-HTTPRestService and 2 fields from IPAMPoolMonitor.
3. Added Test function to test the new debug api response.

**Reason for Change**: Helping in debug commands for CNS service.

**Notes**: Please review and suggest the naming of the command, handler and end point. 
