### PR TITLE
CNS writes Cilium Conflist

### DIFF
--- a/cns/cniconflist/generator.go
+++ b/cns/cniconflist/generator.go
@@ -7,10 +7,15 @@ import (
 )
 
 const (
-	cniVersion     = "0.3.0"         //nolint:unused,deadcode,varcheck // used in linux
-	cniName        = "azure"         //nolint:unused,deadcode,varcheck // used in linux
-	cniType        = "azure-vnet"    //nolint:unused,deadcode,varcheck // used in linux
-	nodeLocalDNSIP = "169.254.20.10" //nolint:unused,deadcode,varcheck // used in linux
+	ciliumcniVersion  = "0.3.1"                   //nolint:unused,deadcode,varcheck // used in linux
+	ciliumcniName     = "cilium"                  //nolint:unused,deadcode,varcheck // used in linux
+	ciliumcniType     = "cilium-cni"              //nolint:unused,deadcode,varcheck // used in linux
+	ciliumLogFile     = "/var/log/cilium-cni.log" //nolint:unused,deadcode,varcheck // used in linux
+	ciliumIPAM        = "azure-ipam"              //nolint:unused,deadcode,varcheck // used in linux
+	overlaycniVersion = "0.3.0"                   //nolint:unused,deadcode,varcheck // used in linux
+	overlaycniName    = "azure"                   //nolint:unused,deadcode,varcheck // used in linux
+	overlaycniType    = "azure-vnet"              //nolint:unused,deadcode,varcheck // used in linux
+	nodeLocalDNSIP    = "169.254.20.10"           //nolint:unused,deadcode,varcheck // used in linux
 )
 
 // cniConflist represents the containernetworking/cni/pkg/types.NetConfList
@@ -23,8 +28,7 @@ type cniConflist struct { //nolint:unused,deadcode // used in linux
 
 // NetConf describes a network. It represents the Cilium specific containernetworking/cni/pkg/types.NetConf
 type NetConf struct {
-	CNIVersion string `json:"cniVersion,omitempty"`
-
+	CNIVersion   string          `json:"cniVersion,omitempty"`
 	Name         string          `json:"name,omitempty"`
 	Type         string          `json:"type,omitempty"`
 	Capabilities map[string]bool `json:"capabilities,omitempty"`

--- a/cns/cniconflist/generator.go
+++ b/cns/cniconflist/generator.go
@@ -21,12 +21,43 @@ type cniConflist struct { //nolint:unused,deadcode // used in linux
 	Plugins      []any  `json:"plugins,omitempty"`
 }
 
+// NetConf describes a network. It represents the Cilium specific containernetworking/cni/pkg/types.NetConf
+type NetConf struct {
+	CNIVersion string `json:"cniVersion,omitempty"`
+
+	Name         string          `json:"name,omitempty"`
+	Type         string          `json:"type,omitempty"`
+	Capabilities map[string]bool `json:"capabilities,omitempty"`
+	IPAM         IPAM            `json:"ipam,omitempty"`
+	EnableDebug  bool            `json:"enable-debug"`
+	LogFile      string          `json:"log-file"`
+
+	RawPrevResult map[string]interface{} `json:"prevResult,omitempty"`
+}
+
+type IPAM struct {
+	Type string `json:"type,omitempty"`
+}
+
 // V4OverlayGenerator generates the Azure CNI conflist for the ipv4 Overlay scenario
 type V4OverlayGenerator struct {
 	Writer io.WriteCloser
 }
 
+// CiliumGenerator generates the Azure CNI conflist for the Cilium scenario
+type CiliumGenerator struct {
+	Writer io.WriteCloser
+}
+
 func (v *V4OverlayGenerator) Close() error {
+	if err := v.Writer.Close(); err != nil {
+		return errors.Wrap(err, "error closing generator")
+	}
+
+	return nil
+}
+
+func (v *CiliumGenerator) Close() error {
 	if err := v.Writer.Close(); err != nil {
 		return errors.Wrap(err, "error closing generator")
 	}

--- a/cns/cniconflist/generator_linux.go
+++ b/cns/cniconflist/generator_linux.go
@@ -26,11 +26,11 @@ var portmapConfig any = struct {
 // Generate writes the CNI conflist to the Generator's output stream
 func (v *V4OverlayGenerator) Generate() error {
 	conflist := cniConflist{
-		CNIVersion: cniVersion,
-		Name:       cniName,
+		CNIVersion: overlaycniVersion,
+		Name:       overlaycniName,
 		Plugins: []any{
 			cni.NetworkConfig{
-				Type:              cniType,
+				Type:              overlaycniType,
 				Mode:              cninet.OpModeTransparent,
 				ExecutionMode:     string(util.V4Swift),
 				IPsToRouteViaHost: []string{nodeLocalDNSIP},
@@ -55,15 +55,15 @@ func (v *V4OverlayGenerator) Generate() error {
 // Generate writes the CNI conflist to the Generator's output stream
 func (v *CiliumGenerator) Generate() error {
 	conflist := cniConflist{
-		CNIVersion: "0.3.1",
-		Name:       "cilium",
+		CNIVersion: ciliumcniVersion,
+		Name:       ciliumcniName,
 		Plugins: []any{
 			NetConf{
-				Type:        "cilium-cni",
-				LogFile:     "/var/log/cilium-cni.log",
+				Type:        ciliumcniType,
+				LogFile:     ciliumLogFile,
 				EnableDebug: true,
 				IPAM: IPAM{
-					Type: "azure-ipam",
+					Type: ciliumIPAM,
 				},
 			},
 		},

--- a/cns/cniconflist/generator_linux.go
+++ b/cns/cniconflist/generator_linux.go
@@ -51,3 +51,29 @@ func (v *V4OverlayGenerator) Generate() error {
 
 	return nil
 }
+
+// Generate writes the CNI conflist to the Generator's output stream
+func (v *CiliumGenerator) Generate() error {
+	conflist := cniConflist{
+		CNIVersion: "0.3.1",
+		Name:       "cilium",
+		Plugins: []any{
+			NetConf{
+				Type:        "cilium-cni",
+				LogFile:     "/var/log/cilium-cni.log",
+				EnableDebug: true,
+				IPAM: IPAM{
+					Type: "azure-ipam",
+				},
+			},
+		},
+	}
+
+	enc := json.NewEncoder(v.Writer)
+	enc.SetIndent("", "\t")
+	if err := enc.Encode(conflist); err != nil {
+		return errors.Wrap(err, "error encoding conflist to json")
+	}
+
+	return nil
+}

--- a/cns/cniconflist/generator_linux_test.go
+++ b/cns/cniconflist/generator_linux_test.go
@@ -32,6 +32,21 @@ func TestGenerateV4OverlayConflist(t *testing.T) {
 	assert.Equal(t, removeNewLines(fixtureBytes), removeNewLines(buffer.Bytes()))
 }
 
+func TestGenerateCiliumConflist(t *testing.T) {
+	fixture := "testdata/fixtures/cilium.conflist"
+
+	buffer := new(bytes.Buffer)
+	g := cniconflist.CiliumGenerator{Writer: &bufferWriteCloser{buffer}}
+	err := g.Generate()
+	assert.NoError(t, err)
+
+	fixtureBytes, err := os.ReadFile(fixture)
+	assert.NoError(t, err)
+
+	// remove newlines and carriage returns in case these UTs are running on Windows
+	assert.Equal(t, removeNewLines(fixtureBytes), removeNewLines(buffer.Bytes()))
+}
+
 // removeNewLines will remove the newlines and carriage returns from the byte slice
 func removeNewLines(b []byte) []byte {
 	var bb []byte //nolint:prealloc // can't prealloc since we don't know how many bytes will get removed

--- a/cns/cniconflist/generator_windows.go
+++ b/cns/cniconflist/generator_windows.go
@@ -9,3 +9,7 @@ var errNotImplemented = errors.New("cni conflist generator not implemented on Wi
 func (v *V4OverlayGenerator) Generate() error {
 	return errNotImplemented
 }
+
+func (v *CiliumGenerator) Generate() error {
+	return errNotImplemented
+}

--- a/cns/cniconflist/testdata/fixtures/cilium.conflist
+++ b/cns/cniconflist/testdata/fixtures/cilium.conflist
@@ -1,0 +1,14 @@
+{
+	"cniVersion": "0.3.1",
+	"name": "cilium",
+	"plugins": [
+		{
+			"type": "cilium-cni",
+			"ipam": {
+				"type": "azure-ipam"
+			},
+			"enable-debug": true,
+			"log-file": "/var/log/cilium-cni.log"
+		}
+	]
+}

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -87,6 +87,7 @@ type cniConflistScenario string
 
 const (
 	scenarioV4Overlay cniConflistScenario = "v4overlay"
+	scenarioCilium    cniConflistScenario = "cilium"
 )
 
 var (
@@ -535,6 +536,8 @@ func main() {
 		switch scenario := cniConflistScenario(scenarioString); scenario {
 		case scenarioV4Overlay:
 			conflistGenerator = &cniconflist.V4OverlayGenerator{Writer: writer}
+		case scenarioCilium:
+			conflistGenerator = &cniconflist.CiliumGenerator{Writer: writer}
 		default:
 			logger.Errorf("unable to generate cni conflist for unknown scenario: %s", scenario)
 			os.Exit(1)


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Today we use dropgz as an initcontainer to bring the cilium conflist to clusters. This PR allows for CNS to write the cilium conflist instead. Dropgz will still be required to install azure-ipam. This feature already exists for the overlay scenario, and it keeps nodes in NotReady state until the network is ready. Now, CNS can write the cilium conflist if we set in the cnsconfig: EnableCNIConflistGeneration as true, specify the conflist scenario to cilium, and set the conflist filepath. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests


**Notes**:
Changes were validated in byocni overlay-cilium and byocni pod subnet cilium clusters. The azure-cns deployment was modified so that dropgz only installs azure-ipam, and CNS writes the cilium conflist to etc/cni/net.d.