### PR TITLE
fix: setdir in CNI client

### DIFF
--- a/cni/client/client.go
+++ b/cni/client/client.go
@@ -14,12 +14,6 @@ import (
 	utilexec "k8s.io/utils/exec"
 )
 
-type Client interface {
-	GetEndpointState() (*api.AzureCNIState, error)
-}
-
-var _ (Client) = (*client)(nil)
-
 type client struct {
 	exec utilexec.Interface
 }
@@ -30,7 +24,7 @@ func New(exec utilexec.Interface) *client {
 
 func (c *client) GetEndpointState() (*api.AzureCNIState, error) {
 	cmd := c.exec.Command(platform.CNIBinaryPath)
-
+	cmd.SetDir(CNIExecDir)
 	envs := os.Environ()
 	cmdenv := fmt.Sprintf("%s=%s", cni.Cmd, cni.CmdGetEndpointsState)
 	log.Printf("Setting cmd to %s", cmdenv)
@@ -52,7 +46,7 @@ func (c *client) GetEndpointState() (*api.AzureCNIState, error) {
 
 func (c *client) GetVersion() (*semver.Version, error) {
 	cmd := c.exec.Command(platform.CNIBinaryPath, "-v")
-
+	cmd.SetDir(CNIExecDir)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Azure CNI version with err: [%w], output: [%s]", err, string(output))

--- a/cni/client/const_linux.go
+++ b/cni/client/const_linux.go
@@ -1,0 +1,7 @@
+package client
+
+// CNIExecDir is the working directory that the invoker must execute the CNI from
+// in order for it to correctly map its state and lock files.
+// Does not need to be set on Linux, as absolute paths are correctly used during
+// the actual CNI execution.
+const CNIExecDir = ""

--- a/cni/client/const_windows.go
+++ b/cni/client/const_windows.go
@@ -1,0 +1,6 @@
+package client
+
+// CNIExecDir is the working directory that the invoker must execute the CNI from
+// in order for it to correctly map its state and lock files.
+// Only needs to be set on Windows.
+const CNIExecDir = "C:\\k"


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Sets the working directory when CNS invokes the CNI (only on Windows) so that the CNS reconcile from CNI finds the real CNI statefile and reinitializes the CNS state correctly.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Due to the lack of [CNIRuntimePath set when CNI is running on Windows](https://github.com/Azure/azure-container-networking/blob/390977d5c2128fdd57c39c70a1fdb79035edfb70/platform/os_windows.go#LL27C21-L27C21): when CNS invokes CNI to restore state during initialization on Windows, it looks for the [statefile in the local directory](https://github.com/Azure/azure-container-networking/blob/390977d5c2128fdd57c39c70a1fdb79035edfb70/cni/plugin.go#L170) (`.\azure-vnet.json`) instead of the absolute path at `C:\k\azure-vnet.json`. No statefile exists in the current directory, so the CNI returns empty PodInfo to CNS, leading CNS to think there are no Pods scheduled and that all of its IPs are available.

Running a CNS built with this change, we can see that it finds the CNI statefile and correctly restores from it:
> 2023/06/21 18:11:58 [17776] Initializing from CNI
2023/06/21 18:11:58 [17776] Setting cmd to CNI_COMMAND=GET_ENDPOINT_STATE
2023/06/21 18:11:58 [17776] Reconciling initial CNS state as PodInfoByIP is not empty: 19
2023/06/21 18:11:58 [17776] reconciling initial CNS state attempt: 1

restoring CNS to the previous version and restarting shows that the statefile is not used:
> 2023/06/21 18:13:54 [124] Initializing from CNI
2023/06/21 18:13:54 [124] Setting cmd to CNI_COMMAND=GET_ENDPOINT_STATE
[no reconcile logs]
2023/06/21 18:13:56 [124] initialized and started IPAM pool monitor


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
