### PR TITLE
fix: [NPM] fix Windows build errors

### DIFF
--- a/npm/cmd/start.go
+++ b/npm/cmd/start.go
@@ -37,7 +37,7 @@ var npmV2DataplaneCfg = &dataplane.Config{
 		NetworkName: "azure", // FIXME  should be specified in DP config instead
 	},
 	PolicyManagerCfg: &policies.PolicyManagerCfg{
-		Mode: policies.IPSetPolicyMode,
+		PolicyMode: policies.IPSetPolicyMode,
 	},
 }
 

--- a/npm/pkg/dataplane/dataplane_test.go
+++ b/npm/pkg/dataplane/dataplane_test.go
@@ -23,7 +23,7 @@ var (
 			NetworkName: "azure",
 		},
 		PolicyManagerCfg: &policies.PolicyManagerCfg{
-			Mode: policies.IPSetPolicyMode,
+			PolicyMode: policies.IPSetPolicyMode,
 		},
 	}
 

--- a/npm/pkg/dataplane/dataplane_windows.go
+++ b/npm/pkg/dataplane/dataplane_windows.go
@@ -12,25 +12,22 @@ import (
 )
 
 const (
-	policyWithSets     policyMode = "policyWithSets"
-	policyWithIPs      policyMode = "policyWithIPs"
-	maxNoNetRetryCount int        = 240 // max wait time 240*5 == 20 mins
-	maxNoNetSleepTime  int        = 5   // in seconds
+	maxNoNetRetryCount int = 240 // max wait time 240*5 == 20 mins
+	maxNoNetSleepTime  int = 5   // in seconds
 )
 
 func (dp *DataPlane) setPolicyMode() {
-	dp.policyMode = policyWithSets
+	dp.PolicyMode = policies.IPSetPolicyMode
 	err := hcn.SetPolicySupported()
 	if err != nil {
-		dp.policyMode = policyWithIPs
+		dp.PolicyMode = policies.IPPolicyMode
 	}
 }
 
 // initializeDataPlane will help gather network and endpoint details
 func (dp *DataPlane) initializeDataPlane() error {
 	klog.Infof("[DataPlane] Initializing dataplane for windows")
-	// policy mode is only needed for windows, move this to a more central position.
-	if dp.policyMode == "" {
+	if dp.PolicyMode == "" {
 		dp.setPolicyMode()
 	}
 
@@ -82,7 +79,7 @@ func (dp *DataPlane) bootupDataPlane() error {
 	epIDs := dp.getAllEndpointIDs()
 
 	// It is important to keep order to clean-up ACLs before ipsets. Otherwise we won't be able to delete ipsets referenced by ACLs
-	if err := dp.policyMgr.Reset(epIDs); err != nil {
+	if err := dp.policyMgr.Bootup(epIDs); err != nil {
 		return npmerrors.ErrorWrapper(npmerrors.ResetDataPlane, false, "failed to reset policy dataplane", err)
 	}
 	if err := dp.ipsetMgr.ResetIPSets(); err != nil {

--- a/npm/pkg/dataplane/policies/policymanager.go
+++ b/npm/pkg/dataplane/policies/policymanager.go
@@ -24,7 +24,8 @@ const (
 )
 
 type PolicyManagerCfg struct {
-	Mode PolicyManagerMode
+	// PolicyMode only affects Windows
+	PolicyMode PolicyManagerMode
 }
 
 type PolicyMap struct {

--- a/npm/pkg/dataplane/policies/policymanager_test.go
+++ b/npm/pkg/dataplane/policies/policymanager_test.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	ipsetConfig = &PolicyManagerCfg{
-		Mode: IPSetPolicyMode,
+		PolicyMode: IPSetPolicyMode,
 	}
 
 	// below epList is no-op for linux

--- a/npm/pkg/dataplane/policies/policymanager_windows_test.go
+++ b/npm/pkg/dataplane/policies/policymanager_windows_test.go
@@ -147,7 +147,10 @@ func getPMgr(t *testing.T) (*PolicyManager, *hnswrapper.Hnsv2wrapperFake) {
 		_, err := hns.CreateEndpoint(ep)
 		require.NoError(t, err)
 	}
-	return NewPolicyManager(io, IpsetAndNoRebootConfig), hns
+	cfg := &PolicyManagerCfg{
+		PolicyMode: IPSetPolicyMode,
+	}
+	return NewPolicyManager(io, cfg), hns
 }
 
 func verifyFakeHNSCacheACLs(t *testing.T, expected, actual []*hnswrapper.FakeEndpointPolicy) bool {

--- a/npm/pkg/dataplane/policies/testutils_windows.go
+++ b/npm/pkg/dataplane/policies/testutils_windows.go
@@ -10,10 +10,6 @@ func GetRemovePolicyTestCalls(_ *NPMNetworkPolicy) []testutils.TestCmd {
 	return []testutils.TestCmd{}
 }
 
-func GetInitializeTestCalls() []testutils.TestCmd {
-	return []testutils.TestCmd{}
-}
-
-func GetResetTestCalls() []testutils.TestCmd {
+func GetBootupTestCalls() []testutils.TestCmd {
 	return []testutils.TestCmd{}
 }

--- a/test/integration/npm/main.go
+++ b/test/integration/npm/main.go
@@ -22,7 +22,7 @@ var (
 			NetworkName: "azure",
 		},
 		PolicyManagerCfg: &policies.PolicyManagerCfg{
-			Mode: policies.IPSetPolicyMode,
+			PolicyMode: policies.IPSetPolicyMode,
 		},
 	}
 


### PR DESCRIPTION
- Fix build errors from #1150 in dataplane_windows.go and in dataplane_test.go for Windows.
- Rename `Mode` to `PolicyMode` for the dataplane config.

This PR doesn't try to fix UT errors for Windows that existed before #1150.