### PR TITLE
scale: [NPM] ignore leaked ipset references

### DIFF
--- a/npm/iptm/iptm.go
+++ b/npm/iptm/iptm.go
@@ -19,10 +19,9 @@ import (
 )
 
 const (
-	defaultlockWaitTimeInSeconds string = "60"
-	iptablesErrDoesNotExist      int    = 1
-	reconcileChainTimeInMinutes         = 5
-	minLineNumberStringLength    int    = 3
+	iptablesErrDoesNotExist     int = 1
+	reconcileChainTimeInMinutes     = 5
+	minLineNumberStringLength   int = 3
 )
 
 var (
@@ -139,7 +138,7 @@ func (iptMgr *IptablesManager) UninitNpmChains() error {
 		util.IptablesAzureTargetSetsChain,
 		util.IptablesAzureIngressWrongDropsChain,
 	)
-	currentAzureChains, err := ioutil.AllCurrentAzureChains(iptMgr.exec, defaultlockWaitTimeInSeconds)
+	currentAzureChains, err := ioutil.AllCurrentAzureChains(iptMgr.exec, util.IptablesDefaultWaitTime)
 	if err != nil {
 		metrics.SendErrorLogAndMetric(util.IptmID, "Warning: failed to get all current AZURE-NPM chains, so stale v2 chains may exist")
 	} else {
@@ -490,7 +489,7 @@ func (iptMgr *IptablesManager) run(entry *IptEntry) (int, error) {
 	}
 
 	if entry.LockWaitTimeInSeconds == "" {
-		entry.LockWaitTimeInSeconds = defaultlockWaitTimeInSeconds
+		entry.LockWaitTimeInSeconds = util.IptablesDefaultWaitTime
 	}
 
 	cmdArgs := append([]string{util.IptablesWaitFlag, entry.LockWaitTimeInSeconds, iptMgr.OperationFlag, entry.Chain}, entry.Specs...)

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_linux.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_linux.go
@@ -107,6 +107,10 @@ func (iMgr *IPSetManager) resetIPSets() error {
 
 	// flush all NPM sets
 	creator, names, failedNames := iMgr.fileCreatorForFlushAll(azureIPSets)
+	// FIXME: remove
+	creator = ioutil.NewFileCreator(iMgr.ioShim, maxTryCount, ipsetRestoreLineFailurePattern)
+	creator.AddLine("", nil, ipsetCreateFlag, "azure-npm-test", ipsetExistFlag, ipsetNetHashFlag)
+
 	restoreError := creator.RunCommandWithFile(ipsetCommand, ipsetRestoreFlag)
 	if restoreError != nil {
 		klog.Errorf(

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_linux.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_linux.go
@@ -107,10 +107,6 @@ func (iMgr *IPSetManager) resetIPSets() error {
 
 	// flush all NPM sets
 	creator, names, failedNames := iMgr.fileCreatorForFlushAll(azureIPSets)
-	// FIXME: remove
-	creator = ioutil.NewFileCreator(iMgr.ioShim, maxTryCount, ipsetRestoreLineFailurePattern)
-	creator.AddLine("", nil, ipsetCreateFlag, "azure-npm-test", ipsetExistFlag, ipsetNetHashFlag)
-
 	restoreError := creator.RunCommandWithFile(ipsetCommand, ipsetRestoreFlag)
 	if restoreError != nil {
 		klog.Errorf(

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_linux.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_linux.go
@@ -105,11 +105,11 @@ func (iMgr *IPSetManager) resetIPSets() error {
 	listNamesCommand := iMgr.ioShim.Exec.Command(ipsetCommand, ipsetListFlag, ipsetNameFlag)
 	grepCommand := iMgr.ioShim.Exec.Command(ioutil.Grep, azureNPMPrefix)
 	klog.Infof("running this command while resetting ipsets: [%s %s %s | %s %s]", ipsetCommand, ipsetListFlag, ipsetNameFlag, ioutil.Grep, azureNPMRegex)
-	azureIPSets, haveAzureIPSets, commandError := ioutil.PipeCommandToGrep(listNamesCommand, grepCommand)
+	azureIPSets, haveAzureNPMIPSets, commandError := ioutil.PipeCommandToGrep(listNamesCommand, grepCommand)
 	if commandError != nil {
 		return npmerrors.SimpleErrorWrapper("failed to run ipset list for resetting IPSets (prometheus metrics may be off now)", commandError)
 	}
-	if !haveAzureIPSets {
+	if !haveAzureNPMIPSets {
 		return nil
 	}
 
@@ -143,12 +143,12 @@ func (iMgr *IPSetManager) resetWithoutRestore() bool {
 	grepCommand := iMgr.ioShim.Exec.Command(ioutil.Grep, ioutil.GrepQuietFlag, ioutil.GrepAntiMatchFlag, azureNPMPrefix)
 	commandString := fmt.Sprintf(" [%s %s %s | %s %s %s %s]", ipsetCommand, ipsetListFlag, ipsetNameFlag, ioutil.Grep, ioutil.GrepQuietFlag, ioutil.GrepAntiMatchFlag, azureNPMPrefix)
 	klog.Infof("running this command while resetting ipsets: [%s]", commandString)
-	_, haveNonAzureIPSets, commandError := ioutil.PipeCommandToGrep(listNamesCommand, grepCommand)
+	_, haveNonAzureNPMIPSets, commandError := ioutil.PipeCommandToGrep(listNamesCommand, grepCommand)
 	if commandError != nil {
 		metrics.SendErrorLogAndMetric(util.IpsmID, "failed to determine if there were non-azure sets while resetting. err: %v", commandError)
 		return false
 	}
-	if haveNonAzureIPSets {
+	if haveNonAzureNPMIPSets {
 		return false
 	}
 

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_linux_test.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_linux_test.go
@@ -400,8 +400,6 @@ func TestDestroyNPMIPSets(t *testing.T) {
 		{
 			name: "success with no results from grep",
 			calls: []testutils.TestCmd{
-				{Cmd: []string{"iptables-save"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
 				{Cmd: []string{"ipset", "list", "--name"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "azure-npm-"}, ExitCode: 1},
 			},
@@ -410,48 +408,19 @@ func TestDestroyNPMIPSets(t *testing.T) {
 		{
 			name: "successfully delete sets",
 			calls: []testutils.TestCmd{
-				{Cmd: []string{"iptables-save"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
 				{Cmd: []string{"ipset", "list", "--name"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "azure-npm-"}, Stdout: resetIPSetsListOutputString},
 				fakeRestoreSuccessCommand,
 				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-B", "6", "-P", "Number of entries: \\d"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
-				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-B", "5", "-P", "References: \\d"}, PipedToCommand: true},
+				{Cmd: []string{"grep", "-B", "5", "-P", "References: [1-9]"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
 				fakeRestoreSuccessCommand,
 			},
 			wantErr: false,
 		},
 		{
-			name: "fail because some sets have entries",
-			calls: []testutils.TestCmd{
-				{Cmd: []string{"iptables-save"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
-				{Cmd: []string{"ipset", "list", "--name"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "azure-npm-"}, Stdout: resetIPSetsListOutputString},
-				fakeRestoreSuccessCommand,
-				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-B", "6", "-P", "Number of entries: \\d"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, Stdout: resetIPSetsListOutputString},
-			},
-			wantErr: true,
-		},
-		{
-			name: "fail because some sets have iptables references",
-			calls: []testutils.TestCmd{
-				{Cmd: []string{"iptables-save"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, Stdout: resetIPSetsListOutputString},
-			},
-			wantErr: true,
-		},
-		{
 			name: "grep error",
 			calls: []testutils.TestCmd{
-				{Cmd: []string{"iptables-save"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
 				{Cmd: []string{"ipset", "list", "--name"}, HasStartError: true, PipedToCommand: true, ExitCode: 1},
 				{Cmd: []string{"grep", "azure-npm-"}},
 			},
@@ -460,8 +429,6 @@ func TestDestroyNPMIPSets(t *testing.T) {
 		{
 			name: "restore error from max flush tries",
 			calls: []testutils.TestCmd{
-				{Cmd: []string{"iptables-save"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
 				{Cmd: []string{"ipset", "list", "--name"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "azure-npm-"}, Stdout: resetIPSetsListOutputString},
 				{Cmd: ipsetRestoreStringSlice, ExitCode: 1},
@@ -473,16 +440,11 @@ func TestDestroyNPMIPSets(t *testing.T) {
 		{
 			name: "restore error from max destroy tries",
 			calls: []testutils.TestCmd{
-				{Cmd: []string{"iptables-save"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
 				{Cmd: []string{"ipset", "list", "--name"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "azure-npm-"}, Stdout: resetIPSetsListOutputString},
 				fakeRestoreSuccessCommand,
 				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-B", "6", "-P", "Number of entries: \\d"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
-				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-B", "5", "-P", "References: \\d"}, PipedToCommand: true},
+				{Cmd: []string{"grep", "-B", "5", "-P", "References: [1-9]"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
 				{Cmd: ipsetRestoreStringSlice, ExitCode: 1},
 				{Cmd: ipsetRestoreStringSlice, ExitCode: 1},
@@ -493,16 +455,11 @@ func TestDestroyNPMIPSets(t *testing.T) {
 		{
 			name: "success despite all sets having references",
 			calls: []testutils.TestCmd{
-				{Cmd: []string{"iptables-save"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
 				{Cmd: []string{"ipset", "list", "--name"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "azure-npm-"}, Stdout: resetIPSetsListOutputString},
 				fakeRestoreSuccessCommand,
 				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-B", "6", "-P", "Number of entries: \\d"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
-				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-B", "5", "-P", "References: \\d"}, PipedToCommand: true},
+				{Cmd: []string{"grep", "-B", "5", "-P", "References: [1-9]"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, Stdout: resetIPSetsListOutputString},
 			},
 			wantErr: false,
@@ -510,16 +467,11 @@ func TestDestroyNPMIPSets(t *testing.T) {
 		{
 			name: "success despite one set having references",
 			calls: []testutils.TestCmd{
-				{Cmd: []string{"iptables-save"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
 				{Cmd: []string{"ipset", "list", "--name"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "azure-npm-"}, Stdout: resetIPSetsListOutputString},
 				fakeRestoreSuccessCommand,
 				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-B", "6", "-P", "Number of entries: \\d"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
-				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-B", "5", "-P", "References: \\d"}, PipedToCommand: true},
+				{Cmd: []string{"grep", "-B", "5", "-P", "References: [1-9]"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, Stdout: otherIPSetsListOutput},
 				fakeRestoreSuccessCommand,
 			},
@@ -528,8 +480,6 @@ func TestDestroyNPMIPSets(t *testing.T) {
 		{
 			name: "successfully restore, but fail to flush/destroy 1 set since the set doesn't exist when flushing",
 			calls: []testutils.TestCmd{
-				{Cmd: []string{"iptables-save"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
 				{Cmd: []string{"ipset", "list", "--name"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "azure-npm-"}, Stdout: resetIPSetsListOutputString},
 				{
@@ -539,10 +489,7 @@ func TestDestroyNPMIPSets(t *testing.T) {
 				},
 				fakeRestoreSuccessCommand,
 				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-B", "6", "-P", "Number of entries: \\d"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
-				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-B", "5", "-P", "References: \\d"}, PipedToCommand: true},
+				{Cmd: []string{"grep", "-B", "5", "-P", "References: [1-9]"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
 				fakeRestoreSuccessCommand,
 			},
@@ -551,8 +498,6 @@ func TestDestroyNPMIPSets(t *testing.T) {
 		{
 			name: "successfully restore, but fail to flush/destroy 1 set due to other flush error",
 			calls: []testutils.TestCmd{
-				{Cmd: []string{"iptables-save"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
 				{Cmd: []string{"ipset", "list", "--name"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "azure-npm-"}, Stdout: resetIPSetsListOutputString},
 				{
@@ -562,10 +507,7 @@ func TestDestroyNPMIPSets(t *testing.T) {
 				},
 				fakeRestoreSuccessCommand,
 				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-B", "6", "-P", "Number of entries: \\d"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
-				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-B", "5", "-P", "References: \\d"}, PipedToCommand: true},
+				{Cmd: []string{"grep", "-B", "5", "-P", "References: [1-9]"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
 				fakeRestoreSuccessCommand,
 			},
@@ -574,16 +516,11 @@ func TestDestroyNPMIPSets(t *testing.T) {
 		{
 			name: "successfully restore, but fail to destroy 1 set since the set doesn't exist when destroying",
 			calls: []testutils.TestCmd{
-				{Cmd: []string{"iptables-save"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
 				{Cmd: []string{"ipset", "list", "--name"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "azure-npm-"}, Stdout: resetIPSetsListOutputString},
 				fakeRestoreSuccessCommand,
 				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-B", "6", "-P", "Number of entries: \\d"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
-				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-B", "5", "-P", "References: \\d"}, PipedToCommand: true},
+				{Cmd: []string{"grep", "-B", "5", "-P", "References: [1-9]"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
 				{
 					Cmd:      ipsetRestoreStringSlice,
@@ -597,16 +534,11 @@ func TestDestroyNPMIPSets(t *testing.T) {
 		{
 			name: "successfully restore, but fail to destroy 1 set due to other destroy error",
 			calls: []testutils.TestCmd{
-				{Cmd: []string{"iptables-save"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
 				{Cmd: []string{"ipset", "list", "--name"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "azure-npm-"}, Stdout: resetIPSetsListOutputString},
 				fakeRestoreSuccessCommand,
 				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-B", "6", "-P", "Number of entries: \\d"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
-				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-B", "5", "-P", "References: \\d"}, PipedToCommand: true},
+				{Cmd: []string{"grep", "-B", "5", "-P", "References: [1-9]"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
 				{
 					Cmd:      ipsetRestoreStringSlice,
@@ -641,8 +573,6 @@ func TestDestroyNPMIPSets(t *testing.T) {
 func TestResetIPSetsOnFailure(t *testing.T) {
 	metrics.ReinitializeAll()
 	calls := []testutils.TestCmd{
-		{Cmd: []string{"iptables-save"}, PipedToCommand: true},
-		{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
 		{Cmd: []string{"ipset", "list", "--name"}, PipedToCommand: true, HasStartError: true, ExitCode: 1},
 		{Cmd: []string{"grep", "azure-npm-"}},
 	}

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_linux_test.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_linux_test.go
@@ -643,7 +643,7 @@ func TestResetIPSetsOnFailure(t *testing.T) {
 	calls := []testutils.TestCmd{
 		{Cmd: []string{"iptables-save"}, PipedToCommand: true},
 		{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
-		{Cmd: []string{"ipset", "list", "--name"}, PipedToCommand: true, HasStartError: true},
+		{Cmd: []string{"ipset", "list", "--name"}, PipedToCommand: true, HasStartError: true, ExitCode: 1},
 		{Cmd: []string{"grep", "azure-npm-"}},
 	}
 	ioShim := common.NewMockIOShim(calls)
@@ -658,7 +658,7 @@ func TestResetIPSetsOnFailure(t *testing.T) {
 	metrics.AddEntryToIPSet("test1")
 	metrics.AddEntryToIPSet("test2")
 
-	require.NoError(t, iMgr.ResetIPSets())
+	require.Error(t, iMgr.ResetIPSets())
 
 	assertExpectedInfo(t, iMgr, &expectedInfo{
 		mainCache:        nil,

--- a/npm/pkg/dataplane/ipsets/testutils_linux.go
+++ b/npm/pkg/dataplane/ipsets/testutils_linux.go
@@ -23,6 +23,7 @@ func GetApplyIPSetsTestCalls(toAddOrUpdateIPSets, toDeleteIPSets []*IPSetMetadat
 func GetResetTestCalls() []testutils.TestCmd {
 	return []testutils.TestCmd{
 		{Cmd: []string{"ipset", "list", "--name"}, PipedToCommand: true},
-		{Cmd: []string{"grep", "azure-npm-"}, ExitCode: 1}, // grep didn't find anything
+		{Cmd: []string{"grep", "-q", "-v", "azure-npm-"}, ExitCode: 1}, // grep didn't find anything
+		{Cmd: []string{"bash", "-c", "ipset flush && ipset destroy"}},
 	}
 }

--- a/npm/pkg/dataplane/ipsets/testutils_linux.go
+++ b/npm/pkg/dataplane/ipsets/testutils_linux.go
@@ -22,8 +22,6 @@ func GetApplyIPSetsTestCalls(toAddOrUpdateIPSets, toDeleteIPSets []*IPSetMetadat
 
 func GetResetTestCalls() []testutils.TestCmd {
 	return []testutils.TestCmd{
-		{Cmd: []string{"iptables-save"}, PipedToCommand: true},
-		{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
 		{Cmd: []string{"ipset", "list", "--name"}, PipedToCommand: true},
 		{Cmd: []string{"grep", "azure-npm-"}, ExitCode: 1}, // grep didn't find anything
 	}

--- a/npm/pkg/dataplane/ipsets/testutils_linux.go
+++ b/npm/pkg/dataplane/ipsets/testutils_linux.go
@@ -22,6 +22,8 @@ func GetApplyIPSetsTestCalls(toAddOrUpdateIPSets, toDeleteIPSets []*IPSetMetadat
 
 func GetResetTestCalls() []testutils.TestCmd {
 	return []testutils.TestCmd{
+		{Cmd: []string{"iptables-save"}, PipedToCommand: true},
+		{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
 		{Cmd: []string{"ipset", "list", "--name"}, PipedToCommand: true},
 		{Cmd: []string{"grep", "azure-npm-"}, ExitCode: 1}, // grep didn't find anything
 	}

--- a/npm/pkg/dataplane/policies/chain-management_linux.go
+++ b/npm/pkg/dataplane/policies/chain-management_linux.go
@@ -181,7 +181,7 @@ func (pMgr *PolicyManager) bootup(_ []string) error {
 		klog.Errorf("failed to delete deprecated jump rule from FORWARD chain to AZURE-NPM chain for unexpected reason with exit code %d and error: %s", deprecatedErrCode, deprecatedErr.Error())
 	}
 
-	currentChains, err := ioutil.AllCurrentAzureChains(pMgr.ioShim.Exec, defaultlockWaitTimeInSeconds)
+	currentChains, err := ioutil.AllCurrentAzureChains(pMgr.ioShim.Exec, util.IptablesDefaultWaitTime)
 	if err != nil {
 		return npmerrors.SimpleErrorWrapper("failed to get current chains for bootup", err)
 	}
@@ -267,7 +267,7 @@ func (pMgr *PolicyManager) runIPTablesCommand(operationFlag string, args ...stri
 }
 
 func (pMgr *PolicyManager) ignoreErrorsAndRunIPTablesCommand(ignored []*exitErrorInfo, operationFlag string, args ...string) (int, error) {
-	allArgs := []string{util.IptablesWaitFlag, defaultlockWaitTimeInSeconds, operationFlag}
+	allArgs := []string{util.IptablesWaitFlag, util.IptablesDefaultWaitTime, operationFlag}
 	allArgs = append(allArgs, args...)
 
 	klog.Infof("Executing iptables command with args %v", allArgs)

--- a/npm/pkg/dataplane/policies/chain-management_linux.go
+++ b/npm/pkg/dataplane/policies/chain-management_linux.go
@@ -18,9 +18,6 @@ import (
 )
 
 const (
-	// TODO replace all util constants with local constants
-	defaultlockWaitTimeInSeconds string = "60"
-
 	doesNotExistErrorCode      int = 1 // stderr possibility: Bad rule (does a matching rule exist in that chain?)
 	couldntLoadTargetErrorCode int = 2 // Couldn't load target `AZURE-NPM-EGRESS':No such file or directory
 
@@ -66,7 +63,7 @@ var (
 	}
 
 	listForwardEntriesArgs = []string{
-		util.IptablesWaitFlag, defaultlockWaitTimeInSeconds, util.IptablesTableFlag, util.IptablesFilterTable,
+		util.IptablesWaitFlag, util.IptablesDefaultWaitTime, util.IptablesTableFlag, util.IptablesFilterTable,
 		util.IptablesNumericFlag, util.IptablesListFlag, util.IptablesForwardChain, util.IptablesLineNumbersFlag,
 	}
 	spaceByte                                 = []byte(" ")

--- a/npm/pkg/dataplane/policies/chain-management_linux_test.go
+++ b/npm/pkg/dataplane/policies/chain-management_linux_test.go
@@ -45,7 +45,7 @@ func TestBootupFailure(t *testing.T) {
 	metrics.ReinitializeAll()
 	calls := []testutils.TestCmd{
 		{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}, ExitCode: 2}, //nolint // AZURE-NPM chain didn't exist
-		{Cmd: listAllCommandStrings, PipedToCommand: true, HasStartError: true},
+		{Cmd: listAllCommandStrings, PipedToCommand: true, HasStartError: true, ExitCode: 1},
 		{Cmd: []string{"grep", "Chain AZURE-NPM"}},
 	}
 	ioshim := common.NewMockIOShim(calls)
@@ -702,6 +702,7 @@ func TestPositionAzureChainJumpRule(t *testing.T) {
 			calls: []testutils.TestCmd{
 				{Cmd: listLineNumbersCommandStrings, PipedToCommand: true},
 				{Cmd: []string{"grep", "AZURE-NPM"}, ExitCode: 1},
+				// should add ExitCode: 1 to below, but this causes an error for the previous commands actually...
 				{Cmd: listLineNumbersCommandStrings, PipedToCommand: true, HasStartError: true},
 				{Cmd: []string{"grep", "KUBE-SERVICES"}},
 			},

--- a/npm/pkg/dataplane/policies/policymanager_linux.go
+++ b/npm/pkg/dataplane/policies/policymanager_linux.go
@@ -91,7 +91,7 @@ func (pMgr *PolicyManager) removePolicy(networkPolicy *NPMNetworkPolicy, _ map[s
 }
 
 func restore(creator *ioutil.FileCreator) error {
-	err := creator.RunCommandWithFile(util.IptablesRestore, util.IptablesWaitFlag, defaultlockWaitTimeInSeconds, util.IptablesRestoreTableFlag, util.IptablesFilterTable, util.IptablesRestoreNoFlushFlag)
+	err := creator.RunCommandWithFile(util.IptablesRestore, util.IptablesWaitFlag, util.IptablesDefaultWaitTime, util.IptablesRestoreTableFlag, util.IptablesFilterTable, util.IptablesRestoreNoFlushFlag)
 	if err != nil {
 		return npmerrors.SimpleErrorWrapper("failed to restore iptables file", err)
 	}

--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -81,7 +81,6 @@ const (
 	IptablesListFlag        string = "-L"
 	IptablesNumericFlag     string = "-n"
 	IptablesLineNumbersFlag string = "--line-numbers"
-	defa
 
 	IptablesKubeServicesChain          string = "KUBE-SERVICES"
 	IptablesForwardChain               string = "FORWARD"

--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -191,6 +191,11 @@ const (
 	SetPolicyDelimiter string = ","
 )
 
+const (
+	BashCommand     string = "bash"
+	BashCommandFlag string = "-c"
+)
+
 // NPM telemetry constants.
 const (
 	AddNamespaceEvent    string = "Add Namespace"

--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -43,6 +43,7 @@ const (
 	IptablesDestroyFlag        string = "-X"
 	IptablesJumpFlag           string = "-j"
 	IptablesWaitFlag           string = "-w"
+	IptablesDefaultWaitTime    string = "60"
 	IptablesAccept             string = "ACCEPT"
 	IptablesReject             string = "REJECT"
 	IptablesDrop               string = "DROP"
@@ -80,6 +81,7 @@ const (
 	IptablesListFlag        string = "-L"
 	IptablesNumericFlag     string = "-n"
 	IptablesLineNumbersFlag string = "--line-numbers"
+	defa
 
 	IptablesKubeServicesChain          string = "KUBE-SERVICES"
 	IptablesForwardChain               string = "FORWARD"

--- a/npm/util/ioutil/current-azure-chains.go
+++ b/npm/util/ioutil/current-azure-chains.go
@@ -22,9 +22,9 @@ var (
 	errInvalidGrepResult    = errors.New("unexpectedly got no lines while grepping for current Azure chains")
 )
 
-func AllCurrentAzureChains(exec utilexec.Interface, defaultlockWaitTimeInSeconds string) (map[string]struct{}, error) {
+func AllCurrentAzureChains(exec utilexec.Interface, lockWaitTimeSeconds string) (map[string]struct{}, error) {
 	iptablesListCommand := exec.Command(util.Iptables,
-		util.IptablesWaitFlag, defaultlockWaitTimeInSeconds, util.IptablesTableFlag, util.IptablesFilterTable,
+		util.IptablesWaitFlag, lockWaitTimeSeconds, util.IptablesTableFlag, util.IptablesFilterTable,
 		util.IptablesNumericFlag, util.IptablesListFlag,
 	)
 	grepCommand := exec.Command(Grep, azureChainGrepPattern)

--- a/npm/util/ioutil/grep.go
+++ b/npm/util/ioutil/grep.go
@@ -13,6 +13,8 @@ const (
 	Grep                 = "grep"
 	GrepRegexFlag        = "-P"
 	GrepOnlyMatchingFlag = "-o"
+	GrepAntiMatchFlag    = "-v"
+	GrepQuietFlag        = "-q"
 	GrepBeforeFlag       = "-B"
 )
 

--- a/npm/util/ioutil/grep.go
+++ b/npm/util/ioutil/grep.go
@@ -63,7 +63,7 @@ func DoublePipeToGrep(command, grepCommand1, grepCommand2 utilexec.Cmd) (searchR
 	}
 	searchResults = output
 	gotMatches = true
-	return searchResults, gotMatches, commandError
+	return searchResults, gotMatches, commandError // include named results to appease lint
 }
 
 func PipeCommandToGrep(command, grepCommand utilexec.Cmd) (searchResults []byte, gotMatches bool, commandError error) {

--- a/npm/util/ioutil/grep.go
+++ b/npm/util/ioutil/grep.go
@@ -63,7 +63,7 @@ func DoublePipeToGrep(command, grepCommand1, grepCommand2 utilexec.Cmd) (searchR
 	}
 	searchResults = output
 	gotMatches = true
-	return
+	return searchResults, gotMatches, commandError
 }
 
 func PipeCommandToGrep(command, grepCommand utilexec.Cmd) (searchResults []byte, gotMatches bool, commandError error) {

--- a/npm/util/ioutil/grep.go
+++ b/npm/util/ioutil/grep.go
@@ -2,10 +2,69 @@
 
 package ioutil
 
-import utilexec "k8s.io/utils/exec"
+import (
+	"fmt"
+
+	utilexec "k8s.io/utils/exec"
+)
 
 // Grep is the grep command string
-const Grep = "grep"
+const (
+	Grep                 = "grep"
+	GrepRegexFlag        = "-P"
+	GrepOnlyMatchingFlag = "-o"
+	GrepBeforeFlag       = "-B"
+)
+
+func DoublePipeToGrep(command, grepCommand1, grepCommand2 utilexec.Cmd) (searchResults []byte, gotMatches bool, commandError error) {
+	pipe, commandError := command.StdoutPipe()
+	if commandError != nil {
+		return
+	}
+	grepCommand1.SetStdin(pipe)
+
+	grepPipe, commandError := grepCommand1.StdoutPipe()
+	if commandError != nil {
+		_ = pipe.Close()
+		commandError = fmt.Errorf("error getting pipe for grep command: %w", commandError)
+		return
+	}
+	grepCommand2.SetStdin(grepPipe)
+
+	closePipes := func() {
+		_ = grepPipe.Close()
+		_ = pipe.Close()
+	}
+	defer closePipes()
+
+	commandError = grepCommand1.Start()
+	if commandError != nil {
+		commandError = fmt.Errorf("error while starting first grep command: %w", commandError)
+		return
+	}
+
+	commandError = command.Start()
+	if commandError != nil {
+		commandError = fmt.Errorf("error while starting command: %w", commandError)
+		_ = grepCommand1.Wait()
+		return
+	}
+
+	waitForAll := func() {
+		_ = command.Wait()
+		_ = grepCommand1.Wait()
+	}
+	defer waitForAll()
+
+	output, err := grepCommand2.CombinedOutput()
+	if err != nil {
+		// grep returns err status 1 if nothing is found
+		return
+	}
+	searchResults = output
+	gotMatches = true
+	return
+}
 
 func PipeCommandToGrep(command, grepCommand utilexec.Cmd) (searchResults []byte, gotMatches bool, commandError error) {
 	pipe, commandError := command.StdoutPipe()

--- a/npm/util/ioutil/restore.go
+++ b/npm/util/ioutil/restore.go
@@ -141,7 +141,7 @@ func (creator *FileCreator) RunCommandWithFile(cmd string, args ...string) error
 		if wasFileAltered {
 			sameNew = "updated"
 		}
-		msg := fmt.Sprintf("on try number %d, failed to run command [%s]. Rerunning with %s file. Had error [%s].Used file:%s", creator.tryCount, commandString, sameNew, err.Error(), fileString)
+		msg := fmt.Sprintf("on try number %d, failed to run command [%s]. Rerunning with %s file. err: [%s]", creator.tryCount, commandString, sameNew, err.Error())
 		klog.Error(msg)
 		metrics.SendErrorLogAndMetric(util.UtilID, "error: %s", msg)
 
@@ -180,6 +180,8 @@ func (creator *FileCreator) runCommandOnceWithFile(fileString, cmd string, args 
 		klog.Infof("returning as a success without running command [%s] since the fileString is empty", commandString)
 		return false, nil
 	}
+
+	klog.Infof("running this restore command: [%s]", commandString)
 
 	command := creator.ioShim.Exec.Command(cmd, args...)
 	command.SetStdin(bytes.NewBufferString(fileString))


### PR DESCRIPTION
Sometimes at high scale, the Linux *ipset* utility will leak reference counts for ipsets e.g. there will be no iptables rules or lists referencing an ipset, yet it will have a positive reference count. As a result, some lingering ipsets can't be deleted when NPM boots up. 

In NPM "v1", we ignore these in-use-by-kernel errors. Now we do the same in "v2" to prevent a CrashLoopBackOff when this kernel leak happens.