### PR TITLE
Add two more CNS endpoints to the CNS client

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -30,6 +30,7 @@ const (
 	PathDebugPodContext                      = "/debug/podcontext"
 	PathDebugRestData                        = "/debug/restdata"
 	NumberOfCPUCores                         = "/hostcpucores"
+	NMAgentSupportedAPIs                     = "/network/nmagentsupportedapis"
 )
 
 // NetworkContainer Prefixes

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -29,6 +29,7 @@ const (
 	PathDebugIPAddresses                     = "/debug/ipaddresses"
 	PathDebugPodContext                      = "/debug/podcontext"
 	PathDebugRestData                        = "/debug/restdata"
+	NumberOfCPUCores                         = "/hostcpucores"
 )
 
 // NetworkContainer Prefixes

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -29,8 +29,8 @@ const (
 	PathDebugIPAddresses                     = "/debug/ipaddresses"
 	PathDebugPodContext                      = "/debug/podcontext"
 	PathDebugRestData                        = "/debug/restdata"
-	NumberOfCPUCores                         = "/hostcpucores"
-	NMAgentSupportedAPIs                     = "/network/nmagentsupportedapis"
+	NumberOfCPUCores                         = NumberOfCPUCoresPath
+	NMAgentSupportedAPIs                     = NmAgentSupportedApisPath
 )
 
 // NetworkContainer Prefixes

