### PR TITLE
feat: [NPM] Clean up iptables chains in Linux v2

### DIFF
--- a/npm/pkg/dataplane/policies/chain-management_linux.go
+++ b/npm/pkg/dataplane/policies/chain-management_linux.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/Azure/azure-container-networking/npm/metrics"
 	"github.com/Azure/azure-container-networking/npm/pkg/dataplane/ioutil"
@@ -54,6 +53,25 @@ var (
 	ingressOrEgressPolicyChainPattern = fmt.Sprintf("'Chain %s-\\|Chain %s-'", util.IptablesAzureIngressPolicyChainPrefix, util.IptablesAzureEgressPolicyChainPrefix)
 )
 
+type osTools struct {
+	chainsToCleanup map[string]struct{}
+}
+
+func makeTools() osTools {
+	return osTools{make(map[string]struct{})}
+}
+
+func (pMgr *PolicyManager) reboot() error {
+	// TODO for the sake of UTs, need to have a pMgr config specifying whether or not this reboot happens
+	// if err := pMgr.reset(); err != nil {
+	// 	return npmerrors.SimpleErrorWrapper("failed to remove NPM chains while rebooting", err)
+	// }
+	// if err := pMgr.initialize(); err != nil {
+	// 	return npmerrors.SimpleErrorWrapper("failed to initialize NPM chains while rebooting", err)
+	// }
+	return nil
+}
+
 func (pMgr *PolicyManager) initialize() error {
 	if err := pMgr.initializeNPMChains(); err != nil {
 		return npmerrors.SimpleErrorWrapper("failed to initialize NPM chains", err)
@@ -65,6 +83,7 @@ func (pMgr *PolicyManager) reset() error {
 	if err := pMgr.removeNPMChains(); err != nil {
 		return npmerrors.SimpleErrorWrapper("failed to remove NPM chains", err)
 	}
+	pMgr.chainsToCleanup = make(map[string]struct{})
 	return nil
 }
 
@@ -123,26 +142,48 @@ func (pMgr *PolicyManager) removeNPMChains() error {
 	return nil
 }
 
-// ReconcileChains periodically creates the jump rule from FORWARD chain to AZURE-NPM chain (if it d.n.e)
-// and makes sure it's after the jumps to KUBE-FORWARD & KUBE-SERVICES chains (if they exist).
-func (pMgr *PolicyManager) ReconcileChains(stopChannel <-chan struct{}) {
-	go pMgr.reconcileChains(stopChannel)
+// reconcile does the following:
+// - cleans up old policy chains
+// - creates the jump rule from FORWARD chain to AZURE-NPM chain (if it d.n.e) and makes sure it's after the jumps to KUBE-FORWARD & KUBE-SERVICES chains (if they exist).
+func (pMgr *PolicyManager) reconcile(stopChannel <-chan struct{}) {
+	if err := pMgr.positionAzureChainJumpRule(); err != nil {
+		klog.Errorf("failed to reconcile jump rule to Azure-NPM due to %s", err.Error())
+	}
+	if err := pMgr.cleanupChains(pMgr.oldPolicyChains()); err != nil {
+		klog.Errorf("failed to clean up old policy chains with the following error %s", err.Error())
+	}
 }
 
-func (pMgr *PolicyManager) reconcileChains(stopChannel <-chan struct{}) {
-	ticker := time.NewTicker(time.Minute * time.Duration(reconcileChainTimeInMinutes))
-	defer ticker.Stop()
+func (pMgr *PolicyManager) oldPolicyChains() []string {
+	result := make([]string, len(pMgr.chainsToCleanup))
+	k := 0
+	for chain := range pMgr.chainsToCleanup {
+		result[k] = chain
+		k++
+	}
+	return result
+}
 
-	for {
-		select {
-		case <-stopChannel:
-			return
-		case <-ticker.C:
-			if err := pMgr.positionAzureChainJumpRule(); err != nil {
-				metrics.SendErrorLogAndMetric(util.NpmID, "Error: failed to reconcile jump rule to Azure-NPM due to %s", err.Error())
+// have to use slice argument for deterministic behavior for UTs
+func (pMgr *PolicyManager) cleanupChains(chains []string) error {
+	var aggregateError error
+	for _, chain := range chains {
+		errCode, err := pMgr.runIPTablesCommand(util.IptablesDestroyFlag, chain) // TODO run the one that ignores doesNotExistErrorCode
+		if err == nil || errCode == doesNotExistErrorCode {
+			delete(pMgr.chainsToCleanup, chain)
+		} else {
+			currentErrString := fmt.Sprintf("failed to clean up policy chain %s with err [%v]", chain, err)
+			if aggregateError == nil {
+				aggregateError = npmerrors.SimpleError(currentErrString)
+			} else {
+				aggregateError = npmerrors.SimpleErrorWrapper(fmt.Sprintf("%s and had previous error", currentErrString), aggregateError)
 			}
 		}
 	}
+	if aggregateError != nil {
+		return npmerrors.SimpleErrorWrapper("failed to clean up some policy chains with errors", aggregateError)
+	}
+	return nil
 }
 
 // this function has a direct comparison in NPM v1 iptables manager (iptm.go)

--- a/npm/pkg/dataplane/policies/chain-management_linux.go
+++ b/npm/pkg/dataplane/policies/chain-management_linux.go
@@ -16,7 +16,6 @@ import (
 
 const (
 	defaultlockWaitTimeInSeconds string = "60"
-	reconcileChainTimeInMinutes  int    = 5
 
 	doesNotExistErrorCode      int = 1 // Bad rule (does a matching rule exist in that chain?)
 	couldntLoadTargetErrorCode int = 2 // Couldn't load target `AZURE-NPM-EGRESS':No such file or directory

--- a/npm/pkg/dataplane/policies/chain-management_linux.go
+++ b/npm/pkg/dataplane/policies/chain-management_linux.go
@@ -53,12 +53,35 @@ var (
 	ingressOrEgressPolicyChainPattern = fmt.Sprintf("'Chain %s-\\|Chain %s-'", util.IptablesAzureIngressPolicyChainPrefix, util.IptablesAzureEgressPolicyChainPrefix)
 )
 
-type osTools struct {
+type staleChains struct {
 	chainsToCleanup map[string]struct{}
 }
 
-func makeTools() osTools {
-	return osTools{make(map[string]struct{})}
+func newStaleChains() *staleChains {
+	return &staleChains{make(map[string]struct{})}
+}
+
+func (s *staleChains) add(chain string) {
+	s.chainsToCleanup[chain] = struct{}{}
+}
+
+func (s *staleChains) remove(chain string) {
+	delete(s.chainsToCleanup, chain)
+}
+
+func (s *staleChains) emptyAndGetAll() []string {
+	result := make([]string, len(s.chainsToCleanup))
+	k := 0
+	for chain := range s.chainsToCleanup {
+		result[k] = chain
+		s.remove(chain)
+		k++
+	}
+	return result
+}
+
+func (s *staleChains) empty() {
+	s.chainsToCleanup = make(map[string]struct{})
 }
 
 func (pMgr *PolicyManager) reboot() error {
@@ -83,7 +106,7 @@ func (pMgr *PolicyManager) reset() error {
 	if err := pMgr.removeNPMChains(); err != nil {
 		return npmerrors.SimpleErrorWrapper("failed to remove NPM chains", err)
 	}
-	pMgr.chainsToCleanup = make(map[string]struct{})
+	pMgr.staleChains.empty()
 	return nil
 }
 
@@ -149,19 +172,9 @@ func (pMgr *PolicyManager) reconcile(stopChannel <-chan struct{}) {
 	if err := pMgr.positionAzureChainJumpRule(); err != nil {
 		klog.Errorf("failed to reconcile jump rule to Azure-NPM due to %s", err.Error())
 	}
-	if err := pMgr.cleanupChains(pMgr.oldPolicyChains()); err != nil {
+	if err := pMgr.cleanupChains(pMgr.staleChains.emptyAndGetAll()); err != nil {
 		klog.Errorf("failed to clean up old policy chains with the following error %s", err.Error())
 	}
-}
-
-func (pMgr *PolicyManager) oldPolicyChains() []string {
-	result := make([]string, len(pMgr.chainsToCleanup))
-	k := 0
-	for chain := range pMgr.chainsToCleanup {
-		result[k] = chain
-		k++
-	}
-	return result
 }
 
 // have to use slice argument for deterministic behavior for UTs
@@ -169,9 +182,8 @@ func (pMgr *PolicyManager) cleanupChains(chains []string) error {
 	var aggregateError error
 	for _, chain := range chains {
 		errCode, err := pMgr.runIPTablesCommand(util.IptablesDestroyFlag, chain) // TODO run the one that ignores doesNotExistErrorCode
-		if err == nil || errCode == doesNotExistErrorCode {
-			delete(pMgr.chainsToCleanup, chain)
-		} else {
+		if err != nil && errCode != doesNotExistErrorCode {
+			pMgr.staleChains.add(chain)
 			currentErrString := fmt.Sprintf("failed to clean up policy chain %s with err [%v]", chain, err)
 			if aggregateError == nil {
 				aggregateError = npmerrors.SimpleError(currentErrString)

--- a/npm/pkg/dataplane/policies/chain-management_linux.go
+++ b/npm/pkg/dataplane/policies/chain-management_linux.go
@@ -168,7 +168,7 @@ func (pMgr *PolicyManager) removeNPMChains() error {
 // reconcile does the following:
 // - cleans up old policy chains
 // - creates the jump rule from FORWARD chain to AZURE-NPM chain (if it d.n.e) and makes sure it's after the jumps to KUBE-FORWARD & KUBE-SERVICES chains (if they exist).
-func (pMgr *PolicyManager) reconcile(stopChannel <-chan struct{}) {
+func (pMgr *PolicyManager) reconcile() {
 	if err := pMgr.positionAzureChainJumpRule(); err != nil {
 		klog.Errorf("failed to reconcile jump rule to Azure-NPM due to %s", err.Error())
 	}

--- a/npm/pkg/dataplane/policies/chain-management_linux.go
+++ b/npm/pkg/dataplane/policies/chain-management_linux.go
@@ -91,7 +91,7 @@ func (pMgr *PolicyManager) reset() error {
 // AZURE-NPM chain is after the jumps to KUBE-FORWARD & KUBE-SERVICES chains (if they exist).
 func (pMgr *PolicyManager) initializeNPMChains() error {
 	klog.Infof("Initializing AZURE-NPM chains.")
-	creator := pMgr.getCreatorForInitChains()
+	creator := pMgr.creatorForInitChains()
 	err := restore(creator)
 	if err != nil {
 		return npmerrors.SimpleErrorWrapper("failed to create chains and rules", err)
@@ -120,7 +120,7 @@ func (pMgr *PolicyManager) removeNPMChains() error {
 	}
 
 	// flush all chains (will create any chain, including deprecated ones, if they don't exist)
-	creatorToFlush, chainsToDelete := pMgr.getCreatorAndChainsForReset()
+	creatorToFlush, chainsToDelete := pMgr.creatorAndChainsForReset()
 	restoreError := restore(creatorToFlush)
 	if restoreError != nil {
 		return npmerrors.SimpleErrorWrapper("failed to flush chains", restoreError)
@@ -211,8 +211,8 @@ func (pMgr *PolicyManager) runIPTablesCommand(operationFlag string, args ...stri
 	return 0, nil
 }
 
-func (pMgr *PolicyManager) getCreatorForInitChains() *ioutil.FileCreator {
-	creator := pMgr.getNewCreatorWithChains(iptablesAzureChains)
+func (pMgr *PolicyManager) creatorForInitChains() *ioutil.FileCreator {
+	creator := pMgr.newCreatorWithChains(iptablesAzureChains)
 
 	// add AZURE-NPM chain rules
 	creator.AddLine("", nil, util.IptablesAppendFlag, util.IptablesAzureChain, util.IptablesJumpFlag, util.IptablesAzureIngressChain)
@@ -221,32 +221,32 @@ func (pMgr *PolicyManager) getCreatorForInitChains() *ioutil.FileCreator {
 
 	// add AZURE-NPM-INGRESS chain rules
 	ingressDropSpecs := []string{util.IptablesAppendFlag, util.IptablesAzureIngressChain, util.IptablesJumpFlag, util.IptablesDrop}
-	ingressDropSpecs = append(ingressDropSpecs, getOnMarkSpecs(util.IptablesAzureIngressDropMarkHex)...)
-	ingressDropSpecs = append(ingressDropSpecs, getCommentSpecs(fmt.Sprintf("DROP-ON-INGRESS-DROP-MARK-%s", util.IptablesAzureIngressDropMarkHex))...)
+	ingressDropSpecs = append(ingressDropSpecs, onMarkSpecs(util.IptablesAzureIngressDropMarkHex)...)
+	ingressDropSpecs = append(ingressDropSpecs, commentSpecs(fmt.Sprintf("DROP-ON-INGRESS-DROP-MARK-%s", util.IptablesAzureIngressDropMarkHex))...)
 	creator.AddLine("", nil, ingressDropSpecs...)
 
 	// add AZURE-NPM-INGRESS-ALLOW-MARK chain
 	markIngressAllowSpecs := []string{util.IptablesAppendFlag, util.IptablesAzureIngressAllowMarkChain}
-	markIngressAllowSpecs = append(markIngressAllowSpecs, getSetMarkSpecs(util.IptablesAzureIngressAllowMarkHex)...)
-	markIngressAllowSpecs = append(markIngressAllowSpecs, getCommentSpecs(fmt.Sprintf("SET-INGRESS-ALLOW-MARK-%s", util.IptablesAzureIngressAllowMarkHex))...)
+	markIngressAllowSpecs = append(markIngressAllowSpecs, setMarkSpecs(util.IptablesAzureIngressAllowMarkHex)...)
+	markIngressAllowSpecs = append(markIngressAllowSpecs, commentSpecs(fmt.Sprintf("SET-INGRESS-ALLOW-MARK-%s", util.IptablesAzureIngressAllowMarkHex))...)
 	creator.AddLine("", nil, markIngressAllowSpecs...)
 	creator.AddLine("", nil, util.IptablesAppendFlag, util.IptablesAzureIngressAllowMarkChain, util.IptablesJumpFlag, util.IptablesAzureEgressChain)
 
 	// add AZURE-NPM-EGRESS chain rules
 	egressDropSpecs := []string{util.IptablesAppendFlag, util.IptablesAzureEgressChain, util.IptablesJumpFlag, util.IptablesDrop}
-	egressDropSpecs = append(egressDropSpecs, getOnMarkSpecs(util.IptablesAzureEgressDropMarkHex)...)
-	egressDropSpecs = append(egressDropSpecs, getCommentSpecs(fmt.Sprintf("DROP-ON-EGRESS-DROP-MARK-%s", util.IptablesAzureEgressDropMarkHex))...)
+	egressDropSpecs = append(egressDropSpecs, onMarkSpecs(util.IptablesAzureEgressDropMarkHex)...)
+	egressDropSpecs = append(egressDropSpecs, commentSpecs(fmt.Sprintf("DROP-ON-EGRESS-DROP-MARK-%s", util.IptablesAzureEgressDropMarkHex))...)
 	creator.AddLine("", nil, egressDropSpecs...)
 
 	jumpOnIngressMatchSpecs := []string{util.IptablesAppendFlag, util.IptablesAzureEgressChain, util.IptablesJumpFlag, util.IptablesAzureAcceptChain}
-	jumpOnIngressMatchSpecs = append(jumpOnIngressMatchSpecs, getOnMarkSpecs(util.IptablesAzureIngressAllowMarkHex)...)
-	jumpOnIngressMatchSpecs = append(jumpOnIngressMatchSpecs, getCommentSpecs(fmt.Sprintf("ACCEPT-ON-INGRESS-ALLOW-MARK-%s", util.IptablesAzureIngressAllowMarkHex))...)
+	jumpOnIngressMatchSpecs = append(jumpOnIngressMatchSpecs, onMarkSpecs(util.IptablesAzureIngressAllowMarkHex)...)
+	jumpOnIngressMatchSpecs = append(jumpOnIngressMatchSpecs, commentSpecs(fmt.Sprintf("ACCEPT-ON-INGRESS-ALLOW-MARK-%s", util.IptablesAzureIngressAllowMarkHex))...)
 	creator.AddLine("", nil, jumpOnIngressMatchSpecs...)
 
 	// add AZURE-NPM-ACCEPT chain rules
 	clearSpecs := []string{util.IptablesAppendFlag, util.IptablesAzureAcceptChain}
-	clearSpecs = append(clearSpecs, getSetMarkSpecs(util.IptablesAzureClearMarkHex)...)
-	clearSpecs = append(clearSpecs, getCommentSpecs("Clear-AZURE-NPM-MARKS")...)
+	clearSpecs = append(clearSpecs, setMarkSpecs(util.IptablesAzureClearMarkHex)...)
+	clearSpecs = append(clearSpecs, commentSpecs("Clear-AZURE-NPM-MARKS")...)
 	creator.AddLine("", nil, clearSpecs...)
 	creator.AddLine("", nil, util.IptablesAppendFlag, util.IptablesAzureAcceptChain, util.IptablesJumpFlag, util.IptablesAccept)
 	creator.AddLine("", nil, util.IptablesRestoreCommit)
@@ -256,7 +256,7 @@ func (pMgr *PolicyManager) getCreatorForInitChains() *ioutil.FileCreator {
 // add/reposition AZURE-NPM chain after KUBE-FORWARD and KUBE-SERVICE chains if they exist
 // this function has a direct comparison in NPM v1 iptables manager (iptm.go)
 func (pMgr *PolicyManager) positionAzureChainJumpRule() error {
-	kubeServicesLine, kubeServicesLineNumErr := pMgr.getChainLineNumber(util.IptablesKubeServicesChain)
+	kubeServicesLine, kubeServicesLineNumErr := pMgr.chainLineNumber(util.IptablesKubeServicesChain)
 	if kubeServicesLineNumErr != nil {
 		// not possible to cover this branch currently because of testing limitations for PipeCommandToGrep()
 		baseErrString := "failed to get index of jump from KUBE-SERVICES chain to FORWARD chain with error"
@@ -266,7 +266,7 @@ func (pMgr *PolicyManager) positionAzureChainJumpRule() error {
 
 	index := kubeServicesLine + 1
 
-	// TODO could call getChainLineNumber instead, and say it doesn't exist for lineNum == 0
+	// TODO could call chainLineNumber instead, and say it doesn't exist for lineNum == 0
 	jumpRuleErrCode, checkErr := pMgr.runIPTablesCommand(util.IptablesCheckFlag, jumpFromForwardToAzureChainArgs...)
 	hadCheckError := checkErr != nil && jumpRuleErrCode != doesNotExistErrorCode
 	if hadCheckError {
@@ -293,7 +293,7 @@ func (pMgr *PolicyManager) positionAzureChainJumpRule() error {
 		return nil
 	}
 
-	npmChainLine, npmLineNumErr := pMgr.getChainLineNumber(util.IptablesAzureChain)
+	npmChainLine, npmLineNumErr := pMgr.chainLineNumber(util.IptablesAzureChain)
 	if npmLineNumErr != nil {
 		// not possible to cover this branch currently because of testing limitations for PipeCommandToGrep()
 		baseErrString := "failed to get index of jump from FORWARD chain to AZURE-NPM chain"
@@ -334,7 +334,7 @@ func (pMgr *PolicyManager) positionAzureChainJumpRule() error {
 
 // returns 0 if the chain d.n.e.
 // this function has a direct comparison in NPM v1 iptables manager (iptm.go)
-func (pMgr *PolicyManager) getChainLineNumber(chain string) (int, error) {
+func (pMgr *PolicyManager) chainLineNumber(chain string) (int, error) {
 	// TODO could call this once and use regex instead of grep to cut down on OS calls
 	listForwardEntriesCommand := pMgr.ioShim.Exec.Command(util.Iptables,
 		util.IptablesWaitFlag, defaultlockWaitTimeInSeconds, util.IptablesTableFlag, util.IptablesFilterTable,
@@ -357,20 +357,20 @@ func (pMgr *PolicyManager) getChainLineNumber(chain string) (int, error) {
 }
 
 // make this a function for easier testing
-func (pMgr *PolicyManager) getCreatorAndChainsForReset() (creator *ioutil.FileCreator, chainsToFlush []string) {
-	oldPolicyChains, err := pMgr.getPolicyChainNames()
+func (pMgr *PolicyManager) creatorAndChainsForReset() (creator *ioutil.FileCreator, chainsToFlush []string) {
+	oldPolicyChains, err := pMgr.policyChainNames()
 	if err != nil {
 		// not possible to cover this branch currently because of testing limitations for PipeCommandToGrep()
 		metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to determine NPM ingress/egress policy chains to delete")
 	}
 	chainsToFlush = iptablesOldAndNewChains
 	chainsToFlush = append(chainsToFlush, oldPolicyChains...) // will work even if oldPolicyChains is nil
-	creator = pMgr.getNewCreatorWithChains(chainsToFlush)
+	creator = pMgr.newCreatorWithChains(chainsToFlush)
 	creator.AddLine("", nil, util.IptablesRestoreCommit)
 	return
 }
 
-func (pMgr *PolicyManager) getPolicyChainNames() ([]string, error) {
+func (pMgr *PolicyManager) policyChainNames() ([]string, error) {
 	iptablesListCommand := pMgr.ioShim.Exec.Command(util.Iptables,
 		util.IptablesWaitFlag, defaultlockWaitTimeInSeconds, util.IptablesTableFlag, util.IptablesFilterTable,
 		util.IptablesNumericFlag, util.IptablesListFlag,
@@ -396,7 +396,7 @@ func (pMgr *PolicyManager) getPolicyChainNames() ([]string, error) {
 	return chainNames, nil
 }
 
-func getOnMarkSpecs(mark string) []string {
+func onMarkSpecs(mark string) []string {
 	return []string{
 		util.IptablesModuleFlag,
 		util.IptablesMarkVerb,

--- a/npm/pkg/dataplane/policies/chain-management_linux_test.go
+++ b/npm/pkg/dataplane/policies/chain-management_linux_test.go
@@ -2,6 +2,7 @@ package policies
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
 
@@ -10,6 +11,58 @@ import (
 	testutils "github.com/Azure/azure-container-networking/test/utils"
 	"github.com/stretchr/testify/require"
 )
+
+const (
+	testChain1 = "chain1"
+	testChain2 = "chain2"
+	testChain3 = "chain3"
+)
+
+func TestOldPolicyChains(t *testing.T) {
+	pMgr := NewPolicyManager(common.NewMockIOShim(nil))
+	pMgr.chainsToCleanup[testChain1] = struct{}{}
+	pMgr.chainsToCleanup[testChain2] = struct{}{}
+	chainsToCleanup := pMgr.oldPolicyChains()
+	require.Equal(t, 2, len(chainsToCleanup))
+	require.True(t, chainsToCleanup[0] == testChain1 || chainsToCleanup[1] == testChain1)
+	require.True(t, chainsToCleanup[0] == testChain2 || chainsToCleanup[1] == testChain2)
+}
+
+func TestCleanupChainsSuccess(t *testing.T) {
+	calls := []testutils.TestCmd{
+		getFakeDestroyCommand(testChain1),
+		getFakeDestroyCommandWithExitCode(testChain2, 1), // exit code 1 means the chain d.n.e.
+	}
+	ioshim := common.NewMockIOShim(calls)
+	// TODO defer ioshim.VerifyCalls(t, ioshim, calls)
+	pMgr := NewPolicyManager(ioshim)
+
+	pMgr.chainsToCleanup[testChain1] = struct{}{}
+	pMgr.chainsToCleanup[testChain2] = struct{}{}
+	chainsToCleanup := pMgr.oldPolicyChains()
+	sort.Strings(chainsToCleanup)
+	require.NoError(t, pMgr.cleanupChains(chainsToCleanup))
+	assertEqualCleanupContents(t, pMgr)
+}
+
+func TestCleanupChainsFailure(t *testing.T) {
+	calls := []testutils.TestCmd{
+		getFakeDestroyCommandWithExitCode(testChain1, 2),
+		getFakeDestroyCommand(testChain2),
+		getFakeDestroyCommandWithExitCode(testChain3, 2),
+	}
+	ioshim := common.NewMockIOShim(calls)
+	// TODO defer ioshim.VerifyCalls(t, ioshim, calls)
+	pMgr := NewPolicyManager(ioshim)
+
+	pMgr.chainsToCleanup[testChain1] = struct{}{}
+	pMgr.chainsToCleanup[testChain2] = struct{}{}
+	pMgr.chainsToCleanup[testChain3] = struct{}{}
+	chainsToCleanup := pMgr.oldPolicyChains()
+	sort.Strings(chainsToCleanup)
+	require.Error(t, pMgr.cleanupChains(chainsToCleanup))
+	assertEqualCleanupContents(t, pMgr, testChain1, testChain3)
+}
 
 func TestInitChainsCreator(t *testing.T) {
 	pMgr := NewPolicyManager(common.NewMockIOShim(nil))
@@ -109,7 +162,7 @@ func TestRemoveChainsCreator(t *testing.T) {
 
 func TestRemoveChainsSuccess(t *testing.T) {
 	calls := GetResetTestCalls()
-	for _, chain := range iptablesOldAndNewChains {
+	for _, chain := range iptablesOldAndNewChains { // TODO write these out, don't use variable
 		calls = append(calls, getFakeDestroyCommand(chain))
 	}
 	calls = append(
@@ -162,7 +215,7 @@ func TestRemoveChainsFailureOnDestroy(t *testing.T) {
 		{Cmd: []string{"grep", ingressOrEgressPolicyChainPattern}}, // ExitCode 0 for the iptables restore command
 		fakeIPTablesRestoreCommand,
 	}
-	calls = append(calls, getFakeDestroyFailureCommand(iptablesOldAndNewChains[0])) // this ExitCode here will actually impact the next below
+	calls = append(calls, getFakeDestroyCommandWithExitCode(iptablesOldAndNewChains[0], 2)) // this ExitCode here will actually impact the next below
 	for _, chain := range iptablesOldAndNewChains[1:] {
 		calls = append(calls, getFakeDestroyCommand(chain))
 	}
@@ -411,8 +464,8 @@ func getFakeDestroyCommand(chain string) testutils.TestCmd {
 	return testutils.TestCmd{Cmd: []string{"iptables", "-w", "60", "-X", chain}}
 }
 
-func getFakeDestroyFailureCommand(chain string) testutils.TestCmd {
+func getFakeDestroyCommandWithExitCode(chain string, exitCode int) testutils.TestCmd {
 	command := getFakeDestroyCommand(chain)
-	command.ExitCode = 1
+	command.ExitCode = exitCode
 	return command
 }

--- a/npm/pkg/dataplane/policies/chain-management_linux_test.go
+++ b/npm/pkg/dataplane/policies/chain-management_linux_test.go
@@ -66,7 +66,7 @@ func TestCleanupChainsFailure(t *testing.T) {
 
 func TestInitChainsCreator(t *testing.T) {
 	pMgr := NewPolicyManager(common.NewMockIOShim(nil))
-	creator := pMgr.getCreatorForInitChains() // doesn't make any exec calls
+	creator := pMgr.creatorForInitChains() // doesn't make any exec calls
 	actualLines := strings.Split(creator.ToString(), "\n")
 	expectedLines := []string{"*filter"}
 	for _, chain := range iptablesAzureChains {
@@ -130,7 +130,7 @@ func TestRemoveChainsCreator(t *testing.T) {
 	}
 
 	pMgr := NewPolicyManager(common.NewMockIOShim(creatorCalls))
-	creator, chainsToFlush := pMgr.getCreatorAndChainsForReset()
+	creator, chainsToFlush := pMgr.creatorAndChainsForReset()
 	expectedChainsToFlush := []string{
 		"AZURE-NPM",
 		"AZURE-NPM-INGRESS",
@@ -408,7 +408,7 @@ func TestGetChainLineNumber(t *testing.T) {
 		grepCommand,
 	}
 	pMgr := NewPolicyManager(common.NewMockIOShim(calls))
-	lineNum, err := pMgr.getChainLineNumber(testChainName)
+	lineNum, err := pMgr.chainLineNumber(testChainName)
 	require.Equal(t, 3, lineNum)
 	require.NoError(t, err)
 
@@ -421,7 +421,7 @@ func TestGetChainLineNumber(t *testing.T) {
 		grepCommand,
 	}
 	pMgr = NewPolicyManager(common.NewMockIOShim(calls))
-	lineNum, err = pMgr.getChainLineNumber(testChainName)
+	lineNum, err = pMgr.chainLineNumber(testChainName)
 	require.Equal(t, 0, lineNum)
 	require.NoError(t, err)
 }
@@ -437,7 +437,7 @@ func TestGetPolicyChainNames(t *testing.T) {
 		grepCommand,
 	}
 	pMgr := NewPolicyManager(common.NewMockIOShim(calls))
-	chainNames, err := pMgr.getPolicyChainNames()
+	chainNames, err := pMgr.policyChainNames()
 	expectedChainNames := []string{
 		"AZURE-NPM-INGRESS-123456",
 		"AZURE-NPM-EGRESS-123456",
@@ -454,7 +454,7 @@ func TestGetPolicyChainNames(t *testing.T) {
 		grepCommand,
 	}
 	pMgr = NewPolicyManager(common.NewMockIOShim(calls))
-	chainNames, err = pMgr.getPolicyChainNames()
+	chainNames, err = pMgr.policyChainNames()
 	expectedChainNames = nil
 	require.Equal(t, expectedChainNames, chainNames)
 	require.NoError(t, err)

--- a/npm/pkg/dataplane/policies/policy_linux.go
+++ b/npm/pkg/dataplane/policies/policy_linux.go
@@ -1,0 +1,27 @@
+package policies
+
+import "github.com/Azure/azure-container-networking/npm/util"
+
+// returns two booleans indicating whether the network policy has ingress and egress respectively
+func (networkPolicy *NPMNetworkPolicy) hasIngressAndEgress() (hasIngress, hasEgress bool) {
+	hasIngress = false
+	hasEgress = false
+	for _, aclPolicy := range networkPolicy.ACLs {
+		hasIngress = hasIngress || aclPolicy.hasIngress()
+		hasEgress = hasEgress || aclPolicy.hasEgress()
+	}
+	return
+}
+
+func (networkPolicy *NPMNetworkPolicy) egressChainName() string {
+	return networkPolicy.chainName(util.IptablesAzureEgressPolicyChainPrefix)
+}
+
+func (networkPolicy *NPMNetworkPolicy) ingressChainName() string {
+	return networkPolicy.chainName(util.IptablesAzureIngressPolicyChainPrefix)
+}
+
+func (networkPolicy *NPMNetworkPolicy) chainName(prefix string) string {
+	policyHash := util.Hash(networkPolicy.Name) // assuming the name is unique
+	return joinWithDash(prefix, policyHash)
+}

--- a/npm/pkg/dataplane/policies/policymanager.go
+++ b/npm/pkg/dataplane/policies/policymanager.go
@@ -45,7 +45,6 @@ func (pMgr *PolicyManager) Reset() error {
 	return nil
 }
 
-// TODO Windows doesn't need this go routine
 func (pMgr *PolicyManager) Reconcile(stopChannel <-chan struct{}) {
 	go func() {
 		ticker := time.NewTicker(time.Minute * time.Duration(reconcileChainTimeInMinutes))
@@ -58,7 +57,7 @@ func (pMgr *PolicyManager) Reconcile(stopChannel <-chan struct{}) {
 			case <-ticker.C:
 				pMgr.Lock()
 				defer pMgr.Unlock()
-				pMgr.reconcile(stopChannel)
+				pMgr.reconcile()
 			}
 		}
 	}()

--- a/npm/pkg/dataplane/policies/policymanager.go
+++ b/npm/pkg/dataplane/policies/policymanager.go
@@ -15,9 +15,9 @@ type PolicyMap struct {
 }
 
 type PolicyManager struct {
-	policyMap *PolicyMap
-	ioShim    *common.IOShim
-	osTools
+	policyMap   *PolicyMap
+	ioShim      *common.IOShim
+	staleChains *staleChains
 	sync.Mutex
 }
 
@@ -26,8 +26,8 @@ func NewPolicyManager(ioShim *common.IOShim) *PolicyManager {
 		policyMap: &PolicyMap{
 			cache: make(map[string]*NPMNetworkPolicy),
 		},
-		ioShim:  ioShim,
-		osTools: makeTools(),
+		ioShim:      ioShim,
+		staleChains: newStaleChains(),
 	}
 }
 
@@ -45,6 +45,7 @@ func (pMgr *PolicyManager) Reset() error {
 	return nil
 }
 
+// TODO Windows doesn't need this go routine
 func (pMgr *PolicyManager) Reconcile(stopChannel <-chan struct{}) {
 	go func() {
 		ticker := time.NewTicker(time.Minute * time.Duration(reconcileChainTimeInMinutes))

--- a/npm/pkg/dataplane/policies/policymanager.go
+++ b/npm/pkg/dataplane/policies/policymanager.go
@@ -10,6 +10,8 @@ import (
 	"k8s.io/klog"
 )
 
+const reconcileChainTimeInMinutes = 5
+
 type PolicyMap struct {
 	cache map[string]*NPMNetworkPolicy
 }

--- a/npm/pkg/dataplane/policies/policymanager_linux.go
+++ b/npm/pkg/dataplane/policies/policymanager_linux.go
@@ -28,7 +28,7 @@ func (pMgr *PolicyManager) addPolicy(networkPolicy *NPMNetworkPolicy, _ map[stri
 		return npmerrors.SimpleErrorWrapper("failed to restore iptables with updated policies", err)
 	}
 	for _, chain := range allChainNames {
-		delete(pMgr.chainsToCleanup, chain)
+		pMgr.staleChains.remove(chain)
 	}
 	return nil
 }
@@ -45,7 +45,7 @@ func (pMgr *PolicyManager) removePolicy(networkPolicy *NPMNetworkPolicy, _ map[s
 		return npmerrors.SimpleErrorWrapper("failed to flush policies", restoreErr)
 	}
 	for _, chain := range allChainNames {
-		pMgr.chainsToCleanup[chain] = struct{}{}
+		pMgr.staleChains.add(chain)
 	}
 	return nil
 }

--- a/npm/pkg/dataplane/policies/policymanager_linux.go
+++ b/npm/pkg/dataplane/policies/policymanager_linux.go
@@ -81,30 +81,6 @@ func allChainNames(networkPolicies []*NPMNetworkPolicy) []string {
 	return chainNames
 }
 
-// returns two booleans indicating whether the network policy has ingress and egress respectively
-func (networkPolicy *NPMNetworkPolicy) hasIngressAndEgress() (hasIngress, hasEgress bool) {
-	hasIngress = false
-	hasEgress = false
-	for _, aclPolicy := range networkPolicy.ACLs {
-		hasIngress = hasIngress || aclPolicy.hasIngress()
-		hasEgress = hasEgress || aclPolicy.hasEgress()
-	}
-	return
-}
-
-func (networkPolicy *NPMNetworkPolicy) egressChainName() string {
-	return networkPolicy.chainName(util.IptablesAzureEgressPolicyChainPrefix)
-}
-
-func (networkPolicy *NPMNetworkPolicy) ingressChainName() string {
-	return networkPolicy.chainName(util.IptablesAzureIngressPolicyChainPrefix)
-}
-
-func (networkPolicy *NPMNetworkPolicy) chainName(prefix string) string {
-	policyHash := util.Hash(networkPolicy.Name) // assuming the name is unique
-	return joinWithDash(prefix, policyHash)
-}
-
 func (pMgr *PolicyManager) newCreatorWithChains(chainNames []string) *ioutil.FileCreator {
 	creator := ioutil.NewFileCreator(pMgr.ioShim, maxRetryCount, knownLineErrorPattern, unknownLineErrorPattern) // TODO pass an array instead of this ... thing
 

--- a/npm/pkg/dataplane/policies/policymanager_linux.go
+++ b/npm/pkg/dataplane/policies/policymanager_linux.go
@@ -229,7 +229,7 @@ func writeNetworkPolicyRules(creator *ioutil.FileCreator, networkPolicy *NPMNetw
 func iptablesRuleSpecs(aclPolicy *ACLPolicy) []string {
 	specs := make([]string, 0)
 	specs = append(specs, util.IptablesProtFlag, string(aclPolicy.Protocol)) // NOTE: protocol must be ALL instead of nil
-	specs = append(specs, portSpecs([]Ports{aclPolicy.DstPorts})...)
+	specs = append(specs, dstPortSpecs(aclPolicy.DstPorts)...)
 	specs = append(specs, matchSetSpecsFromSetInfo(aclPolicy.SrcList)...)
 	specs = append(specs, matchSetSpecsFromSetInfo(aclPolicy.DstList)...)
 	if aclPolicy.Comment != "" {
@@ -238,18 +238,11 @@ func iptablesRuleSpecs(aclPolicy *ACLPolicy) []string {
 	return specs
 }
 
-func portSpecs(portRanges []Ports) []string {
-	// TODO(jungukcho): do not need to take slices since it can only have one dst port
-	if len(portRanges) != 1 {
+func dstPortSpecs(portRange Ports) []string {
+	if portRange.Port == 0 && portRange.EndPort == 0 {
 		return []string{}
 	}
-
-	// TODO(jungukcho): temporary solution and need to fix it.
-	if portRanges[0].Port == 0 && portRanges[0].EndPort == 0 {
-		return []string{}
-	}
-
-	return []string{util.IptablesDstPortFlag, portRanges[0].toIPTablesString()}
+	return []string{util.IptablesDstPortFlag, portRange.toIPTablesString()}
 }
 
 func matchSetSpecsForNetworkPolicy(networkPolicy *NPMNetworkPolicy, matchType MatchType) []string {

--- a/npm/pkg/dataplane/policies/policymanager_linux.go
+++ b/npm/pkg/dataplane/policies/policymanager_linux.go
@@ -21,10 +21,14 @@ const (
 // shouldn't call this if the np has no ACLs (check in generic)
 func (pMgr *PolicyManager) addPolicy(networkPolicy *NPMNetworkPolicy, _ map[string]string) error {
 	// TODO check for newPolicy errors
-	creator := pMgr.getCreatorForNewNetworkPolicies(networkPolicy)
+	allChainNames := getAllChainNames([]*NPMNetworkPolicy{networkPolicy})
+	creator := pMgr.getCreatorForNewNetworkPolicies(allChainNames, networkPolicy)
 	err := restore(creator)
 	if err != nil {
 		return npmerrors.SimpleErrorWrapper("failed to restore iptables with updated policies", err)
+	}
+	for _, chain := range allChainNames {
+		delete(pMgr.chainsToCleanup, chain)
 	}
 	return nil
 }
@@ -34,10 +38,14 @@ func (pMgr *PolicyManager) removePolicy(networkPolicy *NPMNetworkPolicy, _ map[s
 	if deleteErr != nil {
 		return npmerrors.SimpleErrorWrapper("failed to delete jumps to policy chains", deleteErr)
 	}
-	creator := pMgr.getCreatorForRemovingPolicies(networkPolicy)
+	allChainNames := getAllChainNames([]*NPMNetworkPolicy{networkPolicy})
+	creator := pMgr.getCreatorForRemovingPolicies(allChainNames)
 	restoreErr := restore(creator)
 	if restoreErr != nil {
 		return npmerrors.SimpleErrorWrapper("failed to flush policies", restoreErr)
+	}
+	for _, chain := range allChainNames {
+		pMgr.chainsToCleanup[chain] = struct{}{}
 	}
 	return nil
 }
@@ -50,8 +58,8 @@ func restore(creator *ioutil.FileCreator) error {
 	return nil
 }
 
-func (pMgr *PolicyManager) getCreatorForRemovingPolicies(networkPolicies ...*NPMNetworkPolicy) *ioutil.FileCreator {
-	allChainNames := getAllChainNames(networkPolicies)
+// TODO use array instead of ...
+func (pMgr *PolicyManager) getCreatorForRemovingPolicies(allChainNames []string) *ioutil.FileCreator {
 	creator := pMgr.getNewCreatorWithChains(allChainNames)
 	creator.AddLine("", nil, util.IptablesRestoreCommit)
 	return creator
@@ -165,8 +173,8 @@ func getEgressJumpSpecs(networkPolicy *NPMNetworkPolicy) []string {
 }
 
 // noflush add to chains impacted
-func (pMgr *PolicyManager) getCreatorForNewNetworkPolicies(networkPolicies ...*NPMNetworkPolicy) *ioutil.FileCreator {
-	allChainNames := getAllChainNames(networkPolicies)
+// TODO use array instead of ...
+func (pMgr *PolicyManager) getCreatorForNewNetworkPolicies(allChainNames []string, networkPolicies ...*NPMNetworkPolicy) *ioutil.FileCreator {
 	creator := pMgr.getNewCreatorWithChains(allChainNames)
 
 	ingressJumpLineNumber := 1

--- a/npm/pkg/dataplane/policies/policymanager_linux.go
+++ b/npm/pkg/dataplane/policies/policymanager_linux.go
@@ -21,8 +21,8 @@ const (
 // shouldn't call this if the np has no ACLs (check in generic)
 func (pMgr *PolicyManager) addPolicy(networkPolicy *NPMNetworkPolicy, _ map[string]string) error {
 	// TODO check for newPolicy errors
-	allChainNames := getAllChainNames([]*NPMNetworkPolicy{networkPolicy})
-	creator := pMgr.getCreatorForNewNetworkPolicies(allChainNames, networkPolicy)
+	allChainNames := allChainNames([]*NPMNetworkPolicy{networkPolicy})
+	creator := pMgr.creatorForNewNetworkPolicies(allChainNames, networkPolicy)
 	err := restore(creator)
 	if err != nil {
 		return npmerrors.SimpleErrorWrapper("failed to restore iptables with updated policies", err)
@@ -38,8 +38,8 @@ func (pMgr *PolicyManager) removePolicy(networkPolicy *NPMNetworkPolicy, _ map[s
 	if deleteErr != nil {
 		return npmerrors.SimpleErrorWrapper("failed to delete jumps to policy chains", deleteErr)
 	}
-	allChainNames := getAllChainNames([]*NPMNetworkPolicy{networkPolicy})
-	creator := pMgr.getCreatorForRemovingPolicies(allChainNames)
+	allChainNames := allChainNames([]*NPMNetworkPolicy{networkPolicy})
+	creator := pMgr.creatorForRemovingPolicies(allChainNames)
 	restoreErr := restore(creator)
 	if restoreErr != nil {
 		return npmerrors.SimpleErrorWrapper("failed to flush policies", restoreErr)
@@ -59,23 +59,23 @@ func restore(creator *ioutil.FileCreator) error {
 }
 
 // TODO use array instead of ...
-func (pMgr *PolicyManager) getCreatorForRemovingPolicies(allChainNames []string) *ioutil.FileCreator {
-	creator := pMgr.getNewCreatorWithChains(allChainNames)
+func (pMgr *PolicyManager) creatorForRemovingPolicies(allChainNames []string) *ioutil.FileCreator {
+	creator := pMgr.newCreatorWithChains(allChainNames)
 	creator.AddLine("", nil, util.IptablesRestoreCommit)
 	return creator
 }
 
 // returns all chain names (ingress and egress policy chain names)
-func getAllChainNames(networkPolicies []*NPMNetworkPolicy) []string {
+func allChainNames(networkPolicies []*NPMNetworkPolicy) []string {
 	chainNames := make([]string, 0)
 	for _, networkPolicy := range networkPolicies {
 		hasIngress, hasEgress := networkPolicy.hasIngressAndEgress()
 
 		if hasIngress {
-			chainNames = append(chainNames, networkPolicy.getIngressChainName())
+			chainNames = append(chainNames, networkPolicy.ingressChainName())
 		}
 		if hasEgress {
-			chainNames = append(chainNames, networkPolicy.getEgressChainName())
+			chainNames = append(chainNames, networkPolicy.egressChainName())
 		}
 	}
 	return chainNames
@@ -92,20 +92,20 @@ func (networkPolicy *NPMNetworkPolicy) hasIngressAndEgress() (hasIngress, hasEgr
 	return
 }
 
-func (networkPolicy *NPMNetworkPolicy) getEgressChainName() string {
-	return networkPolicy.getChainName(util.IptablesAzureEgressPolicyChainPrefix)
+func (networkPolicy *NPMNetworkPolicy) egressChainName() string {
+	return networkPolicy.chainName(util.IptablesAzureEgressPolicyChainPrefix)
 }
 
-func (networkPolicy *NPMNetworkPolicy) getIngressChainName() string {
-	return networkPolicy.getChainName(util.IptablesAzureIngressPolicyChainPrefix)
+func (networkPolicy *NPMNetworkPolicy) ingressChainName() string {
+	return networkPolicy.chainName(util.IptablesAzureIngressPolicyChainPrefix)
 }
 
-func (networkPolicy *NPMNetworkPolicy) getChainName(prefix string) string {
+func (networkPolicy *NPMNetworkPolicy) chainName(prefix string) string {
 	policyHash := util.Hash(networkPolicy.Name) // assuming the name is unique
 	return joinWithDash(prefix, policyHash)
 }
 
-func (pMgr *PolicyManager) getNewCreatorWithChains(chainNames []string) *ioutil.FileCreator {
+func (pMgr *PolicyManager) newCreatorWithChains(chainNames []string) *ioutil.FileCreator {
 	creator := ioutil.NewFileCreator(pMgr.ioShim, maxRetryCount, knownLineErrorPattern, unknownLineErrorPattern) // TODO pass an array instead of this ... thing
 
 	creator.AddLine("", nil, "*"+util.IptablesFilterTable) // specify the table
@@ -140,13 +140,13 @@ func (pMgr *PolicyManager) deleteJumpRule(policy *NPMNetworkPolicy, isIngress bo
 	var baseChainName string
 	var chainName string
 	if isIngress {
-		specs = getIngressJumpSpecs(policy)
+		specs = ingressJumpSpecs(policy)
 		baseChainName = util.IptablesAzureIngressChain
-		chainName = policy.getIngressChainName()
+		chainName = policy.ingressChainName()
 	} else {
-		specs = getEgressJumpSpecs(policy)
+		specs = egressJumpSpecs(policy)
 		baseChainName = util.IptablesAzureEgressChain
-		chainName = policy.getEgressChainName()
+		chainName = policy.egressChainName()
 	}
 
 	specs = append([]string{baseChainName}, specs...)
@@ -160,22 +160,22 @@ func (pMgr *PolicyManager) deleteJumpRule(policy *NPMNetworkPolicy, isIngress bo
 	return nil
 }
 
-func getIngressJumpSpecs(networkPolicy *NPMNetworkPolicy) []string {
-	chainName := networkPolicy.getIngressChainName()
+func ingressJumpSpecs(networkPolicy *NPMNetworkPolicy) []string {
+	chainName := networkPolicy.ingressChainName()
 	specs := []string{util.IptablesJumpFlag, chainName}
-	return append(specs, getMatchSetSpecsForNetworkPolicy(networkPolicy, DstMatch)...)
+	return append(specs, matchSetSpecsForNetworkPolicy(networkPolicy, DstMatch)...)
 }
 
-func getEgressJumpSpecs(networkPolicy *NPMNetworkPolicy) []string {
-	chainName := networkPolicy.getEgressChainName()
+func egressJumpSpecs(networkPolicy *NPMNetworkPolicy) []string {
+	chainName := networkPolicy.egressChainName()
 	specs := []string{util.IptablesJumpFlag, chainName}
-	return append(specs, getMatchSetSpecsForNetworkPolicy(networkPolicy, SrcMatch)...)
+	return append(specs, matchSetSpecsForNetworkPolicy(networkPolicy, SrcMatch)...)
 }
 
 // noflush add to chains impacted
 // TODO use array instead of ...
-func (pMgr *PolicyManager) getCreatorForNewNetworkPolicies(allChainNames []string, networkPolicies ...*NPMNetworkPolicy) *ioutil.FileCreator {
-	creator := pMgr.getNewCreatorWithChains(allChainNames)
+func (pMgr *PolicyManager) creatorForNewNetworkPolicies(allChainNames []string, networkPolicies ...*NPMNetworkPolicy) *ioutil.FileCreator {
+	creator := pMgr.newCreatorWithChains(allChainNames)
 
 	ingressJumpLineNumber := 1
 	egressJumpLineNumber := 1
@@ -185,12 +185,12 @@ func (pMgr *PolicyManager) getCreatorForNewNetworkPolicies(allChainNames []strin
 		// add jump rule(s) to policy chain(s)
 		hasIngress, hasEgress := networkPolicy.hasIngressAndEgress()
 		if hasIngress {
-			ingressJumpSpecs := getInsertSpecs(util.IptablesAzureIngressChain, ingressJumpLineNumber, getIngressJumpSpecs(networkPolicy))
+			ingressJumpSpecs := insertSpecs(util.IptablesAzureIngressChain, ingressJumpLineNumber, ingressJumpSpecs(networkPolicy))
 			creator.AddLine("", nil, ingressJumpSpecs...) // TODO error handler
 			ingressJumpLineNumber++
 		}
 		if hasEgress {
-			egressJumpSpecs := getInsertSpecs(util.IptablesAzureEgressChain, egressJumpLineNumber, getEgressJumpSpecs(networkPolicy))
+			egressJumpSpecs := insertSpecs(util.IptablesAzureEgressChain, egressJumpLineNumber, egressJumpSpecs(networkPolicy))
 			creator.AddLine("", nil, egressJumpSpecs...) // TODO error handler
 			egressJumpLineNumber++
 		}
@@ -205,40 +205,40 @@ func writeNetworkPolicyRules(creator *ioutil.FileCreator, networkPolicy *NPMNetw
 		var chainName string
 		var actionSpecs []string
 		if aclPolicy.hasIngress() {
-			chainName = networkPolicy.getIngressChainName()
+			chainName = networkPolicy.ingressChainName()
 			if aclPolicy.Target == Allowed {
 				actionSpecs = []string{util.IptablesJumpFlag, util.IptablesAzureEgressChain}
 			} else {
-				actionSpecs = getSetMarkSpecs(util.IptablesAzureIngressDropMarkHex)
+				actionSpecs = setMarkSpecs(util.IptablesAzureIngressDropMarkHex)
 			}
 		} else {
-			chainName = networkPolicy.getEgressChainName()
+			chainName = networkPolicy.egressChainName()
 			if aclPolicy.Target == Allowed {
 				actionSpecs = []string{util.IptablesJumpFlag, util.IptablesAzureAcceptChain}
 			} else {
-				actionSpecs = getSetMarkSpecs(util.IptablesAzureEgressDropMarkHex)
+				actionSpecs = setMarkSpecs(util.IptablesAzureEgressDropMarkHex)
 			}
 		}
 		line := []string{"-A", chainName}
 		line = append(line, actionSpecs...)
-		line = append(line, getIPTablesRuleSpecs(aclPolicy)...)
+		line = append(line, iptablesRuleSpecs(aclPolicy)...)
 		creator.AddLine("", nil, line...) // TODO add error handler
 	}
 }
 
-func getIPTablesRuleSpecs(aclPolicy *ACLPolicy) []string {
+func iptablesRuleSpecs(aclPolicy *ACLPolicy) []string {
 	specs := make([]string, 0)
 	specs = append(specs, util.IptablesProtFlag, string(aclPolicy.Protocol)) // NOTE: protocol must be ALL instead of nil
-	specs = append(specs, getPortSpecs([]Ports{aclPolicy.DstPorts})...)
-	specs = append(specs, getMatchSetSpecsFromSetInfo(aclPolicy.SrcList)...)
-	specs = append(specs, getMatchSetSpecsFromSetInfo(aclPolicy.DstList)...)
+	specs = append(specs, portSpecs([]Ports{aclPolicy.DstPorts})...)
+	specs = append(specs, matchSetSpecsFromSetInfo(aclPolicy.SrcList)...)
+	specs = append(specs, matchSetSpecsFromSetInfo(aclPolicy.DstList)...)
 	if aclPolicy.Comment != "" {
-		specs = append(specs, getCommentSpecs(aclPolicy.Comment)...)
+		specs = append(specs, commentSpecs(aclPolicy.Comment)...)
 	}
 	return specs
 }
 
-func getPortSpecs(portRanges []Ports) []string {
+func portSpecs(portRanges []Ports) []string {
 	// TODO(jungukcho): do not need to take slices since it can only have one dst port
 	if len(portRanges) != 1 {
 		return []string{}
@@ -252,7 +252,7 @@ func getPortSpecs(portRanges []Ports) []string {
 	return []string{util.IptablesDstPortFlag, portRanges[0].toIPTablesString()}
 }
 
-func getMatchSetSpecsForNetworkPolicy(networkPolicy *NPMNetworkPolicy, matchType MatchType) []string {
+func matchSetSpecsForNetworkPolicy(networkPolicy *NPMNetworkPolicy, matchType MatchType) []string {
 	// TODO update to use included boolean/new data structure from Junguk's PR
 	specs := make([]string, 0, maxLengthForMatchSetSpecs*len(networkPolicy.PodSelectorIPSets))
 	for _, translatedIPSet := range networkPolicy.PodSelectorIPSets {
@@ -263,7 +263,7 @@ func getMatchSetSpecsForNetworkPolicy(networkPolicy *NPMNetworkPolicy, matchType
 	return specs
 }
 
-func getMatchSetSpecsFromSetInfo(setInfoList []SetInfo) []string {
+func matchSetSpecsFromSetInfo(setInfoList []SetInfo) []string {
 	specs := make([]string, 0, maxLengthForMatchSetSpecs*len(setInfoList))
 	for _, setInfo := range setInfoList {
 		matchString := setInfo.MatchType.toIPTablesString()
@@ -277,7 +277,7 @@ func getMatchSetSpecsFromSetInfo(setInfoList []SetInfo) []string {
 	return specs
 }
 
-func getSetMarkSpecs(mark string) []string {
+func setMarkSpecs(mark string) []string {
 	return []string{
 		util.IptablesJumpFlag,
 		util.IptablesMark,
@@ -286,7 +286,7 @@ func getSetMarkSpecs(mark string) []string {
 	}
 }
 
-func getCommentSpecs(comment string) []string {
+func commentSpecs(comment string) []string {
 	return []string{
 		util.IptablesModuleFlag,
 		util.IptablesCommentModuleFlag,
@@ -295,7 +295,7 @@ func getCommentSpecs(comment string) []string {
 	}
 }
 
-func getInsertSpecs(chainName string, index int, specs []string) []string {
+func insertSpecs(chainName string, index int, specs []string) []string {
 	indexString := fmt.Sprint(index)
 	insertSpecs := []string{util.IptablesInsertionFlag, chainName, indexString}
 	return append(insertSpecs, specs...)

--- a/npm/pkg/dataplane/policies/policymanager_linux_test.go
+++ b/npm/pkg/dataplane/policies/policymanager_linux_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/azure-container-networking/common"
 	"github.com/Azure/azure-container-networking/npm/pkg/dataplane/ipsets"
 	dptestutils "github.com/Azure/azure-container-networking/npm/pkg/dataplane/testutils"
+	"github.com/Azure/azure-container-networking/npm/util"
 	testutils "github.com/Azure/azure-container-networking/test/utils"
 	"github.com/stretchr/testify/require"
 )
@@ -33,10 +34,17 @@ var (
 	testACLRule4 = fmt.Sprintf("-j AZURE-NPM-ACCEPT -p all -m set --match-set %s src -m comment --comment comment4", ipsets.TestCIDRSet.HashedName)
 )
 
+func TestChainNames(t *testing.T) {
+	expectedName := fmt.Sprintf("AZURE-NPM-INGRESS-%s", util.Hash(TestNetworkPolicies[0].Name))
+	require.Equal(t, expectedName, TestNetworkPolicies[0].getIngressChainName())
+	expectedName = fmt.Sprintf("AZURE-NPM-EGRESS-%s", util.Hash(TestNetworkPolicies[0].Name))
+	require.Equal(t, expectedName, TestNetworkPolicies[0].getEgressChainName())
+}
+
 func TestAddPolicies(t *testing.T) {
 	calls := []testutils.TestCmd{fakeIPTablesRestoreCommand}
 	pMgr := NewPolicyManager(common.NewMockIOShim(calls))
-	creator := pMgr.getCreatorForNewNetworkPolicies(TestNetworkPolicies...)
+	creator := pMgr.getCreatorForNewNetworkPolicies(getAllChainNames(TestNetworkPolicies), TestNetworkPolicies...)
 	actualLines := strings.Split(creator.ToString(), "\n")
 	expectedLines := []string{
 		"*filter",
@@ -81,7 +89,7 @@ func TestRemovePolicies(t *testing.T) {
 		fakeIPTablesRestoreCommand,
 	}
 	pMgr := NewPolicyManager(common.NewMockIOShim(calls))
-	creator := pMgr.getCreatorForRemovingPolicies(TestNetworkPolicies...)
+	creator := pMgr.getCreatorForRemovingPolicies(getAllChainNames(TestNetworkPolicies))
 	actualLines := strings.Split(creator.ToString(), "\n")
 	expectedLines := []string{
 		"*filter",
@@ -113,7 +121,7 @@ func TestRemovePoliciesErrorOnRestore(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestRemovePoliciesErrorOnIngressRule(t *testing.T) {
+func TestRemovePoliciesErrorOnDeleteForIngress(t *testing.T) {
 	calls := []testutils.TestCmd{
 		fakeIPTablesRestoreCommand,
 		getFakeDeleteJumpCommandWithCode("AZURE-NPM-INGRESS", testPolicy1IngressJump, 1), // anything but 0 or 2
@@ -125,7 +133,7 @@ func TestRemovePoliciesErrorOnIngressRule(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestRemovePoliciesErrorOnEgressRule(t *testing.T) {
+func TestRemovePoliciesErrorOnDeleteForEgress(t *testing.T) {
 	calls := []testutils.TestCmd{
 		fakeIPTablesRestoreCommand,
 		getFakeDeleteJumpCommand("AZURE-NPM-INGRESS", testPolicy1IngressJump),
@@ -136,4 +144,44 @@ func TestRemovePoliciesErrorOnEgressRule(t *testing.T) {
 	require.NoError(t, err)
 	err = pMgr.RemovePolicy(TestNetworkPolicies[0].Name, nil)
 	require.Error(t, err)
+}
+
+func TestUpdatingChainsToCleanup(t *testing.T) {
+	calls := GetAddPolicyTestCalls(TestNetworkPolicies[0])
+	calls = append(calls, GetRemovePolicyTestCalls(TestNetworkPolicies[0])...)
+	calls = append(calls, GetAddPolicyTestCalls(TestNetworkPolicies[1])...)
+	calls = append(calls, GetRemovePolicyFailureTestCalls(TestNetworkPolicies[1])...)
+	calls = append(calls, GetAddPolicyTestCalls(TestNetworkPolicies[2])...)
+	calls = append(calls, GetRemovePolicyTestCalls(TestNetworkPolicies[2])...)
+	calls = append(calls, GetAddPolicyFailureTestCalls(TestNetworkPolicies[2])...)
+	calls = append(calls, GetAddPolicyTestCalls(TestNetworkPolicies[0])...)
+	ioshim := common.NewMockIOShim(calls)
+	// TODO defer ioshim.VerifyCalls(t, ioshim, calls)
+	pMgr := NewPolicyManager(ioshim)
+
+	// FIXME off because of grep stuff
+	require.NoError(t, pMgr.AddPolicy(TestNetworkPolicies[0], nil))
+	assertEqualCleanupContents(t, pMgr)
+	require.NoError(t, pMgr.RemovePolicy(TestNetworkPolicies[0].Name, nil))
+	assertEqualCleanupContents(t, pMgr, testPolicy1IngressChain, testPolicy1EgressChain)
+
+	// require.NoError(t, pMgr.AddPolicy(TestNetworkPolicies[1], nil))
+	// assertEqualCleanupContents(t, pMgr, testPolicy1IngressChain, testPolicy1EgressChain)
+	// require.Error(t, pMgr.RemovePolicy(TestNetworkPolicies[1].Name, nil))
+	// assertEqualCleanupContents(t, pMgr, testPolicy1IngressChain, testPolicy1EgressChain)
+
+	// require.NoError(t, pMgr.AddPolicy(TestNetworkPolicies[2], nil))
+	// assertEqualCleanupContents(t, pMgr, testPolicy1IngressChain, testPolicy1EgressChain)
+	// require.Error(t, pMgr.RemovePolicy(TestNetworkPolicies[2].Name, nil))
+	// assertEqualCleanupContents(t, pMgr, testPolicy1IngressChain, testPolicy1EgressChain, testPolicy3EgressChain)
+	// require.NoError(t, pMgr.AddPolicy(TestNetworkPolicies[0], nil))
+	// assertEqualCleanupContents(t, pMgr, testPolicy3EgressChain)
+}
+
+func assertEqualCleanupContents(t *testing.T, pMgr *PolicyManager, expectedChains ...string) {
+	require.Equal(t, len(expectedChains), len(pMgr.chainsToCleanup), "incorrectly tracking chains for cleanup")
+	for _, chain := range expectedChains {
+		_, exists := pMgr.chainsToCleanup[chain]
+		require.True(t, exists, "incorrectly tracking chains for cleanup")
+	}
 }

--- a/npm/pkg/dataplane/policies/policymanager_linux_test.go
+++ b/npm/pkg/dataplane/policies/policymanager_linux_test.go
@@ -160,27 +160,19 @@ func TestUpdatingChainsToCleanup(t *testing.T) {
 	pMgr := NewPolicyManager(ioshim)
 
 	require.NoError(t, pMgr.AddPolicy(TestNetworkPolicies[0], nil))
-	assertEqualCleanupContents(t, pMgr)
+	assertStaleChainsContain(t, pMgr.staleChains)
 	require.NoError(t, pMgr.RemovePolicy(TestNetworkPolicies[0].Name, nil))
-	assertEqualCleanupContents(t, pMgr, testPolicy1IngressChain, testPolicy1EgressChain)
+	assertStaleChainsContain(t, pMgr.staleChains, testPolicy1IngressChain, testPolicy1EgressChain)
 
 	// TODO uncomment when grep stuff is fixed
 	// require.NoError(t, pMgr.AddPolicy(TestNetworkPolicies[1], nil))
-	// assertEqualCleanupContents(t, pMgr, testPolicy1IngressChain, testPolicy1EgressChain)
+	// assertStaleChainsContain(t, pMgr.staleChains, testPolicy1IngressChain, testPolicy1EgressChain)
 	// require.Error(t, pMgr.RemovePolicy(TestNetworkPolicies[1].Name, nil))
-	// assertEqualCleanupContents(t, pMgr, testPolicy1IngressChain, testPolicy1EgressChain)
+	// assertStaleChainsContain(t, pMgr.staleChains, testPolicy1IngressChain, testPolicy1EgressChain)
 	// require.NoError(t, pMgr.AddPolicy(TestNetworkPolicies[2], nil))
-	// assertEqualCleanupContents(t, pMgr, testPolicy1IngressChain, testPolicy1EgressChain)
+	// assertStaleChainsContain(t, pMgr.staleChains, testPolicy1IngressChain, testPolicy1EgressChain)
 	// require.Error(t, pMgr.RemovePolicy(TestNetworkPolicies[2].Name, nil))
-	// assertEqualCleanupContents(t, pMgr, testPolicy1IngressChain, testPolicy1EgressChain, testPolicy3EgressChain)
+	// assertStaleChainsContain(t, pMgr.staleChains, testPolicy1IngressChain, testPolicy1EgressChain, testPolicy3EgressChain)
 	// require.NoError(t, pMgr.AddPolicy(TestNetworkPolicies[0], nil))
-	// assertEqualCleanupContents(t, pMgr, testPolicy3EgressChain)
-}
-
-func assertEqualCleanupContents(t *testing.T, pMgr *PolicyManager, expectedChains ...string) {
-	require.Equal(t, len(expectedChains), len(pMgr.chainsToCleanup), "incorrectly tracking chains for cleanup")
-	for _, chain := range expectedChains {
-		_, exists := pMgr.chainsToCleanup[chain]
-		require.True(t, exists, "incorrectly tracking chains for cleanup")
-	}
+	// assertStaleChainsContain(t, pMgr.staleChains, testPolicy3EgressChain)
 }

--- a/npm/pkg/dataplane/policies/policymanager_linux_test.go
+++ b/npm/pkg/dataplane/policies/policymanager_linux_test.go
@@ -159,17 +159,16 @@ func TestUpdatingChainsToCleanup(t *testing.T) {
 	// TODO defer ioshim.VerifyCalls(t, ioshim, calls)
 	pMgr := NewPolicyManager(ioshim)
 
-	// FIXME off because of grep stuff
 	require.NoError(t, pMgr.AddPolicy(TestNetworkPolicies[0], nil))
 	assertEqualCleanupContents(t, pMgr)
 	require.NoError(t, pMgr.RemovePolicy(TestNetworkPolicies[0].Name, nil))
 	assertEqualCleanupContents(t, pMgr, testPolicy1IngressChain, testPolicy1EgressChain)
 
+	// TODO uncomment when grep stuff is fixed
 	// require.NoError(t, pMgr.AddPolicy(TestNetworkPolicies[1], nil))
 	// assertEqualCleanupContents(t, pMgr, testPolicy1IngressChain, testPolicy1EgressChain)
 	// require.Error(t, pMgr.RemovePolicy(TestNetworkPolicies[1].Name, nil))
 	// assertEqualCleanupContents(t, pMgr, testPolicy1IngressChain, testPolicy1EgressChain)
-
 	// require.NoError(t, pMgr.AddPolicy(TestNetworkPolicies[2], nil))
 	// assertEqualCleanupContents(t, pMgr, testPolicy1IngressChain, testPolicy1EgressChain)
 	// require.Error(t, pMgr.RemovePolicy(TestNetworkPolicies[2].Name, nil))

--- a/npm/pkg/dataplane/policies/policymanager_linux_test.go
+++ b/npm/pkg/dataplane/policies/policymanager_linux_test.go
@@ -14,10 +14,10 @@ import (
 )
 
 var (
-	testPolicy1IngressChain = TestNetworkPolicies[0].getIngressChainName()
-	testPolicy1EgressChain  = TestNetworkPolicies[0].getEgressChainName()
-	testPolicy2IngressChain = TestNetworkPolicies[1].getIngressChainName()
-	testPolicy3EgressChain  = TestNetworkPolicies[2].getEgressChainName()
+	testPolicy1IngressChain = TestNetworkPolicies[0].ingressChainName()
+	testPolicy1EgressChain  = TestNetworkPolicies[0].egressChainName()
+	testPolicy2IngressChain = TestNetworkPolicies[1].ingressChainName()
+	testPolicy3EgressChain  = TestNetworkPolicies[2].egressChainName()
 
 	testPolicy1IngressJump = fmt.Sprintf("-j %s -m set --match-set %s dst", testPolicy1IngressChain, ipsets.TestKVNSList.HashedName)
 	testPolicy1EgressJump  = fmt.Sprintf("-j %s -m set --match-set %s src", testPolicy1EgressChain, ipsets.TestKVNSList.HashedName)
@@ -36,15 +36,15 @@ var (
 
 func TestChainNames(t *testing.T) {
 	expectedName := fmt.Sprintf("AZURE-NPM-INGRESS-%s", util.Hash(TestNetworkPolicies[0].Name))
-	require.Equal(t, expectedName, TestNetworkPolicies[0].getIngressChainName())
+	require.Equal(t, expectedName, TestNetworkPolicies[0].ingressChainName())
 	expectedName = fmt.Sprintf("AZURE-NPM-EGRESS-%s", util.Hash(TestNetworkPolicies[0].Name))
-	require.Equal(t, expectedName, TestNetworkPolicies[0].getEgressChainName())
+	require.Equal(t, expectedName, TestNetworkPolicies[0].egressChainName())
 }
 
 func TestAddPolicies(t *testing.T) {
 	calls := []testutils.TestCmd{fakeIPTablesRestoreCommand}
 	pMgr := NewPolicyManager(common.NewMockIOShim(calls))
-	creator := pMgr.getCreatorForNewNetworkPolicies(getAllChainNames(TestNetworkPolicies), TestNetworkPolicies...)
+	creator := pMgr.creatorForNewNetworkPolicies(allChainNames(TestNetworkPolicies), TestNetworkPolicies...)
 	actualLines := strings.Split(creator.ToString(), "\n")
 	expectedLines := []string{
 		"*filter",
@@ -89,7 +89,7 @@ func TestRemovePolicies(t *testing.T) {
 		fakeIPTablesRestoreCommand,
 	}
 	pMgr := NewPolicyManager(common.NewMockIOShim(calls))
-	creator := pMgr.getCreatorForRemovingPolicies(getAllChainNames(TestNetworkPolicies))
+	creator := pMgr.creatorForRemovingPolicies(allChainNames(TestNetworkPolicies))
 	actualLines := strings.Split(creator.ToString(), "\n")
 	expectedLines := []string{
 		"*filter",

--- a/npm/pkg/dataplane/policies/policymanager_windows.go
+++ b/npm/pkg/dataplane/policies/policymanager_windows.go
@@ -15,15 +15,15 @@ var (
 	ErrFailedUnMarshalACLSettings = errors.New("Failed to unmarshal ACL settings")
 )
 
-type osTools struct{}
+type staleChains struct{} // unused in Windows
 
 type endpointPolicyBuilder struct {
 	aclPolicies   []*NPMACLPolSettings
 	otherPolicies []hcn.EndpointPolicy
 }
 
-func makeTools() osTools {
-	return osTools{}
+func newStaleChains() *staleChains {
+	return &staleChains{}
 }
 
 func (pMgr *PolicyManager) reboot() error {

--- a/npm/pkg/dataplane/policies/policymanager_windows.go
+++ b/npm/pkg/dataplane/policies/policymanager_windows.go
@@ -15,9 +15,20 @@ var (
 	ErrFailedUnMarshalACLSettings = errors.New("Failed to unmarshal ACL settings")
 )
 
+type osTools struct{}
+
 type endpointPolicyBuilder struct {
 	aclPolicies   []*NPMACLPolSettings
 	otherPolicies []hcn.EndpointPolicy
+}
+
+func makeTools() osTools {
+	return osTools{}
+}
+
+func (pMgr *PolicyManager) reboot() error {
+	// TODO should we something here?
+	return nil
 }
 
 func (pMgr *PolicyManager) initialize() error {
@@ -28,6 +39,10 @@ func (pMgr *PolicyManager) initialize() error {
 func (pMgr *PolicyManager) reset() error {
 	// TODO
 	return nil
+}
+
+func (pMgr *PolicyManager) reconcile(stopChannel <-chan struct{}) {
+	// TODO
 }
 
 func (pMgr *PolicyManager) addPolicy(policy *NPMNetworkPolicy, endpointList map[string]string) error {

--- a/npm/pkg/dataplane/policies/policymanager_windows.go
+++ b/npm/pkg/dataplane/policies/policymanager_windows.go
@@ -41,7 +41,7 @@ func (pMgr *PolicyManager) reset() error {
 	return nil
 }
 
-func (pMgr *PolicyManager) reconcile(stopChannel <-chan struct{}) {
+func (pMgr *PolicyManager) reconcile() {
 	// TODO
 }
 

--- a/npm/pkg/dataplane/policies/testutils_linux.go
+++ b/npm/pkg/dataplane/policies/testutils_linux.go
@@ -19,6 +19,10 @@ func GetAddPolicyTestCalls(_ *NPMNetworkPolicy) []testutils.TestCmd {
 	return []testutils.TestCmd{fakeIPTablesRestoreCommand}
 }
 
+func GetAddPolicyFailureTestCalls(_ *NPMNetworkPolicy) []testutils.TestCmd {
+	return []testutils.TestCmd{fakeIPTablesRestoreFailureCommand}
+}
+
 func GetRemovePolicyTestCalls(policy *NPMNetworkPolicy) []testutils.TestCmd {
 	calls := []testutils.TestCmd{}
 	hasIngress, hasEgress := policy.hasIngressAndEgress()
@@ -34,6 +38,13 @@ func GetRemovePolicyTestCalls(policy *NPMNetworkPolicy) []testutils.TestCmd {
 	}
 
 	calls = append(calls, fakeIPTablesRestoreCommand)
+	return calls
+}
+
+// GetRemovePolicyFailureTestCalls fails on the restore
+func GetRemovePolicyFailureTestCalls(policy *NPMNetworkPolicy) []testutils.TestCmd {
+	calls := GetRemovePolicyTestCalls(policy)
+	calls[len(calls)-1] = fakeIPTablesRestoreFailureCommand // replace the restore success with a failure
 	return calls
 }
 

--- a/npm/pkg/dataplane/policies/testutils_linux.go
+++ b/npm/pkg/dataplane/policies/testutils_linux.go
@@ -28,12 +28,12 @@ func GetRemovePolicyTestCalls(policy *NPMNetworkPolicy) []testutils.TestCmd {
 	hasIngress, hasEgress := policy.hasIngressAndEgress()
 	if hasIngress {
 		deleteIngressJumpSpecs := []string{"iptables", "-w", "60", "-D", util.IptablesAzureIngressChain}
-		deleteIngressJumpSpecs = append(deleteIngressJumpSpecs, getIngressJumpSpecs(policy)...)
+		deleteIngressJumpSpecs = append(deleteIngressJumpSpecs, ingressJumpSpecs(policy)...)
 		calls = append(calls, testutils.TestCmd{Cmd: deleteIngressJumpSpecs})
 	}
 	if hasEgress {
 		deleteEgressJumpSpecs := []string{"iptables", "-w", "60", "-D", util.IptablesAzureEgressChain}
-		deleteEgressJumpSpecs = append(deleteEgressJumpSpecs, getEgressJumpSpecs(policy)...)
+		deleteEgressJumpSpecs = append(deleteEgressJumpSpecs, egressJumpSpecs(policy)...)
 		calls = append(calls, testutils.TestCmd{Cmd: deleteEgressJumpSpecs})
 	}
 


### PR DESCRIPTION
Features:
- Cleans up dead policy chains in the background.
- Removes and adds all chains when the number of policies becomes 0.