### PR TITLE
update: add pod info to windows endpoint

### DIFF
--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -386,6 +386,9 @@ func (nw *network) newEndpointImplHnsV2(cli apipaClient, epInfo *EndpointInfo) (
 		AllowInboundFromNCToHost: epInfo.AllowInboundFromNCToHost,
 		AllowInboundFromHostToNC: epInfo.AllowInboundFromHostToNC,
 		NetworkContainerID:       epInfo.NetworkContainerID,
+		ContainerID:              epInfo.ContainerID,
+		PODName:                  epInfo.PODName,
+		PODNameSpace:             epInfo.PODNameSpace,
 	}
 
 	for _, route := range epInfo.Routes {


### PR DESCRIPTION
**Reason for Change**:
Kappie HNS plugin for windows provides metrics for endpoints, but lacks pod info for the metrics. Adding these here will help us map endpoints to pods.

Linux endpoints currently set these properties, but windows is currently not set.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
I have tested this by copying the binary to a windows node and restarting a pod. The new properties show up. I have also replaced the new cni binary with the live version to ensure that there were no errors in the logs.