### PR TITLE
fix: hysteresis in ipampool during rapid pool scaling

### DIFF
--- a/cns/fakes/requestcontrollerfake.go
+++ b/cns/fakes/requestcontrollerfake.go
@@ -114,9 +114,6 @@ func (rc *RequestControllerFake) Reconcile(removePendingReleaseIPs bool) error {
 			rc.cachedCRD.Status.NetworkContainers[0].IPAssignments = remove(rc.cachedCRD.Status.NetworkContainers[0].IPAssignments, index)
 
 		}
-
-		// empty the not in use ip's from the spec
-		// rc.cachedCRD.Spec.IPsNotInUse = []string{}
 	}
 
 	// remove ipconfig from CNS

--- a/cns/fakes/requestcontrollerfake.go
+++ b/cns/fakes/requestcontrollerfake.go
@@ -37,6 +37,7 @@ func NewRequestControllerFake(cnsService *HTTPServiceFake, scalar nnc.Scaler, su
 	rc.ip, _, _ = net.ParseCIDR(subnetAddressSpace)
 
 	rc.CarveIPConfigsAndAddToStatusAndCNS(numberOfIPConfigs)
+	rc.cachedCRD.Spec.RequestedIPCount = int64(numberOfIPConfigs)
 
 	return rc
 }
@@ -62,7 +63,6 @@ func (rc *RequestControllerFake) CarveIPConfigsAndAddToStatusAndCNS(numberOfIPCo
 	}
 
 	rc.fakecns.IPStateManager.AddIPConfigs(cnsIPConfigs)
-	rc.cachedCRD.Spec.RequestedIPCount = int64(len(cnsIPConfigs))
 
 	return cnsIPConfigs
 }
@@ -88,7 +88,7 @@ func remove(slice []nnc.IPAssignment, s int) []nnc.IPAssignment {
 	return append(slice[:s], slice[s+1:]...)
 }
 
