### PR TITLE
fix: [CNI] CNI load test failing due to namespace already created

### DIFF
--- a/test/integration/load/load_test.go
+++ b/test/integration/load/load_test.go
@@ -62,9 +62,17 @@ func TestLoad(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
 
-	err = k8sutils.MustCreateNamespace(ctx, clientset, namespace)
+	// Create namespace if it doesn't exist
+	namespaceExists, err := k8sutils.NamespaceExists(ctx, clientset, namespace)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if !namespaceExists {
+		err = k8sutils.MustCreateNamespace(ctx, clientset, namespace)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	deployment, err := k8sutils.MustParseDeployment(noopdeployment)
@@ -145,10 +153,19 @@ func TestScaleDeployment(t *testing.T) {
 		t.Fatal(err)
 	}
 	ctx := context.Background()
-	err = k8sutils.MustCreateNamespace(ctx, clientset, namespace)
+	// Create namespace if it doesn't exist
+	namespaceExists, err := k8sutils.NamespaceExists(ctx, clientset, namespace)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	if !namespaceExists {
+		err = k8sutils.MustCreateNamespace(ctx, clientset, namespace)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
 	deployment, err := k8sutils.MustParseDeployment(noopdeployment)
 	if err != nil {
 		t.Fatal(err)

--- a/test/internal/k8sutils/utils.go
+++ b/test/internal/k8sutils/utils.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
@@ -359,4 +360,15 @@ func ExecCmdOnPod(ctx context.Context, clientset *kubernetes.Clientset, namespac
 	}
 
 	return stdout.Bytes(), nil
+}
+
+func NamespaceExists(ctx context.Context, clientset *kubernetes.Clientset, namespace string) (bool, error) {
+	_, err := clientset.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, errors.Wrapf(err, "error in getting namespace %s", namespace)
+	}
+	return true, nil
 }

--- a/test/internal/k8sutils/utils_create.go
+++ b/test/internal/k8sutils/utils_create.go
@@ -169,9 +169,6 @@ func MustCreateNamespace(ctx context.Context, clienset *kubernetes.Clientset, na
 		},
 	}, metav1.CreateOptions{})
 
-	if apierrors.IsAlreadyExists(err) {
-		return errors.Wrapf(err, "namespace: %v already exists", namespace)
-	}
 	if err != nil {
 		return errors.Wrapf(err, "failed to create namespace %v", namespace)
 	}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
The load test pipeline for CNI is failing if the `load-test` namespace is already created.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes the load test pipeline.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
