### PR TITLE
fix: Windows Overlay Gateway Bug

### DIFF
--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -110,9 +110,10 @@ func (invoker *CNSIPAMInvoker) Add(addConfig IPAMAddConfig) (IPAMAddResult, erro
 			return IPAMAddResult{}, errors.Wrap(errInvalidArgs, "%w: Gateway address "+info.ncGatewayIPAddress+" from response is invalid")
 		}
 
-		ncgw = ncipnet.IP.Mask(ncipnet.Mask)
+		ncgw = ncipnet.IP
 		ncgw[3]++
-		if !ncipnet.Contains(ncgw) {
+		ncgw = net.ParseIP(ncgw.String())
+		if ncgw == nil || !ncipnet.Contains(ncgw) {
 			return IPAMAddResult{}, errors.Wrap(errInvalidArgs, "%w: Invalid gateway address "+ncgw.String())
 		}
 	}

--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -110,11 +110,9 @@ func (invoker *CNSIPAMInvoker) Add(addConfig IPAMAddConfig) (IPAMAddResult, erro
 			return IPAMAddResult{}, errors.Wrap(errInvalidArgs, "%w: Gateway address "+info.ncGatewayIPAddress+" from response is invalid")
 		}
 
-		ncgw = ncipnet.IP
-		ncgw[3]++
-		ncgw = net.ParseIP(ncgw.String())
-		if ncgw == nil || !ncipnet.Contains(ncgw) {
-			return IPAMAddResult{}, errors.Wrap(errInvalidArgs, "%w: Invalid gateway address "+ncgw.String())
+		ncgw, err = getOverlayGateway(ncipnet)
+		if err != nil {
+			return IPAMAddResult{}, err
 		}
 	}
 

