### PR TITLE
fix: [WIN-NPM] don't remove policy from cache when updating pod

### DIFF
--- a/npm/pkg/dataplane/dataplane.go
+++ b/npm/pkg/dataplane/dataplane.go
@@ -293,7 +293,7 @@ func (dp *DataPlane) RemovePolicy(policyKey string) error {
 		return nil
 	}
 	// Use the endpoint list saved in cache for this network policy to remove
-	err := dp.policyMgr.RemovePolicy(policy.PolicyKey, nil)
+	err := dp.policyMgr.RemovePolicy(policy.PolicyKey)
 	if err != nil {
 		return fmt.Errorf("[DataPlane] error while removing policy: %w", err)
 	}

--- a/npm/pkg/dataplane/dataplane_windows.go
+++ b/npm/pkg/dataplane/dataplane_windows.go
@@ -169,7 +169,7 @@ func (dp *DataPlane) updatePod(pod *updateNPMPod) error {
 				endpointList := map[string]string{
 					endpoint.ip: endpoint.id,
 				}
-				err := dp.policyMgr.RemovePolicy(policyKey, endpointList)
+				err := dp.policyMgr.RemovePolicyForEndpoints(policyKey, endpointList)
 				if err != nil {
 					return err
 				}

--- a/npm/pkg/dataplane/policies/policymanager_linux_test.go
+++ b/npm/pkg/dataplane/policies/policymanager_linux_test.go
@@ -334,7 +334,7 @@ func TestRemovePoliciesAcceptableError(t *testing.T) {
 	defer ioshim.VerifyCalls(t, calls)
 	pMgr := NewPolicyManager(ioshim, ipsetConfig)
 	require.NoError(t, pMgr.AddPolicy(bothDirectionsNetPol, epList))
-	require.NoError(t, pMgr.RemovePolicy(bothDirectionsNetPol.PolicyKey, nil))
+	require.NoError(t, pMgr.RemovePolicy(bothDirectionsNetPol.PolicyKey))
 	_, ok := pMgr.GetPolicy(bothDirectionsNetPol.PolicyKey)
 	require.False(t, ok)
 	promVals{0, 1}.testPrometheusMetrics(t)
@@ -381,7 +381,7 @@ func TestRemovePoliciesError(t *testing.T) {
 			pMgr := NewPolicyManager(ioshim, ipsetConfig)
 			err := pMgr.AddPolicy(bothDirectionsNetPol, nil)
 			require.NoError(t, err)
-			err = pMgr.RemovePolicy(bothDirectionsNetPol.PolicyKey, nil)
+			err = pMgr.RemovePolicy(bothDirectionsNetPol.PolicyKey)
 			require.Error(t, err)
 
 			promVals{6, 1}.testPrometheusMetrics(t)
@@ -407,7 +407,7 @@ func TestUpdatingStaleChains(t *testing.T) {
 	assertStaleChainsContain(t, pMgr.staleChains)
 
 	// successful removal, so mark the policy's chains as stale
-	require.NoError(t, pMgr.RemovePolicy(bothDirectionsNetPol.PolicyKey, nil))
+	require.NoError(t, pMgr.RemovePolicy(bothDirectionsNetPol.PolicyKey))
 	assertStaleChainsContain(t, pMgr.staleChains, bothDirectionsNetPolIngressChain, bothDirectionsNetPolEgressChain)
 
 	// successful add, so keep the same stale chains
@@ -415,7 +415,7 @@ func TestUpdatingStaleChains(t *testing.T) {
 	assertStaleChainsContain(t, pMgr.staleChains, bothDirectionsNetPolIngressChain, bothDirectionsNetPolEgressChain)
 
 	// failure to remove, so keep the same stale chains
-	require.Error(t, pMgr.RemovePolicy(ingressNetPol.PolicyKey, nil))
+	require.Error(t, pMgr.RemovePolicy(ingressNetPol.PolicyKey))
 	assertStaleChainsContain(t, pMgr.staleChains, bothDirectionsNetPolIngressChain, bothDirectionsNetPolEgressChain)
 
 	// successfully add a new policy. keep the same stale chains
@@ -423,7 +423,7 @@ func TestUpdatingStaleChains(t *testing.T) {
 	assertStaleChainsContain(t, pMgr.staleChains, bothDirectionsNetPolIngressChain, bothDirectionsNetPolEgressChain)
 
 	// successful removal, so mark the policy's chains as stale
-	require.NoError(t, pMgr.RemovePolicy(egressNetPol.PolicyKey, nil))
+	require.NoError(t, pMgr.RemovePolicy(egressNetPol.PolicyKey))
 	assertStaleChainsContain(t, pMgr.staleChains, bothDirectionsNetPolIngressChain, bothDirectionsNetPolEgressChain, egressNetPolChain)
 
 	// failure to add, so keep the same stale chains the same

--- a/npm/pkg/dataplane/policies/policymanager_test.go
+++ b/npm/pkg/dataplane/policies/policymanager_test.go
@@ -172,7 +172,7 @@ func TestRemovePolicy(t *testing.T) {
 	defer ioshim.VerifyCalls(t, calls)
 	pMgr := NewPolicyManager(ioshim, ipsetConfig)
 	require.NoError(t, pMgr.AddPolicy(testNetPol, epList))
-	require.NoError(t, pMgr.RemovePolicy(testNetPol.PolicyKey, nil))
+	require.NoError(t, pMgr.RemovePolicy(testNetPol.PolicyKey))
 	_, ok := pMgr.GetPolicy(testNetPol.PolicyKey)
 	require.False(t, ok)
 	promVals{0, 1}.testPrometheusMetrics(t)
@@ -183,7 +183,7 @@ func TestRemoveNonexistentPolicy(t *testing.T) {
 	metrics.ReinitializeAll()
 	ioshim := common.NewMockIOShim(nil)
 	pMgr := NewPolicyManager(ioshim, ipsetConfig)
-	require.NoError(t, pMgr.RemovePolicy("wrong-policy-key", epList))
+	require.NoError(t, pMgr.RemovePolicy("wrong-policy-key"))
 	promVals{0, 0}.testPrometheusMetrics(t)
 }
 

--- a/npm/pkg/dataplane/policies/policymanager_windows.go
+++ b/npm/pkg/dataplane/policies/policymanager_windows.go
@@ -144,6 +144,7 @@ func (pMgr *PolicyManager) removePolicy(policy *NPMNetworkPolicy, endpointList m
 	if err != nil {
 		return err
 	}
+	// FIXME rulesToRemove is a list of pointers
 	klog.Infof("[PolicyManagerWindows] To Remove Policy: %s \n To Delete ACLs: %+v \n To Remove From %+v endpoints", policy.PolicyKey, rulesToRemove, endpointList)
 	// If remove bug is solved we can directly remove the exact policy from the endpoint
 	// but if the bug is not solved then get all existing policies and remove relevant policies from list
@@ -204,6 +205,7 @@ func (pMgr *PolicyManager) removePolicyByEndpointID(ruleID, epID string, noOfRul
 			return nil
 		}
 	}
+	// FIXME epBuilder.aclPolicies is a list of pointers
 	klog.Infof("[DataPlanewindows] Epbuilder ACL policies before removing %+v", epBuilder.aclPolicies)
 	klog.Infof("[DataPlanewindows] Epbuilder Other policies before removing %+v", epBuilder.otherPolicies)
 	epPolicies, err := epBuilder.getHCNPolicyRequest()
@@ -246,6 +248,7 @@ func getEPPolicyReqFromACLSettings(settings []*NPMACLPolSettings) (hcn.PolicyEnd
 	}
 
 	for i, acl := range settings {
+		// FIXME a lot of prints
 		klog.Infof("Acl settings: %+v", acl)
 		byteACL, err := json.Marshal(acl)
 		if err != nil {

--- a/npm/pkg/dataplane/policies/policymanager_windows_test.go
+++ b/npm/pkg/dataplane/policies/policymanager_windows_test.go
@@ -124,7 +124,7 @@ func TestRemovePolicies(t *testing.T) {
 		verifyFakeHNSCacheACLs(t, expectedACLs, acls)
 	}
 
-	err = pMgr.RemovePolicy(TestNetworkPolicies[0].PolicyKey, nil)
+	err = pMgr.RemovePolicy(TestNetworkPolicies[0].PolicyKey)
 	require.NoError(t, err)
 	verifyACLCacheIsCleaned(t, hns, len(endPointIDList))
 }
@@ -150,7 +150,7 @@ func TestRemovePoliciesEndpointNotFound(t *testing.T) {
 	testendPointIDList := map[string]string{
 		"10.0.0.5": "test10",
 	}
-	err = pMgr.RemovePolicy(TestNetworkPolicies[0].PolicyKey, testendPointIDList)
+	err = pMgr.RemovePolicyForEndpoints(TestNetworkPolicies[0].PolicyKey, testendPointIDList)
 	require.NoError(t, err, err)
 	verifyACLCacheIsCleaned(t, hns, len(endPointIDList))
 }


### PR DESCRIPTION
When removing a policy during updatePod(), the policy should not be removed from the cache. This would cause the policy to not be found when deleting the policy.

This PR also fixes the prometheus ACL metric for windows.