### PR TITLE
validating home az value

### DIFF
--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -189,8 +189,8 @@ func SetCNSConfigDefaults(config *CNSConfig) {
 		config.SyncHostNCTimeoutMs = 500 //nolint:gomnd // default times
 	}
 	if config.PopulateHomeAzCacheRetryIntervalSecs == 0 {
-		// set the default PopulateHomeAzCache retry interval to 15 seconds
-		config.PopulateHomeAzCacheRetryIntervalSecs = 15
+		// set the default PopulateHomeAzCache retry interval to 30 seconds
+		config.PopulateHomeAzCacheRetryIntervalSecs = 30
 	}
 	if config.WireserverIP == "" {
 		config.WireserverIP = "168.63.129.16"

--- a/cns/configuration/configuration_test.go
+++ b/cns/configuration/configuration_test.go
@@ -206,7 +206,7 @@ func TestSetCNSConfigDefaults(t *testing.T) {
 				KeyVaultSettings: KeyVaultSettings{
 					RefreshIntervalInHrs: 12,
 				},
-				PopulateHomeAzCacheRetryIntervalSecs: 15,
+				PopulateHomeAzCacheRetryIntervalSecs: 30,
 				WireserverIP:                         "168.63.129.16",
 			},
 		},

--- a/cns/restserver/homeazmonitor.go
+++ b/cns/restserver/homeazmonitor.go
@@ -139,6 +139,13 @@ func (h *HomeAzMonitor) Populate(ctx context.Context) {
 		return
 	}
 
+	// validate home az value, HomeAz is a uint, so it's value >=0
+	if azResponse.HomeAz == 0 {
+		returnMessage := fmt.Sprintf("[HomeAzMonitor] invalid home az value from nmagent: %d", azResponse.HomeAz)
+		returnCode := types.UnexpectedError
+		h.update(returnCode, returnMessage, cns.HomeAzResponse{IsSupported: true})
+		return
+	}
 	h.update(types.Success, "Get Home Az succeeded", cns.HomeAzResponse{IsSupported: true, HomeAz: azResponse.HomeAz})
 }
 

--- a/cns/restserver/homeazmonitor_test.go
+++ b/cns/restserver/homeazmonitor_test.go
@@ -48,6 +48,19 @@ func TestHomeAzMonitor(t *testing.T) {
 			false,
 		},
 		{
+			"api supported but home az value is not valid",
+			&fakes.NMAgentClientFake{
+				SupportedAPIsF: func(ctx context.Context) ([]string, error) {
+					return []string{GetHomeAzAPIName}, nil
+				},
+				GetHomeAzF: func(ctx context.Context) (nmagent.AzResponse, error) {
+					return nmagent.AzResponse{HomeAz: 0}, nil
+				},
+			},
+			cns.HomeAzResponse{IsSupported: true},
+			true,
+		},
+		{
 			"api supported but got unexpected errors",
 			&fakes.NMAgentClientFake{
 				SupportedAPIsF: func(ctx context.Context) ([]string, error) {


### PR DESCRIPTION
validating home az value
change default PopulateHomeAzCacheRetryIntervalSecs value from 15 to 30

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
