### PR TITLE
feat: [NPM] Support endport in v1 NPM

### DIFF
--- a/npm/pkg/controlplane/controllers/v1/translatePolicy_test.go
+++ b/npm/pkg/controlplane/controllers/v1/translatePolicy_test.go
@@ -19,123 +19,135 @@ import (
 const testPolicyDir = "../../../../"
 
 func TestCraftPartialIptEntrySpecFromPort(t *testing.T) {
-	portRule := networkingv1.NetworkPolicyPort{}
+	port := intstr.FromInt(8000)
+	TCP := v1.ProtocolTCP
+	var endPort int32 = 8002
 
-	iptEntrySpec := craftPartialIptEntrySpecFromPort(portRule, util.IptablesDstPortFlag)
-	expectedIptEntrySpec := []string{}
-
-	if !reflect.DeepEqual(iptEntrySpec, expectedIptEntrySpec) {
-		t.Errorf("TestCraftPartialIptEntrySpecFromPort failed @ empty iptEntrySpec comparison")
-		t.Errorf("iptEntrySpec:\n%v", iptEntrySpec)
-		t.Errorf("expectedIptEntrySpec:\n%v", expectedIptEntrySpec)
+	testCases := map[networkingv1.NetworkPolicyPort][]string{
+		{}: {},
+		{
+			Port: &port,
+		}: {
+			util.IptablesDstPortFlag,
+			"8000",
+		},
+		{
+			Protocol: &TCP,
+		}: {
+			util.IptablesProtFlag,
+			string(TCP),
+		},
+		{
+			Protocol: &TCP,
+			Port:     &port,
+		}: {
+			util.IptablesProtFlag,
+			string(TCP),
+			util.IptablesDstPortFlag,
+			"8000",
+		},
+		{
+			Protocol: &TCP,
+			Port:     &port,
+			EndPort:  nil,
+		}: {
+			util.IptablesProtFlag,
+			string(TCP),
+			util.IptablesDstPortFlag,
+			"8000",
+		},
+		{
+			Protocol: &TCP,
+			Port:     &port,
+			EndPort:  &endPort,
+		}: {
+			util.IptablesProtFlag,
+			string(TCP),
+			util.IptablesDstPortFlag,
+			"8000:8002",
+		},
 	}
 
-	tcp := v1.ProtocolTCP
-	portRule = networkingv1.NetworkPolicyPort{
-		Protocol: &tcp,
-	}
-
-	iptEntrySpec = craftPartialIptEntrySpecFromPort(portRule, util.IptablesDstPortFlag)
-	expectedIptEntrySpec = []string{
-		util.IptablesProtFlag,
-		"TCP",
-	}
-
-	if !reflect.DeepEqual(iptEntrySpec, expectedIptEntrySpec) {
-		t.Errorf("TestCraftPartialIptEntrySpecFromPort failed @ tcp iptEntrySpec comparison")
-		t.Errorf("iptEntrySpec:\n%v", iptEntrySpec)
-		t.Errorf("expectedIptEntrySpec:\n%v", expectedIptEntrySpec)
-	}
-
-	port8000 := intstr.FromInt(8000)
-	portRule = networkingv1.NetworkPolicyPort{
-		Port: &port8000,
-	}
-
-	iptEntrySpec = craftPartialIptEntrySpecFromPort(portRule, util.IptablesDstPortFlag)
-	expectedIptEntrySpec = []string{
-		util.IptablesDstPortFlag,
-		"8000",
-	}
-
-	if !reflect.DeepEqual(iptEntrySpec, expectedIptEntrySpec) {
-		t.Errorf("TestCraftPartialIptEntrySpecFromPort failed @ port 8000 iptEntrySpec comparison")
-		t.Errorf("iptEntrySpec:\n%v", iptEntrySpec)
-		t.Errorf("expectedIptEntrySpec:\n%v", expectedIptEntrySpec)
-	}
-
-	portRule = networkingv1.NetworkPolicyPort{
-		Protocol: &tcp,
-		Port:     &port8000,
-	}
-
-	iptEntrySpec = craftPartialIptEntrySpecFromPort(portRule, util.IptablesDstPortFlag)
-	expectedIptEntrySpec = []string{
-		util.IptablesProtFlag,
-		"TCP",
-		util.IptablesDstPortFlag,
-		"8000",
-	}
-
-	if !reflect.DeepEqual(iptEntrySpec, expectedIptEntrySpec) {
-		t.Errorf("TestCraftPartialIptEntrySpecFromPort failed @ tcp port 8000 iptEntrySpec comparison")
-		t.Errorf("iptEntrySpec:\n%v", iptEntrySpec)
-		t.Errorf("expectedIptEntrySpec:\n%v", expectedIptEntrySpec)
+	for portRule, expected := range testCases {
+		iptEntrySpec := craftPartialIptEntrySpecFromPort(portRule, util.IptablesDstPortFlag)
+		if !reflect.DeepEqual(iptEntrySpec, expected) {
+			t.Errorf("TestCraftPartialIptEntrySpecFromPort failed")
+			t.Errorf("Got iptEntrySpec:%v", iptEntrySpec)
+			t.Errorf("Expected iptEntrySpec:%v", expected)
+		}
 	}
 }
 
+func TestGetPortRange(t *testing.T) {
+	port := intstr.FromInt(8000)
+	TCP := v1.ProtocolTCP
+	var endPort int32 = 8002
+
+	testCases := map[networkingv1.NetworkPolicyPort]struct {
+		portRange     string
+		portRuleExist bool
+	}{
+		{}: {"", false},
+		{
+			Port: &port,
+		}: {"8000", true},
+		{
+			Protocol: &TCP,
+			Port:     &port,
+		}: {"8000", true},
+		{
+			Protocol: &TCP,
+			Port:     &port,
+			EndPort:  nil,
+		}: {"8000", true},
+		{
+			Protocol: &TCP,
+			Port:     &port,
+			EndPort:  &endPort,
+		}: {"8000:8002", true},
+	}
+
+	for portRule, expected := range testCases {
+		portRange, exist := getPortRange(portRule)
+		if portRange != expected.portRange || exist != expected.portRuleExist {
+			t.Errorf("TestGetPortRange failed got = %s (%v), want %s (%v)", portRange, exist, expected.portRange, expected.portRuleExist)
+		}
+	}
+}
 func TestCraftPartialIptablesCommentFromPort(t *testing.T) {
-	portRule := networkingv1.NetworkPolicyPort{}
+	port := intstr.FromInt(8000)
+	TCP := v1.ProtocolTCP
+	var endPort int32 = 8002
 
-	comment := craftPartialIptablesCommentFromPort(portRule, util.IptablesDstPortFlag)
-	expectedComment := ""
-
-	if !reflect.DeepEqual(comment, expectedComment) {
-		t.Errorf("TestCraftPartialIptablesCommentFromPort failed @ empty comment comparison")
-		t.Errorf("comment:\n%v", comment)
-		t.Errorf("expectedComment:\n%v", expectedComment)
+	testCases := map[networkingv1.NetworkPolicyPort]string{
+		{}: "",
+		{
+			Port: &port,
+		}: "PORT-8000",
+		{
+			Protocol: &TCP,
+		}: string(TCP),
+		{
+			Protocol: &TCP,
+			Port:     &port,
+		}: "TCP-PORT-8000",
+		{
+			Protocol: &TCP,
+			Port:     &port,
+			EndPort:  nil,
+		}: "TCP-PORT-8000",
+		{
+			Protocol: &TCP,
+			Port:     &port,
+			EndPort:  &endPort,
+		}: "TCP-PORT-8000:8002",
 	}
 
-	tcp := v1.ProtocolTCP
-	portRule = networkingv1.NetworkPolicyPort{
-		Protocol: &tcp,
-	}
-
-	comment = craftPartialIptablesCommentFromPort(portRule, util.IptablesDstPortFlag)
-	expectedComment = "TCP"
-
-	if !reflect.DeepEqual(comment, expectedComment) {
-		t.Errorf("TestCraftPartialIptablesCommentFromPort failed @ tcp comment comparison")
-		t.Errorf("comment:\n%v", comment)
-		t.Errorf("expectedComment:\n%v", expectedComment)
-	}
-
-	port8000 := intstr.FromInt(8000)
-	portRule = networkingv1.NetworkPolicyPort{
-		Port: &port8000,
-	}
-
-	comment = craftPartialIptablesCommentFromPort(portRule, util.IptablesDstPortFlag)
-	expectedComment = "PORT-8000"
-
-	if !reflect.DeepEqual(comment, expectedComment) {
-		t.Errorf("TestCraftPartialIptablesCommentFromPort failed @ port 8000 comment comparison")
-		t.Errorf("comment:\n%v", comment)
-		t.Errorf("expectedIptEntrySpec:\n%v", expectedComment)
-	}
-
-	portRule = networkingv1.NetworkPolicyPort{
-		Protocol: &tcp,
-		Port:     &port8000,
-	}
-
-	comment = craftPartialIptablesCommentFromPort(portRule, util.IptablesDstPortFlag)
-	expectedComment = "TCP-PORT-8000"
-
-	if !reflect.DeepEqual(comment, expectedComment) {
-		t.Errorf("TestCraftPartialIptablesCommentFromPort failed @ tcp port 8000 comment comparison")
-		t.Errorf("comment:\n%v", comment)
-		t.Errorf("expectedIptEntrySpec:\n%v", expectedComment)
+	for portRule, expected := range testCases {
+		portRuleComments := craftPartialIptablesCommentFromPort(portRule)
+		if portRuleComments != expected {
+			t.Errorf("TestCraftPartialIptablesCommentFromPort failed got= %s want= %s", portRuleComments, expected)
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
**Note that it needs to check how `npm` works in the AKS cluster version lower than  v1.22.**

<!-- What does this PR improve or fix in Azure Container Networking? -->
This PR is to support [endPort feature ](https://kubernetes.io/docs/concepts/services-networking/network-policies/#targeting-a-range-of-ports)in NPM which is supported by Kubernetes v1.21 [alpha]
Only "npm/translatePolicy.go" and "npm/translatePolicy_test.go" files are updated and the rest of them are module updates.

For example, below yaml snippet from example network policy from [endPort feature ](https://kubernetes.io/docs/concepts/services-networking/network-policies/#targeting-a-range-of-ports), the target port is between the range 32000 and 32768.
```yaml
    ports:
    - protocol: TCP
      port: 32000
      endPort: 32768
```
Since iptables supports "--destination-port port[:port]", this PR leverages the capability.
Below is data plane representation of above yaml snippet with this PR and without this PR
```shell
# With this PR (dpts:32000:32768")
Chain AZURE-NPM-INGRESS-PORT (1 references)
 pkts bytes target     prot opt in     out     source               destination
    0     0 MARK       tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            match-set azure-npm-784554818 dst match-set azure-npm-1547420863 dst match-set azure-npm-784554818 src match-set azure-npm-3036499794 src tcp **dpts:32000:32768** /* ALLOW-role:client-IN-ns-default-AND-TCP-PORT-32000:32768-TO-role:db-IN-ns-default */ MARK set 0x2000

# Current NPM without this PR ("dpt:32000")
Chain AZURE-NPM-INGRESS-PORT (1 references)
 pkts bytes target     prot opt in     out     source               destination
    0     0 MARK       tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            match-set azure-npm-784554818 dst match-set azure-npm-1547420863 dst match-set azure-npm-784554818 src match-set azure-npm-3036499794 src **tcp dpt:32000** /* ALLOW-role:client-IN-ns-default-AND-TCP-PORT-32000-TO-role:db-IN-ns-default */ MARK set 0x2000
```


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
Based on [endPort feature ](https://kubernetes.io/docs/concepts/services-networking/network-policies/#targeting-a-range-of-ports), this feature as an alpha feature is disabled by default. To enable the endPort field at a cluster level, you (or your cluster administrator) need to enable the NetworkPolicyEndPort feature gate for the API server with --feature-gates=NetworkPolicyEndPort=true,….

In addition, it needs to update multiple modules (e.g., client-go, etc).
Thus, it may need to discuss how to proceed PR.


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [X] includes documentation ("npm/Network policy examples to test NPM new features or bug-fix/end-port" directory in acndoc: describe how to reproduce this PR and you can play with endport)
- [X] adds unit tests


**Notes**:
Since some duplicated rules can be installed in iptables based on submitted network policies, we will need to optimize them later.
For example, when two yaml files (below A.yaml and B.yaml) are the same except for endPort field, the two rules in iptables are installed.
```yaml
# A.yaml
    ports:
    - protocol: TCP
      port: 32000
      endPort: 32768

# B.yaml
    ports:
    - protocol: TCP
      port: 32000
```