### PR TITLE
fix: implement String for logging of PodInfo and IPConfig

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -169,6 +169,8 @@ type PodInfo interface {
 	OrchestratorContext() (json.RawMessage, error)
 	// Equals implements a functional equals for PodInfos
 	Equals(PodInfo) bool
+	// String implements string for logging PodInfos
+	String() string
 }
 
 type KubernetesPodInfo struct {
@@ -184,6 +186,11 @@ type podInfo struct {
 	PodInfraContainerID string
 	PodInterfaceID      string
 	Version             podInfoScheme
+}
+
+func (p podInfo) String() string {
+	return fmt.Sprintf("InfraContainerID: [%s], InterfaceID: [%s], Key: [%s], Name: [%s], Namespace: [%s]",
+		p.InfraContainerID(), p.InterfaceID(), p.Key(), p.Name(), p.Namespace())
 }
 
 func (p *podInfo) Equals(o PodInfo) bool {

--- a/cns/api.go
+++ b/cns/api.go
@@ -97,9 +97,9 @@ func (i *IPConfigurationStatus) WithStateMiddleware(fs ...stateMiddlewareFunc) {
 	i.stateMiddlewareFuncs = append(i.stateMiddlewareFuncs, fs...)
 }
 
-func (i *IPConfigurationStatus) String() string {
-	return fmt.Sprintf("IPConfigurationStatus: Id: [%s], NcId: [%s], IpAddress: [%s], State: [%s], PodInfo: [%v]",
-		i.ID, i.NCID, i.IPAddress, i.state, i.PodInfo)
+func (i IPConfigurationStatus) String() string {
+	return fmt.Sprintf("ID: [%s], NCID: [%s], IPAddress: [%s], State: [%s], LastStateTransition: [%s] PodInfo: [%s]",
+		i.ID, i.NCID, i.IPAddress, i.state, i.LastStateTransition.Format(time.RFC3339), i.PodInfo)
 }
 
 // MarshalJSON is a custom marshaller for IPConfigurationStatus that

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -290,7 +290,7 @@ func (service *HTTPRestService) addIPConfigStateUntransacted(ncID string, hostVe
 
 		if ipState, exists := service.PodIPConfigState[ipID]; exists {
 			logger.Printf("[Azure-Cns] Set ipId %s, IP %s version to %d, programmed host nc version is %d, "+
-				"ipState: %+v", ipID, ipconfig.IPAddress, ipconfig.NCVersion, hostVersion, ipState)
+				"ipState: %s", ipID, ipconfig.IPAddress, ipconfig.NCVersion, hostVersion, ipState)
 			continue
 		}
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Adds `String()` to PodInfo so that logging the interface type works.
Currently, logging with `%[+]v` will insert the interface address in to the string instead of the values of the underlying type:

> ... ipState: {ID:abc IPAddress:123.456.789.0 LastStateTransition:2023-06-15 05:30:57.855233208 +0000 UTC m=+4.301209489 NCID:def **PodInfo:0xc000529ae0** state:Assigned **stateMiddlewareFuncs:[0x164faa0]**}


Note:
> PodInfo:0xc000529ae0

and (impl detail which should be removed)
> stateMiddlewareFuncs:[0x164faa0]

With `String()` implemented on both types, loggers may use `%s` and get correctly formatted and populated output for the underlying types:

> ... ipState: {ID: [abc], NCID: [def], IPAddress: [123.456.789.0], State: [Assigned], LastStateTransition: [2023-06-16T21:26:43Z] PodInfo: [InfraContainerID: [pqr], InterfaceID: [mno], Key: [mno], Name: [ghi], Namespace: [jkl]]


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
