### PR TITLE
ci: [WIN-NPM] fix download failures in Cyclonus Pipeline

### DIFF
--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -371,8 +371,6 @@ jobs:
           PROFILE: "cyc-ws22"
     steps:
       - checkout: self
-      - download: current
-        artifact: Test
       - task: AzureCLI@2
         displayName: "Create AKS Cluster"
         inputs:


### PR DESCRIPTION
**Reason for Change**:
Windows Cyclonus pipeline keeps failing with below error:
```
##[error]Artifact Test was not found for build 71469484.
```

**Issue Fixed**:


**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
Removing the step that downloads the Test artifact. This artifact isn't needed actually. It only contains the Conformance test binary.