### PR TITLE
fix: [NPM] check for valid ipv4 podip while adding to sets

### DIFF
--- a/npm/util/errors/errors.go
+++ b/npm/util/errors/errors.go
@@ -60,6 +60,7 @@ const (
 	AddNetPolReference      = "AddNetPolReference"
 	DeleteNetPolReference   = "DeleteNetPolReference"
 	RunFileCreator          = "RunCommandWithFile"
+	AddPod                  = "AddPod"
 )
 
 // Error codes for ipsetmanager

--- a/npm/util/util.go
+++ b/npm/util/util.go
@@ -5,6 +5,7 @@ package util
 import (
 	"fmt"
 	"hash/fnv"
+	"net"
 	"os"
 	"regexp"
 	"runtime"
@@ -351,4 +352,8 @@ func CompareSlices(list1, list2 []string) bool {
 
 func SliceToString(list []string) string {
 	return strings.Join(list, SetPolicyDelimiter)
+}
+
+func IsIPV4(ip string) bool {
+	return net.ParseIP(ip).To4() != nil
 }


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
NPM V2 is trying to add empty "" ips to sets in kernel, causing failures. This PR will check if valid IPV4 addresses are provided to NPM.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
