### PR TITLE
test: [WIN-NPM] ignore a test case with an unsupported namedport

### DIFF
--- a/test/cyclonus/test-cyclonus-windows.sh
+++ b/test/cyclonus/test-cyclonus-windows.sh
@@ -8,7 +8,7 @@ curl -fsSL github.com/mattfenwick/cyclonus/releases/latest/download/cyclonus_lin
     --pod-creation-timeout-seconds=480 \
     --job-timeout-seconds=15 \
     --server-protocol=TCP,UDP \
-    --exclude sctp,named-port,ip-block-with-except,multi-peer,upstream-e2e,example,end-port,namespaces-by-default-label | tee cyclonus-$CLUSTER_NAME
+    --exclude sctp,named-port,ip-block-with-except,multi-peer,upstream-e2e,example,end-port,namespaces-by-default-label,update-policy | tee cyclonus-$CLUSTER_NAME
 
 rc=0
 cat cyclonus-$CLUSTER_NAME | grep "failed" > /dev/null 2>&1 || rc=$?


### PR DESCRIPTION
test case 60 always failed because it had a namedport. It was the only test case with the label 'update-policy'