### PR TITLE
cilium ci: set l7proxy to false

### DIFF
--- a/.github/workflows/golangci.yaml
+++ b/.github/workflows/golangci.yaml
@@ -27,5 +27,5 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         version: v1.52.2
-        args: --timeout=10m 
+        args: --timeout=15m
         only-new-issues: true

--- a/cilium/cilium_helm_values.yaml
+++ b/cilium/cilium_helm_values.yaml
@@ -28,7 +28,7 @@ ipv4NativeRoutingCIDR: 10.241.0.0/16
 enableIPv4Masquerade: false
 install-no-conntrack-iptables-rules: false
 installIptablesRules: true
-l7Proxy: true
+l7Proxy: false
 hubble:
   enabled: false
 kubeProxyReplacement: strict


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
L7proxy has been disabled in AKS cilium config for GA. Setting L7Proxy to false for ACN pipeline testing.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
