### PR TITLE
fix: [NPM] manage policies on pod endpoints

### DIFF
--- a/npm/pkg/dataplane/dataplane.go
+++ b/npm/pkg/dataplane/dataplane.go
@@ -13,10 +13,7 @@ import (
 	"k8s.io/klog"
 )
 
-const (
-	reconcileTimeInMinutes = 5
-	unspecifiedPodKey      = ""
-)
+const reconcileTimeInMinutes = 5
 
 type PolicyMode string
 

--- a/npm/pkg/dataplane/dataplane.go
+++ b/npm/pkg/dataplane/dataplane.go
@@ -118,7 +118,7 @@ func (dp *DataPlane) AddToSets(setNames []*ipsets.IPSetMetadata, podMetadata *Po
 	if dp.shouldUpdatePod() {
 		klog.Infof("[DataPlane] Updating Sets to Add for pod key %s", podMetadata.PodKey)
 		if _, ok := dp.updatePodCache[podMetadata.PodKey]; !ok {
-			klog.Infof("[DataPlane] {AddToSet} pod key %s not found creating a new obj", podMetadata.PodKey)
+			klog.Infof("[DataPlane] {AddToSet} pod key %s not found in updatePodCache. creating a new obj", podMetadata.PodKey)
 			dp.updatePodCache[podMetadata.PodKey] = newUpdateNPMPod(podMetadata)
 		}
 
@@ -139,7 +139,7 @@ func (dp *DataPlane) RemoveFromSets(setNames []*ipsets.IPSetMetadata, podMetadat
 	if dp.shouldUpdatePod() {
 		klog.Infof("[DataPlane] Updating Sets to Remove for pod key %s", podMetadata.PodKey)
 		if _, ok := dp.updatePodCache[podMetadata.PodKey]; !ok {
-			klog.Infof("[DataPlane] {RemoveFromSet} pod key %s not found creating a new obj", podMetadata.PodKey)
+			klog.Infof("[DataPlane] {RemoveFromSet} pod key %s not found in updatePodCache. creating a new obj", podMetadata.PodKey)
 			dp.updatePodCache[podMetadata.PodKey] = newUpdateNPMPod(podMetadata)
 		}
 

--- a/npm/pkg/dataplane/dataplane.go
+++ b/npm/pkg/dataplane/dataplane.go
@@ -213,6 +213,8 @@ func (dp *DataPlane) AddPolicy(policy *policies.NPMNetworkPolicy) error {
 		return fmt.Errorf("[DataPlane] error while adding Rule IPSet references: %w", err)
 	}
 
+	// NOTE: if apply dataplane succeeds, but another area fails, then currently,
+	// netpol controller won't cache the netpol, and the IPSets applied will remain in the kernel since they will have a netpol reference
 	err = dp.ApplyDataPlane()
 	if err != nil {
 		return fmt.Errorf("[DataPlane] error while applying dataplane: %w", err)

--- a/npm/pkg/dataplane/dataplane_windows.go
+++ b/npm/pkg/dataplane/dataplane_windows.go
@@ -162,7 +162,9 @@ func (dp *DataPlane) updatePod(pod *updateNPMPod) error {
 		}
 
 		for policyKey := range selectorReference {
-			toAddPolicies[policyKey] = struct{}{}
+			if _, ok := dp.pendingPolicies[policyKey]; !ok {
+				toAddPolicies[policyKey] = struct{}{}
+			}
 		}
 	}
 

--- a/npm/pkg/dataplane/dataplane_windows.go
+++ b/npm/pkg/dataplane/dataplane_windows.go
@@ -126,7 +126,7 @@ func (dp *DataPlane) updatePod(pod *updateNPMPod) error {
 		return nil
 	}
 
-	if pod.PodKey == unspecifiedPodKey {
+	if endpoint.podKey == unspecifiedPodKey {
 		// while refreshing pod endpoints, newly discovered endpoints are given an unspecified pod key
 		if pod.PodKey == endpoint.stalePodKey.key {
 			klog.Infof("ignoring pod update since pod with key %s is stale and likely was deleted", pod.PodKey)

--- a/npm/pkg/dataplane/dataplane_windows.go
+++ b/npm/pkg/dataplane/dataplane_windows.go
@@ -128,7 +128,7 @@ func (dp *DataPlane) updatePod(pod *updateNPMPod) error {
 
 	if endpoint.podKey == unspecifiedPodKey {
 		// while refreshing pod endpoints, newly discovered endpoints are given an unspecified pod key
-		if pod.PodKey == endpoint.stalePodKey.key {
+		if endpoint.isStalePodKey(pod.PodKey) {
 			klog.Infof("ignoring pod update since pod with key %s is stale and likely was deleted", pod.PodKey)
 			return nil
 		}

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_windows.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_windows.go
@@ -123,7 +123,6 @@ func (iMgr *IPSetManager) GetIPsFromSelectorIPSets(setList map[string]struct{}) 
 			}
 		}
 	}
-	klog.Infof("IPs in selector IPSets: %+v", ips) // FIXME remove after debugging
 	return ips, nil
 }
 
@@ -395,12 +394,12 @@ func getPolicyNetworkRequestMarshal(setPolicySettings map[string]*hcn.SetPolicyS
 		Policies: make([]hcn.NetworkPolicy, 0),
 	}
 
-	for setPol := range setPolicySettings {
-		if setPolicySettings[setPol].PolicyType != policyType {
+	for _, setPol := range setPolicySettings {
+		if setPol.PolicyType != policyType {
 			continue
 		}
-		klog.Infof("Found set pol %+v", setPolicySettings[setPol])
-		rawSettings, err := json.Marshal(setPolicySettings[setPol])
+		klog.Infof("will perform %s operation on set pol %+v", policyType, setPol)
+		rawSettings, err := json.Marshal(setPol)
 		if err != nil {
 			return nil, err
 		}

--- a/npm/pkg/dataplane/policies/policy.go
+++ b/npm/pkg/dataplane/policies/policy.go
@@ -38,7 +38,7 @@ func NewNPMNetworkPolicy(netPolName, netPolNamespace string) *NPMNetworkPolicy {
 	return &NPMNetworkPolicy{
 		Namespace:   netPolNamespace,
 		PolicyKey:   fmt.Sprintf("%s/%s", netPolNamespace, netPolName),
-		ACLPolicyID: aclPolicyID(netPolName, netPolNamespace),
+		ACLPolicyID: aclPolicyID(netPolNamespace, netPolName),
 	}
 }
 

--- a/npm/pkg/dataplane/policies/policymanager_windows.go
+++ b/npm/pkg/dataplane/policies/policymanager_windows.go
@@ -46,6 +46,8 @@ func (pMgr *PolicyManager) reconcile() {
 	// not implemented
 }
 
+// addPolicy will add the policy for each specified endpoint if the policy doesn't exist on the endpoint yet,
+// and will add the endpoint to the PodEndpoints of the policy if successful.
 func (pMgr *PolicyManager) addPolicy(policy *NPMNetworkPolicy, endpointList map[string]string) error {
 	klog.Infof("[DataPlane Windows] adding policy %s on %+v", policy.PolicyKey, endpointList)
 	if len(endpointList) == 0 {
@@ -55,6 +57,8 @@ func (pMgr *PolicyManager) addPolicy(policy *NPMNetworkPolicy, endpointList map[
 
 	if policy.PodEndpoints == nil {
 		policy.PodEndpoints = make(map[string]string)
+		// return since there are no endpoints to apply policy on
+		return nil
 	}
 
 	for epIP, epID := range policy.PodEndpoints {
@@ -103,10 +107,11 @@ func (pMgr *PolicyManager) addPolicy(policy *NPMNetworkPolicy, endpointList map[
 	return aggregateErr
 }
 
+// removePolicy will remove the policy from the specified endpoints, or
+// if the endpointList is nil, then the policy will be removed from the PodEndpoints of the policy
 func (pMgr *PolicyManager) removePolicy(policy *NPMNetworkPolicy, endpointList map[string]string) error {
-
 	if endpointList == nil {
-		if policy.PodEndpoints == nil {
+		if len(policy.PodEndpoints) == 0 {
 			klog.Infof("[DataPlane Windows] No Endpoints to remove policy %s on", policy.PolicyKey)
 			return nil
 		}

--- a/npm/pkg/dataplane/types.go
+++ b/npm/pkg/dataplane/types.go
@@ -4,7 +4,6 @@ import (
 	"github.com/Azure/azure-container-networking/npm/pkg/dataplane/ipsets"
 	"github.com/Azure/azure-container-networking/npm/pkg/dataplane/policies"
 	"github.com/Azure/azure-container-networking/npm/util"
-	"github.com/Microsoft/hcsshim/hcn"
 )
 
 const minutesToKeepStalePodKey = 10
@@ -71,53 +70,4 @@ func (npmPod *updateNPMPod) updateIPSetsToRemove(setNames []*ipsets.IPSetMetadat
 	for _, set := range setNames {
 		npmPod.IPSetsToRemove = append(npmPod.IPSetsToRemove, set.GetPrefixName())
 	}
-}
-
-type npmEndpoint struct {
-	name   string
-	id     string
-	ip     string
-	podKey string
-	// stalePodKey is used to keep track of the previous pod that had this IP
-	stalePodKey *staleKey
-	// Map with Key as Network Policy name to to emulate set
-	// and value as struct{} for minimal memory consumption
-	netPolReference map[string]struct{}
-}
-
-func newNPMEndpoint(endpoint *hcn.HostComputeEndpoint) *npmEndpoint {
-	return &npmEndpoint{
-		name:            endpoint.Name,
-		id:              endpoint.Id,
-		podKey:          unspecifiedPodKey,
-		netPolReference: make(map[string]struct{}),
-		ip:              endpoint.IpConfigurations[0].IpAddress,
-	}
-}
-
-// update creates a new endpoint and marks the old endpoint's pod key as stale
-// currentTime should be time.Now().Unix()
-func (ep *npmEndpoint) update(endpoint *hcn.HostComputeEndpoint, currentTime int64) *npmEndpoint {
-	newEP := newNPMEndpoint(endpoint)
-	newEP.stalePodKey = &staleKey{
-		key:       ep.podKey,
-		timestamp: currentTime,
-	}
-	return newEP
-}
-
-// shouldDelete if enough time has passed since the last update.
-// Should pass in time.Now().Unix() as the current time.
-func (ep *npmEndpoint) shouldDelete(currentTime int64) bool {
-	return ep.stalePodKey == nil || ep.stalePodKey.minutesElapsed(currentTime) > minutesToKeepStalePodKey
-}
-
-type staleKey struct {
-	key string
-	// timestamp represents the Unix time this struct was created
-	timestamp int64
-}
-
-func (spk *staleKey) minutesElapsed(currentTime int64) int {
-	return int(currentTime-spk.timestamp) / 60
 }

--- a/npm/pkg/dataplane/types.go
+++ b/npm/pkg/dataplane/types.go
@@ -6,8 +6,6 @@ import (
 	"github.com/Azure/azure-container-networking/npm/util"
 )
 
-const minutesToKeepStalePodKey = 10
-
 type GenericDataplane interface {
 	BootupDataplane() error
 	RunPeriodicTasks()

--- a/npm/pkg/dataplane/types_linux.go
+++ b/npm/pkg/dataplane/types_linux.go
@@ -1,0 +1,4 @@
+package dataplane
+
+// npmEndpoint holds info relevant for endpoints in windows
+type npmEndpoint struct{}

--- a/npm/pkg/dataplane/types_windows.go
+++ b/npm/pkg/dataplane/types_windows.go
@@ -1,5 +1,12 @@
 package dataplane
 
+import "github.com/Microsoft/hcsshim/hcn"
+
+const (
+	unspecifiedPodKey        = ""
+	minutesToKeepStalePodKey = 10
+)
+
 // npmEndpoint holds info relevant for endpoints in windows
 type npmEndpoint struct {
 	name   string

--- a/npm/pkg/dataplane/types_windows.go
+++ b/npm/pkg/dataplane/types_windows.go
@@ -1,0 +1,54 @@
+package dataplane
+
+// npmEndpoint holds info relevant for endpoints in windows
+type npmEndpoint struct {
+	name   string
+	id     string
+	ip     string
+	podKey string
+	// stalePodKey is used to keep track of the previous pod that had this IP
+	stalePodKey *staleKey
+	// Map with Key as Network Policy name to to emulate set
+	// and value as struct{} for minimal memory consumption
+	netPolReference map[string]struct{}
+}
+
+// newNPMEndpoint initializes npmEndpoint and copies relevant information from hcn.HostComputeEndpoint.
+// This function must be defined in a file with a windows build tag for proper vendoring since it uses the hcn pkg
+func newNPMEndpoint(endpoint *hcn.HostComputeEndpoint) *npmEndpoint {
+	return &npmEndpoint{
+		name:            endpoint.Name,
+		id:              endpoint.Id,
+		podKey:          unspecifiedPodKey,
+		netPolReference: make(map[string]struct{}),
+		ip:              endpoint.IpConfigurations[0].IpAddress,
+	}
+}
+
+// update creates a new endpoint and marks the old endpoint's pod key as stale.
+// currentTime should be time.Now().Unix()
+// This function must be defined in a file with a windows build tag for proper vendoring since it uses the hcn pkg
+func (ep *npmEndpoint) update(endpoint *hcn.HostComputeEndpoint, currentTime int64) *npmEndpoint {
+	newEP := newNPMEndpoint(endpoint)
+	newEP.stalePodKey = &staleKey{
+		key:       ep.podKey,
+		timestamp: currentTime,
+	}
+	return newEP
+}
+
+// shouldDelete if enough time has passed since the last update.
+// Should pass in time.Now().Unix() as the current time.
+func (ep *npmEndpoint) shouldDelete(currentTime int64) bool {
+	return ep.stalePodKey == nil || ep.stalePodKey.minutesElapsed(currentTime) > minutesToKeepStalePodKey
+}
+
+type staleKey struct {
+	key string
+	// timestamp represents the Unix time this struct was created
+	timestamp int64
+}
+
+func (spk *staleKey) minutesElapsed(currentTime int64) int {
+	return int(currentTime-spk.timestamp) / 60
+}

--- a/npm/pkg/dataplane/types_windows.go
+++ b/npm/pkg/dataplane/types_windows.go
@@ -38,42 +38,6 @@ func newNPMEndpoint(endpoint *hcn.HostComputeEndpoint) *npmEndpoint {
 	}
 }
 
-// update creates a new endpoint and marks the old endpoint's pod key as stale.
-// currentTime should be time.Now().Unix()
-// This function must be defined in a file with a windows build tag for proper vendoring since it uses the hcn pkg
-func (ep *npmEndpoint) update(endpoint *hcn.HostComputeEndpoint, currentTime int64) *npmEndpoint {
-	newEP := newNPMEndpoint(endpoint)
-	newEP.stalePodKey = &staleKey{
-		key:       ep.podKey,
-		timestamp: currentTime,
-	}
-	return newEP
-}
-
 func (ep *npmEndpoint) isStalePodKey(podKey string) bool {
 	return ep.stalePodKey != nil && ep.stalePodKey.key == podKey
-}
-
-// markPodKeyStale will remove any existing podKey if needed and mark it as stale
-// currentTime should be time.Now().Unix()
-func (ep *npmEndpoint) markPodKeyStale(currentTime int64) {
-	if ep.podKey == unspecifiedPodKey {
-		return
-	}
-	ep.stalePodKey = &staleKey{
-		key:       ep.podKey,
-		timestamp: currentTime,
-	}
-	ep.podKey = unspecifiedPodKey
-}
-
-// shouldDelete if enough time has passed since the last update.
-// Should pass in time.Now().Unix() as the current time.
-func (ep *npmEndpoint) shouldDelete(currentTime int64) bool {
-	spk := ep.stalePodKey
-	if spk == nil {
-		return true
-	}
-	minutesElapsed := int(currentTime-spk.timestamp) / 60
-	return minutesElapsed > minutesToKeepStalePodKey
 }

--- a/npm/pkg/dataplane/types_windows.go
+++ b/npm/pkg/dataplane/types_windows.go
@@ -54,6 +54,19 @@ func (ep *npmEndpoint) isStalePodKey(podKey string) bool {
 	return ep.stalePodKey != nil && ep.stalePodKey.key == podKey
 }
 
+// markPodKeyStale will remove any existing podKey if needed and mark it as stale
+// currentTime should be time.Now().Unix()
+func (ep *npmEndpoint) markPodKeyStale(currentTime int64) {
+	if ep.podKey == unspecifiedPodKey {
+		return
+	}
+	ep.stalePodKey = &staleKey{
+		key:       ep.podKey,
+		timestamp: currentTime,
+	}
+	ep.podKey = unspecifiedPodKey
+}
+
 // shouldDelete if enough time has passed since the last update.
 // Should pass in time.Now().Unix() as the current time.
 func (ep *npmEndpoint) shouldDelete(currentTime int64) bool {


### PR DESCRIPTION
- maintain the netpol references of endpoints so we can delete netpols off the endpoint if needed
- don't need to update an endpoint if a pod update is called for a stale (deleted) pod
- garbage collect the endpoint cache