### PR TITLE
Added IP Usage metrics at Rest server.

### DIFF
--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -408,6 +408,12 @@ func (service *HTTPRestService) reserveIPAddress(w http.ResponseWriter, r *http.
 		Message:    returnMessage,
 	}
 
+	if resp.ReturnCode == 0 {
+		// If Response is success i.e. code 0, then publish metrics.
+		state := service.buildIPState()
+		publishIPStateMetrics(state)
+	}
+
 	reserveResp := &cns.ReserveIPAddressResponse{Response: resp, IPAddress: address}
 	err = service.Listener.Encode(w, &reserveResp)
 	logger.Response(service.Name, reserveResp, resp.ReturnCode, err)
@@ -473,6 +479,12 @@ func (service *HTTPRestService) releaseIPAddress(w http.ResponseWriter, r *http.
 	resp := cns.Response{
 		ReturnCode: returnCode,
 		Message:    returnMessage,
+	}
+
+	if resp.ReturnCode == 0 {
+		// If Response is success i.e. code 0, then publish metrics.
+		state := service.buildIPState()
+		publishIPStateMetrics(state)
 	}
 
 	err = service.Listener.Encode(w, &resp)

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -410,8 +410,7 @@ func (service *HTTPRestService) reserveIPAddress(w http.ResponseWriter, r *http.
 
 	if resp.ReturnCode == 0 {
 		// If Response is success i.e. code 0, then publish metrics.
-		state := service.buildIPState()
-		publishIPStateMetrics(state)
+		publishIPStateMetrics(service.buildIPState())
 	}
 
 	reserveResp := &cns.ReserveIPAddressResponse{Response: resp, IPAddress: address}
@@ -483,8 +482,7 @@ func (service *HTTPRestService) releaseIPAddress(w http.ResponseWriter, r *http.
 
 	if resp.ReturnCode == 0 {
 		// If Response is success i.e. code 0, then publish metrics.
-		state := service.buildIPState()
-		publishIPStateMetrics(state)
+		publishIPStateMetrics(service.buildIPState())
 	}
 
 	err = service.Listener.Encode(w, &resp)

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -395,6 +395,9 @@ func (service *HTTPRestService) CreateOrUpdateNetworkContainerInternal(req *cns.
 	// If the NC was created successfully, log NC snapshot.
 	if returnCode == 0 {
 		logNCSnapshot(*req)
+
+		state := service.buildIPState()
+		publishIPStateMetrics(state)
 	} else {
 		logger.Errorf(returnMessage)
 	}

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -396,8 +396,7 @@ func (service *HTTPRestService) CreateOrUpdateNetworkContainerInternal(req *cns.
 	if returnCode == 0 {
 		logNCSnapshot(*req)
 
-		state := service.buildIPState()
-		publishIPStateMetrics(state)
+		publishIPStateMetrics(service.buildIPState())
 	} else {
 		logger.Errorf(returnMessage)
 	}

--- a/cns/restserver/ipusage.go
+++ b/cns/restserver/ipusage.go
@@ -18,7 +18,7 @@ type ipState struct {
 	releasingIPs int64
 }
 
-func (service *HTTPRestService) buildIPState() ipState {
+func (service *HTTPRestService) buildIPState() *ipState {
 	service.Lock()
 	defer service.Unlock()
 
@@ -28,6 +28,7 @@ func (service *HTTPRestService) buildIPState() ipState {
 		availableIPs: 0,
 	}
 
+	//nolint:gocritic // This has to iterate over the IP Config state to get the counts.
 	for _, ipConfig := range service.PodIPConfigState {
 		state.allocatedIPs++
 		if ipConfig.GetState() == types.Assigned {
@@ -45,5 +46,5 @@ func (service *HTTPRestService) buildIPState() ipState {
 	}
 
 	logger.Printf("[IP Usage] allocated IPs: %d, assigned IPs: %d, available IPs: %d", state.allocatedIPs, state.assignedIPs, state.availableIPs)
-	return state
+	return &state
 }

--- a/cns/restserver/ipusage.go
+++ b/cns/restserver/ipusage.go
@@ -1,0 +1,49 @@
+package restserver
+
+import (
+	"github.com/Azure/azure-container-networking/cns/logger"
+	"github.com/Azure/azure-container-networking/cns/types"
+)
+
+type ipState struct {
+	// allocatedIPs are all the IPs given to CNS by DNC.
+	allocatedIPs int64
+	// assignedIPs are the IPs CNS gives to Pods.
+	assignedIPs int64
+	// availableIPs are the IPs in state "Available".
+	availableIPs int64
+	// programmingIPs are the IPs in state "PendingProgramming".
+	programmingIPs int64
+	// releasingIPs are the IPs in state "PendingReleasr".
+	releasingIPs int64
+}
+
+func (service *HTTPRestService) buildIPState() ipState {
+	service.Lock()
+	defer service.Unlock()
+
+	state := ipState{
+		allocatedIPs: 0,
+		assignedIPs:  0,
+		availableIPs: 0,
+	}
+
+	for _, ipConfig := range service.PodIPConfigState {
+		state.allocatedIPs++
+		if ipConfig.GetState() == types.Assigned {
+			state.assignedIPs++
+		}
+		if ipConfig.GetState() == types.Available {
+			state.availableIPs++
+		}
+		if ipConfig.GetState() == types.PendingProgramming {
+			state.programmingIPs++
+		}
+		if ipConfig.GetState() == types.PendingRelease {
+			state.releasingIPs++
+		}
+	}
+
+	logger.Printf("[IP Usage] allocated IPs: %d, assigned IPs: %d, available IPs: %d", state.allocatedIPs, state.assignedIPs, state.availableIPs)
+	return state
+}

--- a/cns/restserver/metrics.go
+++ b/cns/restserver/metrics.go
@@ -14,7 +14,7 @@ const (
 	subnetLabel              = "subnet"
 	subnetCIDRLabel          = "subnet_cidr"
 	podnetARMIDLabel         = "podnet_arm_id"
-	cnsReturnCode            = "Cns-Return-Code"
+	cnsReturnCode            = "cns_return_code"
 	customerMetricLabel      = "customer_metric"
 	customerMetricLabelValue = "customer metric"
 )
@@ -64,43 +64,43 @@ var (
 	)
 	allocatedIPCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name:        "cx_allocated_ips",
+			Name:        "cx_allocated_ips_v2",
 			Help:        "Count of IPs CNS has Allocated",
 			ConstLabels: prometheus.Labels{customerMetricLabel: customerMetricLabelValue},
 		},
-		[]string{subnetLabel, subnetCIDRLabel, podnetARMIDLabel},
+		[]string{},
 	)
 	assignedIPCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name:        "cx_assigned_ips",
+			Name:        "cx_assigned_ips_v2",
 			Help:        "Count of IPs CNS has Assigned to Pods",
 			ConstLabels: prometheus.Labels{customerMetricLabel: customerMetricLabelValue},
 		},
-		[]string{subnetLabel, subnetCIDRLabel, podnetARMIDLabel},
+		[]string{},
 	)
 	availableIPCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name:        "cx_available_ips",
+			Name:        "cx_available_ips_v2",
 			Help:        "Count of IPs Available",
 			ConstLabels: prometheus.Labels{customerMetricLabel: customerMetricLabelValue},
 		},
-		[]string{subnetLabel, subnetCIDRLabel, podnetARMIDLabel},
+		[]string{},
 	)
 	pendingProgrammingIPCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name:        "cx_pending_programming_ips",
+			Name:        "cx_pending_programming_ips_v2",
 			Help:        "Count of IPs in Pending Programming State",
 			ConstLabels: prometheus.Labels{customerMetricLabel: customerMetricLabelValue},
 		},
-		[]string{subnetLabel, subnetCIDRLabel, podnetARMIDLabel},
+		[]string{},
 	)
 	pendingReleaseIPCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name:        "cx_pending_release_ips",
+			Name:        "cx_pending_release_ips_v2",
 			Help:        "Count of IPs in Pending Release State",
 			ConstLabels: prometheus.Labels{customerMetricLabel: customerMetricLabelValue},
 		},
-		[]string{subnetLabel, subnetCIDRLabel, podnetARMIDLabel},
+		[]string{},
 	)
 )
 
@@ -142,7 +142,7 @@ func stateTransitionMiddleware(i *cns.IPConfigurationStatus, s types.IPState) {
 	ipConfigStatusStateTransitionTime.WithLabelValues(string(i.GetState()), string(s)).Observe(time.Since(i.LastStateTransition).Seconds())
 }
 
-func publishIPStateMetrics(state ipState) {
+func publishIPStateMetrics(state *ipState) {
 	labels := []string{} // TODO. ragasthya Add dimensions to the IP Usage metrics.
 	allocatedIPCount.WithLabelValues(labels...).Set(float64(state.allocatedIPs))
 	assignedIPCount.WithLabelValues(labels...).Set(float64(state.assignedIPs))

--- a/cns/restserver/metrics.go
+++ b/cns/restserver/metrics.go
@@ -10,51 +10,98 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
-var httpRequestLatency = prometheus.NewHistogramVec(
-	prometheus.HistogramOpts{
-		Name: "http_request_latency_seconds",
-		Help: "Request latency in seconds by endpoint, verb, and response code.",
-		//nolint:gomnd // default bucket consts
-		Buckets: prometheus.ExponentialBuckets(0.001, 2, 15), // 1 ms to ~16 seconds
-	},
-	[]string{"url", "verb", "cns_return_code"},
+const (
+	subnetLabel              = "subnet"
+	subnetCIDRLabel          = "subnet_cidr"
+	podnetARMIDLabel         = "podnet_arm_id"
+	cnsReturnCode            = "Cns-Return-Code"
+	customerMetricLabel      = "customer_metric"
+	customerMetricLabelValue = "customer metric"
 )
 
-var ipAssignmentLatency = prometheus.NewHistogram(
-	prometheus.HistogramOpts{
-		Name: "ip_assignment_latency_seconds",
-		Help: "Pod IP assignment latency in seconds",
-		//nolint:gomnd // default bucket consts
-		Buckets: prometheus.ExponentialBuckets(0.001, 2, 15), // 1 ms to ~16 seconds
-	},
-)
-
-var ipConfigStatusStateTransitionTime = prometheus.NewHistogramVec(
-	prometheus.HistogramOpts{
-		Name: "ipconfigstatus_state_transition_seconds",
-		Help: "Time spent by the IP Configuration Status in each state transition",
-		//nolint:gomnd // default bucket consts
-		Buckets: prometheus.ExponentialBuckets(0.001, 2, 15), // 1 ms to ~16 seconds
-	},
-	[]string{"previous_state", "next_state"},
-)
-
-var syncHostNCVersionCount = prometheus.NewCounterVec(
-	prometheus.CounterOpts{
-		Name: "sync_host_nc_version_total",
-		Help: "Count of Sync Host NC by success or failure",
-	},
-	[]string{"ok"},
-)
-
-var syncHostNCVersionLatency = prometheus.NewHistogramVec(
-	prometheus.HistogramOpts{
-		Name: "sync_host_nc_version_latency_seconds",
-		Help: "Sync Host NC Latency",
-		//nolint:gomnd // default bucket consts
-		Buckets: prometheus.ExponentialBuckets(0.001, 2, 15), // 1 ms to ~16 seconds
-	},
-	[]string{"ok"},
+var (
+	httpRequestLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "http_request_latency_seconds",
+			Help: "Request latency in seconds by endpoint, verb, and response code.",
+			//nolint:gomnd // default bucket consts
+			Buckets: prometheus.ExponentialBuckets(0.001, 2, 15), // 1 ms to ~16 seconds
+		},
+		[]string{"url", "verb", "cns_return_code"},
+	)
+	ipAssignmentLatency = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name: "ip_assignment_latency_seconds",
+			Help: "Pod IP assignment latency in seconds",
+			//nolint:gomnd // default bucket consts
+			Buckets: prometheus.ExponentialBuckets(0.001, 2, 15), // 1 ms to ~16 seconds
+		},
+	)
+	ipConfigStatusStateTransitionTime = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "ipconfigstatus_state_transition_seconds",
+			Help: "Time spent by the IP Configuration Status in each state transition",
+			//nolint:gomnd // default bucket consts
+			Buckets: prometheus.ExponentialBuckets(0.001, 2, 15), // 1 ms to ~16 seconds
+		},
+		[]string{"previous_state", "next_state"},
+	)
+	syncHostNCVersionCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "sync_host_nc_version_total",
+			Help: "Count of Sync Host NC by success or failure",
+		},
+		[]string{"ok"},
+	)
+	syncHostNCVersionLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "sync_host_nc_version_latency_seconds",
+			Help: "Sync Host NC Latency",
+			//nolint:gomnd // default bucket consts
+			Buckets: prometheus.ExponentialBuckets(0.001, 2, 15), // 1 ms to ~16 seconds
+		},
+		[]string{"ok"},
+	)
+	allocatedIPCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:        "cx_allocated_ips",
+			Help:        "Count of IPs CNS has Allocated",
+			ConstLabels: prometheus.Labels{customerMetricLabel: customerMetricLabelValue},
+		},
+		[]string{subnetLabel, subnetCIDRLabel, podnetARMIDLabel},
+	)
+	assignedIPCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:        "cx_assigned_ips",
+			Help:        "Count of IPs CNS has Assigned to Pods",
+			ConstLabels: prometheus.Labels{customerMetricLabel: customerMetricLabelValue},
+		},
+		[]string{subnetLabel, subnetCIDRLabel, podnetARMIDLabel},
+	)
+	availableIPCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:        "cx_available_ips",
+			Help:        "Count of IPs Available",
+			ConstLabels: prometheus.Labels{customerMetricLabel: customerMetricLabelValue},
+		},
+		[]string{subnetLabel, subnetCIDRLabel, podnetARMIDLabel},
+	)
+	pendingProgrammingIPCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:        "cx_pending_programming_ips",
+			Help:        "Count of IPs in Pending Programming State",
+			ConstLabels: prometheus.Labels{customerMetricLabel: customerMetricLabelValue},
+		},
+		[]string{subnetLabel, subnetCIDRLabel, podnetARMIDLabel},
+	)
+	pendingReleaseIPCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:        "cx_pending_release_ips",
+			Help:        "Count of IPs in Pending Release State",
+			ConstLabels: prometheus.Labels{customerMetricLabel: customerMetricLabelValue},
+		},
+		[]string{subnetLabel, subnetCIDRLabel, podnetARMIDLabel},
+	)
 )
 
 func init() {
@@ -64,10 +111,13 @@ func init() {
 		ipConfigStatusStateTransitionTime,
 		syncHostNCVersionCount,
 		syncHostNCVersionLatency,
+		allocatedIPCount,
+		assignedIPCount,
+		availableIPCount,
+		pendingProgrammingIPCount,
+		pendingReleaseIPCount,
 	)
 }
-
-const cnsReturnCode = "Cns-Return-Code"
 
 // Every http response is 200 so we really want cns  response code.
 // Hard tto do with middleware unless we derserialize the responses but making it an explit header works around it.
@@ -90,4 +140,13 @@ func stateTransitionMiddleware(i *cns.IPConfigurationStatus, s types.IPState) {
 		return
 	}
 	ipConfigStatusStateTransitionTime.WithLabelValues(string(i.GetState()), string(s)).Observe(time.Since(i.LastStateTransition).Seconds())
+}
+
+func publishIPStateMetrics(state ipState) {
+	labels := []string{} // TODO. ragasthya Add dimensions to the IP Usage metrics.
+	allocatedIPCount.WithLabelValues(labels...).Set(float64(state.allocatedIPs))
+	assignedIPCount.WithLabelValues(labels...).Set(float64(state.assignedIPs))
+	availableIPCount.WithLabelValues(labels...).Set(float64(state.availableIPs))
+	pendingProgrammingIPCount.WithLabelValues(labels...).Set(float64(state.programmingIPs))
+	pendingReleaseIPCount.WithLabelValues(labels...).Set(float64(state.releasingIPs))
 }


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

The IP Usage metrics were not visible for Overlay. 
This change enables the following metrics to be published to prometheus which will then scrape these metrics periodically.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
https://msazure.visualstudio.com/One/_workitems/edit/19364564


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
