### PR TITLE
Changing gcr repo as per k8s issue 4738

### DIFF
--- a/hack/manifests/cni-installer.yaml
+++ b/hack/manifests/cni-installer.yaml
@@ -20,17 +20,17 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.azure.com/cluster
-                operator: Exists
-              - key: type
-                operator: NotIn
-                values:
-                - virtual-kubelet
-              - key: beta.kubernetes.io/os
-                operator: In
-                values:
-                - linux
+              - matchExpressions:
+                  - key: kubernetes.azure.com/cluster
+                    operator: Exists
+                  - key: type
+                    operator: NotIn
+                    values:
+                      - virtual-kubelet
+                  - key: beta.kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
       priorityClassName: system-node-critical
       tolerations:
         - key: CriticalAddonsOnly
@@ -50,7 +50,7 @@ spec:
             - -o
             - /opt/cni/bin/azure-vnet
             - azure-linux-swift.conflist
-            - -o 
+            - -o
             - /etc/cni/net.d/10-azure.conflist
           volumeMounts:
             - name: cni-bin
@@ -59,7 +59,7 @@ spec:
               mountPath: /etc/cni/net.d
       containers:
         - name: pause
-          image: k8s.gcr.io/pause:2.0
+          image: registry.k8s.io/pause:2.0
       hostNetwork: true
       volumes:
         - name: cni-conflist

--- a/hack/manifests/scaler.yaml
+++ b/hack/manifests/scaler.yaml
@@ -16,14 +16,14 @@ spec:
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - node-scaler
-            topologyKey: "kubernetes.io/hostname"
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - node-scaler
+              topologyKey: "kubernetes.io/hostname"
       containers:
-      - name: anti-affinity
-        image: k8s.gcr.io/pause:2.0
+        - name: anti-affinity
+          image: registry.k8s.io/pause:2.0
       hostNetwork: true

--- a/test/kubemark/aks-e/hollow-node.yaml
+++ b/test/kubemark/aks-e/hollow-node.yaml
@@ -100,7 +100,7 @@ spec:
       imagePullSecrets:
         - name: acr-secret
       # - name: hollow-node-problem-detector
-      #   image: k8s.gcr.io/node-problem-detector/node-problem-detector:v0.8.7
+      #   image: registry.k8s.io/node-problem-detector/node-problem-detector:v0.8.7
       #   env:
       #   - name: NODE_NAME
       #     valueFrom:


### PR DESCRIPTION
https://github.com/kubernetes/k8s.io/issues/4738 

Kubernetes is updating registry address [k8s.gcr.io](http://k8s.gcr.io/) -> [registry.k8s.io](http://registry.k8s.io/) by April 3rd. Please scan your codebase to update references from k8s.gcr.io to registry.k8s.io by April 3rd to remain current

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
