### PR TITLE
fix: [NPM] detect multi-digit numbers when getting iptables line number

### DIFF
--- a/npm/pkg/dataplane/policies/chain-management_linux.go
+++ b/npm/pkg/dataplane/policies/chain-management_linux.go
@@ -3,6 +3,7 @@ package policies
 // This file contains code for booting up and reconciling iptables
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"strconv"
@@ -52,6 +53,10 @@ var (
 		util.IptablesCtstateFlag,
 		util.IptablesNewState,
 	}
+
+	spaceByte                     = []byte(" ")
+	errNoLineNumber               = errors.New("no line number found")
+	errUnexpectedLineNumberString = errors.New("unexpected line number string")
 
 	errInvalidGrepResult                      = errors.New("unexpectedly got no lines while grepping for current Azure chains")
 	deprecatedJumpFromForwardToAzureChainArgs = []string{
@@ -380,10 +385,17 @@ func (pMgr *PolicyManager) chainLineNumber(chain string) (int, error) {
 		return 0, nil
 	}
 	if len(searchResults) >= minLineNumberStringLength {
-		lineNum, _ := strconv.Atoi(string(searchResults[0])) // FIXME this returns the first digit of the line number. What if the chain was at line 11? Then we would think it's at line 1
-		return lineNum, nil
+		firstSpaceIndex := bytes.Index(searchResults, spaceByte)
+		if firstSpaceIndex > 0 && firstSpaceIndex < len(searchResults) {
+			lineNumberString := string(searchResults[0:firstSpaceIndex])
+			lineNum, err := strconv.Atoi(lineNumberString)
+			if err != nil {
+				return 0, errNoLineNumber
+			}
+			return lineNum, nil
+		}
 	}
-	return 0, nil
+	return 0, errUnexpectedLineNumberString
 }
 
 func (pMgr *PolicyManager) allCurrentAzureChains() (map[string]struct{}, error) {

--- a/npm/pkg/dataplane/policies/chain-management_linux.go
+++ b/npm/pkg/dataplane/policies/chain-management_linux.go
@@ -24,7 +24,8 @@ const (
 	doesNotExistErrorCode      int = 1 // Bad rule (does a matching rule exist in that chain?)
 	couldntLoadTargetErrorCode int = 2 // Couldn't load target `AZURE-NPM-EGRESS':No such file or directory
 
-	minLineNumberStringLength int = 3 // TODO transferred from iptm.go and not sure why this length is important, but will update the function its used in later anyways
+	// transferred from iptm.go and not sure why this length is important
+	minLineNumberStringLength int = 3
 
 	azureChainGrepPattern   string = "Chain AZURE-NPM"
 	minAzureChainNameLength int    = len("AZURE-NPM")


### PR DESCRIPTION
This PR fixes a bug around getting the iptables line number of the jump from FORWARD chain to AZURE-NPM. The code would take the first digit of the line number, so if the line number were 12, then the code would think the line number is 1.

Updated in both v1 and v2. 

v2 throws errors if the grep output is unexpected, whereas v1 won't. This way, we don't modify the error-throwing behavior of v1.