### PR TITLE
CNS Allow clients to use upper case NC guid

### DIFF
--- a/cns/restserver/api_test.go
+++ b/cns/restserver/api_test.go
@@ -121,6 +121,14 @@ var (
 		podNamespace: "testpodnamespace",
 	}
 	ncDualNicParams = []createOrUpdateNetworkContainerParams{nc3, nc4}
+
+	// upper-case NCIDs
+	upperCaseNCID1             = "Swift_89063DBF-AA31-4BFC-9663-3842A361F188"
+	upperCaseNCID2             = "Swift_89063DBF-AA31-4BFC-9663-3842A361F189"
+	upperCaseNCIDs             = []string{upperCaseNCID1, upperCaseNCID2}
+	nmaProgrammedNCVersionStr1 = "1"
+	nmaProgrammedNCVersionStr2 = "2"
+	ncVersionList              = map[string]string{}
 )
 
 const (
@@ -1290,6 +1298,25 @@ func TestCreateHostNCApipaEndpoint(t *testing.T) {
 	}
 
 	fmt.Printf("createHostNCApipaEndpoint Responded with %+v\n", createHostNCApipaEndpointResponse)
+}
+
+func TestNCIDCaseSensitive(t *testing.T) {
+	setEnv(t)
+	err := setOrchestratorType(t, cns.Kubernetes)
+	if err != nil {
+		t.Fatalf("TestNCIDCaseSensitive failed with error:%+v", err)
+	}
+
+	// add lower-case NCIDs to ncVersionList
+	ncVersionList["Swift_89063dbf-aa31-4bfc-9663-3842a361f188"] = nmaProgrammedNCVersionStr1
+	ncVersionList["Swift_89063dbf-aa31-4bfc-9663-3842a361f189"] = nmaProgrammedNCVersionStr2
+
+	for _, ncid := range upperCaseNCIDs {
+		_, returnCode, errMsg := svc.isNCWaitingForUpdate("0", ncid, ncVersionList)
+		if returnCode != types.NetworkContainerVfpProgramComplete {
+			t.Fatalf("failed to verify TestNCIDCaseSensitive for ncid %s due to %s", ncid, errMsg)
+		}
+	}
 }
 
 func TestGetAllNetworkContainers(t *testing.T) {

--- a/cns/restserver/api_test.go
+++ b/cns/restserver/api_test.go
@@ -121,14 +121,6 @@ var (
 		podNamespace: "testpodnamespace",
 	}
 	ncDualNicParams = []createOrUpdateNetworkContainerParams{nc3, nc4}
-
-	// upper-case NCIDs
-	upperCaseNCID1             = "Swift_89063DBF-AA31-4BFC-9663-3842A361F188"
-	upperCaseNCID2             = "Swift_89063DBF-AA31-4BFC-9663-3842A361F189"
-	upperCaseNCIDs             = []string{upperCaseNCID1, upperCaseNCID2}
-	nmaProgrammedNCVersionStr1 = "1"
-	nmaProgrammedNCVersionStr2 = "2"
-	ncVersionList              = map[string]string{}
 )
 
 const (
@@ -1306,6 +1298,14 @@ func TestNCIDCaseSensitive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TestNCIDCaseSensitive failed with error:%+v", err)
 	}
+
+	// upper-case NCIDs
+	upperCaseNCID1 := "Swift_89063DBF-AA31-4BFC-9663-3842A361F188"
+	upperCaseNCID2 := "Swift_89063DBF-AA31-4BFC-9663-3842A361F189"
+	upperCaseNCIDs := []string{upperCaseNCID1, upperCaseNCID2}
+	nmaProgrammedNCVersionStr1 := "1"
+	nmaProgrammedNCVersionStr2 := "2"
+	ncVersionList := map[string]string{}
 
 	// add lower-case NCIDs to ncVersionList
 	ncVersionList["Swift_89063dbf-aa31-4bfc-9663-3842a361f188"] = nmaProgrammedNCVersionStr1

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -853,10 +853,10 @@ func (service *HTTPRestService) isNCWaitingForUpdate(
 			"Skipping GetNCVersionStatus check from NMAgent", ncVersion, ncid)
 		return true, types.NetworkContainerVfpProgramPending, ""
 	}
