### PR TITLE
Replace the NMAgent client in CNS with the one from the nmagent package

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-container-networking/cns/types"
+	"github.com/Azure/azure-container-networking/nmagent"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -496,7 +497,7 @@ type PublishNetworkContainerRequest struct {
 	NetworkContainerID                string
 	JoinNetworkURL                    string
 	CreateNetworkContainerURL         string
-	CreateNetworkContainerRequestBody []byte
+	CreateNetworkContainerRequestBody nmagent.PutNetworkContainerRequest
 }
 
 // NetworkContainerParameters parameters available in network container operations

--- a/cns/client/client_test.go
+++ b/cns/client/client_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Azure/azure-container-networking/cns/types"
 	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	"github.com/Azure/azure-container-networking/log"
+	"github.com/Azure/azure-container-networking/nmagent"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -1032,14 +1033,14 @@ func TestPublishNC(t *testing.T) {
 				NetworkContainerID:                "frob",
 				JoinNetworkURL:                    "http://example.com",
 				CreateNetworkContainerURL:         "http://example.com",
-				CreateNetworkContainerRequestBody: []byte{},
+				CreateNetworkContainerRequestBody: nmagent.PutNetworkContainerRequest{},
 			},
 			&cns.PublishNetworkContainerRequest{
 				NetworkID:                         "foo",
 				NetworkContainerID:                "frob",
 				JoinNetworkURL:                    "http://example.com",
 				CreateNetworkContainerURL:         "http://example.com",
-				CreateNetworkContainerRequestBody: []byte{},
+				CreateNetworkContainerRequestBody: nmagent.PutNetworkContainerRequest{},
 			},
 			false,
 		},
@@ -1061,14 +1062,14 @@ func TestPublishNC(t *testing.T) {
 				NetworkContainerID:                "frob",
 				JoinNetworkURL:                    "http://example.com",
 				CreateNetworkContainerURL:         "http://example.com",
-				CreateNetworkContainerRequestBody: []byte{},
+				CreateNetworkContainerRequestBody: nmagent.PutNetworkContainerRequest{},
 			},
 			&cns.PublishNetworkContainerRequest{
 				NetworkID:                         "foo",
 				NetworkContainerID:                "frob",
 				JoinNetworkURL:                    "http://example.com",
 				CreateNetworkContainerURL:         "http://example.com",
-				CreateNetworkContainerRequestBody: []byte{},
+				CreateNetworkContainerRequestBody: nmagent.PutNetworkContainerRequest{},
 			},
 			true,
 		},

--- a/cns/fakes/nmagentclientfake.go
+++ b/cns/fakes/nmagentclientfake.go
@@ -9,15 +9,39 @@ package fakes
 import (
 	"context"
 
-	"github.com/Azure/azure-container-networking/cns/nmagent"
+	"github.com/Azure/azure-container-networking/nmagent"
 )
 
 // NMAgentClientFake can be used to query to VM Host info.
 type NMAgentClientFake struct {
-	GetNCVersionListFunc func(context.Context) (*nmagent.NetworkContainerListResponse, error)
+	PutNetworkContainerF    func(context.Context, *nmagent.PutNetworkContainerRequest) error
+	DeleteNetworkContainerF func(context.Context, nmagent.DeleteContainerRequest) error
+	JoinNetworkF            func(context.Context, nmagent.JoinNetworkRequest) error
+	SupportedAPIsF          func(context.Context) ([]string, error)
+	GetNCVersionF           func(context.Context, nmagent.NCVersionRequest) (nmagent.NCVersion, error)
+	GetNCVersionListF       func(context.Context) (nmagent.NCVersionList, error)
 }
 
-// GetNcVersionListWithOutToken is mock implementation to return nc version list.
-func (c *NMAgentClientFake) GetNCVersionList(ctx context.Context) (*nmagent.NetworkContainerListResponse, error) {
-	return c.GetNCVersionListFunc(ctx)
+func (c *NMAgentClientFake) PutNetworkContainer(ctx context.Context, req *nmagent.PutNetworkContainerRequest) error {
+	return c.PutNetworkContainerF(ctx, req)
+}
+
+func (c *NMAgentClientFake) DeleteNetworkContainer(ctx context.Context, req nmagent.DeleteContainerRequest) error {
+	return c.DeleteNetworkContainerF(ctx, req)
+}
+
+func (c *NMAgentClientFake) JoinNetwork(ctx context.Context, req nmagent.JoinNetworkRequest) error {
+	return c.JoinNetworkF(ctx, req)
+}
+
+func (c *NMAgentClientFake) SupportedAPIs(ctx context.Context) ([]string, error) {
+	return c.SupportedAPIsF(ctx)
+}
+
+func (c *NMAgentClientFake) GetNCVersion(ctx context.Context, req nmagent.NCVersionRequest) (nmagent.NCVersion, error) {
+	return c.GetNCVersionF(ctx, req)
+}
+
+func (c *NMAgentClientFake) GetNCVersionList(ctx context.Context) (nmagent.NCVersionList, error) {
+	return c.GetNCVersionListF(ctx)
 }

--- a/cns/nmagent/client.go
+++ b/cns/nmagent/client.go
@@ -1,15 +1,7 @@
 package nmagent
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
-	"time"
-
-	"github.com/Azure/azure-container-networking/cns/logger"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -60,33 +52,4 @@ func NewClient(url string) (*Client, error) {
 	return &Client{
 		connectionURL: url,
 	}, nil
-}
-
-// GetNCVersionList query nmagent for programmed container versions.
-func (c *Client) GetNCVersionList(ctx context.Context) (*NetworkContainerListResponse, error) {
-	now := time.Now()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.connectionURL, nil)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to build nmagent request")
-	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to make nmagent request")
-	}
-	defer resp.Body.Close()
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to read response body")
-	}
-	logger.Printf("[NMAgentClient][Response] GetNcVersionListWithOutToken response: %s, latency is %d", string(b), time.Since(now).Milliseconds())
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, errors.Errorf("failed to GetNCVersionList with status %d", resp.StatusCode)
-	}
-
-	var response NetworkContainerListResponse
-	if err := json.Unmarshal(b, &response); err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal response")
-	}
-	return &response, nil
 }

--- a/cns/nmagent/client.go
+++ b/cns/nmagent/client.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/Azure/azure-container-networking/cns/logger"
@@ -68,42 +67,6 @@ func NewClient(url string) (*Client, error) {
 	return &Client{
 		connectionURL: url,
 	}, nil
-}
-
-// JoinNetwork joins the given network
-func JoinNetwork(networkID string) (*http.Response, error) {
-	logger.Printf("[NMAgentClient] JoinNetwork: %s", networkID)
-
-	// Empty body is required as wireserver cannot handle a post without the body.
-	var body bytes.Buffer
-	json.NewEncoder(&body).Encode("")
-
-	joinNetworkTypeValue := fmt.Sprintf(
-		JoinNetworkURLFmt,
-		networkID)
-
-	joinNetworkURL := url.URL{
-		Host:   WireserverIP,
-		Path:   WireServerPath,
-		Scheme: WireServerScheme,
-	}
-
-	queryString := joinNetworkURL.Query()
-	queryString.Set("type", joinNetworkTypeValue)
-	queryString.Set("comp", "nmagent")
-
-	joinNetworkURL.RawQuery = queryString.Encode()
-
-	response, err := common.PostCtx(context.TODO(), common.GetHttpClient(), joinNetworkURL.String(), "application/json", &body)
-
-	if err == nil && response.StatusCode == http.StatusOK {
-		defer response.Body.Close()
-	}
-
-	logger.Printf("[NMAgentClient][Response] Join network: %s. Response: %+v. Error: %v",
-		networkID, response, err)
-
-	return response, err
 }
 
 // GetNetworkContainerVersion :- Retrieves NC version from NMAgent

