### PR TITLE
feat: nnc client sets ownerref

### DIFF
--- a/crd/nodenetworkconfig/client.go
+++ b/crd/nodenetworkconfig/client.go
@@ -2,6 +2,7 @@ package nodenetworkconfig
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	"github.com/Azure/azure-container-networking/crd"
@@ -155,7 +156,7 @@ func (c *Client) SetOwnerRef(ctx context.Context, nnc *v1alpha.NodeNetworkConfig
 	}
 
 	if err := c.nnccli.Patch(ctx, newNNC, ctrlcli.MergeFrom(nnc)); err != nil {
-		return err
+		return fmt.Errorf("could not PATCH NNC %s: %w", nnc.Name, err)
 	}
 
 	return nil


### PR DESCRIPTION
**Reason for Change**:
Adds SetOwnerRef to nnc client which sets the NNC ownership to the given object

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests

