### PR TITLE
ci: [CNI] Add restart node in stage in the load test of cni pipeline

### DIFF
--- a/.pipelines/cni/cilium/cilium-cni-load-test.yaml
+++ b/.pipelines/cni/cilium/cilium-cni-load-test.yaml
@@ -36,6 +36,8 @@ stages:
                 set -ex
                 az extension add --name aks-preview
                 make -C ./hack/swift set-kubeconf AZCLI=az CLUSTER=${RESOURCE_GROUP}
+                kubectl apply -f hack/manifests/pod.yaml
+                kubectl apply -f hack/manifests/hostprocess.yaml
                 bash hack/scripts/scale_deployment.sh
   - stage: validate_state
     dependsOn: pod_deployment
@@ -56,8 +58,37 @@ stages:
             name: "ValidateState"
             displayName: "Validate State"
             retryCountOnTaskFailure: 3
-  - stage: connectivity_tests
+  - stage: restart_nodes
     dependsOn: validate_state
+    displayName: "Restart Node"
+    jobs:
+      - job: restart_nodes
+        steps:
+          - task: AzureCLI@1
+            inputs:
+              azureSubscription: $(TEST_SUB_SERVICE_CONNECTION)
+              scriptLocation: "inlineScript"
+              scriptType: "bash"
+              addSpnToEnvironment: true
+              inlineScript: |
+                echo "Scale up the pods and immediated restart the nodes"
+                make -C ./hack/swift set-kubeconf AZCLI=az CLUSTER=${RESOURCE_GROUP}
+                make -C ./hack/swift azcfg AZCLI=az REGION=$(LOCATION)
+                echo "Scaling the pods down to 100 per node"
+                bash ./hack/scripts/scale_deployment.sh -n 0 -u 1000 -s
+                echo "Restarting the nodes"
+                vmss_name=$(az vmss list -g MC_${RESOURCE_GROUP}_${RESOURCE_GROUP}_$(LOCATION) --query "[].name" -o tsv)
+                make -C ./hack/swift restart-vmss AZCLI=az CLUSTER=${RESOURCE_GROUP} REGION=$(LOCATION) VMSS_NAME=$vmss_name
+                bash ./hack/scripts/scale_deployment.sh -n 0 -u 1000 -c
+            name: "RestartNodes"
+            displayName: "Restart Nodes"
+          - script: |
+              bash hack/scripts/validate_state.sh
+            name: "ValidateState"
+            displayName: "Validate State"
+            retryCountOnTaskFailure: 3
+  - stage: connectivity_tests
+    dependsOn: restart_nodes
     displayName: "Connectivity Tests"
     jobs:
       - job: cni_tests

--- a/hack/scripts/scale_deployment.sh
+++ b/hack/scripts/scale_deployment.sh
@@ -1,12 +1,23 @@
 #!/bin/bash
 set -ex
-kubectl apply -f hack/manifests/pod.yaml
-kubectl apply -f hack/manifests/hostprocess.yaml
-sleep 1m
-total_num_of_run=4
+total_num_of_run=5
 scale_up_of_pods=2400
 scale_down_pods=1
-echo "Total num of run $total_num_of_run"
+
+function help()
+{
+    echo "Scale deployment based on the parameters."
+    echo "By default script will repeat the process of scale up/down"
+    echo
+    echo "Syntax: scale [-h|n|u|s|c|r]"
+    echo "options:"
+    echo "h     Print this help."
+    echo "n     Number of times the scale down/scale up task should run."
+    echo "u     Number of pods to be scaled up."
+    echo "s     Scale the pods single time. Accepted Values: true, default : false"
+    echo "c     Check deployment status. Accepted Values: true, default : false"
+    echo
+}
 
 function check_deployment() {
     available=-1
@@ -22,16 +33,42 @@ function check_deployment() {
     echo "deployment complete."
 }
 
-for ((i=1; i <= total_num_of_run; i++))
-do 
-    echo "Current Run: $i"
-    echo "Scaling pods to : $scale_up_of_pods"
-    kubectl scale deployment container --replicas $scale_up_of_pods
-    check_deployment $scale_up_of_pods
-    echo "Scaling down pods to : $scale_down_pods"
-    kubectl scale deployment container --replicas $scale_down_pods
-    check_deployment $scale_down_pods
+function scale_deployment()
+{
+    desired_replicas=$1
+    kubectl scale deployment container --replicas "$desired_replicas"
+    echo "Scaled the deployment to $desired_replicas"
+}
+
+function repeat_deployment() {
+    echo "Total num of run $total_num_of_run"
+    for ((i=1; i <= total_num_of_run; i++))
+    do 
+        echo "Current Run: $i"
+        echo "Scaling down pods to : $scale_down_pods"
+        scale_deployment $scale_down_pods
+        check_deployment $scale_down_pods
+        echo "Scaling pods to : $scale_up_of_pods"
+        scale_deployment "$scale_up_of_pods"
+        check_deployment "$scale_up_of_pods"
+    done
+}
+
+while getopts ":h:n:u:sc" option; do
+   case $option in
+        h)  help
+            exit;;
+        n)  total_num_of_run=$OPTARG;;
+        u)  scale_up_of_pods=$OPTARG;;
+        s)  echo "Scale deployment"
+            scale_deployment "$scale_up_of_pods";;
+        c)  echo "Check deployment"
+            check_deployment "$scale_up_of_pods";;
+        \?) echo "Error: Invalid option"
+            exit;;
+   esac
 done
 
-kubectl scale deployment container --replicas $scale_up_of_pods
-check_deployment $scale_up_of_pods
+if [ "$total_num_of_run" -gt 0 ]; then
+    repeat_deployment
+fi

--- a/hack/swift/Makefile
+++ b/hack/swift/Makefile
@@ -56,6 +56,7 @@ vars: ## Show the input vars configured for the cluster commands
 	@echo OS_SKU=$(OS_SKU)
 	@echo VM_SIZE=$(VM_SIZE)
 	@echo NODE_COUNT=$(NODE_COUNT)
+	@echo VMSS_NAME=$(VMSS_NAME)
 
 
 ##@ SWIFT Infra
@@ -165,3 +166,6 @@ down: ## Delete the cluster
 	$(AZCLI) aks delete -g $(GROUP) -n $(CLUSTER) --yes
 	@$(MAKE) unset-kubeconf
 	@$(MAKE) rg-down
+
+restart-vmss: ## Restarts the nodes in the cluster
+	$(AZCLI) vmss restart -g MC_${GROUP}_${CLUSTER}_${REGION} --name $(VMSS_NAME)

--- a/hack/swift/README.md
+++ b/hack/swift/README.md
@@ -29,4 +29,5 @@ AKS Clusters
   swift-cilium-up  Bring up a SWIFT Cilium cluster
   swift-up         Bring up a SWIFT AzCNI cluster
   down             Delete the cluster
+  vmss-restart     Restart the nodes of the cluster
 ```


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
- Added the test of restarting the nodes in the CNI load testing pipeline. It scales down the deployment and then restart the nodes without any delay.
- Update the `scale_deployment` script to include different parameters for CNI load testing


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests - No, tested in the pipeline CNI Load testing - https://msazure.visualstudio.com/One/_build/results?buildId=71712524&view=results


**Notes**:
