### PR TITLE
ci: [CNI] Adding aks cluster creation steps for k8s e2e test

### DIFF
--- a/.pipelines/cni/singletenancy/windows-cni-load-test-template.yaml
+++ b/.pipelines/cni/singletenancy/windows-cni-load-test-template.yaml
@@ -66,7 +66,7 @@ stages:
               addSpnToEnvironment: true
               inlineScript: |
                 set -ex
-                export CNI_IMAGE=$(make acncli-image-name-and-tag OS=$(os) ARCH=$(arch) OS_VERSION=$(os_version))
+                export CNI_IMAGE=$(make cni-plugin-image-name-and-tag OS=$(os) ARCH=$(arch) OS_VERSION=$(os_version))
                 az extension add --name aks-preview
                 clusterName=${{ parameters.clusterName }}-$(make revision)
                 make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${clusterName}

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -167,6 +167,11 @@ stages:
               arch: amd64
               name: cni-dropgz-test
               os: linux
+            cni_plugin_windows2022_amd64:
+              os: windows
+              name: cni-plugin
+              arch: amd64
+              os_version: ltsc2022
             cni_plugin_windows2019_amd64:
               os: windows
               name: cni-plugin
@@ -340,11 +345,21 @@ stages:
     parameters:
       name: "aks_ubuntu_18_04_linux_e2e"
       displayName: AKS Ubuntu 18.04
-      arch: amd64
-      os: linux
+      arch: 'amd64'
+      os: 'linux'
       clusterType: linux-cniv1-up
-      clusterName: "ubuntu18e2e"
+      clusterName: 'ubuntu18e2e'
       k8sVersion: 1.24.9
+
+  - template: singletenancy/aks/e2e-job-template.yaml
+    parameters:
+      name: "aks_ubuntu_22_linux_e2e"
+      displayName: AKS Ubuntu 22
+      arch: 'amd64'
+      os: 'linux'
+      clusterType: linux-cniv1-up
+      clusterName: 'ubuntu22e2e'
+      k8sVersion: 1.25
 
   - template: singletenancy/aks/e2e-job-template.yaml
     parameters:
@@ -353,9 +368,20 @@ stages:
       arch: amd64
       os: windows
       clusterType: windows-cniv1-up
-      clusterName: "win19e2e"
-      windowsOsSku: Windows2019
-      os_version: ltsc2019
+      clusterName: 'win19e2e'
+      windowsOsSku: 'Windows2019'
+      os_version: 'ltsc2019'
+
+  - template: singletenancy/aks/e2e-job-template.yaml
+    parameters:
+      name: "aks_windows_22_e2e"
+      displayName: AKS Windows 2022
+      arch: amd64
+      os: windows
+      clusterType: windows-cniv1-up
+      clusterName: 'win22e2e'
+      windowsOsSku: 'Windows2022'
+      os_version: 'ltsc2022'
 
   - template: singletenancy/aks-engine/e2e-job-template.yaml
     parameters:
@@ -402,6 +428,10 @@ stages:
     dependsOn:
       - "aks_swift_e2e"
       - "cilium_e2e"
+      - "aks_ubuntu_18_04_linux_e2e"
+      - "aks_windows_19_03_e2e"
+      - "aks_ubuntu_22_linux_e2e"
+      - "aks_windows_22_e2e"
       - "ubuntu_18_04_linux_e2e"
       - "windows_19_03_e2e"
     jobs:

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -36,6 +36,7 @@ stages:
               echo "##vso[task.setvariable variable=Tag;isOutput=true]$(make version)"
               echo "##vso[task.setvariable variable=cniVersion;isOutput=true]$(make cni-version)"
               echo "##vso[task.setvariable variable=npmVersion;isOutput=true]$(make npm-version)"
+              echo "##vso[task.setvariable variable=dropgzVersion;isOutput=true]$(make cni-dropgz-version)"
               cat /etc/os-release
               uname -a
               sudo chown -R $(whoami):$(whoami) .
@@ -166,6 +167,11 @@ stages:
               arch: amd64
               name: cni-dropgz-test
               os: linux
+            cni_plugin_windows2019_amd64:
+              os: windows
+              name: cni-plugin
+              arch: amd64
+              os_version: ltsc2019
             cns_linux_amd64:
               arch: amd64
               name: cns
@@ -329,6 +335,27 @@ stages:
       testDropgz: ""
       clusterName: "swifte2e"
       osSku: "Ubuntu"
+
+  - template: singletenancy/aks/e2e-job-template.yaml
+    parameters:
+      name: "aks_ubuntu_18_04_linux_e2e"
+      displayName: AKS Ubuntu 18.04
+      arch: amd64
+      os: linux
+      clusterType: linux-cniv1-up
+      clusterName: "ubuntu18e2e"
+      k8sVersion: 1.24.9
+
+  - template: singletenancy/aks/e2e-job-template.yaml
+    parameters:
+      name: "aks_windows_19_03_e2e"
+      displayName: AKS Windows 1903
+      arch: amd64
+      os: windows
+      clusterType: windows-cniv1-up
+      clusterName: "win19e2e"
+      windowsOsSku: Windows2019
+      os_version: ltsc2019
 
   - template: singletenancy/aks-engine/e2e-job-template.yaml
     parameters:

--- a/.pipelines/singletenancy/aks/e2e-job-template.yaml
+++ b/.pipelines/singletenancy/aks/e2e-job-template.yaml
@@ -41,4 +41,4 @@ stages:
               windowsOsSku: ${{ parameters.windowsOsSku }}
               os_version: ${{ parameters.os_version }}
               version: $(dropgzVersion)
-              cniVersion: $(cniVersion)        
+              cniVersion: $(cniVersion)

--- a/.pipelines/singletenancy/aks/e2e-job-template.yaml
+++ b/.pipelines/singletenancy/aks/e2e-job-template.yaml
@@ -1,0 +1,44 @@
+parameters:
+  name: ""
+  displayName: ""
+  arch: ""  
+  os: ""
+  clusterType: ""
+  clusterName: ""
+  k8sVersion: ""
+  windowsOsSku: ""
+  os_version: ""
+
+stages:
+  - stage: ${{ parameters.name }}
+    displayName: E2E - ${{ parameters.displayName }}
+    dependsOn: 
+    - setup
+    - publish
+    jobs:
+      - job: ${{ parameters.name }}
+        displayName: Singletenancy AKS - (${{ parameters.name }})
+        pool:
+          name: $(BUILD_POOL_NAME_DEFAULT)
+          demands: 
+          - agent.os -equals Linux
+          - Role -equals $(CUSTOM_E2E_ROLE)
+        variables:
+          GOPATH: "$(Agent.TempDirectory)/go" # Go workspace path
+          GOBIN: "$(GOPATH)/bin" # Go binaries path
+          modulePath: "$(GOPATH)/src/github.com/Azure/azure-container-networking"
+          dropgzVersion: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.dropgzVersion'] ]
+          cniVersion: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.cniVersion'] ]
+        steps:
+          - template: e2e-step-template.yaml
+            parameters:
+              name: ${{ parameters.name }}
+              clusterType: ${{ parameters.clusterType }}
+              clusterName: ${{ parameters.clusterName }}
+              arch: ${{ parameters.arch }}
+              os: ${{ parameters.os }}
+              k8sVersion: ${{ parameters.k8sVersion }}
+              windowsOsSku: ${{ parameters.windowsOsSku }}
+              os_version: ${{ parameters.os_version }}
+              version: $(dropgzVersion)
+              cniVersion: $(cniVersion)        

--- a/.pipelines/singletenancy/aks/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks/e2e-step-template.yaml
@@ -40,14 +40,14 @@ steps:
   - script: |
       echo "Upload CNI"
       if [ "${{parameters.os}}" == "windows" ]; then
-        export DROP_GZ_URL=$( make cni-dropgz-image-name-and-tag OS='linux' ARCH=${{ parameters.arch }} CNI_DROPGZ_VERSION=${{ parameters.version }})
+        export DROP_GZ_URL=$( make cni-dropgz-test-image-name-and-tag OS='linux' ARCH=${{ parameters.arch }} CNI_DROPGZ_VERSION=${{ parameters.version }})
         envsubst < ./test/integration/manifests/cni/cni-installer-v1.yaml | kubectl apply -f -
         kubectl rollout status daemonset/azure-cni -n kube-system
         export CNI_IMAGE=$(make cni-plugin-image-name-and-tag OS=${{ parameters.os }} ARCH=${{ parameters.arch }} OS_VERSION=${{ parameters.os_version }} CNI_VERSION=${{ parameters.cniVersion }})
         envsubst < ./hack/manifests/windows-update.yaml | kubectl apply -f -
         kubectl rollout status daemonset/azure-cni-windows -n kube-system
       else
-        export DROP_GZ_URL=$( make cni-dropgz-image-name-and-tag OS=${{ parameters.os }} ARCH=${{ parameters.arch }} CNI_DROPGZ_VERSION=${{ parameters.version }})
+        export DROP_GZ_URL=$( make cni-dropgz-test-image-name-and-tag OS=${{ parameters.os }} ARCH=${{ parameters.arch }} CNI_DROPGZ_VERSION=${{ parameters.version }})
         envsubst < ./test/integration/manifests/cni/cni-installer-v1.yaml | kubectl apply -f -
         kubectl rollout status daemonset/azure-cni -n kube-system
       fi
@@ -68,6 +68,10 @@ steps:
     displayName: "Restart Nodes"
   - script: |
       kubectl get pods -A -o wide
+      echo "Deploying test pods"
+      cd test/integration/load
+      go test -count 1 -timeout 30m -tags load -run ^TestLoad$ -tags=load -iterations=2 -scaleup=40 -os=${{ parameters.os }}
+      cd ../../..
       # Remove this once we have cniv1 support for validating the test cluster
       echo "Validate State skipped for linux cniv1 for now"
       if [ "${{parameters.os}}" == "windows" ]; then

--- a/.pipelines/singletenancy/aks/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks/e2e-step-template.yaml
@@ -1,0 +1,69 @@
+parameters:
+  name: ""
+  clusterType: ""
+  clusterName: ""
+  nodeCount: ""
+  vmSize: ""
+  windowsVMSize: ""
+  k8sVersion: ""
+  version: ""
+  os: ""
+  windowsOsSku: ""
+  cniVersion: ""
+  os_version: ""
+
+steps:
+  - bash: |
+      go version
+      go env
+      mkdir -p '$(GOBIN)'
+      mkdir -p '$(GOPATH)/pkg'
+      mkdir -p '$(modulePath)'
+      echo '##vso[task.prependpath]$(GOBIN)'
+      echo '##vso[task.prependpath]$(GOROOT)/bin'
+    name: "GoEnv"
+    displayName: "Set up the Go environment"
+  - task: AzureCLI@1
+    inputs:
+      azureSubscription: $(AZURE_TEST_AGENT_SERVICE_CONNECTION)
+      scriptLocation: "inlineScript"
+      scriptType: "bash"
+      addSpnToEnvironment: true
+      inlineScript: |
+        mkdir -p ~/.kube/
+        echo "Create AKS cluster"
+        make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
+        make -C ./hack/aks ${{ parameters.clusterType }} AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST) SUB=$(SUB_AZURE_NETWORK_AGENT_TEST) CLUSTER=${{ parameters.clusterName }}-$(make revision) K8S_VER=${{ parameters.k8sVersion }} \ 
+          WINDOWS_OS_SKU=${{ parameters.windowsOsSku }} WINDOWS_USERNAME=${WINDOWS_USERNAME} WINDOWS_PASSWORD=${WINDOWS_PASSWORD}
+        echo "Cluster successfully created"
+    displayName: Create test cluster
+  - script: |
+      echo "Upload CNI"
+      if [ "${{parameters.os}}" == "windows" ]; then
+        export DROP_GZ_URL=$( make cni-dropgz-image-name-and-tag OS='linux' ARCH=${{ parameters.arch }} CNI_DROPGZ_VERSION=${{ parameters.version }})
+        envsubst < ./test/integration/manifests/cni/cni-installer-v1.yaml | kubectl apply -f -
+        kubectl rollout status daemonset/azure-cni -n kube-system
+        export CNI_IMAGE=$(make cni-plugin-image-name-and-tag OS=${{ parameters.os }} ARCH=${{ parameters.arch }} os_version=${{ parameters.os_version }} CNI_VERSION=${{ parameters.cniVersion }})
+        envsubst < ./hack/manifests/windows-update.yaml | kubectl apply -f -
+        kubectl rollout status daemonset/azure-cni-windows -n kube-system
+      else
+        export DROP_GZ_URL=$( make cni-dropgz-image-name-and-tag OS=${{ parameters.os }} ARCH=${{ parameters.arch }} CNI_DROPGZ_VERSION=${{ parameters.version }})
+        envsubst < ./test/integration/manifests/cni/cni-installer-v1.yaml | kubectl apply -f -
+        kubectl rollout status daemonset/azure-cni -n kube-system
+      fi
+    name: "UploadCni"
+    displayName: "Upload CNI"
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: $(AZURE_TEST_AGENT_SERVICE_CONNECTION)
+      scriptLocation: "inlineScript"
+      scriptType: "bash"
+      addSpnToEnvironment: true
+      inlineScript: |
+        echo "Skipping Deleting cluster"
+        # make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
+        # make -C ./hack/aks down AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST) SUB=$(SUB_AZURE_NETWORK_AGENT_TEST) CLUSTER=${{ parameters.clusterName }}-$(make revision)
+        echo "Cluster and resources down"
+    name: "Cleanupcluster"
+    displayName: "Cleanup cluster"
+    condition: always()

--- a/.pipelines/singletenancy/aks/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks/e2e-step-template.yaml
@@ -32,9 +32,9 @@ steps:
       inlineScript: |
         mkdir -p ~/.kube/
         echo "Create AKS cluster"
+        echo "parameters ${{ parameters.windowsOsSku }}"
         make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
-        make -C ./hack/aks ${{ parameters.clusterType }} AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST) SUB=$(SUB_AZURE_NETWORK_AGENT_TEST) CLUSTER=${{ parameters.clusterName }}-$(make revision) K8S_VER=${{ parameters.k8sVersion }} \ 
-          WINDOWS_OS_SKU=${{ parameters.windowsOsSku }} WINDOWS_USERNAME=${WINDOWS_USERNAME} WINDOWS_PASSWORD=${WINDOWS_PASSWORD}
+        make -C ./hack/aks ${{ parameters.clusterType }} AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST) SUB=$(SUB_AZURE_NETWORK_AGENT_TEST) CLUSTER=${{ parameters.clusterName }}-$(make revision) K8S_VER=${{ parameters.k8sVersion }} WINDOWS_OS_SKU=${{ parameters.windowsOsSku }} WINDOWS_USERNAME=${WINDOWS_USERNAME} WINDOWS_PASSWORD=${WINDOWS_PASSWORD}
         echo "Cluster successfully created"
     displayName: Create test cluster
   - script: |
@@ -43,7 +43,7 @@ steps:
         export DROP_GZ_URL=$( make cni-dropgz-image-name-and-tag OS='linux' ARCH=${{ parameters.arch }} CNI_DROPGZ_VERSION=${{ parameters.version }})
         envsubst < ./test/integration/manifests/cni/cni-installer-v1.yaml | kubectl apply -f -
         kubectl rollout status daemonset/azure-cni -n kube-system
-        export CNI_IMAGE=$(make cni-plugin-image-name-and-tag OS=${{ parameters.os }} ARCH=${{ parameters.arch }} os_version=${{ parameters.os_version }} CNI_VERSION=${{ parameters.cniVersion }})
+        export CNI_IMAGE=$(make cni-plugin-image-name-and-tag OS=${{ parameters.os }} ARCH=${{ parameters.arch }} OS_VERSION=${{ parameters.os_version }} CNI_VERSION=${{ parameters.cniVersion }})
         envsubst < ./hack/manifests/windows-update.yaml | kubectl apply -f -
         kubectl rollout status daemonset/azure-cni-windows -n kube-system
       else
@@ -53,7 +53,29 @@ steps:
       fi
     name: "UploadCni"
     displayName: "Upload CNI"
-  - task: AzureCLI@2
+  - task: AzureCLI@1
+    inputs:
+      azureSubscription: $(AZURE_TEST_AGENT_SERVICE_CONNECTION)
+      scriptLocation: "inlineScript"
+      scriptType: "bash"
+      addSpnToEnvironment: true
+      inlineScript: |
+        clusterName=${{ parameters.clusterName }}-$(make revision)
+        echo "Restarting nodes"
+        for val in $(az vmss list -g MC_${clusterName}_${clusterName}_$(REGION_AKS_CLUSTER_TEST) --query "[].name" -o tsv); do 
+          make -C ./hack/aks restart-vmss AZCLI=az CLUSTER=${clusterName} REGION=$(REGION_AKS_CLUSTER_TEST) VMSS_NAME=${val} 
+        done
+    displayName: "Restart Nodes"
+  - script: |
+      kubectl get pods -A -o wide
+      # Remove this once we have cniv1 support for validating the test cluster
+      echo "Validate State skipped for linux cniv1 for now"
+      if [ "${{parameters.os}}" == "windows" ]; then
+        make test-validate-state OS=${{ parameters.os }}
+      fi
+    displayName: "Validate State"
+    retryCountOnTaskFailure: 3
+  - task: AzureCLI@1
     inputs:
       azureSubscription: $(AZURE_TEST_AGENT_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"
@@ -61,9 +83,9 @@ steps:
       addSpnToEnvironment: true
       inlineScript: |
         echo "Skipping Deleting cluster"
-        # make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
-        # make -C ./hack/aks down AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST) SUB=$(SUB_AZURE_NETWORK_AGENT_TEST) CLUSTER=${{ parameters.clusterName }}-$(make revision)
+        make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
+        make -C ./hack/aks down AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST) SUB=$(SUB_AZURE_NETWORK_AGENT_TEST) CLUSTER=${{ parameters.clusterName }}-$(make revision)
         echo "Cluster and resources down"
-    name: "Cleanupcluster"
-    displayName: "Cleanup cluster"
+    displayName: "Delete test cluster"
     condition: always()
+

--- a/Makefile
+++ b/Makefile
@@ -247,6 +247,7 @@ endif
 
 ## Image name definitions.
 ACNCLI_IMAGE     	  = acncli
+CNI_PLUGIN_IMAGE 	  = azure-cni-plugin
 CNI_DROPGZ_IMAGE 	  = cni-dropgz
 CNI_DROPGZ_TEST_IMAGE = cni-dropgz-test
 CNS_IMAGE        	  = azure-cns
@@ -254,6 +255,7 @@ NPM_IMAGE        	  = azure-npm
 
 ## Image platform tags.
 ACNCLI_PLATFORM_TAG    		 ?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(ACN_VERSION)
+CNI_PLUGIN_PLATFORM_TAG 	 ?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(CNI_VERSION)
 CNI_DROPGZ_PLATFORM_TAG 	 ?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(CNI_DROPGZ_VERSION)
 CNI_DROPGZ_TEST_PLATFORM_TAG ?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(CNI_DROPGZ_TEST_VERSION)
 CNS_PLATFORM_TAG        	 ?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(CNS_VERSION)
@@ -438,15 +440,17 @@ npm-image-pull: ## pull cns container image.
 		IMAGE=$(NPM_IMAGE) \
 		TAG=$(NPM_PLATFORM_TAG)
 
-# cni-plugin 
+# cni-plugin - Specifically used for windows clusters, will be removed once we have Dropgz for windows
+cni-plugin-image-name-and-tag: # util target to print the CNI plugin image name and tag.
+	@echo $(IMAGE_REGISTRY)/$(CNI_PLUGIN_IMAGE):$(CNI_PLUGIN_PLATFORM_TAG)
 
 cni-plugin-image: ## build cni plugin container image.
 	$(MAKE) container \
 		DOCKERFILE=cni/build/$(OS).Dockerfile \
-		IMAGE=$(ACNCLI_IMAGE) \
+		IMAGE=$(CNI_PLUGIN_IMAGE) \
 		EXTRA_BUILD_ARGS='--build-arg  CNI_AI_PATH=$(CNI_AI_PATH) --build-arg CNI_AI_ID=$(CNI_AI_ID) --build-arg OS_VERSION=$(OS_VERSION)' \
 		PLATFORM=$(PLATFORM) \
-		TAG=$(ACNCLI_PLATFORM_TAG) \
+		TAG=$(CNI_PLUGIN_PLATFORM_TAG) \
 		OS=$(OS) \
 		ARCH=$(ARCH) \
 		OS_VERSION=$(OS_VERSION)

--- a/cni/build/windows.Dockerfile
+++ b/cni/build/windows.Dockerfile
@@ -13,6 +13,7 @@ FROM mcr.microsoft.com/windows/servercore:${OS_VERSION}
 SHELL ["powershell", "-command"]
 COPY --from=builder /azure-container-networking/azure-vnet.exe azure-vnet.exe
 COPY --from=builder /azure-container-networking/azure-vnet-telemetry.exe azure-vnet-telemetry.exe
+COPY --from=builder /azure-container-networking/telemetry/azure-vnet-telemetry.config azure-vnet-telemetry.config
 COPY --from=builder /azure-container-networking/azure-vnet-ipam.exe azure-vnet-ipam.exe
 
 # This would be replaced with dropgz version of windows.

