### PR TITLE
fix: [CI] adding profile name to logs

### DIFF
--- a/.github/workflows/cyclonus-netpol-test.yaml
+++ b/.github/workflows/cyclonus-netpol-test.yaml
@@ -67,8 +67,8 @@ jobs:
       - name: Fetch logs
         if: always()
         run: |
-          kubectl logs -n kube-system -l k8s-app=azure-npm --tail -1 --prefix > npm-logs.txt
-          mv ./test/cyclonus/cyclonus-test.txt ./cyclonus-test.txt
+          kubectl logs -n kube-system -l k8s-app=azure-npm --tail -1 --prefix > npm-logs_${{ matrix.profile }}.txt
+          mv ./test/cyclonus/cyclonus-test.txt ./cyclonus-test_${{ matrix.profile }}.txt
 
       - name: 'Upload Logs'
         uses: actions/upload-artifact@v2

--- a/.github/workflows/cyclonus-netpol-test.yaml
+++ b/.github/workflows/cyclonus-netpol-test.yaml
@@ -76,5 +76,5 @@ jobs:
         with:
           name: logs
           path: |
-            ./npm-logs.txt
-            ./cyclonus-test.txt
+            ./npm-logs_${{ matrix.profile }}.txt
+            ./cyclonus-test_${{ matrix.profile }}.txt


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

All profile cyclonus logs are emitted same name resulting in overwritten results. Adding the profile suffix to differentiate logs. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
