### PR TITLE
ci: fix cilium validate state check for PRs

### DIFF
--- a/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
@@ -108,14 +108,6 @@ steps:
     condition: always()
 
   - script: |
-      echo "validate pod IP assignment and check systemd-networkd restart"
-      kubectl apply -f hack/manifests/hostprocess.yaml
-      kubectl get pod -owide -A
-      bash hack/scripts/validate_state.sh
-    name: "validatePods"
-    displayName: "Validate Pods"
-
-  - script: |
       echo "Run Service Conformance E2E"
       export PATH=${PATH}:/usr/local/bin/gsutil
       KUBECONFIG=~/.kube/config kubetest2 noop \
@@ -131,6 +123,18 @@ steps:
     retryCountOnTaskFailure: 3
     name: "ciliumConnectivityTests"
     displayName: "Run Cilium Connectivity Tests"
+
+  - script: |
+      echo "validate pod IP assignment and check systemd-networkd restart"
+      kubectl apply -f hack/manifests/hostprocess.yaml
+      kubectl get pod -owide -A
+      bash hack/scripts/validate_state.sh
+      echo "delete cilium connectivity test resources and re-validate state"
+      kubectl delete ns cilium-test
+      kubectl get pod -owide -A
+      bash hack/scripts/validate_state.sh
+    name: "validatePods"
+    displayName: "Validate Pods"
   
   - script: |
       ARTIFACT_DIR=$(Build.ArtifactStagingDirectory)/test-output/

--- a/.pipelines/singletenancy/overlay/overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/overlay/overlay-e2e-step-template.yaml
@@ -114,14 +114,6 @@ steps:
     condition: always()
 
   - script: |
-      echo "validate pod IP assignment and check systemd-networkd restart"
-      kubectl apply -f hack/manifests/hostprocess.yaml
-      kubectl get pod -owide -A
-      bash hack/scripts/validate_state.sh
-    name: "validatePods"
-    displayName: "Validate Pods"
-
-  - script: |
       echo "Run Service Conformance E2E"
       export PATH=${PATH}:/usr/local/bin/gsutil
       KUBECONFIG=~/.kube/config kubetest2 noop \
@@ -136,6 +128,18 @@ steps:
       cilium connectivity test
     name: "ciliumConnectivityTests"
     displayName: "Run Cilium Connectivity Tests"
+
+  - script: |
+      echo "validate pod IP assignment and check systemd-networkd restart"
+      kubectl apply -f hack/manifests/hostprocess.yaml
+      kubectl get pod -owide -A
+      bash hack/scripts/validate_state.sh
+      echo "delete cilium connectivity test resources and re-validate state"
+      kubectl delete ns cilium-test
+      kubectl get pod -owide -A
+      bash hack/scripts/validate_state.sh
+    name: "validatePods"
+    displayName: "Validate Pods"
   
   - script: |
       ARTIFACT_DIR=$(Build.ArtifactStagingDirectory)/test-output/

--- a/hack/scripts/validate_state.sh
+++ b/hack/scripts/validate_state.sh
@@ -15,9 +15,11 @@ do
     node_name="${node##*/}"
     node_ip=$(kubectl get "$node"  -o jsonpath='{$.status.addresses[?(@.type=="InternalIP")].address}')
     echo "Node internal ip: $node_ip"
+    # Check pod count after restarting nodes, statefile does not exist after restart
     echo "checking whether the node has any pods deployed to it or not"
-    pod_count=$(kubectl get pods -o wide | grep "$node_name" -c)
+    pod_count=$(kubectl get pods -A -o wide | grep "$node_name" -c)
     if [[ $pod_count -eq 0 ]]; then
+        echo "Skipping validation for this node. No pods were deployed after the restart, so no statefile exists"
         continue
     fi
     privileged_pod=$(kubectl get pods -n kube-system -l app=privileged-daemonset -o wide | grep "$node_name" | awk '{print $1}')

--- a/hack/swift/Makefile
+++ b/hack/swift/Makefile
@@ -20,8 +20,6 @@ GROUP      ?= $(CLUSTER)
 VNET       ?= $(CLUSTER)
 
 
-KUBE_PROXY_CONFIG = $(kube-proxy.json)
-
 
 ##@ Help
 
@@ -137,7 +135,6 @@ swift-byocni-up: rg-up swift-net-up ## Bring up a SWIFT BYO CNI cluster
 		--pod-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/podnet \
 		--no-ssh-key \
 		--os-sku $(OS_SKU) \
-		--kube-proxy-config kube-proxy.json
 		--yes
 	@$(MAKE) set-kubeconf
 
@@ -175,5 +172,3 @@ down: ## Delete the cluster
 restart-vmss: ## Restarts the nodes in the cluster
 	$(AZCLI) vmss restart -g MC_${GROUP}_${CLUSTER}_${REGION} --name $(VMSS_NAME)
 
-disable-kube-proxy: ## Updates cluster to remove kube-proxy
-	$(AZCLI) aks update -g ${GROUP} -n ${CLUSTER} --kube-proxy-config /kube-proxy.json

--- a/hack/swift/Makefile
+++ b/hack/swift/Makefile
@@ -19,8 +19,6 @@ CLUSTER    ?= $(USER)-$(REGION)
 GROUP      ?= $(CLUSTER)
 VNET       ?= $(CLUSTER)
 
-
-
 ##@ Help
 
 help:  ## Display this help
@@ -171,4 +169,3 @@ down: ## Delete the cluster
 
 restart-vmss: ## Restarts the nodes in the cluster
 	$(AZCLI) vmss restart -g MC_${GROUP}_${CLUSTER}_${REGION} --name $(VMSS_NAME)
-

--- a/hack/swift/Makefile
+++ b/hack/swift/Makefile
@@ -19,6 +19,10 @@ CLUSTER    ?= $(USER)-$(REGION)
 GROUP      ?= $(CLUSTER)
 VNET       ?= $(CLUSTER)
 
+
+KUBE_PROXY_CONFIG = $(kube-proxy.json)
+
+
 ##@ Help
 
 help:  ## Display this help
@@ -133,6 +137,7 @@ swift-byocni-up: rg-up swift-net-up ## Bring up a SWIFT BYO CNI cluster
 		--pod-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/podnet \
 		--no-ssh-key \
 		--os-sku $(OS_SKU) \
+		--kube-proxy-config kube-proxy.json
 		--yes
 	@$(MAKE) set-kubeconf
 
@@ -169,3 +174,6 @@ down: ## Delete the cluster
 
 restart-vmss: ## Restarts the nodes in the cluster
 	$(AZCLI) vmss restart -g MC_${GROUP}_${CLUSTER}_${REGION} --name $(VMSS_NAME)
+
+disable-kube-proxy: ## Updates cluster to remove kube-proxy
+	$(AZCLI) aks update -g ${GROUP} -n ${CLUSTER} --kube-proxy-config /kube-proxy.json


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
After restart node stage was added, the PR check to validate pods was getting skipped. 
- Updating the condition in the script to check all namespaces
- Running the check before and after deletion of cilium-test namespace to verify the check works when endpoints change. 


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
load test pipeline run: https://msazure.visualstudio.com/One/_build/results?buildId=73145191&view=results
