### PR TITLE
remove udp port 3389

### DIFF
--- a/.pipelines/singletenancy/aks-engine/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks-engine/e2e-step-template.yaml
@@ -31,23 +31,23 @@ steps:
       echo Using AKS-Engine version $aksEVersion
 
       #download source
-      wget https://github.com/csfmomo/aks-engine/archive/v1.0.9.2.tar.gz
+      wget https://github.com/csfmomo/aks-engine/archive/v1.0.9.3.tar.gz
 
       # extract source
       #tar -zxf $aksEVersion.tar.gz
-      tar -zxf v1.0.9.2.tar.gz
+      tar -zxf v1.0.9.3.tar.gz
 
       # move source to current directory
       mv aks-engine-*/* .
 
       # download binary
-      wget https://github.com/csfmomo/aks-engine/releases/download/v1.0.9.2/aks-engine-v1.0.9.2-linux-amd64.tar.gz
+      wget https://github.com/csfmomo/aks-engine/releases/download/v1.0.9.3/aks-engine-v1.0.9.3-linux-amd64.tar.gz
 
       rm -rf ./bin
       mkdir ./bin
 
       # extract binary
-      tar -zxvf aks-engine-v1.0.9.2-linux-amd64.tar.gz -C bin
+      tar -zxvf aks-engine-v1.0.9.3-linux-amd64.tar.gz -C bin
       mv ./bin/aks-engine-*/* ./bin/
       ls -l ./bin
       ./bin/aks-engine version


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
We should have removed 3389 port from AKS Engine PR. Those were getting reported in S360 and are also part of exposed ports.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
https://github.com/csfmomo/aks-engine/releases/tag/v1.0.9.3

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests


**Notes**:
