### PR TITLE
use goldpinger image which supports IPv6 and only pings ready pods

### DIFF
--- a/test/integration/manifests/goldpinger/daemonset.yaml
+++ b/test/integration/manifests/goldpinger/daemonset.yaml
@@ -53,7 +53,7 @@ spec:
                   fieldPath: status.podIP
 #            - name: HOSTS_TO_RESOLVE
 #              value: "1.1.1.1 8.8.8.8 www.bing.com"
-          image: "docker.io/bloomberg/goldpinger:v3.0.0"
+          image: "docker.io/bloomberg/goldpinger:v3.3.0"
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/test/integration/manifests/goldpinger/deployment.yaml
+++ b/test/integration/manifests/goldpinger/deployment.yaml
@@ -49,7 +49,7 @@ spec:
                   fieldPath: status.podIP
             - name: HOSTS_TO_RESOLVE
               value: "1.1.1.1 8.8.8.8 www.bing.com"
-          image: "docker.io/bloomberg/goldpinger:v3.0.0"
+          image: "docker.io/bloomberg/goldpinger:v3.3.0"
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true


### PR DESCRIPTION
Signed-off-by: Evan Baker <rbtr@users.noreply.github.com>

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
While we wait for bloomberg to cut a new goldpinger release, I have updated the e2e with an image with [my change that only pings ready pods.](https://github.com/bloomberg/goldpinger/pull/107)

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
