### PR TITLE
fix: updating CNI version in dropgz to 1.5.4

### DIFF
--- a/dropgz/build/linux.Dockerfile
+++ b/dropgz/build/linux.Dockerfile
@@ -12,7 +12,7 @@ COPY ./azure-ipam .
 RUN curl -LO --cacert /etc/ssl/certs/ca-certificates.crt https://github.com/Azure/azure-container-networking/releases/download/azure-ipam%2F$AZIPAM_VERSION/azure-ipam-$OS-$ARCH-$AZIPAM_VERSION.tgz && tar -xvf azure-ipam-$OS-$ARCH-$AZIPAM_VERSION.tgz
 
 FROM tar AS azure-vnet
-ARG AZCNI_VERSION=v1.5.0
+ARG AZCNI_VERSION=v1.5.4
 ARG VERSION
 ARG OS
 ARG ARCH


### PR DESCRIPTION
Updating CNI version in dropgz to CNI v1.5.4, so that the CNI conflist installed with dropgz doesn't break CNI (was using CNI binary 1.5.0 in dropgz, which doesn't support new 'overlay' CNI conflist option, breaking it)

Release [dropgz/v0.0.8](https://github.com/Azure/azure-container-networking/releases/tag/dropgz%2Fv0.0.8) is unusable/unstable, we should not share it with anyone, should I delete the release @rbtr ?

I did not realize I had to change this variable for dropgz to use a new CNI version, that is my bad
I tested this new change, with dropgz both installing the conflist, **and** installing the binary, pod creation worked, and connectivity was good:
[new-dropgz-testing.zip](https://github.com/Azure/azure-container-networking/files/11776736/new-dropgz-testing.zip)
