### PR TITLE
[Cilium] [Pipeline] Enable Kubeproxy replacement healthz endpoint

### DIFF
--- a/test/integration/manifests/cilium/cilium-config.yaml
+++ b/test/integration/manifests/cilium/cilium-config.yaml
@@ -47,7 +47,7 @@ data:
   install-no-conntrack-iptables-rules: "false"
   ipam: delegated-plugin
   kube-proxy-replacement: strict
-  kube-proxy-replacement-healthz-bind-address: ""
+  kube-proxy-replacement-healthz-bind-address: "0.0.0.0:10256"
   local-router-ipv4: 169.254.23.0
   metrics: +cilium_bpf_map_pressure
   monitor-aggregation: medium


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
To enable health check server for the kube-proxy replacement, the kubeProxyReplacementHealthzBindAddr option has to be set (disabled by default). The option accepts the IP address with port for the health check server to serve on.  This change is required for new AKS external lb design where health probe would be sent to this port instead of redirecting to pod. This modifies our pipeline cilium config map

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
