### PR TITLE
feat: [NPM] perf metrics for pod/ns/policy CRUD

### DIFF
--- a/npm/http/api/api.go
+++ b/npm/http/api/api.go
@@ -1,12 +1,11 @@
 package api
 
 const (
-	DefaultListeningIP         = "0.0.0.0"
-	DefaultHttpPort            = "10091"
-	NodeMetricsPath            = "/node-metrics"
-	ClusterMetricsPath         = "/cluster-metrics"
-	DataplaneHealthMetricsPath = "/dataplane-health-metrics"
-	NPMMgrPath                 = "/npm/v1/debug/manager"
+	DefaultListeningIP = "0.0.0.0"
+	DefaultHttpPort    = "10091"
+	NodeMetricsPath    = "/node-metrics"
+	ClusterMetricsPath = "/cluster-metrics"
+	NPMMgrPath         = "/npm/v1/debug/manager"
 )
 
 type DescribeIPSetRequest struct{}

--- a/npm/http/server/server.go
+++ b/npm/http/server/server.go
@@ -28,9 +28,8 @@ func NPMRestServerListenAndServe(config npmconfig.Config, npmEncoder json.Marsha
 
 	// prometheus handlers
 	if config.Toggles.EnablePrometheusMetrics {
-		rs.router.Handle(api.NodeMetricsPath, metrics.GetHandler(metrics.CustomerNodeMetrics))
-		rs.router.Handle(api.ClusterMetricsPath, metrics.GetHandler(metrics.CustomerClusterMetrics))
-		rs.router.Handle(api.DataplaneHealthMetricsPath, metrics.GetHandler(metrics.DataplaneHealthMetrics))
+		rs.router.Handle(api.NodeMetricsPath, metrics.GetHandler(metrics.NodeMetrics))
+		rs.router.Handle(api.ClusterMetricsPath, metrics.GetHandler(metrics.ClusterMetrics))
 	}
 
 	if config.Toggles.EnableHTTPDebugAPI {

--- a/npm/metrics/ipsets.go
+++ b/npm/metrics/ipsets.go
@@ -5,7 +5,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var ipsetInventoryMap = make(map[string]int)
+var ipsetInventoryMap map[string]int
 
 // IncNumIPSets increments the number of IPSets.
 func IncNumIPSets() {

--- a/npm/metrics/namespaces.go
+++ b/npm/metrics/namespaces.go
@@ -1,0 +1,16 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// RecordNamespaceApplyTime adds an observation of namespace apply time for the specified apply mode.
+// The execution time is from the timer's start until now.
+func RecordNamespaceApplyTime(timer *Timer, mode ApplyMode) {
+	timer.stopAndRecordApplyTime(namespaceApplyTime, mode)
+}
+
+// GetPodApplyCount returns the number of observations for namespace apply time for the specified apply mode.
+// This function is slow.
+func GetNamespaceApplyCount(mode ApplyMode) (int, error) {
+	labels := prometheus.Labels{applyModeLabel: string(mode)}
+	return getCountValue(namespaceApplyTime.With(labels))
+}

--- a/npm/metrics/namespaces.go
+++ b/npm/metrics/namespaces.go
@@ -1,18 +1,13 @@
 package metrics
 
-import (
-	"github.com/prometheus/client_golang/prometheus"
-)
-
-// RecordNamespaceExecTime adds an observation of namespace exec time for the specified operation.
+// RecordControllerNamespaceExecTime adds an observation of namespace exec time (unless the operation is NoOp).
 // The execution time is from the timer's start until now.
-func RecordNamespaceExecTime(timer *Timer, op OperationKind) {
-	timer.stopAndRecordCRUDExecTime(controllerNamespaceExecTime, op)
+func RecordControllerNamespaceExecTime(timer *Timer, op OperationKind, hadError bool) {
+	timer.stopAndRecordCRUDExecTime(controllerNamespaceExecTime, op, hadError)
 }
 
-// GetNamespaceExecCount returns the number of observations for namespace exec time for the specified operation.
+// GetControllerNamespaceExecCount returns the number of observations for namespace exec time for the specified operation.
 // This function is slow.
-func GetNamespaceExecCount(op OperationKind) (int, error) {
-	labels := prometheus.Labels{operationLabel: string(op)}
-	return getCountVecValue(controllerNamespaceExecTime, labels)
+func GetControllerNamespaceExecCount(op OperationKind, hadError bool) (int, error) {
+	return getCountVecValue(controllerNamespaceExecTime, getCRUDExecTimeLabels(op, hadError))
 }

--- a/npm/metrics/namespaces.go
+++ b/npm/metrics/namespaces.go
@@ -1,16 +1,18 @@
 package metrics
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
 
-// RecordNamespaceApplyTime adds an observation of namespace apply time for the specified apply mode.
+// RecordNamespaceExecTime adds an observation of namespace exec time for the specified operation.
 // The execution time is from the timer's start until now.
-func RecordNamespaceApplyTime(timer *Timer, mode ApplyMode) {
-	timer.stopAndRecordApplyTime(namespaceApplyTime, mode)
+func RecordNamespaceExecTime(timer *Timer, op OperationKind) {
+	timer.stopAndRecordCRUDExecTime(controllerNamespaceExecTime, op)
 }
 
-// GetPodApplyCount returns the number of observations for namespace apply time for the specified apply mode.
+// GetNamespaceExecCount returns the number of observations for namespace exec time for the specified operation.
 // This function is slow.
-func GetNamespaceApplyCount(mode ApplyMode) (int, error) {
-	labels := prometheus.Labels{applyModeLabel: string(mode)}
-	return getCountValue(namespaceApplyTime.With(labels))
+func GetNamespaceExecCount(op OperationKind) (int, error) {
+	labels := prometheus.Labels{operationLabel: string(op)}
+	return getCountVecValue(controllerNamespaceExecTime, labels)
 }

--- a/npm/metrics/namespaces_test.go
+++ b/npm/metrics/namespaces_test.go
@@ -2,9 +2,9 @@ package metrics
 
 import "testing"
 
-func TestRecordNamespaceApplyTime(t *testing.T) {
-	testStopAndRecordApplyTime(t, &applyMetric{
-		RecordNamespaceApplyTime,
-		GetNamespaceApplyCount,
+func TestRecordNamespaceExecTime(t *testing.T) {
+	testStopAndRecordCRUDExecTime(t, &crudExecMetric{
+		RecordNamespaceExecTime,
+		GetNamespaceExecCount,
 	})
 }

--- a/npm/metrics/namespaces_test.go
+++ b/npm/metrics/namespaces_test.go
@@ -1,0 +1,10 @@
+package metrics
+
+import "testing"
+
+func TestRecordNamespaceApplyTime(t *testing.T) {
+	testStopAndRecordApplyTime(t, &applyMetric{
+		RecordNamespaceApplyTime,
+		GetNamespaceApplyCount,
+	})
+}

--- a/npm/metrics/namespaces_test.go
+++ b/npm/metrics/namespaces_test.go
@@ -2,9 +2,9 @@ package metrics
 
 import "testing"
 
-func TestRecordNamespaceExecTime(t *testing.T) {
+func TestRecordControllerNamespaceExecTime(t *testing.T) {
 	testStopAndRecordCRUDExecTime(t, &crudExecMetric{
-		RecordNamespaceExecTime,
-		GetNamespaceExecCount,
+		RecordControllerNamespaceExecTime,
+		GetControllerNamespaceExecCount,
 	})
 }

--- a/npm/metrics/pods.go
+++ b/npm/metrics/pods.go
@@ -1,16 +1,13 @@
 package metrics
 
-import "github.com/prometheus/client_golang/prometheus"
-
-// RecordPodExecTime adds an observation of pod exec time for the specified operation.
+// RecordControllerPodExecTime adds an observation of pod exec time for the specified operation (unless the operation is NoOp).
 // The execution time is from the timer's start until now.
-func RecordPodExecTime(timer *Timer, op OperationKind) {
-	timer.stopAndRecordCRUDExecTime(controllerPodExecTime, op)
+func RecordControllerPodExecTime(timer *Timer, op OperationKind, hadError bool) {
+	timer.stopAndRecordCRUDExecTime(controllerPodExecTime, op, hadError)
 }
 
-// GetPodExecCount returns the number of observations for pod exec time for the specified operation.
+// GetControllerPodExecCount returns the number of observations for pod exec time for the specified operation.
 // This function is slow.
-func GetPodExecCount(op OperationKind) (int, error) {
-	labels := prometheus.Labels{operationLabel: string(op)}
-	return getCountVecValue(controllerPodExecTime, labels)
+func GetControllerPodExecCount(op OperationKind, hadError bool) (int, error) {
+	return getCountVecValue(controllerPodExecTime, getCRUDExecTimeLabels(op, hadError))
 }

--- a/npm/metrics/pods.go
+++ b/npm/metrics/pods.go
@@ -1,0 +1,16 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// RecordPolicyApplyTime adds an observation of pod apply time for the specified apply mode.
+// The execution time is from the timer's start until now.
+func RecordPodApplyTime(timer *Timer, mode ApplyMode) {
+	timer.stopAndRecordApplyTime(podApplyTime, mode)
+}
+
+// GetPodApplyCount returns the number of observations for pod apply time for the specified apply mode.
+// This function is slow.
+func GetPodApplyCount(mode ApplyMode) (int, error) {
+	labels := prometheus.Labels{applyModeLabel: string(mode)}
+	return getCountValue(podApplyTime.With(labels))
+}

--- a/npm/metrics/pods.go
+++ b/npm/metrics/pods.go
@@ -2,15 +2,15 @@ package metrics
 
 import "github.com/prometheus/client_golang/prometheus"
 
-// RecordPolicyApplyTime adds an observation of pod apply time for the specified apply mode.
+// RecordPodExecTime adds an observation of pod exec time for the specified operation.
 // The execution time is from the timer's start until now.
-func RecordPodApplyTime(timer *Timer, mode ApplyMode) {
-	timer.stopAndRecordApplyTime(podApplyTime, mode)
+func RecordPodExecTime(timer *Timer, op OperationKind) {
+	timer.stopAndRecordCRUDExecTime(controllerPodExecTime, op)
 }
 
-// GetPodApplyCount returns the number of observations for pod apply time for the specified apply mode.
+// GetPodExecCount returns the number of observations for pod exec time for the specified operation.
 // This function is slow.
-func GetPodApplyCount(mode ApplyMode) (int, error) {
-	labels := prometheus.Labels{applyModeLabel: string(mode)}
-	return getCountValue(podApplyTime.With(labels))
+func GetPodExecCount(op OperationKind) (int, error) {
+	labels := prometheus.Labels{operationLabel: string(op)}
+	return getCountVecValue(controllerPodExecTime, labels)
 }

--- a/npm/metrics/pods_test.go
+++ b/npm/metrics/pods_test.go
@@ -2,9 +2,9 @@ package metrics
 
 import "testing"
 
-func TestRecordPodExecTime(t *testing.T) {
+func TestRecordControllerPodExecTime(t *testing.T) {
 	testStopAndRecordCRUDExecTime(t, &crudExecMetric{
-		RecordPodExecTime,
-		GetPodExecCount,
+		RecordControllerPodExecTime,
+		GetControllerPodExecCount,
 	})
 }

--- a/npm/metrics/pods_test.go
+++ b/npm/metrics/pods_test.go
@@ -1,0 +1,10 @@
+package metrics
+
+import "testing"
+
+func TestRecordPodApplyTime(t *testing.T) {
+	testStopAndRecordApplyTime(t, &applyMetric{
+		RecordPodApplyTime,
+		GetPodApplyCount,
+	})
+}

--- a/npm/metrics/pods_test.go
+++ b/npm/metrics/pods_test.go
@@ -2,9 +2,9 @@ package metrics
 
 import "testing"
 
-func TestRecordPodApplyTime(t *testing.T) {
-	testStopAndRecordApplyTime(t, &applyMetric{
-		RecordPodApplyTime,
-		GetPodApplyCount,
+func TestRecordPodExecTime(t *testing.T) {
+	testStopAndRecordCRUDExecTime(t, &crudExecMetric{
+		RecordPodExecTime,
+		GetPodExecCount,
 	})
 }

--- a/npm/metrics/policies.go
+++ b/npm/metrics/policies.go
@@ -19,7 +19,7 @@ func ResetNumPolicies() {
 // The execution time is from the timer's start until now.
 func RecordControllerPolicyExecTime(timer *Timer, op OperationKind, hadError bool) {
 	if op == CreateOp {
-		timer.stopAndRecord(addPolicyExecTime)
+		timer.stopAndRecordExecTimeWithError(addPolicyExecTime, hadError)
 	} else {
 		timer.stopAndRecordCRUDExecTime(controllerPolicyExecTime, op, hadError)
 	}
@@ -35,7 +35,7 @@ func GetNumPolicies() (int, error) {
 // This function is slow.
 func GetControllerPolicyExecCount(op OperationKind, hadError bool) (int, error) {
 	if op == CreateOp {
-		return getCountValue(addPolicyExecTime)
+		return getCountVecValue(addPolicyExecTime, getErrorLabels(hadError))
 	}
 	return getCountVecValue(controllerPolicyExecTime, getCRUDExecTimeLabels(op, hadError))
 }

--- a/npm/metrics/policies.go
+++ b/npm/metrics/policies.go
@@ -17,13 +17,13 @@ func ResetNumPolicies() {
 	numPolicies.Set(0)
 }
 
-// RecordPolicyApplyTime adds an observation of policy apply time for the specified apply mode.
+// RecordPolicyExecTime adds an observation of policy exec time for the specified operation.
 // The execution time is from the timer's start until now.
-func RecordPolicyApplyTime(timer *Timer, mode ApplyMode) {
-	if mode == CreateMode {
+func RecordPolicyExecTime(timer *Timer, op OperationKind) {
+	if op == CreateOp {
 		timer.stopAndRecord(addPolicyExecTime)
 	} else {
-		timer.stopAndRecordApplyTime(policyApplyTime, mode)
+		timer.stopAndRecordCRUDExecTime(controllerPolicyExecTime, op)
 	}
 }
 
@@ -33,12 +33,12 @@ func GetNumPolicies() (int, error) {
 	return getValue(numPolicies)
 }
 
-// GetPolicyApplyCount returns the number of observations for policy apply time for the specified apply mode.
+// GetPolicyExecCount returns the number of observations for policy exec time for the specified operation.
 // This function is slow.
-func GetPolicyApplyCount(mode ApplyMode) (int, error) {
-	if mode == CreateMode {
+func GetPolicyExecCount(op OperationKind) (int, error) {
+	if op == CreateOp {
 		return getCountValue(addPolicyExecTime)
 	}
-	labels := prometheus.Labels{applyModeLabel: string(mode)}
-	return getCountValue(policyApplyTime.With(labels))
+	labels := prometheus.Labels{operationLabel: string(op)}
+	return getCountVecValue(controllerPolicyExecTime, labels)
 }

--- a/npm/metrics/policies_test.go
+++ b/npm/metrics/policies_test.go
@@ -4,11 +4,23 @@ import "testing"
 
 var numPoliciesMetric = &basicMetric{ResetNumPolicies, IncNumPolicies, DecNumPolicies, GetNumPolicies}
 
-func TestRecordPolicyExecTime(t *testing.T) {
-	testStopAndRecordCRUDExecTime(t, &crudExecMetric{
-		RecordPolicyExecTime,
-		GetPolicyExecCount,
-	})
+func TestRecordControllerPolicyExecTime(t *testing.T) {
+	// copied and modified from testStopAndRecordCRUDExecTime
+	for _, mode := range []OperationKind{CreateOp, UpdateOp, DeleteOp} {
+		for _, hadError := range []bool{true, false} {
+			if mode == CreateOp && hadError {
+				continue
+			}
+			testStopAndRecord(t, &recordingMetric{
+				func(timer *Timer) {
+					RecordControllerPolicyExecTime(timer, mode, hadError)
+				},
+				func() (int, error) {
+					return GetControllerPolicyExecCount(mode, hadError)
+				},
+			})
+		}
+	}
 }
 
 func TestIncNumPolicies(t *testing.T) {

--- a/npm/metrics/policies_test.go
+++ b/npm/metrics/policies_test.go
@@ -2,13 +2,13 @@ package metrics
 
 import "testing"
 
-var (
-	numPoliciesMetric = &basicMetric{ResetNumPolicies, IncNumPolicies, DecNumPolicies, GetNumPolicies}
-	policyExecMetric  = &recordingMetric{RecordPolicyExecTime, GetPolicyExecCount}
-)
+var numPoliciesMetric = &basicMetric{ResetNumPolicies, IncNumPolicies, DecNumPolicies, GetNumPolicies}
 
-func TestRecordPolicyExecTime(t *testing.T) {
-	testStopAndRecord(t, policyExecMetric)
+func TestRecordPolicyApplyTime(t *testing.T) {
+	testStopAndRecordApplyTime(t, &applyMetric{
+		RecordPolicyApplyTime,
+		GetPolicyApplyCount,
+	})
 }
 
 func TestIncNumPolicies(t *testing.T) {

--- a/npm/metrics/policies_test.go
+++ b/npm/metrics/policies_test.go
@@ -4,10 +4,10 @@ import "testing"
 
 var numPoliciesMetric = &basicMetric{ResetNumPolicies, IncNumPolicies, DecNumPolicies, GetNumPolicies}
 
-func TestRecordPolicyApplyTime(t *testing.T) {
-	testStopAndRecordApplyTime(t, &applyMetric{
-		RecordPolicyApplyTime,
-		GetPolicyApplyCount,
+func TestRecordPolicyExecTime(t *testing.T) {
+	testStopAndRecordCRUDExecTime(t, &crudExecMetric{
+		RecordPolicyExecTime,
+		GetPolicyExecCount,
 	})
 }
 

--- a/npm/metrics/policies_test.go
+++ b/npm/metrics/policies_test.go
@@ -5,22 +5,10 @@ import "testing"
 var numPoliciesMetric = &basicMetric{ResetNumPolicies, IncNumPolicies, DecNumPolicies, GetNumPolicies}
 
 func TestRecordControllerPolicyExecTime(t *testing.T) {
-	// copied and modified from testStopAndRecordCRUDExecTime
-	for _, mode := range []OperationKind{CreateOp, UpdateOp, DeleteOp} {
-		for _, hadError := range []bool{true, false} {
-			if mode == CreateOp && hadError {
-				continue
-			}
-			testStopAndRecord(t, &recordingMetric{
-				func(timer *Timer) {
-					RecordControllerPolicyExecTime(timer, mode, hadError)
-				},
-				func() (int, error) {
-					return GetControllerPolicyExecCount(mode, hadError)
-				},
-			})
-		}
-	}
+	testStopAndRecordCRUDExecTime(t, &crudExecMetric{
+		RecordControllerPolicyExecTime,
+		GetControllerPolicyExecCount,
+	})
 }
 
 func TestIncNumPolicies(t *testing.T) {

--- a/npm/metrics/prometheus-metrics.go
+++ b/npm/metrics/prometheus-metrics.go
@@ -98,11 +98,11 @@ var (
 	// TODO add health metrics
 )
 
-type RegistryType bool
+type RegistryType string
 
 const (
-	NodeMetrics    RegistryType = false
-	ClusterMetrics RegistryType = true
+	NodeMetrics    RegistryType = "node-metrics"
+	ClusterMetrics RegistryType = "cluster-metrics"
 )
 
 type OperationKind string

--- a/npm/metrics/prometheus-metrics.go
+++ b/npm/metrics/prometheus-metrics.go
@@ -172,7 +172,8 @@ func InitializeAll() {
 	}
 }
 
-// ReinitializeAll creates/replaces Prometheus metrics. This function is intended for UTs.
+// ReinitializeAll creates/replaces Prometheus metrics.
+// This function is intended for UTs. It will cause error messages ("error creating metric") from trying to re-register each metric.
 // Be sure to reset helper variables e.g. ipsetInventoryMap.
 func ReinitializeAll() {
 	haveInitialized = false

--- a/npm/metrics/prometheus-values.go
+++ b/npm/metrics/prometheus-values.go
@@ -25,8 +25,12 @@ func getVecValue(gaugeVecMetric *prometheus.GaugeVec, labels prometheus.Labels) 
 
 // getCountValue returns the number of times a Summary metric has recorded an observation.
 // This function is slow.
-func getCountValue(summaryMetric prometheus.Summary) (int, error) {
-	dtoMetric, err := getDTOMetric(summaryMetric)
+func getCountValue(summaryMetric interface{}) (int, error) {
+	collector, ok := summaryMetric.(prometheus.Collector)
+	if !ok {
+		return 0, fmt.Errorf("summary metric is not a collector")
+	}
+	dtoMetric, err := getDTOMetric(collector)
 	if err != nil {
 		return 0, err
 	}

--- a/npm/metrics/prometheus-values.go
+++ b/npm/metrics/prometheus-values.go
@@ -7,6 +7,8 @@ import (
 	dto "github.com/prometheus/client_model/go"
 )
 
+var errNotCollector = fmt.Errorf("error: summary metric is not a collector")
+
 // getValue returns a Gauge metric's value.
 // This function is slow.
 func getValue(gaugeMetric prometheus.Gauge) (int, error) {
@@ -25,16 +27,20 @@ func getVecValue(gaugeVecMetric *prometheus.GaugeVec, labels prometheus.Labels) 
 
 // getCountValue returns the number of times a Summary metric has recorded an observation.
 // This function is slow.
-func getCountValue(summaryMetric interface{}) (int, error) {
-	collector, ok := summaryMetric.(prometheus.Collector)
-	if !ok {
-		return 0, fmt.Errorf("summary metric is not a collector")
-	}
+func getCountValue(collector prometheus.Collector) (int, error) {
 	dtoMetric, err := getDTOMetric(collector)
 	if err != nil {
 		return 0, err
 	}
 	return int(dtoMetric.Summary.GetSampleCount()), nil
+}
+
+func getCountVecValue(summaryVecMetric *prometheus.SummaryVec, labels prometheus.Labels) (int, error) {
+	collector, ok := summaryVecMetric.With(labels).(prometheus.Collector)
+	if !ok {
+		return 0, errNotCollector
+	}
+	return getCountValue(collector)
 }
 
 // This function is slow.

--- a/npm/metrics/prometheus-values.go
+++ b/npm/metrics/prometheus-values.go
@@ -43,6 +43,17 @@ func getCountVecValue(summaryVecMetric *prometheus.SummaryVec, labels prometheus
 	return getCountValue(collector)
 }
 
+func getCRUDExecTimeLabels(op OperationKind, hadError bool) prometheus.Labels {
+	hadErrorVal := "false"
+	if hadError {
+		hadErrorVal = "true"
+	}
+	return prometheus.Labels{
+		operationLabel: string(op),
+		hadErrorLabel:  hadErrorVal,
+	}
+}
+
 // This function is slow.
 func getQuantiles(summaryMetric prometheus.Summary) ([]*dto.Quantile, error) {
 	dtoMetric, err := getDTOMetric(summaryMetric)

--- a/npm/metrics/prometheus-values.go
+++ b/npm/metrics/prometheus-values.go
@@ -54,6 +54,14 @@ func getCRUDExecTimeLabels(op OperationKind, hadError bool) prometheus.Labels {
 	}
 }
 
+func getErrorLabels(hadError bool) prometheus.Labels {
+	hadErrorVal := "false"
+	if hadError {
+		hadErrorVal = "true"
+	}
+	return prometheus.Labels{hadErrorLabel: hadErrorVal}
+}
+
 // This function is slow.
 func getQuantiles(summaryMetric prometheus.Summary) ([]*dto.Quantile, error) {
 	dtoMetric, err := getDTOMetric(summaryMetric)

--- a/npm/metrics/prometheus_metrics_test.go
+++ b/npm/metrics/prometheus_metrics_test.go
@@ -13,7 +13,7 @@ import (
 func TestPrometheusNodeHandler(t *testing.T) {
 	assert := assert.New(t)
 	InitializeAll()
-	handler := GetHandler(CustomerNodeMetrics)
+	handler := GetHandler(NodeMetrics)
 	req, err := http.NewRequest(http.MethodGet, api.NodeMetricsPath, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -28,7 +28,7 @@ func TestPrometheusNodeHandler(t *testing.T) {
 func TestPrometheusClusterHandler(t *testing.T) {
 	assert := assert.New(t)
 	InitializeAll()
-	handler := GetHandler(CustomerClusterMetrics)
+	handler := GetHandler(ClusterMetrics)
 	req, err := http.NewRequest(http.MethodGet, api.ClusterMetricsPath, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/npm/metrics/prometheus_test.go
+++ b/npm/metrics/prometheus_test.go
@@ -29,8 +29,8 @@ type recordingMetric struct {
 }
 
 type crudExecMetric struct {
-	record   func(timer *Timer, op OperationKind)
-	getCount func(op OperationKind) (int, error)
+	record   func(timer *Timer, op OperationKind, hadError bool)
+	getCount func(op OperationKind, hadError bool) (int, error)
 }
 
 func assertMetricVal(t *testing.T, metric *basicMetric, expectedVal int) {
@@ -65,14 +65,16 @@ func testResetMetric(t *testing.T, metric *basicMetric) {
 
 func testStopAndRecordCRUDExecTime(t *testing.T, m *crudExecMetric) {
 	for _, mode := range []OperationKind{CreateOp, UpdateOp, DeleteOp} {
-		testStopAndRecord(t, &recordingMetric{
-			func(timer *Timer) {
-				m.record(timer, mode)
-			},
-			func() (int, error) {
-				return m.getCount(mode)
-			},
-		})
+		for _, hadError := range []bool{true, false} {
+			testStopAndRecord(t, &recordingMetric{
+				func(timer *Timer) {
+					m.record(timer, mode, hadError)
+				},
+				func() (int, error) {
+					return m.getCount(mode, hadError)
+				},
+			})
+		}
 	}
 }
 

--- a/npm/metrics/prometheus_test.go
+++ b/npm/metrics/prometheus_test.go
@@ -28,6 +28,11 @@ type recordingMetric struct {
 	getCount func() (int, error)
 }
 
+type applyMetric struct {
+	record   func(timer *Timer, mode ApplyMode)
+	getCount func(mode ApplyMode) (int, error)
+}
+
 func assertMetricVal(t *testing.T, metric *basicMetric, expectedVal int) {
 	val, err := metric.get()
 	promutil.NotifyIfErrors(t, err)
@@ -56,6 +61,19 @@ func testResetMetric(t *testing.T, metric *basicMetric) {
 	metric.inc()
 	metric.reset()
 	assertMetricVal(t, metric, 0)
+}
+
+func testStopAndRecordApplyTime(t *testing.T, m *applyMetric) {
+	for _, mode := range []ApplyMode{CreateMode, UpdateMode, DeleteMode} {
+		testStopAndRecord(t, &recordingMetric{
+			func(timer *Timer) {
+				m.record(timer, mode)
+			},
+			func() (int, error) {
+				return m.getCount(mode)
+			},
+		})
+	}
 }
 
 func testStopAndRecord(t *testing.T, metric *recordingMetric) {

--- a/npm/metrics/prometheus_test.go
+++ b/npm/metrics/prometheus_test.go
@@ -28,9 +28,9 @@ type recordingMetric struct {
 	getCount func() (int, error)
 }
 
-type applyMetric struct {
-	record   func(timer *Timer, mode ApplyMode)
-	getCount func(mode ApplyMode) (int, error)
+type crudExecMetric struct {
+	record   func(timer *Timer, op OperationKind)
+	getCount func(op OperationKind) (int, error)
 }
 
 func assertMetricVal(t *testing.T, metric *basicMetric, expectedVal int) {
@@ -63,8 +63,8 @@ func testResetMetric(t *testing.T, metric *basicMetric) {
 	assertMetricVal(t, metric, 0)
 }
 
-func testStopAndRecordApplyTime(t *testing.T, m *applyMetric) {
-	for _, mode := range []ApplyMode{CreateMode, UpdateMode, DeleteMode} {
+func testStopAndRecordCRUDExecTime(t *testing.T, m *crudExecMetric) {
+	for _, mode := range []OperationKind{CreateOp, UpdateOp, DeleteOp} {
 		testStopAndRecord(t, &recordingMetric{
 			func(timer *Timer) {
 				m.record(timer, mode)

--- a/npm/metrics/timer.go
+++ b/npm/metrics/timer.go
@@ -36,6 +36,12 @@ func (timer *Timer) stopAndRecordCRUDExecTime(observer *prometheus.SummaryVec, o
 	}
 }
 
+func (timer *Timer) stopAndRecordExecTimeWithError(observer *prometheus.SummaryVec, hadError bool) {
+	timer.stop()
+	labels := getErrorLabels(hadError)
+	observer.With(labels).Observe(timer.timeElapsed())
+}
+
 func (timer *Timer) stop() {
 	timer.after = time.Now().UnixNano()
 }

--- a/npm/metrics/timer.go
+++ b/npm/metrics/timer.go
@@ -23,13 +23,13 @@ func (timer *Timer) stopAndRecord(observer prometheus.Summary) {
 	observer.Observe(timer.timeElapsed())
 }
 
-func (timer *Timer) stopAndRecordApplyTime(observer *prometheus.SummaryVec, mode ApplyMode) {
+func (timer *Timer) stopAndRecordCRUDExecTime(observer *prometheus.SummaryVec, op OperationKind) {
 	timer.stop()
-	if _, ok := knownApplyModes[mode]; !ok {
-		klog.Errorf("Unknown apply mode [%v] when recording apply time", mode)
+	if !op.isValid() {
+		klog.Errorf("Unknown operation [%v] when recording exec time", op)
 		return
 	}
-	labels := prometheus.Labels{applyModeLabel: string(mode)}
+	labels := prometheus.Labels{operationLabel: string(op)}
 	observer.With(labels).Observe(timer.timeElapsed())
 }
 

--- a/npm/pkg/controlplane/controllers/v1/nameSpaceController.go
+++ b/npm/pkg/controlplane/controllers/v1/nameSpaceController.go
@@ -398,7 +398,7 @@ func (nsc *NamespaceController) syncUpdateNameSpace(newNsObj *corev1.Namespace) 
 		klog.Infof("Deleting namespace %s from ipset list %s", newNsName, labelKey)
 		if err = nsc.ipsMgr.DeleteFromList(labelKey, newNsName); err != nil {
 			metrics.SendErrorLogAndMetric(util.NSID, "[UpdateNamespace] Error: failed to delete namespace %s from ipset list %s with err: %v", newNsName, labelKey, err)
-			return metrics.UpdateOp, err
+			return metrics.UpdateOp, fmt.Errorf("failed to delete namespace %s from ipset list %s with err: %w", newNsName, labelKey, err)
 		}
 		// {IMPORTANT} The order of compared list will be key and then key+val. NPM should only append after both key
 		// key + val ipsets are worked on.
@@ -415,7 +415,7 @@ func (nsc *NamespaceController) syncUpdateNameSpace(newNsObj *corev1.Namespace) 
 		klog.Infof("Adding namespace %s to ipset list %s", newNsName, labelKey)
 		if err = nsc.ipsMgr.AddToList(labelKey, newNsName); err != nil {
 			metrics.SendErrorLogAndMetric(util.NSID, "[UpdateNamespace] Error: failed to add namespace %s to ipset list %s with err: %v", newNsName, labelKey, err)
-			return metrics.UpdateOp, err
+			return metrics.UpdateOp, fmt.Errorf("failed to add namespace %s to ipset list %s with err: %w", newNsName, labelKey, err)
 		}
 		// {IMPORTANT} Same as above order is assumed to be key and then key+val. NPM should only append to existing labels
 		// only after both ipsets for a given label's key value pair are added successfully

--- a/npm/pkg/controlplane/controllers/v1/nameSpaceController_test.go
+++ b/npm/pkg/controlplane/controllers/v1/nameSpaceController_test.go
@@ -434,17 +434,17 @@ func TestNewNameSpaceUpdate(t *testing.T) {
 	testCases := []expectedNsValues{
 		{0, 1, 0, nsPromVals{1, 1, 0}},
 	}
-	checkNsTestResult("TestDeleteandUpdateNamespaceLabel", f, testCases)
+	checkNsTestResult("TestNewNameSpaceUpdate", f, testCases)
 
 	if _, exists := f.nsController.npmNamespaceCache.NsMap[util.GetNSNameWithPrefix(newNsObj.Name)]; !exists {
-		t.Errorf("TestDeleteandUpdateNamespaceLabel failed @ nsMap check")
+		t.Errorf("TestNewNameSpaceUpdate failed @ nsMap check")
 	}
 
 	if !reflect.DeepEqual(
 		newNsObj.Labels,
 		f.nsController.npmNamespaceCache.NsMap[util.GetNSNameWithPrefix(oldNsObj.Name)].LabelsMap,
 	) {
-		t.Fatalf("TestDeleteandUpdateNamespaceLabel failed @ nsMap labelMap check")
+		t.Fatalf("TestNewNameSpaceUpdate failed @ nsMap labelMap check")
 	}
 }
 

--- a/npm/pkg/controlplane/controllers/v1/nameSpaceController_test.go
+++ b/npm/pkg/controlplane/controllers/v1/nameSpaceController_test.go
@@ -202,6 +202,9 @@ func TestAddNamespace(t *testing.T) {
 
 	addNamespace(t, f, nsObj)
 
+	// already exists (will be a no-op)
+	addNamespace(t, f, nsObj)
+
 	testCases := []expectedNsValues{
 		{0, 1, 0, nsPromVals{1, 0, 0}},
 	}

--- a/npm/pkg/controlplane/controllers/v1/networkPolicyController.go
+++ b/npm/pkg/controlplane/controllers/v1/networkPolicyController.go
@@ -249,7 +249,7 @@ func (c *NetworkPolicyController) syncNetPol(key string) error {
 			if _, ok := c.rawNpMap[key]; ok {
 				// record time to delete policy if it exists (can't call within cleanUpNetworkPolicy because this can be called by a pod update)
 				timer := metrics.StartNewTimer()
-				defer metrics.RecordPolicyApplyTime(timer, metrics.DeleteMode)
+				defer metrics.RecordPolicyExecTime(timer, metrics.DeleteOp)
 			}
 
 			// netPolObj is not found, but should need to check the RawNpMap cache with key.
@@ -269,7 +269,7 @@ func (c *NetworkPolicyController) syncNetPol(key string) error {
 		if _, ok := c.rawNpMap[key]; ok {
 			// record time to delete policy if it exists (can't call within cleanUpNetworkPolicy because this can be called by a pod update)
 			timer := metrics.StartNewTimer()
-			defer metrics.RecordPolicyApplyTime(timer, metrics.DeleteMode)
+			defer metrics.RecordPolicyExecTime(timer, metrics.DeleteOp)
 		}
 		err = c.cleanUpNetworkPolicy(key, safeToCleanUpAzureNpmChain)
 		if err != nil {
@@ -339,13 +339,13 @@ func (c *NetworkPolicyController) syncAddAndUpdateNetPol(netPolObj *networkingv1
 	// To achieve it, use flag unSafeToCleanUpAzureNpmChain to indicate that the default Azure NPM chain cannot be deleted.
 	// delete existing network policy
 
-	var mode metrics.ApplyMode
+	var mode metrics.OperationKind
 	if _, ok := c.rawNpMap[netpolKey]; ok {
-		mode = metrics.UpdateMode
+		mode = metrics.UpdateOp
 	} else {
-		mode = metrics.CreateMode
+		mode = metrics.CreateOp
 	}
-	defer metrics.RecordPolicyApplyTime(timer, mode)
+	defer metrics.RecordPolicyExecTime(timer, mode)
 
 	err = c.cleanUpNetworkPolicy(netpolKey, unSafeToCleanUpAzureNpmChain)
 	if err != nil {

--- a/npm/pkg/controlplane/controllers/v1/networkPolicyController_test.go
+++ b/npm/pkg/controlplane/controllers/v1/networkPolicyController_test.go
@@ -239,7 +239,7 @@ func TestAddMultipleNetworkPolicies(t *testing.T) {
 	defer close(stopCh)
 	f.newNetPolController(stopCh)
 
-	// metrics.ReinitializeAll()
+	metrics.ReinitializeAll()
 
 	addNetPol(t, f, netPolObj1)
 	addNetPol(t, f, netPolObj2)
@@ -261,7 +261,7 @@ func TestAddNetworkPolicy(t *testing.T) {
 	defer close(stopCh)
 	f.newNetPolController(stopCh)
 
-	// metrics.ReinitializeAll()
+	metrics.ReinitializeAll()
 
 	addNetPol(t, f, netPolObj)
 	testCases := []expectedNetPolValues{
@@ -282,7 +282,7 @@ func TestDeleteNetworkPolicy(t *testing.T) {
 	defer close(stopCh)
 	f.newNetPolController(stopCh)
 
-	// metrics.ReinitializeAll()
+	metrics.ReinitializeAll()
 
 	deleteNetPol(t, f, netPolObj, DeletedFinalStateknownObject)
 	testCases := []expectedNetPolValues{
@@ -302,7 +302,7 @@ func TestDeleteNetworkPolicyWithTombstone(t *testing.T) {
 	defer close(stopCh)
 	f.newNetPolController(stopCh)
 
-	// metrics.ReinitializeAll()
+	metrics.ReinitializeAll()
 
 	netPolKey := getKey(netPolObj, t)
 	tombstone := cache.DeletedFinalStateUnknown{
@@ -328,7 +328,7 @@ func TestDeleteNetworkPolicyWithTombstoneAfterAddingNetworkPolicy(t *testing.T) 
 	defer close(stopCh)
 	f.newNetPolController(stopCh)
 
-	// metrics.ReinitializeAll()
+	metrics.ReinitializeAll()
 
 	deleteNetPol(t, f, netPolObj, DeletedFinalStateUnknownObject)
 	testCases := []expectedNetPolValues{
@@ -350,7 +350,7 @@ func TestUpdateNetworkPolicy(t *testing.T) {
 	defer close(stopCh)
 	f.newNetPolController(stopCh)
 
-	// metrics.ReinitializeAll()
+	metrics.ReinitializeAll()
 
 	newNetPolObj := oldNetPolObj.DeepCopy()
 	// oldNetPolObj.ResourceVersion value is "0"
@@ -375,7 +375,7 @@ func TestLabelUpdateNetworkPolicy(t *testing.T) {
 	defer close(stopCh)
 	f.newNetPolController(stopCh)
 
-	// metrics.ReinitializeAll()
+	metrics.ReinitializeAll()
 
 	newNetPolObj := oldNetPolObj.DeepCopy()
 	// update podSelctor in a new network policy field

--- a/npm/pkg/controlplane/controllers/v1/networkPolicyController_test.go
+++ b/npm/pkg/controlplane/controllers/v1/networkPolicyController_test.go
@@ -204,23 +204,29 @@ func (p *netPolPromVals) testPrometheusMetrics(t *testing.T) {
 		require.FailNowf(t, "", "Number of policies didn't register correctly in Prometheus. Expected %d. Got %d.", p.expectedNumPolicies, numPolicies)
 	}
 
-	addExecCount, err := metrics.GetPolicyExecCount(metrics.CreateOp)
+	addExecCount, err := metrics.GetControllerPolicyExecCount(metrics.CreateOp, false)
 	promutil.NotifyIfErrors(t, err)
-	if addExecCount != p.expectedAddExecCount {
-		require.FailNowf(t, "", "Count for add execution time didn't register correctly in Prometheus. Expected %d. Got %d.", p.expectedAddExecCount, addExecCount)
-	}
+	require.Equal(t, p.expectedAddExecCount, addExecCount, "Count for add execution time didn't register correctly in Prometheus")
 
-	updateExecCount, err := metrics.GetPolicyExecCount(metrics.UpdateOp)
+	addErrorExecCount, err := metrics.GetControllerPolicyExecCount(metrics.CreateOp, true)
 	promutil.NotifyIfErrors(t, err)
-	if updateExecCount != p.expectedUpdateExecCount {
-		require.FailNowf(t, "", "Count for update execution time didn't register correctly in Prometheus. Expected %d. Got %d.", p.expectedUpdateExecCount, updateExecCount)
-	}
+	require.Equal(t, 0, addErrorExecCount, "Count for add error execution time should be 0")
 
-	deleteExecCount, err := metrics.GetPolicyExecCount(metrics.DeleteOp)
+	updateExecCount, err := metrics.GetControllerPolicyExecCount(metrics.UpdateOp, false)
 	promutil.NotifyIfErrors(t, err)
-	if deleteExecCount != p.expectedDeleteExecCount {
-		require.FailNowf(t, "", "Count for delete execution time didn't register correctly in Prometheus. Expected %d. Got %d.", p.expectedDeleteExecCount, deleteExecCount)
-	}
+	require.Equal(t, p.expectedUpdateExecCount, updateExecCount, "Count for update execution time didn't register correctly in Prometheus")
+
+	updateErrorExecCount, err := metrics.GetControllerPolicyExecCount(metrics.UpdateOp, true)
+	promutil.NotifyIfErrors(t, err)
+	require.Equal(t, 0, updateErrorExecCount, "Count for update error execution time should be 0")
+
+	deleteExecCount, err := metrics.GetControllerPolicyExecCount(metrics.DeleteOp, false)
+	promutil.NotifyIfErrors(t, err)
+	require.Equal(t, p.expectedDeleteExecCount, deleteExecCount, "Count for delete execution time didn't register correctly in Prometheus")
+
+	deleteErrorExecCount, err := metrics.GetControllerPolicyExecCount(metrics.DeleteOp, true)
+	promutil.NotifyIfErrors(t, err)
+	require.Equal(t, 0, deleteErrorExecCount, "Count for delete error execution time should be 0")
 }
 
 func TestAddMultipleNetworkPolicies(t *testing.T) {

--- a/npm/pkg/controlplane/controllers/v1/parsePolicy.go
+++ b/npm/pkg/controlplane/controllers/v1/parsePolicy.go
@@ -33,7 +33,6 @@ func isSamePolicy(old, new *networkingv1.NetworkPolicy) bool {
 		return false
 	}
 
-	fmt.Println("same!!!")
 	return true
 }
 

--- a/npm/pkg/controlplane/controllers/v1/parsePolicy.go
+++ b/npm/pkg/controlplane/controllers/v1/parsePolicy.go
@@ -33,6 +33,7 @@ func isSamePolicy(old, new *networkingv1.NetworkPolicy) bool {
 		return false
 	}
 
+	fmt.Println("same!!!")
 	return true
 }
 

--- a/npm/pkg/controlplane/controllers/v1/podController.go
+++ b/npm/pkg/controlplane/controllers/v1/podController.go
@@ -329,7 +329,7 @@ func (c *PodController) syncPod(key string) error {
 			if _, ok := c.podMap[key]; ok {
 				// record time to delete pod if it exists (can't call within cleanUpDeletedPod because this can be called by a pod update)
 				timer := metrics.StartNewTimer()
-				defer metrics.RecordPodApplyTime(timer, metrics.DeleteMode)
+				defer metrics.RecordPodExecTime(timer, metrics.DeleteOp)
 			}
 
 			// cleanUpDeletedPod will check if the pod exists in cache, if it does then proceeds with deletion
@@ -352,7 +352,7 @@ func (c *PodController) syncPod(key string) error {
 		if _, ok := c.podMap[key]; ok {
 			// record time to delete pod if it exists (can't call within cleanUpDeletedPod because this can be called by a pod update)
 			timer := metrics.StartNewTimer()
-			defer metrics.RecordPodApplyTime(timer, metrics.DeleteMode)
+			defer metrics.RecordPodExecTime(timer, metrics.DeleteOp)
 		}
 		if err = c.cleanUpDeletedPod(key); err != nil {
 			return fmt.Errorf("Error: %v when when pod is in completed state.\n", err)
@@ -453,13 +453,13 @@ func (c *PodController) syncAddAndUpdatePod(newPodObj *corev1.Pod) error {
 	klog.Infof("[syncAddAndUpdatePod] updating Pod with key %s", podKey)
 	// No cached npmPod exists. start adding the pod in a cache
 	if !exists {
-		defer metrics.RecordPodApplyTime(timer, metrics.CreateMode)
+		defer metrics.RecordPodExecTime(timer, metrics.CreateOp)
 		if err = c.syncAddedPod(newPodObj); err != nil {
 			return err
 		}
 		return nil
 	}
-	defer metrics.RecordPodApplyTime(timer, metrics.UpdateMode)
+	defer metrics.RecordPodExecTime(timer, metrics.UpdateOp)
 
 	// Dealing with "updatePod" event - Compare last applied states against current Pod states
 	// There are two possiblities for npmPodObj and newPodObj

--- a/npm/pkg/controlplane/controllers/v1/podController_test.go
+++ b/npm/pkg/controlplane/controllers/v1/podController_test.go
@@ -285,6 +285,9 @@ func TestAddMultiplePods(t *testing.T) {
 	addPod(t, f, podObj1)
 	addPod(t, f, podObj2)
 
+	// already exists (will be a no-op)
+	addPod(t, f, podObj1)
+
 	testCases := []expectedValues{
 		{2, 1, 0, podPromVals{2, 0, 0}},
 	}

--- a/npm/pkg/controlplane/controllers/v1/podController_test.go
+++ b/npm/pkg/controlplane/controllers/v1/podController_test.go
@@ -189,23 +189,29 @@ type podPromVals struct {
 }
 
 func (p *podPromVals) testPrometheusMetrics(t *testing.T) {
-	addExecCount, err := metrics.GetPodExecCount(metrics.CreateOp)
+	addExecCount, err := metrics.GetControllerPodExecCount(metrics.CreateOp, false)
 	promutil.NotifyIfErrors(t, err)
-	if addExecCount != p.expectedAddExecCount {
-		require.FailNowf(t, "", "Count for add execution time didn't register correctly in Prometheus. Expected %d. Got %d.", p.expectedAddExecCount, addExecCount)
-	}
+	require.Equal(t, p.expectedAddExecCount, addExecCount, "Count for add execution time didn't register correctly in Prometheus")
 
-	updateExecCount, err := metrics.GetPodExecCount(metrics.UpdateOp)
+	addErrorExecCount, err := metrics.GetControllerPodExecCount(metrics.CreateOp, true)
 	promutil.NotifyIfErrors(t, err)
-	if updateExecCount != p.expectedUpdateExecCount {
-		require.FailNowf(t, "", "Count for update execution time didn't register correctly in Prometheus. Expected %d. Got %d.", p.expectedUpdateExecCount, updateExecCount)
-	}
+	require.Equal(t, 0, addErrorExecCount, "Count for add error execution time should be 0")
 
-	deleteExecCount, err := metrics.GetPodExecCount(metrics.DeleteOp)
+	updateExecCount, err := metrics.GetControllerPodExecCount(metrics.UpdateOp, false)
 	promutil.NotifyIfErrors(t, err)
-	if deleteExecCount != p.expectedDeleteExecCount {
-		require.FailNowf(t, "", "Count for delete execution time didn't register correctly in Prometheus. Expected %d. Got %d.", p.expectedDeleteExecCount, deleteExecCount)
-	}
+	require.Equal(t, p.expectedUpdateExecCount, updateExecCount, "Count for update execution time didn't register correctly in Prometheus")
+
+	updateErrorExecCount, err := metrics.GetControllerPodExecCount(metrics.UpdateOp, true)
+	promutil.NotifyIfErrors(t, err)
+	require.Equal(t, 0, updateErrorExecCount, "Count for update error execution time should be 0")
+
+	deleteExecCount, err := metrics.GetControllerPodExecCount(metrics.DeleteOp, false)
+	promutil.NotifyIfErrors(t, err)
+	require.Equal(t, p.expectedDeleteExecCount, deleteExecCount, "Count for delete execution time didn't register correctly in Prometheus")
+
+	deleteErrorExecCount, err := metrics.GetControllerPodExecCount(metrics.DeleteOp, true)
+	promutil.NotifyIfErrors(t, err)
+	require.Equal(t, 0, deleteErrorExecCount, "Count for delete error execution time should be 0")
 }
 
 func checkPodTestResult(testName string, f *podFixture, testCases []expectedValues) {

--- a/npm/pkg/controlplane/controllers/v2/namespaceController.go
+++ b/npm/pkg/controlplane/controllers/v2/namespaceController.go
@@ -245,12 +245,24 @@ func (nsc *NamespaceController) processNextWorkItem() bool {
 
 // syncNamespace compares the actual state with the desired, and attempts to converge the two.
 func (nsc *NamespaceController) syncNamespace(nsKey string) error {
+	// timer for recording execution times
+	timer := metrics.StartNewTimer()
+
 	// Get the Namespace resource with this key
 	nsObj, err := nsc.nameSpaceLister.Get(nsKey)
 
-	// apply dataplane after syncing
+	// apply dataplane and record exec time after syncing
+	operationKind := metrics.NoOp
 	defer func() {
 		dperr := nsc.dp.ApplyDataPlane()
+
+		// NOTE: it may seem like Prometheus is considering some ns create events as updates.
+		// This happens when pod create events beat ns create events, so the pod controller will create the ipset
+		// for the ns. This results in a ns "update" later when the ns controller processes the ns create event
+
+		// can't record this in another deferred func since deferred funcs are processed in LIFO order
+		metrics.RecordControllerNamespaceExecTime(timer, operationKind, err != nil && dperr != nil)
+
 		if dperr != nil {
 			err = fmt.Errorf("failed with error %w, apply failed with %v", err, dperr)
 		}
@@ -265,8 +277,7 @@ func (nsc *NamespaceController) syncNamespace(nsKey string) error {
 
 			if _, ok := nsc.npmNamespaceCache.NsMap[nsKey]; ok {
 				// record time to delete namespace if it exists (can't call within cleanDeletedNamespace because this can be called by a pod update)
-				timer := metrics.StartNewTimer()
-				defer metrics.RecordNamespaceExecTime(timer, metrics.DeleteOp)
+				operationKind = metrics.DeleteOp
 			}
 
 			// cleanDeletedNamespace will check if the NS exists in cache, if it does, then proceeds with deletion
@@ -284,8 +295,7 @@ func (nsc *NamespaceController) syncNamespace(nsKey string) error {
 	if nsObj.DeletionTimestamp != nil || nsObj.DeletionGracePeriodSeconds != nil {
 		if _, ok := nsc.npmNamespaceCache.NsMap[nsKey]; ok {
 			// record time to delete namespace if it exists (can't call within cleanDeletedNamespace because this can be called by a pod update)
-			timer := metrics.StartNewTimer()
-			defer metrics.RecordNamespaceExecTime(timer, metrics.DeleteOp)
+			operationKind = metrics.DeleteOp
 		}
 		return nsc.cleanDeletedNamespace(nsKey)
 	}
@@ -298,7 +308,7 @@ func (nsc *NamespaceController) syncNamespace(nsKey string) error {
 		}
 	}
 
-	err = nsc.syncUpdateNamespace(nsObj)
+	operationKind, err = nsc.syncUpdateNamespace(nsObj)
 	if err != nil {
 		metrics.SendErrorLogAndMetric(util.NSID, "[syncNamespace] failed to sync namespace due to  %s", err.Error())
 		return err
@@ -338,9 +348,7 @@ func (nsc *NamespaceController) syncAddNamespace(nsObj *corev1.Namespace) error 
 }
 
 // syncUpdateNamespace handles updating namespace in ipset.
-func (nsc *NamespaceController) syncUpdateNamespace(newNsObj *corev1.Namespace) error {
-	timer := metrics.StartNewTimer()
-
+func (nsc *NamespaceController) syncUpdateNamespace(newNsObj *corev1.Namespace) (metrics.OperationKind, error) {
 	var err error
 	newNsName, newNsLabel := newNsObj.ObjectMeta.Name, newNsObj.ObjectMeta.Labels
 	klog.Infof("NAMESPACE UPDATING:\n namespace: [%s/%v]", newNsName, newNsLabel)
@@ -351,15 +359,14 @@ func (nsc *NamespaceController) syncUpdateNamespace(newNsObj *corev1.Namespace) 
 	curNsObj, exists := nsc.npmNamespaceCache.NsMap[newNsName]
 	if !exists {
 		if newNsObj.ObjectMeta.DeletionTimestamp == nil && newNsObj.ObjectMeta.DeletionGracePeriodSeconds == nil {
-			defer metrics.RecordNamespaceExecTime(timer, metrics.CreateOp)
 			if er := nsc.syncAddNamespace(newNsObj); er != nil {
-				return fmt.Errorf("failed to sync add namespace with err %w", err)
+				return metrics.CreateOp, fmt.Errorf("failed to sync add namespace with err %w", err)
 			}
 		}
 
-		return nil
+		return metrics.CreateOp, nil
 	}
-	defer metrics.RecordNamespaceExecTime(timer, metrics.UpdateOp)
+	// now we know this is an update event, and we'll return metrics.UpdateOp
 
 	// If the Namespace is not deleted, delete removed labels and create new labels
 	addToIPSets, deleteFromIPSets := util.GetIPSetListCompareLabels(curNsObj.LabelsMap, newNsLabel)
@@ -376,7 +383,7 @@ func (nsc *NamespaceController) syncUpdateNamespace(newNsObj *corev1.Namespace) 
 		klog.Infof("Deleting namespace %s from ipset list %s", newNsName, nsLabelVal)
 		if err = nsc.dp.RemoveFromList(labelSet, toBeRemoved); err != nil {
 			metrics.SendErrorLogAndMetric(util.NSID, "[UpdateNamespace] Error: failed to delete namespace %s from ipset list %s with err: %v", newNsName, nsLabelVal, err)
-			return fmt.Errorf("failed to remove from list during sync update namespace with err %w", err)
+			return metrics.UpdateOp, fmt.Errorf("failed to remove from list during sync update namespace with err %w", err)
 		}
 		// {IMPORTANT} The order of compared list will be key and then key+val. NPM should only append after both key
 		// key + val ipsets are worked on.
@@ -401,7 +408,7 @@ func (nsc *NamespaceController) syncUpdateNamespace(newNsObj *corev1.Namespace) 
 
 		if err = nsc.dp.AddToLists(labelSet, toBeAdded); err != nil {
 			metrics.SendErrorLogAndMetric(util.NSID, "[UpdateNamespace] Error: failed to add namespace %s to ipset list %s with err: %v", newNsName, nsLabelVal, err)
-			return fmt.Errorf("failed to add %v sets to %v lists during addtolists in sync update namespace with err %w", toBeAdded, labelSet, err)
+			return metrics.UpdateOp, fmt.Errorf("failed to add %v sets to %v lists during addtolists in sync update namespace with err %w", toBeAdded, labelSet, err)
 		}
 		// {IMPORTANT} Same as above order is assumed to be key and then key+val. NPM should only append to existing labels
 		// only after both ipsets for a given label's key value pair are added successfully
@@ -417,7 +424,7 @@ func (nsc *NamespaceController) syncUpdateNamespace(newNsObj *corev1.Namespace) 
 	curNsObj.appendLabels(newNsLabel, clearExistingLabels)
 	nsc.npmNamespaceCache.NsMap[newNsName] = curNsObj
 
-	return nil
+	return metrics.UpdateOp, nil
 }
 
 // cleanDeletedNamespace handles deleting namespace from ipset.

--- a/npm/pkg/controlplane/controllers/v2/namespaceController.go
+++ b/npm/pkg/controlplane/controllers/v2/namespaceController.go
@@ -266,7 +266,7 @@ func (nsc *NamespaceController) syncNamespace(nsKey string) error {
 			if _, ok := nsc.npmNamespaceCache.NsMap[nsKey]; ok {
 				// record time to delete namespace if it exists (can't call within cleanDeletedNamespace because this can be called by a pod update)
 				timer := metrics.StartNewTimer()
-				defer metrics.RecordNamespaceApplyTime(timer, metrics.DeleteMode)
+				defer metrics.RecordNamespaceExecTime(timer, metrics.DeleteOp)
 			}
 
 			// cleanDeletedNamespace will check if the NS exists in cache, if it does, then proceeds with deletion
@@ -285,7 +285,7 @@ func (nsc *NamespaceController) syncNamespace(nsKey string) error {
 		if _, ok := nsc.npmNamespaceCache.NsMap[nsKey]; ok {
 			// record time to delete namespace if it exists (can't call within cleanDeletedNamespace because this can be called by a pod update)
 			timer := metrics.StartNewTimer()
-			defer metrics.RecordNamespaceApplyTime(timer, metrics.DeleteMode)
+			defer metrics.RecordNamespaceExecTime(timer, metrics.DeleteOp)
 		}
 		return nsc.cleanDeletedNamespace(nsKey)
 	}
@@ -351,7 +351,7 @@ func (nsc *NamespaceController) syncUpdateNamespace(newNsObj *corev1.Namespace) 
 	curNsObj, exists := nsc.npmNamespaceCache.NsMap[newNsName]
 	if !exists {
 		if newNsObj.ObjectMeta.DeletionTimestamp == nil && newNsObj.ObjectMeta.DeletionGracePeriodSeconds == nil {
-			defer metrics.RecordPodApplyTime(timer, metrics.CreateMode)
+			defer metrics.RecordNamespaceExecTime(timer, metrics.CreateOp)
 			if er := nsc.syncAddNamespace(newNsObj); er != nil {
 				return fmt.Errorf("failed to sync add namespace with err %w", err)
 			}
@@ -359,7 +359,7 @@ func (nsc *NamespaceController) syncUpdateNamespace(newNsObj *corev1.Namespace) 
 
 		return nil
 	}
-	defer metrics.RecordPodApplyTime(timer, metrics.UpdateMode)
+	defer metrics.RecordNamespaceExecTime(timer, metrics.UpdateOp)
 
 	// If the Namespace is not deleted, delete removed labels and create new labels
 	addToIPSets, deleteFromIPSets := util.GetIPSetListCompareLabels(curNsObj.LabelsMap, newNsLabel)

--- a/npm/pkg/controlplane/controllers/v2/networkPolicyController.go
+++ b/npm/pkg/controlplane/controllers/v2/networkPolicyController.go
@@ -210,7 +210,7 @@ func (c *NetworkPolicyController) syncNetPol(key string) error {
 			if _, ok := c.rawNpSpecMap[key]; ok {
 				// record time to delete policy if it exists (can't call within cleanUpNetworkPolicy because this can be called by a pod update)
 				timer := metrics.StartNewTimer()
-				defer metrics.RecordPolicyApplyTime(timer, metrics.DeleteMode)
+				defer metrics.RecordPolicyExecTime(timer, metrics.DeleteOp)
 			}
 
 			// netPolObj is not found, but should need to check the RawNpMap cache with key.
@@ -230,7 +230,7 @@ func (c *NetworkPolicyController) syncNetPol(key string) error {
 		if _, ok := c.rawNpSpecMap[key]; ok {
 			// record time to delete policy if it exists (can't call within cleanUpNetworkPolicy because this can be called by a pod update)
 			timer := metrics.StartNewTimer()
-			defer metrics.RecordPolicyApplyTime(timer, metrics.DeleteMode)
+			defer metrics.RecordPolicyExecTime(timer, metrics.DeleteOp)
 		}
 		err = c.cleanUpNetworkPolicy(key)
 		if err != nil {
@@ -281,13 +281,13 @@ func (c *NetworkPolicyController) syncAddAndUpdateNetPol(netPolObj *networkingv1
 	}
 
 	_, policyExisted := c.rawNpSpecMap[netpolKey]
-	var mode metrics.ApplyMode
+	var mode metrics.OperationKind
 	if policyExisted {
-		mode = metrics.UpdateMode
+		mode = metrics.UpdateOp
 	} else {
-		mode = metrics.CreateMode
+		mode = metrics.CreateOp
 	}
-	defer metrics.RecordPolicyApplyTime(timer, mode)
+	defer metrics.RecordPolicyExecTime(timer, mode)
 
 	// install translated rules into Dataplane
 	// DP update policy call will check if this policy already exists in kernel

--- a/npm/pkg/controlplane/controllers/v2/networkPolicyController_test.go
+++ b/npm/pkg/controlplane/controllers/v2/networkPolicyController_test.go
@@ -57,6 +57,8 @@ func (f *netPolFixture) newNetPolController(_ chan struct{}, dp dataplane.Generi
 		}
 	}
 
+	metrics.ReinitializeAll()
+
 	// Do not start informer to avoid unnecessary event triggers
 	// (TODO): Leave stopCh and below commented code to enhance UTs to even check event triggers as well later if possible
 	// f.kubeInformer.Start(stopCh)
@@ -168,9 +170,47 @@ func updateNetPol(t *testing.T, f *netPolFixture, oldNetPolObj, netNetPolObj *ne
 type expectedNetPolValues struct {
 	expectedLenOfRawNpMap  int
 	expectedLenOfWorkQueue int
-	// prometheus metrics
-	expectedNumPolicies int
-	expectedExecCount   int
+	netPolPromVals
+}
+
+type netPolPromVals struct {
+	expectedNumPolicies     int
+	expectedAddExecCount    int
+	expectedUpdateExecCount int
+	expectedDeleteExecCount int
+}
+
+// for local testing, prepend the following to your go test command: sudo -E env 'PATH=$PATH'
+func (p *netPolPromVals) testPrometheusMetrics(t *testing.T) {
+	numPolicies, err := metrics.GetNumPolicies()
+	promutil.NotifyIfErrors(t, err)
+	if numPolicies != p.expectedNumPolicies {
+		require.FailNowf(t, "", "Number of policies didn't register correctly in Prometheus. Expected %d. Got %d.", p.expectedNumPolicies, numPolicies)
+	}
+
+	addExecCount, err := metrics.GetControllerPolicyExecCount(metrics.CreateOp, false)
+	promutil.NotifyIfErrors(t, err)
+	require.Equal(t, p.expectedAddExecCount, addExecCount, "Count for add execution time didn't register correctly in Prometheus")
+
+	addErrorExecCount, err := metrics.GetControllerPolicyExecCount(metrics.CreateOp, true)
+	promutil.NotifyIfErrors(t, err)
+	require.Equal(t, 0, addErrorExecCount, "Count for add error execution time should be 0")
+
+	updateExecCount, err := metrics.GetControllerPolicyExecCount(metrics.UpdateOp, false)
+	promutil.NotifyIfErrors(t, err)
+	require.Equal(t, p.expectedUpdateExecCount, updateExecCount, "Count for update execution time didn't register correctly in Prometheus")
+
+	updateErrorExecCount, err := metrics.GetControllerPolicyExecCount(metrics.UpdateOp, true)
+	promutil.NotifyIfErrors(t, err)
+	require.Equal(t, 0, updateErrorExecCount, "Count for update error execution time should be 0")
+
+	deleteExecCount, err := metrics.GetControllerPolicyExecCount(metrics.DeleteOp, false)
+	promutil.NotifyIfErrors(t, err)
+	require.Equal(t, p.expectedDeleteExecCount, deleteExecCount, "Count for delete execution time didn't register correctly in Prometheus")
+
+	deleteErrorExecCount, err := metrics.GetControllerPolicyExecCount(metrics.DeleteOp, true)
+	promutil.NotifyIfErrors(t, err)
+	require.Equal(t, 0, deleteErrorExecCount, "Count for delete error execution time should be 0")
 }
 
 func checkNetPolTestResult(testName string, f *netPolFixture, testCases []expectedNetPolValues) {
@@ -183,22 +223,7 @@ func checkNetPolTestResult(testName string, f *netPolFixture, testCases []expect
 			f.t.Errorf("Test: %s, Workqueue length = %d, want %d", testName, got, test.expectedLenOfWorkQueue)
 		}
 
-		testPrometheusMetrics(f.t, test.expectedNumPolicies, test.expectedExecCount)
-	}
-}
-
-func testPrometheusMetrics(t *testing.T, expectedNumPolicies, expectedExecCount int) {
-	numPolicies, err := metrics.GetNumPolicies()
-	promutil.NotifyIfErrors(t, err)
-	if numPolicies != expectedNumPolicies {
-		require.FailNowf(t, "", "Number of policies didn't register correctly in Prometheus. Expected %d. Got %d.", expectedNumPolicies, numPolicies)
-	}
-
-	// FIXME update UTs for prometheus metrics like in v1
-	execCount, err := metrics.GetControllerPolicyExecCount(metrics.CreateOp, false)
-	promutil.NotifyIfErrors(t, err)
-	if execCount != expectedExecCount {
-		require.FailNowf(t, "", "Count for execution time didn't register correctly in Prometheus. Expected %d. Got %d.", expectedExecCount, execCount)
+		test.netPolPromVals.testPrometheusMetrics(f.t)
 	}
 }
 
@@ -226,13 +251,14 @@ func TestAddMultipleNetworkPolicies(t *testing.T) {
 
 	dp.EXPECT().UpdatePolicy(gomock.Any()).Times(2)
 
-	metrics.ReinitializeAll()
-
 	addNetPol(f, netPolObj1)
 	addNetPol(f, netPolObj2)
 
+	// already exists (will be a no-op)
+	addNetPol(f, netPolObj1)
+
 	testCases := []expectedNetPolValues{
-		{2, 0, 2, 2},
+		{2, 0, netPolPromVals{2, 2, 0, 0}},
 	}
 	checkNetPolTestResult("TestAddMultipleNetPols", f, testCases)
 }
@@ -251,12 +277,11 @@ func TestAddNetworkPolicy(t *testing.T) {
 	dp := dpmocks.NewMockGenericDataplane(ctrl)
 	f.newNetPolController(stopCh, dp)
 
-	metrics.ReinitializeAll()
 	dp.EXPECT().UpdatePolicy(gomock.Any()).Times(1)
 
 	addNetPol(f, netPolObj)
 	testCases := []expectedNetPolValues{
-		{1, 0, 1, 1},
+		{1, 0, netPolPromVals{1, 1, 0, 0}},
 	}
 
 	checkNetPolTestResult("TestAddNetPol", f, testCases)
@@ -276,13 +301,12 @@ func TestDeleteNetworkPolicy(t *testing.T) {
 	dp := dpmocks.NewMockGenericDataplane(ctrl)
 	f.newNetPolController(stopCh, dp)
 
-	metrics.ReinitializeAll()
 	dp.EXPECT().UpdatePolicy(gomock.Any()).Times(1)
 	dp.EXPECT().RemovePolicy(gomock.Any()).Times(1)
 
 	deleteNetPol(t, f, netPolObj, DeletedFinalStateknownObject)
 	testCases := []expectedNetPolValues{
-		{0, 0, 0, 1},
+		{0, 0, netPolPromVals{0, 1, 0, 1}},
 	}
 	checkNetPolTestResult("TestDelNetPol", f, testCases)
 }
@@ -301,8 +325,6 @@ func TestDeleteNetworkPolicyWithTombstone(t *testing.T) {
 	dp := dpmocks.NewMockGenericDataplane(ctrl)
 	f.newNetPolController(stopCh, dp)
 
-	metrics.ReinitializeAll()
-
 	netPolKey := getKey(netPolObj, t)
 	tombstone := cache.DeletedFinalStateUnknown{
 		Key: netPolKey,
@@ -311,7 +333,7 @@ func TestDeleteNetworkPolicyWithTombstone(t *testing.T) {
 
 	f.netPolController.deleteNetworkPolicy(tombstone)
 	testCases := []expectedNetPolValues{
-		{0, 1, 0, 0},
+		{0, 1, netPolPromVals{0, 0, 0, 0}},
 	}
 	checkNetPolTestResult("TestDeleteNetworkPolicyWithTombstone", f, testCases)
 }
@@ -330,13 +352,12 @@ func TestDeleteNetworkPolicyWithTombstoneAfterAddingNetworkPolicy(t *testing.T) 
 	dp := dpmocks.NewMockGenericDataplane(ctrl)
 	f.newNetPolController(stopCh, dp)
 
-	metrics.ReinitializeAll()
 	dp.EXPECT().UpdatePolicy(gomock.Any()).Times(1)
 	dp.EXPECT().RemovePolicy(gomock.Any()).Times(1)
 
 	deleteNetPol(t, f, netPolObj, DeletedFinalStateUnknownObject)
 	testCases := []expectedNetPolValues{
-		{0, 0, 0, 1},
+		{0, 0, netPolPromVals{0, 1, 0, 1}},
 	}
 	checkNetPolTestResult("TestDeleteNetworkPolicyWithTombstoneAfterAddingNetworkPolicy", f, testCases)
 }
@@ -357,8 +378,6 @@ func TestUpdateNetworkPolicy(t *testing.T) {
 	dp := dpmocks.NewMockGenericDataplane(ctrl)
 	f.newNetPolController(stopCh, dp)
 
-	metrics.ReinitializeAll()
-
 	newNetPolObj := oldNetPolObj.DeepCopy()
 	// oldNetPolObj.ResourceVersion value is "0"
 	newRV, _ := strconv.Atoi(oldNetPolObj.ResourceVersion)
@@ -367,7 +386,7 @@ func TestUpdateNetworkPolicy(t *testing.T) {
 
 	updateNetPol(t, f, oldNetPolObj, newNetPolObj)
 	testCases := []expectedNetPolValues{
-		{1, 0, 1, 1},
+		{1, 0, netPolPromVals{1, 1, 0, 0}},
 	}
 	checkNetPolTestResult("TestUpdateNetPol", f, testCases)
 }
@@ -386,8 +405,6 @@ func TestLabelUpdateNetworkPolicy(t *testing.T) {
 	dp := dpmocks.NewMockGenericDataplane(ctrl)
 	f.newNetPolController(stopCh, dp)
 
-	metrics.ReinitializeAll()
-
 	newNetPolObj := oldNetPolObj.DeepCopy()
 	// update podSelctor in a new network policy field
 	newNetPolObj.Spec.PodSelector = metav1.LabelSelector{
@@ -404,7 +421,7 @@ func TestLabelUpdateNetworkPolicy(t *testing.T) {
 	updateNetPol(t, f, oldNetPolObj, newNetPolObj)
 
 	testCases := []expectedNetPolValues{
-		{1, 0, 1, 2},
+		{1, 0, netPolPromVals{1, 1, 1, 0}},
 	}
 	checkNetPolTestResult("TestUpdateNetPol", f, testCases)
 }

--- a/npm/pkg/controlplane/controllers/v2/networkPolicyController_test.go
+++ b/npm/pkg/controlplane/controllers/v2/networkPolicyController_test.go
@@ -195,7 +195,7 @@ func testPrometheusMetrics(t *testing.T, expectedNumPolicies, expectedExecCount 
 	}
 
 	// FIXME update UTs for prometheus metrics like in v1
-	execCount, err := metrics.GetPolicyExecCount(metrics.CreateOp)
+	execCount, err := metrics.GetControllerPolicyExecCount(metrics.CreateOp, false)
 	promutil.NotifyIfErrors(t, err)
 	if execCount != expectedExecCount {
 		require.FailNowf(t, "", "Count for execution time didn't register correctly in Prometheus. Expected %d. Got %d.", expectedExecCount, execCount)

--- a/npm/pkg/controlplane/controllers/v2/networkPolicyController_test.go
+++ b/npm/pkg/controlplane/controllers/v2/networkPolicyController_test.go
@@ -195,7 +195,7 @@ func testPrometheusMetrics(t *testing.T, expectedNumPolicies, expectedExecCount 
 	}
 
 	// FIXME update UTs for prometheus metrics like in v1
-	execCount, err := metrics.GetPolicyApplyCount(metrics.CreateMode)
+	execCount, err := metrics.GetPolicyExecCount(metrics.CreateOp)
 	promutil.NotifyIfErrors(t, err)
 	if execCount != expectedExecCount {
 		require.FailNowf(t, "", "Count for execution time didn't register correctly in Prometheus. Expected %d. Got %d.", expectedExecCount, execCount)

--- a/npm/pkg/controlplane/controllers/v2/podController.go
+++ b/npm/pkg/controlplane/controllers/v2/podController.go
@@ -327,6 +327,13 @@ func (c *PodController) syncPod(key string) error {
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			klog.Infof("pod %s not found, may be it is deleted", key)
+
+			if _, ok := c.podMap[key]; ok {
+				// record time to delete pod if it exists (can't call within cleanUpDeletedPod because this can be called by a pod update)
+				timer := metrics.StartNewTimer()
+				defer metrics.RecordPodApplyTime(timer, metrics.DeleteMode)
+			}
+
 			// cleanUpDeletedPod will check if the pod exists in cache, if it does then proceeds with deletion
 			// if it does not exists, then event will be no-op
 			err = c.cleanUpDeletedPod(key)
@@ -344,6 +351,11 @@ func (c *PodController) syncPod(key string) error {
 	// NPM starts clean-up the lastly applied states even in update events.
 	// This proactive clean-up helps to miss stale pod object in case delete event is missed.
 	if isCompletePod(pod) {
+		if _, ok := c.podMap[key]; ok {
+			// record time to delete pod if it exists (can't call within cleanUpDeletedPod because this can be called by a pod update)
+			timer := metrics.StartNewTimer()
+			defer metrics.RecordPodApplyTime(timer, metrics.DeleteMode)
+		}
 		if err = c.cleanUpDeletedPod(key); err != nil {
 			return fmt.Errorf("Error: %w when when pod is in completed state", err)
 		}
@@ -418,6 +430,8 @@ func (c *PodController) syncAddedPod(podObj *corev1.Pod) error {
 
 // syncAddAndUpdatePod handles updating pod ip in its label's ipset.
 func (c *PodController) syncAddAndUpdatePod(newPodObj *corev1.Pod) error {
+	timer := metrics.StartNewTimer()
+
 	var err error
 	podKey, _ := cache.MetaNamespaceKeyFunc(newPodObj)
 
@@ -442,8 +456,10 @@ func (c *PodController) syncAddAndUpdatePod(newPodObj *corev1.Pod) error {
 	klog.Infof("[syncAddAndUpdatePod] updating Pod with key %s", podKey)
 	// No cached npmPod exists. start adding the pod in a cache
 	if !exists {
+		defer metrics.RecordPodApplyTime(timer, metrics.CreateMode)
 		return c.syncAddedPod(newPodObj)
 	}
+	defer metrics.RecordPodApplyTime(timer, metrics.UpdateMode)
 
 	// Dealing with "updatePod" event - Compare last applied states against current Pod states
 	// There are two possibilities for npmPodObj and newPodObj

--- a/npm/pkg/controlplane/controllers/v2/podController.go
+++ b/npm/pkg/controlplane/controllers/v2/podController.go
@@ -303,6 +303,9 @@ func (c *PodController) processNextWorkItem() bool {
 
 // syncPod compares the actual state with the desired, and attempts to converge the two.
 func (c *PodController) syncPod(key string) error {
+	// timer for recording execution times
+	timer := metrics.StartNewTimer()
+
 	// Convert the namespace/name string into a distinct namespace and name
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
@@ -313,9 +316,12 @@ func (c *PodController) syncPod(key string) error {
 	// Get the Pod resource with this namespace/name
 	pod, err := c.podLister.Pods(namespace).Get(name)
 
-	// apply dataplane after syncing
+	// apply dataplane and record exec time after syncing
+	operationKind := metrics.NoOp
 	defer func() {
 		dperr := c.dp.ApplyDataPlane()
+		// can't record this in another deferred func since deferred funcs are processed in LIFO order
+		metrics.RecordControllerPodExecTime(timer, operationKind, err != nil && dperr != nil)
 		if dperr != nil {
 			err = fmt.Errorf("failed with error %w, apply failed with %v", err, dperr)
 		}
@@ -330,8 +336,7 @@ func (c *PodController) syncPod(key string) error {
 
 			if _, ok := c.podMap[key]; ok {
 				// record time to delete pod if it exists (can't call within cleanUpDeletedPod because this can be called by a pod update)
-				timer := metrics.StartNewTimer()
-				defer metrics.RecordPodExecTime(timer, metrics.DeleteOp)
+				operationKind = metrics.DeleteOp
 			}
 
 			// cleanUpDeletedPod will check if the pod exists in cache, if it does then proceeds with deletion
@@ -353,8 +358,7 @@ func (c *PodController) syncPod(key string) error {
 	if isCompletePod(pod) {
 		if _, ok := c.podMap[key]; ok {
 			// record time to delete pod if it exists (can't call within cleanUpDeletedPod because this can be called by a pod update)
-			timer := metrics.StartNewTimer()
-			defer metrics.RecordPodExecTime(timer, metrics.DeleteOp)
+			operationKind = metrics.DeleteOp
 		}
 		if err = c.cleanUpDeletedPod(key); err != nil {
 			return fmt.Errorf("Error: %w when when pod is in completed state", err)
@@ -372,7 +376,7 @@ func (c *PodController) syncPod(key string) error {
 		}
 	}
 
-	err = c.syncAddAndUpdatePod(pod)
+	operationKind, err = c.syncAddAndUpdatePod(pod)
 	if err != nil {
 		return fmt.Errorf("Failed to sync pod due to %w", err)
 	}
@@ -429,9 +433,7 @@ func (c *PodController) syncAddedPod(podObj *corev1.Pod) error {
 }
 
 // syncAddAndUpdatePod handles updating pod ip in its label's ipset.
-func (c *PodController) syncAddAndUpdatePod(newPodObj *corev1.Pod) error {
-	timer := metrics.StartNewTimer()
-
+func (c *PodController) syncAddAndUpdatePod(newPodObj *corev1.Pod) (metrics.OperationKind, error) {
 	var err error
 	podKey, _ := cache.MetaNamespaceKeyFunc(newPodObj)
 
@@ -443,7 +445,8 @@ func (c *PodController) syncAddAndUpdatePod(newPodObj *corev1.Pod) error {
 		toBeAdded := []*ipsets.IPSetMetadata{ipsets.NewIPSetMetadata(newPodObj.Namespace, ipsets.Namespace)}
 		if err = c.dp.AddToLists([]*ipsets.IPSetMetadata{kubeAllNamespaces}, toBeAdded); err != nil {
 			c.npmNamespaceCache.Unlock()
-			return fmt.Errorf("[syncAddAndUpdatePod] Error: failed to add %s to all-namespace ipset list with err: %w", newPodObj.Namespace, err)
+			// since the namespace doesn't exist, this must be a pod create event, so we'll return metrics.CreateOp
+			return metrics.CreateOp, fmt.Errorf("[syncAddAndUpdatePod] Error: failed to add %s to all-namespace ipset list with err: %w", newPodObj.Namespace, err)
 		}
 
 		// Add namespace object into NsMap cache only when two ipset operations are successful.
@@ -456,10 +459,9 @@ func (c *PodController) syncAddAndUpdatePod(newPodObj *corev1.Pod) error {
 	klog.Infof("[syncAddAndUpdatePod] updating Pod with key %s", podKey)
 	// No cached npmPod exists. start adding the pod in a cache
 	if !exists {
-		defer metrics.RecordPodExecTime(timer, metrics.CreateOp)
-		return c.syncAddedPod(newPodObj)
+		return metrics.CreateOp, c.syncAddedPod(newPodObj)
 	}
-	defer metrics.RecordPodExecTime(timer, metrics.UpdateOp)
+	// now we know this is an update event, and we'll return metrics.UpdateOp
 
 	// Dealing with "updatePod" event - Compare last applied states against current Pod states
 	// There are two possibilities for npmPodObj and newPodObj
@@ -475,11 +477,11 @@ func (c *PodController) syncAddAndUpdatePod(newPodObj *corev1.Pod) error {
 
 		klog.Infof("Deleting cached Pod with key:%s first due to IP Mistmatch", podKey)
 		if er := c.cleanUpDeletedPod(podKey); er != nil {
-			return er
+			return metrics.UpdateOp, er
 		}
 
 		klog.Infof("Adding back Pod with key:%s after IP Mistmatch", podKey)
-		return c.syncAddedPod(newPodObj)
+		return metrics.UpdateOp, c.syncAddedPod(newPodObj)
 	}
 
 	// Dealing with #1 pod update event, the IP addresses of cached npmPod and newPodObj are same
@@ -502,7 +504,7 @@ func (c *PodController) syncAddAndUpdatePod(newPodObj *corev1.Pod) error {
 			toRemoveSet = ipsets.NewIPSetMetadata(removeIPSetName, ipsets.KeyLabelOfPod)
 		}
 		if err = c.dp.RemoveFromSets([]*ipsets.IPSetMetadata{toRemoveSet}, cachedPodMetadata); err != nil {
-			return fmt.Errorf("[syncAddAndUpdatePod] Error: failed to delete pod from label ipset with err: %w", err)
+			return metrics.UpdateOp, fmt.Errorf("[syncAddAndUpdatePod] Error: failed to delete pod from label ipset with err: %w", err)
 		}
 		// {IMPORTANT} The order of compared list will be key and then key+val. NPM should only append after both key
 		// key + val ipsets are worked on. 0th index will be key and 1st index will be value of the label
@@ -526,7 +528,7 @@ func (c *PodController) syncAddAndUpdatePod(newPodObj *corev1.Pod) error {
 
 		klog.Infof("Adding pod %s (ip : %s) to ipset %s", podKey, newPodObj.Status.PodIP, addIPSetName)
 		if err = c.dp.AddToSets([]*ipsets.IPSetMetadata{toAddSet}, newPodMetadata); err != nil {
-			return fmt.Errorf("[syncAddAndUpdatePod] Error: failed to add pod to label ipset with err: %w", err)
+			return metrics.UpdateOp, fmt.Errorf("[syncAddAndUpdatePod] Error: failed to add pod to label ipset with err: %w", err)
 		}
 		// {IMPORTANT} Same as above order is assumed to be key and then key+val. NPM should only append to existing labels
 		// only after both ipsets for a given label's key value pair are added successfully
@@ -549,20 +551,20 @@ func (c *PodController) syncAddAndUpdatePod(newPodObj *corev1.Pod) error {
 		// Delete cached pod's named ports from its ipset.
 		if err = c.manageNamedPortIpsets(
 			cachedNpmPod.ContainerPorts, podKey, cachedNpmPod.PodIP, "", deleteNamedPort); err != nil {
-			return fmt.Errorf("[syncAddAndUpdatePod] Error: failed to delete pod from named port ipset with err: %w", err)
+			return metrics.UpdateOp, fmt.Errorf("[syncAddAndUpdatePod] Error: failed to delete pod from named port ipset with err: %w", err)
 		}
 		// Since portList ipset deletion is successful, NPM can remove cachedContainerPorts
 		cachedNpmPod.removeContainerPorts()
 
 		// Add new pod's named ports from its ipset.
 		if err = c.manageNamedPortIpsets(newPodPorts, podKey, newPodObj.Status.PodIP, newPodObj.Spec.NodeName, addNamedPort); err != nil {
-			return fmt.Errorf("[syncAddAndUpdatePod] Error: failed to add pod to named port ipset with err: %w", err)
+			return metrics.UpdateOp, fmt.Errorf("[syncAddAndUpdatePod] Error: failed to add pod to named port ipset with err: %w", err)
 		}
 		cachedNpmPod.appendContainerPorts(newPodObj)
 	}
 	cachedNpmPod.updateNpmPodAttributes(newPodObj)
 
-	return nil
+	return metrics.UpdateOp, nil
 }
 
 // cleanUpDeletedPod cleans up all ipset associated with this pod

--- a/npm/pkg/controlplane/controllers/v2/podController.go
+++ b/npm/pkg/controlplane/controllers/v2/podController.go
@@ -331,7 +331,7 @@ func (c *PodController) syncPod(key string) error {
 			if _, ok := c.podMap[key]; ok {
 				// record time to delete pod if it exists (can't call within cleanUpDeletedPod because this can be called by a pod update)
 				timer := metrics.StartNewTimer()
-				defer metrics.RecordPodApplyTime(timer, metrics.DeleteMode)
+				defer metrics.RecordPodExecTime(timer, metrics.DeleteOp)
 			}
 
 			// cleanUpDeletedPod will check if the pod exists in cache, if it does then proceeds with deletion
@@ -354,7 +354,7 @@ func (c *PodController) syncPod(key string) error {
 		if _, ok := c.podMap[key]; ok {
 			// record time to delete pod if it exists (can't call within cleanUpDeletedPod because this can be called by a pod update)
 			timer := metrics.StartNewTimer()
-			defer metrics.RecordPodApplyTime(timer, metrics.DeleteMode)
+			defer metrics.RecordPodExecTime(timer, metrics.DeleteOp)
 		}
 		if err = c.cleanUpDeletedPod(key); err != nil {
 			return fmt.Errorf("Error: %w when when pod is in completed state", err)
@@ -456,10 +456,10 @@ func (c *PodController) syncAddAndUpdatePod(newPodObj *corev1.Pod) error {
 	klog.Infof("[syncAddAndUpdatePod] updating Pod with key %s", podKey)
 	// No cached npmPod exists. start adding the pod in a cache
 	if !exists {
-		defer metrics.RecordPodApplyTime(timer, metrics.CreateMode)
+		defer metrics.RecordPodExecTime(timer, metrics.CreateOp)
 		return c.syncAddedPod(newPodObj)
 	}
-	defer metrics.RecordPodApplyTime(timer, metrics.UpdateMode)
+	defer metrics.RecordPodExecTime(timer, metrics.UpdateOp)
 
 	// Dealing with "updatePod" event - Compare last applied states against current Pod states
 	// There are two possibilities for npmPodObj and newPodObj


### PR DESCRIPTION
This PR adds controller exec time metrics for pods/namespaces/policies. Metric labels are "operation" (create/update/delete) and "error" ("true" or "false").

Completed UTs:
- apply time metrics
- v1 controllers

TODO:
- UTs for v2 controllers