### PR TITLE
fix: [CNI] Windows image change for load test

### DIFF
--- a/test/integration/manifests/noop-deployment-windows.yaml
+++ b/test/integration/manifests/noop-deployment-windows.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: noop
-        image: mcr.microsoft.com/windows/nanoserver:ltsc2022
+        image: mcr.microsoft.com/oss/kubernetes/pause:3.6
         ports:
           - containerPort: 80
       nodeSelector:

--- a/test/internal/k8sutils/utils.go
+++ b/test/internal/k8sutils/utils.go
@@ -246,6 +246,8 @@ func WaitForPodDeployment(ctx context.Context, clientset *kubernetes.Clientset, 
 		}
 
 		if deployment.Status.AvailableReplicas != int32(replicas) {
+			// Provide real-time deployment availability to console
+			log.Printf("deployment %s has %d replicas in available status, expected %d", deploymentName, deployment.Status.AvailableReplicas, replicas)
 			return errors.New("deployment does not have the expected number of available replicas")
 		}
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Window cniv1 load-test was failing due to the nanoserver image. Pods were reaching the complete state at various, quick, intervals resulting in a failed availability check. Pipeline logs were missing this interaction.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:

PM for pipeline run.