### PR TITLE
fix: Windows CNI Overlay Gateway Bug

### DIFF
--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -110,9 +110,10 @@ func (invoker *CNSIPAMInvoker) Add(addConfig IPAMAddConfig) (IPAMAddResult, erro
 			return IPAMAddResult{}, errors.Wrap(errInvalidArgs, "%w: Gateway address "+info.ncGatewayIPAddress+" from response is invalid")
 		}
 
-		ncgw = ncipnet.IP.Mask(ncipnet.Mask)
+		ncgw = ncipnet.IP
 		ncgw[3]++
-		if !ncipnet.Contains(ncgw) {
+		ncgw = net.ParseIP(ncgw.String())
+		if ncgw == nil || !ncipnet.Contains(ncgw) {
 			return IPAMAddResult{}, errors.Wrap(errInvalidArgs, "%w: Invalid gateway address "+ncgw.String())
 		}
 	}

--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -110,11 +110,9 @@ func (invoker *CNSIPAMInvoker) Add(addConfig IPAMAddConfig) (IPAMAddResult, erro
 			return IPAMAddResult{}, errors.Wrap(errInvalidArgs, "%w: Gateway address "+info.ncGatewayIPAddress+" from response is invalid")
 		}
 
-		ncgw = ncipnet.IP
-		ncgw[3]++
-		ncgw = net.ParseIP(ncgw.String())
-		if ncgw == nil || !ncipnet.Contains(ncgw) {
-			return IPAMAddResult{}, errors.Wrap(errInvalidArgs, "%w: Invalid gateway address "+ncgw.String())
+		ncgw, err = getOverlayGateway(ncipnet)
+		if err != nil {
+			return IPAMAddResult{}, err
 		}
 	}
 

--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -20,9 +20,8 @@ import (
 )
 
 var (
-	errEmptyCNIArgs  = errors.New("empty CNI cmd args not allowed")
-	errInvalidArgs   = errors.New("invalid arg(s)")
-	overlayGatewayIP = "169.254.1.1"
+	errEmptyCNIArgs = errors.New("empty CNI cmd args not allowed")
+	errInvalidArgs  = errors.New("invalid arg(s)")
 )
 
 type CNSIPAMInvoker struct {
@@ -99,19 +98,23 @@ func (invoker *CNSIPAMInvoker) Add(addConfig IPAMAddConfig) (IPAMAddResult, erro
 
 	log.Printf("[cni-invoker-cns] Received info %+v for pod %v", info, podInfo)
 
+	// set result ipconfigArgument from CNS Response Body
+	ip, ncipnet, err := net.ParseCIDR(info.podIPAddress + "/" + fmt.Sprint(info.ncSubnetPrefix))
+	if ip == nil {
+		return IPAMAddResult{}, errors.Wrap(err, "Unable to parse IP from response: "+info.podIPAddress+" with err %w")
+	}
+
 	ncgw := net.ParseIP(info.ncGatewayIPAddress)
 	if ncgw == nil {
 		if invoker.ipamMode != util.V4Overlay {
 			return IPAMAddResult{}, errors.Wrap(errInvalidArgs, "%w: Gateway address "+info.ncGatewayIPAddress+" from response is invalid")
 		}
 
-		ncgw = net.ParseIP(overlayGatewayIP)
-	}
-
-	// set result ipconfigArgument from CNS Response Body
-	ip, ncipnet, err := net.ParseCIDR(info.podIPAddress + "/" + fmt.Sprint(info.ncSubnetPrefix))
-	if ip == nil {
-		return IPAMAddResult{}, errors.Wrap(err, "Unable to parse IP from response: "+info.podIPAddress+" with err %w")
+		ncgw = ncipnet.IP.Mask(ncipnet.Mask)
+		ncgw[3]++
+		if !ncipnet.Contains(ncgw) {
+			return IPAMAddResult{}, errors.Wrap(errInvalidArgs, "%w: Invalid gateway address "+ncgw.String())
+		}
 	}
 
 	// construct ipnet for result

--- a/cni/network/invoker_cns_test.go
+++ b/cni/network/invoker_cns_test.go
@@ -2,7 +2,6 @@ package network
 
 import (
 	"errors"
-	"fmt"
 	"net"
 	"testing"
 
@@ -41,12 +40,6 @@ func TestCNSIPAMInvoker_Add(t *testing.T) {
 		hostSubnetPrefix *net.IPNet
 		options          map[string]interface{}
 	}
-
-	overlayPodIP := "10.240.1.242"
-	var overlayNcSubnetPrefix uint8 = 16
-	_, ncipnet, _ := net.ParseCIDR(fmt.Sprintf("%s/%d", overlayPodIP, overlayNcSubnetPrefix))
-	overlayGateway := ncipnet.IP.Mask(ncipnet.Mask)
-	overlayGateway[3]++
 
 	tests := []struct {
 		name    string
@@ -154,13 +147,13 @@ func TestCNSIPAMInvoker_Add(t *testing.T) {
 						result: &cns.IPConfigResponse{
 							PodIpInfo: cns.PodIpInfo{
 								PodIPConfig: cns.IPSubnet{
-									IPAddress:    overlayPodIP,
-									PrefixLength: overlayNcSubnetPrefix,
+									IPAddress:    "10.240.1.242",
+									PrefixLength: 16,
 								},
 								NetworkContainerPrimaryIPConfig: cns.IPConfiguration{
 									IPSubnet: cns.IPSubnet{
 										IPAddress:    "10.240.1.0",
-										PrefixLength: overlayNcSubnetPrefix,
+										PrefixLength: 16,
 									},
 									DNSServers:       nil,
 									GatewayIPAddress: "",
@@ -194,13 +187,13 @@ func TestCNSIPAMInvoker_Add(t *testing.T) {
 				IPs: []*cniTypesCurr.IPConfig{
 					{
 						Address: *getCIDRNotationForAddress("10.240.1.242/16"),
-						Gateway: overlayGateway,
+						Gateway: net.ParseIP("10.240.0.1"),
 					},
 				},
 				Routes: []*cniTypes.Route{
 					{
 						Dst: network.Ipv4DefaultRouteDstPrefix,
-						GW:  overlayGateway,
+						GW:  net.ParseIP("10.240.0.1"),
 					},
 				},
 			},

--- a/cni/network/invoker_cns_test.go
+++ b/cni/network/invoker_cns_test.go
@@ -2,7 +2,9 @@ package network
 
 import (
 	"errors"
+	"fmt"
 	"net"
+	"runtime"
 	"testing"
 
 	"github.com/Azure/azure-container-networking/cni"
@@ -24,6 +26,14 @@ func getTestIPConfigRequest() cns.IPConfigRequest {
 		InfraContainerID:    "testcontainerid",
 		OrchestratorContext: marshallPodInfo(testPodInfo),
 	}
+}
+
+func getTestOverlayGateway() net.IP {
+	if runtime.GOOS == "windows" {
+		return net.ParseIP("10.240.0.1")
+	}
+
+	return net.ParseIP("169.254.1.1")
 }
 
 func TestCNSIPAMInvoker_Add(t *testing.T) {
@@ -187,13 +197,13 @@ func TestCNSIPAMInvoker_Add(t *testing.T) {
 				IPs: []*cniTypesCurr.IPConfig{
 					{
 						Address: *getCIDRNotationForAddress("10.240.1.242/16"),
-						Gateway: net.ParseIP("10.240.0.1"),
+						Gateway: getTestOverlayGateway(),
 					},
 				},
 				Routes: []*cniTypes.Route{
 					{
 						Dst: network.Ipv4DefaultRouteDstPrefix,
-						GW:  net.ParseIP("10.240.0.1"),
+						GW:  getTestOverlayGateway(),
 					},
 				},
 			},
@@ -219,6 +229,7 @@ func TestCNSIPAMInvoker_Add(t *testing.T) {
 				require.NoError(err)
 			}
 
+			fmt.Printf("want:%+v\nrest:%+v\n", tt.want, ipamAddResult.ipv4Result)
 			require.Equalf(tt.want, ipamAddResult.ipv4Result, "incorrect ipv4 response")
 			require.Equalf(tt.want1, ipamAddResult.ipv6Result, "incorrect ipv6 response")
 		})

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -538,7 +538,7 @@ func (plugin *NetPlugin) Add(args *cniSkel.CmdArgs) error {
 			logAndSendEvent(plugin, fmt.Sprintf("[cni-net] Created network %v with subnet %v.", networkID, ipamAddResult.hostSubnetPrefix.String()))
 		}
 
-		natInfo := getNATInfo(nwCfg.ExecutionMode, options[network.SNATIPKey], nwCfg.MultiTenancy, enableSnatForDNS)
+		natInfo := getNATInfo(nwCfg.ExecutionMode, nwCfg.IPAM.Mode, options[network.SNATIPKey], nwCfg.MultiTenancy, enableSnatForDNS)
 
 		createEndpointInternalOpt := createEndpointInternalOpt{
 			nwCfg:            nwCfg,

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -538,7 +538,7 @@ func (plugin *NetPlugin) Add(args *cniSkel.CmdArgs) error {
 			logAndSendEvent(plugin, fmt.Sprintf("[cni-net] Created network %v with subnet %v.", networkID, ipamAddResult.hostSubnetPrefix.String()))
 		}
 
-		natInfo := getNATInfo(nwCfg.ExecutionMode, nwCfg.IPAM.Mode, options[network.SNATIPKey], nwCfg.MultiTenancy, enableSnatForDNS)
+		natInfo := getNATInfo(nwCfg, options[network.SNATIPKey], enableSnatForDNS)
 
 		createEndpointInternalOpt := createEndpointInternalOpt{
 			nwCfg:            nwCfg,

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -136,7 +136,7 @@ func (plugin *NetPlugin) getNetworkName(_ string, _ *IPAMAddResult, nwCfg *cni.N
 	return nwCfg.Name, nil
 }
 
-func getNATInfo(_ string, _ interface{}, _, _ bool) (natInfo []policy.NATInfo) {
+func getNATInfo(_, _ string, _ interface{}, _, _ bool) (natInfo []policy.NATInfo) {
 	return natInfo
 }
 
@@ -145,4 +145,8 @@ func platformInit(cniConfig *cni.NetworkConfig) {}
 // isDualNicFeatureSupported returns if the dual nic feature is supported. Currently it's only supported for windows hnsv2 path
 func (plugin *NetPlugin) isDualNicFeatureSupported(netNs string) bool {
 	return false
+}
+
+func getOverlayGateway(_ *net.IPNet) (net.IP, error) {
+	return net.ParseIP("169.254.1.1"), nil
 }

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -136,7 +136,7 @@ func (plugin *NetPlugin) getNetworkName(_ string, _ *IPAMAddResult, nwCfg *cni.N
 	return nwCfg.Name, nil
 }
 
-func getNATInfo(_, _ string, _ interface{}, _, _ bool) (natInfo []policy.NATInfo) {
+func getNATInfo(_ *cni.NetworkConfig, _ interface{}, _ bool) (natInfo []policy.NATInfo) {
 	return natInfo
 }
 

--- a/cni/network/network_test.go
+++ b/cni/network/network_test.go
@@ -1007,11 +1007,15 @@ func TestGetAllEndpointState(t *testing.T) {
 
 	ep1 := getTestEndpoint("podname1", "podnamespace1", "10.0.0.1/24", "podinterfaceid1", "testcontainerid1")
 	ep2 := getTestEndpoint("podname2", "podnamespace2", "10.0.0.2/24", "podinterfaceid2", "testcontainerid2")
+	ep3 := getTestEndpoint("podname3", "podnamespace3", "10.240.1.242/16", "podinterfaceid3", "testcontainerid3")
 
 	err := plugin.nm.CreateEndpoint(nil, networkid, ep1)
 	require.NoError(t, err)
 
 	err = plugin.nm.CreateEndpoint(nil, networkid, ep2)
+	require.NoError(t, err)
+
+	err = plugin.nm.CreateEndpoint(nil, networkid, ep3)
 	require.NoError(t, err)
 
 	state, err := plugin.GetAllEndpointState(networkid)
@@ -1032,6 +1036,13 @@ func TestGetAllEndpointState(t *testing.T) {
 				PodNamespace:  ep2.PODNameSpace,
 				ContainerID:   ep2.ContainerID,
 				IPAddresses:   ep2.IPAddresses,
+			},
+			ep3.Id: {
+				PodEndpointId: ep3.Id,
+				PodName:       ep3.PODName,
+				PodNamespace:  ep3.PODNameSpace,
+				ContainerID:   ep3.ContainerID,
+				IPAddresses:   ep3.IPAddresses,
 			},
 		},
 	}

--- a/cni/network/network_test.go
+++ b/cni/network/network_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/Azure/azure-container-networking/cni"
@@ -11,6 +12,8 @@ import (
 	"github.com/Azure/azure-container-networking/cni/util"
 	"github.com/Azure/azure-container-networking/common"
 	acnnetwork "github.com/Azure/azure-container-networking/network"
+	"github.com/Azure/azure-container-networking/network/networkutils"
+	"github.com/Azure/azure-container-networking/network/policy"
 	"github.com/Azure/azure-container-networking/nns"
 	"github.com/Azure/azure-container-networking/telemetry"
 	cniSkel "github.com/containernetworking/cni/pkg/skel"
@@ -1084,4 +1087,18 @@ func TestGetOverlayNatInfo(t *testing.T) {
 	nwCfg := &cni.NetworkConfig{ExecutionMode: string(util.V4Swift), IPAM: cni.IPAM{Mode: string(util.V4Overlay)}}
 	natInfo := getNATInfo(nwCfg, nil, false)
 	require.Empty(t, natInfo, "overlay natInfo should be empty")
+}
+
+func TestGetPodSubnetNatInfo(t *testing.T) {
+	ncPrimaryIP := "10.241.0.4"
+	nwCfg := &cni.NetworkConfig{ExecutionMode: string(util.V4Swift)}
+	natInfo := getNATInfo(nwCfg, ncPrimaryIP, false)
+	if runtime.GOOS == "windows" {
+		require.Equalf(t, natInfo, []policy.NATInfo{
+			{VirtualIP: ncPrimaryIP, Destinations: []string{networkutils.AzureDNS}},
+			{Destinations: []string{networkutils.AzureIMDS}},
+		}, "invalid windows podsubnet natInfo")
+	} else {
+		require.Empty(t, natInfo, "linux podsubnet natInfo should be empty")
+	}
 }

--- a/cni/network/network_test.go
+++ b/cni/network/network_test.go
@@ -1079,3 +1079,9 @@ func TestGetNetworkName(t *testing.T) {
 		})
 	}
 }
+
+func TestGetOverlayNatInfo(t *testing.T) {
+	nwCfg := &cni.NetworkConfig{ExecutionMode: string(util.V4Swift), IPAM: cni.IPAM{Mode: string(util.V4Overlay)}}
+	natInfo := getNATInfo(nwCfg, nil, false)
+	require.Empty(t, natInfo, "overlay natInfo should be empty")
+}

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -378,8 +378,8 @@ func determineWinVer() {
 	}
 }
 
-func getNATInfo(executionMode string, ncPrimaryIPIface interface{}, multitenancy, enableSnatForDNS bool) (natInfo []policy.NATInfo) {
-	if executionMode == string(util.V4Swift) {
+func getNATInfo(executionMode, ipamMode string, ncPrimaryIPIface interface{}, multitenancy, enableSnatForDNS bool) (natInfo []policy.NATInfo) {
+	if executionMode == string(util.V4Swift) && ipamMode != string(util.V4Overlay) {
 		ncPrimaryIP := ""
 		if ncPrimaryIPIface != nil {
 			ncPrimaryIP = ncPrimaryIPIface.(string)
@@ -409,4 +409,15 @@ func (plugin *NetPlugin) isDualNicFeatureSupported(netNs string) bool {
 	}
 	log.Errorf("DualNicFeature is not supported")
 	return false
+}
+
+func getOverlayGateway(podsubnet *net.IPNet) (net.IP, error) {
+	ncgw := podsubnet.IP
+	ncgw[3]++
+	ncgw = net.ParseIP(ncgw.String())
+	if ncgw == nil || !podsubnet.Contains(ncgw) {
+		return nil, errors.Wrap(errInvalidArgs, "%w: Failed to retrieve overlay gateway from podsubnet"+podsubnet.IP.String())
+	}
+
+	return ncgw, nil
 }

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -378,15 +378,15 @@ func determineWinVer() {
 	}
 }
 
-func getNATInfo(executionMode, ipamMode string, ncPrimaryIPIface interface{}, multitenancy, enableSnatForDNS bool) (natInfo []policy.NATInfo) {
-	if executionMode == string(util.V4Swift) && ipamMode != string(util.V4Overlay) {
+func getNATInfo(nwCfg *cni.NetworkConfig, ncPrimaryIPIface interface{}, enableSnatForDNS bool) (natInfo []policy.NATInfo) {
+	if nwCfg.ExecutionMode == string(util.V4Swift) && nwCfg.IPAM.Mode != string(util.V4Overlay) {
 		ncPrimaryIP := ""
 		if ncPrimaryIPIface != nil {
 			ncPrimaryIP = ncPrimaryIPIface.(string)
 		}
 
 		natInfo = append(natInfo, []policy.NATInfo{{VirtualIP: ncPrimaryIP, Destinations: []string{networkutils.AzureDNS}}, {Destinations: []string{networkutils.AzureIMDS}}}...)
-	} else if multitenancy && enableSnatForDNS {
+	} else if nwCfg.MultiTenancy && enableSnatForDNS {
 		natInfo = append(natInfo, policy.NATInfo{Destinations: []string{networkutils.AzureDNS}})
 	}
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Fixing overlay gateway bug that prevented cloud-node-manager-windows from initializing node because it couldn't reach IMDS. An additional VFP rule was implicitly plumbed by HNS to add 169.254.1.1/16 to the exception list. This is most likely based off the RouteConfiguration in the "azure" HNS network.  This additional VFP rule was skipping SNAT for any IP address in this range 169.254.0.0-169.254.255.255. We'll set the first .1 IP of podcidr as the gateway now.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests


**Notes**:
