### PR TITLE
[Vnet Scale - CNS]: Flattening CIDR ranges for Node NNC to a list

### DIFF
--- a/cns/ipampool/monitor.go
+++ b/cns/ipampool/monitor.go
@@ -133,7 +133,7 @@ func (pm *Monitor) Start(ctx context.Context) error {
 				if nc.Type == v1alpha.VNETBlock {
 					primaryPrefix, err := netip.ParsePrefix(nc.PrimaryIP)
 					if err != nil {
-						return errors.Wrapf(err, "IP: %s", nc.PrimaryIP)
+						return errors.Wrapf(err, "unable to parse ip prefix: %s", nc.PrimaryIP)
 					}
 					pm.metastate.primaryIPAddresses[primaryPrefix.Addr().String()] = struct{}{}
 				}

--- a/cns/ipampool/monitor.go
+++ b/cns/ipampool/monitor.go
@@ -3,6 +3,7 @@ package ipampool
 import (
 	"context"
 	"fmt"
+	"net/netip"
 	"strconv"
 	"sync"
 	"time"
@@ -124,9 +125,17 @@ func (pm *Monitor) Start(ctx context.Context) error {
 			// Add Primary IP to Map, if not present.
 			// This is only for Swift i.e. if NC Type is vnet.
 			for i := 0; i < len(nnc.Status.NetworkContainers); i++ {
-				if nnc.Status.NetworkContainers[i].Type == "" ||
-					nnc.Status.NetworkContainers[i].Type == v1alpha.VNET {
-					pm.metastate.primaryIPAddresses[nnc.Status.NetworkContainers[i].PrimaryIP] = struct{}{}
+				nc := nnc.Status.NetworkContainers[i]
+				if nc.Type == "" || nc.Type == v1alpha.VNET {
+					pm.metastate.primaryIPAddresses[nc.PrimaryIP] = struct{}{}
+				}
+
+				if nc.Type == v1alpha.VNETBlock {
+					primaryPrefix, err := netip.ParsePrefix(nc.PrimaryIP)
+					if err != nil {
+						return errors.Wrapf(err, "IP: %s", nc.PrimaryIP)
+					}
+					pm.metastate.primaryIPAddresses[primaryPrefix.Addr().String()] = struct{}{}
 				}
 			}
 

--- a/cns/kubecontroller/nodenetworkconfig/conversion.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion.go
@@ -90,7 +90,7 @@ func CreateNCRequestFromStaticNC(nc v1alpha.NetworkContainer) (*cns.CreateNetwor
 
 	req, err := createNCRequestFromStaticNCHelper(nc, primaryPrefix, subnet)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error while creatng NC request from static NC")
+		return nil, errors.Wrapf(err, "error while creating NC request from static NC")
 	}
 	return req, err
 }

--- a/cns/kubecontroller/nodenetworkconfig/conversion.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion.go
@@ -89,5 +89,8 @@ func CreateNCRequestFromStaticNC(nc v1alpha.NetworkContainer) (*cns.CreateNetwor
 	}
 
 	req, err := createNCRequestFromStaticNCHelper(nc, primaryPrefix, subnet)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error while creatng NC request from static NC")
+	}
 	return req, err
 }

--- a/cns/kubecontroller/nodenetworkconfig/conversion.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion.go
@@ -73,7 +73,10 @@ func CreateNCRequestFromDynamicNC(nc v1alpha.NetworkContainer) (*cns.CreateNetwo
 //
 //nolint:gocritic //ignore hugeparam
 func CreateNCRequestFromStaticNC(nc v1alpha.NetworkContainer) (*cns.CreateNetworkContainerRequest, error) {
-	nc.Version = 0 // fix for NMA always giving us version 0 for Overlay NCs
+	if nc.Type == v1alpha.Overlay {
+		nc.Version = 0 // fix for NMA always giving us version 0 for Overlay NCs
+	}
+
 	primaryPrefix, err := netip.ParsePrefix(nc.PrimaryIP)
 	if err != nil {
 		return nil, errors.Wrapf(err, "IP: %s", nc.PrimaryIP)

--- a/cns/kubecontroller/nodenetworkconfig/conversion.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion.go
@@ -88,6 +88,6 @@ func CreateNCRequestFromStaticNC(nc v1alpha.NetworkContainer) (*cns.CreateNetwor
 		PrefixLength: uint8(subnetPrefix.Bits()),
 	}
 
-	req := createNCRequestFromStaticNCHelper(nc, primaryPrefix, subnet)
-	return req, nil
+	req, err := createNCRequestFromStaticNCHelper(nc, primaryPrefix, subnet)
+	return req, err
 }

--- a/cns/kubecontroller/nodenetworkconfig/conversion_test.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_test.go
@@ -10,19 +10,27 @@ import (
 )
 
 const (
-	uuid               = "539970a2-c2dd-11ea-b3de-0242ac130004"
-	defaultGateway     = "10.0.0.2"
-	ipIsCIDR           = "10.0.0.1/32"
-	ipMalformed        = "10.0.0.0.0"
-	ncID               = "160005ba-cd02-11ea-87d0-0242ac130003"
-	primaryIP          = "10.0.0.1"
-	overlayPrimaryIP   = "10.0.0.1/30"
-	subnetAddressSpace = "10.0.0.0/24"
-	subnetName         = "subnet1"
-	subnetPrefixLen    = 24
-	testSecIP          = "10.0.0.2"
-	version            = 1
-	nodeIP             = "10.1.0.5"
+	uuid                        = "539970a2-c2dd-11ea-b3de-0242ac130004"
+	defaultGateway              = "10.0.0.2"
+	ipIsCIDR                    = "10.0.0.1/32"
+	ipMalformed                 = "10.0.0.0.0"
+	ncID                        = "160005ba-cd02-11ea-87d0-0242ac130003"
+	primaryIP                   = "10.0.0.1"
+	overlayPrimaryIP            = "10.0.0.1/30"
+	subnetAddressSpace          = "10.0.0.0/24"
+	subnetName                  = "subnet1"
+	subnetPrefixLen             = 24
+	testSecIP                   = "10.0.0.2"
+	version                     = 1
+	nodeIP                      = "10.1.0.5"
+	vnetBlockPrimaryIP          = "10.224.0.4"
+	vnetBlockPrimaryIPPrefix    = "10.224.0.4/30"
+	vnetBlockSubnetAddressSpace = "10.224.0.0/14"
+	vnetBlockSubnetPrefixLen    = 14
+	vnetBlockNodeIP             = "10.228.0.6"
+	vnetBlockDefaultGateway     = "10.224.0.1"
+	vnetBlockCIDR1              = "10.224.0.8/30"
+	vnetBlockCIDR2              = "10.224.0.12/30"
 )
 
 var invalidStatusMultiNC = v1alpha.NodeNetworkConfigStatus{
@@ -85,6 +93,88 @@ var validOverlayNC = v1alpha.NetworkContainer{
 	SubnetName:         subnetName,
 	SubnetAddressSpace: subnetAddressSpace,
 	Version:            version,
+}
+
+var validVNETBlockNC = v1alpha.NetworkContainer{
+	ID:             ncID,
+	AssignmentMode: v1alpha.Static,
+	Type:           v1alpha.VNETBlock,
+	IPAssignments: []v1alpha.IPAssignment{
+		{
+			Name: uuid,
+			IP:   vnetBlockCIDR1,
+		},
+		{
+			Name: uuid,
+			IP:   vnetBlockCIDR2,
+		},
+	},
+	NodeIP:             vnetBlockNodeIP,
+	PrimaryIP:          vnetBlockPrimaryIPPrefix,
+	SubnetName:         subnetName,
+	SubnetAddressSpace: vnetBlockSubnetAddressSpace,
+	DefaultGateway:     vnetBlockDefaultGateway,
+	Version:            version,
+}
+
+var validVNETBlockRequest = &cns.CreateNetworkContainerRequest{
+	Version: strconv.FormatInt(version, 10),
+	IPConfiguration: cns.IPConfiguration{
+		GatewayIPAddress: vnetBlockDefaultGateway,
+		IPSubnet: cns.IPSubnet{
+			PrefixLength: uint8(vnetBlockSubnetPrefixLen),
+			IPAddress:    vnetBlockPrimaryIP,
+		},
+	},
+	NetworkContainerid:   ncID,
+	NetworkContainerType: cns.Docker,
+	// Ignore first IP in first CIDR Block, i.e. 10.224.0.4
+	SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+		"10.224.0.5": {
+			IPAddress: "10.224.0.5",
+			NCVersion: version,
+		},
+		"10.224.0.6": {
+			IPAddress: "10.224.0.6",
+			NCVersion: version,
+		},
+		"10.224.0.7": {
+			IPAddress: "10.224.0.7",
+			NCVersion: version,
+		},
+		"10.224.0.8": {
+			IPAddress: "10.224.0.8",
+			NCVersion: version,
+		},
+		"10.224.0.9": {
+			IPAddress: "10.224.0.9",
+			NCVersion: version,
+		},
+		"10.224.0.10": {
+			IPAddress: "10.224.0.10",
+			NCVersion: version,
+		},
+		"10.224.0.11": {
+			IPAddress: "10.224.0.11",
+			NCVersion: version,
+		},
+		"10.224.0.12": {
+			IPAddress: "10.224.0.12",
+			NCVersion: version,
+		},
+		"10.224.0.13": {
+			IPAddress: "10.224.0.13",
+			NCVersion: version,
+		},
+		"10.224.0.14": {
+			IPAddress: "10.224.0.14",
+			NCVersion: version,
+		},
+		"10.224.0.15": {
+			IPAddress: "10.224.0.15",
+			NCVersion: version,
+		},
+	},
 }
 
 func TestCreateNCRequestFromDynamicNC(t *testing.T) {
@@ -267,6 +357,41 @@ func TestCreateNCRequestFromStaticNC(t *testing.T) {
 					},
 				},
 				SubnetAddressSpace: "10.0.0.0", // not a cidr range
+			},
+			wantErr: true,
+		},
+		// VNET Block test cases
+		{
+			name:    "valid VNET Block",
+			input:   validVNETBlockNC,
+			wantErr: false,
+			want:    validVNETBlockRequest,
+		},
+		{
+			name: "PrimaryIP is not CIDR",
+			input: v1alpha.NetworkContainer{
+				AssignmentMode:     v1alpha.Static,
+				Type:               v1alpha.VNETBlock,
+				PrimaryIP:          vnetBlockPrimaryIP,
+				ID:                 ncID,
+				SubnetAddressSpace: "10.224.0.0/14",
+			},
+			wantErr: true,
+		},
+		{
+			name: "IP assignment is not CIDR",
+			input: v1alpha.NetworkContainer{
+				AssignmentMode: v1alpha.Static,
+				Type:           v1alpha.VNETBlock,
+				PrimaryIP:      vnetBlockPrimaryIPPrefix,
+				ID:             ncID,
+				IPAssignments: []v1alpha.IPAssignment{
+					{
+						Name: uuid,
+						IP:   "10.224.0.4",
+					},
+				},
+				SubnetAddressSpace: "10.224.0.0/14",
 			},
 			wantErr: true,
 		},

--- a/cns/kubecontroller/nodenetworkconfig/conversion_windows.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_windows.go
@@ -21,13 +21,17 @@ func createNCRequestFromStaticNCHelper(nc v1alpha.NetworkContainer, primaryIPPre
 	// as secondary IPs
 	startingAddr := primaryIPPrefix.Masked().Addr() // the masked address is the 0th IP in the subnet
 	if nc.DefaultGateway == "" && nc.Type == v1alpha.Overlay {
+		// assign 0th IP to the default gateway
 		nc.DefaultGateway = startingAddr.String()
 		startingAddr = startingAddr.Next()
 	} else if nc.DefaultGateway == "" && nc.Type == v1alpha.VNETBlock {
+		// skipping 0th IP for the Primary IP of NC
 		startingAddr = startingAddr.Next()
+		// assign next IP to default gateway
 		nc.DefaultGateway = startingAddr.String()
 		startingAddr = startingAddr.Next()
 	} else if nc.Type == v1alpha.VNETBlock {
+		// skipping 0th IP for the Primary IP of NC
 		startingAddr = startingAddr.Next()
 	}
 

--- a/cns/kubecontroller/nodenetworkconfig/conversion_windows.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_windows.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
+	"github.com/pkg/errors"
 )
 
 // createNCRequestFromStaticNCHelper generates a CreateNetworkContainerRequest from a static NetworkContainer.

--- a/cns/kubecontroller/nodenetworkconfig/conversion_windows.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_windows.go
@@ -24,12 +24,6 @@ func createNCRequestFromStaticNCHelper(nc v1alpha.NetworkContainer, primaryIPPre
 		// assign 0th IP to the default gateway
 		nc.DefaultGateway = startingAddr.String()
 		startingAddr = startingAddr.Next()
-	} else if nc.DefaultGateway == "" && nc.Type == v1alpha.VNETBlock {
-		// skipping 0th IP for the Primary IP of NC
-		startingAddr = startingAddr.Next()
-		// assign next IP to default gateway
-		nc.DefaultGateway = startingAddr.String()
-		startingAddr = startingAddr.Next()
 	} else if nc.Type == v1alpha.VNETBlock {
 		// skipping 0th IP for the Primary IP of NC
 		startingAddr = startingAddr.Next()

--- a/cns/kubecontroller/nodenetworkconfig/reconciler.go
+++ b/cns/kubecontroller/nodenetworkconfig/reconciler.go
@@ -89,8 +89,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		var req *cns.CreateNetworkContainerRequest
 		var err error
 		switch nnc.Status.NetworkContainers[i].AssignmentMode { //nolint:exhaustive // skipping dynamic case
+		// For Overlay and Vnet Scale Scenarios
 		case v1alpha.Static:
 			req, err = CreateNCRequestFromStaticNC(nnc.Status.NetworkContainers[i])
+		// For Pod Subnet scenario
 		default: // For backward compatibility, default will be treated as Dynamic too.
 			req, err = CreateNCRequestFromDynamicNC(nnc.Status.NetworkContainers[i])
 			// in dynamic, we will also push this NNC to the IPAM Pool Monitor when we're done.

--- a/cns/kubecontroller/nodenetworkconfig/reconciler.go
+++ b/cns/kubecontroller/nodenetworkconfig/reconciler.go
@@ -89,7 +89,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		var req *cns.CreateNetworkContainerRequest
 		var err error
 		switch nnc.Status.NetworkContainers[i].AssignmentMode { //nolint:exhaustive // skipping dynamic case
-		// For Overlay and Vnet Scale Scenarios
+		// For Overlay and Vnet Scale Scenario
 		case v1alpha.Static:
 			req, err = CreateNCRequestFromStaticNC(nnc.Status.NetworkContainers[i])
 		// For Pod Subnet scenario

--- a/cns/kubecontroller/nodenetworkconfig/reconciler.go
+++ b/cns/kubecontroller/nodenetworkconfig/reconciler.go
@@ -89,7 +89,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		var req *cns.CreateNetworkContainerRequest
 		var err error
 		switch nnc.Status.NetworkContainers[i].AssignmentMode { //nolint:exhaustive // skipping dynamic case
-		// For Overlay and Vnet Scale Scenario
+		// For Overlay and Vnet Scale Scenarios
 		case v1alpha.Static:
 			req, err = CreateNCRequestFromStaticNC(nnc.Status.NetworkContainers[i])
 		// For Pod Subnet scenario


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
*Introduces VNETBlock NCType in CNS
*Reads CIDR IP blocks from VNETBlock NC and updates secondaryIP config accordingly

VNETScale mode NNC example: 
https://microsoft-my.sharepoint.com/personal/asn_microsoft_com/_layouts/15/onedrive.aspx?id=%2Fpersonal%2Fasn%5Fmicrosoft%5Fcom%2FDocuments%2FMicrosoft%20Teams%20Chat%20Files%2FSampleVnetScaleNNC%2Eyaml&parent=%2Fpersonal%2Fasn%5Fmicrosoft%5Fcom%2FDocuments%2FMicrosoft%20Teams%20Chat%20Files&ga=1

This PR introduces support for VNET Scale mode in CNS. The NNC will have CIDR blocks for secondary IPs. Also primaryIP will also be a CIDR block where first IP will be used as PrimaryIP for NC and rest of the IPs will be assigned to secondary IP for pods.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [*] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [*] includes documentation
- [*] adds unit tests


**Notes**:
