### PR TITLE
prevents a goroutine from being leaked in internalapi.go

### DIFF
--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -172,7 +172,7 @@ func (service *HTTPRestService) SyncHostNCVersion(ctx context.Context, channelMo
 	service.RUnlock()
 	if len(hostVersionNeedUpdateNcList) > 0 {
 		logger.Printf("Updating version of the following NC IDs: %v", hostVersionNeedUpdateNcList)
-		ncVersionChannel := make(chan map[string]int)
+		ncVersionChannel := make(chan map[string]int, 1)
 		ctxWithTimeout, _ := context.WithTimeout(ctx, syncHostNCTimeoutMilliSec*time.Millisecond)
 		go func() {
 			ncVersionChannel <- service.nmagentClient.GetNcVersionListWithOutToken(hostVersionNeedUpdateNcList)


### PR DESCRIPTION
**Reason for Change**:
Fixes a potential bug that could cause a goroutine to leak/hang if a timeout occurs

**Issue Fixed**:
N/A

**Requirements**:

- [ X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests

**Notes**:

The goroutine on https://github.com/Azure/azure-container-networking/blob/master/cns/restserver/internalapi.go#L177-L180 could be leaked as a result of using an unbuffered channel.

If a timeout occurs, which would execute the case on https://github.com/Azure/azure-container-networking/blob/master/cns/restserver/internalapi.go#L203, goroutine on L177 would be blocked and therefore leaked when the `SyncHostNCVersion` function returns.
