### PR TITLE
removing unit tag so as to leave as default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -480,7 +480,7 @@ lint-old: $(GOLANGCI_LINT) ## Fast lint including previous issues
 # run all tests
 .PHONY: test-all
 test-all:
-	go test -tags "unit" -coverpkg=./... -v -race -covermode atomic -failfast -coverprofile=coverage.out ./...
+	go test -coverpkg=./... -v -race -covermode atomic -failfast -coverprofile=coverage.out ./...
 
 
 # run all tests

--- a/cni/client/client_common_test.go
+++ b/cni/client/client_common_test.go
@@ -1,4 +1,4 @@
-// +build unit integration
+// +build integration
 
 package client
 

--- a/cni/client/client_unit_test.go
+++ b/cni/client/client_unit_test.go
@@ -1,5 +1,3 @@
-// +build unit
-
 package client
 
 import (


### PR DESCRIPTION

**Reason for Change**:
Making unit tests as default instead of specifying tag

