### PR TITLE
chore: remove rename from nnc/v1alpha import

### DIFF
--- a/cns/api.go
+++ b/cns/api.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/Azure/azure-container-networking/cns/common"
 	"github.com/Azure/azure-container-networking/cns/types"
-	nnc "github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
+	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 )
 
 // Container Network Service remote API Contract
@@ -215,7 +215,7 @@ type NodeConfiguration struct {
 
 type IPAMPoolMonitor interface {
 	Start(ctx context.Context, poolMonitorRefreshMilliseconds int) error
-	Update(scalar nnc.Scaler, spec nnc.NodeNetworkConfigSpec)
+	Update(scalar v1alpha.Scaler, spec v1alpha.NodeNetworkConfigSpec)
 	GetStateSnapshot() IpamPoolMonitorStateSnapshot
 }
 
@@ -224,7 +224,7 @@ type IpamPoolMonitorStateSnapshot struct {
 	MinimumFreeIps           int64
 	MaximumFreeIps           int64
 	UpdatingIpsNotInUseCount int
-	CachedNNC                nnc.NodeNetworkConfig
+	CachedNNC                v1alpha.NodeNetworkConfig
 }
 
 // Response describes generic response from CNS.

--- a/cns/cnsclient/apiclient.go
+++ b/cns/cnsclient/apiclient.go
@@ -2,14 +2,14 @@ package cnsclient
 
 import (
 	"github.com/Azure/azure-container-networking/cns"
-	nnc "github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
+	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 )
 
 // APIClient interface to update cns state
 type APIClient interface {
-	ReconcileNCState(nc *cns.CreateNetworkContainerRequest, pods map[string]cns.PodInfo, scalar nnc.Scaler, spec nnc.NodeNetworkConfigSpec) error
+	ReconcileNCState(nc *cns.CreateNetworkContainerRequest, pods map[string]cns.PodInfo, scalar v1alpha.Scaler, spec v1alpha.NodeNetworkConfigSpec) error
 	CreateOrUpdateNC(nc cns.CreateNetworkContainerRequest) error
-	UpdateIPAMPoolMonitor(scalar nnc.Scaler, spec nnc.NodeNetworkConfigSpec)
+	UpdateIPAMPoolMonitor(scalar v1alpha.Scaler, spec v1alpha.NodeNetworkConfigSpec)
 	GetNC(nc cns.GetNetworkContainerRequest) (cns.GetNetworkContainerResponse, error)
 	DeleteNC(nc cns.DeleteNetworkContainerRequest) error
 }

--- a/cns/cnsclient/cnsclient_test.go
+++ b/cns/cnsclient/cnsclient_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/Azure/azure-container-networking/cns/fakes"
 	"github.com/Azure/azure-container-networking/cns/logger"
 	"github.com/Azure/azure-container-networking/cns/restserver"
-	nnc "github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
+	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	"github.com/Azure/azure-container-networking/log"
 	"github.com/google/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -133,25 +133,25 @@ func TestMain(m *testing.M) {
 	httpRestService, err := restserver.NewHTTPRestService(&config, fakes.NewFakeImdsClient(), fakes.NewFakeNMAgentClient())
 	svc = httpRestService.(*restserver.HTTPRestService)
 	svc.Name = "cns-test-server"
-	fakeNNC := nnc.NodeNetworkConfig{
+	fakeNNC := v1alpha.NodeNetworkConfig{
 		TypeMeta:   metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{},
-		Spec: nnc.NodeNetworkConfigSpec{
+		Spec: v1alpha.NodeNetworkConfigSpec{
 			RequestedIPCount: 16,
 			IPsNotInUse:      []string{"abc"},
 		},
-		Status: nnc.NodeNetworkConfigStatus{
-			Scaler: nnc.Scaler{
+		Status: v1alpha.NodeNetworkConfigStatus{
+			Scaler: v1alpha.Scaler{
 				BatchSize:               10,
 				ReleaseThresholdPercent: 50,
 				RequestThresholdPercent: 40,
 			},
-			NetworkContainers: []nnc.NetworkContainer{
+			NetworkContainers: []v1alpha.NetworkContainer{
 				{
 					ID:         "nc1",
 					PrimaryIP:  "10.0.0.11",
 					SubnetName: "sub1",
-					IPAssignments: []nnc.IPAssignment{
+					IPAssignments: []v1alpha.IPAssignment{
 						{
 							Name: "ip1",
 							IP:   "10.0.0.10",

--- a/cns/cnsclient/httpapi/client.go
+++ b/cns/cnsclient/httpapi/client.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/restserver"
 	"github.com/Azure/azure-container-networking/cns/types"
-	nnc "github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
+	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	"github.com/pkg/errors"
 )
 
@@ -27,12 +27,12 @@ func (client *Client) CreateOrUpdateNC(ncRequest cns.CreateNetworkContainerReque
 }
 
 // UpdateIPAMPoolMonitor updates IPAM pool monitor.
-func (client *Client) UpdateIPAMPoolMonitor(scalar nnc.Scaler, spec nnc.NodeNetworkConfigSpec) {
+func (client *Client) UpdateIPAMPoolMonitor(scalar v1alpha.Scaler, spec v1alpha.NodeNetworkConfigSpec) {
 	client.RestService.IPAMPoolMonitor.Update(scalar, spec)
 }
 
 // ReconcileNCState initializes cns state
-func (client *Client) ReconcileNCState(ncRequest *cns.CreateNetworkContainerRequest, podInfoByIP map[string]cns.PodInfo, scalar nnc.Scaler, spec nnc.NodeNetworkConfigSpec) error {
+func (client *Client) ReconcileNCState(ncRequest *cns.CreateNetworkContainerRequest, podInfoByIP map[string]cns.PodInfo, scalar v1alpha.Scaler, spec v1alpha.NodeNetworkConfigSpec) error {
 	returnCode := client.RestService.ReconcileNCState(ncRequest, podInfoByIP, scalar, spec)
 
 	if returnCode != 0 {

--- a/cns/fakes/cnsfake.go
+++ b/cns/fakes/cnsfake.go
@@ -10,7 +10,7 @@ import (
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/common"
 	"github.com/Azure/azure-container-networking/cns/types"
-	nnc "github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
+	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 )
 
 type StringStack struct {
@@ -18,16 +18,16 @@ type StringStack struct {
 	items []string
 }
 
-func NewFakeScalar(releaseThreshold, requestThreshold, batchSize int) nnc.Scaler {
-	return nnc.Scaler{
+func NewFakeScalar(releaseThreshold, requestThreshold, batchSize int) v1alpha.Scaler {
+	return v1alpha.Scaler{
 		BatchSize:               int64(batchSize),
 		ReleaseThresholdPercent: int64(releaseThreshold),
 		RequestThresholdPercent: int64(requestThreshold),
 	}
 }
 
-func NewFakeNodeNetworkConfigSpec(requestedIPCount int) nnc.NodeNetworkConfigSpec {
-	return nnc.NodeNetworkConfigSpec{
+func NewFakeNodeNetworkConfigSpec(requestedIPCount int) v1alpha.NodeNetworkConfigSpec {
+	return v1alpha.NodeNetworkConfigSpec{
 		RequestedIPCount: int64(requestedIPCount),
 	}
 }

--- a/cns/fakes/ipampoolmonitorfake.go
+++ b/cns/fakes/ipampoolmonitorfake.go
@@ -4,21 +4,21 @@ import (
 	"context"
 
 	"github.com/Azure/azure-container-networking/cns"
-	nnc "github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
+	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 )
 
 type IPAMPoolMonitorFake struct {
 	FakeMinimumIps       int
 	FakeMaximumIps       int
 	FakeIpsNotInUseCount int
-	FakecachedNNC        nnc.NodeNetworkConfig
+	FakecachedNNC        v1alpha.NodeNetworkConfig
 }
 
 func (ipm *IPAMPoolMonitorFake) Start(ctx context.Context, poolMonitorRefreshMilliseconds int) error {
 	return nil
 }
 
-func (ipm *IPAMPoolMonitorFake) Update(scalar nnc.Scaler, spec nnc.NodeNetworkConfigSpec) {}
+func (ipm *IPAMPoolMonitorFake) Update(scalar v1alpha.Scaler, spec v1alpha.NodeNetworkConfigSpec) {}
 
 func (ipm *IPAMPoolMonitorFake) Reconcile() error {
 	return nil

--- a/cns/fakes/requestcontrollerfake.go
+++ b/cns/fakes/requestcontrollerfake.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/singletenantcontroller"
-	nnc "github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
+	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	"github.com/google/uuid"
 )
 
@@ -14,18 +14,18 @@ var _ singletenantcontroller.RequestController = (*RequestControllerFake)(nil)
 
 type RequestControllerFake struct {
 	fakecns   *HTTPServiceFake
-	cachedCRD nnc.NodeNetworkConfig
+	cachedCRD v1alpha.NodeNetworkConfig
 	ip        net.IP
 }
 
-func NewRequestControllerFake(cnsService *HTTPServiceFake, scalar nnc.Scaler, subnetAddressSpace string, numberOfIPConfigs int) *RequestControllerFake {
+func NewRequestControllerFake(cnsService *HTTPServiceFake, scalar v1alpha.Scaler, subnetAddressSpace string, numberOfIPConfigs int) *RequestControllerFake {
 	rc := &RequestControllerFake{
 		fakecns: cnsService,
-		cachedCRD: nnc.NodeNetworkConfig{
-			Spec: nnc.NodeNetworkConfigSpec{},
-			Status: nnc.NodeNetworkConfigStatus{
+		cachedCRD: v1alpha.NodeNetworkConfig{
+			Spec: v1alpha.NodeNetworkConfigSpec{},
+			Status: v1alpha.NodeNetworkConfigStatus{
 				Scaler: scalar,
-				NetworkContainers: []nnc.NetworkContainer{
+				NetworkContainers: []v1alpha.NetworkContainer{
 					{
 						SubnetAddressSpace: subnetAddressSpace,
 					},
@@ -46,7 +46,7 @@ func (rc *RequestControllerFake) CarveIPConfigsAndAddToStatusAndCNS(numberOfIPCo
 	var cnsIPConfigs []cns.IPConfigurationStatus
 	for i := 0; i < numberOfIPConfigs; i++ {
 
-		ipconfigCRD := nnc.IPAssignment{
+		ipconfigCRD := v1alpha.IPAssignment{
 			Name: uuid.New().String(),
 			IP:   rc.ip.String(),
 		}
@@ -79,12 +79,12 @@ func (rc *RequestControllerFake) IsStarted() bool {
 	return true
 }
 
-func (rc *RequestControllerFake) UpdateCRDSpec(_ context.Context, desiredSpec nnc.NodeNetworkConfigSpec) error {
+func (rc *RequestControllerFake) UpdateCRDSpec(_ context.Context, desiredSpec v1alpha.NodeNetworkConfigSpec) error {
 	rc.cachedCRD.Spec = desiredSpec
 	return nil
 }
 
-func remove(slice []nnc.IPAssignment, s int) []nnc.IPAssignment {
+func remove(slice []v1alpha.IPAssignment, s int) []v1alpha.IPAssignment {
 	return append(slice[:s], slice[s+1:]...)
 }
 

--- a/cns/ipampoolmonitor/ipampoolmonitor.go
+++ b/cns/ipampoolmonitor/ipampoolmonitor.go
@@ -9,7 +9,7 @@ import (
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/logger"
 	"github.com/Azure/azure-container-networking/cns/singletenantcontroller"
-	nnc "github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
+	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 )
 
 const defaultMaxIPCount = int64(250)
@@ -17,11 +17,11 @@ const defaultMaxIPCount = int64(250)
 type CNSIPAMPoolMonitor struct {
 	MaximumFreeIps           int64
 	MinimumFreeIps           int64
-	cachedNNC                nnc.NodeNetworkConfig
+	cachedNNC                v1alpha.NodeNetworkConfig
 	httpService              cns.HTTPService
 	mu                       sync.RWMutex
 	rc                       singletenantcontroller.RequestController
-	scalarUnits              nnc.Scaler
+	scalarUnits              v1alpha.Scaler
 	updatingIpsNotInUseCount int
 }
 
@@ -229,8 +229,8 @@ func (pm *CNSIPAMPoolMonitor) cleanPendingRelease(ctx context.Context) error {
 }
 
 // createNNCSpecForCRD translates CNS's map of IPs to be released and requested IP count into an NNC Spec.
-func (pm *CNSIPAMPoolMonitor) createNNCSpecForCRD() nnc.NodeNetworkConfigSpec {
-	var spec nnc.NodeNetworkConfigSpec
+func (pm *CNSIPAMPoolMonitor) createNNCSpecForCRD() v1alpha.NodeNetworkConfigSpec {
+	var spec v1alpha.NodeNetworkConfigSpec
 
 	// Update the count from cached spec
 	spec.RequestedIPCount = pm.cachedNNC.Spec.RequestedIPCount
@@ -245,7 +245,7 @@ func (pm *CNSIPAMPoolMonitor) createNNCSpecForCRD() nnc.NodeNetworkConfigSpec {
 }
 
 // UpdatePoolLimitsTransacted called by request controller on reconcile to set the batch size limits
-func (pm *CNSIPAMPoolMonitor) Update(scalar nnc.Scaler, spec nnc.NodeNetworkConfigSpec) {
+func (pm *CNSIPAMPoolMonitor) Update(scalar v1alpha.Scaler, spec v1alpha.NodeNetworkConfigSpec) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 

--- a/cns/ipampoolmonitor/ipampoolmonitor_test.go
+++ b/cns/ipampoolmonitor/ipampoolmonitor_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/Azure/azure-container-networking/cns/fakes"
 	"github.com/Azure/azure-container-networking/cns/logger"
-	nnc "github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
+	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 )
 
 func initFakes(t *testing.T,
@@ -18,7 +18,7 @@ func initFakes(t *testing.T,
 	maxPodIPCount int64) (*fakes.HTTPServiceFake, *fakes.RequestControllerFake, *CNSIPAMPoolMonitor) {
 	logger.InitLogger("testlogs", 0, 0, "./")
 
-	scalarUnits := nnc.Scaler{
+	scalarUnits := v1alpha.Scaler{
 		BatchSize:               int64(batchSize),
 		RequestThresholdPercent: int64(requestThresholdPercent),
 		ReleaseThresholdPercent: int64(releaseThresholdPercent),

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -19,7 +19,7 @@ import (
 	"github.com/Azure/azure-container-networking/cns/nmagentclient"
 	"github.com/Azure/azure-container-networking/cns/types"
 	"github.com/Azure/azure-container-networking/common"
-	nnc "github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
+	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	"github.com/pkg/errors"
 )
 
@@ -211,8 +211,8 @@ func (service *HTTPRestService) SyncHostNCVersion(ctx context.Context, channelMo
 
 // This API will be called by CNS RequestController on CRD update.
 func (service *HTTPRestService) ReconcileNCState(
-	ncRequest *cns.CreateNetworkContainerRequest, podInfoByIP map[string]cns.PodInfo, scalar nnc.Scaler,
-	spec nnc.NodeNetworkConfigSpec) types.ResponseCode {
+	ncRequest *cns.CreateNetworkContainerRequest, podInfoByIP map[string]cns.PodInfo, scalar v1alpha.Scaler,
+	spec v1alpha.NodeNetworkConfigSpec) types.ResponseCode {
 	logger.Printf("Reconciling NC state with podInfo %+v", podInfoByIP)
 	// check if ncRequest is null, then return as there is no CRD state yet
 	if ncRequest == nil {

--- a/cns/singletenantcontroller/kubecontroller/crdreconciler.go
+++ b/cns/singletenantcontroller/kubecontroller/crdreconciler.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/cnsclient"
 	"github.com/Azure/azure-container-networking/cns/logger"
-	nnc "github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
+	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -24,7 +24,7 @@ type CrdReconciler struct {
 // Reconcile is called on CRD status changes
 func (r *CrdReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	var (
-		nodeNetConfig nnc.NodeNetworkConfig
+		nodeNetConfig v1alpha.NodeNetworkConfig
 		ncRequest     cns.CreateNetworkContainerRequest
 		err           error
 	)
@@ -80,7 +80,7 @@ func (r *CrdReconciler) Reconcile(ctx context.Context, request reconcile.Request
 // SetupWithManager Sets up the reconciler with a new manager, filtering using NodeNetworkConfigFilter
 func (r *CrdReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&nnc.NodeNetworkConfig{}).
+		For(&v1alpha.NodeNetworkConfig{}).
 		WithEventFilter(NodeNetworkConfigFilter{nodeName: r.NodeName}).
 		Complete(r)
 }

--- a/cns/singletenantcontroller/kubecontroller/crdrequestcontroller.go
+++ b/cns/singletenantcontroller/kubecontroller/crdrequestcontroller.go
@@ -15,7 +15,7 @@ import (
 	"github.com/Azure/azure-container-networking/cns/restserver"
 	"github.com/Azure/azure-container-networking/cns/singletenantcontroller"
 	"github.com/Azure/azure-container-networking/crd"
-	nnc "github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
+	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -93,7 +93,7 @@ func New(cfg Config) (*requestController, error) {
 	}
 
 	// Add CRD scheme to runtime sheme so manager can recognize it
-	if err := nnc.AddToScheme(scheme); err != nil {
+	if err := v1alpha.AddToScheme(scheme); err != nil {
 		return nil, errors.New("Error adding NodeNetworkConfig scheme to runtime scheme")
 	}
 
@@ -104,7 +104,7 @@ func New(cfg Config) (*requestController, error) {
 	}
 
 	// Create a direct client to the API server configured to get nodenetconfigs to get nnc for same reason above
-	directCRDClient, err := NewCRDDirectClient(cfg.KubeConfig, &nnc.GroupVersion)
+	directCRDClient, err := NewCRDDirectClient(cfg.KubeConfig, &v1alpha.GroupVersion)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating direct CRD client: %v", err)
 	}
@@ -281,7 +281,7 @@ func (rc *requestController) kubePodsToPodInfoByIP(pods []corev1.Pod) map[string
 }
 
 // UpdateCRDSpec updates the CRD spec
-func (rc *requestController) UpdateCRDSpec(ctx context.Context, crdSpec nnc.NodeNetworkConfigSpec) error {
+func (rc *requestController) UpdateCRDSpec(ctx context.Context, crdSpec v1alpha.NodeNetworkConfigSpec) error {
 	nodeNetworkConfig, err := rc.getNodeNetConfig(ctx, rc.nodeName, k8sNamespace)
 	if err != nil {
 		logger.Errorf("[cns-rc] Error getting CRD when updating spec %v", err)
@@ -305,8 +305,8 @@ func (rc *requestController) UpdateCRDSpec(ctx context.Context, crdSpec nnc.Node
 }
 
 // getNodeNetConfig gets the nodeNetworkConfig CRD given the name and namespace of the CRD object
-func (rc *requestController) getNodeNetConfig(ctx context.Context, name, namespace string) (*nnc.NodeNetworkConfig, error) {
-	nodeNetworkConfig := &nnc.NodeNetworkConfig{}
+func (rc *requestController) getNodeNetConfig(ctx context.Context, name, namespace string) (*v1alpha.NodeNetworkConfig, error) {
+	nodeNetworkConfig := &v1alpha.NodeNetworkConfig{}
 
 	err := rc.KubeClient.Get(ctx, client.ObjectKey{
 		Namespace: namespace,
@@ -320,9 +320,9 @@ func (rc *requestController) getNodeNetConfig(ctx context.Context, name, namespa
 }
 
 // getNodeNetConfigDirect gets the nodeNetworkConfig CRD using a direct client
-func (rc *requestController) getNodeNetConfigDirect(ctx context.Context, name, namespace string) (*nnc.NodeNetworkConfig, error) {
+func (rc *requestController) getNodeNetConfigDirect(ctx context.Context, name, namespace string) (*v1alpha.NodeNetworkConfig, error) {
 	var (
-		nodeNetworkConfig *nnc.NodeNetworkConfig
+		nodeNetworkConfig *v1alpha.NodeNetworkConfig
 		err               error
 	)
 
@@ -334,7 +334,7 @@ func (rc *requestController) getNodeNetConfigDirect(ctx context.Context, name, n
 }
 
 // updateNodeNetConfig updates the nodeNetConfig object in the API server with the given nodeNetworkConfig object
-func (rc *requestController) updateNodeNetConfig(ctx context.Context, nodeNetworkConfig *nnc.NodeNetworkConfig) error {
+func (rc *requestController) updateNodeNetConfig(ctx context.Context, nodeNetworkConfig *v1alpha.NodeNetworkConfig) error {
 	if err := rc.KubeClient.Update(ctx, nodeNetworkConfig); err != nil {
 		return err
 	}

--- a/cns/singletenantcontroller/kubecontroller/crdtranslator.go
+++ b/cns/singletenantcontroller/kubecontroller/crdtranslator.go
@@ -7,17 +7,17 @@ import (
 
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/logger"
-	nnc "github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
+	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 )
 
 // CRDStatusToNCRequest translates a crd status to createnetworkcontainer request
-func CRDStatusToNCRequest(crdStatus nnc.NodeNetworkConfigStatus) (cns.CreateNetworkContainerRequest, error) {
+func CRDStatusToNCRequest(crdStatus v1alpha.NodeNetworkConfigStatus) (cns.CreateNetworkContainerRequest, error) {
 	var (
 		ncRequest         cns.CreateNetworkContainerRequest
-		nc                nnc.NetworkContainer
+		nc                v1alpha.NetworkContainer
 		secondaryIPConfig cns.SecondaryIPConfig
 		ipSubnet          cns.IPSubnet
-		ipAssignment      nnc.IPAssignment
+		ipAssignment      v1alpha.IPAssignment
 		err               error
 		ip                net.IP
 		ipNet             *net.IPNet

--- a/cns/singletenantcontroller/kubecontroller/crdtranslator_test.go
+++ b/cns/singletenantcontroller/kubecontroller/crdtranslator_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-container-networking/cns"
-	nnc "github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
+	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 )
 
 const (
@@ -22,16 +22,16 @@ const (
 
 func TestStatusToNCRequestMalformedPrimaryIP(t *testing.T) {
 	var (
-		status nnc.NodeNetworkConfigStatus
+		status v1alpha.NodeNetworkConfigStatus
 		err    error
 	)
 
-	status = nnc.NodeNetworkConfigStatus{
-		NetworkContainers: []nnc.NetworkContainer{
+	status = v1alpha.NodeNetworkConfigStatus{
+		NetworkContainers: []v1alpha.NetworkContainer{
 			{
 				PrimaryIP: ipMalformed,
 				ID:        ncID,
-				IPAssignments: []nnc.IPAssignment{
+				IPAssignments: []v1alpha.IPAssignment{
 					{
 						Name: allocatedUUID,
 						IP:   testSecIp1,
@@ -52,16 +52,16 @@ func TestStatusToNCRequestMalformedPrimaryIP(t *testing.T) {
 
 func TestStatusToNCRequestMalformedIPAssignment(t *testing.T) {
 	var (
-		status nnc.NodeNetworkConfigStatus
+		status v1alpha.NodeNetworkConfigStatus
 		err    error
 	)
 
-	status = nnc.NodeNetworkConfigStatus{
-		NetworkContainers: []nnc.NetworkContainer{
+	status = v1alpha.NodeNetworkConfigStatus{
+		NetworkContainers: []v1alpha.NetworkContainer{
 			{
 				PrimaryIP: primaryIp,
 				ID:        ncID,
-				IPAssignments: []nnc.IPAssignment{
+				IPAssignments: []v1alpha.IPAssignment{
 					{
 						Name: allocatedUUID,
 						IP:   ipMalformed,
@@ -82,16 +82,16 @@ func TestStatusToNCRequestMalformedIPAssignment(t *testing.T) {
 
 func TestStatusToNCRequestPrimaryIPInCIDR(t *testing.T) {
 	var (
-		status nnc.NodeNetworkConfigStatus
+		status v1alpha.NodeNetworkConfigStatus
 		err    error
 	)
 
-	status = nnc.NodeNetworkConfigStatus{
-		NetworkContainers: []nnc.NetworkContainer{
+	status = v1alpha.NodeNetworkConfigStatus{
+		NetworkContainers: []v1alpha.NetworkContainer{
 			{
 				PrimaryIP: ipInCIDR,
 				ID:        ncID,
-				IPAssignments: []nnc.IPAssignment{
+				IPAssignments: []v1alpha.IPAssignment{
 					{
 						Name: allocatedUUID,
 						IP:   testSecIp1,
@@ -112,16 +112,16 @@ func TestStatusToNCRequestPrimaryIPInCIDR(t *testing.T) {
 
 func TestStatusToNCRequestIPAssignmentNotCIDR(t *testing.T) {
 	var (
-		status nnc.NodeNetworkConfigStatus
+		status v1alpha.NodeNetworkConfigStatus
 		err    error
 	)
 
-	status = nnc.NodeNetworkConfigStatus{
-		NetworkContainers: []nnc.NetworkContainer{
+	status = v1alpha.NodeNetworkConfigStatus{
+		NetworkContainers: []v1alpha.NetworkContainer{
 			{
 				PrimaryIP: primaryIp,
 				ID:        ncID,
-				IPAssignments: []nnc.IPAssignment{
+				IPAssignments: []v1alpha.IPAssignment{
 					{
 						Name: allocatedUUID,
 						IP:   ipInCIDR,
@@ -142,16 +142,16 @@ func TestStatusToNCRequestIPAssignmentNotCIDR(t *testing.T) {
 
 func TestStatusToNCRequestWithIncorrectSubnetAddressSpace(t *testing.T) {
 	var (
-		status nnc.NodeNetworkConfigStatus
+		status v1alpha.NodeNetworkConfigStatus
 		err    error
 	)
 
-	status = nnc.NodeNetworkConfigStatus{
-		NetworkContainers: []nnc.NetworkContainer{
+	status = v1alpha.NodeNetworkConfigStatus{
+		NetworkContainers: []v1alpha.NetworkContainer{
 			{
 				PrimaryIP: primaryIp,
 				ID:        ncID,
-				IPAssignments: []nnc.IPAssignment{
+				IPAssignments: []v1alpha.IPAssignment{
 					{
 						Name: allocatedUUID,
 						IP:   testSecIp1,
@@ -172,7 +172,7 @@ func TestStatusToNCRequestWithIncorrectSubnetAddressSpace(t *testing.T) {
 
 func TestStatusToNCRequestSuccess(t *testing.T) {
 	var (
-		status       nnc.NodeNetworkConfigStatus
+		status       v1alpha.NodeNetworkConfigStatus
 		ncRequest    cns.CreateNetworkContainerRequest
 		secondaryIPs map[string]cns.SecondaryIPConfig
 		secondaryIP  cns.SecondaryIPConfig
@@ -180,12 +180,12 @@ func TestStatusToNCRequestSuccess(t *testing.T) {
 		err          error
 	)
 
-	status = nnc.NodeNetworkConfigStatus{
-		NetworkContainers: []nnc.NetworkContainer{
+	status = v1alpha.NodeNetworkConfigStatus{
+		NetworkContainers: []v1alpha.NetworkContainer{
 			{
 				PrimaryIP: primaryIp,
 				ID:        ncID,
-				IPAssignments: []nnc.IPAssignment{
+				IPAssignments: []v1alpha.IPAssignment{
 					{
 						Name: allocatedUUID,
 						IP:   testSecIp1,

--- a/cns/singletenantcontroller/kubecontroller/directcrdclient.go
+++ b/cns/singletenantcontroller/kubecontroller/directcrdclient.go
@@ -3,7 +3,7 @@ package kubecontroller
 import (
 	"context"
 
-	nnc "github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
+	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -18,13 +18,13 @@ type CRDDirectClient struct {
 }
 
 // Get gets a crd
-func (crdClient *CRDDirectClient) Get(ctx context.Context, name, namespace, typeName string) (*nnc.NodeNetworkConfig, error) {
+func (crdClient *CRDDirectClient) Get(ctx context.Context, name, namespace, typeName string) (*v1alpha.NodeNetworkConfig, error) {
 	var (
-		nodeNetConfig *nnc.NodeNetworkConfig
+		nodeNetConfig *v1alpha.NodeNetworkConfig
 		err           error
 	)
 
-	nodeNetConfig = &nnc.NodeNetworkConfig{}
+	nodeNetConfig = &v1alpha.NodeNetworkConfig{}
 	if err = crdClient.restClient.Get().Namespace(namespace).Resource(crdTypeName).Name(name).Do(ctx).Into(nodeNetConfig); err != nil {
 		return nil, err
 	}

--- a/cns/singletenantcontroller/kubecontroller/kubeclientinterface.go
+++ b/cns/singletenantcontroller/kubecontroller/kubeclientinterface.go
@@ -3,9 +3,8 @@ package kubecontroller
 import (
 	"context"
 
+	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	corev1 "k8s.io/api/core/v1"
-
-	nnc "github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -17,7 +16,7 @@ type KubeClient interface {
 
 // DirectCRDClient is an interface to get CRDs directly, without cache
 type DirectCRDClient interface {
-	Get(ctx context.Context, name, namespace, typeName string) (*nnc.NodeNetworkConfig, error)
+	Get(ctx context.Context, name, namespace, typeName string) (*v1alpha.NodeNetworkConfig, error)
 }
 
 // DirectAPIClient is an interface to talk directly with API Server without cache

--- a/cns/singletenantcontroller/requestcontrollerinterface.go
+++ b/cns/singletenantcontroller/requestcontrollerinterface.go
@@ -3,13 +3,13 @@ package singletenantcontroller
 import (
 	"context"
 
-	nnc "github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
+	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 )
 
 // RequestController interface for cns to interact with the request controller
 type RequestController interface {
 	Init(context.Context) error
 	Start(context.Context) error
-	UpdateCRDSpec(context.Context, nnc.NodeNetworkConfigSpec) error
+	UpdateCRDSpec(context.Context, v1alpha.NodeNetworkConfigSpec) error
 	IsStarted() bool
 }


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
removes unnecessary "nnc" rename from some "...nnc/api/v1alpha" imports, since it is already unambiguous 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
