### PR TITLE
pass the populated IPTables opts instead of overwriting with empty map

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -525,7 +525,8 @@ func (plugin *NetPlugin) Add(args *cniSkel.CmdArgs) error {
 	if nwInfoErr != nil {
 		// Network does not exist.
 		telemetry.LogAndSendEvent(plugin.tb, fmt.Sprintf("[cni-net] Creating network %v.", networkID))
-		if nwInfo, err = plugin.createNetworkInternal(networkID, policies, args, nwCfg, cnsNetworkConfig, subnetPrefix, result, resultV6); err != nil {
+		// opts map needs to get passed in here
+		if nwInfo, err = plugin.createNetworkInternal(networkID, policies, args, nwCfg, cnsNetworkConfig, subnetPrefix, result, resultV6, options); err != nil {
 			log.Errorf("Create network failed:%w", err)
 			return err
 		}
@@ -588,10 +589,9 @@ func (plugin *NetPlugin) createNetworkInternal(
 	cnsNetworkConfig *cns.GetNetworkContainerResponse,
 	subnetPrefix net.IPNet,
 	result *cniTypesCurr.Result,
-	resultV6 *cniTypesCurr.Result) (network.NetworkInfo, error) {
-
+	resultV6 *cniTypesCurr.Result,
+	options map[string]interface{}) (network.NetworkInfo, error) {
 	nwInfo := network.NetworkInfo{}
-	options := make(map[string]interface{})
 	gateway := result.IPs[0].Gateway
 	subnetPrefix.IP = subnetPrefix.IP.Mask(subnetPrefix.Mask)
 	nwCfg.Ipam.Subnet = subnetPrefix.String()


### PR DESCRIPTION
Signed-off-by: Evan Baker <rbtr@users.noreply.github.com>

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Fixes a regression since [CNI 1.4.13](https://github.com/Azure/azure-container-networking/compare/v1.4.12...v1.4.13#diff-a2f1c51b6e94c2d11383e394bdae9391a1cdef8e6b6ff24210e4ff04f7692f5eL596) where the IPTables chains were set in the opts map, then that opts map was thrown away and an empty opts map was used in the function that execs IPTables with the contents of the opts map.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
