### PR TITLE
Improving port forwarding error handling

### DIFF
--- a/test/integration/label.go
+++ b/test/integration/label.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package k8s
 
 import (

--- a/test/integration/portforward.go
+++ b/test/integration/portforward.go
@@ -6,7 +6,10 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
+	"sync"
+	"time"
 
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -14,91 +17,87 @@ import (
 	"k8s.io/client-go/transport/spdy"
 )
 
-// PortForwarder can initiate port forwarding to a k8s pod.
+type logger interface {
+	Logf(format string, args ...any)
+}
+
+// PortForwarder can manage a port forwarding session.
 type PortForwarder struct {
 	clientset *kubernetes.Clientset
 	transport http.RoundTripper
 	upgrader  spdy.Upgrader
+	logger    logger
+
+	opts PortForwardingOpts
+
+	stopChan    chan struct{}
+	errChan     chan error
+	address     string
+	lazyAddress sync.Once
 }
 
-// PortForwardStreamHandle contains information about the port forwarding session and can terminate it.
-type PortForwardStreamHandle struct {
-	url      string
-	stopChan chan struct{}
-	errChan  chan error
-}
-
-// Stop terminates a port forwarding session.
-func (p *PortForwardStreamHandle) Stop() {
-	p.stopChan <- struct{}{}
-}
-
-// Error returns a channel where any port forwarding errors during runtime are sent.
-// Receiving from this channel generally indicates that the port forwarding session
-// should be stopped.
-//
-// as of client-go v0.26.1, if the connection is successful at first but then fails,
-// an error is logged but not sent to this channel. this will be fixed in v0.27.x,
-// which at the time of writing has not been released.
-//
-// see https://github.com/kubernetes/client-go/commit/d0842249d3b92ea67c446fe273f84fe74ebaed9f
-// for the relevant change.
-func (p *PortForwardStreamHandle) Error() chan error {
-	return p.errChan
-}
-
-// Url returns a url for communicating with the pod.
-func (p *PortForwardStreamHandle) Url() string {
-	return p.url
+type PortForwardingOpts struct {
+	Namespace     string
+	LabelSelector string
+	LocalPort     int
+	DestPort      int
 }
 
 // NewPortForwarder creates a PortForwarder.
-func NewPortForwarder(restConfig *rest.Config) (*PortForwarder, error) {
+func NewPortForwarder(restConfig *rest.Config, logger logger, opts PortForwardingOpts) (*PortForwarder, error) {
 	clientset, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
-		return nil, fmt.Errorf("could not create clientset: %v", err)
+		return nil, fmt.Errorf("could not create clientset: %w", err)
 	}
+
 	transport, upgrader, err := spdy.RoundTripperFor(restConfig)
 	if err != nil {
-		return nil, fmt.Errorf("could not create spdy roundtripper: %v", err)
+		return nil, fmt.Errorf("could not create spdy roundtripper: %w", err)
 	}
+
 	return &PortForwarder{
 		clientset: clientset,
 		transport: transport,
 		upgrader:  upgrader,
+		logger:    logger,
+		opts:      opts,
+		stopChan:  make(chan struct{}, 1),
 	}, nil
 }
 
 // todo: can be made more flexible to allow a service to be specified
 
-// Forward attempts to initiate port forwarding to the specified pod and port using labels.
-func (p *PortForwarder) Forward(ctx context.Context, namespace, labelSelector string, localPort, destPort int) (PortForwardStreamHandle, error) {
-	pods, err := p.clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector, FieldSelector: "status.phase=Running"})
+// Forward attempts to initiate port forwarding a pod and port using the configured namespace and labels.
+// An error is returned if a port forwarding session could not be started. If no error is returned, the
+// Address method can be used to communicate with the pod, and the Stop and KeepAlive methods can be used
+// to manage the lifetime of the port forwarding session.
+func (p *PortForwarder) Forward(ctx context.Context) error {
+	pods, err := p.clientset.CoreV1().Pods(p.opts.Namespace).List(ctx, metav1.ListOptions{LabelSelector: p.opts.LabelSelector, FieldSelector: "status.phase=Running"})
 	if err != nil {
-		return PortForwardStreamHandle{}, fmt.Errorf("could not list pods in %q with label %q: %v", namespace, labelSelector, err)
+		return fmt.Errorf("could not list pods in %q with label %q: %w", p.opts.Namespace, p.opts.LabelSelector, err)
 	}
+
 	if len(pods.Items) < 1 {
-		return PortForwardStreamHandle{}, fmt.Errorf("no pods found in %q with label %q", namespace, labelSelector)
+		return fmt.Errorf("no pods found in %q with label %q", p.opts.Namespace, p.opts.LabelSelector) //nolint:goerr113 //no specific handling expected
 	}
+
 	randomIndex := rand.Intn(len(pods.Items))
 	podName := pods.Items[randomIndex].Name
 	portForwardURL := p.clientset.CoreV1().RESTClient().Post().
 		Resource("pods").
-		Namespace(namespace).
+		Namespace(p.opts.Namespace).
 		Name(podName).
 		SubResource("portforward").URL()
 
-	stopChan := make(chan struct{}, 1)
-	errChan := make(chan error, 1)
 	readyChan := make(chan struct{}, 1)
-
 	dialer := spdy.NewDialer(p.upgrader, &http.Client{Transport: p.transport}, http.MethodPost, portForwardURL)
-	ports := []string{fmt.Sprintf("%d:%d", localPort, destPort)}
-	pf, err := portforward.New(dialer, ports, stopChan, readyChan, io.Discard, io.Discard)
+	ports := []string{fmt.Sprintf("%d:%d", p.opts.LocalPort, p.opts.DestPort)}
+	pf, err := portforward.New(dialer, ports, p.stopChan, readyChan, io.Discard, io.Discard)
 	if err != nil {
-		return PortForwardStreamHandle{}, fmt.Errorf("could not create portforwarder: %v", err)
+		return fmt.Errorf("could not create portforwarder: %w", err)
 	}
 
+	errChan := make(chan error, 1)
 	go func() {
 		// ForwardPorts is a blocking function thus it has to be invoked in a goroutine to allow callers to do
 		// other things, but it can return 2 kinds of errors: initial dial errors that will be caught in the select
@@ -111,26 +110,74 @@ func (p *PortForwarder) Forward(ctx context.Context, namespace, labelSelector st
 	var portForwardPort int
 	select {
 	case <-ctx.Done():
-		return PortForwardStreamHandle{}, ctx.Err()
+		return fmt.Errorf("portforward cancelled: %w", ctx.Err())
 	case err := <-errChan:
-		return PortForwardStreamHandle{}, fmt.Errorf("portforward failed: %v", err)
+		return fmt.Errorf("portforward failed: %w", err)
 	case <-pf.Ready:
-		ports, err := pf.GetPorts()
+		prts, err := pf.GetPorts()
 		if err != nil {
-			return PortForwardStreamHandle{}, fmt.Errorf("get portforward port: %v", err)
+			return fmt.Errorf("get portforward port: %w", err)
 		}
-		for _, port := range ports {
-			portForwardPort = int(port.Local)
-			break
+
+		if len(prts) < 1 {
+			return errors.New("no ports forwarded")
 		}
-		if portForwardPort < 1 {
-			return PortForwardStreamHandle{}, fmt.Errorf("invalid port returned: %d", portForwardPort)
-		}
+
+		portForwardPort = int(prts[0].Local)
 	}
 
-	return PortForwardStreamHandle{
-		url:      fmt.Sprintf("http://localhost:%d", portForwardPort),
-		stopChan: stopChan,
-		errChan:  errChan,
-	}, nil
+	// once successful, any subsequent port forwarding sessions from keep alive would yield the same address.
+	// since the address could be read at the same time as the session is renewed, it's appropriate to initialize
+	// lazily.
+	p.lazyAddress.Do(func() {
+		p.address = fmt.Sprintf("http://localhost:%d", portForwardPort)
+	})
+
+	p.errChan = errChan
+
+	return nil
+}
+
+// Address returns an address for communicating with a port-forwarded pod.
+func (p *PortForwarder) Address() string {
+	return p.address
+}
+
+// Stop terminates a port forwarding session.
+func (p *PortForwarder) Stop() {
+	select {
+	case p.stopChan <- struct{}{}:
+	default:
+	}
+}
+
+// KeepAlive can be used to restart the port forwarding session in the background.
+func (p *PortForwarder) KeepAlive(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			p.logger.Logf("port forwarder: keep alive cancelled: %v", ctx.Err())
+			return
+		case pfErr := <-p.errChan:
+			// as of client-go v0.26.1, if the connection is successful at first but then fails,
+			// an error is logged but only a nil error is sent to this channel. this will be fixed
+			// in v0.27.x, which at the time of writing has not been released.
+			//
+			// see https://github.com/kubernetes/client-go/commit/d0842249d3b92ea67c446fe273f84fe74ebaed9f
+			// for the relevant change.
+			p.logger.Logf("port forwarder: received error signal: %v. restarting session", pfErr)
+			p.Stop()
+			if err := p.Forward(ctx); err != nil {
+				p.logger.Logf("port forwarder: could not restart session: %v. retrying", err)
+
+				select {
+				case <-ctx.Done():
+					p.logger.Logf("port forwarder: keep alive cancelled: %v", ctx.Err())
+					return
+				case <-time.After(time.Second): // todo: make configurable?
+					continue
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
**Reason for Change**:

Port forwarding to a Kubernetes pod can be brittle but can be restarted if the appropriate signals are handled. This PR improves the API of the internal port forwarding wrapper `PortForwarder` to allow clients to maintain port forwarding sessions alive.

Example usage:

```go
pfOpts := PortForwardingOpts{
    Namespace:     "default",
    LabelSelector: "type=goldpinger-pod",
    LocalPort:     9090,
    DestPort:      8080,
}

pf, _ := NewPortForwarder(restConfig, logger, pfOpts)

if err := pf.Forward(ctx); err != nil {
    // errors if initial connection fails
}

go pf.KeepAlive(ctx) // handles connection failures and re-attempts to port forward any pod matching the opts to the same local address

defer pf.Stop()
```

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [ ] adds unit tests


**Notes**:
