### PR TITLE
fix: file busy error while deploying through dropgz

### DIFF
--- a/dropgz/README.md
+++ b/dropgz/README.md
@@ -1,0 +1,10 @@
+### Running the dropgz locally
+
+Select the file(for example azure-ipam binary) you want to deploy using the dropgz.
+
+1. Copy the file (i.e azure-ipam) to the directory `/dropgz/pkg/embed/fs` 
+2. Add the sha of the file to the sum.txt file.(`sha256sum * > sum.txt`)
+3. You need to gzip the file, so run the cmd `gzip --verbose --best --recursive azure-ipam` and rename the output .gz file to original file name.
+4. Do the step 3 for `sum.txt` file as well.
+5. go to dropgz directory and build it. (`go build .`)
+6. You can now test the dropgz command locally. (`./dropgz deploy azure-ipam -o ./azure-ipam`)

--- a/dropgz/pkg/embed/payload.go
+++ b/dropgz/pkg/embed/payload.go
@@ -90,10 +90,10 @@ func deploy(src, dest string) error {
 	if _, err := os.Stat(dest); err == nil || !os.IsNotExist(err) {
 		old_file_dest := dest + OLD_FILE_SUFFIX
 		if err = os.RemoveAll(old_file_dest); err != nil {
-			return errors.Wrapf(err, "not able to remove the %s", &old_file_dest)
+			return errors.Wrapf(err, "failed to remove the %s", old_file_dest)
 		}
 		if err = os.Rename(dest, old_file_dest); err != nil {
-			return errors.Wrapf(err, "not able to rename the %s to %s", dest, old_file_dest)
+			return errors.Wrapf(err, "failed to rename the %s to %s", dest, old_file_dest)
 		}
 	} else {
 		return err

--- a/dropgz/pkg/embed/payload.go
+++ b/dropgz/pkg/embed/payload.go
@@ -87,12 +87,8 @@ func deploy(src, dest string) error {
 		return err
 	}
 	defer rc.Close()
-	_, err = os.Stat(dest)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return err
-		}
-	} else {
+	// check if the file exists at dest already and rename it as an old one
+	if _, err := os.Stat(dest); err == nil {
 		oldDest := dest + oldFileSuffix
 		if err = os.Rename(dest, oldDest); err != nil {
 			return errors.Wrapf(err, "failed to rename the %s to %s", dest, oldDest)

--- a/dropgz/pkg/embed/payload.go
+++ b/dropgz/pkg/embed/payload.go
@@ -94,9 +94,6 @@ func deploy(src, dest string) error {
 		}
 	} else {
 		oldDest := dest + oldFileSuffix
-		if err = os.RemoveAll(oldDest); err != nil {
-			return errors.Wrapf(err, "failed to remove the %s", oldDest)
-		}
 		if err = os.Rename(dest, oldDest); err != nil {
 			return errors.Wrapf(err, "failed to rename the %s to %s", dest, oldDest)
 		}

--- a/dropgz/pkg/embed/payload.go
+++ b/dropgz/pkg/embed/payload.go
@@ -15,9 +15,9 @@ import (
 )
 
 const (
-	cwd             = "fs"
-	pathPrefix      = cwd + string(filepath.Separator)
-	OLD_FILE_SUFFIX = ".old"
+	cwd           = "fs"
+	pathPrefix    = cwd + string(filepath.Separator)
+	oldFileSuffix = ".old"
 )
 
 var ErrArgsMismatched = errors.New("mismatched argument count")
@@ -87,16 +87,19 @@ func deploy(src, dest string) error {
 		return err
 	}
 	defer rc.Close()
-	if _, err := os.Stat(dest); err == nil || !os.IsNotExist(err) {
-		old_file_dest := dest + OLD_FILE_SUFFIX
-		if err = os.RemoveAll(old_file_dest); err != nil {
-			return errors.Wrapf(err, "failed to remove the %s", old_file_dest)
-		}
-		if err = os.Rename(dest, old_file_dest); err != nil {
-			return errors.Wrapf(err, "failed to rename the %s to %s", dest, old_file_dest)
+	_, err = os.Stat(dest)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
 		}
 	} else {
-		return err
+		oldDest := dest + oldFileSuffix
+		if err = os.RemoveAll(oldDest); err != nil {
+			return errors.Wrapf(err, "failed to remove the %s", oldDest)
+		}
+		if err = os.Rename(dest, oldDest); err != nil {
+			return errors.Wrapf(err, "failed to rename the %s to %s", dest, oldDest)
+		}
 	}
 	target, err := os.OpenFile(dest, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o755) //nolint:gomnd // executable file bitmask
 	if err != nil {


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
This is a fix for the cyclic dependency in the dropgz deploy subcommand. The deploy command is trying to write a file that is already being executed by some other program.
This change renames the current dest as old one ( deleting the old dest if it exists) and then try to write the new content to the dest.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [X] includes documentation
- [ ] adds unit tests


**Notes**:
Tested the change locally by trying to use the `deploy` cmd for a file that was running continuously in the background.