### PR TITLE
refactor to remove channel mode sprawl

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -63,14 +63,6 @@ const (
 	Vxlan = "Vxlan"
 )
 
-// ChannelMode :- CNS channel modes
-const (
-	Direct         = "Direct"
-	Managed        = "Managed"
-	CRD            = "CRD"
-	MultiTenantCRD = "MultiTenantCRD"
-)
-
 // CreateNetworkContainerRequest specifies request to create a network container or network isolation boundary.
 type CreateNetworkContainerRequest struct {
 	Version                    string

--- a/cns/client/client_test.go
+++ b/cns/client/client_test.go
@@ -168,7 +168,7 @@ func TestMain(m *testing.M) {
 	logger.InitLogger(logName, 0, 0, tmpLogDir+"/")
 	config := common.ServiceConfig{}
 
-	httpRestService, err := restserver.NewHTTPRestService(&config, &fakes.WireserverClientFake{}, &fakes.NMAgentClientFake{})
+	httpRestService, err := restserver.NewHTTPRestService(config, &fakes.WireserverClientFake{}, &fakes.NMAgentClientFake{})
 	svc = httpRestService.(*restserver.HTTPRestService)
 	svc.Name = "cns-test-server"
 	fakeNNC := v1alpha.NodeNetworkConfig{
@@ -211,13 +211,13 @@ func TestMain(m *testing.M) {
 	}
 
 	if httpRestService != nil {
-		err = httpRestService.Init(&config)
+		err = httpRestService.Init(nil, config)
 		if err != nil {
 			logger.Errorf("Failed to initialize HttpService, err:%v.\n", err)
 			return
 		}
 
-		err = httpRestService.Start(&config)
+		err = httpRestService.Start(nil)
 		if err != nil {
 			logger.Errorf("Failed to start HttpService, err:%v.\n", err)
 			return

--- a/cns/common/service.go
+++ b/cns/common/service.go
@@ -4,8 +4,6 @@
 package common
 
 import (
-	"errors"
-
 	"github.com/Azure/azure-container-networking/cns/logger"
 	acn "github.com/Azure/azure-container-networking/common"
 	"github.com/Azure/azure-container-networking/server/tls"
@@ -14,18 +12,17 @@ import (
 
 // Service implements behavior common to all services.
 type Service struct {
-	Name        string
-	Version     string
-	Options     map[string]interface{}
-	ErrChan     chan<- error
-	Store       store.KeyValueStore
-	ChannelMode string
+	Name    string
+	Version string
+	Options map[string]interface{}
+	ErrChan chan<- error
+	Store   store.KeyValueStore
 }
 
 // ServiceAPI defines base interface.
 type ServiceAPI interface {
-	Init(*ServiceConfig) error
-	Start(*ServiceConfig) error
+	Init(chan<- error, ServiceConfig) error
+	Start(chan<- error) error
 	Stop()
 	GetOption(string) interface{}
 	SetOption(string, interface{})
@@ -33,45 +30,35 @@ type ServiceAPI interface {
 
 // ServiceConfig specifies common configuration.
 type ServiceConfig struct {
-	Name        string
-	Version     string
-	Listener    *acn.Listener
-	ErrChan     chan<- error
-	Store       store.KeyValueStore
-	ChannelMode string
-	TlsSettings tls.TlsSettings
+	ChannelModeManaged bool
+	Name               string
+	Version            string
+	Listener           *acn.Listener
+	Store              store.KeyValueStore
+	TLSSettings        tls.TlsSettings
 }
 
 // NewService creates a new Service object.
-func NewService(name, version, channelMode string, store store.KeyValueStore) (*Service, error) {
-	logger.Debugf("[Azure CNS] Going to create a service object with name: %v. version: %v.", name, version)
+func NewService(name, version string, kvstore store.KeyValueStore) (*Service, error) {
+	logger.Debugf("[Azure CNS] Going to create a service object with name: %v. version: %v", name, version)
 
 	svc := &Service{
-		Name:        name,
-		Version:     version,
-		ChannelMode: channelMode,
-		Options:     make(map[string]interface{}),
-		Store:       store,
+		Name:    name,
+		Version: version,
+		Options: make(map[string]interface{}),
+		Store:   kvstore,
 	}
 
-	logger.Debugf("[Azure CNS] Finished creating service object with name: %v. version: %v. managed: %s", name, version, channelMode)
+	logger.Debugf("[Azure CNS] Finished creating service object with name: %v. version: %v", name, version)
 	return svc, nil
 }
 
 // Initialize initializes the service.
-func (service *Service) Initialize(config *ServiceConfig) error {
-	if config == nil {
-		err := "[Azure CNS Errror] Initialize called with nil ServiceConfig."
-		logger.Errorf(err)
-		return errors.New(err)
-	}
-
+func (service *Service) Initialize(config ServiceConfig) error { //nolint:gocritic // ignore hugeParam
 	logger.Debugf("[Azure CNS] Going to initialize the service: %+v with config: %+v.", service, config)
 
-	service.ErrChan = config.ErrChan
 	service.Store = config.Store
 	service.Version = config.Version
-	service.ChannelMode = config.ChannelMode
 
 	logger.Debugf("[Azure CNS] nitialized service: %+v with config: %+v.", service, config)
 

--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/logger"
+	"github.com/Azure/azure-container-networking/cns/types"
 	"github.com/Azure/azure-container-networking/common"
 	"github.com/pkg/errors"
 )
@@ -19,7 +19,7 @@ const (
 )
 
 type CNSConfig struct {
-	ChannelMode                 string
+	ChannelMode                 types.ChannelMode
 	InitializeFromCNI           bool
 	ManagedSettings             ManagedSettings
 	MetricsBindAddress          string
@@ -148,7 +148,7 @@ func SetCNSConfigDefaults(config *CNSConfig) {
 	setTelemetrySettingDefaults(&config.TelemetrySettings)
 	setManagedSettingDefaults(&config.ManagedSettings)
 	if config.ChannelMode == "" {
-		config.ChannelMode = cns.Direct
+		config.ChannelMode = types.Direct
 	}
 	if config.MetricsBindAddress == "" {
 		config.MetricsBindAddress = ":9090"

--- a/cns/fakes/cnsfake.go
+++ b/cns/fakes/cnsfake.go
@@ -267,11 +267,11 @@ func (fake *HTTPServiceFake) GetOption(string) interface{} {
 
 func (fake *HTTPServiceFake) SetOption(string, interface{}) {}
 
-func (fake *HTTPServiceFake) Start(*common.ServiceConfig) error {
+func (fake *HTTPServiceFake) Start(chan<- error) error {
 	return nil
 }
 
-func (fake *HTTPServiceFake) Init(*common.ServiceConfig) error {
+func (fake *HTTPServiceFake) Init(chan<- error, common.ServiceConfig) error {
 	return nil
 }
 

--- a/cns/restserver/api_test.go
+++ b/cns/restserver/api_test.go
@@ -608,7 +608,8 @@ func TestGetNetworkContainerVersionStatus(t *testing.T) {
 func createNC(
 	t *testing.T,
 	params createOrUpdateNetworkContainerParams,
-	expectError bool) {
+	expectError bool,
+) {
 	if err := createOrUpdateNetworkContainerWithParams(t, params); err != nil {
 		t.Errorf("createOrUpdateNetworkContainerWithParams failed Err:%+v", err)
 		t.Fatal(err)
@@ -658,7 +659,8 @@ func publishNCViaCNS(t *testing.T,
 	networkID,
 	networkContainerID,
 	createNetworkContainerURL string,
-	expectError bool) error {
+	expectError bool,
+) error {
 	var (
 		body bytes.Buffer
 		resp cns.PublishNetworkContainerResponse
@@ -1076,7 +1078,7 @@ func startService() error {
 	}
 
 	nmagentClient := &fakes.NMAgentClientFake{}
-	service, err = NewHTTPRestService(&config, &fakes.WireserverClientFake{}, nmagentClient)
+	service, err = NewHTTPRestService(config, &fakes.WireserverClientFake{}, nmagentClient)
 	if err != nil {
 		return err
 	}
@@ -1122,13 +1124,13 @@ func startService() error {
 		file, _ := os.Create(cnsJsonFileName)
 		file.Close()
 
-		err = service.Init(&config)
+		err = service.Init(nil, config)
 		if err != nil {
 			logger.Errorf("Failed to Init CNS, err:%v.\n", err)
 			return err
 		}
 
-		err = service.Start(&config)
+		err = service.Start(nil)
 		if err != nil {
 			logger.Errorf("Failed to start CNS, err:%v.\n", err)
 			return err

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -117,14 +117,6 @@ func TestCreateAndUpdateNCWithSecondaryIPNCVersion(t *testing.T) {
 }
 
 func TestSyncHostNCVersion(t *testing.T) {
-	// cns.KubernetesCRD has one more logic compared to other orchestrator type, so test both of them
-	orchestratorTypes := []string{cns.Kubernetes, cns.KubernetesCRD}
-	for _, orchestratorType := range orchestratorTypes {
-		testSyncHostNCVersion(t, orchestratorType)
-	}
-}
-
-func testSyncHostNCVersion(t *testing.T, orchestratorType string) {
 	req := createNCReqeustForSyncHostNCVersion(t)
 	containerStatus := svc.state.ContainerStatus[req.NetworkContainerid]
 	if containerStatus.HostVersion != "-1" {
@@ -134,7 +126,7 @@ func testSyncHostNCVersion(t *testing.T, orchestratorType string) {
 		t.Errorf("Unexpected nc version in containerStatus as %s, expeted VM version should be 0 in string", containerStatus.CreateNetworkContainerRequest.Version)
 	}
 	// When sync host NC version, it will use the orchestratorType pass in.
-	svc.SyncHostNCVersion(context.Background(), orchestratorType)
+	svc.SyncHostNCVersion(context.Background(), false)
 	containerStatus = svc.state.ContainerStatus[req.NetworkContainerid]
 	if containerStatus.HostVersion != "0" {
 		t.Errorf("Unexpected containerStatus.HostVersion %s, expeted host version should be 0 in string", containerStatus.HostVersion)
@@ -158,7 +150,7 @@ func TestPendingIPsGotUpdatedWhenSyncHostNCVersion(t *testing.T) {
 			t.Errorf("Unexpected State %s, expected State is %s, IP address is %s", podIPConfigState.GetState(), types.PendingProgramming, podIPConfigState.IPAddress)
 		}
 	}
-	svc.SyncHostNCVersion(context.Background(), cns.CRD)
+	svc.SyncHostNCVersion(context.Background(), true)
 	containerStatus = svc.state.ContainerStatus[req.NetworkContainerid]
 
 	receivedSecondaryIPConfigs = containerStatus.CreateNetworkContainerRequest.SecondaryIPConfigs

--- a/cns/restserver/ipam_test.go
+++ b/cns/restserver/ipam_test.go
@@ -37,7 +37,7 @@ var (
 
 func getTestService() *HTTPRestService {
 	var config common.ServiceConfig
-	httpsvc, _ := NewHTTPRestService(&config, &fakes.WireserverClientFake{}, &fakes.NMAgentClientFake{})
+	httpsvc, _ := NewHTTPRestService(config, &fakes.WireserverClientFake{}, &fakes.NMAgentClientFake{})
 	svc = httpsvc.(*HTTPRestService)
 	svc.IPAMPoolMonitor = &fakes.MonitorFake{}
 	setOrchestratorTypeInternal(cns.KubernetesCRD)

--- a/cns/types/doc.go
+++ b/cns/types/doc.go
@@ -1,0 +1,4 @@
+// package types holds global type definitions for CNS.
+// No file in this package should have dependencies on any other code in this repo,
+// to prevent circular dependencies. These need to be static, independent definitions.
+package types

--- a/cns/types/modes.go
+++ b/cns/types/modes.go
@@ -1,0 +1,11 @@
+package types
+
+// ChannelMode CNS channel modes.
+type ChannelMode string
+
+const (
+	Direct         ChannelMode = "Direct"
+	Managed        ChannelMode = "Managed"
+	CRD            ChannelMode = "CRD"
+	MultiTenantCRD ChannelMode = "MultiTenantCRD"
+)


### PR DESCRIPTION
Signed-off-by: Evan Baker <rbtr@users.noreply.github.com>

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Removes knowledge of the configuration value for "ChannelMode" from everywhere except main(). Where components were previously comparing against the channel mode, they have toggles set in their scoped configs instead.
This moves us away from passing a sprawling root config around everywhere and towards injecting just what each component needs to know to do its job.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
