### PR TITLE
npm: fix error wrapping with go 1.18

### DIFF
--- a/npm/http/server/server.go
+++ b/npm/http/server/server.go
@@ -71,7 +71,7 @@ func (n *NPMRestServer) npmCacheHandler(npmCacheEncoder json.Marshaler) http.Han
 		}
 		_, err = w.Write(b)
 		if err != nil {
-			log.Errorf("failed to write resp: %w", err)
+			log.Errorf("failed to write resp: %v", err)
 		}
 	})
 }

--- a/npm/http/server/server_test.go
+++ b/npm/http/server/server_test.go
@@ -37,7 +37,7 @@ func TestGetNPMCacheHandler(t *testing.T) {
 
 	byteArray, err := io.ReadAll(rr.Body)
 	if err != nil {
-		t.Errorf("failed to read response's data : %w", err)
+		t.Errorf("failed to read response's data : %v", err)
 	}
 
 	actual := &controllersv1.Cache{}

--- a/npm/pkg/dataplane/debug/converter_test.go
+++ b/npm/pkg/dataplane/debug/converter_test.go
@@ -18,7 +18,7 @@ func TestGetJSONRulesFromIptableFile(t *testing.T) {
 		iptableSaveFile,
 	)
 	if err != nil {
-		t.Errorf("failed to test GetJSONRulesFromIptable : %w", err)
+		t.Errorf("failed to test GetJSONRulesFromIptable : %v", err)
 	}
 }
 
@@ -30,7 +30,7 @@ func TestGetProtobufRulesFromIptableFile(t *testing.T) {
 		iptableSaveFile,
 	)
 	if err != nil {
-		t.Errorf("error during TestGetJSONRulesFromIptable : %w", err)
+		t.Errorf("error during TestGetJSONRulesFromIptable : %v", err)
 	}
 }
 
@@ -38,7 +38,7 @@ func TestNpmCacheFromFile(t *testing.T) {
 	c := &Converter{}
 	err := c.NpmCacheFromFile(npmCacheFile)
 	if err != nil {
-		t.Errorf("Failed to decode NPMCache from %s file : %w", npmCacheFile, err)
+		t.Errorf("Failed to decode NPMCache from %s file : %v", npmCacheFile, err)
 	}
 }
 
@@ -93,7 +93,7 @@ func TestGetSetType(t *testing.T) {
 	c := &Converter{}
 	err := c.initConverterFile(npmCacheFile)
 	if err != nil {
-		t.Errorf("error during initilizing converter : %w", err)
+		t.Errorf("error during initilizing converter : %v", err)
 	}
 
 	for name, test := range tests {
@@ -315,7 +315,7 @@ func TestGetRulesFromChain(t *testing.T) {
 	c := &Converter{}
 	err := c.initConverterFile(npmCacheFile)
 	if err != nil {
-		t.Errorf("error during initilizing converter : %w", err)
+		t.Errorf("error during initilizing converter : %v", err)
 	}
 
 	for name, test := range testCases {
@@ -323,7 +323,7 @@ func TestGetRulesFromChain(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			actuatlReponsesArr, err := c.getRulesFromChain(test.input)
 			if err != nil {
-				t.Errorf("error during get rules : %w", err)
+				t.Errorf("error during get rules : %v", err)
 			}
 			if !reflect.DeepEqual(test.expected, actuatlReponsesArr) {
 				t.Errorf("got '%+v', expected '%+v'", actuatlReponsesArr, test.expected)
@@ -504,12 +504,12 @@ func TestGetModulesFromRule(t *testing.T) {
 	c := &Converter{}
 	err := c.initConverterFile(npmCacheFile)
 	if err != nil {
-		t.Errorf("error during initilizing converter : %w", err)
+		t.Errorf("error during initilizing converter : %v", err)
 	}
 
 	err = c.getModulesFromRule(modules, actualRuleResponse)
 	if err != nil {
-		t.Errorf("error during getNPMIPtable.ModulesFromRule : %w", err)
+		t.Errorf("error during getNPMIPtable.ModulesFromRule : %v", err)
 	}
 
 	if !reflect.DeepEqual(expectedRuleResponse, actualRuleResponse) {

--- a/npm/pkg/dataplane/debug/trafficanalyzer_test.go
+++ b/npm/pkg/dataplane/debug/trafficanalyzer_test.go
@@ -237,7 +237,7 @@ func TestGetNetworkTuple(t *testing.T) {
 				iptableSaveFile,
 			)
 			if err != nil {
-				t.Errorf("error during get network tuple : %w", err)
+				t.Errorf("error during get network tuple : %v", err)
 			}
 			sortedActualTupleList := hashTheSortTupleList(actualTupleList)
 			if !reflect.DeepEqual(sortedExpectedTupleList, sortedActualTupleList) {


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

%w directive is not allowed in fmt.Errorf, go1.18 caught this

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
