### PR TITLE
Remove redundant routes in dualstackoverlay for windows nodes

### DIFF
--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -227,7 +227,6 @@ func (nm *networkManager) addNewNetRules(nwInfo *NetworkInfo) error {
 		if subnet.Gateway == nil {
 			return fmt.Errorf("[net] failed to get subnet gateway") // nolint
 		}
-		gateway := subnet.Gateway.String()
 
 		log.Printf("[net] Adding ipv4 and ipv6 net rules to windows node")
 
@@ -244,17 +243,6 @@ func (nm *networkManager) addNewNetRules(nwInfo *NetworkInfo) error {
 			if out, err = nm.plClient.ExecuteCommand(addNetshV4DefaultRoute); err != nil {
 				log.Printf("[net] Adding ipv4 default route failed: %v:%v", out, err)
 			}
-
-			deleteNetshV4GatewayRoute := fmt.Sprintf(netRouteCmd, "ipv4", "delete", prefix, ifName, gateway)
-			if _, delErr := nm.plClient.ExecuteCommand(deleteNetshV4GatewayRoute); delErr != nil {
-				log.Printf("[net] Deleting ipv4 gateway route failed: %v", delErr)
-			}
-
-			// netsh interface ipv4 add route $subnetV4 $hostInterfaceAlias $gatewayV4
-			addNetshV4GatewayRoute := fmt.Sprintf(netRouteCmd, "ipv4", "add", prefix, ifName, gateway)
-			if out, err = nm.plClient.ExecuteCommand(addNetshV4GatewayRoute); err != nil {
-				log.Printf("[net] Adding ipv4 gateway route failed: %v:%v", out, err)
-			}
 		} else {
 			deleteNetshV6DefaultRoute := fmt.Sprintf(netRouteCmd, "ipv6", "delete", prefix, ifName, ipv6DefaultHop)
 			if _, delErr := nm.plClient.ExecuteCommand(deleteNetshV6DefaultRoute); delErr != nil {
@@ -265,17 +253,6 @@ func (nm *networkManager) addNewNetRules(nwInfo *NetworkInfo) error {
 			addNetshV6DefaultRoute := fmt.Sprintf(netRouteCmd, "ipv6", "add", prefix, ifName, ipv6DefaultHop)
 			if out, err = nm.plClient.ExecuteCommand(addNetshV6DefaultRoute); err != nil {
 				log.Printf("[net] Adding ipv6 default route failed: %v:%v", out, err)
-			}
-
-			deleteNetshV6GatewayRoute := fmt.Sprintf(netRouteCmd, "ipv6", "delete", prefix, ifName, gateway)
-			if _, delErr := nm.plClient.ExecuteCommand(deleteNetshV6GatewayRoute); delErr != nil {
-				log.Printf("[net] Deleting ipv6 gateway route failed: %v", delErr)
-			}
-
-			// netsh interface ipv6 add route $subnetV6 $hostInterfaceAlias $gatewayV6
-			addNetshV6GatewayRoute := fmt.Sprintf(netRouteCmd, "ipv6", "add", prefix, ifName, gateway)
-			if out, err = nm.plClient.ExecuteCommand(addNetshV6GatewayRoute); err != nil {
-				log.Printf("[net] Adding ipv6 gateway route failed: %v:%v", out, err)
 			}
 		}
 	}


### PR DESCRIPTION
Removing a redundant route added to Windows VMs for dualstackoverlay

Redundant route being removed:
`netsh interface ipv4 add route "<overlay-subnet-prefix>" "<interface-name>" "<overlay-subnet-gateway>"`

Example:
`netsh interface ipv4 add route "10.244.0.0/16" "vEthernet (Ethernet 2)" "10.244.0.1"`

This route is redundant, because prior to it being added, there is another route added with the **same matching-prefix**:
Route being added before redundant route:
`netsh interface ipv4 add route "10.244.0.0/16" "vEthernet (Ethernet 2)" "0.0.0.0"`

So the second route is rendered useless, and we don't need it

This was confirmed by @princepereira, so removing the redundant route (both for IPV4 and IPV6)