### PR TITLE
fix: [NPM] reposition iptables jump to AZURE-NPM chain

### DIFF
--- a/npm/config/config.go
+++ b/npm/config/config.go
@@ -18,7 +18,7 @@ var DefaultConfig = Config{
 		EnablePprof:                true,
 		EnableHTTPDebugAPI:         true,
 		EnableV2Controllers:        false,
-		ShouldPlaceAzureChainFirst: true, // FIXME! default to false after validating
+		ShouldPlaceAzureChainFirst: false,
 	},
 }
 

--- a/npm/config/config.go
+++ b/npm/config/config.go
@@ -18,7 +18,7 @@ var DefaultConfig = Config{
 		EnablePprof:                true,
 		EnableHTTPDebugAPI:         true,
 		EnableV2Controllers:        false,
-		ShouldPlaceAzureChainFirst: false,
+		ShouldPlaceAzureChainFirst: true, // FIXME! default to false after validating
 	},
 }
 

--- a/npm/config/config.go
+++ b/npm/config/config.go
@@ -14,11 +14,11 @@ var DefaultConfig = Config{
 	ListeningPort:         defaultListeningPort,
 	ListeningAddress:      "0.0.0.0",
 	Toggles: Toggles{
-		EnablePrometheusMetrics:    true,
-		EnablePprof:                true,
-		EnableHTTPDebugAPI:         true,
-		EnableV2Controllers:        false,
-		ShouldPlaceAzureChainFirst: false,
+		EnablePrometheusMetrics: true,
+		EnablePprof:             true,
+		EnableHTTPDebugAPI:      true,
+		EnableV2Controllers:     false,
+		PlaceAzureChainFirst:    false,
 	},
 }
 
@@ -30,9 +30,9 @@ type Config struct {
 }
 
 type Toggles struct {
-	EnablePrometheusMetrics    bool
-	EnablePprof                bool
-	EnableHTTPDebugAPI         bool
-	EnableV2Controllers        bool
-	ShouldPlaceAzureChainFirst bool
+	EnablePrometheusMetrics bool
+	EnablePprof             bool
+	EnableHTTPDebugAPI      bool
+	EnableV2Controllers     bool
+	PlaceAzureChainFirst    bool
 }

--- a/npm/config/config.go
+++ b/npm/config/config.go
@@ -18,7 +18,7 @@ var DefaultConfig = Config{
 		EnablePprof:             true,
 		EnableHTTPDebugAPI:      true,
 		EnableV2Controllers:     false,
-		PlaceAzureChainFirst:    false,
+		PlaceAzureChainFirst:    true,
 	},
 }
 

--- a/npm/config/config.go
+++ b/npm/config/config.go
@@ -14,11 +14,11 @@ var DefaultConfig = Config{
 	ListeningPort:         defaultListeningPort,
 	ListeningAddress:      "0.0.0.0",
 	Toggles: Toggles{
-		EnablePrometheusMetrics:          true,
-		EnablePprof:                      true,
-		EnableHTTPDebugAPI:               true,
-		EnableV2Controllers:              false,
-		PlaceAzureChainBeforeKubeForward: false,
+		EnablePrometheusMetrics:    true,
+		EnablePprof:                true,
+		EnableHTTPDebugAPI:         true,
+		EnableV2Controllers:        false,
+		ShouldPlaceAzureChainFirst: false,
 	},
 }
 
@@ -30,9 +30,9 @@ type Config struct {
 }
 
 type Toggles struct {
-	EnablePrometheusMetrics          bool
-	EnablePprof                      bool
-	EnableHTTPDebugAPI               bool
-	EnableV2Controllers              bool
-	PlaceAzureChainBeforeKubeForward bool
+	EnablePrometheusMetrics    bool
+	EnablePprof                bool
+	EnableHTTPDebugAPI         bool
+	EnableV2Controllers        bool
+	ShouldPlaceAzureChainFirst bool
 }

--- a/npm/config/config.go
+++ b/npm/config/config.go
@@ -14,10 +14,11 @@ var DefaultConfig = Config{
 	ListeningPort:         defaultListeningPort,
 	ListeningAddress:      "0.0.0.0",
 	Toggles: Toggles{
-		EnablePrometheusMetrics: true,
-		EnablePprof:             true,
-		EnableHTTPDebugAPI:      true,
-		EnableV2Controllers:     false,
+		EnablePrometheusMetrics:          true,
+		EnablePprof:                      true,
+		EnableHTTPDebugAPI:               true,
+		EnableV2Controllers:              false,
+		PlaceAzureChainBeforeKubeForward: false,
 	},
 }
 
@@ -29,8 +30,9 @@ type Config struct {
 }
 
 type Toggles struct {
-	EnablePrometheusMetrics bool
-	EnablePprof             bool
-	EnableHTTPDebugAPI      bool
-	EnableV2Controllers     bool
+	EnablePrometheusMetrics          bool
+	EnablePprof                      bool
+	EnableHTTPDebugAPI               bool
+	EnableV2Controllers              bool
+	PlaceAzureChainBeforeKubeForward bool
 }

--- a/npm/config/config.go
+++ b/npm/config/config.go
@@ -18,7 +18,7 @@ var DefaultConfig = Config{
 		EnablePprof:             true,
 		EnableHTTPDebugAPI:      true,
 		EnableV2Controllers:     false,
-		PlaceAzureChainFirst:    true,
+		PlaceAzureChainFirst:    false,
 	},
 }
 

--- a/npm/iptm/iptm.go
+++ b/npm/iptm/iptm.go
@@ -206,6 +206,19 @@ func (iptMgr *IptablesManager) checkAndAddForwardChain() error {
 		},
 	}
 
