### PR TITLE
fix: [NPM] disable v2 CLI & polish linux policy manager

### DIFF
--- a/npm/http/server/server.go
+++ b/npm/http/server/server.go
@@ -32,8 +32,10 @@ func NPMRestServerListenAndServe(config npmconfig.Config, npmEncoder json.Marsha
 		rs.router.Handle(api.ClusterMetricsPath, metrics.GetHandler(metrics.ClusterMetrics))
 	}
 
-	if config.Toggles.EnableHTTPDebugAPI && npmEncoder != nil {
-		// ACN CLI debug handlerss
+	// TODO support the debug CLI for v2
+	// the nil check is for fan-out npm
+	if config.Toggles.EnableHTTPDebugAPI && npmEncoder != nil && !config.Toggles.EnableV2NPM {
+		// ACN CLI debug handlers
 		rs.router.Handle(api.NPMMgrPath, rs.npmCacheHandler(npmEncoder)).Methods(http.MethodGet)
 	}
 

--- a/npm/pkg/dataplane/policies/chain-management_linux.go
+++ b/npm/pkg/dataplane/policies/chain-management_linux.go
@@ -139,10 +139,9 @@ func isBaseChain(chain string) bool {
 			- delete all deprecated chains
 			- delete old v2 policy chains
 	3. Add/reposition the jump from FORWARD chain to AZURE-NPM chain.
-		TODO: add this jump (if necessary) in the iptables-restore call
 
-	TODO: could use one grep call instead of one for getting the jump line num and one for getting deprecated chains and old v2 policy chains
-		- should use a grep pattern like so: <line num...AZURE-NPM>|<Chain AZURE-NPM>
+	TODO: could use one grep call instead of separate calls for getting jump line nums and for getting deprecated chains and old v2 policy chains
+		- would use a grep pattern like so: <line num...AZURE-NPM>|<Chain AZURE-NPM>
 */
 func (pMgr *PolicyManager) bootup(_ []string) error {
 	klog.Infof("booting up iptables Azure chains")

--- a/npm/pkg/dataplane/policies/chain-management_linux_test.go
+++ b/npm/pkg/dataplane/policies/chain-management_linux_test.go
@@ -372,6 +372,20 @@ func TestBootupLinux(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "success after restore failure (no NPM prior)",
+			calls: []testutils.TestCmd{
+				{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}, ExitCode: 2}, // AZURE-NPM chain didn't exist
+				{Cmd: listAllCommandStrings, PipedToCommand: true},
+				{Cmd: []string{"grep", "Chain AZURE-NPM"}, ExitCode: 1},
+				fakeIPTablesRestoreFailureCommand, // e.g. xtables lock held by another app. Currently the stdout doesn't matter for retrying
+				fakeIPTablesRestoreCommand,
+				{Cmd: listLineNumbersCommandStrings, PipedToCommand: true},
+				{Cmd: []string{"grep", "AZURE-NPM"}, ExitCode: 1},
+				{Cmd: []string{"iptables", "-w", "60", "-I", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
+			},
+			wantErr: false,
+		},
+		{
 			name: "success: v2 existed prior",
 			calls: []testutils.TestCmd{
 				{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}, ExitCode: 1}, // deprecated rule did not exist
@@ -429,11 +443,12 @@ func TestBootupLinux(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "failure on restore (no NPM prior)",
+			name: "failure twice on restore (no NPM prior)",
 			calls: []testutils.TestCmd{
 				{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}, ExitCode: 2}, // AZURE-NPM chain didn't exist
 				{Cmd: listAllCommandStrings, PipedToCommand: true},
 				{Cmd: []string{"grep", "Chain AZURE-NPM"}, ExitCode: 1},
+				fakeIPTablesRestoreFailureCommand,
 				fakeIPTablesRestoreFailureCommand,
 			},
 			wantErr: true,

--- a/npm/pkg/dataplane/policies/policy.go
+++ b/npm/pkg/dataplane/policies/policy.go
@@ -18,6 +18,7 @@ type NPMNetworkPolicy struct {
 	PolicyKey string
 	// PodSelectorIPSets holds all the IPSets generated from Pod Selector
 	PodSelectorIPSets []*ipsets.TranslatedIPSet
+	// TODO change to slice of pointers
 	// PodSelectorList holds target pod information to avoid duplicatoin in SrcList and DstList fields in ACLs
 	PodSelectorList []SetInfo
 	// RuleIPSets holds all IPSets generated from policy's rules

--- a/npm/pkg/dataplane/policies/policy_linux.go
+++ b/npm/pkg/dataplane/policies/policy_linux.go
@@ -15,6 +15,9 @@ type UniqueDirection bool
 const (
 	forIngress UniqueDirection = true
 	forEgress  UniqueDirection = false
+
+	// 5-6 elements depending on Included boolean
+	maxLengthForMatchSetSpecs = 6
 )
 
 // returns two booleans indicating whether the network policy has ingress and egress respectively
@@ -81,6 +84,17 @@ func (info SetInfo) comment() string {
 		return name
 	}
 	return "!" + name
+}
+
+func (info SetInfo) matchSetSpecs(matchString string) []string {
+	specs := make([]string, 0, maxLengthForMatchSetSpecs)
+	specs = append(specs, util.IptablesModuleFlag, util.IptablesSetModuleFlag)
+	if !info.Included {
+		specs = append(specs, util.IptablesNotFlag)
+	}
+	hashedSetName := info.IPSet.GetHashedName()
+	specs = append(specs, util.IptablesMatchSetFlag, hashedSetName, matchString)
+	return specs
 }
 
 func (aclPolicy *ACLPolicy) comment() string {

--- a/npm/pkg/dataplane/policies/testutils_linux.go
+++ b/npm/pkg/dataplane/policies/testutils_linux.go
@@ -20,7 +20,7 @@ func GetAddPolicyTestCalls(_ *NPMNetworkPolicy) []testutils.TestCmd {
 }
 
 func GetAddPolicyFailureTestCalls(_ *NPMNetworkPolicy) []testutils.TestCmd {
-	return []testutils.TestCmd{fakeIPTablesRestoreFailureCommand}
+	return []testutils.TestCmd{fakeIPTablesRestoreFailureCommand, fakeIPTablesRestoreFailureCommand}
 }
 
 func GetRemovePolicyTestCalls(policy *NPMNetworkPolicy) []testutils.TestCmd {
@@ -44,8 +44,10 @@ func GetRemovePolicyTestCalls(policy *NPMNetworkPolicy) []testutils.TestCmd {
 // GetRemovePolicyFailureTestCalls fails on the restore
 func GetRemovePolicyFailureTestCalls(policy *NPMNetworkPolicy) []testutils.TestCmd {
 	calls := GetRemovePolicyTestCalls(policy)
-	calls[len(calls)-1] = fakeIPTablesRestoreFailureCommand // replace the restore success with a failure
-	return calls
+	// replace the restore success with a failure
+	calls[len(calls)-1] = fakeIPTablesRestoreFailureCommand
+	// add another failure
+	return append(calls, fakeIPTablesRestoreFailureCommand)
 }
 
 func GetBootupTestCalls() []testutils.TestCmd {


### PR DESCRIPTION
Changes:
- disable the CLI for v2
- update some comments
- polish linux policy manager
  - increase the max try count to 2 for iptables-restore
  - fix the exit code that we ignore when deleting jumps to policy chains (now we ignore when the rule doesn't exist