### PR TITLE
refactor: [NPM] General translation logic for egress and ingress

### DIFF
--- a/npm/pkg/controlplane/translation/parseSelector.go
+++ b/npm/pkg/controlplane/translation/parseSelector.go
@@ -163,7 +163,8 @@ func newParsedSelectors() parsedSelectors {
 func (ps *parsedSelectors) addSelector(include bool, setType ipsets.SetType, setName string, members ...string) {
 	setNameWithOp := setName
 	if !include {
-		setNameWithOp = "!" + setName
+		// adding setType.String() is not necessary, but it has more robust just in case.
+		setNameWithOp = "!" + setName + setType.String()
 	}
 
 	// in case setNameWithOp exists in a set, do not need to add it.

--- a/npm/pkg/controlplane/translation/translatePolicy.go
+++ b/npm/pkg/controlplane/translation/translatePolicy.go
@@ -384,7 +384,7 @@ func ingressPolicy(npmNetPol *policies.NPMNetworkPolicy, ingress []networkingv1.
 		return
 	}
 
-	// #2. If ingress is nil (in yaml, it is specified with `[]``), it means it does not allow receiving any traffic from others.
+	// #2. If ingress is nil (in yaml, it is specified with '[]'), it means it does not allow receiving any traffic from others.
 	// In the case, skip translateRule function call and only need default drop ACL..
 	// If ingress is not nil, it is not AllowAll and DropAll. So, start translateRule ingress policy.
 	if ingress != nil {
@@ -416,7 +416,7 @@ func egressPolicy(npmNetPol *policies.NPMNetworkPolicy, egress []networkingv1.Ne
 		return
 	}
 
-	// #2. If egress is nil (in yaml, it is specified with `[]``), it means it does not allow sending traffic to others.
+	// #2. If egress is nil (in yaml, it is specified with '[]'), it means it does not allow sending traffic to others.
 	// In the case, skip translateRule function call and only need default drop ACL..
 	// If egress is not nil, it is not AllowAll and DropAll. So, start translateRule egress policy.
 	if egress != nil {

--- a/npm/pkg/controlplane/translation/translatePolicy.go
+++ b/npm/pkg/controlplane/translation/translatePolicy.go
@@ -270,12 +270,12 @@ func translateRule(npmNetPol *policies.NPMNetworkPolicy, direction policies.Dire
 	ports []networkingv1.NetworkPolicyPort, peers []networkingv1.NetworkPolicyPeer) {
 	// TODO(jungukcho): need to clean up it.
 	// Leave allowExternal variable now while the condition is checked before calling this function.
-	allowExternal, portRuleExists, fromRuleExists := ruleExists(ports, peers)
+	allowExternal, portRuleExists, peerRuleExists := ruleExists(ports, peers)
 
 	// #0. TODO(jungukcho): cannot come up when this condition is met.
 	// The code inside if condition is to handle allowing all internal traffic, but the case is handled in #2.4.
 	// So, this code may not execute. After confirming this, need to delete it.
-	if !portRuleExists && !fromRuleExists && !allowExternal {
+	if !portRuleExists && !peerRuleExists && !allowExternal {
 		acl := policies.NewACLPolicy(npmNetPol.NameSpace, npmNetPol.Name, policies.Allowed, direction)
 		ruleIPSets, allowAllInternalSetInfo := allowAllInternal(matchType)
 		npmNetPol.RuleIPSets = append(npmNetPol.RuleIPSets, ruleIPSets)
@@ -285,7 +285,7 @@ func translateRule(npmNetPol *policies.NPMNetworkPolicy, direction policies.Dire
 	}
 
 	// #1. Only Ports fields exist in rule
-	if portRuleExists && !fromRuleExists && !allowExternal {
+	if portRuleExists && !peerRuleExists && !allowExternal {
 		for i := range ports {
 			portKind, err := portType(ports[i])
 			if err != nil {

--- a/npm/pkg/controlplane/translation/translatePolicy_test.go
+++ b/npm/pkg/controlplane/translation/translatePolicy_test.go
@@ -1106,7 +1106,7 @@ func TestAllowAllTraffic(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			nsSelectorIPSets, nsSelectorList := allowAllTraffic(tt.matchType)
+			nsSelectorIPSets, nsSelectorList := allowAllInternal(tt.matchType)
 			require.Equal(t, tt.nsSelectorIPSets, nsSelectorIPSets)
 			require.Equal(t, tt.nsSelectorList, nsSelectorList)
 		})
@@ -1595,7 +1595,7 @@ func TestPeerAndPortRule(t *testing.T) {
 				Name:      tt.npmNetPol.Name,
 				NameSpace: tt.npmNetPol.NameSpace,
 			}
-			peerAndPortRule(npmNetPol, tt.ports, setInfo)
+			peerAndPortRule(npmNetPol, policies.Ingress, tt.ports, setInfo)
 			require.Equal(t, tt.npmNetPol, npmNetPol)
 		})
 	}
@@ -1603,7 +1603,7 @@ func TestPeerAndPortRule(t *testing.T) {
 
 func TestIngressPolicy(t *testing.T) {
 	tcp := v1.ProtocolTCP
-	targetPodMatchType := policies.DstMatch
+	targetPodMatchType := policies.EitherMatch
 	peerMatchType := policies.SrcMatch
 	// TODO(jungukcho): add test cases with more complex rules
 	tests := []struct {
@@ -1650,6 +1650,7 @@ func TestIngressPolicy(t *testing.T) {
 						},
 						Protocol: "TCP",
 					},
+					defaultDropACL("default", "serve-tcp", policies.Ingress),
 				},
 			},
 		},
@@ -1695,6 +1696,7 @@ func TestIngressPolicy(t *testing.T) {
 							policies.NewSetInfo("only-ipblock-in-ns-default-0IN", ipsets.CIDRBlocks, included, peerMatchType),
 						},
 					},
+					defaultDropACL("default", "only-ipblock", policies.Ingress),
 				},
 			},
 		},
@@ -1743,6 +1745,7 @@ func TestIngressPolicy(t *testing.T) {
 							policies.NewSetInfo("default", ipsets.Namespace, included, peerMatchType),
 						},
 					},
+					defaultDropACL("default", "only-peer-podSelector", policies.Ingress),
 				},
 			},
 		},
