### PR TITLE
fix: [NPM] windows-specific controller race leads to policy doesn't exist error while policy is pending

### DIFF
--- a/npm/pkg/dataplane/dataplane_windows.go
+++ b/npm/pkg/dataplane/dataplane_windows.go
@@ -162,7 +162,9 @@ func (dp *DataPlane) updatePod(pod *updateNPMPod) error {
 		}
 
 		for policyKey := range selectorReference {
-			toAddPolicies[policyKey] = struct{}{}
+			if _, ok := dp.pendingPolicies[policyKey]; !ok {
+				toAddPolicies[policyKey] = struct{}{}
+			}
 		}
 	}
 


### PR DESCRIPTION
Any of the three controllers can call `dp.ApplyDataPlane()` at any time, so we have to be careful of this situation: 
- `AddPolicy` is called
- an existing pod satisfies a policy's selector
- `ApplyDataPlane()` is called after the selector IPSets are created, but before the network policy is applied

When applying ipsets to the kernel in Windows, we need to add/remove policies from pod endpoints based on whether the pod now satisfies or no longer satisfies a policy's selector. This change makes sure we don't try to add a policy that is "pending" (about to be added to the kernel) in `dp.updatePod()`

Once the pending policy is applied, then existing code already applies the policy to all necessary endpoints.