--- a/cns/nmagent/client.go
+++ b/cns/nmagent/client.go
@@ -106,39 +106,6 @@ func JoinNetwork(networkID string) (*http.Response, error) {
 	return response, err
 }
 
-// UnpublishNetworkContainer unpublishes given network container
-func UnpublishNetworkContainer(networkContainerID, associatedInterfaceID, accessToken string) (*http.Response, error) {
-	logger.Printf("[NMAgentClient] UnpublishNetworkContainer NC: %s", networkContainerID)
-
-	deleteNCTypeValue := fmt.Sprintf(
-		DeleteNetworkContainerURLFmt,
-		associatedInterfaceID,
-		networkContainerID,
-		accessToken)
-
-	deleteURL := url.URL{
-		Host:   WireserverIP,
-		Path:   WireServerPath,
-		Scheme: WireServerScheme,
-	}
-
-	queryString := deleteURL.Query()
-	queryString.Set("type", deleteNCTypeValue)
-	queryString.Set("comp", "nmagent")
-
-	deleteURL.RawQuery = queryString.Encode()
-
-	// Empty body is required as wireserver cannot handle a post without the body.
-	var body bytes.Buffer
-	json.NewEncoder(&body).Encode("")
-	response, err := common.PostCtx(context.TODO(), common.GetHttpClient(), deleteURL.String(), "application/json", &body)
-
-	logger.Printf("[NMAgentClient][Response] Unpublish NC: %s. Response: %+v. Error: %v",
-		networkContainerID, response, err)
-
-	return response, err
-}
-
 // GetNetworkContainerVersion :- Retrieves NC version from NMAgent
 func GetNetworkContainerVersion(networkContainerID, getNetworkContainerVersionURL string) (*http.Response, error) {
 	logger.Printf("[NMAgentClient] GetNetworkContainerVersion NC: %s", networkContainerID)

--- a/cns/nmagent/client.go
+++ b/cns/nmagent/client.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-container-networking/cns/logger"
-	"github.com/Azure/azure-container-networking/common"
 	"github.com/pkg/errors"
 )
 
@@ -61,17 +60,6 @@ func NewClient(url string) (*Client, error) {
 	return &Client{
 		connectionURL: url,
 	}, nil
-}
-
-// GetNetworkContainerVersion :- Retrieves NC version from NMAgent
-func GetNetworkContainerVersion(networkContainerID, getNetworkContainerVersionURL string) (*http.Response, error) {
-	logger.Printf("[NMAgentClient] GetNetworkContainerVersion NC: %s", networkContainerID)
-
-	response, err := common.GetHttpClient().Get(getNetworkContainerVersionURL)
-
-	logger.Printf("[NMAgentClient][Response] GetNetworkContainerVersion NC: %s. Response: %+v. Error: %v",
-		networkContainerID, response, err)
-	return response, err
 }
 
 // GetNCVersionList query nmagent for programmed container versions.

--- a/cns/nmagent/client.go
+++ b/cns/nmagent/client.go
@@ -106,37 +106,6 @@ func JoinNetwork(networkID string) (*http.Response, error) {
 	return response, err
 }
 
-// PublishNetworkContainer publishes given network container
-func PublishNetworkContainer(networkContainerID, associatedInterfaceID, accessToken string, requestBodyData []byte) (*http.Response, error) {
-	logger.Printf("[NMAgentClient] PublishNetworkContainer NC: %s", networkContainerID)
-
-	createNcTypeValue := fmt.Sprintf(
-		PutNetworkValueFmt,
-		associatedInterfaceID,
-		networkContainerID,
-		accessToken)
-
-	createURL := url.URL{
-		Host:   WireserverIP,
-		Path:   WireServerPath,
-		Scheme: WireServerScheme,
-	}
-
-	queryString := createURL.Query()
-	queryString.Set("type", createNcTypeValue)
-	queryString.Set("comp", "nmagent")
-
-	createURL.RawQuery = queryString.Encode()
-
-	requestBody := bytes.NewBuffer(requestBodyData)
-	response, err := common.PostCtx(context.TODO(), common.GetHttpClient(), createURL.String(), "application/json", requestBody)
-
-	logger.Printf("[NMAgentClient][Response] Publish NC: %s. Response: %+v. Error: %v",
-		networkContainerID, response, err)
-
-	return response, err
-}
-
 // UnpublishNetworkContainer unpublishes given network container
 func UnpublishNetworkContainer(networkContainerID, associatedInterfaceID, accessToken string) (*http.Response, error) {
 	logger.Printf("[NMAgentClient] UnpublishNetworkContainer NC: %s", networkContainerID)

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -1117,7 +1117,6 @@ func (service *HTTPRestService) publishNetworkContainer(w http.ResponseWriter, r
 	ctx := r.Context()
 
 	var (
-		err                 error
 		req                 cns.PublishNetworkContainerRequest
 		returnCode          types.ResponseCode
 		returnMessage       string
@@ -1127,7 +1126,7 @@ func (service *HTTPRestService) publishNetworkContainer(w http.ResponseWriter, r
 		isNetworkJoined     bool
 	)
 
-	err = service.Listener.Decode(w, r, &req)
+	err := service.Listener.Decode(w, r, &req)
 
 	creteNcURLCopy := req.CreateNetworkContainerURL
 
@@ -1172,7 +1171,7 @@ func (service *HTTPRestService) publishNetworkContainer(w http.ResponseWriter, r
 		// Please refactor this
 		// do not reuse the below variable between network join and publish
 		// nolint:bodyclose // existing code needs refactoring
-		err := service.joinNetwork(req.NetworkID)
+		err = service.joinNetwork(req.NetworkID)
 		if err != nil {
 			returnMessage = err.Error()
 			returnCode = types.NetworkJoinFailed
@@ -1308,7 +1307,7 @@ func (service *HTTPRestService) unpublishNetworkContainer(w http.ResponseWriter,
 				AuthenticationToken: ncParameters.AuthToken,
 			}
 
-			err := service.nma.DeleteNetworkContainer(ctx, dcr)
+			err = service.nma.DeleteNetworkContainer(ctx, dcr)
 			if err != nil {
 				returnMessage = fmt.Sprintf("Failed to unpublish Network Container: %s", req.NetworkContainerID)
 				returnCode = types.NetworkContainerUnpublishFailed

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -1177,7 +1177,8 @@ func (service *HTTPRestService) publishNetworkContainer(w http.ResponseWriter, r
 			returnCode = types.NetworkJoinFailed
 			publishErrorStr = err.Error()
 
-			if nmaErr, ok := err.(nma.Error); ok {
+			var nmaErr nma.Error
+			if errors.As(err, &nmaErr) {
 				publishStatusCode = nmaErr.StatusCode()
 			}
 		} else {
@@ -1291,7 +1292,8 @@ func (service *HTTPRestService) unpublishNetworkContainer(w http.ResponseWriter,
 				returnCode = types.NetworkJoinFailed
 				unpublishErrorStr = err.Error()
 
-				if nmaErr, ok := err.(nma.Error); ok {
+				var nmaErr nma.Error
+				if errors.As(err, &nmaErr) {
 					unpublishStatusCode = nmaErr.StatusCode()
 				}
 

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -1192,7 +1192,7 @@ func (service *HTTPRestService) publishNetworkContainer(w http.ResponseWriter, r
 			pncr.AuthenticationToken = ncParameters.AuthToken
 			pncr.PrimaryAddress = ncParameters.AssociatedInterfaceID
 
-			err := service.nma.PutNetworkContainer(ctx, &pncr)
+			err = service.nma.PutNetworkContainer(ctx, &pncr)
 			// nolint:bodyclose // existing code needs refactoring
 			if err != nil {
 				returnMessage = fmt.Sprintf("Failed to publish Network Container: %s", req.NetworkContainerID)

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -19,7 +19,6 @@ import (
 	"github.com/Azure/azure-container-networking/cns/nmagent"
 	"github.com/Azure/azure-container-networking/cns/types"
 	"github.com/Azure/azure-container-networking/cns/wireserver"
-	"github.com/Azure/azure-container-networking/common"
 	nma "github.com/Azure/azure-container-networking/nmagent"
 	"github.com/Azure/azure-container-networking/platform"
 	"github.com/pkg/errors"
@@ -1448,6 +1447,8 @@ func (service *HTTPRestService) nmAgentSupportedApisHandler(w http.ResponseWrite
 		supportedApis []string
 	)
 
+	ctx := r.Context()
+
 	err = service.Listener.Decode(w, r, &req)
 	logger.Request(service.Name, &req, err)
 	if err != nil {
@@ -1456,15 +1457,12 @@ func (service *HTTPRestService) nmAgentSupportedApisHandler(w http.ResponseWrite
 
 	switch r.Method {
 	case http.MethodPost:
-		supportedApis, retErr = nmagent.GetNmAgentSupportedApis(common.GetHttpClient(),
-			req.GetNmAgentSupportedApisURL)
-		if retErr != nil {
+		apis, err := service.nma.SupportedAPIs(ctx)
+		if err != nil {
 			returnCode = types.NmAgentSupportedApisError
 			returnMessage = fmt.Sprintf("[Azure-CNS] %s", retErr.Error())
 		}
-		if supportedApis == nil {
-			supportedApis = []string{}
-		}
+		supportedApis = apis
 
 	default:
 		returnMessage = "[Azure-CNS] NmAgentSupported API list expects a POST method."

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -1171,7 +1171,7 @@ func (service *HTTPRestService) publishNetworkContainer(w http.ResponseWriter, r
 		// Please refactor this
 		// do not reuse the below variable between network join and publish
 		// nolint:bodyclose // existing code needs refactoring
-		err = service.joinNetwork(req.NetworkID)
+		err = service.joinNetwork(ctx, req.NetworkID)
 		if err != nil {
 			returnMessage = err.Error()
 			returnCode = types.NetworkJoinFailed
@@ -1286,7 +1286,7 @@ func (service *HTTPRestService) unpublishNetworkContainer(w http.ResponseWriter,
 		isNetworkJoined = service.isNetworkJoined(req.NetworkID)
 		if !isNetworkJoined {
 			// nolint:bodyclose // existing code needs refactoring
-			err = service.joinNetwork(req.NetworkID)
+			err = service.joinNetwork(ctx, req.NetworkID)
 			if err != nil {
 				returnMessage = err.Error()
 				returnCode = types.NetworkJoinFailed

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -16,7 +16,6 @@ import (
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/hnsclient"
 	"github.com/Azure/azure-container-networking/cns/logger"
-	"github.com/Azure/azure-container-networking/cns/nmagent"
 	"github.com/Azure/azure-container-networking/cns/types"
 	"github.com/Azure/azure-container-networking/cns/wireserver"
 	nma "github.com/Azure/azure-container-networking/nmagent"
@@ -1202,13 +1201,13 @@ func (service *HTTPRestService) publishNetworkContainer(w http.ResponseWriter, r
 			}
 		}
 
-		// Store ncGetVersionURL needed for calling NMAgent to check if vfp programming is completed for the NC
-		ncGetVersionURL := fmt.Sprintf(nmagent.GetNetworkContainerVersionURLFmt,
-			nmagent.WireserverIP,
-			ncParameters.AssociatedInterfaceID,
-			req.NetworkContainerID,
-			ncParameters.AuthToken)
-		ncVersionURLs.Store(cns.SwiftPrefix+req.NetworkContainerID, ncGetVersionURL)
+		req := nma.NCVersionRequest{
+			AuthToken:          ncParameters.AuthToken,
+			NetworkContainerID: req.NetworkContainerID,
+			PrimaryAddress:     ncParameters.AssociatedInterfaceID,
+		}
+
+		ncVersionURLs.Store(cns.SwiftPrefix+req.NetworkContainerID, req)
 
 	default:
 		returnMessage = "PublishNetworkContainer API expects a POST"

--- a/cns/restserver/api_test.go
+++ b/cns/restserver/api_test.go
@@ -1207,7 +1207,7 @@ func getNonExistNetworkContainerByContext(params createOrUpdateNetworkContainerP
 	json.NewEncoder(&body).Encode(getReq)
 	req, err := http.NewRequest(http.MethodPost, cns.GetNetworkContainerByOrchestratorContext, &body)
 	if err != nil {
-		fmt.Errorf("sending http post to get NC by orchestrator endpoint: %w", err)
+		return fmt.Errorf("sending http post to get NC by orchestrator endpoint: %w", err)
 	}
 
 	w := httptest.NewRecorder()

--- a/cns/restserver/api_test.go
+++ b/cns/restserver/api_test.go
@@ -691,6 +691,9 @@ func publishNCViaCNS(t *testing.T,
 		PutNetworkContainerF: func(_ context.Context, _ *nma.PutNetworkContainerRequest) error {
 			return nil
 		},
+		JoinNetworkF: func(_ context.Context, _ nma.JoinNetworkRequest) error {
+			return nil
+		},
 	}
 
 	setMockNMAgent(svc, mnma)
@@ -786,6 +789,9 @@ func testUnpublishNCViaCNS(t *testing.T,
 
 	mnma := &MockNMAgent{
 		DeleteNetworkContainerF: func(_ context.Context, _ nma.DeleteContainerRequest) error {
+			return nil
+		},
+		JoinNetworkF: func(_ context.Context, _ nma.JoinNetworkRequest) error {
 			return nil
 		},
 	}

--- a/cns/restserver/api_test.go
+++ b/cns/restserver/api_test.go
@@ -573,7 +573,8 @@ func TestGetNetworkContainerVersionStatus(t *testing.T) {
 	}
 	expectCNSSuccess(t, resp.Response)
 
-	if err := deleteNetworkContainerWithParams(params); err != nil {
+	err = deleteNetworkContainerWithParams(params)
+	if err != nil {
 		t.Fatal("error deleting NC: err:", err)
 	}
 
@@ -607,7 +608,8 @@ func TestGetNetworkContainerVersionStatus(t *testing.T) {
 	}
 	expectCNSFailure(t, resp.Response)
 
-	if err := deleteNetworkContainerWithParams(params); err != nil {
+	err = deleteNetworkContainerWithParams(params)
+	if err != nil {
 		t.Fatal("error deleting interface: err:", err)
 	}
 
@@ -644,7 +646,8 @@ func TestGetNetworkContainerVersionStatus(t *testing.T) {
 	}
 	expectCNSSuccess(t, resp.Response)
 
-	if err := deleteNetworkContainerWithParams(params); err != nil {
+	err = deleteNetworkContainerWithParams(params)
+	if err != nil {
 		t.Fatal("error deleting network container: err:", err)
 	}
 

--- a/cns/restserver/api_test.go
+++ b/cns/restserver/api_test.go
@@ -626,13 +626,13 @@ func TestGetNetworkContainerVersionStatus(t *testing.T) {
 	}
 
 	mnma.GetNCVersionF = func(_ context.Context, _ nma.NCVersionRequest) (nma.NCVersion, error) {
-		return nma.NCVersion{}, errors.New("boom")
+		return nma.NCVersion{}, errors.New("boom") //nolint:goerr113 // it's just a test
 	}
 	mnma.JoinNetworkF = func(_ context.Context, _ nma.JoinNetworkRequest) error {
-		return errors.New("boom")
+		return errors.New("boom") //nolint:goerr113 // it's just a test
 	}
 	mnma.PutNetworkContainerF = func(_ context.Context, _ *nma.PutNetworkContainerRequest) error {
-		return errors.New("boom")
+		return errors.New("boom") //nolint:goerr113 // it's just a test
 	}
 
 	err = createNC(params)

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -187,7 +187,7 @@ func (service *HTTPRestService) syncHostNCVersion(ctx context.Context, channelMo
 	if len(outdatedNCs) == 0 {
 		return nil
 	}
-	ncVersionListResp, err := service.nmagentClient.GetNCVersionList(ctx)
+	ncVersionListResp, err := service.nma.GetNCVersionList(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to get nc version list from nmagent")
 	}

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -16,10 +16,10 @@ import (
 
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/logger"
-	"github.com/Azure/azure-container-networking/cns/nmagent"
 	"github.com/Azure/azure-container-networking/cns/types"
 	"github.com/Azure/azure-container-networking/common"
 	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
+	"github.com/Azure/azure-container-networking/nmagent"
 	"github.com/pkg/errors"
 )
 
@@ -96,22 +96,22 @@ func (service *HTTPRestService) SyncNodeStatus(dncEP, infraVnet, nodeID string, 
 
 	// check if the version is valid and save it to service state
 	for ncid, nc := range ncsToBeAdded {
-		var (
-			versionURL = fmt.Sprintf(nmagent.GetNetworkContainerVersionURLFmt,
-				nmagent.WireserverIP,
-				nc.PrimaryInterfaceIdentifier,
-				nc.NetworkContainerid,
-				nc.AuthorizationToken)
-			w = httptest.NewRecorder()
-		)
+		nmaReq := nmagent.NCVersionRequest{
+			AuthToken:          nc.AuthorizationToken,
+			NetworkContainerID: nc.NetworkContainerid,
+			PrimaryAddress:     nc.PrimaryInterfaceIdentifier,
+		}
 
-		ncVersionURLs.Store(nc.NetworkContainerid, versionURL)
+		ncVersionURLs.Store(nc.NetworkContainerid, nmaReq)
 		waitingForUpdate, _, _ := service.isNCWaitingForUpdate(nc.Version, nc.NetworkContainerid)
 
 		body, _ = json.Marshal(nc)
 		req, _ = http.NewRequest(http.MethodPost, "", bytes.NewBuffer(body))
 		req.Header.Set(common.ContentType, common.JsonContent)
+
+		w := httptest.NewRecorder()
 		service.createOrUpdateNetworkContainer(w, req)
+
 		if w.Result().StatusCode == http.StatusOK {
 			var resp cns.CreateNetworkContainerResponse
 			if err = json.Unmarshal(w.Body.Bytes(), &resp); err == nil && resp.Response.ReturnCode == types.Success {

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/fakes"
 	"github.com/Azure/azure-container-networking/cns/types"
 	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	nma "github.com/Azure/azure-container-networking/nmagent"
@@ -131,7 +132,7 @@ func TestSyncHostNCVersion(t *testing.T) {
 				t.Errorf("Unexpected nc version in containerStatus as %s, expected VM version should be 0 in string", containerStatus.CreateNetworkContainerRequest.Version)
 			}
 
-			mnma := &MockNMAgent{
+			mnma := &fakes.NMAgentClientFake{
 				GetNCVersionListF: func(_ context.Context) (nma.NCVersionList, error) {
 					return nma.NCVersionList{
 						Containers: []nma.NCVersion{
@@ -175,7 +176,7 @@ func TestPendingIPsGotUpdatedWhenSyncHostNCVersion(t *testing.T) {
 		}
 	}
 
-	mnma := &MockNMAgent{
+	mnma := &fakes.NMAgentClientFake{
 		GetNCVersionListF: func(_ context.Context) (nma.NCVersionList, error) {
 			return nma.NCVersionList{
 				Containers: []nma.NCVersion{

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/types"
 	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
+	nma "github.com/Azure/azure-container-networking/nmagent"
 	"github.com/google/uuid"
 )
 
@@ -120,27 +121,42 @@ func TestSyncHostNCVersion(t *testing.T) {
 	// cns.KubernetesCRD has one more logic compared to other orchestrator type, so test both of them
 	orchestratorTypes := []string{cns.Kubernetes, cns.KubernetesCRD}
 	for _, orchestratorType := range orchestratorTypes {
-		testSyncHostNCVersion(t, orchestratorType)
-	}
-}
+		t.Run(orchestratorType, func(t *testing.T) {
+			req := createNCReqeustForSyncHostNCVersion(t)
+			containerStatus := svc.state.ContainerStatus[req.NetworkContainerid]
+			if containerStatus.HostVersion != "-1" {
+				t.Errorf("Unexpected containerStatus.HostVersion %s, expected host version should be -1 in string", containerStatus.HostVersion)
+			}
+			if containerStatus.CreateNetworkContainerRequest.Version != "0" {
+				t.Errorf("Unexpected nc version in containerStatus as %s, expected VM version should be 0 in string", containerStatus.CreateNetworkContainerRequest.Version)
+			}
 
-func testSyncHostNCVersion(t *testing.T, orchestratorType string) {
-	req := createNCReqeustForSyncHostNCVersion(t)
-	containerStatus := svc.state.ContainerStatus[req.NetworkContainerid]
-	if containerStatus.HostVersion != "-1" {
-		t.Errorf("Unexpected containerStatus.HostVersion %s, expeted host version should be -1 in string", containerStatus.HostVersion)
-	}
-	if containerStatus.CreateNetworkContainerRequest.Version != "0" {
-		t.Errorf("Unexpected nc version in containerStatus as %s, expeted VM version should be 0 in string", containerStatus.CreateNetworkContainerRequest.Version)
-	}
-	// When sync host NC version, it will use the orchestratorType pass in.
-	svc.SyncHostNCVersion(context.Background(), orchestratorType)
-	containerStatus = svc.state.ContainerStatus[req.NetworkContainerid]
-	if containerStatus.HostVersion != "0" {
-		t.Errorf("Unexpected containerStatus.HostVersion %s, expeted host version should be 0 in string", containerStatus.HostVersion)
-	}
-	if containerStatus.CreateNetworkContainerRequest.Version != "0" {
-		t.Errorf("Unexpected nc version in containerStatus as %s, expeted VM version should be 0 in string", containerStatus.CreateNetworkContainerRequest.Version)
+			mnma := &MockNMAgent{
+				GetNCVersionListF: func(_ context.Context) (nma.NCVersionList, error) {
+					return nma.NCVersionList{
+						Containers: []nma.NCVersion{
+							{
+								NetworkContainerID: req.NetworkContainerid,
+								Version:            "0",
+							},
+						},
+					}, nil
+				},
+			}
+			cleanup := setMockNMAgent(svc, mnma)
+			defer cleanup()
+
+			// When syncing the host NC version, it will use the orchestratorType passed
+			// in.
+			svc.SyncHostNCVersion(context.Background(), orchestratorType)
+			containerStatus = svc.state.ContainerStatus[req.NetworkContainerid]
+			if containerStatus.HostVersion != "0" {
+				t.Errorf("Unexpected containerStatus.HostVersion %s, expected host version should be 0 in string", containerStatus.HostVersion)
+			}
+			if containerStatus.CreateNetworkContainerRequest.Version != "0" {
+				t.Errorf("Unexpected nc version in containerStatus as %s, expected VM version should be 0 in string", containerStatus.CreateNetworkContainerRequest.Version)
+			}
+		})
 	}
 }
 
@@ -158,6 +174,22 @@ func TestPendingIPsGotUpdatedWhenSyncHostNCVersion(t *testing.T) {
 			t.Errorf("Unexpected State %s, expected State is %s, IP address is %s", podIPConfigState.GetState(), types.PendingProgramming, podIPConfigState.IPAddress)
 		}
 	}
+
+	mnma := &MockNMAgent{
+		GetNCVersionListF: func(_ context.Context) (nma.NCVersionList, error) {
+			return nma.NCVersionList{
+				Containers: []nma.NCVersion{
+					{
+						NetworkContainerID: req.NetworkContainerid,
+						Version:            "0",
+					},
+				},
+			}, nil
+		},
+	}
+	cleanup := setMockNMAgent(svc, mnma)
+	defer cleanup()
+
 	svc.SyncHostNCVersion(context.Background(), cns.CRD)
 	containerStatus = svc.state.ContainerStatus[req.NetworkContainerid]
 

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -69,6 +69,7 @@ type HTTPRestService struct {
 		JoinNetwork(context.Context, nma.JoinNetworkRequest) error
 		SupportedAPIs(context.Context) ([]string, error)
 		GetNCVersion(context.Context, nma.NCVersionRequest) (nma.NCVersion, error)
+		GetNCVersionList(context.Context) (nma.NCVersionList, error)
 	}
 }
 

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -67,6 +67,7 @@ type HTTPRestService struct {
 		PutNetworkContainer(context.Context, *nma.PutNetworkContainerRequest) error
 		DeleteNetworkContainer(context.Context, nma.DeleteContainerRequest) error
 		JoinNetwork(context.Context, nma.JoinNetworkRequest) error
+		SupportedAPIs(context.Context) ([]string, error)
 	}
 }
 

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -66,6 +66,7 @@ type HTTPRestService struct {
 	nma                interface {
 		PutNetworkContainer(context.Context, *nma.PutNetworkContainerRequest) error
 		DeleteNetworkContainer(context.Context, nma.DeleteContainerRequest) error
+		JoinNetwork(context.Context, nma.JoinNetworkRequest) error
 	}
 }
 

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -68,6 +68,7 @@ type HTTPRestService struct {
 		DeleteNetworkContainer(context.Context, nma.DeleteContainerRequest) error
 		JoinNetwork(context.Context, nma.JoinNetworkRequest) error
 		SupportedAPIs(context.Context) ([]string, error)
+		GetNCVersion(context.Context, nma.NCVersionRequest) (nma.NCVersion, error)
 	}
 }
 

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Azure/azure-container-networking/cns/types/bounded"
 	"github.com/Azure/azure-container-networking/cns/wireserver"
 	acn "github.com/Azure/azure-container-networking/common"
+	nma "github.com/Azure/azure-container-networking/nmagent"
 	"github.com/Azure/azure-container-networking/store"
 	"github.com/pkg/errors"
 )
@@ -62,6 +63,9 @@ type HTTPRestService struct {
 	dncPartitionKey    string
 	EndpointState      map[string]*EndpointInfo // key : container id
 	EndpointStateStore store.KeyValueStore
+	nma                interface {
+		PutNetworkContainer(context.Context, *nma.PutNetworkContainerRequest) error
+	}
 }
 
 type EndpointInfo struct {

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -65,6 +65,7 @@ type HTTPRestService struct {
 	EndpointStateStore store.KeyValueStore
 	nma                interface {
 		PutNetworkContainer(context.Context, *nma.PutNetworkContainerRequest) error
+		DeleteNetworkContainer(context.Context, nma.DeleteContainerRequest) error
 	}
 }
 

--- a/cns/restserver/restserver_test.go
+++ b/cns/restserver/restserver_test.go
@@ -1,0 +1,26 @@
+package restserver
+
+import (
+	"context"
+
+	"github.com/Azure/azure-container-networking/nmagent"
+)
+
+func setMockNMAgent(h *HTTPRestService, m *MockNMAgent) {
+	// this is a hack that exists because the tests are too DRY, so the setup
+	// logic has ossified in TestMain
+	h.nma = m
+}
+
+type MockNMAgent struct {
+	PutNetworkContainerF    func(context.Context, *nmagent.PutNetworkContainerRequest) error
+	DeleteNetworkContainerF func(context.Context, nmagent.DeleteContainerRequest) error
+}
+
+func (m *MockNMAgent) PutNetworkContainer(ctx context.Context, pncr *nmagent.PutNetworkContainerRequest) error {
+	return m.PutNetworkContainerF(ctx, pncr)
+}
+
+func (m *MockNMAgent) DeleteNetworkContainer(ctx context.Context, dcr nmagent.DeleteContainerRequest) error {
+	return m.DeleteNetworkContainerF(ctx, dcr)
+}

--- a/cns/restserver/restserver_test.go
+++ b/cns/restserver/restserver_test.go
@@ -29,6 +29,7 @@ type MockNMAgent struct {
 	JoinNetworkF            func(context.Context, nmagent.JoinNetworkRequest) error
 	SupportedAPIsF          func(context.Context) ([]string, error)
 	GetNCVersionF           func(context.Context, nmagent.NCVersionRequest) (nmagent.NCVersion, error)
+	GetNCVersionListF       func(context.Context) (nmagent.NCVersionList, error)
 }
 
 func (m *MockNMAgent) PutNetworkContainer(ctx context.Context, pncr *nmagent.PutNetworkContainerRequest) error {
@@ -49,4 +50,8 @@ func (m *MockNMAgent) SupportedAPIs(ctx context.Context) ([]string, error) {
 
 func (m *MockNMAgent) GetNCVersion(ctx context.Context, req nmagent.NCVersionRequest) (nmagent.NCVersion, error) {
 	return m.GetNCVersionF(ctx, req)
+}
+
+func (m *MockNMAgent) GetNCVersionList(ctx context.Context) (nmagent.NCVersionList, error) {
+	return m.GetNCVersionListF(ctx)
 }

--- a/cns/restserver/restserver_test.go
+++ b/cns/restserver/restserver_test.go
@@ -16,6 +16,7 @@ type MockNMAgent struct {
 	PutNetworkContainerF    func(context.Context, *nmagent.PutNetworkContainerRequest) error
 	DeleteNetworkContainerF func(context.Context, nmagent.DeleteContainerRequest) error
 	JoinNetworkF            func(context.Context, nmagent.JoinNetworkRequest) error
+	SupportedAPIsF          func(context.Context) ([]string, error)
 }
 
 func (m *MockNMAgent) PutNetworkContainer(ctx context.Context, pncr *nmagent.PutNetworkContainerRequest) error {
@@ -28,4 +29,8 @@ func (m *MockNMAgent) DeleteNetworkContainer(ctx context.Context, dcr nmagent.De
 
 func (m *MockNMAgent) JoinNetwork(ctx context.Context, jnr nmagent.JoinNetworkRequest) error {
 	return m.JoinNetworkF(ctx, jnr)
+}
+
+func (m *MockNMAgent) SupportedAPIs(ctx context.Context) ([]string, error) {
+	return m.SupportedAPIsF(ctx)
 }

--- a/cns/restserver/restserver_test.go
+++ b/cns/restserver/restserver_test.go
@@ -15,6 +15,7 @@ func setMockNMAgent(h *HTTPRestService, m *MockNMAgent) {
 type MockNMAgent struct {
 	PutNetworkContainerF    func(context.Context, *nmagent.PutNetworkContainerRequest) error
 	DeleteNetworkContainerF func(context.Context, nmagent.DeleteContainerRequest) error
+	JoinNetworkF            func(context.Context, nmagent.JoinNetworkRequest) error
 }
 
 func (m *MockNMAgent) PutNetworkContainer(ctx context.Context, pncr *nmagent.PutNetworkContainerRequest) error {
@@ -23,4 +24,8 @@ func (m *MockNMAgent) PutNetworkContainer(ctx context.Context, pncr *nmagent.Put
 
 func (m *MockNMAgent) DeleteNetworkContainer(ctx context.Context, dcr nmagent.DeleteContainerRequest) error {
 	return m.DeleteNetworkContainerF(ctx, dcr)
+}
+
+func (m *MockNMAgent) JoinNetwork(ctx context.Context, jnr nmagent.JoinNetworkRequest) error {
+	return m.JoinNetworkF(ctx, jnr)
 }

--- a/cns/restserver/restserver_test.go
+++ b/cns/restserver/restserver_test.go
@@ -1,12 +1,8 @@
 package restserver
 
-import (
-	"context"
+import "github.com/Azure/azure-container-networking/cns/fakes"
 
-	"github.com/Azure/azure-container-networking/nmagent"
-)
-
-func setMockNMAgent(h *HTTPRestService, m *MockNMAgent) func() {
+func setMockNMAgent(h *HTTPRestService, m *fakes.NMAgentClientFake) func() {
 	// this is a hack that exists because the tests are too DRY, so the setup
 	// logic has ossified in TestMain
 
@@ -21,37 +17,4 @@ func setMockNMAgent(h *HTTPRestService, m *MockNMAgent) func() {
 	return func() {
 		h.nma = prev
 	}
-}
-
-type MockNMAgent struct {
-	PutNetworkContainerF    func(context.Context, *nmagent.PutNetworkContainerRequest) error
-	DeleteNetworkContainerF func(context.Context, nmagent.DeleteContainerRequest) error
-	JoinNetworkF            func(context.Context, nmagent.JoinNetworkRequest) error
-	SupportedAPIsF          func(context.Context) ([]string, error)
-	GetNCVersionF           func(context.Context, nmagent.NCVersionRequest) (nmagent.NCVersion, error)
-	GetNCVersionListF       func(context.Context) (nmagent.NCVersionList, error)
-}
-
-func (m *MockNMAgent) PutNetworkContainer(ctx context.Context, pncr *nmagent.PutNetworkContainerRequest) error {
-	return m.PutNetworkContainerF(ctx, pncr)
-}
-
-func (m *MockNMAgent) DeleteNetworkContainer(ctx context.Context, dcr nmagent.DeleteContainerRequest) error {
-	return m.DeleteNetworkContainerF(ctx, dcr)
-}
-
-func (m *MockNMAgent) JoinNetwork(ctx context.Context, jnr nmagent.JoinNetworkRequest) error {
-	return m.JoinNetworkF(ctx, jnr)
-}
-
-func (m *MockNMAgent) SupportedAPIs(ctx context.Context) ([]string, error) {
-	return m.SupportedAPIsF(ctx)
-}
-
-func (m *MockNMAgent) GetNCVersion(ctx context.Context, req nmagent.NCVersionRequest) (nmagent.NCVersion, error) {
-	return m.GetNCVersionF(ctx, req)
-}
-
-func (m *MockNMAgent) GetNCVersionList(ctx context.Context) (nmagent.NCVersionList, error) {
-	return m.GetNCVersionListF(ctx)
 }

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -649,7 +649,7 @@ func (service *HTTPRestService) joinNetwork(ctx context.Context, networkID strin
 
 	err := service.nma.JoinNetwork(ctx, jnr)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "sending join network request")
 	}
 
 	// Network joined successfully

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -642,14 +642,12 @@ func (service *HTTPRestService) setNetworkStateJoined(networkID string) {
 }
 
 // Join Network by calling nmagent
-func (service *HTTPRestService) joinNetwork(
-	networkID string,
-) error {
+func (service *HTTPRestService) joinNetwork(ctx context.Context, networkID string) error {
 	jnr := nma.JoinNetworkRequest{
 		NetworkID: networkID,
 	}
 
-	err := service.nma.JoinNetwork(context.TODO(), jnr)
+	err := service.nma.JoinNetwork(ctx, jnr)
 	if err != nil {
 		return err
 	}

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -16,7 +16,7 @@ import (
 	"github.com/Azure/azure-container-networking/cns/types"
 	"github.com/Azure/azure-container-networking/cns/wireserver"
 	acn "github.com/Azure/azure-container-networking/common"
-	nma "github.com/Azure/azure-container-networking/nmagent"
+	"github.com/Azure/azure-container-networking/nmagent"
 	"github.com/Azure/azure-container-networking/platform"
 	"github.com/Azure/azure-container-networking/store"
 	"github.com/pkg/errors"
@@ -643,11 +643,11 @@ func (service *HTTPRestService) setNetworkStateJoined(networkID string) {
 
 // Join Network by calling nmagent
 func (service *HTTPRestService) joinNetwork(ctx context.Context, networkID string) error {
-	jnr := nma.JoinNetworkRequest{
+	req := nmagent.JoinNetworkRequest{
 		NetworkID: networkID,
 	}
 
-	err := service.nma.JoinNetwork(ctx, jnr)
+	err := service.nma.JoinNetwork(ctx, req)
 	if err != nil {
 		return errors.Wrap(err, "sending join network request")
 	}
@@ -796,8 +796,8 @@ func (service *HTTPRestService) isNCWaitingForUpdate(
 		return true, types.NetworkContainerVfpProgramCheckSkipped, ""
 	}
 
-	resp, err := service.nma.GetNCVersion(context.TODO(), getNCVersionURL.(nma.NCVersionRequest))
-	var nmaErr nma.Error
+	resp, err := service.nma.GetNCVersion(context.TODO(), getNCVersionURL.(nmagent.NCVersionRequest))
+	var nmaErr nmagent.Error
 	if errors.As(err, &nmaErr) && nmaErr.Unauthorized() {
 		return true, types.NetworkContainerVfpProgramPending, ""
 	}

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -800,7 +800,7 @@ func (service *HTTPRestService) isNCWaitingForUpdate(
 
 	resp, err := service.nma.GetNCVersion(context.TODO(), getNCVersionURL.(nma.NCVersionRequest))
 	var nmaErr nma.Error
-	if errors.As(err, &nmaErr); nmaErr.Unauthorized() {
+	if errors.As(err, &nmaErr) && nmaErr.Unauthorized() {
 		return true, types.NetworkContainerVfpProgramPending, ""
 	}
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -46,7 +46,6 @@ import (
 	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	"github.com/Azure/azure-container-networking/log"
 	"github.com/Azure/azure-container-networking/nmagent"
-	nma "github.com/Azure/azure-container-networking/nmagent"
 	"github.com/Azure/azure-container-networking/platform"
 	"github.com/Azure/azure-container-networking/processlock"
 	localtls "github.com/Azure/azure-container-networking/server/tls"
@@ -495,7 +494,7 @@ func main() {
 
 	// create an NMAgent Client based on provided configuration
 	if cnsconfig.WireserverIP != "" {
-		host, prt, err := net.SplitHostPort(cnsconfig.WireserverIP)
+		host, prt, err := net.SplitHostPort(cnsconfig.WireserverIP) //nolint:govet // it's fine to shadow err here
 		if err != nil {
 			logger.Errorf("[Azure CNS] Invalid IP for Wireserver: %q: %s", cnsconfig.WireserverIP, err.Error())
 			return
@@ -511,7 +510,7 @@ func main() {
 		nmaConfig.Port = uint16(port)
 	}
 
-	nmaClient, err := nma.NewClient(nmaConfig)
+	nmaClient, err := nmagent.NewClient(nmaConfig)
 	if err != nil {
 		logger.Errorf("[Azure CNS] Failed to start nmagent client due to error: %v", err)
 		return

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -313,12 +313,14 @@ func printVersion() {
 	fmt.Printf("Version %v\n", version)
 }
 
-type NodeInquirer interface {
+// NodeInterrogator is functionality necessary to read information about nodes.
+// It is intended to be strictly read-only.
+type NodeInterrogator interface {
 	SupportedAPIs(context.Context) ([]string, error)
 }
 
 // RegisterNode - Tries to register node with DNC when CNS is started in managed DNC mode
-func registerNode(httpc *http.Client, httpRestService cns.HTTPService, dncEP, infraVnet, nodeID string, ni NodeInquirer) error {
+func registerNode(httpc *http.Client, httpRestService cns.HTTPService, dncEP, infraVnet, nodeID string, ni NodeInterrogator) error {
 	logger.Printf("[Azure CNS] Registering node %s with Infrastructure Network: %s PrivateEndpoint: %s", nodeID, infraVnet, dncEP)
 
 	var (

--- a/nmagent/client.go
+++ b/nmagent/client.go
@@ -210,6 +210,31 @@ func (c *Client) DeleteNetworkContainer(ctx context.Context, dcr DeleteContainer
 	return nil
 }
 
+func (c *Client) GetNCVersionList(ctx context.Context) (NCVersionList, error) {
+	req, err := c.buildRequest(ctx, &NCVersionListRequest{})
+	if err != nil {
+		return NCVersionList{}, errors.Wrap(err, "building request")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return NCVersionList{}, errors.Wrap(err, "submitting request")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return NCVersionList{}, die(resp.StatusCode, resp.Header, resp.Body)
+	}
+
+	var out NCVersionList
+	err = json.NewDecoder(resp.Body).Decode(&out)
+	if err != nil {
+		return NCVersionList{}, errors.Wrap(err, "decoding response")
+	}
+
+	return out, nil
+}
+
 func die(code int, headers http.Header, body io.ReadCloser) error {
 	// nolint:errcheck // make a best effort to return whatever information we can
 	// returning an error here without the code and source would

--- a/nmagent/nmagent_test.go
+++ b/nmagent/nmagent_test.go
@@ -2,6 +2,7 @@ package nmagent_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -125,5 +126,26 @@ func TestContentErrorNew(t *testing.T) {
 				t.Error("unexpected error message: got:", got, "exp:", test.exp)
 			}
 		})
+	}
+}
+
+// testContext creates a context from the provided testing.T that will be
+// canceled if the test suite is terminated.
+func testContext(t *testing.T) (context.Context, context.CancelFunc) {
+	if deadline, ok := t.Deadline(); ok {
+		return context.WithDeadline(context.Background(), deadline)
+	}
+	return context.WithCancel(context.Background())
+}
+
+// checkErr is an assertion of the presence or absence of an error
+func checkErr(t *testing.T, err error, shouldErr bool) {
+	t.Helper()
+	if err != nil && !shouldErr {
+		t.Fatal("unexpected error: err:", err)
+	}
+
+	if err == nil && shouldErr {
+		t.Fatal("expected error but received none")
 	}
 }

--- a/nmagent/requests.go
+++ b/nmagent/requests.go
@@ -282,3 +282,31 @@ func (g GetNetworkConfigRequest) Validate() error {
 	}
 	return err
 }
+
+var _ Request = &SupportedAPIsRequest{}
+
+// SupportedAPIsRequest is a collection of parameters necessary to submit a
+// valid request to retrieve the supported APIs from an NMAgent instance.
+type SupportedAPIsRequest struct{}
+
+// Body is a no-op method to satisfy the Request interface while indicating
+// that there is no body for a SupportedAPIs Request.
+func (s *SupportedAPIsRequest) Body() (io.Reader, error) {
+	return nil, nil
+}
+
+// Method indicates that SupportedAPIs requests are GET requests.
+func (s *SupportedAPIsRequest) Method() string {
+	return http.MethodGet
+}
+
+// Path returns the necessary URI path for invoking a supported APIs request.
+func (s *SupportedAPIsRequest) Path() string {
+	return "/network/nmagentsupportedapis"
+}
+
+// Validate is a no-op method because SupportedAPIsRequests have no parameters,
+// and therefore can never be invalid.
+func (s *SupportedAPIsRequest) Validate() error {
+	return nil
+}

--- a/nmagent/requests.go
+++ b/nmagent/requests.go
@@ -359,3 +359,31 @@ func (n NCVersionRequest) Validate() error {
 
 	return err
 }
+
+var _ Request = NCVersionListRequest{}
+
+// NCVersionListRequest is a collection of parameters necessary to submit a
+// request to receive a list of NCVersions available from the NMAgent instance.
+type NCVersionListRequest struct{}
+
+func (NCVersionListRequest) Body() (io.Reader, error) {
+	// there is no body for this request so...
+	return nil, nil
+}
+
+// Method returns the HTTP method required for the request.
+func (NCVersionListRequest) Method() string {
+	return http.MethodGet
+}
+
+// Path returns the path required to issue the request.
+func (NCVersionListRequest) Path() string {
+	return "/NetworkManagement/interfaces/api-version/1"
+}
+
+// Validate performs any necessary validations for the request.
+func (NCVersionListRequest) Validate() error {
+	// there are no parameters, thus nothing to validate. Since the request
+	// cannot be made invalid it's fine for this to simply...
+	return nil
+}

--- a/nmagent/requests.go
+++ b/nmagent/requests.go
@@ -310,3 +310,52 @@ func (s *SupportedAPIsRequest) Path() string {
 func (s *SupportedAPIsRequest) Validate() error {
 	return nil
 }
+
+var _ Request = NCVersionRequest{}
+
+type NCVersionRequest struct {
+	AuthToken          string `json:"-"`
+	NetworkContainerID string `json:"-"`
+	PrimaryAddress     string `json:"-"`
+}
+
+func (n NCVersionRequest) Body() (io.Reader, error) {
+	// there is no body to an NCVersionRequest, so return nil
+	return nil, nil
+}
+
+// Method indicates this request is a GET request
+func (n NCVersionRequest) Method() string {
+	return http.MethodGet
+}
+
+// Path returns the URL Path for the request with parameters interpolated as
+// necessary.
+func (n NCVersionRequest) Path() string {
+	const path = "/NetworkManagement/interfaces/%s/networkContainers/%s/version/authenticationToken/%s/api-version/1"
+	return fmt.Sprintf(path, n.PrimaryAddress, n.NetworkContainerID, n.AuthToken)
+}
+
+// Validate ensures the presence of all parameters of the NCVersionRequest, as
+// none are optional.
+func (n NCVersionRequest) Validate() error {
+	err := internal.ValidationError{}
+
+	if n.AuthToken == "" {
+		err.MissingFields = append(err.MissingFields, "AuthToken")
+	}
+
+	if n.NetworkContainerID == "" {
+		err.MissingFields = append(err.MissingFields, "NetworkContainerID")
+	}
+
+	if n.PrimaryAddress == "" {
+		err.MissingFields = append(err.MissingFields, "PrimaryAddress")
+	}
+
+	if err.IsEmpty() {
+		return nil
+	}
+
+	return err
+}

--- a/nmagent/requests_test.go
+++ b/nmagent/requests_test.go
@@ -400,3 +400,87 @@ func TestPutNetworkContainerRequestValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestNCVersionRequestValidate(t *testing.T) {
+	tests := []struct {
+		name          string
+		req           nmagent.NCVersionRequest
+		shouldBeValid bool
+	}{
+		{
+			"empty",
+			nmagent.NCVersionRequest{},
+			false,
+		},
+		{
+			"complete",
+			nmagent.NCVersionRequest{
+				AuthToken:          "blah",
+				NetworkContainerID: "12345",
+				PrimaryAddress:     "4815162342",
+			},
+			true,
+		},
+		{
+			"missing ncid",
+			nmagent.NCVersionRequest{
+				AuthToken:      "blah",
+				PrimaryAddress: "4815162342",
+			},
+			false,
+		},
+		{
+			"missing auth token",
+			nmagent.NCVersionRequest{
+				NetworkContainerID: "12345",
+				PrimaryAddress:     "4815162342",
+			},
+			false,
+		},
+		{
+			"missing primary address",
+			nmagent.NCVersionRequest{
+				AuthToken:          "blah",
+				NetworkContainerID: "12345",
+			},
+			false,
+		},
+		{
+			"only auth token",
+			nmagent.NCVersionRequest{
+				AuthToken: "blah",
+			},
+			false,
+		},
+		{
+			"only ncid",
+			nmagent.NCVersionRequest{
+				NetworkContainerID: "12345",
+			},
+			false,
+		},
+		{
+			"only primary address",
+			nmagent.NCVersionRequest{
+				PrimaryAddress: "4815162342",
+			},
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := test.req.Validate()
+			if err != nil && test.shouldBeValid {
+				t.Fatal("request was not valid when it should have been: err:", err)
+			}
+
+			if err == nil && !test.shouldBeValid {
+				t.Fatal("expected request to be invalid when it was valid")
+			}
+		})
+	}
+}

--- a/nmagent/responses.go
+++ b/nmagent/responses.go
@@ -19,3 +19,7 @@ type Tag struct {
 	Name string `json:"name"`
 	Type string `json:"type"` // the type of the tag (e.g. "System" or "Custom")
 }
+
+type SupportedAPIsResponseXML struct {
+	SupportedApis []string `xml:"type"`
+}

--- a/nmagent/responses.go
+++ b/nmagent/responses.go
@@ -30,3 +30,9 @@ type NCVersion struct {
 	NetworkContainerID string `json:"networkContainerId"`
 	Version            string `json:"version"` // the current network container version
 }
+
+// NetworkContainerListResponse is a collection of network container IDs mapped
+// to their current versions.
+type NCVersionList struct {
+	Containers []NCVersion `json:"networkContainers"`
+}

--- a/nmagent/responses.go
+++ b/nmagent/responses.go
@@ -23,3 +23,10 @@ type Tag struct {
 type SupportedAPIsResponseXML struct {
 	SupportedApis []string `xml:"type"`
 }
+
+// NCVersion is a response produced from requests for a network container's
+// version.
+type NCVersion struct {
+	NetworkContainerID string `json:"networkContainerId"`
+	Version            string `json:"version"` // the current network container version
+}


### PR DESCRIPTION
The NMAgent client used previously in CNS is older, and a duplication of the one added in `nmagent/`. In order to maintain one nmagent client and prevent duplication / wasted effort, this changes CNS to use the "official" client instead.

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [X] includes documentation
- [X] adds unit tests


**Notes**:
