### PR TITLE
include 0th address when parsing overlay cidrs

### DIFF
--- a/cns/singletenantcontroller/conversion.go
+++ b/cns/singletenantcontroller/conversion.go
@@ -88,8 +88,7 @@ func CreateNCRequestFromStaticNC(nc v1alpha.NetworkContainer) (*cns.CreateNetwor
 
 	// iterate through all IP addresses in the subnet described by primaryPrefix and
 	// add them to the request as secondary IPConfigs.
-	zeroAddr := primaryPrefix.Masked().Addr() // the masked address is the 0th IP in the subnet
-	for addr := zeroAddr.Next(); primaryPrefix.Contains(addr); addr = addr.Next() {
+	for addr := primaryPrefix.Masked().Addr(); primaryPrefix.Contains(addr); addr = addr.Next() {
 		secondaryIPConfigs[addr.String()] = cns.SecondaryIPConfig{
 			IPAddress: addr.String(),
 			NCVersion: int(nc.Version),

--- a/cns/singletenantcontroller/conversion_test.go
+++ b/cns/singletenantcontroller/conversion_test.go
@@ -94,6 +94,10 @@ var validOverlayRequest = &cns.CreateNetworkContainerRequest{
 	NetworkContainerid:   ncID,
 	NetworkContainerType: cns.Docker,
 	SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+		"10.0.0.0": {
+			IPAddress: "10.0.0.0",
+			NCVersion: version,
+		},
 		"10.0.0.1": {
 			IPAddress: "10.0.0.1",
 			NCVersion: version,


### PR DESCRIPTION
Signed-off-by: Evan Baker <rbtr@users.noreply.github.com>

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
We don't need to reserve a gateway IP, so we can claim the full, inclusive span of the subnet

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
