### PR TITLE
[NPM] Fix recent unit test failures from each controller

### DIFF
--- a/npm/nameSpaceController_test.go
+++ b/npm/nameSpaceController_test.go
@@ -70,7 +70,8 @@ func (f *nameSpaceFixture) newNsController(stopCh chan struct{}) {
 	for _, ns := range f.nsLister {
 		f.kubeInformer.Core().V1().Namespaces().Informer().GetIndexer().Add(ns)
 	}
-	// Do not start informer to avoid unnecessary event triggers
+	// Do not start informer to avoid unnecessary event triggers.
+	// (TODO) Leave stopCh and below commented code to enhance UTs to even check event triggers as well later if possible
 	//f.kubeInformer.Start()
 }
 

--- a/npm/networkPolicyController_test.go
+++ b/npm/networkPolicyController_test.go
@@ -79,6 +79,7 @@ func (f *netPolFixture) newNetPolController(stopCh chan struct{}) {
 	}
 
 	// Do not start informer to avoid unnecessary event triggers
+	// (TODO): Leave stopCh and below commented code to enhance UTs to even check event triggers as well later if possible
 	//f.kubeInformer.Start(stopCh)
 }
 

--- a/npm/podController_test.go
+++ b/npm/podController_test.go
@@ -68,6 +68,7 @@ func (f *podFixture) newPodController(stopCh chan struct{}) {
 	}
 
 	// Do not start informer to avoid unnecessary event triggers
+	// (TODO): Leave stopCh and below commented code to enhance UTs to even check event triggers as well later if possible
 	//f.kubeInformer.Start(stopCh)
 }
 


### PR DESCRIPTION

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

This PR is to fix unit test failures in each controller. The root cause for the issues is that extra events are called even though controller's unit test does not call them. So, the result of unit tests are different from expected values.  Since we activate all capabilities of sharedInformer, extra events are called based on sharedinformer's local cache.
Especially this issue comes up recently since a new extension for controller's unit tests by using fake exec seems to take longer than real exec. Thus, there is enough time for sharedInformer to call multiple events.
To make deterministic unit test for each controller, unit tests almost only leverage sharedInformer's local cache.



**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
