### PR TITLE
pipeline: use platform tag make targets in e2e test calls

### DIFF
--- a/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
@@ -57,7 +57,7 @@ steps:
       sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
       kubectl cluster-info
       kubectl get po -owide -A
-      sudo -E env "PATH=$PATH" make test-integration CNS_VERSION=$(make cns-version) CNI_DROPGZ_VERSION=$(make cni-dropgz-version) INSTALL_CNS=true INSTALL_AZURE_VNET=true
+      sudo -E env "PATH=$PATH" make test-integration CNS_PLATFORM_VERSION=$(make cns-platform-tag) CNI_DROPGZ_PLATFORM_VERSION=$(make cni-dropgz-platform-tag) INSTALL_CNS=true INSTALL_AZURE_VNET=true
     retryCountOnTaskFailure: 3
     name: "aksswifte2e"
     displayName: "Run AKS Swift E2E"

--- a/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
@@ -84,7 +84,7 @@ steps:
   - script: |
       echo "Start Azilium E2E Tests"
       kubectl get po -owide -A
-      sudo -E env "PATH=$PATH" make test-integration CNS_VERSION=$(make cns-version) CNI_DROPGZ_VERSION=$(make cni-dropgz-version) INSTALL_CNS=true INSTALL_AZILIUM=true
+      sudo -E env "PATH=$PATH" make test-integration CNS_PLATFORM_VERSION=$(make cns-platform-tag) CNI_DROPGZ_PLATFORM_VERSION=$(make cni-dropgz-platform-tag) INSTALL_CNS=true INSTALL_AZILIUM=true
     retryCountOnTaskFailure: 3
     name: "aziliumTest"
     displayName: "Run Azilium E2E"

--- a/Makefile
+++ b/Makefile
@@ -665,8 +665,8 @@ test-all: ## run all unit tests.
 
 
 test-integration: ## run all integration tests.
-	CNI_DROPGZ_VERSION=$(CNI_DROPGZ_VERSION) \
-		CNS_VERSION=$(CNS_VERSION) \
+	CNI_DROPGZ_VERSION=$(CNI_DROPGZ_PLATFORM_TAG) \
+		CNS_VERSION=$(CNS_PLATFORM_TAG) \
 		go test -buildvcs=false -timeout 1h -coverpkg=./... -race -covermode atomic -coverprofile=coverage.out -tags=integration ./test/integration...
 
 test-cyclonus: ## run the cyclonus test for npm.

--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,19 @@ npm-version:
 zapai-version: ## prints the zapai version
 	@echo $(ZAPAI_VERSION)
 
+acncli-platform-tag: ## prints the acncli platform tag
+	@echo $(ACNCLI_PLATFORM_TAG)
+
+cni-dropgz-platform-tag: ## prints the cni-dropgz platform tag
+	@echo $(CNI_DROPGZ_PLATFORM_TAG)
+
+cns-platform-tag: ## prints the cns platform tag
+	@echo $(CNS_PLATFORM_TAG)
+
+npm-platform-tag: ## prints the npm platform tag
+	@echo $(NPM_PLATFORM_TAG)
+
+
 ##@ Binaries 
 
 # Build the delegated IPAM plugin binary.

--- a/test/integration/setup_test.go
+++ b/test/integration/setup_test.go
@@ -16,8 +16,8 @@ import (
 const (
 	exitFail = 1
 
-	envCNIDropgzVersion = "CNI_DROPGZ_VERSION"
-	envCNSVersion       = "CNS_VERSION"
+	envCNIDropgzPlatformVersion = "CNI_DROPGZ_PLATFORM_VERSION"
+	envCNSPlatformVersion       = "CNS_PLATFORM_VERSION"
 	envInstallCNS       = "INSTALL_CNS"
 	envInstallAzilium   = "INSTALL_AZILIUM"
 	envInstallAzureVnet = "INSTALL_AZURE_VNET"

--- a/test/integration/setup_test.go
+++ b/test/integration/setup_test.go
@@ -89,8 +89,8 @@ func TestMain(m *testing.M) {
 }
 
 func installCNSDaemonset(ctx context.Context, clientset *kubernetes.Clientset, logDir string) (func() error, error) {
-	cniDropgzVersion := os.Getenv(envCNIDropgzVersion)
-	cnsVersion := os.Getenv(envCNSVersion)
+	cniDropgzVersion := os.Getenv(envCNIDropgzPlatformVersion)
+	cnsVersion := os.Getenv(envCNSPlatformVersion)
 
 	// setup daemonset
 	cns, err := mustParseDaemonSet(cnsDaemonSetPath)


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
In swifte2e and ciliume2e tests are called with CNS and CNI dropgz versions. Including new make targets for all platform tags to be used in e2e test calls. 

Changing from current:
![image](https://user-images.githubusercontent.com/31013536/189419820-a5ded3ea-1a29-4a4f-a15c-5a9cdc7faff7.png)

to also include OS/ARCH for clarity, and to keep it consistent with the pattern of image build. 


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
