### PR TITLE
drop go1.17 from golangci-lint and update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,10 @@
-/npm/   @azure/acn-npm-reviewers
+# The intention of the CODEOWNERS is that a reviewer can be automatically assigned
+# to a PR when it is opened instead of needing to be manually assigned or being left 
+# unassigned. PRs without assigned Reviewers do not get the prompt attention that 
+# they should.
+# The CODEOWNERS are not Gatekeepers, just someone who has the domain knowledge to 
+# review a PR in an area. 
+/npm/       @azure/acn-npm-reviewers
+/cns/       @azure/acn-cns-reviewers
+/.github/   @rbtr @matmerr @vakalapa
+/go.mod     @rbtr @matmerr

--- a/.github/workflows/golangci.yaml
+++ b/.github/workflows/golangci.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.17.x, 1.18.x]
+        go-version: [1.18.x]
         os: [ubuntu-latest, windows-latest]
     name: Lint
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
The intention of CODEOWNERS is not to set up gatekeepers, but to expedite reviews by automatically assigning someone with domain knowledge when the PR is opened.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
