### PR TITLE
fix: [NPM] Testing Changes and updates to Linux Policy Manager

### DIFF
--- a/npm/pkg/dataplane/dataplane.go
+++ b/npm/pkg/dataplane/dataplane.go
@@ -97,13 +97,14 @@ func (dp *DataPlane) InitializeDataPlane() error {
 }
 
 // ResetDataPlane helps in cleaning up dataplane sets and policies programmed
-// by NPM, retunring a clean slate
+// by NPM, returning a clean slate
 func (dp *DataPlane) ResetDataPlane() error {
-	if err := dp.ipsetMgr.ResetIPSets(); err != nil {
-		return npmerrors.ErrorWrapper(npmerrors.ResetDataPlane, false, "failed to reset ipsets dataplane", err)
-	}
+	// It is important to keep order to clean-up ACLs before ipsets. Otherwise we won't be able to delete ipsets referenced by ACLs
 	if err := dp.policyMgr.Reset(); err != nil {
 		return npmerrors.ErrorWrapper(npmerrors.ResetDataPlane, false, "failed to reset policy dataplane", err)
+	}
+	if err := dp.ipsetMgr.ResetIPSets(); err != nil {
+		return npmerrors.ErrorWrapper(npmerrors.ResetDataPlane, false, "failed to reset ipsets dataplane", err)
 	}
 	return dp.resetDataPlane()
 }

--- a/npm/pkg/dataplane/dataplane.go
+++ b/npm/pkg/dataplane/dataplane.go
@@ -90,10 +90,9 @@ func (dp *DataPlane) InitializeDataPlane() error {
 	if err := dp.initializeDataPlane(); err != nil {
 		return npmerrors.ErrorWrapper(npmerrors.InitializeDataPlane, false, "failed to initialize overall dataplane", err)
 	}
-	// TODO update when piped error is fixed in fexec
-	// if err := dp.policyMgr.Initialize(); err != nil {
-	// 	return npmerrors.ErrorWrapper(npmerrors.InitializeDataPlane, false, "failed to initialize policy dataplane", err)
-	// }
+	if err := dp.policyMgr.Initialize(); err != nil {
+		return npmerrors.ErrorWrapper(npmerrors.InitializeDataPlane, false, "failed to initialize policy dataplane", err)
+	}
 	return nil
 }
 
@@ -103,10 +102,9 @@ func (dp *DataPlane) ResetDataPlane() error {
 	if err := dp.ipsetMgr.ResetIPSets(); err != nil {
 		return npmerrors.ErrorWrapper(npmerrors.ResetDataPlane, false, "failed to reset ipsets dataplane", err)
 	}
-	// TODO update when piped error is fixed in fexec
-	// if err := dp.policyMgr.Reset(); err != nil {
-	// 	return npmerrors.ErrorWrapper(npmerrors.ResetDataPlane, false, "failed to reset policy dataplane", err)
-	// }
+	if err := dp.policyMgr.Reset(); err != nil {
+		return npmerrors.ErrorWrapper(npmerrors.ResetDataPlane, false, "failed to reset policy dataplane", err)
+	}
 	return dp.resetDataPlane()
 }
 

--- a/npm/pkg/dataplane/dataplane_test.go
+++ b/npm/pkg/dataplane/dataplane_test.go
@@ -70,7 +70,6 @@ func TestNewDataPlane(t *testing.T) {
 
 	calls := getNewDataplaneTestCalls()
 	ioshim := common.NewMockIOShim(calls)
-	fmt.Println(calls)
 	defer ioshim.VerifyCalls(t, calls)
 	dp, err := NewDataPlane("testnode", ioshim)
 	require.NoError(t, err)

--- a/npm/pkg/dataplane/dataplane_test.go
+++ b/npm/pkg/dataplane/dataplane_test.go
@@ -69,7 +69,10 @@ func TestNewDataPlane(t *testing.T) {
 	metrics.InitializeAll()
 
 	calls := getNewDataplaneTestCalls()
-	dp, err := NewDataPlane("testnode", common.NewMockIOShim(calls))
+	ioshim := common.NewMockIOShim(calls)
+	fmt.Println(calls)
+	defer ioshim.VerifyCalls(t, calls)
+	dp, err := NewDataPlane("testnode", ioshim)
 	require.NoError(t, err)
 
 	if dp == nil {
@@ -84,7 +87,9 @@ func TestInitializeDataPlane(t *testing.T) {
 	metrics.InitializeAll()
 
 	calls := append(getNewDataplaneTestCalls(), policies.GetInitializeTestCalls()...)
-	dp, err := NewDataPlane("testnode", common.NewMockIOShim(calls))
+	ioshim := common.NewMockIOShim(calls)
+	defer ioshim.VerifyCalls(t, calls)
+	dp, err := NewDataPlane("testnode", ioshim)
 	require.NoError(t, err)
 
 	assert.NotNil(t, dp)
@@ -97,7 +102,9 @@ func TestResetDataPlane(t *testing.T) {
 
 	calls := append(getNewDataplaneTestCalls(), getInitializeTestCalls()...)
 	calls = append(calls, getResetTestCalls()...)
-	dp, err := NewDataPlane("testnode", common.NewMockIOShim(calls))
+	ioshim := common.NewMockIOShim(calls)
+	defer ioshim.VerifyCalls(t, calls)
+	dp, err := NewDataPlane("testnode", ioshim)
 	require.NoError(t, err)
 
 	assert.NotNil(t, dp)
@@ -111,7 +118,9 @@ func TestCreateAndDeleteIpSets(t *testing.T) {
 	metrics.InitializeAll()
 
 	calls := getNewDataplaneTestCalls()
-	dp, err := NewDataPlane("testnode", common.NewMockIOShim(calls))
+	ioshim := common.NewMockIOShim(calls)
+	defer ioshim.VerifyCalls(t, calls)
+	dp, err := NewDataPlane("testnode", ioshim)
 	require.NoError(t, err)
 	assert.NotNil(t, dp)
 	setsTocreate := []*ipsets.IPSetMetadata{
@@ -151,7 +160,9 @@ func TestAddToSet(t *testing.T) {
 	metrics.InitializeAll()
 
 	calls := getNewDataplaneTestCalls()
-	dp, err := NewDataPlane("testnode", common.NewMockIOShim(calls))
+	ioshim := common.NewMockIOShim(calls)
+	defer ioshim.VerifyCalls(t, calls)
+	dp, err := NewDataPlane("testnode", ioshim)
 	require.NoError(t, err)
 
 	setsTocreate := []*ipsets.IPSetMetadata{
@@ -213,8 +224,9 @@ func TestApplyPolicy(t *testing.T) {
 	metrics.InitializeAll()
 
 	calls := append(getNewDataplaneTestCalls(), getAddPolicyTestCallsForDP(&testPolicyobj)...)
-	ioShim := common.NewMockIOShim(calls)
-	dp, err := NewDataPlane("testnode", ioShim)
+	ioshim := common.NewMockIOShim(calls)
+	defer ioshim.VerifyCalls(t, calls)
+	dp, err := NewDataPlane("testnode", ioshim)
 	require.NoError(t, err)
 
 	err = dp.AddPolicy(&testPolicyobj)
@@ -226,8 +238,9 @@ func TestRemovePolicy(t *testing.T) {
 
 	calls := append(getNewDataplaneTestCalls(), getAddPolicyTestCallsForDP(&testPolicyobj)...)
 	calls = append(calls, getRemovePolicyTestCallsForDP(&testPolicyobj)...)
-	ioShim := common.NewMockIOShim(calls)
-	dp, err := NewDataPlane("testnode", ioShim)
+	ioshim := common.NewMockIOShim(calls)
+	defer ioshim.VerifyCalls(t, calls)
+	dp, err := NewDataPlane("testnode", ioshim)
 	require.NoError(t, err)
 
 	err = dp.AddPolicy(&testPolicyobj)
@@ -255,8 +268,9 @@ func TestUpdatePolicy(t *testing.T) {
 	for _, call := range calls {
 		fmt.Println(call)
 	}
-	ioShim := common.NewMockIOShim(calls)
-	dp, err := NewDataPlane("testnode", ioShim)
+	ioshim := common.NewMockIOShim(calls)
+	defer ioshim.VerifyCalls(t, calls)
+	dp, err := NewDataPlane("testnode", ioshim)
 	require.NoError(t, err)
 
 	err = dp.AddPolicy(&testPolicyobj)
@@ -271,15 +285,11 @@ func getNewDataplaneTestCalls() []testutils.TestCmd {
 }
 
 func getInitializeTestCalls() []testutils.TestCmd {
-	return []testutils.TestCmd{}
-	// TODO update when piped error is fixed in fexec
-	// return policies.GetInitializeTestCalls()
+	return policies.GetInitializeTestCalls()
 }
 
 func getResetTestCalls() []testutils.TestCmd {
-	return ipsets.GetResetTestCalls()
-	// TODO update when piped error is fixed in fexec
-	// return append(ipsets.GetResetTestCalls(), policies.GetResetTestCalls()...)
+	return append(ipsets.GetResetTestCalls(), policies.GetResetTestCalls()...)
 }
 
 func getAddPolicyTestCallsForDP(networkPolicy *policies.NPMNetworkPolicy) []testutils.TestCmd {

--- a/npm/pkg/dataplane/dataplane_test.go
+++ b/npm/pkg/dataplane/dataplane_test.go
@@ -288,7 +288,7 @@ func getInitializeTestCalls() []testutils.TestCmd {
 }
 
 func getResetTestCalls() []testutils.TestCmd {
-	return append(ipsets.GetResetTestCalls(), policies.GetResetTestCalls()...)
+	return append(policies.GetResetTestCalls(), ipsets.GetResetTestCalls()...)
 }
 
 func getAddPolicyTestCallsForDP(networkPolicy *policies.NPMNetworkPolicy) []testutils.TestCmd {

--- a/npm/pkg/dataplane/ioutil/restore_linux.go
+++ b/npm/pkg/dataplane/ioutil/restore_linux.go
@@ -126,6 +126,7 @@ func (creator *FileCreator) ToString() string {
 
 func (creator *FileCreator) RunCommandWithFile(cmd string, args ...string) error {
 	fileString := creator.ToString()
+	klog.Infof("beginning to run command for restorer:\nEND-CREATOR-FILE-FOR-COMMAND-%s\n%s\nEND-CREATOR-FILE-FOR-COMMAND-%s", cmd, fileString, cmd) // TODO remove
 	wasFileAltered, err := creator.runCommandOnceWithFile(fileString, cmd, args...)
 	if err == nil {
 		return nil

--- a/npm/pkg/dataplane/policies/chain-management_linux.go
+++ b/npm/pkg/dataplane/policies/chain-management_linux.go
@@ -15,13 +15,16 @@ import (
 )
 
 const (
+	// TODO replace all util constants with local constants
 	defaultlockWaitTimeInSeconds string = "60"
 
 	doesNotExistErrorCode      int = 1 // Bad rule (does a matching rule exist in that chain?)
 	couldntLoadTargetErrorCode int = 2 // Couldn't load target `AZURE-NPM-EGRESS':No such file or directory
 
-	minLineNumberStringLength int = 3
-	minChainStringLength      int = 7
+	minLineNumberStringLength int    = 3
+	azureChainGrepPattern     string = "Chain AZURE-NPM"
+	minAzureChainStringLength int    = len(azureChainGrepPattern)
+	azureChainStartIndex      int    = 6
 )
 
 var (
@@ -32,24 +35,15 @@ var (
 		util.IptablesAzureEgressChain,
 		util.IptablesAzureAcceptChain,
 	}
-	iptablesAzureDeprecatedChains = []string{
-		// NPM v1
-		util.IptablesAzureIngressFromChain,
-		util.IptablesAzureIngressPortChain,
-		util.IptablesAzureIngressDropsChain,
-		util.IptablesAzureEgressToChain,
-		util.IptablesAzureEgressPortChain,
-		util.IptablesAzureEgressDropsChain,
-		// older
-		util.IptablesAzureTargetSetsChain,
-		util.IptablesAzureIngressWrongDropsChain,
+	jumpFromForwardToAzureChainArgs = []string{
+		util.IptablesForwardChain,
+		util.IptablesJumpFlag,
+		util.IptablesAzureChain,
+		util.IptablesModuleFlag,
+		util.IptablesCtstateModuleFlag,
+		util.IptablesCtstateFlag,
+		util.IptablesNewState,
 	}
-	iptablesOldAndNewChains = append(iptablesAzureChains, iptablesAzureDeprecatedChains...)
-
-	jumpToAzureChainArgs            = []string{util.IptablesJumpFlag, util.IptablesAzureChain, util.IptablesModuleFlag, util.IptablesCtstateModuleFlag, util.IptablesCtstateFlag, util.IptablesNewState}
-	jumpFromForwardToAzureChainArgs = append([]string{util.IptablesForwardChain}, jumpToAzureChainArgs...)
-
-	ingressOrEgressPolicyChainPattern = fmt.Sprintf("'Chain %s-\\|Chain %s-'", util.IptablesAzureIngressPolicyChainPrefix, util.IptablesAzureEgressPolicyChainPrefix)
 )
 
 type staleChains struct {
@@ -135,17 +129,16 @@ func (pMgr *PolicyManager) initializeNPMChains() error {
 // and flushes and deletes all NPM Chains.
 func (pMgr *PolicyManager) removeNPMChains() error {
 	deleteErrCode, deleteErr := pMgr.runIPTablesCommand(util.IptablesDeletionFlag, jumpFromForwardToAzureChainArgs...)
-	hadDeleteError := deleteErr != nil && deleteErrCode != couldntLoadTargetErrorCode
-	// TODO check rule doesn't exist error code instead. The first call of dp.Reset() we will have exit code 2 (couldn't load target) since AZURE-NPM won't exist
+	hadDeleteError := deleteErr != nil && deleteErrCode != couldntLoadTargetErrorCode // couldntLoadTargetErrorCode happens when AZURE-NPM chain doesn't exist (and hence the jump rule doesn't exist too)
 	if hadDeleteError {
-		baseErrString := "failed to delete jump from FORWARD chain to AZURE-NPM chain"
-		metrics.SendErrorLogAndMetric(util.IptmID, "Error: %s with exit code %d and error: %s", baseErrString, deleteErrCode, deleteErr.Error())
+		metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to delete jump from FORWARD chain to AZURE-NPM chain with exit code %d and error: %s", deleteErrCode, deleteErr.Error())
 		// FIXME update ID
-		return npmerrors.SimpleErrorWrapper(baseErrString, deleteErr)
 	}
 
-	// flush all chains (will create any chain, including deprecated ones, if they don't exist)
 	creatorToFlush, chainsToDelete := pMgr.creatorAndChainsForReset()
+	if len(chainsToDelete) == 0 {
+		return nil
+	}
 	restoreError := restore(creatorToFlush)
 	if restoreError != nil {
 		return npmerrors.SimpleErrorWrapper("failed to flush chains", restoreError)
@@ -171,19 +164,22 @@ func (pMgr *PolicyManager) removeNPMChains() error {
 // - cleans up stale policy chains
 // - creates the jump rule from FORWARD chain to AZURE-NPM chain (if it does not exist) and makes sure it's after the jumps to KUBE-FORWARD & KUBE-SERVICES chains (if they exist).
 func (pMgr *PolicyManager) reconcile() {
+	klog.Infof("repositioning azure chain jump rule")
 	if err := pMgr.positionAzureChainJumpRule(); err != nil {
 		klog.Errorf("failed to reconcile jump rule to Azure-NPM due to %s", err.Error())
 	}
-	if err := pMgr.cleanupChains(pMgr.staleChains.emptyAndGetAll()); err != nil {
+	staleChains := pMgr.staleChains.emptyAndGetAll()
+	klog.Infof("cleaning up these stale chains: %+v", staleChains)
+	if err := pMgr.cleanupChains(staleChains); err != nil {
 		klog.Errorf("failed to clean up old policy chains with the following error %s", err.Error())
 	}
 }
 
-// have to use slice argument for deterministic behavior for UTs
+// have to use slice argument for deterministic behavior for ioshim in UTs
 func (pMgr *PolicyManager) cleanupChains(chains []string) error {
 	var aggregateError error
 	for _, chain := range chains {
-		errCode, err := pMgr.runIPTablesCommand(util.IptablesDestroyFlag, chain) // TODO run the one that ignores doesNotExistErrorCode
+		errCode, err := pMgr.runIPTablesCommand(util.IptablesDestroyFlag, chain)
 		if err != nil && errCode != doesNotExistErrorCode {
 			pMgr.staleChains.add(chain)
 			currentErrString := fmt.Sprintf("failed to clean up policy chain %s with err [%v]", chain, err)
@@ -270,30 +266,17 @@ func (pMgr *PolicyManager) creatorForInitChains() *ioutil.FileCreator {
 // add/reposition AZURE-NPM chain after KUBE-FORWARD and KUBE-SERVICE chains if they exist
 // this function has a direct comparison in NPM v1 iptables manager (iptm.go)
 func (pMgr *PolicyManager) positionAzureChainJumpRule() error {
-	kubeServicesLine, kubeServicesLineNumErr := pMgr.chainLineNumber(util.IptablesKubeServicesChain)
-	if kubeServicesLineNumErr != nil {
-		// not possible to cover this branch currently because of testing limitations for PipeCommandToGrep()
-		baseErrString := "failed to get index of jump from KUBE-SERVICES chain to FORWARD chain with error"
-		metrics.SendErrorLogAndMetric(util.IptmID, "Error: %s: %s", baseErrString, kubeServicesLineNumErr.Error())
-		return npmerrors.SimpleErrorWrapper(baseErrString, kubeServicesLineNumErr)
+	npmLineNum, npmLineNumErr := pMgr.chainLineNumber(util.IptablesAzureChain)
+	if npmLineNumErr != nil {
+		baseErrString := "failed to get index of jump from FORWARD chain to AZURE-NPM chain"
+		metrics.SendErrorLogAndMetric(util.IptmID, "Error: %s: %s", baseErrString, npmLineNumErr.Error())
+		// FIXME update ID
+		return npmerrors.SimpleErrorWrapper(baseErrString, npmLineNumErr)
 	}
-
-	index := kubeServicesLine + 1
-
-	// TODO could call chainLineNumber instead, and say it doesn't exist for lineNum == 0
-	jumpRuleErrCode, checkErr := pMgr.runIPTablesCommand(util.IptablesCheckFlag, jumpFromForwardToAzureChainArgs...)
-	hadCheckError := checkErr != nil && jumpRuleErrCode != doesNotExistErrorCode
-	if hadCheckError {
-		baseErrString := "failed to check if jump from FORWARD chain to AZURE-NPM chain exists"
-		metrics.SendErrorLogAndMetric(util.IptmID, "Error: %s: %s", baseErrString, checkErr.Error())
-		return npmerrors.SimpleErrorWrapper(baseErrString, checkErr)
-	}
-	jumpRuleExists := jumpRuleErrCode != doesNotExistErrorCode
-
+	jumpRuleExists := npmLineNum > 0
 	if !jumpRuleExists {
 		klog.Infof("Inserting jump from FORWARD chain to AZURE-NPM chain")
-		jumpRuleInsertionArgs := append([]string{util.IptablesForwardChain, strconv.Itoa(index)}, jumpToAzureChainArgs...)
-		if insertErrCode, insertErr := pMgr.runIPTablesCommand(util.IptablesInsertionFlag, jumpRuleInsertionArgs...); insertErr != nil {
+		if insertErrCode, insertErr := pMgr.runIPTablesCommand(util.IptablesInsertionFlag, jumpFromForwardToAzureChainArgs...); insertErr != nil {
 			baseErrString := "failed to insert jump from FORWARD chain to AZURE-NPM chain"
 			metrics.SendErrorLogAndMetric(util.IptmID, "Error: %s with error code %d and error %s", baseErrString, insertErrCode, insertErr.Error())
 			// FIXME update ID
@@ -301,28 +284,10 @@ func (pMgr *PolicyManager) positionAzureChainJumpRule() error {
 		}
 		return nil
 	}
-
-	if kubeServicesLine <= 1 {
-		// jump to KUBE-SERVICES chain doesn't exist or is the first rule
+	if npmLineNum == 1 {
 		return nil
 	}
-
-	npmChainLine, npmLineNumErr := pMgr.chainLineNumber(util.IptablesAzureChain)
-	if npmLineNumErr != nil {
-		// not possible to cover this branch currently because of testing limitations for PipeCommandToGrep()
-		baseErrString := "failed to get index of jump from FORWARD chain to AZURE-NPM chain"
-		metrics.SendErrorLogAndMetric(util.IptmID, "Error: %s: %s", baseErrString, npmLineNumErr.Error())
-		// FIXME update ID
-		return npmerrors.SimpleErrorWrapper(baseErrString, npmLineNumErr)
-	}
-
-	// Kube-services line number is less than npm chain line number then all good
-	if kubeServicesLine < npmChainLine {
-		return nil
-	}
-
-	// AZURE-NPM chain is before KUBE-SERVICES then
-	// delete existing jump rule and add it in the right order
+	// delete existing jump rule and add it at the top
 	metrics.SendErrorLogAndMetric(util.IptmID, "Info: Reconciler deleting and re-adding jump from FORWARD chain to AZURE-NPM chain table.")
 	if deleteErrCode, deleteErr := pMgr.runIPTablesCommand(util.IptablesDeletionFlag, jumpFromForwardToAzureChainArgs...); deleteErr != nil {
 		baseErrString := "failed to delete jump from FORWARD chain to AZURE-NPM chain"
@@ -330,26 +295,18 @@ func (pMgr *PolicyManager) positionAzureChainJumpRule() error {
 		// FIXME update ID
 		return npmerrors.SimpleErrorWrapper(baseErrString, deleteErr)
 	}
-
-	// Reduce index for deleted AZURE-NPM chain
-	if index > 1 {
-		index--
-	}
-	jumpRuleInsertionArgs := append([]string{util.IptablesForwardChain, strconv.Itoa(index)}, jumpToAzureChainArgs...)
-	if insertErrCode, insertErr := pMgr.runIPTablesCommand(util.IptablesInsertionFlag, jumpRuleInsertionArgs...); insertErr != nil {
+	if insertErrCode, insertErr := pMgr.runIPTablesCommand(util.IptablesInsertionFlag, jumpFromForwardToAzureChainArgs...); insertErr != nil {
 		baseErrString := "after deleting, failed to insert jump from FORWARD chain to AZURE-NPM chain"
 		// FIXME update ID
 		metrics.SendErrorLogAndMetric(util.IptmID, "Error: %s with error code %d and error %s", baseErrString, insertErrCode, insertErr.Error())
 		return npmerrors.SimpleErrorWrapper(baseErrString, insertErr)
 	}
-
 	return nil
 }
 
 // returns 0 if the chain d.n.e.
 // this function has a direct comparison in NPM v1 iptables manager (iptm.go)
 func (pMgr *PolicyManager) chainLineNumber(chain string) (int, error) {
-	// TODO could call this once and use regex instead of grep to cut down on OS calls
 	listForwardEntriesCommand := pMgr.ioShim.Exec.Command(util.Iptables,
 		util.IptablesWaitFlag, defaultlockWaitTimeInSeconds, util.IptablesTableFlag, util.IptablesFilterTable,
 		util.IptablesNumericFlag, util.IptablesListFlag, util.IptablesForwardChain, util.IptablesLineNumbersFlag,
@@ -357,14 +314,13 @@ func (pMgr *PolicyManager) chainLineNumber(chain string) (int, error) {
 	grepCommand := pMgr.ioShim.Exec.Command(ioutil.Grep, chain)
 	searchResults, gotMatches, err := ioutil.PipeCommandToGrep(listForwardEntriesCommand, grepCommand)
 	if err != nil {
-		// not possible to cover this branch currently because of testing limitations for PipeCommandToGrep()
 		return 0, npmerrors.SimpleErrorWrapper(fmt.Sprintf("failed to determine line number for jump from FORWARD chain to %s chain", chain), err)
 	}
 	if !gotMatches {
 		return 0, nil
 	}
 	if len(searchResults) >= minLineNumberStringLength {
-		lineNum, _ := strconv.Atoi(string(searchResults[0]))
+		lineNum, _ := strconv.Atoi(string(searchResults[0])) // FIXME this returns the first digit of the line number. What if the chain was at line 11? Then we would think it's at line 1
 		return lineNum, nil
 	}
 	return 0, nil
@@ -372,27 +328,24 @@ func (pMgr *PolicyManager) chainLineNumber(chain string) (int, error) {
 
 // make this a function for easier testing
 func (pMgr *PolicyManager) creatorAndChainsForReset() (creator *ioutil.FileCreator, chainsToFlush []string) {
-	oldPolicyChains, err := pMgr.policyChainNames()
+	// get current chains because including them in the restore file would create them if they don't exist
+	chainsToFlush, err := pMgr.allCurrentAzureChains()
 	if err != nil {
-		// not possible to cover this branch currently because of testing limitations for PipeCommandToGrep()
 		metrics.SendErrorLogAndMetric(util.IptmID, "Error: failed to determine NPM ingress/egress policy chains to delete")
 	}
-	chainsToFlush = iptablesOldAndNewChains
-	chainsToFlush = append(chainsToFlush, oldPolicyChains...) // will work even if oldPolicyChains is nil
 	creator = pMgr.newCreatorWithChains(chainsToFlush)
 	creator.AddLine("", nil, util.IptablesRestoreCommit)
 	return
 }
 
-func (pMgr *PolicyManager) policyChainNames() ([]string, error) {
+func (pMgr *PolicyManager) allCurrentAzureChains() ([]string, error) {
 	iptablesListCommand := pMgr.ioShim.Exec.Command(util.Iptables,
 		util.IptablesWaitFlag, defaultlockWaitTimeInSeconds, util.IptablesTableFlag, util.IptablesFilterTable,
 		util.IptablesNumericFlag, util.IptablesListFlag,
 	)
-	grepCommand := pMgr.ioShim.Exec.Command(ioutil.Grep, ingressOrEgressPolicyChainPattern)
+	grepCommand := pMgr.ioShim.Exec.Command(ioutil.Grep, azureChainGrepPattern)
 	searchResults, gotMatches, err := ioutil.PipeCommandToGrep(iptablesListCommand, grepCommand)
 	if err != nil {
-		// not possible to cover this branch currently because of testing limitations for PipeCommandToGrep()
 		return nil, npmerrors.SimpleErrorWrapper("failed to get policy chain names", err)
 	}
 	if !gotMatches {
@@ -401,10 +354,12 @@ func (pMgr *PolicyManager) policyChainNames() ([]string, error) {
 	lines := strings.Split(string(searchResults), "\n")
 	chainNames := make([]string, 0, len(lines)) // don't want to preallocate size in case of have malformed lines
 	for _, line := range lines {
-		if len(line) < minChainStringLength {
-			klog.Errorf("got unexpected grep output for ingress/egress policy chains")
+		if len(line) < minAzureChainStringLength {
+			klog.Errorf("got unexpected grep output [%s] for ingress/egress policy chains", line)
 		} else {
-			chainNames = append(chainNames, line[minChainStringLength-1:])
+			chainNameWithRestOfLine := line[azureChainStartIndex:] // e.g. "AZURE-NPM-INGRESS-ALLOW-MARK (1 reference)"
+			chainName := strings.Split(chainNameWithRestOfLine, " ")[0]
+			chainNames = append(chainNames, chainName)
 		}
 	}
 	return chainNames, nil

--- a/npm/pkg/dataplane/policies/chain-management_linux_test.go
+++ b/npm/pkg/dataplane/policies/chain-management_linux_test.go
@@ -43,7 +43,7 @@ func TestCleanupChainsSuccess(t *testing.T) {
 		getFakeDestroyCommandWithExitCode(testChain2, 1), // exit code 1 means the chain d.n.e.
 	}
 	ioshim := common.NewMockIOShim(calls)
-	// TODO defer ioshim.VerifyCalls(t, ioshim, calls)
+	defer ioshim.VerifyCalls(t, calls)
 	pMgr := NewPolicyManager(ioshim)
 
 	pMgr.staleChains.add(testChain1)
@@ -61,7 +61,7 @@ func TestCleanupChainsFailure(t *testing.T) {
 		getFakeDestroyCommandWithExitCode(testChain3, 2),
 	}
 	ioshim := common.NewMockIOShim(calls)
-	// TODO defer ioshim.VerifyCalls(t, ioshim, calls)
+	defer ioshim.VerifyCalls(t, calls)
 	pMgr := NewPolicyManager(ioshim)
 
 	pMgr.staleChains.add(testChain1)
@@ -97,67 +97,68 @@ func TestInitChainsCreator(t *testing.T) {
 	dptestutils.AssertEqualLines(t, expectedLines, actualLines)
 }
 
-func TestInitChainsSuccess(t *testing.T) {
-	calls := GetInitializeTestCalls()
-	pMgr := NewPolicyManager(common.NewMockIOShim(calls))
-	require.NoError(t, pMgr.initializeNPMChains())
-}
-
-func TestInitChainsFailureOnRestore(t *testing.T) {
-	calls := []testutils.TestCmd{fakeIPTablesRestoreFailureCommand}
-	pMgr := NewPolicyManager(common.NewMockIOShim(calls))
-	require.Error(t, pMgr.initializeNPMChains())
-}
-
-func TestInitChainsFailureOnPosition(t *testing.T) {
-	calls := []testutils.TestCmd{
-		fakeIPTablesRestoreCommand, // gives correct exit code
+func TestInitChains(t *testing.T) {
+	tests := []struct {
+		name    string
+		calls   []testutils.TestCmd
+		wantErr bool
+	}{
 		{
-			Cmd:      listLineNumbersCommandStrings,
-			ExitCode: 1, // grep call gets this exit code (exit code 1 means grep found nothing)
+			name:    "success",
+			calls:   GetInitializeTestCalls(),
+			wantErr: false,
 		},
-		// NOTE: after the StdOut pipe used for grep, MockIOShim gets confused and each command's ExitCode and Stdout are applied to the ensuing command
 		{
-			Cmd:      []string{"grep", "KUBE-SERVICES"},
-			Stdout:   "iptables: No chain/target/match by that name.", // this Stdout and ExitCode are for the iptables check command below
-			ExitCode: 2,                                               // Check failed for unknown reason
+			name:    "failure on restore",
+			calls:   []testutils.TestCmd{fakeIPTablesRestoreFailureCommand},
+			wantErr: true,
 		},
-		{Cmd: []string{"iptables", "-w", "60", "-C", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
+		{
+			name: "failure on position",
+			calls: []testutils.TestCmd{
+				fakeIPTablesRestoreCommand,
+				{Cmd: listLineNumbersCommandStrings, PipedToCommand: true, HasStartError: true, ExitCode: 1},
+				{Cmd: []string{"grep", "AZURE-NPM"}},
+			},
+			wantErr: true,
+		},
 	}
-	pMgr := NewPolicyManager(common.NewMockIOShim(calls))
-	require.Error(t, pMgr.initializeNPMChains())
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ioshim := common.NewMockIOShim(tt.calls)
+			defer ioshim.VerifyCalls(t, tt.calls)
+			pMgr := NewPolicyManager(ioshim)
+			err := pMgr.initializeNPMChains()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }
 
-func TestRemoveChainsCreator(t *testing.T) {
+func TestRemoveNPMChainsCreator(t *testing.T) {
 	creatorCalls := []testutils.TestCmd{
+		{Cmd: listPolicyChainNamesCommandStrings, PipedToCommand: true},
 		{
-			Cmd:    listPolicyChainNamesCommandStrings,
-			Stdout: "Chain AZURE-NPM-INGRESS-123456\nChain AZURE-NPM-EGRESS-123456",
+			Cmd:    []string{"grep", "Chain AZURE-NPM"},
+			Stdout: grepOutputAzureChainsWithPolicies,
 		},
-		// NOTE: after the StdOut pipe used for grep, MockIOShim gets confused and each command's ExitCode and Stdout are applied to the ensuing command
-		{Cmd: []string{"grep", ingressOrEgressPolicyChainPattern}},
 	}
-
-	pMgr := NewPolicyManager(common.NewMockIOShim(creatorCalls))
+	ioshim := common.NewMockIOShim(creatorCalls)
+	defer ioshim.VerifyCalls(t, creatorCalls)
+	pMgr := NewPolicyManager(ioshim)
 	creator, chainsToFlush := pMgr.creatorAndChainsForReset()
 	expectedChainsToFlush := []string{
 		"AZURE-NPM",
-		"AZURE-NPM-INGRESS",
-		"AZURE-NPM-INGRESS-ALLOW-MARK",
-		"AZURE-NPM-EGRESS",
 		"AZURE-NPM-ACCEPT",
-		// deprecated
-		"AZURE-NPM-INGRESS-FROM",
-		"AZURE-NPM-INGRESS-PORT",
-		"AZURE-NPM-INGRESS-DROPS",
-		"AZURE-NPM-EGRESS-TO",
-		"AZURE-NPM-EGRESS-PORT",
-		"AZURE-NPM-EGRESS-DROPS",
-		"AZURE-NPM-TARGET-SETS",
-		"AZURE-NPM-INRGESS-DROPS",
-		// policy chains
-		"AZURE-NPM-INGRESS-123456",
+		"AZURE-NPM-EGRESS",
 		"AZURE-NPM-EGRESS-123456",
+		"AZURE-NPM-INGRESS",
+		"AZURE-NPM-INGRESS-123456",
+		"AZURE-NPM-INGRESS-ALLOW-MARK",
 	}
 	require.Equal(t, expectedChainsToFlush, chainsToFlush)
 	actualLines := strings.Split(creator.ToString(), "\n")
@@ -169,304 +170,331 @@ func TestRemoveChainsCreator(t *testing.T) {
 	dptestutils.AssertEqualLines(t, expectedLines, actualLines)
 }
 
-func TestRemoveChainsSuccess(t *testing.T) {
-	calls := GetResetTestCalls()
-	for _, chain := range iptablesOldAndNewChains { // TODO write these out, don't use variable
-		calls = append(calls, getFakeDestroyCommand(chain))
+func TestRemoveNPMChains(t *testing.T) {
+	tests := []struct {
+		name    string
+		calls   []testutils.TestCmd
+		wantErr bool
+	}{
+		{
+			name: "success when there are chains currently",
+			calls: []testutils.TestCmd{
+				{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
+				{Cmd: listPolicyChainNamesCommandStrings, PipedToCommand: true},
+				{
+					Cmd:    []string{"grep", "Chain AZURE-NPM"},
+					Stdout: grepOutputAzureChainsWithoutPolicies,
+				},
+				fakeIPTablesRestoreCommand,
+				getFakeDestroyCommand("AZURE-NPM"),
+				getFakeDestroyCommand("AZURE-NPM-ACCEPT"),
+				getFakeDestroyCommand("AZURE-NPM-EGRESS"),
+				getFakeDestroyCommand("AZURE-NPM-INGRESS"),
+				getFakeDestroyCommand("AZURE-NPM-INGRESS-ALLOW-MARK"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "success when there are no chains currently",
+			calls: []testutils.TestCmd{
+				{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
+				{Cmd: listPolicyChainNamesCommandStrings, PipedToCommand: true},
+				{Cmd: []string{"grep", "Chain AZURE-NPM"}, ExitCode: 1},
+			},
+			wantErr: false,
+		},
+		{
+			name: "no error on failure to delete",
+			calls: []testutils.TestCmd{
+				{
+					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
+					ExitCode: 1, // delete failure
+				},
+				{Cmd: listPolicyChainNamesCommandStrings, PipedToCommand: true},
+				{Cmd: []string{"grep", "Chain AZURE-NPM"}, ExitCode: 1},
+			},
+			wantErr: false,
+		},
+		{
+			name: "failure on restore",
+			calls: []testutils.TestCmd{
+				{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
+				{Cmd: listPolicyChainNamesCommandStrings, PipedToCommand: true},
+				{
+					Cmd:    []string{"grep", "Chain AZURE-NPM"},
+					Stdout: grepOutputAzureChainsWithoutPolicies,
+				},
+				fakeIPTablesRestoreFailureCommand,
+			},
+			wantErr: true,
+		},
+		{
+			name: "failure on destroy",
+			calls: []testutils.TestCmd{
+				{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
+				{Cmd: listPolicyChainNamesCommandStrings, PipedToCommand: true},
+				{
+					Cmd:    []string{"grep", "Chain AZURE-NPM"},
+					Stdout: grepOutputAzureChainsWithoutPolicies,
+				},
+				fakeIPTablesRestoreCommand,
+				getFakeDestroyCommandWithExitCode("AZURE-NPM", 2),
+				getFakeDestroyCommandWithExitCode("AZURE-NPM-ACCEPT", 2),
+				getFakeDestroyCommand("AZURE-NPM-EGRESS"),
+				getFakeDestroyCommand("AZURE-NPM-INGRESS"),
+				getFakeDestroyCommand("AZURE-NPM-INGRESS-ALLOW-MARK"),
+			},
+			wantErr: true,
+		},
 	}
-	calls = append(
-		calls,
-		getFakeDestroyCommand("AZURE-NPM-INGRESS-123456"),
-		getFakeDestroyCommand("AZURE-NPM-EGRESS-123456"),
-	)
-
-	pMgr := NewPolicyManager(common.NewMockIOShim(calls))
-	require.NoError(t, pMgr.removeNPMChains())
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ioshim := common.NewMockIOShim(tt.calls)
+			defer ioshim.VerifyCalls(t, tt.calls)
+			pMgr := NewPolicyManager(ioshim)
+			err := pMgr.removeNPMChains()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }
 
-func TestRemoveChainsFailureOnDelete(t *testing.T) {
-	calls := []testutils.TestCmd{
+func TestPositionAzureChainJumpRule(t *testing.T) {
+	tests := []struct {
+		name    string
+		calls   []testutils.TestCmd
+		wantErr bool
+	}{
 		{
-			Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
-			ExitCode: 1, // delete failure
+			name: "no jump rule yet",
+			calls: []testutils.TestCmd{
+				{Cmd: listLineNumbersCommandStrings, PipedToCommand: true},
+				{Cmd: []string{"grep", "AZURE-NPM"}, ExitCode: 1},
+				{Cmd: []string{"iptables", "-w", "60", "-I", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "no jump rule yet and insert fails",
+			calls: []testutils.TestCmd{
+				{Cmd: listLineNumbersCommandStrings, PipedToCommand: true},
+				{Cmd: []string{"grep", "AZURE-NPM"}, ExitCode: 1},
+				{Cmd: []string{"iptables", "-w", "60", "-I", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}, ExitCode: 1},
+			},
+			wantErr: true,
+		},
+		{
+			name: "command error while grepping",
+			calls: []testutils.TestCmd{
+				{Cmd: listLineNumbersCommandStrings, PipedToCommand: true, HasStartError: true, ExitCode: 1},
+				{Cmd: []string{"grep", "AZURE-NPM"}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "jump rule already at top",
+			calls: []testutils.TestCmd{
+				{Cmd: listLineNumbersCommandStrings, PipedToCommand: true},
+				{
+					Cmd:    []string{"grep", "AZURE-NPM"},
+					Stdout: "1    AZURE-NPM  all  --  0.0.0.0/0            0.0.0.0/0    ...",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "jump rule not at top",
+			calls: []testutils.TestCmd{
+				{Cmd: listLineNumbersCommandStrings, PipedToCommand: true},
+				{
+					Cmd:    []string{"grep", "AZURE-NPM"},
+					Stdout: "2    AZURE-NPM  all  --  0.0.0.0/0            0.0.0.0/0    ...",
+				},
+				{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
+				{Cmd: []string{"iptables", "-w", "60", "-I", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "jump rule not at top and delete fails",
+			calls: []testutils.TestCmd{
+				{Cmd: listLineNumbersCommandStrings, PipedToCommand: true},
+				{
+					Cmd:    []string{"grep", "AZURE-NPM"},
+					Stdout: "2    AZURE-NPM  all  --  0.0.0.0/0            0.0.0.0/0    ...",
+				},
+				{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}, ExitCode: 1},
+			},
+			wantErr: true,
+		},
+		{
+			name: "jump rule not at top and insert fails",
+			calls: []testutils.TestCmd{
+				{Cmd: listLineNumbersCommandStrings, PipedToCommand: true},
+				{
+					Cmd:    []string{"grep", "AZURE-NPM"},
+					Stdout: "2    AZURE-NPM  all  --  0.0.0.0/0            0.0.0.0/0    ...",
+				},
+				{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
+				{Cmd: []string{"iptables", "-w", "60", "-I", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}, ExitCode: 1},
+			},
+			wantErr: true,
 		},
 	}
-	pMgr := NewPolicyManager(common.NewMockIOShim(calls))
-	require.Error(t, pMgr.removeNPMChains())
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ioshim := common.NewMockIOShim(tt.calls)
+			defer ioshim.VerifyCalls(t, tt.calls)
+			pMgr := NewPolicyManager(ioshim)
+			err := pMgr.positionAzureChainJumpRule()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }
 
-func TestRemoveChainsFailureOnRestore(t *testing.T) {
-	calls := []testutils.TestCmd{
-		{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
-		{
-			Cmd:    listPolicyChainNamesCommandStrings,
-			Stdout: "Chain AZURE-NPM-INGRESS-123456\nChain AZURE-NPM-EGRESS-123456",
-		},
-		// NOTE: after the StdOut pipe used for grep, MockIOShim gets confused and each command's ExitCode and Stdout are applied to the ensuing command
-		{
-			Cmd:      []string{"grep", ingressOrEgressPolicyChainPattern},
-			ExitCode: 1, // ExitCode 1 for the iptables restore command
-		},
-		fakeIPTablesRestoreFailureCommand, // the exit code doesn't matter for this command since it receives the exit code of the command above
-	}
-	pMgr := NewPolicyManager(common.NewMockIOShim(calls))
-	require.Error(t, pMgr.removeNPMChains())
-}
-
-func TestRemoveChainsFailureOnDestroy(t *testing.T) {
-	calls := []testutils.TestCmd{
-		{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
-		{
-			Cmd:    listPolicyChainNamesCommandStrings,
-			Stdout: "Chain AZURE-NPM-INGRESS-123456\nChain AZURE-NPM-EGRESS-123456",
-		},
-		// NOTE: after the StdOut pipe used for grep, MockIOShim gets confused and each command's ExitCode and Stdout are applied to the ensuing command
-		{Cmd: []string{"grep", ingressOrEgressPolicyChainPattern}}, // ExitCode 0 for the iptables restore command
-		fakeIPTablesRestoreCommand,
-	}
-	calls = append(calls, getFakeDestroyCommandWithExitCode(iptablesOldAndNewChains[0], 2)) // this ExitCode here will actually impact the next below
-	for _, chain := range iptablesOldAndNewChains[1:] {
-		calls = append(calls, getFakeDestroyCommand(chain))
-	}
-	calls = append(
-		calls,
-		getFakeDestroyCommand("AZURE-NPM-INGRESS-123456"),
-		getFakeDestroyCommand("AZURE-NPM-EGRESS-123456"),
-	)
-	pMgr := NewPolicyManager(common.NewMockIOShim(calls))
-	require.Error(t, pMgr.removeNPMChains())
-}
-
-func TestPositionJumpWhenNoChainsExist(t *testing.T) {
-	calls := []testutils.TestCmd{
-		{
-			Cmd:      listLineNumbersCommandStrings,
-			ExitCode: 1, // grep call gets this exit code (exit code 1 means grep found nothing)
-		},
-		// NOTE: after the StdOut pipe used for grep, MockIOShim gets confused and each command's ExitCode and Stdout are applied to the ensuing command
-		{
-			Cmd:      []string{"grep", "KUBE-SERVICES"},
-			Stdout:   "iptables: No chain/target/match by that name.", // this Stdout and ExitCode are for the iptables check command below
-			ExitCode: 1,
-		},
-		{Cmd: []string{"iptables", "-w", "60", "-C", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
-		{Cmd: []string{"iptables", "-w", "60", "-I", "FORWARD", "1", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
-	}
-	pMgr := NewPolicyManager(common.NewMockIOShim(calls))
-	require.NoError(t, pMgr.positionAzureChainJumpRule())
-}
-
-func TestPositionJumpWhenOnlyAzureExists(t *testing.T) {
-	calls := []testutils.TestCmd{
-		{
-			Cmd:      listLineNumbersCommandStrings,
-			ExitCode: 1, // grep call gets this exit code (exit code 1 means grep found nothing)
-		},
-		// NOTE: after the StdOut pipe used for grep, MockIOShim gets confused and each command's ExitCode and Stdout are applied to the ensuing command
-		{Cmd: []string{"grep", "KUBE-SERVICES"}}, // ExitCode 0 for the iptables check command below
-		{Cmd: []string{"iptables", "-w", "60", "-C", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
-	}
-	pMgr := NewPolicyManager(common.NewMockIOShim(calls))
-	require.NoError(t, pMgr.positionAzureChainJumpRule())
-}
-
-func TestPositionJumpWhenOnlyKubeServicesExists(t *testing.T) {
-	calls := []testutils.TestCmd{
-		{
-			Cmd:    listLineNumbersCommandStrings,
-			Stdout: "3    KUBE-SERVICES  all  --  0.0.0.0/0            0.0.0.0/0 ", // grep call gets this Stdout
-		},
-		// NOTE: after the StdOut pipe used for grep, MockIOShim gets confused and each command's ExitCode and Stdout are applied to the ensuing command
-		{
-			Cmd:      []string{"grep", "KUBE-SERVICES"},
-			Stdout:   "iptables: No chain/target/match by that name.", // this Stdout and ExitCode are for the iptables check command below
-			ExitCode: 1,
-		},
-		{Cmd: []string{"iptables", "-w", "60", "-C", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
-		{Cmd: []string{"iptables", "-w", "60", "-I", "FORWARD", "4", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
-	}
-	pMgr := NewPolicyManager(common.NewMockIOShim(calls))
-	require.NoError(t, pMgr.positionAzureChainJumpRule())
-}
-
-func TestPositionJumpWhenOnlyKubeServicesExistsAndInsertFails(t *testing.T) {
-	calls := []testutils.TestCmd{
-		{
-			Cmd:    listLineNumbersCommandStrings,
-			Stdout: "3    KUBE-SERVICES  all  --  0.0.0.0/0            0.0.0.0/0 ", // grep call gets this Stdout
-		},
-		// NOTE: after the StdOut pipe used for grep, MockIOShim gets confused and each command's ExitCode and Stdout are applied to the ensuing command
-		{
-			Cmd:      []string{"grep", "KUBE-SERVICES"},
-			Stdout:   "iptables: No chain/target/match by that name.", // this Stdout and ExitCode are for the iptables check command below
-			ExitCode: 1,
-		},
-		{
-			Cmd:      []string{"iptables", "-w", "60", "-C", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
-			ExitCode: 1, // ExitCode 1 for insert below
-		},
-		{Cmd: []string{"iptables", "-w", "60", "-I", "FORWARD", "4", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
-	}
-	pMgr := NewPolicyManager(common.NewMockIOShim(calls))
-	require.Error(t, pMgr.positionAzureChainJumpRule())
-}
-
-func TestPositionJumpWhenAzureAfterKubeServices(t *testing.T) {
-	// don't move the rule for AZURE-NPM
-	calls := []testutils.TestCmd{
-		{
-			Cmd:    listLineNumbersCommandStrings,
-			Stdout: "3    KUBE-SERVICES  all  --  0.0.0.0/0            0.0.0.0/0 ", // grep call gets this Stdout
-		},
-		// NOTE: after the StdOut pipe used for grep, MockIOShim gets confused and each command's ExitCode and Stdout are applied to the ensuing command
-		{Cmd: []string{"grep", "KUBE-SERVICES"}}, // ExitCode 0 for the iptables check command below
-		{
-			Cmd:    []string{"iptables", "-w", "60", "-C", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
-			Stdout: "4    AZURE-NPM  all  --  0.0.0.0/0            0.0.0.0/0 ", // grep call below gets this Stdout
-		},
-		{Cmd: listLineNumbersCommandStrings},
-		{Cmd: []string{"grep", "AZURE-NPM"}},
-	}
-	pMgr := NewPolicyManager(common.NewMockIOShim(calls))
-	require.NoError(t, pMgr.positionAzureChainJumpRule())
-}
-
-func TestPositionJumpWhenAzureBeforeKubeServices(t *testing.T) {
-	// move the rule for AZURE-NPM
-	calls := []testutils.TestCmd{
-		{
-			Cmd:    listLineNumbersCommandStrings,
-			Stdout: "3    KUBE-SERVICES  all  --  0.0.0.0/0            0.0.0.0/0 ", // grep call gets this Stdout
-		},
-		// NOTE: after the StdOut pipe used for grep, MockIOShim gets confused and each command's ExitCode and Stdout are applied to the ensuing command
-		{Cmd: []string{"grep", "KUBE-SERVICES"}}, // ExitCode 0 for the iptables check command below
-		{
-			Cmd:    []string{"iptables", "-w", "60", "-C", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
-			Stdout: "2    AZURE-NPM  all  --  0.0.0.0/0            0.0.0.0/0 ", // grep call below gets this Stdout
-		},
-		{Cmd: listLineNumbersCommandStrings},
-		{Cmd: []string{"grep", "AZURE-NPM"}},
-		{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
-		{Cmd: []string{"iptables", "-w", "60", "-I", "FORWARD", "3", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
-	}
-	pMgr := NewPolicyManager(common.NewMockIOShim(calls))
-	require.NoError(t, pMgr.positionAzureChainJumpRule())
-}
-
-func TestPositionJumpWhenAzureBeforeKubeServicesAndDeleteFails(t *testing.T) {
-	calls := []testutils.TestCmd{
-		{
-			Cmd:    listLineNumbersCommandStrings,
-			Stdout: "3    KUBE-SERVICES  all  --  0.0.0.0/0            0.0.0.0/0 ", // grep call gets this Stdout
-		},
-		// NOTE: after the StdOut pipe used for grep, MockIOShim gets confused and each command's ExitCode and Stdout are applied to the ensuing command
-		{Cmd: []string{"grep", "KUBE-SERVICES"}}, // ExitCode 0 for the iptables check command below
-		{
-			Cmd:    []string{"iptables", "-w", "60", "-C", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
-			Stdout: "2    AZURE-NPM  all  --  0.0.0.0/0            0.0.0.0/0 ", // grep call below gets this Stdout
-		},
-		{
-			Cmd:      listLineNumbersCommandStrings,
-			ExitCode: 1,
-			// NOTE: now MockIOShim is off by 2 for ExitCodes and Stdout
-			// ExitCode 1 for delete command below
-		},
-		{Cmd: []string{"grep", "AZURE-NPM"}},
-		{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
-	}
-	pMgr := NewPolicyManager(common.NewMockIOShim(calls))
-	require.Error(t, pMgr.positionAzureChainJumpRule())
-}
-
-func TestPositionJumpWhenAzureBeforeKubeServicesAndInsertFails(t *testing.T) {
-	calls := []testutils.TestCmd{
-		{
-			Cmd:    listLineNumbersCommandStrings,
-			Stdout: "3    KUBE-SERVICES  all  --  0.0.0.0/0            0.0.0.0/0 ", // grep call gets this Stdout
-		},
-		// NOTE: after the StdOut pipe used for grep, MockIOShim gets confused and each command's ExitCode and Stdout are applied to the ensuing command
-		{Cmd: []string{"grep", "KUBE-SERVICES"}}, // ExitCode 0 for the iptables check command below
-		{
-			Cmd:    []string{"iptables", "-w", "60", "-C", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
-			Stdout: "2    AZURE-NPM  all  --  0.0.0.0/0            0.0.0.0/0 ", // grep call below gets this Stdout
-		},
-		{Cmd: listLineNumbersCommandStrings}, // NOTE: now MockIOShim is off by 2 for ExitCodes and Stdout
-		// ExitCode 0 for delete command below
-		{
-			Cmd:      []string{"grep", "AZURE-NPM"},
-			ExitCode: 1, // ExitCode 1 for insert command below
-		},
-		{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
-		{Cmd: []string{"iptables", "-w", "60", "-I", "FORWARD", "3", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
-	}
-	pMgr := NewPolicyManager(common.NewMockIOShim(calls))
-	require.Error(t, pMgr.positionAzureChainJumpRule())
-}
-
-func TestGetChainLineNumber(t *testing.T) {
+func TestChainLineNumber(t *testing.T) {
 	testChainName := "TEST-CHAIN-NAME"
-	grepCommand := testutils.TestCmd{Cmd: []string{"grep", testChainName}}
-
-	// chain exists at line 3
-	calls := []testutils.TestCmd{
+	tests := []struct {
+		name            string
+		calls           []testutils.TestCmd
+		expectedLineNum int
+		wantErr         bool
+	}{
 		{
-			Cmd:      listLineNumbersCommandStrings,
-			Stdout:   fmt.Sprintf("3    %s  all  --  0.0.0.0/0            0.0.0.0/0 ", testChainName),
-			ExitCode: 0,
+			name: "chain exists",
+			calls: []testutils.TestCmd{
+				{Cmd: listLineNumbersCommandStrings, PipedToCommand: true},
+				{
+					Cmd:    []string{"grep", testChainName},
+					Stdout: fmt.Sprintf("3    %s  all  --  0.0.0.0/0            0.0.0.0/0 ", testChainName),
+				},
+			},
+			expectedLineNum: 3,
+			wantErr:         false,
 		},
-		grepCommand,
-	}
-	pMgr := NewPolicyManager(common.NewMockIOShim(calls))
-	lineNum, err := pMgr.chainLineNumber(testChainName)
-	require.Equal(t, 3, lineNum)
-	require.NoError(t, err)
-
-	// chain doesn't exist
-	calls = []testutils.TestCmd{
+		// TODO test for chain line number with 2+ digits
 		{
-			Cmd:      listLineNumbersCommandStrings,
-			ExitCode: 1, // grep found nothing
+			name: "ignore unexpected grep output",
+			calls: []testutils.TestCmd{
+				{Cmd: listLineNumbersCommandStrings, PipedToCommand: true},
+				{
+					Cmd:    []string{"grep", testChainName},
+					Stdout: "3",
+				},
+			},
+			expectedLineNum: 0,
+			wantErr:         false,
 		},
-		grepCommand,
+		{
+			name: "chain doesn't exist",
+			calls: []testutils.TestCmd{
+				{Cmd: listLineNumbersCommandStrings, PipedToCommand: true},
+				{Cmd: []string{"grep", testChainName}, ExitCode: 1},
+			},
+			expectedLineNum: 0,
+			wantErr:         false,
+		},
+		{
+			name: "command error while grepping",
+			calls: []testutils.TestCmd{
+				{Cmd: listLineNumbersCommandStrings, PipedToCommand: true, HasStartError: true, ExitCode: 1},
+				{Cmd: []string{"grep", testChainName}},
+			},
+			expectedLineNum: 0,
+			wantErr:         true,
+		},
 	}
-	pMgr = NewPolicyManager(common.NewMockIOShim(calls))
-	lineNum, err = pMgr.chainLineNumber(testChainName)
-	require.Equal(t, 0, lineNum)
-	require.NoError(t, err)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ioshim := common.NewMockIOShim(tt.calls)
+			defer ioshim.VerifyCalls(t, tt.calls)
+			pMgr := NewPolicyManager(ioshim)
+			lineNum, err := pMgr.chainLineNumber(testChainName)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.expectedLineNum, lineNum)
+		})
+	}
 }
 
-func TestGetPolicyChainNames(t *testing.T) {
-	// grep that finds results
-	grepCommand := testutils.TestCmd{Cmd: []string{"grep", ingressOrEgressPolicyChainPattern}}
-	calls := []testutils.TestCmd{
+func TestAllCurrentAzureChains(t *testing.T) {
+	tests := []struct {
+		name           string
+		calls          []testutils.TestCmd
+		expectedChains []string
+		wantErr        bool
+	}{
 		{
-			Cmd:    listPolicyChainNamesCommandStrings,
-			Stdout: "Chain AZURE-NPM-INGRESS-123456\nChain AZURE-NPM-EGRESS-123456",
+			name: "success with chains",
+			calls: []testutils.TestCmd{
+				{Cmd: listPolicyChainNamesCommandStrings, PipedToCommand: true},
+				{
+					Cmd:    []string{"grep", "Chain AZURE-NPM"},
+					Stdout: grepOutputAzureChainsWithPolicies,
+				},
+			},
+			expectedChains: []string{"AZURE-NPM", "AZURE-NPM-ACCEPT", "AZURE-NPM-EGRESS", "AZURE-NPM-EGRESS-123456", "AZURE-NPM-INGRESS", "AZURE-NPM-INGRESS-123456", "AZURE-NPM-INGRESS-ALLOW-MARK"},
+			wantErr:        false,
 		},
-		grepCommand,
-	}
-	pMgr := NewPolicyManager(common.NewMockIOShim(calls))
-	chainNames, err := pMgr.policyChainNames()
-	expectedChainNames := []string{
-		"AZURE-NPM-INGRESS-123456",
-		"AZURE-NPM-EGRESS-123456",
-	}
-	require.Equal(t, expectedChainNames, chainNames)
-	require.NoError(t, err)
-
-	// grep with no results
-	calls = []testutils.TestCmd{
 		{
-			Cmd:      listPolicyChainNamesCommandStrings,
-			ExitCode: 1, // grep found nothing
+			name: "ignore chain that isn't long enough",
+			calls: []testutils.TestCmd{
+				{Cmd: []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
+				{
+					Cmd:    []string{"grep", "Chain AZURE-NPM"},
+					Stdout: "Chain abc",
+				},
+			},
+			expectedChains: []string{},
+			wantErr:        false,
 		},
-		grepCommand,
+		{
+			name: "success with no chains",
+			calls: []testutils.TestCmd{
+				{Cmd: []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
+				{Cmd: []string{"grep", "Chain AZURE-NPM"}, ExitCode: 1},
+			},
+			expectedChains: nil,
+			wantErr:        false,
+		},
+		{
+			name: "failure",
+			calls: []testutils.TestCmd{
+				{Cmd: []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true, HasStartError: true, ExitCode: 1},
+				{Cmd: []string{"grep", "Chain AZURE-NPM"}},
+			},
+			expectedChains: nil,
+			wantErr:        true,
+		},
 	}
-	pMgr = NewPolicyManager(common.NewMockIOShim(calls))
-	chainNames, err = pMgr.policyChainNames()
-	expectedChainNames = nil
-	require.Equal(t, expectedChainNames, chainNames)
-	require.NoError(t, err)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ioshim := common.NewMockIOShim(tt.calls)
+			defer ioshim.VerifyCalls(t, tt.calls)
+			pMgr := NewPolicyManager(ioshim)
+			chains, err := pMgr.allCurrentAzureChains()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.expectedChains, chains)
+		})
+	}
 }
 
 func getFakeDestroyCommand(chain string) testutils.TestCmd {

--- a/npm/pkg/dataplane/policies/chain-management_linux_test.go
+++ b/npm/pkg/dataplane/policies/chain-management_linux_test.go
@@ -16,6 +16,20 @@ const (
 	testChain1 = "chain1"
 	testChain2 = "chain2"
 	testChain3 = "chain3"
+
+	grepOutputAzureChainsWithoutPolicies = `Chain AZURE-NPM (1 references)
+Chain AZURE-NPM-ACCEPT (1 references)
+Chain AZURE-NPM-EGRESS (1 references)
+Chain AZURE-NPM-INGRESS (1 references)
+Chain AZURE-NPM-INGRESS-ALLOW-MARK (1 references)`
+
+	grepOutputAzureChainsWithPolicies = `Chain AZURE-NPM (1 references)
+Chain AZURE-NPM-ACCEPT (1 references)
+Chain AZURE-NPM-EGRESS (1 references)
+Chain AZURE-NPM-EGRESS-123456 (1 references)
+Chain AZURE-NPM-INGRESS (1 references)
+Chain AZURE-NPM-INGRESS-123456 (1 references)
+Chain AZURE-NPM-INGRESS-ALLOW-MARK (1 references)`
 )
 
 func TestEmptyAndGetAll(t *testing.T) {
@@ -450,12 +464,24 @@ func TestAllCurrentAzureChains(t *testing.T) {
 			wantErr:        false,
 		},
 		{
-			name: "ignore chain that isn't long enough",
+			name: "ignore unexpected grep output (chain name too short)",
 			calls: []testutils.TestCmd{
 				{Cmd: []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
 				{
 					Cmd:    []string{"grep", "Chain AZURE-NPM"},
-					Stdout: "Chain abc",
+					Stdout: "Chain abc (1 references)",
+				},
+			},
+			expectedChains: []string{},
+			wantErr:        false,
+		},
+		{
+			name: "ignore unexpected grep output (no space)",
+			calls: []testutils.TestCmd{
+				{Cmd: []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
+				{
+					Cmd:    []string{"grep", "Chain AZURE-NPM"},
+					Stdout: "abc",
 				},
 			},
 			expectedChains: []string{},

--- a/npm/pkg/dataplane/policies/policymanager.go
+++ b/npm/pkg/dataplane/policies/policymanager.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/klog"
 )
 
-const reconcileChainTimeInMinutes = 5
+const reconcileTimeInMinutes = 5
 
 type PolicyMap struct {
 	cache map[string]*NPMNetworkPolicy
@@ -47,9 +47,11 @@ func (pMgr *PolicyManager) Reset() error {
 	return nil
 }
 
+// TODO call this function in DP
+
 func (pMgr *PolicyManager) Reconcile(stopChannel <-chan struct{}) {
 	go func() {
-		ticker := time.NewTicker(time.Minute * time.Duration(reconcileChainTimeInMinutes))
+		ticker := time.NewTicker(time.Minute * time.Duration(reconcileTimeInMinutes))
 		defer ticker.Stop()
 
 		for {

--- a/npm/pkg/dataplane/policies/policymanager_test.go
+++ b/npm/pkg/dataplane/policies/policymanager_test.go
@@ -1,7 +1,6 @@
 package policies
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/Azure/azure-container-networking/common"
@@ -99,7 +98,6 @@ func TestGetPolicy(t *testing.T) {
 
 func TestRemovePolicy(t *testing.T) {
 	calls := append(GetAddPolicyTestCalls(testNetPol), GetRemovePolicyTestCalls(testNetPol)...)
-	fmt.Println(calls)
 	pMgr := NewPolicyManager(common.NewMockIOShim(calls))
 
 	require.NoError(t, pMgr.AddPolicy(testNetPol, epList))

--- a/npm/pkg/dataplane/policies/testutils.go
+++ b/npm/pkg/dataplane/policies/testutils.go
@@ -8,15 +8,15 @@ var (
 		{
 			Name: "test1",
 			PodSelectorIPSets: []*ipsets.TranslatedIPSet{
-				{Metadata: ipsets.TestKVNSList.Metadata},
+				{Metadata: ipsets.TestKeyPodSet.Metadata},
 			},
 			ACLs: testACLs,
 		},
 		{
 			Name: "test2",
 			PodSelectorIPSets: []*ipsets.TranslatedIPSet{
-				{Metadata: ipsets.TestKVNSList.Metadata},
 				{Metadata: ipsets.TestKeyPodSet.Metadata},
+				{Metadata: ipsets.TestKVPodSet.Metadata},
 			},
 			ACLs: []*ACLPolicy{
 				testACLs[0],

--- a/npm/pkg/dataplane/policies/testutils_linux.go
+++ b/npm/pkg/dataplane/policies/testutils_linux.go
@@ -13,6 +13,20 @@ var (
 
 	listLineNumbersCommandStrings      = []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L", "FORWARD", "--line-numbers"}
 	listPolicyChainNamesCommandStrings = []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}
+
+	grepOutputAzureChainsWithoutPolicies = `Chain AZURE-NPM (1 references)
+Chain AZURE-NPM-ACCEPT (1 references)
+Chain AZURE-NPM-EGRESS (1 references)
+Chain AZURE-NPM-INGRESS (1 references)
+Chain AZURE-NPM-INGRESS-ALLOW-MARK (1 references)`
+
+	grepOutputAzureChainsWithPolicies = `Chain AZURE-NPM (1 references)
+Chain AZURE-NPM-ACCEPT (1 references)
+Chain AZURE-NPM-EGRESS (1 references)
+Chain AZURE-NPM-EGRESS-123456 (1 references)
+Chain AZURE-NPM-INGRESS (1 references)
+Chain AZURE-NPM-INGRESS-123456 (1 references)
+Chain AZURE-NPM-INGRESS-ALLOW-MARK (1 references)`
 )
 
 func GetAddPolicyTestCalls(_ *NPMNetworkPolicy) []testutils.TestCmd {
@@ -50,32 +64,21 @@ func GetRemovePolicyFailureTestCalls(policy *NPMNetworkPolicy) []testutils.TestC
 
 func GetInitializeTestCalls() []testutils.TestCmd {
 	return []testutils.TestCmd{
-		fakeIPTablesRestoreCommand, // gives correct exit code
-		{
-			Cmd:      listLineNumbersCommandStrings,
-			ExitCode: 1, // grep call gets this exit code (exit code 1 means grep found nothing)
-		},
-		// NOTE: after the StdOut pipe used for grep, MockIOShim gets confused and each command's ExitCode and Stdout are applied to the ensuing command
-		{
-			Cmd:      []string{"grep", "KUBE-SERVICES"},
-			Stdout:   "iptables: No chain/target/match by that name.", // this Stdout and ExitCode are for the iptables check command below
-			ExitCode: 1,
-		},
-		{Cmd: []string{"iptables", "-w", "60", "-C", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
-		{Cmd: []string{"iptables", "-w", "60", "-I", "FORWARD", "1", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
+		fakeIPTablesRestoreCommand,
+		{Cmd: listLineNumbersCommandStrings, PipedToCommand: true},
+		{Cmd: []string{"grep", "AZURE-NPM"}, ExitCode: 1},
+		{Cmd: []string{"iptables", "-w", "60", "-I", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
 	}
 }
 
 func GetResetTestCalls() []testutils.TestCmd {
 	return []testutils.TestCmd{
 		{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
+		{Cmd: listPolicyChainNamesCommandStrings, PipedToCommand: true},
 		{
-			Cmd:    listPolicyChainNamesCommandStrings,
-			Stdout: "Chain AZURE-NPM-INGRESS-123456\nChain AZURE-NPM-EGRESS-123456",
+			Cmd:      []string{"grep", "Chain AZURE-NPM"},
+			ExitCode: 1,
 		},
-		// NOTE: after the StdOut pipe used for grep, MockIOShim gets confused and each command's ExitCode and Stdout are applied to the ensuing command
-		{Cmd: []string{"grep", ingressOrEgressPolicyChainPattern}}, // ExitCode 0 for the iptables restore command
-		fakeIPTablesRestoreCommand,
 	}
 }
 

--- a/npm/pkg/dataplane/policies/testutils_linux.go
+++ b/npm/pkg/dataplane/policies/testutils_linux.go
@@ -13,20 +13,6 @@ var (
 
 	listLineNumbersCommandStrings      = []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L", "FORWARD", "--line-numbers"}
 	listPolicyChainNamesCommandStrings = []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}
-
-	grepOutputAzureChainsWithoutPolicies = `Chain AZURE-NPM (1 references)
-Chain AZURE-NPM-ACCEPT (1 references)
-Chain AZURE-NPM-EGRESS (1 references)
-Chain AZURE-NPM-INGRESS (1 references)
-Chain AZURE-NPM-INGRESS-ALLOW-MARK (1 references)`
-
-	grepOutputAzureChainsWithPolicies = `Chain AZURE-NPM (1 references)
-Chain AZURE-NPM-ACCEPT (1 references)
-Chain AZURE-NPM-EGRESS (1 references)
-Chain AZURE-NPM-EGRESS-123456 (1 references)
-Chain AZURE-NPM-INGRESS (1 references)
-Chain AZURE-NPM-INGRESS-123456 (1 references)
-Chain AZURE-NPM-INGRESS-ALLOW-MARK (1 references)`
 )
 
 func GetAddPolicyTestCalls(_ *NPMNetworkPolicy) []testutils.TestCmd {

--- a/test/integration/npm/main.go
+++ b/test/integration/npm/main.go
@@ -115,34 +115,15 @@ func main() {
 	printAndWait()
 
 	panicOnError(dp.AddPolicy(testNetPol))
-
-	testPolicyManager()
-}
-
-func testPolicyManager() {
-	pMgr := policies.NewPolicyManager(common.NewIOShim())
-
-	panicOnError(pMgr.Reset())
+	panicOnError(dp.AddPolicy(policies.TestNetworkPolicies[0]))
+	panicOnError(dp.AddPolicy(policies.TestNetworkPolicies[1]))
 	printAndWait()
 
-	panicOnError(pMgr.Initialize())
+	panicOnError(dp.RemovePolicy(policies.TestNetworkPolicies[2].Name)) // no-op
+	panicOnError(dp.AddPolicy(policies.TestNetworkPolicies[2]))
 	printAndWait()
 
-	panicOnError(pMgr.AddPolicy(policies.TestNetworkPolicies[0], nil))
-	printAndWait()
-
-	panicOnError(pMgr.AddPolicy(policies.TestNetworkPolicies[1], nil))
-	printAndWait()
-
-	// remove something that doesn't exist
-	panicOnError(pMgr.RemovePolicy(policies.TestNetworkPolicies[2].Name, nil))
-	printAndWait()
-
-	panicOnError(pMgr.AddPolicy(policies.TestNetworkPolicies[2], nil))
-	printAndWait()
-
-	// remove something that exists
-	panicOnError(pMgr.RemovePolicy(policies.TestNetworkPolicies[1].Name, nil))
+	panicOnError(dp.RemovePolicy(policies.TestNetworkPolicies[1].Name))
 }
 
 func panicOnError(err error) {


### PR DESCRIPTION
Linux DP wasn't working for integration tests before this PR. Now it does. 

It will fail conformance tests though due to the first problem in the TODOs below.

TODO in followup PR: 
- fix problem: accept rules for iptables ingress chains jump to EGRESS instead of jumping to ALLOW-INGRESS-MARK chain
- uncomment reboot code for Linux Policy Manager (reset and initialize Azure chains when we have 0 network policies)
- call reconcile for policy manager within DP
- getting the chain line number will return the first digit of the line number, not the whole number. So we might think position 15 is ok when we need position 1.

# Notes on Changes
Linux Policy Manager fixes (in _chain-management_linux.go_):
1. make the jump from FORWARD chain to AZURE-NPM chain the first rule in the FORWARD chain
2. Don't throw an error if we fail to delete this jump rule when it doesn't exist
3. fix how we reset chains by only flushing/delete current chains (as opposed to creating/flushing/deleting all possible chains before)
4. Also, don't make an iptables-restore call when there are no azure chains currently

Fix DP:
1. uncomment code that initializes policy manager
2. same with resetting

Unit Testing:
1. verify all exec calls now
2. fix UTs for grep
3. consolidate tests in _chain-management_linux_test.go_ into tests with subtests for better readability and maintenance

Integration Testing: 
1. Better testing for network policies (had to update some test network policies which impacted tests in _policymanager_linux_test.go_)