### PR TITLE
feat: don't use CNS for CNI DEL command in windows multitenancy

### DIFF
--- a/cni/client/client_common_test.go
+++ b/cni/client/client_common_test.go
@@ -1,3 +1,4 @@
+//go:build unit || integration
 // +build unit integration
 
 package client

--- a/cni/client/client_integration_test.go
+++ b/cni/client/client_integration_test.go
@@ -1,5 +1,5 @@
-// +build linux
-// +build integration
+//go:build linux && integration
+// +build linux,integration
 
 package client
 

--- a/cni/client/client_unit_test.go
+++ b/cni/client/client_unit_test.go
@@ -1,3 +1,4 @@
+//go:build unit
 // +build unit
 
 package client

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -969,7 +969,7 @@ func (plugin *NetPlugin) Delete(args *cniSkel.CmdArgs) error {
 	if err != nil {
 		log.Printf("[cni-net] Failed to extract network name from network config. error: %v", err)
 
-		if !cnscli.IsNotFound(err) {
+		if !cnscli.IsNotFound(err) || network.IsNetworkNotFoundError(err) {
 			err = plugin.Errorf("Failed to extract network name from network config. error: %v", err)
 			return err
 		}

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -453,7 +453,7 @@ func (plugin *NetPlugin) Add(args *cniSkel.CmdArgs) error {
 	}
 
 	// Initialize values from network config.
-	networkID, err := plugin.getNetworkName(k8sPodName, k8sNamespace, args.IfName, nwCfg)
+	networkID, err := plugin.getNetworkName(k8sPodName, k8sNamespace, args.IfName, args.Netns, nwCfg)
 	if err != nil {
 		log.Printf("[cni-net] Failed to extract network name from network config. error: %v", err)
 		return err
@@ -843,7 +843,7 @@ func (plugin *NetPlugin) Get(args *cniSkel.CmdArgs) error {
 	}
 
 	// Initialize values from network config.
-	if networkId, err = plugin.getNetworkName(k8sPodName, k8sNamespace, args.IfName, nwCfg); err != nil {
+	if networkId, err = plugin.getNetworkName(k8sPodName, k8sNamespace, args.IfName, args.Netns, nwCfg); err != nil {
 		// TODO: Ideally we should return from here only.
 		log.Printf("[cni-net] Failed to extract network name from network config. error: %v", err)
 	}
@@ -963,7 +963,7 @@ func (plugin *NetPlugin) Delete(args *cniSkel.CmdArgs) error {
 		}
 	}
 	// Initialize values from network config.
-	networkID, err = plugin.getNetworkName(k8sPodName, k8sNamespace, args.IfName, nwCfg)
+	networkID, err = plugin.getNetworkName(k8sPodName, k8sNamespace, args.IfName, args.Netns, nwCfg)
 
 	// If error is not found error, then we ignore it, to comply with CNI SPEC.
 	if err != nil {
@@ -1024,8 +1024,12 @@ func (plugin *NetPlugin) Delete(args *cniSkel.CmdArgs) error {
 	telemetry.LogAndSendEvent(plugin.tb, fmt.Sprintf("Deleting endpoint:%v", endpointID))
 	// Delete the endpoint.
 	if err = plugin.nm.DeleteEndpoint(cnsclient, networkID, endpointID); err != nil {
-		err = plugin.Errorf("Failed to delete endpoint: %v", err)
-		return err
+		pluginErr := plugin.RetriableError(fmt.Errorf("failed to delete endpoint: %w", err))
+		// If it is not a networkNotFound error, then return a retriable error so the container runtime will keep retrying.
+		// If it is a networkNotFoundError, then simply skip it and move on to cleanup of InfraVnet.
+		if !network.IsNetworkNotFoundError(err) {
+			return pluginErr
+		}
 	}
 
 	if !nwCfg.MultiTenancy {

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -1013,17 +1013,11 @@ func (plugin *NetPlugin) Delete(args *cniSkel.CmdArgs) error {
 		return err
 	}
 
-	cnsclient, err := cnscli.New(nwCfg.CNSUrl, defaultRequestTimeout)
-	if err != nil {
-		log.Printf("failed to initialized cns client with URL %s: %v", nwCfg.CNSUrl, err.Error())
-		return plugin.Errorf(err.Error())
-	}
-
 	// schedule send metric before attempting delete
 	defer sendMetricFunc()
 	telemetry.LogAndSendEvent(plugin.tb, fmt.Sprintf("Deleting endpoint:%v", endpointID))
 	// Delete the endpoint.
-	if err = plugin.nm.DeleteEndpoint(cnsclient, networkID, endpointID); err != nil {
+	if err = plugin.nm.DeleteEndpoint(networkID, endpointID); err != nil {
 		pluginErr := plugin.RetriableError(fmt.Errorf("failed to delete endpoint: %w", err))
 		// If it is not a networkNotFound error, then return a retriable error so the container runtime will keep retrying.
 		// If it is a networkNotFoundError, then simply skip it and move on to cleanup of InfraVnet.

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -453,7 +453,7 @@ func (plugin *NetPlugin) Add(args *cniSkel.CmdArgs) error {
 	}
 
 	// Initialize values from network config.
-	networkID, err := plugin.getNetworkName(k8sPodName, k8sNamespace, args.IfName, args.Netns, nwCfg)
+	networkID, err := plugin.getNetworkName(k8sPodName, k8sNamespace, args.IfName, args.Netns, cnsNetworkConfig, nwCfg)
 	if err != nil {
 		log.Printf("[cni-net] Failed to extract network name from network config. error: %v", err)
 		return err
@@ -843,7 +843,7 @@ func (plugin *NetPlugin) Get(args *cniSkel.CmdArgs) error {
 	}
 
 	// Initialize values from network config.
-	if networkId, err = plugin.getNetworkName(k8sPodName, k8sNamespace, args.IfName, args.Netns, nwCfg); err != nil {
+	if networkId, err = plugin.getNetworkName(k8sPodName, k8sNamespace, args.IfName, args.Netns, nil, nwCfg); err != nil {
 		// TODO: Ideally we should return from here only.
 		log.Printf("[cni-net] Failed to extract network name from network config. error: %v", err)
 	}
@@ -963,7 +963,7 @@ func (plugin *NetPlugin) Delete(args *cniSkel.CmdArgs) error {
 		}
 	}
 	// Initialize values from network config.
-	networkID, err = plugin.getNetworkName(k8sPodName, k8sNamespace, args.IfName, args.Netns, nwCfg)
+	networkID, err = plugin.getNetworkName(k8sPodName, k8sNamespace, args.IfName, args.Netns, nil, nwCfg)
 
 	// If error is not found error, then we ignore it, to comply with CNI SPEC.
 	if err != nil {

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -962,14 +962,13 @@ func (plugin *NetPlugin) Delete(args *cniSkel.CmdArgs) error {
 			plugin.ipamInvoker = NewAzureIpamInvoker(plugin, &nwInfo)
 		}
 	}
+
 	// Initialize values from network config.
 	networkID, err = plugin.getNetworkName(k8sPodName, k8sNamespace, args.IfName, args.Netns, nil, nwCfg)
-
-	// If error is not found error, then we ignore it, to comply with CNI SPEC.
 	if err != nil {
 		log.Printf("[cni-net] Failed to extract network name from network config. error: %v", err)
-
-		if !cnscli.IsNotFound(err) || network.IsNetworkNotFoundError(err) {
+		// If error is not found error, then we ignore it, to comply with CNI SPEC.
+		if !network.IsNetworkNotFoundError(err) {
 			err = plugin.Errorf("Failed to extract network name from network config. error: %v", err)
 			return err
 		}

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -135,7 +135,7 @@ func updateSubnetPrefix(cnsNetworkConfig *cns.GetNetworkContainerResponse, subne
 	return nil
 }
 
-func (plugin *NetPlugin) getNetworkName(podName, podNs, ifName, netNs string, nwCfg *cni.NetworkConfig) (string, error) {
+func (plugin *NetPlugin) getNetworkName(_, _, _, _ string, _ *cns.GetNetworkContainerResponse, nwCfg *cni.NetworkConfig) (string, error) {
 	return nwCfg.Name, nil
 }
 

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -135,7 +135,7 @@ func updateSubnetPrefix(cnsNetworkConfig *cns.GetNetworkContainerResponse, subne
 	return nil
 }
 
-func (plugin *NetPlugin) getNetworkName(podName, podNs, ifName string, nwCfg *cni.NetworkConfig) (string, error) {
+func (plugin *NetPlugin) getNetworkName(podName, podNs, ifName, netNs string, nwCfg *cni.NetworkConfig) (string, error) {
 	return nwCfg.Name, nil
 }
 

--- a/cni/network/network_linux_test.go
+++ b/cni/network/network_linux_test.go
@@ -1,4 +1,5 @@
-//+build linux
+//go:build linux
+// +build linux
 
 package network
 

--- a/cni/network/network_test.go
+++ b/cni/network/network_test.go
@@ -1060,7 +1060,7 @@ func TestGetNetworkName(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			nwName, _ := plugin.getNetworkName("", "", "", &tt.nwCfg)
+			nwName, _ := plugin.getNetworkName("", "", "", "", &tt.nwCfg)
 			require.Equal(t, tt.nwCfg.Name, nwName)
 		})
 	}

--- a/cni/network/network_test.go
+++ b/cni/network/network_test.go
@@ -1060,7 +1060,7 @@ func TestGetNetworkName(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			nwName, _ := plugin.getNetworkName("", "", "", "", &tt.nwCfg)
+			nwName, _ := plugin.getNetworkName("", "", "", "", nil, &tt.nwCfg)
 			require.Equal(t, tt.nwCfg.Name, nwName)
 		})
 	}

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -172,6 +172,7 @@ func (plugin *NetPlugin) getNetworkName(podName, podNs, ifName, netNs string, cn
 	}
 
 	// First try to build the network name from the cnsResponse if present
+	// This will happen during ADD call
 	if cnsResponse != nil {
 		var subnet net.IPNet
 		if err := updateSubnetPrefix(cnsResponse, &subnet); err != nil {
@@ -188,6 +189,7 @@ func (plugin *NetPlugin) getNetworkName(podName, podNs, ifName, netNs string, cn
 	}
 
 	// If no cnsResponse was present, try to get the network name from the state file
+	// This will happen during DEL call
 	networkName, err := plugin.nm.FindNetworkIDFromNetNs(netNs)
 	if err != nil {
 		log.Printf("Error getting network name from state: %v.", err)

--- a/cni/network/network_windows_test.go
+++ b/cni/network/network_windows_test.go
@@ -183,7 +183,7 @@ func TestSetEndpointOptions(t *testing.T) {
 					ID: 1,
 				},
 				CnetAddressSpace: []cns.IPSubnet{
-					cns.IPSubnet{
+					{
 						IPAddress:    "192.168.0.4",
 						PrefixLength: 24,
 					},
@@ -221,7 +221,7 @@ func TestSetPoliciesFromNwCfg(t *testing.T) {
 			nwCfg: cni.NetworkConfig{
 				RuntimeConfig: cni.RuntimeConfig{
 					PortMappings: []cni.PortMapping{
-						cni.PortMapping{
+						{
 							Protocol:      "tcp",
 							HostIp:        "19.268.0.4",
 							HostPort:      8000,

--- a/cni/plugin.go
+++ b/cni/plugin.go
@@ -150,6 +150,13 @@ func (plugin *Plugin) Errorf(format string, args ...interface{}) *cniTypes.Error
 	return plugin.Error(fmt.Errorf(format, args...))
 }
 
+// RetriableError logs and returns a CNI error with the TryAgainLater error code
+func (plugin *Plugin) RetriableError(err error) *cniTypes.Error {
+	tryAgainErr := cniTypes.NewError(cniTypes.ErrTryAgainLater, err.Error(), "")
+	log.Printf("[%v] %+v.", plugin.Name, tryAgainErr.Error())
+	return tryAgainErr
+}
+
 // Initialize key-value store
 func (plugin *Plugin) InitializeKeyValueStore(config *common.PluginConfig) error {
 	// Create the key value store.

--- a/cnm/network/network.go
+++ b/cnm/network/network.go
@@ -271,12 +271,8 @@ func (plugin *netPlugin) deleteEndpoint(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	cnscli, err := cnsclient.New("", defaultCNSTimeout)
-	if err != nil {
-		log.Errorf("failed to init CNS client", err)
-	}
 	// Process request.
-	err = plugin.nm.DeleteEndpoint(cnscli, req.NetworkID, req.EndpointID)
+	err = plugin.nm.DeleteEndpoint(req.NetworkID, req.EndpointID)
 	if err != nil {
 		plugin.SendErrorResponse(w, err)
 		return

--- a/network/api.go
+++ b/network/api.go
@@ -4,6 +4,7 @@
 package network
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -12,7 +13,7 @@ var (
 	errSubnetNotFound         = fmt.Errorf("Subnet not found")
 	errNetworkModeInvalid     = fmt.Errorf("Network mode is invalid")
 	errNetworkExists          = fmt.Errorf("Network already exists")
-	errNetworkNotFound        = fmt.Errorf("Network not found")
+	errNetworkNotFound        = &networkNotFoundError{}
 	errEndpointExists         = fmt.Errorf("Endpoint already exists")
 	errEndpointNotFound       = fmt.Errorf("Endpoint not found")
 	errNamespaceNotFound      = fmt.Errorf("Namespace not found")
@@ -20,3 +21,13 @@ var (
 	errEndpointInUse          = fmt.Errorf("Endpoint is already joined to a sandbox")
 	errEndpointNotInUse       = fmt.Errorf("Endpoint is not joined to a sandbox")
 )
+
+type networkNotFoundError struct{}
+
+func (n *networkNotFoundError) Error() string {
+	return "Network not found"
+}
+
+func IsNetworkNotFoundError(err error) bool {
+	return errors.Is(err, errNetworkNotFound)
+}

--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -124,7 +124,7 @@ func (nw *network) newEndpoint(cli apipaClient, nl netlink.NetlinkInterface, plc
 }
 
 // DeleteEndpoint deletes an existing endpoint from the network.
-func (nw *network) deleteEndpoint(cli apipaClient, nl netlink.NetlinkInterface, plc platform.ExecClient, endpointID string) error {
+func (nw *network) deleteEndpoint(nl netlink.NetlinkInterface, plc platform.ExecClient, endpointID string) error {
 	var err error
 
 	log.Printf("[net] Deleting endpoint %v from network %v.", endpointID, nw.Id)
@@ -142,7 +142,7 @@ func (nw *network) deleteEndpoint(cli apipaClient, nl netlink.NetlinkInterface, 
 	}
 
 	// Call the platform implementation.
-	err = nw.deleteEndpointImpl(cli, nl, plc, ep)
+	err = nw.deleteEndpointImpl(nl, plc, ep)
 	if err != nil {
 		return err
 	}

--- a/network/endpoint_linux.go
+++ b/network/endpoint_linux.go
@@ -231,7 +231,7 @@ func (nw *network) newEndpointImpl(_ apipaClient, nl netlink.NetlinkInterface, p
 }
 
 // deleteEndpointImpl deletes an existing endpoint from the network.
-func (nw *network) deleteEndpointImpl(_ apipaClient, nl netlink.NetlinkInterface, plc platform.ExecClient, ep *endpoint) error {
+func (nw *network) deleteEndpointImpl(nl netlink.NetlinkInterface, plc platform.ExecClient, ep *endpoint) error {
 	var epClient EndpointClient
 
 	// Delete the veth pair by deleting one of the peer interfaces.

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -281,7 +281,7 @@ func (nw *network) configureHcnEndpoint(epInfo *EndpointInfo) (*hcn.HostComputeE
 	return hcnEndpoint, nil
 }
 
-func (nw *network) deleteHostNCApipaEndpoint(cli apipaClient, networkContainerID string) error {
+func (nw *network) deleteHostNCApipaEndpoint(networkContainerID string) error {
 	// Delete the host NC apipa endpoint directly from CNI
 	log.Printf("[net] Deleting HosNCApipaEndpoint for network container [%s]")
 
@@ -320,7 +320,7 @@ func (nw *network) createHostNCApipaEndpoint(cli apipaClient, epInfo *EndpointIn
 
 	defer func() {
 		if err != nil {
-			nw.deleteHostNCApipaEndpoint(cli, epInfo.NetworkContainerID)
+			nw.deleteHostNCApipaEndpoint(epInfo.NetworkContainerID)
 		}
 	}()
 
@@ -422,13 +422,13 @@ func (nw *network) newEndpointImplHnsV2(cli apipaClient, epInfo *EndpointInfo) (
 }
 
 // deleteEndpointImpl deletes an existing endpoint from the network.
-func (nw *network) deleteEndpointImpl(cli apipaClient, _ netlink.NetlinkInterface, _ platform.ExecClient, ep *endpoint) error {
+func (nw *network) deleteEndpointImpl(_ netlink.NetlinkInterface, _ platform.ExecClient, ep *endpoint) error {
 	if useHnsV2, err := UseHnsV2(ep.NetNs); useHnsV2 {
 		if err != nil {
 			return err
 		}
 
-		return nw.deleteEndpointImplHnsV2(cli, ep)
+		return nw.deleteEndpointImplHnsV2(ep)
 	}
 
 	return nw.deleteEndpointImplHnsV1(ep)
@@ -454,14 +454,14 @@ func (nw *network) deleteEndpointImplHnsV1(ep *endpoint) error {
 }
 
 // deleteEndpointImplHnsV2 deletes an existing endpoint from the network using HNS v2.
-func (nw *network) deleteEndpointImplHnsV2(cli apipaClient, ep *endpoint) error {
+func (nw *network) deleteEndpointImplHnsV2(ep *endpoint) error {
 	var (
 		hcnEndpoint *hcn.HostComputeEndpoint
 		err         error
 	)
 
 	if ep.AllowInboundFromHostToNC || ep.AllowInboundFromNCToHost {
-		if err = nw.deleteHostNCApipaEndpoint(cli, ep.NetworkContainerID); err != nil {
+		if err = nw.deleteHostNCApipaEndpoint(ep.NetworkContainerID); err != nil {
 			log.Errorf("[net] Failed to delete HostNCApipaEndpoint due to error: %v", err)
 			return err
 		}

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -282,26 +282,18 @@ func (nw *network) configureHcnEndpoint(epInfo *EndpointInfo) (*hcn.HostComputeE
 }
 
 func (nw *network) deleteHostNCApipaEndpoint(cli apipaClient, networkContainerID string) error {
-	// First try to delete the host NC apipa endpoint directly from CNI
-	log.Printf("[net] Deleting HosNCApipaEndpoint for network container [%s] directly")
-	if err := nw.deleteHostNCApipaEndpointDirect(networkContainerID); err != nil {
-		log.Printf("[net] Error deleting HostNCApipaEndpoint for network container [%s] directly, fallback to CNS")
-		// Fallback to deleting the host NC apipa endpoint with CNS
-		log.Printf("[net] Deleting HostNCApipaEndpoint for network container [%s] with CNS", networkContainerID)
-		if err := cli.DeleteHostNCApipaEndpoint(context.TODO(), networkContainerID); err != nil {
-			log.Printf("[net] Completed HostNCApipaEndpoint deletion for network container: %s with error: %v", networkContainerID, err)
-			return err
-		}
+	// Delete the host NC apipa endpoint directly from CNI
+	log.Printf("[net] Deleting HosNCApipaEndpoint for network container [%s]")
+
+	// TODO: this hnsclient function logs with prefix [Azure CNS] which can be confusing in CNI logs, need to refactor this function
+	// to use a prefix like [net] instead
+	if err := hnsclient.DeleteHostNCApipaEndpoint(networkContainerID); err != nil {
+		log.Printf("[net] Error deleting HostNCApipaEndpoint for network container [%s]: %v", networkContainerID, err)
+		return err
 	}
 
 	log.Printf("[net] Completed HostNCApipaEndpoint deletion for network container [%s] successfully", networkContainerID)
 	return nil
-}
-
-func (nw *network) deleteHostNCApipaEndpointDirect(networkContainerID string) error {
-	// TODO: this hnsclient function logs with prefix [Azure CNS] which can be confusing in CNI logs, need to refactor this function
-	// to use a prefix like [net] instead
-	return hnsclient.DeleteHostNCApipaEndpoint(networkContainerID)
 }
 
 // createHostNCApipaEndpoint creates a new endpoint in the HostNCApipaNetwork

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -286,13 +286,13 @@ func (nw *network) configureHcnEndpoint(epInfo *EndpointInfo) (*hcn.HostComputeE
 
 func (nw *network) deleteHostNCApipaEndpoint(networkContainerID string) error {
 	// Delete the host NC apipa endpoint directly from CNI
-	log.Printf("[net] Deleting HosNCApipaEndpoint for network container [%s]")
+	log.Printf("[net] Deleting HosNCApipaEndpoint for network container [%s]", networkContainerID)
 
 	// TODO: this code is duplicated in cns/hnsclient, but that code has logging messages that require a CNSLogger,
 	// which makes is hard to use in this package. We should refactor this into a common package with no logging deps
 	// so it can be called in both places
 	endpointName := getHostNCApipaEndpointName(networkContainerID)
-	log.Printf("[net]] Deleting HostNCApipaEndpoint: %s", endpointName)
+	log.Printf("[net] Deleting HostNCApipaEndpoint: %s", endpointName)
 	if err := deleteEndpointByNameHnsV2(endpointName); err != nil {
 		log.Printf("[net] Error deleting HostNCApipaEndpoint for network container [%s]: %v", networkContainerID, err)
 		return err

--- a/network/endpoint_windows_test.go
+++ b/network/endpoint_windows_test.go
@@ -8,9 +8,10 @@ package network
 
 import (
 	"fmt"
-	"github.com/Azure/azure-container-networking/network/hnswrapper"
 	"net"
 	"testing"
+
+	"github.com/Azure/azure-container-networking/network/hnswrapper"
 )
 
 func TestNewAndDeleteEndpointImplHnsV2(t *testing.T) {
@@ -42,7 +43,7 @@ func TestNewAndDeleteEndpointImplHnsV2(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = nw.deleteEndpointImplHnsV2(nil, endpoint)
+	err = nw.deleteEndpointImplHnsV2(endpoint)
 
 	if err != nil {
 		fmt.Printf("+%v", err)

--- a/network/endpoint_windows_test.go
+++ b/network/endpoint_windows_test.go
@@ -1,6 +1,7 @@
 // Copyright 2017 Microsoft. All rights reserved.
 // MIT License
 
+//go:build windows
 // +build windows
 
 package network
@@ -12,7 +13,7 @@ import (
 	"testing"
 )
 
-func TestNewAndDeleteEndpointImplHnsV2(t *testing.T){
+func TestNewAndDeleteEndpointImplHnsV2(t *testing.T) {
 	nw := &network{
 		Endpoints: map[string]*endpoint{},
 	}
@@ -22,19 +23,19 @@ func TestNewAndDeleteEndpointImplHnsV2(t *testing.T){
 	hnsv2 = hnswrapper.Hnsv2wrapperFake{}
 
 	epInfo := &EndpointInfo{
-		Id:                 "753d3fb6-e9b3-49e2-a109-2acc5dda61f1",
-		ContainerID:        "545055c2-1462-42c8-b222-e75d0b291632",
-		NetNsPath:          "fakeNameSpace",
-		IfName:             "eth0",
-		Data:               make(map[string]interface{}),
-		DNS: 	DNSInfo{
-			Suffix: "10.0.0.0",
+		Id:          "753d3fb6-e9b3-49e2-a109-2acc5dda61f1",
+		ContainerID: "545055c2-1462-42c8-b222-e75d0b291632",
+		NetNsPath:   "fakeNameSpace",
+		IfName:      "eth0",
+		Data:        make(map[string]interface{}),
+		DNS: DNSInfo{
+			Suffix:  "10.0.0.0",
 			Servers: []string{"10.0.0.1, 10.0.0.2"},
 			Options: nil,
 		},
 		MacAddress: net.HardwareAddr("00:00:5e:00:53:01"),
 	}
-	endpoint,err := nw.newEndpointImplHnsV2(nil, epInfo)
+	endpoint, err := nw.newEndpointImplHnsV2(nil, epInfo)
 
 	if err != nil {
 		fmt.Printf("+%v", err)

--- a/network/hnswrapper/hnsv2wrapper.go
+++ b/network/hnswrapper/hnsv2wrapper.go
@@ -72,3 +72,7 @@ func (f Hnsv2wrapper) ListEndpointsOfNetwork(networkId string) ([]hcn.HostComput
 func (f Hnsv2wrapper) ApplyEndpointPolicy(endpoint *hcn.HostComputeEndpoint, requestType hcn.RequestType, endpointPolicy hcn.PolicyEndpointRequest) error {
 	return endpoint.ApplyPolicy(requestType, endpointPolicy)
 }
+
+func (f Hnsv2wrapper) GetEndpointByName(endpointName string) (*hcn.HostComputeEndpoint, error) {
+	return hcn.GetEndpointByName(endpointName)
+}

--- a/network/hnswrapper/hnsv2wrapperfake.go
+++ b/network/hnswrapper/hnsv2wrapperfake.go
@@ -285,6 +285,10 @@ func (f Hnsv2wrapperFake) ApplyEndpointPolicy(endpoint *hcn.HostComputeEndpoint,
 	return nil
 }
 
+func (Hnsv2wrapperFake) GetEndpointByName(endpointName string) (*hcn.HostComputeEndpoint, error) {
+	return nil, hcn.EndpointNotFoundError{EndpointName: endpointName}
+}
+
 type FakeHNSCache struct {
 	networks  map[string]*FakeHostComputeNetwork
 	endpoints map[string]*FakeHostComputeEndpoint

--- a/network/hnswrapper/hnsv2wrapperinterface.go
+++ b/network/hnswrapper/hnsv2wrapperinterface.go
@@ -24,4 +24,5 @@ type HnsV2WrapperInterface interface {
 	GetEndpointByID(endpointId string) (*hcn.HostComputeEndpoint, error)
 	ListEndpointsOfNetwork(networkId string) ([]hcn.HostComputeEndpoint, error)
 	ApplyEndpointPolicy(endpoint *hcn.HostComputeEndpoint, requestType hcn.RequestType, endpointPolicy hcn.PolicyEndpointRequest) error
+	GetEndpointByName(endpointName string) (*hcn.HostComputeEndpoint, error)
 }

--- a/network/manager.go
+++ b/network/manager.go
@@ -354,7 +354,7 @@ func (nm *networkManager) CreateEndpoint(cli apipaClient, networkID string, epIn
 }
 
 // DeleteEndpoint deletes an existing container endpoint.
-func (nm *networkManager) DeleteEndpoint(networkID string, endpointID string) error {
+func (nm *networkManager) DeleteEndpoint(networkID, endpointID string) error {
 	nm.Lock()
 	defer nm.Unlock()
 

--- a/network/manager.go
+++ b/network/manager.go
@@ -78,7 +78,7 @@ type NetworkManager interface {
 	FindNetworkIDFromNetNs(netNs string) (string, error)
 
 	CreateEndpoint(client apipaClient, networkID string, epInfo *EndpointInfo) error
-	DeleteEndpoint(cli apipaClient, networkID string, endpointID string) error
+	DeleteEndpoint(networkID string, endpointID string) error
 	GetEndpointInfo(networkID string, endpointID string) (*EndpointInfo, error)
 	GetAllEndpoints(networkID string) (map[string]*EndpointInfo, error)
 	GetEndpointInfoBasedOnPODDetails(networkID string, podName string, podNameSpace string, doExactMatchForPodName bool) (*EndpointInfo, error)
@@ -354,7 +354,7 @@ func (nm *networkManager) CreateEndpoint(cli apipaClient, networkID string, epIn
 }
 
 // DeleteEndpoint deletes an existing container endpoint.
-func (nm *networkManager) DeleteEndpoint(cli apipaClient, networkID string, endpointID string) error {
+func (nm *networkManager) DeleteEndpoint(networkID string, endpointID string) error {
 	nm.Lock()
 	defer nm.Unlock()
 
@@ -363,7 +363,7 @@ func (nm *networkManager) DeleteEndpoint(cli apipaClient, networkID string, endp
 		return err
 	}
 
-	err = nw.deleteEndpoint(cli, nm.netlink, nm.plClient, endpointID)
+	err = nw.deleteEndpoint(nm.netlink, nm.plClient, endpointID)
 	if err != nil {
 		return err
 	}

--- a/network/manager.go
+++ b/network/manager.go
@@ -74,8 +74,8 @@ type NetworkManager interface {
 	CreateNetwork(nwInfo *NetworkInfo) error
 	DeleteNetwork(networkID string) error
 	GetNetworkInfo(networkID string) (NetworkInfo, error)
-	// FindNetworkNameFromNetNs returns the network name that contains an endpoint created for this netNS, errNetworkNotFound if no network is found
-	FindNetworkNameFromNetNs(netNs string) (string, error)
+	// FindNetworkIDFromNetNs returns the network name that contains an endpoint created for this netNS, errNetworkNotFound if no network is found
+	FindNetworkIDFromNetNs(netNs string) (string, error)
 
 	CreateEndpoint(client apipaClient, networkID string, epInfo *EndpointInfo) error
 	DeleteEndpoint(cli apipaClient, networkID string, endpointID string) error

--- a/network/manager.go
+++ b/network/manager.go
@@ -74,6 +74,8 @@ type NetworkManager interface {
 	CreateNetwork(nwInfo *NetworkInfo) error
 	DeleteNetwork(networkID string) error
 	GetNetworkInfo(networkID string) (NetworkInfo, error)
+	// FindNetworkNameFromNetNs returns the network name that contains an endpoint created for this netNS, errNetworkNotFound if no network is found
+	FindNetworkNameFromNetNs(netNs string) (string, error)
 
 	CreateEndpoint(client apipaClient, networkID string, epInfo *EndpointInfo) error
 	DeleteEndpoint(cli apipaClient, networkID string, endpointID string) error

--- a/network/manager_mock.go
+++ b/network/manager_mock.go
@@ -105,7 +105,7 @@ func (nm *MockNetworkManager) SetupNetworkUsingState(networkMonitor *cnms.Networ
 	return nil
 }
 
-func (nm *MockNetworkManager) FindNetworkNameFromNetNs(netNs string) (string, error) {
+func (nm *MockNetworkManager) FindNetworkIDFromNetNs(netNs string) (string, error) {
 	// based on the GetAllEndpoints func above, it seems that this mock is only intended to be used with
 	// one network, so just return the network here if it exists
 	for network := range nm.TestNetworkInfoMap {

--- a/network/manager_mock.go
+++ b/network/manager_mock.go
@@ -58,7 +58,7 @@ func (nm *MockNetworkManager) CreateEndpoint(_ apipaClient, networkID string, ep
 }
 
 // DeleteEndpoint mock
-func (nm *MockNetworkManager) DeleteEndpoint(_ apipaClient, networkID string, endpointID string) error {
+func (nm *MockNetworkManager) DeleteEndpoint(networkID string, endpointID string) error {
 	delete(nm.TestEndpointInfoMap, endpointID)
 	return nil
 }

--- a/network/manager_mock.go
+++ b/network/manager_mock.go
@@ -104,3 +104,13 @@ func (nm *MockNetworkManager) GetNumberOfEndpoints(ifName string, networkID stri
 func (nm *MockNetworkManager) SetupNetworkUsingState(networkMonitor *cnms.NetworkMonitor) error {
 	return nil
 }
+
+func (nm *MockNetworkManager) FindNetworkNameFromNetNs(netNs string) (string, error) {
+	// based on the GetAllEndpoints func above, it seems that this mock is only intended to be used with
+	// one network, so just return the network here if it exists
+	for network, _ := range nm.TestNetworkInfoMap {
+		return network, nil
+	}
+
+	return "", errNetworkNotFound
+}

--- a/network/manager_mock.go
+++ b/network/manager_mock.go
@@ -58,7 +58,7 @@ func (nm *MockNetworkManager) CreateEndpoint(_ apipaClient, networkID string, ep
 }
 
 // DeleteEndpoint mock
-func (nm *MockNetworkManager) DeleteEndpoint(networkID string, endpointID string) error {
+func (nm *MockNetworkManager) DeleteEndpoint(networkID, endpointID string) error {
 	delete(nm.TestEndpointInfoMap, endpointID)
 	return nil
 }

--- a/network/manager_mock.go
+++ b/network/manager_mock.go
@@ -108,7 +108,7 @@ func (nm *MockNetworkManager) SetupNetworkUsingState(networkMonitor *cnms.Networ
 func (nm *MockNetworkManager) FindNetworkNameFromNetNs(netNs string) (string, error) {
 	// based on the GetAllEndpoints func above, it seems that this mock is only intended to be used with
 	// one network, so just return the network here if it exists
-	for network, _ := range nm.TestNetworkInfoMap {
+	for network := range nm.TestNetworkInfoMap {
 		return network, nil
 	}
 

--- a/network/network.go
+++ b/network/network.go
@@ -258,6 +258,7 @@ func (nm *networkManager) FindNetworkIDFromNetNs(netNs string) (string, error) {
 			for _, endpoint := range network.Endpoints {
 				// If the netNs matches for this endpoint, return the network ID (which is the name)
 				if endpoint.NetNs == netNs {
+					log.Printf("Found network [%s] for NetNS [%s]", network.Id, netNs)
 					return network.Id, nil
 				}
 			}

--- a/network/network.go
+++ b/network/network.go
@@ -244,3 +244,25 @@ func (nm *networkManager) getNetwork(networkId string) (*network, error) {
 
 	return nil, errNetworkNotFound
 }
+
+// getNetworkNameForNetNs finds the network that contains the endpoint that was created for this netNs. Returns
+// and errNetworkNotFound if the netNs is not found in any network
+func (nm *networkManager) FindNetworkNameFromNetNs(netNs string) (string, error) {
+	log.Printf("Querying state for network for NetNs [%s]", netNs)
+
+	// Look through the external interfaces
+	for _, iface := range nm.ExternalInterfaces {
+		// Look through the networks
+		for _, network := range iface.Networks {
+			// Network may have multiple endpoints, so look through all of them
+			for _, endpoint := range network.Endpoints {
+				// If the netNs matches for this endpoint, return the network ID (which is the name)
+				if endpoint.NetNs == netNs {
+					return network.Id, nil
+				}
+			}
+		}
+	}
+
+	return "", errNetworkNotFound
+}

--- a/network/network.go
+++ b/network/network.go
@@ -245,9 +245,9 @@ func (nm *networkManager) getNetwork(networkId string) (*network, error) {
 	return nil, errNetworkNotFound
 }
 
-// getNetworkNameForNetNs finds the network that contains the endpoint that was created for this netNs. Returns
+// getNetworkIDForNetNs finds the network that contains the endpoint that was created for this netNs. Returns
 // and errNetworkNotFound if the netNs is not found in any network
-func (nm *networkManager) FindNetworkNameFromNetNs(netNs string) (string, error) {
+func (nm *networkManager) FindNetworkIDFromNetNs(netNs string) (string, error) {
 	log.Printf("Querying state for network for NetNs [%s]", netNs)
 
 	// Look through the external interfaces

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -213,4 +213,48 @@ var _ = Describe("Test Network", func() {
 			})
 		})
 	})
+
+	Describe("Test FindNetworkIDFromNetNs", func() {
+		Context("When network exists", func() {
+			It("Should be returned", func() {
+				netNs := "989c079b-45a6-485f-8f9e-88b05d6c55c4"
+				networkID := "byovnetbridge-vlan1-10-128-8-0_23"
+				nm := &networkManager{
+					ExternalInterfaces: map[string]*externalInterface{
+						networkID: {
+							Name: networkID,
+							Networks: map[string]*network{
+								"byovnetbridge-vlan1-10-128-8-0_23": {
+									Id: "byovnetbridge-vlan1-10-128-8-0_23",
+									Endpoints: map[string]*endpoint{
+										"a591be2a-eth0": {
+											Id:    "a591be2a-eth0",
+											NetNs: netNs,
+										},
+									},
+									NetNs: "aaac079b-45a6-485f-8f9e-88b05d6c55c4",
+								},
+							},
+						},
+					},
+				}
+
+				got, err := nm.FindNetworkIDFromNetNs(netNs)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(got).To(Equal(networkID))
+			})
+		})
+
+		Context("When network does not exist", func() {
+			It("Should return an errNetworkNotFound", func() {
+				nm := &networkManager{
+					ExternalInterfaces: make(map[string]*externalInterface),
+				}
+
+				_, err := nm.FindNetworkIDFromNetNs("989c079b-45a6-485f-8f9e-88b05d6c55c4")
+				Expect(err).To(HaveOccurred())
+				Expect(IsNetworkNotFoundError(err)).To(BeTrue())
+			})
+		})
+	})
 })

--- a/network/network_windows_test.go
+++ b/network/network_windows_test.go
@@ -1,17 +1,19 @@
 // Copyright 2017 Microsoft. All rights reserved.
 // MIT License
 
+//go:build windows
 // +build windows
 
 package network
 
 import (
 	"fmt"
-	"github.com/Azure/azure-container-networking/network/hnswrapper"
 	"testing"
+
+	"github.com/Azure/azure-container-networking/network/hnswrapper"
 )
 
-func TestNewAndDeleteNetworkImplHnsV2(t *testing.T){
+func TestNewAndDeleteNetworkImplHnsV2(t *testing.T) {
 	nm := &networkManager{
 		ExternalInterfaces: map[string]*externalInterface{},
 	}
@@ -23,7 +25,7 @@ func TestNewAndDeleteNetworkImplHnsV2(t *testing.T){
 	nwInfo := &NetworkInfo{
 		Id:           "d3e97a83-ba4c-45d5-ba88-dc56757ece28",
 		MasterIfName: "eth0",
-		Mode: "bridge",
+		Mode:         "bridge",
 	}
 
 	extInterface := &externalInterface{
@@ -31,7 +33,7 @@ func TestNewAndDeleteNetworkImplHnsV2(t *testing.T){
 		Subnets: []string{"subnet1", "subnet2"},
 	}
 
-	network,err := nm.newNetworkImplHnsV2(nwInfo,extInterface)
+	network, err := nm.newNetworkImplHnsV2(nwInfo, extInterface)
 
 	if err != nil {
 		fmt.Printf("+%v", err)

--- a/network/transparent_endpoint_linux_test.go
+++ b/network/transparent_endpoint_linux_test.go
@@ -1,4 +1,5 @@
-//+build linux
+//go:build linux
+// +build linux
 
 package network
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Today in Azure CNI in windows multitenancy, we depend on the NC state to exist in CNS in order for host endpoint cleanup to work. But, if the NC state got deleted from CNS before the CNI DEL command was invoked, the CNI DEL will fail since the CNS state doesn't exist. This PR allows the CNI DEL command to use only the CNI state instead of relying on CNS.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests


**Notes**:
