### PR TITLE
wip: replaced docker@2 tasks in build pipeline with buildx script

### DIFF
--- a/.pipelines/containers/container-template-windows.yaml
+++ b/.pipelines/containers/container-template-windows.yaml
@@ -15,29 +15,23 @@ steps:
     command: 'login'
     addPipelineData: false
 
-- task: Docker@2
+- script: |
+    set -x
+    docker version
+    echo tag: $TAG
+    docker buildx create --name winbuilder --use --platform windows/amd64
+    echo pwd: $(pwd)
+    docker buildx build \
+      --push \
+      --platform windows/amd64  \
+      -f ${{ parameters.name }}/windows.buildx.Dockerfile \
+      --build-arg VERSION=windows-${{ parameters.arch }}-${{ parameters.tag }} \
+      --build-arg ${{ parameters.ai_path_var }}=${{ parameters.ai_path }} \
+      --build-arg ${{ parameters.ai_id_var }}=${{ parameters.ai_id }} \
+      -t acnpublic.azurecr.io/azure-${{ parameters.name }}:windows-${{ parameters.arch }}-${{ parameters.tag }} \
+      .
+  name: image_build
   displayName: Image Build
-  retryCountOnTaskFailure: 3
-  inputs:
-    command: 'build'
-    containerRegistry: $(ACR_SERVICE_CONNECTION)
-    repository: 'azure-${{ parameters.name }}'
-    tags: 'windows-${{ parameters.arch }}-${{ parameters.tag }}'
-    Dockerfile: '${{ parameters.name }}/windows.Dockerfile'
-    arguments: '
-    --build-arg VERSION=windows-${{ parameters.arch }}-${{ parameters.tag }} 
-    --build-arg ${{ parameters.ai_path_var }}=${{ parameters.ai_path }} 
-    --build-arg ${{ parameters.ai_id_var }}=${{ parameters.ai_id }}'
-    buildContext: '**/..'
-
-- task: Docker@2
-  displayName: Image Push
-  retryCountOnTaskFailure: 3
-  inputs:
-    command: 'push'
-    containerRegistry: $(ACR_SERVICE_CONNECTION)
-    repository: 'azure-${{ parameters.name }}'
-    tags: 'windows-${{ parameters.arch }}-${{ parameters.tag }}'
 
 - task: Docker@2
   displayName: Logout

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -224,7 +224,7 @@ stages:
         variables:
           TAG: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.Tag'] ]
         pool:
-          name: "$(BUILD_POOL_NAME_WINDOWS_AMD64)"
+          name: "$(BUILD_POOL_NAME_LINUX_AMD64)"
         strategy:
           matrix:
             cns_windows_amd64:

--- a/cns/windows.buildx.Dockerfile
+++ b/cns/windows.buildx.Dockerfile
@@ -1,0 +1,24 @@
+# Build cns
+FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.19 as builder
+# Build args
+ARG VERSION
+ARG CNS_AI_PATH
+ARG CNS_AI_ID
+
+ENV GOOS=windows
+ENV GOARCH=amd64
+# Build cns
+#RUN make azure-cns-binary
+WORKDIR /usr/src/cns
+COPY . .
+
+RUN go build -mod mod -v -o /usr/bin/azure-cns.exe -ldflags "-X main.version=$VERSION -X $CNS_AI_PATH=$CNS_AI_ID" -gcflags="-dwarflocationlists=true" ./cns/service/
+
+# Copy into final image
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
+COPY --from=builder /usr/src/cns/cns/kubeconfigtemplate.yaml kubeconfigtemplate.yaml
+COPY --from=builder /usr/src/cns/npm/examples/windows/setkubeconfigpath.ps1 setkubeconfigpath.ps1
+COPY --from=builder /usr/bin/azure-cns.exe azure-cns.exe
+
+ENTRYPOINT ["azure-cns.exe"]
+EXPOSE 10090

--- a/npm/windows.buildx.Dockerfile
+++ b/npm/windows.buildx.Dockerfile
@@ -1,0 +1,22 @@
+FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.19 as builder
+# Build args
+ARG VERSION
+ARG NPM_AI_PATH
+ARG NPM_AI_ID
+
+ENV GOOS=windows
+ENV GOARCH=amd64
+
+WORKDIR /usr/src/npm
+# Copy the source
+COPY . .
+
+RUN go build -mod=mod -v -o /usr/bin/npm.exe -ldflags "-X main.version=$VERSION -X $NPM_AI_PATH=$NPM_AI_ID" -gcflags="-dwarflocationlists=true" ./npm/cmd/
+
+# Copy into final image
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
+COPY --from=builder /usr/src/npm/npm/examples/windows/kubeconfigtemplate.yaml kubeconfigtemplate.yaml
+COPY --from=builder /usr/src/npm/npm/examples/windows/setkubeconfigpath.ps1 setkubeconfigpath.ps1
+COPY --from=builder /usr/bin/npm.exe npm.exe
+
+CMD ["npm.exe", "start" "--kubeconfig=.\\kubeconfig"]


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
This replaces the way cns and npm windows amd64 images for e2e testing in PR pipeline are generated. Before we used docker build in windows, but there is an intermittent permissions issues in windows docker agent that we could not figure out with 1es and obp team.
This replaces docker build with docker buildx to produce windows images in Linux, where we don't have that issue.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
