### PR TITLE
ci: validate CNS in-memory state after restart

### DIFF
--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
@@ -166,6 +166,18 @@ steps:
     displayName: "Validate Pods"
 
   - script: |
+      echo "validate pod IP assignment and check systemd-networkd restart"
+      kubectl get pod -owide -A
+      make test-validate-state
+      echo "restart CNS"
+      kubectl rollout restart ds azure-cns -n kube-system
+      kubectl get pod -owide -A
+      echo "validate pods after CNS restart"
+      make test-validate-state
+    name: "restartCNS"
+    displayName: "Restart CNS and validate pods"
+
+  - script: |
       echo "Run wireserver and metadata connectivity Tests"
       bash test/network/wireserver_metadata_test.sh
     retryCountOnTaskFailure: 3

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
@@ -166,7 +166,7 @@ steps:
     displayName: "Validate Pods"
 
   - script: |
-      echo "validate pod IP assignment and check systemd-networkd restart"
+      echo "validate pod IP assignment"
       kubectl get pod -owide -A
       make test-validate-state
       echo "restart CNS"

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
@@ -166,7 +166,7 @@ steps:
     displayName: "Validate Pods"
 
   - script: |
-      echo "validate pod IP assignment"
+      echo "validate pod IP assignment before CNS restart"
       kubectl get pod -owide -A
       make test-validate-state
       echo "restart CNS"

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
@@ -171,6 +171,7 @@ steps:
       make test-validate-state
       echo "restart CNS"
       kubectl rollout restart ds azure-cns -n kube-system
+      kubectl rollout status ds azure-cns -n kube-system
       kubectl get pod -owide -A
       echo "validate pods after CNS restart"
       make test-validate-state

--- a/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
@@ -150,7 +150,7 @@ steps:
     displayName: "Validate Pods"
 
   - script: |
-      echo "validate pod IP assignment and check systemd-networkd restart"
+      echo "validate pod IP assignment"
       kubectl get pod -owide -A
       make test-validate-state
       echo "restart CNS"

--- a/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
@@ -149,6 +149,18 @@ steps:
     name: "validatePods"
     displayName: "Validate Pods"
 
+    - script: |
+      echo "validate pod IP assignment and check systemd-networkd restart"
+      kubectl get pod -owide -A
+      make test-validate-state
+      echo "restart CNS"
+      kubectl rollout restart ds azure-cns -n kube-system
+      kubectl get pod -owide -A
+      echo "validate pods after CNS restart"
+      make test-validate-state
+    name: "restartCNS"
+    displayName: "Restart CNS and validate pods"
+
   - script: |
       echo "Run wireserver and metadata connectivity Tests"
       bash test/network/wireserver_metadata_test.sh

--- a/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
@@ -149,7 +149,7 @@ steps:
     name: "validatePods"
     displayName: "Validate Pods"
 
-    - script: |
+  - script: |
       echo "validate pod IP assignment and check systemd-networkd restart"
       kubectl get pod -owide -A
       make test-validate-state

--- a/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
@@ -155,6 +155,7 @@ steps:
       make test-validate-state
       echo "restart CNS"
       kubectl rollout restart ds azure-cns -n kube-system
+      kubectl rollout status ds azure-cns -n kube-system
       kubectl get pod -owide -A
       echo "validate pods after CNS restart"
       make test-validate-state

--- a/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
@@ -150,7 +150,7 @@ steps:
     displayName: "Validate Pods"
 
   - script: |
-      echo "validate pod IP assignment"
+      echo "validate pod IP assignment before CNS restart"
       kubectl get pod -owide -A
       make test-validate-state
       echo "restart CNS"


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Adds check to validate CNS pod IP assignment before and after the CNS daemonset is restarted.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
