### PR TITLE
Arm64 docker

### DIFF
--- a/.github/workflows/cyclonus-netpol-test.yaml
+++ b/.github/workflows/cyclonus-netpol-test.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Make NPM image
         run: |
-          VERSION=cyclonus make azure-npm-image
+          VERSION=cyclonus IMAGE_PLATFORM_ARCHES=linux/amd64 IMAGE_ACTION=load make azure-npm-image
       
       - name: Install Azure NPM
         run: |

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -72,8 +72,8 @@ jobs:
   - script: |
       echo Tag: $(TAG)
       echo ResourceGroup: $(RESOURCE_GROUP)
+      docker run --privileged --rm tonistiigi/binfmt --install arm64
       VERSION=$(TAG) make azure-npm-image
-      docker push $IMAGE_REGISTRY/azure-npm:$(TAG)
     displayName: 'Build and Push NPM Image'
 
   - task: Docker@2

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -91,10 +91,18 @@ stages:
         pool:
           name: "$(BUILD_POOL_NAME_DEFAULT)"
         steps:
+          - task: Docker@2
+            displayName: Docker Login
+            inputs:
+              containerRegistry: $(ACR_SERVICE_CONNECTION)
+              command: 'login'
+              addPipelineData: false
+
           - script: |
               echo Tag is $(TAG)
               sudo make tools-images VERSION=$(TAG)
-              sudo make all-images VERSION=$(TAG)
+              docker run --privileged --rm tonistiigi/binfmt --install arm64
+              make all-images VERSION=$(TAG)
             name: "BuildImages"
             displayName: "Build Images"
 
@@ -108,20 +116,7 @@ stages:
             name: "TrivyScan"
             displayName: "Image Vulnerability Scan"
 
-          - task: Docker@2
-            displayName: Docker Login
-            inputs:
-              containerRegistry: $(ACR_SERVICE_CONNECTION)
-              command: 'login'
-              addPipelineData: false
-
           - script: |
-              docker tag $IMAGE_REGISTRY/azure-npm:$(TAG) $IMAGE_REGISTRY/azure-npm:$(TAG)-test
-              docker push $IMAGE_REGISTRY/azure-npm:$(TAG)-test
-
-              docker tag $IMAGE_REGISTRY/azure-cns:$(TAG) $IMAGE_REGISTRY/azure-cns:$(TAG)-test
-              docker push $IMAGE_REGISTRY/azure-cns:$(TAG)-test
-
               docker tag $IMAGE_REGISTRY/azure-cni-manager:$(TAG) $IMAGE_REGISTRY/azure-cni-manager:$(TAG)-test
               docker push $IMAGE_REGISTRY/azure-cni-manager:$(TAG)-test
 
@@ -135,8 +130,8 @@ stages:
                   done
               }
 
-              auto-retry docker pull $IMAGE_REGISTRY/azure-npm:$(TAG)-test
-              auto-retry docker pull $IMAGE_REGISTRY/azure-cns:$(TAG)-test
+              auto-retry docker pull $IMAGE_REGISTRY/azure-npm:$(TAG)
+              auto-retry docker pull $IMAGE_REGISTRY/azure-cns:$(TAG)
               auto-retry docker pull $IMAGE_REGISTRY/azure-cni-manager:$(TAG)-test
             name: "mcrreplication"
             displayName: "Push NPM Image and Wait for Repository"

--- a/.pipelines/singletenancy/aks-engine/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks-engine/e2e-step-template.yaml
@@ -68,7 +68,7 @@ steps:
       cat '${{ parameters.clusterDefinition }}'
       cat '${{ parameters.clusterDefinition }}' | jq --arg cnikey $CNI_TYPE --arg cniurl $CNI_URL '.properties.orchestratorProfile.kubernetesConfig[$cnikey]= $cniurl' > '${{ parameters.clusterDefinition }}'.tmp	
       cat '${{ parameters.clusterDefinition }}'.tmp | jq --arg tag $(Tag) '.properties.orchestratorProfile.kubernetesConfig.azureCNIVersion = $tag' > '${{ parameters.clusterDefinition }}'
