### PR TITLE
fix: Add 169.254.1.1 GW for Windows CNI Overlay Mode

### DIFF
--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -20,8 +20,9 @@ import (
 )
 
 var (
-	errEmptyCNIArgs = errors.New("empty CNI cmd args not allowed")
-	errInvalidArgs  = errors.New("invalid arg(s)")
+	errEmptyCNIArgs  = errors.New("empty CNI cmd args not allowed")
+	errInvalidArgs   = errors.New("invalid arg(s)")
+	overlayGatewayIP = "169.254.1.1"
 )
 
 type CNSIPAMInvoker struct {
@@ -99,8 +100,12 @@ func (invoker *CNSIPAMInvoker) Add(addConfig IPAMAddConfig) (IPAMAddResult, erro
 	log.Printf("[cni-invoker-cns] Received info %+v for pod %v", info, podInfo)
 
 	ncgw := net.ParseIP(info.ncGatewayIPAddress)
-	if ncgw == nil && invoker.ipamMode != util.V4Overlay {
-		return IPAMAddResult{}, errors.Wrap(errInvalidArgs, "%w: Gateway address "+info.ncGatewayIPAddress+" from response is invalid")
+	if ncgw == nil {
+		if invoker.ipamMode != util.V4Overlay {
+			return IPAMAddResult{}, errors.Wrap(errInvalidArgs, "%w: Gateway address "+info.ncGatewayIPAddress+" from response is invalid")
+		}
+
+		ncgw = net.ParseIP(overlayGatewayIP)
 	}
 
 	// set result ipconfigArgument from CNS Response Body


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Use 169.254.1.1 gw for cni in overlay mode, tested in standalone aksdev cluster

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
CreateNetwork fails in windows cni overlay mode because the GW is nil

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
