### PR TITLE
ci: increase golint timeout to 25m

### DIFF
--- a/.github/workflows/golangci.yaml
+++ b/.github/workflows/golangci.yaml
@@ -27,5 +27,5 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         version: v1.52.2
-        args: --timeout=15m
+        args: --timeout=25m
         only-new-issues: true


### PR DESCRIPTION
**Reason for Change**:
PRs keep timing out even with 15m timeout (e.g. #1848 and #1879)


**Issue Fixed**:

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
