### PR TITLE
Use aks-engine binary that doesn't add nsg allow ssh rule

### DIFF
--- a/.pipelines/singletenancy/aks-engine/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks-engine/e2e-step-template.yaml
@@ -29,23 +29,21 @@ steps:
       echo Using AKS-Engine version $aksEVersion
 
       #download source
-      wget https://github.com/jaer-tsun/aks-engine/archive/v1.0.5.tar.gz
+      wget https://github.com/pjohnst5/aks-engine/archive/v1.0.6.tar.gz
 
       # extract source
       #tar -zxf $aksEVersion.tar.gz
-      tar -zxf v1.0.5.tar.gz
+      tar -zxf v1.0.6.tar.gz
 
       # move source to current directory
       mv aks-engine-*/* .
 
       # download binary
-      wget https://github.com/jaer-tsun/aks-engine/releases/download/v1.0.5/aks-engine-v1.0.5-linux-amd64.tar.gz
+      wget https://github.com/pjohnst5/aks-engine/releases/download/v1.0.6/aks-engine
+      chmod 0555 aks-engine
       rm -rf ./bin
       mkdir ./bin
-
-      # extract binary
-      tar -zxvf aks-engine-v1.0.5-linux-amd64.tar.gz -C bin
-      mv ./bin/aks-engine-*/* ./bin/
+      mv ./aks-engine ./bin/
       ls -l ./bin
       ./bin/aks-engine version
       echo '##vso[task.prependpath]$(GOBIN)'
@@ -70,7 +68,7 @@ steps:
       echo CNI_URL is $CNI_URL
       echo Config: '${{ parameters.clusterDefinition }}'
       cat '${{ parameters.clusterDefinition }}'
-      cat '${{ parameters.clusterDefinition }}' | jq --arg cnikey $CNI_TYPE --arg cniurl $CNI_URL '.properties.orchestratorProfile.kubernetesConfig[$cnikey]= $cniurl' > '${{ parameters.clusterDefinition }}'.tmp	
+      cat '${{ parameters.clusterDefinition }}' | jq --arg cnikey $CNI_TYPE --arg cniurl $CNI_URL '.properties.orchestratorProfile.kubernetesConfig[$cnikey]= $cniurl' > '${{ parameters.clusterDefinition }}'.tmp
       cat '${{ parameters.clusterDefinition }}'.tmp | jq --arg tag $(Tag) '.properties.orchestratorProfile.kubernetesConfig.azureCNIVersion = $tag' > '${{ parameters.clusterDefinition }}'
       cat '${{ parameters.clusterDefinition }}' | jq --arg npmimage $IMAGE_REGISTRY/azure-npm:$(Tag) '.properties.orchestratorProfile.kubernetesConfig.addons[0].containers[0].image = $npmimage' > '${{ parameters.clusterDefinition }}'.tmp
       if [ "${{ parameters.Name }}" == "windows_20_22_e2e" ]; then
@@ -83,7 +81,7 @@ steps:
         fi
       fi
       mv '${{ parameters.clusterDefinition }}'.tmp '${{ parameters.clusterDefinition }}'
-      echo "Running E2E tests against a cluster built with the following API model:" 
+      echo "Running E2E tests against a cluster built with the following API model:"
       cp ${{ parameters.clusterDefinition }} clusterDefinition.json
     displayName: Configure AKS-Engine
     workingDirectory: "$(modulePath)"
@@ -96,18 +94,18 @@ steps:
       workingDirectory: "$(modulePath)"
       inlineScript: |
         export CLIENT_ID=$servicePrincipalId
-        export CLIENT_SECRET=$servicePrincipalKey 
+        export CLIENT_SECRET=$servicePrincipalKey
         export PATH=$PATH:'$(GOPATH)'
         export CLUSTER_DEFINITION=./clusterDefinition.json
-        export ORCHESTRATOR=kubernetes 
-        export CREATE_VNET=false 
-        export TIMEOUT=20m 
-        export TENANT_ID=$(AKS_ENGINE_TENANT_ID) 
-        export SUBSCRIPTION_ID=$(AKS_ENGINE_SUBSCRIPTION_ID) 
+        export ORCHESTRATOR=kubernetes
+        export CREATE_VNET=false
+        export TIMEOUT=20m
+        export TENANT_ID=$(AKS_ENGINE_TENANT_ID)
+        export SUBSCRIPTION_ID=$(AKS_ENGINE_SUBSCRIPTION_ID)
         export CLEANUP_ON_EXIT=true
         export CLEANUP_IF_FAIL=false
-        export REGIONS=$(AKS_ENGINE_REGION) 
-        export IS_JENKINS=false 
+        export REGIONS=$(AKS_ENGINE_REGION)
+        export IS_JENKINS=false
         export DEBUG_CRASHING_PODS=true
         export AZURE_CORE_ONLY_SHOW_ERRORS=True
         RGNAME="kubernetes"$RANDOM

--- a/test/apimodels/cniLinux1804.json
+++ b/test/apimodels/cniLinux1804.json
@@ -4,7 +4,7 @@
       "orchestratorProfile": {
          "orchestratorType": "Kubernetes",
          "orchestratorRelease": "1.22",
-         "orchestratorVersion": "1.22.7",
+         "orchestratorVersion": "1.22.12",
          "kubernetesConfig": {
             "networkPlugin": "azure",
             "networkPolicy": "azure",

--- a/test/apimodels/cniWindows1903.json
+++ b/test/apimodels/cniWindows1903.json
@@ -4,7 +4,7 @@
       "orchestratorProfile": {
          "orchestratorType": "Kubernetes",
          "orchestratorRelease": "1.22",
-         "orchestratorVersion": "1.22.7",
+         "orchestratorVersion": "1.22.12",
          "kubernetesConfig": {
             "networkPlugin": "azure",
             "networkPolicy": "azure",

--- a/test/apimodels/cniWindows2004.json
+++ b/test/apimodels/cniWindows2004.json
@@ -4,7 +4,7 @@
       "orchestratorProfile": {
          "orchestratorType": "Kubernetes",
          "orchestratorRelease": "1.22",
-         "orchestratorVersion": "1.22.7",
+         "orchestratorVersion": "1.22.12",
          "kubernetesConfig": {
             "networkPlugin": "azure",
             "networkPolicy": "azure",


### PR DESCRIPTION
Using an aks-engine version that doesn't add nsg allow ssh rule to master nodes
https://github.com/pjohnst5/aks-engine/releases/tag/v1.0.6