### PR TITLE
test: [NPM] conformance tests for multiple profiles

### DIFF
--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -192,10 +192,12 @@ jobs:
     displayName: "Gather NPM Logs"
     condition: always()
 
-  # FIXME do other jobs in the matrix override this?
   - publish: $(System.DefaultWorkingDirectory)/npmLogs
     condition: always()
     artifact: NpmLogs
+  - publish: $(System.DefaultWorkingDirectory)/kubeconfig
+    condition: always()
+    artifact: kubeconfig
 
 - job: Clean_up
   displayName: "Cleanup"
@@ -204,7 +206,6 @@ jobs:
     demands: 
     - agent.os -equals Linux
     - Role -equals Build
-  condition: always()
   dependsOn: [Create_Cluster_and_Run_Test, setup]
   variables:
     RESOURCE_GROUP: $[ dependencies.setup.outputs['EnvironmentalVariables.RESOURCE_GROUP'] ]

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -1,5 +1,5 @@
 trigger:
-- master
+- v2-conformance
 
 variables:
 - name: VNET_NAME

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -137,7 +137,7 @@ jobs:
     demands: 
     - agent.os -equals Linux
     - Role -equals Build
-  dependsOn: [Create_cluster, Build_test, setup]
+  dependsOn: [Create_RG, Build_test, setup]
   variables:
     RESOURCE_GROUP: $[ dependencies.setup.outputs['EnvironmentalVariables.RESOURCE_GROUP'] ]
     TAG: $[ dependencies.setup.outputs['EnvironmentalVariables.TAG'] ]

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -197,7 +197,7 @@ jobs:
     artifact: NpmLogs
   - publish: $(System.DefaultWorkingDirectory)/kubeconfig
     condition: always()
-    artifact: kubeconfig
+    artifact: KubeConfig
 
 - job: Clean_up
   displayName: "Cleanup"

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -208,7 +208,7 @@ jobs:
     - agent.os -equals Linux
     - Role -equals Build
   condition: always()
-  dependsOn: [Run_test, setup]
+  dependsOn: [Create_Cluster_and_Run_Test, setup]
   variables:
     RESOURCE_GROUP: $[ dependencies.setup.outputs['EnvironmentalVariables.RESOURCE_GROUP'] ]
     TAG: $[ dependencies.setup.outputs['EnvironmentalVariables.TAG'] ]

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -2,12 +2,8 @@ trigger:
 - master
 
 variables:
-- name: AZURE_CLUSTER
-  value: azure-npm
 - name: VNET_NAME
   value: npm-vnet
-- name: FQDN
-  value: empty
 
 jobs:
 - job: setup
@@ -94,9 +90,8 @@ jobs:
   - publish: $(System.DefaultWorkingDirectory)/kubernetes/_output/local/bin/linux/amd64
     artifact: Test
 
-
-- job: Create_cluster
-  displayName: "Deploy AKS Cluster"
+- job: Create_RG
+  displayName: "Create AKS Resource Group"
   pool:
     name: $(BUILD_POOL_NAME_DEFAULT)
     demands: 
@@ -105,7 +100,6 @@ jobs:
   dependsOn: [setup]
   variables:
     RESOURCE_GROUP: $[ dependencies.setup.outputs['EnvironmentalVariables.RESOURCE_GROUP'] ]
