### PR TITLE
Watch ClusterSubnetState and drive subnet exhaustion batch changes

### DIFF
--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -21,6 +21,7 @@ const (
 type CNSConfig struct {
 	ChannelMode                 string
 	EnablePprof                 bool
+	EnableSubnetScarcity        bool
 	InitializeFromCNI           bool
 	ManagedSettings             ManagedSettings
 	MetricsBindAddress          string

--- a/cns/configuration/configuration_test.go
+++ b/cns/configuration/configuration_test.go
@@ -53,8 +53,10 @@ func TestReadConfigFromFile(t *testing.T) {
 			name: "full config",
 			path: "testdata/good.json",
 			want: &CNSConfig{
-				ChannelMode:       "Direct",
-				InitializeFromCNI: true,
+				ChannelMode:          "Direct",
+				InitializeFromCNI:    true,
+				EnablePprof:          true,
+				EnableSubnetScarcity: true,
 				ManagedSettings: ManagedSettings{
 					PrivateEndpoint:           "abc",
 					InfrastructureNetworkID:   "abc",

--- a/cns/configuration/testdata/good.json
+++ b/cns/configuration/testdata/good.json
@@ -1,6 +1,8 @@
 {
     "ChannelMode": "Direct",
     "InitializeFromCNI": true,
+    "EnablePprof": true,
+    "EnableSubnetScarcity": true,
     "ManagedSettings": {
         "InfrastructureNetworkID": "abc",
         "NodeID": "abc",

--- a/cns/ipampool/monitor.go
+++ b/cns/ipampool/monitor.go
@@ -50,9 +50,9 @@ type Monitor struct {
 	metastate   metaState
 	nnccli      nodeNetworkConfigSpecUpdater
 	httpService cns.HTTPService
-	started     chan interface{}
 	cssSource   <-chan v1alpha1.ClusterSubnetState
 	nncSource   chan v1alpha.NodeNetworkConfig
+	started     chan interface{}
 	once        sync.Once
 }
 
@@ -71,8 +71,9 @@ func NewMonitor(httpService cns.HTTPService, nnccli nodeNetworkConfigSpecUpdater
 		opts:        opts,
 		httpService: httpService,
 		nnccli:      nnccli,
-		started:     make(chan interface{}),
+		cssSource:   cssSource,
 		nncSource:   make(chan v1alpha.NodeNetworkConfig),
+		started:     make(chan interface{}),
 	}
 }
 
@@ -263,7 +264,7 @@ func (pm *Monitor) increasePoolSize(ctx context.Context, meta metaState, state i
 	tempNNCSpec.RequestedIPCount += batchSize
 	if tempNNCSpec.RequestedIPCount > meta.max {
 		// We don't want to ask for more ips than the max
-		logger.Printf("[ipam-pool-monitor] Requested IP count (%d) is over max limit (%d), requesting max limit instead.", tempNNCSpec.RequestedIPCount, pm.metastate.max)
+		logger.Printf("[ipam-pool-monitor] Requested IP count (%d) is over max limit (%d), requesting max limit instead.", tempNNCSpec.RequestedIPCount, meta.max)
 		tempNNCSpec.RequestedIPCount = meta.max
 	}
 

--- a/cns/ipampool/monitor_test.go
+++ b/cns/ipampool/monitor_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/fakes"
 	"github.com/Azure/azure-container-networking/cns/logger"
-	"github.com/Azure/azure-container-networking/crd/clustersubnetstate/api/v1alpha1"
 	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	"github.com/stretchr/testify/assert"
 )
@@ -38,6 +37,7 @@ type testState struct {
 	allocated               int64
 	assigned                int
 	batch                   int64
+	exhausted               bool
 	max                     int64
 	pendingRelease          int64
 	releaseThresholdPercent int64
@@ -61,12 +61,12 @@ func initFakes(state testState) (*fakes.HTTPServiceFake, *fakes.RequestControlle
 	}
 	fakecns := fakes.NewHTTPServiceFake()
 	fakerc := fakes.NewRequestControllerFake(fakecns, scalarUnits, subnetaddresspace, state.totalIPs)
-	fakeCSSSource := make(chan v1alpha1.ClusterSubnetState)
 
-	poolmonitor := NewMonitor(fakecns, &fakeNodeNetworkConfigUpdater{fakerc.NNC}, fakeCSSSource, &Options{RefreshDelay: 100 * time.Second})
+	poolmonitor := NewMonitor(fakecns, &fakeNodeNetworkConfigUpdater{fakerc.NNC}, nil, &Options{RefreshDelay: 100 * time.Second})
 	poolmonitor.metastate = metaState{
-		batch: state.batch,
-		max:   state.max,
+		batch:     state.batch,
+		max:       state.max,
+		exhausted: state.exhausted,
 	}
 	fakecns.PoolMonitor = &directUpdatePoolMonitor{m: poolmonitor}
 	if err := fakecns.SetNumberOfAssignedIPs(state.assigned); err != nil {
@@ -88,26 +88,39 @@ func TestPoolSizeIncrease(t *testing.T) {
 		{
 			name: "typ",
 			in: testState{
-				batch:                   10,
-				assigned:                8,
 				allocated:               10,
-				requestThresholdPercent: 50,
-				releaseThresholdPercent: 150,
+				assigned:                8,
+				batch:                   10,
 				max:                     30,
+				releaseThresholdPercent: 150,
+				requestThresholdPercent: 50,
 			},
 			want: 20,
 		},
 		{
-			name: "starvation",
+			name: "odd batch",
 			in: testState{
-				batch:                   1,
-				assigned:                10,
 				allocated:               10,
-				requestThresholdPercent: 50,
-				releaseThresholdPercent: 150,
+				assigned:                10,
+				batch:                   3,
 				max:                     30,
+				releaseThresholdPercent: 150,
+				requestThresholdPercent: 50,
 			},
-			want: 11,
+			want: 13,
+		},
+		{
+			name: "subnet exhausted",
+			in: testState{
+				allocated:               10,
+				assigned:                8,
+				batch:                   10,
+				exhausted:               true,
+				max:                     30,
+				releaseThresholdPercent: 150,
+				requestThresholdPercent: 50,
+			},
+			want: 9,
 		},
 	}
 
@@ -267,36 +280,54 @@ func TestIncreaseWithPendingRelease(t *testing.T) {
 
 func TestPoolDecrease(t *testing.T) {
 	tests := []struct {
-		name         string
-		in           testState
-		want         int64
-		wantReleased int
+		name           string
+		in             testState
+		targetAssigned int
+		want           int64
+		wantReleased   int
 	}{
 		{
 			name: "typ",
 			in: testState{
-				batch:                   10,
 				allocated:               20,
 				assigned:                15,
-				requestThresholdPercent: 50,
-				releaseThresholdPercent: 150,
+				batch:                   10,
 				max:                     30,
+				releaseThresholdPercent: 150,
+				requestThresholdPercent: 50,
 			},
-			want:         10,
-			wantReleased: 10,
+			targetAssigned: 5,
+			want:           10,
+			wantReleased:   10,
 		},
 		{
-			name: "starvation",
+			name: "odd batch",
 			in: testState{
-				batch:                   1,
-				allocated:               20,
+				allocated:               21,
 				assigned:                19,
-				requestThresholdPercent: 50,
-				releaseThresholdPercent: 150,
+				batch:                   3,
 				max:                     30,
+				releaseThresholdPercent: 150,
+				requestThresholdPercent: 50,
 			},
-			want:         19,
-			wantReleased: 1,
+			targetAssigned: 15,
+			want:           18,
+			wantReleased:   3,
+		},
+		{
+			name: "exhausted",
+			in: testState{
+				allocated:               20,
+				assigned:                15,
+				batch:                   10,
+				exhausted:               true,
+				max:                     30,
+				releaseThresholdPercent: 150,
+				requestThresholdPercent: 50,
+			},
+			targetAssigned: 15,
+			want:           16,
+			wantReleased:   4,
 		},
 	}
 	for _, tt := range tests {
@@ -305,20 +336,25 @@ func TestPoolDecrease(t *testing.T) {
 			fakecns, fakerc, poolmonitor := initFakes(tt.in)
 			assert.NoError(t, fakerc.Reconcile(true))
 
-			// Pool monitor does nothing, as the current number of IPs falls in the threshold
-			assert.NoError(t, poolmonitor.reconcile(context.Background()))
+			// Decrease the number of allocated IPs down to target. This may trigger a scale down.
+			assert.NoError(t, fakecns.SetNumberOfAssignedIPs(tt.targetAssigned))
 
-			// Decrease the number of allocated IPs down to 5. This should trigger a scale down
-			assert.NoError(t, fakecns.SetNumberOfAssignedIPs(4))
+			assert.Eventually(t, func() bool {
+				_ = poolmonitor.reconcile(context.Background())
+				return tt.want == poolmonitor.spec.RequestedIPCount
+			}, time.Second, 1*time.Millisecond)
 
-			// Pool monitor will adjust the spec so the pool size will be 1 batch size smaller
-			assert.NoError(t, poolmonitor.reconcile(context.Background()))
+			// verify that the adjusted spec is smaller than the initial pool size
+			assert.Less(t, poolmonitor.spec.RequestedIPCount, tt.in.allocated)
 
-			// ensure that the adjusted spec is smaller than the initial pool size
+			// verify that we have released the expected amount
 			assert.Len(t, poolmonitor.spec.IPsNotInUse, tt.wantReleased)
 
 			// reconcile the fake request controller
 			assert.NoError(t, fakerc.Reconcile(true))
+
+			// make sure IPConfig state size reflects the new pool size
+			assert.Len(t, fakecns.GetPodIPConfigState(), int(tt.want))
 
 			// CNS won't actually clean up the IPsNotInUse until it changes the spec for some other reason (i.e. scale up)
 			// so instead we should just verify that the CNS state has no more PendingReleaseIPConfigs,

--- a/cns/ipampool/monitor_test.go
+++ b/cns/ipampool/monitor_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/fakes"
 	"github.com/Azure/azure-container-networking/cns/logger"
+	"github.com/Azure/azure-container-networking/crd/clustersubnetstate/api/v1alpha1"
 	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	"github.com/stretchr/testify/assert"
 )
@@ -60,8 +61,9 @@ func initFakes(state testState) (*fakes.HTTPServiceFake, *fakes.RequestControlle
 	}
 	fakecns := fakes.NewHTTPServiceFake()
 	fakerc := fakes.NewRequestControllerFake(fakecns, scalarUnits, subnetaddresspace, state.totalIPs)
+	fakeCSSSource := make(chan v1alpha1.ClusterSubnetState)
 
-	poolmonitor := NewMonitor(fakecns, &fakeNodeNetworkConfigUpdater{fakerc.NNC}, &Options{RefreshDelay: 100 * time.Second})
+	poolmonitor := NewMonitor(fakecns, &fakeNodeNetworkConfigUpdater{fakerc.NNC}, fakeCSSSource, &Options{RefreshDelay: 100 * time.Second})
 	poolmonitor.metastate = metaState{
 		batch: state.batch,
 		max:   state.max,

--- a/cns/kubecontroller/clustersubnetstate/reconciler.go
+++ b/cns/kubecontroller/clustersubnetstate/reconciler.go
@@ -1,0 +1,34 @@
+package clustersubnetstate
+
+import (
+	"context"
+
+	"github.com/Azure/azure-container-networking/crd/clustersubnetstate/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type cssClient interface {
+	Get(context.Context, types.NamespacedName) (*v1alpha1.ClusterSubnetState, error)
+}
+
+type Reconciler struct {
+	Cli  cssClient
+	Sink chan<- v1alpha1.ClusterSubnetState
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	css, err := r.Cli.Get(ctx, req.NamespacedName)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	r.Sink <- *css
+	return reconcile.Result{}, nil
+}
+
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1alpha1.ClusterSubnetState{}).
+		Complete(r)
+}

--- a/cns/kubecontroller/clustersubnetstate/reconciler.go
+++ b/cns/kubecontroller/clustersubnetstate/reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/Azure/azure-container-networking/crd/clustersubnetstate/api/v1alpha1"
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -21,14 +22,15 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	css, err := r.Cli.Get(ctx, req.NamespacedName)
 	if err != nil {
-		return reconcile.Result{}, err
+		return reconcile.Result{}, errors.Wrapf(err, "failed to get css %s", req.String())
 	}
 	r.Sink <- *css
 	return reconcile.Result{}, nil
 }
 
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
+	err := ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.ClusterSubnetState{}).
 		Complete(r)
+	return errors.Wrap(err, "failed to setup clustersubnetstate reconciler with manager")
 }

--- a/cns/kubecontroller/nodenetworkconfig/reconciler.go
+++ b/cns/kubecontroller/nodenetworkconfig/reconciler.go
@@ -149,7 +149,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, node *v1.Node) error {
 			return metav1.IsControlledBy(object, node)
 		})).
 		WithEventFilter(predicate.Funcs{
-			// check that the generation is the same - status changes don't update generation.a
+			// check that the generation is the same - status changes don't update generation.
 			UpdateFunc: func(ue event.UpdateEvent) bool {
 				return ue.ObjectOld.GetGeneration() == ue.ObjectNew.GetGeneration()
 			},

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1083,7 +1083,7 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 	// NodeNetworkConfig reconciler
 	nncReconciler := nncctrl.NewReconciler(httpRestServiceImplementation, nnccli, poolMonitor)
 	// pass Node to the Reconciler for Controller xref
-	if err := nncReconciler.SetupWithManager(manager, node); err != nil {
+	if err := nncReconciler.SetupWithManager(manager, node); err != nil { //nolint:govet // intentional shadow
 		return errors.Wrapf(err, "failed to setup nnc reconciler with manager")
 	}
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Azure/azure-container-networking/cns/healthserver"
 	"github.com/Azure/azure-container-networking/cns/hnsclient"
 	"github.com/Azure/azure-container-networking/cns/ipampool"
+	cssctrl "github.com/Azure/azure-container-networking/cns/kubecontroller/clustersubnetstate"
 	nncctrl "github.com/Azure/azure-container-networking/cns/kubecontroller/nodenetworkconfig"
 	"github.com/Azure/azure-container-networking/cns/logger"
 	"github.com/Azure/azure-container-networking/cns/multitenantcontroller"
@@ -39,6 +40,8 @@ import (
 	"github.com/Azure/azure-container-networking/cns/wireserver"
 	acn "github.com/Azure/azure-container-networking/common"
 	"github.com/Azure/azure-container-networking/crd"
+	"github.com/Azure/azure-container-networking/crd/clustersubnetstate"
+	"github.com/Azure/azure-container-networking/crd/clustersubnetstate/api/v1alpha1"
 	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig"
 	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	"github.com/Azure/azure-container-networking/log"
@@ -1001,11 +1004,12 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 	// TODO(rbtr): nodename and namespace should be in the cns config
 	scopedcli := nncctrl.NewScopedClient(nnccli, types.NamespacedName{Namespace: "kube-system", Name: nodeName})
 
+	clusterSubnetStateChan := make(chan v1alpha1.ClusterSubnetState)
 	// initialize the ipam pool monitor
 	poolOpts := ipampool.Options{
 		RefreshDelay: poolIPAMRefreshRateInMilliseconds * time.Millisecond,
 	}
-	poolMonitor := ipampool.NewMonitor(httpRestServiceImplementation, scopedcli, &poolOpts)
+	poolMonitor := ipampool.NewMonitor(httpRestServiceImplementation, scopedcli, clusterSubnetStateChan, &poolOpts)
 	httpRestServiceImplementation.IPAMPoolMonitor = poolMonitor
 
 	// reconcile initial CNS state from CNI or apiserver.
@@ -1076,10 +1080,25 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 		return errors.Wrapf(err, "failed to get node %s", nodeName)
 	}
 
-	reconciler := nncctrl.NewReconciler(httpRestServiceImplementation, nnccli, poolMonitor)
+	// NodeNetworkConfig reconciler
+	nncReconciler := nncctrl.NewReconciler(httpRestServiceImplementation, nnccli, poolMonitor)
 	// pass Node to the Reconciler for Controller xref
-	if err := reconciler.SetupWithManager(manager, node); err != nil {
-		return errors.Wrapf(err, "failed to setup reconciler with manager")
+	if err := nncReconciler.SetupWithManager(manager, node); err != nil {
+		return errors.Wrapf(err, "failed to setup nnc reconciler with manager")
+	}
+
+	cssCli, err := clustersubnetstate.NewClient(kubeConfig)
+	if err != nil {
+		return errors.Wrapf(err, "failed to init css client")
+	}
+
+	// ClusterSubnetState reconciler
+	cssReconciler := cssctrl.Reconciler{
+		Cli:  cssCli,
+		Sink: clusterSubnetStateChan,
+	}
+	if err := cssReconciler.SetupWithManager(manager); err != nil {
+		return errors.Wrapf(err, "failed to setup css reconciler with manager")
 	}
 
 	// adding some routes to the root service mux
@@ -1123,7 +1142,7 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 	// wait for up to 10m for the Reconciler to run once.
 	timedCtx, cancel := context.WithTimeout(ctx, 10*time.Minute) //nolint:gomnd // default 10m
 	defer cancel()
-	if started := reconciler.Started(timedCtx); !started {
+	if started := nncReconciler.Started(timedCtx); !started {
 		return errors.Errorf("timed out waiting for reconciler start")
 	}
 	logger.Printf("started NodeNetworkConfig reconciler")

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1087,18 +1087,20 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 		return errors.Wrapf(err, "failed to setup nnc reconciler with manager")
 	}
 
-	cssCli, err := clustersubnetstate.NewClient(kubeConfig)
-	if err != nil {
-		return errors.Wrapf(err, "failed to init css client")
-	}
+	if cnsconfig.EnableSubnetScarcity {
+		cssCli, err := clustersubnetstate.NewClient(kubeConfig)
+		if err != nil {
+			return errors.Wrapf(err, "failed to init css client")
+		}
 
-	// ClusterSubnetState reconciler
-	cssReconciler := cssctrl.Reconciler{
-		Cli:  cssCli,
-		Sink: clusterSubnetStateChan,
-	}
-	if err := cssReconciler.SetupWithManager(manager); err != nil {
-		return errors.Wrapf(err, "failed to setup css reconciler with manager")
+		// ClusterSubnetState reconciler
+		cssReconciler := cssctrl.Reconciler{
+			Cli:  cssCli,
+			Sink: clusterSubnetStateChan,
+		}
+		if err := cssReconciler.SetupWithManager(manager); err != nil {
+			return errors.Wrapf(err, "failed to setup css reconciler with manager")
+		}
 	}
 
 	// adding some routes to the root service mux


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Watch the ClusterSubnetState CRDs for Subnet Exhausted states, push those to the IPAM Pool Monitor to trigger a batch override to 1, releasing all extra IPs and scaling one IP at a time.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
