### PR TITLE
fix: [NPM] trim logs & fix bug where restore file wasn't updated on failure

### DIFF
--- a/npm/pkg/dataplane/policies/chain-management_linux.go
+++ b/npm/pkg/dataplane/policies/chain-management_linux.go
@@ -408,7 +408,6 @@ func (pMgr *PolicyManager) positionAzureChainJumpRule() error {
 // this function has a direct comparison in NPM v1 iptables manager (iptm.go)
 func (pMgr *PolicyManager) chainLineNumber(chain string) (int, error) {
 	listForwardEntriesCommand := pMgr.ioShim.Exec.Command(util.Iptables, listForwardEntriesArgs...)
-	klog.Infof("grepping for chain %s after running iptables with args %v", chain, listForwardEntriesArgs)
 	grepCommand := pMgr.ioShim.Exec.Command(ioutil.Grep, chain)
 	searchResults, gotMatches, err := ioutil.PipeCommandToGrep(listForwardEntriesCommand, grepCommand)
 	if err != nil {

--- a/npm/pkg/dataplane/policies/policymanager_linux.go
+++ b/npm/pkg/dataplane/policies/policymanager_linux.go
@@ -25,7 +25,8 @@ const (
 /*
 Error handling for iptables-restore:
 Currently we retry on any error and will make two tries max.
-The section IDs and line error patterns are pointless currently. Although we can eventually use them to skip a section with an error and salvage the rest of the file.
+The section IDs and line error patterns are pointless currently.
+Although we can eventually use them to skip a section with an error and salvage the rest of the file.
 
 Known errors that we should retry on:
 - exit status 4


### PR DESCRIPTION
`fileString` wasn't reassigned in `RunCommandWithFile` in _restore.go_ when the file is fixed before the retry.