### PR TITLE
[NPM]Make order of iptables entries in UT determinisitc in case of MultipleLabelsToMultipleLabels

### DIFF
--- a/npm/testpolicies/allow-ns-y-z-pod-b-c-with-namedPort.yaml
+++ b/npm/testpolicies/allow-ns-y-z-pod-b-c-with-namedPort.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-ns-y-z-pod-b-c
+  name: allow-ns-y-z-pod-b-c-with-namedPort
   namespace: netpol-4537-x
 spec:
   ingress:

--- a/npm/testpolicies/allow-ns-y-z-pod-b-c-with-namedPort.yaml
+++ b/npm/testpolicies/allow-ns-y-z-pod-b-c-with-namedPort.yaml
@@ -1,0 +1,39 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ns-y-z-pod-b-c
+  namespace: netpol-4537-x
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchExpressions:
+        - key: ns
+          operator: NotIn
+          values:
+          - netpol-4537-x
+          - netpol-4537-y
+      podSelector:
+        matchExpressions:
+        - key: pod
+          operator: In
+          values:
+          - b
+          - c
+        - key: app
+          operator: In
+          values:
+          - test
+          - int
+    ports:
+    - port: serve-80
+      protocol: TCP
+  podSelector:
+    matchExpressions:
+    - key: pod
+      operator: In
+      values:
+      - a
+      - x
+  policyTypes:
+  - Ingress

--- a/npm/translatePolicy.go
+++ b/npm/translatePolicy.go
@@ -1700,10 +1700,9 @@ func translatePolicy(npObj *networkingv1.NetworkPolicy) ([]string, []string, map
 	}
 
 	entries = append(entries, getDefaultDropEntries(npNs, npObj.Spec.PodSelector, hasIngress, hasEgress)...)
-	resultSets = util.UniqueStrSlice(resultSets)
 	for resultListKey, resultLists := range resultListMap {
 		resultListMap[resultListKey] = util.UniqueStrSlice(resultLists)
 	}
 
-	return resultSets, resultNamedPorts, resultListMap, resultIngressIPCidrs, resultEgressIPCidrs, entries
+	return util.UniqueStrSlice(resultSets), util.UniqueStrSlice(resultNamedPorts), resultListMap, resultIngressIPCidrs, resultEgressIPCidrs, entries
 }

--- a/npm/translatePolicy_test.go
+++ b/npm/translatePolicy_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/Azure/azure-container-networking/npm/iptm"
@@ -2519,6 +2520,15 @@ func TestAllowMultiplePodSelectors(t *testing.T) {
 	expectedIptEntries = append(expectedIptEntries, nonKubeSystemEntries...)
 	// has egress, but empty map means allow all
 	expectedIptEntries = append(expectedIptEntries, getDefaultDropEntries("netpol-4537-x", multiPodSlector.Spec.PodSelector, true, false)...)
+
+	// Since the order of all ipset values in Specs is not guaranteed in MultiplePodSelectors case, sorting Specs is necessary before comparing them.
+	if len(iptEntries) == len(expectedIptEntries) {
+		for i := 0; i < len(expectedIptEntries); i++ {
+			sort.Strings(iptEntries[i].Specs)
+			sort.Strings(expectedIptEntries[i].Specs)
+		}
+	}
+
 	if !reflect.DeepEqual(iptEntries, expectedIptEntries) {
 		t.Errorf("translatedPolicy failed @ allow-ns-y-z-pod-b-c policy comparison")
 		marshalledIptEntries, _ := json.Marshal(iptEntries)

--- a/npm/util/util.go
+++ b/npm/util/util.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"os"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -334,10 +335,7 @@ func StrExistsInSlice(items []string, val string) bool {
 }
 
 func CompareSlices(list1, list2 []string) bool {
-	for _, item := range list1 {
-		if !StrExistsInSlice(list2, item) {
-			return false
-		}
-	}
-	return true
+	sort.Strings(list1)
+	sort.Strings(list2)
+	return reflect.DeepEqual(list1, list2)
 }


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
TestAllowMultiplePodSelectors has a flake UT result due to the ordering of ipset in Specs since the order of all ipset values in Specs is not guaranteed in MultiplePodSelectors case.
Thus, in this UT, before checking the iptables entries, sorting Specs is necessary before comparing them.

You can break this UT with this script without this PR.
```shell

max=1000
idx=0
while [[ $idx -ne $max ]]
do
/usr/local/go/bin/go test -timeout 30s -v --count=1 -run ^TestAllowMultiplePodSelectors$ github.com/Azure/azure-container-networking/npm
if [[ $? -ne 0 ]]
then
	exit
fi

idx=$((idx+1))
echo $idx
done
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests


**Notes**:
While we have one UT to be sorted in current UTs, we need to generalize this approach in all tests to avoid undeterministic behavior in the added UTs in the future.  In addition, I feel like we need to clean up translatePolicy_test.go since it is unnecessarily too lengthy.