### PR TITLE
run workflows when PR promoted out of draft

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -5,6 +5,11 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/crdgen.yaml
+++ b/.github/workflows/crdgen.yaml
@@ -2,6 +2,11 @@ name: crdgen
 on:
   workflow_dispatch:
   pull_request:
+    types:
+        - opened
+        - reopened
+        - synchronize
+        - ready_for_review
 jobs:
   crdgen:
     strategy:

--- a/.github/workflows/golangci.yaml
+++ b/.github/workflows/golangci.yaml
@@ -2,6 +2,11 @@ name: golangci-lint
 on:
   workflow_dispatch:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 jobs:
   golangci:
     strategy:


### PR DESCRIPTION
Signed-off-by: Evan Baker <rbtr@users.noreply.github.com>

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**: Moving a PR from "Draft" to "Ready for Review" should run the configured PR Workflows. Other states are defaults that need to be specified now.
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
