### PR TITLE
Accept NNC with no NC as valid and consider pool monitor and reconciler started

### DIFF
--- a/cns/kubecontroller/nodenetworkconfig/reconciler.go
+++ b/cns/kubecontroller/nodenetworkconfig/reconciler.go
@@ -70,12 +70,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	logger.Printf("[cns-rc] CRD Spec: %+v", nnc.Spec)
 
-	// if there are no network containers, don't continue to updating Listeners
-	if len(nnc.Status.NetworkContainers) == 0 {
-		logger.Errorf("[cns-rc] Empty NetworkContainers")
-		return reconcile.Result{}, nil
-	}
-
 	ipAssignments := 0
 	// for each NC, parse it in to a CreateNCRequest and forward it to the appropriate Listener
 	for i := range nnc.Status.NetworkContainers {


### PR DESCRIPTION
Signed-off-by: Evan Baker <rbtr@users.noreply.github.com>

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**: Due to superficial usage of the NC in the IPAM Pool Monitor, it was considered un-started until it received an NNC with an NC. This change fixes that and considers the reconciler and monitor started as soon as an NNC is ready, whether or not the NC is ready also.
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