--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -20,9 +20,8 @@ import (
 )
 
 var (
-	errEmptyCNIArgs  = errors.New("empty CNI cmd args not allowed")
-	errInvalidArgs   = errors.New("invalid arg(s)")
-	overlayGatewayIP = "169.254.1.1"
+	errEmptyCNIArgs = errors.New("empty CNI cmd args not allowed")
+	errInvalidArgs  = errors.New("invalid arg(s)")
 )
 
 type CNSIPAMInvoker struct {
@@ -99,19 +98,23 @@ func (invoker *CNSIPAMInvoker) Add(addConfig IPAMAddConfig) (IPAMAddResult, erro
 
 	log.Printf("[cni-invoker-cns] Received info %+v for pod %v", info, podInfo)
 
+	// set result ipconfigArgument from CNS Response Body
+	ip, ncipnet, err := net.ParseCIDR(info.podIPAddress + "/" + fmt.Sprint(info.ncSubnetPrefix))
+	if ip == nil {
+		return IPAMAddResult{}, errors.Wrap(err, "Unable to parse IP from response: "+info.podIPAddress+" with err %w")
+	}
+
 	ncgw := net.ParseIP(info.ncGatewayIPAddress)
 	if ncgw == nil {
 		if invoker.ipamMode != util.V4Overlay {
 			return IPAMAddResult{}, errors.Wrap(errInvalidArgs, "%w: Gateway address "+info.ncGatewayIPAddress+" from response is invalid")
 		}
 
-		ncgw = net.ParseIP(overlayGatewayIP)
-	}
-
-	// set result ipconfigArgument from CNS Response Body
-	ip, ncipnet, err := net.ParseCIDR(info.podIPAddress + "/" + fmt.Sprint(info.ncSubnetPrefix))
-	if ip == nil {
-		return IPAMAddResult{}, errors.Wrap(err, "Unable to parse IP from response: "+info.podIPAddress+" with err %w")
+		ncgw = ncipnet.IP.Mask(ncipnet.Mask)
+		ncgw[3]++
+		if !ncipnet.Contains(ncgw) {
+			return IPAMAddResult{}, errors.Wrap(errInvalidArgs, "%w: Invalid gateway address "+ncgw.String())
+		}
 	}
 
 	// construct ipnet for result

--- a/cni/network/invoker_cns_test.go
+++ b/cni/network/invoker_cns_test.go
@@ -42,6 +42,7 @@ func TestCNSIPAMInvoker_Add(t *testing.T) {
 		podName      string
 		podNamespace string
 		cnsClient    cnsclient
+		ipamMode     util.IpamMode
 	}
 	type args struct {
 		nwCfg            *cni.NetworkConfig
@@ -216,6 +217,9 @@ func TestCNSIPAMInvoker_Add(t *testing.T) {
 				podName:      tt.fields.podName,
 				podNamespace: tt.fields.podNamespace,
 				cnsClient:    tt.fields.cnsClient,
+			}
+			if tt.fields.ipamMode != "" {
+				invoker.ipamMode = tt.fields.ipamMode
 			}
 			ipamAddResult, err := invoker.Add(IPAMAddConfig{nwCfg: tt.args.nwCfg, args: tt.args.args, options: tt.args.options})
 			if tt.wantErr {

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -536,7 +536,7 @@ func (plugin *NetPlugin) Add(args *cniSkel.CmdArgs) error {
 		logAndSendEvent(plugin, fmt.Sprintf("[cni-net] Created network %v with subnet %v.", networkID, ipamAddResult.hostSubnetPrefix.String()))
 	}
 
-	natInfo := getNATInfo(nwCfg.ExecutionMode, nwCfg.Ipam.Mode, options[network.SNATIPKey], nwCfg.MultiTenancy, enableSnatForDNS)
+	natInfo := getNATInfo(nwCfg, options[network.SNATIPKey], enableSnatForDNS)
 
 	createEndpointInternalOpt := createEndpointInternalOpt{
 		nwCfg:            nwCfg,

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -536,7 +536,7 @@ func (plugin *NetPlugin) Add(args *cniSkel.CmdArgs) error {
 		logAndSendEvent(plugin, fmt.Sprintf("[cni-net] Created network %v with subnet %v.", networkID, ipamAddResult.hostSubnetPrefix.String()))
 	}
 
-	natInfo := getNATInfo(nwCfg.ExecutionMode, options[network.SNATIPKey], nwCfg.MultiTenancy, enableSnatForDNS)
+	natInfo := getNATInfo(nwCfg.ExecutionMode, nwCfg.Ipam.Mode, options[network.SNATIPKey], nwCfg.MultiTenancy, enableSnatForDNS)
 
 	createEndpointInternalOpt := createEndpointInternalOpt{
 		nwCfg:            nwCfg,

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -136,8 +136,12 @@ func (plugin *NetPlugin) getNetworkName(_ string, _ *IPAMAddResult, nwCfg *cni.N
 	return nwCfg.Name, nil
 }
 
-func getNATInfo(_ string, _ interface{}, _, _ bool) (natInfo []policy.NATInfo) {
+func getNATInfo(_, _ string, _ interface{}, _, _ bool) (natInfo []policy.NATInfo) {
 	return natInfo
 }
 
 func platformInit(cniConfig *cni.NetworkConfig) {}
+
+func getOverlayGateway(_ *net.IPNet) (net.IP, error) {
+	return net.ParseIP("169.254.1.1"), nil
+}

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -136,7 +136,7 @@ func (plugin *NetPlugin) getNetworkName(_ string, _ *IPAMAddResult, nwCfg *cni.N
 	return nwCfg.Name, nil
 }
 
-func getNATInfo(_, _ string, _ interface{}, _, _ bool) (natInfo []policy.NATInfo) {
+func getNATInfo(_ *cni.NetworkConfig, _ interface{}, _ bool) (natInfo []policy.NATInfo) {
 	return natInfo
 }
 

--- a/cni/network/network_test.go
+++ b/cni/network/network_test.go
@@ -1067,3 +1067,9 @@ func TestGetNetworkName(t *testing.T) {
 		})
 	}
 }
+
+func TestGetOverlayNatInfo(t *testing.T) {
+	nwCfg := &cni.NetworkConfig{ExecutionMode: string(util.V4Swift), IPAM: cni.IPAM{Mode: string(util.V4Overlay)}}
+	natInfo := getNATInfo(nwCfg, nil, false)
+	require.Empty(t, natInfo, "overlay natInfo should be empty")
+}

--- a/cni/network/network_test.go
+++ b/cni/network/network_test.go
@@ -709,7 +709,7 @@ func TestPluginMultitenancyDelete(t *testing.T) {
 }
 
 /*
-	Baremetal scenarios
+Baremetal scenarios
 */
 func TestPluginBaremetalAdd(t *testing.T) {
 	plugin, _ := cni.NewPlugin("test", "0.3.0")
@@ -838,7 +838,7 @@ func TestPluginBaremetalDelete(t *testing.T) {
 }
 
 /*
-	AKS-Swift scenario
+AKS-Swift scenario
 */
 func TestPluginAKSSwiftAdd(t *testing.T) {
 	plugin := GetTestResources()
@@ -1072,7 +1072,8 @@ func TestGetNetworkName(t *testing.T) {
 }
 
 func TestGetOverlayNatInfo(t *testing.T) {
-	nwCfg := &cni.NetworkConfig{ExecutionMode: string(util.V4Swift), IPAM: cni.IPAM{Mode: string(util.V4Overlay)}}
+	nwCfg := &cni.NetworkConfig{ExecutionMode: string(util.V4Swift)}
+	nwCfg.Ipam.Mode = string(util.V4Overlay)
 	natInfo := getNATInfo(nwCfg, nil, false)
 	require.Empty(t, natInfo, "overlay natInfo should be empty")
 }

--- a/cni/network/network_test.go
+++ b/cni/network/network_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/Azure/azure-container-networking/cni"
@@ -11,6 +12,8 @@ import (
 	"github.com/Azure/azure-container-networking/cni/util"
 	"github.com/Azure/azure-container-networking/common"
 	acnnetwork "github.com/Azure/azure-container-networking/network"
+	"github.com/Azure/azure-container-networking/network/networkutils"
+	"github.com/Azure/azure-container-networking/network/policy"
 	"github.com/Azure/azure-container-networking/nns"
 	"github.com/Azure/azure-container-networking/telemetry"
 	cniSkel "github.com/containernetworking/cni/pkg/skel"
@@ -1072,4 +1075,18 @@ func TestGetOverlayNatInfo(t *testing.T) {
 	nwCfg := &cni.NetworkConfig{ExecutionMode: string(util.V4Swift), IPAM: cni.IPAM{Mode: string(util.V4Overlay)}}
 	natInfo := getNATInfo(nwCfg, nil, false)
 	require.Empty(t, natInfo, "overlay natInfo should be empty")
+}
+
+func TestGetPodSubnetNatInfo(t *testing.T) {
+	ncPrimaryIP := "10.241.0.4"
+	nwCfg := &cni.NetworkConfig{ExecutionMode: string(util.V4Swift)}
+	natInfo := getNATInfo(nwCfg, ncPrimaryIP, false)
+	if runtime.GOOS == "windows" {
+		require.Equalf(t, natInfo, []policy.NATInfo{
+			{VirtualIP: ncPrimaryIP, Destinations: []string{networkutils.AzureDNS}},
+			{Destinations: []string{networkutils.AzureIMDS}},
+		}, "invalid windows podsubnet natInfo")
+	} else {
+		require.Empty(t, natInfo, "linux podsubnet natInfo should be empty")
+	}
 }

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -379,7 +379,7 @@ func determineWinVer() {
 }
 
 func getNATInfo(nwCfg *cni.NetworkConfig, ncPrimaryIPIface interface{}, enableSnatForDNS bool) (natInfo []policy.NATInfo) {
-	if nwCfg.ExecutionMode == string(util.V4Swift) && nwCfg.IPAM.Mode != string(util.V4Overlay) {
+	if nwCfg.ExecutionMode == string(util.V4Swift) && nwCfg.Ipam.Mode != string(util.V4Overlay) {
 		ncPrimaryIP := ""
 		if ncPrimaryIPIface != nil {
 			ncPrimaryIP = ncPrimaryIPIface.(string)

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -378,15 +378,15 @@ func determineWinVer() {
 	}
 }
 
-func getNATInfo(executionMode, ipamMode string, ncPrimaryIPIface interface{}, multitenancy, enableSnatForDNS bool) (natInfo []policy.NATInfo) {
-	if executionMode == string(util.V4Swift) && ipamMode != string(util.V4Overlay) {
+func getNATInfo(nwCfg *cni.NetworkConfig, ncPrimaryIPIface interface{}, enableSnatForDNS bool) (natInfo []policy.NATInfo) {
+	if nwCfg.ExecutionMode == string(util.V4Swift) && nwCfg.IPAM.Mode != string(util.V4Overlay) {
 		ncPrimaryIP := ""
 		if ncPrimaryIPIface != nil {
 			ncPrimaryIP = ncPrimaryIPIface.(string)
 		}
 
 		natInfo = append(natInfo, []policy.NATInfo{{VirtualIP: ncPrimaryIP, Destinations: []string{networkutils.AzureDNS}}, {Destinations: []string{networkutils.AzureIMDS}}}...)
-	} else if multitenancy && enableSnatForDNS {
+	} else if nwCfg.MultiTenancy && enableSnatForDNS {
 		natInfo = append(natInfo, policy.NATInfo{Destinations: []string{networkutils.AzureDNS}})
 	}
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Fixing overlay gateway bug that prevented cloud-node-manager-windows from initializing node because it couldn't reach IMDS. An additional VFP rule was implicitly plumbed by HNS to add 169.254.1.1/16 to the exception list. This is most likely based off the RouteConfiguration in the "azure" HNS network.  This additional VFP rule was skipping SNAT for any IP address in this range 169.254.0.0-169.254.255.255. We'll set the first .1 IP of podcidr as the gateway now.

cherry-picked changes from #1849 to v1.4.35 based branch

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests


**Notes**:
