### PR TITLE
feat: Modify IPT to support AKS-SWIFT Multi-Vnet Mode

### DIFF
--- a/cni/netconfig.go
+++ b/cni/netconfig.go
@@ -72,6 +72,12 @@ type NetworkConfig struct {
 		Address       string `json:"ipAddress,omitempty"`
 		QueryInterval string `json:"queryInterval,omitempty"`
 	} `json:"ipam,omitempty"`
+	// NonOverlappingMultitenancyMode :- populated when ExecutionMode is NonOverlappingMultitenancyMode
+	NonOverlappingMultitenancyMode struct {
+		ConnectivityType    string `json:"connectivityType,omitempty"`
+		EnablePodToNodeSnat bool   `json:"enablePodToNodeSnat,omitempty"`
+		EnableNodeToPodSnat bool   `json:"enableNodeToPodSnat,omitempty"`
+	} `json:"nonOverlappingMultitenancyMode,omitempty"`
 	DNS            cniTypes.DNS  `json:"dns,omitempty"`
 	RuntimeConfig  RuntimeConfig `json:"runtimeConfig,omitempty"`
 	AdditionalArgs []KVPair      `json:"AdditionalArgs,omitempty"`

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -67,8 +67,15 @@ const (
 type ExecutionMode string
 
 const (
-	Default   ExecutionMode = "default"
-	Baremetal ExecutionMode = "baremetal"
+	Default                    ExecutionMode = "default"
+	Baremetal                  ExecutionMode = "baremetal"
+	NonOverlappingMultitenancy ExecutionMode = "nonOverlappingMultitenancy"
+)
+
+type ConnectivityType string
+
+const (
+	Snat ConnectivityType = "snat"
 )
 
 // NetPlugin represents the CNI network plugin.


### PR DESCRIPTION
**Reason for Change**:
Initial changes for AKS-SWIFT multi-vnet mode

We'll add the iptables entry below when running in NonOverlappingMultitenancy mode via SNAT:

    if EnablePodToNodeSnat
    + iptables -t nat -A SWIFT -s [pod subnet] -j MASQUERADE
    + iptables -t nat  -I POSTROUTING -s [pod subnet]  -d [pod subnet] -m iprange ! --dst-range 168.63.129.16-168.63.129.16 -j ACCEPT

    if EnableNodeToPodSnat
    + iptables -t nat -A SWIFT -s [host subnet] -d [pod subnet] -j SNAT --to [NC primary IP]


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**: 
pending other paths e.g. peering vs snat