-    TAG: $[ dependencies.setup.outputs['EnvironmentalVariables.TAG'] ]
   steps:
   - script: |
       sudo rm -rf ./*
@@ -123,14 +117,21 @@ jobs:
         az group create -n $(RESOURCE_GROUP) -l $(LOCATION) -o table
         echo created RG $(RESOURCE_GROUP) in $(LOCATION)
         az version
-        az aks create --no-ssh-key \
-        --resource-group $(RESOURCE_GROUP) \
-        --name $(AZURE_CLUSTER) \
-        --network-plugin azure
 
-- job: Run_test
+- job: Create_Cluster_and_Run_Test
   timeoutInMinutes: 360
   displayName: "Run Kubernetes Network Policy Test Suite"
+  strategy:
+    matrix:
+      v1-default:
+        AZURE_CLUSTER: 'v1-default-cluster'
+        PROFILE: 'v1-default.yaml'
+      v1-place-azure-chain-first:
+        AZURE_CLUSTER: 'v1-place-azure-chain-first-cluster'
+        PROFILE: 'v1-place-azure-chain-first.yaml'
+      v2-default:
+        AZURE_CLUSTER: 'v2-default-cluster'
+        PROFILE: 'v2-default.yaml'
   pool:
     name: $(BUILD_POOL_NAME_DEFAULT)
     demands: 
@@ -140,6 +141,7 @@ jobs:
   variables:
     RESOURCE_GROUP: $[ dependencies.setup.outputs['EnvironmentalVariables.RESOURCE_GROUP'] ]
     TAG: $[ dependencies.setup.outputs['EnvironmentalVariables.TAG'] ]
+    FQDN: empty
   steps:
   - checkout: none
   - download: current
@@ -151,6 +153,11 @@ jobs:
       scriptType: 'bash'
       scriptLocation: 'inlineScript'
       inlineScript: |
+        az aks create --no-ssh-key \
+        --resource-group $(RESOURCE_GROUP) \
+        --name $(AZURE_CLUSTER) \
+        --network-plugin azure
+
         echo Cluster $(AZURE_CLUSTER)
         echo Resource $(RESOURCE_GROUP)
 
@@ -164,6 +171,10 @@ jobs:
 
         # swap azure-npm image with one built during run
         ./kubectl --kubeconfig=./kubeconfig set image daemonset/azure-npm -n kube-system azure-npm=$IMAGE_REGISTRY/azure-npm:$(TAG)
+
+        # swap NPM profile with one specified as parameter
+        ./kubectl --kubeconfig=./kubeconfig apply -f https://raw.githubusercontent.com/Azure/azure-container-networking/master/npm/profiles/$(PROFILE)
+        ./kubectl --kubeconfig=./kubeconfig rollout restart ds azure-npm -n kube-system
 
         ./kubectl --kubeconfig=./kubeconfig describe daemonset azure-npm -n kube-system
 
@@ -184,6 +195,7 @@ jobs:
     displayName: "Gather NPM Logs"
     condition: always()
 
+  # FIXME do other jobs in the matrix override this?
   - publish: $(System.DefaultWorkingDirectory)/npmLogs
     condition: always()
     artifact: NpmLogs

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -127,7 +127,7 @@ jobs:
         AZURE_CLUSTER: 'v1-default-cluster'
         PROFILE: 'v1-default.yaml'
       v1-place-azure-chain-first:
-        AZURE_CLUSTER: 'v1-place-azure-chain-first-cluster'
+        AZURE_CLUSTER: 'v1-place-first-cluster'
         PROFILE: 'v1-place-azure-chain-first.yaml'
       v2-default:
         AZURE_CLUSTER: 'v2-default-cluster'

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -126,9 +126,6 @@ jobs:
       v1-default:
         AZURE_CLUSTER: 'v1-default-cluster'
         PROFILE: 'v1-default.yaml'
-      v1-place-azure-chain-first:
-        AZURE_CLUSTER: 'v1-place-first-cluster'
-        PROFILE: 'v1-place-azure-chain-first.yaml'
       v2-default:
         AZURE_CLUSTER: 'v2-default-cluster'
         PROFILE: 'v2-default.yaml'

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -1,5 +1,5 @@
 trigger:
-- v2-conformance
+- master
 
 variables:
 - name: VNET_NAME

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -189,15 +189,13 @@ jobs:
       npmPodList=`kubectl get pods -n kube-system | grep npm | awk '{print $1}'`
       mkdir -p $(System.DefaultWorkingDirectory)/npmLogs
       for npm in $npmPodList; do ./kubectl logs -n kube-system $npm --kubeconfig=./kubeconfig > $(System.DefaultWorkingDirectory)/npmLogs/$npm ;done
+      mv ./kubeconfig $(System.DefaultWorkingDirectory)/npmLogs/kubeconfig
     displayName: "Gather NPM Logs"
     condition: always()
 
   - publish: $(System.DefaultWorkingDirectory)/npmLogs
     condition: always()
     artifact: NpmLogs
-  - publish: $(System.DefaultWorkingDirectory)/kubeconfig
-    condition: always()
-    artifact: KubeConfig
 
 - job: Clean_up
   displayName: "Cleanup"


### PR DESCRIPTION
Does shared work in single jobs, then runs the actual testing for each NPM profile in parallel.

Shared work:
- setting up the environment
- making conformance binaries
- creating a shared Azure Resource Group

Work done for each profile:
- creating an AKS cluster
- installing NPM with the given profile
- running conformance and publishing results and logs