### PR TITLE
fix/refactor: [NPM] eliminate struct fields to prevent errors & reduce memory

### DIFF
--- a/npm/pkg/controlplane/goalstateprocessor/goalstateprocessor.go
+++ b/npm/pkg/controlplane/goalstateprocessor/goalstateprocessor.go
@@ -374,12 +374,12 @@ func (gsp *GoalStateProcessor) processPolicyApplyEvent(goalState *protos.GoalSta
 			klog.Warningf("Empty Policy apply event")
 			continue
 		}
-		klog.Infof("Processing %s Policy ADD event", netpol.Name)
+		klog.Infof("Processing %s Policy ADD event", netpol.PolicyKey)
 		klog.Infof("Netpol: %v", netpol)
 
 		err = gsp.dp.UpdatePolicy(netpol)
 		if err != nil {
-			klog.Errorf("Error applying policy %s to dataplane with error: %s", netpol.Name, err.Error())
+			klog.Errorf("Error applying policy %s to dataplane with error: %s", netpol.PolicyKey, err.Error())
 			return nil, npmerrors.SimpleErrorWrapper("failed update policy event", err)
 		}
 		appendedPolicies[netpol.PolicyKey] = struct{}{}

--- a/npm/pkg/controlplane/goalstateprocessor/goalstateprocessor_test.go
+++ b/npm/pkg/controlplane/goalstateprocessor/goalstateprocessor_test.go
@@ -28,8 +28,9 @@ var (
 	testNestedKeyPodSet   = ipsets.NewIPSetMetadata("test-nestedkeyPod-set", ipsets.NestedLabelOfPod)
 	testNestedKeyPodCPSet = controlplane.NewControllerIPSets(testNestedKeyPodSet)
 	testNetPol            = &policies.NPMNetworkPolicy{
-		Namespace: "x",
-		PolicyKey: "x/test-netpol",
+		Namespace:   "x",
+		PolicyKey:   "x/test-netpol",
+		ACLPolicyID: "azure-acl-x-test-netpol",
 		PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 			{
 				Metadata: testNSSet,
@@ -48,12 +49,10 @@ var (
 		},
 		ACLs: []*policies.ACLPolicy{
 			{
-				PolicyID:  "azure-acl-123",
 				Target:    policies.Dropped,
 				Direction: policies.Ingress,
 			},
 			{
-				PolicyID:  "azure-acl-234",
 				Target:    policies.Allowed,
 				Direction: policies.Ingress,
 				SrcList: []policies.SetInfo{

--- a/npm/pkg/controlplane/goalstateprocessor/goalstateprocessor_test.go
+++ b/npm/pkg/controlplane/goalstateprocessor/goalstateprocessor_test.go
@@ -28,8 +28,7 @@ var (
 	testNestedKeyPodSet   = ipsets.NewIPSetMetadata("test-nestedkeyPod-set", ipsets.NestedLabelOfPod)
 	testNestedKeyPodCPSet = controlplane.NewControllerIPSets(testNestedKeyPodSet)
 	testNetPol            = &policies.NPMNetworkPolicy{
-		Name:      "test-netpol",
-		NameSpace: "x",
+		Namespace: "x",
 		PolicyKey: "x/test-netpol",
 		PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 			{

--- a/npm/pkg/controlplane/translation/translatePolicy.go
+++ b/npm/pkg/controlplane/translation/translatePolicy.go
@@ -304,7 +304,7 @@ func ruleExists(ports []networkingv1.NetworkPolicyPort, peer []networkingv1.Netw
 // (e.g., IPBlock, podSelector, namespaceSelector, or both podSelector and namespaceSelector).
 func peerAndPortRule(npmNetPol *policies.NPMNetworkPolicy, direction policies.Direction, ports []networkingv1.NetworkPolicyPort, setInfo []policies.SetInfo) error {
 	if len(ports) == 0 {
-		acl := policies.NewACLPolicy(npmNetPol.NameSpace, npmNetPol.Name, policies.Allowed, direction)
+		acl := policies.NewACLPolicy(npmNetPol.Namespace, npmNetPol.Name, policies.Allowed, direction)
 		acl.AddSetInfo(setInfo)
 		npmNetPol.ACLs = append(npmNetPol.ACLs, acl)
 		return nil
@@ -316,7 +316,7 @@ func peerAndPortRule(npmNetPol *policies.NPMNetworkPolicy, direction policies.Di
 			return err
 		}
 
-		acl := policies.NewACLPolicy(npmNetPol.NameSpace, npmNetPol.Name, policies.Allowed, direction)
+		acl := policies.NewACLPolicy(npmNetPol.Namespace, npmNetPol.Name, policies.Allowed, direction)
 		acl.AddSetInfo(setInfo)
 		npmNetPol.RuleIPSets = portRule(npmNetPol.RuleIPSets, acl, &ports[i], portKind)
 		npmNetPol.ACLs = append(npmNetPol.ACLs, acl)
@@ -325,7 +325,7 @@ func peerAndPortRule(npmNetPol *policies.NPMNetworkPolicy, direction policies.Di
 }
 
 // translateRule translates ingress or egress rules and update npmNetPol object.
-func translateRule(npmNetPol *policies.NPMNetworkPolicy, direction policies.Direction, matchType policies.MatchType, ruleIndex int,
+func translateRule(npmNetPol *policies.NPMNetworkPolicy, netPolName string, direction policies.Direction, matchType policies.MatchType, ruleIndex int,
 	ports []networkingv1.NetworkPolicyPort, peers []networkingv1.NetworkPolicyPeer) error {
 	// TODO(jungukcho): need to clean up it.
 	// Leave allowExternal variable now while the condition is checked before calling this function.
@@ -335,7 +335,7 @@ func translateRule(npmNetPol *policies.NPMNetworkPolicy, direction policies.Dire
 	// The code inside if condition is to handle allowing all internal traffic, but the case is handled in #2.4.
 	// So, this code may not execute. After confirming this, need to delete it.
 	if !portRuleExists && !peerRuleExists && !allowExternal {
-		acl := policies.NewACLPolicy(npmNetPol.NameSpace, npmNetPol.Name, policies.Allowed, direction)
+		acl := policies.NewACLPolicy(npmNetPol.Namespace, npmNetPol.Name, policies.Allowed, direction)
 		ruleIPSets, allowAllInternalSetInfo := allowAllInternal(matchType)
 		npmNetPol.RuleIPSets = append(npmNetPol.RuleIPSets, ruleIPSets)
 		acl.AddSetInfo([]policies.SetInfo{allowAllInternalSetInfo})
@@ -351,7 +351,7 @@ func translateRule(npmNetPol *policies.NPMNetworkPolicy, direction policies.Dire
 				return err
 			}
 
-			portACL := policies.NewACLPolicy(npmNetPol.NameSpace, npmNetPol.Name, policies.Allowed, direction)
+			portACL := policies.NewACLPolicy(npmNetPol.Namespace, npmNetPol.Name, policies.Allowed, direction)
 			npmNetPol.RuleIPSets = portRule(npmNetPol.RuleIPSets, portACL, &ports[i], portKind)
 			npmNetPol.ACLs = append(npmNetPol.ACLs, portACL)
 		}
@@ -362,7 +362,7 @@ func translateRule(npmNetPol *policies.NPMNetworkPolicy, direction policies.Dire
 		// #2.1 Handle IPBlock and port if exist
 		if peer.IPBlock != nil {
 			if len(peer.IPBlock.CIDR) > 0 {
-				ipBlockIPSet, ipBlockSetInfo := ipBlockRule(npmNetPol.Name, npmNetPol.NameSpace, direction, matchType, ruleIndex, peerIdx, peer.IPBlock)
+				ipBlockIPSet, ipBlockSetInfo := ipBlockRule(netPolName, npmNetPol.Namespace, direction, matchType, ruleIndex, peerIdx, peer.IPBlock)
 				npmNetPol.RuleIPSets = append(npmNetPol.RuleIPSets, ipBlockIPSet)
 				err := peerAndPortRule(npmNetPol, direction, ports, []policies.SetInfo{ipBlockSetInfo})
 				if err != nil {
@@ -397,7 +397,7 @@ func translateRule(npmNetPol *policies.NPMNetworkPolicy, direction policies.Dire
 
 		// #2.3 handle podSelector and port if exist
 		if peer.PodSelector != nil && peer.NamespaceSelector == nil {
-			podSelectorIPSets, podSelectorList, err := podSelectorWithNS(npmNetPol.NameSpace, matchType, peer.PodSelector)
+			podSelectorIPSets, podSelectorList, err := podSelectorWithNS(npmNetPol.Namespace, matchType, peer.PodSelector)
 			if err != nil {
 				return err
 			}
@@ -448,7 +448,7 @@ func defaultDropACL(policyNS, policyName string, direction policies.Direction) *
 
 // allowAllPolicy adds acl to allow all traffic including internal (i.e,. K8s cluster) and external (i.e., internet)
 func allowAllPolicy(npmNetPol *policies.NPMNetworkPolicy, direction policies.Direction) {
-	allowAllACL := policies.NewACLPolicy(npmNetPol.NameSpace, npmNetPol.Name, policies.Allowed, direction)
+	allowAllACL := policies.NewACLPolicy(npmNetPol.Namespace, npmNetPol.Name, policies.Allowed, direction)
 	npmNetPol.ACLs = append(npmNetPol.ACLs, allowAllACL)
 }
 
@@ -462,7 +462,7 @@ func isAllowAllToIngress(ingress []networkingv1.NetworkPolicyIngressRule) bool {
 
 // ingressPolicy traslates NetworkPolicyIngressRule in NetworkPolicy object
 // to NPMNetworkPolicy object.
-func ingressPolicy(npmNetPol *policies.NPMNetworkPolicy, ingress []networkingv1.NetworkPolicyIngressRule) error {
+func ingressPolicy(npmNetPol *policies.NPMNetworkPolicy, netPolName string, ingress []networkingv1.NetworkPolicyIngressRule) error {
 	// #1. Allow all traffic from both internal and external.
 	// In yaml file, it is specified with '{}'.
 	if isAllowAllToIngress(ingress) {
@@ -473,7 +473,7 @@ func ingressPolicy(npmNetPol *policies.NPMNetworkPolicy, ingress []networkingv1.
 	// #2. If ingress is nil (in yaml file, it is specified with '[]'), it means "Deny all" - it does not allow receiving any traffic from others.
 	if ingress == nil {
 		// Except for allow all traffic case in #1, the rest of them should have default drop rules.
-		dropACL := defaultDropACL(npmNetPol.NameSpace, npmNetPol.Name, policies.Ingress)
+		dropACL := defaultDropACL(npmNetPol.Namespace, npmNetPol.Name, policies.Ingress)
 		npmNetPol.ACLs = append(npmNetPol.ACLs, dropACL)
 		return nil
 	}
@@ -481,12 +481,12 @@ func ingressPolicy(npmNetPol *policies.NPMNetworkPolicy, ingress []networkingv1.
 	// #3. Ingress rule is not AllowAll (including internal and external) and DenyAll policy.
 	// So, start translating ingress policy.
 	for i, rule := range ingress {
-		if err := translateRule(npmNetPol, policies.Ingress, policies.SrcMatch, i, rule.Ports, rule.From); err != nil {
+		if err := translateRule(npmNetPol, netPolName, policies.Ingress, policies.SrcMatch, i, rule.Ports, rule.From); err != nil {
 			return err
 		}
 	}
 	// Except for allow all traffic case in #1, the rest of them should have default drop rules.
-	dropACL := defaultDropACL(npmNetPol.NameSpace, npmNetPol.Name, policies.Ingress)
+	dropACL := defaultDropACL(npmNetPol.Namespace, npmNetPol.Name, policies.Ingress)
 	npmNetPol.ACLs = append(npmNetPol.ACLs, dropACL)
 	return nil
 }
@@ -501,7 +501,7 @@ func isAllowAllToEgress(egress []networkingv1.NetworkPolicyEgressRule) bool {
 
 // egressPolicy traslates NetworkPolicyEgressRule in networkpolicy object
 // to NPMNetworkPolicy object.
-func egressPolicy(npmNetPol *policies.NPMNetworkPolicy, egress []networkingv1.NetworkPolicyEgressRule) error {
+func egressPolicy(npmNetPol *policies.NPMNetworkPolicy, netPolName string, egress []networkingv1.NetworkPolicyEgressRule) error {
 	// #1. Allow all traffic to both internal and external.
 	// In yaml file, it is specified with '{}'.
 	if isAllowAllToEgress(egress) {
@@ -512,7 +512,7 @@ func egressPolicy(npmNetPol *policies.NPMNetworkPolicy, egress []networkingv1.Ne
 	// #2. If egress is nil (in yaml file, it is specified with '[]'), it means "Deny all" - it does not allow sending traffic to others.
 	if egress == nil {
 		// Except for allow all traffic case in #1, the rest of them should have default drop rules.
-		dropACL := defaultDropACL(npmNetPol.NameSpace, npmNetPol.Name, policies.Egress)
+		dropACL := defaultDropACL(npmNetPol.Namespace, npmNetPol.Name, policies.Egress)
 		npmNetPol.ACLs = append(npmNetPol.ACLs, dropACL)
 		return nil
 	}
@@ -520,7 +520,7 @@ func egressPolicy(npmNetPol *policies.NPMNetworkPolicy, egress []networkingv1.Ne
 	// #3. Egress rule is not AllowAll (including internal and external) and DenyAll.
 	// So, start translating egress policy.
 	for i, rule := range egress {
-		err := translateRule(npmNetPol, policies.Egress, policies.DstMatch, i, rule.Ports, rule.To)
+		err := translateRule(npmNetPol, netPolName, policies.Egress, policies.DstMatch, i, rule.Ports, rule.To)
 		if err != nil {
 			return err
 		}
@@ -528,7 +528,7 @@ func egressPolicy(npmNetPol *policies.NPMNetworkPolicy, egress []networkingv1.Ne
 
 	// #3. Except for allow all traffic case in #1, the rest of them should have default drop rules.
 	// Add drop ACL to drop the rest of traffic which is not specified in Egress Spec.
-	dropACL := defaultDropACL(npmNetPol.NameSpace, npmNetPol.Name, policies.Egress)
+	dropACL := defaultDropACL(npmNetPol.Namespace, npmNetPol.Name, policies.Egress)
 	npmNetPol.ACLs = append(npmNetPol.ACLs, dropACL)
 	return nil
 }
@@ -536,12 +536,13 @@ func egressPolicy(npmNetPol *policies.NPMNetworkPolicy, egress []networkingv1.Ne
 // TranslatePolicy traslates networkpolicy object to NPMNetworkPolicy object
 // and return the NPMNetworkPolicy object.
 func TranslatePolicy(npObj *networkingv1.NetworkPolicy) (*policies.NPMNetworkPolicy, error) {
-	npmNetPol := policies.NewNPMNetworkPolicy(npObj.Name, npObj.Namespace)
+	netPolName := npObj.Name
+	npmNetPol := policies.NewNPMNetworkPolicy(netPolName, npObj.Namespace)
 
 	// podSelector in spec.PodSelector is common for ingress and egress.
 	// Process this podSelector first.
 	var err error
-	npmNetPol.PodSelectorIPSets, npmNetPol.PodSelectorList, err = podSelectorWithNS(npmNetPol.NameSpace, policies.EitherMatch, &npObj.Spec.PodSelector)
+	npmNetPol.PodSelectorIPSets, npmNetPol.PodSelectorList, err = podSelectorWithNS(npmNetPol.Namespace, policies.EitherMatch, &npObj.Spec.PodSelector)
 	if err != nil {
 		return nil, err
 	}
@@ -551,12 +552,12 @@ func TranslatePolicy(npObj *networkingv1.NetworkPolicy) (*policies.NPMNetworkPol
 	// and Egress will be set if the NetworkPolicy has any egress rules.
 	for _, ptype := range npObj.Spec.PolicyTypes {
 		if ptype == networkingv1.PolicyTypeIngress {
-			err := ingressPolicy(npmNetPol, npObj.Spec.Ingress)
+			err := ingressPolicy(npmNetPol, netPolName, npObj.Spec.Ingress)
 			if err != nil {
 				return nil, err
 			}
 		} else {
-			err := egressPolicy(npmNetPol, npObj.Spec.Egress)
+			err := egressPolicy(npmNetPol, netPolName, npObj.Spec.Egress)
 			if err != nil {
 				return nil, err
 			}

--- a/npm/pkg/controlplane/translation/translatePolicy_test.go
+++ b/npm/pkg/controlplane/translation/translatePolicy_test.go
@@ -934,7 +934,6 @@ func TestDefaultDropACL(t *testing.T) {
 			policyNS:   defaultNS,
 			direction:  direction,
 			dropACL: &policies.ACLPolicy{
-				PolicyID:  "azure-acl-default-test",
 				Target:    policies.Dropped,
 				Direction: direction,
 			},
@@ -945,7 +944,6 @@ func TestDefaultDropACL(t *testing.T) {
 			policyNS:   "testns",
 			direction:  direction,
 			dropACL: &policies.ACLPolicy{
-				PolicyID:  "azure-acl-testns-test",
 				Target:    policies.Dropped,
 				Direction: direction,
 			},
@@ -956,7 +954,7 @@ func TestDefaultDropACL(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			dropACL := defaultDropACL(tt.policyNS, tt.policyName, tt.direction)
+			dropACL := defaultDropACL(tt.direction)
 			require.Equal(t, tt.dropACL, dropACL)
 		})
 	}
@@ -1139,11 +1137,11 @@ func TestPeerAndPortRule(t *testing.T) {
 				},
 			},
 			npmNetPol: &policies.NPMNetworkPolicy{
-				Namespace: defaultNS,
-				PolicyKey: namedPortPolicyKey,
+				Namespace:   defaultNS,
+				PolicyKey:   namedPortPolicyKey,
+				ACLPolicyID: fmt.Sprintf("azure-acl-%s-%s", defaultNS, namedPortPolicyKey),
 				ACLs: []*policies.ACLPolicy{
 					{
-						PolicyID:  "azure-acl-default-serve-tcp",
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 						SrcList:   []policies.SetInfo{},
@@ -1165,14 +1163,14 @@ func TestPeerAndPortRule(t *testing.T) {
 				},
 			},
 			npmNetPol: &policies.NPMNetworkPolicy{
-				Namespace: defaultNS,
-				PolicyKey: namedPortPolicyKey,
+				Namespace:   defaultNS,
+				PolicyKey:   namedPortPolicyKey,
+				ACLPolicyID: fmt.Sprintf("azure-acl-%s-%s", defaultNS, namedPortPolicyKey),
 				RuleIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("serve-tcp", ipsets.NamedPorts),
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
-						PolicyID:  "azure-acl-default-serve-tcp",
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 						SrcList:   []policies.SetInfo{},
@@ -1193,14 +1191,14 @@ func TestPeerAndPortRule(t *testing.T) {
 				},
 			},
 			npmNetPol: &policies.NPMNetworkPolicy{
-				Namespace: defaultNS,
-				PolicyKey: namedPortPolicyKey,
+				Namespace:   defaultNS,
+				PolicyKey:   namedPortPolicyKey,
+				ACLPolicyID: fmt.Sprintf("azure-acl-%s-%s", defaultNS, namedPortPolicyKey),
 				RuleIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("serve-tcp", ipsets.NamedPorts),
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
-						PolicyID:  "azure-acl-default-serve-tcp",
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 						SrcList: []policies.SetInfo{
@@ -1223,14 +1221,14 @@ func TestPeerAndPortRule(t *testing.T) {
 				},
 			},
 			npmNetPol: &policies.NPMNetworkPolicy{
-				Namespace: defaultNS,
-				PolicyKey: namedPortPolicyKey,
+				Namespace:   defaultNS,
+				PolicyKey:   namedPortPolicyKey,
+				ACLPolicyID: fmt.Sprintf("azure-acl-%s-%s", defaultNS, namedPortPolicyKey),
 				RuleIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("serve-tcp", ipsets.NamedPorts),
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
-						PolicyID:  "azure-acl-default-serve-tcp",
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 						SrcList:   []policies.SetInfo{},
@@ -1251,14 +1249,14 @@ func TestPeerAndPortRule(t *testing.T) {
 				},
 			},
 			npmNetPol: &policies.NPMNetworkPolicy{
-				Namespace: defaultNS,
-				PolicyKey: namedPortPolicyKey,
+				Namespace:   defaultNS,
+				PolicyKey:   namedPortPolicyKey,
+				ACLPolicyID: fmt.Sprintf("azure-acl-%s-%s", defaultNS, namedPortPolicyKey),
 				RuleIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("serve-tcp", ipsets.NamedPorts),
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
-						PolicyID:  "azure-acl-default-serve-tcp",
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 						SrcList:   []policies.SetInfo{},
@@ -1281,8 +1279,9 @@ func TestPeerAndPortRule(t *testing.T) {
 				acl.SrcList = setInfo
 			}
 			npmNetPol := &policies.NPMNetworkPolicy{
-				Namespace: tt.npmNetPol.Namespace,
-				PolicyKey: tt.npmNetPol.PolicyKey,
+				Namespace:   tt.npmNetPol.Namespace,
+				PolicyKey:   tt.npmNetPol.PolicyKey,
+				ACLPolicyID: tt.npmNetPol.ACLPolicyID,
 			}
 			err := peerAndPortRule(npmNetPol, policies.Ingress, tt.ports, setInfo)
 			require.NoError(t, err)
@@ -1321,8 +1320,9 @@ func TestIngressPolicy(t *testing.T) {
 				},
 			},
 			npmNetPol: &policies.NPMNetworkPolicy{
-				Namespace: defaultNS,
-				PolicyKey: fmt.Sprintf("%s/%s", defaultNS, namedPortStr),
+				Namespace:   defaultNS,
+				PolicyKey:   namedPortPolicyKey,
+				ACLPolicyID: fmt.Sprintf("azure-acl-%s-%s", defaultNS, namedPortPolicyKey),
 				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet(defaultNS, ipsets.Namespace),
@@ -1333,7 +1333,6 @@ func TestIngressPolicy(t *testing.T) {
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
-						PolicyID:  "azure-acl-default-serve-tcp",
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 						DstPorts: policies.Ports{
@@ -1342,7 +1341,7 @@ func TestIngressPolicy(t *testing.T) {
 						},
 						Protocol: "TCP",
 					},
-					defaultDropACL(defaultNS, "serve-tcp", policies.Ingress),
+					defaultDropACL(policies.Ingress),
 				},
 			},
 		},
@@ -1366,8 +1365,9 @@ func TestIngressPolicy(t *testing.T) {
 				},
 			},
 			npmNetPol: &policies.NPMNetworkPolicy{
-				Namespace: defaultNS,
-				PolicyKey: fmt.Sprintf("%s/%s", defaultNS, "only-ipblock"),
+				Namespace:   defaultNS,
+				PolicyKey:   fmt.Sprintf("%s/%s", defaultNS, "only-ipblock"),
+				ACLPolicyID: fmt.Sprintf("azure-acl-%s-%s", defaultNS, "only-ipblock"),
 				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet(defaultNS, ipsets.Namespace),
@@ -1381,14 +1381,13 @@ func TestIngressPolicy(t *testing.T) {
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
-						PolicyID:  "azure-acl-default-only-ipblock",
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 						SrcList: []policies.SetInfo{
 							policies.NewSetInfo("only-ipblock-in-ns-default-0-0IN", ipsets.CIDRBlocks, included, peerMatchType),
 						},
 					},
-					defaultDropACL(defaultNS, "only-ipblock", policies.Ingress),
+					defaultDropACL(policies.Ingress),
 				},
 			},
 		},
@@ -1413,8 +1412,9 @@ func TestIngressPolicy(t *testing.T) {
 				},
 			},
 			npmNetPol: &policies.NPMNetworkPolicy{
-				Namespace: defaultNS,
-				PolicyKey: fmt.Sprintf("%s/%s", defaultNS, "only-peer-podSelector"),
+				Namespace:   defaultNS,
+				PolicyKey:   fmt.Sprintf("%s/%s", defaultNS, "only-peer-podSelector"),
+				ACLPolicyID: fmt.Sprintf("azure-acl-%s-%s", defaultNS, "only-peer-podSelector"),
 				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet(defaultNS, ipsets.Namespace),
@@ -1429,7 +1429,6 @@ func TestIngressPolicy(t *testing.T) {
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
-						PolicyID:  "azure-acl-default-only-peer-podSelector",
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 						SrcList: []policies.SetInfo{
@@ -1437,7 +1436,7 @@ func TestIngressPolicy(t *testing.T) {
 							policies.NewSetInfo(defaultNS, ipsets.Namespace, included, peerMatchType),
 						},
 					},
-					defaultDropACL(defaultNS, "only-peer-podSelector", policies.Ingress),
+					defaultDropACL(policies.Ingress),
 				},
 			},
 		},
@@ -1462,8 +1461,9 @@ func TestIngressPolicy(t *testing.T) {
 				},
 			},
 			npmNetPol: &policies.NPMNetworkPolicy{
-				PolicyKey: fmt.Sprintf("%s/%s", defaultNS, "only-peer-nsSelector"),
-				Namespace: defaultNS,
+				PolicyKey:   fmt.Sprintf("%s/%s", defaultNS, "only-peer-nsSelector"),
+				Namespace:   defaultNS,
+				ACLPolicyID: fmt.Sprintf("azure-acl-%s-%s", defaultNS, "only-peer-nsSelector"),
 				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet(defaultNS, ipsets.Namespace),
@@ -1477,14 +1477,13 @@ func TestIngressPolicy(t *testing.T) {
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
-						PolicyID:  "azure-acl-default-only-peer-nsSelector",
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 						SrcList: []policies.SetInfo{
 							policies.NewSetInfo("peer-nsselector-kay:peer-nsselector-value", ipsets.KeyValueLabelOfNamespace, included, peerMatchType),
 						},
 					},
-					defaultDropACL(defaultNS, "only-peer-nsSelector", policies.Ingress),
+					defaultDropACL(policies.Ingress),
 				},
 			},
 		},
@@ -1520,8 +1519,9 @@ func TestIngressPolicy(t *testing.T) {
 				},
 			},
 			npmNetPol: &policies.NPMNetworkPolicy{
-				Namespace: defaultNS,
-				PolicyKey: fmt.Sprintf("%s/%s", defaultNS, "only-peer-nsSelector"),
+				Namespace:   defaultNS,
+				PolicyKey:   fmt.Sprintf("%s/%s", defaultNS, "only-peer-nsSelector"),
+				ACLPolicyID: fmt.Sprintf("azure-acl-%s-%s", defaultNS, "only-peer-nsSelector"),
 				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet(defaultNS, ipsets.Namespace),
@@ -1537,7 +1537,6 @@ func TestIngressPolicy(t *testing.T) {
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
-						PolicyID:  "azure-acl-default-only-peer-nsSelector",
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 						SrcList: []policies.SetInfo{
@@ -1545,7 +1544,6 @@ func TestIngressPolicy(t *testing.T) {
 						},
 					},
 					{
-						PolicyID:  "azure-acl-default-only-peer-nsSelector",
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 						SrcList: []policies.SetInfo{
@@ -1553,14 +1551,13 @@ func TestIngressPolicy(t *testing.T) {
 						},
 					},
 					{
-						PolicyID:  "azure-acl-default-only-peer-nsSelector",
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 						SrcList: []policies.SetInfo{
 							policies.NewSetInfo("only-peer-nsSelector-in-ns-default-0-2IN", ipsets.CIDRBlocks, included, peerMatchType),
 						},
 					},
-					defaultDropACL(defaultNS, "only-peer-nsSelector", policies.Ingress),
+					defaultDropACL(policies.Ingress),
 				},
 			},
 		},
@@ -1582,8 +1579,9 @@ func TestIngressPolicy(t *testing.T) {
 				},
 			},
 			npmNetPol: &policies.NPMNetworkPolicy{
-				Namespace: "default",
-				PolicyKey: "default/serve-tcp",
+				Namespace:   "default",
+				PolicyKey:   "default/serve-tcp",
+				ACLPolicyID: "azure-acl-default-serve-tcp",
 				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
@@ -1594,12 +1592,11 @@ func TestIngressPolicy(t *testing.T) {
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
-						PolicyID:  "azure-acl-default-serve-tcp",
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 						Protocol:  "TCP",
 					},
-					defaultDropACL("default", "serve-tcp", policies.Ingress),
+					defaultDropACL(policies.Ingress),
 				},
 			},
 			wantErr: true,
@@ -1615,8 +1612,9 @@ func TestIngressPolicy(t *testing.T) {
 				{},
 			},
 			npmNetPol: &policies.NPMNetworkPolicy{
-				Namespace: "default",
-				PolicyKey: "default/serve-tcp",
+				Namespace:   "default",
+				PolicyKey:   "default/serve-tcp",
+				ACLPolicyID: "azure-acl-default-serve-tcp",
 				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
@@ -1627,7 +1625,6 @@ func TestIngressPolicy(t *testing.T) {
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
-						PolicyID:  "azure-acl-default-serve-tcp",
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 					},
@@ -1643,8 +1640,9 @@ func TestIngressPolicy(t *testing.T) {
 			},
 			rules: nil,
 			npmNetPol: &policies.NPMNetworkPolicy{
-				Namespace: "default",
-				PolicyKey: "default/serve-tcp",
+				Namespace:   "default",
+				PolicyKey:   "default/serve-tcp",
+				ACLPolicyID: "azure-acl-default-serve-tcp",
 				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
@@ -1654,7 +1652,7 @@ func TestIngressPolicy(t *testing.T) {
 					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
 				},
 				ACLs: []*policies.ACLPolicy{
-					defaultDropACL("default", "serve-tcp", policies.Ingress),
+					defaultDropACL(policies.Ingress),
 				},
 			},
 		},
@@ -1714,8 +1712,9 @@ func TestEgressPolicy(t *testing.T) {
 				},
 			},
 			npmNetPol: &policies.NPMNetworkPolicy{
-				Namespace: "default",
-				PolicyKey: "default/serve-tcp",
+				Namespace:   "default",
+				PolicyKey:   "default/serve-tcp",
+				ACLPolicyID: "azure-acl-default-serve-tcp",
 				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("label:dst", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
@@ -1726,7 +1725,6 @@ func TestEgressPolicy(t *testing.T) {
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
-						PolicyID:  "azure-acl-default-serve-tcp",
 						Target:    policies.Allowed,
 						Direction: policies.Egress,
 						DstPorts: policies.Ports{
@@ -1735,7 +1733,7 @@ func TestEgressPolicy(t *testing.T) {
 						},
 						Protocol: "TCP",
 					},
-					defaultDropACL("default", "serve-tcp", policies.Egress),
+					defaultDropACL(policies.Egress),
 				},
 			},
 		},
@@ -1759,8 +1757,9 @@ func TestEgressPolicy(t *testing.T) {
 				},
 			},
 			npmNetPol: &policies.NPMNetworkPolicy{
-				Namespace: "default",
-				PolicyKey: "default/only-ipblock",
+				Namespace:   "default",
+				PolicyKey:   "default/only-ipblock",
+				ACLPolicyID: "azure-acl-default-only-ipblock",
 				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("label:dst", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
@@ -1774,14 +1773,13 @@ func TestEgressPolicy(t *testing.T) {
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
-						PolicyID:  "azure-acl-default-only-ipblock",
 						Target:    policies.Allowed,
 						Direction: policies.Egress,
 						DstList: []policies.SetInfo{
 							policies.NewSetInfo("only-ipblock-in-ns-default-0-0OUT", ipsets.CIDRBlocks, included, peerMatchType),
 						},
 					},
-					defaultDropACL("default", "only-ipblock", policies.Egress),
+					defaultDropACL(policies.Egress),
 				},
 			},
 		},
@@ -1806,8 +1804,9 @@ func TestEgressPolicy(t *testing.T) {
 				},
 			},
 			npmNetPol: &policies.NPMNetworkPolicy{
-				Namespace: "default",
-				PolicyKey: "default/only-peer-podSelector",
+				Namespace:   "default",
+				PolicyKey:   "default/only-peer-podSelector",
+				ACLPolicyID: "azure-acl-default-only-peer-podSelector",
 				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("label:dst", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
@@ -1822,7 +1821,6 @@ func TestEgressPolicy(t *testing.T) {
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
-						PolicyID:  "azure-acl-default-only-peer-podSelector",
 						Target:    policies.Allowed,
 						Direction: policies.Egress,
 						DstList: []policies.SetInfo{
@@ -1830,7 +1828,7 @@ func TestEgressPolicy(t *testing.T) {
 							policies.NewSetInfo("default", ipsets.Namespace, included, peerMatchType),
 						},
 					},
-					defaultDropACL("default", "only-peer-podSelector", policies.Egress),
+					defaultDropACL(policies.Egress),
 				},
 			},
 		},
@@ -1855,8 +1853,9 @@ func TestEgressPolicy(t *testing.T) {
 				},
 			},
 			npmNetPol: &policies.NPMNetworkPolicy{
-				Namespace: "default",
-				PolicyKey: "default/only-peer-nsSelector",
+				Namespace:   "default",
+				PolicyKey:   "default/only-peer-nsSelector",
+				ACLPolicyID: "azure-acl-default-only-peer-nsSelector",
 				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("label:dst", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
@@ -1870,14 +1869,13 @@ func TestEgressPolicy(t *testing.T) {
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
-						PolicyID:  "azure-acl-default-only-peer-nsSelector",
 						Target:    policies.Allowed,
 						Direction: policies.Egress,
 						DstList: []policies.SetInfo{
 							policies.NewSetInfo("peer-nsselector-kay:peer-nsselector-value", ipsets.KeyValueLabelOfNamespace, included, peerMatchType),
 						},
 					},
-					defaultDropACL("default", "only-peer-nsSelector", policies.Egress),
+					defaultDropACL(policies.Egress),
 				},
 			},
 		},
@@ -1890,8 +1888,9 @@ func TestEgressPolicy(t *testing.T) {
 			},
 			rules: nil,
 			npmNetPol: &policies.NPMNetworkPolicy{
-				Namespace: "default",
-				PolicyKey: "default/serve-tcp",
+				Namespace:   "default",
+				PolicyKey:   "default/serve-tcp",
+				ACLPolicyID: "azure-acl-default-serve-tcp",
 				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("label:dst", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
@@ -1901,7 +1900,7 @@ func TestEgressPolicy(t *testing.T) {
 					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
 				},
 				ACLs: []*policies.ACLPolicy{
-					defaultDropACL("default", "serve-tcp", policies.Egress),
+					defaultDropACL(policies.Egress),
 				},
 			},
 		},
@@ -1916,8 +1915,9 @@ func TestEgressPolicy(t *testing.T) {
 				{},
 			},
 			npmNetPol: &policies.NPMNetworkPolicy{
-				Namespace: "default",
-				PolicyKey: "default/serve-tcp",
+				Namespace:   "default",
+				PolicyKey:   "default/serve-tcp",
+				ACLPolicyID: "azure-acl-default-serve-tcp",
 				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("label:dst", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
@@ -1928,7 +1928,6 @@ func TestEgressPolicy(t *testing.T) {
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
-						PolicyID:  "azure-acl-default-serve-tcp",
 						Target:    policies.Allowed,
 						Direction: policies.Egress,
 					},
@@ -1967,8 +1966,9 @@ func TestEgressPolicy(t *testing.T) {
 				},
 			},
 			npmNetPol: &policies.NPMNetworkPolicy{
-				Namespace: "default",
-				PolicyKey: "default/only-peer-nsSelector",
+				Namespace:   "default",
+				PolicyKey:   "default/only-peer-nsSelector",
+				ACLPolicyID: "azure-acl-default-only-peer-nsSelector",
 				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("label:dst", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
@@ -1984,7 +1984,6 @@ func TestEgressPolicy(t *testing.T) {
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
-						PolicyID:  "azure-acl-default-only-peer-nsSelector",
 						Target:    policies.Allowed,
 						Direction: policies.Egress,
 						DstList: []policies.SetInfo{
@@ -1992,7 +1991,6 @@ func TestEgressPolicy(t *testing.T) {
 						},
 					},
 					{
-						PolicyID:  "azure-acl-default-only-peer-nsSelector",
 						Target:    policies.Allowed,
 						Direction: policies.Egress,
 						DstList: []policies.SetInfo{
@@ -2000,14 +1998,13 @@ func TestEgressPolicy(t *testing.T) {
 						},
 					},
 					{
-						PolicyID:  "azure-acl-default-only-peer-nsSelector",
 						Target:    policies.Allowed,
 						Direction: policies.Egress,
 						DstList: []policies.SetInfo{
 							policies.NewSetInfo("only-peer-nsSelector-in-ns-default-0-2OUT", ipsets.CIDRBlocks, included, peerMatchType),
 						},
 					},
-					defaultDropACL("default", "only-peer-nsSelector", policies.Egress),
+					defaultDropACL(policies.Egress),
 				},
 			},
 		},
@@ -2029,8 +2026,9 @@ func TestEgressPolicy(t *testing.T) {
 				},
 			},
 			npmNetPol: &policies.NPMNetworkPolicy{
-				Namespace: "default",
-				PolicyKey: "default/serve-tcp",
+				Namespace:   "default",
+				PolicyKey:   "default/serve-tcp",
+				ACLPolicyID: "azure-acl-default-serve-tcp",
 				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("label:dst", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
@@ -2041,12 +2039,11 @@ func TestEgressPolicy(t *testing.T) {
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
-						PolicyID:  "azure-acl-default-serve-tcp",
 						Target:    policies.Allowed,
 						Direction: policies.Egress,
 						Protocol:  "TCP",
 					},
-					defaultDropACL("default", "serve-tcp", policies.Egress),
+					defaultDropACL(policies.Egress),
 				},
 			},
 			wantErr: true,

--- a/npm/pkg/dataplane/dataplane_test.go
+++ b/npm/pkg/dataplane/dataplane_test.go
@@ -32,8 +32,9 @@ var (
 		Metadata: ipsets.NewIPSetMetadata("setpodkey1", ipsets.KeyLabelOfPod),
 	}
 	testPolicyobj = policies.NPMNetworkPolicy{
-		Namespace: "ns1",
-		PolicyKey: "ns1/testpolicy",
+		Namespace:   "ns1",
+		PolicyKey:   "ns1/testpolicy",
+		ACLPolicyID: "azure-acl-ns1-testpolicy",
 		PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 			{
 				Metadata: ipsets.NewIPSetMetadata("setns1", ipsets.Namespace),
@@ -65,7 +66,6 @@ var (
 		},
 		ACLs: []*policies.ACLPolicy{
 			{
-				PolicyID:  "testpol1",
 				Target:    policies.Dropped,
 				Direction: policies.Egress,
 			},
@@ -226,7 +226,6 @@ func TestUpdatePolicy(t *testing.T) {
 	updatedTestPolicyobj := testPolicyobj
 	updatedTestPolicyobj.ACLs = []*policies.ACLPolicy{
 		{
-			PolicyID:  "testpol1",
 			Target:    policies.Dropped,
 			Direction: policies.Ingress,
 		},

--- a/npm/pkg/dataplane/dataplane_test.go
+++ b/npm/pkg/dataplane/dataplane_test.go
@@ -32,8 +32,7 @@ var (
 		Metadata: ipsets.NewIPSetMetadata("setpodkey1", ipsets.KeyLabelOfPod),
 	}
 	testPolicyobj = policies.NPMNetworkPolicy{
-		Name:      "testpolicy",
-		NameSpace: "ns1",
+		Namespace: "ns1",
 		PolicyKey: "ns1/testpolicy",
 		PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 			{

--- a/npm/pkg/dataplane/dataplane_windows.go
+++ b/npm/pkg/dataplane/dataplane_windows.go
@@ -213,6 +213,8 @@ func (dp *DataPlane) getSelectorIPsByPolicy(policy *policies.NPMNetworkPolicy) (
 		selectorIpSets[ipset.Metadata.GetPrefixName()] = struct{}{}
 	}
 
+	klog.Infof("policy %s has policy selector: %+v", policy.PolicyKey, selectorIpSets) // FIXME remove after debugging
+
 	return dp.ipsetMgr.GetIPsFromSelectorIPSets(selectorIpSets)
 }
 
@@ -238,9 +240,9 @@ func (dp *DataPlane) getEndpointsToApplyPolicy(policy *policies.NPMNetworkPolicy
 			continue
 		}
 		endpointList[ip] = endpoint.ID
-		// TODO make sure this is netpol key and not name
 		endpoint.NetPolReference[policy.PolicyKey] = struct{}{}
 	}
+	klog.Infof("[DataPlane] Endpoints to apply policy %s: %+v", policy.PolicyKey, endpointList) // FIXME remove after debugging
 	return endpointList, nil
 }
 
@@ -278,7 +280,9 @@ func (dp *DataPlane) refreshAllPodEndpoints() error {
 		}
 
 		dp.endpointCache[ep.IP] = ep
+		klog.Infof("updating endpoint cache to include %s: %+v", ep.IP, ep) // FIXME remove after debugging
 	}
+	klog.Infof("endpoint cache after refreshing all pod endpoints: %+v", dp.endpointCache) // FIXME remove after debugging
 	return nil
 }
 

--- a/npm/pkg/dataplane/dataplane_windows.go
+++ b/npm/pkg/dataplane/dataplane_windows.go
@@ -131,20 +131,20 @@ func (dp *DataPlane) updatePod(pod *updateNPMPod) error {
 			return err
 		}
 
-		for policyName := range selectorReference {
+		for policyKey := range selectorReference {
 			// Now check if any of these network policies are applied on this endpoint.
 			// If yes then proceed to delete the network policy
 			// Remove policy should be deleting this netpol reference
-			if _, ok := endpoint.NetPolReference[policyName]; ok {
+			if _, ok := endpoint.NetPolReference[policyKey]; ok {
 				// Delete the network policy
 				endpointList := map[string]string{
 					endpoint.IP: endpoint.ID,
 				}
-				err := dp.policyMgr.RemovePolicy(policyName, endpointList)
+				err := dp.policyMgr.RemovePolicy(policyKey, endpointList)
 				if err != nil {
 					return err
 				}
-				delete(endpoint.NetPolReference, policyName)
+				delete(endpoint.NetPolReference, policyKey)
 			}
 		}
 	}
@@ -157,19 +157,19 @@ func (dp *DataPlane) updatePod(pod *updateNPMPod) error {
 			return err
 		}
 
-		for netpol := range selectorReference {
-			toAddPolicies[netpol] = struct{}{}
+		for policyKey := range selectorReference {
+			toAddPolicies[policyKey] = struct{}{}
 		}
 	}
 
 	// Now check if any of these network policies are applied on this endpoint.
 	// If not then proceed to apply the network policy
-	for policyName := range toAddPolicies {
-		if _, ok := endpoint.NetPolReference[policyName]; ok {
+	for policyKey := range toAddPolicies {
+		if _, ok := endpoint.NetPolReference[policyKey]; ok {
 			continue
 		}
 		// TODO Also check if the endpoint reference in policy for this Ip is right
-		netpolSelectorIPs, err := dp.getSelectorIPsByPolicyName(policyName)
+		netpolSelectorIPs, err := dp.getSelectorIPsByPolicyName(policyKey)
 		if err != nil {
 			return err
 		}
@@ -179,9 +179,9 @@ func (dp *DataPlane) updatePod(pod *updateNPMPod) error {
 		}
 
 		// Apply the network policy
-		policy, ok := dp.policyMgr.GetPolicy(policyName)
+		policy, ok := dp.policyMgr.GetPolicy(policyKey)
 		if !ok {
-			return fmt.Errorf("policy with name %s does not exist", policyName)
+			return fmt.Errorf("policy with name %s does not exist", policyKey)
 		}
 
 		endpointList := map[string]string{
@@ -192,16 +192,16 @@ func (dp *DataPlane) updatePod(pod *updateNPMPod) error {
 			return err
 		}
 
-		endpoint.NetPolReference[policyName] = struct{}{}
+		endpoint.NetPolReference[policyKey] = struct{}{}
 	}
 
 	return nil
 }
 
-func (dp *DataPlane) getSelectorIPsByPolicyName(policyName string) (map[string]struct{}, error) {
-	policy, ok := dp.policyMgr.GetPolicy(policyName)
+func (dp *DataPlane) getSelectorIPsByPolicyName(policyKey string) (map[string]struct{}, error) {
+	policy, ok := dp.policyMgr.GetPolicy(policyKey)
 	if !ok {
-		return nil, fmt.Errorf("policy with name %s does not exist", policyName)
+		return nil, fmt.Errorf("policy with name %s does not exist", policyKey)
 	}
 
 	return dp.getSelectorIPsByPolicy(policy)
@@ -239,7 +239,7 @@ func (dp *DataPlane) getEndpointsToApplyPolicy(policy *policies.NPMNetworkPolicy
 		}
 		endpointList[ip] = endpoint.ID
 		// TODO make sure this is netpol key and not name
-		endpoint.NetPolReference[policy.Name] = struct{}{}
+		endpoint.NetPolReference[policy.PolicyKey] = struct{}{}
 	}
 	return endpointList, nil
 }

--- a/npm/pkg/dataplane/dpshim/dpshim_test.go
+++ b/npm/pkg/dataplane/dpshim/dpshim_test.go
@@ -31,8 +31,7 @@ var (
 		Metadata: ipsets.NewIPSetMetadata("setpodkey1", ipsets.KeyLabelOfPod),
 	}
 	testPolicyobj = &policies.NPMNetworkPolicy{
-		Name:      "testpolicy",
-		NameSpace: "ns1",
+		Namespace: "ns1",
 		PolicyKey: "ns1/testpolicy",
 		PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 			{

--- a/npm/pkg/dataplane/dpshim/dpshim_test.go
+++ b/npm/pkg/dataplane/dpshim/dpshim_test.go
@@ -31,8 +31,9 @@ var (
 		Metadata: ipsets.NewIPSetMetadata("setpodkey1", ipsets.KeyLabelOfPod),
 	}
 	testPolicyobj = &policies.NPMNetworkPolicy{
-		Namespace: "ns1",
-		PolicyKey: "ns1/testpolicy",
+		Namespace:   "ns1",
+		PolicyKey:   "ns1/testpolicy",
+		ACLPolicyID: "azure-acl-ns1-testpolicy",
 		PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 			{
 				Metadata: ipsets.NewIPSetMetadata("setns1", ipsets.Namespace),
@@ -64,7 +65,6 @@ var (
 		},
 		ACLs: []*policies.ACLPolicy{
 			{
-				PolicyID:  "testpol1",
 				Target:    policies.Dropped,
 				Direction: policies.Egress,
 			},

--- a/npm/pkg/dataplane/ipsets/ipset.go
+++ b/npm/pkg/dataplane/ipsets/ipset.go
@@ -134,7 +134,7 @@ type SetType int8
 const (
 	// Unknown SetType
 	UnknownType SetType = 0
-	// NameSpace IPSet is created to hold
+	// Namespace IPSet is created to hold
 	// ips of pods in a given NameSapce
 	Namespace SetType = 1
 	// KeyLabelOfNamespace IPSet is a list kind ipset
@@ -160,7 +160,7 @@ const (
 var (
 	setTypeName = map[SetType]string{
 		UnknownType:              Unknown,
-		Namespace:                "NameSpace",
+		Namespace:                "Namespace",
 		KeyLabelOfNamespace:      "KeyLabelOfNameSpace",
 		KeyValueLabelOfNamespace: "KeyValueLabelOfNameSpace",
 		KeyLabelOfPod:            "KeyLabelOfPod",
@@ -202,7 +202,7 @@ type IPSet struct {
 	// Using a map to emulate set and value as struct{} for
 	// minimal memory consumption
 	// SelectorReference holds networkpolicy names where this IPSet
-	// is being used in PodSelector and NameSpace
+	// is being used in PodSelector and Namespace
 	SelectorReference map[string]struct{}
 	// NetPolReference holds networkpolicy names where this IPSet
 	// is being referred as part of rules

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_windows.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_windows.go
@@ -51,6 +51,7 @@ func (iMgr *IPSetManager) GetIPsFromSelectorIPSets(setList map[string]struct{}) 
 			}
 			firstLoop = false
 		}
+		klog.Infof("set [%s] has ippodkey: %+v", set.Name, set.IPPodKey) // FIXME remove after debugging
 		setintersections, err = set.getSetIntersection(setintersections)
 		if err != nil {
 			return nil, err

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_windows.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_windows.go
@@ -56,6 +56,7 @@ func (iMgr *IPSetManager) GetIPsFromSelectorIPSets(setList map[string]struct{}) 
 			return nil, err
 		}
 	}
+	klog.Infof("setintersection for getIPsFromSelectorIPSets %+v", setintersections) // FIXME remove after debugging
 	return setintersections, err
 }
 

--- a/npm/pkg/dataplane/policies/policy.go
+++ b/npm/pkg/dataplane/policies/policy.go
@@ -145,7 +145,8 @@ func ValidatePolicy(networkPolicy *NPMNetworkPolicy) error {
 		}
 
 		if !aclPolicy.DstPorts.isValidRange() {
-			return npmerrors.SimpleError(fmt.Sprintf("ACL policy for NetPol %s has invalid port range in DstPorts (start: %d, end: %d)", networkPolicy.PolicyKey, aclPolicy.DstPorts.Port, aclPolicy.DstPorts.EndPort))
+			return npmerrors.SimpleError(fmt.Sprintf("ACL policy for NetPol %s has invalid port range in DstPorts (start: %d, end: %d)",
+				networkPolicy.PolicyKey, aclPolicy.DstPorts.Port, aclPolicy.DstPorts.EndPort))
 		}
 
 		for _, setInfo := range aclPolicy.SrcList {

--- a/npm/pkg/dataplane/policies/policy.go
+++ b/npm/pkg/dataplane/policies/policy.go
@@ -11,9 +11,8 @@ import (
 )
 
 type NPMNetworkPolicy struct {
-	Name      string
-	NameSpace string
-	// TODO remove Name and Namespace field
+	// Namespace is only used by Linux to construct an iptables comment
+	Namespace string
 	// PolicyKey is a unique combination of "namespace/name" of network policy
 	PolicyKey string
 	// PodSelectorIPSets holds all the IPSets generated from Pod Selector
@@ -32,8 +31,7 @@ type NPMNetworkPolicy struct {
 
 func NewNPMNetworkPolicy(netPolName, netPolNamespace string) *NPMNetworkPolicy {
 	return &NPMNetworkPolicy{
-		Name:      netPolName,
-		NameSpace: netPolNamespace,
+		Namespace: netPolNamespace,
 		PolicyKey: fmt.Sprintf("%s/%s", netPolNamespace, netPolName),
 	}
 }
@@ -76,12 +74,12 @@ func (netPol *NPMNetworkPolicy) PrettyString() string {
 
 	podSelectorIPSetString := translatedIPSetsToString(netPol.PodSelectorIPSets)
 	podSelectorListString := infoArrayToString(netPol.PodSelectorList)
-	format := `Name:%s  Namespace:%s
+	format := `Namespace/Name: %s
 PodSelectorIPSets: %s
 PodSelectorList: %s
 ACLs:
 %s`
-	return fmt.Sprintf(format, netPol.Name, netPol.NameSpace, podSelectorIPSetString, podSelectorListString, aclArrayString)
+	return fmt.Sprintf(format, netPol.PolicyKey, podSelectorIPSetString, podSelectorListString, aclArrayString)
 }
 
 // ACLPolicy equivalent to a single iptable rule in linux

--- a/npm/pkg/dataplane/policies/policy.go
+++ b/npm/pkg/dataplane/policies/policy.go
@@ -15,6 +15,8 @@ type NPMNetworkPolicy struct {
 	Namespace string
 	// PolicyKey is a unique combination of "namespace/name" of network policy
 	PolicyKey string
+	// ACLPolicyID is only used in Windows. See aclPolicyID() in policy_windows.go for more info
+	ACLPolicyID string
 	// PodSelectorIPSets holds all the IPSets generated from Pod Selector
 	PodSelectorIPSets []*ipsets.TranslatedIPSet
 	// TODO change to slice of pointers
@@ -31,8 +33,9 @@ type NPMNetworkPolicy struct {
 
 func NewNPMNetworkPolicy(netPolName, netPolNamespace string) *NPMNetworkPolicy {
 	return &NPMNetworkPolicy{
-		Namespace: netPolNamespace,
-		PolicyKey: fmt.Sprintf("%s/%s", netPolNamespace, netPolName),
+		Namespace:   netPolNamespace,
+		PolicyKey:   fmt.Sprintf("%s/%s", netPolNamespace, netPolName),
+		ACLPolicyID: aclPolicyID(netPolName, netPolNamespace),
 	}
 }
 
@@ -85,10 +88,6 @@ ACLs:
 // ACLPolicy equivalent to a single iptable rule in linux
 // or a single HNS rule in windows
 type ACLPolicy struct {
-	// PolicyID is the rules name with a given network policy
-	// PolicyID will be same for all ACLs in a Network Policy
-	// it will be "azure-acl-NetPolNS-netPolName"
-	PolicyID string
 	// Comment is the string attached to rule to identity its representation
 	Comment string
 	// TODO(jungukcho): now I think we do not need to manage SrcList and DstList
@@ -112,16 +111,6 @@ type ACLPolicy struct {
 	Protocol Protocol
 }
 
-const policyIDPrefix = "azure-acl"
-
-// FIXME this impacts windows DP if it isn't equivalent to netPol.PolicyKey
-// aclPolicyID returns azure-acl-<network policy namespace>-<network policy name> format
-// to differentiate ACLs among different network policies,
-// but aclPolicy in the same network policy has the same aclPolicyID.
-func aclPolicyID(policyNS, policyName string) string {
-	return fmt.Sprintf("%s-%s-%s", policyIDPrefix, policyNS, policyName)
-}
-
 // NormalizePolicy helps fill in missed fields in aclPolicy
 func NormalizePolicy(networkPolicy *NPMNetworkPolicy) {
 	for _, aclPolicy := range networkPolicy.ACLs {
@@ -139,44 +128,42 @@ func NormalizePolicy(networkPolicy *NPMNetworkPolicy) {
 func ValidatePolicy(networkPolicy *NPMNetworkPolicy) error {
 	for _, aclPolicy := range networkPolicy.ACLs {
 		if !aclPolicy.hasKnownTarget() {
-			return npmerrors.SimpleError(fmt.Sprintf("ACL policy %s has unknown target [%s]", aclPolicy.PolicyID, aclPolicy.Target))
+			return npmerrors.SimpleError(fmt.Sprintf("ACL policy for NetPol %s has unknown target [%s]", networkPolicy.PolicyKey, aclPolicy.Target))
 		}
 		if !aclPolicy.hasKnownDirection() {
-			return npmerrors.SimpleError(fmt.Sprintf("ACL policy %s has unknown direction [%s]", aclPolicy.PolicyID, aclPolicy.Direction))
+			return npmerrors.SimpleError(fmt.Sprintf("ACL policy for NetPol %s has unknown direction [%s]", networkPolicy.PolicyKey, aclPolicy.Direction))
 		}
 		if !aclPolicy.hasKnownProtocol() {
-			return npmerrors.SimpleError(fmt.Sprintf("ACL policy %s has unknown protocol [%s]", aclPolicy.PolicyID, aclPolicy.Protocol))
+			return npmerrors.SimpleError(fmt.Sprintf("ACL policy for NetPol %s has unknown protocol [%s]", networkPolicy.PolicyKey, aclPolicy.Protocol))
 		}
 		if !aclPolicy.satisifiesPortAndProtocolConstraints() {
 			return npmerrors.SimpleError(fmt.Sprintf(
-				"ACL policy %s has dst port(s) (Port or Port and EndPort), so must have protocol tcp, udp, udplite, sctp, or dccp but has protocol %s",
-				aclPolicy.PolicyID,
+				"ACL policy for NetPol %s has dst port(s) (Port or Port and EndPort), so must have protocol tcp, udp, udplite, sctp, or dccp but has protocol %s",
+				networkPolicy.PolicyKey,
 				string(aclPolicy.Protocol),
 			))
 		}
 
 		if !aclPolicy.DstPorts.isValidRange() {
-			return npmerrors.SimpleError(fmt.Sprintf("ACL policy %s has invalid port range in DstPorts (start: %d, end: %d)", aclPolicy.PolicyID, aclPolicy.DstPorts.Port, aclPolicy.DstPorts.EndPort))
+			return npmerrors.SimpleError(fmt.Sprintf("ACL policy for NetPol %s has invalid port range in DstPorts (start: %d, end: %d)", networkPolicy.PolicyKey, aclPolicy.DstPorts.Port, aclPolicy.DstPorts.EndPort))
 		}
 
 		for _, setInfo := range aclPolicy.SrcList {
 			if !setInfo.hasKnownMatchType() {
-				return npmerrors.SimpleError(fmt.Sprintf("ACL policy %s has set %s in SrcList with unknown Match Type", aclPolicy.PolicyID, setInfo.IPSet.Name))
+				return npmerrors.SimpleError(fmt.Sprintf("ACL policy for NetPol %s has set %s in SrcList with unknown Match Type", networkPolicy.PolicyKey, setInfo.IPSet.Name))
 			}
 		}
 		for _, setInfo := range aclPolicy.DstList {
 			if !setInfo.hasKnownMatchType() {
-				return npmerrors.SimpleError(fmt.Sprintf("ACL policy %s has set %s in DstList with unknown Match Type", aclPolicy.PolicyID, setInfo.IPSet.Name))
+				return npmerrors.SimpleError(fmt.Sprintf("ACL policy for NetPol %s has set %s in DstList with unknown Match Type", networkPolicy.PolicyKey, setInfo.IPSet.Name))
 			}
 		}
 	}
 	return nil
 }
 
-// TODO make this a method of NPMNetworkPolicy, and just use netPol.PolicyKey as the PolicyID
-func NewACLPolicy(policyNS, policyName string, target Verdict, direction Direction) *ACLPolicy {
+func NewACLPolicy(target Verdict, direction Direction) *ACLPolicy {
 	acl := &ACLPolicy{
-		PolicyID:  aclPolicyID(policyNS, policyName),
 		Target:    target,
 		Direction: direction,
 	}

--- a/npm/pkg/dataplane/policies/policy_linux.go
+++ b/npm/pkg/dataplane/policies/policy_linux.go
@@ -67,7 +67,7 @@ func (networkPolicy *NPMNetworkPolicy) commentForJump(direction UniqueDirection)
 	if len(networkPolicy.PodSelectorList) > 0 {
 		podSelectorComment = commentForInfos(networkPolicy.PodSelectorList)
 	}
-	return fmt.Sprintf("%s-POLICY-%s-%s-%s-IN-ns-%s", prefix, networkPolicy.PolicyKey, toFrom, podSelectorComment, networkPolicy.NameSpace)
+	return fmt.Sprintf("%s-POLICY-%s-%s-%s-IN-ns-%s", prefix, networkPolicy.PolicyKey, toFrom, podSelectorComment, networkPolicy.Namespace)
 }
 
 func commentForInfos(infos []SetInfo) string {

--- a/npm/pkg/dataplane/policies/policy_linux.go
+++ b/npm/pkg/dataplane/policies/policy_linux.go
@@ -20,6 +20,11 @@ const (
 	maxLengthForMatchSetSpecs = 6
 )
 
+// the NPMNetworkPolicy ACLPolicyID field is unnused in Linux
+func aclPolicyID(_, _ string) string {
+	return ""
+}
+
 // returns two booleans indicating whether the network policy has ingress and egress respectively
 func (networkPolicy *NPMNetworkPolicy) hasIngressAndEgress() (hasIngress, hasEgress bool) {
 	hasIngress = false

--- a/npm/pkg/dataplane/policies/policymanager_linux_test.go
+++ b/npm/pkg/dataplane/policies/policymanager_linux_test.go
@@ -107,8 +107,7 @@ var (
 // NetworkPolicies
 var (
 	bothDirectionsNetPol = &NPMNetworkPolicy{
-		Name:      "test1",
-		NameSpace: "x",
+		Namespace: "x",
 		PolicyKey: "x/test1",
 		PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 			{Metadata: ipsets.TestKeyPodSet.Metadata},
@@ -128,8 +127,7 @@ var (
 		},
 	}
 	ingressNetPol = &NPMNetworkPolicy{
-		Name:      "test2",
-		NameSpace: "y",
+		Namespace: "y",
 		PolicyKey: "y/test2",
 		PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 			{Metadata: ipsets.TestKeyPodSet.Metadata},
@@ -152,8 +150,7 @@ var (
 		},
 	}
 	egressNetPol = &NPMNetworkPolicy{
-		Name:      "test3",
-		NameSpace: "z",
+		Namespace: "z",
 		PolicyKey: "z/test3",
 		ACLs: []*ACLPolicy{
 			egressAllowedACL,

--- a/npm/pkg/dataplane/policies/policymanager_linux_test.go
+++ b/npm/pkg/dataplane/policies/policymanager_linux_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 // ACLs
-// Don't care about PolicyID for Linux
 var (
 	ingressDeniedACL = &ACLPolicy{
 		SrcList: []SetInfo{
@@ -50,7 +49,6 @@ var (
 		Protocol:  UnspecifiedProtocol,
 	}
 	egressDeniedACL = &ACLPolicy{
-		PolicyID: "acl3",
 		DstList: []SetInfo{
 			{
 				ipsets.TestCIDRSet.Metadata,
@@ -64,7 +62,6 @@ var (
 		Protocol:  UDP,
 	}
 	egressAllowedACL = &ACLPolicy{
-		PolicyID: "acl4",
 		DstList: []SetInfo{
 			{
 				ipsets.TestNamedportSet.Metadata,
@@ -107,8 +104,9 @@ var (
 // NetworkPolicies
 var (
 	bothDirectionsNetPol = &NPMNetworkPolicy{
-		Namespace: "x",
-		PolicyKey: "x/test1",
+		Namespace:   "x",
+		PolicyKey:   "x/test1",
+		ACLPolicyID: "azure-acl-x-test1",
 		PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 			{Metadata: ipsets.TestKeyPodSet.Metadata},
 		},
@@ -127,8 +125,9 @@ var (
 		},
 	}
 	ingressNetPol = &NPMNetworkPolicy{
-		Namespace: "y",
-		PolicyKey: "y/test2",
+		Namespace:   "y",
+		PolicyKey:   "y/test2",
+		ACLPolicyID: "azure-acl-y-test2",
 		PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 			{Metadata: ipsets.TestKeyPodSet.Metadata},
 			{Metadata: ipsets.TestNSSet.Metadata},
@@ -150,8 +149,9 @@ var (
 		},
 	}
 	egressNetPol = &NPMNetworkPolicy{
-		Namespace: "z",
-		PolicyKey: "z/test3",
+		Namespace:   "z",
+		PolicyKey:   "z/test3",
+		ACLPolicyID: "azure-acl-z-test3",
 		ACLs: []*ACLPolicy{
 			egressAllowedACL,
 		},

--- a/npm/pkg/dataplane/policies/policymanager_test.go
+++ b/npm/pkg/dataplane/policies/policymanager_test.go
@@ -24,8 +24,7 @@ var (
 	testNSSet     = ipsets.NewIPSetMetadata("test-ns-set", ipsets.Namespace)
 	testKeyPodSet = ipsets.NewIPSetMetadata("test-keyPod-set", ipsets.KeyLabelOfPod)
 	testNetPol    = &NPMNetworkPolicy{
-		Name:      "test-netpol",
-		NameSpace: "x",
+		Namespace: "x",
 		PolicyKey: "x/test-netpol",
 		PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 			{
@@ -138,8 +137,7 @@ func TestAddEmptyPolicy(t *testing.T) {
 
 func TestGetPolicy(t *testing.T) {
 	netpol := &NPMNetworkPolicy{
-		Name:      "test-netpol",
-		NameSpace: "x",
+		Namespace: "x",
 		PolicyKey: "x/test-netpol",
 		ACLs: []*ACLPolicy{
 			{
@@ -217,8 +215,7 @@ func TestNormalizeAndValidatePolicy(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			netPol := &NPMNetworkPolicy{
-				Name:      "test-netpol",
-				NameSpace: "x",
+				Namespace: "x",
 				PolicyKey: "x/test-netpol",
 				ACLs:      []*ACLPolicy{tt.acl},
 			}

--- a/npm/pkg/dataplane/policies/policymanager_windows.go
+++ b/npm/pkg/dataplane/policies/policymanager_windows.go
@@ -48,7 +48,7 @@ func (pMgr *PolicyManager) reconcile() {
 
 func (pMgr *PolicyManager) addPolicy(policy *NPMNetworkPolicy, endpointList map[string]string) error {
 	klog.Infof("[DataPlane Windows] adding policy %s on %+v", policy.PolicyKey, endpointList)
-	if endpointList == nil {
+	if len(endpointList) == 0 {
 		klog.Infof("[DataPlane Windows] No Endpoints to apply policy %s on", policy.PolicyKey)
 		return nil
 	}

--- a/npm/pkg/dataplane/policies/policymanager_windows.go
+++ b/npm/pkg/dataplane/policies/policymanager_windows.go
@@ -77,7 +77,7 @@ func (pMgr *PolicyManager) addPolicy(policy *NPMNetworkPolicy, endpointList map[
 		delete(endpointList, epIP)
 	}
 
-	rulesToAdd, err := getSettingsFromACL(policy.ACLs)
+	rulesToAdd, err := getSettingsFromACL(policy)
 	if err != nil {
 		return err
 	}
@@ -113,7 +113,7 @@ func (pMgr *PolicyManager) removePolicy(policy *NPMNetworkPolicy, endpointList m
 		endpointList = policy.PodEndpoints
 	}
 
-	rulesToRemove, err := getSettingsFromACL(policy.ACLs)
+	rulesToRemove, err := getSettingsFromACL(policy)
 	if err != nil {
 		return err
 	}
@@ -236,10 +236,10 @@ func getEPPolicyReqFromACLSettings(settings []*NPMACLPolSettings) (hcn.PolicyEnd
 	return policyToAdd, nil
 }
 
-func getSettingsFromACL(acls []*ACLPolicy) ([]*NPMACLPolSettings, error) {
-	hnsRules := make([]*NPMACLPolSettings, len(acls))
-	for i, acl := range acls {
-		rule, err := acl.convertToAclSettings()
+func getSettingsFromACL(policy *NPMNetworkPolicy) ([]*NPMACLPolSettings, error) {
+	hnsRules := make([]*NPMACLPolSettings, len(policy.ACLs))
+	for i, acl := range policy.ACLs {
+		rule, err := acl.convertToAclSettings(policy.ACLPolicyID)
 		if err != nil {
 			// TODO need some retry mechanism to check why the translations failed
 			return hnsRules, err

--- a/npm/pkg/dataplane/policies/policymanager_windows.go
+++ b/npm/pkg/dataplane/policies/policymanager_windows.go
@@ -47,9 +47,9 @@ func (pMgr *PolicyManager) reconcile() {
 }
 
 func (pMgr *PolicyManager) addPolicy(policy *NPMNetworkPolicy, endpointList map[string]string) error {
-	klog.Infof("[DataPlane Windows] adding policy %s on %+v", policy.policyKey, endpointList)
+	klog.Infof("[DataPlane Windows] adding policy %s on %+v", policy.PolicyKey, endpointList)
 	if endpointList == nil {
-		klog.Infof("[DataPlane Windows] No Endpoints to apply policy %s on", policy.policyKey)
+		klog.Infof("[DataPlane Windows] No Endpoints to apply policy %s on", policy.PolicyKey)
 		return nil
 	}
 
@@ -67,12 +67,12 @@ func (pMgr *PolicyManager) addPolicy(policy *NPMNetworkPolicy, endpointList map[
 			// If the expected ID is not same as epID, there is a chance that old pod got deleted
 			// and same IP is used by new pod with new endpoint.
 			// so we should delete the non-existent endpoint from policy reference
-			klog.Infof("[DataPlane Windows] PolicyName : %s Endpoint IP: %s's ID %s does not match expected %s", policy.policyKey, epIP, epID, expectedEpID)
+			klog.Infof("[DataPlane Windows] PolicyName : %s Endpoint IP: %s's ID %s does not match expected %s", policy.PolicyKey, epIP, epID, expectedEpID)
 			delete(policy.PodEndpoints, epIP)
 			continue
 		}
 
-		klog.Infof("[DataPlane Windows]  PolicyName : %s Endpoint IP: %s's ID %s is already in cache", policy.policyKey, epIP, epID)
+		klog.Infof("[DataPlane Windows]  PolicyName : %s Endpoint IP: %s's ID %s is already in cache", policy.PolicyKey, epIP, epID)
 		// Deleting the endpoint from EPList so that the policy is not added to this endpoint again
 		delete(endpointList, epIP)
 	}
@@ -107,7 +107,7 @@ func (pMgr *PolicyManager) removePolicy(policy *NPMNetworkPolicy, endpointList m
 
 	if endpointList == nil {
 		if policy.PodEndpoints == nil {
-			klog.Infof("[DataPlane Windows] No Endpoints to remove policy %s on", policy.policyKey)
+			klog.Infof("[DataPlane Windows] No Endpoints to remove policy %s on", policy.PolicyKey)
 			return nil
 		}
 		endpointList = policy.PodEndpoints
@@ -117,7 +117,7 @@ func (pMgr *PolicyManager) removePolicy(policy *NPMNetworkPolicy, endpointList m
 	if err != nil {
 		return err
 	}
-	klog.Infof("[DataPlane Windows] To Remove Policy: %s \n To Delete ACLs: %+v \n To Remove From %+v endpoints", policy.policyKey, rulesToRemove, endpointList)
+	klog.Infof("[DataPlane Windows] To Remove Policy: %s \n To Delete ACLs: %+v \n To Remove From %+v endpoints", policy.PolicyKey, rulesToRemove, endpointList)
 	// If remove bug is solved we can directly remove the exact policy from the endpoint
 	// but if the bug is not solved then get all existing policies and remove relevant policies from list
 	// then apply remaining policies onto the endpoint

--- a/npm/pkg/dataplane/policies/policymanager_windows.go
+++ b/npm/pkg/dataplane/policies/policymanager_windows.go
@@ -47,9 +47,9 @@ func (pMgr *PolicyManager) reconcile() {
 }
 
 func (pMgr *PolicyManager) addPolicy(policy *NPMNetworkPolicy, endpointList map[string]string) error {
-	klog.Infof("[DataPlane Windows] adding policy %s on %+v", policy.Name, endpointList)
+	klog.Infof("[DataPlane Windows] adding policy %s on %+v", policy.policyKey, endpointList)
 	if endpointList == nil {
-		klog.Infof("[DataPlane Windows] No Endpoints to apply policy %s on", policy.Name)
+		klog.Infof("[DataPlane Windows] No Endpoints to apply policy %s on", policy.policyKey)
 		return nil
 	}
 
@@ -67,12 +67,12 @@ func (pMgr *PolicyManager) addPolicy(policy *NPMNetworkPolicy, endpointList map[
 			// If the expected ID is not same as epID, there is a chance that old pod got deleted
 			// and same IP is used by new pod with new endpoint.
 			// so we should delete the non-existent endpoint from policy reference
-			klog.Infof("[DataPlane Windows] PolicyName : %s Endpoint IP: %s's ID %s does not match expected %s", policy.Name, epIP, epID, expectedEpID)
+			klog.Infof("[DataPlane Windows] PolicyName : %s Endpoint IP: %s's ID %s does not match expected %s", policy.policyKey, epIP, epID, expectedEpID)
 			delete(policy.PodEndpoints, epIP)
 			continue
 		}
 
-		klog.Infof("[DataPlane Windows]  PolicyName : %s Endpoint IP: %s's ID %s is already in cache", policy.Name, epIP, epID)
+		klog.Infof("[DataPlane Windows]  PolicyName : %s Endpoint IP: %s's ID %s is already in cache", policy.policyKey, epIP, epID)
 		// Deleting the endpoint from EPList so that the policy is not added to this endpoint again
 		delete(endpointList, epIP)
 	}
@@ -107,7 +107,7 @@ func (pMgr *PolicyManager) removePolicy(policy *NPMNetworkPolicy, endpointList m
 
 	if endpointList == nil {
 		if policy.PodEndpoints == nil {
-			klog.Infof("[DataPlane Windows] No Endpoints to remove policy %s on", policy.Name)
+			klog.Infof("[DataPlane Windows] No Endpoints to remove policy %s on", policy.policyKey)
 			return nil
 		}
 		endpointList = policy.PodEndpoints
@@ -117,7 +117,7 @@ func (pMgr *PolicyManager) removePolicy(policy *NPMNetworkPolicy, endpointList m
 	if err != nil {
 		return err
 	}
-	klog.Infof("[DataPlane Windows] To Remove Policy: %s \n To Delete ACLs: %+v \n To Remove From %+v endpoints", policy.Name, rulesToRemove, endpointList)
+	klog.Infof("[DataPlane Windows] To Remove Policy: %s \n To Delete ACLs: %+v \n To Remove From %+v endpoints", policy.policyKey, rulesToRemove, endpointList)
 	// If remove bug is solved we can directly remove the exact policy from the endpoint
 	// but if the bug is not solved then get all existing policies and remove relevant policies from list
 	// then apply remaining policies onto the endpoint

--- a/npm/pkg/dataplane/policies/policymanager_windows_test.go
+++ b/npm/pkg/dataplane/policies/policymanager_windows_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 var (
+	// TODO fix these expected ACLs (e.g. local/remote addresses and ports are off)
 	expectedACLs = []*hnswrapper.FakeEndpointPolicy{
 		{
 			ID:              TestNetworkPolicies[0].ACLPolicyID,
@@ -123,7 +124,7 @@ func TestRemovePolicies(t *testing.T) {
 		verifyFakeHNSCacheACLs(t, expectedACLs, acls)
 	}
 
-	err = pMgr.RemovePolicy(TestNetworkPolicies[0].Name, nil)
+	err = pMgr.RemovePolicy(TestNetworkPolicies[0].PolicyKey, nil)
 	require.NoError(t, err)
 	verifyACLCacheIsCleaned(t, hns, len(endPointIDList))
 }

--- a/npm/pkg/dataplane/policies/policymanager_windows_test.go
+++ b/npm/pkg/dataplane/policies/policymanager_windows_test.go
@@ -16,7 +16,7 @@ import (
 var (
 	expectedACLs = []*hnswrapper.FakeEndpointPolicy{
 		{
-			ID:              TestNetworkPolicies[0].ACLs[0].PolicyID,
+			ID:              TestNetworkPolicies[0].ACLPolicyID,
 			Protocols:       "6",
 			Direction:       "In",
 			Action:          "Block",
@@ -27,7 +27,7 @@ var (
 			Priority:        blockRulePriotity,
 		},
 		{
-			ID:              TestNetworkPolicies[0].ACLs[0].PolicyID,
+			ID:              TestNetworkPolicies[0].ACLPolicyID,
 			Protocols:       "17",
 			Direction:       "In",
 			Action:          "Allow",
@@ -38,7 +38,7 @@ var (
 			Priority:        allowRulePriotity,
 		},
 		{
-			ID:              TestNetworkPolicies[0].ACLs[0].PolicyID,
+			ID:              TestNetworkPolicies[0].ACLPolicyID,
 			Protocols:       "17",
 			Direction:       "Out",
 			Action:          "Block",
@@ -49,7 +49,7 @@ var (
 			Priority:        blockRulePriotity,
 		},
 		{
-			ID:              TestNetworkPolicies[0].ACLs[0].PolicyID,
+			ID:              TestNetworkPolicies[0].ACLPolicyID,
 			Protocols:       "256",
 			Direction:       "Out",
 			Action:          "Allow",
@@ -93,7 +93,7 @@ func TestAddPolicies(t *testing.T) {
 	err := pMgr.AddPolicy(TestNetworkPolicies[0], endPointIDList)
 	require.NoError(t, err)
 
-	aclID := TestNetworkPolicies[0].ACLs[0].PolicyID
+	aclID := TestNetworkPolicies[0].ACLPolicyID
 
 	aclPolicies, err := hns.Cache.ACLPolicies(endPointIDList, aclID)
 	require.NoError(t, err)
@@ -111,7 +111,7 @@ func TestRemovePolicies(t *testing.T) {
 	err := pMgr.AddPolicy(TestNetworkPolicies[0], endPointIDList)
 	require.NoError(t, err)
 
-	aclID := TestNetworkPolicies[0].ACLs[0].PolicyID
+	aclID := TestNetworkPolicies[0].ACLPolicyID
 
 	aclPolicies, err := hns.Cache.ACLPolicies(endPointIDList, aclID)
 	require.NoError(t, err)

--- a/npm/pkg/dataplane/policies/testutils.go
+++ b/npm/pkg/dataplane/policies/testutils.go
@@ -7,8 +7,9 @@ var (
 	// TestNetworkPolicies for testing
 	TestNetworkPolicies = []*NPMNetworkPolicy{
 		{
-			Namespace: "x",
-			PolicyKey: "x/test1",
+			Namespace:   "x",
+			PolicyKey:   "x/test1",
+			ACLPolicyID: "azure-acl-x-test1",
 			PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 				{Metadata: ipsets.TestKeyPodSet.Metadata},
 			},
@@ -27,8 +28,9 @@ var (
 			ACLs: testACLs,
 		},
 		{
-			Namespace: "y",
-			PolicyKey: "y/test2",
+			Namespace:   "y",
+			PolicyKey:   "y/test2",
+			ACLPolicyID: "azure-acl-y-test2",
 			PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 				{Metadata: ipsets.TestKeyPodSet.Metadata},
 				{Metadata: ipsets.TestKVPodSet.Metadata},
@@ -53,8 +55,9 @@ var (
 			},
 		},
 		{
-			Namespace: "z",
-			PolicyKey: "z/test3",
+			Namespace:   "z",
+			PolicyKey:   "z/test3",
+			ACLPolicyID: "azure-acl-z-test3",
 			RuleIPSets: []*ipsets.TranslatedIPSet{
 				{Metadata: ipsets.TestCIDRSet.Metadata, Members: nil},
 			},

--- a/npm/pkg/dataplane/policies/testutils.go
+++ b/npm/pkg/dataplane/policies/testutils.go
@@ -66,8 +66,7 @@ var (
 
 	testACLs = []*ACLPolicy{
 		{
-			PolicyID: "test1",
-			Comment:  "comment1",
+			Comment: "comment1",
 			SrcList: []SetInfo{
 				{
 					ipsets.TestCIDRSet.Metadata,
@@ -90,8 +89,7 @@ var (
 			Protocol: TCP,
 		},
 		{
-			PolicyID: "test1",
-			Comment:  "comment2",
+			Comment: "comment2",
 			SrcList: []SetInfo{
 				{
 					ipsets.TestCIDRSet.Metadata,
@@ -104,8 +102,7 @@ var (
 			Protocol:  UDP,
 		},
 		{
-			PolicyID: "test1",
-			Comment:  "comment3",
+			Comment: "comment3",
 			SrcList: []SetInfo{
 				{
 					ipsets.TestCIDRSet.Metadata,
@@ -121,8 +118,7 @@ var (
 			Protocol: UDP,
 		},
 		{
-			PolicyID: "test1",
-			Comment:  "comment4",
+			Comment: "comment4",
 			SrcList: []SetInfo{
 				{
 					ipsets.TestCIDRSet.Metadata,

--- a/npm/pkg/dataplane/policies/testutils.go
+++ b/npm/pkg/dataplane/policies/testutils.go
@@ -7,8 +7,7 @@ var (
 	// TestNetworkPolicies for testing
 	TestNetworkPolicies = []*NPMNetworkPolicy{
 		{
-			Name:      "test1",
-			NameSpace: "x",
+			Namespace: "x",
 			PolicyKey: "x/test1",
 			PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 				{Metadata: ipsets.TestKeyPodSet.Metadata},
@@ -28,8 +27,7 @@ var (
 			ACLs: testACLs,
 		},
 		{
-			Name:      "test2",
-			NameSpace: "y",
+			Namespace: "y",
 			PolicyKey: "y/test2",
 			PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 				{Metadata: ipsets.TestKeyPodSet.Metadata},
@@ -55,8 +53,7 @@ var (
 			},
 		},
 		{
-			Name:      "test3",
-			NameSpace: "z",
+			Namespace: "z",
 			PolicyKey: "z/test3",
 			RuleIPSets: []*ipsets.TranslatedIPSet{
 				{Metadata: ipsets.TestCIDRSet.Metadata, Members: nil},

--- a/test/integration/npm/main.go
+++ b/test/integration/npm/main.go
@@ -33,7 +33,9 @@ var (
 
 	nodeName   = "testNode"
 	testNetPol = &policies.NPMNetworkPolicy{
-		PolicyKey: "test/test-netpol",
+		PolicyKey:   "test/test-netpol",
+		Namespace:   "test",
+		ACLPolicyID: "azure-acl-test-netpol",
 		PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 			{
 				Metadata: ipsets.TestNSSet.Metadata,
@@ -52,12 +54,10 @@ var (
 		},
 		ACLs: []*policies.ACLPolicy{
 			{
-				PolicyID:  "azure-acl-123",
 				Target:    policies.Dropped,
 				Direction: policies.Ingress,
 			},
 			{
-				PolicyID:  "azure-acl-123",
 				Target:    policies.Allowed,
 				Direction: policies.Ingress,
 				SrcList: []policies.SetInfo{


### PR DESCRIPTION
- 1st commit: remove Name field from NPMNetworkPolicy because we should be using PolicyKey field instead
  - Windows Dataplane was using the wrong field in some scenarios
- 2nd commit: move PolicyID field in ACLPolicy to NPMNetworkPolicy since it's the same for all ACLs in a netpol