### PR TITLE
[CNI] Specify CNSClient HTTPClient timeout 

### DIFF
--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -39,7 +39,7 @@ type IPv4ResultInfo struct {
 
 func NewCNSInvoker(podName, namespace string) (*CNSIPAMInvoker, error) {
 	cnsURL := "http://localhost:" + strconv.Itoa(cnsPort)
-	cnsClient, err := cnsclient.InitCnsClient(cnsURL)
+	cnsClient, err := cnsclient.InitCnsClient(cnsURL, defaultRequestTimeout)
 
 	return &CNSIPAMInvoker{
 		podName:      podName,

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -36,8 +36,9 @@ const (
 	dockerNetworkOption = "com.docker.network.generic"
 	opModeTransparent   = "transparent"
 	// Supported IP version. Currently support only IPv4
-	ipVersion = "4"
-	ipamV6    = "azure-vnet-ipamv6"
+	ipVersion             = "4"
+	ipamV6                = "azure-vnet-ipamv6"
+	defaultRequestTimeout = 5 * time.Second
 )
 
 // CNI Operation Types
@@ -395,7 +396,7 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) error {
 
 	if nwCfg.MultiTenancy {
 		// Initialize CNSClient
-		cnsclient.InitCnsClient(nwCfg.CNSUrl)
+		cnsclient.InitCnsClient(nwCfg.CNSUrl, defaultRequestTimeout)
 	}
 
 	for _, ns := range nwCfg.PodNamespaceForDualNetwork {
@@ -743,7 +744,7 @@ func (plugin *netPlugin) Get(args *cniSkel.CmdArgs) error {
 
 	if nwCfg.MultiTenancy {
 		// Initialize CNSClient
-		cnsclient.InitCnsClient(nwCfg.CNSUrl)
+		cnsclient.InitCnsClient(nwCfg.CNSUrl, defaultRequestTimeout)
 	}
 
 	// Initialize values from network config.
@@ -853,7 +854,7 @@ func (plugin *netPlugin) Delete(args *cniSkel.CmdArgs) error {
 
 	if nwCfg.MultiTenancy {
 		// Initialize CNSClient
-		cnsclient.InitCnsClient(nwCfg.CNSUrl)
+		cnsclient.InitCnsClient(nwCfg.CNSUrl, defaultRequestTimeout)
 	}
 
 	switch nwCfg.Ipam.Type {
@@ -1054,7 +1055,7 @@ func (plugin *netPlugin) Update(args *cniSkel.CmdArgs) error {
 
 	// now query CNS to get the target routes that should be there in the networknamespace (as a result of update)
 	log.Printf("Going to collect target routes for [name=%v, namespace=%v] from CNS.", k8sPodName, k8sNamespace)
-	if cnsClient, err = cnsclient.InitCnsClient(nwCfg.CNSUrl); err != nil {
+	if cnsClient, err = cnsclient.InitCnsClient(nwCfg.CNSUrl, defaultRequestTimeout); err != nil {
 		log.Printf("Initializing CNS client error in CNI Update%v", err)
 		log.Printf(err.Error())
 		return plugin.Errorf(err.Error())

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -38,7 +38,7 @@ const (
 	// Supported IP version. Currently support only IPv4
 	ipVersion             = "4"
 	ipamV6                = "azure-vnet-ipamv6"
-	defaultRequestTimeout = 5 * time.Second
+	defaultRequestTimeout = 15 * time.Second
 )
 
 // CNI Operation Types

--- a/cns/cnsclient/cli.go
+++ b/cns/cnsclient/cli.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/restserver"
@@ -46,7 +47,7 @@ func HandleCNSClientCommands(cmd, arg string) error {
 	cnsIPAddress := os.Getenv(envCNSIPAddress)
 	cnsPort := os.Getenv(envCNSPort)
 
-	cnsClient, err := InitCnsClient("http://" + cnsIPAddress + ":" + cnsPort)
+	cnsClient, err := InitCnsClient("http://"+cnsIPAddress+":"+cnsPort, 5*time.Second)
 	if err != nil {
 		return err
 	}

--- a/cns/cnsclient/cnsclient_test.go
+++ b/cns/cnsclient/cnsclient_test.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
+	"time"
 
 	nnc "github.com/Azure/azure-container-networking/nodenetworkconfig/api/v1alpha"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -215,7 +216,7 @@ func TestCNSClientRequestAndRelease(t *testing.T) {
 
 	secondaryIps := make([]string, 0)
 	secondaryIps = append(secondaryIps, desiredIpAddress)
-	cnsClient, _ := InitCnsClient("")
+	cnsClient, _ := InitCnsClient("", 2*time.Second)
 
 	addTestStateToRestServer(t, secondaryIps)
 
@@ -289,7 +290,7 @@ func TestCNSClientPodContextApi(t *testing.T) {
 	desiredIpAddress := "10.0.0.5"
 
 	secondaryIps := []string{desiredIpAddress}
-	cnsClient, _ := InitCnsClient("")
+	cnsClient, _ := InitCnsClient("", 2*time.Second)
 
 	addTestStateToRestServer(t, secondaryIps)
 
@@ -329,7 +330,7 @@ func TestCNSClientDebugAPI(t *testing.T) {
 	desiredIpAddress := "10.0.0.5"
 
 	secondaryIps := []string{desiredIpAddress}
-	cnsClient, _ := InitCnsClient("")
+	cnsClient, _ := InitCnsClient("", 2*time.Second)
 
 	addTestStateToRestServer(t, secondaryIps)
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

No timeout specified in CNI, so when CNS is locked and won't respond, this issue gets propagated down to CNI being locked waiting for a response from CNS.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
