### PR TITLE
Cnsclientlog fix

### DIFF
--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -902,6 +902,7 @@ func (service *HTTPRestService) getAllNetworkContainers(w http.ResponseWriter, r
 		for _, failedNetworkContainerResponse := range failedNetworkContainerResponses { // nolint
 			failedToGetNCErrMsg = append(failedToGetNCErrMsg, fmt.Sprintf("Failed to get NC %s due to %s", failedNetworkContainerResponse.NetworkContainerID, failedNetworkContainerResponse.Response.Message))
 		}
+
 		resp.Response.ReturnCode = types.UnexpectedError
 		resp.Response.Message = strings.Join(failedToGetNCErrMsg, "\n")
 	} else {

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -888,18 +888,22 @@ func (service *HTTPRestService) getAllNetworkContainers(w http.ResponseWriter, r
 
 	var resp cns.GetAllNetworkContainersResponse
 
-	failedNCs := make([]string, 0)
+	failedNetworkContainerResponses := make([]cns.GetNetworkContainerResponse, 0)
 	for i := 0; i < len(getAllNetworkContainerResponses); i++ {
 		if getAllNetworkContainerResponses[i].Response.ReturnCode != types.Success {
-			failedNCs = append(failedNCs, getAllNetworkContainerResponses[i].NetworkContainerID)
+			failedNetworkContainerResponses = append(failedNetworkContainerResponses, getAllNetworkContainerResponses[i])
 		}
 	}
 
 	resp.NetworkContainers = getAllNetworkContainerResponses
 
-	if len(failedNCs) > 0 {
+	if len(failedNetworkContainerResponses) > 0 {
+		failedToGetNCErrMsg := make([]string, 0)
+		for _, failedNetworkContainerResponse := range failedNetworkContainerResponses { // nolint
+			failedToGetNCErrMsg = append(failedToGetNCErrMsg, fmt.Sprintf("Failed to get NC %s due to %s", failedNetworkContainerResponse.NetworkContainerID, failedNetworkContainerResponse.Response.Message))
+		}
 		resp.Response.ReturnCode = types.UnexpectedError
-		resp.Response.Message = fmt.Sprintf("Failed to get NCs %s", strings.Join(failedNCs, ","))
+		resp.Response.Message = strings.Join(failedToGetNCErrMsg, "\n")
 	} else {
 		resp.Response.ReturnCode = types.Success
 		resp.Response.Message = "Successfully retrieved NCs"

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -853,13 +853,18 @@ func (service *HTTPRestService) isNCWaitingForUpdate(
 			"Skipping GetNCVersionStatus check from NMAgent", ncVersion, ncid)
 		return true, types.NetworkContainerVfpProgramPending, ""
 	}
-	nmaProgrammedNCVersionStr, ok := ncVersionList[ncid]
+
+	// accept both upper and lower GUID from ncid(Swift_GUID)
+	// check each ncid in lower case if it's in ncVersionList
+	nmaProgrammedNCVersionStr, ok := ncVersionList[strings.ToLower(ncid)]
 	if !ok {
 		// NMA doesn't have this NC that we need programmed yet, bail out
 		logger.Printf("[Azure CNS] Failed to get NC %s doesn't exist in NMAgent NC version list "+
 			"Skipping GetNCVersionStatus check from NMAgent", ncid)
 		return true, types.NetworkContainerVfpProgramPending, ""
+
 	}
+
 	nmaProgrammedNCVersion, err := strconv.Atoi(nmaProgrammedNCVersionStr)
 	if err != nil {
 		// it's unclear whether or not this can actually happen. In the NMAgent

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -853,7 +853,6 @@ func (service *HTTPRestService) isNCWaitingForUpdate(
 			"Skipping GetNCVersionStatus check from NMAgent", ncVersion, ncid)
 		return true, types.NetworkContainerVfpProgramPending, ""
 	}
-
 	nmaProgrammedNCVersionStr, ok := ncVersionList[ncid]
 	if !ok {
 		// NMA doesn't have this NC that we need programmed yet, bail out

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -854,17 +854,13 @@ func (service *HTTPRestService) isNCWaitingForUpdate(
 		return true, types.NetworkContainerVfpProgramPending, ""
 	}
 
-	// accept both upper and lower GUID from ncid(Swift_GUID)
-	// check each ncid in lower case if it's in ncVersionList
-	nmaProgrammedNCVersionStr, ok := ncVersionList[strings.ToLower(ncid)]
+	nmaProgrammedNCVersionStr, ok := ncVersionList[ncid]
 	if !ok {
 		// NMA doesn't have this NC that we need programmed yet, bail out
 		logger.Printf("[Azure CNS] Failed to get NC %s doesn't exist in NMAgent NC version list "+
 			"Skipping GetNCVersionStatus check from NMAgent", ncid)
 		return true, types.NetworkContainerVfpProgramPending, ""
-
 	}
-
 	nmaProgrammedNCVersion, err := strconv.Atoi(nmaProgrammedNCVersionStr)
 	if err != nil {
 		// it's unclear whether or not this can actually happen. In the NMAgent


### PR DESCRIPTION
This PR includes:

Add fixes for cnsclient log to show why sometimes we cannot get NCs
It will log something like:
Failed to get NC "aa" due to "yy"
Failed to get NC "bb" due to "zz"