### PR TITLE
fix: Dropgz deploy cmd - Clearing the `dest` before writing into it to avoid race condition

### DIFF
--- a/dropgz/README.md
+++ b/dropgz/README.md
@@ -1,0 +1,10 @@
+### Running the dropgz locally
+
+Select the file(for example azure-ipam binary) you want to deploy using the dropgz.
+
+1. Copy the file (i.e azure-ipam) to the directory `/dropgz/pkg/embed/fs` 
+2. Add the sha of the file to the sum.txt file.(`sha256sum * > sum.txt`)
+3. You need to gzip the file, so run the cmd `gzip --verbose --best --recursive azure-ipam` and rename the output .gz file to original file name.
+4. Do the step 3 for `sum.txt` file as well.
+5. go to dropgz directory and build it. (`go build .`)
+6. You can now test the dropgz command locally. (`./dropgz deploy azure-ipam -o ./azure-ipam`)


### PR DESCRIPTION

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
This is a fix for the cyclic dependency in the dropgz deploy subcommand. The deploy command is trying to write a file that is already being executed by some other program.
This change renames the current dest as old one ( deleting the old dest if it exists) and then try to write the new content to the dest.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [X] includes documentation
- [ ] adds unit tests


**Notes**:
Tested the change locally by trying to use the `deploy` cmd for a file that was running continuously in the background.