### PR TITLE
fix: [NPM-WIN] add an empty set to lists in Windows

### DIFF
--- a/npm/pkg/dataplane/dataplane.go
+++ b/npm/pkg/dataplane/dataplane.go
@@ -42,6 +42,10 @@ type DataPlane struct {
 
 func NewDataPlane(nodeName string, ioShim *common.IOShim, cfg *Config, stopChannel <-chan struct{}) (*DataPlane, error) {
 	metrics.InitializeAll()
+	if util.IsWindowsDP() {
+		klog.Infof("[DataPlane] enabling AddEmptySetToLists for Windows")
+		cfg.IPSetManagerCfg.AddEmptySetToLists = true
+	}
 	dp := &DataPlane{
 		Config:          cfg,
 		policyMgr:       policies.NewPolicyManager(ioShim, cfg.PolicyManagerCfg),

--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -183,6 +183,7 @@ const (
 	PodLabelPrefix       string = "podlabel-"
 	CIDRPrefix           string = "cidr-"
 	NestedLabelPrefix    string = "nestedlabel-"
+	EmptySetPrefix       string = "empty-"
 
 	NegationPrefix string = "not-"
 


### PR DESCRIPTION
Previous bug: all traffic is incorrectly allowed if a network policy has a namespace selector for a key (or key:value pair) and none of the namespaces have the given key (or key:value).

In HNS, an ACL conditioned on a list (nested ipset) will apply to any IP if the list has no members. This is contrary to Linux `ipset` behavior, where a match on an empty list will never match any IP.