### PR TITLE
ci: retry image build on windows in the event runtime isn't ready

### DIFF
--- a/.pipelines/windows-image.yaml
+++ b/.pipelines/windows-image.yaml
@@ -12,7 +12,7 @@ stages:
           name: "$(BUILD_POOL_NAME_DEFAULT_WINDOWS)"
       steps:
         - powershell: |
-            powershell.exe -command "& { . .\windows.ps1; azure-npm-image $(tag)-windows-amd64 }"
+            powershell.exe -command "& { . .\windows.ps1; Retry({azure-npm-image $(tag)-windows-amd64}) }"
           name: "build_npm"
           displayName: "Build"
 

--- a/windows.ps1
+++ b/windows.ps1
@@ -1,8 +1,27 @@
+# Retry({azure-npm-image $(tag)-windows-amd64})
+
+function Retry([Action]$action) {
+    $attempts = 3    
+    $sleepInSeconds = 5
+    do {
+        try {
+            $action.Invoke();
+            break;
+        }
+        catch [Exception] {
+            Write-Host $_.Exception.Message
+        }            
+        $attempts--
+        if ($attempts -gt 0) { 
+            sleep $sleepInSeconds 
+        }
+    } while ($attempts -gt 0)    
+}
 
 function azure-npm-image {
     $env:ACN_PACKAGE_PATH = "github.com/Azure/azure-container-networking"
     $env:NPM_AI_ID = "014c22bd-4107-459e-8475-67909e96edcb"
-    $env:NPM_AI_PATH="$env:ACN_PACKAGE_PATH/npm.aiMetadata"
+    $env:NPM_AI_PATH = "$env:ACN_PACKAGE_PATH/npm.aiMetadata"
 
     if ($null -eq $env:VERSION) { $env:VERSION = $args[0] } 
     docker build `


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
