### PR TITLE
[NPM] Make each controller independent

### DIFF
--- a/npm/http/server/server.go
+++ b/npm/http/server/server.go
@@ -65,7 +65,7 @@ func NewNpmRestServer(listeningAddress string) *NPMRestServer {
 
 func (n *NPMRestServer) GetNpmMgr(npMgr *npm.NetworkPolicyManager) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// (Question?) What information does it need from npMgr?
+		// QUESTION(jungukcho) What information does it need from npMgr?
 		// Is this function required to hold lock for npMgr?
 		// npMgr.Lock()
 		err := json.NewEncoder(w).Encode(npMgr)

--- a/npm/http/server/server.go
+++ b/npm/http/server/server.go
@@ -65,8 +65,8 @@ func NewNpmRestServer(listeningAddress string) *NPMRestServer {
 
 func (n *NPMRestServer) GetNpmMgr(npMgr *npm.NetworkPolicyManager) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// (Question?) What information does it need from npMgr? Do we need lock?
-		// It looks that this lock is not required
+		// (Question?) What information does it need from npMgr?
+		// Is this function required to hold lock for npMgr?
 		// npMgr.Lock()
 		err := json.NewEncoder(w).Encode(npMgr)
 		if err != nil {

--- a/npm/http/server/server.go
+++ b/npm/http/server/server.go
@@ -65,12 +65,14 @@ func NewNpmRestServer(listeningAddress string) *NPMRestServer {
 
 func (n *NPMRestServer) GetNpmMgr(npMgr *npm.NetworkPolicyManager) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		npMgr.Lock()
+		// (Question?) What information does it need from npMgr? Do we need lock?
+		// It looks that this lock is not required
+		// npMgr.Lock()
 		err := json.NewEncoder(w).Encode(npMgr)
 		if err != nil {
 			http.Error(w, err.Error(), 500)
 			return
 		}
-		npMgr.Unlock()
+		// npMgr.Unlock()
 	})
 }

--- a/npm/http/server/server_test.go
+++ b/npm/http/server/server_test.go
@@ -14,13 +14,7 @@ import (
 
 func TestGetNpmMgrHandler(t *testing.T) {
 	assert := assert.New(t)
-	npMgr := &npm.NetworkPolicyManager{
-		PodMap: map[string]*npm.NpmPod{
-			"": &npm.NpmPod{
-				Name: "testpod",
-			},
-		},
-	}
+	npMgr := &npm.NetworkPolicyManager{}
 	n := NewNpmRestServer("")
 	handler := n.GetNpmMgr(npMgr)
 

--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -21,9 +21,13 @@ import (
 /*
 TODO:
 1. Clarify error codes after running ipset commands and need to use it in a very accurate way
-2. Try to decouple ListMap and SetMap if possible. At least use different locks for ListMap and SetMa
+2. Try to decouple listMap and setMap if possible. At least use different locks for listMap and SetMa
 3. Clean up codes (i.e., just use different functions for "Nethash" and "List" type of IPSet to maintain code better).
 This will also helps to reduce the scope of locks
+4. There are three types of IPSet
+	IpsetSetListFlag    string = "setlist"
+	IpsetNetHashFlag    string = "nethash"
+	IpsetIPPortHashFlag string = "hash:ip,port"
 */
 type ipsEntry struct {
 	operationFlag string
@@ -35,8 +39,8 @@ type ipsEntry struct {
 // IpsetManager stores ipset states.
 type IpsetManager struct {
 	exec    utilexec.Interface
-	ListMap map[string]*ipset //tracks all set lists.
-	SetMap  map[string]*ipset //label -> []ip
+	listMap map[string]*ipset //tracks all set lists.
+	setMap  map[string]*ipset //label -> []ip
 	sync.Mutex
 }
 
@@ -59,16 +63,16 @@ func newIpset(setName string) *ipset {
 func NewIpsetManager(exec utilexec.Interface) *IpsetManager {
 	return &IpsetManager{
 		exec:    exec,
-		ListMap: make(map[string]*ipset),
-		SetMap:  make(map[string]*ipset),
+		listMap: make(map[string]*ipset),
+		setMap:  make(map[string]*ipset),
 	}
 }
 
 // Exists checks if an element exists in setMap/listMap.
 func (ipsMgr *IpsetManager) exists(listName string, setName string, kind string) bool {
-	m := ipsMgr.SetMap
+	m := ipsMgr.setMap
 	if kind == util.IpsetSetListFlag {
-		m = ipsMgr.ListMap
+		m = ipsMgr.listMap
 	}
 
 	if _, exists := m[listName]; !exists {
@@ -84,12 +88,12 @@ func (ipsMgr *IpsetManager) exists(listName string, setName string, kind string)
 
 // SetExists checks if an ipset exists, and returns the type
 func (ipsMgr *IpsetManager) setExists(setName string) (bool, string) {
-	_, exists := ipsMgr.SetMap[setName]
+	_, exists := ipsMgr.setMap[setName]
 	if exists {
 		return exists, util.IpsetSetGenericFlag
 	}
 
-	_, exists = ipsMgr.ListMap[setName]
+	_, exists = ipsMgr.listMap[setName]
 	if exists {
 		return exists, util.IpsetSetListFlag
 	}
@@ -118,7 +122,7 @@ func (ipsMgr *IpsetManager) deleteList(listName string) error {
 		return err
 	}
 
-	delete(ipsMgr.ListMap, listName)
+	delete(ipsMgr.listMap, listName)
 	return nil
 }
 
@@ -148,7 +152,7 @@ func (ipsMgr *IpsetManager) run(entry *ipsEntry) (int, error) {
 
 // to avoid trying to hold lock multiple times (e.g., AddToList called CreateList)
 func (ipsMgr *IpsetManager) createList(listName string) error {
-	if _, exists := ipsMgr.ListMap[listName]; exists {
+	if _, exists := ipsMgr.listMap[listName]; exists {
 		return nil
 	}
 
@@ -164,7 +168,7 @@ func (ipsMgr *IpsetManager) createList(listName string) error {
 		return err
 	}
 
-	ipsMgr.ListMap[listName] = newIpset(listName)
+	ipsMgr.listMap[listName] = newIpset(listName)
 	return nil
 }
 
@@ -192,7 +196,7 @@ func (ipsMgr *IpsetManager) destroy() error {
 func (ipsMgr *IpsetManager) createSet(setName string, spec []string) error {
 	timer := metrics.StartNewTimer()
 
-	if _, exists := ipsMgr.SetMap[setName]; exists {
+	if _, exists := ipsMgr.setMap[setName]; exists {
 		return nil
 	}
 
@@ -212,7 +216,7 @@ func (ipsMgr *IpsetManager) createSet(setName string, spec []string) error {
 		return err
 	}
 
-	ipsMgr.SetMap[setName] = newIpset(setName)
+	ipsMgr.setMap[setName] = newIpset(setName)
 
 	metrics.NumIPSets.Inc()
 	timer.StopAndRecord(metrics.AddIPSetExecTime)
@@ -222,7 +226,7 @@ func (ipsMgr *IpsetManager) createSet(setName string, spec []string) error {
 }
 
 func (ipsMgr *IpsetManager) deleteSet(setName string) error {
-	if _, exists := ipsMgr.SetMap[setName]; !exists {
+	if _, exists := ipsMgr.setMap[setName]; !exists {
 		metrics.SendErrorLogAndMetric(util.IpsmID, "ipset with name %s not found", setName)
 		return nil
 	}
@@ -241,7 +245,7 @@ func (ipsMgr *IpsetManager) deleteSet(setName string) error {
 		return err
 	}
 
-	delete(ipsMgr.SetMap, setName)
+	delete(ipsMgr.setMap, setName)
 
 	metrics.NumIPSets.Dec()
 	metrics.NumIPSetEntries.Add(float64(-metrics.GetIPSetInventory(setName)))
@@ -252,7 +256,6 @@ func (ipsMgr *IpsetManager) deleteSet(setName string) error {
 
 // CreateList creates an ipset list. npm maintains one setlist per namespace label.
 func (ipsMgr *IpsetManager) CreateList(listName string) error {
-	// (TODO): Need more fine-grained lock management after understanding how it used from each controller
 	ipsMgr.Lock()
 	defer ipsMgr.Unlock()
 	return ipsMgr.createList(listName)
@@ -260,7 +263,6 @@ func (ipsMgr *IpsetManager) CreateList(listName string) error {
 
 // AddToList inserts an ipset to an ipset list.
 func (ipsMgr *IpsetManager) AddToList(listName string, setName string) error {
-	// (TODO): Need more fine-grained lock management after understanding how it used from each controller
 	ipsMgr.Lock()
 	defer ipsMgr.Unlock()
 
@@ -268,7 +270,7 @@ func (ipsMgr *IpsetManager) AddToList(listName string, setName string) error {
 		return nil
 	}
 
-	//Check if list being added exists in the listmap, if it exists we don't care about the set type
+	//Check if list being added exists in the listMap, if it exists we don't care about the set type
 	exists, _ := ipsMgr.setExists(setName)
 
 	// if set does not exist, then return because the ipset call will fail due to set not existing
@@ -305,18 +307,17 @@ func (ipsMgr *IpsetManager) AddToList(listName string, setName string) error {
 		return fmt.Errorf("Error: failed to create ipset rules. rule: %+v, error: %v", entry, err)
 	}
 
-	ipsMgr.ListMap[listName].elements[setName] = ""
+	ipsMgr.listMap[listName].elements[setName] = ""
 
 	return nil
 }
 
 // DeleteFromList removes an ipset to an ipset list.
 func (ipsMgr *IpsetManager) DeleteFromList(listName string, setName string) error {
-	// (TODO): Need more fine-grained lock management after understanding how it used from each controller
 	ipsMgr.Lock()
 	defer ipsMgr.Unlock()
 
-	//Check if list being added exists in the listmap, if it exists we don't care about the set type
+	//Check if list being added exists in the listMap, if it exists we don't care about the set type
 	exists, _ := ipsMgr.setExists(setName)
 
 	// if set does not exist, then return because the ipset call will fail due to set not existing
@@ -326,7 +327,7 @@ func (ipsMgr *IpsetManager) DeleteFromList(listName string, setName string) erro
 		return nil
 	}
 
-	//Check if list being added exists in the listmap, if it exists we don't care about the set type
+	//Check if list being added exists in the listMap, if it exists we don't care about the set type
 	exists, listtype := ipsMgr.setExists(listName)
 
 	// if set does not exist, then return because the ipset call will fail due to set not existing
@@ -340,7 +341,7 @@ func (ipsMgr *IpsetManager) DeleteFromList(listName string, setName string) erro
 		return nil
 	}
 
-	if _, exists := ipsMgr.ListMap[listName]; !exists {
+	if _, exists := ipsMgr.listMap[listName]; !exists {
 		metrics.SendErrorLogAndMetric(util.IpsmID, "ipset list with name %s not found", listName)
 		return nil
 	}
@@ -358,11 +359,11 @@ func (ipsMgr *IpsetManager) DeleteFromList(listName string, setName string) erro
 	}
 
 	// Now cleanup the cache
-	if _, exists := ipsMgr.ListMap[listName].elements[setName]; exists {
-		delete(ipsMgr.ListMap[listName].elements, setName)
+	if _, exists := ipsMgr.listMap[listName].elements[setName]; exists {
+		delete(ipsMgr.listMap[listName].elements, setName)
 	}
 
-	if len(ipsMgr.ListMap[listName].elements) == 0 {
+	if len(ipsMgr.listMap[listName].elements) == 0 {
 		if err := ipsMgr.deleteList(listName); err != nil {
 			metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to delete ipset list %s.", listName)
 			return err
@@ -374,7 +375,6 @@ func (ipsMgr *IpsetManager) DeleteFromList(listName string, setName string) erro
 
 // CreateSet creates an ipset.
 func (ipsMgr *IpsetManager) CreateSet(setName string, spec []string) error {
-	// (TODO): Need more fine-grained lock management after understanding how it used from each controller
 	ipsMgr.Lock()
 	defer ipsMgr.Unlock()
 	return ipsMgr.createSet(setName, spec)
@@ -382,7 +382,6 @@ func (ipsMgr *IpsetManager) CreateSet(setName string, spec []string) error {
 
 // DeleteSet removes a set from ipset.
 func (ipsMgr *IpsetManager) DeleteSet(setName string) error {
-	// (TODO): Need more fine-grained lock management after understanding how it used from each controller
 	ipsMgr.Lock()
 	defer ipsMgr.Unlock()
 	return ipsMgr.deleteSet(setName)
@@ -390,18 +389,17 @@ func (ipsMgr *IpsetManager) DeleteSet(setName string) error {
 
 // AddToSet inserts an ip to an entry in setMap, and creates/updates the corresponding ipset.
 func (ipsMgr *IpsetManager) AddToSet(setName, ip, spec, podKey string) error {
-	// (TODO): Need more fine-grained lock management after understanding how it used from each controller
 	ipsMgr.Lock()
 	defer ipsMgr.Unlock()
 
 	if ipsMgr.exists(setName, ip, spec) {
 		// make sure we have updated the podKey in case it gets changed
-		cachedPodKey := ipsMgr.SetMap[setName].elements[ip]
+		cachedPodKey := ipsMgr.setMap[setName].elements[ip]
 		if cachedPodKey != podKey {
 			log.Logf("AddToSet: PodOwner has changed for Ip: %s, setName:%s, Old podKey: %s, new podKey: %s. Replace context with new PodOwner.",
 				ip, setName, cachedPodKey, podKey)
 
-			ipsMgr.SetMap[setName].elements[ip] = podKey
+			ipsMgr.setMap[setName].elements[ip] = podKey
 		}
 
 		return nil
@@ -447,7 +445,7 @@ func (ipsMgr *IpsetManager) AddToSet(setName, ip, spec, podKey string) error {
 	}
 
 	// Stores the podKey as the context for this ip.
-	ipsMgr.SetMap[setName].elements[ip] = podKey
+	ipsMgr.setMap[setName].elements[ip] = podKey
 
 	metrics.NumIPSetEntries.Inc()
 	metrics.IncIPSetInventory(setName)
@@ -457,11 +455,10 @@ func (ipsMgr *IpsetManager) AddToSet(setName, ip, spec, podKey string) error {
 
 // DeleteFromSet removes an ip from an entry in setMap, and delete/update the corresponding ipset.
 func (ipsMgr *IpsetManager) DeleteFromSet(setName, ip, podKey string) error {
-	// (TODO): Need more fine-grained lock management after understanding how it used from each controller
 	ipsMgr.Lock()
 	defer ipsMgr.Unlock()
 
-	ipSet, exists := ipsMgr.SetMap[setName]
+	ipSet, exists := ipsMgr.setMap[setName]
 	if !exists {
 		log.Logf("ipset with name %s not found", setName)
 		return nil
@@ -477,7 +474,7 @@ func (ipsMgr *IpsetManager) DeleteFromSet(setName, ip, podKey string) error {
 		return fmt.Errorf("Failed to add IP to set [%s], the ip to be added was empty", setName)
 	}
 
-	if _, exists := ipsMgr.SetMap[setName].elements[ip]; exists {
+	if _, exists := ipsMgr.setMap[setName].elements[ip]; exists {
 		// in case the IP belongs to a new Pod, then ignore this Delete call as this might be stale
 		cachedPodKey := ipSet.elements[ip]
 		if cachedPodKey != podKey {
@@ -505,12 +502,12 @@ func (ipsMgr *IpsetManager) DeleteFromSet(setName, ip, podKey string) error {
 	}
 
 	// Now cleanup the cache
-	delete(ipsMgr.SetMap[setName].elements, ip)
+	delete(ipsMgr.setMap[setName].elements, ip)
 
 	metrics.NumIPSetEntries.Dec()
 	metrics.DecIPSetInventory(setName)
 
-	if len(ipsMgr.SetMap[setName].elements) == 0 {
+	if len(ipsMgr.setMap[setName].elements) == 0 {
 		ipsMgr.deleteSet(setName)
 	}
 
@@ -519,7 +516,6 @@ func (ipsMgr *IpsetManager) DeleteFromSet(setName, ip, podKey string) error {
 
 // DestroyNpmIpsets destroys only ipsets created by NPM
 func (ipsMgr *IpsetManager) DestroyNpmIpsets() error {
-	// (TODO): Need more fine-grained lock management after understanding how it used from each controller
 	ipsMgr.Lock()
 	defer ipsMgr.Unlock()
 
@@ -588,8 +584,6 @@ func (ipsMgr *IpsetManager) DestroyNpmIpsets() error {
 	return nil
 }
 
-// only used in UT
-// (TODO): may not need this function since npm will used exec-based UT
 // Save saves ipset to file.
 func (ipsMgr *IpsetManager) Save(configFile string) error {
 	if len(configFile) == 0 {
@@ -607,8 +601,6 @@ func (ipsMgr *IpsetManager) Save(configFile string) error {
 	return nil
 }
 
-// only used in UT
-// (TODO): may not need this function since npm will used exec-based UT
 // Restore restores ipset from file.
 func (ipsMgr *IpsetManager) Restore(configFile string) error {
 	if len(configFile) == 0 {
@@ -641,10 +633,9 @@ func (ipsMgr *IpsetManager) Restore(configFile string) error {
 // not used in any other codes
 // Clean removes all the empty sets & lists under the namespace.
 func (ipsMgr *IpsetManager) Clean() error {
-	// (TODO): Need more fine-grained lock management after understanding how it used from each controller
 	ipsMgr.Lock()
 	defer ipsMgr.Unlock()
-	for setName, set := range ipsMgr.SetMap {
+	for setName, set := range ipsMgr.setMap {
 		if len(set.elements) > 0 {
 			continue
 		}
@@ -655,7 +646,7 @@ func (ipsMgr *IpsetManager) Clean() error {
 		}
 	}
 
-	for listName, list := range ipsMgr.ListMap {
+	for listName, list := range ipsMgr.listMap {
 		if len(list.elements) > 0 {
 			continue
 		}

--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+	"sync"
 	"syscall"
 
 	"github.com/Azure/azure-container-networking/log"
@@ -27,20 +28,23 @@ type ipsEntry struct {
 // IpsetManager stores ipset states.
 type IpsetManager struct {
 	exec    utilexec.Interface
-	ListMap map[string]*Ipset //tracks all set lists.
-	SetMap  map[string]*Ipset //label -> []ip
+	ListMap map[string]*ipset //tracks all set lists.
+	SetMap  map[string]*ipset //label -> []ip
+	// (TODO): Further optimization:
+	// Will have two locks for ListMap and SetMap
+	sync.Mutex
 }
 
 // Ipset represents one ipset entry.
-type Ipset struct {
+type ipset struct {
 	name       string
 	elements   map[string]string // key = ip, value: context associated to the ip like podKey
 	referCount int
 }
 
 // NewIpset creates a new instance for Ipset object.
-func NewIpset(setName string) *Ipset {
-	return &Ipset{
+func newIpset(setName string) *ipset {
+	return &ipset{
 		name:     setName,
 		elements: make(map[string]string),
 	}
@@ -50,13 +54,13 @@ func NewIpset(setName string) *Ipset {
 func NewIpsetManager(exec utilexec.Interface) *IpsetManager {
 	return &IpsetManager{
 		exec:    exec,
-		ListMap: make(map[string]*Ipset),
-		SetMap:  make(map[string]*Ipset),
+		ListMap: make(map[string]*ipset),
+		SetMap:  make(map[string]*ipset),
 	}
 }
 
 // Exists checks if an element exists in setMap/listMap.
-func (ipsMgr *IpsetManager) Exists(listName string, setName string, kind string) bool {
+func (ipsMgr *IpsetManager) exists(listName string, setName string, kind string) bool {
 	m := ipsMgr.SetMap
 	if kind == util.IpsetSetListFlag {
 		m = ipsMgr.ListMap
@@ -74,7 +78,7 @@ func (ipsMgr *IpsetManager) Exists(listName string, setName string, kind string)
 }
 
 // SetExists checks if an ipset exists, and returns the type
-func (ipsMgr *IpsetManager) SetExists(setName string) (bool, string) {
+func (ipsMgr *IpsetManager) setExists(setName string) (bool, string) {
 	_, exists := ipsMgr.SetMap[setName]
 	if exists {
 		return exists, util.IpsetSetGenericFlag
@@ -88,12 +92,57 @@ func (ipsMgr *IpsetManager) SetExists(setName string) (bool, string) {
 	return exists, ""
 }
 
+// (TODO): delete. not used in any other places
 func isNsSet(setName string) bool {
 	return !strings.Contains(setName, "-") && !strings.Contains(setName, ":")
 }
 
-// CreateList creates an ipset list. npm maintains one setlist per namespace label.
-func (ipsMgr *IpsetManager) CreateList(listName string) error {
+// DeleteList removes an ipset list.
+func (ipsMgr *IpsetManager) deleteList(listName string) error {
+	entry := &ipsEntry{
+		operationFlag: util.IpsetDestroyFlag,
+		set:           util.GetHashedName(listName),
+	}
+
+	if errCode, err := ipsMgr.run(entry); err != nil {
+		if errCode == 1 {
+			return nil
+		}
+
+		metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to delete ipset %s %+v", listName, entry)
+		return err
+	}
+
+	delete(ipsMgr.ListMap, listName)
+	return nil
+}
+
+// Run execute an ipset command to update ipset.
+func (ipsMgr *IpsetManager) run(entry *ipsEntry) (int, error) {
+	cmdName := util.Ipset
+	cmdArgs := append([]string{entry.operationFlag, util.IpsetExistFlag, entry.set}, entry.spec...)
+	cmdArgs = util.DropEmptyFields(cmdArgs)
+
+	log.Logf("Executing ipset command %s %v", cmdName, cmdArgs)
+
+	cmd := ipsMgr.exec.Command(cmdName, cmdArgs...)
+	output, err := cmd.CombinedOutput()
+
+	if result, isExitError := err.(utilexec.ExitError); isExitError {
+		exitCode := result.ExitStatus()
+		errfmt := fmt.Errorf("Error: There was an error running command: [%s %v] Stderr: [%v, %s]", cmdName, strings.Join(cmdArgs, " "), err, strings.TrimSuffix(string(output), "\n"))
+		if exitCode > 0 {
+			metrics.SendErrorLogAndMetric(util.IpsmID, errfmt.Error())
+		}
+
+		return exitCode, errfmt
+	}
+
+	return 0, nil
+}
+
+// to avoid trying to hold lock multiple times (e.g., AddToList called CreateList)
+func (ipsMgr *IpsetManager) createList(listName string) error {
 	if _, exists := ipsMgr.ListMap[listName]; exists {
 		return nil
 	}
@@ -105,45 +154,117 @@ func (ipsMgr *IpsetManager) CreateList(listName string) error {
 		spec:          []string{util.IpsetSetListFlag},
 	}
 	log.Logf("Creating List: %+v", entry)
-	if errCode, err := ipsMgr.Run(entry); err != nil && errCode != 1 {
+	if errCode, err := ipsMgr.run(entry); err != nil && errCode != 1 {
 		metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to create ipset list %s.", listName)
 		return err
 	}
 
-	ipsMgr.ListMap[listName] = NewIpset(listName)
+	ipsMgr.ListMap[listName] = newIpset(listName)
+	return nil
+}
+
+// Destroy completely cleans ipset.
+func (ipsMgr *IpsetManager) destroy() error {
+	entry := &ipsEntry{
+		operationFlag: util.IpsetFlushFlag,
+	}
+	if _, err := ipsMgr.run(entry); err != nil {
+		metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to flush ipset")
+		return err
+	}
+
+	entry.operationFlag = util.IpsetDestroyFlag
+	if _, err := ipsMgr.run(entry); err != nil {
+		metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to destroy ipset")
+		return err
+	}
+
+	//TODO set IPSetInventory to 0 for all set names
+	return nil
+}
+
+// CreateSet creates an ipset.
+func (ipsMgr *IpsetManager) createSet(setName string, spec []string) error {
+	timer := metrics.StartNewTimer()
+
+	if _, exists := ipsMgr.SetMap[setName]; exists {
+		return nil
+	}
+
+	entry := &ipsEntry{
+		name:          setName,
+		operationFlag: util.IpsetCreationFlag,
+		// Use hashed string for set name to avoid string length limit of ipset.
+		set:  util.GetHashedName(setName),
+		spec: spec,
+	}
+	log.Logf("Creating Set: %+v", entry)
+	// (TODO): need to differentiate errCode handler
+	// since errCode can be one in case of "set with the same name already exists" and "maximal number of sets reached, cannot create more."
+	// It may have more situations with errCode==1.
+	if errCode, err := ipsMgr.run(entry); err != nil && errCode != 1 {
+		metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to create ipset.")
+		return err
+	}
+
+	ipsMgr.SetMap[setName] = newIpset(setName)
+
+	metrics.NumIPSets.Inc()
+	timer.StopAndRecord(metrics.AddIPSetExecTime)
+	metrics.SetIPSetInventory(setName, 0)
 
 	return nil
 }
 
-// DeleteList removes an ipset list.
-func (ipsMgr *IpsetManager) DeleteList(listName string) error {
-	entry := &ipsEntry{
-		operationFlag: util.IpsetDestroyFlag,
-		set:           util.GetHashedName(listName),
+func (ipsMgr *IpsetManager) deleteSet(setName string) error {
+	if _, exists := ipsMgr.SetMap[setName]; !exists {
+		metrics.SendErrorLogAndMetric(util.IpsmID, "ipset with name %s not found", setName)
+		return nil
 	}
 
-	if errCode, err := ipsMgr.Run(entry); err != nil {
+	entry := &ipsEntry{
+		operationFlag: util.IpsetDestroyFlag,
+		set:           util.GetHashedName(setName),
+	}
+
+	if errCode, err := ipsMgr.run(entry); err != nil {
 		if errCode == 1 {
 			return nil
 		}
 
-		metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to delete ipset %s %+v", listName, entry)
+		metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to delete ipset %s. Entry: %+v", setName, entry)
 		return err
 	}
 
-	delete(ipsMgr.ListMap, listName)
+	delete(ipsMgr.SetMap, setName)
+
+	metrics.NumIPSets.Dec()
+	metrics.NumIPSetEntries.Add(float64(-metrics.GetIPSetInventory(setName)))
+	metrics.SetIPSetInventory(setName, 0)
 
 	return nil
 }
 
+// CreateList creates an ipset list. npm maintains one setlist per namespace label.
+func (ipsMgr *IpsetManager) CreateList(listName string) error {
+	// (TODO): Need more fine-grained lock management after understanding how it used from each controller
+	ipsMgr.Lock()
+	defer ipsMgr.Unlock()
+	return ipsMgr.createList(listName)
+}
+
 // AddToList inserts an ipset to an ipset list.
 func (ipsMgr *IpsetManager) AddToList(listName string, setName string) error {
+	// (TODO): Need more fine-grained lock management after understanding how it used from each controller
+	ipsMgr.Lock()
+	defer ipsMgr.Unlock()
+
 	if listName == setName {
 		return nil
 	}
 
 	//Check if list being added exists in the listmap, if it exists we don't care about the set type
-	exists, _ := ipsMgr.SetExists(setName)
+	exists, _ := ipsMgr.setExists(setName)
 
 	// if set does not exist, then return because the ipset call will fail due to set not existing
 	if !exists {
@@ -151,20 +272,20 @@ func (ipsMgr *IpsetManager) AddToList(listName string, setName string) error {
 	}
 
 	// Check if the list that is being added to exists
-	exists, listtype := ipsMgr.SetExists(listName)
+	exists, listtype := ipsMgr.setExists(listName)
 
 	// Make sure that set returned is of list type, otherwise return because we can't add a set to a non setlist type
 	if exists && listtype != util.IpsetSetListFlag {
 		return fmt.Errorf("Failed to add set [%s] to list [%s], but list is of type [%s]", setName, listName, listtype)
 	} else if !exists {
 		// if the list doesn't exist, create it
-		if err := ipsMgr.CreateList(listName); err != nil {
+		if err := ipsMgr.createList(listName); err != nil {
 			return err
 		}
 	}
 
 	// check if set already exists in the list
-	if ipsMgr.Exists(listName, setName, util.IpsetSetListFlag) {
+	if ipsMgr.exists(listName, setName, util.IpsetSetListFlag) {
 		return nil
 	}
 
@@ -175,7 +296,7 @@ func (ipsMgr *IpsetManager) AddToList(listName string, setName string) error {
 	}
 
 	// add set to list
-	if errCode, err := ipsMgr.Run(entry); err != nil && errCode != 1 {
+	if errCode, err := ipsMgr.run(entry); err != nil && errCode != 1 {
 		return fmt.Errorf("Error: failed to create ipset rules. rule: %+v, error: %v", entry, err)
 	}
 
@@ -186,9 +307,12 @@ func (ipsMgr *IpsetManager) AddToList(listName string, setName string) error {
 
 // DeleteFromList removes an ipset to an ipset list.
 func (ipsMgr *IpsetManager) DeleteFromList(listName string, setName string) error {
+	// (TODO): Need more fine-grained lock management after understanding how it used from each controller
+	ipsMgr.Lock()
+	defer ipsMgr.Unlock()
 
 	//Check if list being added exists in the listmap, if it exists we don't care about the set type
-	exists, _ := ipsMgr.SetExists(setName)
+	exists, _ := ipsMgr.setExists(setName)
 
 	// if set does not exist, then return because the ipset call will fail due to set not existing
 	// TODO make sure these are info and not errors, use NPmErr
@@ -198,7 +322,7 @@ func (ipsMgr *IpsetManager) DeleteFromList(listName string, setName string) erro
 	}
 
 	//Check if list being added exists in the listmap, if it exists we don't care about the set type
-	exists, listtype := ipsMgr.SetExists(listName)
+	exists, listtype := ipsMgr.setExists(listName)
 
 	// if set does not exist, then return because the ipset call will fail due to set not existing
 	if !exists {
@@ -223,7 +347,7 @@ func (ipsMgr *IpsetManager) DeleteFromList(listName string, setName string) erro
 		spec:          []string{hashedSetName},
 	}
 
-	if _, err := ipsMgr.Run(entry); err != nil {
+	if _, err := ipsMgr.run(entry); err != nil {
 		metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to delete ipset entry. %+v", entry)
 		return err
 	}
@@ -234,7 +358,7 @@ func (ipsMgr *IpsetManager) DeleteFromList(listName string, setName string) erro
 	}
 
 	if len(ipsMgr.ListMap[listName].elements) == 0 {
-		if err := ipsMgr.DeleteList(listName); err != nil {
+		if err := ipsMgr.deleteList(listName); err != nil {
 			metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to delete ipset list %s.", listName)
 			return err
 		}
@@ -245,71 +369,27 @@ func (ipsMgr *IpsetManager) DeleteFromList(listName string, setName string) erro
 
 // CreateSet creates an ipset.
 func (ipsMgr *IpsetManager) CreateSet(setName string, spec []string) error {
-	timer := metrics.StartNewTimer()
-
-	if _, exists := ipsMgr.SetMap[setName]; exists {
-		return nil
-	}
-
-	entry := &ipsEntry{
-		name:          setName,
-		operationFlag: util.IpsetCreationFlag,
-		// Use hashed string for set name to avoid string length limit of ipset.
-		set:  util.GetHashedName(setName),
-		spec: spec,
-	}
-	log.Logf("Creating Set: %+v", entry)
-	// (TODO): need to differentiate errCode handler
-	// since errCode can be one in case of "set with the same name already exists" and "maximal number of sets reached, cannot create more."
-	// It may have more situations with errCode==1.
-	if errCode, err := ipsMgr.Run(entry); err != nil && errCode != 1 {
-		metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to create ipset.")
-		return err
-	}
-
-	ipsMgr.SetMap[setName] = NewIpset(setName)
-
-	metrics.NumIPSets.Inc()
-	timer.StopAndRecord(metrics.AddIPSetExecTime)
-	metrics.SetIPSetInventory(setName, 0)
-
-	return nil
+	// (TODO): Need more fine-grained lock management after understanding how it used from each controller
+	ipsMgr.Lock()
+	defer ipsMgr.Unlock()
+	return ipsMgr.createSet(setName, spec)
 }
 
 // DeleteSet removes a set from ipset.
 func (ipsMgr *IpsetManager) DeleteSet(setName string) error {
-	if _, exists := ipsMgr.SetMap[setName]; !exists {
-		metrics.SendErrorLogAndMetric(util.IpsmID, "ipset with name %s not found", setName)
-		return nil
-	}
-
-	entry := &ipsEntry{
-		operationFlag: util.IpsetDestroyFlag,
-		set:           util.GetHashedName(setName),
-	}
-
-	if errCode, err := ipsMgr.Run(entry); err != nil {
-		if errCode == 1 {
-			return nil
-		}
-
-		metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to delete ipset %s. Entry: %+v", setName, entry)
-		return err
-	}
-
-	delete(ipsMgr.SetMap, setName)
-
-	metrics.NumIPSets.Dec()
-	metrics.NumIPSetEntries.Add(float64(-metrics.GetIPSetInventory(setName)))
-	metrics.SetIPSetInventory(setName, 0)
-
-	return nil
+	// (TODO): Need more fine-grained lock management after understanding how it used from each controller
+	ipsMgr.Lock()
+	defer ipsMgr.Unlock()
+	return ipsMgr.deleteSet(setName)
 }
 
 // AddToSet inserts an ip to an entry in setMap, and creates/updates the corresponding ipset.
 func (ipsMgr *IpsetManager) AddToSet(setName, ip, spec, podKey string) error {
-	if ipsMgr.Exists(setName, ip, spec) {
+	// (TODO): Need more fine-grained lock management after understanding how it used from each controller
+	ipsMgr.Lock()
+	defer ipsMgr.Unlock()
 
+	if ipsMgr.exists(setName, ip, spec) {
 		// make sure we have updated the podKey in case it gets changed
 		cachedPodKey := ipsMgr.SetMap[setName].elements[ip]
 		if cachedPodKey != podKey {
@@ -333,10 +413,10 @@ func (ipsMgr *IpsetManager) AddToSet(setName, ip, spec, podKey string) error {
 	}
 
 	// check if the set exists, ignore the type of the set being added if it exists since the only purpose is to see if it's created or not
-	exists, _ := ipsMgr.SetExists(setName)
+	exists, _ := ipsMgr.setExists(setName)
 
 	if !exists {
-		if err := ipsMgr.CreateSet(setName, append([]string{spec})); err != nil {
+		if err := ipsMgr.createSet(setName, append([]string{spec})); err != nil {
 			return err
 		}
 	}
@@ -356,7 +436,7 @@ func (ipsMgr *IpsetManager) AddToSet(setName, ip, spec, podKey string) error {
 	}
 
 	// todo: check err handling besides error code, corrupt state possible here
-	if errCode, err := ipsMgr.Run(entry); err != nil && errCode != 1 {
+	if errCode, err := ipsMgr.run(entry); err != nil && errCode != 1 {
 		metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to create ipset rules. %+v", entry)
 		return err
 	}
@@ -372,6 +452,10 @@ func (ipsMgr *IpsetManager) AddToSet(setName, ip, spec, podKey string) error {
 
 // DeleteFromSet removes an ip from an entry in setMap, and delete/update the corresponding ipset.
 func (ipsMgr *IpsetManager) DeleteFromSet(setName, ip, podKey string) error {
+	// (TODO): Need more fine-grained lock management after understanding how it used from each controller
+	ipsMgr.Lock()
+	defer ipsMgr.Unlock()
+
 	ipSet, exists := ipsMgr.SetMap[setName]
 	if !exists {
 		log.Logf("ipset with name %s not found", setName)
@@ -406,7 +490,7 @@ func (ipsMgr *IpsetManager) DeleteFromSet(setName, ip, podKey string) error {
 		spec:          append([]string{ip}),
 	}
 
-	if errCode, err := ipsMgr.Run(entry); err != nil {
+	if errCode, err := ipsMgr.run(entry); err != nil {
 		if errCode == 1 {
 			return nil
 		}
@@ -422,137 +506,22 @@ func (ipsMgr *IpsetManager) DeleteFromSet(setName, ip, podKey string) error {
 	metrics.DecIPSetInventory(setName)
 
 	if len(ipsMgr.SetMap[setName].elements) == 0 {
-		ipsMgr.DeleteSet(setName)
+		ipsMgr.deleteSet(setName)
 	}
-
-	return nil
-}
-
-// Clean removes all the empty sets & lists under the namespace.
-func (ipsMgr *IpsetManager) Clean() error {
-	for setName, set := range ipsMgr.SetMap {
-		if len(set.elements) > 0 {
-			continue
-		}
-
-		if err := ipsMgr.DeleteSet(setName); err != nil {
-			metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to clean ipset")
-			return err
-		}
-	}
-
-	for listName, list := range ipsMgr.ListMap {
-		if len(list.elements) > 0 {
-			continue
-		}
-
-		if err := ipsMgr.DeleteList(listName); err != nil {
-			metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to clean ipset list")
-			return err
-		}
-	}
-
-	return nil
-}
-
-// Destroy completely cleans ipset.
-func (ipsMgr *IpsetManager) Destroy() error {
-	entry := &ipsEntry{
-		operationFlag: util.IpsetFlushFlag,
-	}
-	if _, err := ipsMgr.Run(entry); err != nil {
-		metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to flush ipset")
-		return err
-	}
-
-	entry.operationFlag = util.IpsetDestroyFlag
-	if _, err := ipsMgr.Run(entry); err != nil {
-		metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to destroy ipset")
-		return err
-	}
-
-	//TODO set IPSetInventory to 0 for all set names
-
-	return nil
-}
-
-// Run execute an ipset command to update ipset.
-func (ipsMgr *IpsetManager) Run(entry *ipsEntry) (int, error) {
-	cmdName := util.Ipset
-	cmdArgs := append([]string{entry.operationFlag, util.IpsetExistFlag, entry.set}, entry.spec...)
-	cmdArgs = util.DropEmptyFields(cmdArgs)
-
-	log.Logf("Executing ipset command %s %v", cmdName, cmdArgs)
-
-	cmd := ipsMgr.exec.Command(cmdName, cmdArgs...)
-	output, err := cmd.CombinedOutput()
-
-	if result, isExitError := err.(utilexec.ExitError); isExitError {
-		exitCode := result.ExitStatus()
-		errfmt := fmt.Errorf("Error: There was an error running command: [%s %v] Stderr: [%v, %s]", cmdName, strings.Join(cmdArgs, " "), err, strings.TrimSuffix(string(output), "\n"))
-		if exitCode > 0 {
-			metrics.SendErrorLogAndMetric(util.IpsmID, errfmt.Error())
-		}
-
-		return exitCode, errfmt
-	}
-
-	return 0, nil
-}
-
-// Save saves ipset to file.
-func (ipsMgr *IpsetManager) Save(configFile string) error {
-	if len(configFile) == 0 {
-		configFile = util.IpsetConfigFile
-	}
-
-	cmd := ipsMgr.exec.Command(util.Ipset, util.IpsetSaveFlag, util.IpsetFileFlag, configFile)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to save ipset: [%s] Stderr: [%v, %s]", cmd, err, strings.TrimSuffix(string(output), "\n"))
-		return err
-	}
-	cmd.Wait()
-
-	return nil
-}
-
-// Restore restores ipset from file.
-func (ipsMgr *IpsetManager) Restore(configFile string) error {
-	if len(configFile) == 0 {
-		configFile = util.IpsetConfigFile
-	}
-
-	f, err := os.Stat(configFile)
-	if err != nil {
-		metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to get file %s stat from ipsm.Restore", configFile)
-		return err
-	}
-
-	if f.Size() == 0 {
-		if err := ipsMgr.Destroy(); err != nil {
-			return err
-		}
-	}
-
-	cmd := ipsMgr.exec.Command(util.Ipset, util.IpsetRestoreFlag, util.IpsetFileFlag, configFile)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to to restore ipset from file: [%s] Stderr: [%v, %s]", cmd, err, strings.TrimSuffix(string(output), "\n"))
-		return err
-	}
-
-	//TODO based on the set name and number of entries in the config file, update IPSetInventory
 
 	return nil
 }
 
 // DestroyNpmIpsets destroys only ipsets created by NPM
 func (ipsMgr *IpsetManager) DestroyNpmIpsets() error {
+	// (TODO): Need more fine-grained lock management after understanding how it used from each controller
+	ipsMgr.Lock()
+	defer ipsMgr.Unlock()
+
 	cmdName := util.Ipset
 	cmdArgs := util.IPsetCheckListFlag
 
-	reply, err := ipsMgr.exec.Command(cmdName, cmdArgs).CombinedOutput()
+	reply, err := exec.Command(cmdName, cmdArgs).Output()
 	if msg, failed := err.(*exec.ExitError); failed {
 		errCode := msg.Sys().(syscall.WaitStatus).ExitStatus()
 		if errCode > 0 {
@@ -598,7 +567,7 @@ func (ipsMgr *IpsetManager) DestroyNpmIpsets() error {
 			set:           ipsetName,
 		}
 
-		if _, err := ipsMgr.Run(entry); err != nil {
+		if _, err := ipsMgr.run(entry); err != nil {
 			metrics.SendErrorLogAndMetric(util.IpsmID, "{DestroyNpmIpsets} Error: failed to flush ipset %s", ipsetName)
 		}
 	}
@@ -606,8 +575,89 @@ func (ipsMgr *IpsetManager) DestroyNpmIpsets() error {
 	for _, ipsetName := range ipsetLists {
 		entry.operationFlag = util.IpsetDestroyFlag
 		entry.set = ipsetName
-		if _, err := ipsMgr.Run(entry); err != nil {
+		if _, err := ipsMgr.run(entry); err != nil {
 			metrics.SendErrorLogAndMetric(util.IpsmID, "{DestroyNpmIpsets} Error: failed to destroy ipset %s", ipsetName)
+		}
+	}
+
+	return nil
+}
+
+// only used in UT
+// (TODO): may not need this function since npm will used exec-based UT
+// Save saves ipset to file.
+func (ipsMgr *IpsetManager) Save(configFile string) error {
+	if len(configFile) == 0 {
+		configFile = util.IpsetConfigFile
+	}
+
+	cmd := ipsMgr.exec.Command(util.Ipset, util.IpsetSaveFlag, util.IpsetFileFlag, configFile)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to save ipset: [%s] Stderr: [%v, %s]", cmd, err, strings.TrimSuffix(string(output), "\n"))
+		return err
+	}
+	cmd.Wait()
+
+	return nil
+}
+
+// only used in UT
+// (TODO): may not need this function since npm will used exec-based UT
+// Restore restores ipset from file.
+func (ipsMgr *IpsetManager) Restore(configFile string) error {
+	if len(configFile) == 0 {
+		configFile = util.IpsetConfigFile
+	}
+
+	f, err := os.Stat(configFile)
+	if err != nil {
+		metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to get file %s stat from ipsm.Restore", configFile)
+		return err
+	}
+
+	if f.Size() == 0 {
+		if err := ipsMgr.destroy(); err != nil {
+			return err
+		}
+	}
+
+	cmd := ipsMgr.exec.Command(util.Ipset, util.IpsetRestoreFlag, util.IpsetFileFlag, configFile)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to to restore ipset from file: [%s] Stderr: [%v, %s]", cmd, err, strings.TrimSuffix(string(output), "\n"))
+		return err
+	}
+
+	//TODO based on the set name and number of entries in the config file, update IPSetInventory
+	return nil
+}
+
+// not used in any other codes
+// Clean removes all the empty sets & lists under the namespace.
+func (ipsMgr *IpsetManager) Clean() error {
+	// (TODO): Need more fine-grained lock management after understanding how it used from each controller
+	ipsMgr.Lock()
+	defer ipsMgr.Unlock()
+	for setName, set := range ipsMgr.SetMap {
+		if len(set.elements) > 0 {
+			continue
+		}
+
+		if err := ipsMgr.deleteSet(setName); err != nil {
+			metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to clean ipset")
+			return err
+		}
+	}
+
+	for listName, list := range ipsMgr.ListMap {
+		if len(list.elements) > 0 {
+			continue
+		}
+
+		if err := ipsMgr.deleteList(listName); err != nil {
+			metrics.SendErrorLogAndMetric(util.IpsmID, "Error: failed to clean ipset list")
+			return err
 		}
 	}
 

--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -101,7 +101,6 @@ func (ipsMgr *IpsetManager) setExists(setName string) (bool, string) {
 	return exists, ""
 }
 
-// (TODO): delete. not used in any other places
 func isNsSet(setName string) bool {
 	return !strings.Contains(setName, "-") && !strings.Contains(setName, ":")
 }
@@ -150,7 +149,6 @@ func (ipsMgr *IpsetManager) run(entry *ipsEntry) (int, error) {
 	return 0, nil
 }
 
-// to avoid trying to hold lock multiple times (e.g., AddToList called CreateList)
 func (ipsMgr *IpsetManager) createList(listName string) error {
 	if _, exists := ipsMgr.listMap[listName]; exists {
 		return nil
@@ -208,6 +206,7 @@ func (ipsMgr *IpsetManager) createSet(setName string, spec []string) error {
 		spec: spec,
 	}
 	log.Logf("Creating Set: %+v", entry)
+
 	// (TODO): need to differentiate errCode handler
 	// since errCode can be one in case of "set with the same name already exists" and "maximal number of sets reached, cannot create more."
 	// It may have more situations with errCode==1.

--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -18,6 +18,13 @@ import (
 	utilexec "k8s.io/utils/exec"
 )
 
+/*
+TODO:
+1. Clarify error codes after running ipset commands and need to use it in a very accurate way
+2. Try to decouple ListMap and SetMap if possible. At least use different locks for ListMap and SetMa
+3. Clean up codes (i.e., just use different functions for "Nethash" and "List" type of IPSet to maintain code better).
+This will also helps to reduce the scope of locks
+*/
 type ipsEntry struct {
 	operationFlag string
 	name          string
@@ -30,8 +37,6 @@ type IpsetManager struct {
 	exec    utilexec.Interface
 	ListMap map[string]*ipset //tracks all set lists.
 	SetMap  map[string]*ipset //label -> []ip
-	// (TODO): Further optimization:
-	// Will have two locks for ListMap and SetMap
 	sync.Mutex
 }
 

--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -18,17 +18,6 @@ import (
 	utilexec "k8s.io/utils/exec"
 )
 
-/*
-TODO:
-1. Clarify error codes after running ipset commands and need to use it in a very accurate way
-2. Try to decouple listMap and setMap if possible. At least use different locks for listMap and SetMa
-3. Clean up codes (i.e., just use different functions for "Nethash" and "List" type of IPSet to maintain code better).
-This will also helps to reduce the scope of locks
-4. There are three types of IPSet
-	IpsetSetListFlag    string = "setlist"
-	IpsetNetHashFlag    string = "nethash"
-	IpsetIPPortHashFlag string = "hash:ip,port"
-*/
 type ipsEntry struct {
 	operationFlag string
 	name          string
@@ -515,6 +504,8 @@ func (ipsMgr *IpsetManager) DeleteFromSet(setName, ip, podKey string) error {
 
 // DestroyNpmIpsets destroys only ipsets created by NPM
 func (ipsMgr *IpsetManager) DestroyNpmIpsets() error {
+	log.Logf("Azure-NPM creating, cleaning existing Azure NPM IPSets")
+
 	ipsMgr.Lock()
 	defer ipsMgr.Unlock()
 
@@ -629,7 +620,6 @@ func (ipsMgr *IpsetManager) Restore(configFile string) error {
 	return nil
 }
 
-// not used in any other codes
 // Clean removes all the empty sets & lists under the namespace.
 func (ipsMgr *IpsetManager) Clean() error {
 	ipsMgr.Lock()

--- a/npm/ipsm/ipsm_test.go
+++ b/npm/ipsm/ipsm_test.go
@@ -362,7 +362,7 @@ func TestAddToSetWithCachePodInfo(t *testing.T) {
 	}
 
 	// validate if Pod1 exists
-	cachedPodUid := ipsMgr.SetMap[setname].elements[ip]
+	cachedPodUid := ipsMgr.setMap[setname].elements[ip]
 	if cachedPodUid != pod1 {
 		t.Errorf("setname: %s, hashedname: %s is added with wrong podUid: %s, expected: %s", setname, util.GetHashedName(setname), cachedPodUid, pod1)
 	}
@@ -373,7 +373,7 @@ func TestAddToSetWithCachePodInfo(t *testing.T) {
 		t.Errorf("TestAddToSetWithCachePodInfo with pod2 failed @ ipsMgr.AddToSet")
 	}
 
-	cachedPodUid = ipsMgr.SetMap[setname].elements[ip]
+	cachedPodUid = ipsMgr.setMap[setname].elements[ip]
 	if cachedPodUid != pod2 {
 		t.Errorf("setname: %s, hashedname: %s is added with wrong podUid: %s, expected: %s", setname, util.GetHashedName(setname), cachedPodUid, pod2)
 	}
@@ -400,7 +400,7 @@ func TestDeleteFromSet(t *testing.T) {
 		t.Errorf("TestDeleteFromSet failed @ ipsMgr.AddToSet")
 	}
 
-	if len(ipsMgr.SetMap[testSetName].elements) != 1 {
+	if len(ipsMgr.setMap[testSetName].elements) != 1 {
 		t.Errorf("TestDeleteFromSet failed @ ipsMgr.AddToSet")
 	}
 
@@ -409,7 +409,7 @@ func TestDeleteFromSet(t *testing.T) {
 	}
 
 	// After deleting the only entry, "1.2.3.4" from "test-set", "test-set" ipset won't exist
-	if _, exists := ipsMgr.SetMap[testSetName]; exists {
+	if _, exists := ipsMgr.setMap[testSetName]; exists {
 		t.Errorf("TestDeleteFromSet failed @ ipsMgr.DeleteFromSet")
 	}
 
@@ -440,7 +440,7 @@ func TestDeleteFromSetWithPodCache(t *testing.T) {
 		t.Errorf("TestDeleteFromSetWithPodCache failed for pod1 @ ipsMgr.AddToSet with err %+v", err)
 	}
 
-	if len(ipsMgr.SetMap[setname].elements) != 1 {
+	if len(ipsMgr.setMap[setname].elements) != 1 {
 		t.Errorf("TestDeleteFromSetWithPodCache failed @ ipsMgr.AddToSet")
 	}
 
@@ -465,7 +465,7 @@ func TestDeleteFromSetWithPodCache(t *testing.T) {
 	}
 
 	// note the set will stil exist with pod ip
-	cachedPodUid := ipsMgr.SetMap[setname].elements[ip]
+	cachedPodUid := ipsMgr.setMap[setname].elements[ip]
 	if cachedPodUid != pod2 {
 		t.Errorf("setname: %s, hashedname: %s is added with wrong podUid: %s, expected: %s", setname, util.GetHashedName(setname), cachedPodUid, pod2)
 	}
@@ -475,7 +475,7 @@ func TestDeleteFromSetWithPodCache(t *testing.T) {
 		t.Errorf("TestDeleteFromSetWithPodCache for pod2 failed @ ipsMgr.DeleteFromSet with err %+v", err)
 	}
 
-	if _, exists := ipsMgr.SetMap[setname]; exists {
+	if _, exists := ipsMgr.setMap[setname]; exists {
 		t.Errorf("TestDeleteFromSetWithPodCache failed @ ipsMgr.DeleteFromSet")
 	}
 }

--- a/npm/ipsm/ipsm_test.go
+++ b/npm/ipsm/ipsm_test.go
@@ -48,7 +48,7 @@ func TestCreateList(t *testing.T) {
 		}
 	}()
 
-	if err := ipsMgr.CreateList("test-list"); err != nil {
+	if err := ipsMgr.createList("test-list"); err != nil {
 		t.Errorf("TestCreateList failed @ ipsMgr.CreateList")
 	}
 }
@@ -65,11 +65,11 @@ func TestDeleteList(t *testing.T) {
 		}
 	}()
 
-	if err := ipsMgr.CreateList("test-list"); err != nil {
+	if err := ipsMgr.createList("test-list"); err != nil {
 		t.Errorf("TestDeleteList failed @ ipsMgr.CreateList")
 	}
 
-	if err := ipsMgr.DeleteList("test-list"); err != nil {
+	if err := ipsMgr.deleteList("test-list"); err != nil {
 		t.Errorf("TestDeleteList failed @ ipsMgr.DeleteList")
 	}
 }
@@ -86,8 +86,8 @@ func TestAddToList(t *testing.T) {
 		}
 	}()
 
-	if err := ipsMgr.CreateSet("test-set", append([]string{util.IpsetNetHashFlag})); err != nil {
-		t.Errorf("TestAddToList failed @ ipsMgr.CreateSet")
+	if err := ipsMgr.createSet("test-set", append([]string{util.IpsetNetHashFlag})); err != nil {
+		t.Errorf("TestAddToList failed @ ipsMgr.createSet")
 	}
 
 	if err := ipsMgr.AddToList("test-list", "test-set"); err != nil {
@@ -116,8 +116,8 @@ func TestDeleteFromList(t *testing.T) {
 
 	// Create set and validate set is created.
 	setName := "test-set"
-	if err := ipsMgr.CreateSet(setName, append([]string{util.IpsetNetHashFlag})); err != nil {
-		t.Errorf("TestDeleteFromList failed @ ipsMgr.CreateSet")
+	if err := ipsMgr.createSet(setName, append([]string{util.IpsetNetHashFlag})); err != nil {
+		t.Errorf("TestDeleteFromList failed @ ipsMgr.createSet")
 	}
 
 	entry := &ipsEntry{
@@ -125,8 +125,8 @@ func TestDeleteFromList(t *testing.T) {
 		set:           util.GetHashedName(setName),
 	}
 
-	if _, err := ipsMgr.Run(entry); err != nil {
-		t.Errorf("TestDeleteFromList failed @ ipsMgr.CreateSet since %s not exist in kernel", setName)
+	if _, err := ipsMgr.run(entry); err != nil {
+		t.Errorf("TestDeleteFromList failed @ ipsMgr.createSet since %s not exist in kernel", setName)
 	}
 
 	// Create list, add set to list and validate set is in the list.
@@ -141,7 +141,7 @@ func TestDeleteFromList(t *testing.T) {
 		spec:          append([]string{util.GetHashedName(setName)}),
 	}
 
-	if _, err := ipsMgr.Run(entry); err != nil {
+	if _, err := ipsMgr.run(entry); err != nil {
 		t.Errorf("TestDeleteFromList failed @ ipsMgr.AddToList since %s not exist in %s set", listName, setName)
 	}
 
@@ -166,14 +166,14 @@ func TestDeleteFromList(t *testing.T) {
 		spec:          append([]string{util.GetHashedName(setName)}),
 	}
 
-	if _, err := ipsMgr.Run(entry); err == nil {
+	if _, err := ipsMgr.run(entry); err == nil {
 		t.Errorf("TestDeleteFromList failed @ ipsMgr.DeleteFromList since %s still exist in %s set", listName, setName)
 	}
 
 	// Delete List and validate list is not exist.
 
-	if err := ipsMgr.DeleteSet(listName); err != nil {
-		t.Errorf("TestDeleteSet failed @ ipsMgr.DeleteSet")
+	if err := ipsMgr.deleteSet(listName); err != nil {
+		t.Errorf("TestdeleteSet failed @ ipsMgr.deleteSet")
 	}
 
 	entry = &ipsEntry{
@@ -181,13 +181,13 @@ func TestDeleteFromList(t *testing.T) {
 		set:           util.GetHashedName(listName),
 	}
 
-	if _, err := ipsMgr.Run(entry); err == nil {
-		t.Errorf("TestDeleteFromList failed @ ipsMgr.DeleteSet since %s still exist in kernel", listName)
+	if _, err := ipsMgr.run(entry); err == nil {
+		t.Errorf("TestDeleteFromList failed @ ipsMgr.deleteSet since %s still exist in kernel", listName)
 	}
 
 	// Delete set and validate set is not exist.
-	if err := ipsMgr.DeleteSet(setName); err != nil {
-		t.Errorf("TestDeleteSet failed @ ipsMgr.DeleteSet")
+	if err := ipsMgr.deleteSet(setName); err != nil {
+		t.Errorf("TestdeleteSet failed @ ipsMgr.deleteSet")
 	}
 
 	entry = &ipsEntry{
@@ -195,23 +195,23 @@ func TestDeleteFromList(t *testing.T) {
 		set:           util.GetHashedName(setName),
 	}
 
-	if _, err := ipsMgr.Run(entry); err == nil {
-		t.Errorf("TestDeleteFromList failed @ ipsMgr.DeleteSet since %s still exist in kernel", setName)
+	if _, err := ipsMgr.run(entry); err == nil {
+		t.Errorf("TestDeleteFromList failed @ ipsMgr.deleteSet since %s still exist in kernel", setName)
 	}
 
 	testutils.VerifyCallsMatch(t, calls, fexec, fcmd)
 }
 
-func TestCreateSet(t *testing.T) {
+func TestcreateSet(t *testing.T) {
 	metrics.NumIPSetEntries.Set(0)
 	ipsMgr := NewIpsetManager(exec.New())
 	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
-		t.Errorf("TestCreateSet failed @ ipsMgr.Save")
+		t.Errorf("TestcreateSet failed @ ipsMgr.Save")
 	}
 
 	defer func() {
 		if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
-			t.Errorf("TestCreateSet failed @ ipsMgr.Restore")
+			t.Errorf("TestcreateSet failed @ ipsMgr.Restore")
 		}
 	}()
 
@@ -219,23 +219,23 @@ func TestCreateSet(t *testing.T) {
 	countVal, err2 := promutil.GetCountValue(metrics.AddIPSetExecTime)
 
 	testSet1Name := "test-set"
-	if err := ipsMgr.CreateSet(testSet1Name, []string{util.IpsetNetHashFlag}); err != nil {
-		t.Errorf("TestCreateSet failed @ ipsMgr.CreateSet")
+	if err := ipsMgr.createSet(testSet1Name, []string{util.IpsetNetHashFlag}); err != nil {
+		t.Errorf("TestcreateSet failed @ ipsMgr.createSet")
 	}
 
 	testSet2Name := "test-set-with-maxelem"
 	spec := append([]string{util.IpsetNetHashFlag, util.IpsetMaxelemName, util.IpsetMaxelemNum})
-	if err := ipsMgr.CreateSet(testSet2Name, spec); err != nil {
-		t.Errorf("TestCreateSet failed @ ipsMgr.CreateSet when set maxelem")
+	if err := ipsMgr.createSet(testSet2Name, spec); err != nil {
+		t.Errorf("TestcreateSet failed @ ipsMgr.createSet when set maxelem")
 	}
 
 	testSet3Name := "test-set-with-port"
 	spec = append([]string{util.IpsetIPPortHashFlag})
-	if err := ipsMgr.CreateSet(testSet3Name, spec); err != nil {
-		t.Errorf("TestCreateSet failed @ ipsMgr.CreateSet when creating port set")
+	if err := ipsMgr.createSet(testSet3Name, spec); err != nil {
+		t.Errorf("TestcreateSet failed @ ipsMgr.createSet when creating port set")
 	}
 	if err := ipsMgr.AddToSet(testSet3Name, fmt.Sprintf("%s,%s%d", "1.1.1.1", "tcp", 8080), util.IpsetIPPortHashFlag, "0"); err != nil {
-		t.Errorf("AddToSet failed @ ipsMgr.CreateSet when set port")
+		t.Errorf("AddToSet failed @ ipsMgr.createSet when set port")
 	}
 
 	newGaugeVal, err3 := promutil.GetValue(metrics.NumIPSets)
@@ -256,28 +256,28 @@ func TestCreateSet(t *testing.T) {
 	}
 }
 
-func TestDeleteSet(t *testing.T) {
+func TestdeleteSet(t *testing.T) {
 	metrics.NumIPSetEntries.Set(0)
 	ipsMgr := NewIpsetManager(exec.New())
 	if err := ipsMgr.Save(util.IpsetTestConfigFile); err != nil {
-		t.Errorf("TestDeleteSet failed @ ipsMgr.Save")
+		t.Errorf("TestdeleteSet failed @ ipsMgr.Save")
 	}
 
 	defer func() {
 		if err := ipsMgr.Restore(util.IpsetTestConfigFile); err != nil {
-			t.Errorf("TestDeleteSet failed @ ipsMgr.Restore")
+			t.Errorf("TestdeleteSet failed @ ipsMgr.Restore")
 		}
 	}()
 
 	testSetName := "test-delete-set"
-	if err := ipsMgr.CreateSet(testSetName, append([]string{util.IpsetNetHashFlag})); err != nil {
-		t.Errorf("TestDeleteSet failed @ ipsMgr.CreateSet")
+	if err := ipsMgr.createSet(testSetName, append([]string{util.IpsetNetHashFlag})); err != nil {
+		t.Errorf("TestdeleteSet failed @ ipsMgr.createSet")
 	}
 
 	gaugeVal, err1 := promutil.GetValue(metrics.NumIPSets)
 
-	if err := ipsMgr.DeleteSet(testSetName); err != nil {
-		t.Errorf("TestDeleteSet failed @ ipsMgr.DeleteSet")
+	if err := ipsMgr.deleteSet(testSetName); err != nil {
+		t.Errorf("TestdeleteSet failed @ ipsMgr.deleteSet")
 	}
 
 	newGaugeVal, err2 := promutil.GetValue(metrics.NumIPSets)
@@ -433,7 +433,7 @@ func TestDeleteFromSetWithPodCache(t *testing.T) {
 		}
 	}()
 
-	var setname = "test-deleteset-withcache"
+	var setname = "test-deleteSet-withcache"
 	var ip = "10.0.2.8"
 	var pod1 = "pod1"
 	if err := ipsMgr.AddToSet(setname, ip, util.IpsetNetHashFlag, pod1); err != nil {
@@ -492,8 +492,8 @@ func TestClean(t *testing.T) {
 		}
 	}()
 
-	if err := ipsMgr.CreateSet("test-set", append([]string{util.IpsetNetHashFlag})); err != nil {
-		t.Errorf("TestClean failed @ ipsMgr.CreateSet with err %+v", err)
+	if err := ipsMgr.createSet("test-set", append([]string{util.IpsetNetHashFlag})); err != nil {
+		t.Errorf("TestClean failed @ ipsMgr.createSet with err %+v", err)
 	}
 
 	if err := ipsMgr.Clean(); err != nil {
@@ -520,14 +520,14 @@ func TestDestroy(t *testing.T) {
 	}
 
 	// Call Destroy and validate. Destroy can only work when no ipset is referenced from iptables.
-	if err := ipsMgr.Destroy(); err == nil {
+	if err := ipsMgr.destroy(); err == nil {
 		// Validate ipset is not exist when destroy can happen.
 		entry := &ipsEntry{
 			operationFlag: util.IPsetCheckListFlag,
 			set:           util.GetHashedName(setName),
 		}
 
-		if _, err := ipsMgr.Run(entry); err == nil {
+		if _, err := ipsMgr.run(entry); err == nil {
 			t.Errorf("TestDestroy failed @ ipsMgr.Destroy since %s still exist in kernel with err %+v", setName, err)
 		}
 	} else {
@@ -538,7 +538,7 @@ func TestDestroy(t *testing.T) {
 			spec:          append([]string{testIP}),
 		}
 
-		if _, err := ipsMgr.Run(entry); err == nil {
+		if _, err := ipsMgr.run(entry); err == nil {
 			t.Errorf("TestDestroy failed @ ipsMgr.Destroy since %s still exist in ipset with err %+v", testIP, err)
 		}
 	}
@@ -561,7 +561,7 @@ func TestRun(t *testing.T) {
 		set:           "test-set",
 		spec:          append([]string{util.IpsetNetHashFlag}),
 	}
-	if _, err := ipsMgr.Run(entry); err != nil {
+	if _, err := ipsMgr.run(entry); err != nil {
 		t.Errorf("TestRun failed @ ipsMgr.Run with err %+v", err)
 	}
 }
@@ -581,7 +581,7 @@ func TestRunError(t *testing.T) {
 		set:           util.GetHashedName(setname),
 		spec:          append([]string{util.IpsetNetHashFlag}),
 	}
-	if _, err := ipsMgr.Run(entry); err != nil {
+	if _, err := ipsMgr.run(entry); err != nil {
 		require.Error(t, err)
 	}
 
@@ -591,15 +591,15 @@ func TestRunError(t *testing.T) {
 func TestDestroyNpmIpsets(t *testing.T) {
 	ipsMgr := NewIpsetManager(exec.New())
 
-	err := ipsMgr.CreateSet("azure-npm-123456", []string{"nethash"})
+	err := ipsMgr.createSet("azure-npm-123456", []string{"nethash"})
 	if err != nil {
-		t.Errorf("TestDestroyNpmIpsets failed @ ipsMgr.CreateSet")
+		t.Errorf("TestDestroyNpmIpsets failed @ ipsMgr.createSet")
 		t.Errorf(err.Error())
 	}
 
-	err = ipsMgr.CreateSet("azure-npm-56543", []string{"nethash"})
+	err = ipsMgr.createSet("azure-npm-56543", []string{"nethash"})
 	if err != nil {
-		t.Errorf("TestDestroyNpmIpsets failed @ ipsMgr.CreateSet")
+		t.Errorf("TestDestroyNpmIpsets failed @ ipsMgr.createSet")
 		t.Errorf(err.Error())
 	}
 
@@ -640,7 +640,7 @@ func TestSetCannotBeDestroyed(t *testing.T) {
 	testset1 := GetIPSetName()
 	testlist1 := GetIPSetName()
 
-	if err := ipsMgr.CreateSet(testset1, append([]string{util.IpsetNetHashFlag})); err != nil {
+	if err := ipsMgr.createSet(testset1, append([]string{util.IpsetNetHashFlag})); err != nil {
 		t.Errorf("Failed to create set with err %v", err)
 	}
 
@@ -653,7 +653,7 @@ func TestSetCannotBeDestroyed(t *testing.T) {
 	}
 
 	// Delete set and validate set is not exist.
-	if err := ipsMgr.DeleteSet(testset1); err != nil {
+	if err := ipsMgr.deleteSet(testset1); err != nil {
 		if err.ErrID != npmerr.SetCannotBeDestroyedInUseByKernelComponent {
 			t.Errorf("Expected to error with ipset in use by kernel component")
 		}
@@ -674,8 +674,8 @@ func TestElemSeparatorSupportsNone(t *testing.T) {
 
 	testset1 := GetIPSetName()
 
-	if err := ipsMgr.CreateSet(testset1, append([]string{util.IpsetNetHashFlag})); err != nil {
-		t.Errorf("TestAddToList failed @ ipsMgr.CreateSet")
+	if err := ipsMgr.createSet(testset1, append([]string{util.IpsetNetHashFlag})); err != nil {
+		t.Errorf("TestAddToList failed @ ipsMgr.createSet")
 	}
 
 	entry := &ipsEntry{
@@ -770,8 +770,8 @@ func TestIPSetSecondElementIsMissingWhenAddingIpWithNoPort(t *testing.T) {
 	testset1 := GetIPSetName()
 
 	spec := append([]string{util.IpsetIPPortHashFlag})
-	if err := ipsMgr.CreateSet(testset1, spec); err != nil {
-		t.Errorf("TestCreateSet failed @ ipsMgr.CreateSet when creating port set")
+	if err := ipsMgr.createSet(testset1, spec); err != nil {
+		t.Errorf("TestcreateSet failed @ ipsMgr.createSet when creating port set")
 	}
 
 	entry := &ipsEntry{
@@ -800,8 +800,8 @@ func TestIPSetMissingSecondMandatoryArgument(t *testing.T) {
 	testset1 := GetIPSetName()
 
 	spec := append([]string{util.IpsetIPPortHashFlag})
-	if err := ipsMgr.CreateSet(testset1, spec); err != nil {
-		t.Errorf("TestCreateSet failed @ ipsMgr.CreateSet when creating port set")
+	if err := ipsMgr.createSet(testset1, spec); err != nil {
+		t.Errorf("TestcreateSet failed @ ipsMgr.createSet when creating port set")
 	}
 
 	entry := &ipsEntry{
@@ -861,7 +861,7 @@ func TestMain(m *testing.M) {
 	iptm.UninitNpmChains()
 	log.Printf("Uniniting ipsets")
 	ipsMgr := NewIpsetManager(exec.New())
-	ipsMgr.Destroy()
+	ipsMgr.destroy()
 
 	exitCode := m.Run()
 

--- a/npm/iptm/iptm.go
+++ b/npm/iptm/iptm.go
@@ -177,9 +177,9 @@ func (iptMgr *IptablesManager) Delete(entry *IptEntry) error {
 	return nil
 }
 
+// TODO(jungukcho): Ideally, NPM only needs to run below functions when at least one network policy resource is submitted.
+// Need to fine-grained control below two functions according to status of network policy resources
 func (iptMgr *IptablesManager) ReconcileIPTables() {
-	// (TODO) Ideally, we only need this when network policy installs iptables
-	// Control below two functions with InitNpmChains and UninitNpmChains functions together
 	go iptMgr.backup()
 	go iptMgr.reconcileChains()
 }
@@ -279,7 +279,6 @@ func (iptMgr *IptablesManager) reconcileChains() error {
 func (iptMgr *IptablesManager) backup() {
 	var err error
 	for {
-		// (TODO) check backupWaitTimeInSeconds variables
 		time.Sleep(backupWaitTimeInSeconds * time.Second)
 		if err = iptMgr.Save(util.IptablesConfigFile); err != nil {
 			metrics.SendErrorLogAndMetric(util.NpmID, "Error: failed to back up Azure-NPM states")

--- a/npm/iptm/iptm.go
+++ b/npm/iptm/iptm.go
@@ -22,6 +22,8 @@ import (
 const (
 	defaultlockWaitTimeInSeconds string = "60"
 	iptablesErrDoesNotExist      int    = 1
+	backupWaitTimeInSeconds             = 60
+	reconcileChainTimeInMinutes         = 5
 )
 
 var (
@@ -69,96 +71,16 @@ func NewIptablesManager() *IptablesManager {
 func (iptMgr *IptablesManager) InitNpmChains() error {
 	log.Logf("Initializing AZURE-NPM chains.")
 
-	if err := iptMgr.AddAllChains(); err != nil {
+	if err := iptMgr.addAllChains(); err != nil {
 		return err
 	}
 
-	err := iptMgr.CheckAndAddForwardChain()
+	err := iptMgr.checkAndAddForwardChain()
 	if err != nil {
 		metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to add AZURE-NPM chain to FORWARD chain. %s", err.Error())
 	}
 
-	if err = iptMgr.AddAllRulesToChains(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// CheckAndAddForwardChain initializes and reconciles Azure-NPM chain in right order
-func (iptMgr *IptablesManager) CheckAndAddForwardChain() error {
-
-	// TODO Adding this chain is printing error messages try to clean it up
-	if err := iptMgr.AddChain(util.IptablesAzureChain); err != nil {
-		return err
-	}
-
-	// Insert AZURE-NPM chain to FORWARD chain.
-	entry := &IptEntry{
-		Chain: util.IptablesForwardChain,
-		Specs: []string{
-			util.IptablesJumpFlag,
-			util.IptablesAzureChain,
-		},
-	}
-
-	index := 1
-	// retrieve KUBE-SERVICES index
-	kubeServicesLine, err := iptMgr.GetChainLineNumber(util.IptablesKubeServicesChain, util.IptablesForwardChain)
-	if err != nil {
-		metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to get index of KUBE-SERVICES in FORWARD chain with error: %s", err.Error())
-		return err
-	}
-
-	index = kubeServicesLine + 1
-
-	exists, err := iptMgr.Exists(entry)
-	if err != nil {
-		return err
-	}
-
-	if !exists {
-		// position Azure-NPM chain after Kube-Forward and Kube-Service chains if it exists
-		iptMgr.OperationFlag = util.IptablesInsertionFlag
-		entry.Specs = append([]string{strconv.Itoa(index)}, entry.Specs...)
-		if _, err = iptMgr.Run(entry); err != nil {
-			metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to add AZURE-NPM chain to FORWARD chain.")
-			return err
-		}
-
-		return nil
-	}
-
-	npmChainLine, err := iptMgr.GetChainLineNumber(util.IptablesAzureChain, util.IptablesForwardChain)
-	if err != nil {
-		metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to get index of AZURE-NPM in FORWARD chain with error: %s", err.Error())
-		return err
-	}
-
-	// Kube-services line number is less than npm chain line number then all good
-	if kubeServicesLine < npmChainLine {
-		return nil
-	} else if kubeServicesLine <= 0 {
-		return nil
-	}
-
-	errCode := 0
-	// NPM Chain number is less than KUBE-SERVICES then
-	// delete existing NPM chain and add it in the right order
-	iptMgr.OperationFlag = util.IptablesDeletionFlag
-	metrics.SendErrorLogAndMetric(util.IptmID, "Info: Reconciler deleting and re-adding AZURE-NPM in FORWARD table.")
-	if errCode, err = iptMgr.Run(entry); err != nil {
-		metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to delete AZURE-NPM chain from FORWARD chain with error code %d.", errCode)
-		return err
-	}
-	iptMgr.OperationFlag = util.IptablesInsertionFlag
-	// Reduce index for deleted AZURE-NPM chain
-	if index > 1 {
-		index--
-	}
-	entry.Specs = append([]string{strconv.Itoa(index)}, entry.Specs...)
-	if errCode, err = iptMgr.Run(entry); err != nil {
-		metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to add AZURE-NPM chain to FORWARD chain with error code %d.", errCode)
+	if err = iptMgr.addAllRulesToChains(); err != nil {
 		return err
 	}
 
@@ -167,7 +89,6 @@ func (iptMgr *IptablesManager) CheckAndAddForwardChain() error {
 
 // UninitNpmChains uninitializes Azure NPM chains in iptables.
 func (iptMgr *IptablesManager) UninitNpmChains() error {
-
 	// Remove AZURE-NPM chain from FORWARD chain.
 	entry := &IptEntry{
 		Chain: util.IptablesForwardChain,
@@ -177,7 +98,7 @@ func (iptMgr *IptablesManager) UninitNpmChains() error {
 		},
 	}
 	iptMgr.OperationFlag = util.IptablesDeletionFlag
-	errCode, err := iptMgr.Run(entry)
+	errCode, err := iptMgr.run(entry)
 	if errCode != iptablesErrDoesNotExist && err != nil {
 		metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to add default allow CONNECTED/RELATED rule to AZURE-NPM chain.")
 		return err
@@ -195,14 +116,14 @@ func (iptMgr *IptablesManager) UninitNpmChains() error {
 		entry := &IptEntry{
 			Chain: chain,
 		}
-		errCode, err := iptMgr.Run(entry)
+		errCode, err := iptMgr.run(entry)
 		if errCode != iptablesErrDoesNotExist && err != nil {
 			metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to flush iptables chain %s.", chain)
 		}
 	}
 
 	for _, chain := range allAzureChains {
-		if err := iptMgr.DeleteChain(chain); err != nil {
+		if err := iptMgr.deleteChain(chain); err != nil {
 			return err
 		}
 	}
@@ -210,8 +131,164 @@ func (iptMgr *IptablesManager) UninitNpmChains() error {
 	return nil
 }
 
-// AddAllRulesToChains Checks and adds all the rules in NPM chains
-func (iptMgr *IptablesManager) AddAllRulesToChains() error {
+// Add adds a rule in iptables.
+func (iptMgr *IptablesManager) Add(entry *IptEntry) error {
+	timer := metrics.StartNewTimer()
+
+	log.Logf("Adding iptables entry: %+v.", entry)
+
+	if entry.IsJumpEntry {
+		iptMgr.OperationFlag = util.IptablesAppendFlag
+	} else {
+		iptMgr.OperationFlag = util.IptablesInsertionFlag
+	}
+	if _, err := iptMgr.run(entry); err != nil {
+		metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to create iptables rules.")
+		return err
+	}
+
+	metrics.NumIPTableRules.Inc()
+	timer.StopAndRecord(metrics.AddIPTableRuleExecTime)
+
+	return nil
+}
+
+// Delete removes a rule in iptables.
+func (iptMgr *IptablesManager) Delete(entry *IptEntry) error {
+	log.Logf("Deleting iptables entry: %+v", entry)
+
+	exists, err := iptMgr.exists(entry)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		return nil
+	}
+
+	iptMgr.OperationFlag = util.IptablesDeletionFlag
+	if _, err := iptMgr.run(entry); err != nil {
+		metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to delete iptables rules.")
+		return err
+	}
+
+	metrics.NumIPTableRules.Dec()
+
+	return nil
+}
+
+func (iptMgr *IptablesManager) ReconcileIPTables() {
+	// (TODO) Ideally, we only need this when network policy installs iptables
+	// Control below two functions with InitNpmChains and UninitNpmChains functions together
+	go iptMgr.backup()
+	go iptMgr.reconcileChains()
+}
+
+// checkAndAddForwardChain initializes and reconciles Azure-NPM chain in right order
+func (iptMgr *IptablesManager) checkAndAddForwardChain() error {
+
+	// TODO Adding this chain is printing error messages try to clean it up
+	if err := iptMgr.addChain(util.IptablesAzureChain); err != nil {
+		return err
+	}
+
+	// Insert AZURE-NPM chain to FORWARD chain.
+	entry := &IptEntry{
+		Chain: util.IptablesForwardChain,
+		Specs: []string{
+			util.IptablesJumpFlag,
+			util.IptablesAzureChain,
+		},
+	}
+
+	index := 1
+	// retrieve KUBE-SERVICES index
+	kubeServicesLine, err := iptMgr.getChainLineNumber(util.IptablesKubeServicesChain, util.IptablesForwardChain)
+	if err != nil {
+		metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to get index of KUBE-SERVICES in FORWARD chain with error: %s", err.Error())
+		return err
+	}
+
+	index = kubeServicesLine + 1
+
+	exists, err := iptMgr.exists(entry)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		// position Azure-NPM chain after Kube-Forward and Kube-Service chains if it exists
+		iptMgr.OperationFlag = util.IptablesInsertionFlag
+		entry.Specs = append([]string{strconv.Itoa(index)}, entry.Specs...)
+		if _, err = iptMgr.run(entry); err != nil {
+			metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to add AZURE-NPM chain to FORWARD chain.")
+			return err
+		}
+
+		return nil
+	}
+
+	npmChainLine, err := iptMgr.getChainLineNumber(util.IptablesAzureChain, util.IptablesForwardChain)
+	if err != nil {
+		metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to get index of AZURE-NPM in FORWARD chain with error: %s", err.Error())
+		return err
+	}
+
+	// Kube-services line number is less than npm chain line number then all good
+	if kubeServicesLine < npmChainLine {
+		return nil
+	} else if kubeServicesLine <= 0 {
+		return nil
+	}
+
+	errCode := 0
+	// NPM Chain number is less than KUBE-SERVICES then
+	// delete existing NPM chain and add it in the right order
+	iptMgr.OperationFlag = util.IptablesDeletionFlag
+	metrics.SendErrorLogAndMetric(util.IptmID, "Info: Reconciler deleting and re-adding AZURE-NPM in FORWARD table.")
+	if errCode, err = iptMgr.run(entry); err != nil {
+		metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to delete AZURE-NPM chain from FORWARD chain with error code %d.", errCode)
+		return err
+	}
+	iptMgr.OperationFlag = util.IptablesInsertionFlag
+	// Reduce index for deleted AZURE-NPM chain
+	if index > 1 {
+		index--
+	}
+	entry.Specs = append([]string{strconv.Itoa(index)}, entry.Specs...)
+	if errCode, err = iptMgr.run(entry); err != nil {
+		metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to add AZURE-NPM chain to FORWARD chain with error code %d.", errCode)
+		return err
+	}
+
+	return nil
+}
+
+// reconcileChains checks for ordering of AZURE-NPM chain in FORWARD chain periodically.
+func (iptMgr *IptablesManager) reconcileChains() error {
+	select {
+	case <-time.After(reconcileChainTimeInMinutes * time.Minute):
+		if err := iptMgr.checkAndAddForwardChain(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// backup takes snapshots of iptables filter table and saves it periodically.
+func (iptMgr *IptablesManager) backup() {
+	var err error
+	for {
+		// (TODO) check backupWaitTimeInSeconds variables
+		time.Sleep(backupWaitTimeInSeconds * time.Second)
+		if err = iptMgr.Save(util.IptablesConfigFile); err != nil {
+			metrics.SendErrorLogAndMetric(util.NpmID, "Error: failed to back up Azure-NPM states")
+		}
+	}
+}
+
+// addAllRulesToChains checks and adds all the rules in NPM chains
+func (iptMgr *IptablesManager) addAllRulesToChains() error {
 
 	allChainsAndRules := getAllChainsAndRules()
 	for _, rule := range allChainsAndRules {
@@ -219,14 +296,14 @@ func (iptMgr *IptablesManager) AddAllRulesToChains() error {
 			Chain: rule[0],
 			Specs: rule[1:],
 		}
-		exists, err := iptMgr.Exists(entry)
+		exists, err := iptMgr.exists(entry)
 		if err != nil {
 			return err
 		}
 
 		if !exists {
 			iptMgr.OperationFlag = util.IptablesAppendFlag
-			if _, err = iptMgr.Run(entry); err != nil {
+			if _, err = iptMgr.run(entry); err != nil {
 				msg := "Error: failed to add %s to parent chain %s"
 				switch {
 				case len(rule) == 3:
@@ -250,9 +327,9 @@ func (iptMgr *IptablesManager) AddAllRulesToChains() error {
 }
 
 // Exists checks if a rule exists in iptables.
-func (iptMgr *IptablesManager) Exists(entry *IptEntry) (bool, error) {
+func (iptMgr *IptablesManager) exists(entry *IptEntry) (bool, error) {
 	iptMgr.OperationFlag = util.IptablesCheckFlag
-	returnCode, err := iptMgr.Run(entry)
+	returnCode, err := iptMgr.run(entry)
 	if err == nil {
 		return true, nil
 	}
@@ -265,10 +342,10 @@ func (iptMgr *IptablesManager) Exists(entry *IptEntry) (bool, error) {
 }
 
 // AddAllChains adds all NPM chains
-func (iptMgr *IptablesManager) AddAllChains() error {
+func (iptMgr *IptablesManager) addAllChains() error {
 	// Add all secondary Chains
 	for _, chainToAdd := range IptablesAzureChainList {
-		if err := iptMgr.AddChain(chainToAdd); err != nil {
+		if err := iptMgr.addChain(chainToAdd); err != nil {
 			return err
 		}
 	}
@@ -276,12 +353,12 @@ func (iptMgr *IptablesManager) AddAllChains() error {
 }
 
 // AddChain adds a chain to iptables.
-func (iptMgr *IptablesManager) AddChain(chain string) error {
+func (iptMgr *IptablesManager) addChain(chain string) error {
 	entry := &IptEntry{
 		Chain: chain,
 	}
 	iptMgr.OperationFlag = util.IptablesChainCreationFlag
-	errCode, err := iptMgr.Run(entry)
+	errCode, err := iptMgr.run(entry)
 	if err != nil {
 		if errCode == iptablesErrDoesNotExist {
 			log.Logf("Chain already exists %s.", entry.Chain)
@@ -296,7 +373,7 @@ func (iptMgr *IptablesManager) AddChain(chain string) error {
 }
 
 // GetChainLineNumber given a Chain and its parent chain returns line number
-func (iptMgr *IptablesManager) GetChainLineNumber(chain string, parentChain string) (int, error) {
+func (iptMgr *IptablesManager) getChainLineNumber(chain string, parentChain string) (int, error) {
 
 	var (
 		output []byte
@@ -334,12 +411,12 @@ func (iptMgr *IptablesManager) GetChainLineNumber(chain string, parentChain stri
 }
 
 // DeleteChain deletes a chain from iptables.
-func (iptMgr *IptablesManager) DeleteChain(chain string) error {
+func (iptMgr *IptablesManager) deleteChain(chain string) error {
 	entry := &IptEntry{
 		Chain: chain,
 	}
 	iptMgr.OperationFlag = util.IptablesDestroyFlag
-	errCode, err := iptMgr.Run(entry)
+	errCode, err := iptMgr.run(entry)
 	if err != nil {
 		if errCode == iptablesErrDoesNotExist {
 			log.Logf("Chain doesn't exist %s.", entry.Chain)
@@ -353,54 +430,8 @@ func (iptMgr *IptablesManager) DeleteChain(chain string) error {
 	return nil
 }
 
-// Add adds a rule in iptables.
-func (iptMgr *IptablesManager) Add(entry *IptEntry) error {
-	timer := metrics.StartNewTimer()
-
-	log.Logf("Adding iptables entry: %+v.", entry)
-
-	if entry.IsJumpEntry {
-		iptMgr.OperationFlag = util.IptablesAppendFlag
-	} else {
-		iptMgr.OperationFlag = util.IptablesInsertionFlag
-	}
-	if _, err := iptMgr.Run(entry); err != nil {
-		metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to create iptables rules.")
-		return err
-	}
-
-	metrics.NumIPTableRules.Inc()
-	timer.StopAndRecord(metrics.AddIPTableRuleExecTime)
-
-	return nil
-}
-
-// Delete removes a rule in iptables.
-func (iptMgr *IptablesManager) Delete(entry *IptEntry) error {
-	log.Logf("Deleting iptables entry: %+v", entry)
-
-	exists, err := iptMgr.Exists(entry)
-	if err != nil {
-		return err
-	}
-
-	if !exists {
-		return nil
-	}
-
-	iptMgr.OperationFlag = util.IptablesDeletionFlag
-	if _, err := iptMgr.Run(entry); err != nil {
-		metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to delete iptables rules.")
-		return err
-	}
-
-	metrics.NumIPTableRules.Dec()
-
-	return nil
-}
-
 // Run execute an iptables command to update iptables.
-func (iptMgr *IptablesManager) Run(entry *IptEntry) (int, error) {
+func (iptMgr *IptablesManager) run(entry *IptEntry) (int, error) {
 	cmdName := entry.Command
 	if cmdName == "" {
 		cmdName = util.Iptables

--- a/npm/iptm/iptm_test.go
+++ b/npm/iptm/iptm_test.go
@@ -87,8 +87,8 @@ func TestExists(t *testing.T) {
 			util.IptablesAccept,
 		},
 	}
-	if _, err := iptMgr.Exists(entry); err != nil {
-		t.Errorf("TestExists failed @ iptMgr.Exists")
+	if _, err := iptMgr.exists(entry); err != nil {
+		t.Errorf("TestExists failed @ iptMgr.exists")
 	}
 }
 
@@ -104,8 +104,8 @@ func TestAddChain(t *testing.T) {
 		}
 	}()
 
-	if err := iptMgr.AddChain("TEST-CHAIN"); err != nil {
-		t.Errorf("TestAddChain failed @ iptMgr.AddChain")
+	if err := iptMgr.addChain("TEST-CHAIN"); err != nil {
+		t.Errorf("TestAddChain failed @ iptMgr.addChain")
 	}
 }
 
@@ -121,12 +121,12 @@ func TestDeleteChain(t *testing.T) {
 		}
 	}()
 
-	if err := iptMgr.AddChain("TEST-CHAIN"); err != nil {
-		t.Errorf("TestDeleteChain failed @ iptMgr.AddChain")
+	if err := iptMgr.addChain("TEST-CHAIN"); err != nil {
+		t.Errorf("TestDeleteChain failed @ iptMgr.addChain")
 	}
 
-	if err := iptMgr.DeleteChain("TEST-CHAIN"); err != nil {
-		t.Errorf("TestDeleteChain failed @ iptMgr.DeleteChain")
+	if err := iptMgr.deleteChain("TEST-CHAIN"); err != nil {
+		t.Errorf("TestDeleteChain failed @ iptMgr.deleteChain")
 	}
 }
 
@@ -220,8 +220,8 @@ func TestRun(t *testing.T) {
 	entry := &IptEntry{
 		Chain: "TEST-CHAIN",
 	}
-	if _, err := iptMgr.Run(entry); err != nil {
-		t.Errorf("TestRun failed @ iptMgr.Run")
+	if _, err := iptMgr.run(entry); err != nil {
+		t.Errorf("TestRun failed @ iptMgr.run")
 	}
 }
 
@@ -245,8 +245,8 @@ func TestGetChainLineNumber(t *testing.T) {
 		}
 	}()
 
-	if err = iptMgr.AddChain(util.IptablesKubeServicesChain); err != nil {
-		t.Errorf("TestGetChainLineNumber failed @ kube-services chain iptMgr.AddChain error: %s", err.Error())
+	if err = iptMgr.addChain(util.IptablesKubeServicesChain); err != nil {
+		t.Errorf("TestGetChainLineNumber failed @ kube-services chain iptMgr. addChain error: %s", err.Error())
 	}
 
 	iptMgr.OperationFlag = util.IptablesCheckFlag
@@ -258,8 +258,8 @@ func TestGetChainLineNumber(t *testing.T) {
 		},
 	}
 
-	if kubeExists, err = iptMgr.Exists(entry); err != nil {
-		t.Errorf("TestGetChainLineNumber failed @ kube-services chain iptMgr.Exists error: %s", err.Error())
+	if kubeExists, err = iptMgr.exists(entry); err != nil {
+		t.Errorf("TestGetChainLineNumber failed @ kube-services chain iptMgr. exists error: %s", err.Error())
 	}
 
 	entry = &IptEntry{
@@ -271,9 +271,9 @@ func TestGetChainLineNumber(t *testing.T) {
 	}
 
 	// Ignore not exists errors
-	npmExists, _ = iptMgr.Exists(entry)
+	npmExists, _ = iptMgr.exists(entry)
 
-	lineNum, err = iptMgr.GetChainLineNumber(util.IptablesAzureChain, util.IptablesForwardChain)
+	lineNum, err = iptMgr.getChainLineNumber(util.IptablesAzureChain, util.IptablesForwardChain)
 	if err != nil {
 		t.Errorf("TestGetChainLineNumber @ initial iptMgr.GetChainLineNumber error: %s", err.Error())
 	}
@@ -305,11 +305,11 @@ func TestGetChainLineNumber(t *testing.T) {
 		},
 	}
 
-	if npmExists, err = iptMgr.Exists(entry); err != nil {
-		t.Errorf("TestGetChainLineNumber failed @ azure-npm chain iptMgr.Exists error: %s", err.Error())
+	if npmExists, err = iptMgr.exists(entry); err != nil {
+		t.Errorf("TestGetChainLineNumber failed @ azure-npm chain iptMgr. exists error: %s", err.Error())
 	}
 
-	lineNum, err = iptMgr.GetChainLineNumber(util.IptablesAzureChain, util.IptablesForwardChain)
+	lineNum, err = iptMgr.getChainLineNumber(util.IptablesAzureChain, util.IptablesForwardChain)
 	if err != nil {
 		t.Errorf("TestGetChainLineNumber @ after Init chains iptMgr.GetChainLineNumber error: %s", err.Error())
 	}

--- a/npm/nameSpaceController.go
+++ b/npm/nameSpaceController.go
@@ -101,9 +101,7 @@ func NewNameSpaceController(nameSpaceInformer coreinformer.NamespaceInformer, cl
 }
 
 // Set up default IPsets
-func (nsc *nameSpaceController) initializeIPSets() error {
-	nsc.ipsMgr.DestroyNpmIpsets()
-
+func (nsc *nameSpaceController) initializeDefaultNs() error {
 	allNs := newNs(util.KubeAllNamespacesFlag)
 	nsc.npmNamespaceCache.nsMap[util.KubeAllNamespacesFlag] = allNs
 

--- a/npm/nameSpaceController.go
+++ b/npm/nameSpaceController.go
@@ -182,16 +182,14 @@ func (nsc *nameSpaceController) deleteNamespace(obj interface{}) {
 	nsc.workqueue.Add(key)
 }
 
-func (nsc *nameSpaceController) Run(threadiness int, stopCh <-chan struct{}) error {
+func (nsc *nameSpaceController) Run(stopCh <-chan struct{}) error {
 	defer utilruntime.HandleCrash()
 	defer nsc.workqueue.ShutDown()
 
 	klog.Info("Starting Namespace controller\n")
 	klog.Info("Starting workers")
 	// Launch workers to process namespace resources
-	for i := 0; i < threadiness; i++ {
-		go wait.Until(nsc.runWorker, time.Second, stopCh)
-	}
+	go wait.Until(nsc.runWorker, time.Second, stopCh)
 
 	klog.Info("Started workers")
 	<-stopCh

--- a/npm/nameSpaceController.go
+++ b/npm/nameSpaceController.go
@@ -100,21 +100,6 @@ func NewNameSpaceController(nameSpaceInformer coreinformer.NamespaceInformer, cl
 	return nameSpaceController
 }
 
-// Set up default IPsets
-func (nsc *nameSpaceController) initializeDefaultNs() error {
-	allNs := newNs(util.KubeAllNamespacesFlag)
-	nsc.npmNamespaceCache.nsMap[util.KubeAllNamespacesFlag] = allNs
-
-	// Create ipset for the namespace.
-	kubeSystemNs := util.GetNSNameWithPrefix(util.KubeSystemFlag)
-	if err := nsc.ipsMgr.CreateSet(kubeSystemNs, append([]string{util.IpsetNetHashFlag})); err != nil {
-		metrics.SendErrorLogAndMetric(util.NpmID, "Error: failed to create ipset for namespace %s.", kubeSystemNs)
-		return err
-	}
-
-	return nil
-}
-
 // filter this event if we do not need to handle this event
 func (nsc *nameSpaceController) needSync(obj interface{}, event string) (string, bool) {
 	needSync := false

--- a/npm/nameSpaceController.go
+++ b/npm/nameSpaceController.go
@@ -5,10 +5,10 @@ package npm
 import (
 	"fmt"
 	"reflect"
+	"sync"
 	"time"
 
 	"github.com/Azure/azure-container-networking/npm/ipsm"
-	"github.com/Azure/azure-container-networking/npm/iptm"
 	"github.com/Azure/azure-container-networking/npm/metrics"
 	"github.com/Azure/azure-container-networking/npm/util"
 
@@ -23,7 +23,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
-	utilexec "k8s.io/utils/exec"
 )
 
 type LabelAppendOperation bool
@@ -36,22 +35,15 @@ const (
 type Namespace struct {
 	name      string
 	LabelsMap map[string]string // NameSpace labels
-	SetMap    map[string]string
-	IpsMgr    *ipsm.IpsetManager
-	iptMgr    *iptm.IptablesManager
 }
 
 // newNS constructs a new namespace object.
-func newNs(name string, exec utilexec.Interface) (*Namespace, error) {
+func newNs(name string) *Namespace {
 	ns := &Namespace{
 		name:      name,
 		LabelsMap: make(map[string]string),
-		SetMap:    make(map[string]string),
-		IpsMgr:    ipsm.NewIpsetManager(exec),
-		iptMgr:    iptm.NewIptablesManager(),
 	}
-
-	return ns, nil
+	return ns
 }
 
 func (nsObj *Namespace) getNamespaceObjFromNsObj() *corev1.Namespace {
@@ -85,17 +77,31 @@ type nameSpaceController struct {
 	nameSpaceLister       corelisters.NamespaceLister
 	nameSpaceListerSynced cache.InformerSynced
 	workqueue             workqueue.RateLimitingInterface
-	// TODO does not need to have whole NetworkPolicyManager pointer. Need to improve it
-	npMgr *NetworkPolicyManager
+	ipsMgr                *ipsm.IpsetManager
+	nsMap                 map[string]*Namespace // Key is ns-<nsname>
+	nsMapMutex            sync.RWMutex
 }
 
-func NewNameSpaceController(nameSpaceInformer coreinformer.NamespaceInformer, clientset kubernetes.Interface, npMgr *NetworkPolicyManager) *nameSpaceController {
+func NewNameSpaceController(nameSpaceInformer coreinformer.NamespaceInformer, clientset kubernetes.Interface, ipsMgr *ipsm.IpsetManager) *nameSpaceController {
 	nameSpaceController := &nameSpaceController{
 		clientset:             clientset,
 		nameSpaceLister:       nameSpaceInformer.Lister(),
 		nameSpaceListerSynced: nameSpaceInformer.Informer().HasSynced,
 		workqueue:             workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Namespaces"),
-		npMgr:                 npMgr,
+		ipsMgr:                ipsMgr,
+		nsMap:                 make(map[string]*Namespace),
+	}
+
+	// add all namespaces
+	nameSpaceController.nsMap[util.KubeAllNamespacesFlag] = newNs(util.KubeAllNamespacesFlag)
+
+	// Create ipset for the namespace.
+	// (TODO): check whether we need to panic when it is failed.
+	kubeSystemNs := util.GetNSNameWithPrefix(util.KubeSystemFlag)
+	if err := nameSpaceController.ipsMgr.CreateSet(kubeSystemNs, append([]string{util.IpsetNetHashFlag})); err != nil {
+		// (Question): Do we need to panic here?
+		metrics.SendErrorLogAndMetric(util.NpmID, "Error: failed to create ipset for namespace %s.", kubeSystemNs)
+		// panic(err.Error)
 	}
 
 	nameSpaceInformer.Informer().AddEventHandler(
@@ -106,6 +112,13 @@ func NewNameSpaceController(nameSpaceInformer coreinformer.NamespaceInformer, cl
 		},
 	)
 	return nameSpaceController
+}
+
+func (c *nameSpaceController) LengthOfNsMap() int {
+	length := len(c.nsMap)
+	// Reducing one to remove all-namespaces ns obj
+	// (TODO): Check this is safe or not?
+	return length - 1
 }
 
 // filter this event if we do not need to handle this event
@@ -157,19 +170,19 @@ func (nsc *nameSpaceController) updateNamespace(old, new interface{}) {
 		}
 	}
 
-	nsKey := util.GetNSNameWithPrefix(key)
-
-	nsc.npMgr.Lock()
-	defer nsc.npMgr.Unlock()
-	cachedNsObj, nsExists := nsc.npMgr.NsMap[nsKey]
-	if nsExists {
-		if reflect.DeepEqual(cachedNsObj.LabelsMap, nsObj.ObjectMeta.Labels) {
-			klog.Infof("[NAMESPACE UPDATE EVENT] Namespace [%s] labels did not change", key)
-			return
-		}
-	}
-
 	nsc.workqueue.Add(key)
+
+	// nsKey := util.GetNSNameWithPrefix(key)
+	// nsc.npMgr.NsMapMutex.Lock()
+	// defer nsc.npMgr.NsMapMutex.Unlock()
+	// cachedNsObj, nsExists := nsc.npMgr.NsMap[nsKey]
+	// if nsExists {
+	// 	if reflect.DeepEqual(cachedNsObj.LabelsMap, nsObj.ObjectMeta.Labels) {
+	// 		klog.Infof("[NAMESPACE UPDATE EVENT] Namespace [%s] labels did not change", key)
+	// 		return
+	// 	}
+	// }
+	// nsc.workqueue.Add(key)
 }
 
 func (nsc *nameSpaceController) deleteNamespace(obj interface{}) {
@@ -199,17 +212,16 @@ func (nsc *nameSpaceController) deleteNamespace(obj interface{}) {
 		return
 	}
 
-	nsc.npMgr.Lock()
-	defer nsc.npMgr.Unlock()
-
-	nsKey := util.GetNSNameWithPrefix(key)
-	_, nsExists := nsc.npMgr.NsMap[nsKey]
-	if !nsExists {
-		klog.Infof("[NAMESPACE DELETE EVENT] Namespace [%s] does not exist in case, so returning", key)
-		return
-	}
-
 	nsc.workqueue.Add(key)
+	// nsc.npMgr.NsMapMutex.RLock()
+	// defer nsc.npMgr.NsMapMutex.RUnlock()
+	// nsKey := util.GetNSNameWithPrefix(key)
+	// _, nsExists := nsc.npMgr.NsMap[nsKey]
+	// if !nsExists {
+	// 	klog.Infof("[NAMESPACE DELETE EVENT] Namespace [%s] does not exist in case, so returning", key)
+	// 	return
+	// }
+
 }
 
 func (nsc *nameSpaceController) Run(threadiness int, stopCh <-chan struct{}) error {
@@ -282,15 +294,12 @@ func (nsc *nameSpaceController) processNextWorkItem() bool {
 func (nsc *nameSpaceController) syncNameSpace(key string) error {
 	// Get the NameSpace resource with this key
 	nsObj, err := nsc.nameSpaceLister.Get(key)
-	// lock to complete events
-	// TODO: Reduce scope of lock later
-	nsc.npMgr.Lock()
-	defer nsc.npMgr.Unlock()
+
+	// find the nsMap key
+	cachedNsKey := util.GetNSNameWithPrefix(key)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			klog.Infof("NameSpace %s not found, may be it is deleted", key)
-			// find the nsMap key and start cleaning up process (calling cleanDeletedNamespace function)
-			cachedNsKey := util.GetNSNameWithPrefix(key)
 			// cleanDeletedNamespace will check if the NS exists in cache, if it does, then proceeds with deletion
 			// if it does not exists, then event will be no-op
 			err = nsc.cleanDeletedNamespace(cachedNsKey)
@@ -304,8 +313,15 @@ func (nsc *nameSpaceController) syncNameSpace(key string) error {
 	}
 
 	if nsObj.DeletionTimestamp != nil || nsObj.DeletionGracePeriodSeconds != nil {
-		return nsc.cleanDeletedNamespace(util.GetNSNameWithPrefix(nsObj.Name))
+		return nsc.cleanDeletedNamespace(cachedNsKey)
+	}
 
+	cachedNsObj, nsExists := nsc.nsMap[cachedNsKey]
+	if nsExists {
+		if reflect.DeepEqual(cachedNsObj.LabelsMap, nsObj.ObjectMeta.Labels) {
+			klog.Infof("[NAMESPACE UPDATE EVENT] Namespace [%s] labels did not change", key)
+			return nil
+		}
 	}
 
 	err = nsc.syncUpdateNameSpace(nsObj)
@@ -325,33 +341,32 @@ func (nsc *nameSpaceController) syncAddNameSpace(nsObj *corev1.Namespace) error 
 	corev1NsName, corev1NsLabels := util.GetNSNameWithPrefix(nsObj.ObjectMeta.Name), nsObj.ObjectMeta.Labels
 	klog.Infof("NAMESPACE CREATING: [%s/%v]", corev1NsName, corev1NsLabels)
 
-	ipsMgr := nsc.npMgr.NsMap[util.KubeAllNamespacesFlag].IpsMgr
 	// Create ipset for the namespace.
-	if err = ipsMgr.CreateSet(corev1NsName, []string{util.IpsetNetHashFlag}); err != nil {
+	if err = nsc.ipsMgr.CreateSet(corev1NsName, []string{util.IpsetNetHashFlag}); err != nil {
 		metrics.SendErrorLogAndMetric(util.NSID, "[AddNamespace] Error: failed to create ipset for namespace %s with err: %v", corev1NsName, err)
 		return err
 	}
 
-	if err = ipsMgr.AddToList(util.KubeAllNamespacesFlag, corev1NsName); err != nil {
+	if err = nsc.ipsMgr.AddToList(util.KubeAllNamespacesFlag, corev1NsName); err != nil {
 		metrics.SendErrorLogAndMetric(util.NSID, "[AddNamespace] Error: failed to add %s to all-namespace ipset list with err: %v", corev1NsName, err)
 		return err
 	}
 
-	npmNs, _ := newNs(corev1NsName, nsc.npMgr.Exec)
-	nsc.npMgr.NsMap[corev1NsName] = npmNs
+	npmNs := newNs(corev1NsName)
+	nsc.nsMap[corev1NsName] = npmNs
 
 	// Add the namespace to its label's ipset list.
 	for nsLabelKey, nsLabelVal := range corev1NsLabels {
 		labelIpsetName := util.GetNSNameWithPrefix(nsLabelKey)
 		klog.Infof("Adding namespace %s to ipset list %s", corev1NsName, labelIpsetName)
-		if err = ipsMgr.AddToList(labelIpsetName, corev1NsName); err != nil {
+		if err = nsc.ipsMgr.AddToList(labelIpsetName, corev1NsName); err != nil {
 			metrics.SendErrorLogAndMetric(util.NSID, "[AddNamespace] Error: failed to add namespace %s to ipset list %s with err: %v", corev1NsName, labelIpsetName, err)
 			return err
 		}
 
 		labelIpsetName = util.GetNSNameWithPrefix(util.GetIpSetFromLabelKV(nsLabelKey, nsLabelVal))
 		klog.Infof("Adding namespace %s to ipset list %s", corev1NsName, labelIpsetName)
-		if err = ipsMgr.AddToList(labelIpsetName, corev1NsName); err != nil {
+		if err = nsc.ipsMgr.AddToList(labelIpsetName, corev1NsName); err != nil {
 			metrics.SendErrorLogAndMetric(util.NSID, "[AddNamespace] Error: failed to add namespace %s to ipset list %s with err: %v", corev1NsName, labelIpsetName, err)
 			return err
 		}
@@ -374,7 +389,7 @@ func (nsc *nameSpaceController) syncUpdateNameSpace(newNsObj *corev1.Namespace) 
 
 	// If orignal AddNamespace failed for some reason, then NS will not be found
 	// in nsMap, resulting in retry of ADD.
-	curNsObj, exists := nsc.npMgr.NsMap[newNsName]
+	curNsObj, exists := nsc.nsMap[newNsName]
 	if !exists {
 		if newNsObj.ObjectMeta.DeletionTimestamp == nil && newNsObj.ObjectMeta.DeletionGracePeriodSeconds == nil {
 			if err = nsc.syncAddNameSpace(newNsObj); err != nil {
@@ -388,11 +403,10 @@ func (nsc *nameSpaceController) syncUpdateNameSpace(newNsObj *corev1.Namespace) 
 	//If the Namespace is not deleted, delete removed labels and create new labels
 	addToIPSets, deleteFromIPSets := util.GetIPSetListCompareLabels(curNsObj.LabelsMap, newNsLabel)
 	// Delete the namespace from its label's ipset list.
-	ipsMgr := nsc.npMgr.NsMap[util.KubeAllNamespacesFlag].IpsMgr
 	for _, nsLabelVal := range deleteFromIPSets {
 		labelKey := util.GetNSNameWithPrefix(nsLabelVal)
 		klog.Infof("Deleting namespace %s from ipset list %s", newNsName, labelKey)
-		if err = ipsMgr.DeleteFromList(labelKey, newNsName); err != nil {
+		if err = nsc.ipsMgr.DeleteFromList(labelKey, newNsName); err != nil {
 			metrics.SendErrorLogAndMetric(util.NSID, "[UpdateNamespace] Error: failed to delete namespace %s from ipset list %s with err: %v", newNsName, labelKey, err)
 			return err
 		}
@@ -409,7 +423,7 @@ func (nsc *nameSpaceController) syncUpdateNameSpace(newNsObj *corev1.Namespace) 
 	for _, nsLabelVal := range addToIPSets {
 		labelKey := util.GetNSNameWithPrefix(nsLabelVal)
 		klog.Infof("Adding namespace %s to ipset list %s", newNsName, labelKey)
-		if err = ipsMgr.AddToList(labelKey, newNsName); err != nil {
+		if err = nsc.ipsMgr.AddToList(labelKey, newNsName); err != nil {
 			metrics.SendErrorLogAndMetric(util.NSID, "[UpdateNamespace] Error: failed to add namespace %s to ipset list %s with err: %v", newNsName, labelKey, err)
 			return err
 		}
@@ -425,7 +439,7 @@ func (nsc *nameSpaceController) syncUpdateNameSpace(newNsObj *corev1.Namespace) 
 	// If due to ordering issue the above deleted and added labels are not correct,
 	// this below appendLabels will help ensure correct state in cache for all successful ops.
 	curNsObj.appendLabels(newNsLabel, ClearExistingLabels)
-	nsc.npMgr.NsMap[newNsName] = curNsObj
+	nsc.nsMap[newNsName] = curNsObj
 
 	return nil
 }
@@ -433,8 +447,7 @@ func (nsc *nameSpaceController) syncUpdateNameSpace(newNsObj *corev1.Namespace) 
 // cleanDeletedNamespace handles deleting namespace from ipset.
 func (nsc *nameSpaceController) cleanDeletedNamespace(cachedNsKey string) error {
 	klog.Infof("NAMESPACE DELETING: [%s]", cachedNsKey)
-
-	cachedNsObj, exists := nsc.npMgr.NsMap[cachedNsKey]
+	cachedNsObj, exists := nsc.nsMap[cachedNsKey]
 	if !exists {
 		return nil
 	}
@@ -442,19 +455,18 @@ func (nsc *nameSpaceController) cleanDeletedNamespace(cachedNsKey string) error 
 	klog.Infof("NAMESPACE DELETING cached labels: [%s/%v]", cachedNsKey, cachedNsObj.LabelsMap)
 
 	var err error
-	ipsMgr := nsc.npMgr.NsMap[util.KubeAllNamespacesFlag].IpsMgr
 	// Delete the namespace from its label's ipset list.
 	for nsLabelKey, nsLabelVal := range cachedNsObj.LabelsMap {
 		labelIpsetName := util.GetNSNameWithPrefix(nsLabelKey)
 		klog.Infof("Deleting namespace %s from ipset list %s", cachedNsKey, labelIpsetName)
-		if err = ipsMgr.DeleteFromList(labelIpsetName, cachedNsKey); err != nil {
+		if err = nsc.ipsMgr.DeleteFromList(labelIpsetName, cachedNsKey); err != nil {
 			metrics.SendErrorLogAndMetric(util.NSID, "[DeleteNamespace] Error: failed to delete namespace %s from ipset list %s with err: %v", cachedNsKey, labelIpsetName, err)
 			return err
 		}
 
 		labelIpsetName = util.GetNSNameWithPrefix(util.GetIpSetFromLabelKV(nsLabelKey, nsLabelVal))
 		klog.Infof("Deleting namespace %s from ipset list %s", cachedNsKey, labelIpsetName)
-		if err = ipsMgr.DeleteFromList(labelIpsetName, cachedNsKey); err != nil {
+		if err = nsc.ipsMgr.DeleteFromList(labelIpsetName, cachedNsKey); err != nil {
 			metrics.SendErrorLogAndMetric(util.NSID, "[DeleteNamespace] Error: failed to delete namespace %s from ipset list %s with err: %v", cachedNsKey, labelIpsetName, err)
 			return err
 		}
@@ -464,18 +476,18 @@ func (nsc *nameSpaceController) cleanDeletedNamespace(cachedNsKey string) error 
 	}
 
 	// Delete the namespace from all-namespace ipset list.
-	if err = ipsMgr.DeleteFromList(util.KubeAllNamespacesFlag, cachedNsKey); err != nil {
+	if err = nsc.ipsMgr.DeleteFromList(util.KubeAllNamespacesFlag, cachedNsKey); err != nil {
 		metrics.SendErrorLogAndMetric(util.NSID, "[DeleteNamespace] Error: failed to delete namespace %s from ipset list %s with err: %v", cachedNsKey, util.KubeAllNamespacesFlag, err)
 		return err
 	}
 
 	// Delete ipset for the namespace.
-	if err = ipsMgr.DeleteSet(cachedNsKey); err != nil {
+	if err = nsc.ipsMgr.DeleteSet(cachedNsKey); err != nil {
 		metrics.SendErrorLogAndMetric(util.NSID, "[DeleteNamespace] Error: failed to delete ipset for namespace %s with err: %v", cachedNsKey, err)
 		return err
 	}
 
-	delete(nsc.npMgr.NsMap, cachedNsKey)
+	delete(nsc.nsMap, cachedNsKey)
 
 	return nil
 }

--- a/npm/nameSpaceController_test.go
+++ b/npm/nameSpaceController_test.go
@@ -42,8 +42,6 @@ type nameSpaceFixture struct {
 	// Objects from here preloaded into NewSimpleFake.
 	kubeobjects []runtime.Object
 
-	// (TODO) will remove npMgr if possible
-	npMgr        *NetworkPolicyManager
 	ipsMgr       *ipsm.IpsetManager
 	nsController *nameSpaceController
 	kubeInformer kubeinformers.SharedInformerFactory
@@ -54,7 +52,6 @@ func newNsFixture(t *testing.T, utilexec exec.Interface) *nameSpaceFixture {
 		t:           t,
 		nsLister:    []*corev1.Namespace{},
 		kubeobjects: []runtime.Object{},
-		npMgr:       newNPMgr(t, utilexec),
 		ipsMgr:      ipsm.NewIpsetManager(utilexec),
 	}
 	return f
@@ -64,7 +61,7 @@ func (f *nameSpaceFixture) newNsController(stopCh chan struct{}) {
 	f.kubeclient = k8sfake.NewSimpleClientset(f.kubeobjects...)
 	f.kubeInformer = kubeinformers.NewSharedInformerFactory(f.kubeclient, noResyncPeriodFunc())
 
-	f.nsController = NewNameSpaceController(f.kubeInformer.Core().V1().Namespaces(), f.kubeclient, f.npMgr)
+	f.nsController = NewNameSpaceController(f.kubeInformer.Core().V1().Namespaces(), f.kubeclient, f.ipsMgr)
 	f.nsController.nameSpaceListerSynced = alwaysReady
 
 	for _, ns := range f.nsLister {
@@ -152,13 +149,6 @@ func deleteNamespace(t *testing.T, f *nameSpaceFixture, nsObj *corev1.Namespace,
 	f.nsController.processNextWorkItem()
 }
 
-func TestNewNs(t *testing.T) {
-	fexec := exec.New()
-	if _, err := newNs("test", fexec); err != nil {
-		t.Errorf("TestnewNs failed @ newNs")
-	}
-}
-
 func TestAddNamespace(t *testing.T) {
 	fexec := exec.New()
 	f := newNsFixture(t, fexec)
@@ -186,7 +176,7 @@ func TestAddNamespace(t *testing.T) {
 	}
 	checkNsTestResult("TestAddNamespace", f, testCases)
 
-	if _, exists := f.npMgr.NsMap[util.GetNSNameWithPrefix(nsObj.Name)]; !exists {
+	if _, exists := f.nsController.nsMap[util.GetNSNameWithPrefix(nsObj.Name)]; !exists {
 		t.Errorf("TestAddNamespace failed @ npMgr.nsMap check")
 	}
 }
@@ -225,13 +215,13 @@ func TestUpdateNamespace(t *testing.T) {
 	}
 	checkNsTestResult("TestUpdateNamespace", f, testCases)
 
-	if _, exists := f.npMgr.NsMap[util.GetNSNameWithPrefix(newNsObj.Name)]; !exists {
+	if _, exists := f.nsController.nsMap[util.GetNSNameWithPrefix(newNsObj.Name)]; !exists {
 		t.Errorf("TestUpdateNamespace failed @ npMgr.nsMap check")
 	}
 
 	if !reflect.DeepEqual(
 		newNsObj.Labels,
-		f.npMgr.NsMap[util.GetNSNameWithPrefix(oldNsObj.Name)].LabelsMap,
+		f.nsController.nsMap[util.GetNSNameWithPrefix(oldNsObj.Name)].LabelsMap,
 	) {
 		t.Fatalf("TestUpdateNamespace failed @ npMgr.nsMap labelMap check")
 	}
@@ -271,15 +261,15 @@ func TestAddNamespaceLabel(t *testing.T) {
 	}
 	checkNsTestResult("TestAddNamespaceLabel", f, testCases)
 
-	if _, exists := f.npMgr.NsMap[util.GetNSNameWithPrefix(newNsObj.Name)]; !exists {
-		t.Errorf("TestAddNamespaceLabel failed @ npMgr.nsMap check")
+	if _, exists := f.nsController.nsMap[util.GetNSNameWithPrefix(newNsObj.Name)]; !exists {
+		t.Errorf("TestAddNamespaceLabel failed @ nsMap check")
 	}
 
 	if !reflect.DeepEqual(
 		newNsObj.Labels,
-		f.npMgr.NsMap[util.GetNSNameWithPrefix(oldNsObj.Name)].LabelsMap,
+		f.nsController.nsMap[util.GetNSNameWithPrefix(oldNsObj.Name)].LabelsMap,
 	) {
-		t.Fatalf("TestAddNamespaceLabel failed @ npMgr.nsMap labelMap check")
+		t.Fatalf("TestAddNamespaceLabel failed @ nsMap labelMap check")
 	}
 }
 
@@ -318,15 +308,15 @@ func TestAddNamespaceLabelSameRv(t *testing.T) {
 	}
 	checkNsTestResult("TestAddNamespaceLabelSameRv", f, testCases)
 
-	if _, exists := f.npMgr.NsMap[util.GetNSNameWithPrefix(newNsObj.Name)]; !exists {
-		t.Errorf("TestAddNamespaceLabelSameRv failed @ npMgr.nsMap check")
+	if _, exists := f.nsController.nsMap[util.GetNSNameWithPrefix(newNsObj.Name)]; !exists {
+		t.Errorf("TestAddNamespaceLabelSameRv failed @ nsMap check")
 	}
 
 	if !reflect.DeepEqual(
 		oldNsObj.Labels,
-		f.npMgr.NsMap[util.GetNSNameWithPrefix(oldNsObj.Name)].LabelsMap,
+		f.nsController.nsMap[util.GetNSNameWithPrefix(oldNsObj.Name)].LabelsMap,
 	) {
-		t.Fatalf("TestAddNamespaceLabelSameRv failed @ npMgr.nsMap labelMap check")
+		t.Fatalf("TestAddNamespaceLabelSameRv failed @ nsMap labelMap check")
 	}
 }
 
@@ -367,15 +357,15 @@ func TestDeleteandUpdateNamespaceLabel(t *testing.T) {
 	}
 	checkNsTestResult("TestDeleteandUpdateNamespaceLabel", f, testCases)
 
-	if _, exists := f.npMgr.NsMap[util.GetNSNameWithPrefix(newNsObj.Name)]; !exists {
-		t.Errorf("TestDeleteandUpdateNamespaceLabel failed @ npMgr.nsMap check")
+	if _, exists := f.nsController.nsMap[util.GetNSNameWithPrefix(newNsObj.Name)]; !exists {
+		t.Errorf("TestDeleteandUpdateNamespaceLabel failed @ nsMap check")
 	}
 
 	if !reflect.DeepEqual(
 		newNsObj.Labels,
-		f.npMgr.NsMap[util.GetNSNameWithPrefix(oldNsObj.Name)].LabelsMap,
+		f.nsController.nsMap[util.GetNSNameWithPrefix(oldNsObj.Name)].LabelsMap,
 	) {
-		t.Fatalf("TestDeleteandUpdateNamespaceLabel failed @ npMgr.nsMap labelMap check")
+		t.Fatalf("TestDeleteandUpdateNamespaceLabel failed @ nsMap labelMap check")
 	}
 }
 
@@ -421,15 +411,15 @@ func TestNewNameSpaceUpdate(t *testing.T) {
 	}
 	checkNsTestResult("TestDeleteandUpdateNamespaceLabel", f, testCases)
 
-	if _, exists := f.npMgr.NsMap[util.GetNSNameWithPrefix(newNsObj.Name)]; !exists {
-		t.Errorf("TestDeleteandUpdateNamespaceLabel failed @ npMgr.nsMap check")
+	if _, exists := f.nsController.nsMap[util.GetNSNameWithPrefix(newNsObj.Name)]; !exists {
+		t.Errorf("TestDeleteandUpdateNamespaceLabel failed @ nsMap check")
 	}
 
 	if !reflect.DeepEqual(
 		newNsObj.Labels,
-		f.npMgr.NsMap[util.GetNSNameWithPrefix(oldNsObj.Name)].LabelsMap,
+		f.nsController.nsMap[util.GetNSNameWithPrefix(oldNsObj.Name)].LabelsMap,
 	) {
-		t.Fatalf("TestDeleteandUpdateNamespaceLabel failed @ npMgr.nsMap labelMap check")
+		t.Fatalf("TestDeleteandUpdateNamespaceLabel failed @ nsMap labelMap check")
 	}
 }
 
@@ -459,8 +449,8 @@ func TestDeleteNamespace(t *testing.T) {
 	}
 	checkNsTestResult("TestDeleteNamespace", f, testCases)
 
-	if _, exists := f.npMgr.NsMap[util.GetNSNameWithPrefix(nsObj.Name)]; exists {
-		t.Errorf("TestDeleteNamespace failed @ npMgr.nsMap check")
+	if _, exists := f.nsController.nsMap[util.GetNSNameWithPrefix(nsObj.Name)]; exists {
+		t.Errorf("TestDeleteNamespace failed @ nsMap check")
 	}
 }
 
@@ -517,8 +507,7 @@ func TestDeleteNamespaceWithTombstoneAfterAddingNameSpace(t *testing.T) {
 }
 
 func TestGetNamespaceObjFromNsObj(t *testing.T) {
-	fexec := exec.New()
-	ns, _ := newNs("test-ns", fexec)
+	ns := newNs("test-ns")
 	ns.LabelsMap = map[string]string{
 		"test": "new",
 	}
@@ -540,11 +529,8 @@ func TestIsSystemNs(t *testing.T) {
 
 func checkNsTestResult(testName string, f *nameSpaceFixture, testCases []expectedNsValues) {
 	for _, test := range testCases {
-		if got := len(f.npMgr.PodMap); got != test.expectedLenOfPodMap {
-			f.t.Errorf("PodMap length = %d, want %d. Map: %+v", got, test.expectedLenOfPodMap, f.npMgr.PodMap)
-		}
-		if got := len(f.npMgr.NsMap); got != test.expectedLenOfNsMap {
-			f.t.Errorf("NsMap length = %d, want %d. Map: %+v", got, test.expectedLenOfNsMap, f.npMgr.NsMap)
+		if got := len(f.nsController.nsMap); got != test.expectedLenOfNsMap {
+			f.t.Errorf("NsMap length = %d, want %d. Map: %+v", got, test.expectedLenOfNsMap, f.nsController.nsMap)
 		}
 		if got := f.nsController.workqueue.Len(); got != test.expectedLenOfWorkQueue {
 			f.t.Errorf("Workqueue length = %d, want %d", got, test.expectedLenOfWorkQueue)

--- a/npm/nameSpaceController_test.go
+++ b/npm/nameSpaceController_test.go
@@ -61,7 +61,8 @@ func (f *nameSpaceFixture) newNsController(stopCh chan struct{}) {
 	f.kubeclient = k8sfake.NewSimpleClientset(f.kubeobjects...)
 	f.kubeInformer = kubeinformers.NewSharedInformerFactory(f.kubeclient, noResyncPeriodFunc())
 
-	f.nsController = NewNameSpaceController(f.kubeInformer.Core().V1().Namespaces(), f.kubeclient, f.ipsMgr)
+	npmNamespaceCache := &npmNamespaceCache{nsMap: make(map[string]*Namespace)}
+	f.nsController = NewNameSpaceController(f.kubeInformer.Core().V1().Namespaces(), f.kubeclient, f.ipsMgr, npmNamespaceCache)
 	f.nsController.nameSpaceListerSynced = alwaysReady
 
 	for _, ns := range f.nsLister {
@@ -176,7 +177,7 @@ func TestAddNamespace(t *testing.T) {
 	}
 	checkNsTestResult("TestAddNamespace", f, testCases)
 
-	if _, exists := f.nsController.nsMap[util.GetNSNameWithPrefix(nsObj.Name)]; !exists {
+	if _, exists := f.nsController.npmNamespaceCache.nsMap[util.GetNSNameWithPrefix(nsObj.Name)]; !exists {
 		t.Errorf("TestAddNamespace failed @ npMgr.nsMap check")
 	}
 }
@@ -215,13 +216,13 @@ func TestUpdateNamespace(t *testing.T) {
 	}
 	checkNsTestResult("TestUpdateNamespace", f, testCases)
 
-	if _, exists := f.nsController.nsMap[util.GetNSNameWithPrefix(newNsObj.Name)]; !exists {
+	if _, exists := f.nsController.npmNamespaceCache.nsMap[util.GetNSNameWithPrefix(newNsObj.Name)]; !exists {
 		t.Errorf("TestUpdateNamespace failed @ npMgr.nsMap check")
 	}
 
 	if !reflect.DeepEqual(
 		newNsObj.Labels,
-		f.nsController.nsMap[util.GetNSNameWithPrefix(oldNsObj.Name)].LabelsMap,
+		f.nsController.npmNamespaceCache.nsMap[util.GetNSNameWithPrefix(oldNsObj.Name)].LabelsMap,
 	) {
 		t.Fatalf("TestUpdateNamespace failed @ npMgr.nsMap labelMap check")
 	}
@@ -261,13 +262,13 @@ func TestAddNamespaceLabel(t *testing.T) {
 	}
 	checkNsTestResult("TestAddNamespaceLabel", f, testCases)
 
-	if _, exists := f.nsController.nsMap[util.GetNSNameWithPrefix(newNsObj.Name)]; !exists {
+	if _, exists := f.nsController.npmNamespaceCache.nsMap[util.GetNSNameWithPrefix(newNsObj.Name)]; !exists {
 		t.Errorf("TestAddNamespaceLabel failed @ nsMap check")
 	}
 
 	if !reflect.DeepEqual(
 		newNsObj.Labels,
-		f.nsController.nsMap[util.GetNSNameWithPrefix(oldNsObj.Name)].LabelsMap,
+		f.nsController.npmNamespaceCache.nsMap[util.GetNSNameWithPrefix(oldNsObj.Name)].LabelsMap,
 	) {
 		t.Fatalf("TestAddNamespaceLabel failed @ nsMap labelMap check")
 	}
@@ -308,13 +309,13 @@ func TestAddNamespaceLabelSameRv(t *testing.T) {
 	}
 	checkNsTestResult("TestAddNamespaceLabelSameRv", f, testCases)
 
-	if _, exists := f.nsController.nsMap[util.GetNSNameWithPrefix(newNsObj.Name)]; !exists {
+	if _, exists := f.nsController.npmNamespaceCache.nsMap[util.GetNSNameWithPrefix(newNsObj.Name)]; !exists {
 		t.Errorf("TestAddNamespaceLabelSameRv failed @ nsMap check")
 	}
 
 	if !reflect.DeepEqual(
 		oldNsObj.Labels,
-		f.nsController.nsMap[util.GetNSNameWithPrefix(oldNsObj.Name)].LabelsMap,
+		f.nsController.npmNamespaceCache.nsMap[util.GetNSNameWithPrefix(oldNsObj.Name)].LabelsMap,
 	) {
 		t.Fatalf("TestAddNamespaceLabelSameRv failed @ nsMap labelMap check")
 	}
@@ -357,13 +358,13 @@ func TestDeleteandUpdateNamespaceLabel(t *testing.T) {
 	}
 	checkNsTestResult("TestDeleteandUpdateNamespaceLabel", f, testCases)
 
-	if _, exists := f.nsController.nsMap[util.GetNSNameWithPrefix(newNsObj.Name)]; !exists {
+	if _, exists := f.nsController.npmNamespaceCache.nsMap[util.GetNSNameWithPrefix(newNsObj.Name)]; !exists {
 		t.Errorf("TestDeleteandUpdateNamespaceLabel failed @ nsMap check")
 	}
 
 	if !reflect.DeepEqual(
 		newNsObj.Labels,
-		f.nsController.nsMap[util.GetNSNameWithPrefix(oldNsObj.Name)].LabelsMap,
+		f.nsController.npmNamespaceCache.nsMap[util.GetNSNameWithPrefix(oldNsObj.Name)].LabelsMap,
 	) {
 		t.Fatalf("TestDeleteandUpdateNamespaceLabel failed @ nsMap labelMap check")
 	}
@@ -411,13 +412,13 @@ func TestNewNameSpaceUpdate(t *testing.T) {
 	}
 	checkNsTestResult("TestDeleteandUpdateNamespaceLabel", f, testCases)
 
-	if _, exists := f.nsController.nsMap[util.GetNSNameWithPrefix(newNsObj.Name)]; !exists {
+	if _, exists := f.nsController.npmNamespaceCache.nsMap[util.GetNSNameWithPrefix(newNsObj.Name)]; !exists {
 		t.Errorf("TestDeleteandUpdateNamespaceLabel failed @ nsMap check")
 	}
 
 	if !reflect.DeepEqual(
 		newNsObj.Labels,
-		f.nsController.nsMap[util.GetNSNameWithPrefix(oldNsObj.Name)].LabelsMap,
+		f.nsController.npmNamespaceCache.nsMap[util.GetNSNameWithPrefix(oldNsObj.Name)].LabelsMap,
 	) {
 		t.Fatalf("TestDeleteandUpdateNamespaceLabel failed @ nsMap labelMap check")
 	}
@@ -449,7 +450,7 @@ func TestDeleteNamespace(t *testing.T) {
 	}
 	checkNsTestResult("TestDeleteNamespace", f, testCases)
 
-	if _, exists := f.nsController.nsMap[util.GetNSNameWithPrefix(nsObj.Name)]; exists {
+	if _, exists := f.nsController.npmNamespaceCache.nsMap[util.GetNSNameWithPrefix(nsObj.Name)]; exists {
 		t.Errorf("TestDeleteNamespace failed @ nsMap check")
 	}
 }
@@ -529,8 +530,8 @@ func TestIsSystemNs(t *testing.T) {
 
 func checkNsTestResult(testName string, f *nameSpaceFixture, testCases []expectedNsValues) {
 	for _, test := range testCases {
-		if got := len(f.nsController.nsMap); got != test.expectedLenOfNsMap {
-			f.t.Errorf("NsMap length = %d, want %d. Map: %+v", got, test.expectedLenOfNsMap, f.nsController.nsMap)
+		if got := len(f.nsController.npmNamespaceCache.nsMap); got != test.expectedLenOfNsMap {
+			f.t.Errorf("NsMap length = %d, want %d. Map: %+v", got, test.expectedLenOfNsMap, f.nsController.npmNamespaceCache.nsMap)
 		}
 		if got := f.nsController.workqueue.Len(); got != test.expectedLenOfWorkQueue {
 			f.t.Errorf("Workqueue length = %d, want %d", got, test.expectedLenOfWorkQueue)

--- a/npm/nameSpaceController_test.go
+++ b/npm/nameSpaceController_test.go
@@ -173,7 +173,7 @@ func TestAddNamespace(t *testing.T) {
 	addNamespace(t, f, nsObj)
 
 	testCases := []expectedNsValues{
-		{0, 2, 0},
+		{0, 1, 0},
 	}
 	checkNsTestResult("TestAddNamespace", f, testCases)
 
@@ -212,7 +212,7 @@ func TestUpdateNamespace(t *testing.T) {
 	updateNamespace(t, f, oldNsObj, newNsObj)
 
 	testCases := []expectedNsValues{
-		{0, 2, 0},
+		{0, 1, 0},
 	}
 	checkNsTestResult("TestUpdateNamespace", f, testCases)
 
@@ -258,7 +258,7 @@ func TestAddNamespaceLabel(t *testing.T) {
 	updateNamespace(t, f, oldNsObj, newNsObj)
 
 	testCases := []expectedNsValues{
-		{0, 2, 0},
+		{0, 1, 0},
 	}
 	checkNsTestResult("TestAddNamespaceLabel", f, testCases)
 
@@ -305,7 +305,7 @@ func TestAddNamespaceLabelSameRv(t *testing.T) {
 	updateNamespace(t, f, oldNsObj, newNsObj)
 
 	testCases := []expectedNsValues{
-		{0, 2, 0},
+		{0, 1, 0},
 	}
 	checkNsTestResult("TestAddNamespaceLabelSameRv", f, testCases)
 
@@ -354,7 +354,7 @@ func TestDeleteandUpdateNamespaceLabel(t *testing.T) {
 	updateNamespace(t, f, oldNsObj, newNsObj)
 
 	testCases := []expectedNsValues{
-		{0, 2, 0},
+		{0, 1, 0},
 	}
 	checkNsTestResult("TestDeleteandUpdateNamespaceLabel", f, testCases)
 
@@ -408,7 +408,7 @@ func TestNewNameSpaceUpdate(t *testing.T) {
 	updateNamespace(t, f, oldNsObj, newNsObj)
 
 	testCases := []expectedNsValues{
-		{0, 2, 0},
+		{0, 1, 0},
 	}
 	checkNsTestResult("TestDeleteandUpdateNamespaceLabel", f, testCases)
 
@@ -446,7 +446,7 @@ func TestDeleteNamespace(t *testing.T) {
 	deleteNamespace(t, f, nsObj, DeletedFinalStateknownObject)
 
 	testCases := []expectedNsValues{
-		{0, 1, 0},
+		{0, 0, 0},
 	}
 	checkNsTestResult("TestDeleteNamespace", f, testCases)
 
@@ -479,7 +479,7 @@ func TestDeleteNamespaceWithTombstone(t *testing.T) {
 	f.nsController.deleteNamespace(tombstone)
 
 	testCases := []expectedNsValues{
-		{0, 1, 0},
+		{0, 0, 1},
 	}
 	checkNsTestResult("TestDeleteNamespaceWithTombstone", f, testCases)
 }
@@ -502,7 +502,7 @@ func TestDeleteNamespaceWithTombstoneAfterAddingNameSpace(t *testing.T) {
 
 	deleteNamespace(t, f, nsObj, DeletedFinalStateUnknownObject)
 	testCases := []expectedNsValues{
-		{0, 1, 0},
+		{0, 0, 0},
 	}
 	checkNsTestResult("TestDeleteNamespaceWithTombstoneAfterAddingNameSpace", f, testCases)
 }

--- a/npm/networkPolicyController.go
+++ b/npm/networkPolicyController.go
@@ -68,7 +68,7 @@ func NewNetworkPolicyController(npInformer networkinginformers.NetworkPolicyInfo
 	return netPolController
 }
 
-func (c *networkPolicyController) initializeIPTables() error {
+func (c *networkPolicyController) initializeDataPlane() error {
 	klog.Infof("Azure-NPM creating, cleaning iptables")
 
 	err := c.iptMgr.UninitNpmChains()

--- a/npm/networkPolicyController.go
+++ b/npm/networkPolicyController.go
@@ -37,7 +37,6 @@ type networkPolicyController struct {
 	netPolListerSynced cache.InformerSynced
 	workqueue          workqueue.RateLimitingInterface
 	RawNpMap           map[string]*networkingv1.NetworkPolicy // Key is <nsname>/<policyname>
-	// rawNpMapMutex sync.RWMutex
 	// (TODO): will leverage this strucute to manage network policy more efficiently
 	//ProcessedNpMap map[string]*networkingv1.NetworkPolicy // Key is <nsname>/<podSelectorHash>
 	// flag to indicate default Azure NPM chain is created or not
@@ -61,7 +60,6 @@ func NewNetworkPolicyController(npInformer networkinginformers.NetworkPolicyInfo
 
 	// (TODO):  willl need to return results of these calls - need to panic
 	// Clear out leftover iptables states
-
 	npInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    netPolController.addNetworkPolicy,
@@ -72,12 +70,11 @@ func NewNetworkPolicyController(npInformer networkinginformers.NetworkPolicyInfo
 	return netPolController
 }
 
-func (c *networkPolicyController) initializeIptables() error {
+func (c *networkPolicyController) initializeIpTables() error {
 	klog.Infof("Azure-NPM creating, cleaning iptables")
 
 	// (TODO):  return error
 	err := c.iptMgr.UninitNpmChains()
-
 	if err != nil {
 		return err
 	}
@@ -85,15 +82,10 @@ func (c *networkPolicyController) initializeIptables() error {
 	// (TODO): Check any side effects
 	go c.reconcileChains()
 	go c.backup()
-
 	return nil
 }
 
-// c.podMapMutex.RLock()
-// defer c.podMapMutex.RUnlock()
-func (c *networkPolicyController) LengthOfRawNpMap() int {
-	// c.rawNpMapMutex.RLock()
-	// defer c.rawNpMapMutex.RUnlock()
+func (c *networkPolicyController) lengthOfRawNpMap() int {
 	return len(c.RawNpMap)
 }
 
@@ -143,20 +135,6 @@ func (c *networkPolicyController) updateNetworkPolicy(old, new interface{}) {
 	}
 
 	c.workqueue.Add(netPolkey)
-	// c.rawNpMapMutex.RLock()
-	// defer c.rawNpMapMutex.RUnlock()
-	// // Potential issue -> Other goroutines can update cachedNetPolObj?
-	// cachedNetPolObj, netPolExists := c.RawNpMap[netPolkey]
-	// if netPolExists {
-	// 	// if network policy does not have different states against lastly applied states stored in cachedNetPolObj,
-	// 	// netPolController does not need to reconcile this update.
-	// 	// in this updateNetworkPolicy event, newNetPol was updated with states which netPolController does not need to reconcile.
-	// 	if isSameNetworkPolicy(cachedNetPolObj, newNetPol) {
-	// 		return
-	// 	}
-	// }
-
-	// c.workqueue.Add(netPolkey)
 }
 
 func (c *networkPolicyController) deleteNetworkPolicy(obj interface{}) {
@@ -188,14 +166,6 @@ func (c *networkPolicyController) deleteNetworkPolicy(obj interface{}) {
 	}
 
 	c.workqueue.Add(netPolkey)
-
-	// _, netPolExists := c.RawNpMap[netPolkey]
-	// // If a network policy object is not in the RawNpMap, do not need to clean-up states for the network policy
-	// // since netPolController did not apply for any states for the network policy
-	// if !netPolExists {
-	// 	return
-	// }
-	// c.workqueue.Add(netPolkey)
 }
 
 func (c *networkPolicyController) Run(threadiness int, stopCh <-chan struct{}) error {

--- a/npm/networkPolicyController.go
+++ b/npm/networkPolicyController.go
@@ -173,16 +173,14 @@ func (c *networkPolicyController) deleteNetworkPolicy(obj interface{}) {
 	c.workqueue.Add(netPolkey)
 }
 
-func (c *networkPolicyController) Run(threadiness int, stopCh <-chan struct{}) error {
+func (c *networkPolicyController) Run(stopCh <-chan struct{}) error {
 	defer utilruntime.HandleCrash()
 	defer c.workqueue.ShutDown()
 
-	klog.Infof("Starting Network Policy %d worker(s)", threadiness)
-	for i := 0; i < threadiness; i++ {
-		go wait.Until(c.runWorker, time.Second, stopCh)
-	}
+	klog.Infof("Starting Network Policy worker")
+	go wait.Until(c.runWorker, time.Second, stopCh)
 
-	klog.Infof("Started Network Policy %d worker(s)", threadiness)
+	klog.Infof("Started Network Policy worker")
 	<-stopCh
 	klog.Info("Shutting down Network Policy workers")
 

--- a/npm/networkPolicyController.go
+++ b/npm/networkPolicyController.go
@@ -58,8 +58,6 @@ func NewNetworkPolicyController(npInformer networkinginformers.NetworkPolicyInfo
 		iptMgr:                 iptm.NewIptablesManager(),
 	}
 
-	// (TODO):  willl need to return results of these calls - need to panic
-	// Clear out leftover iptables states
 	npInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    netPolController.addNetworkPolicy,
@@ -70,18 +68,15 @@ func NewNetworkPolicyController(npInformer networkinginformers.NetworkPolicyInfo
 	return netPolController
 }
 
-func (c *networkPolicyController) initializeIpTables() error {
+func (c *networkPolicyController) initializeIPTables() error {
 	klog.Infof("Azure-NPM creating, cleaning iptables")
 
-	// (TODO):  return error
 	err := c.iptMgr.UninitNpmChains()
 	if err != nil {
 		return err
 	}
 
-	// (TODO): Check any side effects
-	go c.reconcileChains()
-	go c.backup()
+	c.iptMgr.ReconcileIPTables()
 	return nil
 }
 
@@ -210,7 +205,6 @@ func (c *networkPolicyController) processNextWorkItem() bool {
 		}
 		// Run the syncNetPol, passing it the namespace/name string of the
 		// network policy resource to be synced.
-		// TODO : may consider using "c.queue.AddAfter(key, *requeueAfter)" according to error type later
 		if err := c.syncNetPol(key); err != nil {
 			// Put the item back on the workqueue to handle any transient errors.
 			c.workqueue.AddRateLimited(key)
@@ -345,7 +339,6 @@ func (c *networkPolicyController) syncAddAndUpdateNetPol(netPolObj *networkingv1
 	c.RawNpMap[netpolKey] = netPolObj
 	metrics.NumPolicies.Inc()
 
-	// (TODO): manage it with lock
 	sets, namedPorts, lists, ingressIPCidrs, egressIPCidrs, iptEntries := translatePolicy(netPolObj)
 	for _, set := range sets {
 		klog.Infof("Creating set: %v, hashedSet: %v", set, util.GetHashedName(set))
@@ -365,11 +358,11 @@ func (c *networkPolicyController) syncAddAndUpdateNetPol(netPolObj *networkingv1
 		}
 	}
 
-	if err = c.createCidrsRule("in", netPolObj.ObjectMeta.Name, netPolObj.ObjectMeta.Namespace, ingressIPCidrs, c.ipsMgr); err != nil {
+	if err = c.createCidrsRule("in", netPolObj.ObjectMeta.Name, netPolObj.ObjectMeta.Namespace, ingressIPCidrs); err != nil {
 		return fmt.Errorf("[syncAddAndUpdateNetPol] Error: createCidrsRule in due to %v", err)
 	}
 
-	if err = c.createCidrsRule("out", netPolObj.ObjectMeta.Name, netPolObj.ObjectMeta.Namespace, egressIPCidrs, c.ipsMgr); err != nil {
+	if err = c.createCidrsRule("out", netPolObj.ObjectMeta.Name, netPolObj.ObjectMeta.Namespace, egressIPCidrs); err != nil {
 		return fmt.Errorf("[syncAddAndUpdateNetPol] Error: createCidrsRule out due to %v", err)
 	}
 
@@ -402,12 +395,12 @@ func (c *networkPolicyController) cleanUpNetworkPolicy(netPolKey string, isSafeC
 	}
 
 	// delete ipset list related to ingress CIDRs
-	if err = c.removeCidrsRule("in", cachedNetPolObj.Name, cachedNetPolObj.Namespace, ingressIPCidrs, c.ipsMgr); err != nil {
+	if err = c.removeCidrsRule("in", cachedNetPolObj.Name, cachedNetPolObj.Namespace, ingressIPCidrs); err != nil {
 		return fmt.Errorf("[cleanUpNetworkPolicy] Error: removeCidrsRule in due to %v", err)
 	}
 
 	// delete ipset list related to egress CIDRs
-	if err = c.removeCidrsRule("out", cachedNetPolObj.Name, cachedNetPolObj.Namespace, egressIPCidrs, c.ipsMgr); err != nil {
+	if err = c.removeCidrsRule("out", cachedNetPolObj.Name, cachedNetPolObj.Namespace, egressIPCidrs); err != nil {
 		return fmt.Errorf("[cleanUpNetworkPolicy] Error: removeCidrsRule out due to %v", err)
 	}
 
@@ -431,8 +424,7 @@ func (c *networkPolicyController) cleanUpNetworkPolicy(netPolKey string, isSafeC
 	return nil
 }
 
-// (TODO) do not need to ipsMgr parameter
-func (c *networkPolicyController) createCidrsRule(ingressOrEgress, policyName, ns string, ipsetEntries [][]string, ipsMgr *ipsm.IpsetManager) error {
+func (c *networkPolicyController) createCidrsRule(ingressOrEgress, policyName, ns string, ipsetEntries [][]string) error {
 	spec := append([]string{util.IpsetNetHashFlag, util.IpsetMaxelemName, util.IpsetMaxelemNum})
 
 	for i, ipCidrSet := range ipsetEntries {
@@ -441,7 +433,7 @@ func (c *networkPolicyController) createCidrsRule(ingressOrEgress, policyName, n
 		}
 		setName := policyName + "-in-ns-" + ns + "-" + strconv.Itoa(i) + ingressOrEgress
 		klog.Infof("Creating set: %v, hashedSet: %v", setName, util.GetHashedName(setName))
-		if err := ipsMgr.CreateSet(setName, spec); err != nil {
+		if err := c.ipsMgr.CreateSet(setName, spec); err != nil {
 			return fmt.Errorf("[createCidrsRule] Error: creating ipset %s with err: %v", ipCidrSet, err)
 		}
 		for _, ipCidrEntry := range util.DropEmptyFields(ipCidrSet) {
@@ -450,12 +442,12 @@ func (c *networkPolicyController) createCidrsRule(ingressOrEgress, policyName, n
 			if ipCidrEntry == "0.0.0.0/0" {
 				splitEntry := [2]string{"1.0.0.0/1", "128.0.0.0/1"}
 				for _, entry := range splitEntry {
-					if err := ipsMgr.AddToSet(setName, entry, util.IpsetNetHashFlag, ""); err != nil {
+					if err := c.ipsMgr.AddToSet(setName, entry, util.IpsetNetHashFlag, ""); err != nil {
 						return fmt.Errorf("[createCidrsRule] adding ip cidrs %s into ipset %s with err: %v", entry, ipCidrSet, err)
 					}
 				}
 			} else {
-				if err := ipsMgr.AddToSet(setName, ipCidrEntry, util.IpsetNetHashFlag, ""); err != nil {
+				if err := c.ipsMgr.AddToSet(setName, ipCidrEntry, util.IpsetNetHashFlag, ""); err != nil {
 					return fmt.Errorf("[createCidrsRule] adding ip cidrs %s into ipset %s with err: %v", ipCidrEntry, ipCidrSet, err)
 				}
 			}
@@ -465,30 +457,18 @@ func (c *networkPolicyController) createCidrsRule(ingressOrEgress, policyName, n
 	return nil
 }
 
-// (TODO) do not need to ipsMgr parameter
-func (c *networkPolicyController) removeCidrsRule(ingressOrEgress, policyName, ns string, ipsetEntries [][]string, ipsMgr *ipsm.IpsetManager) error {
+func (c *networkPolicyController) removeCidrsRule(ingressOrEgress, policyName, ns string, ipsetEntries [][]string) error {
 	for i, ipCidrSet := range ipsetEntries {
 		if ipCidrSet == nil || len(ipCidrSet) == 0 {
 			continue
 		}
 		setName := policyName + "-in-ns-" + ns + "-" + strconv.Itoa(i) + ingressOrEgress
 		klog.Infof("Delete set: %v, hashedSet: %v", setName, util.GetHashedName(setName))
-		if err := ipsMgr.DeleteSet(setName); err != nil {
+		if err := c.ipsMgr.DeleteSet(setName); err != nil {
 			return fmt.Errorf("[removeCidrsRule] deleting ipset %s with err: %v", ipCidrSet, err)
 		}
 	}
 
-	return nil
-}
-
-// reconcileChains checks for ordering of AZURE-NPM chain in FORWARD chain periodically.
-func (c *networkPolicyController) reconcileChains() error {
-	select {
-	case <-time.After(reconcileChainTimeInMinutes * time.Minute):
-		if err := c.iptMgr.CheckAndAddForwardChain(); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 
@@ -506,18 +486,6 @@ func (c *networkPolicyController) restore() {
 	metrics.SendErrorLogAndMetric(util.NpmID, "Error: timeout restoring Azure-NPM states")
 	// Check this panic
 	panic(err.Error)
-}
-
-// backup takes snapshots of iptables filter table and saves it periodically.
-func (c *networkPolicyController) backup() {
-	var err error
-	for {
-		// (TODO) check backupWaitTimeInSeconds variables
-		time.Sleep(backupWaitTimeInSeconds * time.Second)
-		if err = c.iptMgr.Save(util.IptablesConfigFile); err != nil {
-			metrics.SendErrorLogAndMetric(util.NpmID, "Error: failed to back up Azure-NPM states")
-		}
-	}
 }
 
 // GetProcessedNPKey will return netpolKey

--- a/npm/networkPolicyController.go
+++ b/npm/networkPolicyController.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-container-networking/npm/ipsm"
+	"github.com/Azure/azure-container-networking/npm/iptm"
 	"github.com/Azure/azure-container-networking/npm/metrics"
 	"github.com/Azure/azure-container-networking/npm/util"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -35,21 +36,31 @@ type networkPolicyController struct {
 	netPolLister       netpollister.NetworkPolicyLister
 	netPolListerSynced cache.InformerSynced
 	workqueue          workqueue.RateLimitingInterface
-	// (TODO): networkPolController does not need to have whole NetworkPolicyManager pointer. Need to improve it
-	npMgr *NetworkPolicyManager
+	RawNpMap           map[string]*networkingv1.NetworkPolicy // Key is <nsname>/<policyname>
+	// rawNpMapMutex sync.RWMutex
+	// (TODO): will leverage this strucute to manage network policy more efficiently
+	//ProcessedNpMap map[string]*networkingv1.NetworkPolicy // Key is <nsname>/<podSelectorHash>
 	// flag to indicate default Azure NPM chain is created or not
 	isAzureNpmChainCreated bool
+	ipsMgr                 *ipsm.IpsetManager
+	iptMgr                 *iptm.IptablesManager
 }
 
-func NewNetworkPolicyController(npInformer networkinginformers.NetworkPolicyInformer, clientset kubernetes.Interface, npMgr *NetworkPolicyManager) *networkPolicyController {
+func NewNetworkPolicyController(npInformer networkinginformers.NetworkPolicyInformer, clientset kubernetes.Interface, ipsMgr *ipsm.IpsetManager) *networkPolicyController {
 	netPolController := &networkPolicyController{
-		clientset:              clientset,
-		netPolLister:           npInformer.Lister(),
-		netPolListerSynced:     npInformer.Informer().HasSynced,
-		workqueue:              workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "NetworkPolicy"),
-		npMgr:                  npMgr,
+		clientset:          clientset,
+		netPolLister:       npInformer.Lister(),
+		netPolListerSynced: npInformer.Informer().HasSynced,
+		workqueue:          workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "NetworkPolicy"),
+		RawNpMap:           make(map[string]*networkingv1.NetworkPolicy),
+		//ProcessedNpMap:         make(map[string]*networkingv1.NetworkPolicy),
 		isAzureNpmChainCreated: false,
+		ipsMgr:                 ipsMgr,
+		iptMgr:                 iptm.NewIptablesManager(),
 	}
+
+	// (TODO):  willl need to return results of these calls - need to panic
+	// Clear out leftover iptables states
 
 	npInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
@@ -59,6 +70,31 @@ func NewNetworkPolicyController(npInformer networkinginformers.NetworkPolicyInfo
 		},
 	)
 	return netPolController
+}
+
+func (c *networkPolicyController) initializeIptables() error {
+	klog.Infof("Azure-NPM creating, cleaning iptables")
+
+	// (TODO):  return error
+	err := c.iptMgr.UninitNpmChains()
+
+	if err != nil {
+		return err
+	}
+
+	// (TODO): Check any side effects
+	go c.reconcileChains()
+	go c.backup()
+
+	return nil
+}
+
+// c.podMapMutex.RLock()
+// defer c.podMapMutex.RUnlock()
+func (c *networkPolicyController) LengthOfRawNpMap() int {
+	// c.rawNpMapMutex.RLock()
+	// defer c.rawNpMapMutex.RUnlock()
+	return len(c.RawNpMap)
 }
 
 // getNetworkPolicyKey returns namespace/name of network policy object if it is valid network policy object and has valid namespace/name.
@@ -106,19 +142,21 @@ func (c *networkPolicyController) updateNetworkPolicy(old, new interface{}) {
 		}
 	}
 
-	c.npMgr.Lock()
-	cachedNetPolObj, netPolExists := c.npMgr.RawNpMap[netPolkey]
-	c.npMgr.Unlock()
-	if netPolExists {
-		// if network policy does not have different states against lastly applied states stored in cachedNetPolObj,
-		// netPolController does not need to reconcile this update.
-		// in this updateNetworkPolicy event, newNetPol was updated with states which netPolController does not need to reconcile.
-		if isSameNetworkPolicy(cachedNetPolObj, newNetPol) {
-			return
-		}
-	}
-
 	c.workqueue.Add(netPolkey)
+	// c.rawNpMapMutex.RLock()
+	// defer c.rawNpMapMutex.RUnlock()
+	// // Potential issue -> Other goroutines can update cachedNetPolObj?
+	// cachedNetPolObj, netPolExists := c.RawNpMap[netPolkey]
+	// if netPolExists {
+	// 	// if network policy does not have different states against lastly applied states stored in cachedNetPolObj,
+	// 	// netPolController does not need to reconcile this update.
+	// 	// in this updateNetworkPolicy event, newNetPol was updated with states which netPolController does not need to reconcile.
+	// 	if isSameNetworkPolicy(cachedNetPolObj, newNetPol) {
+	// 		return
+	// 	}
+	// }
+
+	// c.workqueue.Add(netPolkey)
 }
 
 func (c *networkPolicyController) deleteNetworkPolicy(obj interface{}) {
@@ -149,17 +187,15 @@ func (c *networkPolicyController) deleteNetworkPolicy(obj interface{}) {
 		return
 	}
 
-	// (TODO): need to decouple this lock from npMgr if possible
-	c.npMgr.Lock()
-	_, netPolExists := c.npMgr.RawNpMap[netPolkey]
-	c.npMgr.Unlock()
-	// If a network policy object is not in the RawNpMap, do not need to clean-up states for the network policy
-	// since netPolController did not apply for any states for the network policy
-	if !netPolExists {
-		return
-	}
-
 	c.workqueue.Add(netPolkey)
+
+	// _, netPolExists := c.RawNpMap[netPolkey]
+	// // If a network policy object is not in the RawNpMap, do not need to clean-up states for the network policy
+	// // since netPolController did not apply for any states for the network policy
+	// if !netPolExists {
+	// 	return
+	// }
+	// c.workqueue.Add(netPolkey)
 }
 
 func (c *networkPolicyController) Run(threadiness int, stopCh <-chan struct{}) error {
@@ -237,11 +273,6 @@ func (c *networkPolicyController) syncNetPol(key string) error {
 
 	// Get the network policy resource with this namespace/name
 	netPolObj, err := c.netPolLister.NetworkPolicies(namespace).Get(name)
-
-	// (TODO): Reduce scope of lock later
-	c.npMgr.Lock()
-	defer c.npMgr.Unlock()
-
 	if err != nil {
 		if errors.IsNotFound(err) {
 			klog.Infof("Network Policy %s is not found, may be it is deleted", key)
@@ -266,6 +297,16 @@ func (c *networkPolicyController) syncNetPol(key string) error {
 		return nil
 	}
 
+	cachedNetPolObj, netPolExists := c.RawNpMap[key]
+	if netPolExists {
+		// if network policy does not have different states against lastly applied states stored in cachedNetPolObj,
+		// netPolController does not need to reconcile this update.
+		// in this updateNetworkPolicy event, newNetPol was updated with states which netPolController does not need to reconcile.
+		if isSameNetworkPolicy(cachedNetPolObj, netPolObj) {
+			return nil
+		}
+	}
+
 	err = c.syncAddAndUpdateNetPol(netPolObj)
 	if err != nil {
 		return fmt.Errorf("[syncNetPol] Error due to  %s\n", err.Error())
@@ -280,12 +321,10 @@ func (c *networkPolicyController) initializeDefaultAzureNpmChain() error {
 		return nil
 	}
 
-	ipsMgr := c.npMgr.NsMap[util.KubeAllNamespacesFlag].IpsMgr
-	iptMgr := c.npMgr.NsMap[util.KubeAllNamespacesFlag].iptMgr
-	if err := ipsMgr.CreateSet(util.KubeSystemFlag, append([]string{util.IpsetNetHashFlag})); err != nil {
+	if err := c.ipsMgr.CreateSet(util.KubeSystemFlag, append([]string{util.IpsetNetHashFlag})); err != nil {
 		return fmt.Errorf("[initializeDefaultAzureNpmChain] Error: failed to initialize kube-system ipset with err %s", err)
 	}
-	if err := iptMgr.InitNpmChains(); err != nil {
+	if err := c.iptMgr.InitNpmChains(); err != nil {
 		return fmt.Errorf("[initializeDefaultAzureNpmChain] Error: failed to initialize azure-npm chains with err %s", err)
 	}
 
@@ -333,40 +372,39 @@ func (c *networkPolicyController) syncAddAndUpdateNetPol(netPolObj *networkingv1
 	// Cache network object first before applying ipsets and iptables.
 	// If error happens while applying ipsets and iptables,
 	// the key is re-queued in workqueue and process this function again, which eventually meets desired states of network policy
-	c.npMgr.RawNpMap[netpolKey] = netPolObj
+	c.RawNpMap[netpolKey] = netPolObj
 	metrics.NumPolicies.Inc()
 
-	ipsMgr := c.npMgr.NsMap[util.KubeAllNamespacesFlag].IpsMgr
-	iptMgr := c.npMgr.NsMap[util.KubeAllNamespacesFlag].iptMgr
+	// (TODO): manage it with lock
 	sets, namedPorts, lists, ingressIPCidrs, egressIPCidrs, iptEntries := translatePolicy(netPolObj)
 	for _, set := range sets {
 		klog.Infof("Creating set: %v, hashedSet: %v", set, util.GetHashedName(set))
-		if err = ipsMgr.CreateSet(set, append([]string{util.IpsetNetHashFlag})); err != nil {
+		if err = c.ipsMgr.CreateSet(set, append([]string{util.IpsetNetHashFlag})); err != nil {
 			return fmt.Errorf("[syncAddAndUpdateNetPol] Error: creating ipset %s with err: %v", set, err)
 		}
 	}
 	for _, set := range namedPorts {
 		klog.Infof("Creating set: %v, hashedSet: %v", set, util.GetHashedName(set))
-		if err = ipsMgr.CreateSet(set, append([]string{util.IpsetIPPortHashFlag})); err != nil {
+		if err = c.ipsMgr.CreateSet(set, append([]string{util.IpsetIPPortHashFlag})); err != nil {
 			return fmt.Errorf("[syncAddAndUpdateNetPol] Error: creating ipset named port %s with err: %v", set, err)
 		}
 	}
 	for _, list := range lists {
-		if err = ipsMgr.CreateList(list); err != nil {
+		if err = c.ipsMgr.CreateList(list); err != nil {
 			return fmt.Errorf("[syncAddAndUpdateNetPol] Error: creating ipset list %s with err: %v", list, err)
 		}
 	}
 
-	if err = c.createCidrsRule("in", netPolObj.ObjectMeta.Name, netPolObj.ObjectMeta.Namespace, ingressIPCidrs, ipsMgr); err != nil {
+	if err = c.createCidrsRule("in", netPolObj.ObjectMeta.Name, netPolObj.ObjectMeta.Namespace, ingressIPCidrs, c.ipsMgr); err != nil {
 		return fmt.Errorf("[syncAddAndUpdateNetPol] Error: createCidrsRule in due to %v", err)
 	}
 
-	if err = c.createCidrsRule("out", netPolObj.ObjectMeta.Name, netPolObj.ObjectMeta.Namespace, egressIPCidrs, ipsMgr); err != nil {
+	if err = c.createCidrsRule("out", netPolObj.ObjectMeta.Name, netPolObj.ObjectMeta.Namespace, egressIPCidrs, c.ipsMgr); err != nil {
 		return fmt.Errorf("[syncAddAndUpdateNetPol] Error: createCidrsRule out due to %v", err)
 	}
 
 	for _, iptEntry := range iptEntries {
-		if err = iptMgr.Add(iptEntry); err != nil {
+		if err = c.iptMgr.Add(iptEntry); err != nil {
 			return fmt.Errorf("[syncAddAndUpdateNetPol] Error: failed to apply iptables rule. Rule: %+v with err: %v", iptEntry, err)
 		}
 	}
@@ -376,47 +414,45 @@ func (c *networkPolicyController) syncAddAndUpdateNetPol(netPolObj *networkingv1
 
 // DeleteNetworkPolicy handles deleting network policy based on netPolKey.
 func (c *networkPolicyController) cleanUpNetworkPolicy(netPolKey string, isSafeCleanUpAzureNpmChain IsSafeCleanUpAzureNpmChain) error {
-	cachedNetPolObj, cachedNetPolObjExists := c.npMgr.RawNpMap[netPolKey]
+	cachedNetPolObj, cachedNetPolObjExists := c.RawNpMap[netPolKey]
 	// if there is no applied network policy with the netPolKey, do not need to clean up process.
 	if !cachedNetPolObjExists {
 		return nil
 	}
 
-	ipsMgr := c.npMgr.NsMap[util.KubeAllNamespacesFlag].IpsMgr
-	iptMgr := c.npMgr.NsMap[util.KubeAllNamespacesFlag].iptMgr
 	// translate policy from "cachedNetPolObj"
 	_, _, _, ingressIPCidrs, egressIPCidrs, iptEntries := translatePolicy(cachedNetPolObj)
 
 	var err error
 	// delete iptables entries
 	for _, iptEntry := range iptEntries {
-		if err = iptMgr.Delete(iptEntry); err != nil {
+		if err = c.iptMgr.Delete(iptEntry); err != nil {
 			return fmt.Errorf("[cleanUpNetworkPolicy] Error: failed to apply iptables rule. Rule: %+v with err: %v", iptEntry, err)
 		}
 	}
 
 	// delete ipset list related to ingress CIDRs
-	if err = c.removeCidrsRule("in", cachedNetPolObj.Name, cachedNetPolObj.Namespace, ingressIPCidrs, ipsMgr); err != nil {
+	if err = c.removeCidrsRule("in", cachedNetPolObj.Name, cachedNetPolObj.Namespace, ingressIPCidrs, c.ipsMgr); err != nil {
 		return fmt.Errorf("[cleanUpNetworkPolicy] Error: removeCidrsRule in due to %v", err)
 	}
 
 	// delete ipset list related to egress CIDRs
-	if err = c.removeCidrsRule("out", cachedNetPolObj.Name, cachedNetPolObj.Namespace, egressIPCidrs, ipsMgr); err != nil {
+	if err = c.removeCidrsRule("out", cachedNetPolObj.Name, cachedNetPolObj.Namespace, egressIPCidrs, c.ipsMgr); err != nil {
 		return fmt.Errorf("[cleanUpNetworkPolicy] Error: removeCidrsRule out due to %v", err)
 	}
 
 	// Sucess to clean up ipset and iptables operations in kernel and delete the cached network policy from RawNpMap
-	delete(c.npMgr.RawNpMap, netPolKey)
+	delete(c.RawNpMap, netPolKey)
 	metrics.NumPolicies.Dec()
 
 	// If there is no cached network policy in RawNPMap anymore and no immediate network policy to process, start cleaning up default azure npm chains
 	// However, UninitNpmChains function is failed which left failed states and will not retry, but functionally it is ok.
 	// (TODO): Ideally, need to decouple cleaning-up default azure npm chains from "network policy deletion" event.
-	if isSafeCleanUpAzureNpmChain && len(c.npMgr.RawNpMap) == 0 {
+	if isSafeCleanUpAzureNpmChain && len(c.RawNpMap) == 0 {
 		// Even though UninitNpmChains function returns error, isAzureNpmChainCreated sets up false.
 		// So, when a new network policy is added, the "default Azure NPM chain" can be installed.
 		c.isAzureNpmChainCreated = false
-		if err = iptMgr.UninitNpmChains(); err != nil {
+		if err = c.iptMgr.UninitNpmChains(); err != nil {
 			utilruntime.HandleError(fmt.Errorf("Error: failed to uninitialize azure-npm chains with err: %s", err))
 			return nil
 		}
@@ -425,6 +461,7 @@ func (c *networkPolicyController) cleanUpNetworkPolicy(netPolKey string, isSafeC
 	return nil
 }
 
+// (TODO) do not need to ipsMgr parameter
 func (c *networkPolicyController) createCidrsRule(ingressOrEgress, policyName, ns string, ipsetEntries [][]string, ipsMgr *ipsm.IpsetManager) error {
 	spec := append([]string{util.IpsetNetHashFlag, util.IpsetMaxelemName, util.IpsetMaxelemNum})
 
@@ -458,6 +495,7 @@ func (c *networkPolicyController) createCidrsRule(ingressOrEgress, policyName, n
 	return nil
 }
 
+// (TODO) do not need to ipsMgr parameter
 func (c *networkPolicyController) removeCidrsRule(ingressOrEgress, policyName, ns string, ipsetEntries [][]string, ipsMgr *ipsm.IpsetManager) error {
 	for i, ipCidrSet := range ipsetEntries {
 		if ipCidrSet == nil || len(ipCidrSet) == 0 {
@@ -471,6 +509,45 @@ func (c *networkPolicyController) removeCidrsRule(ingressOrEgress, policyName, n
 	}
 
 	return nil
+}
+
+// reconcileChains checks for ordering of AZURE-NPM chain in FORWARD chain periodically.
+func (c *networkPolicyController) reconcileChains() error {
+	select {
+	case <-time.After(reconcileChainTimeInMinutes * time.Minute):
+		if err := c.iptMgr.CheckAndAddForwardChain(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// backup takes snapshots of iptables filter table and saves it periodically.
+func (c *networkPolicyController) restore() {
+	var err error
+	for i := 0; i < restoreMaxRetries; i++ {
+		if err = c.iptMgr.Restore(util.IptablesConfigFile); err == nil {
+			return
+		}
+
+		time.Sleep(restoreRetryWaitTimeInSeconds * time.Second)
+	}
+
+	metrics.SendErrorLogAndMetric(util.NpmID, "Error: timeout restoring Azure-NPM states")
+	// Check this panic
+	panic(err.Error)
+}
+
+// backup takes snapshots of iptables filter table and saves it periodically.
+func (c *networkPolicyController) backup() {
+	var err error
+	for {
+		// (TODO) check backupWaitTimeInSeconds variables
+		time.Sleep(backupWaitTimeInSeconds * time.Second)
+		if err = c.iptMgr.Save(util.IptablesConfigFile); err != nil {
+			metrics.SendErrorLogAndMetric(util.NpmID, "Error: failed to back up Azure-NPM states")
+		}
+	}
 }
 
 // GetProcessedNPKey will return netpolKey

--- a/npm/networkPolicyController_test.go
+++ b/npm/networkPolicyController_test.go
@@ -37,18 +37,14 @@ type netPolFixture struct {
 	ipsMgr           *ipsm.IpsetManager
 	netPolController *networkPolicyController
 	kubeInformer     kubeinformers.SharedInformerFactory
-
-	// to test whether unnecessary enqueuing event into workqueue was correctly filtered in eventhandler code of network policy controller
-	isEnqueueEventIntoWorkQueue bool
 }
 
 func newNetPolFixture(t *testing.T, utilexec exec.Interface) *netPolFixture {
 	f := &netPolFixture{
-		t:                           t,
-		netPolLister:                []*networkingv1.NetworkPolicy{},
-		kubeobjects:                 []runtime.Object{},
-		ipsMgr:                      ipsm.NewIpsetManager(utilexec),
-		isEnqueueEventIntoWorkQueue: true,
+		t:            t,
+		netPolLister: []*networkingv1.NetworkPolicy{},
+		kubeobjects:  []runtime.Object{},
+		ipsMgr:       ipsm.NewIpsetManager(utilexec),
 	}
 
 	// While running "make test-all", metrics hold states which was executed in previous unit test.
@@ -153,7 +149,6 @@ func addNetPol(t *testing.T, f *netPolFixture, netPolObj *networkingv1.NetworkPo
 	f.netPolController.addNetworkPolicy(netPolObj)
 
 	if f.netPolController.workqueue.Len() == 0 {
-		f.isEnqueueEventIntoWorkQueue = false
 		return
 	}
 
@@ -178,7 +173,6 @@ func deleteNetPol(t *testing.T, f *netPolFixture, netPolObj *networkingv1.Networ
 	}
 
 	if f.netPolController.workqueue.Len() == 0 {
-		f.isEnqueueEventIntoWorkQueue = false
 		return
 	}
 
@@ -194,7 +188,6 @@ func updateNetPol(t *testing.T, f *netPolFixture, oldNetPolObj, netNetPolObj *ne
 	f.netPolController.updateNetworkPolicy(oldNetPolObj, netNetPolObj)
 
 	if f.netPolController.workqueue.Len() == 0 {
-		f.isEnqueueEventIntoWorkQueue = false
 		return
 	}
 
@@ -202,12 +195,9 @@ func updateNetPol(t *testing.T, f *netPolFixture, oldNetPolObj, netNetPolObj *ne
 }
 
 type expectedNetPolValues struct {
-	// (TODO): do not check ns map
-	expectedLenOfNsMap                int
-	expectedLenOfRawNpMap             int
-	expectedLenOfWorkQueue            int
-	expectedIsAzureNpmChainCreated    bool
-	expectedEnqueueEventIntoWorkQueue bool
+	expectedLenOfRawNpMap          int
+	expectedLenOfWorkQueue         int
+	expectedIsAzureNpmChainCreated bool
 	// prometheus metrics
 	expectedNumPoliciesMetric                   int
 	expectedNumPoliciesMetricError              error
@@ -217,10 +207,6 @@ type expectedNetPolValues struct {
 
 func checkNetPolTestResult(testName string, f *netPolFixture, testCases []expectedNetPolValues) {
 	for _, test := range testCases {
-		// if got := len(f.npMgr.Network); got != test.expectedLenOfNsMap {
-		// 	f.t.Errorf("npMgr namespace map length = %d, want %d", got, test.expectedLenOfNsMap)
-		// }
-
 		if got := len(f.netPolController.RawNpMap); got != test.expectedLenOfRawNpMap {
 			f.t.Errorf("Raw NetPol Map length = %d, want %d", got, test.expectedLenOfRawNpMap)
 		}
@@ -231,10 +217,6 @@ func checkNetPolTestResult(testName string, f *netPolFixture, testCases []expect
 
 		if got := f.netPolController.isAzureNpmChainCreated; got != test.expectedIsAzureNpmChainCreated {
 			f.t.Errorf("isAzureNpmChainCreated %v, want %v", got, test.expectedIsAzureNpmChainCreated)
-		}
-
-		if got := f.isEnqueueEventIntoWorkQueue; got != test.expectedEnqueueEventIntoWorkQueue {
-			f.t.Errorf("isEnqueueEventIntoWorkQueue %v, want %v", got, test.expectedEnqueueEventIntoWorkQueue)
 		}
 
 		// Check prometheus metrics
@@ -278,7 +260,7 @@ func TestAddMultipleNetworkPolicies(t *testing.T) {
 	addNetPol(t, f, netPolObj2)
 
 	testCases := []expectedNetPolValues{
-		{1, 2, 0, true, true, 2, nil, 2, nil},
+		{2, 0, true, 2, nil, 2, nil},
 	}
 	checkNetPolTestResult("TestAddMultipleNetPols", f, testCases)
 }
@@ -296,7 +278,7 @@ func TestAddNetworkPolicy(t *testing.T) {
 
 	addNetPol(t, f, netPolObj)
 	testCases := []expectedNetPolValues{
-		{1, 1, 0, true, true, 1, nil, 1, nil},
+		{1, 0, true, 1, nil, 1, nil},
 	}
 
 	checkNetPolTestResult("TestAddNetPol", f, testCases)
@@ -315,7 +297,7 @@ func TestDeleteNetworkPolicy(t *testing.T) {
 
 	deleteNetPol(t, f, netPolObj, DeletedFinalStateknownObject)
 	testCases := []expectedNetPolValues{
-		{1, 0, 0, false, true, 0, nil, 1, nil},
+		{0, 0, false, 0, nil, 1, nil},
 	}
 	checkNetPolTestResult("TestDelNetPol", f, testCases)
 }
@@ -325,7 +307,6 @@ func TestDeleteNetworkPolicyWithTombstone(t *testing.T) {
 
 	fexec := exec.New()
 	f := newNetPolFixture(t, fexec)
-	f.isEnqueueEventIntoWorkQueue = false
 	f.netPolLister = append(f.netPolLister, netPolObj)
 	f.kubeobjects = append(f.kubeobjects, netPolObj)
 	stopCh := make(chan struct{})
@@ -340,7 +321,7 @@ func TestDeleteNetworkPolicyWithTombstone(t *testing.T) {
 
 	f.netPolController.deleteNetworkPolicy(tombstone)
 	testCases := []expectedNetPolValues{
-		{1, 0, 0, false, false, 0, nil, 0, nil},
+		{0, 1, false, 0, nil, 0, nil},
 	}
 	checkNetPolTestResult("TestDeleteNetworkPolicyWithTombstone", f, testCases)
 }
@@ -358,7 +339,7 @@ func TestDeleteNetworkPolicyWithTombstoneAfterAddingNetworkPolicy(t *testing.T) 
 
 	deleteNetPol(t, f, netPolObj, DeletedFinalStateUnknownObject)
 	testCases := []expectedNetPolValues{
-		{1, 0, 0, false, true, 0, nil, 1, nil},
+		{0, 0, false, 0, nil, 1, nil},
 	}
 	checkNetPolTestResult("TestDeleteNetworkPolicyWithTombstoneAfterAddingNetworkPolicy", f, testCases)
 }
@@ -383,7 +364,7 @@ func TestUpdateNetworkPolicy(t *testing.T) {
 
 	updateNetPol(t, f, oldNetPolObj, newNetPolObj)
 	testCases := []expectedNetPolValues{
-		{1, 1, 0, true, false, 1, nil, 1, nil},
+		{1, 0, true, 1, nil, 1, nil},
 	}
 	checkNetPolTestResult("TestUpdateNetPol", f, testCases)
 }
@@ -413,7 +394,7 @@ func TestLabelUpdateNetworkPolicy(t *testing.T) {
 	updateNetPol(t, f, oldNetPolObj, newNetPolObj)
 
 	testCases := []expectedNetPolValues{
-		{1, 1, 0, true, true, 1, nil, 2, nil},
+		{1, 0, true, 1, nil, 2, nil},
 	}
 	checkNetPolTestResult("TestUpdateNetPol", f, testCases)
 }

--- a/npm/npm.go
+++ b/npm/npm.go
@@ -30,8 +30,8 @@ var aiMetadata string
 const (
 	telemetryRetryTimeInSeconds = 60
 	heartbeatIntervalInMinutes  = 30
-	// TODO(jungukcho) consider increasing thread number later when controller logics are safe to run in parallel
-	threadness = 1
+	// TODO(jungukcho): consider increasing thread numbers later when controller logics are safe to run in parallel
+	// threadness = 1
 )
 
 // Cache to store namespace struct in nameSpaceController.go.
@@ -219,8 +219,8 @@ func (npMgr *NetworkPolicyManager) Start(stopCh <-chan struct{}) error {
 	}
 
 	// start controllers after synced
-	go npMgr.podController.Run(threadness, stopCh)
-	go npMgr.nameSpaceController.Run(threadness, stopCh)
-	go npMgr.netPolController.Run(threadness, stopCh)
+	go npMgr.podController.Run(stopCh)
+	go npMgr.nameSpaceController.Run(stopCh)
+	go npMgr.netPolController.Run(stopCh)
 	return nil
 }

--- a/npm/npm.go
+++ b/npm/npm.go
@@ -30,10 +30,8 @@ var aiMetadata string
 const (
 	restoreRetryWaitTimeInSeconds = 5
 	restoreMaxRetries             = 10
-	backupWaitTimeInSeconds       = 60
 	telemetryRetryTimeInSeconds   = 60
 	heartbeatIntervalInMinutes    = 30
-	reconcileChainTimeInMinutes   = 5
 	// TODO: consider increasing thread number later when logics are correct
 	threadness = 1
 )
@@ -120,14 +118,14 @@ func NewNetworkPolicyManager(clientset *kubernetes.Clientset, informerFactory in
 	// create network policy controller
 	npMgr.netPolController = NewNetworkPolicyController(npMgr.npInformer, clientset, npMgr.ipsMgr)
 
-	// (TODO): Need to handle panic if initializing iptables and ipsets are failed?
+	// (TODO): Do we need to handle panic if initializing iptables and ipsets are failed with multiple retries?
 	// It is important to keep cleaning-up order between iptables and ipset
 	// 1. clean-up NPM-related iptables information and then running regular processes to keep iptable information
-	npMgr.netPolController.initializeIpTables()
+	npMgr.netPolController.initializeIPTables()
 
 	// 2. then initialize ipsets states (clean-up existing ipset and then install default ipset)
 	log.Logf("Azure-NPM creating, cleaning existing Azure NPM IPSets")
-	npMgr.nameSpaceController.initializeIpSets()
+	npMgr.nameSpaceController.initializeIPSets()
 
 	return npMgr
 }

--- a/npm/npm.go
+++ b/npm/npm.go
@@ -121,12 +121,13 @@ func NewNetworkPolicyManager(clientset *kubernetes.Clientset, informerFactory in
 	// (TODO): Do we need to handle panic if initializing iptables and ipsets are failed with multiple retries?
 	// It is important to keep cleaning-up order between iptables and ipset
 	// 1. clean-up NPM-related iptables information and then running regular processes to keep iptable information
-	npMgr.netPolController.initializeIPTables()
+	npMgr.netPolController.initializeDataPlane()
 
-	// 2. then initialize ipsets states (clean-up existing ipset and then install default ipset)
-	log.Logf("Azure-NPM creating, cleaning existing Azure NPM IPSets")
-	npMgr.nameSpaceController.initializeIPSets()
+	// 2. then initialize ipsets states (clean-up existing ipset)
+	npMgr.ipsMgr.DestroyNpmIpsets()
 
+	// 3. install default namespace
+	npMgr.nameSpaceController.initializeDefaultNs()
 	return npMgr
 }
 

--- a/npm/npm.go
+++ b/npm/npm.go
@@ -120,27 +120,14 @@ func NewNetworkPolicyManager(clientset *kubernetes.Clientset, informerFactory in
 	// create network policy controller
 	npMgr.netPolController = NewNetworkPolicyController(npMgr.npInformer, clientset, npMgr.ipsMgr)
 
-	// It is important to keep the order between iptables and ipset
-	// 1. first initialize iptables
-	npMgr.netPolController.initializeIptables()
+	// (TODO): Need to handle panic if initializing iptables and ipsets are failed?
+	// It is important to keep cleaning-up order between iptables and ipset
+	// 1. clean-up NPM-related iptables information and then running regular processes to keep iptable information
+	npMgr.netPolController.initializeIpTables()
 
-	// (TODO): correct return values
-	// err = npMgr.netPolController.initializeIptables()
-	// if err != nil {
-	// 	klog.Info(err.Error())
-	// 	panic(err.Error())
-	// }
-
-	// 2. then clear out leftover ipsets states
+	// 2. then initialize ipsets states (clean-up existing ipset and then install default ipset)
 	log.Logf("Azure-NPM creating, cleaning existing Azure NPM IPSets")
-	npMgr.ipsMgr.DestroyNpmIpsets()
-
-	// (TODO): correct return values
-	// err = npMgr.ipsMgr.DestroyNpmIpsets()
-	// if err != nil {
-	// 	klog.Info(err.Error())
-	// 	panic(err.Error())
-	// }
+	npMgr.nameSpaceController.initializeIpSets()
 
 	return npMgr
 }
@@ -203,15 +190,16 @@ func (npMgr *NetworkPolicyManager) SendClusterMetrics() {
 	for {
 		<-heartbeat
 
-		// (TODO): If it needs very accurate metrics, need lock for each one
-		lenOfNsMap := npMgr.nameSpaceController.LengthOfNsMap()
-		nsCount.Value = float64(lenOfNsMap)
+		// Reducing one to remove all-namespaces ns obj
+		// (TODO): Check this is safe or not?
+		lenOfNsMap := len(npMgr.npmNamespaceCache.nsMap)
+		nsCount.Value = float64(lenOfNsMap - 1)
 
-		lenOfRawNpMap := npMgr.netPolController.LengthOfRawNpMap()
+		lenOfRawNpMap := npMgr.netPolController.lengthOfRawNpMap()
 		nwPolicyCount.Value += float64(lenOfRawNpMap)
 
 		podCount.Value = 0
-		lenOfPodMap := npMgr.podController.LengthOfPodMap()
+		lenOfPodMap := npMgr.podController.lengthOfPodMap()
 		podCount.Value += float64(lenOfPodMap)
 
 		metrics.SendMetric(podCount)

--- a/npm/npm_test.go
+++ b/npm/npm_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/Azure/azure-container-networking/npm/ipsm"
 	"github.com/Azure/azure-container-networking/npm/iptm"
 	"github.com/Azure/azure-container-networking/npm/metrics"
-	"github.com/Azure/azure-container-networking/npm/util"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/exec"
 	utilexec "k8s.io/utils/exec"
@@ -32,15 +31,10 @@ func getKey(obj interface{}, t *testing.T) string {
 
 func newNPMgr(t *testing.T, exec utilexec.Interface) *NetworkPolicyManager {
 	npMgr := &NetworkPolicyManager{
-		Exec:             exec,
-		NsMap:            make(map[string]*Namespace),
-		PodMap:           make(map[string]*NpmPod),
+		ipsMgr:           ipsm.NewIpsetManager(exec),
 		TelemetryEnabled: false,
 	}
 
-	// This initialization important as without this NPM will panic
-	allNs, _ := newNs(util.KubeAllNamespacesFlag, npMgr.Exec)
-	npMgr.NsMap[util.KubeAllNamespacesFlag] = allNs
 	return npMgr
 }
 
@@ -50,7 +44,7 @@ func TestMain(m *testing.M) {
 	iptMgr.UninitNpmChains()
 
 	ipsMgr := ipsm.NewIpsetManager(exec.New())
-	ipsMgr.Destroy()
+	ipsMgr.DestroyNpmIpsets()
 
 	exitCode := m.Run()
 

--- a/npm/podController.go
+++ b/npm/podController.go
@@ -106,14 +106,12 @@ func (nPod *NpmPod) updateNpmPodAttributes(podObj *corev1.Pod) {
 }
 
 type podController struct {
-	clientset       kubernetes.Interface
-	podLister       corelisters.PodLister
-	podListerSynced cache.InformerSynced
-	workqueue       workqueue.RateLimitingInterface
-	ipsMgr          *ipsm.IpsetManager
-	podMap          map[string]*NpmPod // Key is <nsname>/<podname>
-	// podMapMutex     sync.RWMutex
-	//nsSet map[string]struct{}
+	clientset         kubernetes.Interface
+	podLister         corelisters.PodLister
+	podListerSynced   cache.InformerSynced
+	workqueue         workqueue.RateLimitingInterface
+	ipsMgr            *ipsm.IpsetManager
+	podMap            map[string]*NpmPod // Key is <nsname>/<podname>
 	npmNamespaceCache *npmNamespaceCache
 }
 
@@ -138,10 +136,7 @@ func NewPodController(podInformer coreinformer.PodInformer, clientset kubernetes
 	return podController
 }
 
-// (TODO) need lock if we really want very accurate podMap numbers, but I think it is over engineering.
-func (c *podController) LengthOfPodMap() int {
-	// c.podMapMutex.RLock()
-	// defer c.podMapMutex.RUnlock()
+func (c *podController) lengthOfPodMap() int {
 	return len(c.podMap)
 }
 
@@ -215,17 +210,6 @@ func (c *podController) updatePod(old, new interface{}) {
 	}
 
 	c.workqueue.Add(key)
-	// c.podMapMutex.RLock()
-	// defer c.podMapMutex.RUnlock()
-	// cachedNpmPodObj, npmPodExists := c.PodMap[key]
-	// if npmPodExists {
-	// 	// if newPod does not have different states against lastly applied states stored in cachedNpmPodObj,
-	// 	// podController does not need to reconcile this update.
-	// 	// in this updatePod event, newPod was updated with states which PodController does not need to reconcile.
-	// 	if isInvalidPodUpdate(cachedNpmPodObj, newPod) {
-	// 		return
-	// 	}
-	// }
 }
 
 func (c *podController) deletePod(obj interface{}) {
@@ -263,17 +247,6 @@ func (c *podController) deletePod(obj interface{}) {
 	}
 
 	c.workqueue.Add(key)
-	// // (TODO): Reduce scope of lock later
-	// c.podMapMutex.RLock()
-	// defer c.podMapMutex.RUnlock()
-
-	// // If this pod object is not in the PodMap, we do not need to clean-up states for this pod
-	// // since podController did not apply for any states for this pod
-	// _, npmPodExists := c.PodMap[key]
-	// if !npmPodExists {
-	// 	return
-	// }
-
 }
 
 func (c *podController) Run(threadiness int, stopCh <-chan struct{}) error {

--- a/npm/podController.go
+++ b/npm/podController.go
@@ -360,7 +360,6 @@ func (c *podController) syncPod(key string) error {
 
 	err = c.syncAddAndUpdatePod(pod)
 	if err != nil {
-		metrics.SendErrorLogAndMetric(util.PodID, "Error: Failed to sync pod due to %v", err)
 		return fmt.Errorf("Failed to sync pod due to %v\n", err)
 	}
 
@@ -454,7 +453,7 @@ func (c *podController) syncAddAndUpdatePod(newPodObj *corev1.Pod) error {
 	// NPM should clean up existing references of cached pod obj and its IP.
 	// then, re-add new pod obj.
 	if cachedNpmPodObj.PodIP != newPodObj.Status.PodIP {
-		metrics.SendErrorLogAndMetric(util.PodID, "[syncAddAndUpdatePod] Info: Unexpected state. Pod (Namespace:%s, Name:%s, newUid:%s) , has cachedPodIp:%s which is different from PodIp:%s",
+		klog.Infof("[syncAddAndUpdatePod] Info: Unexpected state. Pod (Namespace:%s, Name:%s, newUid:%s) , has cachedPodIp:%s which is different from PodIp:%s",
 			newPodObj.Namespace, newPodObj.Name, string(newPodObj.UID), cachedNpmPodObj.PodIP, newPodObj.Status.PodIP)
 
 		klog.Infof("Deleting cached Pod with key:%s first due to IP Mistmatch", podKey)

--- a/npm/podController.go
+++ b/npm/podController.go
@@ -249,14 +249,12 @@ func (c *podController) deletePod(obj interface{}) {
 	c.workqueue.Add(key)
 }
 
-func (c *podController) Run(threadiness int, stopCh <-chan struct{}) error {
+func (c *podController) Run(stopCh <-chan struct{}) error {
 	defer utilruntime.HandleCrash()
 	defer c.workqueue.ShutDown()
 
-	klog.Infof("Starting Pod %d worker(s)", threadiness)
-	for i := 0; i < threadiness; i++ {
-		go wait.Until(c.runWorker, time.Second, stopCh)
-	}
+	klog.Infof("Starting Pod worker")
+	go wait.Until(c.runWorker, time.Second, stopCh)
 
 	klog.Info("Started Pod workers")
 	<-stopCh

--- a/npm/podController_test.go
+++ b/npm/podController_test.go
@@ -673,6 +673,8 @@ func TestHasValidPodIP(t *testing.T) {
 	}
 }
 
+// Extra unit test which is not quite related to PodController, but help to understand how workqueue works to make event handler logic lock-free.
+// If the same key are queued into workqueue in multiple times, they are combined into one item (accurately, if the item is not processed).
 func TestWorkQueue(t *testing.T) {
 	labels := map[string]string{
 		"app": "test-pod",
@@ -688,15 +690,14 @@ func TestWorkQueue(t *testing.T) {
 	defer close(stopCh)
 	f.newPodController(stopCh)
 
-	podKey := getKey(podObj, t)
-	// (TODO): will confirm WQ internals.
-	// It does not add multiple elements with the same key.
-	f.podController.workqueue.Add(podKey)
-	t.Logf("WQ len %d ", f.podController.workqueue.Len())
+	podKeys := []string{"test-pod", "test-pod", "test-pod1"}
+	expectedWorkQueueLength := []int{1, 1, 2}
 
-	f.podController.workqueue.Add(podKey)
-	t.Logf("WQ len %d ", f.podController.workqueue.Len())
-
-	f.podController.workqueue.Add(podKey + "1")
-	t.Logf("WQ len %d ", f.podController.workqueue.Len())
+	for idx, podKey := range podKeys {
+		f.podController.workqueue.Add(podKey)
+		workQueueLength := f.podController.workqueue.Len()
+		if workQueueLength != expectedWorkQueueLength[idx] {
+			t.Errorf("TestWorkQueue failed due to returned workqueue length = %d, want %d", workQueueLength, expectedWorkQueueLength)
+		}
+	}
 }

--- a/npm/podController_test.go
+++ b/npm/podController_test.go
@@ -245,7 +245,7 @@ func TestAddMultiplePods(t *testing.T) {
 	addPod(t, f, podObj2)
 
 	testCases := []expectedValues{
-		{2, 2, 0},
+		{2, 1, 0},
 	}
 	checkPodTestResult("TestAddMultiplePods", f, testCases)
 	checkNpmPodWithInput("TestAddMultiplePods", f, podObj1)
@@ -284,7 +284,7 @@ func TestAddPod(t *testing.T) {
 
 	addPod(t, f, podObj)
 	testCases := []expectedValues{
-		{1, 2, 0},
+		{1, 1, 0},
 	}
 	checkPodTestResult("TestAddPod", f, testCases)
 	checkNpmPodWithInput("TestAddPod", f, podObj)
@@ -312,7 +312,7 @@ func TestAddHostNetworkPod(t *testing.T) {
 
 	addPod(t, f, podObj)
 	testCases := []expectedValues{
-		{0, 1, 0},
+		{0, 0, 0},
 	}
 	checkPodTestResult("TestAddHostNetworkPod", f, testCases)
 
@@ -365,7 +365,7 @@ func TestDeletePod(t *testing.T) {
 
 	deletePod(t, f, podObj, DeletedFinalStateknownObject)
 	testCases := []expectedValues{
-		{0, 2, 0},
+		{0, 1, 0},
 	}
 
 	checkPodTestResult("TestDeletePod", f, testCases)
@@ -396,7 +396,7 @@ func TestDeleteHostNetworkPod(t *testing.T) {
 
 	deletePod(t, f, podObj, DeletedFinalStateknownObject)
 	testCases := []expectedValues{
-		{0, 1, 0},
+		{0, 0, 0},
 	}
 	checkPodTestResult("TestDeleteHostNetworkPod", f, testCases)
 	if _, exists := f.podController.podMap[podKey]; exists {
@@ -406,6 +406,7 @@ func TestDeleteHostNetworkPod(t *testing.T) {
 	testutils.VerifyCallsMatch(t, calls, fexec, fcmd)
 }
 
+// this UT only tests deletePod event handler function in podController
 func TestDeletePodWithTombstone(t *testing.T) {
 	labels := map[string]string{
 		"app": "test-pod",
@@ -429,7 +430,7 @@ func TestDeletePodWithTombstone(t *testing.T) {
 
 	f.podController.deletePod(tombstone)
 	testCases := []expectedValues{
-		{0, 1, 0},
+		{0, 0, 1},
 	}
 	checkPodTestResult("TestDeletePodWithTombstone", f, testCases)
 
@@ -477,7 +478,7 @@ func TestDeletePodWithTombstoneAfterAddingPod(t *testing.T) {
 
 	deletePod(t, f, podObj, DeletedFinalStateUnknownObject)
 	testCases := []expectedValues{
-		{0, 2, 0},
+		{0, 1, 0},
 	}
 	checkPodTestResult("TestDeletePodWithTombstoneAfterAddingPod", f, testCases)
 
@@ -529,7 +530,7 @@ func TestLabelUpdatePod(t *testing.T) {
 	updatePod(t, f, oldPodObj, newPodObj)
 
 	testCases := []expectedValues{
-		{1, 2, 0},
+		{1, 1, 0},
 	}
 	checkPodTestResult("TestLabelUpdatePod", f, testCases)
 	checkNpmPodWithInput("TestLabelUpdatePod", f, newPodObj)
@@ -593,7 +594,7 @@ func TestIPAddressUpdatePod(t *testing.T) {
 	updatePod(t, f, oldPodObj, newPodObj)
 
 	testCases := []expectedValues{
-		{1, 2, 0},
+		{1, 1, 0},
 	}
 	checkPodTestResult("TestIPAddressUpdatePod", f, testCases)
 	checkNpmPodWithInput("TestIPAddressUpdatePod", f, newPodObj)
@@ -651,7 +652,7 @@ func TestPodStatusUpdatePod(t *testing.T) {
 	updatePod(t, f, oldPodObj, newPodObj)
 
 	testCases := []expectedValues{
-		{0, 2, 0},
+		{0, 1, 0},
 	}
 	checkPodTestResult("TestPodStatusUpdatePod", f, testCases)
 	if _, exists := f.podController.podMap[podKey]; exists {


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
This PR is the first step to make each controller independent as much as possible.
Current NPM uses a global lock to avoid race condition among controllers even though they can be independent. It results in slow processing events and increases memory usages by queuing k8s resources for long time in client-go.

1. Remove a global lock in NetworkPolicyManager 
2. Make event handling functions (e.g., add, update, delete) for each resource (e.g., Pod, Namespace and NetworkPolicy) lock-free to keep processing event handler logics in each controller independently
3. Concurrently processing between event handling functions and actual reconcile function in each controller
4. Minimize a lock scope as much as possible between podController and Namespace controller
5. Cleaning up codes (e.g., encapsulation, removing redundant codes, etc)

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation (in npm doc directory)
- [ ] adds unit tests


**Notes**:
ipsm.go requires more works (e.g., reducing lock scope, error handling, etc) since now it is a synchronization point among all controllers. That will be next PR after completing this PR throughly.