### PR TITLE
Revert "skip podtocidr(1.1.1.1:80) tests in cilium connectivity tests"

### DIFF
--- a/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
@@ -120,7 +120,7 @@ steps:
   - script: |
       echo "Run Cilium Connectivity Tests"
       cilium status
-      cilium connectivity test --test '!/pod-to-cidr'
+      cilium connectivity test
     retryCountOnTaskFailure: 3
     name: "ciliumConnectivityTests"
     displayName: "Run Cilium Connectivity Tests"


### PR DESCRIPTION
Reverts Azure/azure-container-networking#1698

This connectivity test fails out of eastus2 but succeeds elsewhere - this re-enables it and we will run the e2e in another region for now.