### PR TITLE
Add missing client paths to CNS Client

### DIFF
--- a/cns/client/client.go
+++ b/cns/client/client.go
@@ -33,6 +33,10 @@ var clientPaths = []string{
 	cns.PathDebugIPAddresses,
 	cns.PathDebugPodContext,
 	cns.PathDebugRestData,
+	cns.UnpublishNetworkContainer,
+	cns.PublishNetworkContainer,
+	cns.CreateOrUpdateNetworkContainer,
+	cns.SetOrchestratorType,
 }
 
 type do interface {


### PR DESCRIPTION
These were forgotten during a previous effort to add endpoints to the
CNS client. Consequently, those endpoints don't actually work unless
these paths are present here.

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
