### PR TITLE
feat: [NPM] Support pod grace period for v2 

### DIFF
--- a/npm/pkg/controlplane/controllers/v1/podController.go
+++ b/npm/pkg/controlplane/controllers/v1/podController.go
@@ -21,11 +21,10 @@ import (
 	coreinformer "k8s.io/client-go/informers/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 
+	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
-
-	k8slabels "k8s.io/apimachinery/pkg/labels"
 )
 
 // NamedPortOperation decides opeartion (e.g., delete or add) for named port ipset in manageNamedPortIpsets

--- a/npm/pkg/controlplane/controllers/v1/podController.go
+++ b/npm/pkg/controlplane/controllers/v1/podController.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
+
+	k8slabels "k8s.io/apimachinery/pkg/labels"
 )
 
 // NamedPortOperation decides opeartion (e.g., delete or add) for named port ipset in manageNamedPortIpsets
@@ -88,7 +90,7 @@ func (nPod *NpmPod) noUpdate(podObj *corev1.Pod) bool {
 		nPod.Name == podObj.ObjectMeta.Name &&
 		nPod.Phase == podObj.Status.Phase &&
 		nPod.PodIP == podObj.Status.PodIP &&
-		util.IsSameLabels(nPod.Labels, podObj.ObjectMeta.Labels) &&
+		k8slabels.Equals(nPod.Labels, podObj.ObjectMeta.Labels) &&
 		// TODO(jungukcho) to avoid using DeepEqual for ContainerPorts,
 		// it needs a precise sorting. Will optimize it later if needed.
 		reflect.DeepEqual(nPod.ContainerPorts, getContainerPortList(podObj))

--- a/npm/util/util.go
+++ b/npm/util/util.go
@@ -338,18 +338,3 @@ func CompareSlices(list1, list2 []string) bool {
 func SliceToString(list []string) string {
 	return strings.Join(list, SetPolicyDelimiter)
 }
-
-// IsSameLabels return if all pairs of key and value in two maps are same.
-// Otherwise, it returns false.
-func IsSameLabels(labelA, labelB map[string]string) bool {
-	if len(labelA) != len(labelB) {
-		return false
-	}
-
-	for labelKey, labelVal := range labelA {
-		if val, exist := labelB[labelKey]; !exist || labelVal != val {
-			return false
-		}
-	}
-	return true
-}

--- a/npm/util/util_test.go
+++ b/npm/util/util_test.go
@@ -4,7 +4,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/version"
 )
 
@@ -322,110 +321,5 @@ func TestCompareSlices(t *testing.T) {
 
 	if !CompareSlices(list1, list2) {
 		t.Errorf("TestCompareSlices failed @ slice comparison 4")
-	}
-}
-
-func TestIsSameLabels(t *testing.T) {
-	var nilLabel map[string]string
-	tests := []struct {
-		name                string
-		labelA              map[string]string
-		labelB              map[string]string
-		expectedIsSameLabel bool
-	}{
-		{
-			name:                "Empty labels",
-			labelA:              map[string]string{},
-			labelB:              map[string]string{},
-			expectedIsSameLabel: true,
-		},
-		{
-			name:                "Empty label and Nil label",
-			labelA:              map[string]string{},
-			labelB:              nilLabel,
-			expectedIsSameLabel: true,
-		},
-		{
-			name: "Same labels",
-			labelA: map[string]string{
-				"e": "f",
-				"c": "d",
-				"a": "b",
-			},
-			labelB: map[string]string{
-				"e": "f",
-				"c": "d",
-				"a": "b",
-			},
-			expectedIsSameLabel: true,
-		},
-		{
-			name: "Same labels with different ordered addition",
-			labelA: map[string]string{
-				"e": "f",
-				"c": "d",
-				"a": "b",
-			},
-			labelB: map[string]string{
-				"c": "d",
-				"e": "f",
-				"a": "b",
-			},
-			expectedIsSameLabel: true,
-		},
-		{
-			name: "Different length",
-			labelA: map[string]string{
-				"e": "f",
-			},
-			labelB: map[string]string{
-				"e": "f",
-				"a": "b",
-			},
-			expectedIsSameLabel: false,
-		},
-		{
-			name:   "Different (empty map and non-empty map)",
-			labelA: map[string]string{},
-			labelB: map[string]string{
-				"e": "f",
-				"c": "d",
-				"a": "b",
-			},
-			expectedIsSameLabel: false,
-		},
-		{
-			name:   "Different (nil map and non-empty map)",
-			labelA: nilLabel,
-			labelB: map[string]string{
-				"e": "f",
-				"c": "d",
-				"a": "b",
-			},
-			expectedIsSameLabel: false,
-		},
-		{
-			name: "Have a different one pair of key and value",
-			labelA: map[string]string{
-				"e": "f",
-				"d": "c",
-				"a": "b",
-			},
-			labelB: map[string]string{
-				"e": "f",
-				"c": "d",
-				"a": "b",
-			},
-			expectedIsSameLabel: false,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := IsSameLabels(tt.labelA, tt.labelB)
-			require.Equal(t, tt.expectedIsSameLabel, got)
-		})
 	}
 }


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
PodController in NPM removes ipset information as soon as Pod's status becomes “Terminating”.
So, even though terminated Pod has some activities (e.g., sending traffic to other pods to notify something) during "Terminating" status, NPM does not allow this connection from the Pod.
Thus, NPM needs to delay cleanup process until Pod completes graceful shutdown.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #1066

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation - in `support-pod-grace-period` directory in acndoc
- [x] adds unit tests


**Notes**:
Previous PR for v1 - feat: [NPM] Support graceful shutdown in pod #1083 