### PR TITLE
timeout after 15 minutes waiting for the NNC reconciler to start

### DIFF
--- a/cns/kubecontroller/nodenetworkconfig/reconciler.go
+++ b/cns/kubecontroller/nodenetworkconfig/reconciler.go
@@ -134,7 +134,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 // then, and any time that it is called after that, it immediately returns true.
 // It accepts a cancellable Context and if the context is closed
 // before Start it will return false. Passing a closed Context after the
-// Reconciler is started is indeterminate and the response is psuedorandom.
+// Reconciler is started is indeterminate.
 func (r *Reconciler) Started(ctx context.Context) (bool, error) {
 	select {
 	case <-r.started:

--- a/cns/kubecontroller/nodenetworkconfig/reconciler.go
+++ b/cns/kubecontroller/nodenetworkconfig/reconciler.go
@@ -135,12 +135,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 // It accepts a cancellable Context and if the context is closed
 // before Start it will return false. Passing a closed Context after the
 // Reconciler is started is indeterminate and the response is psuedorandom.
-func (r *Reconciler) Started(ctx context.Context) bool {
+func (r *Reconciler) Started(ctx context.Context) (bool, error) {
 	select {
 	case <-r.started:
-		return true
+		return true, nil
 	case <-ctx.Done():
-		return false
+		return false, errors.Wrap(ctx.Err(), "context closed")
 	}
 }
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1255,39 +1255,38 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 	// The Reconciler will send an initial NodeNetworkConfig update to the PoolMonitor, starting the
 	// Monitor's internal loop.
 	go func() {
-		logger.Printf("Starting NodeNetworkConfig reconciler.")
+		logger.Printf("Starting controller-manager.")
 		for {
 			if err := manager.Start(ctx); err != nil {
-				logger.Errorf("[Azure CNS] Failed to start request controller: %v", err)
+				logger.Errorf("Failed to start controller-manager: %v", err)
 				// retry to start the request controller
 				// inc the managerStartFailures metric for failure tracking
 				managerStartFailures.Inc()
 			} else {
-				logger.Printf("exiting NodeNetworkConfig reconciler")
+				logger.Printf("Stopped controller-manager.")
 				return
 			}
-
-			// Retry after 1sec
-			time.Sleep(time.Second)
+			time.Sleep(time.Second) // TODO(rbtr): make this exponential backoff
 		}
 	}()
-	logger.Printf("initialized NodeNetworkConfig reconciler")
+	logger.Printf("Initialized controller-manager.")
 	for {
-		logger.Printf("waiting for NodeNetworkConfig reconciler to start")
+		logger.Printf("Waiting for NodeNetworkConfig reconciler to start.")
 		// wait for the Reconciler to run once on a NNC that was made for this Node.
 		// the nncReadyCtx has a timeout of 15 minutes, after which we will consider
 		// this false and the NNC Reconciler stuck/failed, log and retry.
 		nncReadyCtx, _ := context.WithTimeout(ctx, 15*time.Minute) //nolint // it will time out and not leak
 		if started, err := nncReconciler.Started(nncReadyCtx); !started {
-			log.Errorf("context cancelled while waiting for reconciler start, does the NNC exist? err: %v", err)
+			log.Errorf("NNC reconciler has not started, does the NNC exist? err: %v", err)
+			nncReconcilerStartFailures.Inc()
 			continue
 		}
-		logger.Printf("NodeNetworkConfig reconciler has started")
+		logger.Printf("NodeNetworkConfig reconciler has started.")
 		break
 	}
 
 	go func() {
-		logger.Printf("starting SyncHostNCVersion loop")
+		logger.Printf("Starting SyncHostNCVersion loop.")
 		// Periodically poll vfp programmed NC version from NMAgent
 		tickerChannel := time.Tick(time.Duration(cnsconfig.SyncHostNCVersionIntervalMs) * time.Millisecond)
 		for {
@@ -1297,11 +1296,11 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 				httpRestServiceImplementation.SyncHostNCVersion(timedCtx, cnsconfig.ChannelMode)
 				cancel()
 			case <-ctx.Done():
-				logger.Printf("exiting SyncHostNCVersion")
+				logger.Printf("Stopping SyncHostNCVersion loop.")
 				return
 			}
 		}
 	}()
-	logger.Printf("initialized and started SyncHostNCVersion loop")
+	logger.Printf("Initialized SyncHostNCVersion loop.")
 	return nil
 }

--- a/cns/service/metrics.go
+++ b/cns/service/metrics.go
@@ -11,13 +11,25 @@ import (
 // failing and retrying.
 var managerStartFailures = prometheus.NewCounter(
 	prometheus.CounterOpts{
-		Name: "manager_start_failures_total",
+		Name: "cns_ctrlmanager_start_failures_total",
 		Help: "Number of times the controller-runtime manager failed to start.",
+	},
+)
+
+// nncReconcilerStartFailures is a monotic counter which tracks the number of times the NNC reconciler
+// has failed to start within the timeout period. To drive alerting based on this metric, it is
+// recommended to use the rate of increase over a period of time. A positive rate of change indicates
+// that the CNS is actively failing and retrying.
+var nncReconcilerStartFailures = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Name: "cns_nnc_reconciler_start_failures_total",
+		Help: "Number of times the NNC reconciler has failed to start within the timeout period.",
 	},
 )
 
 func init() {
 	metrics.Registry.MustRegister(
 		managerStartFailures,
+		nncReconcilerStartFailures,
 	)
 }


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Currently we wait indefinitely for the NNC reconciler to receive an NNC and run the first reconcile before continuing execution (starting the CNS webserver, IPAM pool monitor, etc).
Instead, if the NNC Reconciler does not get an NNC and successfully run a reconcile within 15 minutes, timeout and fail to make it evident that CNS is encountering a fatal error/stuck.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
