### PR TITLE
fix: skip reserved IPs

### DIFF
--- a/cns/kubecontroller/nodenetworkconfig/conversion_linux_test.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_linux_test.go
@@ -35,3 +35,63 @@ var validOverlayRequest = &cns.CreateNetworkContainerRequest{
 		},
 	},
 }
+
+var validVNETBlockRequest = &cns.CreateNetworkContainerRequest{
+	Version: strconv.FormatInt(version, 10),
+	IPConfiguration: cns.IPConfiguration{
+		GatewayIPAddress: vnetBlockDefaultGateway,
+		IPSubnet: cns.IPSubnet{
+			PrefixLength: uint8(vnetBlockSubnetPrefixLen),
+			IPAddress:    vnetBlockPrimaryIP,
+		},
+	},
+	NetworkContainerid:   ncID,
+	NetworkContainerType: cns.Docker,
+	// Ignore first IP in first CIDR Block, i.e. 10.224.0.4
+	SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+		"10.224.0.5": {
+			IPAddress: "10.224.0.5",
+			NCVersion: version,
+		},
+		"10.224.0.6": {
+			IPAddress: "10.224.0.6",
+			NCVersion: version,
+		},
+		"10.224.0.7": {
+			IPAddress: "10.224.0.7",
+			NCVersion: version,
+		},
+		"10.224.0.8": {
+			IPAddress: "10.224.0.8",
+			NCVersion: version,
+		},
+		"10.224.0.9": {
+			IPAddress: "10.224.0.9",
+			NCVersion: version,
+		},
+		"10.224.0.10": {
+			IPAddress: "10.224.0.10",
+			NCVersion: version,
+		},
+		"10.224.0.11": {
+			IPAddress: "10.224.0.11",
+			NCVersion: version,
+		},
+		"10.224.0.12": {
+			IPAddress: "10.224.0.12",
+			NCVersion: version,
+		},
+		"10.224.0.13": {
+			IPAddress: "10.224.0.13",
+			NCVersion: version,
+		},
+		"10.224.0.14": {
+			IPAddress: "10.224.0.14",
+			NCVersion: version,
+		},
+		"10.224.0.15": {
+			IPAddress: "10.224.0.15",
+			NCVersion: version,
+		},
+	},
+}

--- a/cns/kubecontroller/nodenetworkconfig/conversion_test.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_test.go
@@ -117,66 +117,6 @@ var validVNETBlockNC = v1alpha.NetworkContainer{
 	Version:            version,
 }
 
-var validVNETBlockRequest = &cns.CreateNetworkContainerRequest{
-	Version: strconv.FormatInt(version, 10),
-	IPConfiguration: cns.IPConfiguration{
-		GatewayIPAddress: vnetBlockDefaultGateway,
-		IPSubnet: cns.IPSubnet{
-			PrefixLength: uint8(vnetBlockSubnetPrefixLen),
-			IPAddress:    vnetBlockPrimaryIP,
-		},
-	},
-	NetworkContainerid:   ncID,
-	NetworkContainerType: cns.Docker,
-	// Ignore first IP in first CIDR Block, i.e. 10.224.0.4
-	SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
-		"10.224.0.5": {
-			IPAddress: "10.224.0.5",
-			NCVersion: version,
-		},
-		"10.224.0.6": {
-			IPAddress: "10.224.0.6",
-			NCVersion: version,
-		},
-		"10.224.0.7": {
-			IPAddress: "10.224.0.7",
-			NCVersion: version,
-		},
-		"10.224.0.8": {
-			IPAddress: "10.224.0.8",
-			NCVersion: version,
-		},
-		"10.224.0.9": {
-			IPAddress: "10.224.0.9",
-			NCVersion: version,
-		},
-		"10.224.0.10": {
-			IPAddress: "10.224.0.10",
-			NCVersion: version,
-		},
-		"10.224.0.11": {
-			IPAddress: "10.224.0.11",
-			NCVersion: version,
-		},
-		"10.224.0.12": {
-			IPAddress: "10.224.0.12",
-			NCVersion: version,
-		},
-		"10.224.0.13": {
-			IPAddress: "10.224.0.13",
-			NCVersion: version,
-		},
-		"10.224.0.14": {
-			IPAddress: "10.224.0.14",
-			NCVersion: version,
-		},
-		"10.224.0.15": {
-			IPAddress: "10.224.0.15",
-			NCVersion: version,
-		},
-	},
-}
-
 func TestCreateNCRequestFromDynamicNC(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/cns/kubecontroller/nodenetworkconfig/conversion_windows_test.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_windows_test.go
@@ -13,21 +13,69 @@ var validOverlayRequest = &cns.CreateNetworkContainerRequest{
 			PrefixLength: uint8(subnetPrefixLen),
 			IPAddress:    primaryIP,
 		},
-		GatewayIPAddress: "10.0.0.0",
+		GatewayIPAddress: "10.0.0.1",
 	},
 	NetworkContainerid:   ncID,
 	NetworkContainerType: cns.Docker,
 	SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
-		"10.0.0.1": {
-			IPAddress: "10.0.0.1",
-			NCVersion: version,
-		},
 		"10.0.0.2": {
 			IPAddress: "10.0.0.2",
+			NCVersion: 0,
+		},
+	},
+}
+
+var validVNETBlockRequest = &cns.CreateNetworkContainerRequest{
+	Version: strconv.FormatInt(version, 10),
+	IPConfiguration: cns.IPConfiguration{
+		GatewayIPAddress: vnetBlockDefaultGateway,
+		IPSubnet: cns.IPSubnet{
+			PrefixLength: uint8(vnetBlockSubnetPrefixLen),
+			IPAddress:    vnetBlockPrimaryIP,
+		},
+	},
+	NetworkContainerid:   ncID,
+	NetworkContainerType: cns.Docker,
+	// Ignore first IP in first CIDR Block, i.e. 10.224.0.4
+	SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+		"10.224.0.5": {
+			IPAddress: "10.224.0.5",
 			NCVersion: version,
 		},
-		"10.0.0.3": {
-			IPAddress: "10.0.0.3",
+		"10.224.0.6": {
+			IPAddress: "10.224.0.6",
+			NCVersion: version,
+		},
+		"10.224.0.7": {
+			IPAddress: "10.224.0.7",
+			NCVersion: version,
+		},
+		"10.224.0.8": {
+			IPAddress: "10.224.0.8",
+			NCVersion: version,
+		},
+		"10.224.0.9": {
+			IPAddress: "10.224.0.9",
+			NCVersion: version,
+		},
+		"10.224.0.10": {
+			IPAddress: "10.224.0.10",
+			NCVersion: version,
+		},
+		"10.224.0.11": {
+			IPAddress: "10.224.0.11",
+			NCVersion: version,
+		},
+		"10.224.0.12": {
+			IPAddress: "10.224.0.12",
+			NCVersion: version,
+		},
+		"10.224.0.13": {
+			IPAddress: "10.224.0.13",
+			NCVersion: version,
+		},
+		"10.224.0.14": {
+			IPAddress: "10.224.0.14",
 			NCVersion: version,
 		},
 	},


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
We need to use .1 address of subnet as GW; skipping 0th and last IP of subnets since they are reserved from HNS POV

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
