### PR TITLE
refactor: [NPM] parsing label selector for general translation logic

### DIFF
--- a/npm/pkg/controlplane/translation/doc.go
+++ b/npm/pkg/controlplane/translation/doc.go
@@ -1,0 +1,5 @@
+// Package translation converts NetworkPolicy object to policies.NPMNetworkPolicy object
+// which contains necessary information to program dataplanes.
+// The basic rule of conversion is to start from simple single rule (e.g., allow all traffic, only port, only IPBlock, etc)
+// to composite rules (e.g., port with IPBlock or port rule with peers rule (e.g., podSelector, namespaceSelector, or both podSelector and namespaceSelector)).
+package translation

--- a/npm/pkg/controlplane/translation/parseSelector.go
+++ b/npm/pkg/controlplane/translation/parseSelector.go
@@ -306,7 +306,7 @@ func parseNSSelector(selector *metav1.LabelSelector) []labelSelector {
 
 	// #1. All namespaces case
 	if len(selector.MatchLabels) == 0 && len(selector.MatchExpressions) == 0 {
-		parsedSelectors.addSelector(true, ipsets.Namespace, util.KubeAllNamespacesFlag)
+		parsedSelectors.addSelector(true, ipsets.KeyLabelOfNamespace, util.KubeAllNamespacesFlag)
 		return parsedSelectors.labelSelectors
 	}
 

--- a/npm/pkg/controlplane/translation/parseSelector.go
+++ b/npm/pkg/controlplane/translation/parseSelector.go
@@ -239,16 +239,25 @@ func parseSelector(selector *metav1.LabelSelector) (labels []string, vals map[st
 	return labels, vals
 }
 
+// labelSelector has parsed matchLabels and MatchExpressions information.
 type labelSelector struct {
+	// include is a flag to indicate whether Op exists or not.
 	include bool
 	settype ipsets.SetType
-	label   string
+	// label is among
+	// 1. "(!) + matchKey + ":" + matchVal (can be empty string) case
+	// 2. "(!) + matchKey" case
+	// or 3. "(!) + matchKey + : + multiple matchVals" case.
+	label string
+	// members slice exists only if setType is only NestedLabelOfPod.
 	members []string
 }
+
+// parsedSelectors maintains slice of unique labelSelector.
 type parsedSelectors struct {
 	labelSelectors []labelSelector
 	// To avoid the duplilcate matchLabel among matchLabels and MatchExpression
-	// key of labelSet including "!" if operator is "OpNOtIn" or "OpDoesNotExist"
+	// key of labelSet including "!" if operator is "OpNOtIn" or "OpDoesNotExist".
 	labelSet map[string]struct{}
 }
 
@@ -281,7 +290,6 @@ func (ps *parsedSelectors) addSelector(include bool, setType ipsets.SetType, mat
 
 	ps.labelSelectors = append(ps.labelSelectors, ls)
 	ps.labelSet[matchLabelWithOp] = struct{}{}
-
 }
 
 // parseNSSelector parses namespaceSelector and returns slice of labelSelector object

--- a/npm/pkg/controlplane/translation/parseSelector.go
+++ b/npm/pkg/controlplane/translation/parseSelector.go
@@ -245,9 +245,9 @@ type labelSelector struct {
 	include bool
 	settype ipsets.SetType
 	// label is among
-	// 1. "(!) + matchKey + ":" + matchVal (can be empty string) case
-	// 2. "(!) + matchKey" case
-	// or 3. "(!) + matchKey + : + multiple matchVals" case.
+	// 1. matchKey + ":" + matchVal (can be empty string) case
+	// 2. "matchKey" case
+	// or 3. "matchKey + : + multiple matchVals" case.
 	label string
 	// members slice exists only if setType is only NestedLabelOfPod.
 	members []string

--- a/npm/pkg/controlplane/translation/translatePolicy.go
+++ b/npm/pkg/controlplane/translation/translatePolicy.go
@@ -120,7 +120,7 @@ func portRule(ruleIPSets []*ipsets.TranslatedIPSet, acl *policies.ACLPolicy, por
 // as ipset name of the IPBlock.
 // For example, in case network policy object has
 // name: "test"
-// namespace: "deafult"
+// namespace: "default"
 // ingress rule
 // it returns "test-in-ns-default-0IN".
 func ipBlockSetName(policyName, ns string, direction policies.Direction, ipBlockSetIndex int) string {

--- a/npm/pkg/controlplane/translation/translatePolicy.go
+++ b/npm/pkg/controlplane/translation/translatePolicy.go
@@ -268,11 +268,11 @@ func podSelector(ns string, matchType policies.MatchType, selector *metav1.Label
 
 	for i := 0; i < LenOfPodSelectors; i++ {
 		ps := podSelectors[i]
-		podSelectorIPSets = append(podSelectorIPSets, ipsets.NewTranslatedIPSet(ps.label, ps.settype, ps.Members))
+		podSelectorIPSets = append(podSelectorIPSets, ipsets.NewTranslatedIPSet(ps.label, ps.settype, ps.members))
 		// if value is nested value, create translatedIPSet with the nested value
-		for j := 0; j < len(ps.Members); j++ {
+		for j := 0; j < len(ps.members); j++ {
 			var nilSlices []string
-			podSelectorIPSets = append(podSelectorIPSets, ipsets.NewTranslatedIPSet(ps.Members[j], ipsets.KeyValueLabelOfPod, nilSlices))
+			podSelectorIPSets = append(podSelectorIPSets, ipsets.NewTranslatedIPSet(ps.members[j], ipsets.KeyValueLabelOfPod, nilSlices))
 		}
 
 		podSelectorList[i] = policies.NewSetInfo(ps.label, ps.settype, ps.include, matchType)

--- a/npm/pkg/controlplane/translation/translatePolicy.go
+++ b/npm/pkg/controlplane/translation/translatePolicy.go
@@ -38,6 +38,7 @@ const (
 	keyValueLabel                       = 2
 )
 
+// portType returns type of ports (e.g., numeric port or namedPort) given NetworkPolicyPort object.
 func portType(portRule networkingv1.NetworkPolicyPort) (netpolPortType, error) {
 	if portRule.Port == nil || portRule.Port.IntValue() != 0 {
 		return numericPortType, nil
@@ -48,6 +49,8 @@ func portType(portRule networkingv1.NetworkPolicyPort) (netpolPortType, error) {
 	return "", errUnknownPortType
 }
 
+// numericPortRule returns policies.Ports (port, endport) and protocol type
+// based on NetworkPolicyPort holding numeric port information.
 func numericPortRule(portRule *networkingv1.NetworkPolicyPort) (portRuleInfo policies.Ports, protocol string) {
 	portRuleInfo = policies.Ports{}
 	protocol = "TCP"
@@ -67,6 +70,8 @@ func numericPortRule(portRule *networkingv1.NetworkPolicyPort) (portRuleInfo pol
 	return portRuleInfo, protocol
 }
 
+// namedPortRuleInfo returns translatedIPSet and protocol type
+// based on NetworkPolicyPort holding named port information.
 func namedPortRuleInfo(portRule *networkingv1.NetworkPolicyPort) (namedPortIPSet *ipsets.TranslatedIPSet, protocol string) {
 	if portRule == nil {
 		return nil, ""
@@ -110,10 +115,19 @@ func portRule(ruleIPSets []*ipsets.TranslatedIPSet, acl *policies.ACLPolicy, por
 	return ruleIPSets
 }
 
+// ipBlockIPSet returns ipset name of the IPBlock.
+// It is our contract to format "<policyname>-in-ns-<namespace>-<ipblock index><direction of ipblock (i.e., ingress: IN, egress: OUT>"
+// as ipset name of the IPBlock.
+// For example, in case network policy object has
+// name: "test"
+// namespace: "deafult"
+// ingress rule
+// it returns "test-in-ns-default-0IN".
 func ipBlockSetName(policyName, ns string, direction policies.Direction, ipBlockSetIndex int) string {
 	return fmt.Sprintf(ipBlocksetNameFormat, policyName, ns, ipBlockSetIndex, direction)
 }
 
+// ipBlockIPSet
 func ipBlockIPSet(policyName, ns string, direction policies.Direction, ipBlockSetIndex int, ipBlockRule *networkingv1.IPBlock) *ipsets.TranslatedIPSet {
 	if ipBlockRule == nil || ipBlockRule.CIDR == "" {
 		return nil
@@ -155,7 +169,7 @@ func podLabelType(label string) ipsets.SetType {
 	}
 }
 
-// podSelectorRule return srcList for ACL by using ops and labelsForSpec
+// podSelectorRule returns srcList for ACL by using ops and labelsForSpec
 func podSelectorRule(matchType policies.MatchType, ops, ipSetForACL []string) []policies.SetInfo {
 	podSelectorList := []policies.SetInfo{}
 	for i := 0; i < len(ipSetForACL); i++ {
@@ -183,6 +197,8 @@ func podSelectorIPSets(ipSetForSingleVal []string, ipSetNameForMultiVal map[stri
 	return podSelectorIPSets
 }
 
+// targetPodSelectorInfo converts podSelector information to operators and corresponding label information.
+// The label information has various types based on type of labels (e.g., single value or multiple value in labels).
 func targetPodSelectorInfo(selector *metav1.LabelSelector) (ops, ipSetForACL, ipSetForSingleVal []string, ipSetNameForMultiVal map[string][]string) {
 	// TODO(jungukcho) : need to revise parseSelector function to reduce computations and enhance readability
 	// 1. use better variables to indicate included instead of "".
@@ -213,6 +229,8 @@ func targetPodSelectorInfo(selector *metav1.LabelSelector) (ops, ipSetForACL, ip
 	return ops, ipSetForACL, ipSetForSingleVal, ipSetNameForMultiVal
 }
 
+// allPodsSelectorInNs returns translatedIPSet and SetInfo
+// in case podSelector field has {} which means all pods in the ns namespace.
 func allPodsSelectorInNs(ns string, matchType policies.MatchType) ([]*ipsets.TranslatedIPSet, []policies.SetInfo) {
 	// TODO(jungukcho): important this is common component - double-check whether it has duplicated one or not
 	ipset := ipsets.NewTranslatedIPSet(ns, ipsets.Namespace, []string{})
@@ -223,6 +241,8 @@ func allPodsSelectorInNs(ns string, matchType policies.MatchType) ([]*ipsets.Tra
 	return podSelectorIPSets, podSelectorList
 }
 
+// PodSelector translates podSelector of spec field and NetworkPolicyPeer in networkpolicy object to trasnslatedIPSet and SetInfo.
+// TODO(jungukcho): change name of function to podSelector since it uses both podSelector of spec field and NetworkPolicyPeer in networkpolicy object.
 func targetPodSelector(ns string, matchType policies.MatchType, selector *metav1.LabelSelector) ([]*ipsets.TranslatedIPSet, []policies.SetInfo) {
 	// (TODO): some data in singleValueLabels and multiValuesLabels are duplicated
 	ops, ipSetForACL, ipSetForSingleVal, ipSetNameForMultiVal := targetPodSelectorInfo(selector)
@@ -283,6 +303,8 @@ func nameSpaceSelectorInfo(selector *metav1.LabelSelector) (ops, singleValueLabe
 	return ops, singleValueLabels
 }
 
+// allNameSpaceRule returns translatedIPSet and SetInfo
+// in case namespaceSelector field has {} which means all namespaces.
 func allNameSpaceRule(matchType policies.MatchType) ([]*ipsets.TranslatedIPSet, []policies.SetInfo) {
 	translatedIPSet := ipsets.NewTranslatedIPSet(util.KubeAllNamespacesFlag, ipsets.Namespace, []string{})
 	nsSelectorIPSets := []*ipsets.TranslatedIPSet{translatedIPSet}
@@ -292,6 +314,7 @@ func allNameSpaceRule(matchType policies.MatchType) ([]*ipsets.TranslatedIPSet, 
 	return nsSelectorIPSets, nsSelectorList
 }
 
+// nameSpaceSelector translates namespaceSelector of NetworkPolicyPeer in networkpolicy object to trasnslatedIPSet and SetInfo.
 func nameSpaceSelector(matchType policies.MatchType, selector *metav1.LabelSelector) ([]*ipsets.TranslatedIPSet, []policies.SetInfo) {
 	ops, singleValueLabels := nameSpaceSelectorInfo(selector)
 
@@ -305,12 +328,14 @@ func nameSpaceSelector(matchType policies.MatchType, selector *metav1.LabelSelec
 	return nsSelectorIPSets, nsSelectorList
 }
 
+// allowAllTraffic returns translatedIPSet and SetInfo in case of allow all internal traffic.
 func allowAllTraffic(matchType policies.MatchType) (*ipsets.TranslatedIPSet, policies.SetInfo) {
 	allowAllIPSets := ipsets.NewTranslatedIPSet(util.KubeAllNamespacesFlag, ipsets.Namespace, []string{})
 	setInfo := policies.NewSetInfo(util.KubeAllNamespacesFlag, ipsets.Namespace, included, matchType)
 	return allowAllIPSets, setInfo
 }
 
+// defaultDropACL returns ACLPolicy to drop traffic which is not allowed.
 func defaultDropACL(policyNS, policyName string, direction policies.Direction) *policies.ACLPolicy {
 	dropACL := policies.NewACLPolicy(policyNS, policyName, policies.Dropped, direction)
 	return dropACL
@@ -341,6 +366,8 @@ func ruleExists(ports []networkingv1.NetworkPolicyPort, peer []networkingv1.Netw
 	return allowExternal, portRuleExists, peerRuleExists
 }
 
+// peerAndPortRule deals with composite rules including ports and peers
+// (e.g., IPBlock, podSelector, namespaceSelector, or both podSelector and namespaceSelector)
 func peerAndPortRule(npmNetPol *policies.NPMNetworkPolicy, ports []networkingv1.NetworkPolicyPort, setInfo []policies.SetInfo) {
 	if len(ports) == 0 {
 		acl := policies.NewACLPolicy(npmNetPol.NameSpace, npmNetPol.Name, policies.Allowed, policies.Ingress)
@@ -364,6 +391,8 @@ func peerAndPortRule(npmNetPol *policies.NPMNetworkPolicy, ports []networkingv1.
 	}
 }
 
+// translateIngress traslates podSelector of spec field and NetworkPolicyIngressRule in networkpolicy object
+// to NPMNetworkPolicy object.
 func translateIngress(npmNetPol *policies.NPMNetworkPolicy, targetSelector *metav1.LabelSelector, rules []networkingv1.NetworkPolicyIngressRule) {
 	// TODO(jungukcho) : Double-check addedCidrEntry.
 	var addedCidrEntry bool // all cidr entry will be added in one set per from/to rule
@@ -480,6 +509,8 @@ func existIngress(npObj *networkingv1.NetworkPolicy) bool {
 		len(npObj.Spec.Ingress[0].From) == 0)
 }
 
+// TranslatePolicy traslates networkpolicy object to NPMNetworkPolicy object
+// and return the NPMNetworkPolicy object.
 func TranslatePolicy(npObj *networkingv1.NetworkPolicy) *policies.NPMNetworkPolicy {
 	npmNetPol := &policies.NPMNetworkPolicy{
 		Name:      npObj.ObjectMeta.Name,

--- a/npm/pkg/controlplane/translation/translatePolicy.go
+++ b/npm/pkg/controlplane/translation/translatePolicy.go
@@ -268,14 +268,14 @@ func podSelector(ns string, matchType policies.MatchType, selector *metav1.Label
 
 	for i := 0; i < LenOfPodSelectors; i++ {
 		ps := podSelectors[i]
-		podSelectorIPSets = append(podSelectorIPSets, ipsets.NewTranslatedIPSet(ps.label, ps.settype, ps.members))
+		podSelectorIPSets = append(podSelectorIPSets, ipsets.NewTranslatedIPSet(ps.setName, ps.settype, ps.members))
 		// if value is nested value, create translatedIPSet with the nested value
 		for j := 0; j < len(ps.members); j++ {
 			var nilSlices []string
 			podSelectorIPSets = append(podSelectorIPSets, ipsets.NewTranslatedIPSet(ps.members[j], ipsets.KeyValueLabelOfPod, nilSlices))
 		}
 
-		podSelectorList[i] = policies.NewSetInfo(ps.label, ps.settype, ps.include, matchType)
+		podSelectorList[i] = policies.NewSetInfo(ps.setName, ps.settype, ps.include, matchType)
 	}
 
 	return podSelectorIPSets, podSelectorList
@@ -345,8 +345,8 @@ func nameSpaceSelector(matchType policies.MatchType, selector *metav1.LabelSelec
 
 	for i := 0; i < LenOfnsSelectors; i++ {
 		nsc := nsSelectors[i]
-		nsSelectorIPSets[i] = ipsets.NewTranslatedIPSet(nsc.label, nsc.settype, []string{})
-		nsSelectorList[i] = policies.NewSetInfo(nsc.label, nsc.settype, nsc.include, matchType)
+		nsSelectorIPSets[i] = ipsets.NewTranslatedIPSet(nsc.setName, nsc.settype, []string{})
+		nsSelectorList[i] = policies.NewSetInfo(nsc.setName, nsc.settype, nsc.include, matchType)
 	}
 
 	return nsSelectorIPSets, nsSelectorList

--- a/npm/pkg/controlplane/translation/translatePolicy_test.go
+++ b/npm/pkg/controlplane/translation/translatePolicy_test.go
@@ -2040,7 +2040,6 @@ func TestNameSpaceSelector(t *testing.T) {
 						Operator: metav1.LabelSelectorOpIn,
 						Values: []string{
 							"v10",
-							"v11",
 						},
 					},
 					{
@@ -2050,12 +2049,17 @@ func TestNameSpaceSelector(t *testing.T) {
 					},
 				},
 			},
-			// Multiple values are ignored in namespace case
-			// Refer to FlattenNameSpaceSelector function in parseSelector.go
 			nsSelectorIPSets: []*ipsets.TranslatedIPSet{
 				{
 					Metadata: &ipsets.IPSetMetadata{
 						Name: "k0:v0",
+						Type: ipsets.KeyValueLabelOfNamespace,
+					},
+					Members: []string{},
+				},
+				{
+					Metadata: &ipsets.IPSetMetadata{
+						Name: "k1:v10",
 						Type: ipsets.KeyValueLabelOfNamespace,
 					},
 					Members: []string{},
@@ -2072,6 +2076,14 @@ func TestNameSpaceSelector(t *testing.T) {
 				{
 					IPSet: &ipsets.IPSetMetadata{
 						Name: "k0:v0",
+						Type: ipsets.KeyValueLabelOfNamespace,
+					},
+					Included:  included,
+					MatchType: matchType,
+				},
+				{
+					IPSet: &ipsets.IPSetMetadata{
+						Name: "k1:v10",
 						Type: ipsets.KeyValueLabelOfNamespace,
 					},
 					Included:  included,

--- a/npm/pkg/controlplane/translation/translatePolicy_test.go
+++ b/npm/pkg/controlplane/translation/translatePolicy_test.go
@@ -1789,7 +1789,7 @@ func TestNameSpaceSelector(t *testing.T) {
 				{
 					Metadata: &ipsets.IPSetMetadata{
 						Name: util.KubeAllNamespacesFlag,
-						Type: ipsets.Namespace,
+						Type: ipsets.KeyLabelOfNamespace,
 					},
 					Members: []string{},
 				},
@@ -1798,7 +1798,7 @@ func TestNameSpaceSelector(t *testing.T) {
 				{
 					IPSet: &ipsets.IPSetMetadata{
 						Name: util.KubeAllNamespacesFlag,
-						Type: ipsets.Namespace,
+						Type: ipsets.KeyLabelOfNamespace,
 					},
 					Included:  included,
 					MatchType: matchType,

--- a/npm/pkg/controlplane/translation/translatePolicy_test.go
+++ b/npm/pkg/controlplane/translation/translatePolicy_test.go
@@ -1064,7 +1064,6 @@ func TestTargetPodSelector(t *testing.T) {
 						Name: "default",
 						Type: ipsets.Namespace,
 					},
-					Members: []string{},
 				},
 			},
 			podSelectorList: []policies.SetInfo{
@@ -1091,7 +1090,6 @@ func TestTargetPodSelector(t *testing.T) {
 						Name: "test",
 						Type: ipsets.Namespace,
 					},
-					Members: []string{},
 				},
 			},
 			podSelectorList: []policies.SetInfo{
@@ -1119,7 +1117,6 @@ func TestTargetPodSelector(t *testing.T) {
 						Name: "label:src",
 						Type: ipsets.KeyValueLabelOfPod,
 					},
-					Members: []string{},
 				},
 			},
 			podSelectorList: []policies.SetInfo{
@@ -1153,14 +1150,12 @@ func TestTargetPodSelector(t *testing.T) {
 						Name: "label:src",
 						Type: ipsets.KeyValueLabelOfPod,
 					},
-					Members: []string{},
 				},
 				{
 					Metadata: &ipsets.IPSetMetadata{
 						Name: "label",
 						Type: ipsets.KeyLabelOfPod,
 					},
-					Members: []string{},
 				},
 			},
 			podSelectorList: []policies.SetInfo{
@@ -1205,14 +1200,12 @@ func TestTargetPodSelector(t *testing.T) {
 						Name: "label:src",
 						Type: ipsets.KeyValueLabelOfPod,
 					},
-					Members: []string{},
 				},
 				{
 					Metadata: &ipsets.IPSetMetadata{
 						Name: "labelIn:src",
 						Type: ipsets.KeyValueLabelOfPod,
 					},
-					Members: []string{},
 				},
 			},
 			podSelectorList: []policies.SetInfo{
@@ -1257,14 +1250,12 @@ func TestTargetPodSelector(t *testing.T) {
 						Name: "label:src",
 						Type: ipsets.KeyValueLabelOfPod,
 					},
-					Members: []string{},
 				},
 				{
 					Metadata: &ipsets.IPSetMetadata{
 						Name: "labelNotIn:src",
 						Type: ipsets.KeyValueLabelOfPod,
 					},
-					Members: []string{},
 				},
 			},
 			podSelectorList: []policies.SetInfo{
@@ -1315,28 +1306,6 @@ func TestTargetPodSelector(t *testing.T) {
 						Name: "k0:v0",
 						Type: ipsets.KeyValueLabelOfPod,
 					},
-					Members: []string{},
-				},
-				{
-					Metadata: &ipsets.IPSetMetadata{
-						Name: "k2",
-						Type: ipsets.KeyLabelOfPod,
-					},
-					Members: []string{},
-				},
-				{
-					Metadata: &ipsets.IPSetMetadata{
-						Name: "k1:v10",
-						Type: ipsets.KeyValueLabelOfPod,
-					},
-					Members: []string{},
-				},
-				{
-					Metadata: &ipsets.IPSetMetadata{
-						Name: "k1:v11",
-						Type: ipsets.KeyValueLabelOfPod,
-					},
-					Members: []string{},
 				},
 				{
 					Metadata: &ipsets.IPSetMetadata{
@@ -1344,6 +1313,24 @@ func TestTargetPodSelector(t *testing.T) {
 						Type: ipsets.NestedLabelOfPod,
 					},
 					Members: []string{"k1:v10", "k1:v11"},
+				},
+				{
+					Metadata: &ipsets.IPSetMetadata{
+						Name: "k1:v10",
+						Type: ipsets.KeyValueLabelOfPod,
+					},
+				},
+				{
+					Metadata: &ipsets.IPSetMetadata{
+						Name: "k1:v11",
+						Type: ipsets.KeyValueLabelOfPod,
+					},
+				},
+				{
+					Metadata: &ipsets.IPSetMetadata{
+						Name: "k2",
+						Type: ipsets.KeyLabelOfPod,
+					},
 				},
 			},
 			podSelectorList: []policies.SetInfo{
@@ -1357,18 +1344,18 @@ func TestTargetPodSelector(t *testing.T) {
 				},
 				{
 					IPSet: &ipsets.IPSetMetadata{
-						Name: "k2",
-						Type: ipsets.KeyLabelOfPod,
-					},
-					Included:  nonIncluded,
-					MatchType: matchType,
-				},
-				{
-					IPSet: &ipsets.IPSetMetadata{
 						Name: "k1:v10:v11",
 						Type: ipsets.NestedLabelOfPod,
 					},
 					Included:  included,
+					MatchType: matchType,
+				},
+				{
+					IPSet: &ipsets.IPSetMetadata{
+						Name: "k2",
+						Type: ipsets.KeyLabelOfPod,
+					},
+					Included:  nonIncluded,
 					MatchType: matchType,
 				},
 			},
@@ -1378,7 +1365,8 @@ func TestTargetPodSelector(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			podSelectorIPSets, podSelectorList := targetPodSelector(tt.namespace, tt.matchType, tt.labelSelector)
+			t.Parallel()
+			podSelectorIPSets, podSelectorList := podSelector(tt.namespace, tt.matchType, tt.labelSelector)
 			require.Equal(t, tt.podSelectorIPSets, podSelectorIPSets)
 			require.Equal(t, tt.podSelectorList, podSelectorList)
 		})

--- a/npm/pkg/controlplane/translation/translatePolicy_test.go
+++ b/npm/pkg/controlplane/translation/translatePolicy_test.go
@@ -1043,6 +1043,7 @@ func TestPodSelectorRule(t *testing.T) {
 
 func TestTargetPodSelector(t *testing.T) {
 	matchType := policies.DstMatch
+	var nilSlices []string
 	tests := []struct {
 		name              string
 		namespace         string
@@ -1059,22 +1060,10 @@ func TestTargetPodSelector(t *testing.T) {
 				MatchLabels: map[string]string{},
 			},
 			podSelectorIPSets: []*ipsets.TranslatedIPSet{
-				{
-					Metadata: &ipsets.IPSetMetadata{
-						Name: "default",
-						Type: ipsets.Namespace,
-					},
-				},
+				ipsets.NewTranslatedIPSet("default", ipsets.Namespace, nilSlices),
 			},
 			podSelectorList: []policies.SetInfo{
-				{
-					IPSet: &ipsets.IPSetMetadata{
-						Name: "default",
-						Type: ipsets.Namespace,
-					},
-					Included:  included,
-					MatchType: matchType,
-				},
+				policies.NewSetInfo("default", ipsets.Namespace, included, matchType),
 			},
 		},
 		{
@@ -1085,22 +1074,10 @@ func TestTargetPodSelector(t *testing.T) {
 				MatchLabels: map[string]string{},
 			},
 			podSelectorIPSets: []*ipsets.TranslatedIPSet{
-				{
-					Metadata: &ipsets.IPSetMetadata{
-						Name: "test",
-						Type: ipsets.Namespace,
-					},
-				},
+				ipsets.NewTranslatedIPSet("test", ipsets.Namespace, nilSlices),
 			},
 			podSelectorList: []policies.SetInfo{
-				{
-					IPSet: &ipsets.IPSetMetadata{
-						Name: "test",
-						Type: ipsets.Namespace,
-					},
-					Included:  included,
-					MatchType: matchType,
-				},
+				policies.NewSetInfo("test", ipsets.Namespace, included, matchType),
 			},
 		},
 		{
@@ -1112,22 +1089,10 @@ func TestTargetPodSelector(t *testing.T) {
 				},
 			},
 			podSelectorIPSets: []*ipsets.TranslatedIPSet{
-				{
-					Metadata: &ipsets.IPSetMetadata{
-						Name: "label:src",
-						Type: ipsets.KeyValueLabelOfPod,
-					},
-				},
+				ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod, nilSlices),
 			},
 			podSelectorList: []policies.SetInfo{
-				{
-					IPSet: &ipsets.IPSetMetadata{
-						Name: "label:src",
-						Type: ipsets.KeyValueLabelOfPod,
-					},
-					Included:  included,
-					MatchType: matchType,
-				},
+				policies.NewSetInfo("label:src", ipsets.KeyValueLabelOfPod, included, matchType),
 			},
 		},
 		{
@@ -1145,36 +1110,12 @@ func TestTargetPodSelector(t *testing.T) {
 				},
 			},
 			podSelectorIPSets: []*ipsets.TranslatedIPSet{
-				{
-					Metadata: &ipsets.IPSetMetadata{
-						Name: "label:src",
-						Type: ipsets.KeyValueLabelOfPod,
-					},
-				},
-				{
-					Metadata: &ipsets.IPSetMetadata{
-						Name: "label",
-						Type: ipsets.KeyLabelOfPod,
-					},
-				},
+				ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod, nilSlices),
+				ipsets.NewTranslatedIPSet("label", ipsets.KeyLabelOfPod, nilSlices),
 			},
 			podSelectorList: []policies.SetInfo{
-				{
-					IPSet: &ipsets.IPSetMetadata{
-						Name: "label:src",
-						Type: ipsets.KeyValueLabelOfPod,
-					},
-					Included:  included,
-					MatchType: matchType,
-				},
-				{
-					IPSet: &ipsets.IPSetMetadata{
-						Name: "label",
-						Type: ipsets.KeyLabelOfPod,
-					},
-					Included:  included,
-					MatchType: matchType,
-				},
+				policies.NewSetInfo("label:src", ipsets.KeyValueLabelOfPod, included, matchType),
+				policies.NewSetInfo("label", ipsets.KeyLabelOfPod, included, matchType),
 			},
 		},
 		{
@@ -1195,36 +1136,12 @@ func TestTargetPodSelector(t *testing.T) {
 				},
 			},
 			podSelectorIPSets: []*ipsets.TranslatedIPSet{
-				{
-					Metadata: &ipsets.IPSetMetadata{
-						Name: "label:src",
-						Type: ipsets.KeyValueLabelOfPod,
-					},
-				},
-				{
-					Metadata: &ipsets.IPSetMetadata{
-						Name: "labelIn:src",
-						Type: ipsets.KeyValueLabelOfPod,
-					},
-				},
+				ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod, nilSlices),
+				ipsets.NewTranslatedIPSet("labelIn:src", ipsets.KeyValueLabelOfPod, nilSlices),
 			},
 			podSelectorList: []policies.SetInfo{
-				{
-					IPSet: &ipsets.IPSetMetadata{
-						Name: "label:src",
-						Type: ipsets.KeyValueLabelOfPod,
-					},
-					Included:  included,
-					MatchType: matchType,
-				},
-				{
-					IPSet: &ipsets.IPSetMetadata{
-						Name: "labelIn:src",
-						Type: ipsets.KeyValueLabelOfPod,
-					},
-					Included:  included,
-					MatchType: matchType,
-				},
+				policies.NewSetInfo("label:src", ipsets.KeyValueLabelOfPod, included, matchType),
+				policies.NewSetInfo("labelIn:src", ipsets.KeyValueLabelOfPod, included, matchType),
 			},
 		},
 		{
@@ -1245,36 +1162,12 @@ func TestTargetPodSelector(t *testing.T) {
 				},
 			},
 			podSelectorIPSets: []*ipsets.TranslatedIPSet{
-				{
-					Metadata: &ipsets.IPSetMetadata{
-						Name: "label:src",
-						Type: ipsets.KeyValueLabelOfPod,
-					},
-				},
-				{
-					Metadata: &ipsets.IPSetMetadata{
-						Name: "labelNotIn:src",
-						Type: ipsets.KeyValueLabelOfPod,
-					},
-				},
+				ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod, nilSlices),
+				ipsets.NewTranslatedIPSet("labelNotIn:src", ipsets.KeyValueLabelOfPod, nilSlices),
 			},
 			podSelectorList: []policies.SetInfo{
-				{
-					IPSet: &ipsets.IPSetMetadata{
-						Name: "label:src",
-						Type: ipsets.KeyValueLabelOfPod,
-					},
-					Included:  included,
-					MatchType: matchType,
-				},
-				{
-					IPSet: &ipsets.IPSetMetadata{
-						Name: "labelNotIn:src",
-						Type: ipsets.KeyValueLabelOfPod,
-					},
-					Included:  nonIncluded,
-					MatchType: matchType,
-				},
+				policies.NewSetInfo("label:src", ipsets.KeyValueLabelOfPod, included, matchType),
+				policies.NewSetInfo("labelNotIn:src", ipsets.KeyValueLabelOfPod, nonIncluded, matchType),
 			},
 		},
 		{
@@ -1301,63 +1194,16 @@ func TestTargetPodSelector(t *testing.T) {
 				},
 			},
 			podSelectorIPSets: []*ipsets.TranslatedIPSet{
-				{
-					Metadata: &ipsets.IPSetMetadata{
-						Name: "k0:v0",
-						Type: ipsets.KeyValueLabelOfPod,
-					},
-				},
-				{
-					Metadata: &ipsets.IPSetMetadata{
-						Name: "k1:v10:v11",
-						Type: ipsets.NestedLabelOfPod,
-					},
-					Members: []string{"k1:v10", "k1:v11"},
-				},
-				{
-					Metadata: &ipsets.IPSetMetadata{
-						Name: "k1:v10",
-						Type: ipsets.KeyValueLabelOfPod,
-					},
-				},
-				{
-					Metadata: &ipsets.IPSetMetadata{
-						Name: "k1:v11",
-						Type: ipsets.KeyValueLabelOfPod,
-					},
-				},
-				{
-					Metadata: &ipsets.IPSetMetadata{
-						Name: "k2",
-						Type: ipsets.KeyLabelOfPod,
-					},
-				},
+				ipsets.NewTranslatedIPSet("k0:v0", ipsets.KeyValueLabelOfPod, nilSlices),
+				ipsets.NewTranslatedIPSet("k1:v10:v11", ipsets.NestedLabelOfPod, []string{"k1:v10", "k1:v11"}),
+				ipsets.NewTranslatedIPSet("k1:v10", ipsets.KeyValueLabelOfPod, nilSlices),
+				ipsets.NewTranslatedIPSet("k1:v11", ipsets.KeyValueLabelOfPod, nilSlices),
+				ipsets.NewTranslatedIPSet("k2", ipsets.KeyLabelOfPod, nilSlices),
 			},
 			podSelectorList: []policies.SetInfo{
-				{
-					IPSet: &ipsets.IPSetMetadata{
-						Name: "k0:v0",
-						Type: ipsets.KeyValueLabelOfPod,
-					},
-					Included:  included,
-					MatchType: matchType,
-				},
-				{
-					IPSet: &ipsets.IPSetMetadata{
-						Name: "k1:v10:v11",
-						Type: ipsets.NestedLabelOfPod,
-					},
-					Included:  included,
-					MatchType: matchType,
-				},
-				{
-					IPSet: &ipsets.IPSetMetadata{
-						Name: "k2",
-						Type: ipsets.KeyLabelOfPod,
-					},
-					Included:  nonIncluded,
-					MatchType: matchType,
-				},
+				policies.NewSetInfo("k0:v0", ipsets.KeyValueLabelOfPod, included, matchType),
+				policies.NewSetInfo("k1:v10:v11", ipsets.NestedLabelOfPod, included, matchType),
+				policies.NewSetInfo("k2", ipsets.KeyLabelOfPod, nonIncluded, matchType),
 			},
 		},
 	}
@@ -1366,7 +1212,13 @@ func TestTargetPodSelector(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			podSelectorIPSets, podSelectorList := podSelector(tt.namespace, tt.matchType, tt.labelSelector)
+			var podSelectorIPSets []*ipsets.TranslatedIPSet
+			var podSelectorList []policies.SetInfo
+			if tt.namespace == "" {
+				podSelectorIPSets, podSelectorList = podSelector(tt.matchType, tt.labelSelector)
+			} else {
+				podSelectorIPSets, podSelectorList = podSelectorWithNS(tt.namespace, tt.matchType, tt.labelSelector)
+			}
 			require.Equal(t, tt.podSelectorIPSets, podSelectorIPSets)
 			require.Equal(t, tt.podSelectorList, podSelectorList)
 		})
@@ -2636,6 +2488,8 @@ func TestTranslateIngress(t *testing.T) {
 	tcp := v1.ProtocolTCP
 	targetPodMatchType := policies.DstMatch
 	peerMatchType := policies.SrcMatch
+	// TODO(jungukcho): this nilSlices will be removed.
+	var nilSlices []string
 	// TODO(jungukcho): add test cases with more complex rules
 	tests := []struct {
 		name           string
@@ -2663,23 +2517,12 @@ func TestTranslateIngress(t *testing.T) {
 				Name:      "serve-tcp",
 				NameSpace: "default",
 				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
-					{
-						Metadata: &ipsets.IPSetMetadata{
-							Name: "label:src",
-							Type: ipsets.KeyValueLabelOfPod,
-						},
-						Members: []string{},
-					},
+					ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod, nilSlices),
+					ipsets.NewTranslatedIPSet("default", ipsets.Namespace, nilSlices),
 				},
 				PodSelectorList: []policies.SetInfo{
-					{
-						IPSet: &ipsets.IPSetMetadata{
-							Name: "label:src",
-							Type: ipsets.KeyValueLabelOfPod,
-						},
-						Included:  included,
-						MatchType: targetPodMatchType,
-					},
+					policies.NewSetInfo("label:src", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
+					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
@@ -2718,32 +2561,15 @@ func TestTranslateIngress(t *testing.T) {
 				Name:      "only-ipblock",
 				NameSpace: "default",
 				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
-					{
-						Metadata: &ipsets.IPSetMetadata{
-							Name: "label:src",
-							Type: ipsets.KeyValueLabelOfPod,
-						},
-						Members: []string{},
-					},
+					ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod, nilSlices),
+					ipsets.NewTranslatedIPSet("default", ipsets.Namespace, nilSlices),
 				},
 				PodSelectorList: []policies.SetInfo{
-					{
-						IPSet: &ipsets.IPSetMetadata{
-							Name: "label:src",
-							Type: ipsets.KeyValueLabelOfPod,
-						},
-						Included:  included,
-						MatchType: targetPodMatchType,
-					},
+					policies.NewSetInfo("label:src", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
+					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
 				},
 				RuleIPSets: []*ipsets.TranslatedIPSet{
-					{
-						Metadata: &ipsets.IPSetMetadata{
-							Name: "only-ipblock-in-ns-default-0IN",
-							Type: ipsets.CIDRBlocks,
-						},
-						Members: []string{"172.17.0.0/16", "172.17.1.0/24nomatch"},
-					},
+					ipsets.NewTranslatedIPSet("only-ipblock-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24nomatch"}),
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
@@ -2751,14 +2577,7 @@ func TestTranslateIngress(t *testing.T) {
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 						SrcList: []policies.SetInfo{
-							{
-								IPSet: &ipsets.IPSetMetadata{
-									Name: "only-ipblock-in-ns-default-0IN",
-									Type: ipsets.CIDRBlocks,
-								},
-								Included:  included,
-								MatchType: peerMatchType,
-							},
+							policies.NewSetInfo("only-ipblock-in-ns-default-0IN", ipsets.CIDRBlocks, included, peerMatchType),
 						},
 					},
 				},
@@ -2788,32 +2607,16 @@ func TestTranslateIngress(t *testing.T) {
 				Name:      "only-peer-podSelector",
 				NameSpace: "default",
 				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
-					{
-						Metadata: &ipsets.IPSetMetadata{
-							Name: "label:src",
-							Type: ipsets.KeyValueLabelOfPod,
-						},
-						Members: []string{},
-					},
+					ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod, nilSlices),
+					ipsets.NewTranslatedIPSet("default", ipsets.Namespace, nilSlices),
 				},
 				PodSelectorList: []policies.SetInfo{
-					{
-						IPSet: &ipsets.IPSetMetadata{
-							Name: "label:src",
-							Type: ipsets.KeyValueLabelOfPod,
-						},
-						Included:  included,
-						MatchType: targetPodMatchType,
-					},
+					policies.NewSetInfo("label:src", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
+					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
 				},
 				RuleIPSets: []*ipsets.TranslatedIPSet{
-					{
-						Metadata: &ipsets.IPSetMetadata{
-							Name: "peer-podselector-kay:peer-podselector-value",
-							Type: ipsets.KeyValueLabelOfPod,
-						},
-						Members: []string{},
-					},
+					ipsets.NewTranslatedIPSet("peer-podselector-kay:peer-podselector-value", ipsets.KeyValueLabelOfPod, nilSlices),
+					ipsets.NewTranslatedIPSet("default", ipsets.Namespace, nilSlices),
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
@@ -2821,14 +2624,8 @@ func TestTranslateIngress(t *testing.T) {
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 						SrcList: []policies.SetInfo{
-							{
-								IPSet: &ipsets.IPSetMetadata{
-									Name: "peer-podselector-kay:peer-podselector-value",
-									Type: ipsets.KeyValueLabelOfPod,
-								},
-								Included:  included,
-								MatchType: peerMatchType,
-							},
+							policies.NewSetInfo("peer-podselector-kay:peer-podselector-value", ipsets.KeyValueLabelOfPod, included, peerMatchType),
+							policies.NewSetInfo("default", ipsets.Namespace, included, peerMatchType),
 						},
 					},
 				},
@@ -2858,32 +2655,15 @@ func TestTranslateIngress(t *testing.T) {
 				Name:      "only-peer-nsSelector",
 				NameSpace: "default",
 				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
-					{
-						Metadata: &ipsets.IPSetMetadata{
-							Name: "label:src",
-							Type: ipsets.KeyValueLabelOfPod,
-						},
-						Members: []string{},
-					},
+					ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod, nilSlices),
+					ipsets.NewTranslatedIPSet("default", ipsets.Namespace, nilSlices),
 				},
 				PodSelectorList: []policies.SetInfo{
-					{
-						IPSet: &ipsets.IPSetMetadata{
-							Name: "label:src",
-							Type: ipsets.KeyValueLabelOfPod,
-						},
-						Included:  included,
-						MatchType: targetPodMatchType,
-					},
+					policies.NewSetInfo("label:src", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
+					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
 				},
 				RuleIPSets: []*ipsets.TranslatedIPSet{
-					{
-						Metadata: &ipsets.IPSetMetadata{
-							Name: "peer-nsselector-kay:peer-nsselector-value",
-							Type: ipsets.KeyValueLabelOfNamespace,
-						},
-						Members: []string{},
-					},
+					ipsets.NewTranslatedIPSet("peer-nsselector-kay:peer-nsselector-value", ipsets.KeyValueLabelOfNamespace, []string{}),
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
@@ -2891,14 +2671,7 @@ func TestTranslateIngress(t *testing.T) {
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 						SrcList: []policies.SetInfo{
-							{
-								IPSet: &ipsets.IPSetMetadata{
-									Name: "peer-nsselector-kay:peer-nsselector-value",
-									Type: ipsets.KeyValueLabelOfNamespace,
-								},
-								Included:  included,
-								MatchType: peerMatchType,
-							},
+							policies.NewSetInfo("peer-nsselector-kay:peer-nsselector-value", ipsets.KeyValueLabelOfNamespace, included, peerMatchType),
 						},
 					},
 				},


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
This PR includes
1. Add comments of translation packages.
2. Refactor parseSelector.go before egress translation logic to better understand parseSelector code and significantly simplify codes and reduce multiple computations in translatePolicy.go

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
You can find the generic ingress translation PR (https://github.com/Azure/azure-container-networking/pull/1055)
Will delete unused codes add UTs for parseSelector.go in a next PR.
Will follow egress translation PR.
