### PR TITLE
[NPM] fix incorrect NsMap local cache management between nameSpaceController and PodController

### DIFF
--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -256,6 +256,9 @@ func (ipsMgr *IpsetManager) CreateSet(setName string, spec []string) error {
 		spec: spec,
 	}
 	log.Logf("Creating Set: %+v", entry)
+	// (TODO): need to differentiate errCode handler
+	// since errCode can be one in case of "set with the same name already exists" and "maximal number of sets reached, cannot create more."
+	// It may have more situations with errCode==1.
 	if errCode, err := ipsMgr.Run(entry); err != nil && errCode != 1 {
 		metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to create ipset.")
 		return err

--- a/npm/nameSpaceController.go
+++ b/npm/nameSpaceController.go
@@ -41,6 +41,7 @@ type Namespace struct {
 }
 
 // newNS constructs a new namespace object.
+// (TODO): need to change newNS function. It always returns "nil"
 func newNs(name string) (*Namespace, error) {
 	ns := &Namespace{
 		name:      name,

--- a/npm/podController.go
+++ b/npm/podController.go
@@ -384,18 +384,9 @@ func (c *podController) syncAddedPod(podObj *corev1.Pod) error {
 	ipsMgr := c.npMgr.NsMap[util.KubeAllNamespacesFlag].IpsMgr
 	klog.Infof("POD CREATING: [%s%s/%s/%s%+v%s]", string(podObj.GetUID()), podNs, podObj.Name, podObj.Spec.NodeName, podObj.Labels, podObj.Status.PodIP)
 
-	// Add pod namespace if it doesn't exist
 	var err error
-	if _, exists := c.npMgr.NsMap[podNs]; !exists {
-		// (TODO): need to change newNS function. It always returns "nil"
-		c.npMgr.NsMap[podNs], _ = newNs(podNs)
-		klog.Infof("Creating set: %v, hashedSet: %v", podNs, util.GetHashedName(podNs))
-		if err = ipsMgr.CreateSet(podNs, append([]string{util.IpsetNetHashFlag})); err != nil {
-			return fmt.Errorf("[syncAddedPod] Error: creating ipset %s with err: %v", podNs, err)
-		}
-	}
-
 	npmPodObj := newNpmPod(podObj)
+
 	// Add the pod to its namespace's ipset.
 	klog.Infof("Adding pod %s to ipset %s", npmPodObj.PodIP, podNs)
 	if err = ipsMgr.AddToSet(podNs, npmPodObj.PodIP, util.IpsetNetHashFlag, podKey); err != nil {
@@ -433,24 +424,21 @@ func (c *podController) syncAddedPod(podObj *corev1.Pod) error {
 
 // syncAddAndUpdatePod handles updating pod ip in its label's ipset.
 func (c *podController) syncAddAndUpdatePod(newPodObj *corev1.Pod) error {
-	podKey, _ := cache.MetaNamespaceKeyFunc(newPodObj)
-
-	klog.Infof("[syncAddAndUpdatePod] updating Pod with key %s", podKey)
-	newPodObjNs := util.GetNSNameWithPrefix(newPodObj.ObjectMeta.Namespace)
+	var err error
 	ipsMgr := c.npMgr.NsMap[util.KubeAllNamespacesFlag].IpsMgr
 
-	// Add pod namespace if it doesn't exist
-	var err error
+	// Create ipset related to namespace which this pod belong to if they do not exist.
+	// Make the shared NsMap structure read-only in podController
+	newPodObjNs := util.GetNSNameWithPrefix(newPodObj.Namespace)
 	if _, exists := c.npMgr.NsMap[newPodObjNs]; !exists {
-		// (TODO): need to change newNS function. It always returns "nil"
-		c.npMgr.NsMap[newPodObjNs], _ = newNs(newPodObjNs)
-		klog.Infof("Creating set: %v, hashedSet: %v", newPodObjNs, util.GetHashedName(newPodObjNs))
 		if err = ipsMgr.CreateSet(newPodObjNs, []string{util.IpsetNetHashFlag}); err != nil {
-			return fmt.Errorf("[syncAddAndUpdatePod] Error: creating ipset %s with err: %v", newPodObjNs, err)
+			return fmt.Errorf("[syncAddAndUpdatePod] Error: failed to create ipset for namespace %s with err: %v", newPodObjNs, err)
 		}
 	}
 
+	podKey, _ := cache.MetaNamespaceKeyFunc(newPodObj)
 	cachedNpmPodObj, exists := c.npMgr.PodMap[podKey]
+	klog.Infof("[syncAddAndUpdatePod] updating Pod with key %s", podKey)
 	// No cached npmPod exists. start adding the pod in a cache
 	if !exists {
 		if err = c.syncAddedPod(newPodObj); err != nil {
@@ -469,7 +457,7 @@ func (c *podController) syncAddAndUpdatePod(newPodObj *corev1.Pod) error {
 	// then, re-add new pod obj.
 	if cachedNpmPodObj.PodIP != newPodObj.Status.PodIP {
 		metrics.SendErrorLogAndMetric(util.PodID, "[syncAddAndUpdatePod] Info: Unexpected state. Pod (Namespace:%s, Name:%s, newUid:%s) , has cachedPodIp:%s which is different from PodIp:%s",
-			newPodObjNs, newPodObj.Name, string(newPodObj.UID), cachedNpmPodObj.PodIP, newPodObj.Status.PodIP)
+			newPodObj.Namespace, newPodObj.Name, string(newPodObj.UID), cachedNpmPodObj.PodIP, newPodObj.Status.PodIP)
 
 		klog.Infof("Deleting cached Pod with key:%s first due to IP Mistmatch", podKey)
 		if err = c.cleanUpDeletedPod(podKey); err != nil {

--- a/npm/podController.go
+++ b/npm/podController.go
@@ -427,7 +427,7 @@ func (c *podController) syncAddAndUpdatePod(newPodObj *corev1.Pod) error {
 	var err error
 	ipsMgr := c.npMgr.NsMap[util.KubeAllNamespacesFlag].IpsMgr
 
-	// Create ipset related to namespace which this pod belong to if they do not exist.
+	// Create ipset related to namespace which this pod belong to if it does not exist.
 	// Make the shared NsMap structure read-only in podController
 	newPodObjNs := util.GetNSNameWithPrefix(newPodObj.Namespace)
 	if _, exists := c.npMgr.NsMap[newPodObjNs]; !exists {


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

The shared NsMap local cache is incorrectly managed between nameSpaceController and PodController. So, if the podController first reconciles the event and adds the npm-namespace object into NsMap, nameSpaceController missed the chance to call AddToList function since the npm-namespace object exists in our NsMap cache.

In this PR, podController adds the npm-namespace object into NsMap only after successfully completing ipset operations for namespace of the pod if the npm-namespace object does not exist in NsMap cache.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
#865

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
