### PR TITLE
update nnc printcols for kubectl output

### DIFF
--- a/crd/nodenetworkconfig/api/v1alpha/nodenetworkconfig.go
+++ b/crd/nodenetworkconfig/api/v1alpha/nodenetworkconfig.go
@@ -42,7 +42,7 @@ type NodeNetworkConfigList struct {
 
 // NodeNetworkConfigSpec defines the desired state of NetworkConfig
 type NodeNetworkConfigSpec struct {
-	RequestedIPCount int64    `json:"requestedIPCount,omitempty"`
+	RequestedIPCount int64    `json:"requestedIPCount"`
 	IPsNotInUse      []string `json:"ipsNotInUse,omitempty"`
 }
 
@@ -58,7 +58,7 @@ const (
 
 // NodeNetworkConfigStatus defines the observed state of NetworkConfig
 type NodeNetworkConfigStatus struct {
-	AssignedIPCount   int                `json:"assignedIPCount,omitempty"`
+	AssignedIPCount   int                `json:"assignedIPCount"`
 	Scaler            Scaler             `json:"scaler,omitempty"`
 	Status            Status             `json:"status,omitempty"`
 	NetworkContainers []NetworkContainer `json:"networkContainers,omitempty"`
@@ -94,14 +94,15 @@ const (
 type NetworkContainer struct {
 	ID string `json:"id,omitempty"`
 	// +kubebuilder:default=dynamic
-	AssignmentMode     AssignmentMode `json:"assignmentMode,omitempty"`
+	AssignmentMode AssignmentMode `json:"assignmentMode,omitempty"`
+	// +kubebuilder:default=vnet
 	Type               NCType         `json:"type,omitempty"`
 	PrimaryIP          string         `json:"primaryIP,omitempty"`
 	SubnetName         string         `json:"subnetName,omitempty"`
 	IPAssignments      []IPAssignment `json:"ipAssignments,omitempty"`
 	DefaultGateway     string         `json:"defaultGateway,omitempty"`
 	SubnetAddressSpace string         `json:"subnetAddressSpace,omitempty"`
-	Version            int64          `json:"version,omitempty"`
+	Version            int64          `json:"version"`
 	NodeIP             string         `json:"nodeIP,omitempty"`
 	SubscriptionID     string         `json:"subcriptionID,omitempty"`
 	ResourceGroupID    string         `json:"resourceGroupID,omitempty"`

--- a/crd/nodenetworkconfig/api/v1alpha/nodenetworkconfig.go
+++ b/crd/nodenetworkconfig/api/v1alpha/nodenetworkconfig.go
@@ -22,7 +22,7 @@ import (
 // +kubebuilder:printcolumn:name="NC ID",type=string,priority=1,JSONPath=`.status.networkContainers[*].id`
 // +kubebuilder:printcolumn:name="NC Mode",type=string,priority=0,JSONPath=`.status.networkContainers[*].assignmentMode`
 // +kubebuilder:printcolumn:name="NC Type",type=string,priority=1,JSONPath=`.status.networkContainers[*].type`
-// +kubebuilder:printcolumn:name="NC Version",type=integer,priority=1,JSONPath=`.status.networkContainers[*].version`
+// +kubebuilder:printcolumn:name="NC Version",type=integer,priority=0,JSONPath=`.status.networkContainers[*].version`
 type NodeNetworkConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -42,6 +42,8 @@ type NodeNetworkConfigList struct {
 
 // NodeNetworkConfigSpec defines the desired state of NetworkConfig
 type NodeNetworkConfigSpec struct {
+	// +kubebuilder:default=0
+	// +kubebuilder:validation:Optional
 	RequestedIPCount int64    `json:"requestedIPCount"`
 	IPsNotInUse      []string `json:"ipsNotInUse,omitempty"`
 }
@@ -58,6 +60,8 @@ const (
 
 // NodeNetworkConfigStatus defines the observed state of NetworkConfig
 type NodeNetworkConfigStatus struct {
+	// +kubebuilder:default=0
+	// +kubebuilder:validation:Optional
 	AssignedIPCount   int                `json:"assignedIPCount"`
 	Scaler            Scaler             `json:"scaler,omitempty"`
 	Status            Status             `json:"status,omitempty"`
@@ -102,12 +106,14 @@ type NetworkContainer struct {
 	IPAssignments      []IPAssignment `json:"ipAssignments,omitempty"`
 	DefaultGateway     string         `json:"defaultGateway,omitempty"`
 	SubnetAddressSpace string         `json:"subnetAddressSpace,omitempty"`
-	Version            int64          `json:"version"`
-	NodeIP             string         `json:"nodeIP,omitempty"`
-	SubscriptionID     string         `json:"subcriptionID,omitempty"`
-	ResourceGroupID    string         `json:"resourceGroupID,omitempty"`
-	VNETID             string         `json:"vnetID,omitempty"`
-	SubnetID           string         `json:"subnetID,omitempty"`
+	// +kubebuilder:default=0
+	// +kubebuilder:validation:Optional
+	Version         int64  `json:"version"`
+	NodeIP          string `json:"nodeIP,omitempty"`
+	SubscriptionID  string `json:"subcriptionID,omitempty"`
+	ResourceGroupID string `json:"resourceGroupID,omitempty"`
+	VNETID          string `json:"vnetID,omitempty"`
+	SubnetID        string `json:"subnetID,omitempty"`
 }
 
 // IPAssignment groups an IP address and Name. Name is a UUID set by the the IP address assigner.

--- a/crd/nodenetworkconfig/api/v1alpha/nodenetworkconfig.go
+++ b/crd/nodenetworkconfig/api/v1alpha/nodenetworkconfig.go
@@ -15,13 +15,14 @@ import (
 // +kubebuilder:resource:scope=Namespaced
 // +kubebuilder:resource:shortName=nnc
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.status`
-// +kubebuilder:printcolumn:name="Requested IPs",type=string,JSONPath=`.spec.requestedIPCount`
-// +kubebuilder:printcolumn:name="Assigned IPs",type=string,JSONPath=`.status.assignedIPCount`
-// +kubebuilder:printcolumn:name="Subnet",type=string,JSONPath=`.status.networkContainers[*].subnetName`
-// +kubebuilder:printcolumn:name="Subnet CIDR",type=string,JSONPath=`.status.networkContainers[*].subnetAddressSpace`
-// +kubebuilder:printcolumn:name="NC ID",type=string,JSONPath=`.status.networkContainers[*].id`
-// +kubebuilder:printcolumn:name="NC Version",type=string,JSONPath=`.status.networkContainers[*].version`
+// +kubebuilder:printcolumn:name="Requested IPs",type=integer,priority=1,JSONPath=`.spec.requestedIPCount`
+// +kubebuilder:printcolumn:name="Allocated IPs",type=integer,priority=0,JSONPath=`.status.assignedIPCount`
+// +kubebuilder:printcolumn:name="Subnet",type=string,priority=1,JSONPath=`.status.networkContainers[*].subnetName`
+// +kubebuilder:printcolumn:name="Subnet CIDR",type=string,priority=1,JSONPath=`.status.networkContainers[*].subnetAddressSpace`
+// +kubebuilder:printcolumn:name="NC ID",type=string,priority=1,JSONPath=`.status.networkContainers[*].id`
+// +kubebuilder:printcolumn:name="NC Mode",type=string,priority=0,JSONPath=`.status.networkContainers[*].assignmentMode`
+// +kubebuilder:printcolumn:name="NC Type",type=string,priority=1,JSONPath=`.status.networkContainers[*].type`
+// +kubebuilder:printcolumn:name="NC Version",type=integer,priority=1,JSONPath=`.status.networkContainers[*].version`
 type NodeNetworkConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/crd/nodenetworkconfig/manifests/acn.azure.com_nodenetworkconfigs.yaml
+++ b/crd/nodenetworkconfig/manifests/acn.azure.com_nodenetworkconfigs.yaml
@@ -75,6 +75,8 @@ spec:
               requestedIPCount:
                 format: int64
                 type: integer
+            required:
+            - requestedIPCount
             type: object
           status:
             description: NodeNetworkConfigStatus defines the observed state of NetworkConfig
@@ -124,6 +126,7 @@ spec:
                     subnetName:
                       type: string
                     type:
+                      default: vnet
                       description: NCType is the specific type of network this NC
                         represents.
                       type: string
@@ -132,6 +135,8 @@ spec:
                       type: integer
                     vnetID:
                       type: string
+                  required:
+                  - version
                   type: object
                 type: array
               scaler:
@@ -157,6 +162,8 @@ spec:
                 - Updated
                 - Error
                 type: string
+            required:
+            - assignedIPCount
             type: object
         type: object
     served: true

--- a/crd/nodenetworkconfig/manifests/acn.azure.com_nodenetworkconfigs.yaml
+++ b/crd/nodenetworkconfig/manifests/acn.azure.com_nodenetworkconfigs.yaml
@@ -46,7 +46,6 @@ spec:
       type: string
     - jsonPath: .status.networkContainers[*].version
       name: NC Version
-      priority: 1
       type: integer
     name: v1alpha
     schema:
@@ -73,15 +72,15 @@ spec:
                   type: string
                 type: array
               requestedIPCount:
+                default: 0
                 format: int64
                 type: integer
-            required:
-            - requestedIPCount
             type: object
           status:
             description: NodeNetworkConfigStatus defines the observed state of NetworkConfig
             properties:
               assignedIPCount:
+                default: 0
                 type: integer
               networkContainers:
                 items:
@@ -131,12 +130,11 @@ spec:
                         represents.
                       type: string
                     version:
+                      default: 0
                       format: int64
                       type: integer
                     vnetID:
                       type: string
-                  required:
-                  - version
                   type: object
                 type: array
               scaler:
@@ -162,8 +160,6 @@ spec:
                 - Updated
                 - Error
                 type: string
-            required:
-            - assignedIPCount
             type: object
         type: object
     served: true

--- a/crd/nodenetworkconfig/manifests/acn.azure.com_nodenetworkconfigs.yaml
+++ b/crd/nodenetworkconfig/manifests/acn.azure.com_nodenetworkconfigs.yaml
@@ -18,27 +18,36 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.status
-      name: Status
-      type: string
     - jsonPath: .spec.requestedIPCount
       name: Requested IPs
-      type: string
+      priority: 1
+      type: integer
     - jsonPath: .status.assignedIPCount
-      name: Assigned IPs
-      type: string
+      name: Allocated IPs
+      type: integer
     - jsonPath: .status.networkContainers[*].subnetName
       name: Subnet
+      priority: 1
       type: string
     - jsonPath: .status.networkContainers[*].subnetAddressSpace
       name: Subnet CIDR
+      priority: 1
       type: string
     - jsonPath: .status.networkContainers[*].id
       name: NC ID
+      priority: 1
+      type: string
+    - jsonPath: .status.networkContainers[*].assignmentMode
+      name: NC Mode
+      type: string
+    - jsonPath: .status.networkContainers[*].type
+      name: NC Type
+      priority: 1
       type: string
     - jsonPath: .status.networkContainers[*].version
       name: NC Version
-      type: string
+      priority: 1
+      type: integer
     name: v1alpha
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Updates the kubectl output for NNCs to be more immediately useful.

There is an extant bug in the RC which is preventing the "Allocated IPs" from being correctly populated (the value is currently `0` in otherwise correct NNCs). After this change and an update to this dependency over there, this can be fixed to correctly display the number of Allocated IPs, and the kubectl output will look like: 
```
➜  k get nnc
NAME                                ALLOCATED IPS   NC MODE   NC VERSION
aks-nodepool1-39652274-vmss000000   48              dynamic   2
aks-nodepool1-39652274-vmss000001   48              dynamic   2
```

Further information is now available behind the `-o wide` flag, that looks like:
```
➜  k get nnc -o wide
NAME                                REQUESTED IPS   ALLOCATED IPS   SUBNET   SUBNET CIDR     NC ID                                  NC MODE   NC TYPE   NC VERSION
aks-nodepool1-39652274-vmss000000   48              48              podnet   10.241.0.0/16   7f68a6e2-b0a5-4c78-bc0d-24bb9bcefbcf   dynamic   vnet      2
aks-nodepool1-39652274-vmss000001   48              48              podnet   10.241.0.0/16   206d3a69-69d3-488e-bd08-61dc45898d68   dynamic   vnet      2
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
