### PR TITLE
errors.Wrap automatically add colon and append error

### DIFF
--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -81,7 +81,7 @@ func (invoker *CNSIPAMInvoker) Add(addConfig IPAMAddConfig) (IPAMAddResult, erro
 	response, err := invoker.cnsClient.RequestIPAddress(context.TODO(), ipconfig)
 	if err != nil {
 		log.Printf("Failed to get IP address from CNS with error %v, response: %v", err, response)
-		return IPAMAddResult{}, errors.Wrap(err, "Failed to get IP address from CNS with error")
+		return IPAMAddResult{}, errors.Wrap(err, "failed to get IP address from CNS")
 	}
 
 	info := IPv4ResultInfo{

--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -81,7 +81,7 @@ func (invoker *CNSIPAMInvoker) Add(addConfig IPAMAddConfig) (IPAMAddResult, erro
 	response, err := invoker.cnsClient.RequestIPAddress(context.TODO(), ipconfig)
 	if err != nil {
 		log.Printf("Failed to get IP address from CNS with error %v, response: %v", err, response)
-		return IPAMAddResult{}, errors.Wrap(err, "Failed to get IP address from CNS with error: %w")
+		return IPAMAddResult{}, errors.Wrap(err, "Failed to get IP address from CNS with error")
 	}
 
 	info := IPv4ResultInfo{


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
errors.Wrap() automatically appends colon and error. We don't need to add `: %w`. Here's the log:
`IPAM Invoker Add failed with error: Failed to get IP address from CNS with error: %w: http request failed: Post "`


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
