### PR TITLE
Server-side filtering for NodeNetworkConfig, Node, and Pod objects

### DIFF
--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -46,7 +46,6 @@ import (
 	"github.com/Azure/azure-container-networking/store"
 	"github.com/avast/retry-go/v3"
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -942,12 +941,6 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 	nodeScopedCache := cache.BuilderWithOptions(cache.Options{
 		SelectorsByObject: cache.SelectorsByObject{
 			&v1alpha.NodeNetworkConfig{}: {
-				Field: fields.SelectorFromSet(fields.Set{"metadata.name": nodeName}),
-			},
-			&corev1.Pod{}: {
-				Field: fields.SelectorFromSet(fields.Set{"spec.nodeName": nodeName}),
-			},
-			&corev1.Node{}: {
 				Field: fields.SelectorFromSet(fields.Set{"metadata.name": nodeName}),
 			},
 		},

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -46,8 +46,11 @@ import (
 	"github.com/Azure/azure-container-networking/store"
 	"github.com/avast/retry-go/v3"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -932,10 +935,28 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 		return err
 	}
 
+	// the nodeScopedCache sets Selector options on the Manager cache which are used
+	// to perform *server-side* filtering of the cached objects. This is very important
+	// for high node/pod count clusters, as it keeps us from watching objects at the
+	// whole cluster scope when we are only interested in the Node's scope.
+	nodeScopedCache := cache.BuilderWithOptions(cache.Options{
+		SelectorsByObject: cache.SelectorsByObject{
+			&v1alpha.NodeNetworkConfig{}: {
+				Field: fields.SelectorFromSet(fields.Set{"metadata.name": nodeName}),
+			},
+			&corev1.Pod{}: {
+				Field: fields.SelectorFromSet(fields.Set{"spec.nodeName": nodeName}),
+			},
+			&corev1.Node{}: {
+				Field: fields.SelectorFromSet(fields.Set{"metadata.name": nodeName}),
+			},
+		},
+	})
 	manager, err := ctrl.NewManager(kubeConfig, ctrl.Options{
 		Scheme:             nodenetworkconfig.Scheme,
 		MetricsBindAddress: cnsconfig.MetricsBindAddress,
 		Namespace:          "kube-system", // TODO(rbtr): namespace should be in the cns config
+		NewCache:           nodeScopedCache,
 	})
 	if err != nil {
 		return errors.Wrap(err, "failed to create manager")


### PR DESCRIPTION
Signed-off-by: Evan Baker <rbtr@users.noreply.github.com>

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Instead of watching all NNCs (and Nodes and Pods) and filtering on the client-side, we should modify the Manager's cache to only Watch objects with the appropriate fields set which match our Node. This filtering happens server-side as part of the WatchList initialization and should effectively scope CNS's apiserver traffic to its own Node's objects instead of letting it scale with Node and Pod count.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
