### PR TITLE
feat: [NPM] Reset ipsets & update a Prometheus function ResetIPSetEntries (previously just used for UTs)

### DIFF
--- a/npm/ipsm/ipsm.go
+++ b/npm/ipsm/ipsm.go
@@ -644,6 +644,9 @@ func (ipsMgr *IpsetManager) DestroyNpmIpsets() error {
 	} else {
 		metrics.ResetNumIPSets()
 	}
+	// NOTE: in v2, we reset ipset entries, but in v1 we only remove entries for ipsets we delete.
+	// So v2 may underestimate the number of entries if there are destroy failures,
+	// but v1 may miss removing entries if some sets are in the prometheus metric but not in the kernel.
 
 	return nil
 }

--- a/npm/ipsm/ipsm_test.go
+++ b/npm/ipsm/ipsm_test.go
@@ -528,6 +528,7 @@ func TestDestroyNpmIpsets(t *testing.T) {
 	calls := []testutils.TestCmd{
 		{Cmd: []string{"ipset", "-N", "-exist", util.GetHashedName(testSet1Name), "nethash"}},
 		{Cmd: []string{"ipset", "-N", "-exist", util.GetHashedName(testSet2Name), "nethash"}},
+		{Cmd: []string{"ipset", "-A", "-exist", util.GetHashedName(testSet1Name), "1.2.3.4"}},
 		{Cmd: []string{"ipset", "list"}, Stdout: ipsetListStdout},
 		{Cmd: []string{"ipset", "-F", "-exist", testSet1Name}},
 		{Cmd: []string{"ipset", "-F", "-exist", testSet2Name}},
@@ -552,6 +553,13 @@ func TestDestroyNpmIpsets(t *testing.T) {
 	err = ipsMgr.createSet(testSet2Name, []string{"nethash"})
 	if err != nil {
 		t.Errorf("TestDestroyNpmIpsets failed @ ipsMgr.createSet")
+		t.Errorf(err.Error())
+	}
+
+	// expect prometheus to add this entry, but remove it when destroying npm sets
+	err = ipsMgr.AddToSet(testSet1Name, "1.2.3.4", util.IpsetNetHashFlag, "")
+	if err != nil {
+		t.Errorf("TestDestroyNpmIpsets failed @ ipsMgr.addToSet")
 		t.Errorf(err.Error())
 	}
 

--- a/npm/metrics/ipsets.go
+++ b/npm/metrics/ipsets.go
@@ -81,6 +81,9 @@ func DeleteIPSet(setName string) {
 // It doesn't ever update the number of IPSets.
 func ResetIPSetEntries() {
 	numIPSetEntries.Set(0)
+	for setName := range ipsetInventoryMap {
+		removeFromIPSetInventory(setName)
+	}
 	ipsetInventoryMap = make(map[string]int)
 }
 

--- a/npm/pkg/dataplane/ipsets/ipsetmanager.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager.go
@@ -38,6 +38,7 @@ type IPSetManagerCfg struct {
 }
 
 // TODO delegate prometheus metrics logic to OS-specific ones?
+
 func NewIPSetManager(iMgrCfg *IPSetManagerCfg, ioShim *common.IOShim) *IPSetManager {
 	return &IPSetManager{
 		iMgrCfg:            iMgrCfg,

--- a/npm/pkg/dataplane/ipsets/ipsetmanager.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager.go
@@ -37,6 +37,7 @@ type IPSetManagerCfg struct {
 	NetworkName string
 }
 
+// TODO delegate prometheus metrics logic to OS-specific ones?
 func NewIPSetManager(iMgrCfg *IPSetManagerCfg, ioShim *common.IOShim) *IPSetManager {
 	return &IPSetManager{
 		iMgrCfg:            iMgrCfg,

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_linux.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_linux.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/Azure/azure-container-networking/npm/metrics"
 	"github.com/Azure/azure-container-networking/npm/pkg/dataplane/ioutil"
 	"github.com/Azure/azure-container-networking/npm/pkg/dataplane/parse"
 	"github.com/Azure/azure-container-networking/npm/util"
@@ -15,6 +16,8 @@ const (
 	azureNPMPrefix = "azure-npm-"
 
 	ipsetCommand        = "ipset"
+	ipsetListFlag       = "list"
+	ipsetNameFlag       = "--name"
 	ipsetSaveFlag       = "save"
 	ipsetRestoreFlag    = "restore"
 	ipsetCreateFlag     = "-N"
@@ -57,14 +60,135 @@ var (
 	nameForAddRegex    = regexp.MustCompile(fmt.Sprintf("%s (%s) ", ipsetAddString, hashedNamePattern))
 )
 
+/*
+	based on ipset list output with azure-npm- prefix, create an ipset restore file where we flush all sets first, then destroy all sets
+
+	overall error handling:
+	- if flush fails because the set doesn't exist (should never happen because we're listing sets right before), then ignore it and the destroy
+	- if flush fails otherwise, then add to destroyFailureCount and continue (aborting the destroy too)
+	- if destroy fails because the set doesn't exist (should never happen since the flush operation would have worked), then ignore it
+	- if destroy fails for another reason, then ignore it and add to destroyFailureCount and mark for reconcile (TODO)
+
+	example:
+		grep output:
+			azure-npm-123456
+			azure-npm-987654
+			azure-npm-777777
+
+		example restore file [flag meanings: -F (flush), -X (destroy)]:
+			-F azure-npm-123456
+			-F azure-npm-987654
+			-F azure-npm-777777
+			-X azure-npm-123456
+			-X azure-npm-987654
+			-X azure-npm-777777
+
+	prometheus metrics:
+		After this function, NumIPSets should be 0 or the number of NPM IPSets that existed and failed to be destroyed.
+		When NPM restarts, Prometheus metrics will initialize at 0, but NPM IPSets may exist.
+		We will reset ipset entry metrics if the restore succeeds whether or not some flushes/destroys failed (NOTE: this is different behavior than v1).
+		If a flush fails, we could update the num entries for that set, but that would be a lot of overhead.
+*/
 func (iMgr *IPSetManager) resetIPSets() error {
-	// called on failure or when NPM is created
-	// so no ipset cache. need to use ipset list like in ipsm.go
-
-	// create restore file that flushes all sets, then deletes all sets
-	// technically don't need to flush a hashset
-
+	listCommand := iMgr.ioShim.Exec.Command(ipsetCommand, ipsetListFlag, ipsetNameFlag)
+	grepCommand := iMgr.ioShim.Exec.Command(ioutil.Grep, azureNPMPrefix)
+	searchResults, gotMatches, grepError := ioutil.PipeCommandToGrep(listCommand, grepCommand)
+	if grepError != nil {
+		return npmerrors.SimpleErrorWrapper("failed to run ipset list for resetting IPSets", grepError)
+	}
+	if !gotMatches {
+		metrics.ResetNumIPSets()
+		metrics.ResetIPSetEntries()
+		return nil
+	}
+	creator, originalNumSets, destroyFailureCount := iMgr.fileCreatorForReset(searchResults)
+	restoreError := creator.RunCommandWithFile(ipsetCommand, ipsetRestoreFlag)
+	if restoreError != nil {
+		metrics.SetNumIPSets(originalNumSets)
+		// NOTE: the num entries for sets may be incorrect if the restore fails
+		return npmerrors.SimpleErrorWrapper("failed to run ipset restore for resetting IPSets", restoreError)
+	}
+	if metrics.NumIPSetsIsPositive() {
+		metrics.SetNumIPSets(*destroyFailureCount)
+	} else {
+		metrics.ResetNumIPSets()
+	}
+	metrics.ResetIPSetEntries() // NOTE: the num entries for sets that fail to flush may be incorrect after this
 	return nil
+}
+
+// this needs to be a separate function because we need to check creator contents in UTs
+func (iMgr *IPSetManager) fileCreatorForReset(ipsetListOutput []byte) (creator *ioutil.FileCreator, numSets int, destroyFailureCount *int) {
+	zero := 0
+	destroyFailureCount = &zero
+	creator = ioutil.NewFileCreator(iMgr.ioShim, maxTryCount, ipsetRestoreLineFailurePattern)
+	names := make([]string, 0)
+	readIndex := 0
+	var line []byte
+	// flush all the sets and create a list of the sets so we can destroy them
+	for readIndex < len(ipsetListOutput) {
+		line, readIndex = parse.Line(readIndex, ipsetListOutput)
+		hashedSetName := string(line)
+		names = append(names, hashedSetName)
+		// error handlers specific to resetting ipsets
+		errorHandlers := []*ioutil.LineErrorHandler{
+			{
+				Definition: setDoesntExistDefinition,
+				Method:     ioutil.ContinueAndAbortSection,
+				Callback: func() {
+					klog.Infof("[RESET-IPSETS] skipping flush and upcoming destroy for set %s since the set doesn't exist", hashedSetName)
+				},
+			},
+			{
+				Definition: ioutil.AlwaysMatchDefinition,
+				Method:     ioutil.ContinueAndAbortSection,
+				Callback: func() {
+					klog.Errorf("[RESET-IPSETS] marking flush and upcoming destroy for set %s as a failure due to unknown error", hashedSetName)
+					*destroyFailureCount++
+					// TODO mark as a failure
+				},
+			},
+		}
+		sectionID := sectionID(destroySectionPrefix, hashedSetName)
+		creator.AddLine(sectionID, errorHandlers, ipsetFlushFlag, hashedSetName) // flush set
+	}
+
+	// destroy all the sets
+	for _, hashedSetName := range names {
+		hashedSetName := hashedSetName // to appease go lint
+		errorHandlers := []*ioutil.LineErrorHandler{
+			// error handlers specific to resetting ipsets
+			{
+				Definition: setInUseByKernelDefinition,
+				Method:     ioutil.Continue,
+				Callback: func() {
+					klog.Errorf("[RESET-IPSETS] marking destroy for set %s as a failure since the set is in use by a kernel component", hashedSetName)
+					*destroyFailureCount++
+					// TODO mark the set as a failure and reconcile what iptables rule or ipset is referring to it
+				},
+			},
+			{
+				Definition: setDoesntExistDefinition,
+				Method:     ioutil.Continue,
+				Callback: func() {
+					klog.Infof("[RESET-IPSETS] skipping destroy for set %s since the set does not exist", hashedSetName)
+				},
+			},
+			{
+				Definition: ioutil.AlwaysMatchDefinition,
+				Method:     ioutil.Continue,
+				Callback: func() {
+					klog.Errorf("[RESET-IPSETS] marking destroy for set %s as a failure due to unknown error", hashedSetName)
+					*destroyFailureCount++
+					// TODO mark the set as a failure and reconcile what iptables rule or ipset is referring to it
+				},
+			},
+		}
+		sectionID := sectionID(destroySectionPrefix, hashedSetName)
+		creator.AddLine(sectionID, errorHandlers, ipsetDestroyFlag, hashedSetName) // destroy set
+	}
+	numSets = len(names)
+	return creator, numSets, destroyFailureCount
 }
 
 /*
@@ -134,7 +258,6 @@ example where every set in add/update cache should have ip 1.2.3.4 and 2.3.4.5:
 		-A new-set-3 2.3.4.5
 
 */
-
 func (iMgr *IPSetManager) applyIPSets() error {
 	var saveFile []byte
 	var saveError error
@@ -144,7 +267,7 @@ func (iMgr *IPSetManager) applyIPSets() error {
 			return npmerrors.SimpleErrorWrapper("ipset save failed when applying ipsets", saveError)
 		}
 	}
-	creator := iMgr.fileCreator(maxTryCount, saveFile)
+	creator := iMgr.fileCreatorForApply(maxTryCount, saveFile)
 	restoreError := creator.RunCommandWithFile(ipsetCommand, ipsetRestoreFlag)
 	if restoreError != nil {
 		return npmerrors.SimpleErrorWrapper("ipset restore failed when applying ipsets", restoreError)
@@ -165,7 +288,7 @@ func (iMgr *IPSetManager) ipsetSave() ([]byte, error) {
 	return searchResults, nil
 }
 
-func (iMgr *IPSetManager) fileCreator(maxTryCount int, saveFile []byte) *ioutil.FileCreator {
+func (iMgr *IPSetManager) fileCreatorForApply(maxTryCount int, saveFile []byte) *ioutil.FileCreator {
 	creator := ioutil.NewFileCreator(iMgr.ioShim, maxTryCount, ipsetRestoreLineFailurePattern) // TODO make the line failure pattern into a definition constant eventually
 
 	// flush all sets first so we don't try to delete an ipset referenced by a list we're deleting too
@@ -350,15 +473,14 @@ func (iMgr *IPSetManager) flushSetInFile(creator *ioutil.FileCreator, prefixedNa
 			Definition: setDoesntExistDefinition,
 			Method:     ioutil.ContinueAndAbortSection,
 			Callback: func() {
-				// no action needed
-				klog.Infof("skipping flush and upcoming delete for set %s since the set doesn't exist", prefixedName)
+				klog.Infof("skipping flush and upcoming destroy for set %s since the set doesn't exist", prefixedName)
 			},
 		},
 		{
 			Definition: ioutil.AlwaysMatchDefinition,
 			Method:     ioutil.ContinueAndAbortSection,
 			Callback: func() {
-				klog.Errorf("skipping flush and upcoming delete for set %s due to unknown error", prefixedName)
+				klog.Errorf("skipping flush and upcoming destroy for set %s due to unknown error", prefixedName)
 				// TODO mark as a failure
 				// would this ever happen?
 			},
@@ -366,7 +488,7 @@ func (iMgr *IPSetManager) flushSetInFile(creator *ioutil.FileCreator, prefixedNa
 	}
 	sectionID := sectionID(destroySectionPrefix, prefixedName)
 	hashedName := util.GetHashedName(prefixedName)
-	creator.AddLine(sectionID, errorHandlers, ipsetFlushFlag, hashedName)
+	creator.AddLine(sectionID, errorHandlers, ipsetFlushFlag, hashedName) // flush set
 }
 
 func (iMgr *IPSetManager) destroySetInFile(creator *ioutil.FileCreator, prefixedName string) {
@@ -438,7 +560,7 @@ func (iMgr *IPSetManager) deleteMemberInFile(creator *ioutil.FileCreator, set *I
 			},
 		},
 	}
-	creator.AddLine(sectionID, errorHandlers, ipsetDeleteFlag, set.HashedName, member)
+	creator.AddLine(sectionID, errorHandlers, ipsetDeleteFlag, set.HashedName, member) // delete member
 }
 
 func (iMgr *IPSetManager) addMemberInFile(creator *ioutil.FileCreator, set *IPSet, sectionID, member string) {
@@ -472,7 +594,7 @@ func (iMgr *IPSetManager) addMemberInFile(creator *ioutil.FileCreator, set *IPSe
 			},
 		}
 	}
-	creator.AddLine(sectionID, errorHandlers, ipsetAddFlag, set.HashedName, member)
+	creator.AddLine(sectionID, errorHandlers, ipsetAddFlag, set.HashedName, member) // add member
 }
 
 func sectionID(prefix, prefixedName string) string {

--- a/npm/pkg/dataplane/ipsets/testutils_linux.go
+++ b/npm/pkg/dataplane/ipsets/testutils_linux.go
@@ -25,5 +25,8 @@ func GetApplyIPSetsTestCalls(toAddOrUpdateIPSets, toDeleteIPSets []*IPSetMetadat
 }
 
 func GetResetTestCalls() []testutils.TestCmd {
-	return []testutils.TestCmd{}
+	return []testutils.TestCmd{
+		{Cmd: []string{"ipset", "list", "--name"}, PipedToCommand: true},
+		{Cmd: []string{"grep", "azure-npm-"}, ExitCode: 1}, // grep didn't find anything
+	}
 }


### PR DESCRIPTION
Logic for resetting IPSets in Linux:
- get current npm IPSets: 
  - run `ipset list --name` (which returns just the set names per line) and grep for "azure-npm-"
- create a restore file which flushes all these sets and then deletes all of them
- see the code for detailed description of the error handling logic and Prometheus metrics logic

Update for Prometheus `ResetIPSetEntries`: 
- removes all sets from the Prometheus metric for IPSet entries