### PR TITLE
perf: Store Lock timeout for CNI in Windows is increased to 1 minute.

### DIFF
--- a/aitelemetry/telemetrywrapper.go
+++ b/aitelemetry/telemetrywrapper.go
@@ -116,9 +116,12 @@ func getMetadata(th *telemetryHandle) {
 		debugLog("[AppInsights] Error initializing kvs store: %v", err)
 		return
 	}
-
-	err = kvs.Lock(store.DefaultLockTimeout)
-	if err != nil {
+	// Acquire store lock. For windows 1m timeout is used while for Linux 10s timeout is assigned.
+	var lockTimeoutValue time.Duration = store.DefaultLockTimeout
+	if runtime.GOOS == "windows" {
+		lockTimeoutValue = store.DefaultLockTimeoutWindows
+	}
+	if err = kvs.Lock(lockTimeoutValue); err != nil {
 		log.Errorf("getMetadata: Not able to acquire lock:%v", err)
 		return
 	}

--- a/aitelemetry/telemetrywrapper.go
+++ b/aitelemetry/telemetrywrapper.go
@@ -116,12 +116,8 @@ func getMetadata(th *telemetryHandle) {
 		debugLog("[AppInsights] Error initializing kvs store: %v", err)
 		return
 	}
-	// Acquire store lock. For windows 1m timeout is used while for Linux 10s timeout is assigned.
-	var lockTimeoutValue time.Duration = store.DefaultLockTimeout
-	if runtime.GOOS == "windows" {
-		lockTimeoutValue = store.DefaultLockTimeoutWindows
-	}
-	if err = kvs.Lock(lockTimeoutValue); err != nil {
+	// Acquire store lock.
+	if err = kvs.Lock(store.DefaultLockTimeout); err != nil {
 		log.Errorf("getMetadata: Not able to acquire lock:%v", err)
 		return
 	}

--- a/cni/plugin.go
+++ b/cni/plugin.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/Azure/azure-container-networking/common"
 	"github.com/Azure/azure-container-networking/log"
@@ -174,8 +175,12 @@ func (plugin *Plugin) InitializeKeyValueStore(config *common.PluginConfig) error
 		}
 	}
 
-	// Acquire store lock.
-	if err := plugin.Store.Lock(store.DefaultLockTimeout); err != nil {
+	// Acquire store lock. For windows 1m timeout is used while for Linux 10s timeout is assigned.
+	var lockTimeoutValue time.Duration = store.DefaultLockTimeout
+	if runtime.GOOS == "windows" {
+		lockTimeoutValue = store.DefaultLockTimeoutWindows
+	}
+	if err := plugin.Store.Lock(lockTimeoutValue); err != nil {
 		log.Printf("[cni] Failed to lock store: %v.", err)
 		return errors.Wrap(err, "error Acquiring store lock")
 	}

--- a/store/json.go
+++ b/store/json.go
@@ -23,7 +23,8 @@ const (
 	LockExtension = ".lock"
 
 	// DefaultLockTimeout - lock timeout in milliseconds
-	DefaultLockTimeout = 10000 * time.Millisecond
+	DefaultLockTimeout        = 10000 * time.Millisecond
+	DefaultLockTimeoutWindows = 60000 * time.Millisecond
 )
 
 // jsonFileStore is an implementation of KeyValueStore using a local JSON file.
@@ -35,8 +36,9 @@ type jsonFileStore struct {
 	sync.Mutex
 }
 
-//nolint:revive // ignoring name change
 // NewJsonFileStore creates a new jsonFileStore object, accessed as a KeyValueStore.
+//
+//nolint:revive // ignoring name change
 func NewJsonFileStore(fileName string, lockclient processlock.Interface) (KeyValueStore, error) {
 	if fileName == "" {
 		return &jsonFileStore{}, errors.New("need to pass in a json file path")
@@ -195,7 +197,7 @@ func (kvs *jsonFileStore) Lock(timeout time.Duration) error {
 		return errors.Wrap(err, "processLock acquire error")
 	}
 
-	log.Printf("Acquired process lock")
+	log.Printf("Acquired process lock with timeout value of %v ", timeout)
 	return nil
 }
 


### PR DESCRIPTION
perf: Performance Improvements of Azure CNI by increasing store Lock timeout for CNI in Windows to 1 minute.


**Reason for Change**:
The current value of lock timeout for Azure CNI is 10 second. This value will cause a lot of CNI add call timeout specially on large scale scenarios in Windows. To prevent this add call failure in Windows, we are increasing the value to 1 minutes on Windows to prevent subsequent delete request form Containerd for the failed add request.
**Issue Fixed**:

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
