### PR TITLE
reset the http status code to 500 in case we encounter an error

### DIFF
--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -1239,6 +1239,10 @@ func (service *HTTPRestService) publishNetworkContainer(w http.ResponseWriter, r
 		returnCode = types.UnsupportedVerb
 	}
 
+	if returnCode != 0 {
+		publishStatusCode = http.StatusInternalServerError
+	}
+
 	// create a synthetic response from NMAgent so that clients that previously
 	// relied on its presence can continue to do so.
 	publishResponseBody := fmt.Sprintf(`{"httpStatusCode":"%d"}`, publishStatusCode)
@@ -1348,6 +1352,10 @@ func (service *HTTPRestService) unpublishNetworkContainer(w http.ResponseWriter,
 	default:
 		returnMessage = "UnpublishNetworkContainer API expects a POST"
 		returnCode = types.UnsupportedVerb
+	}
+
+	if returnCode != 0 {
+		unpublishStatusCode = http.StatusInternalServerError
 	}
 
 	// create a synthetic response from NMAgent so that clients that previously


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
During NC publish and unpublish, we do not reset the httpStatusCode that we return back to DNC. As a result, even if we encounter an error we send back HTTP 200 back to DNC

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
https://msazure.visualstudio.com/DefaultCollection/One/_workitems/edit/17035213


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
