### PR TITLE
add azid and enableazr fields to putNC call

### DIFF
--- a/nmagent/requests.go
+++ b/nmagent/requests.go
@@ -68,6 +68,12 @@ type PutNetworkContainerRequest struct {
 	// PrimaryAddress is the primary customer address of the interface in the
 	// management VNet
 	PrimaryAddress string
+
+	// AzID is the home AZ ID of the network container
+	AzID uint `json:"azID"`
+
+	// EnableAZR denotes whether AZR is enabled for network container or not
+	EnableAZR bool `json:"enableAZR"`
 }
 
 type internalNC struct {
@@ -83,6 +89,8 @@ type internalNC struct {
 	Policies   []Policy `json:"policies"`
 	VlanID     int      `json:"vlanId"`
 	GREKey     uint16   `json:"greKey"`
+	AzID       uint     `json:"azID"`
+	EnableAZR  bool     `json:"enableAZR"`
 }
 
 func (p *PutNetworkContainerRequest) MarshalJSON() ([]byte, error) {
@@ -94,6 +102,8 @@ func (p *PutNetworkContainerRequest) MarshalJSON() ([]byte, error) {
 		Policies:   p.Policies,
 		VlanID:     p.VlanID,
 		GREKey:     p.GREKey,
+		AzID:       p.AzID,
+		EnableAZR:  p.EnableAZR,
 	}
 
 	body, err := json.Marshal(pBody)
@@ -123,6 +133,8 @@ func (p *PutNetworkContainerRequest) UnmarshalJSON(in []byte) error {
 	p.Policies = req.Policies
 	p.VlanID = req.VlanID
 	p.GREKey = req.GREKey
+	p.AzID = req.AzID
+	p.EnableAZR = req.EnableAZR
 
 	return nil
 }

--- a/nmagent/requests.go
+++ b/nmagent/requests.go
@@ -70,10 +70,10 @@ type PutNetworkContainerRequest struct {
 	PrimaryAddress string
 
 	// AzID is the home AZ ID of the network container
-	AzID uint `json:"azID"`
+	AzID uint
 
 	// EnableAZR denotes whether AZR is enabled for network container or not
-	EnableAZR bool `json:"enableAZR"`
+	EnableAZR bool
 }
 
 type internalNC struct {


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
To enable AZR support, we need to pass two extra params `azID` (uint) and `enableAZR` (boolean) as part of body to NMAgent.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
https://msazure.visualstudio.com/DefaultCollection/One/_workitems/edit/16223444


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [ ] adds unit tests


**Notes**: e2e flow has been tested by creating and deleting NCs with both `enableAZR` set to `true` and `false`
