### PR TITLE
change ipv6 gateway as cidr IP

### DIFF
--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -21,9 +21,8 @@ import (
 )
 
 var (
-	errEmptyCNIArgs    = errors.New("empty CNI cmd args not allowed")
-	errInvalidArgs     = errors.New("invalid arg(s)")
-	overlayGatewayV6IP = "fe80::1234:5678:9abc"
+	errEmptyCNIArgs = errors.New("empty CNI cmd args not allowed")
+	errInvalidArgs  = errors.New("invalid arg(s)")
 )
 
 type CNSIPAMInvoker struct {
@@ -145,7 +144,10 @@ func (invoker *CNSIPAMInvoker) Add(addConfig IPAMAddConfig) (IPAMAddResult, erro
 					return IPAMAddResult{}, err
 				}
 			} else if net.ParseIP(info.podIPAddress).To16() != nil {
-				ncgw = net.ParseIP(overlayGatewayV6IP)
+				ncgw, err = getOverlayIPv6Gateway(ncIPNet)
+				if err != nil {
+					return IPAMAddResult{}, err
+				}
 			} else {
 				return IPAMAddResult{}, errors.Wrap(err, "No podIPAddress is found: %w")
 			}

--- a/cni/network/invoker_cns_test.go
+++ b/cni/network/invoker_cns_test.go
@@ -44,6 +44,14 @@ func getTestOverlayGateway() net.IP {
 	return net.ParseIP("169.254.1.1")
 }
 
+func getTestOverlayIPv6Gateway() net.IP {
+	if runtime.GOOS == "windows" {
+		return net.ParseIP("fd34:8e19:aa39:5380::2a4")
+	}
+
+	return net.ParseIP("fe80::1234:5678:9abc")
+}
+
 func TestCNSIPAMInvoker_Add_Overlay(t *testing.T) {
 	require := require.New(t) //nolint further usage of require without passing t
 
@@ -230,13 +238,13 @@ func TestCNSIPAMInvoker_Add_Overlay(t *testing.T) {
 				IPs: []*cniTypesCurr.IPConfig{
 					{
 						Address: *getCIDRNotationForAddress("fd11:1234::1/112"),
-						Gateway: net.ParseIP("fe80::1234:5678:9abc"),
+						Gateway: getTestOverlayIPv6Gateway(),
 					},
 				},
 				Routes: []*cniTypes.Route{
 					{
 						Dst: network.Ipv6DefaultRouteDstPrefix,
-						GW:  net.ParseIP("fe80::1234:5678:9abc"),
+						GW:  getTestOverlayIPv6Gateway(),
 					},
 				},
 			},

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -150,3 +150,7 @@ func (plugin *NetPlugin) isDualNicFeatureSupported(netNs string) bool {
 func getOverlayGateway(_ *net.IPNet) (net.IP, error) {
 	return net.ParseIP("169.254.1.1"), nil
 }
+
+func getOverlayIPv6Gateway(_ *net.IPNet) (net.IP, error) {
+	return net.ParseIP("fe80::1234:5678:9abc"), nil
+}

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -425,3 +425,13 @@ func getOverlayGateway(podsubnet *net.IPNet) (net.IP, error) {
 
 	return ncgw, nil
 }
+
+func getOverlayIPv6Gateway(podv6subnet *net.IPNet) (net.IP, error) {
+	ncgw := podv6subnet.IP
+	ncgw = net.ParseIP(ncgw.String() + "1")
+	if ncgw == nil || !podv6subnet.Contains(ncgw) {
+		return nil, errors.Wrap(errInvalidArgs, "%w: Failed to retrieve dualstack overlay ipv6 gateway from podsubnet"+podv6subnet.IP.String())
+	}
+
+	return ncgw, nil
+}


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
This PR is to fix the issue that default gateway is `fe80::1234:5678:9abc`, instead we should use one ipv6 cidr address 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
HNS team has verified this issue. Need AKS team to change the node ipv6 default gateway to one cidr address as well


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests


**Notes**:
