### PR TITLE
Enable auto updates for windows aks-engine clusters

### DIFF
--- a/test/apimodels/cniWindows1903.json
+++ b/test/apimodels/cniWindows1903.json
@@ -39,7 +39,7 @@
       "windowsProfile": {
          "adminUsername": "azureuser",
          "adminPassword": "azureTest@!",
-         "enableAutomaticUpdates": false,
+         "enableAutomaticUpdates": true,
          "sshEnabled": true,
          "windowsPublisher": "MicrosoftWindowsServer",
          "windowsOffer": "WindowsServer",

--- a/test/apimodels/cniWindows2004.json
+++ b/test/apimodels/cniWindows2004.json
@@ -39,7 +39,7 @@
       "windowsProfile": {
          "adminUsername": "azureuser",
          "adminPassword": "azureTest@!",
-         "enableAutomaticUpdates": false,
+         "enableAutomaticUpdates": true,
          "sshEnabled": true,
          "windowsPublisher": "MicrosoftWindowsServer",
          "windowsOffer": "WindowsServer",

--- a/test/apimodels/cniWindows2022.json
+++ b/test/apimodels/cniWindows2022.json
@@ -46,7 +46,7 @@
         "windowsProfile": {
             "adminUsername": "azureuser",
             "adminPassword": "azureTest@!",
-            "enableAutomaticUpdates": false,
+            "enableAutomaticUpdates": true,
             "sshEnabled": false,
             "windowsPauseImageURL": "mcr.microsoft.com/oss/kubernetes/pause:3.6",
             "alwaysPullWindowsPauseImage": true,

--- a/test/apimodels/cniWindowsDualstack2004.json
+++ b/test/apimodels/cniWindowsDualstack2004.json
@@ -56,6 +56,7 @@
     "windowsProfile": {
       "adminUsername": "azureuser",
       "adminPassword": "azureTest@!",
+      "enableAutomaticUpdates": true,
       "windowsPublisher": "MicrosoftWindowsServer",
       "windowsOffer": "WindowsServer",
       "windowsSku": "Datacenter-Core-2004-with-Containers-smalldisk",


### PR DESCRIPTION
We get several s360 items for this, so enabling auto updates on windows aks-engine clusters