### PR TITLE
feat: Adds support for HNS L4WFPProxyPolicy

### DIFF
--- a/network/policy/policy.go
+++ b/network/policy/policy.go
@@ -11,6 +11,7 @@ const (
 	RoutePolicy       CNIPolicyType = "ROUTE"
 	PortMappingPolicy CNIPolicyType = "NAT"
 	ACLPolicy         CNIPolicyType = "ACL"
+	L4WFPProxyPolicy  CNIPolicyType = "L4WFPPROXY"
 )
 
 type CNIPolicyType string

--- a/network/policy/policy_windows_test.go
+++ b/network/policy/policy_windows_test.go
@@ -1,0 +1,50 @@
+// Copyright 2021 Microsoft. All rights reserved.
+// MIT License
+
+package policy
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndpoint(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Endpoint Suite")
+}
+
+var _ = Describe("Windows Policies", func() {
+	Describe("Test GetHcnL4WFPProxyPolicy", func() {
+		It("Should raise error for invalid json", func() {
+			policy := Policy{
+				Type: L4WFPProxyPolicy,
+				Data: []byte(`invalid json`),
+			}
+
+			_, err := GetHcnL4WFPProxyPolicy(policy)
+			Expect(err).NotTo(BeNil())
+		})
+
+		It("Should marshall the policy correctly", func() {
+			policy := Policy{
+				Type: L4WFPProxyPolicy,
+				Data: []byte(`{
+					"Type": "L4WFPPROXY",
+					"OutboundProxyPort": "15001",
+					"InboundProxyPort": "15003",
+					"UserSID": "S-1-5-32-556",
+					"FilterTuple": {
+						"Protocols": "6"
+					}}`),
+			}
+
+			expected_policy := `{"InboundProxyPort":"15003","OutboundProxyPort":"15001","FilterTuple":{"Protocols":"6"},"UserSID":"S-1-5-32-556","InboundExceptions":{},"OutboundExceptions":{}}`
+
+			generatedPolicy, err := GetHcnL4WFPProxyPolicy(policy)
+			Expect(err).To(BeNil())
+			Expect(string(generatedPolicy.Settings)).To(Equal(expected_policy))
+		})
+	})
+})


### PR DESCRIPTION
Fixes #1002

Allow the cni plugin to marshall and apply L4WFPProxyPolicy
to Windows endpoints.

Tested on Kubernetes v1.19 with AKS-engine and docker runtime

Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
