### PR TITLE
[NPM] Remove non-fatal error which is causing early bail out

### DIFF
--- a/npm/nwpolicy.go
+++ b/npm/nwpolicy.go
@@ -99,15 +99,6 @@ func (npMgr *NetworkPolicyManager) AddNetworkPolicy(npObj *networkingv1.NetworkP
 		return err
 	}
 
-	if ns, exists = npMgr.NsMap[npNs]; !exists {
-		ns, err = newNs(npNs)
-		if err != nil {
-			metrics.SendErrorLogAndMetric(util.NetpolID, "[AddNetworkPolicy] Error: creating namespace %s with err: %v", npNs, err)
-			return err
-		}
-		npMgr.NsMap[npNs] = ns
-	}
-
 	if npMgr.policyExists(npObj) {
 		return nil
 	}

--- a/npm/nwpolicy.go
+++ b/npm/nwpolicy.go
@@ -177,9 +177,7 @@ func (npMgr *NetworkPolicyManager) AddNetworkPolicy(npObj *networkingv1.NetworkP
 			return err
 		}
 	}
-	if err = npMgr.InitAllNsList(); err != nil {
-		metrics.SendErrorLogAndMetric(util.NetpolID, "[AddNetworkPolicy] Error: initializing all-namespace ipset list with err: %v", err)
-	}
+
 	createCidrsRule("in", npObj.ObjectMeta.Name, npObj.ObjectMeta.Namespace, ingressIPCidrs, ipsMgr)
 	createCidrsRule("out", npObj.ObjectMeta.Name, npObj.ObjectMeta.Namespace, egressIPCidrs, ipsMgr)
 	iptMgr := allNs.iptMgr

--- a/npm/nwpolicy.go
+++ b/npm/nwpolicy.go
@@ -80,8 +80,6 @@ func (npMgr *NetworkPolicyManager) policyExists(npObj *networkingv1.NetworkPolic
 func (npMgr *NetworkPolicyManager) AddNetworkPolicy(npObj *networkingv1.NetworkPolicy) error {
 	var (
 		err            error
-		ns             *Namespace
-		exists         bool
 		npNs           = util.GetNSNameWithPrefix(npObj.ObjectMeta.Namespace)
 		npName         = npObj.ObjectMeta.Name
 		allNs          = npMgr.NsMap[util.KubeAllNamespacesFlag]

--- a/npm/nwpolicy.go
+++ b/npm/nwpolicy.go
@@ -179,7 +179,6 @@ func (npMgr *NetworkPolicyManager) AddNetworkPolicy(npObj *networkingv1.NetworkP
 	}
 	if err = npMgr.InitAllNsList(); err != nil {
 		metrics.SendErrorLogAndMetric(util.NetpolID, "[AddNetworkPolicy] Error: initializing all-namespace ipset list with err: %v", err)
-		return err
 	}
 	createCidrsRule("in", npObj.ObjectMeta.Name, npObj.ObjectMeta.Namespace, ingressIPCidrs, ipsMgr)
 	createCidrsRule("out", npObj.ObjectMeta.Name, npObj.ObjectMeta.Namespace, egressIPCidrs, ipsMgr)


### PR DESCRIPTION
because of this error, none of the valid network policies are being applied.
This error is caused by non-removal of some benign namespaces