### PR TITLE
test: [NPM] fail cyclonus if unfinished

### DIFF
--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -494,7 +494,7 @@ jobs:
           kubectl get pods -n kube-system | grep npm
           kubectl logs -n kube-system -l k8s-app=azure-npm --tail -1 --prefix > $(System.DefaultWorkingDirectory)/$CLUSTER_NAME/npm-logs_$(PROFILE).txt
           # capture any previous logs in case there was a crash
-          npmPodList=`kubectl --kubeconfig=./kubeconfig get pods -n kube-system | grep npm | awk '{print $1}'`
+          npmPodList=`kubectl get pods -n kube-system | grep npm | awk '{print $1}'`
           for npmPod in $npmPodList; do
               previousLogFile=$(System.DefaultWorkingDirectory)/$CLUSTER_NAME/previous-npm-logs_$(PROFILE).txt
               kubectl logs -n kube-system $npmPod -p > $previousLogFile

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -26,7 +26,8 @@ jobs:
           mkdir -p '$(GOBIN)'
           mkdir -p '$(GOPATH)/pkg'
           BUILD_NUMBER=$(Build.BuildNumber)
-          RG=e2e-$(echo "npm-`date "+%Y-%m-%d-%S"`")
+          # format: npm-<year>-<month>-<day>-<minute>-<second>
+          RG=e2e-$(echo "npm-`date "+%Y-%m-%d-%M-%S"`")
           TAG=$(make npm-version)
           echo "Resource group: $RG"
           echo "Image tag: $TAG"

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -268,10 +268,8 @@ jobs:
           mkdir -p $npmLogsFolder
           cp ./kubeconfig $npmLogsFolder/kubeconfig
 
-          ## write to all NPM pod logs in the background (do this in the background instead of after to make sure the logs aren't truncated)
           npmPodList=`kubectl --kubeconfig=./kubeconfig get pods -n kube-system | grep npm | awk '{print $1}'`
           echo "Found NPM pods: $npmPodList"
-
 
           ## Run all Conformance tests in the background
           echo $FQDN
@@ -346,10 +344,23 @@ jobs:
               exitCode=$?
             fi
           fi
-          # kill the background processes (the logs) that have this process' pid (i.e. $$) as a parent
 
+          # get all current npm pods
+          kubectl --kubeconfig=./kubeconfig get pods -n kube-system | grep npm
+          npmPodList=`kubectl --kubeconfig=./kubeconfig get pods -n kube-system | grep npm | awk '{print $1}'`
+          # capture all logs
           for npmPod in $npmPodList; do
               ./kubectl --kubeconfig=./kubeconfig logs -n kube-system $npmPod > $npmLogsFolder/$npmPod-logs.txt
+          done
+
+          # capture any previous logs in case there was a crash
+          for npmPod in $npmPodList; do
+              previousLogFile=$npmLogsFolder/previous-$npmPod-logs.txt
+              ./kubectl --kubeconfig=./kubeconfig logs -n kube-system $npmPod -p > $previousLogFile
+              if [[ $? -ne 0 ]]; then
+                  # remove the empty file if kubectl logs failed (e.g. there was no previous terminated container)
+                  rm $previousLogFile
+              fi
           done
 
           exit $exitCode
@@ -480,7 +491,18 @@ jobs:
           cp cyclonus-$CLUSTER_NAME $(System.DefaultWorkingDirectory)/$CLUSTER_NAME/cyclonus-$CLUSTER_NAME
           echo "Getting cluster state for $CLUSTER_NAME"
           mkdir -p $(System.DefaultWorkingDirectory)/$CLUSTER_NAME
+          kubectl get pods -n kube-system | grep npm
           kubectl logs -n kube-system -l k8s-app=azure-npm --tail -1 --prefix > $(System.DefaultWorkingDirectory)/$CLUSTER_NAME/npm-logs_$(PROFILE).txt
+          # capture any previous logs in case there was a crash
+          npmPodList=`kubectl --kubeconfig=./kubeconfig get pods -n kube-system | grep npm | awk '{print $1}'`
+          for npmPod in $npmPodList; do
+              previousLogFile=$(System.DefaultWorkingDirectory)/$CLUSTER_NAME/previous-npm-logs_$(PROFILE).txt
+              kubectl logs -n kube-system $npmPod -p > $previousLogFile
+              if [[ $? -ne 0 ]]; then
+                  # remove the empty file if kubectl logs failed (e.g. there was no previous terminated container)
+                  rm $previousLogFile
+              fi
+          done
           cp ./kubeconfig $(System.DefaultWorkingDirectory)/$CLUSTER_NAME/.kubeconfig
         condition: always()
 

--- a/test/cyclonus/test-cyclonus-windows.sh
+++ b/test/cyclonus/test-cyclonus-windows.sh
@@ -11,14 +11,19 @@ LOG_FILE=cyclonus-$CLUSTER_NAME
     --server-protocol=TCP,UDP \
     --exclude sctp,named-port,ip-block-with-except,multi-peer,upstream-e2e,example,end-port,namespaces-by-default-label,update-policy | tee $LOG_FILE
 
-cat $LOG_FILE | grep "SummaryTable:" -q
-if [[ $? -ne 0 ]]; then
-    echo "cyclonus tests did not complete"
+# might need to redirect to /dev/null 2>&1 instead of just grepping with -q to avoid "cat: write error: Broken pipe"
+rc=999
+cat $LOG_FILE | grep "SummaryTable:" > /dev/null 2>&1 && rc=$?
+echo $rc
+if [ $rc -ne 0 ]; then
+    echo "FAILING because cyclonus tests did not complete"
     exit 2
 fi
 
-cat $LOG_FILE | grep "failed" -q
-if [[ $? -eq 0 ]]; then
-    echo "failures detected"
-    exit 1
+rc=0
+cat $LOG_FILE | grep "failed" > /dev/null 2>&1 || rc=$?
+echo $rc
+if [ $rc -eq 0 ]; then
+    echo "FAILING because cyclonus completed but failures detected"
+    exit 3
 fi

--- a/test/cyclonus/test-cyclonus.sh
+++ b/test/cyclonus/test-cyclonus.sh
@@ -54,11 +54,14 @@ kubectl delete --ignore-not-found=true clusterrolebinding cyclonus
 kubectl delete --ignore-not-found=true sa cyclonus -n kube-system
 kubectl delete --ignore-not-found=true -f $cyclonusProfile
 
-# if 'failure' is in the logs, fail; otherwise succeed
-rc=0
+cat $LOG_FILE | grep "SummaryTable:" -q
+if [[ $? -ne 0 ]]; then
+    echo "cyclonus tests did not complete"
+    exit 2
+fi
 
-cat "$LOG_FILE" | grep "failed" > /dev/null 2>&1 || rc=$?
-echo $rc
-if [ $rc -eq 0 ]; then
+cat $LOG_FILE | grep "failed" -q
+if [[ $? -eq 0 ]]; then
+    echo "failures detected"
     exit 1
 fi


### PR DESCRIPTION
Previously, a timed-out cyclonus run may be considered green.

Additionally, this PR:
- prints NPM pod state (e.g. restart count) and captures any previous pod logs
- prevents chance of collisions for test resource groups names