### PR TITLE
fix:  [NPM-WIN] Query only local endpoints and ignore remoteEndpoints

### DIFF
--- a/network/hnswrapper/hnsv2wrapper.go
+++ b/network/hnswrapper/hnsv2wrapper.go
@@ -64,6 +64,10 @@ func (f Hnsv2wrapper) GetEndpointByID(endpointId string) (*hcn.HostComputeEndpoi
 	return hcn.GetEndpointByID(endpointId)
 }
 
+func (f Hnsv2wrapper) ListEndpointsQuery(query hcn.HostComputeQuery) ([]hcn.HostComputeEndpoint, error) {
+	return hcn.ListEndpointsQuery(query)
+}
+
 func (f Hnsv2wrapper) ListEndpointsOfNetwork(networkId string) ([]hcn.HostComputeEndpoint, error) {
 	return hcn.ListEndpointsOfNetwork(networkId)
 }

--- a/network/hnswrapper/hnsv2wrapperfake.go
+++ b/network/hnswrapper/hnsv2wrapperfake.go
@@ -238,6 +238,27 @@ func (f Hnsv2wrapperFake) RemoveNamespaceEndpoint(namespaceId string, endpointId
 	return nil
 }
 
+func (f Hnsv2wrapperFake) ListEndpointsQuery(query hcn.HostComputeQuery) ([]hcn.HostComputeEndpoint, error) {
+	f.Lock()
+	defer f.Unlock()
+	delayHnsCall(f.Delay)
+	endpoints := make([]hcn.HostComputeEndpoint, 0)
+	// Can only support query for networkID
+	var queryMap map[string]string
+	err := json.Unmarshal([]byte(query.Filter), queryMap)
+	if err != nil {
+		return nil, newErrorFakeHNS(err.Error())
+	}
+
+	networkID := queryMap["VirtualNetwork"]
+	for _, endpoint := range f.Cache.endpoints {
+		if endpoint.HostComputeNetwork == networkID {
+			endpoints = append(endpoints, *endpoint.GetHCNObj())
+		}
+	}
+	return endpoints, nil
+}
+
 func (f Hnsv2wrapperFake) ListEndpointsOfNetwork(networkId string) ([]hcn.HostComputeEndpoint, error) {
 	f.Lock()
 	defer f.Unlock()

--- a/network/hnswrapper/hnsv2wrapperinterface.go
+++ b/network/hnswrapper/hnsv2wrapperinterface.go
@@ -23,6 +23,7 @@ type HnsV2WrapperInterface interface {
 	GetNetworkByID(networkId string) (*hcn.HostComputeNetwork, error)
 	GetEndpointByID(endpointId string) (*hcn.HostComputeEndpoint, error)
 	ListEndpointsOfNetwork(networkId string) ([]hcn.HostComputeEndpoint, error)
+	ListEndpointsQuery(query hcn.HostComputeQuery) ([]hcn.HostComputeEndpoint, error)
 	ApplyEndpointPolicy(endpoint *hcn.HostComputeEndpoint, requestType hcn.RequestType, endpointPolicy hcn.PolicyEndpointRequest) error
 	GetEndpointByName(endpointName string) (*hcn.HostComputeEndpoint, error)
 }

--- a/network/hnswrapper/hnsv2wrapperwithtimeout.go
+++ b/network/hnswrapper/hnsv2wrapperwithtimeout.go
@@ -320,6 +320,11 @@ func (h Hnsv2wrapperwithtimeout) GetEndpointByID(endpointId string) (*hcn.HostCo
 	}
 }
 
+func (h Hnsv2wrapperwithtimeout) ListEndpointsQuery(query hcn.HostComputeQuery) ([]hcn.HostComputeEndpoint, error) {
+	// Not implementing as this is not required.
+	return nil, nil
+}
+
 func (h Hnsv2wrapperwithtimeout) ListEndpointsOfNetwork(networkId string) ([]hcn.HostComputeEndpoint, error) {
 	r := make(chan ListEndpointsFuncResult)
 	ctx, cancel := context.WithTimeout(context.TODO(), h.HnsCallTimeout)

--- a/npm/pkg/dataplane/dataplane_windows.go
+++ b/npm/pkg/dataplane/dataplane_windows.go
@@ -289,7 +289,7 @@ func (dp *DataPlane) getAllPodEndpoints() ([]hcn.HostComputeEndpoint, error) {
 		Flags: hcn.HostComputeQueryFlagsNone,
 	}
 
-	filterMap := map[string]string{"VirtualNetwork": dp.networkID, "IsRemoteEndpoint": "true"}
+	filterMap := map[string]string{"VirtualNetwork": dp.networkID, "IsRemoteEndpoint": "false"}
 	filter, err := json.Marshal(filterMap)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
NPM Gets endpoints for a pod in all nodes and applies policies in all of them, when in should be applied in only one node where the pod is present.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
