### PR TITLE
fix: remove extra definition of cns-config in test/integration

### DIFF
--- a/test/integration/manifests/cns/configmap.yaml
+++ b/test/integration/manifests/cns/configmap.yaml
@@ -21,5 +21,6 @@ data:
           "NodeID": "",
           "NodeSyncIntervalInSeconds": 30
       },
-      "ChannelMode": "CRD"
+      "ChannelMode": "CRD",
+      "InitializeFromCNI": true
     }

--- a/test/integration/manifests/cns/daemonset.yaml
+++ b/test/integration/manifests/cns/daemonset.yaml
@@ -99,30 +99,3 @@ spec:
           configMap:
             name: cns-config
       serviceAccountName: azure-cns
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cns-config
-  namespace: kube-system
-data:
-  cns_config.json: |
-    {
-      "TelemetrySettings": {
-          "TelemetryBatchSizeBytes": 16384,
-          "TelemetryBatchIntervalInSecs": 15,
-          "RefreshIntervalInSecs": 15,
-          "DisableAll": false,
-          "HeartBeatIntervalInMins": 30,
-          "DebugMode": false,
-          "SnapshotIntervalInMins": 60
-      },
-      "ManagedSettings": {
-          "PrivateEndpoint": "",
-          "InfrastructureNetworkID": "",
-          "NodeID": "",
-          "NodeSyncIntervalInSeconds": 30
-      },
-      "ChannelMode": "CRD",
-      "InitializeFromCNI": true
-    }


### PR DESCRIPTION
Signed-off-by: Evan Baker <rbtr@users.noreply.github.com>

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
removes extra cns-config configmap definition in integration test specs

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
