### PR TITLE
perf: [NPM] Use Equal function for label comparison instead of using reflect.DeepEqual in namespaceController

### DIFF
--- a/npm/pkg/controlplane/controllers/v1/nameSpaceController.go
+++ b/npm/pkg/controlplane/controllers/v1/nameSpaceController.go
@@ -5,7 +5,6 @@ package controllers
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"sync"
 	"time"
 
@@ -15,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	coreinformer "k8s.io/client-go/informers/core/v1"
@@ -288,7 +288,7 @@ func (nsc *NamespaceController) syncNameSpace(key string) error {
 
 	cachedNsObj, nsExists := nsc.npmNamespaceCache.NsMap[cachedNsKey]
 	if nsExists {
-		if reflect.DeepEqual(cachedNsObj.LabelsMap, nsObj.ObjectMeta.Labels) {
+		if k8slabels.Equals(cachedNsObj.LabelsMap, nsObj.ObjectMeta.Labels) {
 			klog.Infof("[NAMESPACE UPDATE EVENT] Namespace [%s] labels did not change", key)
 			return nil
 		}

--- a/npm/pkg/controlplane/controllers/v2/namespacecontroller.go
+++ b/npm/pkg/controlplane/controllers/v2/namespacecontroller.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"reflect"
 	"sync"
 	"time"
 
@@ -16,6 +15,7 @@ import (
 	"github.com/Azure/azure-container-networking/npm/util"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	coreinformer "k8s.io/client-go/informers/core/v1"
@@ -285,7 +285,7 @@ func (nsc *NamespaceController) syncNamespace(nsKey string) error {
 
 	cachedNsObj, nsExists := nsc.npmNamespaceCache.NsMap[nsKey]
 	if nsExists {
-		if reflect.DeepEqual(cachedNsObj.LabelsMap, nsObj.ObjectMeta.Labels) {
+		if k8slabels.Equals(cachedNsObj.LabelsMap, nsObj.ObjectMeta.Labels) {
 			klog.Infof("[NAMESPACE UPDATE EVENT] Namespace [%s] labels did not change", nsKey)
 			return nil
 		}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
To avoid using heavy deepEqual to compare label and be consistent with other controller codes.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
Test two functions and their results.
```go
package testing

import (
	"reflect"
	"testing"

	k8slabels "k8s.io/apimachinery/pkg/labels"
)

func BenchmarkLabelEqual(b *testing.B) {
	labelA := map[string]string{
		"project": "myproject",
		"role":    "frontend",
	}
	labelB := map[string]string{
		"project": "myproject",
		"role":    "frontend",
	}
	for i := 0; i < b.N; i++ {
		k8slabels.Equals(labelA, labelB)
	}
}

func BenchmarkLabelDeepEqual(b *testing.B) {
	labelA := map[string]string{
		"project": "myproject",
		"role":    "frontend",
	}
	labelB := map[string]string{
		"project": "myproject",
		"role":    "frontend",
	}
	for i := 0; i < b.N; i++ {
		reflect.DeepEqual(labelA, labelB)
	}
}

```
```shell
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkLabelEqual$ benchmarking.com

goos: linux
goarch: amd64
pkg: benchmarking.com
cpu: Intel(R) Core(TM) i7-1065G7 CPU @ 1.30GHz
BenchmarkLabelEqual-8   	18292081	        70.08 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	benchmarking.com	1.360s


Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkLabelDeepEqual$ benchmarking.com
goos: linux
goarch: amd64
pkg: benchmarking.com
cpu: Intel(R) Core(TM) i7-1065G7 CPU @ 1.30GHz
BenchmarkLabelDeepEqual-8   	 1522663	      1082 ns/op	     240 B/op	       8 allocs/op
PASS
ok  	benchmarking.com	3.529s
```