### PR TITLE
fix: [WIN-NPM] revert breaking change to .exe filename

### DIFF
--- a/npm/examples/windows/azure-npm.yaml
+++ b/npm/examples/windows/azure-npm.yaml
@@ -83,14 +83,14 @@ spec:
       hostNetwork: true
       containers:
         - name: azure-npm
-          image: mcr.microsoft.com/containernetworking/azure-npm:v1.4.29
+          image: mcr.microsoft.com/containernetworking/azure-npm:v1.4.45
           command: ["powershell.exe"]
           args:
             [
               '.\setkubeconfigpath.ps1',
               ";",
               "powershell.exe",
-              '.\azure-npm.exe',
+              '.\npm.exe',
               "start",
               '--kubeconfig=.\kubeconfig',
             ]

--- a/npm/windows.Dockerfile
+++ b/npm/windows.Dockerfile
@@ -11,5 +11,5 @@ FROM mcr.microsoft.com/windows/servercore:${OS_VERSION}
 COPY --from=builder /usr/local/src/npm/examples/windows/kubeconfigtemplate.yaml kubeconfigtemplate.yaml
 COPY --from=builder /usr/local/src/npm/examples/windows/setkubeconfigpath.ps1 setkubeconfigpath.ps1
 COPY --from=builder /usr/local/src/npm/examples/windows/setkubeconfigpath-capz.ps1 setkubeconfigpath-capz.ps1
-COPY --from=builder /usr/local/bin/azure-npm.exe azure-npm.exe
-CMD ["azure-npm.exe", "start" "--kubeconfig=.\\kubeconfig"]
+COPY --from=builder /usr/local/bin/azure-npm.exe npm.exe
+CMD ["npm.exe", "start" "--kubeconfig=.\\kubeconfig"]


### PR DESCRIPTION
Revert .exe change from:
1. https://github.com/Azure/azure-container-networking/pull/1820
2. https://github.com/Azure/azure-container-networking/pull/1838

These changes would break production DaemonSets since the DaemonSet change rolls out async with the image upgrade.