### PR TITLE
Add increase functionality for multiple NCs

### DIFF
--- a/cns/fakes/requestcontrollerfake.go
+++ b/cns/fakes/requestcontrollerfake.go
@@ -51,7 +51,9 @@ func (rc *RequestControllerFake) CarveIPConfigsAndAddToStatusAndCNS(numberOfIPCo
 			Name: uuid.New().String(),
 			IP:   rc.ip.String(),
 		}
-		rc.NNC.Status.NetworkContainers[0].IPAssignments = append(rc.NNC.Status.NetworkContainers[0].IPAssignments, ipconfigCRD)
+		for j := range rc.NNC.Status.NetworkContainers {
+			rc.NNC.Status.NetworkContainers[j].IPAssignments = append(rc.NNC.Status.NetworkContainers[j].IPAssignments, ipconfigCRD)
+		}
 
 		ipconfigCNS := cns.IPConfigurationStatus{
 			ID:        ipconfigCRD.Name,
@@ -96,15 +98,17 @@ func (rc *RequestControllerFake) Reconcile(removePendingReleaseIPs bool) error {
 		// mimic DNC removing IPConfigs from the CRD
 		for _, notInUseIPConfigName := range rc.NNC.Spec.IPsNotInUse {
 
-			// remove ipconfig from status
-			index := 0
-			for _, ipconfig := range rc.NNC.Status.NetworkContainers[0].IPAssignments {
-				if notInUseIPConfigName == ipconfig.Name {
-					break
+			for i := range rc.NNC.Status.NetworkContainers {
+				// remove ipconfig from status
+				index := 0
+				for _, ipconfig := range rc.NNC.Status.NetworkContainers[i].IPAssignments {
+					if notInUseIPConfigName == ipconfig.Name {
+						break
+					}
+					index++
 				}
-				index++
+				rc.NNC.Status.NetworkContainers[i].IPAssignments = remove(rc.NNC.Status.NetworkContainers[i].IPAssignments, index)
 			}
-			rc.NNC.Status.NetworkContainers[0].IPAssignments = remove(rc.NNC.Status.NetworkContainers[0].IPAssignments, index)
 
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
To allow for dualstack containers we need to ensure that CNS checks over all NCs passed in the array on nnc are checked instead of assuming there is only one and looking at the first index.  

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
