### PR TITLE
Fix failure to start CNS when setting WireserverIP

### DIFF
--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -3,8 +3,12 @@ package configuration
 
 import (
 	"encoding/json"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/logger"
@@ -103,6 +107,53 @@ func getConfigFilePath(cmdLineConfigPath string) (string, error) {
 		configpath = filepath.Join(dir, defaultConfigName)
 	}
 	return configpath, nil
+}
+
+type NMAgentConfig struct {
+	Host   string
+	Port   uint16
+	UseTLS bool
+}
+
+func (c *CNSConfig) NMAgentConfig() (NMAgentConfig, error) {
+	host := "168.63.129.16" // wireserver's IP
+
+	if c.WireserverIP != "" {
+		host = c.WireserverIP
+	}
+
+	if strings.Contains(host, "http") {
+		parts, err := url.Parse(host)
+		if err != nil {
+			return NMAgentConfig{}, errors.Wrap(err, "parsing WireserverIP as URL")
+		}
+		host = parts.Host
+	}
+
+	// create an NMAgent Client based on provided configuration
+	if strings.Contains(host, ":") {
+		host, prt, err := net.SplitHostPort(host) //nolint:govet // it's fine to shadow err here
+		if err != nil {
+			return NMAgentConfig{}, errors.Wrap(err, "splitting wireserver IP into host port")
+		}
+
+		port, err := strconv.ParseUint(prt, 10, 16) //nolint:gomnd // obvious from ParseUint docs
+		if err != nil {
+			return NMAgentConfig{}, errors.Wrap(err, "parsing wireserver port value as uint16")
+		}
+
+		return NMAgentConfig{
+			Host: host,
+			Port: uint16(port),
+		}, nil
+	}
+
+	return NMAgentConfig{
+		Host: host,
+
+		// nolint:gomnd // there's no benefit to constantizing a well-known port
+		Port: 80,
+	}, nil
 }
 
 // ReadConfig returns a CNS config from file or an error.

--- a/cns/configuration/configuration_test.go
+++ b/cns/configuration/configuration_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-container-networking/common"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -255,6 +256,102 @@ func TestSetCNSConfigDefaults(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			SetCNSConfigDefaults(&tt.in)
 			assert.Equal(t, tt.want, tt.in)
+		})
+	}
+}
+
+func TestNMAgentConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		conf      CNSConfig
+		exp       NMAgentConfig
+		shouldErr bool
+	}{
+		{
+			"empty",
+			CNSConfig{
+				WireserverIP: "",
+			},
+			NMAgentConfig{
+				Host: "168.63.129.16",
+				Port: 80,
+			},
+			false,
+		},
+		{
+			"ip",
+			CNSConfig{
+				WireserverIP: "127.0.0.1",
+			},
+			NMAgentConfig{
+				Host: "127.0.0.1",
+				Port: 80,
+			},
+			false,
+		},
+		{
+			"ipport",
+			CNSConfig{
+				WireserverIP: "127.0.0.1:8080",
+			},
+			NMAgentConfig{
+				Host: "127.0.0.1",
+				Port: 8080,
+			},
+			false,
+		},
+		{
+			"scheme",
+			CNSConfig{
+				WireserverIP: "http://127.0.0.1:8080",
+			},
+			NMAgentConfig{
+				Host: "127.0.0.1",
+				Port: 8080,
+			},
+			false,
+		},
+		{
+			"invalid URL",
+			CNSConfig{
+				WireserverIP: "a string containing \"http\" with an invalid character: \x7F",
+			},
+			NMAgentConfig{},
+			true,
+		},
+		{
+			"invalid host:port",
+			CNSConfig{
+				WireserverIP: "way:too:many:colons",
+			},
+			NMAgentConfig{},
+			true,
+		},
+		{
+			"too big for a uint16 port",
+			CNSConfig{
+				WireserverIP: "127.0.0.1:4815162342",
+			},
+			NMAgentConfig{},
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			got, err := test.conf.NMAgentConfig()
+			if err != nil && !test.shouldErr {
+				t.Fatal("unexpected error fetching nmagent config: err:", err)
+			}
+
+			if err == nil && test.shouldErr {
+				t.Fatal("expected error fetching nmagent config but received none")
+			}
+
+			if !cmp.Equal(got, test.exp) {
+				t.Error("received config differs from expectation: diff:", cmp.Diff(got, test.exp))
+			}
 		})
 	}
 }


### PR DESCRIPTION
There was insufficient coverage over cases involving different permutations of the "WireserverIP" configuration option. Consequently, there were instances where reasonable values for this option caused CNS to fail to start.

This moves the logic for transforming the CNS configuration into configuration suitable for the NMAgent client into a method off the CNSConfig. It also permits adding coverage over different scenarios that are likely to emerge.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests


**Notes**:
