### PR TITLE
fix: [WIN-NPM] back-compat mitigation to PATH issue

### DIFF
--- a/npm/examples/windows/azure-npm-capz.yaml
+++ b/npm/examples/windows/azure-npm-capz.yaml
@@ -109,6 +109,8 @@ spec:
                   fieldPath: spec.nodeName
             - name: NPM_CONFIG
               value: .\\etc\\azure-npm\\azure-npm.json
+            - name: PATH
+              value: 'C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Program Files\dotnet\;c:\program files\containerd;C:\Windows\system32\config\systemprofile\AppData\Local\Microsoft\WindowsApps'
           volumeMounts:
             - name: azure-npm-config
               mountPath: .\\etc\\azure-npm

--- a/npm/examples/windows/azure-npm-capz.yaml
+++ b/npm/examples/windows/azure-npm-capz.yaml
@@ -90,7 +90,6 @@ spec:
             [
               '.\setkubeconfigpath-capz.ps1',
               ";",
-              "powershell.exe",
               '.\npm.exe',
               "start",
               '--kubeconfig=.\kubeconfig',
@@ -109,8 +108,6 @@ spec:
                   fieldPath: spec.nodeName
             - name: NPM_CONFIG
               value: .\\etc\\azure-npm\\azure-npm.json
-            - name: PATH
-              value: 'C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Program Files\dotnet\;c:\program files\containerd;C:\Windows\system32\config\systemprofile\AppData\Local\Microsoft\WindowsApps'
           volumeMounts:
             - name: azure-npm-config
               mountPath: .\\etc\\azure-npm

--- a/npm/examples/windows/azure-npm.yaml
+++ b/npm/examples/windows/azure-npm.yaml
@@ -89,7 +89,6 @@ spec:
             [
               '.\setkubeconfigpath.ps1',
               ";",
-              "powershell.exe",
               '.\npm.exe',
               "start",
               '--kubeconfig=.\kubeconfig',
@@ -108,8 +107,6 @@ spec:
                   fieldPath: spec.nodeName
             - name: NPM_CONFIG
               value: .\\etc\\azure-npm\\azure-npm.json
-            - name: PATH
-              value: 'C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Program Files\dotnet\;c:\program files\containerd;C:\Windows\system32\config\systemprofile\AppData\Local\Microsoft\WindowsApps'
           volumeMounts:
             - name: azure-npm-config
               mountPath: .\\etc\\azure-npm

--- a/npm/examples/windows/azure-npm.yaml
+++ b/npm/examples/windows/azure-npm.yaml
@@ -109,7 +109,7 @@ spec:
             - name: NPM_CONFIG
               value: .\\etc\\azure-npm\\azure-npm.json
             - name: PATH
-              value: '%PATH%;%CONTAINER_SANDBOX_MOUNT_POINT%\Windows\System32\WindowsPowershell\v1.0\;C:\Windows\System32\'
+              value: 'C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Program Files\dotnet\;c:\program files\containerd;C:\Windows\system32\config\systemprofile\AppData\Local\Microsoft\WindowsApps'
           volumeMounts:
             - name: azure-npm-config
               mountPath: .\\etc\\azure-npm

--- a/npm/examples/windows/azure-npm.yaml
+++ b/npm/examples/windows/azure-npm.yaml
@@ -109,7 +109,7 @@ spec:
             - name: NPM_CONFIG
               value: .\\etc\\azure-npm\\azure-npm.json
             - name: PATH
-              value: '%CONTAINER_SANDBOX_MOUNT_POINT%\Windows\System32\WindowsPowershell\v1.0\'
+              value: '%CONTAINER_SANDBOX_MOUNT_POINT%\Windows\System32\WindowsPowershell\v1.0\;C:\Windows\System32\'
           volumeMounts:
             - name: azure-npm-config
               mountPath: .\\etc\\azure-npm

--- a/npm/examples/windows/azure-npm.yaml
+++ b/npm/examples/windows/azure-npm.yaml
@@ -109,7 +109,7 @@ spec:
             - name: NPM_CONFIG
               value: .\\etc\\azure-npm\\azure-npm.json
             - name: PATH
-              value: '%CONTAINER_SANDBOX_MOUNT_POINT%\Windows\System32\WindowsPowershell\v1.0\;C:\Windows\System32\'
+              value: '%PATH%;%CONTAINER_SANDBOX_MOUNT_POINT%\Windows\System32\WindowsPowershell\v1.0\;C:\Windows\System32\'
           volumeMounts:
             - name: azure-npm-config
               mountPath: .\\etc\\azure-npm

--- a/npm/examples/windows/setkubeconfigpath.ps1
+++ b/npm/examples/windows/setkubeconfigpath.ps1
@@ -1,7 +1,3 @@
-# add powershell.exe to the path
-$pwshPath = "C:\" + $env:CONTAINER_SANDBOX_MOUNT_POINT +  "\Windows\System32\WindowsPowershell\v1.0\"
-$env:PATH += ";" + $pwshPath
-
 # pull the server value from the kubeconfig on host to construct our own kubeconfig, but using service principal settings
 # this is required to build a kubeconfig using the kubeconfig on disk in c:\k, and the service principle granted in the container mount, to generate clientset
 $cpEndpoint = Get-Content C:\k\config | ForEach-Object -Process {if($_.Contains("server:")) {$_.Trim().Split()[1]}}

--- a/npm/examples/windows/setkubeconfigpath.ps1
+++ b/npm/examples/windows/setkubeconfigpath.ps1
@@ -1,3 +1,7 @@
+# add powershell.exe to the path
+$pwshPath = "C:\" + $env:CONTAINER_SANDBOX_MOUNT_POINT +  "\Windows\System32\WindowsPowershell\v1.0\"
+$env:PATH += ";" + $pwshPath
+
 # pull the server value from the kubeconfig on host to construct our own kubeconfig, but using service principal settings
 # this is required to build a kubeconfig using the kubeconfig on disk in c:\k, and the service principle granted in the container mount, to generate clientset
 $cpEndpoint = Get-Content C:\k\config | ForEach-Object -Process {if($_.Contains("server:")) {$_.Trim().Split()[1]}}


### PR DESCRIPTION
**Reason for Change**:
Resolve PATH issue correctly. Removing `powershell.exe` is **back-compat** with NPM v1.3.34 (in-prod).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests

**Notes**:
Don't want to override PATH variable.

#### Error
```
powershell.exe : The term 'powershell.exe' is not recognized as the name of a cmdlet, function, script file, or
operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try
again.
At line:1 char:27
+ .\setkubeconfigpath.ps1 ; powershell.exe .\npm.exe start --kubeconfig ...
+                           ~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (powershell.exe:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
```