### PR TITLE
fix ipampool scaling - only release IPs we have

### DIFF
--- a/cns/ipampool/metrics.go
+++ b/cns/ipampool/metrics.go
@@ -24,12 +24,6 @@ var (
 			Help: "IPAM IP pool batch size.",
 		},
 	)
-	ipamFreeIPCount = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Name: "ipam_free_ips",
-			Help: "Free IP count.",
-		},
-	)
 	ipamIPPool = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "ipam_ip_pool_size",
@@ -66,6 +60,12 @@ var (
 			Help: "Unallocated IP count.",
 		},
 	)
+	ipamRequestedUnallocatedIPCount = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "ipam_requested_unallocated_ips",
+			Help: "Unallocated IP count using total requested IPs.",
+		},
+	)
 )
 
 func init() {
@@ -73,10 +73,12 @@ func init() {
 		ipamAllocatedIPCount,
 		ipamAvailableIPCount,
 		ipamBatchSize,
-		ipamFreeIPCount,
 		ipamIPPool,
 		ipamMaxIPCount,
 		ipamPendingProgramIPCount,
 		ipamPendingReleaseIPCount,
+		ipamRequestedIPConfigCount,
+		ipamRequestedUnallocatedIPCount,
+		ipamUnallocatedIPCount,
 	)
 }


### PR DESCRIPTION
Signed-off-by: Evan Baker <rbtr@users.noreply.github.com>

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
When scaling up, we should account for the IPs we have requested when we calculate our free. But when scaling down, we should only account for the IPs that we _have_ when calculating free.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