@@ -1789,6 +1792,7 @@ func TestIngressPolicy(t *testing.T) {
 							policies.NewSetInfo("peer-nsselector-kay:peer-nsselector-value", ipsets.KeyValueLabelOfNamespace, included, peerMatchType),
 						},
 					},
+					defaultDropACL("default", "only-peer-nsSelector", policies.Ingress),
 				},
 			},
 		},
@@ -1801,7 +1805,7 @@ func TestIngressPolicy(t *testing.T) {
 				Name:      tt.npmNetPol.Name,
 				NameSpace: tt.npmNetPol.NameSpace,
 			}
-			npmNetPol.PodSelectorIPSets, npmNetPol.PodSelectorList = podSelectorWithNS(npmNetPol.NameSpace, policies.DstMatch, tt.targetSelector)
+			npmNetPol.PodSelectorIPSets, npmNetPol.PodSelectorList = podSelectorWithNS(npmNetPol.NameSpace, policies.EitherMatch, tt.targetSelector)
 			ingressPolicy(npmNetPol, tt.rules)
 			require.Equal(t, tt.npmNetPol, npmNetPol)
 		})

--- a/npm/pkg/controlplane/translation/translatePolicy_test.go
+++ b/npm/pkg/controlplane/translation/translatePolicy_test.go
@@ -1601,7 +1601,7 @@ func TestPeerAndPortRule(t *testing.T) {
 	}
 }
 
-func TestTranslateIngress(t *testing.T) {
+func TestIngressPolicy(t *testing.T) {
 	tcp := v1.ProtocolTCP
 	targetPodMatchType := policies.DstMatch
 	peerMatchType := policies.SrcMatch
@@ -1801,7 +1801,8 @@ func TestTranslateIngress(t *testing.T) {
 				Name:      tt.npmNetPol.Name,
 				NameSpace: tt.npmNetPol.NameSpace,
 			}
-			translateIngress(npmNetPol, tt.targetSelector, tt.rules)
+			npmNetPol.PodSelectorIPSets, npmNetPol.PodSelectorList = podSelectorWithNS(npmNetPol.NameSpace, policies.DstMatch, tt.targetSelector)
+			ingressPolicy(npmNetPol, tt.rules)
 			require.Equal(t, tt.npmNetPol, npmNetPol)
 		})
 	}

