### PR TITLE
Client http refactor & testing

### DIFF
--- a/cns/client/client.go
+++ b/cns/client/client.go
@@ -33,9 +33,13 @@ var clientPaths = []string{
 	cns.PathDebugRestData,
 }
 
+type do interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
 // Client specifies a client to connect to Ipam Plugin.
 type Client struct {
-	client http.Client
+	client do
 	routes map[string]url.URL
 }
 
@@ -51,7 +55,7 @@ func New(baseURL string, requestTimeout time.Duration) (*Client, error) {
 	}
 
 	return &Client{
-		client: http.Client{
+		client: &http.Client{
 			Timeout: requestTimeout,
 		},
 		routes: routes,

--- a/cns/client/client_test.go
+++ b/cns/client/client_test.go
@@ -407,7 +407,7 @@ func TestNew(t *testing.T) {
 			url:  "",
 			want: &Client{
 				routes: emptyRoutes,
-				client: http.Client{
+				client: &http.Client{
 					Timeout: 0,
 				},
 			},

--- a/cns/client/client_test.go
+++ b/cns/client/client_test.go
@@ -346,7 +346,11 @@ func TestCNSClientDebugAPI(t *testing.T) {
 }
 
 func TestNew(t *testing.T) {
+	fqdnBaseURL := "http://testinstance.centraluseuap.cloudapp.azure.com"
+	fqdnWithPortBaseURL := fqdnBaseURL + ":10090"
 	emptyRoutes, _ := buildRoutes(defaultBaseURL, clientPaths)
+	fqdnRoutes, _ := buildRoutes(fqdnBaseURL, clientPaths)
+	fqdnWithPortRoutes, _ := buildRoutes(fqdnWithPortBaseURL, clientPaths)
 	tests := []struct {
 		name    string
 		url     string
@@ -364,6 +368,34 @@ func TestNew(t *testing.T) {
 				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "FQDN",
+			url:  fqdnBaseURL,
+			want: &Client{
+				routes: fqdnRoutes,
+				client: &http.Client{
+					Timeout: 0,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "FQDN with port",
+			url:  fqdnWithPortBaseURL,
+			want: &Client{
+				routes: fqdnWithPortRoutes,
+				client: &http.Client{
+					Timeout: 0,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "bad path",
+			url:     "postgres://user:abc{DEf1=ghi@example.com:5432/db?sslmode=require",
+			want:    nil,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/cns/client/client_test.go
+++ b/cns/client/client_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	"github.com/Azure/azure-container-networking/log"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -418,13 +420,12 @@ func TestNew(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := New(tt.url, tt.timeout)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("New() = %#v, want %#v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
**Reason for Change**:
- Making an http client interface
- Testify - TestNew
- Testify - existing cases
- TestNew more cases
- buildRoutes tests
- GetNetworkConfiguration tests
- CreateHostNCApipaEndpoint tests
- DeleteHostNCApipaEndpoint tests
- RequestIPAddress tests improvements
- ReleaseIPAddress tests improvements
- GetIPAddressesMatchingStates tests improvements
- GetPodOrchestratorContext tests improvements
- GetHTTPServiceData tests improvements