### PR TITLE
fix: update controller-gen args for multitenantnetworkcontainer crd

### DIFF
--- a/crd/multitenantnetworkcontainer/Makefile
+++ b/crd/multitenantnetworkcontainer/Makefile
@@ -10,7 +10,7 @@ generate: $(CONTROLLER_GEN)
 
 manifests: $(CONTROLLER_GEN)
 	mkdir -p manifests
-	$(CONTROLLER_GEN) crd:trivialVersions=true paths="./..." output:crd:artifacts:config=manifests/
+	$(CONTROLLER_GEN) crd paths="./..." output:crd:artifacts:config=manifests/
 
 $(CONTROLLER_GEN):
 	@make -C $(REPO_ROOT) $(CONTROLLER_GEN)

--- a/crd/multitenantnetworkcontainer/manifests/networking.azure.com_multitenantnetworkcontainers.yaml
+++ b/crd/multitenantnetworkcontainer/manifests/networking.azure.com_multitenantnetworkcontainers.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: multitenantnetworkcontainers.networking.azure.com
 spec:


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Fix the controller-gen args used in multitenantnetworkcontainer makefile and update the generated version to 0.7.0

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
