### PR TITLE
Adding a build stage for arm64 cni

### DIFF
--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -51,6 +51,7 @@ stages:
               cd ./output
               find . -name '*.tgz' -print -exec mv -t ./bins/ {} +
               find . -name '*.zip' -print -exec mv -t ./bins/ {} +
+              shopt -s extglob
               rm -rf !("bins")
             name: "PrepareArtifacts"
             displayName: "Prepare Artifacts"

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -49,8 +49,8 @@ stages:
           - script: |
               mkdir -p ./output/bins
               cd ./output
-              find . -name '*.tgz' -print -exec mv -t ./bins/ {} +;
-              find . -name '*.zip' -print -exec mv -t ./bins/ {} +;
+              find . -name '*.tgz' -print -exec mv -t ./bins/ {} +
+              find . -name '*.zip' -print -exec mv -t ./bins/ {} +
               rm -rf !("bins")
             name: "PrepareArtifacts"
             displayName: "Prepare Artifacts"

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -42,35 +42,16 @@ stages:
           name: "$(BUILD_POOL_NAME_DEFAULT)"
         steps:
           - script: |
-              GOOS=windows make all-binaries VERSION=$(TAG)
-            name: "BuildWindows"
-            displayName: "Build Windows"
-
-          - script: |
-              GOOS=linux make all-binaries VERSION=$(TAG)
-            name: "BuildLinux"
-            displayName: "Build Linux"
-
-          - script: |
-              GOOS=linux GOARCH=arm64 make azure-cni-plugin VERSION=$(TAG)
-            name: "BuildCNIArm64"
-            displayName: "Build CNI ARM64"
+              make all-binaries-platforms GOOS=linux,windows GOARCH=amd64,arm64 VERSION=$(TAG)
+            name: "BuildAllPlatformBinaries"
+            displayName: "Build all platform binaries"
 
           - script: |
               mkdir -p ./output/bins
-              cd ./output/linux_amd64
-              sudo find . -mindepth 2 -type f -regextype posix-extended ! -iregex '.*\.(zip|tgz)$' -delete
-              sudo find . -mindepth 2 -type f -print -exec mv {} ../bins \;
-              sudo rm -R -- */ && cd ..
-              cd ./output/linux_arm64
-              sudo find . -mindepth 2 -type f -regextype posix-extended ! -iregex '.*\.(zip|tgz)$' -delete
-              sudo find . -mindepth 2 -type f -print -exec mv {} ../bins \;
-              sudo rm -R -- */ && cd ..
-              cd ./windows_amd64
-              sudo find . -mindepth 2 -type f -regextype posix-extended ! -iregex '.*\.(zip|tgz)$' -delete
-              sudo find . -mindepth 2 -type f -print -exec mv {} ../bins \;
-              sudo rm -R -- */ && cd ..
-              rmdir ./linux_amd64 && rmdir ./windows_amd64
+              cd ./output
+              find . -name '*.tgz' -print -exec mv -t ./bins/ {} +;
+              find . -name '*.zip' -print -exec mv -t ./bins/ {} +;
+              rm -rf !("bins")
             name: "PrepareArtifacts"
             displayName: "Prepare Artifacts"
 

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -42,7 +42,7 @@ stages:
           name: "$(BUILD_POOL_NAME_DEFAULT)"
         steps:
           - script: |
-              make all-binaries-platforms GOOS=linux,windows GOARCH=amd64,arm64 VERSION=$(TAG)
+              make all-binaries-platforms VERSION=$(TAG)
             name: "BuildAllPlatformBinaries"
             displayName: "Build all platform binaries"
 

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -62,6 +62,10 @@ stages:
               sudo find . -mindepth 2 -type f -regextype posix-extended ! -iregex '.*\.(zip|tgz)$' -delete
               sudo find . -mindepth 2 -type f -print -exec mv {} ../bins \;
               sudo rm -R -- */ && cd ..
+              cd ./output/linux_arm64
+              sudo find . -mindepth 2 -type f -regextype posix-extended ! -iregex '.*\.(zip|tgz)$' -delete
+              sudo find . -mindepth 2 -type f -print -exec mv {} ../bins \;
+              sudo rm -R -- */ && cd ..
               cd ./windows_amd64
               sudo find . -mindepth 2 -type f -regextype posix-extended ! -iregex '.*\.(zip|tgz)$' -delete
               sudo find . -mindepth 2 -type f -print -exec mv {} ../bins \;

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -52,6 +52,11 @@ stages:
             displayName: "Build Linux"
 
           - script: |
+              GOOS=linux GOARCH=arm64 make azure-cni-plugin VERSION=$(TAG)
+            name: "BuildCNIArm64"
+            displayName: "Build CNI ARM64"
+
+          - script: |
               mkdir -p ./output/bins
               cd ./output/linux_amd64
               sudo find . -mindepth 2 -type f -regextype posix-extended ! -iregex '.*\.(zip|tgz)$' -delete

--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,8 @@ NPMFILES = \
 # Build defaults.
 GOOS ?= linux
 GOARCH ?= amd64
-GOOSES ?= "linux windows"
-GOARCHES ?= "amd64 arm64"
+GOOSES ?= "linux windows" # To override at the cli do: GOOSES="\"darwin bsd\""
+GOARCHES ?= "amd64 arm64" # To override at the cli do: GOARCHES="\"ppc64 mips\""
 
 # Build directories.
 ROOT_DIR = $(shell pwd)

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL=/bin/bash
+
 # Source files common to all targets.
 COREFILES = \
 	$(wildcard common/*.go) \
@@ -269,11 +271,14 @@ all-containerized:
 	docker rm $(BUILD_CONTAINER_NAME)
 	docker rmi $(BUILD_CONTAINER_IMAGE):$(VERSION)
 
-# Make both linux and windows binaries
+# Make all platform binaries
 .PHONY: all-binaries-platforms
 all-binaries-platforms:
-	export GOOS=linux; make all-binaries
-	export GOOS=windows; make all-binaries
+	for goos in $$(echo $(GOOS) | sed "s/,/ /g"); do \
+		for goarch in $$(echo $(GOARCH) | sed "s/,/ /g"); do \
+			make all-binaries GOOS=$$goos GOARCH=$$goarch; \
+		done \
+	done
 
 
 .PHONY: tools

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,8 @@ NPMFILES = \
 # Build defaults.
 GOOS ?= linux
 GOARCH ?= amd64
+GOOSES ?= "linux windows"
+GOARCHES ?= "amd64 arm64"
 
 # Build directories.
 ROOT_DIR = $(shell pwd)
@@ -168,6 +170,14 @@ VERSION ?= $(shell git describe --tags --always --dirty)
 CNS_AI_ID = ce672799-8f08-4235-8c12-08563dc2acef
 cnsaipath=github.com/Azure/azure-container-networking/cns/logger.aiMetadata
 ENSURE_OUTPUT_DIR_EXISTS := $(shell mkdir -p $(OUTPUT_DIR))
+
+.PHONY: all-binaries-platforms
+all-binaries-platforms: ## Make all platform binaries
+	@for goos in "$(GOOSES)"; do \
+		for goarch in "$(GOARCHES)"; do \
+			make all-binaries GOOS=$$goos GOARCH=$$goarch; \
+		done \
+	done
 
 # Shorthand target names for convenience.
 azure-cnm-plugin: $(CNM_BUILD_DIR)/azure-vnet-plugin$(EXE_EXT) cnm-archive
@@ -270,15 +280,6 @@ all-containerized:
 	docker cp $(BUILD_CONTAINER_NAME):$(BUILD_CONTAINER_REPO_PATH)/$(BUILD_DIR) $(OUTPUT_DIR)
 	docker rm $(BUILD_CONTAINER_NAME)
 	docker rmi $(BUILD_CONTAINER_IMAGE):$(VERSION)
-
-# Make all platform binaries
-.PHONY: all-binaries-platforms
-all-binaries-platforms:
-	for goos in $$(echo $(GOOS) | sed "s/,/ /g"); do \
-		for goarch in $$(echo $(GOARCH) | sed "s/,/ /g"); do \
-			make all-binaries GOOS=$$goos GOARCH=$$goarch; \
-		done \
-	done
 
 
 .PHONY: tools


### PR DESCRIPTION
**Reason for Change**:
We need to build an ARM64 version of CNI too now.
Validation on an ARM64 machine:
```
azureuser@test-vm:~$ lscpu
Architecture:        aarch64
Byte Order:          Little Endian
CPU(s):              32
On-line CPU(s) list: 0-31
Thread(s) per core:  1
Core(s) per socket:  32
Socket(s):           1
NUMA node(s):        1
Vendor ID:           Cavium
Model:               2
Model name:          ThunderX2 99xx
Stepping:            0x1
BogoMIPS:            400.00
NUMA node0 CPU(s):   0-31
Flags:               fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics cpuid asimdrdm
azureuser@test-vm:~$ sudo ./azure-vnet
v1.4.11
```

And when I try running an amd64`cni binary on an arm64 machine, it fails
```
azureuser@test-vm:~$ sudo amd64/azure-vnet
amd64/azure-vnet: 3: amd64/azure-vnet: Syntax error: end of file unexpected (expecting ")")
```