### PR TITLE
[NPM][Windows] remove Windows22 preview flag and k8s version

### DIFF
--- a/.pipelines/npm/npm-conformance-tests-latest-release.yaml
+++ b/.pipelines/npm/npm-conformance-tests-latest-release.yaml
@@ -133,7 +133,6 @@ jobs:
                   --windows-admin-password alpha@numeric!password2 \
                   --network-plugin azure \
                   --vm-set-type VirtualMachineScaleSets \
-                  --kubernetes-version v1.23.5 \
                   --node-vm-size Standard_D4s_v3 \
                   --node-count 1
 
@@ -362,7 +361,6 @@ jobs:
                 --network-plugin azure \
                 --vm-set-type VirtualMachineScaleSets \
                 --node-vm-size Standard_D4s_v3 \
-                --kubernetes-version v1.23.5 \
                 --node-count 1
 
             # don't schedule anything on the linux system pool

--- a/.pipelines/npm/npm-conformance-tests-latest-release.yaml
+++ b/.pipelines/npm/npm-conformance-tests-latest-release.yaml
@@ -124,10 +124,6 @@ jobs:
               az extension add --name aks-preview
               az extension update --name aks-preview
 
-              # Enable Microsoft.ContainerService/AKSWindows2022Preview
-              az feature register --namespace Microsoft.ContainerService --name AKSWindows2022Preview
-              az provider register -n Microsoft.ContainerService
-
               echo "creating WS22 Cluster";
               az aks create \
                   --resource-group $(RESOURCE_GROUP) \
@@ -350,10 +346,6 @@ jobs:
           inlineScript: |
             az extension add --name aks-preview
             az extension update --name aks-preview
-
-            # Enable Microsoft.ContainerService/AKSWindows2022Preview
-            az feature register --namespace Microsoft.ContainerService --name AKSWindows2022Preview
-            az provider register -n Microsoft.ContainerService
 
             export CLUSTER_NAME=$(RESOURCE_GROUP)-$(PROFILE)
 

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -169,10 +169,6 @@ jobs:
               az extension add --name aks-preview
               az extension update --name aks-preview
 
-              # Enable Microsoft.ContainerService/AKSWindows2022Preview
-              az feature register --namespace Microsoft.ContainerService --name AKSWindows2022Preview
-              az provider register -n Microsoft.ContainerService
-
               echo "creating WS22 Cluster";
               az aks create \
                   --resource-group $(RESOURCE_GROUP) \
@@ -395,10 +391,6 @@ jobs:
           inlineScript: |
             az extension add --name aks-preview
             az extension update --name aks-preview
-
-            # Enable Microsoft.ContainerService/AKSWindows2022Preview
-            az feature register --namespace Microsoft.ContainerService --name AKSWindows2022Preview
-            az provider register -n Microsoft.ContainerService
 
             export CLUSTER_NAME=$(RESOURCE_GROUP)-$(PROFILE)
 

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -178,7 +178,6 @@ jobs:
                   --windows-admin-password alpha@numeric!password2 \
                   --network-plugin azure \
                   --vm-set-type VirtualMachineScaleSets \
-                  --kubernetes-version v1.23.5 \
                   --node-vm-size Standard_D4s_v3 \
                   --node-count 1
 
@@ -407,7 +406,6 @@ jobs:
                 --network-plugin azure \
                 --vm-set-type VirtualMachineScaleSets \
                 --node-vm-size Standard_D4s_v3 \
-                --kubernetes-version v1.23.5 \
                 --node-count 1
 
             # don't schedule anything on the linux system pool

--- a/.pipelines/npm/npm-cyc-win-tests-latest-release.yaml
+++ b/.pipelines/npm/npm-cyc-win-tests-latest-release.yaml
@@ -90,7 +90,6 @@ jobs:
                 --network-plugin azure \
                 --vm-set-type VirtualMachineScaleSets \
                 --node-vm-size Standard_D4s_v3 \
-                --kubernetes-version v1.23.5 \
                 --node-count 1
 
             if [ $? != 0 ]

--- a/.pipelines/npm/npm-cyc-win-tests-latest-release.yaml
+++ b/.pipelines/npm/npm-cyc-win-tests-latest-release.yaml
@@ -69,10 +69,6 @@ jobs:
             az extension add --name aks-preview
             az extension update --name aks-preview
 
-            # Enable Microsoft.ContainerService/AKSWindows2022Preview
-            az feature register --namespace Microsoft.ContainerService --name AKSWindows2022Preview
-            az provider register -n Microsoft.ContainerService
-
             export CLUSTER_NAME=$(RESOURCE_GROUP)
 
             echo "Creating resource group named $CLUSTER_NAME"


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
- AKSWindows2022Preview flag is removed since Windows Server 22 is now GA'ed.
- k8s version does not need to be specified and can prevent cluster from creating if the version goes out of service.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