--- a/cns/client/client.go
+++ b/cns/client/client.go
@@ -38,6 +38,7 @@ var clientPaths = []string{
 	cns.CreateOrUpdateNetworkContainer,
 	cns.SetOrchestratorType,
 	cns.NumberOfCPUCores,
+	cns.NMAgentSupportedAPIs,
 }
 
 type do interface {

--- a/cns/client/client.go
+++ b/cns/client/client.go
@@ -727,7 +727,9 @@ func (c *Client) NMAgentSupportedAPIs(ctx context.Context) (*cns.NmAgentSupporte
 	defer resp.Body.Close()
 
 	if code := resp.StatusCode; code != http.StatusOK {
-		return nil, fmt.Errorf("http request failed: %s (%d)", http.StatusText(code), code)
+		return nil, &FailedHTTPRequest{
+			Code: code,
+		}
 	}
 
 	// decode response

--- a/cns/client/client.go
+++ b/cns/client/client.go
@@ -423,7 +423,7 @@ func (c *Client) GetHTTPServiceData(ctx context.Context) (*restserver.GetHTTPSer
 func (c *Client) NumOfCPUCores(ctx context.Context) (*cns.NumOfCPUCoresResponse, error) {
 	// build the request
 	u := c.routes[cns.NumberOfCPUCores]
-	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	req, err := http.NewRequest(http.MethodGet, u.String(), http.NoBody)
 	if err != nil {
 		return nil, errors.Wrap(err, "building http request")
 	}

--- a/cns/client/client.go
+++ b/cns/client/client.go
@@ -423,7 +423,7 @@ func (c *Client) GetHTTPServiceData(ctx context.Context) (*restserver.GetHTTPSer
 func (c *Client) NumOfCPUCores(ctx context.Context) (*cns.NumOfCPUCoresResponse, error) {
 	// build the request
 	u := c.routes[cns.NumberOfCPUCores]
-	req, err := http.NewRequest(http.MethodGet, u.String(), http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), http.NoBody)
 	if err != nil {
 		return nil, errors.Wrap(err, "building http request")
 	}
@@ -472,7 +472,7 @@ func (c *Client) DeleteNetworkContainer(ctx context.Context, ncID string) error 
 		return errors.Wrap(err, "encoding request body")
 	}
 	u := c.routes[cns.DeleteNetworkContainer]
-	req, err := http.NewRequest(http.MethodPost, u.String(), bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(body))
 	if err != nil {
 		return errors.Wrap(err, "building HTTP request")
 	}
@@ -526,7 +526,7 @@ func (c *Client) SetOrchestratorType(ctx context.Context, sotr cns.SetOrchestrat
 		return errors.Wrap(err, "encoding request body")
 	}
 	u := c.routes[cns.SetOrchestratorType]
-	req, err := http.NewRequest(http.MethodPost, u.String(), bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(body))
 	if err != nil {
 		return errors.Wrap(err, "building HTTP request")
 	}
@@ -575,7 +575,7 @@ func (c *Client) CreateNetworkContainer(ctx context.Context, cncr cns.CreateNetw
 		return errors.Wrap(err, "encoding request as JSON")
 	}
 	u := c.routes[cns.CreateOrUpdateNetworkContainer]
-	req, err := http.NewRequest(http.MethodPost, u.String(), bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(body))
 	if err != nil {
 		return errors.Wrap(err, "building HTTP request")
 	}
@@ -623,7 +623,7 @@ func (c *Client) PublishNetworkContainer(ctx context.Context, pncr cns.PublishNe
 		return errors.Wrap(err, "encoding request body as json")
 	}
 	u := c.routes[cns.PublishNetworkContainer]
-	req, err := http.NewRequest(http.MethodPost, u.String(), bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(body))
 	if err != nil {
 		return errors.Wrap(err, "building HTTP request")
 	}
@@ -669,7 +669,7 @@ func (c *Client) UnpublishNC(ctx context.Context, uncr cns.UnpublishNetworkConta
 		return errors.Wrap(err, "encoding request body as json")
 	}
 	u := c.routes[cns.UnpublishNetworkContainer]
-	req, err := http.NewRequest(http.MethodPost, u.String(), bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(body))
 	if err != nil {
 		return errors.Wrap(err, "building HTTP request")
 	}
@@ -714,7 +714,7 @@ func (c *Client) NMAgentSupportedAPIs(ctx context.Context) (*cns.NmAgentSupporte
 	}
 
 	u := c.routes[cns.NMAgentSupportedAPIs]
-	req, err := http.NewRequest(http.MethodGet, u.String(), bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), bytes.NewReader(body))
 	if err != nil {
 		return nil, errors.Wrap(err, "building http request")
 	}

--- a/cns/client/client.go
+++ b/cns/client/client.go
@@ -726,6 +726,10 @@ func (c *Client) NMAgentSupportedAPIs(ctx context.Context) (*cns.NmAgentSupporte
 	}
 	defer resp.Body.Close()
 
+	if code := resp.StatusCode; code != http.StatusOK {
+		return nil, fmt.Errorf("http request failed: %s (%d)", http.StatusText(code), code)
+	}
+
 	// decode response
 	var out cns.NmAgentSupportedApisResponse
 	err = json.NewDecoder(resp.Body).Decode(&out)

--- a/cns/client/client_test.go
+++ b/cns/client/client_test.go
@@ -2076,11 +2076,13 @@ func TestNMASupportedAPIs(t *testing.T) {
 	tests := []struct {
 		name      string
 		shouldErr bool
+		respCode  int
 		exp       *cns.NmAgentSupportedApisResponse
 	}{
 		{
 			"happy",
 			false,
+			http.StatusOK,
 			&cns.NmAgentSupportedApisResponse{
 				Response: cns.Response{
 					ReturnCode: 0,
@@ -2092,6 +2094,7 @@ func TestNMASupportedAPIs(t *testing.T) {
 		{
 			"unspecified error",
 			true,
+			http.StatusOK,
 			&cns.NmAgentSupportedApisResponse{
 				Response: cns.Response{
 					ReturnCode: types.MalformedSubnet,
@@ -2099,6 +2102,12 @@ func TestNMASupportedAPIs(t *testing.T) {
 				},
 				SupportedApis: []string{},
 			},
+		},
+		{
+			"not found",
+			true,
+			http.StatusNotFound,
+			nil,
 		},
 	}
 
@@ -2111,7 +2120,7 @@ func TestNMASupportedAPIs(t *testing.T) {
 				client: &mockdo{
 					errToReturn:            nil,
 					objToReturn:            test.exp,
-					httpStatusCodeToReturn: http.StatusOK,
+					httpStatusCodeToReturn: test.respCode,
 				},
 				routes: emptyRoutes,
 			}

--- a/cns/client/client_test.go
+++ b/cns/client/client_test.go
@@ -2009,3 +2009,53 @@ func TestGetHTTPServiceData(t *testing.T) {
 		})
 	}
 }
+
+func TestNumberOfCPUCores(t *testing.T) {
+	emptyRoutes, _ := buildRoutes(defaultBaseURL, clientPaths)
+	tests := []struct {
+		name      string
+		shouldErr bool
+		exp       *cns.NumOfCPUCoresResponse
+	}{
+		{
+			"happy path",
+			false,
+			&cns.NumOfCPUCoresResponse{
+				Response: cns.Response{
+					ReturnCode: 0,
+					Message:    "success",
+				},
+				NumOfCPUCores: 42,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := &Client{
+				client: &mockdo{
+					errToReturn:            nil,
+					objToReturn:            test.exp,
+					httpStatusCodeToReturn: http.StatusOK,
+				},
+				routes: emptyRoutes,
+			}
+
+			got, err := client.NumOfCPUCores(context.Background())
+			if err != nil && !test.shouldErr {
+				t.Fatal("unexpected error: err:", err)
+			}
+
+			if err == nil && test.shouldErr {
+				t.Fatal("expected an error but received none")
+			}
+
+			if !cmp.Equal(got, *test.exp) {
+				t.Error("received response differs from expectation: diff:", cmp.Diff(got, *test.exp))
+			}
+		})
+	}
+}

--- a/cns/client/client_test.go
+++ b/cns/client/client_test.go
@@ -2028,6 +2028,17 @@ func TestNumberOfCPUCores(t *testing.T) {
 				NumOfCPUCores: 42,
 			},
 		},
+		{
+			"unspecified error",
+			true,
+			&cns.NumOfCPUCoresResponse{
+				Response: cns.Response{
+					ReturnCode: types.MalformedSubnet,
+					Message:    "malformed subnet",
+				},
+				NumOfCPUCores: 0,
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -2053,8 +2064,8 @@ func TestNumberOfCPUCores(t *testing.T) {
 				t.Fatal("expected an error but received none")
 			}
 
-			if !cmp.Equal(got, *test.exp) {
-				t.Error("received response differs from expectation: diff:", cmp.Diff(got, *test.exp))
+			if !test.shouldErr && !cmp.Equal(got, test.exp) {
+				t.Error("received response differs from expectation: diff:", cmp.Diff(got, test.exp))
 			}
 		})
 	}

--- a/cns/client/error.go
+++ b/cns/client/error.go
@@ -3,9 +3,20 @@ package client
 import (
 	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/Azure/azure-container-networking/cns/types"
 )
+
+// FailedHTTPRequest describes an HTTP request to CNS that has returned a
+// non-200 status code.
+type FailedHTTPRequest struct {
+	Code int
+}
+
+func (f *FailedHTTPRequest) Error() string {
+	return fmt.Sprintf("http request failed: %s (%d)", http.StatusText(f.Code), f.Code)
+}
 
 // CNSClientError records an error and relevant code
 type CNSClientError struct {


### PR DESCRIPTION
These are the final two endpoints that DNC uses without going through the CNS client. Adding these makes it possible to use the CNS client exclusively in DNC.

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