-	// accept both upper and lower GUID from ncid(Swift_ncGuid)
-	// Split ncid by 'Swift_' and lower-case ncGuid(i.e, 89063DBF-AA31) and check if each ncid(Swift_ncGuid, i.e, Swift_89063dbf-aa31) is in ncVersionList
-	ncGuid := strings.ToLower(strings.Split(ncid, cns.SwiftPrefix)[1])
-	nmaProgrammedNCVersionStr, ok := ncVersionList[cns.SwiftPrefix+ncGuid]
+	// accept both upper and lower GUID from ncid(Swift_ncGUID)
+	// Split ncid by 'Swift_' and lower-case ncGUID(i.e, 89063DBF-AA31) and check if each ncid(Swift_ncGUID, i.e, Swift_89063dbf-aa31) is in ncVersionList
+	ncGUID := strings.ToLower(strings.Split(ncid, cns.SwiftPrefix)[1])
+	nmaProgrammedNCVersionStr, ok := ncVersionList[cns.SwiftPrefix+ncGUID]
 	if !ok {
 		// NMA doesn't have this NC that we need programmed yet, bail out
 		logger.Printf("[Azure CNS] Failed to get NC %s doesn't exist in NMAgent NC version list "+

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -416,7 +416,6 @@ func (service *HTTPRestService) getAllNetworkContainerResponses(
 			nmaNCs[cns.SwiftPrefix+strings.ToLower(nc.NetworkContainerID)] = nc.Version
 		}
 
-		logger.Printf("nmaNCs are %+v", nmaNCs)
 		if !skipNCVersionCheck {
 			for _, ncid := range ncs {
 				waitingForUpdate := false
@@ -854,8 +853,8 @@ func (service *HTTPRestService) isNCWaitingForUpdate(
 			"Skipping GetNCVersionStatus check from NMAgent", ncVersion, ncid)
 		return true, types.NetworkContainerVfpProgramPending, ""
 	}
-	// accept both upper and lower GUID from ncid(Swift_GUID)
-	// check each ncid in lower case if it's in ncVersionList
+	// accept both upper and lower GUID from ncid(Swift_ncGuid)
+	// Split ncid by 'Swift_' and lower-case ncGuid(i.e, 89063DBF-AA31) and check if each ncid(Swift_ncGuid, i.e, Swift_89063dbf-aa31) is in ncVersionList
 	ncGuid := strings.ToLower(strings.Split(ncid, cns.SwiftPrefix)[1])
 	nmaProgrammedNCVersionStr, ok := ncVersionList[cns.SwiftPrefix+ncGuid]
 	if !ok {

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -853,7 +853,9 @@ func (service *HTTPRestService) isNCWaitingForUpdate(
 			"Skipping GetNCVersionStatus check from NMAgent", ncVersion, ncid)
 		return true, types.NetworkContainerVfpProgramPending, ""
 	}
-	nmaProgrammedNCVersionStr, ok := ncVersionList[ncid]
+	// accept both upper and lower GUID from ncid(Swift_GUID)
+	// check each ncid in lower case if it's in ncVersionList
+	nmaProgrammedNCVersionStr, ok := ncVersionList[strings.ToLower(ncid)]
 	if !ok {
 		// NMA doesn't have this NC that we need programmed yet, bail out
 		logger.Printf("[Azure CNS] Failed to get NC %s doesn't exist in NMAgent NC version list "+

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -413,9 +413,10 @@ func (service *HTTPRestService) getAllNetworkContainerResponses(
 		}
 		nmaNCs := map[string]string{}
 		for _, nc := range ncVersionListResp.Containers {
-			nmaNCs[cns.SwiftPrefix+nc.NetworkContainerID] = nc.Version
+			nmaNCs[cns.SwiftPrefix+strings.ToLower(nc.NetworkContainerID)] = nc.Version
 		}
 
+		logger.Printf("nmaNCs are %+v", nmaNCs)
 		if !skipNCVersionCheck {
 			for _, ncid := range ncs {
 				waitingForUpdate := false
@@ -855,7 +856,8 @@ func (service *HTTPRestService) isNCWaitingForUpdate(
 	}
 	// accept both upper and lower GUID from ncid(Swift_GUID)
 	// check each ncid in lower case if it's in ncVersionList
-	nmaProgrammedNCVersionStr, ok := ncVersionList[strings.ToLower(ncid)]
+	ncGuid := strings.ToLower(strings.Split(ncid, cns.SwiftPrefix)[1])
+	nmaProgrammedNCVersionStr, ok := ncVersionList[cns.SwiftPrefix+ncGuid]
 	if !ok {
 		// NMA doesn't have this NC that we need programmed yet, bail out
 		logger.Printf("[Azure CNS] Failed to get NC %s doesn't exist in NMAgent NC version list "+


### PR DESCRIPTION
PR description:

Partner team uses Upper-Case GUID (i.e, Swift_ABCASRE123A), so it's not in NMA List since the format is lower case. This PR is to Convert Upper-Case GUID to lower-case GUID to check if it can be found from ncVersionList; 