### PR TITLE
validate nnc in swift e2e scale/connectivity test

### DIFF
--- a/test/integration/goldpinger/client.go
+++ b/test/integration/goldpinger/client.go
@@ -1,4 +1,3 @@
-// +build integration
 
 package goldpinger
 

--- a/test/integration/goldpinger/models.go
+++ b/test/integration/goldpinger/models.go
@@ -1,4 +1,3 @@
-// +build integration
 
 package goldpinger
 

--- a/test/integration/goldpinger/utils.go
+++ b/test/integration/goldpinger/utils.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package goldpinger
 

--- a/test/integration/k8s_test.go
+++ b/test/integration/k8s_test.go
@@ -184,7 +184,7 @@ func TestPodScaling(t *testing.T) {
 				}
 				t.Log("all pods have been allocated IPs")
 			}) {
-				t.Error("some pods don't have IP's")
+				t.Error("some pods don't have IPs")
 			}
 
 			t.Run("nodenetworkconfig has converged", func(t *testing.T) {

--- a/test/integration/kube/client.go
+++ b/test/integration/kube/client.go
@@ -1,0 +1,11 @@
+package kube
+
+import (
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func GetClientOrDie() *kubernetes.Clientset {
+	kubeconf := ctrl.GetConfigOrDie()
+	return kubernetes.NewForConfigOrDie(kubeconf)
+}

--- a/test/integration/kube/nnc.go
+++ b/test/integration/kube/nnc.go
@@ -1,0 +1,22 @@
+package kube
+
+import (
+	"math"
+	"testing"
+
+	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
+	"github.com/stretchr/testify/assert"
+)
+
+func ValidateNNC(t *testing.T, nnc v1alpha.NodeNetworkConfig, pods int64, subnetScarcity bool) {
+	assert.GreaterOrEqual(t, nnc.Spec.RequestedIPCount, pods)
+	expectedReq := calculateExpectedRequest(pods, nnc.Status.Scaler.BatchSize, float64(nnc.Status.Scaler.RequestThresholdPercent)/100) //nolint:gomnd // percentage
+	if subnetScarcity {
+		expectedReq = calculateExpectedRequest(pods, 1, float64(nnc.Status.Scaler.RequestThresholdPercent)/100) //nolint:gomnd // percentage
+	}
+	assert.Equal(t, expectedReq, nnc.Spec.RequestedIPCount)
+}
+
+func calculateExpectedRequest(used, batch int64, minfree float64) int64 {
+	return int64(float64(batch) * math.Ceil(minfree+(float64(used)/float64(batch))))
+}

--- a/test/integration/kube/pod.go
+++ b/test/integration/kube/pod.go
@@ -1,0 +1,28 @@
+package kube
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+)
+
+type podLister interface {
+	List(context.Context, metav1.ListOptions) (*corev1.PodList, error)
+}
+
+func GetPodsByNode(ctx context.Context, podcli podLister, node string) (*corev1.PodList, error) {
+	nodeSelector := fields.SelectorFromSet(fields.Set{"spec.nodeName": node})
+	return podcli.List(ctx, metav1.ListOptions{FieldSelector: nodeSelector.String()}) //nolint:wrapcheck // test file
+}
+
+func FilterHostnet(pods []corev1.Pod) []corev1.Pod {
+	out := []corev1.Pod{}
+	for i := range pods {
+		if !pods[i].Spec.HostNetwork {
+			out = append(out, pods[i])
+		}
+	}
+	return out
+}

--- a/test/integration/label.go
+++ b/test/integration/label.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package k8s
 
 import (

--- a/test/integration/manifests/cns/ciliumconfigmap.yaml
+++ b/test/integration/manifests/cns/ciliumconfigmap.yaml
@@ -22,6 +22,7 @@ data:
           "NodeSyncIntervalInSeconds": 30
       },
       "ChannelMode": "CRD",
+      "EnableSubnetScarcity": true,
       "InitializeFromCNI": false,
       "ManageEndpointState": true,
       "ProgramSNATIPTables" : true

--- a/test/integration/manifests/cns/clusterrole.yaml
+++ b/test/integration/manifests/cns/clusterrole.yaml
@@ -5,9 +5,17 @@ metadata:
   name: pod-reader-all-namespaces
   namespace: kube-system
 rules:
-- apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["get", "watch", "list"]
-- apiGroups: [""]
-  resources: ["nodes"]
-  verbs: ["get"]
+- apiGroups: 
+  - ""
+  resources: 
+  - "pods"
+  verbs: 
+  - get
+  - watch
+  - list
+- apiGroups: 
+  - ""
+  resources: 
+  - nodes
+  verbs: 
+  - get

--- a/test/integration/manifests/cns/role.yaml
+++ b/test/integration/manifests/cns/role.yaml
@@ -4,6 +4,14 @@ metadata:
   namespace: kube-system
   name: nodeNetConfigEditor
 rules:
-  - apiGroups: ["acn.azure.com"]
-    resources: ["nodenetworkconfigs"]
-    verbs: ["get", "list", "watch", "patch", "update"]
+- apiGroups: 
+  - acn.azure.com
+  resources: 
+  - nodenetworkconfigs
+  - clustersubnetstates
+  verbs:
+  - get
+  - list
+  - watch
+  - patch 
+  - update

--- a/test/integration/manifests/cns/swiftconfigmap.yaml
+++ b/test/integration/manifests/cns/swiftconfigmap.yaml
@@ -22,6 +22,7 @@ data:
           "NodeSyncIntervalInSeconds": 30
       },
       "ChannelMode": "CRD",
+      "EnableSubnetScarcity": true,
       "InitializeFromCNI": true,
       "ManageEndpointState": false,
       "ProgramSNATIPTables" : false

--- a/test/integration/portforward.go
+++ b/test/integration/portforward.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package k8s
 
 import (

--- a/test/integration/retry/retry.go
+++ b/test/integration/retry/retry.go
@@ -1,5 +1,3 @@
-// +build integration
-
 // todo: there are more robust retry packages out there, discuss with team
 package retry
 

--- a/test/integration/setup_test.go
+++ b/test/integration/setup_test.go
@@ -70,7 +70,7 @@ func TestMain(m *testing.M) {
 		os.Exit(exitCode)
 	}()
 
-	clientset, err := mustGetClientset()
+	clientset, err := mustGetClientset(*kubeconfig)
 	if err != nil {
 		return
 	}

--- a/test/integration/utils_create_test.go
+++ b/test/integration/utils_create_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package k8s
 
 import (

--- a/test/integration/utils_delete_test.go
+++ b/test/integration/utils_delete_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package k8s
 
 import (

--- a/test/integration/utils_parse_test.go
+++ b/test/integration/utils_parse_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package k8s
 
 import (

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package k8s
 
 import (
@@ -8,12 +6,10 @@ import (
 	"errors"
 	"io"
 	"log"
-	"strings"
-	"time"
-
-	// crd "dnc/requestcontroller/kubernetes"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/Azure/azure-container-networking/test/integration/retry"
 	apiv1 "k8s.io/api/core/v1"
@@ -31,8 +27,8 @@ const (
 	SubnetNameLabel        = "kubernetes.azure.com/podnetwork-subnet"
 )
 
-func mustGetClientset() (*kubernetes.Clientset, error) {
-	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+func mustGetClientset(kubeconfig string) (*kubernetes.Clientset, error) { //nolint:unused,deadcode // used by test
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
 		return nil, err
 	}
@@ -43,8 +39,8 @@ func mustGetClientset() (*kubernetes.Clientset, error) {
 	return clientset, nil
 }
 
-func mustGetRestConfig(t *testing.T) *rest.Config {
-	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+func mustGetRestConfig(t *testing.T, kubeconfig string) *rest.Config { //nolint:unused,deadcode // used by test
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Signed-off-by: Evan Baker <rbtr@users.noreply.github.com>

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Adds a validation of the NNC (requested IPs) during the swift e2e.
This includes functionality to support testing in subnet scarcity mode, but it is hardcoded to false until the clustersubnetstates are being written by RC.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
