### PR TITLE
build azure-vnet-telemetry and azure-vnet-ipam in dropgz-test

### DIFF
--- a/dropgz/build/cniTest.Dockerfile
+++ b/dropgz/build/cniTest.Dockerfile
@@ -9,6 +9,8 @@ ARG VERSION
 WORKDIR /azure-container-networking
 COPY . .
 RUN CGO_ENABLED=0 go build -a -o bin/azure-vnet -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/plugin/main.go
+RUN CGO_ENABLED=0 go build -a -o bin/azure-vnet-telemetry -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/telemetry/service/telemetrymain.go
+RUN CGO_ENABLED=0 go build -a -o bin/azure-vnet-ipam -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/ipam/plugin/main.go
 
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS compressor
 ARG OS


### PR DESCRIPTION
for parity with release image. 
this was causing test failures, as we [try to deploy these bins](https://github.com/Azure/azure-container-networking/commit/9dc035473b01ea4b72f5c3a3cb21d5a4fbc3d9cd) which are present in the release image but were not being built in the test image.

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
