### PR TITLE
remove windows 2004 aks-e tests from pipeline

### DIFF
--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -390,7 +390,6 @@ stages:
       - "aks_swift_e2e"
       - "cilium_e2e"
       - "windows_19_03_e2e"
-      - "windows_20_04_e2e"
     jobs:
       - job: delete_remote_artifacts
         displayName: Delete remote artifacts

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -364,16 +364,6 @@ stages:
       clusterDefinitionCniBuildOS: "windows"
       clusterDefinitionCniBuildExt: ".zip"
 
-  - template: singletenancy/aks-engine/e2e-job-template.yaml
-    parameters:
-      name: "windows_20_04_e2e"
-      displayName: "Windows 2004"
-      pipelineBuildImage: "$(BUILD_IMAGE)"
-      clusterDefinition: "cniWindows2004.json"
-      clusterDefinitionCniTypeKey: "azureCNIURLWindows"
-      clusterDefinitionCniBuildOS: "windows"
-      clusterDefinitionCniBuildExt: ".zip"
-
   - stage: validate2
     displayName: Validate Tags
     dependsOn:


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
We still don't support windows 2004 for aks and aks-e tests are failing very often. While we determine the root cause, in order to allow PRs to go in, and since we'll still run windows 1903 tests, we can disable 2004 tests as a mitigation
A new task was reported to add win 22 tests once we migrate over from aks-e (https://msazure.visualstudio.com/One/_workitems/edit/16667635)

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
