### PR TITLE
[NPM] fix management of DeletedFinalStateUnknown object on deletion event in each controller

### DIFF
--- a/npm/nameSpaceController.go
+++ b/npm/nameSpaceController.go
@@ -192,7 +192,7 @@ func (nsc *nameSpaceController) deleteNamespace(obj interface{}) {
 
 	var err error
 	var key string
-	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
+	if key, err = cache.MetaNamespaceKeyFunc(nsObj); err != nil {
 		utilruntime.HandleError(err)
 		metrics.SendErrorLogAndMetric(util.NSID, "[NAMESPACE DELETE EVENT] Error: nameSpaceKey is empty for %s namespace", util.GetNSNameWithPrefix(nsObj.Name))
 		return
@@ -287,7 +287,7 @@ func (nsc *nameSpaceController) syncNameSpace(key string) error {
 	defer nsc.npMgr.Unlock()
 	if err != nil {
 		if errors.IsNotFound(err) {
-			utilruntime.HandleError(fmt.Errorf("NameSpace '%s' in work queue no longer exists", key))
+			klog.Infof("NameSpace %s not found, may be it is deleted", key)
 			// find the nsMap key and start cleaning up process (calling cleanDeletedNamespace function)
 			cachedNsKey := util.GetNSNameWithPrefix(key)
 			// cleanDeletedNamespace will check if the NS exists in cache, if it does, then proceeds with deletion

--- a/npm/networkPolicyController.go
+++ b/npm/networkPolicyController.go
@@ -122,7 +122,7 @@ func (c *networkPolicyController) updateNetworkPolicy(old, new interface{}) {
 }
 
 func (c *networkPolicyController) deleteNetworkPolicy(obj interface{}) {
-	_, ok := obj.(*networkingv1.NetworkPolicy)
+	netPolObj, ok := obj.(*networkingv1.NetworkPolicy)
 	// DeleteFunc gets the final state of the resource (if it is known).
 	// Otherwise, it gets an object of type DeletedFinalStateUnknown.
 	// This can happen if the watch is closed and misses the delete event and
@@ -135,7 +135,7 @@ func (c *networkPolicyController) deleteNetworkPolicy(obj interface{}) {
 			return
 		}
 
-		if _, ok = tombstone.Obj.(*networkingv1.NetworkPolicy); !ok {
+		if netPolObj, ok = tombstone.Obj.(*networkingv1.NetworkPolicy); !ok {
 			metrics.SendErrorLogAndMetric(util.NetpolID, "[NETPOL DELETE EVENT] Received unexpected object type (error decoding object tombstone, invalid type): %v", obj)
 			utilruntime.HandleError(fmt.Errorf("error decoding object tombstone, invalid type"))
 			return
@@ -144,7 +144,7 @@ func (c *networkPolicyController) deleteNetworkPolicy(obj interface{}) {
 
 	var netPolkey string
 	var err error
-	if netPolkey, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
+	if netPolkey, err = cache.MetaNamespaceKeyFunc(netPolObj); err != nil {
 		utilruntime.HandleError(err)
 		return
 	}

--- a/npm/npm_test.go
+++ b/npm/npm_test.go
@@ -8,7 +8,25 @@ import (
 	"github.com/Azure/azure-container-networking/npm/iptm"
 	"github.com/Azure/azure-container-networking/npm/metrics"
 	"github.com/Azure/azure-container-networking/npm/util"
+	"k8s.io/client-go/tools/cache"
 )
+
+// To indicate the object is needed to be DeletedFinalStateUnknown Object
+type IsDeletedFinalStateUnknownObject bool
+
+const (
+	DeletedFinalStateUnknownObject IsDeletedFinalStateUnknownObject = true
+	DeletedFinalStateknownObject   IsDeletedFinalStateUnknownObject = false
+)
+
+func getKey(obj interface{}, t *testing.T) string {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		t.Errorf("Unexpected error getting key for obj %v: %v", obj, err)
+		return ""
+	}
+	return key
+}
 
 func newNPMgr(t *testing.T) *NetworkPolicyManager {
 	npMgr := &NetworkPolicyManager{

--- a/npm/podController.go
+++ b/npm/podController.go
@@ -245,7 +245,7 @@ func (c *podController) deletePod(obj interface{}) {
 
 	var err error
 	var key string
-	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
+	if key, err = cache.MetaNamespaceKeyFunc(podObj); err != nil {
 		utilruntime.HandleError(err)
 		metrics.SendErrorLogAndMetric(util.PodID, "[POD DELETE EVENT] Error: podKey is empty for %s pod in %s with UID %s",
 			podObj.ObjectMeta.Name, util.GetNSNameWithPrefix(podObj.Namespace), podObj.UID)


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Current code does not enqueue a key of DeletedFinalStateUnknown object on deletion event, which may cause leak of applied states (e.g., ipset, iptables) and keep an item in a local cache (e.g., podMap, nsMap, nsMap).
This PR is to properly clean up applied states (e.g., ipset, iptables, and local cache (e.g., podMap, nsMap, nsMap) in case of DeletedFinalStateUnknown object on deletion event in each controller.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests


**Notes**:
