### PR TITLE
test: [NPM] Stress Testing & Fix Conformance Logs

### DIFF
--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -185,6 +185,9 @@ jobs:
         echo "##vso[task.setvariable variable=FQDN]$FQDN"
 
   - bash: |
+      echo "sleeping 3 minutes to allow NPM pods to restart"
+      sleep 180
+
       ## create the output folder and include the kubeconfig there
       npmLogsFolder=$(System.DefaultWorkingDirectory)/npmLogs_$(AZURE_CLUSTER)
       mkdir -p $npmLogsFolder
@@ -223,7 +226,7 @@ jobs:
       
     displayName: "Run Test Suite and Get Logs"
     
-  - publish: $(System.DefaultWorkingDirectory)/npmLogs_$(PROFILE)
+  - publish: $(System.DefaultWorkingDirectory)/npmLogs_$(AZURE_CLUSTER)
     condition: always()
     artifact: NpmLogs_$(AZURE_CLUSTER)
 

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -4,6 +4,8 @@ trigger:
 variables:
 - name: VNET_NAME
   value: npm-vnet
+- name: NUM_PARALLEL_JOBS_FOR_STRESS_TEST
+  value: "3"
 
 jobs:
 - job: setup
@@ -210,10 +212,9 @@ jobs:
 
       exitCode=0
       if [ $(IS_STRESS_TEST) == "true" ]; then
-          numParallelJobs=3
-          echo "Running $numParallelJobs conformance tests at once and writing outputs to files"
+          echo "Running $NUM_PARALLEL_JOBS_FOR_STRESS_TEST conformance tests at once and writing outputs to files"
           declare -a conformancePIDs
-          for round in $(seq 1 $numParallelJobs); do
+          for round in $(seq 1 $NUM_PARALLEL_JOBS_FOR_STRESS_TEST); do
               # for each iteration, run the conformance test and echos in the background, and write the output of the conformance test to a file
               echo "starting conformance test #$round" && \
                   runConformance > $npmLogsFolder/conformance-results-$round && \
@@ -223,7 +224,7 @@ jobs:
           done
 
           # wait until all conformance tests finish and take note of any failed tests
-          for round in $(seq 1 $numParallelJobs); do
+          for round in $(seq 1 $NUM_PARALLEL_JOBS_FOR_STRESS_TEST); do
               i=$((round-1))
               wait ${conformancePIDs[$i]}
               exitCode=$?

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -197,32 +197,48 @@ jobs:
       npmPodList=`kubectl --kubeconfig=./kubeconfig get pods -n kube-system | grep npm | awk '{print $1}'`
       echo "Found NPM pods: $npmPodList"
       for npmPod in $npmPodList; do
-        ./kubectl --kubeconfig=./kubeconfig logs -n kube-system $npmPod -f > $npmLogsFolder/$npmPod-logs.txt &
+          ./kubectl --kubeconfig=./kubeconfig logs -n kube-system $npmPod -f > $npmLogsFolder/$npmPod-logs.txt &
       done
 
       ## Run all Conformance tests in the background
       echo $FQDN
       chmod +x $(Pipeline.Workspace)/Test/e2e.test
-      numParallelJobs=1
-      if [ $(IS_STRESS_TEST) == "true" ]; then
-        numParallelJobs=3
-      fi
-      declare -a pids
-      for i in $(seq 1 $numParallelJobs); do
-        # for each iteration, run the conformance test and echos in the background, and write the output of the conformance test to a file
-        echo "starting conformance test #$i" && \
-          KUBERNETES_SERVICE_HOST="$FQDN" KUBERNETES_SERVICE_PORT=443 $(Pipeline.Workspace)/Test/e2e.test --provider=local --ginkgo.focus="NetworkPolicy" --ginkgo.skip="SCTP" --kubeconfig=./kubeconfig > $npmLogsFolder/conformance-results-$i.txt && \
-          echo "finished conformance test #$i" &
-        pidOfConformanceTest=$!
-        index=$((i-1))
-        pids[$index]=$pidOfConformanceTest
-      done
+      runConformance () {
+          KUBERNETES_SERVICE_HOST="$FQDN" KUBERNETES_SERVICE_PORT=443 $(Pipeline.Workspace)/Test/e2e.test --provider=local --ginkgo.focus="NetworkPolicy" --ginkgo.skip="SCTP" --kubeconfig=./kubeconfig
+      }
 
-      # wait until all conformance tests finish
-      wait "${pids[@]}"
+      exitCode=0
+      if [ $(IS_STRESS_TEST) == "true" ]; then
+          numParallelJobs=3
+          echo "Running $numParallelJobs conformance tests at once and writing outputs to files"
+          declare -a conformancePIDs
+          for round in $(seq 1 $numParallelJobs); do
+              # for each iteration, run the conformance test and echos in the background, and write the output of the conformance test to a file
+              echo "starting conformance test #$round" && \
+                  runConformance > $npmLogsFolder/conformance-results-$round.txt && \
+                  echo "finished conformance test #$round" &
+              pidOfConformanceTest=$!
+              conformancePIDs+=($pidOfConformanceTest)
+          done
+
+          # wait until all conformance tests finish and take note of any failed tests
+          for round in $(seq 1 $numParallelJobs); do
+              i=$((round-1))
+              wait ${conformancePIDs[$i]}
+              exitCode=$?
+              if [ $exitCode != 0 ]; then
+                  echo "conformance test #$round failed"
+                  break
+              fi
+          done
+      else
+          # run the conformance test in the foreground, and don't write the output to a file
+          runConformance
+          exitCode=$?
+      fi
       # kill the background processes (the logs) that have this process' pid (i.e. $$) as a parent
       pkill -P $$
-      
+      exit $exitCode
     displayName: "Run Test Suite and Get Logs"
     
   - publish: $(System.DefaultWorkingDirectory)/npmLogs_$(AZURE_CLUSTER)

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -191,7 +191,7 @@ jobs:
       mv ./kubeconfig $npmLogsFolder/kubeconfig
 
       ## write to all NPM pod logs in the background (do this in the background instead of after to make sure the logs aren't truncated)
-      npmPodList=`kubectl get pods -n kube-system --kubeconfig=./kubeconfig | grep npm | awk '{print $1}'`
+      npmPodList=`kubectl --kubeconfig=./kubeconfig get pods -n kube-system | grep npm | awk '{print $1}'`
       echo "Found NPM pods: $npmPodList"
       for npmPod in $npmPodList; do
         ./kubectl --kubeconfig=./kubeconfig logs -n kube-system $npmPod -f > $npmLogsFolder/$npmPod-logs.txt &

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -204,7 +204,10 @@ jobs:
       echo $FQDN
       chmod +x $(Pipeline.Workspace)/Test/e2e.test
       runConformance () {
-          KUBERNETES_SERVICE_HOST="$FQDN" KUBERNETES_SERVICE_PORT=443 $(Pipeline.Workspace)/Test/e2e.test --provider=local --ginkgo.focus="NetworkPolicy" --ginkgo.skip="SCTP" --kubeconfig=./kubeconfig
+          # KUBERNETES_SERVICE_HOST="$FQDN" KUBERNETES_SERVICE_PORT=443 $(Pipeline.Workspace)/Test/e2e.test --provider=local --ginkgo.focus="NetworkPolicy" --ginkgo.skip="SCTP" --kubeconfig=./kubeconfig
+          # there can't be a command after e2e.test because the exit code is important
+          # FIXME uncomment and remove below line
+          test -f asdfasdf
       }
 
       exitCode=0
@@ -215,7 +218,7 @@ jobs:
           for round in $(seq 1 $numParallelJobs); do
               # for each iteration, run the conformance test and echos in the background, and write the output of the conformance test to a file
               echo "starting conformance test #$round" && \
-                  runConformance > $npmLogsFolder/conformance-results-$round.txt && \
+                  runConformance > $npmLogsFolder/conformance-results-$round && \
                   echo "finished conformance test #$round" &
               pidOfConformanceTest=$!
               conformancePIDs+=($pidOfConformanceTest)
@@ -232,8 +235,8 @@ jobs:
               fi
           done
       else
-          # run the conformance test in the foreground, and don't write the output to a file
-          runConformance
+          # run the conformance test in the foreground and write the output to stdout and a file
+          runConformance | tee $npmLogsFolder/conformance-results
           exitCode=$?
       fi
       # kill the background processes (the logs) that have this process' pid (i.e. $$) as a parent

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -204,10 +204,8 @@ jobs:
       echo $FQDN
       chmod +x $(Pipeline.Workspace)/Test/e2e.test
       runConformance () {
-          # KUBERNETES_SERVICE_HOST="$FQDN" KUBERNETES_SERVICE_PORT=443 $(Pipeline.Workspace)/Test/e2e.test --provider=local --ginkgo.focus="NetworkPolicy" --ginkgo.skip="SCTP" --kubeconfig=./kubeconfig
+          KUBERNETES_SERVICE_HOST="$FQDN" KUBERNETES_SERVICE_PORT=443 $(Pipeline.Workspace)/Test/e2e.test --provider=local --ginkgo.focus="NetworkPolicy" --ginkgo.skip="SCTP" --kubeconfig=./kubeconfig
           # there can't be a command after e2e.test because the exit code is important
-          # FIXME uncomment and remove below line
-          test -f asdfasdf
       }
 
       exitCode=0
@@ -236,7 +234,7 @@ jobs:
           done
       else
           # run the conformance test in the foreground and write the output to stdout and a file
-          runConformance | tee $npmLogsFolder/conformance-results
+          runConformance > $npmLogsFolder/conformance-results
           exitCode=$?
       fi
       # kill the background processes (the logs) that have this process' pid (i.e. $$) as a parent

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -178,21 +178,45 @@ jobs:
         FQDN=`az aks show -n $(AZURE_CLUSTER) -g $(RESOURCE_GROUP) --query fqdn -o tsv`
         echo "##vso[task.setvariable variable=FQDN]$FQDN"
 
-  # - bash: |
-  #     echo $FQDN
-  #     chmod +x $(Pipeline.Workspace)/Test/e2e.test
-  #     KUBERNETES_SERVICE_HOST="$FQDN" KUBERNETES_SERVICE_PORT=443 $(Pipeline.Workspace)/Test/e2e.test --provider=local --ginkgo.focus="NetworkPolicy" --ginkgo.skip="SCTP" --kubeconfig=./kubeconfig
-  #   displayName: "Run Test Suite"
   - bash: |
+      ## create the output folder and include the kubeconfig there
       npmLogsFolder=$(System.DefaultWorkingDirectory)/npmLogs_$(PROFILE)
       mkdir -p $npmLogsFolder
       mv ./kubeconfig $npmLogsFolder/kubeconfig
-      npmPodList=`kubectl get pods -n kube-system | grep npm | awk '{print $1}'`
-      echo "Found NPM pods: $npmPodList"
-      for npm in $npmPodList; do ./kubectl logs -n kube-system $npm --kubeconfig=./kubeconfig > $npmLogsFolder/$npm-logs.txt ;done
-    displayName: "Gather NPM Logs"
-    condition: always()
 
+      ## write to all NPM pod logs in the background (do this in the background instead of after to make sure the logs aren't truncated)
+      npmPodList=`kubectl get pods -n kube-system --kubeconfig=./kubeconfig | grep npm | awk '{print $1}'`
+      echo "Found NPM pods: $npmPodList"
+      for npmPod in $npmPodList; do
+        ./kubectl --kubeconfig=./kubeconfig logs -n kube-system $npmPod -f > $npmLogsFolder/$npmPod-logs.txt &
+      done
+
+      ## Run all Conformance tests in the background
+      echo $FQDN
+      chmod +x $(Pipeline.Workspace)/Test/e2e.test
+      numParallelJobs=1
+      if [ $(IS_STRESS_TEST) == "true" ]; then
+        numParallelJobs=5
+      fi
+      declare -a pids
+      for i in $(seq 1 $numParallelJobs); do
+        # run the echos/conformance test in the background
+        echo "starting conformance test #$i" && \
+        #  KUBERNETES_SERVICE_HOST="$FQDN" KUBERNETES_SERVICE_PORT=443 $(Pipeline.Workspace)/Test/e2e.test --provider=local --ginkgo.focus="NetworkPolicy" --ginkgo.skip="SCTP" --kubeconfig=./kubeconfig && \
+          sleep $i && \
+          echo "finished conformance test #$i" &
+        pidOfConformanceTest=$!
+        index=$((i-1))
+        pids[$index]=$pidOfConformanceTest
+      done
+
+      # wait until all conformance tests finish
+      wait "${pids[@]}"
+      # kill the background processes (the logs) that have this process' pid (i.e. $$) as a parent
+      pkill -P $$
+      
+    displayName: "Run Test Suite and Get Logs"
+    
   - publish: $(System.DefaultWorkingDirectory)/npmLogs_$(PROFILE)
     condition: always()
     artifact: NpmLogs_$(PROFILE)

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -126,9 +126,15 @@ jobs:
       v1-default:
         AZURE_CLUSTER: 'v1-default-cluster'
         PROFILE: 'v1-default'
+        IS_STRESS_TEST: 'false'
       v2-default:
         AZURE_CLUSTER: 'v2-default-cluster'
         PROFILE: 'v2-default'
+        IS_STRESS_TEST: 'false'
+      v2-default-stress:
+        AZURE_CLUSTER: 'v2-default-stress-cluster'
+        PROFILE: 'v2-default'
+        IS_STRESS_TEST: 'true'
   pool:
     name: $(BUILD_POOL_NAME_DEFAULT)
     demands: 

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -41,7 +41,7 @@ jobs:
   displayName: "Build NPM and Kubernetes Test Suite"
   pool:
     name: $(BUILD_POOL_NAME_DEFAULT)
-    demands: 
+    demands:
     - agent.os -equals Linux
     - Role -equals Build
   dependsOn: [setup]
@@ -178,19 +178,18 @@ jobs:
         FQDN=`az aks show -n $(AZURE_CLUSTER) -g $(RESOURCE_GROUP) --query fqdn -o tsv`
         echo "##vso[task.setvariable variable=FQDN]$FQDN"
 
+  # - bash: |
+  #     echo $FQDN
+  #     chmod +x $(Pipeline.Workspace)/Test/e2e.test
+  #     KUBERNETES_SERVICE_HOST="$FQDN" KUBERNETES_SERVICE_PORT=443 $(Pipeline.Workspace)/Test/e2e.test --provider=local --ginkgo.focus="NetworkPolicy" --ginkgo.skip="SCTP" --kubeconfig=./kubeconfig
+  #   displayName: "Run Test Suite"
   - bash: |
-      echo $FQDN
-      chmod +x $(Pipeline.Workspace)/Test/e2e.test
-      KUBERNETES_SERVICE_HOST="$FQDN" KUBERNETES_SERVICE_PORT=443 $(Pipeline.Workspace)/Test/e2e.test --provider=local --ginkgo.focus="NetworkPolicy" --ginkgo.skip="SCTP" --kubeconfig=./kubeconfig
-    displayName: "Run Test Suite"
-  - bash: |
-      curl -LO https://dl.k8s.io/release/v1.20.0/bin/linux/amd64/kubectl
-      chmod +x kubectl
-      npmPodList=`kubectl get pods -n kube-system | grep npm | awk '{print $1}'`
       npmLogsFolder=$(System.DefaultWorkingDirectory)/npmLogs_$(PROFILE)
       mkdir -p $npmLogsFolder
-      for npm in $npmPodList; do ./kubectl logs -n kube-system $npm --kubeconfig=./kubeconfig > $npmLogsFolder/$npm ;done
       mv ./kubeconfig $npmLogsFolder/kubeconfig
+      npmPodList=`kubectl get pods -n kube-system | grep npm | awk '{print $1}'`
+      echo "Found NPM pods: $npmPodList"
+      for npm in $npmPodList; do ./kubectl logs -n kube-system $npm --kubeconfig=./kubeconfig > $npmLogsFolder/$npm-logs.txt ;done
     displayName: "Gather NPM Logs"
     condition: always()
 

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -205,14 +205,13 @@ jobs:
       chmod +x $(Pipeline.Workspace)/Test/e2e.test
       numParallelJobs=1
       if [ $(IS_STRESS_TEST) == "true" ]; then
-        numParallelJobs=5
+        numParallelJobs=3
       fi
       declare -a pids
       for i in $(seq 1 $numParallelJobs); do
-        # run the echos/conformance test in the background
+        # for each iteration, run the conformance test and echos in the background, and write the output of the conformance test to a file
         echo "starting conformance test #$i" && \
-        #  KUBERNETES_SERVICE_HOST="$FQDN" KUBERNETES_SERVICE_PORT=443 $(Pipeline.Workspace)/Test/e2e.test --provider=local --ginkgo.focus="NetworkPolicy" --ginkgo.skip="SCTP" --kubeconfig=./kubeconfig && \
-          sleep $i && \
+          KUBERNETES_SERVICE_HOST="$FQDN" KUBERNETES_SERVICE_PORT=443 $(Pipeline.Workspace)/Test/e2e.test --provider=local --ginkgo.focus="NetworkPolicy" --ginkgo.skip="SCTP" --kubeconfig=./kubeconfig > $npmLogsFolder/conformance-results-$i.txt && \
           echo "finished conformance test #$i" &
         pidOfConformanceTest=$!
         index=$((i-1))


### PR DESCRIPTION
Grab non-truncated NPM logs and introduce stress test option to test matrix. 

- NPM logs are tailed and written to file in the background. Conformance exit codes are returned properly.
- Stress testing runs multiple conformance (currently 3) in the background, waits for these processes to finish, and exits with the first failed tests code or 0 if all pass.
- Only adds a profile for v2 stress testing.
- All conformance runs are written to file and published.
