### PR TITLE
log: [NPM-WIN] clean up some logs

### DIFF
--- a/npm/pkg/dataplane/dataplane_windows.go
+++ b/npm/pkg/dataplane/dataplane_windows.go
@@ -317,9 +317,6 @@ func (dp *DataPlane) getPodEndpoints(includeRemoteEndpoints bool) ([]*hcn.HostCo
 		if includeRemoteEndpoints || e.Flags == hcn.EndpointFlagsNone {
 			// having EndpointFlagsNone means it is a local endpoint
 			localEndpoints = append(localEndpoints, e)
-		} else {
-			// TODO remove for GA
-			klog.Infof("ignoring remote endpoint. ID: %s, IP configs: %+v", e.Id, e.IpConfigurations)
 		}
 	}
 	return localEndpoints, nil

--- a/npm/pkg/dataplane/policies/policymanager_windows.go
+++ b/npm/pkg/dataplane/policies/policymanager_windows.go
@@ -35,7 +35,8 @@ func newStaleChains() *staleChains {
 func (pMgr *PolicyManager) bootup(epIDs []string) error {
 	var aggregateErr error
 	for _, epID := range epIDs {
-		err := pMgr.removePolicyByEndpointID("", epID, 0, resetAllACLs)
+		// ruleID="RESET-ALL" is only used for logging when specifying shouldResetACLs=resestAllACLs
+		err := pMgr.removePolicyByEndpointID("RESET-ALL", epID, 0, resetAllACLs)
 		if err != nil {
 			if aggregateErr == nil {
 				aggregateErr = fmt.Errorf("skipping resetting policies on %s ID Endpoint with err: %w", epID, err)
@@ -178,7 +179,7 @@ func (pMgr *PolicyManager) removePolicyByEndpointID(ruleID, epID string, noOfRul
 	if err != nil {
 		// IsNotFound check is being skipped at times. So adding a redundant check here.
 		if isNotFoundErr(err) || strings.Contains(err.Error(), "endpoint was not found") {
-			klog.Infof("[PolicyManagerWindows] ignoring remove policy since the endpoint wasn't found. the corresponding pod might be deleted. policy: %s, endpoint: %s, err: %s", ruleID, epID, err.Error())
+			klog.Infof("[PolicyManagerWindows] ignoring remove policy since the endpoint wasn't found. the corresponding pod might be deleted. policy: %s, endpoint: %s, HNS response: %s", ruleID, epID, err.Error())
 			return nil
 		}
 		return fmt.Errorf("[PolicyManagerWindows] failed to remove policy while getting the endpoint. policy: %s, endpoint: %s, err: %w", ruleID, epID, err)


### PR DESCRIPTION
1. remove remote endpoint log (superfluous info that dilutes logs)
2. change wording for warning
3. more understandable logs when resetting all ACLs