### PR TITLE
match on Node controller ref in NNC event predicate

### DIFF
--- a/cns/azure-cns.yaml
+++ b/cns/azure-cns.yaml
@@ -10,9 +10,9 @@ metadata:
   namespace: kube-system
   name: nodeNetConfigEditor
 rules:
-  - apiGroups: ["acn.azure.com"]
-    resources: ["nodenetworkconfigs"]
-    verbs: ["get", "list", "watch", "patch", "update"]
+- apiGroups: ["acn.azure.com"]
+  resources: ["nodenetworkconfigs"]
+  verbs: ["get", "list", "watch", "patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -22,6 +22,9 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get", "watch", "list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/crd/nodenetworkconfig/client.go
+++ b/crd/nodenetworkconfig/client.go
@@ -42,13 +42,13 @@ func NewClient(c *rest.Config) (*Client, error) {
 	opts := ctrlcli.Options{
 		Scheme: Scheme,
 	}
-	nnnCli, err := ctrlcli.New(c, opts)
+	nncCli, err := ctrlcli.New(c, opts)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to init nnc client")
 	}
 	return &Client{
 		crdcli: crdCli,
-		nnccli: nnnCli,
+		nnccli: nncCli,
 	}, nil
 }
 

--- a/test/integration/manifests/cns/clusterrole.yaml
+++ b/test/integration/manifests/cns/clusterrole.yaml
@@ -1,9 +1,13 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: pod-reader-all-namespaces
-  namespace: kube-system 
+  namespace: kube-system
 rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get", "watch", "list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]


### PR DESCRIPTION
Signed-off-by: Evan Baker <rbtr@users.noreply.github.com>

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Fixes potential race condition where, since NNCs are named using the Node name:
- a Node named X could be deleted, 
- its NNC might not (yet) be garbage collected, 
- CNS starting on a new Node _also_ named X might fetch that stale NNC and assign IPs from it.
 
this could result in IP leaks/pod connectivity disruptions when the stale NNC eventually gets GC'd and the new one for that node is created.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
