### PR TITLE
Set constant mac for host veth interface in transparent vlan mode

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -466,10 +466,11 @@ func (plugin *NetPlugin) Add(args *cniSkel.CmdArgs) error {
 
 	// iterate ipamAddResults and program the endpoint
 	for i := 0; i < len(ipamAddResults); i++ {
+		var networkID string
 		ipamAddResult = ipamAddResults[i]
 
 		options := make(map[string]any)
-		networkID, err := plugin.getNetworkName(args.Netns, &ipamAddResult, nwCfg)
+		networkID, err = plugin.getNetworkName(args.Netns, &ipamAddResult, nwCfg)
 
 		endpointID := GetEndpointID(args)
 		policies := cni.GetPoliciesFromNwCfg(nwCfg.AdditionalArgs)
@@ -557,7 +558,8 @@ func (plugin *NetPlugin) Add(args *cniSkel.CmdArgs) error {
 			natInfo:          natInfo,
 		}
 
-		epInfo, err := plugin.createEndpointInternal(&createEndpointInternalOpt)
+		var epInfo network.EndpointInfo
+		epInfo, err = plugin.createEndpointInternal(&createEndpointInternalOpt)
 		if err != nil {
 			log.Errorf("Endpoint creation failed:%w", err)
 			return err

--- a/netlink/mocknetlink.go
+++ b/netlink/mocknetlink.go
@@ -13,9 +13,13 @@ func newErrorMockNetlink(errStr string) error {
 	return fmt.Errorf("%w : %s", ErrorMockNetlink, errStr)
 }
 
+type routeValidateFn func(route *Route) error
+
 type MockNetlink struct {
-	returnError bool
-	errorString string
+	returnError   bool
+	errorString   string
+	deleteRouteFn func(route *Route) error
+	addRouteFn    func(route *Route) error
 }
 
 func NewMockNetlink(returnError bool, errorString string) *MockNetlink {
@@ -23,6 +27,14 @@ func NewMockNetlink(returnError bool, errorString string) *MockNetlink {
 		returnError: returnError,
 		errorString: errorString,
 	}
+}
+
+func (f *MockNetlink) SetDeleteRouteValidationFn(fn routeValidateFn) {
+	f.deleteRouteFn = fn
+}
+
+func (f *MockNetlink) SetAddRouteValidationFn(fn routeValidateFn) {
+	f.addRouteFn = fn
 }
 
 func (f *MockNetlink) error() error {
@@ -88,10 +100,16 @@ func (f *MockNetlink) GetIPRoute(*Route) ([]*Route, error) {
 	return nil, f.error()
 }
 
-func (f *MockNetlink) AddIPRoute(*Route) error {
+func (f *MockNetlink) AddIPRoute(r *Route) error {
+	if f.addRouteFn != nil {
+		return f.addRouteFn(r)
+	}
 	return f.error()
 }
 
-func (f *MockNetlink) DeleteIPRoute(*Route) error {
+func (f *MockNetlink) DeleteIPRoute(r *Route) error {
+	if f.deleteRouteFn != nil {
+		return f.deleteRouteFn(r)
+	}
 	return f.error()
 }

--- a/netlink/mocknetlink.go
+++ b/netlink/mocknetlink.go
@@ -18,8 +18,8 @@ type routeValidateFn func(route *Route) error
 type MockNetlink struct {
 	returnError   bool
 	errorString   string
-	deleteRouteFn func(route *Route) error
-	addRouteFn    func(route *Route) error
+	deleteRouteFn routeValidateFn
+	addRouteFn    routeValidateFn
 }
 
 func NewMockNetlink(returnError bool, errorString string) *MockNetlink {

--- a/netns/netns.go
+++ b/netns/netns.go
@@ -36,3 +36,11 @@ func (f *Netns) NewNamed(name string) (int, error) {
 func (f *Netns) DeleteNamed(name string) error {
 	return errors.Wrap(netns.DeleteNamed(name), "netns impl")
 }
+
+func (f *Netns) IsNamespaceEqual(fd1, fd2 int) bool {
+	return netns.NsHandle(fd1).Equal(netns.NsHandle(fd2))
+}
+
+func (f *Netns) NamespaceUniqueID(fd int) string {
+	return netns.NsHandle(fd).UniqueId()
+}

--- a/network/api.go
+++ b/network/api.go
@@ -20,6 +20,7 @@ var (
 	errMultipleEndpointsFound = fmt.Errorf("Multiple endpoints found")
 	errEndpointInUse          = fmt.Errorf("Endpoint is already joined to a sandbox")
 	errEndpointNotInUse       = fmt.Errorf("Endpoint is not joined to a sandbox")
+	errNamespaceCreation      = fmt.Errorf("Network namespace creation error")
 )
 
 type networkNotFoundError struct{}

--- a/network/api.go
+++ b/network/api.go
@@ -20,7 +20,6 @@ var (
 	errMultipleEndpointsFound = fmt.Errorf("Multiple endpoints found")
 	errEndpointInUse          = fmt.Errorf("Endpoint is already joined to a sandbox")
 	errEndpointNotInUse       = fmt.Errorf("Endpoint is not joined to a sandbox")
-	errNamespaceCreation      = fmt.Errorf("Network namespace creation error")
 )
 
 type networkNotFoundError struct{}

--- a/network/bridge_endpointclient_linux.go
+++ b/network/bridge_endpointclient_linux.go
@@ -210,7 +210,7 @@ func (client *LinuxBridgeEndpointClient) ConfigureContainerInterfacesAndRoutes(e
 	return nil
 }
 
-func (client *LinuxBridgeEndpointClient) DeleteEndpoints(ep *endpoint, _ bool) error {
+func (client *LinuxBridgeEndpointClient) DeleteEndpoints(ep *endpoint) error {
 	log.Printf("[net] Deleting veth pair %v %v.", ep.HostIfName, ep.IfName)
 	err := client.netlink.DeleteLink(ep.HostIfName)
 	if err != nil {

--- a/network/bridge_endpointclient_linux.go
+++ b/network/bridge_endpointclient_linux.go
@@ -195,7 +195,7 @@ func (client *LinuxBridgeEndpointClient) ConfigureContainerInterfacesAndRoutes(e
 		return err
 	}
 
-	if err := addRoutes(client.netlink, client.netioshim, client.containerVethName, epInfo.Routes); err != nil {
+	if err := addRoutes(client.netlink, client.netioshim, client.containerVethName, epInfo.Routes, false); err != nil {
 		return err
 	}
 
@@ -288,7 +288,7 @@ func (client *LinuxBridgeEndpointClient) setupIPV6Routes(epInfo *EndpointInfo) e
 		routes = append(routes, defaultV6Route)
 
 		log.Printf("[net] Adding ipv6 routes in container %+v", routes)
-		if err := addRoutes(client.netlink, client.netioshim, client.containerVethName, routes); err != nil {
+		if err := addRoutes(client.netlink, client.netioshim, client.containerVethName, routes, false); err != nil {
 			return nil
 		}
 	}

--- a/network/bridge_endpointclient_linux.go
+++ b/network/bridge_endpointclient_linux.go
@@ -195,7 +195,7 @@ func (client *LinuxBridgeEndpointClient) ConfigureContainerInterfacesAndRoutes(e
 		return err
 	}
 
-	if err := addRoutes(client.netlink, client.netioshim, client.containerVethName, epInfo.Routes, false); err != nil {
+	if err := addRoutes(client.netlink, client.netioshim, client.containerVethName, epInfo.Routes); err != nil {
 		return err
 	}
 
@@ -288,7 +288,7 @@ func (client *LinuxBridgeEndpointClient) setupIPV6Routes(epInfo *EndpointInfo) e
 		routes = append(routes, defaultV6Route)
 
 		log.Printf("[net] Adding ipv6 routes in container %+v", routes)
-		if err := addRoutes(client.netlink, client.netioshim, client.containerVethName, routes, false); err != nil {
+		if err := addRoutes(client.netlink, client.netioshim, client.containerVethName, routes); err != nil {
 			return nil
 		}
 	}

--- a/network/endpoint_linux.go
+++ b/network/endpoint_linux.go
@@ -274,8 +274,6 @@ func addRoutes(nl netlink.NetlinkInterface, netioshim netio.NetIOInterface, inte
 	ifIndex := 0
 
 	for _, route := range routes {
-		log.Printf("[net] Adding IP route %+v to link %v.", route, interfaceName)
-
 		if route.DevName != "" {
 			devIf, _ := netioshim.GetNetworkInterfaceByName(route.DevName)
 			ifIndex = devIf.Index
@@ -320,6 +318,7 @@ func addRoutes(nl netlink.NetlinkInterface, netioshim netio.NetIOInterface, inte
 			}
 		}
 
+		log.Printf("[net] Adding IP route %+v to link %v.", route, interfaceName)
 		if err := nl.AddIPRoute(nlRoute); err != nil {
 			if !strings.Contains(strings.ToLower(err.Error()), "file exists") {
 				return err

--- a/network/endpoint_linux.go
+++ b/network/endpoint_linux.go
@@ -158,7 +158,7 @@ func (nw *network) newEndpointImpl(
 			}
 			// set deleteHostVeth to true to cleanup host veth interface if created
 			//nolint:errcheck // ignore error
-			epClient.DeleteEndpoints(endpt, true)
+			epClient.DeleteEndpoints(endpt)
 		}
 	}()
 
@@ -284,7 +284,7 @@ func (nw *network) deleteEndpointImpl(nl netlink.NetlinkInterface, plc platform.
 	// deleteHostVeth set to false not to delete veth as CRI will remove network namespace and
 	// veth will get removed as part of that.
 	//nolint:errcheck // ignore error
-	epClient.DeleteEndpoints(ep, false)
+	epClient.DeleteEndpoints(ep)
 
 	return nil
 }

--- a/network/endpoint_linux_test.go
+++ b/network/endpoint_linux_test.go
@@ -1,0 +1,137 @@
+package network
+
+import (
+	"net"
+	"testing"
+
+	"github.com/Azure/azure-container-networking/netio"
+	"github.com/Azure/azure-container-networking/netlink"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+)
+
+func TestEndpointLinux(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Endpoint Suite")
+}
+
+var _ = Describe("Test TestEndpointLinux", func() {
+	Describe("Test deleteRoutes", func() {
+		_, dst, _ := net.ParseCIDR("192.168.0.0/16")
+
+		It("DeleteRoute with interfacename explicit", func() {
+			nlc := netlink.NewMockNetlink(false, "")
+			nlc.SetDeleteRouteValidationFn(func(r *netlink.Route) error {
+				Expect(r.LinkIndex).To(Equal(5))
+				return nil
+			})
+
+			netiocl := netio.NewMockNetIO(false, 0)
+			netiocl.SetGetInterfaceValidatonFn(func(ifName string) (*net.Interface, error) {
+				Expect(ifName).To(Equal("eth0"))
+				return &net.Interface{
+					Index: 5,
+				}, nil
+			})
+
+			err := deleteRoutes(nlc, netiocl, "eth0", []RouteInfo{{Dst: *dst, DevName: ""}})
+			Expect(err).To(BeNil())
+		})
+		It("DeleteRoute with interfacename set in Route", func() {
+			nlc := netlink.NewMockNetlink(false, "")
+			nlc.SetDeleteRouteValidationFn(func(r *netlink.Route) error {
+				Expect(r.LinkIndex).To(Equal(6))
+				return nil
+			})
+
+			netiocl := netio.NewMockNetIO(false, 0)
+			netiocl.SetGetInterfaceValidatonFn(func(ifName string) (*net.Interface, error) {
+				Expect(ifName).To(Equal("eth1"))
+				return &net.Interface{
+					Index: 6,
+				}, nil
+			})
+
+			err := deleteRoutes(nlc, netiocl, "", []RouteInfo{{Dst: *dst, DevName: "eth1"}})
+			Expect(err).To(BeNil())
+		})
+		It("DeleteRoute with no ifindex", func() {
+			nlc := netlink.NewMockNetlink(false, "")
+			nlc.SetDeleteRouteValidationFn(func(r *netlink.Route) error {
+				Expect(r.LinkIndex).To(Equal(0))
+				return nil
+			})
+
+			netiocl := netio.NewMockNetIO(false, 0)
+			netiocl.SetGetInterfaceValidatonFn(func(ifName string) (*net.Interface, error) {
+				Expect(ifName).To(Equal("eth1"))
+				return &net.Interface{
+					Index: 6,
+				}, nil
+			})
+
+			err := deleteRoutes(nlc, netiocl, "", []RouteInfo{{Dst: *dst, DevName: ""}})
+			Expect(err).To(BeNil())
+		})
+	})
+	Describe("Test addRoutes", func() {
+		_, dst, _ := net.ParseCIDR("192.168.0.0/16")
+		It("AddRoute with interfacename explicit", func() {
+			nlc := netlink.NewMockNetlink(false, "")
+			nlc.SetAddRouteValidationFn(func(r *netlink.Route) error {
+				Expect(r).NotTo(BeNil())
+				Expect(r.LinkIndex).To(Equal(5))
+				return nil
+			})
+
+			netiocl := netio.NewMockNetIO(false, 0)
+			netiocl.SetGetInterfaceValidatonFn(func(ifName string) (*net.Interface, error) {
+				Expect(ifName).To(Equal("eth0"))
+				return &net.Interface{
+					Index: 5,
+				}, nil
+			})
+
+			err := addRoutes(nlc, netiocl, "eth0", []RouteInfo{{Dst: *dst, DevName: ""}})
+			Expect(err).To(BeNil())
+		})
+		It("AddRoute with interfacename set in route", func() {
+			nlc := netlink.NewMockNetlink(false, "")
+			nlc.SetAddRouteValidationFn(func(r *netlink.Route) error {
+				Expect(r.LinkIndex).To(Equal(6))
+				return nil
+			})
+
+			netiocl := netio.NewMockNetIO(false, 0)
+			netiocl.SetGetInterfaceValidatonFn(func(ifName string) (*net.Interface, error) {
+				Expect(ifName).To(Equal("eth1"))
+				return &net.Interface{
+					Index: 6,
+				}, nil
+			})
+
+			err := addRoutes(nlc, netiocl, "", []RouteInfo{{Dst: *dst, DevName: "eth1"}})
+			Expect(err).To(BeNil())
+		})
+		It("AddRoute with interfacename not set should return error", func() {
+			nlc := netlink.NewMockNetlink(false, "")
+			nlc.SetAddRouteValidationFn(func(r *netlink.Route) error {
+				Expect(r.LinkIndex).To(Equal(0))
+				//nolint:goerr113
+				return errors.New("Cannot add route")
+			})
+
+			netiocl := netio.NewMockNetIO(false, 0)
+			netiocl.SetGetInterfaceValidatonFn(func(ifName string) (*net.Interface, error) {
+				Expect(ifName).To(Equal(""))
+				return &net.Interface{
+					Index: 0,
+				}, errors.Wrapf(netio.ErrInterfaceNil, "Cannot get interface")
+			})
+
+			err := addRoutes(nlc, netiocl, "", []RouteInfo{{Dst: *dst, DevName: ""}})
+			Expect(err).ToNot(BeNil())
+		})
+	})
+})

--- a/network/endpoint_linux_test.go
+++ b/network/endpoint_linux_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Test TestEndpointLinux", func() {
 			nlc := netlink.NewMockNetlink(false, "")
 			nlc.SetAddRouteValidationFn(func(r *netlink.Route) error {
 				Expect(r.LinkIndex).To(Equal(0))
-				//nolint:goerr113
+				//nolint:goerr113 // for testing
 				return errors.New("Cannot add route")
 			})
 

--- a/network/endpoint_test.go
+++ b/network/endpoint_test.go
@@ -4,8 +4,12 @@
 package network
 
 import (
+	"errors"
+	"net"
 	"testing"
 
+	"github.com/Azure/azure-container-networking/netio"
+	"github.com/Azure/azure-container-networking/netlink"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -191,6 +195,122 @@ var _ = Describe("Test Endpoint", func() {
 					Expect(podName).To(Equal(expectedPodName))
 				}
 			})
+		})
+	})
+	Describe("Test deleteRoutes", func() {
+		_, dst, _ := net.ParseCIDR("192.168.0.0/16")
+
+		It("DeleteRoute with interfacename explicit", func() {
+			nlc := netlink.NewMockNetlink(false, "")
+			nlc.SetDeleteRouteValidationFn(func(r *netlink.Route) error {
+				Expect(r.LinkIndex).To(Equal(5))
+				return nil
+			})
+
+			netiocl := netio.NewMockNetIO(false, 0)
+			netiocl.SetGetInterfaceValidatonFn(func(ifName string) (*net.Interface, error) {
+				Expect(ifName).To(Equal("eth0"))
+				return &net.Interface{
+					Index: 5,
+				}, nil
+			})
+
+			err := deleteRoutes(nlc, netiocl, "eth0", []RouteInfo{{Dst: *dst, DevName: ""}})
+			Expect(err).To(BeNil())
+		})
+		It("DeleteRoute with interfacename set in Route", func() {
+			nlc := netlink.NewMockNetlink(false, "")
+			nlc.SetDeleteRouteValidationFn(func(r *netlink.Route) error {
+				Expect(r.LinkIndex).To(Equal(6))
+				return nil
+			})
+
+			netiocl := netio.NewMockNetIO(false, 0)
+			netiocl.SetGetInterfaceValidatonFn(func(ifName string) (*net.Interface, error) {
+				Expect(ifName).To(Equal("eth1"))
+				return &net.Interface{
+					Index: 6,
+				}, nil
+			})
+
+			err := deleteRoutes(nlc, netiocl, "", []RouteInfo{{Dst: *dst, DevName: "eth1"}})
+			Expect(err).To(BeNil())
+		})
+		It("DeleteRoute with no ifindex", func() {
+			nlc := netlink.NewMockNetlink(false, "")
+			nlc.SetDeleteRouteValidationFn(func(r *netlink.Route) error {
+				Expect(r.LinkIndex).To(Equal(0))
+				return nil
+			})
+
+			netiocl := netio.NewMockNetIO(false, 0)
+			netiocl.SetGetInterfaceValidatonFn(func(ifName string) (*net.Interface, error) {
+				Expect(ifName).To(Equal("eth1"))
+				return &net.Interface{
+					Index: 6,
+				}, nil
+			})
+
+			err := deleteRoutes(nlc, netiocl, "", []RouteInfo{{Dst: *dst, DevName: ""}})
+			Expect(err).To(BeNil())
+		})
+	})
+	Describe("Test addRoutes", func() {
+		_, dst, _ := net.ParseCIDR("192.168.0.0/16")
+		It("AddRoute with interfacename explicit", func() {
+			nlc := netlink.NewMockNetlink(false, "")
+			nlc.SetAddRouteValidationFn(func(r *netlink.Route) error {
+				Expect(r).NotTo(BeNil())
+				Expect(r.LinkIndex).To(Equal(5))
+				return nil
+			})
+
+			netiocl := netio.NewMockNetIO(false, 0)
+			netiocl.SetGetInterfaceValidatonFn(func(ifName string) (*net.Interface, error) {
+				Expect(ifName).To(Equal("eth0"))
+				return &net.Interface{
+					Index: 5,
+				}, nil
+			})
+
+			err := addRoutes(nlc, netiocl, "eth0", []RouteInfo{{Dst: *dst, DevName: ""}})
+			Expect(err).To(BeNil())
+		})
+		It("AddRoute with interfacename set in route", func() {
+			nlc := netlink.NewMockNetlink(false, "")
+			nlc.SetAddRouteValidationFn(func(r *netlink.Route) error {
+				Expect(r.LinkIndex).To(Equal(6))
+				return nil
+			})
+
+			netiocl := netio.NewMockNetIO(false, 0)
+			netiocl.SetGetInterfaceValidatonFn(func(ifName string) (*net.Interface, error) {
+				Expect(ifName).To(Equal("eth1"))
+				return &net.Interface{
+					Index: 6,
+				}, nil
+			})
+
+			err := addRoutes(nlc, netiocl, "", []RouteInfo{{Dst: *dst, DevName: "eth1"}})
+			Expect(err).To(BeNil())
+		})
+		It("AddRoute with interfacename not set should return error", func() {
+			nlc := netlink.NewMockNetlink(false, "")
+			nlc.SetAddRouteValidationFn(func(r *netlink.Route) error {
+				Expect(r.LinkIndex).To(Equal(0))
+				return errors.New("Cannot add route")
+			})
+
+			netiocl := netio.NewMockNetIO(false, 0)
+			netiocl.SetGetInterfaceValidatonFn(func(ifName string) (*net.Interface, error) {
+				Expect(ifName).To(Equal(""))
+				return &net.Interface{
+					Index: 0,
+				}, errors.New("interface not found")
+			})
+
+			err := addRoutes(nlc, netiocl, "", []RouteInfo{{Dst: *dst, DevName: ""}})
+			Expect(err).ToNot(BeNil())
 		})
 	})
 })

--- a/network/endpoint_test.go
+++ b/network/endpoint_test.go
@@ -4,7 +4,6 @@
 package network
 
 import (
-	"errors"
 	"net"
 	"testing"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/Azure/azure-container-networking/netlink"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 )
 
 func TestEndpoint(t *testing.T) {
@@ -298,6 +298,7 @@ var _ = Describe("Test Endpoint", func() {
 			nlc := netlink.NewMockNetlink(false, "")
 			nlc.SetAddRouteValidationFn(func(r *netlink.Route) error {
 				Expect(r.LinkIndex).To(Equal(0))
+				//nolint:goerr113
 				return errors.New("Cannot add route")
 			})
 
@@ -306,7 +307,7 @@ var _ = Describe("Test Endpoint", func() {
 				Expect(ifName).To(Equal(""))
 				return &net.Interface{
 					Index: 0,
-				}, errors.New("interface not found")
+				}, errors.Wrapf(netio.ErrInterfaceNil, "Cannot get interface")
 			})
 
 			err := addRoutes(nlc, netiocl, "", []RouteInfo{{Dst: *dst, DevName: ""}})

--- a/network/endpoint_test.go
+++ b/network/endpoint_test.go
@@ -4,14 +4,10 @@
 package network
 
 import (
-	"net"
 	"testing"
 
-	"github.com/Azure/azure-container-networking/netio"
-	"github.com/Azure/azure-container-networking/netlink"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 )
 
 func TestEndpoint(t *testing.T) {
@@ -195,123 +191,6 @@ var _ = Describe("Test Endpoint", func() {
 					Expect(podName).To(Equal(expectedPodName))
 				}
 			})
-		})
-	})
-	Describe("Test deleteRoutes", func() {
-		_, dst, _ := net.ParseCIDR("192.168.0.0/16")
-
-		It("DeleteRoute with interfacename explicit", func() {
-			nlc := netlink.NewMockNetlink(false, "")
-			nlc.SetDeleteRouteValidationFn(func(r *netlink.Route) error {
-				Expect(r.LinkIndex).To(Equal(5))
-				return nil
-			})
-
-			netiocl := netio.NewMockNetIO(false, 0)
-			netiocl.SetGetInterfaceValidatonFn(func(ifName string) (*net.Interface, error) {
-				Expect(ifName).To(Equal("eth0"))
-				return &net.Interface{
-					Index: 5,
-				}, nil
-			})
-
-			err := deleteRoutes(nlc, netiocl, "eth0", []RouteInfo{{Dst: *dst, DevName: ""}})
-			Expect(err).To(BeNil())
-		})
-		It("DeleteRoute with interfacename set in Route", func() {
-			nlc := netlink.NewMockNetlink(false, "")
-			nlc.SetDeleteRouteValidationFn(func(r *netlink.Route) error {
-				Expect(r.LinkIndex).To(Equal(6))
-				return nil
-			})
-
-			netiocl := netio.NewMockNetIO(false, 0)
-			netiocl.SetGetInterfaceValidatonFn(func(ifName string) (*net.Interface, error) {
-				Expect(ifName).To(Equal("eth1"))
-				return &net.Interface{
-					Index: 6,
-				}, nil
-			})
-
-			err := deleteRoutes(nlc, netiocl, "", []RouteInfo{{Dst: *dst, DevName: "eth1"}})
-			Expect(err).To(BeNil())
-		})
-		It("DeleteRoute with no ifindex", func() {
-			nlc := netlink.NewMockNetlink(false, "")
-			nlc.SetDeleteRouteValidationFn(func(r *netlink.Route) error {
-				Expect(r.LinkIndex).To(Equal(0))
-				return nil
-			})
-
-			netiocl := netio.NewMockNetIO(false, 0)
-			netiocl.SetGetInterfaceValidatonFn(func(ifName string) (*net.Interface, error) {
-				Expect(ifName).To(Equal("eth1"))
-				return &net.Interface{
-					Index: 6,
-				}, nil
-			})
-
-			err := deleteRoutes(nlc, netiocl, "", []RouteInfo{{Dst: *dst, DevName: ""}})
-			Expect(err).To(BeNil())
-		})
-	})
-	Describe("Test addRoutes", func() {
-		_, dst, _ := net.ParseCIDR("192.168.0.0/16")
-		It("AddRoute with interfacename explicit", func() {
-			nlc := netlink.NewMockNetlink(false, "")
-			nlc.SetAddRouteValidationFn(func(r *netlink.Route) error {
-				Expect(r).NotTo(BeNil())
-				Expect(r.LinkIndex).To(Equal(5))
-				return nil
-			})
-
-			netiocl := netio.NewMockNetIO(false, 0)
-			netiocl.SetGetInterfaceValidatonFn(func(ifName string) (*net.Interface, error) {
-				Expect(ifName).To(Equal("eth0"))
-				return &net.Interface{
-					Index: 5,
-				}, nil
-			})
-
-			err := addRoutes(nlc, netiocl, "eth0", []RouteInfo{{Dst: *dst, DevName: ""}})
-			Expect(err).To(BeNil())
-		})
-		It("AddRoute with interfacename set in route", func() {
-			nlc := netlink.NewMockNetlink(false, "")
-			nlc.SetAddRouteValidationFn(func(r *netlink.Route) error {
-				Expect(r.LinkIndex).To(Equal(6))
-				return nil
-			})
-
-			netiocl := netio.NewMockNetIO(false, 0)
-			netiocl.SetGetInterfaceValidatonFn(func(ifName string) (*net.Interface, error) {
-				Expect(ifName).To(Equal("eth1"))
-				return &net.Interface{
-					Index: 6,
-				}, nil
-			})
-
-			err := addRoutes(nlc, netiocl, "", []RouteInfo{{Dst: *dst, DevName: "eth1"}})
-			Expect(err).To(BeNil())
-		})
-		It("AddRoute with interfacename not set should return error", func() {
-			nlc := netlink.NewMockNetlink(false, "")
-			nlc.SetAddRouteValidationFn(func(r *netlink.Route) error {
-				Expect(r.LinkIndex).To(Equal(0))
-				//nolint:goerr113
-				return errors.New("Cannot add route")
-			})
-
-			netiocl := netio.NewMockNetIO(false, 0)
-			netiocl.SetGetInterfaceValidatonFn(func(ifName string) (*net.Interface, error) {
-				Expect(ifName).To(Equal(""))
-				return &net.Interface{
-					Index: 0,
-				}, errors.Wrapf(netio.ErrInterfaceNil, "Cannot get interface")
-			})
-
-			err := addRoutes(nlc, netiocl, "", []RouteInfo{{Dst: *dst, DevName: ""}})
-			Expect(err).ToNot(BeNil())
 		})
 	})
 })

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -156,6 +156,7 @@ func (nw *network) newEndpointImplHnsV1(epInfo *EndpointInfo) (*endpoint, error)
 		VlanID:           vlanid,
 		EnableSnatOnHost: epInfo.EnableSnatOnHost,
 		NetNs:            epInfo.NetNsPath,
+		ContainerID:      epInfo.ContainerID,
 	}
 
 	for _, route := range epInfo.Routes {

--- a/network/manager.go
+++ b/network/manager.go
@@ -49,7 +49,7 @@ type EndpointClient interface {
 	MoveEndpointsToContainerNS(epInfo *EndpointInfo, nsID uintptr) error
 	SetupContainerInterfaces(epInfo *EndpointInfo) error
 	ConfigureContainerInterfacesAndRoutes(epInfo *EndpointInfo) error
-	DeleteEndpoints(ep *endpoint, deleteHostVeth bool) error
+	DeleteEndpoints(ep *endpoint) error
 }
 
 // NetworkManager manages the set of container networking resources.

--- a/network/manager.go
+++ b/network/manager.go
@@ -76,7 +76,7 @@ type NetworkManager interface {
 	GetNetworkInfo(networkID string) (NetworkInfo, error)
 	// FindNetworkIDFromNetNs returns the network name that contains an endpoint created for this netNS, errNetworkNotFound if no network is found
 	FindNetworkIDFromNetNs(netNs string) (string, error)
-	GetNumEndpointsInNetNs(netNs string) int
+	GetNumEndpointsByContainerID(containerID string) int
 
 	CreateEndpoint(client apipaClient, networkID string, epInfo *EndpointInfo) error
 	DeleteEndpoint(networkID string, endpointID string) error

--- a/network/manager_mock.go
+++ b/network/manager_mock.go
@@ -116,7 +116,7 @@ func (nm *MockNetworkManager) FindNetworkIDFromNetNs(netNs string) (string, erro
 }
 
 // GetNumEndpointsByContainerID mock
-func (nm *MockNetworkManager) GetNumEndpointsByContainerID(containerID string) int {
+func (nm *MockNetworkManager) GetNumEndpointsByContainerID(_ string) int {
 	// based on the GetAllEndpoints func above, it seems that this mock is only intended to be used with
 	// one network, so just return the number of endpoints if network exists
 	numEndpoints := 0

--- a/network/manager_mock.go
+++ b/network/manager_mock.go
@@ -115,8 +115,8 @@ func (nm *MockNetworkManager) FindNetworkIDFromNetNs(netNs string) (string, erro
 	return "", errNetworkNotFound
 }
 
-// GetNumEndpointsInNetNs mock
-func (nm *MockNetworkManager) GetNumEndpointsInNetNs(netNs string) int {
+// GetNumEndpointsByContainerID mock
+func (nm *MockNetworkManager) GetNumEndpointsByContainerID(containerID string) int {
 	// based on the GetAllEndpoints func above, it seems that this mock is only intended to be used with
 	// one network, so just return the number of endpoints if network exists
 	numEndpoints := 0

--- a/network/mock_endpointclient.go
+++ b/network/mock_endpointclient.go
@@ -58,7 +58,7 @@ func (client *MockEndpointClient) ConfigureContainerInterfacesAndRoutes(_ *Endpo
 	return nil
 }
 
-func (client *MockEndpointClient) DeleteEndpoints(ep *endpoint, _ bool) error {
+func (client *MockEndpointClient) DeleteEndpoints(ep *endpoint) error {
 	delete(client.endpoints, ep.Id)
 	return nil
 }

--- a/network/network.go
+++ b/network/network.go
@@ -276,7 +276,7 @@ func (nm *networkManager) FindNetworkIDFromNetNs(netNs string) (string, error) {
 }
 
 // GetNumEndpointsInNetNs returns number of endpoints
-func (nm *networkManager) GetNumEndpointsInNetNs(netNs string) int {
+func (nm *networkManager) GetNumEndpointsByContainerID(containerID string) int {
 	numEndpoints := 0
 	// Look through the external interfaces
 	for _, iface := range nm.ExternalInterfaces {
@@ -285,8 +285,8 @@ func (nm *networkManager) GetNumEndpointsInNetNs(netNs string) int {
 			// Network may have multiple endpoints, so look through all of them
 			for _, endpoint := range network.Endpoints {
 				// If the netNs matches for this endpoint, return the network ID (which is the name)
-				if endpoint.NetNs == netNs {
-					log.Printf("Found endpoint [%s] for NetNS [%s]", endpoint.Id, netNs)
+				if endpoint.ContainerID == containerID {
+					log.Printf("Found endpoint [%s] for containerID [%s]", endpoint.Id, containerID)
 					numEndpoints++
 				}
 			}

--- a/network/network_linux.go
+++ b/network/network_linux.go
@@ -118,7 +118,7 @@ func (nm *networkManager) newNetworkImpl(nwInfo *NetworkInfo, extIf *externalInt
 func (nm *networkManager) handleCommonOptions(ifName string, nwInfo *NetworkInfo) error {
 	var err error
 	if routes, exists := nwInfo.Options[RoutesKey]; exists {
-		err = addRoutes(nm.netlink, nm.netio, ifName, routes.([]RouteInfo))
+		err = addRoutes(nm.netlink, nm.netio, ifName, routes.([]RouteInfo), false)
 		if err != nil {
 			return err
 		}
@@ -152,7 +152,7 @@ func (nm *networkManager) deleteNetworkImpl(nw *network) error {
 	return nil
 }
 
-//  SaveIPConfig saves the IP configuration of an interface.
+// SaveIPConfig saves the IP configuration of an interface.
 func (nm *networkManager) saveIPConfig(hostIf *net.Interface, extIf *externalInterface) error {
 	// Save the default routes on the interface.
 	routes, err := nm.netlink.GetIPRoute(&netlink.Route{Dst: &net.IPNet{}, LinkIndex: hostIf.Index})
@@ -649,7 +649,7 @@ func AddStaticRoute(nl netlink.NetlinkInterface, netioshim netio.NetIOInterface,
 	gwIP := net.ParseIP("0.0.0.0")
 	route := RouteInfo{Dst: *ipNet, Gw: gwIP}
 	routes = append(routes, route)
-	if err := addRoutes(nl, netioshim, interfaceName, routes); err != nil {
+	if err := addRoutes(nl, netioshim, interfaceName, routes, false); err != nil {
 		if err != nil && !strings.Contains(strings.ToLower(err.Error()), "file exists") {
 			log.Printf("addroutes failed with error %v", err)
 			return err

--- a/network/network_linux.go
+++ b/network/network_linux.go
@@ -118,7 +118,7 @@ func (nm *networkManager) newNetworkImpl(nwInfo *NetworkInfo, extIf *externalInt
 func (nm *networkManager) handleCommonOptions(ifName string, nwInfo *NetworkInfo) error {
 	var err error
 	if routes, exists := nwInfo.Options[RoutesKey]; exists {
-		err = addRoutes(nm.netlink, nm.netio, ifName, routes.([]RouteInfo), false)
+		err = addRoutes(nm.netlink, nm.netio, ifName, routes.([]RouteInfo))
 		if err != nil {
 			return err
 		}
@@ -649,7 +649,7 @@ func AddStaticRoute(nl netlink.NetlinkInterface, netioshim netio.NetIOInterface,
 	gwIP := net.ParseIP("0.0.0.0")
 	route := RouteInfo{Dst: *ipNet, Gw: gwIP}
 	routes = append(routes, route)
-	if err := addRoutes(nl, netioshim, interfaceName, routes, false); err != nil {
+	if err := addRoutes(nl, netioshim, interfaceName, routes); err != nil {
 		if err != nil && !strings.Contains(strings.ToLower(err.Error()), "file exists") {
 			log.Printf("addroutes failed with error %v", err)
 			return err

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -258,10 +258,10 @@ var _ = Describe("Test Network", func() {
 		})
 	})
 
-	Describe("Test GetNumEndpointsInNetNs", func() {
+	Describe("Test GetNumEndpointsByContainerID", func() {
 		Context("When one network has one endpoint and another network has two endpoints", func() {
 			It("Should return three endpoints", func() {
-				netNs := "989c079b-45a6-485f-8f9e-88b05d6c55c5"
+				containerID := "989c079b-45a6-485f-8f9e-88b05d6c55c5"
 				networkOneID := "byovnetbridge-vlan1-10-128-8-0_23"
 				networkTwoID := "byovnetbridge-vlan2-20-128-8-0_23"
 
@@ -274,15 +274,14 @@ var _ = Describe("Test Network", func() {
 									Id: "byovnetbridge-vlan1-10-128-8-0_23",
 									Endpoints: map[string]*endpoint{
 										"a591be2a-eth0": {
-											Id:    "a591be2a-eth0",
-											NetNs: netNs,
+											Id:          "a591be2a-eth0",
+											ContainerID: containerID,
 										},
 										"a691be2b-eth0": {
-											Id:    "a691be2b-eth0",
-											NetNs: netNs,
+											Id:          "a691be2b-eth0",
+											ContainerID: containerID,
 										},
 									},
-									NetNs: "aaac079b-45a6-485f-8f9e-88b05d6c55c5",
 								},
 							},
 						},
@@ -293,30 +292,30 @@ var _ = Describe("Test Network", func() {
 									Id: "byovnetbridge-vlan2-20-128-8-0_23",
 									Endpoints: map[string]*endpoint{
 										"a591be2b-eth0": {
-											Id:    "a591be2b-eth0",
-											NetNs: netNs,
+											Id:          "a591be2b-eth0",
+											ContainerID: containerID,
 										},
 									},
-									NetNs: "aaac079b-45a6-485f-8f9e-88b05d6c55c5",
+									NetNs: "",
 								},
 							},
 						},
 					},
 				}
 
-				got := nm.GetNumEndpointsInNetNs(netNs)
-				Expect(got).To(Equal(3))
+				got := nm.GetNumEndpointsByContainerID(containerID)
+				Expect(3).To(Equal(got))
 			})
 		})
 
 		Context("When network does not exist", func() {
 			It("Should return zero endpoints", func() {
-				netNs := "989c079b-45a6-485f-8f9e-88b05d6c55c9"
+				containerID := "989c079b-45a6-485f-8f9e-88b05d6c55c9"
 				nm := &networkManager{
 					ExternalInterfaces: make(map[string]*externalInterface),
 				}
 
-				got := nm.GetNumEndpointsInNetNs(netNs)
+				got := nm.GetNumEndpointsByContainerID(containerID)
 				Expect(got).To(Equal(0))
 			})
 		})

--- a/network/networkutils/networkutils_linux.go
+++ b/network/networkutils/networkutils_linux.go
@@ -267,6 +267,12 @@ func (nu NetworkUtils) DisableRAForInterface(ifName string) error {
 	return err
 }
 
+func (nu NetworkUtils) SetProxyArp(ifName string) error {
+	cmd := fmt.Sprintf("echo 1 > /proc/sys/net/ipv4/conf/%v/proxy_arp", ifName)
+	_, err := nu.plClient.ExecuteCommand(cmd)
+	return err
+}
+
 func getPrivateIPSpace() []string {
 	privateIPAddresses := []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "169.254.0.0/16"}
 	return privateIPAddresses

--- a/network/networkutils/networkutils_linux.go
+++ b/network/networkutils/networkutils_linux.go
@@ -4,7 +4,6 @@
 package networkutils
 
 import (
-	"errors"
 	"fmt"
 	"net"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/Azure/azure-container-networking/log"
 	"github.com/Azure/azure-container-networking/netlink"
 	"github.com/Azure/azure-container-networking/platform"
+	"github.com/pkg/errors"
 )
 
 /*RFC For Private Address Space: https://tools.ietf.org/html/rfc1918
@@ -270,7 +270,7 @@ func (nu NetworkUtils) DisableRAForInterface(ifName string) error {
 func (nu NetworkUtils) SetProxyArp(ifName string) error {
 	cmd := fmt.Sprintf("echo 1 > /proc/sys/net/ipv4/conf/%v/proxy_arp", ifName)
 	_, err := nu.plClient.ExecuteCommand(cmd)
-	return err
+	return errors.Wrapf(err, "failed to set proxy arp for interface %v", ifName)
 }
 
 func getPrivateIPSpace() []string {

--- a/network/ovs_endpoint_snatroute_linux.go
+++ b/network/ovs_endpoint_snatroute_linux.go
@@ -29,6 +29,7 @@ func (client *OVSEndpointClient) NewSnatClient(snatBridgeIP, localIP string, epI
 			snatBridgeIP,
 			client.hostPrimaryMac,
 			epInfo.DNS.Servers,
+			false,
 			client.netlink,
 			client.plClient,
 		)

--- a/network/ovs_endpointclient_linux.go
+++ b/network/ovs_endpointclient_linux.go
@@ -233,7 +233,7 @@ func (client *OVSEndpointClient) ConfigureContainerInterfacesAndRoutes(epInfo *E
 	return addRoutes(client.netlink, client.netioshim, client.containerVethName, epInfo.Routes)
 }
 
-func (client *OVSEndpointClient) DeleteEndpoints(ep *endpoint, _ bool) error {
+func (client *OVSEndpointClient) DeleteEndpoints(ep *endpoint) error {
 	log.Printf("[ovs] Deleting veth pair %v %v.", ep.HostIfName, ep.IfName)
 	err := client.netlink.DeleteLink(ep.HostIfName)
 	if err != nil {

--- a/network/ovs_endpointclient_linux.go
+++ b/network/ovs_endpointclient_linux.go
@@ -230,7 +230,7 @@ func (client *OVSEndpointClient) ConfigureContainerInterfacesAndRoutes(epInfo *E
 		return err
 	}
 
-	return addRoutes(client.netlink, client.netioshim, client.containerVethName, epInfo.Routes)
+	return addRoutes(client.netlink, client.netioshim, client.containerVethName, epInfo.Routes, false)
 }
 
 func (client *OVSEndpointClient) DeleteEndpoints(ep *endpoint) error {

--- a/network/ovs_endpointclient_linux.go
+++ b/network/ovs_endpointclient_linux.go
@@ -230,7 +230,7 @@ func (client *OVSEndpointClient) ConfigureContainerInterfacesAndRoutes(epInfo *E
 		return err
 	}
 
-	return addRoutes(client.netlink, client.netioshim, client.containerVethName, epInfo.Routes, false)
+	return addRoutes(client.netlink, client.netioshim, client.containerVethName, epInfo.Routes)
 }
 
 func (client *OVSEndpointClient) DeleteEndpoints(ep *endpoint) error {

--- a/network/snat/snat_linux.go
+++ b/network/snat/snat_linux.go
@@ -40,9 +40,9 @@ type Client struct {
 	localIP                string
 	SnatBridgeIP           string
 	SkipAddressesFromBlock []string
+	enableProxyArpOnBridge bool
 	netlink                netlink.NetlinkInterface
-
-	plClient platform.ExecClient
+	plClient               platform.ExecClient
 }
 
 func NewSnatClient(hostIfName string,
@@ -51,20 +51,20 @@ func NewSnatClient(hostIfName string,
 	snatBridgeIP string,
 	hostPrimaryMac string,
 	skipAddressesFromBlock []string,
+	enableProxyArpOnBridge bool,
 	nl netlink.NetlinkInterface,
-
 	plClient platform.ExecClient,
 ) Client {
 	log.Printf("Initialize new snat client")
 	snatClient := Client{
-		hostSnatVethName:      hostIfName,
-		containerSnatVethName: contIfName,
-		localIP:               localIP,
-		SnatBridgeIP:          snatBridgeIP,
-		hostPrimaryMac:        hostPrimaryMac,
-		netlink:               nl,
-
-		plClient: plClient,
+		hostSnatVethName:       hostIfName,
+		containerSnatVethName:  contIfName,
+		localIP:                localIP,
+		SnatBridgeIP:           snatBridgeIP,
+		hostPrimaryMac:         hostPrimaryMac,
+		enableProxyArpOnBridge: enableProxyArpOnBridge,
+		netlink:                nl,
+		plClient:               plClient,
 	}
 
 	snatClient.SkipAddressesFromBlock = append(snatClient.SkipAddressesFromBlock, skipAddressesFromBlock...)
@@ -81,6 +81,16 @@ func (client *Client) CreateSnatEndpoint() error {
 		return err
 	}
 
+	nuc := networkutils.NewNetworkUtils(client.netlink, client.plClient)
+	// Enabling proxy arp on bridge allows bridge to respond to arp requests it receives with its own mac otherwise arp requests are not getting forwarded and responded.
+	if client.enableProxyArpOnBridge {
+		// Enable proxy arp on bridge
+		if err := nuc.SetProxyArp(SnatBridgeName); err != nil {
+			log.Printf("Enabling proxy arp failed with error %v", err)
+			return err
+		}
+	}
+
 	// SNAT Rule to masquerade packets destined to non-vnet ip
 	if err := client.addMasqueradeRule(client.SnatBridgeIP); err != nil {
 		log.Printf("Adding snat rule failed with error %v", err)
@@ -93,9 +103,8 @@ func (client *Client) CreateSnatEndpoint() error {
 		return err
 	}
 
-	epc := networkutils.NewNetworkUtils(client.netlink, client.plClient)
 	// Create veth pair to tie one end to container and other end to linux bridge
-	if err := epc.CreateEndpoint(client.hostSnatVethName, client.containerSnatVethName, nil); err != nil {
+	if err := nuc.CreateEndpoint(client.hostSnatVethName, client.containerSnatVethName, nil); err != nil {
 		log.Printf("Creating Snat Endpoint failed with error %v", err)
 		return newErrorSnatClient(err.Error())
 	}
@@ -127,9 +136,13 @@ func (client *Client) BlockIPAddressesOnSnatBridge() error {
 	return nil
 }
 
-/**
+/*
+*
+
 	Move container veth inside container network namespace
-**/
+
+*
+*/
 func (client *Client) MoveSnatEndpointToContainerNS(netnsPath string, nsID uintptr) error {
 	log.Printf("[snat] Setting link %v netns %v.", client.containerSnatVethName, netnsPath)
 	err := client.netlink.SetLinkNetNs(client.containerSnatVethName, nsID)
@@ -139,9 +152,13 @@ func (client *Client) MoveSnatEndpointToContainerNS(netnsPath string, nsID uintp
 	return nil
 }
 
-/**
+/*
+*
+
 	Configure Routes and setup name for container veth
-**/
+
+*
+*/
 func (client *Client) SetupSnatContainerInterface() error {
 	epc := networkutils.NewNetworkUtils(client.netlink, client.plClient)
 	if err := epc.SetupContainerInterface(client.containerSnatVethName, azureSnatIfName); err != nil {
@@ -159,9 +176,13 @@ func getNCLocalAndGatewayIP(client *Client) (brIP, contIP net.IP) {
 	return bridgeIP, containerIP
 }
 
-/**
+/*
+*
+
 	This function adds iptables rules that allows only host to NC communication and not the other way
-**/
+
+*
+*/
 func (client *Client) AllowInboundFromHostToNC() error {
 	bridgeIP, containerIP := getNCLocalAndGatewayIP(client)
 
@@ -250,9 +271,13 @@ func (client *Client) DeleteInboundFromHostToNC() error {
 	return err
 }
 
-/**
+/*
+*
+
 	This function adds iptables rules that allows only NC to Host communication and not the other way
-**/
+
+*
+*/
 func (client *Client) AllowInboundFromNCToHost() error {
 	bridgeIP, containerIP := getNCLocalAndGatewayIP(client)
 
@@ -388,9 +413,13 @@ func (client *Client) DropArpForSnatBridgeApipaRange(snatBridgeIP, azSnatVethIfN
 	return err
 }
 
-/**
+/*
+*
+
 	This function creates linux bridge which will be used for outbound connectivity by NCs
-**/
+
+*
+*/
 func (client *Client) createSnatBridge(snatBridgeIP, hostPrimaryMac string) error {
 	_, err := net.InterfaceByName(SnatBridgeName)
 	if err == nil {
@@ -437,18 +466,26 @@ func (client *Client) createSnatBridge(snatBridgeIP, hostPrimaryMac string) erro
 	return nil
 }
 
-/**
+/*
+*
+
 	This function adds iptable rules that will snat all traffic that has source ip in apipa range and coming via linux bridge
-**/
+
+*
+*/
 func (client *Client) addMasqueradeRule(snatBridgeIPWithPrefix string) error {
 	_, ipNet, _ := net.ParseCIDR(snatBridgeIPWithPrefix)
 	matchCondition := fmt.Sprintf("-s %s", ipNet.String())
 	return iptables.InsertIptableRule(iptables.V4, iptables.Nat, iptables.Postrouting, matchCondition, iptables.Masquerade)
 }
 
-/**
+/*
+*
+
 	Drop all vlan traffic on linux bridge
-**/
+
+*
+*/
 func (client *Client) addVlanDropRule() error {
 	out, err := client.plClient.ExecuteCommand(l2PreroutingEntries)
 	if err != nil {

--- a/network/snat/snat_linux.go
+++ b/network/snat/snat_linux.go
@@ -136,13 +136,7 @@ func (client *Client) BlockIPAddressesOnSnatBridge() error {
 	return nil
 }
 
-/*
-*
-
-	Move container veth inside container network namespace
-
-*
-*/
+// Move container veth inside container network namespace
 func (client *Client) MoveSnatEndpointToContainerNS(netnsPath string, nsID uintptr) error {
 	log.Printf("[snat] Setting link %v netns %v.", client.containerSnatVethName, netnsPath)
 	err := client.netlink.SetLinkNetNs(client.containerSnatVethName, nsID)
@@ -152,13 +146,7 @@ func (client *Client) MoveSnatEndpointToContainerNS(netnsPath string, nsID uintp
 	return nil
 }
 
-/*
-*
-
-	Configure Routes and setup name for container veth
-
-*
-*/
+// Configure Routes and setup name for container veth
 func (client *Client) SetupSnatContainerInterface() error {
 	epc := networkutils.NewNetworkUtils(client.netlink, client.plClient)
 	if err := epc.SetupContainerInterface(client.containerSnatVethName, azureSnatIfName); err != nil {
@@ -176,13 +164,7 @@ func getNCLocalAndGatewayIP(client *Client) (brIP, contIP net.IP) {
 	return bridgeIP, containerIP
 }
 
-/*
-*
-
-	This function adds iptables rules that allows only host to NC communication and not the other way
-
-*
-*/
+// This function adds iptables rules that allows only host to NC communication and not the other way
 func (client *Client) AllowInboundFromHostToNC() error {
 	bridgeIP, containerIP := getNCLocalAndGatewayIP(client)
 
@@ -271,13 +253,7 @@ func (client *Client) DeleteInboundFromHostToNC() error {
 	return err
 }
 
-/*
-*
-
-	This function adds iptables rules that allows only NC to Host communication and not the other way
-
-*
-*/
+// This function adds iptables rules that allows only NC to Host communication and not the other way
 func (client *Client) AllowInboundFromNCToHost() error {
 	bridgeIP, containerIP := getNCLocalAndGatewayIP(client)
 
@@ -365,10 +341,7 @@ func (client *Client) DeleteInboundFromNCToHost() error {
 	return err
 }
 
-/**
-	Configures Local IP Address for container Veth
-**/
-
+// Configures Local IP Address for container Veth
 func (client *Client) ConfigureSnatContainerInterface() error {
 	log.Printf("[snat] Adding IP address %v to link %v.", client.localIP, client.containerSnatVethName)
 	ip, intIpAddr, _ := net.ParseCIDR(client.localIP)
@@ -413,13 +386,7 @@ func (client *Client) DropArpForSnatBridgeApipaRange(snatBridgeIP, azSnatVethIfN
 	return err
 }
 
-/*
-*
-
-	This function creates linux bridge which will be used for outbound connectivity by NCs
-
-*
-*/
+// This function creates linux bridge which will be used for outbound connectivity by NCs
 func (client *Client) createSnatBridge(snatBridgeIP, hostPrimaryMac string) error {
 	_, err := net.InterfaceByName(SnatBridgeName)
 	if err == nil {
@@ -466,26 +433,14 @@ func (client *Client) createSnatBridge(snatBridgeIP, hostPrimaryMac string) erro
 	return nil
 }
 
-/*
-*
-
-	This function adds iptable rules that will snat all traffic that has source ip in apipa range and coming via linux bridge
-
-*
-*/
+// This function adds iptable rules that will snat all traffic that has source ip in apipa range and coming via linux bridge
 func (client *Client) addMasqueradeRule(snatBridgeIPWithPrefix string) error {
 	_, ipNet, _ := net.ParseCIDR(snatBridgeIPWithPrefix)
 	matchCondition := fmt.Sprintf("-s %s", ipNet.String())
 	return iptables.InsertIptableRule(iptables.V4, iptables.Nat, iptables.Postrouting, matchCondition, iptables.Masquerade)
 }
 
-/*
-*
-
-	Drop all vlan traffic on linux bridge
-
-*
-*/
+// Drop all vlan traffic on linux bridge
 func (client *Client) addVlanDropRule() error {
 	out, err := client.plClient.ExecuteCommand(l2PreroutingEntries)
 	if err != nil {

--- a/network/snat/snat_linux.go
+++ b/network/snat/snat_linux.go
@@ -4,7 +4,6 @@
 package snat
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -15,6 +14,7 @@ import (
 	"github.com/Azure/azure-container-networking/netlink"
 	"github.com/Azure/azure-container-networking/network/networkutils"
 	"github.com/Azure/azure-container-networking/platform"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -87,7 +87,7 @@ func (client *Client) CreateSnatEndpoint() error {
 		// Enable proxy arp on bridge
 		if err := nuc.SetProxyArp(SnatBridgeName); err != nil {
 			log.Printf("Enabling proxy arp failed with error %v", err)
-			return err
+			return errors.Wrap(err, "")
 		}
 	}
 

--- a/network/transparent_endpointclient_linux.go
+++ b/network/transparent_endpointclient_linux.go
@@ -314,6 +314,6 @@ func (client *TransparentEndpointClient) setIPV6NeighEntry() error {
 	return nil
 }
 
-func (client *TransparentEndpointClient) DeleteEndpoints(_ *endpoint, _ bool) error {
+func (client *TransparentEndpointClient) DeleteEndpoints(_ *endpoint) error {
 	return nil
 }

--- a/network/transparent_endpointclient_linux.go
+++ b/network/transparent_endpointclient_linux.go
@@ -152,7 +152,7 @@ func (client *TransparentEndpointClient) AddEndpointRules(epInfo *EndpointInfo) 
 		log.Printf("[net] Adding route for the ip %v", ipNet.String())
 		routeInfo.Dst = ipNet
 		routeInfoList = append(routeInfoList, routeInfo)
-		if err := addRoutes(client.netlink, client.netioshim, client.hostVethName, routeInfoList); err != nil {
+		if err := addRoutes(client.netlink, client.netioshim, client.hostVethName, routeInfoList, false); err != nil {
 			return newErrorTransparentEndpointClient(err.Error())
 		}
 	}
@@ -234,7 +234,7 @@ func (client *TransparentEndpointClient) ConfigureContainerInterfacesAndRoutes(e
 		Dst:   *virtualGwNet,
 		Scope: netlink.RT_SCOPE_LINK,
 	}
-	if err := addRoutes(client.netlink, client.netioshim, client.containerVethName, []RouteInfo{routeInfo}); err != nil {
+	if err := addRoutes(client.netlink, client.netioshim, client.containerVethName, []RouteInfo{routeInfo}, false); err != nil {
 		return newErrorTransparentEndpointClient(err.Error())
 	}
 
@@ -245,7 +245,7 @@ func (client *TransparentEndpointClient) ConfigureContainerInterfacesAndRoutes(e
 		Dst: dstIP,
 		Gw:  virtualGwIP,
 	}
-	if err := addRoutes(client.netlink, client.netioshim, client.containerVethName, []RouteInfo{routeInfo}); err != nil {
+	if err := addRoutes(client.netlink, client.netioshim, client.containerVethName, []RouteInfo{routeInfo}, false); err != nil {
 		return err
 	}
 
@@ -294,7 +294,7 @@ func (client *TransparentEndpointClient) setupIPV6Routes() error {
 		Gw:  virtualGwIP,
 	}
 
-	return addRoutes(client.netlink, client.netioshim, client.containerVethName, []RouteInfo{gwRoute, defaultRoute})
+	return addRoutes(client.netlink, client.netioshim, client.containerVethName, []RouteInfo{gwRoute, defaultRoute}, false)
 }
 
 func (client *TransparentEndpointClient) setIPV6NeighEntry() error {

--- a/network/transparent_endpointclient_linux.go
+++ b/network/transparent_endpointclient_linux.go
@@ -152,7 +152,7 @@ func (client *TransparentEndpointClient) AddEndpointRules(epInfo *EndpointInfo) 
 		log.Printf("[net] Adding route for the ip %v", ipNet.String())
 		routeInfo.Dst = ipNet
 		routeInfoList = append(routeInfoList, routeInfo)
-		if err := addRoutes(client.netlink, client.netioshim, client.hostVethName, routeInfoList, false); err != nil {
+		if err := addRoutes(client.netlink, client.netioshim, client.hostVethName, routeInfoList); err != nil {
 			return newErrorTransparentEndpointClient(err.Error())
 		}
 	}
@@ -234,7 +234,7 @@ func (client *TransparentEndpointClient) ConfigureContainerInterfacesAndRoutes(e
 		Dst:   *virtualGwNet,
 		Scope: netlink.RT_SCOPE_LINK,
 	}
-	if err := addRoutes(client.netlink, client.netioshim, client.containerVethName, []RouteInfo{routeInfo}, false); err != nil {
+	if err := addRoutes(client.netlink, client.netioshim, client.containerVethName, []RouteInfo{routeInfo}); err != nil {
 		return newErrorTransparentEndpointClient(err.Error())
 	}
 
@@ -245,7 +245,7 @@ func (client *TransparentEndpointClient) ConfigureContainerInterfacesAndRoutes(e
 		Dst: dstIP,
 		Gw:  virtualGwIP,
 	}
-	if err := addRoutes(client.netlink, client.netioshim, client.containerVethName, []RouteInfo{routeInfo}, false); err != nil {
+	if err := addRoutes(client.netlink, client.netioshim, client.containerVethName, []RouteInfo{routeInfo}); err != nil {
 		return err
 	}
 
@@ -294,7 +294,7 @@ func (client *TransparentEndpointClient) setupIPV6Routes() error {
 		Gw:  virtualGwIP,
 	}
 
-	return addRoutes(client.netlink, client.netioshim, client.containerVethName, []RouteInfo{gwRoute, defaultRoute}, false)
+	return addRoutes(client.netlink, client.netioshim, client.containerVethName, []RouteInfo{gwRoute, defaultRoute})
 }
 
 func (client *TransparentEndpointClient) setIPV6NeighEntry() error {

--- a/network/transparent_vlan_endpoint_snatroute_linux.go
+++ b/network/transparent_vlan_endpoint_snatroute_linux.go
@@ -17,6 +17,7 @@ func (client *TransparentVlanEndpointClient) NewSnatClient(snatBridgeIP, localIP
 			snatBridgeIP,
 			client.hostPrimaryMac.String(),
 			epInfo.DNS.Servers,
+			true,
 			client.netlink,
 			client.plClient,
 		)

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -191,7 +191,14 @@ func (client *TransparentVlanEndpointClient) PopulateVM(epInfo *EndpointInfo) er
 	}
 	client.vnetNSFileDescriptor = vnetNS
 
-	if err = client.netUtilsClient.CreateEndpoint(client.vnetVethName, client.containerVethName, nil); err != nil {
+	// Get the default constant host veth mac
+	mac, err := net.ParseMAC(defaultHostVethHwAddr)
+	if err != nil {
+		log.Printf("[net] Failed to parse the mac addrress %v", defaultHostVethHwAddr)
+	}
+
+	// Create veth pair
+	if err = client.netUtilsClient.CreateEndpoint(client.vnetVethName, client.containerVethName, mac); err != nil {
 		return errors.Wrap(err, "failed to create veth pair")
 	}
 	// Disable RA for veth pair, and delete if any failure

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -151,7 +151,7 @@ func (client *TransparentVlanEndpointClient) PopulateVM(epInfo *EndpointInfo) er
 		}
 
 		if client.netnsClient.IsNamespaceEqual(vnetNS, vmNS) {
-			deleteNSIfNotNilErr = fmt.Errorf("vnet ns:%d and vm ns:%d are the same. deleting vnet namespace created", vnetNS, vmNS)
+			deleteNSIfNotNilErr = errors.Wrap(errNamespaceCreation, "vnet ns:%d and vm ns:%d are the same. deleting vnet namespace created", vnetNS, vmNS)
 			log.Errorf(deleteNSIfNotNilErr.Error())
 			return deleteNSIfNotNilErr
 		}

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"strings"
 
-	"github.com/Azure/azure-container-networking/cns/logger"
 	"github.com/Azure/azure-container-networking/iptables"
 	"github.com/Azure/azure-container-networking/log"
 	"github.com/Azure/azure-container-networking/netio"
@@ -405,10 +404,8 @@ func (client *TransparentVlanEndpointClient) ConfigureVnetInterfacesAndRoutesImp
 	}
 
 	// Delete old route if any for this IP
-	logger.Printf("[transparent-vlan] Deleting old route if any.")
-	if err = deleteRoutes(client.netlink, client.netioshim, "", routeInfoList); err != nil {
-		return errors.Wrap(err, "failed deleting routes to vnet specific to this container")
-	}
+	err = deleteRoutes(client.netlink, client.netioshim, "", routeInfoList)
+	log.Printf("[transparent-vlan] Deleting old routes returned:%v", err)
 
 	if err = addRoutes(client.netlink, client.netioshim, client.vnetVethName, routeInfoList); err != nil {
 		return errors.Wrap(err, "failed adding routes to vnet specific to this container")

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -151,7 +151,7 @@ func (client *TransparentVlanEndpointClient) PopulateVM(epInfo *EndpointInfo) er
 		}
 
 		if client.netnsClient.IsNamespaceEqual(vnetNS, vmNS) {
-			deleteNSIfNotNilErr = errors.Wrap(errNamespaceCreation, "vnet ns:%d and vm ns:%d are the same. deleting vnet namespace created", vnetNS, vmNS)
+			deleteNSIfNotNilErr = errors.Wrapf(errNamespaceCreation, "vnet ns:%d and vm ns:%d are the same. deleting vnet namespace created", vnetNS, vmNS)
 			log.Errorf(deleteNSIfNotNilErr.Error())
 			return deleteNSIfNotNilErr
 		}

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -26,6 +26,10 @@ const (
 	DisableRPFilterCmd = "sysctl -w net.ipv4.conf.all.rp_filter=0" // Command to disable the rp filter for tunneling
 )
 
+var (
+	errNamespaceCreation = fmt.Errorf("Network namespace creation error")
+)
+
 type netnsClient interface {
 	Get() (fileDescriptor int, err error)
 	GetFromName(name string) (fileDescriptor int, err error)

--- a/network/transparent_vlan_endpointclient_linux_test.go
+++ b/network/transparent_vlan_endpointclient_linux_test.go
@@ -49,11 +49,11 @@ func (netns *mockNetns) DeleteNamed(name string) (err error) {
 	return netns.deleteNamed(name)
 }
 
-func (netns *mockNetns) IsNamespaceEqual(fd1, fd2 int) bool {
+func (netns *mockNetns) IsNamespaceEqual(_, _ int) bool {
 	return false
 }
 
-func (netns *mockNetns) NamespaceUniqueID(fd int) string {
+func (netns *mockNetns) NamespaceUniqueID(_ int) string {
 	return "nsid"
 }
 

--- a/network/transparent_vlan_endpointclient_linux_test.go
+++ b/network/transparent_vlan_endpointclient_linux_test.go
@@ -473,7 +473,7 @@ func TestTransparentVlanDeleteEndpoints(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.client.DeleteEndpointsImpl(tt.ep, tt.routesLeft, false)
+			err := tt.client.DeleteEndpointsImpl(tt.ep, tt.routesLeft)
 			if tt.wantErr {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.wantErrMsg, "Expected:%v actual:%v", tt.wantErrMsg, err.Error())

--- a/network/transparent_vlan_endpointclient_linux_test.go
+++ b/network/transparent_vlan_endpointclient_linux_test.go
@@ -49,6 +49,14 @@ func (netns *mockNetns) DeleteNamed(name string) (err error) {
 	return netns.deleteNamed(name)
 }
 
+func (netns *mockNetns) IsNamespaceEqual(fd1, fd2 int) bool {
+	return false
+}
+
+func (netns *mockNetns) NamespaceUniqueID(fd int) string {
+	return "nsid"
+}
+
 func defaultGet() (int, error) {
 	return 1, nil
 }


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
This PR adds constant mac (aa:aa:aa:aa:aa:aa) for host veth interface. This prevents kernel to allocate unique mac for each host veth interface. Transparent mode already has this change and doing the same for transparent vlan mode here. Also from ubuntu22, we saw mac address getting changed after veth creation and arp entry set to wrong mac due to this. This prevents that if transparent-vlan mode used in ubuntu22 or later.

- Validate netwrok namespace creation and if its same as VM namespace, delete and recreate it
- Check for interface exists after creating vlan interface
- make sure calls are idempotent. even if it fails, retry should succeed
- delete route before adding new route for same ip (only for transparent vlan)

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
