### PR TITLE
Renamed “IPv4HLIPPrefix” to “HLIPv4Prefix”, and “IPv4HLIPAddress” to “HLIPv4Address" in goalstate json.

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -112,10 +112,10 @@ type HoneyCombGoalState struct {
 		ContainerGroupName string `json:"ContainerGroupName"`
 		IPV6Prefix string `json:"IPV6Prefix"`
 		IPV6Gateway string `json:"IPV6Gateway"`
-		IPV4HLIPPrefix string `json:"IPV4HLIPPrefix"`
+		IPV4HLIPPrefix string `json:"HLIPv4Prefix"`
 		IPV6Address string `json:"IPV6Address"`
 		MAC string `json:"MAC"`
-		IPV4HLIPAddress string `json:"IPV4HLIPAddress"`
+		IPV4HLIPAddress string `json:"HLIPv4Address"`
 	} `json:"ContainerGroupNetworkGoalStates"`
 }
 


### PR DESCRIPTION
**Reason for Change**:
Control plane services (DM, DCAS and CSS) are using HLIPv4Prefix and HLIPv4Address names instead of IPv4HLIPPrefix and IPv4HLIPAddress.

**Issue Fixed**:
Container creation failure due to naming misalignment between CNI and CSS service.