### PR TITLE
CNS - Wireserver "proxy"

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -502,6 +502,7 @@ type PublishNetworkContainerRequest struct {
 
 // NetworkContainerParameters parameters available in network container operations
 type NetworkContainerParameters struct {
+	NCID                  string
 	AuthToken             string
 	AssociatedInterfaceID string
 }

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -500,6 +500,12 @@ type PublishNetworkContainerRequest struct {
 	CreateNetworkContainerRequestBody []byte
 }
 
+func (p PublishNetworkContainerRequest) String() string {
+	// %s as a verb on a byte slice prints text instead of individual bytes
+	return fmt.Sprintf("{NetworkID:%s NetworkContainerID:%s JoinNetworkURL:%s CreateNetworkContainerURL:%s CreateNetworkContainerRequestBody:%s}",
+		p.NetworkID, p.NetworkContainerID, p.JoinNetworkURL, p.CreateNetworkContainerURL, p.CreateNetworkContainerRequestBody)
+}
+
 // NetworkContainerParameters parameters available in network container operations
 type NetworkContainerParameters struct {
 	NCID                  string
@@ -513,6 +519,12 @@ type PublishNetworkContainerResponse struct {
 	PublishErrorStr     string
 	PublishStatusCode   int
 	PublishResponseBody []byte
+}
+
+func (p PublishNetworkContainerResponse) String() string {
+	// %s as a verb on a byte slice prints text instead of individual bytes
+	return fmt.Sprintf("{Response:%+v PublishErrStr:%s PublishStatusCode:%d PublishResponseBody:%s}",
+		p.Response, p.PublishErrorStr, p.PublishStatusCode, p.PublishResponseBody)
 }
 
 // UnpublishNetworkContainerRequest specifies request to unpublish network container via NMAgent.
@@ -529,6 +541,12 @@ type UnpublishNetworkContainerResponse struct {
 	UnpublishErrorStr     string
 	UnpublishStatusCode   int
 	UnpublishResponseBody []byte
+}
+
+func (u UnpublishNetworkContainerResponse) String() string {
+	// %s as a verb on a byte slice prints text instead of individual bytes
+	return fmt.Sprintf("{Response:%+v UnpublishErrorStr:%s UnpublishStatusCode:%d UnpublishResponseBody:%s}",
+		u.Response, u.UnpublishErrorStr, u.UnpublishStatusCode, u.UnpublishResponseBody)
 }
 
 // ValidAclPolicySetting - Used to validate ACL policy

--- a/cns/client/client_test.go
+++ b/cns/client/client_test.go
@@ -169,7 +169,7 @@ func TestMain(m *testing.M) {
 	logger.InitLogger(logName, 0, 0, tmpLogDir+"/")
 	config := common.ServiceConfig{}
 
-	httpRestService, err := restserver.NewHTTPRestService(&config, &fakes.WireserverClientFake{}, &fakes.NMAgentClientFake{}, nil, nil, nil)
+	httpRestService, err := restserver.NewHTTPRestService(&config, &fakes.WireserverClientFake{}, &fakes.WireserverProxyFake{}, &fakes.NMAgentClientFake{}, nil, nil, nil)
 	svc = httpRestService.(*restserver.HTTPRestService)
 	svc.Name = "cns-test-server"
 	fakeNNC := v1alpha.NodeNetworkConfig{

--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -193,4 +193,7 @@ func SetCNSConfigDefaults(config *CNSConfig) {
 		// set the default PopulateHomeAzCache retry interval to 15 seconds
 		config.PopulateHomeAzCacheRetryIntervalSecs = 15
 	}
+	if config.WireserverIP == "" {
+		config.WireserverIP = "168.63.129.16"
+	}
 }

--- a/cns/fakes/wireserverproxyfake.go
+++ b/cns/fakes/wireserverproxyfake.go
@@ -1,11 +1,12 @@
 package fakes
 
 import (
-	"context"
-	"github.com/Azure/azure-container-networking/cns"
-	"net/http"
 	"bytes"
+	"context"
 	"io"
+	"net/http"
+
+	"github.com/Azure/azure-container-networking/cns"
 )
 
 type WireserverProxyFake struct {

--- a/cns/fakes/wireserverproxyfake.go
+++ b/cns/fakes/wireserverproxyfake.go
@@ -32,6 +32,7 @@ func (w *WireserverProxyFake) JoinNetwork(ctx context.Context, vnetID string) (*
 
 	return defaultResponse(), nil
 }
+
 func (w *WireserverProxyFake) PublishNC(ctx context.Context, ncParams cns.NetworkContainerParameters, payload []byte) (*http.Response, error) {
 	if w.PublishNCFunc != nil {
 		return w.PublishNCFunc(ctx, ncParams, payload)
@@ -39,6 +40,7 @@ func (w *WireserverProxyFake) PublishNC(ctx context.Context, ncParams cns.Networ
 
 	return defaultResponse(), nil
 }
+
 func (w *WireserverProxyFake) UnpublishNC(ctx context.Context, ncParams cns.NetworkContainerParameters) (*http.Response, error) {
 	if w.UnpublishNCFunc != nil {
 		return w.UnpublishNCFunc(ctx, ncParams)

--- a/cns/fakes/wireserverproxyfake.go
+++ b/cns/fakes/wireserverproxyfake.go
@@ -1,0 +1,47 @@
+package fakes
+
+import (
+	"context"
+	"github.com/Azure/azure-container-networking/cns"
+	"net/http"
+	"bytes"
+	"io"
+)
+
+type WireserverProxyFake struct {
+	JoinNetworkFunc func(context.Context, string) (*http.Response, error)
+	PublishNCFunc   func(context.Context, cns.NetworkContainerParameters, []byte) (*http.Response, error)
+	UnpublishNCFunc func(context.Context, cns.NetworkContainerParameters) (*http.Response, error)
+}
+
+const defaultResponseBody = `{"httpStatusCode":"200"}`
+
+func defaultResponse() *http.Response {
+	return &http.Response{
+		StatusCode:    http.StatusOK,
+		Body:          io.NopCloser(bytes.NewBufferString(defaultResponseBody)),
+		ContentLength: int64(len(defaultResponseBody)),
+	}
+}
+
+func (w *WireserverProxyFake) JoinNetwork(ctx context.Context, vnetID string) (*http.Response, error) {
+	if w.JoinNetworkFunc != nil {
+		return w.JoinNetworkFunc(ctx, vnetID)
+	}
+
+	return defaultResponse(), nil
+}
+func (w *WireserverProxyFake) PublishNC(ctx context.Context, ncParams cns.NetworkContainerParameters, payload []byte) (*http.Response, error) {
+	if w.PublishNCFunc != nil {
+		return w.PublishNCFunc(ctx, ncParams, payload)
+	}
+
+	return defaultResponse(), nil
+}
+func (w *WireserverProxyFake) UnpublishNC(ctx context.Context, ncParams cns.NetworkContainerParameters) (*http.Response, error) {
+	if w.UnpublishNCFunc != nil {
+		return w.UnpublishNCFunc(ctx, ncParams)
+	}
+
+	return defaultResponse(), nil
+}

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Azure/azure-container-networking/cns/wireserver"
 	"github.com/Azure/azure-container-networking/nmagent"
 	"github.com/pkg/errors"
+	"io"
 )
 
 var (
@@ -1097,10 +1098,10 @@ func (service *HTTPRestService) getNumberOfCPUCores(w http.ResponseWriter, r *ht
 	logger.Response(service.Name, numOfCPUCoresResp, resp.ReturnCode, err)
 }
 
-func getAuthTokenAndInterfaceIDFromNcURL(networkContainerURL string) (*cns.NetworkContainerParameters, error) {
+func extractNCParamsFromURL(networkContainerURL string) (cns.NetworkContainerParameters, error) {
 	ncURL, err := url.Parse(networkContainerURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse network container url, %w", err)
+		return cns.NetworkContainerParameters{}, fmt.Errorf("failed to parse network container url, %w", err)
 	}
 
 	queryParams := ncURL.Query()
@@ -1109,7 +1110,7 @@ func getAuthTokenAndInterfaceIDFromNcURL(networkContainerURL string) (*cns.Netwo
 	// doing this parsing due to this structure
 	typeQueryParamVal := queryParams.Get("type")
 	if typeQueryParamVal == "" {
-		return nil, fmt.Errorf("no type query param, %w", ErrInvalidNcURLFormat)
+		return cns.NetworkContainerParameters{}, fmt.Errorf("no type query param, %w", ErrInvalidNcURLFormat)
 	}
 
 	// .{0,128} gets from zero to 128 characters of any kind
@@ -1117,10 +1118,10 @@ func getAuthTokenAndInterfaceIDFromNcURL(networkContainerURL string) (*cns.Netwo
 	matches := ncRegex.FindStringSubmatch(typeQueryParamVal)
 
 	if len(matches) != ncURLExpectedMatches {
-		return nil, fmt.Errorf("unexpected number of matches in url, %w", ErrInvalidNcURLFormat)
+		return cns.NetworkContainerParameters{}, fmt.Errorf("unexpected number of matches in url, %w", ErrInvalidNcURLFormat)
 	}
 
-	return &cns.NetworkContainerParameters{
+	return cns.NetworkContainerParameters{
 		AssociatedInterfaceID: matches[1],
 		NCID:                  matches[2],
 		AuthToken:             matches[3],
@@ -1160,109 +1161,119 @@ func (h *HTTPRestService) doPublish(ctx context.Context, req cns.PublishNetworkC
 	return "", types.Success, http.StatusOK
 }
 
+func respondError(w http.ResponseWriter, statusCode int, body any) {
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.WriteHeader(statusCode)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func respondOK(w http.ResponseWriter, body any) {
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
 // Publish Network Container by calling nmagent
 func (service *HTTPRestService) publishNetworkContainer(w http.ResponseWriter, r *http.Request) {
-	logger.Printf("[Azure-CNS] PublishNetworkContainer")
+	if r.Method != http.MethodPost {
+		http.Error(w, "PublishNetworkContainer expects a POST", http.StatusBadRequest)
+		return
+	}
+
+	var req cns.PublishNetworkContainerRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("could not decode request body: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	logger.Request(service.Name, req, nil)
+
+	ncParams, err := extractNCParamsFromURL(req.CreateNetworkContainerURL)
+	if err != nil {
+		resp := cns.PublishNetworkContainerResponse{
+			Response: cns.Response{
+				ReturnCode: http.StatusBadRequest,
+				Message:    fmt.Sprintf("unexpected create nc url format. url %s: %v ", req.CreateNetworkContainerURL, err),
+			},
+		}
+		respondError(w, http.StatusBadRequest, resp)
+		logger.Response(service.Name, resp, resp.Response.ReturnCode, err)
+		return
+	}
 
 	ctx := r.Context()
 
-	var (
-		req             cns.PublishNetworkContainerRequest
-		returnCode      types.ResponseCode
-		returnMessage   string
-		publishErrorStr string
-		isNetworkJoined bool
-	)
-
-	// publishing is assumed to succeed unless some other error handling sets it
-	// otherwise
-	publishStatusCode := http.StatusOK
-
-	err := service.Listener.Decode(w, r, &req)
-
-	creteNcURLCopy := req.CreateNetworkContainerURL
-
-	// reqCopy creates a copy of incoming request. It doesn't copy the authentication token info
-	// to avoid logging it.
-	reqCopy := cns.PublishNetworkContainerRequest{
-		NetworkID:                 req.NetworkID,
-		NetworkContainerID:        req.NetworkContainerID,
-		JoinNetworkURL:            req.JoinNetworkURL,
-		CreateNetworkContainerURL: strings.Split(req.CreateNetworkContainerURL, "authenticationToken")[0],
-	}
-
-	logger.Request(service.Name, &reqCopy, err)
-
-	// TODO - refactor this method for better error handling
+	joinResp, err := service.wsproxy.JoinNetwork(ctx, req.NetworkID)
 	if err != nil {
-		return
-	}
-
-	var ncParameters *cns.NetworkContainerParameters
-	ncParameters, err = getAuthTokenAndInterfaceIDFromNcURL(creteNcURLCopy)
-	if err != nil {
-		logger.Errorf("[Azure-CNS] nc parameters validation failed with %+v", err)
-		w.WriteHeader(http.StatusBadRequest)
-
-		badRequestResponse := &cns.PublishNetworkContainerResponse{
+		resp := cns.PublishNetworkContainerResponse{
 			Response: cns.Response{
-				ReturnCode: http.StatusBadRequest,
-				Message:    fmt.Sprintf("Request contains a unexpected create url format in request body: %v", reqCopy.CreateNetworkContainerURL),
+				ReturnCode: types.NetworkJoinFailed,
+				Message:    fmt.Sprintf("failed to join network %s: %v", req.NetworkID, err),
 			},
-			PublishErrorStr:   fmt.Sprintf("Bad request: Request contains a unexpected create url format in request body: %v", reqCopy.CreateNetworkContainerURL),
-			PublishStatusCode: http.StatusBadRequest,
+			PublishErrorStr: err.Error(),
 		}
-		err = service.Listener.Encode(w, &badRequestResponse)
-		logger.Response(service.Name, badRequestResponse, badRequestResponse.Response.ReturnCode, err)
+		respondOK(w, resp) // legacy behavior
+		logger.Response(service.Name, resp, resp.Response.ReturnCode, err)
 		return
 	}
 
-	switch r.Method {
-	case http.MethodPost:
-		// Join the network
-		// Please refactor this
-		// do not reuse the below variable between network join and publish
-		// nolint:bodyclose // existing code needs refactoring
-		err = service.joinNetwork(ctx, req.NetworkID)
-		if err != nil {
-			returnMessage = err.Error()
-			returnCode = types.NetworkJoinFailed
-			publishErrorStr = err.Error()
+	joinBytes, _ := io.ReadAll(joinResp.Body)
+	_ = joinResp.Body.Close()
 
-			var nmaErr nmagent.Error
-			if errors.As(err, &nmaErr) {
-				publishStatusCode = nmaErr.StatusCode()
-			}
-		} else {
-			isNetworkJoined = true
+	if joinResp.StatusCode != http.StatusOK {
+		resp := cns.PublishNetworkContainerResponse{
+			Response: cns.Response{
+				ReturnCode: types.NetworkJoinFailed,
+				Message:    fmt.Sprintf("failed to join network %s. did not get 200 from wireserver", req.NetworkID),
+			},
+			PublishStatusCode:   joinResp.StatusCode,
+			PublishResponseBody: joinBytes,
 		}
-
-		if isNetworkJoined {
-			// Publish Network Container
-			returnMessage, returnCode, publishStatusCode = service.doPublish(ctx, req, ncParameters)
-		}
-
-	default:
-		returnMessage = "PublishNetworkContainer API expects a POST"
-		returnCode = types.UnsupportedVerb
+		respondOK(w, resp) // legacy behavior
+		logger.Response(service.Name, resp, resp.Response.ReturnCode, nil)
+		return
 	}
 
-	// create a synthetic response from NMAgent so that clients that previously
-	// relied on its presence can continue to do so.
-	publishResponseBody := fmt.Sprintf(`{"httpStatusCode":"%d"}`, publishStatusCode)
+	logger.Printf("[Azure-CNS] joined vnet %s during nc %s publish. wireserver response: %v", req.NetworkID, req.NetworkContainerID, string(joinBytes))
 
-	response := cns.PublishNetworkContainerResponse{
-		Response: cns.Response{
-			ReturnCode: returnCode,
-			Message:    returnMessage,
-		},
-		PublishErrorStr:     publishErrorStr,
-		PublishStatusCode:   publishStatusCode,
-		PublishResponseBody: []byte(publishResponseBody),
+	publishResp, err := service.wsproxy.PublishNC(ctx, ncParams, req.CreateNetworkContainerRequestBody)
+	if err != nil {
+		resp := cns.PublishNetworkContainerResponse{
+			Response: cns.Response{
+				ReturnCode: types.NetworkContainerPublishFailed,
+				Message:    fmt.Sprintf("failed to publish nc %s: %v", req.NetworkContainerID, err),
+			},
+			PublishErrorStr: err.Error(),
+		}
+		respondOK(w, resp) // legacy behavior
+		logger.Response(service.Name, resp, resp.Response.ReturnCode, err)
+		return
 	}
 
-	err = service.Listener.Encode(w, &response)
-	logger.Response(service.Name, response, response.Response.ReturnCode, err)
+	publishBytes, _ := io.ReadAll(publishResp.Body)
+	_ = publishResp.Body.Close()
+
+	if publishResp.StatusCode != http.StatusOK {
+		resp := cns.PublishNetworkContainerResponse{
+			Response: cns.Response{
+				ReturnCode: types.NetworkContainerPublishFailed,
+				Message:    fmt.Sprintf("failed to publish nc %s. did not get 200 from wireserver", req.NetworkContainerID),
+			},
+			PublishStatusCode:   publishResp.StatusCode,
+			PublishResponseBody: publishBytes,
+		}
+		respondOK(w, resp) // legacy behavior
+		logger.Response(service.Name, resp, resp.Response.ReturnCode, nil)
+		return
+	}
+
+	resp := cns.PublishNetworkContainerResponse{
+		PublishStatusCode:   publishResp.StatusCode,
+		PublishResponseBody: publishBytes,
+	}
+
+	respondOK(w, resp)
+	logger.Response(service.Name, resp, resp.Response.ReturnCode, nil)
 }
 
 // Unpublish Network Container by calling nmagent
@@ -1298,8 +1309,7 @@ func (service *HTTPRestService) unpublishNetworkContainer(w http.ResponseWriter,
 		return
 	}
 
-	var ncParameters *cns.NetworkContainerParameters
-	ncParameters, err = getAuthTokenAndInterfaceIDFromNcURL(deleteNcURLCopy)
+	ncParameters, err := extractNCParamsFromURL(deleteNcURLCopy)
 	if err != nil {
 		logger.Errorf("[Azure-CNS] nc parameters validation failed with %+v", err)
 		w.WriteHeader(http.StatusBadRequest)

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -7,21 +7,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net"
-	"net/http"
-	"net/url"
-	"regexp"
-	"runtime"
-	"strings"
-
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/hnsclient"
 	"github.com/Azure/azure-container-networking/cns/logger"
 	"github.com/Azure/azure-container-networking/cns/types"
 	"github.com/Azure/azure-container-networking/cns/wireserver"
-	"github.com/Azure/azure-container-networking/nmagent"
 	"github.com/pkg/errors"
 	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"regexp"
+	"runtime"
 )
 
 var (
@@ -1128,39 +1125,6 @@ func extractNCParamsFromURL(networkContainerURL string) (cns.NetworkContainerPar
 	}, nil
 }
 
-//nolint:revive // the previous receiver naming "service" is bad, this is correct:
-func (h *HTTPRestService) doPublish(ctx context.Context, req cns.PublishNetworkContainerRequest, ncParameters *cns.NetworkContainerParameters) (msg string, code types.ResponseCode, status int) {
-	innerReqBytes := req.CreateNetworkContainerRequestBody
-
-	var innerReq nmagent.PutNetworkContainerRequest
-	err := json.Unmarshal(innerReqBytes, &innerReq)
-	if err != nil {
-		returnMessage := fmt.Sprintf("Failed to unmarshal embedded NC publish request for NC %s, with err: %v", req.NetworkContainerID, err)
-		returnCode := types.NetworkContainerPublishFailed
-		logger.Errorf("[Azure-CNS] %s", returnMessage)
-		return returnMessage, returnCode, http.StatusInternalServerError
-	}
-
-	innerReq.AuthenticationToken = ncParameters.AuthToken
-	innerReq.PrimaryAddress = ncParameters.AssociatedInterfaceID
-	innerReq.ID = req.NetworkContainerID
-
-	err = h.nma.PutNetworkContainer(ctx, &innerReq)
-	// nolint:bodyclose // existing code needs refactoring
-	if err != nil {
-		returnMessage := fmt.Sprintf("Failed to publish Network Container %s in put Network Container call, with err: %v", req.NetworkContainerID, err)
-		returnCode := types.NetworkContainerPublishFailed
-		logger.Errorf("[Azure-CNS] %s", returnMessage)
-		var nmaErr nmagent.Error
-		if errors.As(err, &nmaErr) {
-			return returnMessage, returnCode, nmaErr.StatusCode()
-		}
-		return returnMessage, returnCode, http.StatusInternalServerError
-	}
-
-	return "", types.Success, http.StatusOK
-}
-
 func respondError(w http.ResponseWriter, statusCode int, body any) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(statusCode)
@@ -1203,38 +1167,41 @@ func (service *HTTPRestService) publishNetworkContainer(w http.ResponseWriter, r
 
 	ctx := r.Context()
 
-	joinResp, err := service.wsproxy.JoinNetwork(ctx, req.NetworkID)
-	if err != nil {
-		resp := cns.PublishNetworkContainerResponse{
-			Response: cns.Response{
-				ReturnCode: types.NetworkJoinFailed,
-				Message:    fmt.Sprintf("failed to join network %s: %v", req.NetworkID, err),
-			},
-			PublishErrorStr: err.Error(),
+	if !service.isNetworkJoined(req.NetworkID) {
+		joinResp, err := service.wsproxy.JoinNetwork(ctx, req.NetworkID)
+		if err != nil {
+			resp := cns.PublishNetworkContainerResponse{
+				Response: cns.Response{
+					ReturnCode: types.NetworkJoinFailed,
+					Message:    fmt.Sprintf("failed to join network %s: %v", req.NetworkID, err),
+				},
+				PublishErrorStr: err.Error(),
+			}
+			respondOK(w, resp) // legacy behavior
+			logger.Response(service.Name, resp, resp.Response.ReturnCode, err)
+			return
 		}
-		respondOK(w, resp) // legacy behavior
-		logger.Response(service.Name, resp, resp.Response.ReturnCode, err)
-		return
-	}
 
-	joinBytes, _ := io.ReadAll(joinResp.Body)
-	_ = joinResp.Body.Close()
+		joinBytes, _ := io.ReadAll(joinResp.Body)
+		_ = joinResp.Body.Close()
 
-	if joinResp.StatusCode != http.StatusOK {
-		resp := cns.PublishNetworkContainerResponse{
-			Response: cns.Response{
-				ReturnCode: types.NetworkJoinFailed,
-				Message:    fmt.Sprintf("failed to join network %s. did not get 200 from wireserver", req.NetworkID),
-			},
-			PublishStatusCode:   joinResp.StatusCode,
-			PublishResponseBody: joinBytes,
+		if joinResp.StatusCode != http.StatusOK {
+			resp := cns.PublishNetworkContainerResponse{
+				Response: cns.Response{
+					ReturnCode: types.NetworkJoinFailed,
+					Message:    fmt.Sprintf("failed to join network %s. did not get 200 from wireserver", req.NetworkID),
+				},
+				PublishStatusCode:   joinResp.StatusCode,
+				PublishResponseBody: joinBytes,
+			}
+			respondOK(w, resp) // legacy behavior
+			logger.Response(service.Name, resp, resp.Response.ReturnCode, nil)
+			return
 		}
-		respondOK(w, resp) // legacy behavior
-		logger.Response(service.Name, resp, resp.Response.ReturnCode, nil)
-		return
-	}
 
-	logger.Printf("[Azure-CNS] joined vnet %s during nc %s publish. wireserver response: %v", req.NetworkID, req.NetworkContainerID, string(joinBytes))
+		service.setNetworkStateJoined(req.NetworkID)
+		logger.Printf("[Azure-CNS] joined vnet %s during nc %s publish. wireserver response: %v", req.NetworkID, req.NetworkContainerID, string(joinBytes))
+	}
 
 	publishResp, err := service.wsproxy.PublishNC(ctx, ncParams, req.CreateNetworkContainerRequestBody)
 	if err != nil {
@@ -1253,141 +1220,118 @@ func (service *HTTPRestService) publishNetworkContainer(w http.ResponseWriter, r
 	publishBytes, _ := io.ReadAll(publishResp.Body)
 	_ = publishResp.Body.Close()
 
-	if publishResp.StatusCode != http.StatusOK {
-		resp := cns.PublishNetworkContainerResponse{
-			Response: cns.Response{
-				ReturnCode: types.NetworkContainerPublishFailed,
-				Message:    fmt.Sprintf("failed to publish nc %s. did not get 200 from wireserver", req.NetworkContainerID),
-			},
-			PublishStatusCode:   publishResp.StatusCode,
-			PublishResponseBody: publishBytes,
-		}
-		respondOK(w, resp) // legacy behavior
-		logger.Response(service.Name, resp, resp.Response.ReturnCode, nil)
-		return
-	}
-
 	resp := cns.PublishNetworkContainerResponse{
 		PublishStatusCode:   publishResp.StatusCode,
 		PublishResponseBody: publishBytes,
+	}
+
+	if publishResp.StatusCode != http.StatusOK {
+		resp.Response = cns.Response{
+			ReturnCode: types.NetworkContainerPublishFailed,
+			Message:    fmt.Sprintf("failed to publish nc %s. did not get 200 from wireserver", req.NetworkContainerID),
+		}
 	}
 
 	respondOK(w, resp)
 	logger.Response(service.Name, resp, resp.Response.ReturnCode, nil)
 }
 
-// Unpublish Network Container by calling nmagent
 func (service *HTTPRestService) unpublishNetworkContainer(w http.ResponseWriter, r *http.Request) {
-	logger.Printf("[Azure-CNS] UnpublishNetworkContainer")
-	ctx := r.Context()
-
-	var (
-		req               cns.UnpublishNetworkContainerRequest
-		returnCode        types.ResponseCode
-		returnMessage     string
-		unpublishErrorStr string
-		isNetworkJoined   bool
-	)
-
-	unpublishStatusCode := http.StatusOK
-
-	err := service.Listener.Decode(w, r, &req)
-
-	deleteNcURLCopy := req.DeleteNetworkContainerURL
-
-	// reqCopy creates a copy of incoming request. It doesn't copy the authentication token info
-	// to avoid logging it.
-	reqCopy := cns.UnpublishNetworkContainerRequest{
-		NetworkID:                 req.NetworkID,
-		NetworkContainerID:        req.NetworkContainerID,
-		JoinNetworkURL:            req.JoinNetworkURL,
-		DeleteNetworkContainerURL: strings.Split(req.DeleteNetworkContainerURL, "authenticationToken")[0],
-	}
-
-	logger.Request(service.Name, &reqCopy, err)
-	if err != nil {
+	if r.Method != http.MethodPost {
+		http.Error(w, "UnpublishNetworkContainer expects a POST", http.StatusBadRequest)
 		return
 	}
 
-	ncParameters, err := extractNCParamsFromURL(deleteNcURLCopy)
-	if err != nil {
-		logger.Errorf("[Azure-CNS] nc parameters validation failed with %+v", err)
-		w.WriteHeader(http.StatusBadRequest)
+	var req cns.UnpublishNetworkContainerRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("could not decode request body: %v", err), http.StatusBadRequest)
+		return
+	}
 
-		badRequestResponse := &cns.UnpublishNetworkContainerResponse{
+	logger.Request(service.Name, req, nil)
+
+	ncParams, err := extractNCParamsFromURL(req.DeleteNetworkContainerURL)
+	if err != nil {
+		resp := cns.UnpublishNetworkContainerResponse{
 			Response: cns.Response{
 				ReturnCode: http.StatusBadRequest,
-				Message:    fmt.Sprintf("Request contains a unexpected delete url format in request body: %v", reqCopy.DeleteNetworkContainerURL),
+				Message:    fmt.Sprintf("unexpected delete nc url format. url %s: %v ", req.DeleteNetworkContainerURL, err),
 			},
-			UnpublishErrorStr:   fmt.Sprintf("Bad request: Request contains a unexpected delete url format in request body: %v", reqCopy.DeleteNetworkContainerURL),
-			UnpublishStatusCode: http.StatusBadRequest,
 		}
-		err = service.Listener.Encode(w, &badRequestResponse)
-		logger.Response(service.Name, badRequestResponse, badRequestResponse.Response.ReturnCode, err)
+		respondError(w, http.StatusBadRequest, resp)
+		logger.Response(service.Name, resp, resp.Response.ReturnCode, err)
 		return
 	}
 
-	switch r.Method {
-	case http.MethodPost:
-		// Join Network if not joined already
-		isNetworkJoined = service.isNetworkJoined(req.NetworkID)
-		if !isNetworkJoined {
-			// nolint:bodyclose // existing code needs refactoring
-			err = service.joinNetwork(ctx, req.NetworkID)
-			if err != nil {
-				returnMessage = err.Error()
-				returnCode = types.NetworkJoinFailed
-				unpublishErrorStr = err.Error()
+	ctx := r.Context()
 
-				var nmaErr nmagent.Error
-				if errors.As(err, &nmaErr) {
-					unpublishStatusCode = nmaErr.StatusCode()
-				}
-
-			} else {
-				isNetworkJoined = true
+	if !service.isNetworkJoined(req.NetworkID) {
+		joinResp, err := service.wsproxy.JoinNetwork(ctx, req.NetworkID)
+		if err != nil {
+			resp := cns.UnpublishNetworkContainerResponse{
+				Response: cns.Response{
+					ReturnCode: types.NetworkJoinFailed,
+					Message:    fmt.Sprintf("failed to join network %s: %v", req.NetworkID, err),
+				},
+				UnpublishErrorStr: err.Error(),
 			}
+			respondOK(w, resp) // legacy behavior
+			logger.Response(service.Name, resp, resp.Response.ReturnCode, err)
+			return
 		}
 
-		if isNetworkJoined {
-			dcr := nmagent.DeleteContainerRequest{
-				NCID:                req.NetworkContainerID,
-				PrimaryAddress:      ncParameters.AssociatedInterfaceID,
-				AuthenticationToken: ncParameters.AuthToken,
-			}
+		joinBytes, _ := io.ReadAll(joinResp.Body)
+		_ = joinResp.Body.Close()
 
-			err = service.nma.DeleteNetworkContainer(ctx, dcr)
-			if err != nil {
-				returnMessage = fmt.Sprintf("Failed to unpublish Network Container: %s", req.NetworkContainerID)
-				returnCode = types.NetworkContainerUnpublishFailed
-				var nmaErr nmagent.Error
-				if errors.As(err, &nmaErr) {
-					unpublishStatusCode = nmaErr.StatusCode()
-				}
-				logger.Errorf("[Azure-CNS] %s", returnMessage)
+		if joinResp.StatusCode != http.StatusOK {
+			resp := cns.UnpublishNetworkContainerResponse{
+				Response: cns.Response{
+					ReturnCode: types.NetworkJoinFailed,
+					Message:    fmt.Sprintf("failed to join network %s. did not get 200 from wireserver", req.NetworkID),
+				},
+				UnpublishStatusCode:   joinResp.StatusCode,
+				UnpublishResponseBody: joinBytes,
 			}
+			respondOK(w, resp) // legacy behavior
+			logger.Response(service.Name, resp, resp.Response.ReturnCode, nil)
+			return
 		}
-	default:
-		returnMessage = "UnpublishNetworkContainer API expects a POST"
-		returnCode = types.UnsupportedVerb
+
+		service.setNetworkStateJoined(req.NetworkID)
+		logger.Printf("[Azure-CNS] joined vnet %s during nc %s unpublish. wireserver response: %v", req.NetworkID, req.NetworkContainerID, string(joinBytes))
 	}
 
-	// create a synthetic response from NMAgent so that clients that previously
-	// relied on its presence can continue to do so.
-	unpublishResponseBody := fmt.Sprintf(`{"httpStatusCode":"%d"}`, unpublishStatusCode)
-
-	response := cns.UnpublishNetworkContainerResponse{
-		Response: cns.Response{
-			ReturnCode: returnCode,
-			Message:    returnMessage,
-		},
-		UnpublishErrorStr:     unpublishErrorStr,
-		UnpublishStatusCode:   unpublishStatusCode,
-		UnpublishResponseBody: []byte(unpublishResponseBody),
+	publishResp, err := service.wsproxy.UnpublishNC(ctx, ncParams)
+	if err != nil {
+		resp := cns.UnpublishNetworkContainerResponse{
+			Response: cns.Response{
+				ReturnCode: types.NetworkContainerUnpublishFailed,
+				Message:    fmt.Sprintf("failed to publish nc %s: %v", req.NetworkContainerID, err),
+			},
+			UnpublishErrorStr: err.Error(),
+		}
+		respondOK(w, resp) // legacy behavior
+		logger.Response(service.Name, resp, resp.Response.ReturnCode, err)
+		return
 	}
 
-	err = service.Listener.Encode(w, &response)
-	logger.Response(service.Name, response, response.Response.ReturnCode, err)
+	publishBytes, _ := io.ReadAll(publishResp.Body)
+	_ = publishResp.Body.Close()
+
+	resp := cns.UnpublishNetworkContainerResponse{
+		UnpublishStatusCode:   publishResp.StatusCode,
+		UnpublishResponseBody: publishBytes,
+	}
+
+	if publishResp.StatusCode != http.StatusOK {
+		resp.Response = cns.Response{
+			ReturnCode: types.NetworkContainerUnpublishFailed,
+			Message:    fmt.Sprintf("failed to unpublish nc %s. did not get 200 from wireserver", req.NetworkContainerID),
+		}
+	}
+
+	respondOK(w, resp)
+	logger.Response(service.Name, resp, resp.Response.ReturnCode, nil)
 }
 
 func (service *HTTPRestService) createHostNCApipaEndpoint(w http.ResponseWriter, r *http.Request) {

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -1120,7 +1120,11 @@ func getAuthTokenAndInterfaceIDFromNcURL(networkContainerURL string) (*cns.Netwo
 		return nil, fmt.Errorf("unexpected number of matches in url, %w", ErrInvalidNcURLFormat)
 	}
 
-	return &cns.NetworkContainerParameters{AssociatedInterfaceID: matches[1], AuthToken: matches[3]}, nil
+	return &cns.NetworkContainerParameters{
+		AssociatedInterfaceID: matches[1],
+		NCID:                  matches[2],
+		AuthToken:             matches[3],
+	}, nil
 }
 
 //nolint:revive // the previous receiver naming "service" is bad, this is correct:

--- a/cns/restserver/api_test.go
+++ b/cns/restserver/api_test.go
@@ -1673,7 +1673,7 @@ func startService() error {
 	config.Store = fileStore
 
 	nmagentClient := &fakes.NMAgentClientFake{}
-	service, err = NewHTTPRestService(&config, &fakes.WireserverClientFake{}, nmagentClient, nil, nil, nil)
+	service, err = NewHTTPRestService(&config, &fakes.WireserverClientFake{}, &fakes.WireserverProxyFake{}, nmagentClient, nil, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/cns/restserver/ipam_test.go
+++ b/cns/restserver/ipam_test.go
@@ -40,7 +40,7 @@ var (
 
 func getTestService() *HTTPRestService {
 	var config common.ServiceConfig
-	httpsvc, _ := NewHTTPRestService(&config, &fakes.WireserverClientFake{}, &fakes.NMAgentClientFake{}, store.NewMockStore(""), nil, nil)
+	httpsvc, _ := NewHTTPRestService(&config, &fakes.WireserverClientFake{}, &fakes.WireserverProxyFake{}, &fakes.NMAgentClientFake{}, store.NewMockStore(""), nil, nil)
 	svc = httpsvc.(*HTTPRestService)
 	svc.IPAMPoolMonitor = &fakes.MonitorFake{}
 	setOrchestratorTypeInternal(cns.KubernetesCRD)

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -39,9 +39,6 @@ type interfaceGetter interface {
 }
 
 type nmagentClient interface {
-	PutNetworkContainer(context.Context, *nma.PutNetworkContainerRequest) error
-	DeleteNetworkContainer(context.Context, nma.DeleteContainerRequest) error
-	JoinNetwork(context.Context, nma.JoinNetworkRequest) error
 	SupportedAPIs(context.Context) ([]string, error)
 	GetNCVersionList(context.Context) (nma.NCVersionList, error)
 	GetHomeAz(context.Context) (nma.AzResponse, error)
@@ -152,7 +149,7 @@ type networkInfo struct {
 }
 
 // NewHTTPRestService creates a new HTTP Service object.
-func NewHTTPRestService(config *common.ServiceConfig, wscli interfaceGetter, nmagentClient nmagentClient,
+func NewHTTPRestService(config *common.ServiceConfig, wscli interfaceGetter, wsproxy wireserverProxy, nmagentClient nmagentClient,
 	endpointStateStore store.KeyValueStore, gen CNIConflistGenerator, homeAzMonitor *HomeAzMonitor,
 ) (cns.HTTPService, error) {
 	service, err := cns.NewService(config.Name, config.Version, config.ChannelMode, config.Store)
@@ -201,7 +198,7 @@ func NewHTTPRestService(config *common.ServiceConfig, wscli interfaceGetter, nma
 		wscli:                    wscli,
 		ipamClient:               ic,
 		nma:                      nmagentClient,
-		wsproxy:                  nil, // todo: inject
+		wsproxy:                  wsproxy,
 		networkContainer:         nc,
 		PodIPIDByPodInterfaceKey: podIPIDByPodInterfaceKey,
 		PodIPConfigState:         podIPConfigState,

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -3,6 +3,7 @@ package restserver
 import (
 	"context"
 	"net"
+	"net/http"
 	"sync"
 	"time"
 
@@ -20,7 +21,6 @@ import (
 	nma "github.com/Azure/azure-container-networking/nmagent"
 	"github.com/Azure/azure-container-networking/store"
 	"github.com/pkg/errors"
-	"net/http"
 )
 
 // This file contains the initialization of RestServer.

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -16,7 +16,6 @@ import (
 	"github.com/Azure/azure-container-networking/cns/types"
 	"github.com/Azure/azure-container-networking/cns/wireserver"
 	acn "github.com/Azure/azure-container-networking/common"
-	"github.com/Azure/azure-container-networking/nmagent"
 	"github.com/Azure/azure-container-networking/platform"
 	"github.com/Azure/azure-container-networking/store"
 	"github.com/pkg/errors"
@@ -666,24 +665,6 @@ func (service *HTTPRestService) setNetworkStateJoined(networkID string) {
 	defer namedLock.LockRelease(stateJoinedNetworks)
 
 	service.state.joinedNetworks[networkID] = struct{}{}
-}
-
-// Join Network by calling nmagent
-func (service *HTTPRestService) joinNetwork(ctx context.Context, networkID string) error {
-	req := nmagent.JoinNetworkRequest{
-		NetworkID: networkID,
-	}
-
-	err := service.nma.JoinNetwork(ctx, req)
-	if err != nil {
-		return errors.Wrap(err, "sending join network request")
-	}
-
-	// Network joined successfully
-	service.setNetworkStateJoined(networkID)
-	logger.Printf("[Azure-CNS] setNetworkStateJoined for network: %s", networkID)
-
-	return nil
 }
 
 func logNCSnapshot(createNetworkContainerRequest cns.CreateNetworkContainerRequest) {

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -642,9 +642,12 @@ func main() {
 		}
 	}
 
-	// Create CNS object.
+	wsProxy := wireserver.Proxy{
+		Host:       cnsconfig.WireserverIP,
+		HTTPClient: &http.Client{},
+	}
 
-	httpRestService, err := restserver.NewHTTPRestService(&config, &wireserver.Client{HTTPClient: &http.Client{}}, nmaClient,
+	httpRestService, err := restserver.NewHTTPRestService(&config, &wireserver.Client{HTTPClient: &http.Client{}}, &wsProxy, nmaClient,
 		endpointStateStore, conflistGenerator, homeAzMonitor)
 	if err != nil {
 		logger.Errorf("Failed to create CNS object, err:%v.\n", err)

--- a/cns/wireserver/proxy.go
+++ b/cns/wireserver/proxy.go
@@ -1,0 +1,69 @@
+package wireserver
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/pkg/errors"
+	"net/http"
+)
+
+const (
+	joinNetworkURLFmt = `http://%s/machine/plugins/?comp=nmagent&type=NetworkManagement/joinedVirtualNetworks/%s/api-version/1`
+	publishNCURLFmt   = `http://%s/machine/plugins/?comp=nmagent&type=NetworkManagement/interfaces/%s/networkContainers/%s/authenticationToken/%s/api-version/1`
+	unpublishNCURLFmt = `http://%s/machine/plugins/?comp=nmagent&type=NetworkManagement/interfaces/%s/networkContainers/%s/authenticationToken/%s/api-version/1/method/DELETE`
+)
+
+type Proxy struct {
+	Host       string
+	HTTPClient do
+}
+
+func (p *Proxy) JoinNetwork(ctx context.Context, vnetID string) (*http.Response, error) {
+	reqURL := fmt.Sprintf(joinNetworkURLFmt, p.Host, vnetID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewBufferString(`""`))
+	if err != nil {
+		return nil, errors.Wrap(err, "wireserver proxy: join network: could not build http request")
+	}
+
+	resp, err := p.HTTPClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "wireserver proxy: join network: could not perform http request")
+	}
+
+	return resp, nil
+}
+
+func (p *Proxy) PublishNC(ctx context.Context, ncParams cns.NetworkContainerParameters, payload []byte) (*http.Response, error) {
+	reqURL := fmt.Sprintf(publishNCURLFmt, p.Host, ncParams.AssociatedInterfaceID, ncParams.NCID, ncParams.AuthToken)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewBuffer(payload))
+	if err != nil {
+		return nil, errors.Wrap(err, "wireserver proxy: publish nc: could not build http request")
+	}
+
+	resp, err := p.HTTPClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "wireserver proxy: publish nc: could not perform http request")
+	}
+
+	return resp, nil
+}
+
+func (p *Proxy) UnpublishNC(ctx context.Context, ncParams cns.NetworkContainerParameters) (*http.Response, error) {
+	reqURL := fmt.Sprintf(unpublishNCURLFmt, p.Host, ncParams.AssociatedInterfaceID, ncParams.NCID, ncParams.AuthToken)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewBufferString(`""`))
+	if err != nil {
+		return nil, errors.Wrap(err, "wireserver proxy: unpublish nc: could not build http request")
+	}
+
+	resp, err := p.HTTPClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "wireserver proxy: unpublish nc: could not perform http request")
+	}
+
+	return resp, nil
+}

--- a/cns/wireserver/proxy.go
+++ b/cns/wireserver/proxy.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http"
+
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/pkg/errors"
-	"net/http"
 )
 
 const (
@@ -28,6 +29,8 @@ func (p *Proxy) JoinNetwork(ctx context.Context, vnetID string) (*http.Response,
 		return nil, errors.Wrap(err, "wireserver proxy: join network: could not build http request")
 	}
 
+	req.Header.Set("Content-Type", "application/json")
+
 	resp, err := p.HTTPClient.Do(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "wireserver proxy: join network: could not perform http request")
@@ -44,6 +47,8 @@ func (p *Proxy) PublishNC(ctx context.Context, ncParams cns.NetworkContainerPara
 		return nil, errors.Wrap(err, "wireserver proxy: publish nc: could not build http request")
 	}
 
+	req.Header.Set("Content-Type", "application/json")
+
 	resp, err := p.HTTPClient.Do(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "wireserver proxy: publish nc: could not perform http request")
@@ -59,6 +64,8 @@ func (p *Proxy) UnpublishNC(ctx context.Context, ncParams cns.NetworkContainerPa
 	if err != nil {
 		return nil, errors.Wrap(err, "wireserver proxy: unpublish nc: could not build http request")
 	}
+
+	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := p.HTTPClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

This PR adds a simple wireserver "proxy", which is mostly aware of how to construct the correct requests to wireserver/nmagent, but is only in charge of making the requests, not interpret the responses. This PR also cleans up some of the existing logic to make the flow of code and all possible return paths clearer, as well as improving some of the logging of requests/responses.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
