### PR TITLE
add v6 port mapping policy to dualstack overlay

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -40,7 +40,6 @@ const (
 	// Supported IP version. Currently support only IPv4
 	ipamV6                = "azure-vnet-ipamv6"
 	defaultRequestTimeout = 15 * time.Second
-	dualStackOverlay      = "dualStackOverlay"
 )
 
 // CNI Operation Types
@@ -638,7 +637,7 @@ func (plugin *NetPlugin) createNetworkInternal(
 		NetNs:                         ipamAddConfig.args.Netns,
 		Options:                       ipamAddConfig.options,
 		DisableHairpinOnHostInterface: ipamAddConfig.nwCfg.DisableHairpinOnHostInterface,
-		IPV6Mode:                      ipamAddConfig.nwCfg.IPV6Mode, //TODO: check if this can be removed.
+		IPV6Mode:                      ipamAddConfig.nwCfg.IPV6Mode, //TODO: check if IPV6Mode field can be deprecated
 		IPAMType:                      ipamAddConfig.nwCfg.IPAM.Type,
 		ServiceCidrs:                  ipamAddConfig.nwCfg.ServiceCidrs,
 		IsIPv6Enabled:                 ipamAddResult.ipv6Result != nil,
@@ -774,7 +773,7 @@ func (plugin *NetPlugin) createEndpointInternal(opt *createEndpointInternalOpt) 
 
 	if opt.resultV6 != nil {
 		// inject ipv6 routes to Linux pod
-		epInfo.IPV6Mode = dualStackOverlay // TODO: can this IPV6Mode be deprecated and can we add IsIPv6Enabled flag for generic working
+		epInfo.IPV6Mode = string(util.IpamMode(opt.nwCfg.IPAM.Mode)) // TODO: check IPV6Mode field can be deprecated and can we add IsIPv6Enabled flag for generic working
 		for _, ipconfig := range opt.resultV6.IPs {
 			epInfo.IPAddresses = append(epInfo.IPAddresses, ipconfig.Address)
 		}

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -637,7 +637,7 @@ func (plugin *NetPlugin) createNetworkInternal(
 		NetNs:                         ipamAddConfig.args.Netns,
 		Options:                       ipamAddConfig.options,
 		DisableHairpinOnHostInterface: ipamAddConfig.nwCfg.DisableHairpinOnHostInterface,
-		IPV6Mode:                      ipamAddConfig.nwCfg.IPV6Mode, //TODO: check if IPV6Mode field can be deprecated
+		IPV6Mode:                      ipamAddConfig.nwCfg.IPV6Mode, // TODO: check if IPV6Mode field can be deprecated
 		IPAMType:                      ipamAddConfig.nwCfg.IPAM.Type,
 		ServiceCidrs:                  ipamAddConfig.nwCfg.ServiceCidrs,
 		IsIPv6Enabled:                 ipamAddResult.ipv6Result != nil,

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -774,7 +774,7 @@ func (plugin *NetPlugin) createEndpointInternal(opt *createEndpointInternalOpt) 
 
 	if opt.resultV6 != nil {
 		// inject ipv6 routes to Linux pod
-		epInfo.IPV6Mode = dualStackOverlay
+		epInfo.IPV6Mode = dualStackOverlay // TODO: can this IPV6Mode be deprecated and can we add IsIPv6Enabled flag for generic working
 		for _, ipconfig := range opt.resultV6.IPs {
 			epInfo.IPAddresses = append(epInfo.IPAddresses, ipconfig.Address)
 		}

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -764,6 +764,8 @@ func (plugin *NetPlugin) createEndpointInternal(opt *createEndpointInternalOpt) 
 		NATInfo:            opt.natInfo,
 	}
 
+	opt.nwCfg.IPV6Mode = opt.nwInfo.IPV6Mode
+
 	epPolicies := getPoliciesFromRuntimeCfg(opt.nwCfg)
 	epInfo.Policies = append(epInfo.Policies, epPolicies...)
 

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -124,7 +124,7 @@ func getEndpointPolicies(PolicyArgs) ([]policy.Policy, error) {
 
 // getPoliciesFromRuntimeCfg returns network policies from network config.
 // getPoliciesFromRuntimeCfg is a dummy function for Linux platform.
-func getPoliciesFromRuntimeCfg(nwCfg *cni.NetworkConfig, isIPv6Enabled bool) []policy.Policy {
+func getPoliciesFromRuntimeCfg(_ *cni.NetworkConfig, isIPv6Enabled bool) []policy.Policy {
 	return nil
 }
 

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -124,7 +124,7 @@ func getEndpointPolicies(PolicyArgs) ([]policy.Policy, error) {
 
 // getPoliciesFromRuntimeCfg returns network policies from network config.
 // getPoliciesFromRuntimeCfg is a dummy function for Linux platform.
-func getPoliciesFromRuntimeCfg(nwCfg *cni.NetworkConfig) []policy.Policy {
+func getPoliciesFromRuntimeCfg(nwCfg *cni.NetworkConfig, isIPv6Enabled bool) []policy.Policy {
 	return nil
 }
 

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -124,7 +124,7 @@ func getEndpointPolicies(PolicyArgs) ([]policy.Policy, error) {
 
 // getPoliciesFromRuntimeCfg returns network policies from network config.
 // getPoliciesFromRuntimeCfg is a dummy function for Linux platform.
-func getPoliciesFromRuntimeCfg(_ *cni.NetworkConfig, isIPv6Enabled bool) []policy.Policy {
+func getPoliciesFromRuntimeCfg(_ *cni.NetworkConfig, _ bool) []policy.Policy {
 	return nil
 }
 

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -276,7 +276,7 @@ func getPoliciesFromRuntimeCfg(nwCfg *cni.NetworkConfig, isIPv6Enabled bool) []p
 		log.Printf("[net] Creating port mapping policy: %+v", policyv4)
 		policies = append(policies, policyv4)
 
-		// add port mapping policy for v6 if it's dualstack overlay mode
+		// add port mapping policy for v6 if we have IPV6 enabled
 		if isIPv6Enabled {
 			// To support hostport policy mapping for ipv6 in dualstack overlay mode
 			// uint32 NatFlagsIPv6 = 2

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -238,7 +238,7 @@ func getEndpointDNSSettings(nwCfg *cni.NetworkConfig, result *cniTypesCurr.Resul
 }
 
 // getPoliciesFromRuntimeCfg returns network policies from network config.
-func getPoliciesFromRuntimeCfg(nwCfg *cni.NetworkConfig) []policy.Policy {
+func getPoliciesFromRuntimeCfg(nwCfg *cni.NetworkConfig, isIPv6Enabled bool) []policy.Policy {
 	log.Printf("[net] RuntimeConfigs: %+v", nwCfg.RuntimeConfig)
 	var policies []policy.Policy
 	var protocol uint32
@@ -277,7 +277,7 @@ func getPoliciesFromRuntimeCfg(nwCfg *cni.NetworkConfig) []policy.Policy {
 		policies = append(policies, policyv4)
 
 		// add port mapping policy for v6 if it's dualstack overlay mode
-		if nwCfg.IPV6Mode == string(util.DualStackOverlay) {
+		if isIPv6Enabled {
 			// To support hostport policy mapping for ipv6 in dualstack overlay mode
 			// uint32 NatFlagsIPv6 = 2
 			rawPolicyv6, _ := json.Marshal(&hnsv2.PortMappingPolicySetting{

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -280,7 +280,7 @@ func getPoliciesFromRuntimeCfg(nwCfg *cni.NetworkConfig, isIPv6Enabled bool) []p
 		if isIPv6Enabled {
 			// To support hostport policy mapping for ipv6 in dualstack overlay mode
 			// uint32 NatFlagsIPv6 = 2
-			rawPolicyv6, _ := json.Marshal(&hnsv2.PortMappingPolicySetting{
+			rawPolicyv6, _ := json.Marshal(&hnsv2.PortMappingPolicySetting{ // nolint
 				ExternalPort: uint16(mapping.HostPort),
 				InternalPort: uint16(mapping.ContainerPort),
 				VIP:          mapping.HostIp,
@@ -288,7 +288,7 @@ func getPoliciesFromRuntimeCfg(nwCfg *cni.NetworkConfig, isIPv6Enabled bool) []p
 				Flags:        hnsv2.NatFlagsIPv6,
 			})
 
-			hnsv2Policyv6, _ := json.Marshal(&hnsv2.EndpointPolicy{
+			hnsv2Policyv6, _ := json.Marshal(&hnsv2.EndpointPolicy{ // nolint
 				Type:     hnsv2.PortMapping,
 				Settings: rawPolicyv6,
 			})

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -242,6 +242,7 @@ func getPoliciesFromRuntimeCfg(nwCfg *cni.NetworkConfig) []policy.Policy {
 	log.Printf("[net] RuntimeConfigs: %+v", nwCfg.RuntimeConfig)
 	var policies []policy.Policy
 	var protocol uint32
+
 	for _, mapping := range nwCfg.RuntimeConfig.PortMappings {
 
 		cfgProto := strings.ToUpper(strings.TrimSpace(mapping.Protocol))
@@ -267,13 +268,39 @@ func getPoliciesFromRuntimeCfg(nwCfg *cni.NetworkConfig) []policy.Policy {
 			Settings: rawPolicy,
 		})
 
-		policy := policy.Policy{
+		policyv4 := policy.Policy{
 			Type: policy.EndpointPolicy,
 			Data: hnsv2Policy,
 		}
-		log.Printf("[net] Creating port mapping policy: %+v", policy)
 
-		policies = append(policies, policy)
+		log.Printf("[net] Creating port mapping policy: %+v", policyv4)
+		policies = append(policies, policyv4)
+
+		// add port mapping policy for v6 if it's dualstack overlay mode
+		if nwCfg.IPV6Mode == string(util.DualStackOverlay) {
+			// To support hostport policy mapping for ipv6 in dualstack overlay mode
+			// uint32 NatFlagsIPv6 = 2
+			rawPolicyv6, _ := json.Marshal(&hnsv2.PortMappingPolicySetting{
+				ExternalPort: uint16(mapping.HostPort),
+				InternalPort: uint16(mapping.ContainerPort),
+				VIP:          mapping.HostIp,
+				Protocol:     protocol,
+				Flags:        hnsv2.NatFlagsIPv6,
+			})
+
+			hnsv2Policyv6, _ := json.Marshal(&hnsv2.EndpointPolicy{
+				Type:     hnsv2.PortMapping,
+				Settings: rawPolicyv6,
+			})
+
+			policyv6 := policy.Policy{
+				Type: policy.EndpointPolicy,
+				Data: hnsv2Policyv6,
+			}
+
+			log.Printf("[net] Creating port mapping policy v6: %+v", policyv6)
+			policies = append(policies, policyv6)
+		}
 	}
 
 	return policies

--- a/cni/network/network_windows_test.go
+++ b/cni/network/network_windows_test.go
@@ -253,7 +253,7 @@ func TestSetPoliciesFromNwCfg(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			policies := getPoliciesFromRuntimeCfg(&tt.nwCfg)
+			policies := getPoliciesFromRuntimeCfg(&tt.nwCfg, false)
 			require.Condition(t, assert.Comparison(func() bool {
 				return len(policies) > 0 && policies[0].Type == policy.EndpointPolicy
 			}))

--- a/cni/network/network_windows_test.go
+++ b/cni/network/network_windows_test.go
@@ -253,7 +253,8 @@ func TestSetPoliciesFromNwCfg(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			policies := getPoliciesFromRuntimeCfg(&tt.nwCfg, false)
+			isIPv6Enabled := false
+			policies := getPoliciesFromRuntimeCfg(&tt.nwCfg, isIPv6Enabled)
 			require.Condition(t, assert.Comparison(func() bool {
 				return len(policies) > 0 && policies[0].Type == policy.EndpointPolicy
 			}))

--- a/cns/client/client.go
+++ b/cns/client/client.go
@@ -400,7 +400,6 @@ func (c *Client) RequestIPs(ctx context.Context, ipconfig cns.IPConfigsRequest) 
 	}
 	req.Header.Set(headerContentType, contentTypeJSON)
 	res, err := c.client.Do(req)
-
 	if err != nil {
 		return nil, errors.Wrap(err, "http request failed")
 	}

--- a/network/network.go
+++ b/network/network.go
@@ -74,6 +74,7 @@ type NetworkInfo struct {
 	IPV6Mode                      string
 	IPAMType                      string
 	ServiceCidrs                  string
+	IsIPv6Enabled                 bool
 }
 
 // SubnetInfo contains subnet information for a container network.

--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -403,7 +403,7 @@ func (nm *networkManager) newNetworkImplHnsV2(nwInfo *NetworkInfo, extIf *extern
 	if err != nil {
 		// if network not found, create the HNS network.
 		if errors.As(err, &hcn.NetworkNotFoundError{}) {
-			// add net routes to windows node in dualStackOverlay mode
+			// add net routes to windows node if we have IPv6 enabled
 			if nwInfo.IsIPv6Enabled {
 				if err := nm.addNewNetRules(nwInfo); err != nil { // nolint
 					log.Printf("[net] Failed to add net rules due to %+v", err)

--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-container-networking/cni/util"
 	"github.com/Azure/azure-container-networking/log"
 	"github.com/Azure/azure-container-networking/network/hnswrapper"
 	"github.com/Azure/azure-container-networking/network/policy"
@@ -404,8 +403,8 @@ func (nm *networkManager) newNetworkImplHnsV2(nwInfo *NetworkInfo, extIf *extern
 	if err != nil {
 		// if network not found, create the HNS network.
 		if errors.As(err, &hcn.NetworkNotFoundError{}) {
-			// in dualStackOverlay mode, add net routes to windows node
-			if nwInfo.IPV6Mode == string(util.DualStackOverlay) {
+			// add net routes to windows node in dualStackOverlay mode
+			if nwInfo.IsIPv6Enabled {
 				if err := nm.addNewNetRules(nwInfo); err != nil { // nolint
 					log.Printf("[net] Failed to add net rules due to %+v", err)
 					return nil, err


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
This PR is to fix this issue: https://github.com/Azure/azure-container-networking/issues/1986

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fix has been verified by HNS team, but looking for another issue(incorrect windows CNI conflist file) to be resolved.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [ ] adds unit tests


**Notes**:
