### PR TITLE
move metrics to service port, add healthz, pprof 

### DIFF
--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -22,7 +22,7 @@ type CNSConfig struct {
 	ChannelMode                 string
 	InitializeFromCNI           bool
 	ManagedSettings             ManagedSettings
-	MetricsBindAddress          string
+	Debug                       bool
 	SyncHostNCTimeoutMs         int
 	SyncHostNCVersionIntervalMs int
 	TLSCertificatePath          string
@@ -149,9 +149,6 @@ func SetCNSConfigDefaults(config *CNSConfig) {
 	setManagedSettingDefaults(&config.ManagedSettings)
 	if config.ChannelMode == "" {
 		config.ChannelMode = cns.Direct
-	}
-	if config.MetricsBindAddress == "" {
-		config.MetricsBindAddress = ":9090"
 	}
 	if config.SyncHostNCVersionIntervalMs == 0 {
 		config.SyncHostNCVersionIntervalMs = 1000 //nolint:gomnd // default times

--- a/cns/configuration/configuration_test.go
+++ b/cns/configuration/configuration_test.go
@@ -61,7 +61,6 @@ func TestReadConfigFromFile(t *testing.T) {
 					NodeID:                    "abc",
 					NodeSyncIntervalInSeconds: 30,
 				},
-				MetricsBindAddress:          ":9091",
 				SyncHostNCTimeoutMs:         5,
 				SyncHostNCVersionIntervalMs: 5,
 				TLSCertificatePath:          "/test",
@@ -191,7 +190,7 @@ func TestSetCNSConfigDefaults(t *testing.T) {
 				ManagedSettings: ManagedSettings{
 					NodeSyncIntervalInSeconds: 30,
 				},
-				MetricsBindAddress:          ":9090",
+				Debug:                       false,
 				SyncHostNCTimeoutMs:         500,
 				SyncHostNCVersionIntervalMs: 1000,
 				TelemetrySettings: TelemetrySettings{
@@ -210,7 +209,6 @@ func TestSetCNSConfigDefaults(t *testing.T) {
 				ManagedSettings: ManagedSettings{
 					NodeSyncIntervalInSeconds: 1,
 				},
-				MetricsBindAddress:          ":9091",
 				SyncHostNCTimeoutMs:         5,
 				SyncHostNCVersionIntervalMs: 1,
 				TelemetrySettings: TelemetrySettings{
@@ -226,7 +224,6 @@ func TestSetCNSConfigDefaults(t *testing.T) {
 				ManagedSettings: ManagedSettings{
 					NodeSyncIntervalInSeconds: 1,
 				},
-				MetricsBindAddress:          ":9091",
 				SyncHostNCTimeoutMs:         5,
 				SyncHostNCVersionIntervalMs: 1,
 				TelemetrySettings: TelemetrySettings{

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -46,6 +46,7 @@ import (
 	"github.com/Azure/azure-container-networking/store"
 	"github.com/avast/retry-go/v3"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
@@ -53,6 +54,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 const (
@@ -991,10 +994,9 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 	})
 
 	manager, err := ctrl.NewManager(kubeConfig, ctrl.Options{
-		Scheme:             nodenetworkconfig.Scheme,
-		MetricsBindAddress: cnsconfig.MetricsBindAddress,
-		Namespace:          "kube-system", // TODO(rbtr): namespace should be in the cns config
-		NewCache:           nodeScopedCache,
+		Scheme:    nodenetworkconfig.Scheme,
+		Namespace: "kube-system", // TODO(rbtr): namespace should be in the cns config
+		NewCache:  nodeScopedCache,
 	})
 	if err != nil {
 		return errors.Wrap(err, "failed to create manager")
@@ -1012,6 +1014,28 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 	if err := reconciler.SetupWithManager(manager, node); err != nil {
 		return errors.Wrapf(err, "failed to setup reconciler with manager")
 	}
+
+	mux := http.NewServeMux()
+
+	/*pprof endpoints
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	*/
+
+	//to reduce
+	mux.Handle("/metrics", promhttp.HandlerFor(metrics.Registry, promhttp.HandlerOpts{
+		ErrorHandling: promhttp.HTTPErrorOnError,
+	}))
+	healthzhandler := healthz.Handler{}
+	healthzhandler.Checks["ping"] = healthz.Ping
+	mux.Handle("/heathz", &healthzhandler)
+
+	go func() {
+		http.ListenAndServe(cnsconfig.MetricsBindAddress, mux)
+	}()
 
 	// Start the Manager which starts the reconcile loop.
 	// The Reconciler will send an initial NodeNetworkConfig update to the PoolMonitor, starting the
@@ -1057,6 +1081,7 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 			}
 		}
 	}()
+
 	logger.Printf("initialized and started SyncHostNCVersion loop")
 
 	return nil


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
- Moves metrics to the CNS service port (from previously a dedicated metrics port).
- Adds healthz handler to the root mux.
- Adds pprof handlers to the root mux conditionally based on a new `debug` config opt.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Closes #1294 (because I can't push to it)

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
