### PR TITLE
fix: repair windows cni lock issue

### DIFF
--- a/cni/network/plugin/main.go
+++ b/cni/network/plugin/main.go
@@ -225,9 +225,10 @@ func rootExecute() error {
 		// Start telemetry process if not already started. This should be done inside lock, otherwise multiple process
 		// end up creating/killing telemetry process results in undesired state.
 		tb = telemetry.NewTelemetryBuffer()
-		tb.ConnectToTelemetryService(telemetryNumRetries, telemetryWaitTimeInMilliseconds)
+		if err = tb.ConnectCNIToTelemetryService(telemetryNumRetries, telemetryWaitTimeInMilliseconds, netPlugin.Plugin); err != nil {
+			log.Errorf("connection to telemetry service failed.")
+		}
 		defer tb.Close()
-
 		netPlugin.SetCNIReport(cniReport, tb)
 
 		t := time.Now()

--- a/cni/plugin.go
+++ b/cni/plugin.go
@@ -174,12 +174,6 @@ func (plugin *Plugin) InitializeKeyValueStore(config *common.PluginConfig) error
 		}
 	}
 
-	// Acquire store lock.
-	if err := plugin.Store.Lock(store.DefaultLockTimeout); err != nil {
-		log.Printf("[cni] Failed to lock store: %v.", err)
-		return err
-	}
-
 	config.Store = plugin.Store
 
 	return nil

--- a/cni/plugin.go
+++ b/cni/plugin.go
@@ -174,6 +174,14 @@ func (plugin *Plugin) InitializeKeyValueStore(config *common.PluginConfig) error
 		}
 	}
 
+	// Acquiring store lock at this stage for optimization purpuses on Windows
+	if runtime.GOOS != "windows" {
+		// Acquire store lock.
+		if err := plugin.Store.Lock(store.DefaultLockTimeout); err != nil {
+			log.Printf("[cni] Failed to lock store: %v.", err)
+			return err
+		}
+	}
 	config.Store = plugin.Store
 
 	return nil

--- a/cni/plugin.go
+++ b/cni/plugin.go
@@ -201,3 +201,25 @@ func (plugin *Plugin) UninitializeKeyValueStore() error {
 
 	return nil
 }
+
+// Lock key-value store. This function is being used for locking access to TelemetryService start for Windows Runtime.
+func (plugin *Plugin) LockKeyValueStore() error {
+	// Acquire store lock.
+	if err := plugin.Store.Lock(store.DefaultLockTimeout); err != nil {
+		log.Printf("[cni] Failed to lock store: %v.", err)
+		return errors.Wrap(err, "error Acquiring store lock")
+	}
+	return nil
+}
+
+// Unlock key-value store
+func (plugin *Plugin) UnLockKeyValueStore() error {
+	if plugin.Store != nil {
+		err := plugin.Store.Unlock()
+		if err != nil {
+			log.Printf("[cni] Failed to unlock store: %v.", err)
+			return errors.Wrap(err, "error unlock store lock")
+		}
+	}
+	return nil
+}

--- a/cni/plugin.go
+++ b/cni/plugin.go
@@ -174,12 +174,13 @@ func (plugin *Plugin) InitializeKeyValueStore(config *common.PluginConfig) error
 		}
 	}
 
-	// Acquiring store lock at this stage for optimization purpuses on Windows
+	// Acquiring store lock at this stage only for Linux. For optimization purpuses on Windows, the store lock will take place at later stage.
+	// TODO: The Linux store locking should be removed from here as well after some more validation.
 	if runtime.GOOS != "windows" {
 		// Acquire store lock.
 		if err := plugin.Store.Lock(store.DefaultLockTimeout); err != nil {
 			log.Printf("[cni] Failed to lock store: %v.", err)
-			return err
+			return errors.Wrap(err, "error Acquiring store lock")
 		}
 	}
 	config.Store = plugin.Store

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -20,7 +20,6 @@ import (
 	"github.com/Azure/azure-container-networking/cns/types"
 	"github.com/Azure/azure-container-networking/cns/wireserver"
 	"github.com/Azure/azure-container-networking/nmagent"
-	"github.com/Azure/azure-container-networking/platform"
 	"github.com/pkg/errors"
 )
 
@@ -882,14 +881,6 @@ func (service *HTTPRestService) getNetworkContainerByOrchestratorContext(w http.
 	err := service.Listener.Decode(w, r, &req)
 	logger.Request(service.Name, &req, err)
 	if err != nil {
-		return
-	}
-
-	// getNetworkContainerByOrchestratorContext gets called for multitenancy and
-	// setting the SDNRemoteArpMacAddress regKey is essential for the multitenancy
-	// to work correctly in case of windows platform. Return if there is an error
-	if err = platform.SetSdnRemoteArpMacAddress(); err != nil {
-		logger.Printf("[Azure CNS] SetSdnRemoteArpMacAddress failed with error: %s", err.Error())
 		return
 	}
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -660,6 +660,13 @@ func main() {
 		}
 	}
 
+	// Setting the remote ARP MAC address to 12-34-56-78-9a-bc on windows for external traffic
+	err = platform.SetSdnRemoteArpMacAddress()
+	if err != nil {
+		logger.Errorf("Failed to set remote ARP MAC address: %v", err)
+		return
+	}
+
 	// Initialze state in if CNS is running in CRD mode
 	// State must be initialized before we start HTTPRestService
 	if config.ChannelMode == cns.CRD {
@@ -697,12 +704,6 @@ func main() {
 			return
 		}
 
-		// Setting the remote ARP MAC address to 12-34-56-78-9a-bc on windows for external traffic
-		err = platform.SetSdnRemoteArpMacAddress()
-		if err != nil {
-			logger.Errorf("Failed to set remote ARP MAC address: %v", err)
-			return
-		}
 	}
 
 	// Initialize multi-tenant controller if the CNS is running in MultiTenantCRD mode.
@@ -714,12 +715,6 @@ func main() {
 			return
 		}
 
-		// Setting the remote ARP MAC address to 12-34-56-78-9a-bc on windows for external traffic
-		err = platform.SetSdnRemoteArpMacAddress()
-		if err != nil {
-			logger.Errorf("Failed to set remote ARP MAC address: %v", err)
-			return
-		}
 	}
 
 	logger.Printf("[Azure CNS] Start HTTP listener")

--- a/ipam/manager.go
+++ b/ipam/manager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-container-networking/log"
 	"github.com/Azure/azure-container-networking/platform"
 	"github.com/Azure/azure-container-networking/store"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -106,7 +107,7 @@ func (am *addressManager) restore(rehydrateIpamInfoOnReboot bool) error {
 		// Acquire store lock.
 		if err := am.store.Lock(store.DefaultLockTimeout); err != nil {
 			log.Printf("[ipam] Failed to lock store: %v.", err)
-			return err
+			return errors.Wrap(err, "error Acquiring store lock")
 		}
 		// Remove the lock on the key-value store
 		defer func() {
@@ -191,7 +192,7 @@ func (am *addressManager) save() error {
 		// Acquire store lock.
 		if err := am.store.Lock(store.DefaultLockTimeout); err != nil {
 			log.Printf("[ipam] Failed to lock store: %v.", err)
-			return err
+			return errors.Wrap(err, "error Acquiring store lock")
 		}
 		// Remove the lock on the key-value store
 		defer func() {

--- a/ipam/manager.go
+++ b/ipam/manager.go
@@ -4,6 +4,7 @@
 package ipam
 
 import (
+	"runtime"
 	"sync"
 	"time"
 
@@ -100,6 +101,22 @@ func (am *addressManager) restore(rehydrateIpamInfoOnReboot bool) error {
 		return nil
 	}
 
+	// Acquiring store lock at this stage for optimization purpuses on Windows
+	if runtime.GOOS == "windows" {
+		// Acquire store lock.
+		if err := am.store.Lock(store.DefaultLockTimeout); err != nil {
+			log.Printf("[ipam] Failed to lock store: %v.", err)
+			return err
+		}
+		// Remove the lock on the key-value store
+		defer func() {
+			err := am.store.Unlock()
+			if err != nil {
+				log.Printf("[ipam] Failed to unlock store: %v.", err)
+			}
+		}()
+	}
+
 	// Read any persisted state.
 	err := am.store.Read(storeKey, am)
 	if err != nil {
@@ -168,6 +185,22 @@ func (am *addressManager) save() error {
 
 	// Update time stamp.
 	am.TimeStamp = time.Now()
+
+	// Acquiring store lock at this stage for optimization purpuses on Windows
+	if runtime.GOOS == "windows" {
+		// Acquire store lock.
+		if err := am.store.Lock(store.DefaultLockTimeout); err != nil {
+			log.Printf("[ipam] Failed to lock store: %v.", err)
+			return err
+		}
+		// Remove the lock on the key-value store
+		defer func() {
+			err := am.store.Unlock()
+			if err != nil {
+				log.Printf("[ipam] Failed to unlock store: %v.", err)
+			}
+		}()
+	}
 
 	log.Printf("[ipam] saving ipam state.\n")
 	err := am.store.Write(storeKey, am)

--- a/network/manager.go
+++ b/network/manager.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/azure-container-networking/netlink"
 	"github.com/Azure/azure-container-networking/platform"
 	"github.com/Azure/azure-container-networking/store"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -133,7 +134,7 @@ func (nm *networkManager) restore(isRehydrationRequired bool) error {
 		// Acquire store lock.
 		if err := nm.store.Lock(store.DefaultLockTimeout); err != nil {
 			log.Printf("[cni] Failed to lock store: %v.", err)
-			return err
+			return errors.Wrap(err, "error Acquiring store lock")
 		}
 		// Remove the lock on the key-value store
 		defer func() {
@@ -246,7 +247,7 @@ func (nm *networkManager) save() error {
 		// Acquire store lock.
 		if err := nm.store.Lock(store.DefaultLockTimeout); err != nil {
 			log.Printf("[cni] Failed to lock store: %v.", err)
-			return err
+			return errors.Wrap(err, "error Acquiring store lock")
 		}
 		// Remove the lock on the key-value store
 		defer func() {


### PR DESCRIPTION
Moving the lock from InitializeKeyValueStore() function to restore/save functions to improve cni performance on windows.

**Reason for Change**:
In Windows CNI We are currently lock access to statefile in the init phase which may cause some CNI performance issue. This PR will move the lock to the exact point when we read/write from/to statefile.


