### PR TITLE
Decrease pipeline AKS cluster cost

### DIFF
--- a/hack/swift/Makefile
+++ b/hack/swift/Makefile
@@ -80,6 +80,7 @@ up: swift-up ## Alias to swift-up
 overlay-up: rg-up overlay-net-up ## Brings up an Overlay AzCNI cluster
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
 		--node-count 2 \
+		--node-vm-size Standard_B2s \
 		--load-balancer-sku basic \
 		--network-plugin azure \
 		--network-plugin-mode overlay \
@@ -92,6 +93,7 @@ overlay-up: rg-up overlay-net-up ## Brings up an Overlay AzCNI cluster
 swift-byocni-up: rg-up net-up ## Bring up a SWIFT BYO CNI cluster
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
 		--node-count 2 \
+		--node-vm-size Standard_B2s \
 		--load-balancer-sku basic \
 		--network-plugin none \
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
@@ -104,6 +106,7 @@ swift-byocni-up: rg-up net-up ## Bring up a SWIFT BYO CNI cluster
 swift-cilium-up: rg-up net-up ## Bring up a SWIFT Cilium cluster
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
 		--node-count 2 \
+		--node-vm-size Standard_B2s \
 		--load-balancer-sku basic \
 		--network-plugin azure \
 		--enable-cilium-dataplane \
@@ -117,6 +120,7 @@ swift-cilium-up: rg-up net-up ## Bring up a SWIFT Cilium cluster
 swift-up: rg-up net-up ## Bring up a SWIFT AzCNI cluster
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
 		--node-count 2 \
+		--node-vm-size Standard_B2s \
 		--load-balancer-sku basic \
 		--network-plugin azure \
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \

--- a/hack/swift/Makefile
+++ b/hack/swift/Makefile
@@ -85,7 +85,7 @@ overlay-up: rg-up overlay-net-up ## Brings up an Overlay AzCNI cluster
 		--network-plugin-mode overlay \
 		--pod-cidr 192.168.0.0/16 \
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
-		--generate-ssh-keys \
+		--no-ssh-key \
 		--yes
 	@$(MAKE) set-kubeconf
 
@@ -96,7 +96,7 @@ swift-byocni-up: rg-up net-up ## Bring up a SWIFT BYO CNI cluster
 		--network-plugin none \
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
 		--pod-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/podnet \
-		--generate-ssh-keys \
+		--no-ssh-key \
 		--os-sku $(OSSKU) \
 		--yes
 	@$(MAKE) set-kubeconf
@@ -110,7 +110,7 @@ swift-cilium-up: rg-up net-up ## Bring up a SWIFT Cilium cluster
 		--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/CiliumDataplanePreview \
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
 		--pod-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/podnet \
-		--generate-ssh-keys \
+		--no-ssh-key \
 		--yes
 	@$(MAKE) set-kubeconf
 
@@ -121,7 +121,7 @@ swift-up: rg-up net-up ## Bring up a SWIFT AzCNI cluster
 		--network-plugin azure \
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
 		--pod-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/podnet \
-		--generate-ssh-keys \
+		--no-ssh-key \
 		--yes
 	@$(MAKE) set-kubeconf
 

--- a/hack/swift/Makefile
+++ b/hack/swift/Makefile
@@ -12,7 +12,7 @@ USER       ?= $(whoami)
 OSSKU      ?= Ubuntu
 CLUSTER    ?= $(USER)-$(REGION)
 GROUP      ?= $(CLUSTER)
-REGION     ?= centraluseuap
+REGION     ?= westus2
 SUB        ?= $(AZURE_SUBSCRIPTION)
 VNET       ?= $(CLUSTER)
 
@@ -80,6 +80,7 @@ up: swift-up ## Alias to swift-up
 overlay-up: rg-up overlay-net-up ## Brings up an Overlay AzCNI cluster
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
 		--node-count 2 \
+		--load-balancer-sku basic \
 		--network-plugin azure \
 		--network-plugin-mode overlay \
 		--pod-cidr 192.168.0.0/16 \
@@ -91,6 +92,7 @@ overlay-up: rg-up overlay-net-up ## Brings up an Overlay AzCNI cluster
 swift-byocni-up: rg-up net-up ## Bring up a SWIFT BYO CNI cluster
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
 		--node-count 2 \
+		--load-balancer-sku basic \
 		--network-plugin none \
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
 		--pod-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/podnet \
@@ -102,6 +104,7 @@ swift-byocni-up: rg-up net-up ## Bring up a SWIFT BYO CNI cluster
 swift-cilium-up: rg-up net-up ## Bring up a SWIFT Cilium cluster
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
 		--node-count 2 \
+		--load-balancer-sku basic \
 		--network-plugin azure \
 		--enable-cilium-dataplane \
 		--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/CiliumDataplanePreview \
@@ -114,6 +117,7 @@ swift-cilium-up: rg-up net-up ## Bring up a SWIFT Cilium cluster
 swift-up: rg-up net-up ## Bring up a SWIFT AzCNI cluster
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
 		--node-count 2 \
+		--load-balancer-sku basic \
 		--network-plugin azure \
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
 		--pod-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/podnet \

--- a/hack/swift/Makefile
+++ b/hack/swift/Makefile
@@ -79,7 +79,7 @@ up: swift-up ## Alias to swift-up
 
 overlay-up: rg-up overlay-net-up ## Brings up an Overlay AzCNI cluster
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
-		--node-count 3 \
+		--node-count 2 \
 		--network-plugin azure \
 		--network-plugin-mode overlay \
 		--pod-cidr 192.168.0.0/16 \
@@ -90,7 +90,7 @@ overlay-up: rg-up overlay-net-up ## Brings up an Overlay AzCNI cluster
 
 swift-byocni-up: rg-up net-up ## Bring up a SWIFT BYO CNI cluster
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
-		--node-count 3 \
+		--node-count 2 \
 		--network-plugin none \
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
 		--pod-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/podnet \
@@ -101,7 +101,7 @@ swift-byocni-up: rg-up net-up ## Bring up a SWIFT BYO CNI cluster
 
 swift-cilium-up: rg-up net-up ## Bring up a SWIFT Cilium cluster
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
-		--node-count 3 \
+		--node-count 2 \
 		--network-plugin azure \
 		--enable-cilium-dataplane \
 		--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/CiliumDataplanePreview \
@@ -113,7 +113,7 @@ swift-cilium-up: rg-up net-up ## Bring up a SWIFT Cilium cluster
 
 swift-up: rg-up net-up ## Bring up a SWIFT AzCNI cluster
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
-		--node-count 3 \
+		--node-count 2 \
 		--network-plugin azure \
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
 		--pod-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/podnet \


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
- decrease default AKS cluster size (3 -> 2 nodes) (immediate savings of 30%)
- change loadbalancer SKU from default "Standard" (~$0.42/hr) to "Basic" (free, $0/hr)
- change region to public westus2 
- change instance size from default `Standard_DS2_v2` ($0.114/hr) to explicit `Standard_B2s` ($0.042/hr), a decrease of 63%. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
