### PR TITLE
[NPM] better error handling and cache building

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	k8s.io/api v0.18.2
 	k8s.io/apimachinery v0.18.2
 	k8s.io/client-go v0.18.2
+	k8s.io/klog v1.0.0
 	sigs.k8s.io/controller-runtime v0.6.0
 	software.sslmate.com/src/go-pkcs12 v0.0.0-20201102150903-66718f75db0e // indirect
 )

--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -188,8 +188,10 @@ func (ipsMgr *IpsetManager) DeleteFromList(listName string, setName string) erro
 	exists, _ := ipsMgr.SetExists(setName)
 
 	// if set does not exist, then return because the ipset call will fail due to set not existing
+	// TODO make sure these are info and not errors, use NPmErr
 	if !exists {
-		return fmt.Errorf("Set [%s] does not exist when attempting to delete from list [%s]", setName, listName)
+		metrics.SendErrorLogAndMetric(util.IpsmID, "Set [%s] does not exist when attempting to delete from list [%s]", setName, listName)
+		return nil
 	}
 
 	//Check if list being added exists in the listmap, if it exists we don't care about the set type
@@ -197,11 +199,13 @@ func (ipsMgr *IpsetManager) DeleteFromList(listName string, setName string) erro
 
 	// if set does not exist, then return because the ipset call will fail due to set not existing
 	if !exists {
-		return fmt.Errorf("Set [%s] does not exist when attempting to add to list [%s]", setName, listName)
+		metrics.SendErrorLogAndMetric(util.IpsmID, "Set [%s] does not exist when attempting to add to list [%s]", setName, listName)
+		return nil
 	}
 
 	if listtype != util.IpsetSetListFlag {
-		return fmt.Errorf("Set [%s] is of the wrong type when attempting to delete list [%s], actual type [%s]", setName, listName, listtype)
+		metrics.SendErrorLogAndMetric(util.IpsmID, "Set [%s] is of the wrong type when attempting to delete list [%s], actual type [%s]", setName, listName, listtype)
+		return nil
 	}
 
 	if _, exists := ipsMgr.ListMap[listName]; !exists {
@@ -552,7 +556,6 @@ func (ipsMgr *IpsetManager) DestroyNpmIpsets() error {
 		return nil
 	}
 
-	log.Logf("{DestroyNpmIpsets} Reply from command %s executed is %s", cmdName+" "+cmdArgs, reply)
 	re := regexp.MustCompile("Name: (" + util.AzureNpmPrefix + "\\d+)")
 	ipsetRegexSlice := re.FindAllSubmatch(reply, -1)
 

--- a/npm/ipsm/ipsm_test.go
+++ b/npm/ipsm/ipsm_test.go
@@ -138,12 +138,12 @@ func TestDeleteFromList(t *testing.T) {
 	}
 
 	// Delete set from list and validate set is not in list anymore.
-	if err := ipsMgr.DeleteFromList(listName, "nonexistentsetname"); err == nil {
+	if err := ipsMgr.DeleteFromList(listName, "nonexistentsetname"); err != nil {
 		t.Errorf("TestDeleteFromList failed @ ipsMgr.DeleteFromList %v", err)
 	}
 
 	// Delete set from list, but list isn't of list type
-	if err := ipsMgr.DeleteFromList(setName, setName); err == nil {
+	if err := ipsMgr.DeleteFromList(setName, setName); err != nil {
 		t.Errorf("TestDeleteFromList failed @ ipsMgr.DeleteFromList %v", err)
 	}
 

--- a/npm/nameSpaceController.go
+++ b/npm/nameSpaceController.go
@@ -412,6 +412,7 @@ func (nsc *nameSpaceController) syncUpdateNameSpace(newNsObj *corev1.Namespace) 
 		}
 		// {IMPORTANT} The order of compared list will be key and then key+val. NPM should only append after both key
 		// key + val ipsets are worked on. 0th index will be key and 1st index will be value of the label
+		// (TODO) need to remove this ordering dependency
 		removedLabel := util.GetLabelKVFromSet(nsLabelVal)
 		if len(removedLabel) > 1 {
 			curNsObj.removeLabelsWithKey(removedLabel[0])

--- a/npm/npm.go
+++ b/npm/npm.go
@@ -266,7 +266,7 @@ func NewNetworkPolicyManager(clientset *kubernetes.Clientset, informerFactory in
 	}
 
 	// create pod controller
-	npMgr.podController = NewPodController(informerFactory.Core().V1().Pods(), clientset, npMgr)
+	npMgr.podController = NewPodController(podInformer, clientset, npMgr)
 
 	// create NameSpace controller
 	npMgr.nameSpaceController = NewNameSpaceController(nsInformer, clientset, npMgr)

--- a/npm/podController.go
+++ b/npm/podController.go
@@ -419,7 +419,6 @@ func (c *podController) syncAddedPod(podObj *corev1.Pod) error {
 	c.npMgr.PodMap[podKey] = npmPodObj
 
 	// Get lists of podLabelKey and podLabelKey + podLavelValue ,and then start adding them to ipsets.
-	//addToIPSets := util.GetIPSetListFromLabels(npmPodObj.Labels)
 	for labelKey, labelVal := range npmPodObj.Labels {
 		log.Logf("Adding pod %s to ipset %s", npmPodObj.PodIP, labelKey)
 		if err = ipsMgr.AddToSet(labelKey, npmPodObj.PodIP, util.IpsetNetHashFlag, podKey); err != nil {
@@ -457,7 +456,7 @@ func (c *podController) syncAddAndUpdatePod(newPodObj *corev1.Pod) error {
 		// (TODO): need to change newNS function. It always returns "nil"
 		c.npMgr.NsMap[newPodObjNs], _ = newNs(newPodObjNs)
 		log.Logf("Creating set: %v, hashedSet: %v", newPodObjNs, util.GetHashedName(newPodObjNs))
-		if err = ipsMgr.CreateSet(newPodObjNs, append([]string{util.IpsetNetHashFlag})); err != nil {
+		if err = ipsMgr.CreateSet(newPodObjNs, []string{util.IpsetNetHashFlag}); err != nil {
 			return fmt.Errorf("[syncAddAndUpdatePod] Error: creating ipset %s with err: %v", newPodObjNs, err)
 		}
 	}
@@ -548,6 +547,7 @@ func (c *podController) syncAddAndUpdatePod(newPodObj *corev1.Pod) error {
 		}
 		// {IMPORTANT} Same as above order is assumed to be key and then key+val. NPM should only append to existing labels
 		// only after both ipsets for a given label's key value pair are added successfully
+		// (TODO) will need to remove this ordering dependency
 		addedLabel := util.GetLabelKVFromSet(addIPSetName)
 		if len(addedLabel) > 1 {
 			c.npMgr.PodMap[podKey].appendLabels(map[string]string{addedLabel[0]: addedLabel[1]}, AppendToExitingLabels)

--- a/npm/podController.go
+++ b/npm/podController.go
@@ -36,7 +36,6 @@ type NpmPod struct {
 	Name           string
 	Namespace      string
 	PodIP          string
-	IsHostNetwork  bool
 	Labels         map[string]string
 	ContainerPorts []corev1.ContainerPort
 	Phase          corev1.PodPhase
@@ -47,7 +46,6 @@ func newNpmPod(podObj *corev1.Pod) *NpmPod {
 		Name:           podObj.ObjectMeta.Name,
 		Namespace:      podObj.ObjectMeta.Namespace,
 		PodIP:          podObj.Status.PodIP,
-		IsHostNetwork:  podObj.Spec.HostNetwork,
 		Labels:         make(map[string]string),
 		ContainerPorts: []corev1.ContainerPort{},
 		Phase:          podObj.Status.Phase,

--- a/npm/podController.go
+++ b/npm/podController.go
@@ -356,13 +356,8 @@ func (c *podController) syncPod(key string) error {
 	if err != nil {
 		if errors.IsNotFound(err) {
 			klog.Infof("pod %s not found, may be it is deleted", key)
-			_, exist := c.npMgr.PodMap[key]
-			// if the npmPod does not exists, we do not need to clean up process and retry it
-			if !exist {
-				return nil
-			}
-
-			// Found the npmPod object from PodMap local cache and start cleaning up processes
+			// cleanUpDeletedPod will check if the pod exists in cache, if it does then proceeds with deletion
+			// if it does not exists, then event will be no-op
 			err = c.cleanUpDeletedPod(key)
 			if err != nil {
 				// need to retry this cleaning-up process

--- a/npm/podController.go
+++ b/npm/podController.go
@@ -91,12 +91,7 @@ func (nPod *NpmPod) removeLabelsWithKey(key string) {
 }
 
 func (nPod *NpmPod) appendContainerPorts(podObj *corev1.Pod) {
-	portList := getContainerPortList(podObj)
-	// To remove any references to objects sent to events by sharedinformer,
-	// NPM will need to deepcopy data from the provided objects
-	copiedPortList := make([]corev1.ContainerPort, len(portList))
-	copy(copiedPortList, portList)
-	nPod.ContainerPorts = copiedPortList
+	nPod.ContainerPorts = getContainerPortList(podObj)
 }
 
 func (nPod *NpmPod) removeContainerPorts() {

--- a/npm/podController.go
+++ b/npm/podController.go
@@ -532,7 +532,7 @@ func (c *podController) syncAddAndUpdatePod(newPodObj *corev1.Pod) error {
 	// named ports are mostly static once configured in todays usage pattern
 	// so keeping this simple by deleting all and re-adding
 	newPodPorts := getContainerPortList(newPodObj)
-	if !reflect.DeepEqual(cachedNpmPodObj.ContainerPorts, newPodPorts) {
+	if !reflect.DeepEqual(cachedNpmPodObj.ContainerPorts, newPodPorts) || cachedPobObjIpChanged {
 		// Delete cached pod's named ports from its ipset.
 		if err = manageNamedPortIpsets(ipsMgr, cachedNpmPodObj.ContainerPorts, podKey, cachedNpmPodObj.PodIP, DeleteNamedPortIpsets); err != nil {
 			return fmt.Errorf("[syncAddAndUpdatePod] Error: failed to delete pod from named port ipset with err: %v", err)

--- a/npm/podController.go
+++ b/npm/podController.go
@@ -503,7 +503,7 @@ func (c *podController) syncAddAndUpdatePod(newPodObj *corev1.Pod) error {
 		)
 
 		// Delete the pod from its namespace's ipset.
-		if err = ipsMgr.DeleteFromSet(cachedNpmPodObj.Namespace, cachedNpmPodObj.PodIP, podKey); err != nil {
+		if err = ipsMgr.DeleteFromSet(util.GetNSNameWithPrefix(cachedNpmPodObj.Namespace), cachedNpmPodObj.PodIP, podKey); err != nil {
 			return fmt.Errorf("[syncAddAndUpdatePod] Error: failed to delete pod from namespace ipset with err: %v", err)
 		}
 	} else {

--- a/npm/podController.go
+++ b/npm/podController.go
@@ -322,6 +322,7 @@ func (c *podController) processNextWorkItem() bool {
 		if err := c.syncPod(key); err != nil {
 			// Put the item back on the workqueue to handle any transient errors.
 			c.workqueue.AddRateLimited(key)
+			metrics.SendErrorLogAndMetric(util.PodID, "[podController processNextWorkItem] Error: failed to syncPod %s. Requeuing with err: %v", key, err)
 			return fmt.Errorf("error syncing '%s': %s, requeuing", key, err.Error())
 		}
 		// Finally, if no error occurs we Forget this item so it does not

--- a/npm/podController.go
+++ b/npm/podController.go
@@ -392,11 +392,10 @@ func (c *podController) syncPod(key string) error {
 }
 
 func (c *podController) syncAddedPod(podObj *corev1.Pod) error {
-	npmPodObj := newNpmPod(podObj)
 	podNs := util.GetNSNameWithPrefix(podObj.Namespace)
 	podKey, _ := cache.MetaNamespaceKeyFunc(podObj)
 	ipsMgr := c.npMgr.NsMap[util.KubeAllNamespacesFlag].IpsMgr
-	klog.Infof("POD CREATING: [%s%s/%s/%s%+v%s]", npmPodObj.PodUID, podNs, npmPodObj.Name, npmPodObj.NodeName, podObj.Labels, npmPodObj.PodIP)
+	klog.Infof("POD CREATING: [%s%s/%s/%s%+v%s]", string(podObj.GetUID()), podNs, podObj.Name, podObj.Spec.NodeName, podObj.Labels, podObj.Status.PodIP)
 
 	// Add pod namespace if it doesn't exist
 	var err error
@@ -409,6 +408,7 @@ func (c *podController) syncAddedPod(podObj *corev1.Pod) error {
 		}
 	}
 
+	npmPodObj := newNpmPod(podObj)
 	// Add the pod to its namespace's ipset.
 	klog.Infof("Adding pod %s to ipset %s", npmPodObj.PodIP, podNs)
 	if err = ipsMgr.AddToSet(podNs, npmPodObj.PodIP, util.IpsetNetHashFlag, podKey); err != nil {

--- a/npm/podController.go
+++ b/npm/podController.go
@@ -174,8 +174,6 @@ func (c *podController) addPod(obj interface{}) {
 	if !needSync {
 		return
 	}
-	// K8s categorizes Succeeded and Failed pods as a terminated pod and will not restart them
-	// So NPM will ignorer adding these pods
 	podObj, _ := obj.(*corev1.Pod)
 
 	// If newPodObj status is either corev1.PodSucceeded or corev1.PodFailed or DeletionTimestamp is set, do not need to add it into workqueue.
@@ -593,6 +591,8 @@ func isCompletePod(podObj *corev1.Pod) bool {
 		return true
 	}
 
+	// K8s categorizes Succeeded and Failed pods as a terminated pod and will not restart them
+	// So NPM will ignorer adding these pods
 	if podObj.Status.Phase == corev1.PodSucceeded || podObj.Status.Phase == corev1.PodFailed {
 		return true
 	}

--- a/npm/podController_test.go
+++ b/npm/podController_test.go
@@ -4,6 +4,7 @@ package npm
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 	"testing"
 
@@ -174,16 +175,35 @@ type expectedValues struct {
 func checkPodTestResult(testName string, f *podFixture, testCases []expectedValues) {
 	for _, test := range testCases {
 		if got := len(f.npMgr.PodMap); got != test.expectedLenOfPodMap {
-			f.t.Errorf("PodMap length = %d, want %d", got, test.expectedLenOfPodMap)
+			f.t.Errorf("%s failed @ PodMap length = %d, want %d", testName, got, test.expectedLenOfPodMap)
 		}
 		if got := len(f.npMgr.NsMap); got != test.expectedLenOfNsMap {
-			f.t.Errorf("npMgr length = %d, want %d", got, test.expectedLenOfNsMap)
+			f.t.Errorf("%s failed @ npMgr length = %d, want %d", testName, got, test.expectedLenOfNsMap)
 		}
 		if got := f.podController.workqueue.Len(); got != test.expectedLenOfWorkQueue {
-			f.t.Errorf("Workqueue length = %d, want %d", got, test.expectedLenOfWorkQueue)
+			f.t.Errorf("%s failed @ Workqueue length = %d, want %d", testName, got, test.expectedLenOfWorkQueue)
 		}
 	}
 }
+
+func checkNpmPodWithInput(testName string, f *podFixture, inputPodObj *corev1.Pod) {
+	podKey := getKey(inputPodObj, f.t)
+	cachedNpmPodObj := f.npMgr.PodMap[podKey]
+
+	if cachedNpmPodObj.PodIP != inputPodObj.Status.PodIP {
+		f.t.Errorf("%s failed @ PodIp check got = %s, want %s", testName, cachedNpmPodObj.PodIP, inputPodObj.Status.PodIP)
+	}
+
+	if !reflect.DeepEqual(cachedNpmPodObj.Labels, inputPodObj.Labels) {
+		f.t.Errorf("%s failed @ Labels check got = %v, want %v", testName, cachedNpmPodObj.Labels, inputPodObj.Labels)
+	}
+
+	inputPortList := getContainerPortList(inputPodObj)
+	if !reflect.DeepEqual(cachedNpmPodObj.ContainerPorts, inputPortList) {
+		f.t.Errorf("%s failed @ Container port check got = %v, want %v", testName, cachedNpmPodObj.PodIP, inputPortList)
+	}
+}
+
 func TestAddMultiplePods(t *testing.T) {
 	labels := map[string]string{
 		"app": "test-pod",
@@ -205,6 +225,8 @@ func TestAddMultiplePods(t *testing.T) {
 		{2, 2, 0},
 	}
 	checkPodTestResult("TestAddMultiplePods", f, testCases)
+	checkNpmPodWithInput("TestAddMultiplePods", f, podObj1)
+	checkNpmPodWithInput("TestAddMultiplePods", f, podObj2)
 }
 
 func TestAddPod(t *testing.T) {
@@ -225,6 +247,7 @@ func TestAddPod(t *testing.T) {
 		{1, 2, 0},
 	}
 	checkPodTestResult("TestAddPod", f, testCases)
+	checkNpmPodWithInput("TestAddPod", f, podObj)
 }
 
 func TestAddHostNetworkPod(t *testing.T) {
@@ -232,6 +255,7 @@ func TestAddHostNetworkPod(t *testing.T) {
 		"app": "test-pod",
 	}
 	podObj := createPod("test-pod", "test-namespace", "0", "1.2.3.4", labels, HostNetwork, corev1.PodRunning)
+	podKey := getKey(podObj, t)
 
 	f := newFixture(t)
 	f.podLister = append(f.podLister, podObj)
@@ -246,6 +270,9 @@ func TestAddHostNetworkPod(t *testing.T) {
 	}
 	checkPodTestResult("TestAddHostNetworkPod", f, testCases)
 
+	if _, exists := f.npMgr.PodMap[podKey]; exists {
+		t.Error("TestAddHostNetworkPod failed @ cached pod obj exists check")
+	}
 }
 
 func TestDeletePod(t *testing.T) {
@@ -253,6 +280,7 @@ func TestDeletePod(t *testing.T) {
 		"app": "test-pod",
 	}
 	podObj := createPod("test-pod", "test-namespace", "0", "1.2.3.4", labels, NonHostNetwork, corev1.PodRunning)
+	podKey := getKey(podObj, t)
 
 	f := newFixture(t)
 	f.podLister = append(f.podLister, podObj)
@@ -266,6 +294,9 @@ func TestDeletePod(t *testing.T) {
 		{0, 2, 0},
 	}
 	checkPodTestResult("TestDeletePod", f, testCases)
+	if _, exists := f.npMgr.PodMap[podKey]; exists {
+		t.Error("TestDeletePod failed @ cached pod obj exists check")
+	}
 }
 
 func TestDeleteHostNetworkPod(t *testing.T) {
@@ -273,6 +304,7 @@ func TestDeleteHostNetworkPod(t *testing.T) {
 		"app": "test-pod",
 	}
 	podObj := createPod("test-pod", "test-namespace", "0", "1.2.3.4", labels, HostNetwork, corev1.PodRunning)
+	podKey := getKey(podObj, t)
 
 	f := newFixture(t)
 	f.podLister = append(f.podLister, podObj)
@@ -286,6 +318,9 @@ func TestDeleteHostNetworkPod(t *testing.T) {
 		{0, 1, 0},
 	}
 	checkPodTestResult("TestDeleteHostNetworkPod", f, testCases)
+	if _, exists := f.npMgr.PodMap[podKey]; exists {
+		t.Error("TestDeleteHostNetworkPod failed @ cached pod obj exists check")
+	}
 }
 
 func TestLabelUpdatePod(t *testing.T) {
@@ -314,6 +349,7 @@ func TestLabelUpdatePod(t *testing.T) {
 		{1, 2, 0},
 	}
 	checkPodTestResult("TestLabelUpdatePod", f, testCases)
+	checkNpmPodWithInput("TestLabelUpdatePod", f, newPodObj)
 }
 
 func TestIPAddressUpdatePod(t *testing.T) {
@@ -341,6 +377,7 @@ func TestIPAddressUpdatePod(t *testing.T) {
 		{1, 2, 0},
 	}
 	checkPodTestResult("TestIPAddressUpdatePod", f, testCases)
+	checkNpmPodWithInput("TestIPAddressUpdatePod", f, newPodObj)
 }
 
 func TestPodStatusUpdatePod(t *testing.T) {
@@ -369,6 +406,7 @@ func TestPodStatusUpdatePod(t *testing.T) {
 		{0, 2, 0},
 	}
 	checkPodTestResult("TestPodStatusUpdatePod", f, testCases)
+	checkNpmPodWithInput("TestPodStatusUpdatePod", f, newPodObj)
 }
 
 func TestHasValidPodIP(t *testing.T) {

--- a/npm/podController_test.go
+++ b/npm/podController_test.go
@@ -385,6 +385,7 @@ func TestPodStatusUpdatePod(t *testing.T) {
 		"app": "test-pod",
 	}
 	oldPodObj := createPod("test-pod", "test-namespace", "0", "1.2.3.4", labels, NonHostNetwork, corev1.PodRunning)
+	podKey := getKey(oldPodObj, t)
 
 	f := newFixture(t)
 	f.podLister = append(f.podLister, oldPodObj)
@@ -406,7 +407,9 @@ func TestPodStatusUpdatePod(t *testing.T) {
 		{0, 2, 0},
 	}
 	checkPodTestResult("TestPodStatusUpdatePod", f, testCases)
-	checkNpmPodWithInput("TestPodStatusUpdatePod", f, newPodObj)
+	if _, exists := f.npMgr.PodMap[podKey]; exists {
+		t.Error("TestPodStatusUpdatePod failed @ cached pod obj exists check")
+	}
 }
 
 func TestHasValidPodIP(t *testing.T) {

--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -129,6 +129,8 @@ const (
 	IpsetSCTPFlag string = "sctp:"
 	IpsetTCPFlag  string = "tcp:"
 
+	IpsetLabelDelimter string = ":"
+
 	AzureNpmFlag   string = "azure-npm"
 	AzureNpmPrefix string = "azure-npm-"
 

--- a/npm/util/util.go
+++ b/npm/util/util.go
@@ -315,6 +315,10 @@ func GetIpSetFromLabelKV(k, v string) string {
 	return fmt.Sprintf("%s%s%s", k, IpsetLabelDelimter, v)
 }
 
-func GetLabelKVFromSet(ipsetName string) []string {
-	return strings.Split(ipsetName, IpsetLabelDelimter)
+func GetLabelKVFromSet(ipsetName string) (string, string) {
+	strSplit := strings.Split(ipsetName, IpsetLabelDelimter)
+	if len(strSplit) > 1 {
+		return strSplit[0], strSplit[1]
+	}
+	return strSplit[0], ""
 }

--- a/npm/util/util.go
+++ b/npm/util/util.go
@@ -78,7 +78,7 @@ func GetIPSetListFromLabels(labels map[string]string) []string {
 		ipsetList = []string{}
 	)
 	for labelKey, labelVal := range labels {
-		ipsetList = append(ipsetList, labelKey, labelKey+":"+labelVal)
+		ipsetList = append(ipsetList, labelKey, labelKey+IpsetLabelDelimter+labelVal)
 
 	}
 	return ipsetList
@@ -93,17 +93,19 @@ func GetIPSetListCompareLabels(orig map[string]string, new map[string]string) ([
 	for keyOrig, valOrig := range orig {
 		if valNew, ok := new[keyOrig]; ok {
 			if valNew != valOrig {
-				notInNew = append(notInNew, keyOrig+":"+valOrig)
-				notInOrig = append(notInOrig, keyOrig+":"+valNew)
+				notInNew = append(notInNew, keyOrig+IpsetLabelDelimter+valOrig)
+				notInOrig = append(notInOrig, keyOrig+IpsetLabelDelimter+valNew)
 			}
 		} else {
-			notInNew = append(notInNew, keyOrig, keyOrig+":"+valOrig)
+			// {IMPORTANT} this order is important, key should be before and key+val later
+			notInNew = append(notInNew, keyOrig, keyOrig+IpsetLabelDelimter+valOrig)
 		}
 	}
 
 	for keyNew, valNew := range new {
 		if _, ok := orig[keyNew]; !ok {
-			notInOrig = append(notInOrig, keyNew, keyNew+":"+valNew)
+			// {IMPORTANT} this order is important, key should be before and key+val later
+			notInOrig = append(notInOrig, keyNew, keyNew+IpsetLabelDelimter+valNew)
 		}
 	}
 
@@ -303,8 +305,16 @@ func GetSetsFromLabels(labels map[string]string) []string {
 	l := []string{}
 
 	for k, v := range labels {
-		l = append(l, k, fmt.Sprintf("%s:%s", k, v))
+		l = append(l, k, fmt.Sprintf("%s%s%s", k, IpsetLabelDelimter, v))
 	}
 
 	return l
+}
+
+func GetIpSetFromLabelKV(k, v string) string {
+	return fmt.Sprintf("%s%s%s", k, IpsetLabelDelimter, v)
+}
+
+func GetLabelKVFromSet(ipsetName string) []string {
+	return strings.Split(ipsetName, IpsetLabelDelimter)
 }


### PR DESCRIPTION
Today, during a resource event handling, NPM will return immediately if it encounters an error and local NPM cache will not be updated. This results in leaked ipset/iptables state in kernel which will never be cleaned up since the local NPM cache is not aware of it. 

Solution:
Build cache after each successful operation. Return on first error.

This PR, incorporates the above logic, NPM now keeps updating the local cache after every successful operation. NPM also ignores the notexists errors in Delete set operations.
Logging is updated to use klog instead of using acn/log.
if the Cached Pod IP changes, now NPM will delete the existing cached pod and adds a new pod.
CleanUpDeletedPod will now only require the key of the pod which needs to be deleted.