### PR TITLE
fix: bump minimum cni to 1.4.7 for reconcile flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -497,6 +497,9 @@ test-cyclonus:
 kind:
 	kind create cluster --config ./test/kind/kind.yaml
 
+version: ## prints the version
+	@echo $(VERSION)
+
 $(TOOLS_DIR)/go.mod:
 	cd $(TOOLS_DIR); go mod init && go mod tidy
 

--- a/cns/cnireconciler/version.go
+++ b/cns/cnireconciler/version.go
@@ -8,7 +8,9 @@ import (
 	"k8s.io/utils/exec"
 )
 
-const lastCNIWithoutDumpStateVer = "1.4.1"
+// >= 1.4.7 is required due to a bug in CNI when the statefile is empty
+// even though the command existed since 1.4.2.
+const lastCNIWithoutDumpStateVer = "1.4.6"
 
 // IsDumpStateVer checks if the CNI executable is a version that
 // has the dump state command required to initialize CNS from CNI

--- a/cns/cnireconciler/version_test.go
+++ b/cns/cnireconciler/version_test.go
@@ -38,13 +38,13 @@ func TestIsDumpStateVer(t *testing.T) {
 		},
 		{
 			name:    "good ver",
-			exec:    newCNIVersionFakeExec(`Azure CNI Version v1.4.2`),
+			exec:    newCNIVersionFakeExec(`Azure CNI Version v1.4.7`),
 			want:    true,
 			wantErr: false,
 		},
 		{
 			name:    "good dirty ver",
-			exec:    newCNIVersionFakeExec(`Azure CNI Version v1.4.2-7-g7b97e1eb`),
+			exec:    newCNIVersionFakeExec(`Azure CNI Version v1.4.7-7-g7b97e1eb`),
 			want:    true,
 			wantErr: false,
 		},


### PR DESCRIPTION
Signed-off-by: Evan Baker <rbtr@users.noreply.github.com>

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
bump required version of CNI to 1.4.7 for CNI reconcile

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
