### PR TITLE
feat: compare node IP with NNCs node IP

### DIFF
--- a/cns/configuration/env.go
+++ b/cns/configuration/env.go
@@ -9,6 +9,8 @@ import (
 const (
 	// EnvNodeName is the NODENAME env var string key.
 	EnvNodeName = "NODENAME"
+	// EnvNodeIP is the IP of the node running this CNS binary
+	EnvNodeIP = "NODE_IP"
 )
 
 // ErrNodeNameUnset indicates the the $EnvNodeName variable is unset in the environment.
@@ -21,4 +23,9 @@ func NodeName() (string, error) {
 		return "", ErrNodeNameUnset
 	}
 	return nodeName, nil
+}
+
+// NodeIP returns the value of the NODE_IP environment variable, or empty string if unset.
+func NodeIP() string {
+	return os.Getenv(EnvNodeIP)
 }

--- a/cns/kubecontroller/nodenetworkconfig/conversion_test.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_test.go
@@ -22,6 +22,7 @@ const (
 	subnetPrefixLen    = 24
 	testSecIP          = "10.0.0.2"
 	version            = 1
+	nodeIP             = "10.1.0.5"
 )
 
 var invalidStatusMultiNC = v1alpha.NodeNetworkConfigStatus{
@@ -46,6 +47,7 @@ var validSwiftNC = v1alpha.NetworkContainer{
 	DefaultGateway:     defaultGateway,
 	SubnetAddressSpace: subnetAddressSpace,
 	Version:            version,
+	NodeIP:             nodeIP,
 }
 
 var validSwiftStatus = v1alpha.NodeNetworkConfigStatus{
@@ -55,7 +57,8 @@ var validSwiftStatus = v1alpha.NodeNetworkConfigStatus{
 }
 
 var validSwiftRequest = &cns.CreateNetworkContainerRequest{
-	Version: strconv.FormatInt(version, 10),
+	HostPrimaryIP: nodeIP,
+	Version:       strconv.FormatInt(version, 10),
 	IPConfiguration: cns.IPConfiguration{
 		GatewayIPAddress: defaultGateway,
 		IPSubnet: cns.IPSubnet{
@@ -78,6 +81,7 @@ var validOverlayNC = v1alpha.NetworkContainer{
 	AssignmentMode:     v1alpha.Static,
 	Type:               v1alpha.Overlay,
 	PrimaryIP:          overlayPrimaryIP,
+	NodeIP:             nodeIP,
 	SubnetName:         subnetName,
 	SubnetAddressSpace: subnetAddressSpace,
 	Version:            version,
@@ -162,6 +166,7 @@ func TestCreateNCRequestFromDynamicNC(t *testing.T) {
 			input: v1alpha.NetworkContainer{
 				PrimaryIP: ipIsCIDR,
 				ID:        ncID,
+				NodeIP:    nodeIP,
 				IPAssignments: []v1alpha.IPAssignment{
 					{
 						Name: uuid,

--- a/cns/kubecontroller/nodenetworkconfig/reconciler.go
+++ b/cns/kubecontroller/nodenetworkconfig/reconciler.go
@@ -40,18 +40,20 @@ type Reconciler struct {
 	nnccli             nncGetter
 	once               sync.Once
 	started            chan interface{}
+	nodeIP             string
 }
 
 // NewReconciler creates a NodeNetworkConfig Reconciler which will get updates from the Kubernetes
 // apiserver for NNC events.
 // Provided nncListeners are passed the NNC after the Reconcile preprocesses it. Note: order matters! The
 // passed Listeners are notified in the order provided.
-func NewReconciler(cnscli cnsClient, nnccli nncGetter, ipampoolmonitorcli nodeNetworkConfigListener) *Reconciler {
+func NewReconciler(cnscli cnsClient, nnccli nncGetter, ipampoolmonitorcli nodeNetworkConfigListener, nodeIP string) *Reconciler {
 	return &Reconciler{
 		cnscli:             cnscli,
 		ipampoolmonitorcli: ipampoolmonitorcli,
 		nnccli:             nnccli,
 		started:            make(chan interface{}),
+		nodeIP:             nodeIP,
 	}
 }
 
@@ -71,8 +73,24 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	logger.Printf("[cns-rc] CRD Spec: %+v", nnc.Spec)
 
 	ipAssignments := 0
+
+	// keep a count of NCs we find that were created for this Node
+	foundNCForNodeCount := 0
+
 	// for each NC, parse it in to a CreateNCRequest and forward it to the appropriate Listener
 	for i := range nnc.Status.NetworkContainers {
+		// check if this NC matches the Node IP if we have one to check against
+		if r.nodeIP != "" {
+			if r.nodeIP != nnc.Status.NetworkContainers[i].NodeIP {
+				// skip this NC since it was created for a different node
+				logger.Debugf("[cns-rc] skipping network container %s found in NNC because node IP doesn't match, got %s, expected %s",
+					nnc.Status.NetworkContainers[i].ID, nnc.Status.NetworkContainers[i].NodeIP, r.nodeIP)
+				continue
+			}
+		}
+
+		foundNCForNodeCount++
+
 		var req *cns.CreateNetworkContainerRequest
 		var err error
 		switch nnc.Status.NetworkContainers[i].AssignmentMode { //nolint:exhaustive // skipping dynamic case
@@ -98,6 +116,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 		ipAssignments += len(req.SecondaryIPConfigs)
 	}
+
+	if foundNCForNodeCount == 0 {
+		logger.Debugf("[cns-rc] reconciler is not yet considered to be started since the NCs in the NNC were not created for this Node")
+		// return nil error since requeuing won't solve anything
+		return reconcile.Result{}, nil
+	}
+
 	// record assigned IPs metric
 	allocatedIPs.Set(float64(ipAssignments))
 

--- a/cns/kubecontroller/nodenetworkconfig/reconciler.go
+++ b/cns/kubecontroller/nodenetworkconfig/reconciler.go
@@ -74,9 +74,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	ipAssignments := 0
 
-	// keep a count of NCs we find that were created for this Node
-	foundNCForNodeCount := 0
-
 	// for each NC, parse it in to a CreateNCRequest and forward it to the appropriate Listener
 	for i := range nnc.Status.NetworkContainers {
 		// check if this NC matches the Node IP if we have one to check against
@@ -88,8 +85,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 				continue
 			}
 		}
-
-		foundNCForNodeCount++
 
 		var req *cns.CreateNetworkContainerRequest
 		var err error
@@ -115,12 +110,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			return reconcile.Result{}, errors.Wrap(err, "failed to create or update network container")
 		}
 		ipAssignments += len(req.SecondaryIPConfigs)
-	}
-
-	if foundNCForNodeCount == 0 {
-		logger.Debugf("[cns-rc] reconciler is not yet considered to be started since the NCs in the NNC were not created for this Node")
-		// return nil error since requeuing won't solve anything
-		return reconcile.Result{}, nil
 	}
 
 	// record assigned IPs metric


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
CNS shouldn't `CreateOrUpdateNCInternal` a NC that was created for a different Node IP. If the Node IPs don't match, DNC-RC will eventually clean it up, so it is not valid for use.