### PR TITLE
ci: use 1.4.44_hotfix image in cilium load test

### DIFF
--- a/test/integration/manifests/cilium/cns-write-ovly.yaml
+++ b/test/integration/manifests/cilium/cns-write-ovly.yaml
@@ -96,7 +96,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: cns-container
-          image: acnpublic.azurecr.io/azure-cns:write-cilium-conf2
+          image: acnpublic.azurecr.io/azure-cns:v1.4.44_hotfix
           imagePullPolicy: IfNotPresent
           args: [ "-c", "tcp://$(CNSIpAddress):$(CNSPort)", "-t", "$(CNSLogTarget)"]
           securityContext:
@@ -148,14 +148,9 @@ spec:
             - azure-ipam
             - -o
             - /opt/cni/bin/azure-ipam
-            # - azilium.conflist
-            # - -o 
-            # - /etc/cni/net.d/05-cilium.conflist
           volumeMounts:
             - name: cni-bin
               mountPath: /opt/cni/bin
-            # - name: cni-conflist
-            #   mountPath: /etc/cni/net.d
       hostNetwork: true
       volumes:
         - name: cni-conflist


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
update load test with v1.4.44_hotfix for cns to write conflist


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
load test pipeline run against this branch: https://msazure.visualstudio.com/One/_build/results?buildId=72946708&view=results
