### PR TITLE
fix: unblock channel for cni

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -111,10 +111,8 @@ func (reportMgr *ReportManager) SendReport(tb *TelemetryBuffer) error {
 	if tb != nil && tb.Connected {
 		report, err = reportMgr.ReportToBytes()
 		if err == nil {
-			// If write fails, try to re-establish connections as server/client
 			if _, err = tb.Write(report); err != nil {
 				log.Printf("telemetry write failed:%v", err)
-				tb.Cancel()
 			}
 		}
 	}
@@ -124,7 +122,6 @@ func (reportMgr *ReportManager) SendReport(tb *TelemetryBuffer) error {
 
 // ReportToBytes - returns the report bytes
 func (reportMgr *ReportManager) ReportToBytes() ([]byte, error) {
-
 	switch reportMgr.Report.(type) {
 	case *CNIReport:
 	case *AIMetric:
@@ -145,9 +142,8 @@ func SendCNIMetric(cniMetric *AIMetric, tb *TelemetryBuffer) error {
 		reportMgr := &ReportManager{Report: cniMetric}
 		report, err = reportMgr.ReportToBytes()
 		if err == nil {
-			// If write fails, try to re-establish connections as server/client
 			if _, err = tb.Write(report); err != nil {
-				tb.Cancel()
+				log.Printf("Error writing to telemetry socket:%v", err)
 			}
 		}
 	}
@@ -160,10 +156,8 @@ func SendCNIEvent(tb *TelemetryBuffer, report *CNIReport) {
 		reportMgr := &ReportManager{Report: report}
 		reportBytes, err := reportMgr.ReportToBytes()
 		if err == nil {
-			// If write fails, try to re-establish connections as server/client
 			if _, err = tb.Write(reportBytes); err != nil {
 				log.Printf("Error writing to telemetry socket:%v", err)
-				tb.Cancel()
 			}
 		}
 	}

--- a/telemetry/telemetrybuffer.go
+++ b/telemetry/telemetrybuffer.go
@@ -216,12 +216,7 @@ func (tb *TelemetryBuffer) Write(b []byte) (c int, err error) {
 
 // Cancel - signal to tear down telemetry buffer
 func (tb *TelemetryBuffer) Cancel() {
-	select {
-	case tb.cancel <- true:
-		log.Logf("server cancel")
-	default:
-		log.Logf("Cancel fn: default case: no message sent")
-	}
+	tb.cancel <- true
 }
 
 // Close - close all connections

--- a/telemetry/telemetrybuffer.go
+++ b/telemetry/telemetrybuffer.go
@@ -216,7 +216,12 @@ func (tb *TelemetryBuffer) Write(b []byte) (c int, err error) {
 
 // Cancel - signal to tear down telemetry buffer
 func (tb *TelemetryBuffer) Cancel() {
-	tb.cancel <- true
+	select {
+	case tb.cancel <- true:
+		log.Logf("server cancel")
+	default:
+		log.Logf("Cancel fn: default case: no message sent")
+	}
 }
 
 // Close - close all connections


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
CNI blocks when sending failure report because CNS exits and is not receiving.
Unblocking channel with select/default clause.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
