### PR TITLE
fix: [NPM-WIN] do not refresh endpoints if pod cache is empty

### DIFF
--- a/npm/pkg/dataplane/dataplane.go
+++ b/npm/pkg/dataplane/dataplane.go
@@ -216,6 +216,11 @@ func (dp *DataPlane) ApplyDataPlane() error {
 
 	// NOTE: ideally we won't refresh Pod Endpoints if the updatePodCache is empty
 	if dp.shouldUpdatePod() {
+		// do not refresh endpoints if the updatePodCache is empty
+		if len(dp.updatePodCache.cache) == 0 {
+			return nil
+		}
+
 		err := dp.refreshPodEndpoints()
 		if err != nil {
 			metrics.SendErrorLogAndMetric(util.DaemonDataplaneID, "[DataPlane] failed to refresh endpoints while updating pods. err: [%s]", err.Error())

--- a/npm/pkg/dataplane/dataplane.go
+++ b/npm/pkg/dataplane/dataplane.go
@@ -216,15 +216,13 @@ func (dp *DataPlane) ApplyDataPlane() error {
 
 	// NOTE: ideally we won't refresh Pod Endpoints if the updatePodCache is empty
 	if dp.shouldUpdatePod() {
-		// lock updatePodCache while driving goal state to kernel
-		// prevents another ApplyDataplane call from updating the same pods
-		dp.updatePodCache.Lock()
-		defer dp.updatePodCache.Unlock()
-
 		// do not refresh endpoints if the updatePodCache is empty
-		if len(dp.updatePodCache.cache) == 0 {
+		dp.updatePodCache.Lock()
+		if len(dp.updatePodCache.cache) != 0 {
+			dp.updatePodCache.Unlock()
 			return nil
 		}
+		dp.updatePodCache.Unlock()
 
 		err := dp.refreshPodEndpoints()
 		if err != nil {
@@ -232,6 +230,11 @@ func (dp *DataPlane) ApplyDataPlane() error {
 			// return as success since this can be retried irrespective of other operations
 			return nil
 		}
+
+		// lock updatePodCache while driving goal state to kernel
+		// prevents another ApplyDataplane call from updating the same pods
+		dp.updatePodCache.Lock()
+		defer dp.updatePodCache.Unlock()
 
 		for podKey, pod := range dp.updatePodCache.cache {
 			err := dp.updatePod(pod)

--- a/npm/pkg/dataplane/dataplane.go
+++ b/npm/pkg/dataplane/dataplane.go
@@ -218,7 +218,7 @@ func (dp *DataPlane) ApplyDataPlane() error {
 	if dp.shouldUpdatePod() {
 		// do not refresh endpoints if the updatePodCache is empty
 		dp.updatePodCache.Lock()
-		if len(dp.updatePodCache.cache) != 0 {
+		if len(dp.updatePodCache.cache) == 0 {
 			dp.updatePodCache.Unlock()
 			return nil
 		}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Not refreshing when not necessary improves NPM efficiency

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
