### PR TITLE
adjust e2e test resource usage for new cheaper nodes and smaller cluster

### DIFF
--- a/test/integration/k8s_test.go
+++ b/test/integration/k8s_test.go
@@ -43,7 +43,7 @@ var (
 	kubeconfig          = flag.String("test-kubeconfig", filepath.Join(homedir.HomeDir(), ".kube", "config"), "(optional) absolute path to the kubeconfig file")
 	delegatedSubnetID   = flag.String("delegated-subnet-id", "", "delegated subnet id for node labeling")
 	delegatedSubnetName = flag.String("subnet-name", "", "subnet name for node labeling")
-	gpPodScaleCounts    = []int{3, 15, 150, 3}
+	gpPodScaleCounts    = []int{2, 10, 100, 2}
 )
 
 func shouldLabelNodes() bool {

--- a/test/integration/manifests/goldpinger/daemonset.yaml
+++ b/test/integration/manifests/goldpinger/daemonset.yaml
@@ -57,12 +57,6 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          resources:
-            limits:
-              memory: 80Mi
-            requests:
-              cpu: 1m
-              memory: 40Mi
           ports:
             - containerPort: 8080
               name: http

--- a/test/integration/manifests/goldpinger/deployment.yaml
+++ b/test/integration/manifests/goldpinger/deployment.yaml
@@ -53,12 +53,6 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          resources:
-            limits:
-              memory: 80Mi
-            requests:
-              cpu: 1m
-              memory: 40Mi
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
Signed-off-by: Evan Baker <rbtr@users.noreply.github.com>

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Scales back the e2e proportionally since we're running a smaller (3->2 nodes) test cluster, and less powerful (DS2->BS2) nodes

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
