### PR TITLE
perf: [NPM] Remove random factor for resync and set resync time 0 as default value

### DIFF
--- a/npm/azure-npm.yaml
+++ b/npm/azure-npm.yaml
@@ -146,7 +146,7 @@ metadata:
 data:
   azure-npm.json: |
     {
-        "ResyncPeriodInMinutes": 15,
+        "ResyncPeriodInMinutes": 0,
         "ListeningPort":         10091,
         "ListeningAddress":      "0.0.0.0",
         "Toggles": {

--- a/npm/cmd/start.go
+++ b/npm/cmd/start.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"time"
 
 	"github.com/Azure/azure-container-networking/common"
@@ -99,10 +98,7 @@ func start(config npmconfig.Config) error {
 
 	// Setting reSyncPeriod
 	minResyncPeriod := time.Duration(config.ResyncPeriodInMinutes) * time.Minute
-
-	// Adding some randomness so all NPM pods will not request for info at once.
-	factor := rand.Float64() + 1
-	resyncPeriod := time.Duration(float64(minResyncPeriod.Nanoseconds()) * factor)
+	resyncPeriod := time.Duration(float64(minResyncPeriod.Nanoseconds()))
 	klog.Infof("Resync period for NPM pod is set to %d.", int(resyncPeriod/time.Minute))
 	factory := informers.NewSharedInformerFactory(clientset, resyncPeriod)
 

--- a/npm/config/config.go
+++ b/npm/config/config.go
@@ -1,7 +1,7 @@
 package npmconfig
 
 const (
-	defaultResyncPeriod  = 15
+	defaultResyncPeriod  = 0
 	defaultListeningPort = 10091
 
 	// ConfigEnvPath is what's used by viper to load config path


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
Random factor for resync is unnecessary since it re-lists cached objects from a local cache in client-go.  In addition, `resync` (15 mins) is not helpful for NPM. 
More detail refers to doc in acn

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation in **acndocs**
- [ ] adds unit tests


**Notes**:
