### PR TITLE
fix: correct golangci format to enable listed linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,24 +1,23 @@
 issues:
   max-same-issues: 0
   max-issues-per-linter: 0
-
-enable:
-    - bodyclose
-    - deadcode
-    - errcheck
-    - goconst
-    - gocritic
-    - gocyclo
-    - gofmt
-    - goimports
-    - golint
-    - gomnd
-    - goprintffuncname
-    - gosec
-    - gosimple
-    - govet
-    - ineffassign
-    - interfacer
-    - lll
-    - misspell
-    - nakedret
+linters:
+  presets: 
+  - bugs
+  - error
+  - format
+  - performance
+  - unused
+  enable:
+  - goconst
+  - gocritic
+  - gocyclo
+  - gofmt
+  - gomnd
+  - goprintffuncname
+  - gosimple
+  - lll
+  - misspell
+  - nakedret
+  - promlinter
+  - revive


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Noticed some things didn't get caught by linters that we had in the config that should have caught them...

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Corrects the golangci-lint config format so that the wanted linters are enabled.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
