### PR TITLE
Fix ClusterSubnetState JSON annotations and kubectl printcolumns

### DIFF
--- a/crd/clustersubnetstate/api/v1alpha1/clustersubnetstate.go
+++ b/crd/clustersubnetstate/api/v1alpha1/clustersubnetstate.go
@@ -15,8 +15,8 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Namespaced
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Timestamp",type=string,JSONPath=`.status.exhausted`
-// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.spec.timestamp`
+// +kubebuilder:printcolumn:name="Exhausted",type=string,JSONPath=`.status.exhausted`
+// +kubebuilder:printcolumn:name="Updated",type=string,JSONPath=`.spec.timestamp`
 type ClusterSubnetState struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -26,8 +26,8 @@ type ClusterSubnetState struct {
 
 // ClusterSubnetStateStatus defines the observed state of ClusterSubnetState
 type ClusterSubnetStateStatus struct {
-	Exhausted bool   `json:"Exhausted"`
-	Timestamp string `json:"Timestamp"`
+	Exhausted bool   `json:"exhausted"`
+	Timestamp string `json:"timestamp"`
 }
 
 // +kubebuilder:object:root=true

--- a/crd/clustersubnetstate/manifests/acn.azure.com_clustersubnetstates.yaml
+++ b/crd/clustersubnetstate/manifests/acn.azure.com_clustersubnetstates.yaml
@@ -17,10 +17,10 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.exhausted
-      name: Timestamp
+      name: Exhausted
       type: string
     - jsonPath: .spec.timestamp
-      name: Status
+      name: Updated
       type: string
     name: v1alpha1
     schema:
@@ -42,13 +42,13 @@ spec:
           status:
             description: ClusterSubnetStateStatus defines the observed state of ClusterSubnetState
             properties:
-              Exhausted:
+              exhausted:
                 type: boolean
-              Timestamp:
+              timestamp:
                 type: string
             required:
-            - Exhausted
-            - Timestamp
+            - exhausted
+            - timestamp
             type: object
         type: object
     served: true


### PR DESCRIPTION
Evan Baker <rbtr@users.noreply.github.com>

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
- Updates the JSON annotations to be lowercase for consistency with the rest of Kubernetes
- Fixes the printercolumns to refer to real fields so that we get values in the `kubectl` output

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
