### PR TITLE
chore: [WIN-NPM] update mcr image to v1.4.45 for capz testing

### DIFF
--- a/npm/examples/windows/azure-npm-capz.yaml
+++ b/npm/examples/windows/azure-npm-capz.yaml
@@ -84,7 +84,7 @@ spec:
       containers:
         - name: azure-npm
           # setting to future version since it will use the updated Dockerfile
-          image: mcr.microsoft.com/containernetworking/azure-npm:v1.4.42
+          image: mcr.microsoft.com/containernetworking/azure-npm:v1.4.45
           command: ["powershell.exe"]
           args:
             [


### PR DESCRIPTION
Update to latest image. Impacts testing of windows nightly builds run on capz (separate repo)