### PR TITLE
lint pre-push hook

### DIFF
--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd $(git rev-parse --show-toplevel)
+make lint

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+-include setup
+
 # Default platform commands
 SHELL=/bin/bash
 MKDIR := mkdir -p
@@ -356,7 +358,7 @@ lint-old: $(GOLANGCI_LINT) ## Fast lint including previous issues
 
 FMT_PKG ?= cni cns npm
 
-fmt format: $(GOFUMPT) ## run gofumpt on $FMT_PKG (default "cni cns npm")
+fmt: $(GOFUMPT) ## run gofumpt on $FMT_PKG (default "cni cns npm")
 	$(GOFUMPT) -s -w $(FMT_PKG)
 
 COVER_PKG ?= .
@@ -382,6 +384,16 @@ test-cyclonus:
 .PHONY: kind
 kind:
 	kind create cluster --config ./test/kind/kind.yaml
+
+##@ Utilities
+
+$(REPO_ROOT)/.git/hooks/pre-push:
+	@ln -s $(REPO_ROOT)/.hooks/pre-push $(REPO_ROOT)/.git/hooks/
+	@echo installed pre-push hook
+
+install-hooks: $(REPO_ROOT)/.git/hooks/pre-push ## installs git hooks
+
+setup: install-hooks ## performs common required repo setup
 
 version: ## prints the version
 	@echo $(VERSION)


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Installs a pre-push git hook that runs lint and only allows pushing when lint is clean.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
