### PR TITLE
add metric for tracking failure to start the controller-runtime manager

### DIFF
--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1260,7 +1260,8 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 			if err := manager.Start(ctx); err != nil {
 				logger.Errorf("[Azure CNS] Failed to start request controller: %v", err)
 				// retry to start the request controller
-				// todo: add a CNS metric to count # of failures
+				// inc the managerStartFailures metric for failure tracking
+				managerStartFailures.Inc()
 			} else {
 				logger.Printf("exiting NodeNetworkConfig reconciler")
 				return

--- a/cns/service/metrics.go
+++ b/cns/service/metrics.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// managerStartFailures is a monotic counter which tracks the number of times the controller-runtime
+// manager failed to start. To drive alerting based on this metric, it is recommended to use the rate
+// of increase over a period of time. A positive rate of change indicates that the CNS is actively
+// failing and retrying.
+var managerStartFailures = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Name: "manager_start_failures_total",
+		Help: "Number of times the controller-runtime manager failed to start.",
+	},
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		managerStartFailures,
+	)
+}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Adds a metric for failure to start the controller-runtime manager, which is infinitely retried, but gives us a signal on which to alert on a CNS that is broken for some reason.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
