### PR TITLE
ignore pods that have not been assigned an IP during CNS initialization

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -262,7 +262,7 @@ func KubePodsToPodInfoByIP(pods []corev1.Pod) (map[string]PodInfo, error) {
 			// ignore host network pods.
 			continue
 		}
-		if pods[i].Status.PodIP == "" {
+		if strings.TrimSpace(pods[i].Status.PodIP) == "" {
 			// ignore pods without an assigned IP.
 			continue
 		}

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -258,12 +258,20 @@ func NewPodInfoFromIPConfigRequest(req IPConfigRequest) (PodInfo, error) {
 func KubePodsToPodInfoByIP(pods []corev1.Pod) (map[string]PodInfo, error) {
 	podInfoByIP := map[string]PodInfo{}
 	for i := range pods {
-		if !pods[i].Spec.HostNetwork {
-			if _, ok := podInfoByIP[pods[i].Status.PodIP]; ok {
-				return nil, errors.Wrap(ErrDuplicateIP, pods[i].Status.PodIP)
-			}
-			podInfoByIP[pods[i].Status.PodIP] = NewPodInfo("", "", pods[i].Name, pods[i].Namespace)
+		if pods[i].Spec.HostNetwork {
+			// ignore host network pods.
+			continue
 		}
+		if pods[i].Status.PodIP == "" {
+			// ignore pods without an assigned IP.
+			continue
+		}
+		// error if we have already recorded that this IP is assigned to a Pod.
+		if _, ok := podInfoByIP[pods[i].Status.PodIP]; ok {
+			return nil, errors.Wrap(ErrDuplicateIP, pods[i].Status.PodIP)
+		}
+		// record the PodInfo by assigned IP.
+		podInfoByIP[pods[i].Status.PodIP] = NewPodInfo("", "", pods[i].Name, pods[i].Namespace)
 	}
 	return podInfoByIP, nil
 }


### PR DESCRIPTION
Signed-off-by: Evan Baker <rbtr@users.noreply.github.com>

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
During CNS initialization, we crash out if we see a Pod with the same IP. However, if there are Pods that have not yet been assigned an IP, they will have the same empty string `""` for that field, triggering this error case.

This ignores pods without IPs during the state initialization.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
