### PR TITLE
[NPM] Modifying destroy ipsets logic

### DIFF
--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -616,22 +616,22 @@ func (ipsMgr *IpsetManager) DestroyNpmIpsets() error {
 			operationFlag: util.IpsetFlushFlag,
 			set:           ipsetName,
 		}
-		_, flushError := ipsMgr.run(flushEntry)
+		_, err := ipsMgr.run(flushEntry)
+		if err != nil {
+			metrics.SendErrorLogAndMetric(util.IpsmID, "{DestroyNpmIpsets} Error: failed to flush ipset %s", ipsetName)
+		}
+	}
 
+	for _, ipsetName := range ipsetLists {
 		deleteEntry := &ipsEntry{
 			operationFlag: util.IpsetDestroyFlag,
 			set:           ipsetName,
 		}
-		_, destroyError := ipsMgr.run(deleteEntry)
-
-		if flushError != nil {
-			metrics.SendErrorLogAndMetric(util.IpsmID, "{DestroyNpmIpsets} Error: failed to flush ipset %s", ipsetName)
-		}
-		if destroyError != nil {
+		_, err := ipsMgr.run(deleteEntry)
+		if err != nil {
 			destroyFailureCount++
 			metrics.SendErrorLogAndMetric(util.IpsmID, "{DestroyNpmIpsets} Error: failed to destroy ipset %s", ipsetName)
-		}
-		if flushError == nil || destroyError == nil {
+		} else {
 			metrics.RemoveAllEntriesFromIPSet(ipsetName)
 		}
 	}

--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -619,6 +619,8 @@ func (ipsMgr *IpsetManager) DestroyNpmIpsets() error {
 		_, err := ipsMgr.run(flushEntry)
 		if err != nil {
 			metrics.SendErrorLogAndMetric(util.IpsmID, "{DestroyNpmIpsets} Error: failed to flush ipset %s", ipsetName)
+		} else {
+			metrics.ResetEntriesInIPSet(ipsetName)
 		}
 	}
 

--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -619,8 +619,6 @@ func (ipsMgr *IpsetManager) DestroyNpmIpsets() error {
 		_, err := ipsMgr.run(flushEntry)
 		if err != nil {
 			metrics.SendErrorLogAndMetric(util.IpsmID, "{DestroyNpmIpsets} Error: failed to flush ipset %s", ipsetName)
-		} else {
-			metrics.ResetEntriesInIPSet(ipsetName)
 		}
 	}
 

--- a/npm/ipsm/ipsm_test.go
+++ b/npm/ipsm/ipsm_test.go
@@ -530,8 +530,8 @@ func TestDestroyNpmIpsets(t *testing.T) {
 		{Cmd: []string{"ipset", "-N", "-exist", util.GetHashedName(testSet2Name), "nethash"}},
 		{Cmd: []string{"ipset", "list"}, Stdout: ipsetListStdout},
 		{Cmd: []string{"ipset", "-F", "-exist", testSet1Name}},
-		{Cmd: []string{"ipset", "-X", "-exist", testSet1Name}},
 		{Cmd: []string{"ipset", "-F", "-exist", testSet2Name}},
+		{Cmd: []string{"ipset", "-X", "-exist", testSet1Name}},
 		{Cmd: []string{"ipset", "-X", "-exist", testSet2Name}},
 	}
 

--- a/npm/metrics/ipsets.go
+++ b/npm/metrics/ipsets.go
@@ -63,7 +63,13 @@ func RemoveEntryFromIPSet(setName string) {
 	}
 }
 
-// RemoveAllEntriesFromIPSet sets the number of entries for ipset setName to 0.
+// ResetEntriesInIPSet sets the number of entries for ipset setName to 0.
+// It doesn't ever update the number of IPSets.
+func ResetEntriesInIPSet(setName string) {
+	numIPSetEntries.Add(-getEntryCountForIPSet(setName))
+}
+
+// RemoveAllEntriesFromIPSet sets the number of entries for ipset setName to 0 and deletes the set
 // It doesn't ever update the number of IPSets.
 func RemoveAllEntriesFromIPSet(setName string) {
 	numIPSetEntries.Add(-getEntryCountForIPSet(setName))

--- a/npm/metrics/ipsets.go
+++ b/npm/metrics/ipsets.go
@@ -63,13 +63,7 @@ func RemoveEntryFromIPSet(setName string) {
 	}
 }
 
-// ResetEntriesInIPSet sets the number of entries for ipset setName to 0.
-// It doesn't ever update the number of IPSets.
-func ResetEntriesInIPSet(setName string) {
-	numIPSetEntries.Add(-getEntryCountForIPSet(setName))
-}
-
-// RemoveAllEntriesFromIPSet sets the number of entries for ipset setName to 0 and deletes the set
+// RemoveAllEntriesFromIPSet sets the number of entries for ipset setName to 0.
 // It doesn't ever update the number of IPSets.
 func RemoveAllEntriesFromIPSet(setName string) {
 	numIPSetEntries.Add(-getEntryCountForIPSet(setName))


### PR DESCRIPTION
Current logic of destroy IPSets flushes and destroy each ipset individually, this results in some ipsets being deleted before their references have been wiped out. This PR will now flush all the Ipsets and then will delete all the ipsets making sure the references are removed while deleting,