### PR TITLE
Remove parsing GatewayIP and passing down to CNI

### DIFF
--- a/azure-ipam/ipam.go
+++ b/azure-ipam/ipam.go
@@ -80,12 +80,12 @@ func (p *IPAMPlugin) CmdAdd(args *cniSkel.CmdArgs) error {
 	p.logger.Debug("Received CNS IP config response", zap.Any("response", resp))
 
 	// Get Pod IP and gateway IP from ip config response
-	podIPNet, gwIP, err := ipconfig.ProcessIPConfigResp(resp)
+	podIPNet, err := ipconfig.ProcessIPConfigResp(resp)
 	if err != nil {
 		p.logger.Error("Failed to interpret CNS IPConfigResponse", zap.Error(err), zap.Any("response", resp))
 		return cniTypes.NewError(ErrProcessIPConfigResponse, err.Error(), "failed to interpret CNS IPConfigResponse")
 	}
-	p.logger.Debug("Parsed pod IP and gateway IP", zap.String("podIPNet", podIPNet.String()), zap.String("gwIP", gwIP.String()))
+	p.logger.Debug("Parsed pod IP", zap.String("podIPNet", podIPNet.String()))
 
 	cniResult := &types100.Result{
 		IPs: []*types100.IPConfig{
@@ -94,16 +94,6 @@ func (p *IPAMPlugin) CmdAdd(args *cniSkel.CmdArgs) error {
 					IP:   net.ParseIP(podIPNet.Addr().String()),
 					Mask: net.CIDRMask(podIPNet.Bits(), 32), // nolint
 				},
-				Gateway: net.ParseIP(gwIP.String()),
-			},
-		},
-		Routes: []*cniTypes.Route{
-			{
-				Dst: net.IPNet{
-					IP:   net.IPv4zero,
-					Mask: net.IPv4Mask(0, 0, 0, 0),
-				},
-				GW: net.ParseIP(gwIP.String()),
 			},
 		},
 	}

--- a/azure-ipam/ipconfig/ipconfig.go
+++ b/azure-ipam/ipconfig/ipconfig.go
@@ -39,7 +39,7 @@ func CreateIPConfigReq(args *cniSkel.CmdArgs) (cns.IPConfigRequest, error) {
 }
 
 // ProcessIPConfigResp processes the IPConfigResponse from the CNS.
-func ProcessIPConfigResp(resp *cns.IPConfigResponse) (*netip.Prefix, *netip.Addr, error) {
+func ProcessIPConfigResp(resp *cns.IPConfigResponse) (*netip.Prefix, error) {
 	podCIDR := fmt.Sprintf(
 		"%s/%d",
 		resp.PodIpInfo.PodIPConfig.IPAddress,
@@ -47,16 +47,10 @@ func ProcessIPConfigResp(resp *cns.IPConfigResponse) (*netip.Prefix, *netip.Addr
 	)
 	podIPNet, err := netip.ParsePrefix(podCIDR)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "cns returned invalid pod CIDR %q", podCIDR)
+		return nil, errors.Wrapf(err, "cns returned invalid pod CIDR %q", podCIDR)
 	}
 
-	ncGatewayIPAddress := resp.PodIpInfo.NetworkContainerPrimaryIPConfig.GatewayIPAddress
-	gwIP, err := netip.ParseAddr(ncGatewayIPAddress)
-	if err != nil {
-		return nil, nil, errors.Wrapf(err, "cns returned an invalid gateway address %q", ncGatewayIPAddress)
-	}
-
-	return &podIPNet, &gwIP, nil
+	return &podIPNet, nil
 }
 
 type k8sPodEnvArgs struct {


### PR DESCRIPTION
…ture

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
This PR fixes azure-ipam support for aks swift overlay cluster. In AKS swift overlay mode, empty gatewayIP is getting passed from cns to azure-ipam and which is expected. Cilium/Azure CNI really doesn't use this gatewayip. So its better to skip parsing this gatewayIP and passing to Azure CNI 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
