### PR TITLE
feat: [NPM] send more AI logs

### DIFF
--- a/npm/cmd/start.go
+++ b/npm/cmd/start.go
@@ -160,6 +160,7 @@ func start(config npmconfig.Config, flags npmconfig.Flags) error {
 
 	go restserver.NPMRestServerListenAndServe(config, npMgr)
 
+	metrics.SendLog(util.NpmID, "starting NPM")
 	if err = npMgr.Start(config, stopChannel); err != nil {
 		metrics.SendErrorLogAndMetric(util.NpmID, "Failed to start NPM due to %+v", err)
 		return fmt.Errorf("failed to start with err: %w", err)

--- a/npm/iptm/iptm.go
+++ b/npm/iptm/iptm.go
@@ -330,6 +330,7 @@ func (iptMgr *IptablesManager) reconcileChains(stopCh <-chan struct{}) {
 			if err := iptMgr.checkAndAddForwardChain(); err != nil {
 				metrics.SendErrorLogAndMetric(util.NpmID, "Error: failed to reconcileChains Azure-NPM due to %s", err.Error())
 			}
+			metrics.SendHeartbeatLog()
 		}
 	}
 }

--- a/npm/metrics/ai-utils.go
+++ b/npm/metrics/ai-utils.go
@@ -69,7 +69,7 @@ func SendErrorLogAndMetric(operationID int, format string, args ...interface{}) 
 // SendMetric sends metrics
 func SendMetric(metric aitelemetry.Metric) {
 	if th == nil {
-		log.Logf("AppInsights didn't initialized.")
+		log.Logf("AppInsights didn't initialize")
 		return
 	}
 	th.TrackMetric(metric)

--- a/npm/metrics/ai-utils.go
+++ b/npm/metrics/ai-utils.go
@@ -62,13 +62,8 @@ func SendErrorLogAndMetric(operationID int, format string, args ...interface{}) 
 
 	// Send error logs
 	msg := fmt.Sprintf(format, args...)
-	report := aitelemetry.Report{
-		Message:          msg,
-		Context:          strconv.Itoa(operationID),
-		CustomDimensions: make(map[string]string),
-	}
 	log.Errorf(msg)
-	SendLog(report)
+	SendLog(operationID, msg)
 }
 
 // SendMetric sends metrics
@@ -81,10 +76,23 @@ func SendMetric(metric aitelemetry.Metric) {
 }
 
 // SendLog sends log
-func SendLog(report aitelemetry.Report) {
+func SendLog(operationID int, msg string) {
+	report := aitelemetry.Report{
+		Message:          msg,
+		Context:          strconv.Itoa(operationID),
+		CustomDimensions: make(map[string]string),
+	}
 	if th == nil {
 		log.Logf("AppInsights didn't initialized.")
 		return
 	}
 	th.TrackLog(report)
+}
+
+func SendHeartbeatLog() {
+	numPolicies, err := GetNumPolicies()
+	if err != nil {
+		message := fmt.Sprintf("Info: NPM currently has %d policies", numPolicies)
+		SendLog(util.NpmID, message)
+	}
 }

--- a/npm/pkg/dataplane/dataplane.go
+++ b/npm/pkg/dataplane/dataplane.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-container-networking/npm/metrics"
 	"github.com/Azure/azure-container-networking/npm/pkg/dataplane/ipsets"
 	"github.com/Azure/azure-container-networking/npm/pkg/dataplane/policies"
+	"github.com/Azure/azure-container-networking/npm/util"
 	npmerrors "github.com/Azure/azure-container-networking/npm/util/errors"
 	"k8s.io/klog"
 )
