### PR TITLE
[NPM] Generate TLS certificates during docker build and bake into image for gRPC secure channels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,10 @@ ipam-*.xml
 controller-gen
 build/tools/bin
 npm/debug/http
+
+# certificates
+*/**/certs/
+*.crt
+*.pem
+*.pem
+*.srl

--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,4 @@ npm/debug/http
 */**/certs/
 *.crt
 *.pem
-*.pem
 *.srl

--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -20,6 +20,9 @@ FROM docker.io/ubuntu:focal
 COPY --from=builder /usr/local/bin/azure-npm \
 	/usr/bin/azure-npm
 
+COPY --from=builder /usr/local/src/npm/npm/scripts \
+  /usr/local/npm
+
 # Install dependencies.
 RUN apt-get update
 RUN apt-get install -y iptables
@@ -28,6 +31,9 @@ RUN apt-get install -y ca-certificates
 RUN apt-get upgrade -y
 
 RUN chmod +x /usr/bin/azure-npm
+
+WORKDIR /usr/local/npm
+RUN ./generate_certs.sh
 
 # Run the npm command by default when the container starts.
 ENTRYPOINT ["/usr/bin/azure-npm", "start"]

--- a/npm/cmd/root.go
+++ b/npm/cmd/root.go
@@ -1,7 +1,14 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	npmconfig "github.com/Azure/azure-container-networking/npm/config"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"k8s.io/klog"
 )
 
 // NewRootCmd returns a root cobra command
@@ -11,6 +18,27 @@ func NewRootCmd() *cobra.Command {
 		Short: "Collection of functions related to Azure NPM's debugging tools",
 		CompletionOptions: cobra.CompletionOptions{
 			DisableDefaultCmd: true,
+		},
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			viper.AutomaticEnv() // read in environment variables that match
+			viper.SetDefault(npmconfig.ConfigEnvPath, npmconfig.GetConfigPath())
+			cfgFile := viper.GetString(npmconfig.ConfigEnvPath)
+			viper.SetConfigFile(cfgFile)
+
+			// If a config file is found, read it in.
+			// NOTE: there is no config merging with default, if config is loaded, options must be set
+			if err := viper.ReadInConfig(); err == nil {
+				klog.Infof("Using config file: %+v", viper.ConfigFileUsed())
+			} else {
+				klog.Infof("Failed to load config from env %s: %v", npmconfig.ConfigEnvPath, err)
+				b, _ := json.Marshal(npmconfig.DefaultConfig)
+				err := viper.ReadConfig(bytes.NewBuffer(b))
+				if err != nil {
+					return fmt.Errorf("failed to read in default with err %w", err)
+				}
+			}
+
+			return nil
 		},
 	}
 

--- a/npm/cmd/root.go
+++ b/npm/cmd/root.go
@@ -31,7 +31,7 @@ func NewRootCmd() *cobra.Command {
 				klog.Infof("Using config file: %+v", viper.ConfigFileUsed())
 			} else {
 				klog.Infof("Failed to load config from env %s: %v", npmconfig.ConfigEnvPath, err)
-				b, _ := json.Marshal(npmconfig.DefaultConfig)
+				b, _ := json.Marshal(npmconfig.DefaultConfig) //nolint // skip checking error
 				err := viper.ReadConfig(bytes.NewBuffer(b))
 				if err != nil {
 					return fmt.Errorf("failed to read in default with err %w", err)

--- a/npm/cmd/start.go
+++ b/npm/cmd/start.go
@@ -3,8 +3,6 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"math/rand"
 	"time"
@@ -48,27 +46,27 @@ func newStartNPMCmd() *cobra.Command {
 	startNPMCmd := &cobra.Command{
 		Use:   "start",
 		Short: "Starts the Azure NPM process",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			viper.AutomaticEnv() // read in environment variables that match
-			viper.SetDefault(npmconfig.ConfigEnvPath, npmconfig.GetConfigPath())
-			cfgFile := viper.GetString(npmconfig.ConfigEnvPath)
-			viper.SetConfigFile(cfgFile)
+		// PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// 	viper.AutomaticEnv() // read in environment variables that match
+		// 	viper.SetDefault(npmconfig.ConfigEnvPath, npmconfig.GetConfigPath())
+		// 	cfgFile := viper.GetString(npmconfig.ConfigEnvPath)
+		// 	viper.SetConfigFile(cfgFile)
 
-			// If a config file is found, read it in.
-			// NOTE: there is no config merging with default, if config is loaded, options must be set
-			if err := viper.ReadInConfig(); err == nil {
-				klog.Infof("Using config file: %+v", viper.ConfigFileUsed())
-			} else {
-				klog.Infof("Failed to load config from env %s: %v", npmconfig.ConfigEnvPath, err)
-				b, _ := json.Marshal(npmconfig.DefaultConfig)
-				err := viper.ReadConfig(bytes.NewBuffer(b))
-				if err != nil {
-					return fmt.Errorf("failed to read in default with err %w", err)
-				}
-			}
+		// 	// If a config file is found, read it in.
+		// 	// NOTE: there is no config merging with default, if config is loaded, options must be set
+		// 	if err := viper.ReadInConfig(); err == nil {
+		// 		klog.Infof("Using config file: %+v", viper.ConfigFileUsed())
+		// 	} else {
+		// 		klog.Infof("Failed to load config from env %s: %v", npmconfig.ConfigEnvPath, err)
+		// 		b, _ := json.Marshal(npmconfig.DefaultConfig)
+		// 		err := viper.ReadConfig(bytes.NewBuffer(b))
+		// 		if err != nil {
+		// 			return fmt.Errorf("failed to read in default with err %w", err)
+		// 		}
+		// 	}
 
-			return nil
-		},
+		// 	return nil
+		// },
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			config := &npmconfig.Config{}

--- a/npm/cmd/start.go
+++ b/npm/cmd/start.go
@@ -46,28 +46,6 @@ func newStartNPMCmd() *cobra.Command {
 	startNPMCmd := &cobra.Command{
 		Use:   "start",
 		Short: "Starts the Azure NPM process",
-		// PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		// 	viper.AutomaticEnv() // read in environment variables that match
-		// 	viper.SetDefault(npmconfig.ConfigEnvPath, npmconfig.GetConfigPath())
-		// 	cfgFile := viper.GetString(npmconfig.ConfigEnvPath)
-		// 	viper.SetConfigFile(cfgFile)
-
-		// 	// If a config file is found, read it in.
-		// 	// NOTE: there is no config merging with default, if config is loaded, options must be set
-		// 	if err := viper.ReadInConfig(); err == nil {
-		// 		klog.Infof("Using config file: %+v", viper.ConfigFileUsed())
-		// 	} else {
-		// 		klog.Infof("Failed to load config from env %s: %v", npmconfig.ConfigEnvPath, err)
-		// 		b, _ := json.Marshal(npmconfig.DefaultConfig)
-		// 		err := viper.ReadConfig(bytes.NewBuffer(b))
-		// 		if err != nil {
-		// 			return fmt.Errorf("failed to read in default with err %w", err)
-		// 		}
-		// 	}
-
-		// 	return nil
-		// },
-
 		RunE: func(cmd *cobra.Command, args []string) error {
 			config := &npmconfig.Config{}
 			err := viper.Unmarshal(config)

--- a/npm/deploy/kustomize/overlays/controller/deployment.yaml
+++ b/npm/deploy/kustomize/overlays/controller/deployment.yaml
@@ -38,7 +38,7 @@ spec:
             containerPort: 10092
           image: azure-npm:v1.4.1
           command: ["azure-npm"]
-          args: ["start", "controlplane"]
+          args: ["controlplane"]
           resources:
             limits:
               cpu: 250m

--- a/npm/deploy/kustomize/overlays/daemon/deployment.yaml
+++ b/npm/deploy/kustomize/overlays/daemon/deployment.yaml
@@ -36,7 +36,7 @@ spec:
             containerPort: 10091
           image: azure-npm:v1.4.1
           command: ["azure-npm"]
-          args: ["start", "daemon"]
+          args: ["daemon"]
           resources:
             limits:
               cpu: 250m

--- a/npm/pkg/transport/errors.go
+++ b/npm/pkg/transport/errors.go
@@ -2,5 +2,9 @@ package transport
 
 import "errors"
 
-// ErrNoPeer is returned when no peer was found in the gRPC context.
-var ErrNoPeer = errors.New("no peer found in gRPC context")
+var (
+	// ErrNoPeer is returned when no peer was found in the gRPC context.
+	ErrNoPeer = errors.New("no peer found in gRPC context")
+	// ErrTLSCerts is returned for any TLS certificate related issue
+	ErrTLSCerts = errors.New("tls certificate error")
+)

--- a/npm/pkg/transport/events_client.go
+++ b/npm/pkg/transport/events_client.go
@@ -52,7 +52,6 @@ func NewEventsClient(ctx context.Context, pod, node, addr string) (*EventsClient
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial %s: %w", addr, err)
 	}
-	// defer cc.Close()
 
 	return &EventsClient{
 		ctx:                   ctx,

--- a/npm/pkg/transport/events_client.go
+++ b/npm/pkg/transport/events_client.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Azure/azure-container-networking/npm/pkg/protos"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials"
 	"k8s.io/klog/v2"
 )
 
@@ -37,12 +37,22 @@ func NewEventsClient(ctx context.Context, pod, node, addr string) (*EventsClient
 	}
 
 	klog.Infof("Connecting to NPM controller gRPC server at address %s\n", addr)
-	// TODO Make this secure
-	// TODO Remove WithBlock option post testing
-	cc, err := grpc.DialContext(ctx, addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	config, err := clientTLSConfig()
+	if err != nil {
+		klog.Errorf("failed to load client tls config : %s", err)
+		return nil, fmt.Errorf("failed to load client tls config : %w", err)
+	}
+
+	cc, err := grpc.DialContext(
+		ctx,
+		addr,
+		grpc.WithTransportCredentials(credentials.NewTLS(config)),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial %s: %w", addr, err)
 	}
+	// defer cc.Close()
 
 	return &EventsClient{
 		ctx:                   ctx,
@@ -81,11 +91,12 @@ func (c *EventsClient) run(ctx context.Context, stopCh <-chan struct{}) error {
 		default:
 			if connectClient == nil {
 				klog.Info("Reconnecting to gRPC server controller")
-				opts := []grpc.CallOption{grpc.WaitForReady(true)}
+				opts := []grpc.CallOption{grpc.WaitForReady(false)}
 				connectClient, err = c.Connect(ctx, clientMetadata, opts...)
 				if err != nil {
 					return fmt.Errorf("failed to connect to dataplane events server: %w", err)
 				}
+				klog.Info("Successfully connected to gRPC server controller")
 			}
 			event, err := connectClient.Recv()
 			if err != nil {

--- a/npm/pkg/transport/events_server.go
+++ b/npm/pkg/transport/events_server.go
@@ -157,7 +157,14 @@ func (m *EventsServer) handle() error {
 		return fmt.Errorf("failed to handle server connections: %w", err)
 	}
 
+	// load the server certificates
+	creds, err := serverTLSCreds()
+	if err != nil {
+		return fmt.Errorf("failed to load TLS certificates: %w", err)
+	}
+
 	var opts []grpc.ServerOption = []grpc.ServerOption{
+		grpc.Creds(creds),
 		grpc.MaxConcurrentStreams(grpcMaxConcurrentStreams),
 		grpc.StatsHandler(m.Watchdog),
 	}

--- a/npm/pkg/transport/tls.go
+++ b/npm/pkg/transport/tls.go
@@ -1,0 +1,44 @@
+package transport
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+
+	"google.golang.org/grpc/credentials"
+)
+
+const (
+	serverCertPEMFilename = "tls.crt"
+	serverKeyPEMFilename  = "tls.key"
+	caCertPEMFilename     = "ca.crt"
+	path                  = "/usr/local/npm"
+)
+
+func serverTLSCreds() (credentials.TransportCredentials, error) {
+	certFilepath := path + "/" + serverCertPEMFilename
+	keyFilepath := path + "/" + serverKeyPEMFilename
+
+	return credentials.NewServerTLSFromFile(certFilepath, keyFilepath)
+}
+
+func clientTLSConfig() (*tls.Config, error) {
+	caCertFilepath := path + "/" + caCertPEMFilename
+	// Load certificate of the CA who signed server's certificate
+	pemServerCA, err := ioutil.ReadFile(caCertFilepath)
+	if err != nil {
+		return nil, err
+	}
+
+	certPool := x509.NewCertPool()
+	if !certPool.AppendCertsFromPEM(pemServerCA) {
+		return nil, fmt.Errorf("failed to add server CA's certificate")
+	}
+
+	// Create the credentials and return it
+	return &tls.Config{
+		RootCAs:            certPool,
+		InsecureSkipVerify: false,
+	}, nil
+}

--- a/npm/scripts/generate_certs.sh
+++ b/npm/scripts/generate_certs.sh
@@ -33,3 +33,6 @@ openssl req -newkey rsa:4096 -nodes -keyout $CERTS_STAGING_DIR/tls.key -out $CER
 
 # Sign the server certificate with the CA
 openssl x509 -req -in $CERTS_STAGING_DIR/server-req.pem -CA $CERTS_STAGING_DIR/ca.crt -CAkey $CERTS_STAGING_DIR/ca.key -CAcreateserial -out $CERTS_STAGING_DIR/tls.crt --days $CERTIFICATE_VALIDITY_DAYS --extfile $SAN_CNF_FILE --extensions v3_req
+
+# Remove the secret CA key and signing request
+rm -rf $CERTS_STAGING_DIR/ca.key $CERTS_STAGING_DIR/server-req.pem

--- a/npm/scripts/generate_certs.sh
+++ b/npm/scripts/generate_certs.sh
@@ -8,21 +8,21 @@ CERT_SUBJ="/C=US/ST=Washington/L=Redmond/O=Microsoft/OU=Azure/CN=azure-npm.kube-
 # Check if openssl is installed
 if ! command -v openssl &> /dev/null
 then
-    echo "openssl could not be found"
-    exit
+  echo "openssl could not be found"
+  exit
 fi
 
 # Check if SAN_CNF_FILE exists
 if [ ! -f "$SAN_CNF_FILE" ]
 then
-		echo "SAN_CNF_FILE does not exist"
-		exit
+  echo "SAN_CNF_FILE does not exist"
+  exit
 fi
 
 if [ ! -d "$CERTS_STAGING_DIR" ]
 then
-    echo "Creating $CERTS_STAGING_DIR"
-		mkdir -p $CERTS_STAGING_DIR
+  echo "Creating $CERTS_STAGING_DIR"
+  mkdir -p $CERTS_STAGING_DIR
 fi
 
 # Generate the ca certificate and key

--- a/npm/scripts/generate_certs.sh
+++ b/npm/scripts/generate_certs.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+CERTS_STAGING_DIR=.
+SAN_CNF_FILE=san.cnf
+CERTIFICATE_VALIDITY_DAYS=3650
+CERT_SUBJ="/C=US/ST=Washington/L=Redmond/O=Microsoft/OU=Azure/CN=azure-npm.kube-system.svc.cluster.local"
+
+# Check if openssl is installed
+if ! command -v openssl &> /dev/null
+then
+    echo "openssl could not be found"
+    exit
+fi
+
+# Check if SAN_CNF_FILE exists
+if [ ! -f "$SAN_CNF_FILE" ]
+then
+		echo "SAN_CNF_FILE does not exist"
+		exit
+fi
+
+if [ ! -d "$CERTS_STAGING_DIR" ]
+then
+    echo "Creating $CERTS_STAGING_DIR"
+		mkdir -p $CERTS_STAGING_DIR
+fi
+
+# Generate the ca certificate and key
+openssl req -x509 -newkey rsa:4096 -days $CERTIFICATE_VALIDITY_DAYS -nodes -keyout $CERTS_STAGING_DIR/ca.key -out $CERTS_STAGING_DIR/ca.crt -subj $CERT_SUBJ
+
+# Create a certificate signing request for the server
+openssl req -newkey rsa:4096 -nodes -keyout $CERTS_STAGING_DIR/tls.key -out $CERTS_STAGING_DIR/server-req.pem -config $SAN_CNF_FILE -extensions v3_req -subj $CERT_SUBJ
+
+# Sign the server certificate with the CA
+openssl x509 -req -in $CERTS_STAGING_DIR/server-req.pem -CA $CERTS_STAGING_DIR/ca.crt -CAkey $CERTS_STAGING_DIR/ca.key -CAcreateserial -out $CERTS_STAGING_DIR/tls.crt --days $CERTIFICATE_VALIDITY_DAYS --extfile $SAN_CNF_FILE --extensions v3_req

--- a/npm/scripts/san.cnf
+++ b/npm/scripts/san.cnf
@@ -1,0 +1,21 @@
+[ req ]
+default_bits       = 2048
+distinguished_name = req_distinguished_name
+req_extensions     = v3_req
+
+[ req_distinguished_name ]
+countryName                 = Country Name (2 letter code)
+stateOrProvinceName         = State or Province Name (full name)
+localityName               = Locality Name (eg, city)
+organizationName           = Organization Name (eg, company)
+commonName                 = Common Name (e.g. server FQDN or YOUR name)
+
+[ v3_req ]
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1   = azure-npm.kube-system.svc.cluster.local 
+DNS.2   = azure-npm.kube-system 
+DNS.3   = azure-npm
+DNS.4   = 0.0.0.0 


### PR DESCRIPTION
This change adds the generation of the Server cert and CA cert to the docker image. These certs are available to both the client and the server side to establish a secure gRPC connection between client & server.

Changes include,
- Adding tls helper functions to transport package
- Generate script to generate the TLS certificates
- Dockerfile (Linux) updated to run the generate script at build time.

TODOs,
- Create a generate script for Windows.

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
