### PR TITLE
fix: don't use 0th ip as gateway for ipv6

### DIFF
--- a/cns/kubecontroller/nodenetworkconfig/conversion_windows.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_windows.go
@@ -17,9 +17,9 @@ func createNCRequestFromStaticNCHelper(nc v1alpha.NetworkContainer, primaryIPPre
 	secondaryIPConfigs := map[string]cns.SecondaryIPConfig{}
 
 	// if NC DefaultGateway is empty, set the 0th IP to the gateway and add the rest of the IPs
-	// as secondary IPs
+	// as secondary IPs (for ipv4 only)
 	startingAddr := primaryIPPrefix.Masked().Addr() // the masked address is the 0th IP in the subnet
-	if nc.DefaultGateway == "" {
+	if nc.DefaultGateway == "" && startingAddr.Is4() {
 		nc.DefaultGateway = startingAddr.String()
 		startingAddr = startingAddr.Next()
 	}


### PR DESCRIPTION
**Reason for Change**:
For overlay on windows, we are setting the gateway IP to the 0th IP of the the block assigned to each node. For ipv6, we want to skip this behavior and pass empty gateway to CNI. This PR fixes that.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests


**Notes**:
