### PR TITLE
Add Delete Network call to NMAgent client

### DIFF
--- a/nmagent/client.go
+++ b/nmagent/client.go
@@ -77,6 +77,25 @@ func (c *Client) JoinNetwork(ctx context.Context, jnr JoinNetworkRequest) error 
 	return err // nolint:wrapcheck // wrapping this just introduces noise
 }
 
+// DeleteNetwork deletes a customer network and it's associated subnets.
+func (c *Client) DeleteNetwork(ctx context.Context, dnr DeleteNetworkRequest) error {
+	req, err := c.buildRequest(ctx, dnr)
+	if err != nil {
+		return errors.Wrap(err, "building request")
+	}
+
+	resp, err := c.httpClient.Do(req) // nolint:govet // the shadow is intentional
+	if err != nil {
+		return errors.Wrap(err, "submitting request")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return die(resp.StatusCode, resp.Header, resp.Body)
+	}
+	return nil
+}
+
 // GetNetworkConfiguration retrieves the configuration of a customer's virtual
 // network. Only subnets which have been delegated will be returned.
 func (c *Client) GetNetworkConfiguration(ctx context.Context, gncr GetNetworkConfigRequest) (VirtualNetwork, error) {

--- a/nmagent/client_test.go
+++ b/nmagent/client_test.go
@@ -78,7 +78,6 @@ func TestNMAgentClientJoinNetwork(t *testing.T) {
 			defer cancel()
 
 			// attempt to join network
-			// TODO(timraymond): need a more realistic network ID, I think
 			err := client.JoinNetwork(ctx, nmagent.JoinNetworkRequest{test.id})
 			checkErr(t, err, test.shouldErr)
 
@@ -175,7 +174,6 @@ func TestNMAgentClientDeleteNetwork(t *testing.T) {
 			defer cancel()
 
 			// attempt to delete network
-			// TODO(timraymond/diegobecerra): need a more realistic network ID, I think
 			err := client.DeleteNetwork(ctx, nmagent.DeleteNetworkRequest{test.id})
 			checkErr(t, err, test.shouldErr)
 

--- a/nmagent/requests.go
+++ b/nmagent/requests.go
@@ -239,7 +239,7 @@ func (p *Policy) UnmarshalJSON(in []byte) error {
 var _ Request = JoinNetworkRequest{}
 
 type JoinNetworkRequest struct {
-	NetworkID string `validate:"presence" json:"-"` // the customer's VNet ID
+	NetworkID string `json:"-"` // the customer's VNet ID
 }
 
 // Path constructs a URL path for invoking a JoinNetworkRequest using the
@@ -278,7 +278,7 @@ var _ Request = DeleteNetworkRequest{}
 // DeleteNetworkRequest represents all information necessary to request that
 // NMAgent delete a particular network
 type DeleteNetworkRequest struct {
-	NetworkID string `validate:"presence" json:"-"` // the customer's VNet ID
+	NetworkID string `json:"-"` // the customer's VNet ID
 }
 
 // Path constructs a URL path for invoking a DeleteNetworkRequest using the

--- a/nmagent/requests.go
+++ b/nmagent/requests.go
@@ -273,6 +273,45 @@ func (j JoinNetworkRequest) Validate() error {
 	return err
 }
 
+var _ Request = DeleteNetworkRequest{}
+
+// DeleteNetworkRequest represents all information necessary to request that
+// NMAgent delete a particular network
+type DeleteNetworkRequest struct {
+	NetworkID string `validate:"presence" json:"-"` // the customer's VNet ID
+}
+
+// Path constructs a URL path for invoking a DeleteNetworkRequest using the
+// provided parameters
+func (d DeleteNetworkRequest) Path() string {
+	const DeleteNetworkPath = "/NetworkManagement/joinedVirtualNetworks/%s/api-version/1/method/DELETE"
+	return fmt.Sprintf(DeleteNetworkPath, d.NetworkID)
+}
+
+// Body returns nothing, because DeleteNetworkRequest has no request body
+func (d DeleteNetworkRequest) Body() (io.Reader, error) {
+	return nil, nil
+}
+
+// Method returns the HTTP request method to submit a DeleteNetworkRequest
+func (d DeleteNetworkRequest) Method() string {
+	return http.MethodPost
+}
+
+// Validate ensures that the provided parameters of the request are valid
+func (d DeleteNetworkRequest) Validate() error {
+	err := internal.ValidationError{}
+
+	if d.NetworkID == "" {
+		err.MissingFields = append(err.MissingFields, "NetworkID")
+	}
+
+	if err.IsEmpty() {
+		return nil
+	}
+	return err
+}
+
 var _ Request = DeleteContainerRequest{}
 
 // DeleteContainerRequest represents all information necessary to request that


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
This change implements the Delete Network API call in the NMAgent client. Adding this method allows for future changes to invoke the Delete Network call on NMAgent after receiving a Delete Network request in DNC.


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [ ] relevant PR labels added