### PR TITLE
test: [NPM-WIN] automate windows/HNS investigations

### DIFF
--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -288,9 +288,8 @@ jobs:
           }
 
           runConformanceWindows () {
-            git clone https://github.com/huntergregory/kubernetes.git
+            git clone https://github.com/huntergregory/kubernetes.git --depth=1 --branch=quit-on-failure
             cd kubernetes
-            git checkout sleep-before-probing
             export PATH=$PATH:/usr/local/go/bin/
             make WHAT=test/e2e/e2e.test
             cd ..
@@ -347,6 +346,14 @@ jobs:
             then
               runConformanceWindows | tee $npmLogsFolder/conformance-results
               exitCode=$?
+              if [[ $exitCode != 0 ]]; then
+                # capture HNS state
+                curl -LO https://raw.githubusercontent.com/Azure/azure-container-networking/master/debug/windows/npm/win-debug.sh
+                chmod +x win-debug.sh
+                ./win-debug.sh ./kubeconfig > $npmLogsFolder/win-debug.out
+                # move HNS logs from win-debug.sh to the artifact folder
+                mv logs_* $npmLogsFolder/
+              fi
             else
               runConformance | tee $npmLogsFolder/conformance-results
               exitCode=$?

--- a/debug/windows/npm/README.md
+++ b/debug/windows/npm/README.md
@@ -1,6 +1,6 @@
 # Introduction 
 
-This script will collect Windows NPM logs and the HNS and VFP state of the cluster and write them to a new local folder.
+These scripts will collect Windows NPM logs and the HNS and VFP state of the cluster and write them to a new local folder.
 
 ## How to collect logs
 In a PowerShell terminal, navigate to the `azure-container-networking/debug/windows/npm folder`. Make sure your kubectl is configured to point to the cluster you want to collect logs from (`az aks get-credentials -g <resource-group> -n <cluster-name>`)
@@ -8,6 +8,11 @@ In a PowerShell terminal, navigate to the `azure-container-networking/debug/wind
 Run `.\win-debug.ps1`. The script will create a new folder called logs_DATE containing the results.
 
 ### Linux
-Run `.\win-debug.sh`. The script will create a new folder called logs_DATE containing the results.
+Run `./win-debug.sh`. The script will create a new folder called logs_DATE containing the results.
 
 Note: You may not be able to unzip logs.zip in Linux since it was compressed in Windows.
+
+## Automating Investigation of Conformance and Cyclonus Failures
+These scripts help reproduce even random issues, and on failure, they run the above `./win-debug.sh` and also stop the node to assist with HNS trace capture.
+
+See both `./run-multiple-conformance-until-failure.sh` and `./run-multiple-cyclonus-until-failure.sh` for more info.

--- a/debug/windows/npm/run-multiple-conformance-until-failure.sh
+++ b/debug/windows/npm/run-multiple-conformance-until-failure.sh
@@ -1,10 +1,35 @@
+############################################################################################################
+# This script will run multiple rounds of cyclonus until failure. On failure, it will:
+# - Capture HNS/VFP state, cluster info, and NPM logs.
+# - Stop VMs on the windows nodepool (to stop an HNS trace).
+
+# Requirements:
+# - AKS cluster with Windows NPM and Windows Server '22 nodepool named like $WINDOWS_NODEPOOL.
+# - Conformance binary with path specified in $E2E_FILE (installation instructions directly below).
+
+# Steps:
+# - Identify test cases to run (modifying $toRun and $toSkip).
+# - To get the same order every time, set random $SEED (see top of the failed conformance run).
+#     For random order, comment out the line referencing $SEED.
+# - Create cluster as described above.
+# - Create Bastion with defaults on a Windows VMSS instance.
+# - Login to Bastion on every node (should have minimum nodes necessary for repro).
+# - On each node, run C:\k\starthnstrace.ps1 -MaxFileSize 2000.
+# - Start this script with its arguments (see directly below).
+############################################################################################################
+
+## Conformance Installation
+# git clone https://github.com/huntergregory/kubernetes.git --depth=1 --branch=quit-on-failure
+# cd kubernetes
+# make WHAT=test/e2e/e2e.test
+# cd ../
+# mv kubernetes/_output/local/bin/linux/amd64/e2e.test $E2E_FILE
+
 # constants
 START=1
 END=10
 WINDOWS_NODEPOOL=akswin22
 E2E_FILE=./e2e-quit-on-failure.test
-# to install the correct e2e run:
-# git clone https://github.com/huntergregory/kubernetes.git --depth=1 --branch=quit-on-failure && cd kubernetes && make WHAT=test/e2e/e2e.test && cd ../ && mv kubernetes/_output/local/bin/linux/amd64/e2e.test $E2E_FILE
 
 # IMPORTANT for reproducibility. Find from top of conformance run
 # or comment out if randomness is desired

--- a/debug/windows/npm/run-multiple-conformance-until-failure.sh
+++ b/debug/windows/npm/run-multiple-conformance-until-failure.sh
@@ -73,7 +73,7 @@ aksRGPrefix=MC_$resourceGroup_$clusterName
 aksRG=`az group list -otable | grep $aksRGPrefix | awk '{print $1}'`
 if [[ -z $aksRG ]]; then
     echo "AKS resource group not found. Should start with $aksRGPrefix..."
-    # exit 1
+    exit 1
 fi
 echo "found AKS resource group: $aksRG"
 echo "this AKS RG MUST have one WS22 nodepool named $WINDOWS_NODEPOOL..."
@@ -133,7 +133,7 @@ for i in $(seq $START $END); do
         for pod in `kubectl --kubeconfig $absoluteKubeConfig get pod -n kube-system | grep azure-npm-win | awk '{print $1}'`; do
             # using -l k8s-app=azure-npm weirdly only gets ~20 lines of log
             kubectl --kubeconfig $absoluteKubeConfig logs -n kube-system $pod > $fname.$pod.log
-        fi
+        done
 
         echo "stopping vmss instance to stop hns log capture"
         az vmss stop --instance-ids="*" -n $WINDOWS_NODEPOOL -g $aksRG

--- a/debug/windows/npm/run-multiple-conformance-until-failure.sh
+++ b/debug/windows/npm/run-multiple-conformance-until-failure.sh
@@ -1,0 +1,120 @@
+# constants
+START=1
+END=10
+WINDOWS_NODEPOOL=akswin22
+E2E_FILE=./e2e-quit-on-failure.test
+# to install the correct e2e run:
+# git clone https://github.com/huntergregory/kubernetes.git --depth=1 --branch=quit-on-failure && cd kubernetes && make WHAT=test/e2e/e2e.test && cd ../ && mv kubernetes/_output/local/bin/linux/amd64/e2e.test $E2E_FILE
+
+# IMPORTANT for reproducibility. Find from top of conformance run
+# or comment out if randomness is desired
+SEED=1672942821
+
+# toRun="NetworkPolicy"
+
+toRun1="Netpol NetworkPolicy between server and client should support allow-all policy"
+toRun2="Netpol NetworkPolicy between server and client should allow ingress access from updated pod"
+toRun3="Netpol NetworkPolicy between server and client should deny ingress access to updated pod"
+toRun4="Netpol NetworkPolicy between server and client should enforce policy to allow traffic based on NamespaceSelector with MatchLabels using default ns label"
+toRun5="Netpol NetworkPolicy between server and client should enforce policy to allow traffic only from a pod in a different namespace based on PodSelector and NamespaceSelector"
+toRun6="Netpol NetworkPolicy between server and client should enforce policy to allow ingress traffic from pods in all namespaces"
+toRun7="Netpol NetworkPolicy between server and client should deny ingress from pods on other namespaces"
+toRun8="NetworkPolicy API should support creating NetworkPolicy API operations"
+toRun9="Netpol NetworkPolicy between server and client should enforce policy to allow traffic only from a different namespace, based on NamespaceSelector"
+toRun="$toRun1|$toRun2|$toRun3|$toRun4|$toRun5|$toRun6|$toRun7|$toRun8|$toRun9"
+# 1 hour 5 minutes (10:20:22 to 11:25:33)
+
+nomatch1="should enforce policy based on PodSelector or NamespaceSelector"
+nomatch2="should enforce policy based on NamespaceSelector with MatchExpressions using default ns label"
+nomatch3="should enforce policy based on PodSelector and NamespaceSelector"
+nomatch4="should enforce policy based on Multiple PodSelectors and NamespaceSelectors"
+cidrExcept1="should ensure an IP overlapping both IPBlock.CIDR and IPBlock.Except is allowed"
+cidrExcept2="should enforce except clause while egress access to server in CIDR block"
+namedPorts="named port"
+wrongK8sVersion="Netpol API"
+toSkip="\[LinuxOnly\]|$nomatch1|$nomatch2|$nomatch3|$nomatch4|$cidrExcept1|$cidrExcept2|$namedPorts|$wrongK8sVersion|SCTP"
+
+# parameters
+absoluteKubeConfig=$1
+clusterName=$2
+resourceGroup=$3
+
+if [[ -z $1 || -z $2 || -z $3 ]]; then
+    echo "need absolute path of kubeconfig, and cluster name, and resource group"
+    exit 1
+fi
+
+aksRGPrefix=MC_$resourceGroup_$clusterName
+aksRG=`az group list -otable | grep $aksRGPrefix | awk '{print $1}'`
+if [[ -z $aksRG ]]; then
+    echo "AKS resource group not found. Should start with $aksRGPrefix..."
+    # exit 1
+fi
+echo "found AKS resource group: $aksRG"
+echo "this AKS RG MUST have one WS22 nodepool named $WINDOWS_NODEPOOL..."
+echo "START the HNS trace BEFORE running this:  .\starthnstrace.ps1 -maxFileSize 2000 ..."
+sleep 15s
+
+echo "beginning conf with kubeconfig: $absoluteKubeConfig, clusterName: $clusterName, resourceGroup: $resourceGroup"
+
+# script
+# NOTE: number of folders here impacts cdBack
+dateString=`date -I` # like 2022-09-24
+base=results-$clusterName/$dateString
+mkdir -p $base
+
+set -e
+FQDN=`az aks show -n $resourceGroup -g $clusterName --query fqdn -o tsv`
+set +e
+
+for i in $(seq $START $END); do
+    # delete any old conf-namespaces
+    kubectl --kubeconfig $absoluteKubeConfig delete ns -l pod-security.kubernetes.io/enforce | grep "No resources found" || echo "sleeping 3m while HNS state resets" && sleep 3m
+
+    # clear NPM logs and reset HNS state
+    echo "restarting npm windows then sleeping 3m"
+    kubectl --kubeconfig $absoluteKubeConfig rollout restart -n kube-system ds azure-npm-win
+    sleep 3m
+
+    if [[ $i -lt 10 ]]; then
+        i="0$i"
+    fi
+    fname=$base/conf-$i.out
+    test -f $fname && echo "conf $i already exists. exiting..." && exit 2
+    
+    echo "RUNNING CONF #$i at $(date)"
+    KUBERNETES_SERVICE_HOST="$FQDN" KUBERNETES_SERVICE_PORT=443 $E2E_FILE \
+        --provider=local \
+        --node-os-distro=windows \
+        --allowed-not-ready-nodes=1 \
+        --ginkgo.focus="$toRun" \
+        --ginkgo.skip="$toSkip" \
+        --kubeconfig=$absoluteKubeConfig \
+        --ginkgo.seed=$SEED \
+        --delete-namespace=true \
+        --delete-namespace-on-failure=true | tee $fname
+
+    cat $fname | grep '"failed":1'
+    if [[ $? == 0 ]]; then
+        echo "FOUND FAILURE FOR $fname"
+        hnsBase=$base/conf-$i-failure-hns-logs
+        cdBack=../../..
+        mkdir -p $hnsBase
+        cd $hnsBase
+        ./win-debug.sh $absoluteKubeConfig
+        cd $cdBack
+
+        # NPM logs
+        for pod in `kubectl --kubeconfig $absoluteKubeConfig get pod -n kube-system | grep azure-npm-win | awk '{print $1}'`; do
+            # using -l k8s-app=azure-npm weirdly only gets ~20 lines of log
+            kubectl --kubeconfig $absoluteKubeConfig logs -n kube-system $pod > $fname.$pod.log
+        fi
+
+        echo "stopping vmss instance to stop hns log capture"
+        az vmss stop --instance-ids="*" -n $WINDOWS_NODEPOOL -g $aksRG
+
+        exit 3
+    fi
+
+    echo "FINISHED SUCCESSFULLY FOR $fname"
+done

--- a/debug/windows/npm/run-multiple-cyclonus-until-failure.sh
+++ b/debug/windows/npm/run-multiple-cyclonus-until-failure.sh
@@ -1,0 +1,99 @@
+# constants
+START=1
+END=10
+WINDOWS_NODEPOOL=akswin22
+
+# parameters
+absolutePathKubeConfig=$1
+kubecontext=$2
+clusterName=$3
+resourceGroup=$4
+
+if [[ -z $1 || -z $2 || -z $3 || -z $4 ]]; then
+    echo "need absolute path of kubeconfig, and kubecontext string"
+    exit 1
+fi
+
+aksRGPrefix=MC_$resourceGroup_$clusterName
+aksRG=`az group list -otable | grep $aksRGPrefix | awk '{print $1}'`
+if [[ -z $aksRG ]]; then
+    echo "AKS resource group not found. Should start with $aksRGPrefix..."
+    # exit 1
+fi
+echo "found AKS resource group: $aksRG"
+echo "this AKS RG MUST have one WS22 nodepool named $WINDOWS_NODEPOOL..."
+echo "START the HNS trace BEFORE running this:  .\starthnstrace.ps1 -maxFileSize 2000 ..."
+sleep 15s
+
+echo "using kubeconfig: $absolutePathKubeConfig"
+echo "using kubecontext: $kubecontext"
+
+dateString=`date -I` # like 2022-09-24
+
+base=results-$kubecontext/$dateString
+mkdir -p results-$kubecontext
+test -d $base && echo "folder $base/ already exists" && exit 1
+mkdir $base
+for i in $(seq $START $END); do
+    echo "round $i"
+    if [[ i -lt 10 ]]; then
+        i=0$i
+    fi
+    roundBase=$base/round-$i
+    mkdir $roundBase
+    cd $roundBase
+
+    ## run cyc
+    kubectl delete ns x y z --kubeconfig $absolutePathKubeConfig
+
+    # clear NPM logs and reset HNS state
+    echo "restarting npm windows then sleeping 3m"
+    kubectl --kubeconfig $absoluteKubeConfig rollout restart -n kube-system ds azure-npm-win
+    sleep 3m
+
+    set -x
+    LOG_FILE=run.out
+    ../../../cyclonus-stop-on-failure generate \
+        --context=$kubecontext \
+        --noisy=true \
+        --retries=3 \
+        --ignore-loopback=true \
+        --cleanup-namespaces=true \
+        --perturbation-wait-seconds=20 \
+        --pod-creation-timeout-seconds=480 \
+        --job-timeout-seconds=15 \
+        --server-protocol=TCP,UDP \
+        --exclude sctp,named-port,ip-block-with-except,multi-peer,upstream-e2e,example,end-port,namespaces-by-default-label,update-policy | tee $LOG_FILE
+    set +x
+
+    # might need to redirect to /dev/null 2>&1 instead of just grepping with -q to avoid "cat: write error: Broken pipe"
+    rc=999
+    cat $LOG_FILE | grep "SummaryTable:" > /dev/null 2>&1 && rc=$?
+    echo $rc
+    if [ $rc -ne 0 ]; then
+        echo "FAILING because cyclonus tests did not complete" | tee -a $LOG_FILE
+        exit 2
+    fi
+
+    rc=0
+    cat $LOG_FILE | grep "failed" > /dev/null 2>&1 || rc=$?
+    echo $rc
+    if [ $rc -eq 0 ]; then
+        echo "FAILING because cyclonus completed but failures detected" | tee -a $LOG_FILE
+        ./win-debug.sh $absolutePathKubeConfig | tee -a $LOG_FILE
+
+        # NPM logs
+        for pod in `kubectl --kubeconfig $absoluteKubeConfig get pod -n kube-system | grep azure-npm-win | awk '{print $1}'`; do
+            # using -l k8s-app=azure-npm weirdly only gets ~20 lines of log
+            kubectl --kubeconfig $absoluteKubeConfig logs -n kube-system $pod > $fname.$pod.log
+        fi
+
+        echo "stopping vmss instance to stop hns log capture"
+        az vmss stop --instance-ids="*" -n $WINDOWS_NODEPOOL -g $aksRG
+
+        exit 3
+    fi
+
+    echo "FINISHED SUCCESSFULLY FOR ROUND $i"
+    cd ../../../
+done

--- a/debug/windows/npm/run-multiple-cyclonus-until-failure.sh
+++ b/debug/windows/npm/run-multiple-cyclonus-until-failure.sh
@@ -34,7 +34,7 @@ clusterName=$3
 resourceGroup=$4
 
 if [[ -z $1 || -z $2 || -z $3 || -z $4 ]]; then
-    echo "need absolute path of kubeconfig, and kubecontext string"
+    echo "need absolute path of kubeconfig, and kubecontext string, and cluster name, and resource group"
     exit 1
 fi
 
@@ -65,16 +65,16 @@ for i in $(seq $START $END); do
         i=0$i
     fi
     roundBase=$base/round-$i
-    mkdir $roundBase || echo "folder $roundBase already exists" && exit 1
+    mkdir $roundBase || (echo "folder $roundBase already exists" ; exit 1)
     cd $roundBase
     cdBack=../../..
 
     ## run cyc
-    kubectl delete ns x y z --kubeconfig $absolutePathKubeConfig
+    kubectl --kubeconfig $absolutePathKubeConfig delete ns x y z
 
     # clear NPM logs and reset HNS state
     echo "restarting npm windows then sleeping 3m"
-    kubectl --kubeconfig $absoluteKubeConfig rollout restart -n kube-system ds azure-npm-win
+    kubectl --kubeconfig $absolutePathKubeConfig rollout restart -n kube-system ds azure-npm-win
     sleep 3m
 
     set -x

--- a/debug/windows/npm/run-multiple-cyclonus-until-failure.sh
+++ b/debug/windows/npm/run-multiple-cyclonus-until-failure.sh
@@ -25,6 +25,9 @@
 # constants
 START=1
 END=10
+
+STOP_NODES_ON_FAILURE_FOR_TRACES=false
+# must be accurate if STOP_NODES_ON_FAILURE_FOR_TRACES=true
 WINDOWS_NODEPOOL=akswin22
 
 # parameters
@@ -38,16 +41,18 @@ if [[ -z $1 || -z $2 || -z $3 || -z $4 ]]; then
     exit 1
 fi
 
-aksRGPrefix=MC_$resourceGroup_$clusterName
-aksRG=`az group list -otable | grep $aksRGPrefix | awk '{print $1}'`
-if [[ -z $aksRG ]]; then
-    echo "AKS resource group not found. Should start with $aksRGPrefix..."
-    exit 1
+if [[ $STOP_NODES_ON_FAILURE_FOR_TRACES == true ]]; then
+    aksRGPrefix=MC_$resourceGroup_$clusterName
+    aksRG=`az group list -otable | grep $aksRGPrefix | awk '{print $1}'`
+    if [[ -z $aksRG ]]; then
+        echo "AKS resource group not found. Should start with $aksRGPrefix..."
+        exit 1
+    fi
+    echo "found AKS resource group: $aksRG"
+    echo "this AKS RG MUST have one WS22 nodepool named $WINDOWS_NODEPOOL..."
+    echo "START the HNS trace BEFORE running this:  .\starthnstrace.ps1 -maxFileSize 2000 ..."
+    sleep 15s
 fi
-echo "found AKS resource group: $aksRG"
-echo "this AKS RG MUST have one WS22 nodepool named $WINDOWS_NODEPOOL..."
-echo "START the HNS trace BEFORE running this:  .\starthnstrace.ps1 -maxFileSize 2000 ..."
-sleep 15s
 
 echo "using kubeconfig: $absolutePathKubeConfig"
 echo "using kubecontext: $kubecontext"
@@ -114,8 +119,10 @@ for i in $(seq $START $END); do
             kubectl --kubeconfig $absoluteKubeConfig logs -n kube-system $pod > $fname.$pod.log
         done
 
-        echo "stopping vmss instance to stop hns log capture"
-        az vmss stop --instance-ids="*" -n $WINDOWS_NODEPOOL -g $aksRG
+        if [[ $STOP_NODES_ON_FAILURE_FOR_TRACES == "true" ]]; then
+            echo "stopping vmss instance to stop hns log capture"
+            az vmss stop --instance-ids="*" -n $WINDOWS_NODEPOOL -g $aksRG
+        fi
 
         exit 3
     fi

--- a/debug/windows/npm/run-multiple-cyclonus-until-failure.sh
+++ b/debug/windows/npm/run-multiple-cyclonus-until-failure.sh
@@ -42,7 +42,7 @@ aksRGPrefix=MC_$resourceGroup_$clusterName
 aksRG=`az group list -otable | grep $aksRGPrefix | awk '{print $1}'`
 if [[ -z $aksRG ]]; then
     echo "AKS resource group not found. Should start with $aksRGPrefix..."
-    # exit 1
+    exit 1
 fi
 echo "found AKS resource group: $aksRG"
 echo "this AKS RG MUST have one WS22 nodepool named $WINDOWS_NODEPOOL..."
@@ -112,7 +112,7 @@ for i in $(seq $START $END); do
         for pod in `kubectl --kubeconfig $absoluteKubeConfig get pod -n kube-system | grep azure-npm-win | awk '{print $1}'`; do
             # using -l k8s-app=azure-npm weirdly only gets ~20 lines of log
             kubectl --kubeconfig $absoluteKubeConfig logs -n kube-system $pod > $fname.$pod.log
-        fi
+        done
 
         echo "stopping vmss instance to stop hns log capture"
         az vmss stop --instance-ids="*" -n $WINDOWS_NODEPOOL -g $aksRG

--- a/debug/windows/npm/win-debug.sh
+++ b/debug/windows/npm/win-debug.sh
@@ -18,6 +18,17 @@ kubectl $kubeconfigArg get pod -A -o wide --show-labels > $filepath/allpods.out
 kubectl $kubeconfigArg get netpol -A -o yaml > $filepath/all-netpol-yamls.out
 kubectl $kubeconfigArg describe netpol -A > $filepath/all-netpol-descriptions.out
 
+for ns in `kubectl $kubeconfigArg get pod -A | grep -v Running | grep -v STATUS | awk '{print $1}' | sort | uniq`; do
+    echo "describing failed pods in namespace $ns..."
+    failingPods=`kubectl $kubeconfigArg get pod -n $ns | grep -v Running | grep -v STATUS | awk '{print $1}' | xargs echo`
+    if [[ -z $failingPods ]]; then
+        continue
+    fi
+    echo "failing Pods: $failingPods"
+    kubectl $kubeconfigArg describe pod -n $ns $failingPods > $filepath/describepod_$ns.out
+    break
+done
+
 npmPods=()
 nodes=()
 for npmPodOrNode in `kubectl $kubeconfigArg get pod -n kube-system -owide --output=custom-columns='Name:.metadata.name,Node:spec.nodeName' | grep "npm-win"`; do

--- a/debug/windows/npm/win-debug.sh
+++ b/debug/windows/npm/win-debug.sh
@@ -7,7 +7,7 @@ else
 fi
 
 # NOTE: you may not be able to unzip logs.zip in Linux since it was compressed in Windows
-set -e
+set -x
 dateString=`date -I` # like 2022-09-24
 filepath=logs_$dateString
 mkdir $filepath
@@ -33,7 +33,6 @@ npmPods=()
 nodes=()
 for npmPodOrNode in `kubectl $kubeconfigArg get pod -n kube-system -owide --output=custom-columns='Name:.metadata.name,Node:spec.nodeName' | grep "npm-win"`; do
     # for loop will go over each item (npm pod, then its node, then the next npm pod, then its node, ...)
-    set +e
     echo $npmPodOrNode | grep -q azure-npm-win-
     if [ $? -eq 0 ]; then
         npmPods+=($npmPodOrNode)
@@ -41,7 +40,6 @@ for npmPodOrNode in `kubectl $kubeconfigArg get pod -n kube-system -owide --outp
         nodes+=($npmPodOrNode)
     fi
 done
-set -e
 
 echo "npm pods: ${npmPods[@]}"
 echo "nodes of npm pods: ${nodes[@]}"

--- a/debug/windows/npm/win-debug.sh
+++ b/debug/windows/npm/win-debug.sh
@@ -1,3 +1,8 @@
+kubeconfig=$1
+if [[ -z $1 ]]; then
+    echo "need kubeconfig file argument" && exit 1
+fi
+
 # NOTE: you may not be able to unzip logs.zip in Linux since it was compressed in Windows
 set -e
 dateString=`date -I` # like 2022-09-24
@@ -6,13 +11,13 @@ mkdir $filepath
 
 echo "gathering logs and writing to $filepath/"
 
-kubectl get pod -A -o wide --show-labels > $filepath/allpods.out
-kubectl get netpol -A -o yaml > $filepath/all-netpol-yamls.out
-kubectl describe netpol -A > $filepath/all-netpol-descriptions.out
+kubectl --kubeconfig $kubeconfig get pod -A -o wide --show-labels > $filepath/allpods.out
+kubectl --kubeconfig $kubeconfig get netpol -A -o yaml > $filepath/all-netpol-yamls.out
+kubectl --kubeconfig $kubeconfig describe netpol -A > $filepath/all-netpol-descriptions.out
 
 npmPods=()
 nodes=()
-for npmPodOrNode in `kubectl get pod -n kube-system -owide --output=custom-columns='Name:.metadata.name,Node:spec.nodeName' | grep "npm-win"`; do
+for npmPodOrNode in `kubectl --kubeconfig $kubeconfig get pod -n kube-system -owide --output=custom-columns='Name:.metadata.name,Node:spec.nodeName' | grep "npm-win"`; do
     # for loop will go over each item (npm pod, then its node, then the next npm pod, then its node, ...)
     set +e
     echo $npmPodOrNode | grep -q azure-npm-win-
@@ -33,22 +38,22 @@ for i in $(seq 1 ${#npmPods[*]}); do
     node=${nodes[$j]}
 
     echo "gathering logs. npm pod: $npmPod. node: $node"
-    kubectl logs -n kube-system $npmPod > $filepath/logs_$npmPod.out
+    kubectl --kubeconfig $kubeconfig logs -n kube-system $npmPod > $filepath/logs_$npmPod.out
 
     ips=()
-    for ip in `kubectl get pod -A -owide --output=custom-columns='IP:.status.podIP,Node:spec.nodeName' | grep $node | grep -oP "\d+\.\d+\.\d+\.\d+"`; do 
+    for ip in `kubectl --kubeconfig $kubeconfig get pod -A -owide --output=custom-columns='IP:.status.podIP,Node:spec.nodeName' | grep $node | grep -oP "\d+\.\d+\.\d+\.\d+"`; do 
         ips+=($ip)
     done
     echo "node $node has IPs: ${ips[@]}"
 
     echo "copying ps1 file into $npmPod"
-    kubectl cp ./pod_exec.ps1 kube-system/"$npmPod":execw.ps1
+    kubectl --kubeconfig $kubeconfig cp ./pod_exec.ps1 kube-system/"$npmPod":execw.ps1
 
     echo "executing ps1 file on $npmPod"
-    kubectl exec -it -n kube-system $npmPod -- powershell.exe -Command  .\\execw.ps1 "'${ips[@]}'"
+    kubectl --kubeconfig $kubeconfig exec -it -n kube-system $npmPod -- powershell.exe -Command  .\\execw.ps1 "'${ips[@]}'"
 
     echo "copying logs.zip from $npmPod. NOTE: this will be a windows-based compressed archive (probably need windows to expand it)"
-    kubectl cp kube-system/"$npmPod":npm-exec-logs.zip $filepath/npm-exec-logs_$node.zip
+    kubectl --kubeconfig $kubeconfig cp kube-system/"$npmPod":npm-exec-logs.zip $filepath/npm-exec-logs_$node.zip
 done
 
 echo "finished gathering all logs. written to $filepath/"

--- a/debug/windows/npm/win-debug.sh
+++ b/debug/windows/npm/win-debug.sh
@@ -1,6 +1,9 @@
 kubeconfig=$1
 if [[ -z $1 ]]; then
-    echo "need kubeconfig file argument" && exit 1
+    echo "kubeconfig not provided. using default kubeconfig"
+else
+    echo "using kubeconfig: $kubeconfig"
+    kubeconfigArg="--kubeconfig $kubeconfig"
 fi
 
 # NOTE: you may not be able to unzip logs.zip in Linux since it was compressed in Windows
@@ -11,13 +14,13 @@ mkdir $filepath
 
 echo "gathering logs and writing to $filepath/"
 
-kubectl --kubeconfig $kubeconfig get pod -A -o wide --show-labels > $filepath/allpods.out
-kubectl --kubeconfig $kubeconfig get netpol -A -o yaml > $filepath/all-netpol-yamls.out
-kubectl --kubeconfig $kubeconfig describe netpol -A > $filepath/all-netpol-descriptions.out
+kubectl $kubeconfigArg get pod -A -o wide --show-labels > $filepath/allpods.out
+kubectl $kubeconfigArg get netpol -A -o yaml > $filepath/all-netpol-yamls.out
+kubectl $kubeconfigArg describe netpol -A > $filepath/all-netpol-descriptions.out
 
 npmPods=()
 nodes=()
-for npmPodOrNode in `kubectl --kubeconfig $kubeconfig get pod -n kube-system -owide --output=custom-columns='Name:.metadata.name,Node:spec.nodeName' | grep "npm-win"`; do
+for npmPodOrNode in `kubectl $kubeconfigArg get pod -n kube-system -owide --output=custom-columns='Name:.metadata.name,Node:spec.nodeName' | grep "npm-win"`; do
     # for loop will go over each item (npm pod, then its node, then the next npm pod, then its node, ...)
     set +e
     echo $npmPodOrNode | grep -q azure-npm-win-
@@ -38,22 +41,22 @@ for i in $(seq 1 ${#npmPods[*]}); do
     node=${nodes[$j]}
 
     echo "gathering logs. npm pod: $npmPod. node: $node"
-    kubectl --kubeconfig $kubeconfig logs -n kube-system $npmPod > $filepath/logs_$npmPod.out
+    kubectl $kubeconfigArg logs -n kube-system $npmPod > $filepath/logs_$npmPod.out
 
     ips=()
-    for ip in `kubectl --kubeconfig $kubeconfig get pod -A -owide --output=custom-columns='IP:.status.podIP,Node:spec.nodeName' | grep $node | grep -oP "\d+\.\d+\.\d+\.\d+"`; do 
+    for ip in `kubectl $kubeconfigArg get pod -A -owide --output=custom-columns='IP:.status.podIP,Node:spec.nodeName' | grep $node | grep -oP "\d+\.\d+\.\d+\.\d+"`; do 
         ips+=($ip)
     done
     echo "node $node has IPs: ${ips[@]}"
 
     echo "copying ps1 file into $npmPod"
-    kubectl --kubeconfig $kubeconfig cp ./pod_exec.ps1 kube-system/"$npmPod":execw.ps1
+    kubectl $kubeconfigArg cp ./pod_exec.ps1 kube-system/"$npmPod":execw.ps1
 
     echo "executing ps1 file on $npmPod"
-    kubectl --kubeconfig $kubeconfig exec -it -n kube-system $npmPod -- powershell.exe -Command  .\\execw.ps1 "'${ips[@]}'"
+    kubectl $kubeconfigArg exec -it -n kube-system $npmPod -- powershell.exe -Command  .\\execw.ps1 "'${ips[@]}'"
 
     echo "copying logs.zip from $npmPod. NOTE: this will be a windows-based compressed archive (probably need windows to expand it)"
-    kubectl --kubeconfig $kubeconfig cp kube-system/"$npmPod":npm-exec-logs.zip $filepath/npm-exec-logs_$node.zip
+    kubectl $kubeconfigArg cp kube-system/"$npmPod":npm-exec-logs.zip $filepath/npm-exec-logs_$node.zip
 done
 
 echo "finished gathering all logs. written to $filepath/"


### PR DESCRIPTION
## Changes
### 1/3: Pipeline Changes
As soon as a test case fails, quit Conformance and record HNS state.

Will *not* be quitting a failed *Cyclonus* run and capturing HNS state.

### 2/3: Enhance win-debug Script
1. Describe failing Pods.
2. Allow for setting kubeconfig.

### 3/3: Scripts for Cyclonus and Conformance 
Help reproduce random issues.
1. Run the test suite on repeat until failure.
2. Capture state and stop traces on the VM.

## Custom Binaries
### Conformance
https://github.com/huntergregory/kubernetes/tree/quit-on-failure
1. On failure, keep all Pods (no deleting).
3. Rest of the test cases will "run" and fail, not performing any actions.

### Cyclonus
https://github.com/huntergregory/cyclonus/tree/stop-after-failure
Quit the run on failure.