### PR TITLE
[Fix][CNS] InterfaceID should be set to containerID instead of interfaceName if CNS managing state

### DIFF
--- a/cns/cnireconciler/podinfoprovider.go
+++ b/cns/cnireconciler/podinfoprovider.go
@@ -71,14 +71,14 @@ func cniStateToPodInfoByIP(state *api.AzureCNIState) (map[string]cns.PodInfo, er
 func endpointStateToPodInfoByIP(state map[string]*restserver.EndpointInfo) (map[string]cns.PodInfo, error) {
 	podInfoByIP := map[string]cns.PodInfo{}
 	for containerID, endpointInfo := range state { // for each endpoint
-		for ifname, ipinfo := range endpointInfo.IfnameToIPMap { // for each IP info object of the endpoint's interfaces
+		for _, ipinfo := range endpointInfo.IfnameToIPMap { // for each IP info object of the endpoint's interfaces
 			for _, ipv4conf := range ipinfo.IPv4 { // for each IPv4 config of the endpoint's interfaces
 				if _, ok := podInfoByIP[ipv4conf.IP.String()]; ok {
 					return nil, errors.Wrap(cns.ErrDuplicateIP, ipv4conf.IP.String())
 				}
 				podInfoByIP[ipv4conf.IP.String()] = cns.NewPodInfo(
 					containerID,
-					ifname,
+					containerID,
 					endpointInfo.PodName,
 					endpointInfo.PodNamespace,
 				)
@@ -89,7 +89,7 @@ func endpointStateToPodInfoByIP(state map[string]*restserver.EndpointInfo) (map[
 				}
 				podInfoByIP[ipv6conf.IP.String()] = cns.NewPodInfo(
 					containerID,
-					ifname,
+					containerID,
 					endpointInfo.PodName,
 					endpointInfo.PodNamespace,
 				)

--- a/cns/cnireconciler/podinfoprovider_test.go
+++ b/cns/cnireconciler/podinfoprovider_test.go
@@ -81,9 +81,10 @@ func TestNewCNSPodInfoProvider(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "good",
-			store:   goodStore,
-			want:    map[string]cns.PodInfo{"10.241.0.65": cns.NewPodInfo("0a4917617e15d24dc495e407d8eb5c88e4406e58fa209e4eb75a2c2fb7045eea", "eth0", "goldpinger-deploy-bbbf9fd7c-z8v4l", "default")},
+			name:  "good",
+			store: goodStore,
+			want: map[string]cns.PodInfo{"10.241.0.65": cns.NewPodInfo("0a4917617e15d24dc495e407d8eb5c88e4406e58fa209e4eb75a2c2fb7045eea",
+				"0a4917617e15d24dc495e407d8eb5c88e4406e58fa209e4eb75a2c2fb7045eea", "goldpinger-deploy-bbbf9fd7c-z8v4l", "default")},
 			wantErr: false,
 		},
 		{

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -655,6 +655,7 @@ func (service *HTTPRestService) GetExistingIPConfig(podInfo cns.PodInfo) ([]cns.
 		}
 	}
 
+	logger.Printf("[GetExistingIPConfig] IPConfigExists [%t] for pod [%+v]", ipConfigExists, podInfo.Key())
 	return podIPInfo, ipConfigExists, nil
 }
 


### PR DESCRIPTION


<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
This PR fixes an issue where interfaceID is set to interfaceName instead of containerID and this leads to incorrect CNS reconcilation where CNS key is interfaceName instead of containerID. This is the PR to change CNS running in managed state to recocile based on InterfaceID instead of podname+namespace: https://github.com/Azure/azure-container-networking/pull/1811 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
