### PR TITLE
Scale ipampool directly to final request size

### DIFF
--- a/cns/api.go
+++ b/cns/api.go
@@ -42,9 +42,6 @@ type HTTPService interface {
 	SendNCSnapShotPeriodically(context.Context, int)
 	SetNodeOrchestrator(*SetOrchestratorTypeRequest)
 	SyncNodeStatus(string, string, string, json.RawMessage) (types.ResponseCode, string)
-	GetPendingProgramIPConfigs() []IPConfigurationStatus
-	GetAvailableIPConfigs() []IPConfigurationStatus
-	GetAssignedIPConfigs() []IPConfigurationStatus
 	GetPendingReleaseIPConfigs() []IPConfigurationStatus
 	GetPodIPConfigState() map[string]IPConfigurationStatus
 	MarkIPAsPendingRelease(numberToMark int) (map[string]IPConfigurationStatus, error)

--- a/cns/fakes/cnsfake.go
+++ b/cns/fakes/cnsfake.go
@@ -209,34 +209,10 @@ func (fake *HTTPServiceFake) SyncNodeStatus(string, string, string, json.RawMess
 // SyncHostNCVersion will update HostVersion in containerstatus.
 func (fake *HTTPServiceFake) SyncHostNCVersion(context.Context, string, time.Duration) {}
 
-func (fake *HTTPServiceFake) GetPendingProgramIPConfigs() []cns.IPConfigurationStatus {
-	ipconfigs := []cns.IPConfigurationStatus{}
-	for _, ipconfig := range fake.IPStateManager.PendingProgramIPConfigState {
-		ipconfigs = append(ipconfigs, ipconfig)
-	}
-	return ipconfigs
-}
-
-func (fake *HTTPServiceFake) GetAvailableIPConfigs() []cns.IPConfigurationStatus {
-	ipconfigs := []cns.IPConfigurationStatus{}
-	for _, ipconfig := range fake.IPStateManager.AvailableIPConfigState {
-		ipconfigs = append(ipconfigs, ipconfig)
-	}
-	return ipconfigs
-}
-
-func (fake *HTTPServiceFake) GetAssignedIPConfigs() []cns.IPConfigurationStatus {
-	ipconfigs := []cns.IPConfigurationStatus{}
-	for _, ipconfig := range fake.IPStateManager.AssignedIPConfigState {
-		ipconfigs = append(ipconfigs, ipconfig)
-	}
-	return ipconfigs
-}
-
 func (fake *HTTPServiceFake) GetPendingReleaseIPConfigs() []cns.IPConfigurationStatus {
 	ipconfigs := []cns.IPConfigurationStatus{}
-	for _, ipconfig := range fake.IPStateManager.PendingReleaseIPConfigState {
-		ipconfigs = append(ipconfigs, ipconfig)
+	for key := range fake.IPStateManager.PendingReleaseIPConfigState {
+		ipconfigs = append(ipconfigs, fake.IPStateManager.PendingReleaseIPConfigState[key])
 	}
 	return ipconfigs
 }
@@ -244,14 +220,17 @@ func (fake *HTTPServiceFake) GetPendingReleaseIPConfigs() []cns.IPConfigurationS
 // Return union of all state maps
 func (fake *HTTPServiceFake) GetPodIPConfigState() map[string]cns.IPConfigurationStatus {
 	ipconfigs := make(map[string]cns.IPConfigurationStatus)
-	for key, val := range fake.IPStateManager.AssignedIPConfigState {
-		ipconfigs[key] = val
+	for key := range fake.IPStateManager.AssignedIPConfigState {
+		ipconfigs[key] = fake.IPStateManager.AssignedIPConfigState[key]
 	}
-	for key, val := range fake.IPStateManager.AvailableIPConfigState {
-		ipconfigs[key] = val
+	for key := range fake.IPStateManager.AvailableIPConfigState {
+		ipconfigs[key] = fake.IPStateManager.AvailableIPConfigState[key]
 	}
-	for key, val := range fake.IPStateManager.PendingReleaseIPConfigState {
-		ipconfigs[key] = val
+	for key := range fake.IPStateManager.PendingReleaseIPConfigState {
+		ipconfigs[key] = fake.IPStateManager.PendingReleaseIPConfigState[key]
+	}
+	for key := range fake.IPStateManager.PendingProgramIPConfigState {
+		ipconfigs[key] = fake.IPStateManager.PendingProgramIPConfigState[key]
 	}
 	return ipconfigs
 }

--- a/cns/ipampool/metrics.go
+++ b/cns/ipampool/metrics.go
@@ -83,15 +83,15 @@ func init() {
 	)
 }
 
-func observeIPPoolState(state ipPoolState, meta metaState) {
-	ipamAllocatedIPCount.Set(float64(state.allocated))
-	ipamAssignedIPCount.Set(float64(state.assigned))
-	ipamAvailableIPCount.Set(float64(state.available))
-	ipamBatchSize.Set(float64(meta.batch))
-	ipamMaxIPCount.Set(float64(meta.max))
-	ipamPendingProgramIPCount.Set(float64(state.pendingProgramming))
-	ipamPendingReleaseIPCount.Set(float64(state.pendingRelease))
-	ipamRequestedIPConfigCount.Set(float64(state.requested))
-	ipamRequestedUnassignedIPConfigCount.Set(float64(state.requestedUnassigned))
-	ipamUnassignedIPCount.Set(float64(state.unassigned))
+func observeIPPoolState(pool ipPool, state metaState) {
+	ipamAllocatedIPCount.Set(float64(pool.allocated))
+	ipamAssignedIPCount.Set(float64(pool.assigned))
+	ipamAvailableIPCount.Set(float64(pool.available))
+	ipamBatchSize.Set(float64(state.batch))
+	ipamMaxIPCount.Set(float64(state.max))
+	ipamPendingProgramIPCount.Set(float64(pool.pendingProgramming))
+	ipamPendingReleaseIPCount.Set(float64(pool.pendingRelease))
+	ipamRequestedIPConfigCount.Set(float64(pool.requested))
+	ipamRequestedUnassignedIPConfigCount.Set(float64(pool.expectedUnassigned()))
+	ipamUnassignedIPCount.Set(float64(pool.unassigned()))
 }

--- a/cns/ipampool/pool.go
+++ b/cns/ipampool/pool.go
@@ -22,8 +22,6 @@ type ipPool struct {
 	pendingRelease int64
 	// requested are the IPs CNS has requested that it be allocated.
 	requested int64
-
-	// expectedUnassigned int64
 }
 
 // unassigned is the current unassigned IP count.

--- a/cns/ipampool/pool.go
+++ b/cns/ipampool/pool.go
@@ -1,0 +1,86 @@
+package ipampool
+
+import (
+	"math"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/types"
+	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
+)
+
+// ipPool is the current actual state of the CNS IP ipPool.
+type ipPool struct {
+	// allocated are the IPs given to CNS.
+	allocated int64
+	// assigned are the IPs CNS gives to Pods.
+	assigned int64
+	// available are the allocated IPs in state "Available".
+	available int64
+	// pendingProgramming are the allocated IPs in state "PendingProgramming".
+	pendingProgramming int64
+	// pendingRelease are the allocated IPs in state "PendingRelease".
+	pendingRelease int64
+	// requested are the IPs CNS has requested that it be allocated.
+	requested int64
+
+	// expectedUnassigned int64
+}
+
+// unassigned is the current unassigned IP count.
+func (p *ipPool) unassigned() int64 {
+	return p.allocated - p.assigned
+}
+
+// expectedUnassigned is the expected future unassigned IP count,
+// assuming that the current requested IP  is honored.
+func (p *ipPool) expectedUnassigned() int64 {
+	return p.requested - p.assigned
+}
+
+func newIPPool(ips map[string]cns.IPConfigurationStatus, spec v1alpha.NodeNetworkConfigSpec) ipPool {
+	p := ipPool{
+		allocated: int64(len(ips)),
+		requested: spec.RequestedIPCount,
+	}
+	for _, v := range ips { //nolint:gocritic // ignore value copy
+		switch v.GetState() {
+		case types.Assigned:
+			p.assigned++
+		case types.Available:
+			p.available++
+		case types.PendingProgramming:
+			p.pendingProgramming++
+		case types.PendingRelease:
+			p.pendingRelease++
+		}
+	}
+	return p
+}
+
+// scale returns a new pool scaled according to the provided boundary conditions.
+func (p ipPool) scale(batch int64, minFree, maxFree float64) ipPool {
+	if p.expectedUnassigned() < int64(float64(batch)*minFree) {
+		p.requested = batch * int64(math.Ceil(minFree+float64(p.requested-p.expectedUnassigned())/float64(batch)))
+	} else if p.unassigned() >= int64(float64(batch)*maxFree) {
+		p.requested = batch * int64(math.Floor(maxFree+float64(p.requested-p.unassigned())/float64(batch)))
+	}
+	return p
+}
+
+func (p *ipPool) shouldScaleUp(minFreeCount, max int64) bool {
+	if p.expectedUnassigned() >= minFreeCount {
+		return false
+	}
+	if p.requested >= max {
+		return false
+	}
+	return true
+}
+
+func (p *ipPool) shouldScaleDown(maxFreeCount int64) bool {
+	return p.unassigned() >= maxFreeCount
+}
+
+func (p *ipPool) shouldCleanPendingRelease(notInUse int64) bool {
+	return p.pendingRelease != notInUse
+}

--- a/cns/ipampool/pool_test.go
+++ b/cns/ipampool/pool_test.go
@@ -162,6 +162,54 @@ func TestScale(t *testing.T) {
 			},
 			want: 16,
 		},
+		{
+			name:    "noop at exactly scale up threshold",
+			minFree: 0.5,
+			maxFree: 1.5,
+			batch:   10,
+			in: ipPool{
+				requested: 10,
+				allocated: 10,
+				assigned:  5,
+			},
+			want: 10,
+		},
+		{
+			name:    "noop at exactly scale down threshold",
+			minFree: 0.5,
+			maxFree: 1.5,
+			batch:   10,
+			in: ipPool{
+				requested: 20,
+				allocated: 20,
+				assigned:  5,
+			},
+			want: 20,
+		},
+		{
+			name:    "up just over scale up threshold",
+			minFree: 0.5,
+			maxFree: 1.5,
+			batch:   10,
+			in: ipPool{
+				requested: 10,
+				allocated: 10,
+				assigned:  6,
+			},
+			want: 20,
+		},
+		{
+			name:    "down just under scale down threshold",
+			minFree: 0.5,
+			maxFree: 1.5,
+			batch:   10,
+			in: ipPool{
+				requested: 20,
+				allocated: 20,
+				assigned:  4,
+			},
+			want: 10,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/cns/ipampool/pool_test.go
+++ b/cns/ipampool/pool_test.go
@@ -1,0 +1,172 @@
+package ipampool
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldScaleUp(t *testing.T) {
+	tests := []struct {
+		name         string
+		max, minFree int64
+		in           ipPool
+		want         bool
+	}{
+		{
+			name:    "yes",
+			max:     32,
+			minFree: 8,
+			in: ipPool{
+				requested: 16,
+				assigned:  9,
+			},
+			want: true,
+		},
+		{
+			name:    "no: enough free",
+			max:     32,
+			minFree: 8,
+			in: ipPool{
+				requested: 16,
+				assigned:  7,
+			},
+			want: false,
+		},
+		{
+			name:    "no: at max",
+			max:     16,
+			minFree: 16,
+			in: ipPool{
+				requested: 16,
+				assigned:  16,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.in.shouldScaleUp(tt.minFree, tt.max))
+		})
+	}
+}
+
+func TestShouldScaleDown(t *testing.T) {
+	tests := []struct {
+		name    string
+		maxFree int64
+		in      ipPool
+		want    bool
+	}{
+		{
+			name:    "yes",
+			maxFree: 24,
+			in: ipPool{
+				allocated: 32,
+				assigned:  1,
+			},
+			want: true,
+		},
+		{
+			name:    "no",
+			maxFree: 24,
+			in: ipPool{
+				allocated: 32,
+				assigned:  16,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.in.shouldScaleDown(tt.maxFree))
+		})
+	}
+}
+
+func TestShouldCleanPendingRelease(t *testing.T) {
+	tests := []struct {
+		name     string
+		notInUse int64
+		in       ipPool
+		want     bool
+	}{
+		{
+			name:     "yes",
+			notInUse: 24,
+			in: ipPool{
+				pendingRelease: 32,
+			},
+			want: true,
+		},
+		{
+			name:     "no",
+			notInUse: 24,
+			in: ipPool{
+				pendingRelease: 24,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.in.shouldCleanPendingRelease(tt.notInUse))
+		})
+	}
+}
+
+func TestScale(t *testing.T) {
+	tests := []struct {
+		name             string
+		minFree, maxFree float64
+		batch            int64
+		in               ipPool
+		want             int64
+	}{
+		{
+			name:    "noop",
+			minFree: 0.5,
+			maxFree: 1.5,
+			batch:   16,
+			in: ipPool{
+				requested: 16,
+				allocated: 16,
+				assigned:  8,
+			},
+			want: 16,
+		},
+		{
+			name:    "up",
+			minFree: 0.5,
+			maxFree: 1.5,
+			batch:   16,
+			in: ipPool{
+				requested: 16,
+				allocated: 16,
+				assigned:  9,
+			},
+			want: 32,
+		},
+		{
+			name:    "down",
+			minFree: 0.5,
+			maxFree: 1.5,
+			batch:   16,
+			in: ipPool{
+				requested: 32,
+				allocated: 32,
+				assigned:  7,
+			},
+			want: 16,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.in.scale(tt.batch, tt.minFree, tt.maxFree).requested)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Scales the ipampool directly to the final request size, using some math based on batch, min, max, and current assigned IP count. 

Includes changes from https://github.com/Azure/azure-container-networking/pull/1168 so should go after that one (opening to get some prelim CI runs in)

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
