### PR TITLE
Update ClusterSubnetStates crd

### DIFF
--- a/crd/clustersubnetstate/api/v1alpha1/clustersubnetstate.go
+++ b/crd/clustersubnetstate/api/v1alpha1/clustersubnetstate.go
@@ -16,7 +16,7 @@ import (
 // +kubebuilder:resource:scope=Namespaced
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Exhausted",type=string,JSONPath=`.status.exhausted`
-// +kubebuilder:printcolumn:name="Updated",type=string,JSONPath=`.spec.timestamp`
+// +kubebuilder:printcolumn:name="Updated",type=string,JSONPath=`.status.timestamp`
 type ClusterSubnetState struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/crd/clustersubnetstate/manifests/acn.azure.com_clustersubnetstates.yaml
+++ b/crd/clustersubnetstate/manifests/acn.azure.com_clustersubnetstates.yaml
@@ -19,7 +19,7 @@ spec:
     - jsonPath: .status.exhausted
       name: Exhausted
       type: string
-    - jsonPath: .spec.timestamp
+    - jsonPath: .status.timestamp
       name: Updated
       type: string
     name: v1alpha1


### PR DESCRIPTION
Update timestamp in ccs crd.

**Reason for Change**:
ccs timestamp is controlled by DNC so it belongs to status. Then update it in status.  
