### PR TITLE
Emit a metric in CNS for NC Sync count by status

### DIFF
--- a/cns/restserver/metrics.go
+++ b/cns/restserver/metrics.go
@@ -39,14 +39,22 @@ var ipConfigStatusStateTransitionTime = prometheus.NewHistogramVec(
 	[]string{"previous_state", "next_state"},
 )
 
-var syncHostNCVersion = prometheus.NewHistogramVec(
+var syncHostNCVersionCount = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "sync_host_nc_version_total",
+		Help: "Count of Sync Host NC by success or failure",
+	},
+	[]string{"ok"},
+)
+
+var syncHostNCVersionLatency = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
-		Name: "sync_host_nc_version_seconds",
+		Name: "sync_host_nc_version_latency_seconds",
 		Help: "Sync Host NC Latency",
 		//nolint:gomnd // default bucket consts
 		Buckets: prometheus.ExponentialBuckets(0.001, 2, 15), // 1 ms to ~16 seconds
 	},
-	[]string{"success"},
+	[]string{"ok"},
 )
 
 func init() {
@@ -54,7 +62,8 @@ func init() {
 		httpRequestLatency,
 		ipAssignmentLatency,
 		ipConfigStatusStateTransitionTime,
-		syncHostNCVersion,
+		syncHostNCVersionCount,
+		syncHostNCVersionLatency,
 	)
 }
 


### PR DESCRIPTION
Signed-off-by: Evan Baker <rbtr@users.noreply.github.com>

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
- emits a metric for total NC sync (attempt) count, labelled by success/failure
- improves the sync method to consider the scenario where not all of the NCs that CNS knows about are present in the NMA response an error, and return an error indicating this after processing the NCs that are present in the response.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
