### PR TITLE
Optimize subnet exhaustion handling

### DIFF
--- a/cns/ipampool/metrics.go
+++ b/cns/ipampool/metrics.go
@@ -120,7 +120,8 @@ func init() {
 	)
 }
 
-func observeIPPoolState(state ipPoolState, meta metaState, labels []string) {
+func observeIPPoolState(state ipPoolState, meta metaState) {
+	labels := []string{meta.subnet, meta.subnetCIDR, meta.subnetARMID}
 	ipamAllocatedIPCount.WithLabelValues(labels...).Set(float64(state.allocatedToPods))
 	ipamAvailableIPCount.WithLabelValues(labels...).Set(float64(state.available))
 	ipamBatchSize.WithLabelValues(labels...).Set(float64(meta.batch))


### PR DESCRIPTION
Signed-off-by: Evan Baker <rbtr@users.noreply.github.com>

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Removes extra local fields to simplify the code for exhausted subnet state handling, and builds a compound CRD Scheme for a shared ctrl runtime manager.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