@@ -111,9 +112,9 @@ func (dp *DataPlane) AddToSets(setNames []*ipsets.IPSetMetadata, podMetadata *Po
 		return fmt.Errorf("[DataPlane] error while adding to set: %w", err)
 	}
 	if dp.shouldUpdatePod() {
-		klog.Infof("[Dataplane] Updating Sets to Add for pod key %s", podMetadata.PodKey)
+		klog.Infof("[DataPlane] Updating Sets to Add for pod key %s", podMetadata.PodKey)
 		if _, ok := dp.updatePodCache[podMetadata.PodKey]; !ok {
-			klog.Infof("[Dataplane] {AddToSet} pod key %s not found creating a new obj", podMetadata.PodKey)
+			klog.Infof("[DataPlane] {AddToSet} pod key %s not found creating a new obj", podMetadata.PodKey)
 			dp.updatePodCache[podMetadata.PodKey] = newUpdateNPMPod(podMetadata)
 		}
 
@@ -132,9 +133,9 @@ func (dp *DataPlane) RemoveFromSets(setNames []*ipsets.IPSetMetadata, podMetadat
 	}
 
 	if dp.shouldUpdatePod() {
-		klog.Infof("[Dataplane] Updating Sets to Remove for pod key %s", podMetadata.PodKey)
+		klog.Infof("[DataPlane] Updating Sets to Remove for pod key %s", podMetadata.PodKey)
 		if _, ok := dp.updatePodCache[podMetadata.PodKey]; !ok {
-			klog.Infof("[Dataplane] {RemoveFromSet} pod key %s not found creating a new obj", podMetadata.PodKey)
+			klog.Infof("[DataPlane] {RemoveFromSet} pod key %s not found creating a new obj", podMetadata.PodKey)
 			dp.updatePodCache[podMetadata.PodKey] = newUpdateNPMPod(podMetadata)
 		}
 
@@ -179,6 +180,7 @@ func (dp *DataPlane) ApplyDataPlane() error {
 		for podKey, pod := range dp.updatePodCache {
 			err := dp.updatePod(pod)
 			if err != nil {
+				metrics.SendErrorLogAndMetric(util.DaemonDataplaneID, "error: failed to update pods: %s", err.Error())
 				return fmt.Errorf("[DataPlane] error while updating pod: %w", err)
 			}
 			delete(dp.updatePodCache, podKey)
@@ -292,7 +294,7 @@ func (dp *DataPlane) createIPSetsAndReferences(sets []*ipsets.TranslatedIPSet, n
 		dp.ipsetMgr.CreateIPSets([]*ipsets.IPSetMetadata{set.Metadata})
 		err := dp.ipsetMgr.AddReference(set.Metadata.GetPrefixName(), netpolName, referenceType)
 		if err != nil {
-			return npmerrors.Errorf(npmErrorString, false, fmt.Sprintf("[dataplane] failed to add reference with err: %s", err.Error()))
+			return npmerrors.Errorf(npmErrorString, false, fmt.Sprintf("[DataPlane] failed to add reference with err: %s", err.Error()))
 		}
 	}
 
@@ -308,11 +310,11 @@ func (dp *DataPlane) createIPSetsAndReferences(sets []*ipsets.TranslatedIPSet, n
 			for _, ipblock := range set.Members {
 				err := validateIPBlock(ipblock)
 				if err != nil {
-					return npmerrors.Errorf(npmErrorString, false, fmt.Sprintf("[dataplane] failed to parseCIDR in addIPSetReferences with err: %s", err.Error()))
+					return npmerrors.Errorf(npmErrorString, false, fmt.Sprintf("[DataPlane] failed to parseCIDR in addIPSetReferences with err: %s", err.Error()))
 				}
 				err = dp.ipsetMgr.AddToSets([]*ipsets.IPSetMetadata{set.Metadata}, ipblock, "")
 				if err != nil {
-					return npmerrors.Errorf(npmErrorString, false, fmt.Sprintf("[dataplane] failed to AddToSet in addIPSetReferences with err: %s", err.Error()))
+					return npmerrors.Errorf(npmErrorString, false, fmt.Sprintf("[DataPlane] failed to AddToSet in addIPSetReferences with err: %s", err.Error()))
 				}
 			}
 		} else if setType == ipsets.NestedLabelOfPod && len(set.Members) > 0 {
@@ -320,7 +322,7 @@ func (dp *DataPlane) createIPSetsAndReferences(sets []*ipsets.TranslatedIPSet, n
 			// Apply members to the list set
 			err := dp.ipsetMgr.AddToLists([]*ipsets.IPSetMetadata{set.Metadata}, getMembersOfTranslatedSets(set.Members))
 			if err != nil {
-				return npmerrors.Errorf(npmErrorString, false, fmt.Sprintf("[dataplane] failed to AddToList in addIPSetReferences with err: %s", err.Error()))
+				return npmerrors.Errorf(npmErrorString, false, fmt.Sprintf("[DataPlane] failed to AddToList in addIPSetReferences with err: %s", err.Error()))
 			}
 		}
 	}
@@ -338,7 +340,7 @@ func (dp *DataPlane) deleteIPSetsAndReferences(sets []*ipsets.TranslatedIPSet, n
 		// TODO add delete ipset after removing members
 		err := dp.ipsetMgr.DeleteReference(set.Metadata.GetPrefixName(), netpolName, referenceType)
 		if err != nil {
-			return npmerrors.Errorf(npmErrorString, false, fmt.Sprintf("[dataplane] failed to deleteIPSetReferences with err: %s", err.Error()))
+			return npmerrors.Errorf(npmErrorString, false, fmt.Sprintf("[DataPlane] failed to deleteIPSetReferences with err: %s", err.Error()))
 		}
 	}
 
@@ -356,18 +358,18 @@ func (dp *DataPlane) deleteIPSetsAndReferences(sets []*ipsets.TranslatedIPSet, n
 			for _, ipblock := range set.Members {
 				err := validateIPBlock(ipblock)
 				if err != nil {
-					return npmerrors.Errorf(npmErrorString, false, fmt.Sprintf("[dataplane] failed to parseCIDR in deleteIPSetReferences with err: %s", err.Error()))
+					return npmerrors.Errorf(npmErrorString, false, fmt.Sprintf("[DataPlane] failed to parseCIDR in deleteIPSetReferences with err: %s", err.Error()))
 				}
 				err = dp.ipsetMgr.RemoveFromSets([]*ipsets.IPSetMetadata{set.Metadata}, ipblock, "")
 				if err != nil {
-					return npmerrors.Errorf(npmErrorString, false, fmt.Sprintf("[dataplane] failed to RemoveFromSet in deleteIPSetReferences with err: %s", err.Error()))
+					return npmerrors.Errorf(npmErrorString, false, fmt.Sprintf("[DataPlane] failed to RemoveFromSet in deleteIPSetReferences with err: %s", err.Error()))
 				}
 			}
 		} else if set.Metadata.GetSetKind() == ipsets.ListSet && len(set.Members) > 0 {
 			// Delete if any 2nd level IPSets are generated by Controller with members
 			err := dp.ipsetMgr.RemoveFromList(set.Metadata, getMembersOfTranslatedSets(set.Members))
 			if err != nil {
-				return npmerrors.Errorf(npmErrorString, false, fmt.Sprintf("[dataplane] failed to RemoveFromList in deleteIPSetReferences with err: %s", err.Error()))
+				return npmerrors.Errorf(npmErrorString, false, fmt.Sprintf("[DataPlane] failed to RemoveFromList in deleteIPSetReferences with err: %s", err.Error()))
 			}
 
 		}

--- a/npm/pkg/dataplane/dataplane.go
+++ b/npm/pkg/dataplane/dataplane.go
@@ -387,6 +387,7 @@ func validateIPBlock(ipblock string) error {
 	onlyCidr := strings.Split(ipblock, " ")[0]
 	_, _, err := net.ParseCIDR(onlyCidr)
 	if err != nil {
+		metrics.SendErrorLogAndMetric(util.IpsmID, "error: failed to parse CIDR: %s", err.Error())
 		return npmerrors.SimpleErrorWrapper("failed to parse CIDR", err)
 	}
 	return nil

--- a/npm/pkg/dataplane/policies/chain-management_linux.go
+++ b/npm/pkg/dataplane/policies/chain-management_linux.go
@@ -194,7 +194,9 @@ func (pMgr *PolicyManager) bootup(_ []string) error {
 // - cleans up stale policy chains. It can be forced to stop this process if reconcileManager.forceLock() is called.
 func (pMgr *PolicyManager) reconcile() {
 	if err := pMgr.positionAzureChainJumpRule(); err != nil {
-		klog.Errorf("failed to reconcile jump rule to Azure-NPM due to %s", err.Error())
+		msg := fmt.Sprintf("failed to reconcile jump rule to Azure-NPM due to %s", err.Error())
+		metrics.SendErrorLogAndMetric(util.IptmID, "error: %s", msg)
+		klog.Error(msg)
 	}
 
 	pMgr.reconcileManager.Lock()
@@ -207,7 +209,9 @@ func (pMgr *PolicyManager) reconcile() {
 
 	klog.Infof("cleaning up these stale chains: %+v", staleChains)
 	if err := pMgr.cleanupChains(staleChains); err != nil {
-		klog.Errorf("failed to clean up old policy chains with the following error: %s", err.Error())
+		msg := fmt.Sprintf("failed to clean up old policy chains with the following error: %s", err.Error())
+		metrics.SendErrorLogAndMetric(util.IptmID, "error: %s", msg)
+		klog.Error(msg)
 	}
 }
 

--- a/npm/pkg/dataplane/policies/policymanager.go
+++ b/npm/pkg/dataplane/policies/policymanager.go
@@ -63,6 +63,7 @@ func NewPolicyManager(ioShim *common.IOShim, cfg *PolicyManagerCfg) *PolicyManag
 
 func (pMgr *PolicyManager) Bootup(epIDs []string) error {
 	if err := pMgr.bootup(epIDs); err != nil {
+		metrics.SendErrorLogAndMetric(util.IptmID, "error: failed to bootup policy manager: %s", err.Error())
 		return npmerrors.ErrorWrapper(npmerrors.BootupPolicyMgr, false, "failed to bootup policy manager", err)
 	}
 	return nil

--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -222,11 +222,12 @@ const (
 // It's for better query purpose. In Kusto these value are used in
 // OperationID column
 const (
-	NpmID int = iota + 1
-	IpsmID
-	IptmID
+	NpmID  int = iota + 1
+	IpsmID     // ipsetmanager in v2
+	IptmID     // policymanager in v2
 	NSID
 	PodID
 	NetpolID
 	UtilID
+	DaemonDataplaneID // for v2
 )

--- a/npm/util/ioutil/restore.go
+++ b/npm/util/ioutil/restore.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-container-networking/common"
+	"github.com/Azure/azure-container-networking/npm/metrics"
+	"github.com/Azure/azure-container-networking/npm/util"
 	npmerrors "github.com/Azure/azure-container-networking/npm/util/errors"
 	"k8s.io/klog"
 )
@@ -134,6 +136,7 @@ func (creator *FileCreator) RunCommandWithFile(cmd string, args ...string) error
 		return nil
 	}
 	commandString := cmd + " " + strings.Join(args, " ")
+	metrics.SendErrorLogAndMetric(util.UtilID, "error: failed to run [%s] on try 1 with error: %s", cmd, err.Error())
 	for !creator.hasNoMoreRetries() {
 		if wasFileAltered {
 			klog.Infof("rerunning command [%s] with new file", commandString)
@@ -145,6 +148,7 @@ func (creator *FileCreator) RunCommandWithFile(cmd string, args ...string) error
 			klog.Infof("successfully ran command [%s] on try number %d", commandString, creator.tryCount)
 			return nil
 		}
+		metrics.SendErrorLogAndMetric(util.UtilID, "error: failed to run [%s] on try %d with error: %s", cmd, creator.tryCount, err.Error())
 	}
 	errString := fmt.Sprintf("failed to run command [%s] with error: %v", commandString, err)
 	klog.Error(errString)


### PR DESCRIPTION
This PR does the following:
- Sends a log when NPM starts up (allows us to see if a version reached a customer since we can look for that log)
- Sends a heartbeat log which runs in iptables/policy manager periodic tasks. It includes the number of policies in the cluster
- Sends error logs in the v2 dataplane, which previously sent nothing