### PR TITLE
refactor: [CI-CNI] Removing the predefined interfaces from validate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -724,7 +724,7 @@ test-integration: ## run all integration tests.
 		go test -mod=readonly -buildvcs=false -timeout 1h -coverpkg=./... -race -covermode atomic -coverprofile=coverage.out -tags=integration ./test/integration...
 
 test-validate-state:
-	cd test/integration/load && go test -count 1 -timeout 30m -tags load -run ^TestValidateState -tags=load -restart-case=$(RESTART_CASE) -os=$(OS)
+	cd test/integration/load && go test -mod=readonly -count=1 -timeout 30m -tags load -run ^TestValidateState -tags=load -restart-case=$(RESTART_CASE) -os=$(OS)
 	cd ../../..
 
 test-cyclonus: ## run the cyclonus test for npm.

--- a/test/validate/linux_validate.go
+++ b/test/validate/linux_validate.go
@@ -1,23 +1,14 @@
 package validate
 
 import (
-	"context"
 	"encoding/json"
-	"log"
 
 	"github.com/Azure/azure-container-networking/cns"
 	restserver "github.com/Azure/azure-container-networking/cns/restserver"
-	k8sutils "github.com/Azure/azure-container-networking/test/internal/k8sutils"
 	"github.com/pkg/errors"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 const (
-	privilegedDaemonSetPath = "../manifests/load/privileged-daemonset.yaml"
-	privilegedLabelSelector = "app=privileged-daemonset"
-	privilegedNamespace     = "kube-system"
-
 	cnsLabelSelector    = "k8s-app=azure-cns"
 	ciliumLabelSelector = "k8s-app=cilium"
 )
@@ -31,12 +22,15 @@ var (
 
 type stateFileIpsFunc func([]byte) (map[string]string, error)
 
-type LinuxValidator struct {
-	clientset   *kubernetes.Clientset
-	config      *rest.Config
-	namespace   string
-	cni         string
-	restartCase bool
+var linuxChecksMap = map[string][]check{
+	"cilium": {
+		{"cns", cnsStateFileIps, cnsLabelSelector, privilegedNamespace, cnsStateFileCmd},
+		{"cilium", ciliumStateFileIps, ciliumLabelSelector, privilegedNamespace, ciliumStateFileCmd},
+		{"cns cache", cnsCacheStateFileIps, cnsLabelSelector, privilegedNamespace, cnsLocalCacheCmd},
+	},
+	"cniv2": {
+		{"cns cache", cnsCacheStateFileIps, cnsLabelSelector, privilegedNamespace, cnsLocalCacheCmd},
+	},
 }
 
 type CnsState struct {
@@ -62,79 +56,6 @@ type NetworkingAddressing struct {
 
 type Address struct {
 	Addr string `json:"ipv4"`
-}
-
-func CreateLinuxValidator(ctx context.Context, clienset *kubernetes.Clientset, config *rest.Config, namespace, cni string, restartCase bool) (*LinuxValidator, error) {
-	// deploy privileged pod
-	privilegedDaemonSet, err := k8sutils.MustParseDaemonSet(privilegedDaemonSetPath)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to parse daemonset")
-	}
-	daemonsetClient := clienset.AppsV1().DaemonSets(privilegedNamespace)
-	if err := k8sutils.MustCreateDaemonset(ctx, daemonsetClient, privilegedDaemonSet); err != nil {
-		return nil, errors.Wrap(err, "unable to create daemonset")
-	}
-	if err := k8sutils.WaitForPodsRunning(ctx, clienset, privilegedNamespace, privilegedLabelSelector); err != nil {
-		return nil, errors.Wrap(err, "error while waiting for pods to be running")
-	}
-
-	return &LinuxValidator{
-		clientset:   clienset,
-		config:      config,
-		namespace:   namespace,
-		cni:         cni,
-		restartCase: restartCase,
-	}, nil
-}
-
-// Todo: Based on cni version validate different state files
-func (v *LinuxValidator) ValidateStateFile(ctx context.Context) error {
-	checkSet := make(map[string][]check) // key is cni type, value is a list of check
-	// TODO: add cniv1 when adding Linux related test cases
-	checkSet["cilium"] = []check{
-		{"cns", cnsStateFileIps, cnsLabelSelector, privilegedNamespace, cnsStateFileCmd},
-		{"cilium", ciliumStateFileIps, ciliumLabelSelector, privilegedNamespace, ciliumStateFileCmd},
-		{"cns cache", cnsCacheStateFileIps, cnsLabelSelector, privilegedNamespace, cnsLocalCacheCmd},
-	}
-
-	checkSet["cniv2"] = []check{
-		{"cns cache", cnsCacheStateFileIps, cnsLabelSelector, privilegedNamespace, cnsLocalCacheCmd},
-	}
-
-	for _, check := range checkSet[v.cni] {
-		err := v.validateIPs(ctx, check.stateFileIps, check.cmd, check.name, check.podNamespace, check.podLabelSelector)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (v *LinuxValidator) ValidateRestartNetwork(ctx context.Context) error {
-	nodes, err := k8sutils.GetNodeList(ctx, v.clientset)
-	if err != nil {
-		return errors.Wrapf(err, "failed to get node list")
-	}
-
-	for index := range nodes.Items {
-		// get the privileged pod
-		pod, err := k8sutils.GetPodsByNode(ctx, v.clientset, privilegedNamespace, privilegedLabelSelector, nodes.Items[index].Name)
-		if err != nil {
-			return errors.Wrapf(err, "failed to get privileged pod")
-		}
-
-		privelegedPod := pod.Items[0]
-		// exec into the pod to get the state file
-		_, err = k8sutils.ExecCmdOnPod(ctx, v.clientset, privilegedNamespace, privelegedPod.Name, restartNetworkCmd, v.config)
-		if err != nil {
-			return errors.Wrapf(err, "failed to exec into privileged pod")
-		}
-		err = k8sutils.WaitForPodsRunning(ctx, v.clientset, "", "")
-		if err != nil {
-			return errors.Wrapf(err, "failed to wait for pods running")
-		}
-	}
-	return nil
 }
 
 func cnsStateFileIps(result []byte) (map[string]string, error) {
@@ -187,44 +108,4 @@ func cnsCacheStateFileIps(result []byte) (map[string]string, error) {
 		cnsPodIps[cnsLocalCache.IPConfigurationStatus[index].IPAddress] = cnsLocalCache.IPConfigurationStatus[index].PodInfo.Name()
 	}
 	return cnsPodIps, nil
-}
-
-func (v *LinuxValidator) validateIPs(ctx context.Context, stateFileIps stateFileIpsFunc, cmd []string, checkType, namespace, labelSelector string) error {
-	log.Printf("Validating %s state file", checkType)
-	nodes, err := k8sutils.GetNodeList(ctx, v.clientset)
-	if err != nil {
-		return errors.Wrapf(err, "failed to get node list")
-	}
-
-	for index := range nodes.Items {
-		// get the privileged pod
-		pod, err := k8sutils.GetPodsByNode(ctx, v.clientset, namespace, labelSelector, nodes.Items[index].Name)
-		if err != nil {
-			return errors.Wrapf(err, "failed to get privileged pod")
-		}
-		podName := pod.Items[0].Name
-		// exec into the pod to get the state file
-		result, err := k8sutils.ExecCmdOnPod(ctx, v.clientset, namespace, podName, cmd, v.config)
-		if err != nil {
-			return errors.Wrapf(err, "failed to exec into privileged pod")
-		}
-		filePodIps, err := stateFileIps(result)
-		if err != nil {
-			return errors.Wrapf(err, "failed to get pod ips from state file")
-		}
-		if len(filePodIps) == 0 && v.restartCase {
-			log.Printf("No pods found on node %s", nodes.Items[index].Name)
-			continue
-		}
-		// get the pod ips
-		podIps := getPodIPsWithoutNodeIP(ctx, v.clientset, nodes.Items[index])
-
-		check := compareIPs(filePodIps, podIps)
-
-		if !check {
-			return errors.Wrapf(errors.New("State file validation failed"), "for %s on node %s", checkType, nodes.Items[index].Name)
-		}
-	}
-	log.Printf("State file validation for %s passed", checkType)
-	return nil
 }

--- a/test/validate/validate.go
+++ b/test/validate/validate.go
@@ -1,0 +1,174 @@
+package validate
+
+import (
+	"context"
+	"log"
+
+	k8sutils "github.com/Azure/azure-container-networking/test/internal/k8sutils"
+	"github.com/pkg/errors"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+var privilegedDaemonSetPathMap = map[string]string{
+	"windows": "../manifests/load/privileged-daemonset-windows.yaml",
+	"linux":   "../manifests/load/privileged-daemonset.yaml",
+}
+
+var nodeSelectorMap = map[string]string{
+	"windows": "kubernetes.io/os=windows",
+	"linux":   "kubernetes.io/os=linux",
+}
+
+const (
+	privilegedLabelSelector = "app=privileged-daemonset"
+	privilegedNamespace     = "kube-system"
+)
+
+type Validator struct {
+	clientset   *kubernetes.Clientset
+	config      *rest.Config
+	checks      []check
+	namespace   string
+	cni         string
+	restartCase bool
+	os          string
+}
+
+type check struct {
+	name             string
+	stateFileIps     func([]byte) (map[string]string, error)
+	podLabelSelector string
+	podNamespace     string
+	cmd              []string
+}
+
+func CreateValidator(ctx context.Context, clienset *kubernetes.Clientset, config *rest.Config, namespace, cni string, restartCase bool, os string) (*Validator, error) {
+	// deploy privileged pod
+	privilegedDaemonSet, err := k8sutils.MustParseDaemonSet(privilegedDaemonSetPathMap[os])
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to parse daemonset")
+	}
+	daemonsetClient := clienset.AppsV1().DaemonSets(privilegedNamespace)
+	if err := k8sutils.MustCreateDaemonset(ctx, daemonsetClient, privilegedDaemonSet); err != nil {
+		return nil, errors.Wrap(err, "unable to create daemonset")
+	}
+	if err := k8sutils.WaitForPodsRunning(ctx, clienset, privilegedNamespace, privilegedLabelSelector); err != nil {
+		return nil, errors.Wrap(err, "error while waiting for pods to be running")
+	}
+
+	var checks []check
+	switch os {
+	case "windows":
+		checks = windowsChecksMap[cni]
+	case "linux":
+		checks = linuxChecksMap[cni]
+	default:
+		return nil, errors.Errorf("unsupported os: %s", os)
+	}
+
+	return &Validator{
+		clientset:   clienset,
+		config:      config,
+		namespace:   namespace,
+		cni:         cni,
+		restartCase: restartCase,
+		checks:      checks,
+		os:          os,
+	}, nil
+}
+
+func (v *Validator) Validate(ctx context.Context) error {
+	log.Printf("Validating State File")
+	err := v.ValidateStateFile(ctx)
+	if err != nil {
+		return errors.Wrapf(err, "failed to validate state file")
+	}
+
+	if v.os == "linux" {
+		// We are restarting the systmemd network and checking that the connectivity works after the restart. For more details: https://github.com/cilium/cilium/issues/18706
+		log.Printf("Validating the restart network scenario")
+		err = v.ValidateRestartNetwork(ctx)
+		if err != nil {
+			return errors.Wrapf(err, "failed to validate restart network scenario")
+		}
+	}
+	return nil
+}
+
+func (v *Validator) ValidateStateFile(ctx context.Context) error {
+	for _, check := range v.checks {
+		err := v.validateIPs(ctx, check.stateFileIps, check.cmd, check.name, check.podNamespace, check.podLabelSelector)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *Validator) ValidateRestartNetwork(ctx context.Context) error {
+	nodes, err := k8sutils.GetNodeList(ctx, v.clientset)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get node list")
+	}
+
+	for index := range nodes.Items {
+		// get the privileged pod
+		pod, err := k8sutils.GetPodsByNode(ctx, v.clientset, privilegedNamespace, privilegedLabelSelector, nodes.Items[index].Name)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get privileged pod")
+		}
+
+		privelegedPod := pod.Items[0]
+		// exec into the pod to get the state file
+		_, err = k8sutils.ExecCmdOnPod(ctx, v.clientset, privilegedNamespace, privelegedPod.Name, restartNetworkCmd, v.config)
+		if err != nil {
+			return errors.Wrapf(err, "failed to exec into privileged pod")
+		}
+		err = k8sutils.WaitForPodsRunning(ctx, v.clientset, "", "")
+		if err != nil {
+			return errors.Wrapf(err, "failed to wait for pods running")
+		}
+	}
+	return nil
+}
+
+func (v *Validator) validateIPs(ctx context.Context, stateFileIps stateFileIpsFunc, cmd []string, checkType, namespace, labelSelector string) error {
+	log.Printf("Validating %s state file", checkType)
+	nodes, err := k8sutils.GetNodeListByLabelSelector(ctx, v.clientset, nodeSelectorMap[v.os])
+	if err != nil {
+		return errors.Wrapf(err, "failed to get node list")
+	}
+
+	for index := range nodes.Items {
+		// get the privileged pod
+		pod, err := k8sutils.GetPodsByNode(ctx, v.clientset, namespace, labelSelector, nodes.Items[index].Name)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get privileged pod")
+		}
+		podName := pod.Items[0].Name
+		// exec into the pod to get the state file
+		result, err := k8sutils.ExecCmdOnPod(ctx, v.clientset, namespace, podName, cmd, v.config)
+		if err != nil {
+			return errors.Wrapf(err, "failed to exec into privileged pod")
+		}
+		filePodIps, err := stateFileIps(result)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get pod ips from state file")
+		}
+		if len(filePodIps) == 0 && v.restartCase {
+			log.Printf("No pods found on node %s", nodes.Items[index].Name)
+			continue
+		}
+		// get the pod ips
+		podIps := getPodIPsWithoutNodeIP(ctx, v.clientset, nodes.Items[index])
+
+		check := compareIPs(filePodIps, podIps)
+
+		if !check {
+			return errors.Wrapf(errors.New("State file validation failed"), "for %s on node %s", checkType, nodes.Items[index].Name)
+		}
+	}
+	log.Printf("State file validation for %s passed", checkType)
+	return nil
+}


### PR DESCRIPTION
Removing the predefined interfaces from validate package
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