-func (rc *RequestControllerFake) Reconcile() error {
+func (rc *RequestControllerFake) Reconcile(removePendingReleaseIPs bool) error {
 
 	diff := int(rc.cachedCRD.Spec.RequestedIPCount) - len(rc.fakecns.GetPodIPConfigState())
 
@@ -115,11 +115,13 @@ func (rc *RequestControllerFake) Reconcile() error {
 
 		}
 
-		// remove ipconfig from CNS
-		rc.fakecns.IPStateManager.RemovePendingReleaseIPConfigs(rc.cachedCRD.Spec.IPsNotInUse)
-
 		// empty the not in use ip's from the spec
-		rc.cachedCRD.Spec.IPsNotInUse = []string{}
+		// rc.cachedCRD.Spec.IPsNotInUse = []string{}
+	}
+
+	// remove ipconfig from CNS
+	if removePendingReleaseIPs {
+		rc.fakecns.IPStateManager.RemovePendingReleaseIPConfigs(rc.cachedCRD.Spec.IPsNotInUse)
 	}
 
 	// update

--- a/cns/ipampoolmonitor/ipampoolmonitor.go
+++ b/cns/ipampoolmonitor/ipampoolmonitor.go
@@ -30,8 +30,8 @@ type CNSIPAMPoolMonitor struct {
 func NewCNSIPAMPoolMonitor(httpService cns.HTTPService, rc singletenantcontroller.RequestController) *CNSIPAMPoolMonitor {
 	logger.Printf("NewCNSIPAMPoolMonitor: Create IPAM Pool Monitor")
 	return &CNSIPAMPoolMonitor{
-		httpService:    httpService,
-		rc:             rc,
+		httpService: httpService,
+		rc:          rc,
 	}
 }
 
@@ -236,7 +236,7 @@ func (pm *CNSIPAMPoolMonitor) cleanPendingRelease(ctx context.Context) error {
 }
 
 // CNSToCRDSpec translates CNS's map of Ips to be released and requested ip count into a CRD Spec
-func (pm *CNSIPAMPoolMonitor) createNNCSpecForCRD() (nnc.NodeNetworkConfigSpec) {
+func (pm *CNSIPAMPoolMonitor) createNNCSpecForCRD() nnc.NodeNetworkConfigSpec {
 	var (
 		spec nnc.NodeNetworkConfigSpec
 	)

--- a/cns/ipampoolmonitor/ipampoolmonitor.go
+++ b/cns/ipampoolmonitor/ipampoolmonitor.go
@@ -22,7 +22,6 @@ type CNSIPAMPoolMonitor struct {
 	cachedNNC                nnc.NodeNetworkConfig
 	httpService              cns.HTTPService
 	mu                       sync.RWMutex
-	pendingRelease           bool
 	rc                       singletenantcontroller.RequestController
 	scalarUnits              nnc.Scaler
 	updatingIpsNotInUseCount int
@@ -31,7 +30,6 @@ type CNSIPAMPoolMonitor struct {
 func NewCNSIPAMPoolMonitor(httpService cns.HTTPService, rc singletenantcontroller.RequestController) *CNSIPAMPoolMonitor {
 	logger.Printf("NewCNSIPAMPoolMonitor: Create IPAM Pool Monitor")
 	return &CNSIPAMPoolMonitor{
-		pendingRelease: false,
 		httpService:    httpService,
 		rc:             rc,
 	}
@@ -212,7 +210,6 @@ func (pm *CNSIPAMPoolMonitor) decreasePoolSize(ctx context.Context, existingPend
 
 	// save the updated state to cachedSpec
 	pm.cachedNNC.Spec = tempNNCSpec
-	pm.pendingRelease = true
 
 	// clear the updatingPendingIpsNotInUse, as we have Updated the CRD
 	logger.Printf("[ipam-pool-monitor] cleaning the updatingPendingIpsNotInUse, existing length %d", pm.updatingIpsNotInUseCount)
@@ -244,7 +241,6 @@ func (pm *CNSIPAMPoolMonitor) cleanPendingRelease(ctx context.Context) error {
 
 	// save the updated state to cachedSpec
 	pm.cachedNNC.Spec = tempNNCSpec
-	pm.pendingRelease = false
 	return nil
 }
 

--- a/cns/ipampoolmonitor/ipampoolmonitor.go
+++ b/cns/ipampoolmonitor/ipampoolmonitor.go
@@ -103,10 +103,7 @@ func (pm *CNSIPAMPoolMonitor) increasePoolSize(ctx context.Context) error {
 
 	var err error
 	var tempNNCSpec nnc.NodeNetworkConfigSpec
-	tempNNCSpec, err = pm.createNNCSpecForCRD()
-	if err != nil {
-		return err
-	}
+	tempNNCSpec = pm.createNNCSpecForCRD()
 
 	// Query the max IP count
 	maxIPCount := pm.getMaxIPCount()
@@ -185,10 +182,7 @@ func (pm *CNSIPAMPoolMonitor) decreasePoolSize(ctx context.Context, existingPend
 	}
 
 	var tempNNCSpec nnc.NodeNetworkConfigSpec
-	tempNNCSpec, err = pm.createNNCSpecForCRD()
-	if err != nil {
-		return err
-	}
+	tempNNCSpec = pm.createNNCSpecForCRD()
 
 	if newIpsMarkedAsPending {
 		// cache the updatingPendingRelease so that we dont re-set new IPs to PendingRelease in case UpdateCRD call fails
@@ -226,10 +220,7 @@ func (pm *CNSIPAMPoolMonitor) cleanPendingRelease(ctx context.Context) error {
 
 	var err error
 	var tempNNCSpec nnc.NodeNetworkConfigSpec
-	tempNNCSpec, err = pm.createNNCSpecForCRD()
-	if err != nil {
-		return err
-	}
+	tempNNCSpec = pm.createNNCSpecForCRD()
 
 	err = pm.rc.UpdateCRDSpec(ctx, tempNNCSpec)
 	if err != nil {
@@ -245,7 +236,7 @@ func (pm *CNSIPAMPoolMonitor) cleanPendingRelease(ctx context.Context) error {
 }
 
 // CNSToCRDSpec translates CNS's map of Ips to be released and requested ip count into a CRD Spec
-func (pm *CNSIPAMPoolMonitor) createNNCSpecForCRD() (nnc.NodeNetworkConfigSpec, error) {
+func (pm *CNSIPAMPoolMonitor) createNNCSpecForCRD() (nnc.NodeNetworkConfigSpec) {
 	var (
 		spec nnc.NodeNetworkConfigSpec
 	)
@@ -254,12 +245,12 @@ func (pm *CNSIPAMPoolMonitor) createNNCSpecForCRD() (nnc.NodeNetworkConfigSpec, 
 	spec.RequestedIPCount = pm.cachedNNC.Spec.RequestedIPCount
 
 	// Get All Pending IPs from CNS and populate it again.
-	pendingIps := pm.httpService.GetPendingReleaseIPConfigs()
-	for _, pendingIp := range pendingIps {
-		spec.IPsNotInUse = append(spec.IPsNotInUse, pendingIp.ID)
+	pendingIPs := pm.httpService.GetPendingReleaseIPConfigs()
+	for _, pendingIP := range pendingIPs {
+		spec.IPsNotInUse = append(spec.IPsNotInUse, pendingIP.ID)
 	}
 
-	return spec, nil
+	return spec
 }
 
 // UpdatePoolLimitsTransacted called by request controller on reconcile to set the batch size limits

--- a/cns/ipampoolmonitor/ipampoolmonitor_test.go
+++ b/cns/ipampoolmonitor/ipampoolmonitor_test.go
@@ -71,8 +71,8 @@ func TestPoolSizeIncrease(t *testing.T) {
 
 	// ensure pool monitor has reached quorum with cns
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != int64(initialIPConfigCount+(1*batchSize)) {
-		t.Fatalf("Pool monitor target IP count doesn't match CNS pool state " +
-			"after reconcile: %v, " +
+		t.Fatalf("Pool monitor target IP count doesn't match CNS pool state "+
+			"after reconcile: %v, "+
 			"actual %v", poolmonitor.cachedNNC.Spec.RequestedIPCount, len(fakecns.GetPodIPConfigState()))
 	}
 
@@ -91,18 +91,18 @@ func TestPoolSizeIncrease(t *testing.T) {
 
 	// ensure pool monitor has reached quorum with cns
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != int64(initialIPConfigCount+(1*batchSize)) {
-		t.Fatalf("Pool monitor target IP count doesn't " +
-			"match CNS pool state after reconcile: %v, " +
+		t.Fatalf("Pool monitor target IP count doesn't "+
+			"match CNS pool state after reconcile: %v, "+
 			"actual %v", poolmonitor.cachedNNC.Spec.RequestedIPCount, len(fakecns.GetPodIPConfigState()))
 	}
 
 	// make sure IPConfig state size reflects the new pool size
 	if len(fakecns.GetPodIPConfigState()) != initialIPConfigCount+(1*batchSize) {
-		t.Fatalf("CNS Pod IPConfig state count doesn't " +
+		t.Fatalf("CNS Pod IPConfig state count doesn't "+
 			"match, expected: %v, actual %v", len(fakecns.GetPodIPConfigState()), initialIPConfigCount+(1*batchSize))
 	}
 
-	t.Logf("Pool size %v, Target pool size %v, " +
+	t.Logf("Pool size %v, Target pool size %v, "+
 		"Allocated IP's %v, ", len(fakecns.GetPodIPConfigState()),
 		poolmonitor.cachedNNC.Spec.RequestedIPCount, len(fakecns.GetAllocatedIPConfigs()))
 }
@@ -149,7 +149,7 @@ func TestPoolIncreaseDoesntChangeWhenIncreaseIsAlreadyInProgress(t *testing.T) {
 
 	// ensure pool monitor has reached quorum with cns
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != int64(initialIPConfigCount+(1*batchSize)) {
-		t.Fatalf("Pool monitor target IP count doesn't match CNS pool state after reconcile: %v," +
+		t.Fatalf("Pool monitor target IP count doesn't match CNS pool state after reconcile: %v,"+
 			" actual %v", poolmonitor.cachedNNC.Spec.RequestedIPCount, len(fakecns.GetPodIPConfigState()))
 	}
 
@@ -174,7 +174,7 @@ func TestPoolIncreaseDoesntChangeWhenIncreaseIsAlreadyInProgress(t *testing.T) {
 
 	// ensure pool monitor has reached quorum with cns
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != int64(initialIPConfigCount+(1*batchSize)) {
-		t.Fatalf("Pool monitor target IP count doesn't match CNS pool state after reconcile: %v, " +
+		t.Fatalf("Pool monitor target IP count doesn't match CNS pool state after reconcile: %v, "+
 			"actual %v", poolmonitor.cachedNNC.Spec.RequestedIPCount, len(fakecns.GetPodIPConfigState()))
 	}
 
@@ -215,7 +215,7 @@ func TestPoolSizeIncreaseIdempotency(t *testing.T) {
 
 	// ensure pool monitor has increased batch size
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != int64(initialIPConfigCount+(1*batchSize)) {
-		t.Fatalf("Pool monitor target IP count doesn't match CNS pool state after reconcile: %v," +
+		t.Fatalf("Pool monitor target IP count doesn't match CNS pool state after reconcile: %v,"+
 			" actual %v", poolmonitor.cachedNNC.Spec.RequestedIPCount, len(fakecns.GetPodIPConfigState()))
 	}
 
@@ -227,7 +227,7 @@ func TestPoolSizeIncreaseIdempotency(t *testing.T) {
 
 	// ensure pool monitor requested pool size is unchanged as request controller hasn't reconciled yet
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != int64(initialIPConfigCount+(1*batchSize)) {
-		t.Fatalf("Pool monitor target IP count doesn't match CNS pool state after reconcile: %v," +
+		t.Fatalf("Pool monitor target IP count doesn't match CNS pool state after reconcile: %v,"+
 			" actual %v", poolmonitor.cachedNNC.Spec.RequestedIPCount, len(fakecns.GetPodIPConfigState()))
 	}
 }
@@ -265,7 +265,7 @@ func TestPoolIncreasePastNodeLimit(t *testing.T) {
 
 	// ensure pool monitor has only requested the max pod ip count
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != maxPodIPCount {
-		t.Fatalf("Pool monitor target IP count (%v) should be the node limit (%v) when the max " +
+		t.Fatalf("Pool monitor target IP count (%v) should be the node limit (%v) when the max "+
 			"has been reached", poolmonitor.cachedNNC.Spec.RequestedIPCount, maxPodIPCount)
 	}
 }
@@ -303,7 +303,7 @@ func TestPoolIncreaseBatchSizeGreaterThanMaxPodIPCount(t *testing.T) {
 
 	// ensure pool monitor has only requested the max pod ip count
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != maxPodIPCount {
-		t.Fatalf("Pool monitor target IP count (%v) should be the node limit (%v) " +
+		t.Fatalf("Pool monitor target IP count (%v) should be the node limit (%v) "+
 			"when the max has been reached", poolmonitor.cachedNNC.Spec.RequestedIPCount, maxPodIPCount)
 	}
 }
@@ -322,7 +322,7 @@ func TestPoolIncreaseMaxIPCountSetToZero(t *testing.T) {
 		requestThresholdPercent, releaseThresholdPercent, initialMaxPodIPCount)
 
 	if poolmonitor.getMaxIPCount() != expectedMaxPodIPCount {
-		t.Fatalf("Pool monitor target IP count (%v) should be the node limit (%v) " +
+		t.Fatalf("Pool monitor target IP count (%v) should be the node limit (%v) "+
 			"when the MaxIPCount field in the CRD is zero", poolmonitor.getMaxIPCount(), expectedMaxPodIPCount)
 	}
 }
@@ -380,7 +380,7 @@ func TestPoolDecrease(t *testing.T) {
 
 	// Ensure the size of the requested spec is still the same
 	if len(poolmonitor.cachedNNC.Spec.IPsNotInUse) != 0 {
-		t.Fatalf("Expected IPsNotInUse to be 0 after request controller reconcile, " +
+		t.Fatalf("Expected IPsNotInUse to be 0 after request controller reconcile, "+
 			"actual %v", poolmonitor.cachedNNC.Spec.IPsNotInUse)
 	}
 
@@ -416,13 +416,13 @@ func TestPoolSizeDecreaseWhenDecreaseHasAlreadyBeenRequested(t *testing.T) {
 
 	// Ensure the size of the requested spec is still the same
 	if len(poolmonitor.cachedNNC.Spec.IPsNotInUse) != (initialIPConfigCount - batchSize) {
-		t.Fatalf("Expected IP's not in use be one batch size smaller after reconcile, expected %v," +
+		t.Fatalf("Expected IP's not in use be one batch size smaller after reconcile, expected %v,"+
 			" actual %v", (initialIPConfigCount - batchSize), len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
 	}
 
 	// Ensure the request ipcount is now one batch size smaller than the inital IP count
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != int64(initialIPConfigCount-batchSize) {
-		t.Fatalf("Expected pool size to be one batch size smaller after reconcile, expected %v," +
+		t.Fatalf("Expected pool size to be one batch size smaller after reconcile, expected %v,"+
 			" actual %v", (initialIPConfigCount - batchSize), len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
 	}
 
@@ -434,14 +434,14 @@ func TestPoolSizeDecreaseWhenDecreaseHasAlreadyBeenRequested(t *testing.T) {
 
 	// Ensure the size of the requested spec is still the same
 	if len(poolmonitor.cachedNNC.Spec.IPsNotInUse) != (initialIPConfigCount - batchSize) {
-		t.Fatalf("Expected IP's not in use to be one batch size smaller after reconcile, and not change" +
+		t.Fatalf("Expected IP's not in use to be one batch size smaller after reconcile, and not change"+
 			" after reconcile, expected %v, actual %v",
 			(initialIPConfigCount - batchSize), len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
 	}
 
 	// Ensure the request ipcount is now one batch size smaller than the inital IP count
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != int64(initialIPConfigCount-batchSize) {
-		t.Fatalf("Expected pool size to be one batch size smaller after reconcile, and not change after" +
+		t.Fatalf("Expected pool size to be one batch size smaller after reconcile, and not change after"+
 			" existing call, expected %v, actual %v", (initialIPConfigCount - batchSize),
 			len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
 	}
@@ -490,7 +490,7 @@ func TestDecreaseAndIncreaseToSameCount(t *testing.T) {
 
 	// Pool monitor will increase the count to 20
 	t.Logf("Scaleup: Increase pool size to 20")
-	ReconcileAndValidate(t, context.Background(), poolmonitor, 20, 0)
+	ReconcileAndValidate(context.Background(), t, poolmonitor, 20, 0)
 
 	// Update the IPConfig state
 	t.Logf("Reconcile with PodIPState")
@@ -506,7 +506,7 @@ func TestDecreaseAndIncreaseToSameCount(t *testing.T) {
 	}
 
 	t.Logf("Scaledown: Decrease pool size to 10")
-	ReconcileAndValidate(t, context.Background(), poolmonitor, 10, 10)
+	ReconcileAndValidate(context.Background(), t, poolmonitor, 10, 10)
 
 	// Increase it back to 20
 	// initial pool count is 10, set 5 of them to be allocated
@@ -515,7 +515,7 @@ func TestDecreaseAndIncreaseToSameCount(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	ReconcileAndValidate(t, context.Background(), poolmonitor, 20, 10)
+	ReconcileAndValidate(context.Background(), t, poolmonitor, 20, 10)
 
 	// Update the IPConfig count and dont remove the pending IPs
 	t.Logf("Reconcile with PodIPState")
@@ -526,7 +526,7 @@ func TestDecreaseAndIncreaseToSameCount(t *testing.T) {
 
 	// reconcile again
 	t.Logf("Reconcole with pool monitor again, it should not cleanup ipsnotinuse")
-	ReconcileAndValidate(t, context.Background(), poolmonitor, 20, 10)
+	ReconcileAndValidate(context.Background(), t, poolmonitor, 20, 10)
 
 	t.Logf("Now update podipconfig state")
 	err = fakerc.Reconcile(true)
@@ -538,7 +538,7 @@ func TestDecreaseAndIncreaseToSameCount(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected no pool monitor failure after request controller reconcile: %v", err)
 	}
-	ReconcileAndValidate(t, context.Background(), poolmonitor, 20, 0)
+	ReconcileAndValidate(context.Background(), t, poolmonitor, 20, 0)
 }
 
 func TestPoolSizeDecreaseToReallyLow(t *testing.T) {
@@ -593,7 +593,7 @@ func TestPoolSizeDecreaseToReallyLow(t *testing.T) {
 
 	// Ensure the request ipcount is now one batch size smaller than the inital IP count
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != int64(initialIPConfigCount-batchSize) {
-		t.Fatalf("Expected pool size to be one batch size smaller after reconcile, expected %v, " +
+		t.Fatalf("Expected pool size to be one batch size smaller after reconcile, expected %v, "+
 			"actual %v", (initialIPConfigCount - batchSize), len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
 	}
 
@@ -612,7 +612,7 @@ func TestPoolSizeDecreaseToReallyLow(t *testing.T) {
 
 	// Ensure the request ipcount is now one batch size smaller than the inital IP count
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != int64(initialIPConfigCount-(batchSize*2)) {
-		t.Fatalf("Expected pool size to be one batch size smaller after reconcile, expected %v, " +
+		t.Fatalf("Expected pool size to be one batch size smaller after reconcile, expected %v, "+
 			"actual %v", (initialIPConfigCount - batchSize), len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
 	}
 
@@ -678,15 +678,15 @@ func TestDecreaseAfterNodeLimitReached(t *testing.T) {
 
 	// Ensure poolmonitor asked for a multiple of batch size
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != int64(expectedRequestedIP) {
-		t.Fatalf("Expected requested ips to be %v when scaling by 1 batch size down from %v " +
+		t.Fatalf("Expected requested ips to be %v when scaling by 1 batch size down from %v "+
 			"(max pod limit) but got %v", expectedRequestedIP, maxPodIPCount,
 			poolmonitor.cachedNNC.Spec.RequestedIPCount)
 	}
 
 	// Ensure we minused by the mod result
 	if len(poolmonitor.cachedNNC.Spec.IPsNotInUse) != expectedDecreaseIP {
-		t.Fatalf("Expected to decrease requested IPs by %v (max pod count mod batchsize) to " +
-			"make the requested ip count a multiple of the batch size in the case of hitting " +
+		t.Fatalf("Expected to decrease requested IPs by %v (max pod count mod batchsize) to "+
+			"make the requested ip count a multiple of the batch size in the case of hitting "+
 			"the max before scale down, but got %v", expectedDecreaseIP, len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
 	}
 }
@@ -735,13 +735,13 @@ func TestPoolDecreaseBatchSizeGreaterThanMaxPodIPCount(t *testing.T) {
 
 	// ensure pool monitor has only requested the max pod ip count
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != maxPodIPCount {
-		t.Fatalf("Pool monitor target IP count (%v) should be the node limit (%v) when the max " +
+		t.Fatalf("Pool monitor target IP count (%v) should be the node limit (%v) when the max "+
 			"has been reached", poolmonitor.cachedNNC.Spec.RequestedIPCount, maxPodIPCount)
 	}
 }
 
-func ReconcileAndValidate(t *testing.T,
-	ctx context.Context,
+func ReconcileAndValidate(ctx context.Context,
+	t *testing.T,
 	poolmonitor *CNSIPAMPoolMonitor,
 	expectedRequestCount,
 	expectedIpsNotInUse int) {

--- a/cns/ipampoolmonitor/ipampoolmonitor_test.go
+++ b/cns/ipampoolmonitor/ipampoolmonitor_test.go
@@ -50,7 +50,12 @@ func TestPoolSizeIncrease(t *testing.T) {
 		maxPodIPCount           = int64(30)
 	)
 
-	fakecns, fakerc, poolmonitor := initFakes(t, batchSize, initialIPConfigCount, requestThresholdPercent, releaseThresholdPercent, maxPodIPCount)
+	fakecns, fakerc, poolmonitor := initFakes(t,
+		batchSize,
+		initialIPConfigCount,
+		requestThresholdPercent,
+		releaseThresholdPercent,
+		maxPodIPCount)
 
 	// increase number of allocated IP's in CNS
 	err := fakecns.SetNumberOfAllocatedIPs(8)
@@ -66,7 +71,9 @@ func TestPoolSizeIncrease(t *testing.T) {
 
 	// ensure pool monitor has reached quorum with cns
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != int64(initialIPConfigCount+(1*batchSize)) {
-		t.Fatalf("Pool monitor target IP count doesn't match CNS pool state after reconcile: %v, actual %v", poolmonitor.cachedNNC.Spec.RequestedIPCount, len(fakecns.GetPodIPConfigState()))
+		t.Fatalf("Pool monitor target IP count doesn't match CNS pool state " +
+			"after reconcile: %v, " +
+			"actual %v", poolmonitor.cachedNNC.Spec.RequestedIPCount, len(fakecns.GetPodIPConfigState()))
 	}
 
 	// request controller reconciles, carves new IP's from the test subnet and adds to CNS state
@@ -84,15 +91,20 @@ func TestPoolSizeIncrease(t *testing.T) {
 
 	// ensure pool monitor has reached quorum with cns
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != int64(initialIPConfigCount+(1*batchSize)) {
-		t.Fatalf("Pool monitor target IP count doesn't match CNS pool state after reconcile: %v, actual %v", poolmonitor.cachedNNC.Spec.RequestedIPCount, len(fakecns.GetPodIPConfigState()))
+		t.Fatalf("Pool monitor target IP count doesn't " +
+			"match CNS pool state after reconcile: %v, " +
+			"actual %v", poolmonitor.cachedNNC.Spec.RequestedIPCount, len(fakecns.GetPodIPConfigState()))
 	}
 
 	// make sure IPConfig state size reflects the new pool size
 	if len(fakecns.GetPodIPConfigState()) != initialIPConfigCount+(1*batchSize) {
-		t.Fatalf("CNS Pod IPConfig state count doesn't match, expected: %v, actual %v", len(fakecns.GetPodIPConfigState()), initialIPConfigCount+(1*batchSize))
+		t.Fatalf("CNS Pod IPConfig state count doesn't " +
+			"match, expected: %v, actual %v", len(fakecns.GetPodIPConfigState()), initialIPConfigCount+(1*batchSize))
 	}
 
-	t.Logf("Pool size %v, Target pool size %v, Allocated IP's %v, ", len(fakecns.GetPodIPConfigState()), poolmonitor.cachedNNC.Spec.RequestedIPCount, len(fakecns.GetAllocatedIPConfigs()))
+	t.Logf("Pool size %v, Target pool size %v, " +
+		"Allocated IP's %v, ", len(fakecns.GetPodIPConfigState()),
+		poolmonitor.cachedNNC.Spec.RequestedIPCount, len(fakecns.GetAllocatedIPConfigs()))
 }
 
 func TestPoolIncreaseDoesntChangeWhenIncreaseIsAlreadyInProgress(t *testing.T) {
@@ -137,7 +149,8 @@ func TestPoolIncreaseDoesntChangeWhenIncreaseIsAlreadyInProgress(t *testing.T) {
 
 	// ensure pool monitor has reached quorum with cns
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != int64(initialIPConfigCount+(1*batchSize)) {
-		t.Fatalf("Pool monitor target IP count doesn't match CNS pool state after reconcile: %v, actual %v", poolmonitor.cachedNNC.Spec.RequestedIPCount, len(fakecns.GetPodIPConfigState()))
+		t.Fatalf("Pool monitor target IP count doesn't match CNS pool state after reconcile: %v," +
+			" actual %v", poolmonitor.cachedNNC.Spec.RequestedIPCount, len(fakecns.GetPodIPConfigState()))
 	}
 
 	// request controller reconciles, carves new IP's from the test subnet and adds to CNS state
@@ -155,15 +168,18 @@ func TestPoolIncreaseDoesntChangeWhenIncreaseIsAlreadyInProgress(t *testing.T) {
 
 	// make sure IPConfig state size reflects the new pool size
 	if len(fakecns.GetPodIPConfigState()) != initialIPConfigCount+(1*batchSize) {
-		t.Fatalf("CNS Pod IPConfig state count doesn't match, expected: %v, actual %v", len(fakecns.GetPodIPConfigState()), initialIPConfigCount+(1*batchSize))
+		t.Fatalf("CNS Pod IPConfig state count doesn't match, expected: %v, actual %v",
+			len(fakecns.GetPodIPConfigState()), initialIPConfigCount+(1*batchSize))
 	}
 
 	// ensure pool monitor has reached quorum with cns
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != int64(initialIPConfigCount+(1*batchSize)) {
-		t.Fatalf("Pool monitor target IP count doesn't match CNS pool state after reconcile: %v, actual %v", poolmonitor.cachedNNC.Spec.RequestedIPCount, len(fakecns.GetPodIPConfigState()))
+		t.Fatalf("Pool monitor target IP count doesn't match CNS pool state after reconcile: %v, " +
+			"actual %v", poolmonitor.cachedNNC.Spec.RequestedIPCount, len(fakecns.GetPodIPConfigState()))
 	}
 
-	t.Logf("Pool size %v, Target pool size %v, Allocated IP's %v, ", len(fakecns.GetPodIPConfigState()), poolmonitor.cachedNNC.Spec.RequestedIPCount, len(fakecns.GetAllocatedIPConfigs()))
+	t.Logf("Pool size %v, Target pool size %v, Allocated IP's %v, ", len(fakecns.GetPodIPConfigState()),
+		poolmonitor.cachedNNC.Spec.RequestedIPCount, len(fakecns.GetAllocatedIPConfigs()))
 }
 
 func TestPoolSizeIncreaseIdempotency(t *testing.T) {
@@ -199,7 +215,8 @@ func TestPoolSizeIncreaseIdempotency(t *testing.T) {
 
 	// ensure pool monitor has increased batch size
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != int64(initialIPConfigCount+(1*batchSize)) {
-		t.Fatalf("Pool monitor target IP count doesn't match CNS pool state after reconcile: %v, actual %v", poolmonitor.cachedNNC.Spec.RequestedIPCount, len(fakecns.GetPodIPConfigState()))
+		t.Fatalf("Pool monitor target IP count doesn't match CNS pool state after reconcile: %v," +
+			" actual %v", poolmonitor.cachedNNC.Spec.RequestedIPCount, len(fakecns.GetPodIPConfigState()))
 	}
 
 	// reconcile pool monitor a second time, then verify requested ip count is still the same
@@ -210,7 +227,8 @@ func TestPoolSizeIncreaseIdempotency(t *testing.T) {
 
 	// ensure pool monitor requested pool size is unchanged as request controller hasn't reconciled yet
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != int64(initialIPConfigCount+(1*batchSize)) {
-		t.Fatalf("Pool monitor target IP count doesn't match CNS pool state after reconcile: %v, actual %v", poolmonitor.cachedNNC.Spec.RequestedIPCount, len(fakecns.GetPodIPConfigState()))
+		t.Fatalf("Pool monitor target IP count doesn't match CNS pool state after reconcile: %v," +
+			" actual %v", poolmonitor.cachedNNC.Spec.RequestedIPCount, len(fakecns.GetPodIPConfigState()))
 	}
 }
 
@@ -247,7 +265,8 @@ func TestPoolIncreasePastNodeLimit(t *testing.T) {
 
 	// ensure pool monitor has only requested the max pod ip count
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != maxPodIPCount {
-		t.Fatalf("Pool monitor target IP count (%v) should be the node limit (%v) when the max has been reached", poolmonitor.cachedNNC.Spec.RequestedIPCount, maxPodIPCount)
+		t.Fatalf("Pool monitor target IP count (%v) should be the node limit (%v) when the max " +
+			"has been reached", poolmonitor.cachedNNC.Spec.RequestedIPCount, maxPodIPCount)
 	}
 }
 
@@ -284,7 +303,8 @@ func TestPoolIncreaseBatchSizeGreaterThanMaxPodIPCount(t *testing.T) {
 
 	// ensure pool monitor has only requested the max pod ip count
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != maxPodIPCount {
-		t.Fatalf("Pool monitor target IP count (%v) should be the node limit (%v) when the max has been reached", poolmonitor.cachedNNC.Spec.RequestedIPCount, maxPodIPCount)
+		t.Fatalf("Pool monitor target IP count (%v) should be the node limit (%v) " +
+			"when the max has been reached", poolmonitor.cachedNNC.Spec.RequestedIPCount, maxPodIPCount)
 	}
 }
 
@@ -348,7 +368,8 @@ func TestPoolDecrease(t *testing.T) {
 
 	// ensure that the adjusted spec is smaller than the initial pool size
 	if len(poolmonitor.cachedNNC.Spec.IPsNotInUse) != (initialIPConfigCount - batchSize) {
-		t.Fatalf("Expected pool size to be one batch size smaller after reconcile, expected %v, actual %v", (initialIPConfigCount - batchSize), len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
+		t.Fatalf("Expected pool size to be one batch size smaller after reconcile, expected %v, actual %v",
+			(initialIPConfigCount - batchSize), len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
 	}
 
 	// reconcile the fake request controller
@@ -359,7 +380,8 @@ func TestPoolDecrease(t *testing.T) {
 
 	// Ensure the size of the requested spec is still the same
 	if len(poolmonitor.cachedNNC.Spec.IPsNotInUse) != 0 {
-		t.Fatalf("Expected IPsNotInUse to be 0 after request controller reconcile, actual %v", poolmonitor.cachedNNC.Spec.IPsNotInUse)
+		t.Fatalf("Expected IPsNotInUse to be 0 after request controller reconcile, " +
+			"actual %v", poolmonitor.cachedNNC.Spec.IPsNotInUse)
 	}
 
 	return
@@ -394,12 +416,14 @@ func TestPoolSizeDecreaseWhenDecreaseHasAlreadyBeenRequested(t *testing.T) {
 
 	// Ensure the size of the requested spec is still the same
 	if len(poolmonitor.cachedNNC.Spec.IPsNotInUse) != (initialIPConfigCount - batchSize) {
-		t.Fatalf("Expected IP's not in use be one batch size smaller after reconcile, expected %v, actual %v", (initialIPConfigCount - batchSize), len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
+		t.Fatalf("Expected IP's not in use be one batch size smaller after reconcile, expected %v," +
+			" actual %v", (initialIPConfigCount - batchSize), len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
 	}
 
 	// Ensure the request ipcount is now one batch size smaller than the inital IP count
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != int64(initialIPConfigCount-batchSize) {
-		t.Fatalf("Expected pool size to be one batch size smaller after reconcile, expected %v, actual %v", (initialIPConfigCount - batchSize), len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
+		t.Fatalf("Expected pool size to be one batch size smaller after reconcile, expected %v," +
+			" actual %v", (initialIPConfigCount - batchSize), len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
 	}
 
 	// Update pods with IP count, ensure pool monitor stays the same until request controller reconciles
@@ -410,12 +434,16 @@ func TestPoolSizeDecreaseWhenDecreaseHasAlreadyBeenRequested(t *testing.T) {
 
 	// Ensure the size of the requested spec is still the same
 	if len(poolmonitor.cachedNNC.Spec.IPsNotInUse) != (initialIPConfigCount - batchSize) {
-		t.Fatalf("Expected IP's not in use to be one batch size smaller after reconcile, and not change after reconcile, expected %v, actual %v", (initialIPConfigCount - batchSize), len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
+		t.Fatalf("Expected IP's not in use to be one batch size smaller after reconcile, and not change" +
+			" after reconcile, expected %v, actual %v",
+			(initialIPConfigCount - batchSize), len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
 	}
 
 	// Ensure the request ipcount is now one batch size smaller than the inital IP count
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != int64(initialIPConfigCount-batchSize) {
-		t.Fatalf("Expected pool size to be one batch size smaller after reconcile, and not change after existing call, expected %v, actual %v", (initialIPConfigCount - batchSize), len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
+		t.Fatalf("Expected pool size to be one batch size smaller after reconcile, and not change after" +
+			" existing call, expected %v, actual %v", (initialIPConfigCount - batchSize),
+			len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
 	}
 
 	err = fakerc.Reconcile(true)
@@ -430,7 +458,8 @@ func TestPoolSizeDecreaseWhenDecreaseHasAlreadyBeenRequested(t *testing.T) {
 
 	// Ensure the spec doesn't have any IPsNotInUse after request controller has reconciled
 	if len(poolmonitor.cachedNNC.Spec.IPsNotInUse) != 0 {
-		t.Fatalf("Expected IP's not in use to be 0 after reconcile, expected %v, actual %v", (initialIPConfigCount - batchSize), len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
+		t.Fatalf("Expected IP's not in use to be 0 after reconcile, expected %v, actual %v",
+			(initialIPConfigCount - batchSize), len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
 	}
 }
 
@@ -558,12 +587,14 @@ func TestPoolSizeDecreaseToReallyLow(t *testing.T) {
 
 	// Ensure the size of the requested spec is still the same
 	if len(poolmonitor.cachedNNC.Spec.IPsNotInUse) != batchSize {
-		t.Fatalf("Expected IP's not in use is not correct, expected %v, actual %v", batchSize, len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
+		t.Fatalf("Expected IP's not in use is not correct, expected %v, actual %v",
+			batchSize, len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
 	}
 
 	// Ensure the request ipcount is now one batch size smaller than the inital IP count
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != int64(initialIPConfigCount-batchSize) {
-		t.Fatalf("Expected pool size to be one batch size smaller after reconcile, expected %v, actual %v", (initialIPConfigCount - batchSize), len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
+		t.Fatalf("Expected pool size to be one batch size smaller after reconcile, expected %v, " +
+			"actual %v", (initialIPConfigCount - batchSize), len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
 	}
 
 	// Reconcile again, it should release the second batch
@@ -575,12 +606,14 @@ func TestPoolSizeDecreaseToReallyLow(t *testing.T) {
 
 	// Ensure the size of the requested spec is still the same
 	if len(poolmonitor.cachedNNC.Spec.IPsNotInUse) != batchSize*2 {
-		t.Fatalf("Expected IP's not in use is not correct, expected %v, actual %v", batchSize*2, len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
+		t.Fatalf("Expected IP's not in use is not correct, expected %v, actual %v", batchSize*2,
+			len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
 	}
 
 	// Ensure the request ipcount is now one batch size smaller than the inital IP count
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != int64(initialIPConfigCount-(batchSize*2)) {
-		t.Fatalf("Expected pool size to be one batch size smaller after reconcile, expected %v, actual %v", (initialIPConfigCount - batchSize), len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
+		t.Fatalf("Expected pool size to be one batch size smaller after reconcile, expected %v, " +
+			"actual %v", (initialIPConfigCount - batchSize), len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
 	}
 
 	t.Logf("Update Request Controller")
@@ -596,7 +629,8 @@ func TestPoolSizeDecreaseToReallyLow(t *testing.T) {
 
 	// Ensure the spec doesn't have any IPsNotInUse after request controller has reconciled
 	if len(poolmonitor.cachedNNC.Spec.IPsNotInUse) != 0 {
-		t.Fatalf("Expected IP's not in use to be 0 after reconcile, expected %v, actual %v", (initialIPConfigCount - batchSize), len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
+		t.Fatalf("Expected IP's not in use to be 0 after reconcile, expected %v, actual %v",
+			(initialIPConfigCount - batchSize), len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
 	}
 }
 
@@ -611,7 +645,12 @@ func TestDecreaseAfterNodeLimitReached(t *testing.T) {
 		expectedDecreaseIP      = int(maxPodIPCount) % batchSize
 	)
 
-	fakecns, _, poolmonitor := initFakes(t, batchSize, initialIPConfigCount, requestThresholdPercent, releaseThresholdPercent, maxPodIPCount)
+	fakecns, _, poolmonitor := initFakes(t,
+		batchSize,
+		initialIPConfigCount,
+		requestThresholdPercent,
+		releaseThresholdPercent,
+		maxPodIPCount)
 
 	t.Logf("Minimum free IPs to request: %v", poolmonitor.MinimumFreeIps)
 	t.Logf("Maximum free IPs to release: %v", poolmonitor.MaximumFreeIps)
@@ -639,12 +678,16 @@ func TestDecreaseAfterNodeLimitReached(t *testing.T) {
 
 	// Ensure poolmonitor asked for a multiple of batch size
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != int64(expectedRequestedIP) {
-		t.Fatalf("Expected requested ips to be %v when scaling by 1 batch size down from %v (max pod limit) but got %v", expectedRequestedIP, maxPodIPCount, poolmonitor.cachedNNC.Spec.RequestedIPCount)
+		t.Fatalf("Expected requested ips to be %v when scaling by 1 batch size down from %v " +
+			"(max pod limit) but got %v", expectedRequestedIP, maxPodIPCount,
+			poolmonitor.cachedNNC.Spec.RequestedIPCount)
 	}
 
 	// Ensure we minused by the mod result
 	if len(poolmonitor.cachedNNC.Spec.IPsNotInUse) != expectedDecreaseIP {
-		t.Fatalf("Expected to decrease requested IPs by %v (max pod count mod batchsize) to make the requested ip count a multiple of the batch size in the case of hitting the max before scale down, but got %v", expectedDecreaseIP, len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
+		t.Fatalf("Expected to decrease requested IPs by %v (max pod count mod batchsize) to " +
+			"make the requested ip count a multiple of the batch size in the case of hitting " +
+			"the max before scale down, but got %v", expectedDecreaseIP, len(poolmonitor.cachedNNC.Spec.IPsNotInUse))
 	}
 }
 
@@ -657,7 +700,12 @@ func TestPoolDecreaseBatchSizeGreaterThanMaxPodIPCount(t *testing.T) {
 		maxPodIPCount           = int64(30)
 	)
 
-	fakecns, _, poolmonitor := initFakes(t, batchSize, initialIPConfigCount, requestThresholdPercent, releaseThresholdPercent, maxPodIPCount)
+	fakecns, _, poolmonitor := initFakes(t,
+		batchSize,
+		initialIPConfigCount,
+		requestThresholdPercent,
+		releaseThresholdPercent,
+		maxPodIPCount)
 
 	t.Logf("Minimum free IPs to request: %v", poolmonitor.MinimumFreeIps)
 	t.Logf("Maximum free IPs to release: %v", poolmonitor.MaximumFreeIps)
@@ -687,7 +735,8 @@ func TestPoolDecreaseBatchSizeGreaterThanMaxPodIPCount(t *testing.T) {
 
 	// ensure pool monitor has only requested the max pod ip count
 	if poolmonitor.cachedNNC.Spec.RequestedIPCount != maxPodIPCount {
-		t.Fatalf("Pool monitor target IP count (%v) should be the node limit (%v) when the max has been reached", poolmonitor.cachedNNC.Spec.RequestedIPCount, maxPodIPCount)
+		t.Fatalf("Pool monitor target IP count (%v) should be the node limit (%v) when the max " +
+			"has been reached", poolmonitor.cachedNNC.Spec.RequestedIPCount, maxPodIPCount)
 	}
 }
 

--- a/cns/ipampoolmonitor/ipampoolmonitor_test.go
+++ b/cns/ipampoolmonitor/ipampoolmonitor_test.go
@@ -10,7 +10,12 @@ import (
 	nnc "github.com/Azure/azure-container-networking/nodenetworkconfig/api/v1alpha"
 )
 
-func initFakes(t *testing.T, batchSize, initialIPConfigCount, requestThresholdPercent, releaseThresholdPercent int, maxPodIPCount int64) (*fakes.HTTPServiceFake, *fakes.RequestControllerFake, *CNSIPAMPoolMonitor) {
+func initFakes(t *testing.T,
+	batchSize,
+	initialIPConfigCount,
+	requestThresholdPercent,
+	releaseThresholdPercent int,
+	maxPodIPCount int64) (*fakes.HTTPServiceFake, *fakes.RequestControllerFake, *CNSIPAMPoolMonitor) {
 	logger.InitLogger("testlogs", 0, 0, "./")
 
 	scalarUnits := nnc.Scaler{
@@ -99,7 +104,12 @@ func TestPoolIncreaseDoesntChangeWhenIncreaseIsAlreadyInProgress(t *testing.T) {
 		maxPodIPCount           = int64(30)
 	)
 
-	fakecns, fakerc, poolmonitor := initFakes(t, batchSize, initialIPConfigCount, requestThresholdPercent, releaseThresholdPercent, maxPodIPCount)
+	fakecns, fakerc, poolmonitor := initFakes(t,
+		batchSize,
+		initialIPConfigCount,
+		requestThresholdPercent,
+		releaseThresholdPercent,
+		maxPodIPCount)
 
 	// increase number of allocated IP's in CNS
 	err := fakecns.SetNumberOfAllocatedIPs(8)
@@ -165,7 +175,12 @@ func TestPoolSizeIncreaseIdempotency(t *testing.T) {
 		maxPodIPCount           = int64(30)
 	)
 
-	fakecns, _, poolmonitor := initFakes(t, batchSize, initialIPConfigCount, requestThresholdPercent, releaseThresholdPercent, maxPodIPCount)
+	fakecns, _, poolmonitor := initFakes(t,
+		batchSize,
+		initialIPConfigCount,
+		requestThresholdPercent,
+		releaseThresholdPercent,
+		maxPodIPCount)
 
 	t.Logf("Minimum free IPs to request: %v", poolmonitor.MinimumFreeIps)
 	t.Logf("Maximum free IPs to release: %v", poolmonitor.MaximumFreeIps)
@@ -208,7 +223,12 @@ func TestPoolIncreasePastNodeLimit(t *testing.T) {
 		maxPodIPCount           = int64(30)
 	)
 
-	fakecns, _, poolmonitor := initFakes(t, batchSize, initialIPConfigCount, requestThresholdPercent, releaseThresholdPercent, maxPodIPCount)
+	fakecns, _, poolmonitor := initFakes(t,
+		batchSize,
+		initialIPConfigCount,
+		requestThresholdPercent,
+		releaseThresholdPercent,
+		maxPodIPCount)
 
 	t.Logf("Minimum free IPs to request: %v", poolmonitor.MinimumFreeIps)
 	t.Logf("Maximum free IPs to release: %v", poolmonitor.MaximumFreeIps)
@@ -240,7 +260,12 @@ func TestPoolIncreaseBatchSizeGreaterThanMaxPodIPCount(t *testing.T) {
 		maxPodIPCount           = int64(30)
 	)
 
-	fakecns, _, poolmonitor := initFakes(t, batchSize, initialIPConfigCount, requestThresholdPercent, releaseThresholdPercent, maxPodIPCount)
+	fakecns, _, poolmonitor := initFakes(t,
+		batchSize,
+		initialIPConfigCount,
+		requestThresholdPercent,
+		releaseThresholdPercent,
+		maxPodIPCount)
 
 	t.Logf("Minimum free IPs to request: %v", poolmonitor.MinimumFreeIps)
 	t.Logf("Maximum free IPs to release: %v", poolmonitor.MaximumFreeIps)
@@ -273,10 +298,12 @@ func TestPoolIncreaseMaxIPCountSetToZero(t *testing.T) {
 		expectedMaxPodIPCount   = defaultMaxIPCount
 	)
 
-	_, _, poolmonitor := initFakes(t, batchSize, initialIPConfigCount, requestThresholdPercent, releaseThresholdPercent, initialMaxPodIPCount)
+	_, _, poolmonitor := initFakes(t, batchSize, initialIPConfigCount,
+		requestThresholdPercent, releaseThresholdPercent, initialMaxPodIPCount)
 
 	if poolmonitor.getMaxIPCount() != expectedMaxPodIPCount {
-		t.Fatalf("Pool monitor target IP count (%v) should be the node limit (%v) when the MaxIPCount field in the CRD is zero", poolmonitor.getMaxIPCount(), expectedMaxPodIPCount)
+		t.Fatalf("Pool monitor target IP count (%v) should be the node limit (%v) " +
+			"when the MaxIPCount field in the CRD is zero", poolmonitor.getMaxIPCount(), expectedMaxPodIPCount)
 	}
 }
 
@@ -289,7 +316,8 @@ func TestPoolDecrease(t *testing.T) {
 		maxPodIPCount           = int64(30)
 	)
 
-	fakecns, fakerc, poolmonitor := initFakes(t, batchSize, initialIPConfigCount, requestThresholdPercent, releaseThresholdPercent, maxPodIPCount)
+	fakecns, fakerc, poolmonitor := initFakes(t, batchSize, initialIPConfigCount,
+		requestThresholdPercent, releaseThresholdPercent, maxPodIPCount)
 
 	log.Printf("Min free IP's %v", poolmonitor.MinimumFreeIps)
 	log.Printf("Max free IP %v", poolmonitor.MaximumFreeIps)
@@ -346,7 +374,8 @@ func TestPoolSizeDecreaseWhenDecreaseHasAlreadyBeenRequested(t *testing.T) {
 		maxPodIPCount           = int64(30)
 	)
 
-	fakecns, fakerc, poolmonitor := initFakes(t, batchSize, initialIPConfigCount, requestThresholdPercent, releaseThresholdPercent, maxPodIPCount)
+	fakecns, fakerc, poolmonitor := initFakes(t, batchSize, initialIPConfigCount,
+		requestThresholdPercent, releaseThresholdPercent, maxPodIPCount)
 
 	log.Printf("Min free IP's %v", poolmonitor.MinimumFreeIps)
 	log.Printf("Max free IP %v", poolmonitor.MaximumFreeIps)
@@ -492,7 +521,7 @@ func TestPoolSizeDecreaseToReallyLow(t *testing.T) {
 		maxPodIPCount           = int64(30)
 	)
 
-	fakecns, fakerc, poolmonitor := initFakes(t, batchSize, initialIPConfigCount, requestThresholdPercent, releaseThresholdPercent, maxPodIPCount)
+	fakecns, fakerc, poolmonitor := exit(t, batchSize, initialIPConfigCount, requestThresholdPercent, releaseThresholdPercent, maxPodIPCount)
 
 	log.Printf("Min free IP's %v", poolmonitor.MinimumFreeIps)
 	log.Printf("Max free IP %v", poolmonitor.MaximumFreeIps)

--- a/cns/ipampoolmonitor/ipampoolmonitor_test.go
+++ b/cns/ipampoolmonitor/ipampoolmonitor_test.go
@@ -378,13 +378,12 @@ func TestPoolDecrease(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Ensure the size of the requested spec is still the same
-	if len(poolmonitor.cachedNNC.Spec.IPsNotInUse) != 0 {
-		t.Fatalf("Expected IPsNotInUse to be 0 after request controller reconcile, "+
-			"actual %v", poolmonitor.cachedNNC.Spec.IPsNotInUse)
+	// CNS won't actually clean up the IPsNotInUse until it changes the spec for some other reason (i.e. scale up)
+	// so instead we should just verify that the CNS state has no more PendingReleaseIPConfigs,
+	// and that they were cleaned up.
+	if len(fakecns.GetPendingReleaseIPConfigs()) != 0 {
+		t.Fatalf("expected 0 PendingReleaseIPConfigs, got %d", len(fakecns.GetPendingReleaseIPConfigs()))
 	}
-
-	return
 }
 
 func TestPoolSizeDecreaseWhenDecreaseHasAlreadyBeenRequested(t *testing.T) {

--- a/cns/ipampoolmonitor/ipampoolmonitor_test.go
+++ b/cns/ipampoolmonitor/ipampoolmonitor_test.go
@@ -521,7 +521,12 @@ func TestPoolSizeDecreaseToReallyLow(t *testing.T) {
 		maxPodIPCount           = int64(30)
 	)
 
-	fakecns, fakerc, poolmonitor := exit(t, batchSize, initialIPConfigCount, requestThresholdPercent, releaseThresholdPercent, maxPodIPCount)
+	fakecns, fakerc, poolmonitor := initFakes(t,
+		batchSize,
+		initialIPConfigCount,
+		requestThresholdPercent,
+		releaseThresholdPercent,
+		maxPodIPCount)
 
 	log.Printf("Min free IP's %v", poolmonitor.MinimumFreeIps)
 	log.Printf("Max free IP %v", poolmonitor.MaximumFreeIps)

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -262,20 +262,20 @@ func (service *HTTPRestService) updateIPConfigsStateUntransacted(
 // acquire/release the service lock.
 func (service *HTTPRestService) addIPConfigStateUntransacted(ncId string, hostVersion int, ipconfigs, existingSecondaryIPConfigs map[string]cns.SecondaryIPConfig) {
 	// add ipconfigs to state
-	for ipId, ipconfig := range ipconfigs {
+	for ipID, ipconfig := range ipconfigs {
 		// New secondary IP configs has new NC version however, CNS don't want to override existing IPs'with new NC version
 		// Set it back to previous NC version if IP already exist.
-		if existingIPConfig, existsInPreviousIPConfig := existingSecondaryIPConfigs[ipId]; existsInPreviousIPConfig {
+		if existingIPConfig, existsInPreviousIPConfig := existingSecondaryIPConfigs[ipID]; existsInPreviousIPConfig {
 			ipconfig.NCVersion = existingIPConfig.NCVersion
-			ipconfigs[ipId] = ipconfig
+			ipconfigs[ipID] = ipconfig
 		}
 
-		if ipState, exists := service.PodIPConfigState[ipId]; exists {
-			logger.Printf("[Azure-Cns] Set ipId %s, IP %s version to %d, programmed host nc version is %d, ipState: %+v", ipId, ipconfig.IPAddress, ipconfig.NCVersion, hostVersion, ipState)
+		if ipState, exists := service.PodIPConfigState[ipID]; exists {
+			logger.Printf("[Azure-Cns] Set ipId %s, IP %s version to %d, programmed host nc version is %d, ipState: %+v", ipID, ipconfig.IPAddress, ipconfig.NCVersion, hostVersion, ipState)
 			continue
 		}
 
-		logger.Printf("[Azure-Cns] Set ipId %s, IP %s version to %d, programmed host nc version is %d", ipId, ipconfig.IPAddress, ipconfig.NCVersion, hostVersion)
+		logger.Printf("[Azure-Cns] Set ipId %s, IP %s version to %d, programmed host nc version is %d", ipID, ipconfig.IPAddress, ipconfig.NCVersion, hostVersion)
 		// Using the updated NC version attached with IP to compare with latest nmagent version and determine IP statues.
 		// When reconcile, service.PodIPConfigState doens't exist, rebuild it with the help of NC version attached with IP.
 		var newIPCNSStatus string
@@ -287,14 +287,14 @@ func (service *HTTPRestService) addIPConfigStateUntransacted(ncId string, hostVe
 		// add the new State
 		ipconfigStatus := cns.IPConfigurationStatus{
 			NCID:      ncId,
-			ID:        ipId,
+			ID:        ipID,
 			IPAddress: ipconfig.IPAddress,
 			State:     newIPCNSStatus,
 			PodInfo:   nil,
 		}
 		logger.Printf("[Azure-Cns] Add IP %s as %s", ipconfig.IPAddress, newIPCNSStatus)
 
-		service.PodIPConfigState[ipId] = ipconfigStatus
+		service.PodIPConfigState[ipID] = ipconfigStatus
 
 		// Todo Update batch API and maintain the count
 	}

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -226,8 +226,8 @@ func (service *HTTPRestService) updateIPConfigsStateUntransacted(
 	}
 
 	// Validate TobeDeletedIps are ready to be deleted.
-	for ipId := range tobeDeletedIpConfigs {
-		ipConfigStatus, exists := service.PodIPConfigState[ipId]
+	for ipID := range tobeDeletedIpConfigs {
+		ipConfigStatus, exists := service.PodIPConfigState[ipID]
 		if exists {
 			// pod ip exists, validate if state is not allocated, else fail
 			if ipConfigStatus.State == cns.Allocated {
@@ -238,8 +238,8 @@ func (service *HTTPRestService) updateIPConfigsStateUntransacted(
 	}
 
 	// now actually remove the deletedIPs
-	for ipId := range tobeDeletedIpConfigs {
-		returncode, errMsg := service.removeToBeDeletedIpsStateUntransacted(ipId, true)
+	for ipID := range tobeDeletedIpConfigs {
+		returncode, errMsg := service.removeToBeDeletedIPStateUntransacted(ipID, true)
 		if returncode != types.Success {
 			return returncode, errMsg
 		}
@@ -261,7 +261,7 @@ func (service *HTTPRestService) updateIPConfigsStateUntransacted(
 // addIPConfigStateUntransacted adds the IPConfigs to the PodIpConfigState map with Available state
 // If the IP is already added then it will be an idempotent call. Also note, caller will
 // acquire/release the service lock.
-func (service *HTTPRestService) addIPConfigStateUntransacted(ncId string, hostVersion int, ipconfigs,
+func (service *HTTPRestService) addIPConfigStateUntransacted(ncID string, hostVersion int, ipconfigs,
 	existingSecondaryIPConfigs map[string]cns.SecondaryIPConfig) {
 	// add ipconfigs to state
 	for ipID, ipconfig := range ipconfigs {
@@ -290,7 +290,7 @@ func (service *HTTPRestService) addIPConfigStateUntransacted(ncId string, hostVe
 		}
 		// add the new State
 		ipconfigStatus := cns.IPConfigurationStatus{
-			NCID:      ncId,
+			NCID:      ncID,
 			ID:        ipID,
 			IPAddress: ipconfig.IPAddress,
 			State:     newIPCNSStatus,

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -266,8 +266,7 @@ func (service *HTTPRestService) addIPConfigStateUntransacted(ncId string, hostVe
 	// add ipconfigs to state
 	for ipID, ipconfig := range ipconfigs {
 		// New secondary IP configs has new NC version however, CNS don't want to override existing IPs'with new
-		//NC version
-		// Set it back to previous NC version if IP already exist.
+		// NC version. Set it back to previous NC version if IP already exist.
 		if existingIPConfig, existsInPreviousIPConfig := existingSecondaryIPConfigs[ipID]; existsInPreviousIPConfig {
 			ipconfig.NCVersion = existingIPConfig.NCVersion
 			ipconfigs[ipID] = ipconfig

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -269,10 +269,13 @@ func (service *HTTPRestService) addIPConfigStateUntransacted(ncId string, hostVe
 			ipconfig.NCVersion = existingIPConfig.NCVersion
 			ipconfigs[ipId] = ipconfig
 		}
-		logger.Printf("[Azure-Cns] Set IP %s version to %d, programmed host nc version is %d", ipconfig.IPAddress, ipconfig.NCVersion, hostVersion)
-		if _, exists := service.PodIPConfigState[ipId]; exists {
+
+		if ipState, exists := service.PodIPConfigState[ipId]; exists {
+			logger.Printf("[Azure-Cns] Set ipId %s, IP %s version to %d, programmed host nc version is %d, ipState: %+v", ipId, ipconfig.IPAddress, ipconfig.NCVersion, hostVersion, ipState)
 			continue
 		}
+
+		logger.Printf("[Azure-Cns] Set ipId %s, IP %s version to %d, programmed host nc version is %d", ipId, ipconfig.IPAddress, ipconfig.NCVersion, hostVersion)
 		// Using the updated NC version attached with IP to compare with latest nmagent version and determine IP statues.
 		// When reconcile, service.PodIPConfigState doens't exist, rebuild it with the help of NC version attached with IP.
 		var newIPCNSStatus string


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Finishes and closes https://github.com/Azure/azure-container-networking/pull/962.

> There is a current bug in IPAM pool monitor where if a scale up happens right after scale down then we were accidently deleting the IpsNotInUse list in case Scale up Requested count is same as Total current ip count in CNS.
> 
> As a result DNC was not honoring the scale down as well not allocating new IPs because the existing secondary ip count matches the updated requested count.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
