### PR TITLE
[NPM] pushing Netpol cache update below errors

### DIFF
--- a/npm/nwpolicy.go
+++ b/npm/nwpolicy.go
@@ -156,8 +156,6 @@ func (npMgr *NetworkPolicyManager) AddNetworkPolicy(npObj *networkingv1.NetworkP
 		npMgr.ProcessedNpMap[npProcessedKey] = npObj
 	}
 
-	npMgr.RawNpMap[npKey] = npObj
-
 	sets, namedPorts, lists, ingressIPCidrs, egressIPCidrs, iptEntries = translatePolicy(npObj)
 	for _, set := range sets {
 		log.Logf("Creating set: %v, hashedSet: %v", set, util.GetHashedName(set))
@@ -192,6 +190,7 @@ func (npMgr *NetworkPolicyManager) AddNetworkPolicy(npObj *networkingv1.NetworkP
 			return err
 		}
 	}
+	npMgr.RawNpMap[npKey] = npObj
 
 	metrics.NumPolicies.Inc()
 	timer.StopAndRecord(metrics.AddPolicyExecTime)
@@ -241,8 +240,6 @@ func (npMgr *NetworkPolicyManager) DeleteNetworkPolicy(npObj *networkingv1.Netwo
 	removeCidrsRule("in", npObj.ObjectMeta.Name, npObj.ObjectMeta.Namespace, ingressIPCidrs, allNs.IpsMgr)
 	removeCidrsRule("out", npObj.ObjectMeta.Name, npObj.ObjectMeta.Namespace, egressIPCidrs, allNs.IpsMgr)
 
-	delete(npMgr.RawNpMap, npKey)
-
 	if oldPolicy, oldPolicyExists := npMgr.ProcessedNpMap[npProcessedKey]; oldPolicyExists {
 		deductedPolicy, err := deductPolicy(oldPolicy, npObj)
 		if err != nil {
@@ -264,6 +261,7 @@ func (npMgr *NetworkPolicyManager) DeleteNetworkPolicy(npObj *networkingv1.Netwo
 			return err
 		}
 	}
+	delete(npMgr.RawNpMap, npKey)
 
 	metrics.NumPolicies.Dec()
 

--- a/npm/nwpolicy.go
+++ b/npm/nwpolicy.go
@@ -179,6 +179,7 @@ func (npMgr *NetworkPolicyManager) AddNetworkPolicy(npObj *networkingv1.NetworkP
 	}
 	if err = npMgr.InitAllNsList(); err != nil {
 		metrics.SendErrorLogAndMetric(util.NetpolID, "[AddNetworkPolicy] Error: initializing all-namespace ipset list with err: %v", err)
+		return err
 	}
 	createCidrsRule("in", npObj.ObjectMeta.Name, npObj.ObjectMeta.Namespace, ingressIPCidrs, ipsMgr)
 	createCidrsRule("out", npObj.ObjectMeta.Name, npObj.ObjectMeta.Namespace, egressIPCidrs, ipsMgr)
@@ -257,6 +258,7 @@ func (npMgr *NetworkPolicyManager) DeleteNetworkPolicy(npObj *networkingv1.Netwo
 		npMgr.isAzureNpmChainCreated = false
 		if err = iptMgr.UninitNpmChains(); err != nil {
 			metrics.SendErrorLogAndMetric(util.NetpolID, "[DeleteNetworkPolicy] Error: failed to uninitialize azure-npm chains with err: %s", err)
+			return err
 		}
 	}
 	delete(npMgr.RawNpMap, npKey)

--- a/npm/nwpolicy.go
+++ b/npm/nwpolicy.go
@@ -179,7 +179,6 @@ func (npMgr *NetworkPolicyManager) AddNetworkPolicy(npObj *networkingv1.NetworkP
 	}
 	if err = npMgr.InitAllNsList(); err != nil {
 		metrics.SendErrorLogAndMetric(util.NetpolID, "[AddNetworkPolicy] Error: initializing all-namespace ipset list with err: %v", err)
-		return err
 	}
 	createCidrsRule("in", npObj.ObjectMeta.Name, npObj.ObjectMeta.Namespace, ingressIPCidrs, ipsMgr)
 	createCidrsRule("out", npObj.ObjectMeta.Name, npObj.ObjectMeta.Namespace, egressIPCidrs, ipsMgr)
@@ -258,7 +257,6 @@ func (npMgr *NetworkPolicyManager) DeleteNetworkPolicy(npObj *networkingv1.Netwo
 		npMgr.isAzureNpmChainCreated = false
 		if err = iptMgr.UninitNpmChains(); err != nil {
 			metrics.SendErrorLogAndMetric(util.NetpolID, "[DeleteNetworkPolicy] Error: failed to uninitialize azure-npm chains with err: %s", err)
-			return err
 		}
 	}
 	delete(npMgr.RawNpMap, npKey)


### PR DESCRIPTION
Right now, network policy cache is updated even if there are errors below, this PR will make sure that cache is not updated if error occurs