### PR TITLE
refacto: [NPM] Handle 0.0.0.0/0 ipblock and de-duplicated elements in except field

### DIFF
--- a/npm/pkg/controlplane/controllers/v1/networkPolicyController.go
+++ b/npm/pkg/controlplane/controllers/v1/networkPolicyController.go
@@ -468,10 +468,10 @@ func (c *NetworkPolicyController) createCidrsRule(direction, policyName, ns stri
 			return fmt.Errorf("[createCidrsRule] Error: creating ipset %s with err: %v", ipCidrSet, err)
 		}
 		for _, ipCidrEntry := range util.DropEmptyFields(ipCidrSet) {
-			// Ipset doesn't allow 0.0.0.0/0 to be added. A general solution is split 0.0.0.0/1 in half which convert to
-			// 1.0.0.0/1 and 128.0.0.0/1
+			// Ipset doesn't allow 0.0.0.0/0 to be added.
+			// A solution is split 0.0.0.0/0 in half which convert to 0.0.0.0/1 and 128.0.0.0/1.
 			if ipCidrEntry == "0.0.0.0/0" {
-				splitEntry := [2]string{"1.0.0.0/1", "128.0.0.0/1"}
+				splitEntry := [2]string{"0.0.0.0/1", "128.0.0.0/1"}
 				for _, entry := range splitEntry {
 					if err := c.ipsMgr.AddToSet(setName, entry, util.IpsetNetHashFlag, ""); err != nil {
 						return fmt.Errorf("[createCidrsRule] adding ip cidrs %s into ipset %s with err: %v", entry, ipCidrSet, err)

--- a/npm/pkg/controlplane/translation/translatePolicy.go
+++ b/npm/pkg/controlplane/translation/translatePolicy.go
@@ -155,7 +155,7 @@ func ipBlockIPSet(policyName, ns string, direction policies.Direction, ipBlockSe
 	if ipBlockRule.CIDR == "0.0.0.0/0" {
 		// two cidrs (0.0.0.0/1 and 128.0.0.0/1) for 0.0.0.0/0 + except.
 		members = make([]string, lenOfDeDupExcepts+splitCIDRLen)
-		// in case of 0.0.0.0/0, 0.0.0.0/1 or 0.0.0.0/1nomatch comes eariler than 128.0.0.0/1 or 128.0.0.0/1nomatch.
+		// in case of "0.0.0.0/0", "0.0.0.0/1" or "0.0.0.0/1nomatch" comes eariler than "128.0.0.0/1" or "128.0.0.0/1nomatch".
 		splitCIDRs := []string{"0.0.0.0/1", "128.0.0.0/1"}
 		for _, cidr := range splitCIDRs {
 			members[indexOfMembers] = cidr

--- a/npm/pkg/controlplane/translation/translatePolicy.go
+++ b/npm/pkg/controlplane/translation/translatePolicy.go
@@ -17,11 +17,6 @@ TODO(jungukcho)
 1. namespace is default in label in K8s. Need to check whether I missed something.
 - Targeting a Namespace by its name
 (https://kubernetes.io/docs/concepts/services-networking/network-policies/#targeting-a-namespace-by-its-name)
-2. Check possible error - first check see how K8s guarantees correctness of the submitted network policy
-- Return error and validation
-3. Need to handle 0.0.0.0/0 in IPBlock field
-- Ipset doesn't allow 0.0.0.0/0 to be added. A general solution is split 0.0.0.0/1 in half which convert to
-  1.0.0.0/1 and 128.0.0.0/1 in linux
 */
 
 var errUnknownPortType = errors.New("unknown port Type")

--- a/npm/pkg/controlplane/translation/translatePolicy_test.go
+++ b/npm/pkg/controlplane/translation/translatePolicy_test.go
@@ -375,7 +375,7 @@ func TestIPBlockIPSet(t *testing.T) {
 				CIDR:   "172.17.0.0/16",
 				Except: []string{"172.17.1.0/24"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24nomatch"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch"}...),
 		},
 		{
 			name:        "one cidr and multiple elements in except",
@@ -384,7 +384,7 @@ func TestIPBlockIPSet(t *testing.T) {
 				CIDR:   "172.17.0.0/16",
 				Except: []string{"172.17.1.0/24", "172.17.2.0/24"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-network-policy-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24nomatch", "172.17.2.0/24nomatch"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test-network-policy-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch", "172.17.2.0/24 nomatch"}...),
 		},
 		{
 			name:        "one cidr and multiple and duplicated elements in except",
@@ -393,7 +393,7 @@ func TestIPBlockIPSet(t *testing.T) {
 				CIDR:   "172.17.0.0/16",
 				Except: []string{"172.17.1.0/24", "172.17.2.0/24", "172.17.2.0/24"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-network-policy-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24nomatch", "172.17.2.0/24nomatch"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test-network-policy-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch", "172.17.2.0/24 nomatch"}...),
 		},
 		{
 			name:        "cidr : 0.0.0.0/0",
@@ -410,7 +410,7 @@ func TestIPBlockIPSet(t *testing.T) {
 				CIDR:   "0.0.0.0/0",
 				Except: []string{"10.0.0.0/1"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1", "128.0.0.0/1", "10.0.0.0/1nomatch"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1", "128.0.0.0/1", "10.0.0.0/1 nomatch"}...),
 		},
 		{
 			name:        "cidr: 0.0.0.0/0 and except: 0.0.0.0/1",
@@ -419,7 +419,7 @@ func TestIPBlockIPSet(t *testing.T) {
 				CIDR:   "0.0.0.0/0",
 				Except: []string{"0.0.0.0/1"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1nomatch", "128.0.0.0/1"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1 nomatch", "128.0.0.0/1"}...),
 		},
 		{
 			name:        "cidr: 0.0.0.0/0 and except: 128.0.0.0/1",
@@ -428,7 +428,7 @@ func TestIPBlockIPSet(t *testing.T) {
 				CIDR:   "0.0.0.0/0",
 				Except: []string{"128.0.0.0/1"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1", "128.0.0.0/1nomatch"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1", "128.0.0.0/1 nomatch"}...),
 		},
 		{
 			name:        "cidr: 0.0.0.0/0 and except: 0.0.0.0/1 and 128.0.0.0/1",
@@ -437,7 +437,7 @@ func TestIPBlockIPSet(t *testing.T) {
 				CIDR:   "0.0.0.0/0",
 				Except: []string{"0.0.0.0/1", "128.0.0.0/1"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1nomatch", "128.0.0.0/1nomatch"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1 nomatch", "128.0.0.0/1 nomatch"}...),
 		},
 		{
 			name:        "cidr: 0.0.0.0/0 and except: 0.0.0.0/1 and two 128.0.0.0/1",
@@ -446,7 +446,7 @@ func TestIPBlockIPSet(t *testing.T) {
 				CIDR:   "0.0.0.0/0",
 				Except: []string{"0.0.0.0/1", "128.0.0.0/1", "128.0.0.0/1"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1nomatch", "128.0.0.0/1nomatch"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1 nomatch", "128.0.0.0/1 nomatch"}...),
 		},
 	}
 
@@ -501,7 +501,7 @@ func TestIPBlockRule(t *testing.T) {
 				CIDR:   "172.17.0.0/16",
 				Except: []string{"172.17.1.0/24"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24nomatch"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch"}...),
 			setInfo:         policies.NewSetInfo("test-in-ns-default-0IN", ipsets.CIDRBlocks, included, policies.SrcMatch),
 		},
 		{
@@ -511,7 +511,7 @@ func TestIPBlockRule(t *testing.T) {
 				CIDR:   "172.17.0.0/16",
 				Except: []string{"172.17.1.0/24", "172.17.2.0/24"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-network-policy-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24nomatch", "172.17.2.0/24nomatch"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test-network-policy-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch", "172.17.2.0/24 nomatch"}...),
 			setInfo:         policies.NewSetInfo("test-network-policy-in-ns-default-0IN", ipsets.CIDRBlocks, included, policies.SrcMatch),
 		},
 	}
@@ -1365,7 +1365,7 @@ func TestIngressPolicy(t *testing.T) {
 					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
 				},
 				RuleIPSets: []*ipsets.TranslatedIPSet{
-					ipsets.NewTranslatedIPSet("only-ipblock-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24nomatch"}...),
+					ipsets.NewTranslatedIPSet("only-ipblock-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch"}...),
 				},
 				ACLs: []*policies.ACLPolicy{
 					{

--- a/npm/pkg/controlplane/translation/translatePolicy_test.go
+++ b/npm/pkg/controlplane/translation/translatePolicy_test.go
@@ -368,6 +368,59 @@ func TestIPBlockIPSet(t *testing.T) {
 			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16"}...),
 		},
 		{
+			name:        "0.0.0.0/0 cidr",
+			ipBlockInfo: createIPBlockInfo("test", "default", policies.Ingress, policies.SrcMatch, 0),
+			ipBlockRule: &networkingv1.IPBlock{
+				CIDR: "0.0.0.0/0",
+			},
+			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1", "128.0.0.0/1"}...),
+		},
+		{
+			name:        "0.0.0.0/0 cidr and one 10.0.0.0/1 except",
+			ipBlockInfo: createIPBlockInfo("test", "default", policies.Ingress, policies.SrcMatch, 0),
+			ipBlockRule: &networkingv1.IPBlock{
+				CIDR:   "0.0.0.0/0",
+				Except: []string{"10.0.0.0/1"},
+			},
+			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1", "128.0.0.0/1", "10.0.0.0/1nomatch"}...),
+		},
+		{
+			name:        "0.0.0.0/0 cidr and one 0.0.0.0/1 except",
+			ipBlockInfo: createIPBlockInfo("test", "default", policies.Ingress, policies.SrcMatch, 0),
+			ipBlockRule: &networkingv1.IPBlock{
+				CIDR:   "0.0.0.0/0",
+				Except: []string{"0.0.0.0/1"},
+			},
+			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1nomatch", "128.0.0.0/1"}...),
+		},
+		{
+			name:        "0.0.0.0/0 cidr and one 128.0.0.0/1 except",
+			ipBlockInfo: createIPBlockInfo("test", "default", policies.Ingress, policies.SrcMatch, 0),
+			ipBlockRule: &networkingv1.IPBlock{
+				CIDR:   "0.0.0.0/0",
+				Except: []string{"128.0.0.0/1"},
+			},
+			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1", "128.0.0.0/1nomatch"}...),
+		},
+		{
+			name:        "0.0.0.0/0 cidr and two 0.0.0.0/1 and 128.0.0.0/1 except",
+			ipBlockInfo: createIPBlockInfo("test", "default", policies.Ingress, policies.SrcMatch, 0),
+			ipBlockRule: &networkingv1.IPBlock{
+				CIDR:   "0.0.0.0/0",
+				Except: []string{"0.0.0.0/1", "128.0.0.0/1"},
+			},
+			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1nomatch", "128.0.0.0/1nomatch"}...),
+		},
+		{
+			name:        "0.0.0.0/0 cidr and duplicated 0.0.0.0/1 and 128.0.0.0/1 except",
+			ipBlockInfo: createIPBlockInfo("test", "default", policies.Ingress, policies.SrcMatch, 0),
+			ipBlockRule: &networkingv1.IPBlock{
+				CIDR:   "0.0.0.0/0",
+				Except: []string{"0.0.0.0/1", "128.0.0.0/1", "128.0.0.0/1"},
+			},
+			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1nomatch", "128.0.0.0/1nomatch"}...),
+		},
+		{
 			name:        "one cidr and one except",
 			ipBlockInfo: createIPBlockInfo("test", "default", policies.Ingress, policies.SrcMatch, 0),
 			ipBlockRule: &networkingv1.IPBlock{
@@ -382,6 +435,15 @@ func TestIPBlockIPSet(t *testing.T) {
 			ipBlockRule: &networkingv1.IPBlock{
 				CIDR:   "172.17.0.0/16",
 				Except: []string{"172.17.1.0/24", "172.17.2.0/24"},
+			},
+			translatedIPSet: ipsets.NewTranslatedIPSet("test-network-policy-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24nomatch", "172.17.2.0/24nomatch"}...),
+		},
+		{
+			name:        "one cidr and multiple and duplicated except",
+			ipBlockInfo: createIPBlockInfo("test-network-policy", "default", policies.Ingress, policies.SrcMatch, 0),
+			ipBlockRule: &networkingv1.IPBlock{
+				CIDR:   "172.17.0.0/16",
+				Except: []string{"172.17.1.0/24", "172.17.2.0/24", "172.17.2.0/24"},
 			},
 			translatedIPSet: ipsets.NewTranslatedIPSet("test-network-policy-in-ns-default-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24nomatch", "172.17.2.0/24nomatch"}...),
 		},

--- a/npm/pkg/dataplane/dataplane.go
+++ b/npm/pkg/dataplane/dataplane.go
@@ -3,6 +3,7 @@ package dataplane
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/Azure/azure-container-networking/common"
 	"github.com/Azure/azure-container-networking/npm/metrics"
@@ -321,12 +322,22 @@ func (dp *DataPlane) createIPSetsAndReferences(sets []*ipsets.TranslatedIPSet, n
 		// Check if any CIDR block IPSets needs to be applied
 		setType := set.Metadata.Type
 		if setType == ipsets.CIDRBlocks {
-			for _, ip := range set.Members {
-				_, _, err := net.ParseCIDR(ip)
+			// cidrInfo can have either cidr (CIDR in IPBlock) or "cidr + nomatch" (Except in IPBlock)
+			for _, cidrInfo := range set.Members {
+				// TODO(jungukcho): This is an adhoc approach for linux, but need to refactor data structure for better management.
+				// onlyCidr has only cidr without "nomatch" to validate cidr format.
+				var onlyCidr string
+				if strings.Contains(cidrInfo, util.IpsetNomatch) {
+					onlyCidr = strings.Trim(onlyCidr, util.IpsetNomatch)
+				} else {
+					onlyCidr = cidrInfo
+				}
+
+				_, _, err := net.ParseCIDR(onlyCidr)
 				if err != nil {
 					return npmerrors.Errorf(npmErrorString, false, fmt.Sprintf("[dataplane] failed to parseCIDR in addIPSetReferences with err: %s", err.Error()))
 				}
-				err = dp.ipsetMgr.AddToSets([]*ipsets.IPSetMetadata{set.Metadata}, ip, "")
+				err = dp.ipsetMgr.AddToSets([]*ipsets.IPSetMetadata{set.Metadata}, cidrInfo, "")
 				if err != nil {
 					return npmerrors.Errorf(npmErrorString, false, fmt.Sprintf("[dataplane] failed to AddToSet in addIPSetReferences with err: %s", err.Error()))
 				}

--- a/npm/pkg/dataplane/dataplane.go
+++ b/npm/pkg/dataplane/dataplane.go
@@ -322,7 +322,7 @@ func (dp *DataPlane) createIPSetsAndReferences(sets []*ipsets.TranslatedIPSet, n
 		// Check if any CIDR block IPSets needs to be applied
 		setType := set.Metadata.Type
 		if setType == ipsets.CIDRBlocks {
-			// cidrInfo can have either cidr (CIDR in IPBlock) or "cidr + nomatch" (Except in IPBlock)
+			// cidrInfo can have either cidr (CIDR in IPBlock) or "cidr + " " (space) + nomatch" (Except in IPBlock)
 			for _, cidrInfo := range set.Members {
 				// TODO(jungukcho): This is an adhoc approach for linux, but need to refactor data structure for better management.
 				// onlyCidr has only cidr without "nomatch" to validate cidr format.


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
To handle special IPBlock (0.0.0.0/0) and de-duplicated elements in except in translation logic.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests


**Notes**:
Instead of using `nomatch`, a better data structure to indicate whether `cidr` or `except` is needed for generic data planes.
Will improve it in next PR with revising data structure.
In addition, 0.0.0.0/0 handling was not decided yet in windows dataplane since windows does not support `nomatch` for `cidr` yet. 


Related previous PR:
1. [NPM] General translation logic for linux and windows #1055
2. refactor: [NPM] parsing label selector for general translation logic #1077
3. refactor: [NPM] General translation logic (mainly clean-up codes and correct bugs) #1105
4. refactor: [NPM] General translation logic for egress and ingress #1106 