+	index := 1 // insert the jump to AZURE-NPM at the top
+	kubeServicesLine := 0
+	if !iptMgr.placeAzureChainBeforeKubeForward {
+		// retrieve KUBE-SERVICES index
+		var err error
+		kubeServicesLine, err = iptMgr.getChainLineNumber(util.IptablesKubeServicesChain, util.IptablesForwardChain)
+		if err != nil {
+			metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to get index of KUBE-SERVICES in FORWARD chain with error: %s", err.Error())
+			return err
+		}
+		index = kubeServicesLine + 1 // insert the jump to AZURE-NPM after the jump to KUBE-SERVICES
+	}
+
 	exists, err := iptMgr.exists(entry)
 	if err != nil {
 		return err
@@ -214,7 +227,6 @@ func (iptMgr *IptablesManager) checkAndAddForwardChain() error {
 	if !exists {
 		// position Azure-NPM chain after Kube-Forward and Kube-Service chains if it exists
 		iptMgr.OperationFlag = util.IptablesInsertionFlag
-		index := 1
 		entry.Specs = append([]string{strconv.Itoa(index)}, entry.Specs...)
 		if _, err = iptMgr.run(entry); err != nil {
 			metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to add AZURE-NPM chain to FORWARD chain.")
@@ -222,6 +234,43 @@ func (iptMgr *IptablesManager) checkAndAddForwardChain() error {
 		}
 
 		return nil
+	}
+
+	if iptMgr.placeAzureChainBeforeKubeForward {
+		return nil
+	}
+
+	npmChainLine, err := iptMgr.getChainLineNumber(util.IptablesAzureChain, util.IptablesForwardChain)
+	if err != nil {
+		metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to get index of AZURE-NPM in FORWARD chain with error: %s", err.Error())
+		return err
+	}
+
+	// Kube-services line number is less than npm chain line number then all good
+	if kubeServicesLine < npmChainLine {
+		return nil
+	} else if kubeServicesLine <= 0 {
+		return nil
+	}
+
+	errCode := 0
+	// NPM Chain number is less than KUBE-SERVICES then
+	// delete existing NPM chain and add it in the right order
+	iptMgr.OperationFlag = util.IptablesDeletionFlag
+	metrics.SendErrorLogAndMetric(util.IptmID, "Info: Reconciler deleting and re-adding AZURE-NPM in FORWARD table.")
+	if errCode, err = iptMgr.run(entry); err != nil {
+		metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to delete AZURE-NPM chain from FORWARD chain with error code %d.", errCode)
+		return err
+	}
+	iptMgr.OperationFlag = util.IptablesInsertionFlag
+	// Reduce index for deleted AZURE-NPM chain
+	if index > 1 {
+		index--
+	}
+	entry.Specs = append([]string{strconv.Itoa(index)}, entry.Specs...)
+	if errCode, err = iptMgr.run(entry); err != nil {
+		metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to add AZURE-NPM chain to FORWARD chain with error code %d.", errCode)
+		return err
 	}
 
 	return nil

--- a/npm/iptm/iptm.go
+++ b/npm/iptm/iptm.go
@@ -100,6 +100,8 @@ func (iptMgr *IptablesManager) UninitNpmChains() error {
 		Specs: []string{
 			util.IptablesJumpFlag,
 			util.IptablesAzureChain,
+			util.IptablesModuleFlag,
+			util.IptablesCtstateModuleFlag,
 			util.IptablesCtstateFlag,
 			util.IptablesNewState,
 		},
@@ -205,6 +207,8 @@ func (iptMgr *IptablesManager) checkAndAddForwardChain() error {
 		Specs: []string{
 			util.IptablesJumpFlag,
 			util.IptablesAzureChain,
+			util.IptablesModuleFlag,
+			util.IptablesCtstateModuleFlag,
 			util.IptablesCtstateFlag,
 			util.IptablesNewState,
 		},

--- a/npm/iptm/iptm.go
+++ b/npm/iptm/iptm.go
@@ -48,10 +48,10 @@ type IptEntry struct {
 
 // IptablesManager stores iptables entries.
 type IptablesManager struct {
-	exec                             utilexec.Interface
-	io                               ioshim
-	OperationFlag                    string
-	placeAzureChainBeforeKubeForward bool
+	exec                       utilexec.Interface
+	io                         ioshim
+	OperationFlag              string
+	shouldPlaceAzureChainFirst bool
 }
 
 func isDropsChain(chainName string) bool {
@@ -64,12 +64,12 @@ func isDropsChain(chainName string) bool {
 }
 
 // NewIptablesManager creates a new instance for IptablesManager object.
-func NewIptablesManager(exec utilexec.Interface, io ioshim, placeAzureChainBeforeKubeForward bool) *IptablesManager {
+func NewIptablesManager(exec utilexec.Interface, io ioshim, shouldPlaceAzureChainFirst bool) *IptablesManager {
 	iptMgr := &IptablesManager{
-		exec:                             exec,
-		io:                               io,
-		OperationFlag:                    "",
-		placeAzureChainBeforeKubeForward: placeAzureChainBeforeKubeForward,
+		exec:                       exec,
+		io:                         io,
+		OperationFlag:              "",
+		shouldPlaceAzureChainFirst: shouldPlaceAzureChainFirst,
 	}
 
 	return iptMgr
@@ -208,7 +208,7 @@ func (iptMgr *IptablesManager) checkAndAddForwardChain() error {
 
 	index := 1 // insert the jump to AZURE-NPM at the top
 	kubeServicesLine := 0
-	if !iptMgr.placeAzureChainBeforeKubeForward {
+	if !iptMgr.shouldPlaceAzureChainFirst {
 		// retrieve KUBE-SERVICES index
 		var err error
 		kubeServicesLine, err = iptMgr.getChainLineNumber(util.IptablesKubeServicesChain, util.IptablesForwardChain)
@@ -236,7 +236,7 @@ func (iptMgr *IptablesManager) checkAndAddForwardChain() error {
 		return nil
 	}
 
-	if iptMgr.placeAzureChainBeforeKubeForward {
+	if iptMgr.shouldPlaceAzureChainFirst {
 		return nil
 	}
 

--- a/npm/iptm/iptm.go
+++ b/npm/iptm/iptm.go
@@ -48,9 +48,10 @@ type IptEntry struct {
 
 // IptablesManager stores iptables entries.
 type IptablesManager struct {
-	exec          utilexec.Interface
-	io            ioshim
-	OperationFlag string
+	exec                             utilexec.Interface
+	io                               ioshim
+	OperationFlag                    string
+	placeAzureChainBeforeKubeForward bool
 }
 
 func isDropsChain(chainName string) bool {
@@ -63,11 +64,12 @@ func isDropsChain(chainName string) bool {
 }
 
 // NewIptablesManager creates a new instance for IptablesManager object.
-func NewIptablesManager(exec utilexec.Interface, io ioshim) *IptablesManager {
+func NewIptablesManager(exec utilexec.Interface, io ioshim, placeAzureChainBeforeKubeForward bool) *IptablesManager {
 	iptMgr := &IptablesManager{
-		exec:          exec,
-		io:            io,
-		OperationFlag: "",
+		exec:                             exec,
+		io:                               io,
+		OperationFlag:                    "",
+		placeAzureChainBeforeKubeForward: placeAzureChainBeforeKubeForward,
 	}
 
 	return iptMgr

--- a/npm/iptm/iptm.go
+++ b/npm/iptm/iptm.go
@@ -100,6 +100,8 @@ func (iptMgr *IptablesManager) UninitNpmChains() error {
 		Specs: []string{
 			util.IptablesJumpFlag,
 			util.IptablesAzureChain,
+			util.IptablesCtstateFlag,
+			util.IptablesNewState,
 		},
 	}
 	iptMgr.OperationFlag = util.IptablesDeletionFlag
@@ -203,6 +205,8 @@ func (iptMgr *IptablesManager) checkAndAddForwardChain() error {
 		Specs: []string{
 			util.IptablesJumpFlag,
 			util.IptablesAzureChain,
+			util.IptablesCtstateFlag,
+			util.IptablesNewState,
 		},
 	}
 

--- a/npm/iptm/iptm_test.go
+++ b/npm/iptm/iptm_test.go
@@ -25,14 +25,8 @@ var (
 		{Cmd: []string{"iptables", "-w", "60", "-N", "AZURE-NPM-EGRESS-DROPS"}},
 		{Cmd: []string{"iptables", "-w", "60", "-N", "AZURE-NPM"}},
 
-		{Cmd: []string{"iptables", "-t", "filter", "-n", "--list", "FORWARD", "--line-numbers"}, Stdout: "3  "}, // THIS IS THE GREP CALL
-		{Cmd: []string{"grep", "KUBE-SERVICES"}, Stdout: "4  "},
-
-		{Cmd: []string{"iptables", "-w", "60", "-C", "FORWARD", "-j", "AZURE-NPM"}},
-		{Cmd: []string{"iptables", "-t", "filter", "-n", "--list", "FORWARD", "--line-numbers"}, Stdout: "3  "}, // THIS IS THE GREP CALL
-		{Cmd: []string{"grep", "AZURE-NPM"}, Stdout: "4  "},
-		{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}},
-		{Cmd: []string{"iptables", "-w", "60", "-I", "FORWARD", "3", "-j", "AZURE-NPM"}},
+		{Cmd: []string{"iptables", "-w", "60", "-C", "FORWARD", "-j", "AZURE-NPM"}, ExitCode: 1},
+		{Cmd: []string{"iptables", "-w", "60", "-I", "FORWARD", "1", "-j", "AZURE-NPM"}},
 
 		{Cmd: []string{"iptables", "-w", "60", "-C", "AZURE-NPM", "-j", "AZURE-NPM-INGRESS"}}, // broken here
 		{Cmd: []string{"iptables", "-w", "60", "-C", "AZURE-NPM", "-j", "AZURE-NPM-EGRESS"}},

--- a/npm/iptm/iptm_test.go
+++ b/npm/iptm/iptm_test.go
@@ -33,11 +33,11 @@ var (
 		{Cmd: []string{"iptables", "-t", "filter", "-n", "--list", "FORWARD", "--line-numbers"}, Stdout: "3  "}, // THIS IS THE GREP CALL
 		{Cmd: []string{"grep", "KUBE-SERVICES"}, Stdout: "4  "},
 
-		{Cmd: []string{"iptables", "-w", "60", "-C", "FORWARD", "-j", "AZURE-NPM"}},
+		{Cmd: []string{"iptables", "-w", "60", "-C", "FORWARD", "-j", "AZURE-NPM", "--ctstate", "NEW"}},
 		{Cmd: []string{"iptables", "-t", "filter", "-n", "--list", "FORWARD", "--line-numbers"}, Stdout: "3  "}, // THIS IS THE GREP CALL
 		{Cmd: []string{"grep", "AZURE-NPM"}, Stdout: "4  "},
-		{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}},
-		{Cmd: []string{"iptables", "-w", "60", "-I", "FORWARD", "3", "-j", "AZURE-NPM"}},
+		{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "--ctstate", "NEW"}},
+		{Cmd: []string{"iptables", "-w", "60", "-I", "FORWARD", "3", "-j", "AZURE-NPM", "--ctstate", "NEW"}},
 
 		{Cmd: []string{"iptables", "-w", "60", "-C", "AZURE-NPM", "-j", "AZURE-NPM-INGRESS"}}, // broken here
 		{Cmd: []string{"iptables", "-w", "60", "-C", "AZURE-NPM", "-j", "AZURE-NPM-EGRESS"}},
@@ -66,7 +66,7 @@ var (
 	}
 
 	unInitCalls = []testutils.TestCmd{
-		{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}},
+		{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "--ctstate", "NEW"}},
 		{Cmd: []string{"iptables", "-w", "60", "-F", "AZURE-NPM"}},
 		{Cmd: []string{"iptables", "-w", "60", "-F", "AZURE-NPM-ACCEPT"}},
 		{Cmd: []string{"iptables", "-w", "60", "-F", "AZURE-NPM-INGRESS"}},
@@ -106,8 +106,8 @@ var (
 		{Cmd: []string{"iptables", "-w", "60", "-N", "AZURE-NPM-EGRESS-DROPS"}},
 		{Cmd: []string{"iptables", "-w", "60", "-N", "AZURE-NPM"}},
 
-		{Cmd: []string{"iptables", "-w", "60", "-C", "FORWARD", "-j", "AZURE-NPM"}, ExitCode: 1},
-		{Cmd: []string{"iptables", "-w", "60", "-I", "FORWARD", "1", "-j", "AZURE-NPM"}},
+		{Cmd: []string{"iptables", "-w", "60", "-C", "FORWARD", "-j", "AZURE-NPM", "--ctstate", "NEW"}, ExitCode: 1},
+		{Cmd: []string{"iptables", "-w", "60", "-I", "FORWARD", "1", "-j", "AZURE-NPM", "--ctstate", "NEW"}},
 
 		{Cmd: []string{"iptables", "-w", "60", "-C", "AZURE-NPM", "-j", "AZURE-NPM-INGRESS"}}, // broken here
 		{Cmd: []string{"iptables", "-w", "60", "-C", "AZURE-NPM", "-j", "AZURE-NPM-EGRESS"}},

--- a/npm/iptm/iptm_test.go
+++ b/npm/iptm/iptm_test.go
@@ -48,7 +48,7 @@ var (
 		{Cmd: []string{"iptables", "-w", "60", "-C", "AZURE-NPM-INGRESS", "-j", "RETURN", "-m", "mark", "--mark", "0x2000", "-m", "comment", "--comment", "RETURN-on-INGRESS-mark-0x2000"}},
 		{Cmd: []string{"iptables", "-w", "60", "-C", "AZURE-NPM-INGRESS", "-j", "AZURE-NPM-INGRESS-DROPS"}},
 		{Cmd: []string{"iptables", "-w", "60", "-C", "AZURE-NPM-INGRESS-PORT", "-j", "RETURN", "-m", "mark", "--mark", "0x2000", "-m", "comment", "--comment", "RETURN-on-INGRESS-mark-0x2000"}},
-		///////////
+		// /////////
 		{Cmd: []string{"iptables", "-w", "60", "-C", "AZURE-NPM-INGRESS-PORT", "-j", "AZURE-NPM-INGRESS-FROM", "-m", "comment", "--comment", "ALL-JUMP-TO-AZURE-NPM-INGRESS-FROM"}},
 		{Cmd: []string{"iptables", "-w", "60", "-C", "AZURE-NPM-EGRESS", "-j", "AZURE-NPM-EGRESS-PORT"}},
 		{Cmd: []string{"iptables", "-w", "60", "-C", "AZURE-NPM-EGRESS", "-j", "RETURN", "-m", "mark", "--mark", "0x3000", "-m", "comment", "--comment", "RETURN-on-EGRESS-and-INGRESS-mark-0x3000"}},
@@ -63,6 +63,7 @@ var (
 	}
 
 	unInitCalls = []testutils.TestCmd{
+		{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}},
 		{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
 		{Cmd: []string{"iptables", "-w", "60", "-F", "AZURE-NPM"}},
 		{Cmd: []string{"iptables", "-w", "60", "-F", "AZURE-NPM-ACCEPT"}},
@@ -118,7 +119,7 @@ var (
 		{Cmd: []string{"iptables", "-w", "60", "-C", "AZURE-NPM-INGRESS", "-j", "RETURN", "-m", "mark", "--mark", "0x2000", "-m", "comment", "--comment", "RETURN-on-INGRESS-mark-0x2000"}},
 		{Cmd: []string{"iptables", "-w", "60", "-C", "AZURE-NPM-INGRESS", "-j", "AZURE-NPM-INGRESS-DROPS"}},
 		{Cmd: []string{"iptables", "-w", "60", "-C", "AZURE-NPM-INGRESS-PORT", "-j", "RETURN", "-m", "mark", "--mark", "0x2000", "-m", "comment", "--comment", "RETURN-on-INGRESS-mark-0x2000"}},
-		///////////
+		// /////////
 		{Cmd: []string{"iptables", "-w", "60", "-C", "AZURE-NPM-INGRESS-PORT", "-j", "AZURE-NPM-INGRESS-FROM", "-m", "comment", "--comment", "ALL-JUMP-TO-AZURE-NPM-INGRESS-FROM"}},
 		{Cmd: []string{"iptables", "-w", "60", "-C", "AZURE-NPM-EGRESS", "-j", "AZURE-NPM-EGRESS-PORT"}},
 		{Cmd: []string{"iptables", "-w", "60", "-C", "AZURE-NPM-EGRESS", "-j", "RETURN", "-m", "mark", "--mark", "0x3000", "-m", "comment", "--comment", "RETURN-on-EGRESS-and-INGRESS-mark-0x3000"}},

--- a/npm/iptm/iptm_test.go
+++ b/npm/iptm/iptm_test.go
@@ -28,11 +28,11 @@ var (
 		{Cmd: []string{"iptables", "-t", "filter", "-n", "--list", "FORWARD", "--line-numbers"}, Stdout: "3  "}, // THIS IS THE GREP CALL
 		{Cmd: []string{"grep", "KUBE-SERVICES"}, Stdout: "4  "},
 
-		{Cmd: []string{"iptables", "-w", "60", "-C", "FORWARD", "-j", "AZURE-NPM", "--ctstate", "NEW"}},
+		{Cmd: []string{"iptables", "-w", "60", "-C", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
 		{Cmd: []string{"iptables", "-t", "filter", "-n", "--list", "FORWARD", "--line-numbers"}, Stdout: "3  "}, // THIS IS THE GREP CALL
 		{Cmd: []string{"grep", "AZURE-NPM"}, Stdout: "4  "},
-		{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "--ctstate", "NEW"}},
-		{Cmd: []string{"iptables", "-w", "60", "-I", "FORWARD", "3", "-j", "AZURE-NPM", "--ctstate", "NEW"}},
+		{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
+		{Cmd: []string{"iptables", "-w", "60", "-I", "FORWARD", "3", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
 
 		{Cmd: []string{"iptables", "-w", "60", "-C", "AZURE-NPM", "-j", "AZURE-NPM-INGRESS"}}, // broken here
 		{Cmd: []string{"iptables", "-w", "60", "-C", "AZURE-NPM", "-j", "AZURE-NPM-EGRESS"}},
@@ -61,7 +61,7 @@ var (
 	}
 
 	unInitCalls = []testutils.TestCmd{
-		{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "--ctstate", "NEW"}},
+		{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
 		{Cmd: []string{"iptables", "-w", "60", "-F", "AZURE-NPM"}},
 		{Cmd: []string{"iptables", "-w", "60", "-F", "AZURE-NPM-ACCEPT"}},
 		{Cmd: []string{"iptables", "-w", "60", "-F", "AZURE-NPM-INGRESS"}},
@@ -101,8 +101,8 @@ var (
 		{Cmd: []string{"iptables", "-w", "60", "-N", "AZURE-NPM-EGRESS-DROPS"}},
 		{Cmd: []string{"iptables", "-w", "60", "-N", "AZURE-NPM"}},
 
-		{Cmd: []string{"iptables", "-w", "60", "-C", "FORWARD", "-j", "AZURE-NPM", "--ctstate", "NEW"}, ExitCode: 1},
-		{Cmd: []string{"iptables", "-w", "60", "-I", "FORWARD", "1", "-j", "AZURE-NPM", "--ctstate", "NEW"}},
+		{Cmd: []string{"iptables", "-w", "60", "-C", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}, ExitCode: 1},
+		{Cmd: []string{"iptables", "-w", "60", "-I", "FORWARD", "1", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
 
 		{Cmd: []string{"iptables", "-w", "60", "-C", "AZURE-NPM", "-j", "AZURE-NPM-INGRESS"}}, // broken here
 		{Cmd: []string{"iptables", "-w", "60", "-C", "AZURE-NPM", "-j", "AZURE-NPM-EGRESS"}},

--- a/npm/iptm/iptm_test.go
+++ b/npm/iptm/iptm_test.go
@@ -11,11 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	placeAzureChainAfterKubeServices = false
-	placeAzureChainFirst             = true
-)
-
 var (
 	initCalls = []testutils.TestCmd{
 		{Cmd: []string{"iptables", "-w", "60", "-N", "AZURE-NPM"}},
@@ -141,7 +136,7 @@ func TestInitNpmChains(t *testing.T) {
 
 	fexec := testutils.GetFakeExecWithScripts(calls)
 	defer testutils.VerifyCalls(t, fexec, calls)
-	iptMgr := NewIptablesManager(fexec, NewFakeIptOperationShim(), placeAzureChainAfterKubeServices)
+	iptMgr := NewIptablesManager(fexec, NewFakeIptOperationShim(), util.PlaceAzureChainAfterKubeServices)
 
 	err := iptMgr.InitNpmChains()
 	require.NoError(t, err)
@@ -152,7 +147,7 @@ func TestInitWithJumpToAzureAtTop(t *testing.T) {
 
 	fexec := testutils.GetFakeExecWithScripts(calls)
 	defer testutils.VerifyCalls(t, fexec, calls)
-	iptMgr := NewIptablesManager(fexec, NewFakeIptOperationShim(), placeAzureChainFirst)
+	iptMgr := NewIptablesManager(fexec, NewFakeIptOperationShim(), util.PlaceAzureChainFirst)
 
 	err := iptMgr.InitNpmChains()
 	require.NoError(t, err)
@@ -163,7 +158,7 @@ func TestUninitNpmChains(t *testing.T) {
 
 	fexec := testutils.GetFakeExecWithScripts(calls)
 	defer testutils.VerifyCalls(t, fexec, calls)
-	iptMgr := NewIptablesManager(fexec, NewFakeIptOperationShim(), placeAzureChainAfterKubeServices)
+	iptMgr := NewIptablesManager(fexec, NewFakeIptOperationShim(), util.PlaceAzureChainAfterKubeServices)
 
 	if err := iptMgr.UninitNpmChains(); err != nil {
 		t.Errorf("TestUninitNpmChains @ iptMgr.UninitNpmChains")
@@ -177,7 +172,7 @@ func TestExists(t *testing.T) {
 
 	fexec := testutils.GetFakeExecWithScripts(calls)
 	defer testutils.VerifyCalls(t, fexec, calls)
-	iptMgr := NewIptablesManager(fexec, NewFakeIptOperationShim(), placeAzureChainAfterKubeServices)
+	iptMgr := NewIptablesManager(fexec, NewFakeIptOperationShim(), util.PlaceAzureChainAfterKubeServices)
 
 	iptMgr.OperationFlag = util.IptablesCheckFlag
 	entry := &IptEntry{
@@ -199,7 +194,7 @@ func TestAddChain(t *testing.T) {
 
 	fexec := testutils.GetFakeExecWithScripts(calls)
 	defer testutils.VerifyCalls(t, fexec, calls)
-	iptMgr := NewIptablesManager(fexec, NewFakeIptOperationShim(), placeAzureChainAfterKubeServices)
+	iptMgr := NewIptablesManager(fexec, NewFakeIptOperationShim(), util.PlaceAzureChainAfterKubeServices)
 
 	if err := iptMgr.addChain("TEST-CHAIN"); err != nil {
 		t.Errorf("TestAddChain failed @ iptMgr.addChain")
@@ -214,7 +209,7 @@ func TestDeleteChain(t *testing.T) {
 
 	fexec := testutils.GetFakeExecWithScripts(calls)
 	defer testutils.VerifyCalls(t, fexec, calls)
-	iptMgr := NewIptablesManager(fexec, NewFakeIptOperationShim(), placeAzureChainAfterKubeServices)
+	iptMgr := NewIptablesManager(fexec, NewFakeIptOperationShim(), util.PlaceAzureChainAfterKubeServices)
 
 	if err := iptMgr.addChain("TEST-CHAIN"); err != nil {
 		t.Errorf("TestDeleteChain failed @ iptMgr.addChain")
@@ -232,7 +227,7 @@ func TestAdd(t *testing.T) {
 
 	fexec := testutils.GetFakeExecWithScripts(calls)
 	defer testutils.VerifyCalls(t, fexec, calls)
-	iptMgr := NewIptablesManager(fexec, NewFakeIptOperationShim(), placeAzureChainAfterKubeServices)
+	iptMgr := NewIptablesManager(fexec, NewFakeIptOperationShim(), util.PlaceAzureChainAfterKubeServices)
 
 	execCount := resetPrometheusAndGetExecCount(t)
 	defer testPrometheusMetrics(t, 1, execCount+1)
@@ -280,7 +275,7 @@ func TestDelete(t *testing.T) {
 
 	fexec := testutils.GetFakeExecWithScripts(calls)
 	defer testutils.VerifyCalls(t, fexec, calls)
-	iptMgr := NewIptablesManager(fexec, NewFakeIptOperationShim(), placeAzureChainAfterKubeServices)
+	iptMgr := NewIptablesManager(fexec, NewFakeIptOperationShim(), util.PlaceAzureChainAfterKubeServices)
 
 	execCount := resetPrometheusAndGetExecCount(t)
 	defer testPrometheusMetrics(t, 0, execCount+1)
@@ -308,7 +303,7 @@ func TestRun(t *testing.T) {
 
 	fexec := testutils.GetFakeExecWithScripts(calls)
 	defer testutils.VerifyCalls(t, fexec, calls)
-	iptMgr := NewIptablesManager(fexec, NewFakeIptOperationShim(), placeAzureChainAfterKubeServices)
+	iptMgr := NewIptablesManager(fexec, NewFakeIptOperationShim(), util.PlaceAzureChainAfterKubeServices)
 
 	iptMgr.OperationFlag = util.IptablesChainCreationFlag
 	entry := &IptEntry{
@@ -327,7 +322,7 @@ func TestGetChainLineNumber(t *testing.T) {
 
 	fexec := testutils.GetFakeExecWithScripts(calls)
 	defer testutils.VerifyCalls(t, fexec, calls)
-	iptMgr := NewIptablesManager(fexec, NewFakeIptOperationShim(), placeAzureChainAfterKubeServices)
+	iptMgr := NewIptablesManager(fexec, NewFakeIptOperationShim(), util.PlaceAzureChainAfterKubeServices)
 
 	lineNum, err := iptMgr.getChainLineNumber(util.IptablesAzureChain, util.IptablesForwardChain)
 	require.NoError(t, err)

--- a/npm/npm.go
+++ b/npm/npm.go
@@ -116,7 +116,7 @@ func NewNetworkPolicyManager(config npmconfig.Config,
 	// create NameSpace controller
 	npMgr.namespaceControllerV1 = controllersv1.NewNameSpaceController(npMgr.nsInformer, npMgr.ipsMgr, npMgr.npmNamespaceCacheV1)
 	// create network policy controller
-	npMgr.netPolControllerV1 = controllersv1.NewNetworkPolicyController(npMgr.npInformer, npMgr.ipsMgr, config.Toggles.PlaceAzureChainBeforeKubeForward)
+	npMgr.netPolControllerV1 = controllersv1.NewNetworkPolicyController(npMgr.npInformer, npMgr.ipsMgr, config.Toggles.ShouldPlaceAzureChainFirst)
 
 	return npMgr
 }

--- a/npm/npm.go
+++ b/npm/npm.go
@@ -116,7 +116,7 @@ func NewNetworkPolicyManager(config npmconfig.Config,
 	// create NameSpace controller
 	npMgr.namespaceControllerV1 = controllersv1.NewNameSpaceController(npMgr.nsInformer, npMgr.ipsMgr, npMgr.npmNamespaceCacheV1)
 	// create network policy controller
-	npMgr.netPolControllerV1 = controllersv1.NewNetworkPolicyController(npMgr.npInformer, npMgr.ipsMgr)
+	npMgr.netPolControllerV1 = controllersv1.NewNetworkPolicyController(npMgr.npInformer, npMgr.ipsMgr, config.Toggles.PlaceAzureChainBeforeKubeForward)
 
 	return npMgr
 }

--- a/npm/npm.go
+++ b/npm/npm.go
@@ -116,7 +116,7 @@ func NewNetworkPolicyManager(config npmconfig.Config,
 	// create NameSpace controller
 	npMgr.namespaceControllerV1 = controllersv1.NewNameSpaceController(npMgr.nsInformer, npMgr.ipsMgr, npMgr.npmNamespaceCacheV1)
 	// create network policy controller
-	npMgr.netPolControllerV1 = controllersv1.NewNetworkPolicyController(npMgr.npInformer, npMgr.ipsMgr, config.Toggles.ShouldPlaceAzureChainFirst)
+	npMgr.netPolControllerV1 = controllersv1.NewNetworkPolicyController(npMgr.npInformer, npMgr.ipsMgr, config.Toggles.PlaceAzureChainFirst)
 
 	return npMgr
 }

--- a/npm/npm_v1_test.go
+++ b/npm/npm_v1_test.go
@@ -81,7 +81,7 @@ func TestMarshalUnMarshalJSON(t *testing.T) {
 func TestMain(m *testing.M) {
 	metrics.InitializeAll()
 	exec := exec.New()
-	iptMgr := iptm.NewIptablesManager(exec, iptm.NewFakeIptOperationShim(), npmconfig.DefaultConfig.Toggles.ShouldPlaceAzureChainFirst)
+	iptMgr := iptm.NewIptablesManager(exec, iptm.NewFakeIptOperationShim(), npmconfig.DefaultConfig.Toggles.PlaceAzureChainFirst)
 	iptMgr.UninitNpmChains()
 
 	ipsMgr := ipsm.NewIpsetManager(exec)

--- a/npm/npm_v1_test.go
+++ b/npm/npm_v1_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"testing"
 
+	npmconfig "github.com/Azure/azure-container-networking/npm/config"
 	"github.com/Azure/azure-container-networking/npm/ipsm"
 	"github.com/Azure/azure-container-networking/npm/iptm"
 	"github.com/Azure/azure-container-networking/npm/metrics"
@@ -80,7 +81,7 @@ func TestMarshalUnMarshalJSON(t *testing.T) {
 func TestMain(m *testing.M) {
 	metrics.InitializeAll()
 	exec := exec.New()
-	iptMgr := iptm.NewIptablesManager(exec, iptm.NewFakeIptOperationShim())
+	iptMgr := iptm.NewIptablesManager(exec, iptm.NewFakeIptOperationShim(), npmconfig.DefaultConfig.Toggles.PlaceAzureChainBeforeKubeForward)
 	iptMgr.UninitNpmChains()
 
 	ipsMgr := ipsm.NewIpsetManager(exec)

--- a/npm/npm_v1_test.go
+++ b/npm/npm_v1_test.go
@@ -81,7 +81,7 @@ func TestMarshalUnMarshalJSON(t *testing.T) {
 func TestMain(m *testing.M) {
 	metrics.InitializeAll()
 	exec := exec.New()
-	iptMgr := iptm.NewIptablesManager(exec, iptm.NewFakeIptOperationShim(), npmconfig.DefaultConfig.Toggles.PlaceAzureChainBeforeKubeForward)
+	iptMgr := iptm.NewIptablesManager(exec, iptm.NewFakeIptOperationShim(), npmconfig.DefaultConfig.Toggles.ShouldPlaceAzureChainFirst)
 	iptMgr.UninitNpmChains()
 
 	ipsMgr := ipsm.NewIpsetManager(exec)

--- a/npm/pkg/controlplane/controllers/v1/controllers_v1_test.go
+++ b/npm/pkg/controlplane/controllers/v1/controllers_v1_test.go
@@ -11,10 +11,12 @@ import (
 	"k8s.io/utils/exec"
 )
 
+const placeAzureChainAfterKubeServices = false
+
 func TestMain(m *testing.M) {
 	metrics.InitializeAll()
 	realexec := exec.New()
-	iptMgr := iptm.NewIptablesManager(realexec, iptm.NewFakeIptOperationShim())
+	iptMgr := iptm.NewIptablesManager(realexec, iptm.NewFakeIptOperationShim(), placeAzureChainAfterKubeServices)
 	err := iptMgr.UninitNpmChains()
 	if err != nil {
 		fmt.Println("uninitnpmchains failed with %w", err)

--- a/npm/pkg/controlplane/controllers/v1/controllers_v1_test.go
+++ b/npm/pkg/controlplane/controllers/v1/controllers_v1_test.go
@@ -5,17 +5,17 @@ import (
 	"os"
 	"testing"
 
+	npmconfig "github.com/Azure/azure-container-networking/npm/config"
 	"github.com/Azure/azure-container-networking/npm/ipsm"
 	"github.com/Azure/azure-container-networking/npm/iptm"
 	"github.com/Azure/azure-container-networking/npm/metrics"
-	"github.com/Azure/azure-container-networking/npm/util"
 	"k8s.io/utils/exec"
 )
 
 func TestMain(m *testing.M) {
 	metrics.InitializeAll()
 	realexec := exec.New()
-	iptMgr := iptm.NewIptablesManager(realexec, iptm.NewFakeIptOperationShim(), util.PlaceAzureChainAfterKubeServices)
+	iptMgr := iptm.NewIptablesManager(realexec, iptm.NewFakeIptOperationShim(), npmconfig.DefaultConfig.Toggles.PlaceAzureChainFirst)
 	err := iptMgr.UninitNpmChains()
 	if err != nil {
 		fmt.Println("uninitnpmchains failed with %w", err)

--- a/npm/pkg/controlplane/controllers/v1/controllers_v1_test.go
+++ b/npm/pkg/controlplane/controllers/v1/controllers_v1_test.go
@@ -8,15 +8,14 @@ import (
 	"github.com/Azure/azure-container-networking/npm/ipsm"
 	"github.com/Azure/azure-container-networking/npm/iptm"
 	"github.com/Azure/azure-container-networking/npm/metrics"
+	"github.com/Azure/azure-container-networking/npm/util"
 	"k8s.io/utils/exec"
 )
-
-const placeAzureChainAfterKubeServices = false
 
 func TestMain(m *testing.M) {
 	metrics.InitializeAll()
 	realexec := exec.New()
-	iptMgr := iptm.NewIptablesManager(realexec, iptm.NewFakeIptOperationShim(), placeAzureChainAfterKubeServices)
+	iptMgr := iptm.NewIptablesManager(realexec, iptm.NewFakeIptOperationShim(), util.PlaceAzureChainAfterKubeServices)
 	err := iptMgr.UninitNpmChains()
 	if err != nil {
 		fmt.Println("uninitnpmchains failed with %w", err)

--- a/npm/pkg/controlplane/controllers/v1/networkPolicyController.go
+++ b/npm/pkg/controlplane/controllers/v1/networkPolicyController.go
@@ -43,7 +43,7 @@ type NetworkPolicyController struct {
 	iptMgr                 *iptm.IptablesManager
 }
 
-func NewNetworkPolicyController(npInformer networkinginformers.NetworkPolicyInformer, ipsMgr *ipsm.IpsetManager, shouldPlaceAzureChainFirst bool) *NetworkPolicyController {
+func NewNetworkPolicyController(npInformer networkinginformers.NetworkPolicyInformer, ipsMgr *ipsm.IpsetManager, placeAzureChainFirst bool) *NetworkPolicyController {
 	netPolController := &NetworkPolicyController{
 		netPolLister: npInformer.Lister(),
 		workqueue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "NetworkPolicy"),
@@ -51,7 +51,7 @@ func NewNetworkPolicyController(npInformer networkinginformers.NetworkPolicyInfo
 		// ProcessedNpMap:         make(map[string]*networkingv1.NetworkPolicy),
 		isAzureNpmChainCreated: false,
 		ipsMgr:                 ipsMgr,
-		iptMgr:                 iptm.NewIptablesManager(exec.New(), iptm.NewIptOperationShim(), shouldPlaceAzureChainFirst),
+		iptMgr:                 iptm.NewIptablesManager(exec.New(), iptm.NewIptOperationShim(), placeAzureChainFirst),
 	}
 
 	npInformer.Informer().AddEventHandler(

--- a/npm/pkg/controlplane/controllers/v1/networkPolicyController.go
+++ b/npm/pkg/controlplane/controllers/v1/networkPolicyController.go
@@ -43,7 +43,7 @@ type NetworkPolicyController struct {
 	iptMgr                 *iptm.IptablesManager
 }
 
-func NewNetworkPolicyController(npInformer networkinginformers.NetworkPolicyInformer, ipsMgr *ipsm.IpsetManager, placeAzureChainBeforeKubeForward bool) *NetworkPolicyController {
+func NewNetworkPolicyController(npInformer networkinginformers.NetworkPolicyInformer, ipsMgr *ipsm.IpsetManager, shouldPlaceAzureChainFirst bool) *NetworkPolicyController {
 	netPolController := &NetworkPolicyController{
 		netPolLister: npInformer.Lister(),
 		workqueue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "NetworkPolicy"),
@@ -51,7 +51,7 @@ func NewNetworkPolicyController(npInformer networkinginformers.NetworkPolicyInfo
 		// ProcessedNpMap:         make(map[string]*networkingv1.NetworkPolicy),
 		isAzureNpmChainCreated: false,
 		ipsMgr:                 ipsMgr,
-		iptMgr:                 iptm.NewIptablesManager(exec.New(), iptm.NewIptOperationShim(), placeAzureChainBeforeKubeForward),
+		iptMgr:                 iptm.NewIptablesManager(exec.New(), iptm.NewIptOperationShim(), shouldPlaceAzureChainFirst),
 	}
 
 	npInformer.Informer().AddEventHandler(

--- a/npm/pkg/controlplane/controllers/v1/networkPolicyController.go
+++ b/npm/pkg/controlplane/controllers/v1/networkPolicyController.go
@@ -43,7 +43,7 @@ type NetworkPolicyController struct {
 	iptMgr                 *iptm.IptablesManager
 }
 
-func NewNetworkPolicyController(npInformer networkinginformers.NetworkPolicyInformer, ipsMgr *ipsm.IpsetManager) *NetworkPolicyController {
+func NewNetworkPolicyController(npInformer networkinginformers.NetworkPolicyInformer, ipsMgr *ipsm.IpsetManager, placeAzureChainBeforeKubeForward bool) *NetworkPolicyController {
 	netPolController := &NetworkPolicyController{
 		netPolLister: npInformer.Lister(),
 		workqueue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "NetworkPolicy"),
@@ -51,7 +51,7 @@ func NewNetworkPolicyController(npInformer networkinginformers.NetworkPolicyInfo
 		// ProcessedNpMap:         make(map[string]*networkingv1.NetworkPolicy),
 		isAzureNpmChainCreated: false,
 		ipsMgr:                 ipsMgr,
-		iptMgr:                 iptm.NewIptablesManager(exec.New(), iptm.NewIptOperationShim()),
+		iptMgr:                 iptm.NewIptablesManager(exec.New(), iptm.NewIptOperationShim(), placeAzureChainBeforeKubeForward),
 	}
 
 	npInformer.Informer().AddEventHandler(

--- a/npm/pkg/controlplane/controllers/v1/networkPolicyController_test.go
+++ b/npm/pkg/controlplane/controllers/v1/networkPolicyController_test.go
@@ -45,7 +45,6 @@ func newNetPolFixture(t *testing.T, utilexec exec.Interface) *netPolFixture {
 		netPolLister: []*networkingv1.NetworkPolicy{},
 		kubeobjects:  []runtime.Object{},
 		ipsMgr:       ipsm.NewIpsetManager(utilexec),
-		// iptMgr:                      iptm.NewIptablesManager(utilexec, iptm.NewFakeIptOperationShim()),
 	}
 	return f
 }
@@ -54,7 +53,7 @@ func (f *netPolFixture) newNetPolController(stopCh chan struct{}) {
 	kubeclient := k8sfake.NewSimpleClientset(f.kubeobjects...)
 	f.kubeInformer = kubeinformers.NewSharedInformerFactory(kubeclient, noResyncPeriodFunc())
 
-	f.netPolController = NewNetworkPolicyController(f.kubeInformer.Networking().V1().NetworkPolicies(), f.ipsMgr)
+	f.netPolController = NewNetworkPolicyController(f.kubeInformer.Networking().V1().NetworkPolicies(), f.ipsMgr, placeAzureChainAfterKubeServices)
 
 	for _, netPol := range f.netPolLister {
 		f.kubeInformer.Networking().V1().NetworkPolicies().Informer().GetIndexer().Add(netPol)

--- a/npm/pkg/controlplane/controllers/v1/networkPolicyController_test.go
+++ b/npm/pkg/controlplane/controllers/v1/networkPolicyController_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-container-networking/npm/ipsm"
 	"github.com/Azure/azure-container-networking/npm/metrics"
 	"github.com/Azure/azure-container-networking/npm/metrics/promutil"
+	"github.com/Azure/azure-container-networking/npm/util"
 	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
@@ -53,7 +54,7 @@ func (f *netPolFixture) newNetPolController(stopCh chan struct{}) {
 	kubeclient := k8sfake.NewSimpleClientset(f.kubeobjects...)
 	f.kubeInformer = kubeinformers.NewSharedInformerFactory(kubeclient, noResyncPeriodFunc())
 
-	f.netPolController = NewNetworkPolicyController(f.kubeInformer.Networking().V1().NetworkPolicies(), f.ipsMgr, placeAzureChainAfterKubeServices)
+	f.netPolController = NewNetworkPolicyController(f.kubeInformer.Networking().V1().NetworkPolicies(), f.ipsMgr, util.PlaceAzureChainAfterKubeServices)
 
 	for _, netPol := range f.netPolLister {
 		f.kubeInformer.Networking().V1().NetworkPolicies().Informer().GetIndexer().Add(netPol)

--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -21,6 +21,9 @@ const (
 
 // iptables related constants.
 const (
+	PlaceAzureChainAfterKubeServices = false
+	PlaceAzureChainFirst             = true
+
 	Iptables                   string = "iptables"
 	Ip6tables                  string = "ip6tables" //nolint (avoid warning to capitalize this p)
 	IptablesSave               string = "iptables-save"


### PR DESCRIPTION
Fix #1088 

# Problem
In the iptables nat table, under certain conditions, KUBE-SERVICES will mark a packet sent to an LB service before DNAT to a pod's IP. Then, in iptables filter table the KUBE-FORWARD table will accept packets with this mark before the packet reaches AZURE-NPM chain.

As a result, we might not get a chance to drop packets that we should.

## iptables chains
### filter table
#### FORWARD chain (as it is now)
As it is now, NPM comes after KUBE-FORWARD.
```
Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination         
17386 1819K KUBE-FORWARD  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* kubernetes forwarding rules */
17129 1806K KUBE-SERVICES  all  --  *      *       0.0.0.0/0            0.0.0.0/0            ctstate NEW /* kubernetes service portals */
  845 43940 AZURE-NPM  all  --  *      *       0.0.0.0/0            0.0.0.0/0
17129 1806K KUBE-EXTERNAL-SERVICES  all  --  *      *       0.0.0.0/0            0.0.0.0/0            ctstate NEW /* kubernetes externally-visible service portals */
    0     0 DROP       tcp  --  *      *       0.0.0.0/0            168.63.129.16        tcp dpt:80
```

#### KUBE-FORWARD chain 
Notice the accept on masquerade mark (0x4000).
```
Chain KUBE-FORWARD (1 references)
 pkts bytes target     prot opt in     out     source               destination         
    0     0 DROP       all  --  *      *       0.0.0.0/0            0.0.0.0/0            ctstate INVALID
    0     0 ACCEPT     all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* kubernetes forwarding rules */ mark match 0x4000/0x4000
    0     0 ACCEPT     all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* kubernetes forwarding conntrack pod source rule */ ctstate RELATED,ESTABLISHED
    0     0 ACCEPT     all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* kubernetes forwarding conntrack pod destination rule */ ctstate RELATED,ESTABLISHED
```

### nat table (example with an ILB service named elf/nginx-svc)
For this example, elf/nginx-svc delegates traffic to two pods for incoming traffic on tcp port 80 or nodeport 30525.

KUBE-SERVICES is Kubernetes' nat chain. It is referenced in the OUTPUT AND PREROUTING chains.

Depending on the src, we may mark for masquerading if port 80 is used. Depending on the IP/port used for the svc, we either jump to the svc chain, fwd chain, or nodeports chain.
```
Chain KUBE-SERVICES (2 references)
 pkts bytes target     prot opt in     out     source               destination 
      ...
    0     0 KUBE-MARK-MASQ  tcp  --  *      *      !10.240.0.0/12        ILB_CLUSTER_IP          /* elf/nginx-svc cluster IP */ tcp dpt:80
    0     0 KUBE-SVC-TQTTMDXT2ILLOFTL  tcp  --  *      *       0.0.0.0/0            ILB_CLUSTER_IP          /* elf/nginx-svc cluster IP */ tcp dpt:80
    0     0 KUBE-FW-TQTTMDXT2ILLOFTL  tcp  --  *      *       0.0.0.0/0            ILB_EXTERNAL_IP          /* elf/nginx-svc loadbalancer IP */ tcp dpt:80
      ...
 1453 79972 KUBE-NODEPORTS  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* kubernetes service nodeports; NOTE: this must be the last rule in this chain */ ADDRTYPE match dst-type LOCAL
```

Here's the mark-for-masquerade chain:
```
Chain KUBE-MARK-MASQ (91 references)
 pkts bytes target     prot opt in     out     source               destination         
  890 46280 MARK       all  --  *      *       0.0.0.0/0            0.0.0.0/0            MARK or 0x4000
```

Here's the LB's svc chain, which DNATs to one of the pods randomly. The packet is marked for masquerade (0x4000) if the src IP is the same as the dst pod's IP.
```
Chain KUBE-SVC-TQTTMDXT2ILLOFTL (3 references)
 pkts bytes target     prot opt in     out     source               destination         
  449 23348 KUBE-SEP-7NIBX3P3TLQVYL3E  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* elf/nginx-svc */ statistic mode random probability 0.50000000000
  453 23556 KUBE-SEP-KJY2B5OMZRWCDXG5  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* elf/nginx-svc */

Chain KUBE-SEP-7NIBX3P3TLQVYL3E (1 references)
 pkts bytes target     prot opt in     out     source               destination         
    0     0 KUBE-MARK-MASQ  all  --  *      *       POD2_IP          0.0.0.0/0            /* elf/nginx-svc */
  449 23348 DNAT       tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            /* elf/nginx-svc */ tcp to:POD2_IP:80

Chain KUBE-SEP-KJY2B5OMZRWCDXG5 (1 references)
 pkts bytes target     prot opt in     out     source               destination         
    0     0 KUBE-MARK-MASQ  all  --  *      *       POD1_IP          0.0.0.0/0            /* elf/nginx-svc */
  453 23556 DNAT       tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            /* elf/nginx-svc */ tcp to:POD1_IP:80
```

If the traffic was sent to the LB's external IP, it gets forwarded (marked for masquerade before sent to above svc chain for DNAT).
```
Chain KUBE-FW-TQTTMDXT2ILLOFTL (1 references)
 pkts bytes target     prot opt in     out     source               destination         
    0     0 KUBE-MARK-MASQ  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* elf/nginx-svc loadbalancer IP */
    0     0 KUBE-SVC-TQTTMDXT2ILLOFTL  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* elf/nginx-svc loadbalancer IP */
    0     0 KUBE-MARK-DROP  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* elf/nginx-svc loadbalancer IP */
```

If the nodeport was used, mark for masquerade and send to the svc chain)
```
Chain KUBE-NODEPORTS (1 references)
 pkts bytes target     prot opt in     out     source               destination         
  902 46904 KUBE-MARK-MASQ  tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            /* elf/nginx-svc */ tcp dpt:30525
  902 46904 KUBE-SVC-TQTTMDXT2ILLOFTL  tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            /* elf/nginx-svc */ tcp dpt:30525
```

# Solution
When a toggle is turned on (default off), move the jump from FORWARD to AZURE-NPM chain above the jump to KUBE-FORWARD. 

As a result, packets DNAT to a pod from the ILB will pass through NPM instead of being accepted beforehand. 

## new FORWARD chain in filter table
We add a `ctstate NEW` requirement for the jump to Azure chain, and position the jump depending on the toggle. This follows KUBE-FORWARD's practice and is necessary so for example, we don't deny an HTTP response for an HTTP request that we allow.
 
When the toggle is set to place the azure chain first: 
```
Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination         
  845 43940 AZURE-NPM  all  --  *      *       0.0.0.0/0            0.0.0.0/0            ctstate NEW
17386 1819K KUBE-FORWARD  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* kubernetes forwarding rules */
17129 1806K KUBE-SERVICES  all  --  *      *       0.0.0.0/0            0.0.0.0/0            ctstate NEW /* kubernetes service portals */
17129 1806K KUBE-EXTERNAL-SERVICES  all  --  *      *       0.0.0.0/0            0.0.0.0/0            ctstate NEW /* kubernetes externally-visible service portals */
    0     0 DROP       tcp  --  *      *       0.0.0.0/0            168.63.129.16        tcp dpt:80
```

Keep the rest the same, including the redundant check for state RELATED/ESTABLISHED in the final ACCEPT in Azure chain.
```
Chain AZURE-NPM (1 references)
 pkts bytes target     prot opt in     out     source               destination         
  845 43940 AZURE-NPM-INGRESS  all  --  *      *       0.0.0.0/0            0.0.0.0/0           
    0     0 AZURE-NPM-EGRESS  all  --  *      *       0.0.0.0/0            0.0.0.0/0           
    0     0 AZURE-NPM-ACCEPT  all  --  *      *       0.0.0.0/0            0.0.0.0/0            mark match 0x3000 /* ACCEPT-on-INGRESS-and-EGRESS-mark-0x3000 */
    0     0 AZURE-NPM-ACCEPT  all  --  *      *       0.0.0.0/0            0.0.0.0/0            mark match 0x2000 /* ACCEPT-on-INGRESS-mark-0x2000 */
    0     0 AZURE-NPM-ACCEPT  all  --  *      *       0.0.0.0/0            0.0.0.0/0            mark match 0x1000 /* ACCEPT-on-EGRESS-mark-0x1000 */
    0     0 ACCEPT     all  --  *      *       0.0.0.0/0            0.0.0.0/0            state RELATED,ESTABLISHED /* ACCEPT-on-connection-state */
```