### PR TITLE
fix: [NPM-WIN] validation to prevent cidr except in windows

### DIFF
--- a/npm/pkg/controlplane/controllers/v2/networkPolicyController.go
+++ b/npm/pkg/controlplane/controllers/v2/networkPolicyController.go
@@ -349,5 +349,6 @@ func (c *NetworkPolicyController) cleanUpNetworkPolicy(netPolKey string) error {
 func isUnsupportedWindowsTranslationErr(err error) bool {
 	return errors.Is(err, translation.ErrUnsupportedNamedPort) ||
 		errors.Is(err, translation.ErrUnsupportedNegativeMatch) ||
-		errors.Is(err, translation.ErrUnsupportedSCTP)
+		errors.Is(err, translation.ErrUnsupportedSCTP) ||
+		errors.Is(err, translation.ErrUnsupportedExceptCIDR)
 }

--- a/npm/pkg/controlplane/translation/translatePolicy_test.go
+++ b/npm/pkg/controlplane/translation/translatePolicy_test.go
@@ -33,7 +33,6 @@ func TestPortType(t *testing.T) {
 		name     string
 		portRule networkingv1.NetworkPolicyPort
 		want     netpolPortType
-		wantErr  bool
 	}{
 		{
 			name:     "empty",
@@ -179,7 +178,6 @@ func TestNamedPortRuleInfo(t *testing.T) {
 		name     string
 		portRule *networkingv1.NetworkPolicyPort
 		want     *namedPortOutput
-		wantErr  bool
 	}{
 		{
 			name:     "empty",
@@ -239,7 +237,6 @@ func TestNamedPortRule(t *testing.T) {
 		name     string
 		portRule *networkingv1.NetworkPolicyPort
 		want     *namedPortRuleOutput
-		wantErr  bool
 	}{
 		{
 			name:     "empty",
@@ -249,7 +246,6 @@ func TestNamedPortRule(t *testing.T) {
 				setInfo:         policies.SetInfo{},
 				protocol:        "",
 			},
-			wantErr: false,
 		},
 		{
 			name: "serve-tcp",
@@ -461,7 +457,8 @@ func TestIPBlockIPSet(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := ipBlockIPSet(tt.policyName, tt.namemspace, tt.direction, tt.ipBlockSetIndex, tt.ipBlockPeerIndex, tt.ipBlockRule)
+			got, err := ipBlockIPSet(tt.policyName, tt.namemspace, tt.direction, tt.ipBlockSetIndex, tt.ipBlockPeerIndex, tt.ipBlockRule)
+			require.NoError(t, err)
 			require.Equal(t, tt.translatedIPSet, got)
 		})
 	}
@@ -527,7 +524,8 @@ func TestIPBlockRule(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			translatedIPSet, setInfo := ipBlockRule(tt.policyName, tt.namemspace, tt.direction, tt.matchType, tt.ipBlockSetIndex, tt.ipBlockPeerIndex, tt.ipBlockRule)
+			translatedIPSet, setInfo, err := ipBlockRule(tt.policyName, tt.namemspace, tt.direction, tt.matchType, tt.ipBlockSetIndex, tt.ipBlockPeerIndex, tt.ipBlockRule)
+			require.NoError(t, err)
 			require.Equal(t, tt.translatedIPSet, translatedIPSet)
 			require.Equal(t, tt.setInfo, setInfo)
 		})


### PR DESCRIPTION
negative matches are not supported in windows