### PR TITLE
feat: extend fieldStringer to support zap ErrorType and BoolType

### DIFF
--- a/zapai/encoder.go
+++ b/zapai/encoder.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"fmt"
+	"strconv"
 	"sync"
 
 	"github.com/microsoft/ApplicationInsights-Go/appinsights"
@@ -86,8 +87,17 @@ func (g *gobber) decode(b []byte) (*appinsights.TraceTelemetry, error) {
 
 // fieldStringer evaluates a zapcore.Field in to a best-effort string.
 func fieldStringer(f *zapcore.Field) string {
-	if f.Type == zapcore.StringType {
+	switch f.Type {
+	case zapcore.StringType:
 		return f.String
+
+	case zapcore.ErrorType:
+		return f.Interface.(error).Error()
+
+	case zapcore.BoolType:
+		return strconv.FormatBool(f.Integer == 1)
+
+	default:
+		return fmt.Sprintf("%v", f)
 	}
-	return fmt.Sprintf("%v", f)
 }

--- a/zapai/encoder.go
+++ b/zapai/encoder.go
@@ -90,19 +90,14 @@ func fieldStringer(f *zapcore.Field) string {
 	switch f.Type {
 	case zapcore.StringType:
 		return f.String
-
 	case zapcore.Int64Type:
 		return strconv.FormatInt(f.Integer, 10)
-
 	case zapcore.Uint16Type:
 		return strconv.FormatInt(f.Integer, 10)
-
 	case zapcore.ErrorType:
 		return f.Interface.(error).Error()
-
 	case zapcore.BoolType:
 		return strconv.FormatBool(f.Integer == 1)
-
 	default:
 		return fmt.Sprintf("%v", f)
 	}

--- a/zapai/encoder.go
+++ b/zapai/encoder.go
@@ -91,6 +91,12 @@ func fieldStringer(f *zapcore.Field) string {
 	case zapcore.StringType:
 		return f.String
 
+	case zapcore.Int64Type:
+		return strconv.FormatInt(f.Integer, 10)
+
+	case zapcore.Uint16Type:
+		return strconv.FormatInt(f.Integer, 10)
+
 	case zapcore.ErrorType:
 		return f.Interface.(error).Error()
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
extend fieldStringer to support zap ErrorType and BoolType, so zap.Error and zap.Bool fields can be better map to strings while constructing TraceTelemetry

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
