### PR TITLE
Fix to bubble up the error and restart in case it fails to create CRD…

### DIFF
--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -504,7 +504,11 @@ func main() {
 	if config.ChannelMode == cns.CRD {
 		requestControllerStopChannel := make(chan struct{})
 		defer close(requestControllerStopChannel)
-		IniitalizeCRDState(httpRestService, cnsconfig, requestControllerStopChannel)
+		err = IniitalizeCRDState(httpRestService, cnsconfig, requestControllerStopChannel)
+		if err != nil {
+			logger.Errorf("Failed to start CRD Controller, err:%v.\n", err)
+			return
+		}
 	}
 
 	logger.Printf("[Azure CNS] Start HTTP listener")
@@ -667,7 +671,7 @@ func main() {
 }
 
 // initializeCRD state
-func IniitalizeCRDState(httpRestService cns.HTTPService, cnsconfig configuration.CNSConfig, exitChan <-chan struct{}) {
+func IniitalizeCRDState(httpRestService cns.HTTPService, cnsconfig configuration.CNSConfig, exitChan <-chan struct{}) error {
 	var requestController requestcontroller.RequestController
 
 	logger.Printf("[Azure CNS] Starting request controller")
@@ -675,14 +679,14 @@ func IniitalizeCRDState(httpRestService cns.HTTPService, cnsconfig configuration
 	kubeConfig, err := kubecontroller.GetKubeConfig()
 	if err != nil {
 		logger.Errorf("[Azure CNS] Failed to get kubeconfig for request controller: %v", err)
-		return
+		return err
 	}
 
 	//convert interface type to implementation type
 	httpRestServiceImplementation, ok := httpRestService.(*restserver.HTTPRestService)
 	if !ok {
 		logger.Errorf("[Azure CNS] Failed to convert interface httpRestService to implementation: %v", httpRestService)
-		return
+		return err
 	}
 
 	// Set orchestrator type
@@ -695,7 +699,7 @@ func IniitalizeCRDState(httpRestService cns.HTTPService, cnsconfig configuration
 	requestController, err = kubecontroller.NewCrdRequestController(httpRestServiceImplementation, kubeConfig)
 	if err != nil {
 		logger.Errorf("[Azure CNS] Failed to make crd request controller :%v", err)
-		return
+		return err
 	}
 
     // initialize the ipam pool monitor
@@ -704,7 +708,7 @@ func IniitalizeCRDState(httpRestService cns.HTTPService, cnsconfig configuration
 	err = requestController.InitRequestController()
 	if err != nil {
 		logger.Errorf("[Azure CNS] Failed to initialized cns state :%v", err)
-		return
+		return err
 	}
 
 	//Start the RequestController which starts the reconcile loop
@@ -737,11 +741,18 @@ func IniitalizeCRDState(httpRestService cns.HTTPService, cnsconfig configuration
 	ctx := context.Background()
 	logger.Printf("Starting IPAM Pool Monitor")
 	go func() {
-		if err := httpRestServiceImplementation.IPAMPoolMonitor.Start(ctx, poolIPAMRefreshRateInMilliseconds); err != nil {
-			logger.Errorf("[Azure CNS] Failed to start pool monitor with err: %v", err)
-		}
+		for {
+			if err := httpRestServiceImplementation.IPAMPoolMonitor.Start(ctx, poolIPAMRefreshRateInMilliseconds); err != nil {
+				logger.Errorf("[Azure CNS] Failed to start pool monitor with err: %v", err)
+				// todo: add a CNS metric to count # of failures
+			} else {
+				logger.Printf("[Azure CNS] Exiting IPAM Pool Monitor")
+				return
+			}
 
-		logger.Printf("[Azure CNS] Exiting IPAM Pool Monitor")
+			// Retry after 1sec
+			time.Sleep(time.Second)
+		}
 	}()
 
 	logger.Printf("Starting SyncHostNCVersion")
@@ -755,4 +766,6 @@ func IniitalizeCRDState(httpRestService cns.HTTPService, cnsconfig configuration
 
 		logger.Printf("[Azure CNS] Exiting SyncHostNCVersion")
 	}()
+
+	return nil
 }

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -686,7 +686,8 @@ func IniitalizeCRDState(httpRestService cns.HTTPService, cnsconfig configuration
 	httpRestServiceImplementation, ok := httpRestService.(*restserver.HTTPRestService)
 	if !ok {
 		logger.Errorf("[Azure CNS] Failed to convert interface httpRestService to implementation: %v", httpRestService)
-		return err
+		return  fmt.Errorf("[Azure CNS] Failed to convert interface httpRestService to implementation: %v",
+			httpRestService)
 	}
 
 	// Set orchestrator type


### PR DESCRIPTION
Crash Azure-CNS in case it fails to start the CRD Request Controller. 

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
