### PR TITLE
Fix the NC ID error when get container

### DIFF
--- a/cns/restserver/api_test.go
+++ b/cns/restserver/api_test.go
@@ -431,6 +431,30 @@ func TestGetNetworkContainerByOrchestratorContext(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	mnma := &fakes.NMAgentClientFake{
+		PutNetworkContainerF: func(_ context.Context, _ *nmagent.PutNetworkContainerRequest) error {
+			return nil
+		},
+		JoinNetworkF: func(_ context.Context, _ nmagent.JoinNetworkRequest) error {
+			return nil
+		},
+	}
+
+	cleanup := setMockNMAgent(svc, mnma)
+	defer cleanup()
+
+	mnma.GetNCVersionListF = func(_ context.Context) (nmagent.NCVersionList, error) {
+		return nmagent.NCVersionList{
+			Containers: []nmagent.NCVersion{
+				{
+					// Must set it as params.ncID without cns.SwiftPrefix to mock real nmagent nc format.
+					NetworkContainerID: params.ncID,
+					Version:            params.ncVersion,
+				},
+			},
+		}, nil
+	}
+
 	fmt.Println("Now calling getNetworkContainerByContext")
 	resp, err := getNetworkContainerByContext(params)
 	if err != nil {
@@ -554,7 +578,8 @@ func TestGetNetworkContainerVersionStatus(t *testing.T) {
 		return nmagent.NCVersionList{
 			Containers: []nmagent.NCVersion{
 				{
-					NetworkContainerID: cns.SwiftPrefix + params.ncID,
+					// Must set it as params.ncID without cns.SwiftPrefix to mock real nmagent nc format.
+					NetworkContainerID: params.ncID,
 					Version:            params.ncVersion,
 				},
 			},
@@ -596,7 +621,8 @@ func TestGetNetworkContainerVersionStatus(t *testing.T) {
 		return nmagent.NCVersionList{
 			Containers: []nmagent.NCVersion{
 				{
-					NetworkContainerID: cns.SwiftPrefix + params.ncID,
+					// Must set it as params.ncID without cns.SwiftPrefix to mock real nmagent nc format.
+					NetworkContainerID: params.ncID,
 					Version:            "0",
 				},
 			},

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -104,7 +104,7 @@ func (service *HTTPRestService) SyncNodeStatus(dncEP, infraVnet, nodeID string, 
 	if !skipNCVersionCheck {
 		nmaNCs := map[string]string{}
 		for _, nc := range ncVersionListResp.Containers {
-			nmaNCs[cns.SwiftPrefix+nc.NetworkContainerID] = nc.Version
+			nmaNCs[nc.NetworkContainerID] = nc.Version
 		}
 
 		// check if the version is valid and save it to service state

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -104,7 +104,7 @@ func (service *HTTPRestService) SyncNodeStatus(dncEP, infraVnet, nodeID string, 
 	if !skipNCVersionCheck {
 		nmaNCs := map[string]string{}
 		for _, nc := range ncVersionListResp.Containers {
-			nmaNCs[nc.NetworkContainerID] = nc.Version
+			nmaNCs[cns.SwiftPrefix+nc.NetworkContainerID] = nc.Version
 		}
 
 		// check if the version is valid and save it to service state

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -394,9 +394,8 @@ func (service *HTTPRestService) getNetworkContainerResponse(
 		}
 		nmaNCs := map[string]string{}
 		for _, nc := range ncVersionListResp.Containers {
-			nmaNCs[nc.NetworkContainerID] = nc.Version
+			nmaNCs[cns.SwiftPrefix+nc.NetworkContainerID] = nc.Version
 		}
-
 		if exists && !skipNCVersionCheck {
 			// If the goal state is available with CNS, check if the NC is pending VFP programming
 			waitingForUpdate, getNetworkContainerResponse.Response.ReturnCode, getNetworkContainerResponse.Response.Message = service.isNCWaitingForUpdate(


### PR DESCRIPTION
fix: repair the NC ID mismatch when get network container.

**Reason for Change**:
 Fix the mismatch between NC version returned from nmagent and CNS state. Add unit test to gate it.


**Issue Fixed**:
CNS is onboard with nmagent nc version api 2. NC ID returned from nmagent doesn't include the Swift_ prefix but pure uuid. However, the NC ID in the request and cns state has the Swift_ prefix. This mismatch result in the nc version update failure.


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ X] adds unit tests


**Notes**:
