### PR TITLE
typed IPConfigState and lazy reusable filters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,3 +21,6 @@ linters:
   - nakedret
   - promlinter
   - revive
+linters-settings:
+  lll:
+    line-length: 200

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -60,11 +60,17 @@ const (
 )
 
 // IPConfig States for CNS IPAM
+type IPConfigState string
+
 const (
-	Available          = "Available"
-	Allocated          = "Allocated"
-	PendingRelease     = "PendingRelease"
-	PendingProgramming = "PendingProgramming"
+	// Available IPConfigState for available IPs.
+	Available IPConfigState = "Available"
+	// Allocated IPConfigState for allocated IPs.
+	Allocated IPConfigState = "Allocated"
+	// PendingRelease IPConfigState for pending release IPs.
+	PendingRelease IPConfigState = "PendingRelease"
+	// PendingProgramming IPConfigState for pending programming IPs.
+	PendingProgramming IPConfigState = "PendingProgramming"
 )
 
 // ChannelMode :- CNS channel modes
@@ -85,7 +91,7 @@ type CreateNetworkContainerRequest struct {
 	LocalIPConfiguration       IPConfiguration
 	OrchestratorContext        json.RawMessage
 	IPConfiguration            IPConfiguration
-	SecondaryIPConfigs         map[string]SecondaryIPConfig //uuid is key
+	SecondaryIPConfigs         map[string]SecondaryIPConfig // uuid is key
 	MultiTenancyInfo           MultiTenancyInfo
 	CnetAddressSpace           []IPSubnet // To setup SNAT (should include service endpoint vips).
 	Routes                     []Route
@@ -270,7 +276,7 @@ type IPSubnet struct {
 	PrefixLength uint8
 }
 
-//GetIPNet converts the IPSubnet to the standard net type
+// GetIPNet converts the IPSubnet to the standard net type
 func (ips *IPSubnet) GetIPNet() (net.IP, *net.IPNet, error) {
 	prefix := strconv.Itoa(int(ips.PrefixLength))
 	return net.ParseCIDR(ips.IPAddress + "/" + prefix)
@@ -363,7 +369,7 @@ type IPConfigResponse struct {
 // GetIPAddressesRequest is used in CNS IPAM mode to get the states of IPConfigs
 // The IPConfigStateFilter is a slice of IP's to fetch from CNS that match those states
 type GetIPAddressesRequest struct {
-	IPConfigStateFilter []string
+	IPConfigStateFilter []IPConfigState
 }
 
 // GetIPAddressStateResponse is used in CNS IPAM mode as a response to get IP address state
@@ -378,7 +384,7 @@ type GetIPAddressStatusResponse struct {
 	Response              Response
 }
 
-//GetPodContextResponse is used in CNS Client debug mode to get mapping of Orchestrator Context to Pod IP UUID
+// GetPodContextResponse is used in CNS Client debug mode to get mapping of Orchestrator Context to Pod IP UUID
 type GetPodContextResponse struct {
 	PodContext map[string]string
 	Response   Response
@@ -492,19 +498,19 @@ func (networkContainerRequestPolicy *NetworkContainerRequestPolicies) Validate()
 			if err := json.Unmarshal(networkContainerRequestPolicy.Settings, &requestedAclPolicy); err != nil {
 				return fmt.Errorf("ACL policy failed to pass validation with error: %+v ", err)
 			}
-			//Deny request if ACL Action is empty
+			// Deny request if ACL Action is empty
 			if len(strings.TrimSpace(string(requestedAclPolicy.Action))) == 0 {
 				return fmt.Errorf("Action field cannot be empty in ACL Policy")
 			}
-			//Deny request if ACL Action is not Allow or Deny
+			// Deny request if ACL Action is not Allow or Deny
 			if !strings.EqualFold(requestedAclPolicy.Action, ActionTypeAllow) && !strings.EqualFold(requestedAclPolicy.Action, ActionTypeBlock) {
 				return fmt.Errorf("Only Allow or Block is supported in Action field")
 			}
-			//Deny request if ACL Direction is empty
+			// Deny request if ACL Direction is empty
 			if len(strings.TrimSpace(string(requestedAclPolicy.Direction))) == 0 {
 				return fmt.Errorf("Direction field cannot be empty in ACL Policy")
 			}
-			//Deny request if ACL direction is not In or Out
+			// Deny request if ACL direction is not In or Out
 			if !strings.EqualFold(requestedAclPolicy.Direction, DirectionTypeIn) && !strings.EqualFold(requestedAclPolicy.Direction, DirectionTypeOut) {
 				return fmt.Errorf("Only In or Out is supported in Direction field")
 			}

--- a/cns/api.go
+++ b/cns/api.go
@@ -54,7 +54,7 @@ type IPConfigurationStatus struct {
 	NCID      string
 	ID        string // uuid
 	IPAddress string
-	State     string
+	State     IPConfigState
 	PodInfo   PodInfo
 }
 

--- a/cns/cnsclient/cli.go
+++ b/cns/cnsclient/cli.go
@@ -65,9 +65,9 @@ func HandleCNSClientCommands(cmd, arg string) error {
 }
 
 func getCmd(client *CNSClient, arg string) error {
-	var states []string
+	var states []cns.IPConfigState
 
-	switch arg {
+	switch cns.IPConfigState(arg) {
 	case cns.Available:
 		states = append(states, cns.Available)
 

--- a/cns/cnsclient/cnsclient.go
+++ b/cns/cnsclient/cnsclient.go
@@ -25,9 +25,7 @@ const (
 	contentTypeJSON = "application/json"
 )
 
-var (
-	cnsClient *CNSClient
-)
+var cnsClient *CNSClient
 
 // InitCnsClient initializes new cns client and returns the object
 func InitCnsClient(url string, requestTimeout time.Duration) (*CNSClient, error) {
@@ -54,7 +52,9 @@ func GetCnsClient() (*CNSClient, error) {
 	if cnsClient == nil {
 		err = &CNSClientError{
 			types.UnexpectedError,
-			fmt.Errorf("[Azure CNSClient] CNS Client not initialized")}
+			//nolint:goerr113
+			fmt.Errorf("[Azure CNSClient] CNS Client not initialized"),
+		}
 	}
 
 	return cnsClient, err
@@ -63,9 +63,7 @@ func GetCnsClient() (*CNSClient, error) {
 // GetNetworkConfiguration Request to get network config.
 func (cnsClient *CNSClient) GetNetworkConfiguration(orchestratorContext []byte) (
 	*cns.GetNetworkContainerResponse, error) {
-	var (
-		body bytes.Buffer
-	)
+	var body bytes.Buffer
 
 	url := cnsClient.connectionURL + cns.GetNetworkContainerByOrchestratorContext
 	log.Printf("GetNetworkConfiguration url %v", url)
@@ -316,7 +314,7 @@ func (cnsClient *CNSClient) ReleaseIPAddress(ipconfig *cns.IPConfigRequest) erro
 
 // GetIPAddressesWithStates takes a variadic number of string parameters, to get all IP Addresses matching a number of states
 // usage GetIPAddressesWithStates(cns.Available, cns.Allocated)
-func (cnsClient *CNSClient) GetIPAddressesMatchingStates(StateFilter ...string) ([]cns.IPConfigurationStatus, error) {
+func (cnsClient *CNSClient) GetIPAddressesMatchingStates(stateFilter ...cns.IPConfigState) ([]cns.IPConfigurationStatus, error) {
 	var (
 		resp cns.GetIPAddressStatusResponse
 		err  error
@@ -324,7 +322,7 @@ func (cnsClient *CNSClient) GetIPAddressesMatchingStates(StateFilter ...string) 
 		body bytes.Buffer
 	)
 
-	if len(StateFilter) == 0 {
+	if len(stateFilter) == 0 {
 		return resp.IPConfigurationStatus, nil
 	}
 
@@ -332,7 +330,7 @@ func (cnsClient *CNSClient) GetIPAddressesMatchingStates(StateFilter ...string) 
 	log.Printf("GetIPAddressesMatchingStates url %v", url)
 
 	payload := &cns.GetIPAddressesRequest{
-		IPConfigStateFilter: StateFilter,
+		IPConfigStateFilter: stateFilter,
 	}
 
 	err = json.NewEncoder(&body).Encode(payload)
@@ -369,7 +367,7 @@ func (cnsClient *CNSClient) GetIPAddressesMatchingStates(StateFilter ...string) 
 	return resp.IPConfigurationStatus, err
 }
 
-//GetPodOrchestratorContext calls GetPodIpOrchestratorContext API on CNS
+// GetPodOrchestratorContext calls GetPodIpOrchestratorContext API on CNS
 func (cnsClient *CNSClient) GetPodOrchestratorContext() (map[string]string, error) {
 	var (
 		resp cns.GetPodContextResponse
@@ -408,7 +406,7 @@ func (cnsClient *CNSClient) GetPodOrchestratorContext() (map[string]string, erro
 	return resp.PodContext, err
 }
 
-//GetHTTPServiceData gets all public in-memory struct details for debugging purpose
+// GetHTTPServiceData gets all public in-memory struct details for debugging purpose
 func (cnsClient *CNSClient) GetHTTPServiceData() (restserver.GetHTTPServiceDataResponse, error) {
 	var (
 		resp restserver.GetHTTPServiceDataResponse

--- a/cns/filter/ipam.go
+++ b/cns/filter/ipam.go
@@ -1,0 +1,69 @@
+package filter
+
+import "github.com/Azure/azure-container-networking/cns"
+
+type IPConfigStatePredicate func(ipconfig cns.IPConfigurationStatus) bool
+
+var (
+	// StateAllocated is a preset filter for cns.Allocated.
+	StateAllocated = ipConfigStatePredicate(cns.Allocated)
+	// StateAvailable is a preset filter for cns.Available.
+	StateAvailable = ipConfigStatePredicate(cns.Available)
+	// StatePendingProgramming is a preset filter for cns.PendingProgramming.
+	StatePendingProgramming = ipConfigStatePredicate(cns.PendingProgramming)
+	// StatePendingRelease is a preset filter for cns.PendingRelease.
+	StatePendingRelease = ipConfigStatePredicate(cns.PendingRelease)
+)
+
+var filters = map[cns.IPConfigState]IPConfigStatePredicate{
+	cns.Allocated:          StateAllocated,
+	cns.Available:          StateAvailable,
+	cns.PendingProgramming: StatePendingProgramming,
+	cns.PendingRelease:     StatePendingRelease,
+}
+
+// ipConfigStatePredicate returns a predicate function that compares an IPConfigurationStatus.State to
+// the passed State string and returns true when equal.
+func ipConfigStatePredicate(test cns.IPConfigState) IPConfigStatePredicate {
+	return func(ipconfig cns.IPConfigurationStatus) bool {
+		return ipconfig.State == test
+	}
+}
+
+func matchesAnyIPConfigState(in cns.IPConfigurationStatus, predicates ...IPConfigStatePredicate) bool {
+	for _, p := range predicates {
+		if p(in) {
+			return true
+		}
+	}
+	return false
+}
+
+// MatchAnyIPConfigState filters the passed IPConfigurationStatus map
+// according to the passed predicates and returns the matching values.
+func MatchAnyIPConfigState(in map[string]cns.IPConfigurationStatus, predicates ...IPConfigStatePredicate) []cns.IPConfigurationStatus {
+	out := []cns.IPConfigurationStatus{}
+
+	if len(predicates) == 0 || len(in) == 0 {
+		return out
+	}
+
+	for _, v := range in {
+		if matchesAnyIPConfigState(v, predicates...) {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// PredicatesForStates returns a slice of IPConfigStatePredicates matches
+// that map to the input IPConfigStates.
+func PredicatesForStates(states ...cns.IPConfigState) []IPConfigStatePredicate {
+	var predicates []IPConfigStatePredicate
+	for _, state := range states {
+		if f, ok := filters[state]; ok {
+			predicates = append(predicates, f)
+		}
+	}
+	return predicates
+}

--- a/cns/filter/ipam_test.go
+++ b/cns/filter/ipam_test.go
@@ -1,0 +1,68 @@
+package filter
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/stretchr/testify/assert"
+)
+
+var testStatuses = []struct {
+	State  cns.IPConfigState
+	Status cns.IPConfigurationStatus
+}{
+	{
+		State: cns.Allocated,
+		Status: cns.IPConfigurationStatus{
+			ID:    "allocated",
+			State: cns.Allocated,
+		},
+	},
+	{
+		State: cns.Available,
+		Status: cns.IPConfigurationStatus{
+			ID:    "available",
+			State: cns.Available,
+		},
+	},
+	{
+		State: cns.PendingProgramming,
+		Status: cns.IPConfigurationStatus{
+			ID:    "pending-programming",
+			State: cns.PendingProgramming,
+		},
+	},
+	{
+		State: cns.PendingRelease,
+		Status: cns.IPConfigurationStatus{
+			ID:    "pending-release",
+			State: cns.PendingRelease,
+		},
+	},
+}
+
+func TestMatchesAnyIPConfigState(t *testing.T) {
+	for i := range testStatuses {
+		status := testStatuses[i].Status
+		failStatus := testStatuses[(i+1)%len(testStatuses)].Status
+		predicate := filters[testStatuses[i].State]
+		assert.True(t, matchesAnyIPConfigState(status, predicate))
+		assert.False(t, matchesAnyIPConfigState(failStatus, predicate))
+	}
+}
+
+func TestMatchAnyIPConfigState(t *testing.T) {
+	m := map[string]cns.IPConfigurationStatus{}
+	for i := range testStatuses {
+		key := strconv.Itoa(i)
+		m[key] = testStatuses[i].Status
+	}
+
+	for i := range testStatuses {
+		predicate := filters[testStatuses[i].State]
+		filtered := MatchAnyIPConfigState(m, predicate)
+		expected := []cns.IPConfigurationStatus{testStatuses[i].Status}
+		assert.Equal(t, expected, filtered)
+	}
+}

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -421,7 +421,7 @@ func validateNetworkRequest(t *testing.T, req cns.CreateNetworkContainerRequest)
 		t.Fatalf("Failed as Secondary IP count doesnt match in PodIpConfig state, expected:%d, actual %d", len(req.SecondaryIPConfigs), len(svc.PodIPConfigState))
 	}
 
-	var expectedIPStatus string
+	var expectedIPStatus cns.IPConfigState
 	// 0 is the default NMAgent version return from fake GetNetworkContainerInfoFromHost
 	if containerStatus.CreateNetworkContainerRequest.Version > "0" {
 		expectedIPStatus = cns.PendingProgramming

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/filter"
 	"github.com/Azure/azure-container-networking/cns/logger"
 	"github.com/Azure/azure-container-networking/cns/types"
 )
@@ -124,16 +125,17 @@ func (service *HTTPRestService) MarkIPAsPendingRelease(totalIpsToRelease int) (m
 	return pendingReleasedIps, nil
 }
 
-func (service *HTTPRestService) updateIPConfigState(ipId string, updatedState string, podInfo cns.PodInfo) (cns.IPConfigurationStatus, error) {
-	if ipConfig, found := service.PodIPConfigState[ipId]; found {
-		logger.Printf("[updateIPConfigState] Changing IpId [%s] state to [%s], podInfo [%+v]. Current config [%+v]", ipId, updatedState, podInfo, ipConfig)
+func (service *HTTPRestService) updateIPConfigState(ipID string, updatedState cns.IPConfigState, podInfo cns.PodInfo) (cns.IPConfigurationStatus, error) {
+	if ipConfig, found := service.PodIPConfigState[ipID]; found {
+		logger.Printf("[updateIPConfigState] Changing IpId [%s] state to [%s], podInfo [%+v]. Current config [%+v]", ipID, updatedState, podInfo, ipConfig)
 		ipConfig.State = updatedState
 		ipConfig.PodInfo = podInfo
-		service.PodIPConfigState[ipId] = ipConfig
+		service.PodIPConfigState[ipID] = ipConfig
 		return ipConfig, nil
 	}
 
-	return cns.IPConfigurationStatus{}, fmt.Errorf("[updateIPConfigState] Failed to update state %s for the IPConfig. ID %s not found PodIPConfigState", updatedState, ipId)
+	//nolint:goerr113
+	return cns.IPConfigurationStatus{}, fmt.Errorf("[updateIPConfigState] Failed to update state %s for the IPConfig. ID %s not found PodIPConfigState", updatedState, ipID)
 }
 
 // MarkIpsAsAvailableUntransacted will update pending programming IPs to available if NMAgent side's programmed nc version keep up with nc version.
@@ -239,15 +241,6 @@ func (service *HTTPRestService) GetHTTPStruct() HttpRestServiceData {
 	}
 }
 
-// GetPendingProgramIPConfigs returns list of IPs which are in pending program status
-func (service *HTTPRestService) GetPendingProgramIPConfigs() []cns.IPConfigurationStatus {
-	service.RLock()
-	defer service.RUnlock()
-	return filterIPConfigMap(service.PodIPConfigState, func(ipconfig cns.IPConfigurationStatus) bool {
-		return ipconfig.State == cns.PendingProgramming
-	})
-}
-
 func (service *HTTPRestService) getIPAddressesHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		req           cns.GetIPAddressesRequest
@@ -277,78 +270,43 @@ func (service *HTTPRestService) getIPAddressesHandler(w http.ResponseWriter, r *
 		return
 	}
 
-	filterFunc := func(ipconfig cns.IPConfigurationStatus, states []string) bool {
-		for _, state := range states {
-			if ipconfig.State == state {
-				return true
-			}
-		}
-		return false
-	}
-
 	// Get all IPConfigs matching a state, and append to a slice of IPAddressState
-	resp.IPConfigurationStatus = filterIPConfigsMatchingState(service.PodIPConfigState, req.IPConfigStateFilter, filterFunc)
-
-	return
+	resp.IPConfigurationStatus = filter.MatchAnyIPConfigState(service.PodIPConfigState, filter.PredicatesForStates(req.IPConfigStateFilter...)...)
 }
 
-// filter the ipconfigs in CNS matching a state (Available, Allocated, etc.) and return in a slice
-func filterIPConfigsMatchingState(toBeAdded map[string]cns.IPConfigurationStatus, states []string, f func(cns.IPConfigurationStatus, []string) bool) []cns.IPConfigurationStatus {
-	vsf := make([]cns.IPConfigurationStatus, 0)
-	for _, v := range toBeAdded {
-		if f(v, states) {
-			vsf = append(vsf, v)
-		}
-	}
-	return vsf
-}
-
-// filter ipconfigs based on predicate
-func filterIPConfigs(toBeAdded map[string]cns.IPConfigurationStatus, f func(cns.IPConfigurationStatus) bool) []cns.IPConfigurationStatus {
-	vsf := make([]cns.IPConfigurationStatus, 0)
-	for _, v := range toBeAdded {
-		if f(v) {
-			vsf = append(vsf, v)
-		}
-	}
-	return vsf
-}
-
+// GetAllocatedIPConfigs returns a filtered list of IPs which are in
+// Allocated State.
 func (service *HTTPRestService) GetAllocatedIPConfigs() []cns.IPConfigurationStatus {
 	service.RLock()
 	defer service.RUnlock()
-	return filterIPConfigMap(service.PodIPConfigState, func(ipconfig cns.IPConfigurationStatus) bool {
-		return ipconfig.State == cns.Allocated
-	})
+	return filter.MatchAnyIPConfigState(service.PodIPConfigState, filter.StateAllocated)
 }
 
+// GetAvailableIPConfigs returns a filtered list of IPs which are in
+// Available State.
 func (service *HTTPRestService) GetAvailableIPConfigs() []cns.IPConfigurationStatus {
 	service.RLock()
 	defer service.RUnlock()
-	return filterIPConfigMap(service.PodIPConfigState, func(ipconfig cns.IPConfigurationStatus) bool {
-		return ipconfig.State == cns.Available
-	})
+	return filter.MatchAnyIPConfigState(service.PodIPConfigState, filter.StateAvailable)
 }
 
+// GetPendingProgramIPConfigs returns a filtered list of IPs which are in
+// PendingProgramming State.
+func (service *HTTPRestService) GetPendingProgramIPConfigs() []cns.IPConfigurationStatus {
+	service.RLock()
+	defer service.RUnlock()
+	return filter.MatchAnyIPConfigState(service.PodIPConfigState, filter.StatePendingProgramming)
+}
+
+// GetPendingReleaseIPConfigs returns a filtered list of IPs which are in
+// PendingRelease State.
 func (service *HTTPRestService) GetPendingReleaseIPConfigs() []cns.IPConfigurationStatus {
 	service.RLock()
 	defer service.RUnlock()
-	return filterIPConfigMap(service.PodIPConfigState, func(ipconfig cns.IPConfigurationStatus) bool {
-		return ipconfig.State == cns.PendingRelease
-	})
+	return filter.MatchAnyIPConfigState(service.PodIPConfigState, filter.StatePendingRelease)
 }
 
-func filterIPConfigMap(toBeAdded map[string]cns.IPConfigurationStatus, f func(cns.IPConfigurationStatus) bool) []cns.IPConfigurationStatus {
-	vsf := make([]cns.IPConfigurationStatus, 0)
-	for _, v := range toBeAdded {
-		if f(v) {
-			vsf = append(vsf, v)
-		}
-	}
-	return vsf
-}
-
-//SetIPConfigAsAllocated takes a lock of the service, and sets the ipconfig in the CNS state as allocated, does not take a lock
+// SetIPConfigAsAllocated takes a lock of the service, and sets the ipconfig in the CNS state as allocated, does not take a lock
 func (service *HTTPRestService) setIPConfigAsAllocated(ipconfig cns.IPConfigurationStatus, podInfo cns.PodInfo) (cns.IPConfigurationStatus, error) {
 	ipconfig, err := service.updateIPConfigState(ipconfig.ID, cns.Allocated, podInfo)
 	if err != nil {
@@ -359,7 +317,7 @@ func (service *HTTPRestService) setIPConfigAsAllocated(ipconfig cns.IPConfigurat
 	return ipconfig, nil
 }
 
-//SetIPConfigAsAllocated and sets the ipconfig in the CNS state as allocated, does not take a lock
+// SetIPConfigAsAllocated and sets the ipconfig in the CNS state as allocated, does not take a lock
 func (service *HTTPRestService) setIPConfigAsAvailable(ipconfig cns.IPConfigurationStatus, podInfo cns.PodInfo) (cns.IPConfigurationStatus, error) {
 	ipconfig, err := service.updateIPConfigState(ipconfig.ID, cns.Available, nil)
 	if err != nil {

--- a/cns/restserver/ipam_test.go
+++ b/cns/restserver/ipam_test.go
@@ -49,7 +49,7 @@ func newSecondaryIPConfig(ipAddress string, ncVersion int) cns.SecondaryIPConfig
 	}
 }
 
-func NewPodState(ipaddress string, prefixLength uint8, id, ncid, state string, ncVersion int) cns.IPConfigurationStatus {
+func NewPodState(ipaddress string, prefixLength uint8, id, ncid string, state cns.IPConfigState, ncVersion int) cns.IPConfigurationStatus {
 	ipconfig := newSecondaryIPConfig(ipaddress, ncVersion)
 
 	return cns.IPConfigurationStatus{
@@ -113,7 +113,7 @@ func requestIpAddressAndGetState(t *testing.T, req cns.IPConfigRequest) (cns.IPC
 	return ipState, err
 }
 
-func NewPodStateWithOrchestratorContext(ipaddress, id, ncid, state string, prefixLength uint8, ncVersion int, podInfo cns.PodInfo) (cns.IPConfigurationStatus, error) {
+func NewPodStateWithOrchestratorContext(ipaddress, id, ncid string, state cns.IPConfigState, prefixLength uint8, ncVersion int, podInfo cns.PodInfo) (cns.IPConfigurationStatus, error) {
 	ipconfig := newSecondaryIPConfig(ipaddress, ncVersion)
 	return cns.IPConfigurationStatus{
 		IPAddress: ipconfig.IPAddress,

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -282,7 +282,7 @@ func (service *HTTPRestService) addIPConfigStateUntransacted(ncID string, hostVe
 			ipID, ipconfig.IPAddress, ipconfig.NCVersion, hostVersion)
 		// Using the updated NC version attached with IP to compare with latest nmagent version and determine IP statues.
 		// When reconcile, service.PodIPConfigState doens't exist, rebuild it with the help of NC version attached with IP.
-		var newIPCNSStatus string
+		var newIPCNSStatus cns.IPConfigState
 		if hostVersion < ipconfig.NCVersion {
 			newIPCNSStatus = cns.PendingProgramming
 		} else {


### PR DESCRIPTION
Signed-off-by: Evan Baker <rbtr@users.noreply.github.com>

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
- Adds a custom type for IPConfigState to enforce compile-time type safety, 
- Extracts the filters for IPConfigState, simplifies and tests them

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests


**Notes**:
