### PR TITLE
[CNI] Return retriable error for transient errors

### DIFF
--- a/cni/network/invoker_mock.go
+++ b/cni/network/invoker_mock.go
@@ -85,8 +85,8 @@ func (invoker *MockIpamInvoker) Delete(address *net.IPNet, nwCfg *cni.NetworkCon
 		return errDeleteIpam
 	}
 
-	if address == nil {
-		return errDeleteIpam
+	if address == nil || invoker.ipMap == nil {
+		return nil
 	}
 
 	if _, ok := invoker.ipMap[address.String()]; !ok {

--- a/cni/network/network_test.go
+++ b/cni/network/network_test.go
@@ -368,6 +368,7 @@ func TestIpamAddFail(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var err error
 			for i, method := range tt.methods {
+				fmt.Println("method", method, "wanterr", tt.wantErr[i])
 				if tt.wantErr[i] {
 					plugin.ipamInvoker = NewMockIpamInvoker(false, true, false)
 				} else {

--- a/cni/network/plugin/main.go
+++ b/cni/network/plugin/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Azure/azure-container-networking/aitelemetry"
 	"github.com/Azure/azure-container-networking/cni"
+	"github.com/Azure/azure-container-networking/cni/api"
 	"github.com/Azure/azure-container-networking/cni/network"
 	"github.com/Azure/azure-container-networking/common"
 	"github.com/Azure/azure-container-networking/log"
@@ -128,31 +129,20 @@ func handleIfCniUpdate(update func(*skel.CmdArgs) error) (bool, error) {
 	return isupdate, nil
 }
 
-// Main is the entry point for CNI network plugin.
-func main() {
-	// Initialize and parse command line arguments.
-	common.ParseArgs(&args, printVersion)
-	vers := common.GetArg(common.OptVersion).(bool)
-
-	if vers {
-		printVersion()
-		os.Exit(0)
+func printCNIError(msg string) {
+	log.Errorf(msg)
+	cniErr := &cniTypes.Error{
+		Code: cniTypes.ErrTryAgainLater,
+		Msg:  msg,
 	}
+	cniErr.Print()
+}
 
+func rootExecute() error {
 	var (
-		config       common.PluginConfig
-		logDirectory string // This sets empty string i.e. current location
-		tb           *telemetry.TelemetryBuffer
+		config common.PluginConfig
+		tb     *telemetry.TelemetryBuffer
 	)
-
-	log.SetName(name)
-	log.SetLevel(log.LevelInfo)
-	if err := log.SetTargetLogDirectory(log.TargetLogfile, logDirectory); err != nil {
-		fmt.Printf("Failed to setup cni logging: %v\n", err)
-		return
-	}
-
-	defer log.Close()
 
 	config.Version = version
 	reportManager := &telemetry.ReportManager{
@@ -175,16 +165,9 @@ func main() {
 		&network.Multitenancy{},
 		&acnnetwork.AzureHNSEndpoint{},
 	)
-
-	defer func() {
-		if err != nil {
-			os.Exit(1)
-		}
-	}()
-
 	if err != nil {
-		log.Printf("Failed to create network plugin, err:%v.\n", err)
-		return
+		printCNIError(fmt.Sprintf("Failed to create network plugin, err:%v.\n", err))
+		return err
 	}
 
 	// Check CNI_COMMAND value
@@ -203,18 +186,12 @@ func main() {
 
 		// CNI Acquires lock
 		if err = netPlugin.Plugin.InitializeKeyValueStore(&config); err != nil {
-			log.Errorf("Failed to initialize key-value store of network plugin, err:%v.\n", err)
-
-			cniErr := &cniTypes.Error{
-				Code: cniTypes.ErrTryAgainLater,
-				Msg:  fmt.Sprintf("Failed to initialize key-value store of network plugin: %v", err),
-			}
-			cniErr.Print()
+			printCNIError(fmt.Sprintf("Failed to initialize key-value store of network plugin: %v", err))
 
 			tb = telemetry.NewTelemetryBuffer()
 			if tberr := tb.Connect(); tberr != nil {
 				log.Errorf("Cannot connect to telemetry service:%v", tberr)
-				return
+				return err
 			}
 
 			reportPluginError(reportManager, tb, err)
@@ -231,8 +208,9 @@ func main() {
 					log.Errorf("Couldn't send cnilocktimeout metric: %v", sendErr)
 				}
 			}
+
 			tb.Close()
-			return
+			return err
 		}
 
 		defer func() {
@@ -257,7 +235,7 @@ func main() {
 		cniReport.Timestamp = t.Format("2006-01-02 15:04:05")
 
 		if err = netPlugin.Start(&config); err != nil {
-			log.Errorf("Failed to start network plugin, err:%v.\n", err)
+			printCNIError(fmt.Sprintf("Failed to start network plugin, err:%v.\n", err))
 			reportPluginError(reportManager, tb, err)
 			panic("network plugin start fatal error")
 		}
@@ -265,10 +243,11 @@ func main() {
 		// used to dump state
 		if cniCmd == cni.CmdGetEndpointsState {
 			log.Printf("Retrieving state")
-			simpleState, err := netPlugin.GetAllEndpointState("azure")
+			var simpleState *api.AzureCNIState
+			simpleState, err = netPlugin.GetAllEndpointState("azure")
 			if err != nil {
 				log.Errorf("Failed to get Azure CNI state, err:%v.\n", err)
-				return
+				return err
 			}
 
 			err = simpleState.PrintResult()
@@ -276,7 +255,7 @@ func main() {
 				log.Errorf("Failed to print state result to stdout with err %v\n", err)
 			}
 
-			return
+			return err
 		}
 	}
 
@@ -288,12 +267,40 @@ func main() {
 	}
 
 	if cniCmd == cni.CmdVersion {
-		return
+		return err
 	}
 
 	netPlugin.Stop()
 
 	if err != nil {
 		reportPluginError(reportManager, tb, err)
+	}
+
+	return err
+}
+
+// Main is the entry point for CNI network plugin.
+func main() {
+	// Initialize and parse command line arguments.
+	common.ParseArgs(&args, printVersion)
+	vers := common.GetArg(common.OptVersion).(bool)
+
+	if vers {
+		printVersion()
+		os.Exit(0)
+	}
+
+	log.SetName(name)
+	log.SetLevel(log.LevelInfo)
+	if err := log.SetTargetLogDirectory(log.TargetLogfile, ""); err != nil {
+		fmt.Printf("Failed to setup cni logging: %v\n", err)
+		return
+	}
+
+	err := rootExecute()
+
+	log.Close()
+	if err != nil {
+		os.Exit(1)
 	}
 }

--- a/cni/network/plugin/main.go
+++ b/cni/network/plugin/main.go
@@ -167,7 +167,7 @@ func rootExecute() error {
 	)
 	if err != nil {
 		printCNIError(fmt.Sprintf("Failed to create network plugin, err:%v.\n", err))
-		return err
+		return errors.Wrap(err, "Create plugin error")
 	}
 
 	// Check CNI_COMMAND value
@@ -191,7 +191,7 @@ func rootExecute() error {
 			tb = telemetry.NewTelemetryBuffer()
 			if tberr := tb.Connect(); tberr != nil {
 				log.Errorf("Cannot connect to telemetry service:%v", tberr)
-				return err
+				return errors.Wrap(err, "lock acquire error")
 			}
 
 			reportPluginError(reportManager, tb, err)
@@ -210,7 +210,7 @@ func rootExecute() error {
 			}
 
 			tb.Close()
-			return err
+			return errors.Wrap(err, "lock acquire error")
 		}
 
 		defer func() {
@@ -247,7 +247,7 @@ func rootExecute() error {
 			simpleState, err = netPlugin.GetAllEndpointState("azure")
 			if err != nil {
 				log.Errorf("Failed to get Azure CNI state, err:%v.\n", err)
-				return err
+				return errors.Wrap(err, "Get all endpoints error")
 			}
 
 			err = simpleState.PrintResult()
@@ -255,7 +255,7 @@ func rootExecute() error {
 				log.Errorf("Failed to print state result to stdout with err %v\n", err)
 			}
 
-			return err
+			return errors.Wrap(err, "Get cni state printresult error")
 		}
 	}
 
@@ -267,7 +267,7 @@ func rootExecute() error {
 	}
 
 	if cniCmd == cni.CmdVersion {
-		return err
+		return errors.Wrap(err, "Execute netplugin failure")
 	}
 
 	netPlugin.Stop()
@@ -276,7 +276,7 @@ func rootExecute() error {
 		reportPluginError(reportManager, tb, err)
 	}
 
-	return err
+	return errors.Wrap(err, "Execute netplugin failure")
 }
 
 // Main is the entry point for CNI network plugin.


### PR DESCRIPTION
2. cni to return retriable error for transient errors

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
This PR addresses CNI to return retriable error for transient errors so that cri would retry on error. This will prevent ipleaks in case if cni cannot connect to cns or cni cannot remove endpoint due to transient error

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
