### PR TITLE
changing the HLIP address used in apipa endpoint

### DIFF
--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -43,7 +43,7 @@ const (
 	apipaHostLevelEndpoint = "apipa_hostlevel_endpoint"
 
 	// apipa host level ip
-	apipaHostLevelIP = "169.254.169.2"
+	apipaHostLevelIP = "169.254.255.194"
 )
 
 type AzureHNSEndpointClient interface {


### PR DESCRIPTION
Using the different HLIP prefix.
