### PR TITLE
fix: remove ENV setting in dockerfile

### DIFF
--- a/tools/acncli/Dockerfile
+++ b/tools/acncli/Dockerfile
@@ -14,9 +14,4 @@ FROM scratch
 COPY --from=build /output/linux_amd64/acncli/ .
 COPY --from=build /output /output
 
-ENV AZURE_CNI_OS=linux
-ENV AZURE_CNI_TENANCY=singletenancy
-ENV AZURE_CNI_IPAM=azure-cns
-ENV AZURE_CNI_MODE=transparent
-
 ENTRYPOINT ["./acn", "cni", "manager", "--follow", "--mode", "transparent"]


### PR DESCRIPTION
**Reason for Change**:
Trying to onboard this to MCR so it can be used in AKS.

Should not force these ENV vars on every build, should instead set per environment (ie, if building for Windows OS, use the appropriate flag).

**Issue Fixed**:
N/A


**Requirements**:
N/A

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