--- a/dropgz/build/cniTest.Dockerfile
+++ b/dropgz/build/cniTest.Dockerfile
@@ -18,10 +18,13 @@ WORKDIR /dropgz
 COPY dropgz .
 COPY --from=azure-ipam /azure-ipam/*.conflist pkg/embed/fs
 COPY --from=azure-ipam /azure-ipam/bin/* pkg/embed/fs
+COPY --from=azure-vnet /azure-container-networking/cni/azure-$OS.conflist pkg/embed/fs/azure.conflist
 COPY --from=azure-vnet /azure-container-networking/cni/azure-$OS-swift.conflist pkg/embed/fs/azure-swift.conflist
 COPY --from=azure-vnet /azure-container-networking/cni/azure-$OS-swift-overlay.conflist pkg/embed/fs/azure-swift-overlay.conflist
 COPY --from=azure-vnet /azure-container-networking/cni/azure-$OS-swift-overlay-dualstack.conflist pkg/embed/fs/azure-swift-overlay-dualstack.conflist
 COPY --from=azure-vnet /azure-container-networking/bin/* pkg/embed/fs
+COPY --from=azure-vnet /azure-container-networking/telemetry/azure-vnet-telemetry.config pkg/embed/fs
+
 RUN cd pkg/embed/fs/ && sha256sum * > sum.txt
 RUN gzip --verbose --best --recursive pkg/embed/fs && for f in pkg/embed/fs/*.gz; do mv -- "$f" "${f%%.gz}"; done
 

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -8,10 +8,13 @@ AZIMG   = mcr.microsoft.com/azure-cli
 AZCLI   ?= docker run --rm -v $(AZCFG):/root/.azure -v $(KUBECFG):/root/.kube -v $(SSH):/root/.ssh -v $(PWD):/root/tmpsrc $(AZIMG) az
 
 # overrideable defaults
-REGION     ?= westus2
-OS_SKU     ?= Ubuntu
-VM_SIZE	   ?= Standard_B2s
-NODE_COUNT ?= 2
+REGION          ?= westus2
+OS_SKU          ?= Ubuntu
+WINDOWS_OS_SKU  ?= Windows2022
+VM_SIZE	        ?= Standard_B2s
+NODE_COUNT      ?= 2
+K8S_VER         ?= 1.24.9 # Used only for ubuntu 18, as K8S > 1.25 have Ubuntu 22
+WINDOWS_VM_SKU  ?= Standard_B2s
 
 # overrideable variables
 SUB        ?= $(AZURE_SUBSCRIPTION)
@@ -203,12 +206,25 @@ windows-cniv1-up: rg-up overlay-net-up ## Bring up a Windows CNIv1 cluster
 
 	$(AZCLI) aks nodepool add --resource-group $(GROUP) --cluster-name $(CLUSTER) \
 		--os-type Windows \
-		--os-sku Windows2022 \
+		--os-sku $(WINDOWS_OS_SKU) \
 		--max-pods 250 \
 		--name npwin \
 		--node-count $(NODE_COUNT) \
 		-s $(WINDOWS_VM_SKU)
 
+	@$(MAKE) set-kubeconf
+
+linux-cniv1-up: rg-up overlay-net-up 
+	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
+		--node-count $(NODE_COUNT) \
+		--node-vm-size $(VM_SIZE) \
+		--network-plugin azure \
+		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
+		--kubernetes-version $(K8S_VER) \
+		--os-sku $(OS_SKU) \
+		--no-ssh-key \
+		--yes
+		
 	@$(MAKE) set-kubeconf
 
 down: ## Delete the cluster

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -13,7 +13,7 @@ OS_SKU          ?= Ubuntu
 WINDOWS_OS_SKU  ?= Windows2022
 VM_SIZE	        ?= Standard_B2s
 NODE_COUNT      ?= 2
-K8S_VER         ?= 1.24.9 # Used only for ubuntu 18, as K8S > 1.25 have Ubuntu 22
+K8S_VER         ?= 1.25 # Used only for ubuntu 18 as K8S 1.24.9, as K8S > 1.25 have Ubuntu 22
 WINDOWS_VM_SKU  ?= Standard_B2s
 
 # overrideable variables
@@ -224,7 +224,7 @@ linux-cniv1-up: rg-up overlay-net-up
 		--os-sku $(OS_SKU) \
 		--no-ssh-key \
 		--yes
-		
+
 	@$(MAKE) set-kubeconf
 
 down: ## Delete the cluster

--- a/hack/scripts/updatecni.ps1
+++ b/hack/scripts/updatecni.ps1
@@ -2,6 +2,7 @@ Write-Host $env:CONTAINER_SANDBOX_MOUNT_POINT
 $sourceCNI = $env:CONTAINER_SANDBOX_MOUNT_POINT + "azure-vnet.exe"
 $sourceIpam = $env:CONTAINER_SANDBOX_MOUNT_POINT + "azure-vnet-ipam.exe"
 $sourceTelemetry = $env:CONTAINER_SANDBOX_MOUNT_POINT + "azure-vnet-telemetry.exe"
+$sourceTelemetryConfig = $env:CONTAINER_SANDBOX_MOUNT_POINT + "azure-vnet-telemetry.config"
 
 $sourceCNIVersion = & "$sourceCNI" -v
 $currentVersion = ""
@@ -36,6 +37,10 @@ if ($currentTelemetryVersion -ne $sourceTelemetryVersion){
     Write-Host "copying azure-vnet-telemetry to windows node..."
     Remove-Item "C:\k\azurecni\bin\azure-vnet-telemetry.exe"
     Copy-Item $sourceTelemetry -Destination "C:\k\azurecni\bin"
+
+    Write-Host "copying azure-vnet-telemetry.config to windows node..."
+    Remove-Item "C:\k\azurecni\bin\azure-vnet-telemetry.config"
+    Copy-Item $sourceTelemetryConfig -Destination "C:\k\azurecni\bin"
 }
 
 ## check CNI was already installed so not to get stuck in a infinite loop of rebooting

--- a/test/integration/manifests/cni/cni-installer-v1.yaml
+++ b/test/integration/manifests/cni/cni-installer-v1.yaml
@@ -56,6 +56,9 @@ spec:
             - azure.conflist
             - -o
             - /etc/cni/net.d/10-azure.conflist
+            - azure-vnet-telemetry.config
+            - -o
+            - /opt/cni/bin/azure-vnet-telemetry.config
           volumeMounts:
             - name: cni-bin
               mountPath: /opt/cni/bin

--- a/test/integration/manifests/cni/cni-installer-v1.yaml
+++ b/test/integration/manifests/cni/cni-installer-v1.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: azure-cni
+  namespace: kube-system
+  labels:
+    app: azure-cni
+spec:
+  selector:
+    matchLabels:
+      k8s-app: azure-cni
+  template:
+    metadata:
+      labels:
+        k8s-app: azure-cni
+      annotations:
+        cluster-autoscaler.kubernetes.io/daemonset-pod: "true"
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: type
+                operator: NotIn
+                values:
+                - virtual-kubelet
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+      priorityClassName: system-node-critical
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - operator: "Exists"
+          effect: NoExecute
+        - operator: "Exists"
+          effect: NoSchedule
+      initContainers:
+        - name: azure-cni
+          image:  ${DROP_GZ_URL}
+          imagePullPolicy: Always
+          command: ["/dropgz"]
+          args:
+            - deploy
+            - azure-vnet
+            - -o
+            - /opt/cni/bin/azure-vnet
+            - azure-vnet-ipam
+            - -o
+            - /opt/cni/bin/azure-vnet-ipam
+            - azure-vnet-telemetry
+            - -o 
+            - /opt/cni/bin/azure-vnet-telemetry
+            - azure.conflist
+            - -o
+            - /etc/cni/net.d/10-azure.conflist
+          volumeMounts:
+            - name: cni-bin
+              mountPath: /opt/cni/bin
+            - name: cni-conflist
+              mountPath: /etc/cni/net.d
+      containers:
+        - name: pause
+          image: mcr.microsoft.com/oss/kubernetes/pause:3.6
+      hostNetwork: true
+      volumes:
+        - name: cni-conflist
+          hostPath:
+            path: /etc/cni/net.d
+            type: Directory
+        - name: cni-bin
+          hostPath:
+            path: /opt/cni/bin
+            type: Directory


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->
This PR adds creation of aks cluster and replacing the CNI binaries. This is a step to migrate away from aks-engine(deprecated). @jpayne3506  will be adding the datapath to these created clusters.
 
**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
AKS Engine is deprecated.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
