### PR TITLE
test: [NPM-WIN] eliminate effects of TTL for Windows flow table

### DIFF
--- a/.pipelines/npm/npm-cyc-win-tests-latest-release.yaml
+++ b/.pipelines/npm/npm-cyc-win-tests-latest-release.yaml
@@ -23,7 +23,7 @@ jobs:
           mkdir -p '$(GOBIN)'
           mkdir -p '$(GOPATH)/pkg'
           BUILD_NUMBER=$(Build.BuildNumber)
-          RG=cyc-$(echo "npm-`date "+%Y-%m-%d-%S"`")
+          RG=e2e-$(echo "npm-`date "+%Y-%m-%d-%S"`")
 
           git --version
           TAG=$(git -c "versionsort.suffix=-" ls-remote --tags https://github.com/Azure/azure-container-networking  | grep -v "zapai" | grep -v "ipam" | grep -v "{}"| cut --delimiter="/" --fields=3 | sort -V | tail -1)

--- a/test/cyclonus/test-cyclonus-windows.sh
+++ b/test/cyclonus/test-cyclonus-windows.sh
@@ -1,10 +1,13 @@
 curl -fsSL github.com/mattfenwick/cyclonus/releases/latest/download/cyclonus_linux_amd64.tar.gz | tar -zxv
+# As of 09/14, TTL for Windows flow table is up to 240 seconds.
+# Probes take at least 20 seconds (from logs), so with 7 retries, we will start our last try at least 140 seconds after perturbation.
+# Therefore, setting perturbation-wait-seconds=100 to avoid the effects of current TTL.
 ./cyclonus_linux_amd64/cyclonus generate \
     --noisy=true \
     --retries=7 \
     --ignore-loopback=true \
     --cleanup-namespaces=true \
-    --perturbation-wait-seconds=20 \
+    --perturbation-wait-seconds=80 \
     --pod-creation-timeout-seconds=480 \
     --job-timeout-seconds=15 \
     --server-protocol=TCP,UDP \


### PR DESCRIPTION
Current TTL for Windows flow table can cause delays that cause random test case failures. This change will add almost 2 hours to a Cyclonus run.