### PR TITLE
fix: [NPM] fix windows intersection of IPs

### DIFF
--- a/npm/pkg/controlplane/translation/translatePolicy.go
+++ b/npm/pkg/controlplane/translation/translatePolicy.go
@@ -27,6 +27,12 @@ var (
 	ErrUnsupportedNegativeMatch = errors.New("unsupported NotExist operator translation features used on windows")
 )
 
+type podSelectorResult struct {
+	psSets      []*ipsets.TranslatedIPSet
+	childPSSets []*ipsets.TranslatedIPSet
+	psList      []policies.SetInfo
+}
+
 type netpolPortType string
 
 const (
@@ -217,43 +223,44 @@ func ipBlockRule(policyName, ns string, direction policies.Direction, matchType 
 // PodSelector translates podSelector of NetworkPolicyPeer field in networkpolicy object to translatedIPSets, children of translated IPSets, and SetInfo.
 // Children are members of a list-type IPSet.
 // This function is called only when the NetworkPolicyPeer has namespaceSelector field.
-func podSelector(policyKey string, matchType policies.MatchType, selector *metav1.LabelSelector) (psSets, childPSSets []*ipsets.TranslatedIPSet, psList []policies.SetInfo, err error) {
+func podSelector(policyKey string, matchType policies.MatchType, selector *metav1.LabelSelector) (*podSelectorResult, error) {
 	podSelectors, err := parsePodSelector(policyKey, selector)
 	if err != nil {
-		return
+		return nil, err
 	}
-	lenOfPodSelectors := len(podSelectors)
-	psSets = make([]*ipsets.TranslatedIPSet, 0)
-	childPSSets = make([]*ipsets.TranslatedIPSet, 0)
-	psList = make([]policies.SetInfo, lenOfPodSelectors)
 
+	lenOfPodSelectors := len(podSelectors)
+	psResult := &podSelectorResult{
+		psSets:      make([]*ipsets.TranslatedIPSet, 0),
+		childPSSets: make([]*ipsets.TranslatedIPSet, 0),
+		psList:      make([]policies.SetInfo, lenOfPodSelectors),
+	}
 	for i := 0; i < lenOfPodSelectors; i++ {
 		ps := podSelectors[i]
-		psSets = append(psSets, ipsets.NewTranslatedIPSet(ps.setName, ps.setType, ps.members...))
+		psResult.psSets = append(psResult.psSets, ipsets.NewTranslatedIPSet(ps.setName, ps.setType, ps.members...))
 
 		// if value is nested value, create translatedIPSet with the nested value
 		for j := 0; j < len(ps.members); j++ {
-			childPSSets = append(childPSSets, ipsets.NewTranslatedIPSet(ps.members[j], ipsets.KeyValueLabelOfPod))
+			psResult.childPSSets = append(psResult.childPSSets, ipsets.NewTranslatedIPSet(ps.members[j], ipsets.KeyValueLabelOfPod))
 		}
 
-		psList[i] = policies.NewSetInfo(ps.setName, ps.setType, ps.include, matchType)
+		psResult.psList[i] = policies.NewSetInfo(ps.setName, ps.setType, ps.include, matchType)
 	}
-
-	return
+	return psResult, nil
 }
 
 // podSelectorWithNS translates podSelector of spec and NetworkPolicyPeer in networkpolicy object to translatedIPSets, children of translated IPSets, and SetInfo.
 // Children are members of a list-type IPSet.
 // This function is called only when the NetworkPolicyPeer does not have namespaceSelector field.
-func podSelectorWithNS(policyKey, ns string, matchType policies.MatchType, selector *metav1.LabelSelector) (psSets, childPSSets []*ipsets.TranslatedIPSet, psList []policies.SetInfo, err error) {
-	psSets, childPSSets, psList, err = podSelector(policyKey, matchType, selector)
+func podSelectorWithNS(policyKey, ns string, matchType policies.MatchType, selector *metav1.LabelSelector) (*podSelectorResult, error) {
+	psResult, err := podSelector(policyKey, matchType, selector)
 	if err != nil {
-		return
+		return nil, err
 	}
 	// Add translatedIPSet and SetInfo based on namespace
-	psSets = append(psSets, ipsets.NewTranslatedIPSet(ns, ipsets.Namespace))
-	psList = append(psList, policies.NewSetInfo(ns, ipsets.Namespace, included, matchType))
-	return
+	psResult.psSets = append(psResult.psSets, ipsets.NewTranslatedIPSet(ns, ipsets.Namespace))
+	psResult.psList = append(psResult.psList, policies.NewSetInfo(ns, ipsets.Namespace, included, matchType))
+	return psResult, nil
 }
 
 // nameSpaceSelector translates namespaceSelector of NetworkPolicyPeer in networkpolicy object to translatedIPSet and SetInfo.
@@ -401,13 +408,13 @@ func translateRule(npmNetPol *policies.NPMNetworkPolicy, netPolName string, dire
 
 		// #2.3 handle podSelector and port if exist
 		if peer.PodSelector != nil && peer.NamespaceSelector == nil {
-			podSelectorIPSets, childPodSelectorIPSets, podSelectorList, err := podSelectorWithNS(npmNetPol.PolicyKey, npmNetPol.Namespace, matchType, peer.PodSelector)
+			psResult, err := podSelectorWithNS(npmNetPol.PolicyKey, npmNetPol.Namespace, matchType, peer.PodSelector)
 			if err != nil {
 				return err
 			}
-			npmNetPol.RuleIPSets = append(npmNetPol.RuleIPSets, podSelectorIPSets...)
-			npmNetPol.RuleIPSets = append(npmNetPol.RuleIPSets, childPodSelectorIPSets...)
-			err = peerAndPortRule(npmNetPol, direction, ports, podSelectorList)
+			npmNetPol.RuleIPSets = append(npmNetPol.RuleIPSets, psResult.psSets...)
+			npmNetPol.RuleIPSets = append(npmNetPol.RuleIPSets, psResult.childPSSets...)
+			err = peerAndPortRule(npmNetPol, direction, ports, psResult.psList)
 			if err != nil {
 				return err
 			}
@@ -423,12 +430,12 @@ func translateRule(npmNetPol *policies.NPMNetworkPolicy, netPolName string, dire
 		}
 
 		// #2.4 handle namespaceSelector and podSelector and port if exist
-		podSelectorIPSets, childPodSelectorIPSets, podSelectorList, err := podSelector(npmNetPol.PolicyKey, matchType, peer.PodSelector)
+		psResult, err := podSelector(npmNetPol.PolicyKey, matchType, peer.PodSelector)
 		if err != nil {
 			return err
 		}
-		npmNetPol.RuleIPSets = append(npmNetPol.RuleIPSets, podSelectorIPSets...)
-		npmNetPol.RuleIPSets = append(npmNetPol.RuleIPSets, childPodSelectorIPSets...)
+		npmNetPol.RuleIPSets = append(npmNetPol.RuleIPSets, psResult.psSets...)
+		npmNetPol.RuleIPSets = append(npmNetPol.RuleIPSets, psResult.childPSSets...)
 
 		// Before translating NamespaceSelector, flattenNameSpaceSelector function call should be called
 		// to handle multiple values in matchExpressions spec.
@@ -436,7 +443,7 @@ func translateRule(npmNetPol *policies.NPMNetworkPolicy, netPolName string, dire
 		for i := range flattenNSSelector {
 			nsSelectorIPSets, nsSelectorList := nameSpaceSelector(matchType, &flattenNSSelector[i])
 			npmNetPol.RuleIPSets = append(npmNetPol.RuleIPSets, nsSelectorIPSets...)
-			nsSelectorList = append(nsSelectorList, podSelectorList...)
+			nsSelectorList = append(nsSelectorList, psResult.psList...)
 			err := peerAndPortRule(npmNetPol, direction, ports, nsSelectorList)
 			if err != nil {
 				return err
@@ -547,16 +554,13 @@ func TranslatePolicy(npObj *networkingv1.NetworkPolicy) (*policies.NPMNetworkPol
 
 	// podSelector in spec.PodSelector is common for ingress and egress.
 	// Process this podSelector first.
-	var err error
-	npmNetPol.PodSelectorIPSets, npmNetPol.ChildPodSelectorIPSets, npmNetPol.PodSelectorList, err = podSelectorWithNS(
-		npmNetPol.PolicyKey,
-		npmNetPol.Namespace,
-		policies.EitherMatch,
-		&npObj.Spec.PodSelector,
-	)
+	psResult, err := podSelectorWithNS(npmNetPol.PolicyKey, npmNetPol.Namespace, policies.EitherMatch, &npObj.Spec.PodSelector)
 	if err != nil {
 		return nil, err
 	}
+	npmNetPol.PodSelectorIPSets = psResult.psSets
+	npmNetPol.ChildPodSelectorIPSets = psResult.childPSSets
+	npmNetPol.PodSelectorList = psResult.psList
 
 	// Each NetworkPolicy includes a policyTypes list which may include either Ingress, Egress, or both.
 	// If no policyTypes are specified on a NetworkPolicy then by default Ingress will always be set

--- a/npm/pkg/controlplane/translation/translatePolicy_test.go
+++ b/npm/pkg/controlplane/translation/translatePolicy_test.go
@@ -539,12 +539,13 @@ func TestPodSelector(t *testing.T) {
 	policyKey := "test-ns/test-policy"
 	policyKeyWithDash := policyKey + "-"
 	tests := []struct {
-		name              string
-		namespace         string
-		matchType         policies.MatchType
-		labelSelector     *metav1.LabelSelector
-		podSelectorIPSets []*ipsets.TranslatedIPSet
-		podSelectorList   []policies.SetInfo
+		name                   string
+		namespace              string
+		matchType              policies.MatchType
+		labelSelector          *metav1.LabelSelector
+		podSelectorIPSets      []*ipsets.TranslatedIPSet
+		childPodSelectorIPSets []*ipsets.TranslatedIPSet
+		podSelectorList        []policies.SetInfo
 	}{
 		{
 			name:      "all pods selector in default namespace in ingress",
@@ -556,6 +557,7 @@ func TestPodSelector(t *testing.T) {
 			podSelectorIPSets: []*ipsets.TranslatedIPSet{
 				ipsets.NewTranslatedIPSet(defaultNS, ipsets.Namespace),
 			},
+			childPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
 			podSelectorList: []policies.SetInfo{
 				policies.NewSetInfo(defaultNS, ipsets.Namespace, included, matchType),
 			},
@@ -570,6 +572,7 @@ func TestPodSelector(t *testing.T) {
 			podSelectorIPSets: []*ipsets.TranslatedIPSet{
 				ipsets.NewTranslatedIPSet("test", ipsets.Namespace),
 			},
+			childPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
 			podSelectorList: []policies.SetInfo{
 				policies.NewSetInfo("test", ipsets.Namespace, included, matchType),
 			},
@@ -585,6 +588,7 @@ func TestPodSelector(t *testing.T) {
 			podSelectorIPSets: []*ipsets.TranslatedIPSet{
 				ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod),
 			},
+			childPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
 			podSelectorList: []policies.SetInfo{
 				policies.NewSetInfo("label:src", ipsets.KeyValueLabelOfPod, included, matchType),
 			},
@@ -607,6 +611,7 @@ func TestPodSelector(t *testing.T) {
 				ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod),
 				ipsets.NewTranslatedIPSet("label", ipsets.KeyLabelOfPod),
 			},
+			childPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
 			podSelectorList: []policies.SetInfo{
 				policies.NewSetInfo("label:src", ipsets.KeyValueLabelOfPod, included, matchType),
 				policies.NewSetInfo("label", ipsets.KeyLabelOfPod, included, matchType),
@@ -633,6 +638,7 @@ func TestPodSelector(t *testing.T) {
 				ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod),
 				ipsets.NewTranslatedIPSet("labelIn:src", ipsets.KeyValueLabelOfPod),
 			},
+			childPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
 			podSelectorList: []policies.SetInfo{
 				policies.NewSetInfo("label:src", ipsets.KeyValueLabelOfPod, included, matchType),
 				policies.NewSetInfo("labelIn:src", ipsets.KeyValueLabelOfPod, included, matchType),
@@ -659,6 +665,7 @@ func TestPodSelector(t *testing.T) {
 				ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod),
 				ipsets.NewTranslatedIPSet("labelNotIn:src", ipsets.KeyValueLabelOfPod),
 			},
+			childPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
 			podSelectorList: []policies.SetInfo{
 				policies.NewSetInfo("label:src", ipsets.KeyValueLabelOfPod, included, matchType),
 				policies.NewSetInfo("labelNotIn:src", ipsets.KeyValueLabelOfPod, nonIncluded, matchType),
@@ -690,14 +697,57 @@ func TestPodSelector(t *testing.T) {
 			podSelectorIPSets: []*ipsets.TranslatedIPSet{
 				ipsets.NewTranslatedIPSet("k0:v0", ipsets.KeyValueLabelOfPod),
 				ipsets.NewTranslatedIPSet(policyKeyWithDash+"k1:v10:v11", ipsets.NestedLabelOfPod, []string{"k1:v10", "k1:v11"}...),
+				ipsets.NewTranslatedIPSet("k2", ipsets.KeyLabelOfPod),
+			},
+			childPodSelectorIPSets: []*ipsets.TranslatedIPSet{
 				ipsets.NewTranslatedIPSet("k1:v10", ipsets.KeyValueLabelOfPod),
 				ipsets.NewTranslatedIPSet("k1:v11", ipsets.KeyValueLabelOfPod),
-				ipsets.NewTranslatedIPSet("k2", ipsets.KeyLabelOfPod),
 			},
 			podSelectorList: []policies.SetInfo{
 				policies.NewSetInfo("k0:v0", ipsets.KeyValueLabelOfPod, included, matchType),
 				policies.NewSetInfo(policyKeyWithDash+"k1:v10:v11", ipsets.NestedLabelOfPod, included, matchType),
 				policies.NewSetInfo("k2", ipsets.KeyLabelOfPod, nonIncluded, matchType),
+			},
+		},
+		{
+			name:      "target pod Selector with three labels AND a namespace (one included value, one non-included value, and one included netest value) for acl in ingress",
+			namespace: defaultNS,
+			matchType: matchType,
+			labelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"k0": "v0",
+				},
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "k1",
+						Operator: metav1.LabelSelectorOpIn,
+						Values: []string{
+							"v10",
+							"v11",
+						},
+					},
+					{
+						Key:      "k2",
+						Operator: metav1.LabelSelectorOpDoesNotExist,
+						Values:   []string{},
+					},
+				},
+			},
+			podSelectorIPSets: []*ipsets.TranslatedIPSet{
+				ipsets.NewTranslatedIPSet("k0:v0", ipsets.KeyValueLabelOfPod),
+				ipsets.NewTranslatedIPSet(policyKeyWithDash+"k1:v10:v11", ipsets.NestedLabelOfPod, []string{"k1:v10", "k1:v11"}...),
+				ipsets.NewTranslatedIPSet("k2", ipsets.KeyLabelOfPod),
+				ipsets.NewTranslatedIPSet(defaultNS, ipsets.Namespace),
+			},
+			childPodSelectorIPSets: []*ipsets.TranslatedIPSet{
+				ipsets.NewTranslatedIPSet("k1:v10", ipsets.KeyValueLabelOfPod),
+				ipsets.NewTranslatedIPSet("k1:v11", ipsets.KeyValueLabelOfPod),
+			},
+			podSelectorList: []policies.SetInfo{
+				policies.NewSetInfo("k0:v0", ipsets.KeyValueLabelOfPod, included, matchType),
+				policies.NewSetInfo(policyKeyWithDash+"k1:v10:v11", ipsets.NestedLabelOfPod, included, matchType),
+				policies.NewSetInfo("k2", ipsets.KeyLabelOfPod, nonIncluded, matchType),
+				policies.NewSetInfo(defaultNS, ipsets.Namespace, included, matchType),
 			},
 		},
 	}
@@ -707,16 +757,18 @@ func TestPodSelector(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var podSelectorIPSets []*ipsets.TranslatedIPSet
+			var childPodSelectorIPSets []*ipsets.TranslatedIPSet
 			var podSelectorList []policies.SetInfo
 			var err error
 			if tt.namespace == "" {
-				podSelectorIPSets, podSelectorList, err = podSelector(policyKey, tt.matchType, tt.labelSelector)
+				podSelectorIPSets, childPodSelectorIPSets, podSelectorList, err = podSelector(policyKey, tt.matchType, tt.labelSelector)
 			} else {
 				// technically, the policyKey prefix would contain the namespace, but it might not for these tests
-				podSelectorIPSets, podSelectorList, err = podSelectorWithNS(policyKey, tt.namespace, tt.matchType, tt.labelSelector)
+				podSelectorIPSets, childPodSelectorIPSets, podSelectorList, err = podSelectorWithNS(policyKey, tt.namespace, tt.matchType, tt.labelSelector)
 			}
 			require.NoError(t, err)
 			require.Equal(t, tt.podSelectorIPSets, podSelectorIPSets)
+			require.Equal(t, tt.childPodSelectorIPSets, childPodSelectorIPSets)
 			require.Equal(t, tt.podSelectorList, podSelectorList)
 		})
 	}
@@ -1300,14 +1352,16 @@ func TestIngressPolicy(t *testing.T) {
 	emptyString := intstr.FromString("")
 	// TODO(jungukcho): add test cases with more complex rules
 	tests := []struct {
-		name           string
-		targetSelector *metav1.LabelSelector
-		rules          []networkingv1.NetworkPolicyIngressRule
-		npmNetPol      *policies.NPMNetworkPolicy
-		wantErr        bool
+		name             string
+		isNewNwPolicyVer bool
+		targetSelector   *metav1.LabelSelector
+		rules            []networkingv1.NetworkPolicyIngressRule
+		npmNetPol        *policies.NPMNetworkPolicy
+		wantErr          bool
 	}{
 		{
-			name: "only port in ingress rules",
+			name:             "only port in ingress rules",
+			isNewNwPolicyVer: true,
 			targetSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"label": "src",
@@ -1330,6 +1384,7 @@ func TestIngressPolicy(t *testing.T) {
 					ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet(defaultNS, ipsets.Namespace),
 				},
+				ChildPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
 				PodSelectorList: []policies.SetInfo{
 					policies.NewSetInfo("label:src", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
 					policies.NewSetInfo(defaultNS, ipsets.Namespace, included, targetPodMatchType),
@@ -1349,7 +1404,8 @@ func TestIngressPolicy(t *testing.T) {
 			},
 		},
 		{
-			name: "only ipBlock in ingress rules",
+			name:             "only ipBlock in ingress rules",
+			isNewNwPolicyVer: true,
 			targetSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"label": "src",
@@ -1375,6 +1431,7 @@ func TestIngressPolicy(t *testing.T) {
 					ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet(defaultNS, ipsets.Namespace),
 				},
+				ChildPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
 				PodSelectorList: []policies.SetInfo{
 					policies.NewSetInfo("label:src", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
 					policies.NewSetInfo(defaultNS, ipsets.Namespace, included, targetPodMatchType),
@@ -1395,7 +1452,8 @@ func TestIngressPolicy(t *testing.T) {
 			},
 		},
 		{
-			name: "only peer podSelector in ingress rules",
+			name:             "only peer podSelector in ingress rules",
+			isNewNwPolicyVer: true,
 			targetSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"label": "src",
@@ -1422,6 +1480,7 @@ func TestIngressPolicy(t *testing.T) {
 					ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet(defaultNS, ipsets.Namespace),
 				},
+				ChildPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
 				PodSelectorList: []policies.SetInfo{
 					policies.NewSetInfo("label:src", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
 					policies.NewSetInfo(defaultNS, ipsets.Namespace, included, targetPodMatchType),
@@ -1444,7 +1503,8 @@ func TestIngressPolicy(t *testing.T) {
 			},
 		},
 		{
-			name: "only peer nameSpaceSelector in ingress rules",
+			name:             "only peer nameSpaceSelector in ingress rules",
+			isNewNwPolicyVer: true,
 			targetSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"label": "src",
@@ -1471,6 +1531,7 @@ func TestIngressPolicy(t *testing.T) {
 					ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet(defaultNS, ipsets.Namespace),
 				},
+				ChildPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
 				PodSelectorList: []policies.SetInfo{
 					policies.NewSetInfo("label:src", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
 					policies.NewSetInfo(defaultNS, ipsets.Namespace, included, targetPodMatchType),
@@ -1491,7 +1552,8 @@ func TestIngressPolicy(t *testing.T) {
 			},
 		},
 		{
-			name: "peer nameSpaceSelector and ipblock in ingress rules",
+			name:             "peer nameSpaceSelector and ipblock in ingress rules",
+			isNewNwPolicyVer: true,
 			targetSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"label": "src",
@@ -1529,6 +1591,7 @@ func TestIngressPolicy(t *testing.T) {
 					ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet(defaultNS, ipsets.Namespace),
 				},
+				ChildPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
 				PodSelectorList: []policies.SetInfo{
 					policies.NewSetInfo("label:src", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
 					policies.NewSetInfo(defaultNS, ipsets.Namespace, included, targetPodMatchType),
@@ -1565,7 +1628,8 @@ func TestIngressPolicy(t *testing.T) {
 			},
 		},
 		{
-			name: "error",
+			name:             "error",
+			isNewNwPolicyVer: true,
 			targetSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"label": "src",
@@ -1589,6 +1653,7 @@ func TestIngressPolicy(t *testing.T) {
 					ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
 				},
+				ChildPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
 				PodSelectorList: []policies.SetInfo{
 					policies.NewSetInfo("label:src", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
 					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
@@ -1605,7 +1670,8 @@ func TestIngressPolicy(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "allow all ingress rules",
+			name:             "allow all ingress rules",
+			isNewNwPolicyVer: true,
 			targetSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"label": "src",
@@ -1622,6 +1688,7 @@ func TestIngressPolicy(t *testing.T) {
 					ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
 				},
+				ChildPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
 				PodSelectorList: []policies.SetInfo{
 					policies.NewSetInfo("label:src", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
 					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
@@ -1635,7 +1702,8 @@ func TestIngressPolicy(t *testing.T) {
 			},
 		},
 		{
-			name: "deny all in ingress rules",
+			name:             "deny all in ingress rules",
+			isNewNwPolicyVer: true,
 			targetSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"label": "src",
@@ -1650,6 +1718,7 @@ func TestIngressPolicy(t *testing.T) {
 					ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
 				},
+				ChildPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
 				PodSelectorList: []policies.SetInfo{
 					policies.NewSetInfo("label:src", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
 					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
@@ -1659,19 +1728,204 @@ func TestIngressPolicy(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:             "multi-value pod/target selector",
+			isNewNwPolicyVer: true,
+			targetSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"k0": "v0",
+				},
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "k1",
+						Operator: metav1.LabelSelectorOpIn,
+						Values: []string{
+							"v10",
+							"v11",
+						},
+					},
+					{
+						Key:      "k2",
+						Operator: metav1.LabelSelectorOpDoesNotExist,
+						Values:   []string{},
+					},
+				},
+			},
+			rules: []networkingv1.NetworkPolicyIngressRule{
+				{},
+			},
+			npmNetPol: &policies.NPMNetworkPolicy{
+				Namespace:   "default",
+				PolicyKey:   "default/serve-tcp",
+				ACLPolicyID: "azure-acl-default-serve-tcp",
+				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
+					ipsets.NewTranslatedIPSet("k0:v0", ipsets.KeyValueLabelOfPod),
+					ipsets.NewTranslatedIPSet("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
+					ipsets.NewTranslatedIPSet("k2", ipsets.KeyLabelOfPod),
+					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
+				},
+				ChildPodSelectorIPSets: []*ipsets.TranslatedIPSet{
+					ipsets.NewTranslatedIPSet("k1:v10", ipsets.KeyValueLabelOfPod),
+					ipsets.NewTranslatedIPSet("k1:v11", ipsets.KeyValueLabelOfPod),
+				},
+				PodSelectorList: []policies.SetInfo{
+					policies.NewSetInfo("k0:v0", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
+					policies.NewSetInfo("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, included, targetPodMatchType),
+					policies.NewSetInfo("k2", ipsets.KeyLabelOfPod, nonIncluded, targetPodMatchType),
+					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
+				},
+				ACLs: []*policies.ACLPolicy{
+					{
+						Target:    policies.Allowed,
+						Direction: policies.Ingress,
+					},
+				},
+			},
+		},
+		{
+			name:             "multi-value pod/peer selector",
+			isNewNwPolicyVer: true,
+			targetSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"k0": "v0",
+				},
+			},
+			rules: []networkingv1.NetworkPolicyIngressRule{
+				{
+					From: []networkingv1.NetworkPolicyPeer{
+						{
+							PodSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      "k1",
+										Operator: metav1.LabelSelectorOpIn,
+										Values: []string{
+											"v10",
+											"v11",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			npmNetPol: &policies.NPMNetworkPolicy{
+				Namespace:   "default",
+				PolicyKey:   "default/serve-tcp",
+				ACLPolicyID: "azure-acl-default-serve-tcp",
+				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
+					ipsets.NewTranslatedIPSet("k0:v0", ipsets.KeyValueLabelOfPod),
+					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
+				},
+				ChildPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
+				PodSelectorList: []policies.SetInfo{
+					policies.NewSetInfo("k0:v0", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
+					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
+				},
+				RuleIPSets: []*ipsets.TranslatedIPSet{
+					ipsets.NewTranslatedIPSet("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
+					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
+					ipsets.NewTranslatedIPSet("k1:v10", ipsets.KeyValueLabelOfPod),
+					ipsets.NewTranslatedIPSet("k1:v11", ipsets.KeyValueLabelOfPod),
+				},
+				ACLs: []*policies.ACLPolicy{
+					{
+						Target:    policies.Allowed,
+						Direction: policies.Ingress,
+						SrcList: []policies.SetInfo{
+							policies.NewSetInfo("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, included, peerMatchType),
+							policies.NewSetInfo("default", ipsets.Namespace, included, peerMatchType),
+						},
+					},
+					{
+						Target:    policies.Dropped,
+						Direction: policies.Ingress,
+					},
+				},
+			},
+		},
+		{
+			name:             "multi-value pod/peer selector with namespace selector in same peer rule",
+			isNewNwPolicyVer: true,
+			targetSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"k0": "v0",
+				},
+			},
+			rules: []networkingv1.NetworkPolicyIngressRule{
+				{
+					From: []networkingv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"peer-nsselector-kay": "peer-nsselector-value",
+								},
+							},
+							PodSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      "k1",
+										Operator: metav1.LabelSelectorOpIn,
+										Values: []string{
+											"v10",
+											"v11",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			npmNetPol: &policies.NPMNetworkPolicy{
+				Namespace:   "default",
+				PolicyKey:   "default/serve-tcp",
+				ACLPolicyID: "azure-acl-default-serve-tcp",
+				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
+					ipsets.NewTranslatedIPSet("k0:v0", ipsets.KeyValueLabelOfPod),
+					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
+				},
+				ChildPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
+				PodSelectorList: []policies.SetInfo{
+					policies.NewSetInfo("k0:v0", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
+					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
+				},
+				RuleIPSets: []*ipsets.TranslatedIPSet{
+					ipsets.NewTranslatedIPSet("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
+					ipsets.NewTranslatedIPSet("k1:v10", ipsets.KeyValueLabelOfPod),
+					ipsets.NewTranslatedIPSet("k1:v11", ipsets.KeyValueLabelOfPod),
+					ipsets.NewTranslatedIPSet("peer-nsselector-kay:peer-nsselector-value", ipsets.KeyValueLabelOfNamespace),
+				},
+				ACLs: []*policies.ACLPolicy{
+					{
+						Target:    policies.Allowed,
+						Direction: policies.Ingress,
+						SrcList: []policies.SetInfo{
+							policies.NewSetInfo("peer-nsselector-kay:peer-nsselector-value", ipsets.KeyValueLabelOfNamespace, included, peerMatchType),
+							policies.NewSetInfo("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, included, peerMatchType),
+						},
+					},
+					{
+						Target:    policies.Dropped,
+						Direction: policies.Ingress,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+			util.IsNewNwPolicyVerFlag = tt.isNewNwPolicyVer
 			npmNetPol := &policies.NPMNetworkPolicy{
 				Namespace:   tt.npmNetPol.Namespace,
 				PolicyKey:   tt.npmNetPol.PolicyKey,
 				ACLPolicyID: tt.npmNetPol.ACLPolicyID,
 			}
 			var err error
-			npmNetPol.PodSelectorIPSets, npmNetPol.PodSelectorList, err = podSelectorWithNS(npmNetPol.PolicyKey, npmNetPol.Namespace, policies.EitherMatch, tt.targetSelector)
+			npmNetPol.PodSelectorIPSets, npmNetPol.ChildPodSelectorIPSets, npmNetPol.PodSelectorList, err = podSelectorWithNS(npmNetPol.PolicyKey, npmNetPol.Namespace, policies.EitherMatch, tt.targetSelector)
 			require.NoError(t, err)
 			splitPolicyKey := strings.Split(npmNetPol.PolicyKey, "/")
 			require.Len(t, splitPolicyKey, 2, "policy key must include name")
@@ -1692,14 +1946,16 @@ func TestEgressPolicy(t *testing.T) {
 	targetPodMatchType := policies.EitherMatch
 	peerMatchType := policies.DstMatch
 	tests := []struct {
-		name           string
-		targetSelector *metav1.LabelSelector
-		rules          []networkingv1.NetworkPolicyEgressRule
-		npmNetPol      *policies.NPMNetworkPolicy
-		wantErr        bool
+		name             string
+		isNewNwPolicyVer bool
+		targetSelector   *metav1.LabelSelector
+		rules            []networkingv1.NetworkPolicyEgressRule
+		npmNetPol        *policies.NPMNetworkPolicy
+		wantErr          bool
 	}{
 		{
-			name: "only port in egress rules",
+			name:             "only port in egress rules",
+			isNewNwPolicyVer: true,
 			targetSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"label": "dst",
@@ -1722,6 +1978,7 @@ func TestEgressPolicy(t *testing.T) {
 					ipsets.NewTranslatedIPSet("label:dst", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
 				},
+				ChildPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
 				PodSelectorList: []policies.SetInfo{
 					policies.NewSetInfo("label:dst", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
 					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
@@ -1741,7 +1998,8 @@ func TestEgressPolicy(t *testing.T) {
 			},
 		},
 		{
-			name: "only ipBlock in egress rules",
+			name:             "only ipBlock in egress rules",
+			isNewNwPolicyVer: true,
 			targetSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"label": "dst",
@@ -1771,6 +2029,7 @@ func TestEgressPolicy(t *testing.T) {
 					policies.NewSetInfo("label:dst", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
 					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
 				},
+				ChildPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
 				RuleIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("only-ipblock-in-ns-default-0-0OUT", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch"}...),
 				},
@@ -1787,7 +2046,8 @@ func TestEgressPolicy(t *testing.T) {
 			},
 		},
 		{
-			name: "only peer podSelector in egress rules",
+			name:             "only peer podSelector in egress rules",
+			isNewNwPolicyVer: true,
 			targetSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"label": "dst",
@@ -1814,6 +2074,7 @@ func TestEgressPolicy(t *testing.T) {
 					ipsets.NewTranslatedIPSet("label:dst", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
 				},
+				ChildPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
 				PodSelectorList: []policies.SetInfo{
 					policies.NewSetInfo("label:dst", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
 					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
@@ -1836,7 +2097,8 @@ func TestEgressPolicy(t *testing.T) {
 			},
 		},
 		{
-			name: "only peer nameSpaceSelector in egress rules",
+			name:             "only peer nameSpaceSelector in egress rules",
+			isNewNwPolicyVer: true,
 			targetSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"label": "dst",
@@ -1863,6 +2125,7 @@ func TestEgressPolicy(t *testing.T) {
 					ipsets.NewTranslatedIPSet("label:dst", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
 				},
+				ChildPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
 				PodSelectorList: []policies.SetInfo{
 					policies.NewSetInfo("label:dst", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
 					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
@@ -1883,7 +2146,8 @@ func TestEgressPolicy(t *testing.T) {
 			},
 		},
 		{
-			name: "deny all in egress rules",
+			name:             "deny all in egress rules",
+			isNewNwPolicyVer: true,
 			targetSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"label": "dst",
@@ -1898,6 +2162,7 @@ func TestEgressPolicy(t *testing.T) {
 					ipsets.NewTranslatedIPSet("label:dst", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
 				},
+				ChildPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
 				PodSelectorList: []policies.SetInfo{
 					policies.NewSetInfo("label:dst", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
 					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
@@ -1908,7 +2173,8 @@ func TestEgressPolicy(t *testing.T) {
 			},
 		},
 		{
-			name: "allow all egress rules",
+			name:             "allow all egress rules",
+			isNewNwPolicyVer: true,
 			targetSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"label": "dst",
@@ -1925,6 +2191,7 @@ func TestEgressPolicy(t *testing.T) {
 					ipsets.NewTranslatedIPSet("label:dst", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
 				},
+				ChildPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
 				PodSelectorList: []policies.SetInfo{
 					policies.NewSetInfo("label:dst", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
 					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
@@ -1938,7 +2205,8 @@ func TestEgressPolicy(t *testing.T) {
 			},
 		},
 		{
-			name: "peer nameSpaceSelector and ipblock in egress rules",
+			name:             "peer nameSpaceSelector and ipblock in egress rules",
+			isNewNwPolicyVer: true,
 			targetSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"label": "dst",
@@ -1976,6 +2244,7 @@ func TestEgressPolicy(t *testing.T) {
 					ipsets.NewTranslatedIPSet("label:dst", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
 				},
+				ChildPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
 				PodSelectorList: []policies.SetInfo{
 					policies.NewSetInfo("label:dst", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
 					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
@@ -2012,7 +2281,8 @@ func TestEgressPolicy(t *testing.T) {
 			},
 		},
 		{
-			name: "error",
+			name:             "error",
+			isNewNwPolicyVer: true,
 			targetSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"label": "dst",
@@ -2036,6 +2306,7 @@ func TestEgressPolicy(t *testing.T) {
 					ipsets.NewTranslatedIPSet("label:dst", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
 				},
+				ChildPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
 				PodSelectorList: []policies.SetInfo{
 					policies.NewSetInfo("label:dst", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
 					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
@@ -2051,19 +2322,204 @@ func TestEgressPolicy(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name:             "multi-value pod/target selector",
+			isNewNwPolicyVer: true,
+			targetSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"k0": "v0",
+				},
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "k1",
+						Operator: metav1.LabelSelectorOpIn,
+						Values: []string{
+							"v10",
+							"v11",
+						},
+					},
+					{
+						Key:      "k2",
+						Operator: metav1.LabelSelectorOpDoesNotExist,
+						Values:   []string{},
+					},
+				},
+			},
+			rules: []networkingv1.NetworkPolicyEgressRule{
+				{},
+			},
+			npmNetPol: &policies.NPMNetworkPolicy{
+				Namespace:   "default",
+				PolicyKey:   "default/serve-tcp",
+				ACLPolicyID: "azure-acl-default-serve-tcp",
+				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
+					ipsets.NewTranslatedIPSet("k0:v0", ipsets.KeyValueLabelOfPod),
+					ipsets.NewTranslatedIPSet("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
+					ipsets.NewTranslatedIPSet("k2", ipsets.KeyLabelOfPod),
+					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
+				},
+				ChildPodSelectorIPSets: []*ipsets.TranslatedIPSet{
+					ipsets.NewTranslatedIPSet("k1:v10", ipsets.KeyValueLabelOfPod),
+					ipsets.NewTranslatedIPSet("k1:v11", ipsets.KeyValueLabelOfPod),
+				},
+				PodSelectorList: []policies.SetInfo{
+					policies.NewSetInfo("k0:v0", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
+					policies.NewSetInfo("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, included, targetPodMatchType),
+					policies.NewSetInfo("k2", ipsets.KeyLabelOfPod, nonIncluded, targetPodMatchType),
+					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
+				},
+				ACLs: []*policies.ACLPolicy{
+					{
+						Target:    policies.Allowed,
+						Direction: policies.Egress,
+					},
+				},
+			},
+		},
+		{
+			name:             "multi-value pod/peer selector",
+			isNewNwPolicyVer: true,
+			targetSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"k0": "v0",
+				},
+			},
+			rules: []networkingv1.NetworkPolicyEgressRule{
+				{
+					To: []networkingv1.NetworkPolicyPeer{
+						{
+							PodSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      "k1",
+										Operator: metav1.LabelSelectorOpIn,
+										Values: []string{
+											"v10",
+											"v11",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			npmNetPol: &policies.NPMNetworkPolicy{
+				Namespace:   "default",
+				PolicyKey:   "default/serve-tcp",
+				ACLPolicyID: "azure-acl-default-serve-tcp",
+				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
+					ipsets.NewTranslatedIPSet("k0:v0", ipsets.KeyValueLabelOfPod),
+					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
+				},
+				ChildPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
+				PodSelectorList: []policies.SetInfo{
+					policies.NewSetInfo("k0:v0", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
+					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
+				},
+				RuleIPSets: []*ipsets.TranslatedIPSet{
+					ipsets.NewTranslatedIPSet("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
+					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
+					ipsets.NewTranslatedIPSet("k1:v10", ipsets.KeyValueLabelOfPod),
+					ipsets.NewTranslatedIPSet("k1:v11", ipsets.KeyValueLabelOfPod),
+				},
+				ACLs: []*policies.ACLPolicy{
+					{
+						Target:    policies.Allowed,
+						Direction: policies.Egress,
+						DstList: []policies.SetInfo{
+							policies.NewSetInfo("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, included, peerMatchType),
+							policies.NewSetInfo("default", ipsets.Namespace, included, peerMatchType),
+						},
+					},
+					{
+						Target:    policies.Dropped,
+						Direction: policies.Egress,
+					},
+				},
+			},
+		},
+		{
+			name:             "multi-value pod/peer selector with namespace selector in same peer rule",
+			isNewNwPolicyVer: true,
+			targetSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"k0": "v0",
+				},
+			},
+			rules: []networkingv1.NetworkPolicyEgressRule{
+				{
+					To: []networkingv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"peer-nsselector-kay": "peer-nsselector-value",
+								},
+							},
+							PodSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      "k1",
+										Operator: metav1.LabelSelectorOpIn,
+										Values: []string{
+											"v10",
+											"v11",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			npmNetPol: &policies.NPMNetworkPolicy{
+				Namespace:   "default",
+				PolicyKey:   "default/serve-tcp",
+				ACLPolicyID: "azure-acl-default-serve-tcp",
+				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
+					ipsets.NewTranslatedIPSet("k0:v0", ipsets.KeyValueLabelOfPod),
+					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
+				},
+				ChildPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
+				PodSelectorList: []policies.SetInfo{
+					policies.NewSetInfo("k0:v0", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
+					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
+				},
+				RuleIPSets: []*ipsets.TranslatedIPSet{
+					ipsets.NewTranslatedIPSet("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
+					ipsets.NewTranslatedIPSet("k1:v10", ipsets.KeyValueLabelOfPod),
+					ipsets.NewTranslatedIPSet("k1:v11", ipsets.KeyValueLabelOfPod),
+					ipsets.NewTranslatedIPSet("peer-nsselector-kay:peer-nsselector-value", ipsets.KeyValueLabelOfNamespace),
+				},
+				ACLs: []*policies.ACLPolicy{
+					{
+						Target:    policies.Allowed,
+						Direction: policies.Egress,
+						DstList: []policies.SetInfo{
+							policies.NewSetInfo("peer-nsselector-kay:peer-nsselector-value", ipsets.KeyValueLabelOfNamespace, included, peerMatchType),
+							policies.NewSetInfo("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, included, peerMatchType),
+						},
+					},
+					{
+						Target:    policies.Dropped,
+						Direction: policies.Egress,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+			util.IsNewNwPolicyVerFlag = tt.isNewNwPolicyVer
 			npmNetPol := &policies.NPMNetworkPolicy{
 				Namespace:   tt.npmNetPol.Namespace,
 				PolicyKey:   tt.npmNetPol.PolicyKey,
 				ACLPolicyID: tt.npmNetPol.ACLPolicyID,
 			}
 			var err error
-			npmNetPol.PodSelectorIPSets, npmNetPol.PodSelectorList, err = podSelectorWithNS(npmNetPol.PolicyKey, npmNetPol.Namespace, policies.EitherMatch, tt.targetSelector)
+			npmNetPol.PodSelectorIPSets, npmNetPol.ChildPodSelectorIPSets, npmNetPol.PodSelectorList, err = podSelectorWithNS(npmNetPol.PolicyKey, npmNetPol.Namespace, policies.EitherMatch, tt.targetSelector)
 			require.NoError(t, err)
 			splitPolicyKey := strings.Split(npmNetPol.PolicyKey, "/")
 			require.Len(t, splitPolicyKey, 2, "policy key must include name")

--- a/npm/pkg/dataplane/dataplane.go
+++ b/npm/pkg/dataplane/dataplane.go
@@ -13,12 +13,7 @@ import (
 	"k8s.io/klog"
 )
 
-const (
-	// AzureNetworkName is default network Azure CNI creates
-	AzureNetworkName = "azure"
-
-	reconcileTimeInMinutes = 5
-)
+const reconcileTimeInMinutes = 5
 
 type PolicyMode string
 

--- a/npm/pkg/dataplane/dataplane.go
+++ b/npm/pkg/dataplane/dataplane.go
@@ -203,7 +203,7 @@ func (dp *DataPlane) ApplyDataPlane() error {
 func (dp *DataPlane) AddPolicy(policy *policies.NPMNetworkPolicy) error {
 	klog.Infof("[DataPlane] Add Policy called for %s", policy.PolicyKey)
 	// Create and add references for Selector IPSets first
-	err := dp.createIPSetsAndReferences(policy.PodSelectorIPSets, policy.PolicyKey, ipsets.SelectorType)
+	err := dp.createIPSetsAndReferences(policy.AllPodSelectorIPSets(), policy.PolicyKey, ipsets.SelectorType)
 	if err != nil {
 		klog.Infof("[DataPlane] error while adding Selector IPSet references: %s", err.Error())
 		return fmt.Errorf("[DataPlane] error while adding Selector IPSet references: %w", err)
@@ -254,7 +254,7 @@ func (dp *DataPlane) RemovePolicy(policyKey string) error {
 	}
 
 	// Remove references for Selector IPSets
-	err = dp.deleteIPSetsAndReferences(policy.PodSelectorIPSets, policy.PolicyKey, ipsets.SelectorType)
+	err = dp.deleteIPSetsAndReferences(policy.AllPodSelectorIPSets(), policy.PolicyKey, ipsets.SelectorType)
 	if err != nil {
 		return err
 	}

--- a/npm/pkg/dataplane/ipsets/ipset.go
+++ b/npm/pkg/dataplane/ipsets/ipset.go
@@ -372,49 +372,22 @@ func (set *IPSet) hasMember(memberName string) bool {
 	return isMember
 }
 
-// affiliatedIPs returns the IPs for a hash set or the IPs of the member sets for a list set
-// This method, intersectAffiliatedIPs, and GetSetContents are good examples of how the
-// ipset struct may have been better designed as an interface with hash and list implementations.
-// Not worth it to redesign though.
-func (set *IPSet) affiliatedIPs() map[string]struct{} {
+// isIPAffiliated determines whether an IP belongs to the set or its member sets in the case of a list set.
+// This method and GetSetContents are good examples of how the ipset struct may have been better designed
+// as an interface with hash and list implementations. Not worth it to redesign though.
+func (set *IPSet) isIPAffiliated(ip string) bool {
 	if set.Kind == HashSet {
-		result := make(map[string]struct{}, len(set.IPPodKey))
-		for ip := range set.IPPodKey {
-			result[ip] = struct{}{}
+		if _, ok := set.IPPodKey[ip]; ok {
+			return true
 		}
-		return result
 	}
-
-	result := make(map[string]struct{})
 	for _, memberSet := range set.MemberIPSets {
-		for ip := range memberSet.IPPodKey {
-			result[ip] = struct{}{}
+		_, ok := memberSet.IPPodKey[ip]
+		if ok {
+			return true
 		}
 	}
-	return result
-}
-
-// intersectAffiliatedIPs removes IPs that aren't affiliated with this set
-func (set *IPSet) intersectAffiliatedIPs(existingIPs map[string]struct{}) {
-	for ip := range existingIPs {
-		isAffiliated := false
-		if set.Kind == HashSet {
-			_, ok := set.IPPodKey[ip]
-			isAffiliated = ok
-		} else {
-			for _, memberSet := range set.MemberIPSets {
-				_, ok := memberSet.IPPodKey[ip]
-				if ok {
-					isAffiliated = true
-					break
-				}
-			}
-		}
-
-		if !isAffiliated {
-			delete(existingIPs, ip)
-		}
-	}
+	return false
 }
 
 func (set *IPSet) canSetBeSelectorIPSet() bool {

--- a/npm/pkg/dataplane/ipsets/ipset.go
+++ b/npm/pkg/dataplane/ipsets/ipset.go
@@ -385,8 +385,7 @@ func (set *IPSet) affiliatedIPs() map[string]struct{} {
 		return result
 	}
 
-	// number of member ipsets usually underestimates the final map size
-	result := make(map[string]struct{}, len(set.MemberIPSets))
+	result := make(map[string]struct{})
 	for _, memberSet := range set.MemberIPSets {
 		for ip := range memberSet.IPPodKey {
 			result[ip] = struct{}{}

--- a/npm/pkg/dataplane/ipsets/ipset_test.go
+++ b/npm/pkg/dataplane/ipsets/ipset_test.go
@@ -8,16 +8,16 @@ import (
 
 func TestAffiliatedIPs(t *testing.T) {
 	s1 := NewIPSet(NewIPSetMetadata("test-set1", Namespace))
-	s1.IPPodKey["1.1.1.1"] = "pod-a"
-	s1.IPPodKey["2.2.2.2"] = "pod-b"
+	s1.IPPodKey["1.1.1.1"] = "pod-w"
+	s1.IPPodKey["2.2.2.2"] = "pod-x"
 	s2 := NewIPSet(NewIPSetMetadata("test-set2", Namespace))
-	s2.IPPodKey["3.3.3.3"] = "pod-c"
-	s2.IPPodKey["4.4.4.4"] = "pod-d"
+	s2.IPPodKey["3.3.3.3"] = "pod-y"
+	s2.IPPodKey["4.4.4.4"] = "pod-z"
 
 	// 1 IP from each set above
 	s3 := NewIPSet(NewIPSetMetadata("test-set3", Namespace))
-	s3.IPPodKey["1.1.1.1"] = "pod-a"
-	s3.IPPodKey["4.4.4.4"] = "pod-d"
+	s3.IPPodKey["1.1.1.1"] = "pod-w"
+	s3.IPPodKey["4.4.4.4"] = "pod-z"
 
 	l := NewIPSet(NewIPSetMetadata("test-list", KeyLabelOfNamespace))
 	l.MemberIPSets[s1.Name] = s1

--- a/npm/pkg/dataplane/ipsets/ipset_test.go
+++ b/npm/pkg/dataplane/ipsets/ipset_test.go
@@ -6,54 +6,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAffiliatedIPs(t *testing.T) {
-	s1 := NewIPSet(NewIPSetMetadata("test-set1", Namespace))
-	s1.IPPodKey["1.1.1.1"] = "pod-w"
-	s1.IPPodKey["2.2.2.2"] = "pod-x"
-	s2 := NewIPSet(NewIPSetMetadata("test-set2", Namespace))
-	s2.IPPodKey["3.3.3.3"] = "pod-y"
-	s2.IPPodKey["4.4.4.4"] = "pod-z"
-
-	// 1 IP from each set above
-	s3 := NewIPSet(NewIPSetMetadata("test-set3", Namespace))
-	s3.IPPodKey["1.1.1.1"] = "pod-w"
-	s3.IPPodKey["4.4.4.4"] = "pod-z"
-
-	l := NewIPSet(NewIPSetMetadata("test-list", KeyLabelOfNamespace))
-	l.MemberIPSets[s1.Name] = s1
-	l.MemberIPSets[s2.Name] = s2
-
-	expected := map[string]struct{}{
-		"1.1.1.1": {},
-		"2.2.2.2": {},
-	}
-	require.Equal(t, expected, s1.affiliatedIPs(), "unexpected affiliated IPs for set 1")
-
-	expected = map[string]struct{}{
-		"1.1.1.1": {},
-		"2.2.2.2": {},
-		"3.3.3.3": {},
-		"4.4.4.4": {},
-	}
-	require.Equal(t, expected, l.affiliatedIPs(), "unexpected affiliated IPs for list")
-
-	intersection := s3.affiliatedIPs()
-	l.intersectAffiliatedIPs(intersection)
-	expected = map[string]struct{}{
-		"1.1.1.1": {},
-		"4.4.4.4": {},
-	}
-	require.Equal(t, expected, intersection, "unexpected intersection (direction #1)")
-
-	intersection = l.affiliatedIPs()
-	s3.intersectAffiliatedIPs(intersection)
-	expected = map[string]struct{}{
-		"1.1.1.1": {},
-		"4.4.4.4": {},
-	}
-	require.Equal(t, expected, intersection, "unexpected intersection (direction #2)")
-}
-
 func TestShouldBeInKernelAndCanDelete(t *testing.T) {
 	s := &IPSetMetadata{"test-set", Namespace}
 	l := &IPSetMetadata{"test-list", KeyLabelOfNamespace}

--- a/npm/pkg/dataplane/ipsets/ipset_test.go
+++ b/npm/pkg/dataplane/ipsets/ipset_test.go
@@ -6,6 +6,54 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestAffiliatedIPs(t *testing.T) {
+	s1 := NewIPSet(NewIPSetMetadata("test-set1", Namespace))
+	s1.IPPodKey["1.1.1.1"] = "pod-a"
+	s1.IPPodKey["2.2.2.2"] = "pod-b"
+	s2 := NewIPSet(NewIPSetMetadata("test-set2", Namespace))
+	s2.IPPodKey["3.3.3.3"] = "pod-c"
+	s2.IPPodKey["4.4.4.4"] = "pod-d"
+
+	// 1 IP from each set above
+	s3 := NewIPSet(NewIPSetMetadata("test-set3", Namespace))
+	s3.IPPodKey["1.1.1.1"] = "pod-a"
+	s3.IPPodKey["4.4.4.4"] = "pod-d"
+
+	l := NewIPSet(NewIPSetMetadata("test-list", KeyLabelOfNamespace))
+	l.MemberIPSets[s1.Name] = s1
+	l.MemberIPSets[s2.Name] = s2
+
+	expected := map[string]struct{}{
+		"1.1.1.1": {},
+		"2.2.2.2": {},
+	}
+	require.Equal(t, expected, s1.affiliatedIPs(), "unexpected affiliated IPs for set 1")
+
+	expected = map[string]struct{}{
+		"1.1.1.1": {},
+		"2.2.2.2": {},
+		"3.3.3.3": {},
+		"4.4.4.4": {},
+	}
+	require.Equal(t, expected, l.affiliatedIPs(), "unexpected affiliated IPs for list")
+
+	intersection := s3.affiliatedIPs()
+	l.intersectAffiliatedIPs(intersection)
+	expected = map[string]struct{}{
+		"1.1.1.1": {},
+		"4.4.4.4": {},
+	}
+	require.Equal(t, expected, intersection, "unexpected intersection (direction #1)")
+
+	intersection = l.affiliatedIPs()
+	s3.intersectAffiliatedIPs(intersection)
+	expected = map[string]struct{}{
+		"1.1.1.1": {},
+		"4.4.4.4": {},
+	}
+	require.Equal(t, expected, intersection, "unexpected intersection (direction #2)")
+}
+
 func TestShouldBeInKernelAndCanDelete(t *testing.T) {
 	s := &IPSetMetadata{"test-set", Namespace}
 	l := &IPSetMetadata{"test-list", KeyLabelOfNamespace}

--- a/npm/pkg/dataplane/ipsets/ipsetmanager.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager.go
@@ -42,7 +42,8 @@ type IPSetManager struct {
 }
 
 type IPSetManagerCfg struct {
-	IPSetMode   IPSetMode
+	IPSetMode IPSetMode
+	// NetworkName can be left empty or set to 'azure' (the only supported network)
 	NetworkName string
 }
 

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_windows.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_windows.go
@@ -330,7 +330,7 @@ func getPolicyNetworkRequestMarshal(setPolicySettings map[string]*hcn.SetPolicyS
 	}
 
 	if len(policyNetworkRequest.Policies) == 0 {
-		klog.Info("[Dataplane Windows] no %s type of sets to apply", policyType)
+		klog.Infof("[Dataplane Windows] no %s type of sets to apply", policyType)
 		return nil, nil
 	}
 

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_windows.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_windows.go
@@ -306,6 +306,10 @@ func (setPolicyBuilder *networkPolicyBuilder) setNameExists(setName string) bool
 }
 
 func getPolicyNetworkRequestMarshal(setPolicySettings map[string]*hcn.SetPolicySetting, policyType hcn.SetPolicyType) ([]byte, error) {
+	if len(setPolicySettings) == 0 {
+		klog.Info("[Dataplane Windows] no set policies to apply on network")
+		return nil, nil
+	}
 	klog.Infof("[Dataplane Windows] marshalling %s type of sets", policyType)
 	policyNetworkRequest := &hcn.PolicyNetworkRequest{
 		Policies: make([]hcn.NetworkPolicy, 0),

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_windows.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_windows.go
@@ -58,7 +58,7 @@ func (iMgr *IPSetManager) GetIPsFromSelectorIPSets(setList map[string]struct{}) 
 			ips = set.affiliatedIPs()
 			firstLoop = false
 		} else {
-			set.intersectAffiliatedIPs()
+			set.intersectAffiliatedIPs(ips)
 		}
 	}
 
@@ -177,7 +177,7 @@ func (iMgr *IPSetManager) calculateNewSetPolicies(networkPolicies []hcn.NetworkP
 	for setName := range toAddUpdateSetNames {
 		set, exists := iMgr.setMap[setName] // check if the Set exists
 		if !exists {
-			return nil, errors.Errorf(errors.AppendIPSet, false, fmt.Sprintf("ipset %s does not exist", setName))
+			return nil, npmerrors.Errorf(npmerrors.AppendIPSet, false, fmt.Sprintf("ipset %s does not exist", setName))
 		}
 
 		setPol, err := convertToSetPolicy(set)

--- a/npm/pkg/dataplane/policies/policymanager.go
+++ b/npm/pkg/dataplane/policies/policymanager.go
@@ -19,6 +19,7 @@ const (
 	// IPSetPolicyMode will references IPSets in policies
 	IPSetPolicyMode PolicyManagerMode = "IPSet"
 	// IPPolicyMode will replace ipset names with their value IPs in policies
+	// NOTE: this is currently unimplemented
 	IPPolicyMode PolicyManagerMode = "IP"
 
 	// this number is based on the implementation in chain-management_linux.go

--- a/npm/pkg/dataplane/policies/policymanager_windows.go
+++ b/npm/pkg/dataplane/policies/policymanager_windows.go
@@ -43,7 +43,7 @@ func (pMgr *PolicyManager) bootup(epIDs []string) error {
 }
 
 func (pMgr *PolicyManager) reconcile() {
-	// TODO
+	// not implemented
 }
 
 func (pMgr *PolicyManager) addPolicy(policy *NPMNetworkPolicy, endpointList map[string]string) error {

--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -104,7 +104,6 @@ const (
 	IptablesAzureEgressPolicyChainPrefix  string = "AZURE-NPM-EGRESS"
 
 	// Below chain exists only in NPM before v1.2.6
-	// TODO delete this below set while cleaning up
 	IptablesAzureTargetSetsChain string = "AZURE-NPM-TARGET-SETS"
 	// Below chain existing only in NPM before v1.2.7
 	IptablesAzureIngressWrongDropsChain string = "AZURE-NPM-INRGESS-DROPS"
@@ -223,6 +222,9 @@ const (
 
 	ErrorValue float64 = 1
 )
+
+// AzureNetworkName is the default network Azure CNI creates
+const AzureNetworkName = "azure"
 
 // These ID represents where did the error log generate from.
 // It's for better query purpose. In Kusto these value are used in


### PR DESCRIPTION
Used to never apply policies to endpoints if the policy selector involved a list set. Two changes to enable this:
1. fix calculation getting IPs in the intersection of pod selector IPSets
2. separate out member IPSets of list IPSets in the pod selector

Other change: fail the dataplane if a non "azure" network is specified or if IPPolicyMode is used, which is unimplemented.