### PR TITLE
feat: allow the user to pass an aikey in config

### DIFF
--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -63,6 +63,8 @@ type TelemetrySettings struct {
 	DebugMode bool
 	// Interval for sending snapshot events.
 	SnapshotIntervalInMins int
+	// AppInsightsInstrumentationKey allows the user to override the default appinsights ikey
+	AppInsightsInstrumentationKey string
 }
 
 type ManagedSettings struct {

--- a/cns/logger/cnslogger.go
+++ b/cns/logger/cnslogger.go
@@ -32,7 +32,11 @@ func NewCNSLogger(fileName string, logLevel, logTarget int, logDir string) (*CNS
 }
 
 func (c *CNSLogger) InitAI(aiConfig aitelemetry.AIConfig, disableTraceLogging, disableMetricLogging, disableEventLogging bool) {
-	th, err := aitelemetry.NewAITelemetry("", aiMetadata, aiConfig)
+	c.InitAIWithIKey(aiConfig, aiMetadata, disableTraceLogging, disableMetricLogging, disableEventLogging)
+}
+
+func (c *CNSLogger) InitAIWithIKey(aiConfig aitelemetry.AIConfig, instrumentationKey string, disableTraceLogging, disableMetricLogging, disableEventLogging bool) {
+	th, err := aitelemetry.NewAITelemetry("", instrumentationKey, aiConfig)
 	if err != nil {
 		c.logger.Errorf("Error initializing AI Telemetry:%v", err)
 		return

--- a/cns/logger/log.go
+++ b/cns/logger/log.go
@@ -25,6 +25,10 @@ func InitAI(aiConfig aitelemetry.AIConfig, disableTraceLogging, disableMetricLog
 	Log.InitAI(aiConfig, disableTraceLogging, disableMetricLogging, disableEventLogging)
 }
 
+func InitAIWithIKey(aiConfig aitelemetry.AIConfig, instrumentationKey string, disableTraceLogging, disableMetricLogging, disableEventLogging bool) {
+	Log.InitAIWithIKey(aiConfig, instrumentationKey, disableTraceLogging, disableMetricLogging, disableEventLogging)
+}
+
 func SetContextDetails(orchestrator, nodeID string) {
 	Log.SetContextDetails(orchestrator, nodeID)
 }

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -544,7 +544,11 @@ func main() {
 			DebugMode:                    ts.DebugMode,
 		}
 
-		logger.InitAI(aiConfig, ts.DisableTrace, ts.DisableMetric, ts.DisableEvent)
+		if aiKey := cnsconfig.TelemetrySettings.AppInsightsInstrumentationKey; aiKey != "" {
+			logger.InitAIWithIKey(aiConfig, aiKey, ts.DisableTrace, ts.DisableMetric, ts.DisableEvent)
+		} else {
+			logger.InitAI(aiConfig, ts.DisableTrace, ts.DisableMetric, ts.DisableEvent)
+		}
 	}
 
 	if telemetryDaemonEnabled {


### PR DESCRIPTION
**Reason for Change**:
Allows the user of CNS to specify an appinsights instrumentation key in config so we can split out the telemetry backends to address some of our scale issues.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
no unit tests since there are already no unit tests for the cnslogger and this is a trivial change to grab a string from config and pass it to the Init function