-      cat '${{ parameters.clusterDefinition }}' | jq --arg npmimage $IMAGE_REGISTRY/azure-npm:$(Tag)-test '.properties.orchestratorProfile.kubernetesConfig.addons[0].containers[0].image = $npmimage' > '${{ parameters.clusterDefinition }}'.tmp
+      cat '${{ parameters.clusterDefinition }}' | jq --arg npmimage $IMAGE_REGISTRY/azure-npm:$(Tag) '.properties.orchestratorProfile.kubernetesConfig.addons[0].containers[0].image = $npmimage' > '${{ parameters.clusterDefinition }}'.tmp
       mv '${{ parameters.clusterDefinition }}'.tmp '${{ parameters.clusterDefinition }}'
       echo "Running E2E tests against a cluster built with the following API model:" 
       cp ${{ parameters.clusterDefinition }} clusterDefinition.json

--- a/Makefile
+++ b/Makefile
@@ -250,8 +250,8 @@ ifeq ($(GOOS),linux)
 	--build-arg VERSION=$(VERSION) \
 	--build-arg CNS_AI_PATH=$(CNS_AI_PATH) \
 	--build-arg CNS_AI_ID=$(CNS_AI_ID) \
-	--platform=linux/amd64,linux/arm64 \
-	--push \
+	--platform=$(IMAGE_PLATFORM_ARCHES) \
+	--$(IMAGE_ACTION) \
 	.
 
 	echo $(AZURE_CNS_IMAGE):$(VERSION) > $(IMAGE_DIR)/$(CNS_IMAGE_INFO_FILE)

--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,7 @@ CNI_IPAM_DIR = $(REPO_ROOT)/cni/ipam/plugin
 CNI_IPAMV6_DIR = $(REPO_ROOT)/cni/ipam/pluginv6
 CNI_TELEMETRY_DIR = $(REPO_ROOT)/cni/telemetry/service
 ACNCLI_DIR = $(REPO_ROOT)/tools/acncli
-TELEMETRY_CONF_DIR = $(REPO_ROOT)/telemetry
 CNS_DIR = $(REPO_ROOT)/cns/service
-CNMS_DIR = $(REPO_ROOT)/cnms/service
 NPM_DIR = $(REPO_ROOT)/npm/cmd
 OUTPUT_DIR = $(REPO_ROOT)/output
 BUILD_DIR = $(OUTPUT_DIR)/$(GOOS)_$(GOARCH)
@@ -48,15 +46,16 @@ CNI_MULTITENANCY_BUILD_DIR = $(BUILD_DIR)/cni-multitenancy
 CNI_SWIFT_BUILD_DIR = $(BUILD_DIR)/cni-swift
 CNI_BAREMETAL_BUILD_DIR = $(BUILD_DIR)/cni-baremetal
 CNS_BUILD_DIR = $(BUILD_DIR)/cns
-CNMS_BUILD_DIR = $(BUILD_DIR)/cnms
 NPM_BUILD_DIR = $(BUILD_DIR)/npm
-NPM_RELATIVE_BUILD_DIR = output/$(GOOS)_$(GOARCH)/npm
-NPM_TELEMETRY_DIR = $(NPM_BUILD_DIR)/telemetry
 TOOLS_DIR = $(REPO_ROOT)/build/tools
 TOOLS_BIN_DIR = $(TOOLS_DIR)/bin
 CNI_AI_ID = 5515a1eb-b2bc-406a-98eb-ba462e6f0411
+CNS_AI_ID = ce672799-8f08-4235-8c12-08563dc2acef
 NPM_AI_ID = 014c22bd-4107-459e-8475-67909e96edcb
 ACN_PACKAGE_PATH = github.com/Azure/azure-container-networking
+CNI_AI_PATH=$(ACN_PACKAGE_PATH)/telemetry.aiMetadata
+CNS_AI_PATH=$(ACN_PACKAGE_PATH)/cns/logger.aiMetadata
+NPM_AI_PATH=$(ACN_PACKAGE_PATH)/npm.aiMetadata
 
 # Tool paths
 CONTROLLER_GEN := $(TOOLS_BIN_DIR)/controller-gen
@@ -75,13 +74,10 @@ CNI_MULTITENANCY_ARCHIVE_NAME = azure-vnet-cni-multitenancy-$(GOOS)-$(GOARCH)-$(
 CNI_SWIFT_ARCHIVE_NAME = azure-vnet-cni-swift-$(GOOS)-$(GOARCH)-$(VERSION).$(ARCHIVE_EXT)
 CNI_BAREMETAL_ARCHIVE_NAME = azure-vnet-cni-baremetal-$(GOOS)-$(GOARCH)-$(VERSION).$(ARCHIVE_EXT)
 CNS_ARCHIVE_NAME = azure-cns-$(GOOS)-$(GOARCH)-$(VERSION).$(ARCHIVE_EXT)
-CNMS_ARCHIVE_NAME = azure-cnms-$(GOOS)-$(GOARCH)-$(VERSION).$(ARCHIVE_EXT)
 NPM_ARCHIVE_NAME = azure-npm-$(GOOS)-$(GOARCH)-$(VERSION).$(ARCHIVE_EXT)
-NPM_IMAGE_ARCHIVE_NAME = azure-npm-$(GOOS)-$(GOARCH)-$(VERSION).$(ARCHIVE_EXT)
+NPM_IMAGE_INFO_FILE = azure-npm-$(VERSION).txt
 CNI_IMAGE_ARCHIVE_NAME = azure-cni-manager-$(GOOS)-$(GOARCH)-$(VERSION).$(ARCHIVE_EXT)
-CNMS_IMAGE_ARCHIVE_NAME = azure-cnms-$(GOOS)-$(GOARCH)-$(VERSION).$(ARCHIVE_EXT)
-TELEMETRY_IMAGE_ARCHIVE_NAME = azure-vnet-telemetry-$(GOOS)-$(GOARCH)-$(VERSION).$(ARCHIVE_EXT)
-CNS_IMAGE_ARCHIVE_NAME = azure-cns-$(GOOS)-$(GOARCH)-$(VERSION).$(ARCHIVE_EXT)
+CNS_IMAGE_INFO_FILE = azure-cns-$(VERSION).txt
 
 # Docker libnetwork (CNM) plugin v2 image parameters.
 CNM_PLUGIN_IMAGE ?= microsoft/azure-vnet-plugin
@@ -92,21 +88,16 @@ IMAGE_REGISTRY ?= acnpublic.azurecr.io
 # Azure network policy manager parameters.
 AZURE_NPM_IMAGE ?= $(IMAGE_REGISTRY)/azure-npm
 
-# Azure cnms parameters
-AZURE_CNMS_IMAGE ?= $(IMAGE_REGISTRY)/networkmonitor
-
 # Azure CNI installer parameters
 AZURE_CNI_IMAGE = $(IMAGE_REGISTRY)/azure-cni-manager
-
-# Azure vnet telemetry image parameters.
-AZURE_VNET_TELEMETRY_IMAGE = $(IMAGE_REGISTRY)/azure-vnet-telemetry
 
 # Azure container networking service image paramters.
 AZURE_CNS_IMAGE = $(IMAGE_REGISTRY)/azure-cns
 
+IMAGE_PLATFORM_ARCHES ?= linux/amd64,linux/arm64
+IMAGE_ACTION ?= push
+
 VERSION ?= $(shell git describe --tags --always --dirty)
-CNS_AI_ID = ce672799-8f08-4235-8c12-08563dc2acef
-cnsaipath=github.com/Azure/azure-container-networking/cns/logger.aiMetadata
 
 # Default target
 .PHONY: all-binaries-platforms
@@ -119,7 +110,7 @@ all-binaries-platforms: ## Make all platform binaries
 
 # OS specific binaries/images
 ifeq ($(GOOS),linux)
-all-binaries: azure-cnm-plugin azure-cni-plugin azure-cns azure-cnms azure-npm
+all-binaries: azure-cnm-plugin azure-cni-plugin azure-cns azure-npm
 all-images: azure-npm-image azure-cns-image
 else
 all-binaries: azure-cnm-plugin azure-cni-plugin azure-cns
@@ -166,7 +157,7 @@ azure-vnet-ipamv6-binary:
 # Build the Azure CNI telemetry binary.
 .PHONY: azure-vnet-telemetry-binary
 azure-vnet-telemetry-binary:
-	cd $(CNI_TELEMETRY_DIR) && CGO_ENABLED=0 go build -v -o $(CNI_BUILD_DIR)/azure-vnet-telemetry$(EXE_EXT) -ldflags "-X main.version=$(VERSION) -X $(ACN_PACKAGE_PATH)/telemetry.aiMetadata=$(CNI_AI_ID)" -gcflags="-dwarflocationlists=true"
+	cd $(CNI_TELEMETRY_DIR) && CGO_ENABLED=0 go build -v -o $(CNI_BUILD_DIR)/azure-vnet-telemetry$(EXE_EXT) -ldflags "-X main.version=$(VERSION) -X $(CNI_AI_PATH)=$(CNI_AI_ID)" -gcflags="-dwarflocationlists=true"
 
 # Build the Azure CLI network binary.
 .PHONY: acncli-binary
@@ -176,18 +167,13 @@ acncli-binary:
 # Build the Azure CNS binary.
 .PHONY: azure-cns-binary
 azure-cns-binary:
-	cd $(CNS_DIR) && CGO_ENABLED=0 go build -v -o $(CNS_BUILD_DIR)/azure-cns$(EXE_EXT) -ldflags "-X main.version=$(VERSION) -X $(cnsaipath)=$(CNS_AI_ID)" -gcflags="-dwarflocationlists=true"
-
-# Build the Azure CNMS binary.
-.PHONY: azure-cnms-binary
-azure-cnms-binary:
-	cd $(CNMS_DIR) && CGO_ENABLED=0 go build -v -o $(CNMS_BUILD_DIR)/azure-cnms$(EXE_EXT) -ldflags "-X main.version=$(VERSION)" -gcflags="-dwarflocationlists=true"
+	cd $(CNS_DIR) && CGO_ENABLED=0 go build -v -o $(CNS_BUILD_DIR)/azure-cns$(EXE_EXT) -ldflags "-X main.version=$(VERSION) -X $(CNS_AI_PATH)=$(CNS_AI_ID)" -gcflags="-dwarflocationlists=true"
 
 # Build the Azure NPM binary.
 .PHONY: azure-npm-binary
 azure-npm-binary:
 	cd $(CNI_TELEMETRY_DIR) && CGO_ENABLED=0 go build -v -o $(NPM_BUILD_DIR)/azure-vnet-telemetry$(EXE_EXT) -ldflags "-X main.version=$(VERSION)" -gcflags="-dwarflocationlists=true"
-	cd $(NPM_DIR) && CGO_ENABLED=0 go build -v -o $(NPM_BUILD_DIR)/azure-npm$(EXE_EXT) -ldflags "-X main.version=$(VERSION) -X $(ACN_PACKAGE_PATH)/npm.aiMetadata=$(NPM_AI_ID)" -gcflags="-dwarflocationlists=true"
+	cd $(NPM_DIR) && CGO_ENABLED=0 go build -v -o $(NPM_BUILD_DIR)/azure-npm$(EXE_EXT) -ldflags "-X main.version=$(VERSION) -X $(NPM_AI_PATH)=$(NPM_AI_ID)" -gcflags="-dwarflocationlists=true"
 
 
 ########################### Container Images ########################
@@ -233,58 +219,42 @@ azure-cnm-plugin-image: azure-cnm-plugin
 
 # Build the Azure NPM image.
 .PHONY: azure-npm-image
-azure-npm-image: azure-npm-binary
+azure-npm-image:
 ifeq ($(GOOS),linux)
 	$(MKDIR) $(IMAGE_DIR)
-	docker build \
+	docker buildx create --use
+	docker buildx build \
 	--no-cache \
 	-f npm/Dockerfile \
 	-t $(AZURE_NPM_IMAGE):$(VERSION) \
-	--build-arg NPM_BUILD_DIR=$(NPM_RELATIVE_BUILD_DIR) \
+	--build-arg VERSION=$(VERSION) \
+	--build-arg NPM_AI_PATH=$(NPM_AI_PATH) \
+	--build-arg NPM_AI_ID=$(NPM_AI_ID) \
+	--platform=$(IMAGE_PLATFORM_ARCHES) \
+	--$(IMAGE_ACTION) \
 	.
-	docker save $(AZURE_NPM_IMAGE):$(VERSION) | gzip -c > $(IMAGE_DIR)/$(NPM_IMAGE_ARCHIVE_NAME)
+	
+	echo $(AZURE_NPM_IMAGE):$(VERSION) > $(IMAGE_DIR)/$(NPM_IMAGE_INFO_FILE)
 endif
-
-# Build the Azure CNMS image
-.PHONY: azure-cnms-image
-azure-cnms-image: azure-cnms-binary
-ifeq ($(GOOS),linux)
-	$(MKDIR) $(IMAGE_DIR)
-	docker build \
-	--no-cache \
-	-f cnms/Dockerfile \
-	-t $(AZURE_CNMS_IMAGE):$(VERSION) \
-	--build-arg CNMS_BUILD_DIR=$(CNMS_BUILD_DIR) \
-	.
-	docker save $(AZURE_CNMS_IMAGE):$(VERSION) | gzip -c > $(IMAGE_DIR)/$(CNMS_IMAGE_ARCHIVE_NAME)
-endif
-
-# Build the Azure vnet telemetry image
-.PHONY: azure-vnet-telemetry-image
-azure-vnet-telemetry-image: azure-vnet-telemetry-binary
-	$(MKDIR) $(IMAGE_DIR)
-	docker build \
-	-f cni/telemetry/Dockerfile \
-	-t $(AZURE_VNET_TELEMETRY_IMAGE):$(VERSION) \
-	--build-arg TELEMETRY_BUILD_DIR=$(NPM_BUILD_DIR) \
-	--build-arg TELEMETRY_CONF_DIR=$(TELEMETRY_CONF_DIR) \
-	.
-	docker save $(AZURE_VNET_TELEMETRY_IMAGE):$(VERSION) | gzip -c > $(NPM_BUILD_DIR)/$(TELEMETRY_IMAGE_ARCHIVE_NAME)
 
 # Build the Azure CNS image
 .PHONY: azure-cns-image
 azure-cns-image:
 ifeq ($(GOOS),linux)
 	$(MKDIR) $(IMAGE_DIR)
-	docker build \
+	docker buildx create --use
+	docker buildx build \
 	--no-cache \
 	-f cns/Dockerfile \
 	-t $(AZURE_CNS_IMAGE):$(VERSION) \
 	--build-arg VERSION=$(VERSION) \
-	--build-arg CNS_AI_PATH=$(cnsaipath) \
+	--build-arg CNS_AI_PATH=$(CNS_AI_PATH) \
 	--build-arg CNS_AI_ID=$(CNS_AI_ID) \
+	--platform=linux/amd64,linux/arm64 \
+	--push \
 	.
-	docker save $(AZURE_CNS_IMAGE):$(VERSION) | gzip -c > $(IMAGE_DIR)/$(CNS_IMAGE_ARCHIVE_NAME)
+
+	echo $(AZURE_CNS_IMAGE):$(VERSION) > $(IMAGE_DIR)/$(CNS_IMAGE_INFO_FILE)
 endif
 
 ########################### Archives ################################
@@ -339,13 +309,6 @@ cns-archive: azure-cns-binary
 	cp cns/configuration/cns_config.json $(CNS_BUILD_DIR)/cns_config.json
 	cd $(CNS_BUILD_DIR) && $(ARCHIVE_CMD) $(CNS_ARCHIVE_NAME) azure-cns$(EXE_EXT) cns_config.json
 
-# Create a CNMS archive for the target platform. Only Linux is supported for now.
-.PHONY: cnms-archive
-cnms-archive: azure-cnms-binary
-ifeq ($(GOOS),linux)
-	cd $(CNMS_BUILD_DIR) && $(ARCHIVE_CMD) $(CNMS_ARCHIVE_NAME) azure-cnms$(EXE_EXT)
-endif
-
 # Create a NPM archive for the target platform. Only Linux is supported for now.
 .PHONY: npm-archive
 npm-archive: azure-npm-binary
@@ -363,21 +326,6 @@ release:
 .PHONY: publish-azure-cnm-plugin-image
 publish-azure-cnm-plugin-image:
 	docker plugin push $(CNM_PLUGIN_IMAGE):$(VERSION)
-
-# Publish the Azure vnet telemetry image to a Docker registry
-.PHONY: publish-azure-vnet-telemetry-image
-publish-azure-vnet-telemetry-image:
-	docker push $(AZURE_VNET_TELEMETRY_IMAGE):$(VERSION)
-
-# Publish the Azure NPM image to a Docker registry
-.PHONY: publish-azure-npm-image
-publish-azure-npm-image:
-	docker push $(AZURE_NPM_IMAGE):$(VERSION)
-
-# Publish the Azure CNS image to a Docker registry
-.PHONY: publish-azure-cns-image
-publish-azure-cns-image:
-	docker push $(AZURE_CNS_IMAGE):$(VERSION)
 
 ############################ Linting ################################
 

--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -15,10 +15,10 @@ WORKDIR /usr/local/src/cns
 COPY . .
 
 # Build cns
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o /usr/local/bin/azure-cns -ldflags "-X main.version="$VERSION" -X "$CNS_AI_PATH"="$CNS_AI_ID" -s -w " cns/service/*.go
+RUN CGO_ENABLED=0 go build -a -o /usr/local/bin/azure-cns -ldflags "-X main.version="$VERSION" -X "$CNS_AI_PATH"="$CNS_AI_ID"" -gcflags="-dwarflocationlists=true" cns/service/*.go
 
 # Build aitelemetry
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o /usr/local/bin/azure-vnet-telemetry -ldflags "-X main.version="$VERSION" -s -w" cni/telemetry/service/*.go
+RUN CGO_ENABLED=0 go build -a -o /usr/local/bin/azure-vnet-telemetry -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/telemetry/service/*.go
 
 # Copy into final image
 FROM scratch

--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:latest as certs
 RUN apk --update add ca-certificates
 
 # Build cns
-FROM golang:1.16-alpine AS builder
+FROM golang:1.17 AS builder
 # Build ars
 ARG VERSION
 ARG CNS_AI_PATH

--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -14,18 +14,18 @@ COPY . .
 RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm -ldflags "-X main.version="$VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" -gcflags="-dwarflocationlists=true" npm/cmd/*.go
 
 # Use a minimal image as a final image base
-FROM alpine:3.14
+FROM ubuntu:focal
 
 # Copy into final image
 COPY --from=builder /usr/local/bin/azure-npm \
 	/usr/bin/azure-npm
 
 # Install dependencies.
-RUN apk update
-RUN apk add --no-cache iptables
-RUN apk add --no-cache ipset
-RUN apk add --no-cache ca-certificates
-RUN apk upgrade
+RUN apt-get update
+RUN apt-get install -y iptables
+RUN apt-get install -y ipset
+RUN apt-get install -y ca-certificates
+RUN apt-get upgrade -y
 
 RUN chmod +x /usr/bin/azure-npm
 

--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -1,6 +1,24 @@
-# Use a minimal image as a parent image
+# Build npm
+FROM golang:1.16-alpine AS builder
+# Build args
+ARG VERSION
+ARG NPM_AI_PATH
+ARG NPM_AI_ID
+
+WORKDIR /usr/local/src/npm
+
+# Copy the source
+COPY . .
+
+# Build npm
+RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm -ldflags "-X main.version="$VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" -gcflags="-dwarflocationlists=true" npm/cmd/*.go
+
+# Use a minimal image as a final image base
 FROM ubuntu:focal
-ARG NPM_BUILD_DIR
+
+# Copy into final image
+COPY --from=builder /usr/local/bin/azure-npm \
+	/usr/bin/azure-npm
 
 # Install dependencies.
 RUN apt-get update
@@ -9,10 +27,7 @@ RUN apt-get install -y ipset
 RUN apt-get install -y ca-certificates
 RUN apt-get upgrade -y
 
-# Install plugin.
-COPY $NPM_BUILD_DIR/azure-npm /usr/bin
-
-WORKDIR /usr/bin
+RUN chmod +x /usr/bin/azure-npm
 
 # Run the npm command by default when the container starts.
 ENTRYPOINT ["/usr/bin/azure-npm", "start"]

--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -1,5 +1,5 @@
 # Build npm
-FROM golang:1.16-alpine AS builder
+FROM golang:1.17 AS builder
 # Build args
 ARG VERSION
 ARG NPM_AI_PATH
@@ -14,7 +14,7 @@ COPY . .
 RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm -ldflags "-X main.version="$VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" -gcflags="-dwarflocationlists=true" npm/cmd/*.go
 
 # Use a minimal image as a final image base
-FROM ubuntu:focal
+FROM alpine:3.14
 
 # Copy into final image
 COPY --from=builder /usr/local/bin/azure-npm \

--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -21,11 +21,11 @@ COPY --from=builder /usr/local/bin/azure-npm \
 	/usr/bin/azure-npm
 
 # Install dependencies.
-RUN apt-get update
-RUN apt-get install -y iptables
-RUN apt-get install -y ipset
-RUN apt-get install -y ca-certificates
-RUN apt-get upgrade -y
+RUN apk update
+RUN apk add --no-cache iptables
+RUN apk add --no-cache ipset
+RUN apk add --no-cache ca-certificates
+RUN apk upgrade
 
 RUN chmod +x /usr/bin/azure-npm
 


### PR DESCRIPTION
**Reason for Change**:
This adds arm64 docker images for Azure CNS and Azure NPM.
Uses docker buildx to do this, which makes it possible for the clients to pull which arch image they need at runtime dynically, and keep the same tag for both amd64 and arm64. Read more about it here

https://wiki.onap.org/display/DW/Building+a+Platform-Agnostic+Container+Image
https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/