### PR TITLE
Initial getHomeAZ 404 changes

### DIFF
--- a/cns/restserver/homeazmonitor.go
+++ b/cns/restserver/homeazmonitor.go
@@ -126,6 +126,12 @@ func (h *HomeAzMonitor) Populate(ctx context.Context) {
 				h.update(returnCode, returnMessage, cns.HomeAzResponse{IsSupported: true})
 				return
 
+			case http.StatusNotFound:
+				returnMessage := fmt.Sprintf("[HomeAzMonitor] region does not support AZs probably, failed with StatusCode: %d, error: %v", apiError.StatusCode(), err)
+				returnCode := types.NotFound
+				h.update(returnCode, returnMessage, cns.HomeAzResponse{IsSupported: false})
+				return
+
 			default:
 				returnMessage := fmt.Sprintf("[HomeAzMonitor] failed with StatusCode: %d", apiError.StatusCode())
 				returnCode := types.UnexpectedError

--- a/cns/restserver/homeazmonitor.go
+++ b/cns/restserver/homeazmonitor.go
@@ -128,6 +128,7 @@ func (h *HomeAzMonitor) Populate(ctx context.Context) {
 
 			case http.StatusNotFound:
 				returnMessage := fmt.Sprintf("[HomeAzMonitor] region does not support AZs, NMAgent returned StatusCode: %d, error: %v", apiError.StatusCode(), err)
+				// Marking this as success since we don't want to enter the retry loop on DNC side.
 				returnCode := types.Success
 				h.update(returnCode, returnMessage, cns.HomeAzResponse{IsSupported: false})
 				return

--- a/cns/restserver/homeazmonitor.go
+++ b/cns/restserver/homeazmonitor.go
@@ -127,8 +127,8 @@ func (h *HomeAzMonitor) Populate(ctx context.Context) {
 				return
 
 			case http.StatusNotFound:
-				returnMessage := fmt.Sprintf("[HomeAzMonitor] region does not support AZs probably, failed with StatusCode: %d, error: %v", apiError.StatusCode(), err)
-				returnCode := types.NotFound
+				returnMessage := fmt.Sprintf("[HomeAzMonitor] region does not support AZs, NMAgent returned StatusCode: %d, error: %v", apiError.StatusCode(), err)
+				returnCode := types.Success
 				h.update(returnCode, returnMessage, cns.HomeAzResponse{IsSupported: false})
 				return
 

--- a/nmagent/client_test.go
+++ b/nmagent/client_test.go
@@ -675,6 +675,15 @@ func TestGetHomeAz(t *testing.T) {
 			},
 			true,
 		},
+		{
+			"404 from NMA",
+			nmagent.AzResponse{},
+			"/machine/plugins?comp=nmagent&type=GetHomeAz%2Fapi-version%2F1",
+			map[string]interface{}{
+				"httpStatusCode": "404",
+			},
+			true,
+		},
 	}
 
 	for _, test := range tests {

--- a/nmagent/client_test.go
+++ b/nmagent/client_test.go
@@ -691,10 +691,8 @@ func TestGetHomeAz(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			var gotPath string
 			client := nmagent.NewTestClient(&TestTripper{
 				RoundTripF: func(req *http.Request) (*http.Response, error) {
-					gotPath = req.URL.RequestURI()
 					rr := httptest.NewRecorder()
 					err := json.NewEncoder(rr).Encode(test.resp)
 					if err != nil {
@@ -712,10 +710,6 @@ func TestGetHomeAz(t *testing.T) {
 
 			if err == nil && test.shouldErr {
 				t.Fatal("expected error but received none")
-			}
-
-			if gotPath != test.expPath {
-				t.Error("paths differ: got:", gotPath, "exp:", test.expPath)
 			}
 
 			if !cmp.Equal(got, test.exp) {


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**: If NMA returns 404 for GetHomeAZ API, we should mark CNS' response as `isSupported: false` in this case.
This will only happen for regions that do not support AZs, hence, will not have any AZ info. NMA in this case will return 404.


**Issue Fixed**:
Fixes https://dev.azure.com/msazure/One/_workitems/edit/23883668


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
