### PR TITLE
deprecate SetOwnerRef in favor of SetControllerRef

### DIFF
--- a/crd/nodenetworkconfig/client.go
+++ b/crd/nodenetworkconfig/client.go
@@ -129,7 +129,7 @@ func (c *Client) UpdateSpec(ctx context.Context, key types.NamespacedName, spec 
 	return nnc, nil
 }
 
-// SetControllerRef sets the controller of the NodeNetworkConfig to the given object atomically, using HTTP Patch.
+// SetOwnerRef sets the controller of the NodeNetworkConfig to the given object atomically, using HTTP Patch.
 // Deprecated: SetOwnerRef is deprecated, use the more correctly named SetControllerRef.
 func (c *Client) SetOwnerRef(ctx context.Context, key types.NamespacedName, owner metav1.Object, fieldManager string) (*v1alpha.NodeNetworkConfig, error) {
 	return c.SetControllerRef(ctx, key, owner, fieldManager)

--- a/crd/nodenetworkconfig/client.go
+++ b/crd/nodenetworkconfig/client.go
@@ -129,8 +129,14 @@ func (c *Client) UpdateSpec(ctx context.Context, key types.NamespacedName, spec 
 	return nnc, nil
 }
 
-// SetOwnerRef sets the owner of the NodeNetworkConfig to the given object, using HTTP Patch
+// SetControllerRef sets the controller of the NodeNetworkConfig to the given object atomically, using HTTP Patch.
+// Deprecated: SetOwnerRef is deprecated, use the more correctly named SetControllerRef.
 func (c *Client) SetOwnerRef(ctx context.Context, key types.NamespacedName, owner metav1.Object, fieldManager string) (*v1alpha.NodeNetworkConfig, error) {
+	return c.SetControllerRef(ctx, key, owner, fieldManager)
+}
+
+// SetControllerRef sets the controller of the NodeNetworkConfig to the given object atomically, using HTTP Patch.
+func (c *Client) SetControllerRef(ctx context.Context, key types.NamespacedName, owner metav1.Object, fieldManager string) (*v1alpha.NodeNetworkConfig, error) {
 	obj := genPatchSkel(key)
 	if err := ctrlutil.SetControllerReference(owner, obj, Scheme); err != nil {
 		return nil, errors.Wrapf(err, "failed to set controller reference for nnc")


### PR DESCRIPTION
Signed-off-by: Evan Baker <rbtr@users.noreply.github.com>

The `SetOwnerRef` method was misleadingly named - it actually calls `ctrlutil.SetControllerReference` and patches, not `ctrlutil.SetOwnerReference` which also exists.

This renames the method to `SetControllerRef` so that it is named what it does. A deprecated stub `SetOwnerRef` which forwards to the new method is left for backwards compatibility.

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
