### PR TITLE
[NPM] Filter pod having ipv6

### DIFF
--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -350,7 +350,8 @@ func (ipsMgr *IpsetManager) AddToSet(setName, ip, spec, podKey string) error {
 	}
 
 	// TODO(jungukcho): revisit all error code handling codes in ipsm.go and iptm.go.
-	// For example, in below code, ipsm caches the item even though invalid IPv4 or IPv6 address are inserted in case returned error code is 1.
+	// For example, in below code, ipsm caches the item
+	// even though invalid IPv4 or IPv6 address are inserted if returned error code is 1.
 	// Further it causes controllers to process the rest of operations.
 	// May use error handler code in npm/util/errors/errors.go when revisiting error handling codes.
 	if errCode, err := ipsMgr.Run(entry); err != nil && errCode != 1 {

--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -349,7 +349,10 @@ func (ipsMgr *IpsetManager) AddToSet(setName, ip, spec, podKey string) error {
 		spec:          resultSpec,
 	}
 
-	// todo: check err handling besides error code, corrupt state possible here
+	// TODO(jungukcho): revisit all error code handling codes in ipsm.go and iptm.go.
+	// For example, in below code, ipsm caches the item even though invalid IPv4 or IPv6 address are inserted in case returned error code is 1.
+	// Further it causes controllers to process the rest of operations.
+	// May use error handler code in npm/util/errors/errors.go when revisiting error handling codes.
 	if errCode, err := ipsMgr.Run(entry); err != nil && errCode != 1 {
 		metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to create ipset rules. %+v", entry)
 		return err

--- a/npm/podController.go
+++ b/npm/podController.go
@@ -604,7 +604,6 @@ func isCompletePod(podObj *corev1.Pod) bool {
 // hasValidPodIP returns true when pod has a valid IPv4 form since currently NPM does not support IPv6.
 // (TODO): will need to update this function when NPM wants to support IPV6 and dual stack configuration in K8s
 func hasValidPodIP(podObj *corev1.Pod) bool {
-
 	// First filter IPv6 address. It also filters IPv4-mapped IPv6 ("::ffff:192.0.2.1") form, but not sure this form can happen in k8s
 	if strings.Contains(podObj.Status.PodIP, ":") {
 		utilruntime.HandleError(fmt.Errorf("IPv6 %s may be assigned to Pod, but NPM does not support IPv6 yet", podObj.Status.PodIP))
@@ -613,11 +612,7 @@ func hasValidPodIP(podObj *corev1.Pod) bool {
 
 	// Check a correct IPv4 form.
 	ip := net.ParseIP(podObj.Status.PodIP)
-	if ip == nil {
-		return false
-	}
-
-	return true
+	return ip != nil
 }
 
 func isHostNetworkPod(podObj *corev1.Pod) bool {

--- a/npm/podController.go
+++ b/npm/podController.go
@@ -602,12 +602,12 @@ func isCompletePod(podObj *corev1.Pod) bool {
 }
 
 // hasValidPodIP returns true when pod has a valid IPv4 form since currently NPM does not support IPv6.
-// (TODO): will need to update this function when NPM wants to support IPv4 with dual stack configuration in K8s
+// (TODO): will need to update this function when NPM wants to support IPV6 and dual stack configuration in K8s
 func hasValidPodIP(podObj *corev1.Pod) bool {
 
 	// First filter IPv6 address. It also filters IPv4-mapped IPv6 ("::ffff:192.0.2.1") form, but not sure this form can happen in k8s
 	if strings.Contains(podObj.Status.PodIP, ":") {
-		utilruntime.HandleError(fmt.Errorf("IPv6 %s may be assigned to Pod. NPM does not support IPv6 yet", podObj.Status.PodIP))
+		utilruntime.HandleError(fmt.Errorf("IPv6 %s may be assigned to Pod, but NPM does not support IPv6 yet", podObj.Status.PodIP))
 		return false
 	}
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
This PR is to filter a pod in pod event handler functions when the pod has ipv6 address since NPM does not support ipv6 yet.
In addition, it also checks a valid ipv4 address format of the pod.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation (in NPM/IPTables and IPSet error handling dir in acndoc)
- [x] adds unit tests

**Notes**:
We need to revisit error code handling in ipsm.go and iptm.go.
One example is that ipsm caches the item even though invalid IPv4 or IPv6 address are inserted (returned error code is 1).
Further it causes controllers to process the rest of operations.
While this PR filters invalid IPv4 and IPv6 address in early stage to avoid the situation, we need to revisit all codes thoroughly.
We may need to use this code #840 