### PR TITLE
stupid simple retry

### DIFF
--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -60,7 +60,7 @@ const (
 
 	// 720 * acn.FiveSeconds sec sleeps = 1Hr
 	maxRetryNodeRegister = 720
-	//10 * 30 seconds = 5 minutes of retrying before we crash and backoff.
+	// 10 * 30 seconds = 5 minutes of retrying before we crash and backoff.
 	maxRetryInit      = 10
 	retryIntervalInit = 30 * time.Second
 )

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -61,7 +61,8 @@ const (
 	// 720 * acn.FiveSeconds sec sleeps = 1Hr
 	maxRetryNodeRegister = 720
 	//10 * 30 seconds = 5 minutes of retrying before we crash and backoff.
-	maxRetryInit = 10
+	maxRetryInit      = 10
+	retryIntervalInit = 30 * time.Second
 )
 
 var (
@@ -886,8 +887,8 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 		}
 	}()
 
-	//apiserver nnc might not be registered or api server might be down and crashloop backof puts us outside of 5-10 minutes we have for
-	//aks addons to come up so retry a bit more aggresively here.
+	// apiserver nnc might not be registered or api server might be down and crashloop backof puts us outside of 5-10 minutes we have for
+	// aks addons to come up so retry a bit more aggresively here.
 	for tryNum := 0; tryNum <= maxRetryInit; tryNum++ {
 		err = initCNS(ctx, scopedcli, httpRestServiceImplementation)
 		if err == nil {
@@ -897,7 +898,7 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 		if tryNum >= maxRetryInit {
 			return errors.Wrap(err, "failed to initialize CNS state")
 		}
-		time.Sleep(30 * time.Second)
+		time.Sleep(retryIntervalInit)
 	}
 
 	manager, err := ctrl.NewManager(kubeConfig, ctrl.Options{


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
apiserver nnc might not be registered or api server might be down and crashloop backoff puts us outside of 5-10 minutes we have for aks addons to come up so retry a bit more aggresively here.

We could also exponential backoff here but wouldn't want ot go above 1 minute or we'd be in same place. 


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