--- a/npm/pkg/dataplane/policies/policy.go
+++ b/npm/pkg/dataplane/policies/policy.go
@@ -11,9 +11,6 @@ import (
 type NPMNetworkPolicy struct {
 	Name      string
 	NameSpace string
-	// TODO(jungukcho)
-	// ipsets.IPSetMetadata is common data in both PodSelectorIPSets and PodSelectorList.
-	// So, they can be one datastructure holding all information without redundancy.
 	// PodSelectorIPSets holds all the IPSets generated from Pod Selector
 	PodSelectorIPSets []*ipsets.TranslatedIPSet
 	// PodSelectorList holds target pod information to avoid duplicatoin in SrcList and DstList fields in ACLs
@@ -36,6 +33,10 @@ type ACLPolicy struct {
 	PolicyID string
 	// Comment is the string attached to rule to identity its representation
 	Comment string
+	// TODO(jungukcho): now I think we do not need to manage SrcList and DstList
+	// We may have just one PeerList to hold since it will depend on direction except for namedPort.
+	// They are exclusive and each SetInfo even have its own direction.
+	// PeerList []SetInfo
 	// SrcList source IPSets condition setinfos
 	SrcList []SetInfo
 	// DstList destination IPSets condition setinfos
@@ -68,6 +69,27 @@ func NewACLPolicy(policyNS, policyName string, target Verdict, direction Directi
 		Direction: direction,
 	}
 	return acl
+}
+
+// AddSetInfo is to add setInfo to SrcList or DstList based on direction
+// except for a setInfo for namedPort since namedPort is always for destination.
+// TODO(jungukcho): cannot come up with Both Direction.
+func (aclPolicy *ACLPolicy) AddSetInfo(peerList []SetInfo) {
+	for _, peer := range peerList {
+		// in case peer is a setInfo for namedPort, the peer is always added to DstList in aclPolicy
+		// regardless of direction since namePort is always for destination.
+		if peer.MatchType == DstDstMatch {
+			aclPolicy.DstList = append(aclPolicy.DstList, peer)
+			continue
+		}
+
+		// add peer into SrcList or DstList based on Direction
+		if aclPolicy.Direction == Ingress {
+			aclPolicy.SrcList = append(aclPolicy.SrcList, peer)
+		} else if aclPolicy.Direction == Egress {
+			aclPolicy.DstList = append(aclPolicy.DstList, peer)
+		}
+	}
 }
 
 func (aclPolicy *ACLPolicy) hasKnownDirection() bool {
@@ -181,14 +203,13 @@ const (
 )
 
 // Possible MatchTypes.
-// MatchTypes with 2 locations (e.g. DstDst) are for ip and port respectively.
 const (
 	SrcMatch MatchType = 0
 	DstMatch MatchType = 1
-	// TODO(jungukcho) Question - Why it is 3, not 2?
-	DstDstMatch MatchType = 3
+	// MatchTypes with 2 locations (e.g. DstDst) are for ip and port respectively.
+	DstDstMatch MatchType = 2
 	// This is used for podSelector under spec. It can be Src or Dst based on existence of ingress or egress rule.
-	EitherMatch MatchType = 4
+	EitherMatch MatchType = 3
 )
 
 var matchTypeStrings = map[MatchType]string{

--- a/npm/pkg/dataplane/policies/policy.go
+++ b/npm/pkg/dataplane/policies/policy.go
@@ -183,9 +183,12 @@ const (
 // Possible MatchTypes.
 // MatchTypes with 2 locations (e.g. DstDst) are for ip and port respectively.
 const (
-	SrcMatch    MatchType = 0
-	DstMatch    MatchType = 1
+	SrcMatch MatchType = 0
+	DstMatch MatchType = 1
+	// TODO(jungukcho) Question - Why it is 3, not 2?
 	DstDstMatch MatchType = 3
+	// This is used for podSelector under spec. It can be Src or Dst based on existence of ingress or egress rule.
+	EitherMatch MatchType = 4
 )
 
 var matchTypeStrings = map[MatchType]string{


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
This PR is to support egress and generalizes translation for egress and ingress.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests


**Notes**:
1. [NPM] General translation logic for linux and windows #1055
2. refactor: [NPM] parsing label selector for general translation logic #1077
3. refactor: [NPM] General translation logic (mainly clean-up codes and correct bugs) #1105

As @huntergregory summarized, next PR will deal with below lists.
1. switching to `PeerList` instead of `SrcList` and `DstList` like you suggested
2. deciding what to do for pod selector structs