### PR TITLE
 add EnableAZR flag to make home az goroutine as an opt-in feature

### DIFF
--- a/cns/configuration/cns_config.json
+++ b/cns/configuration/cns_config.json
@@ -29,6 +29,9 @@
     "MSISettings": {
         "ResourceID": ""
     },
-    "PopulateHomeAzCacheRetryIntervalSecs": 15,
-    "MellanoxMonitorIntervalSecs": 30
+    "MellanoxMonitorIntervalSecs": 30,
+    "AZRSettings": {
+        "EnableAZR": false,
+        "PopulateHomeAzCacheRetryIntervalSecs": 60
+    }
 }

--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -20,30 +20,30 @@ const (
 )
 
 type CNSConfig struct {
-	ChannelMode                          string
-	EnablePprof                          bool
-	EnableSubnetScarcity                 bool
-	InitializeFromCNI                    bool
-	ManagedSettings                      ManagedSettings
-	MetricsBindAddress                   string
-	SyncHostNCTimeoutMs                  int
-	SyncHostNCVersionIntervalMs          int
-	TLSCertificatePath                   string
-	TLSEndpoint                          string
-	TLSPort                              string
-	TLSSubjectName                       string
-	TelemetrySettings                    TelemetrySettings
-	UseHTTPS                             bool
-	WireserverIP                         string
-	KeyVaultSettings                     KeyVaultSettings
-	MSISettings                          MSISettings
-	ProgramSNATIPTables                  bool
-	ManageEndpointState                  bool
-	CNIConflistScenario                  string
-	EnableCNIConflistGeneration          bool
-	CNIConflistFilepath                  string
-	PopulateHomeAzCacheRetryIntervalSecs int
-	MellanoxMonitorIntervalSecs          int
+	ChannelMode                 string
+	EnablePprof                 bool
+	EnableSubnetScarcity        bool
+	InitializeFromCNI           bool
+	ManagedSettings             ManagedSettings
+	MetricsBindAddress          string
+	SyncHostNCTimeoutMs         int
+	SyncHostNCVersionIntervalMs int
+	TLSCertificatePath          string
+	TLSEndpoint                 string
+	TLSPort                     string
+	TLSSubjectName              string
+	TelemetrySettings           TelemetrySettings
+	UseHTTPS                    bool
+	WireserverIP                string
+	KeyVaultSettings            KeyVaultSettings
+	MSISettings                 MSISettings
+	ProgramSNATIPTables         bool
+	ManageEndpointState         bool
+	CNIConflistScenario         string
+	EnableCNIConflistGeneration bool
+	CNIConflistFilepath         string
+	MellanoxMonitorIntervalSecs int
+	AZRSettings                 AZRSettings
 }
 
 type TelemetrySettings struct {
@@ -78,6 +78,11 @@ type ManagedSettings struct {
 	InfrastructureNetworkID   string
 	NodeID                    string
 	NodeSyncIntervalInSeconds int
+}
+
+type AZRSettings struct {
+	EnableAZR                            bool
+	PopulateHomeAzCacheRetryIntervalSecs int
 }
 
 type MSISettings struct {
@@ -165,6 +170,13 @@ func setManagedSettingDefaults(managedSettings *ManagedSettings) {
 	}
 }
 
+func setAZRSettingsDefaults(azrSettings *AZRSettings) {
+	if azrSettings.PopulateHomeAzCacheRetryIntervalSecs == 0 {
+		// set the default PopulateHomeAzCache retry interval to 60 seconds
+		azrSettings.PopulateHomeAzCacheRetryIntervalSecs = 60
+	}
+}
+
 func setKeyVaultSettingsDefaults(kvs *KeyVaultSettings) {
 	if kvs.RefreshIntervalInHrs == 0 {
 		kvs.RefreshIntervalInHrs = 12 //nolint:gomnd // default times
@@ -176,6 +188,7 @@ func SetCNSConfigDefaults(config *CNSConfig) {
 	setTelemetrySettingDefaults(&config.TelemetrySettings)
 	setManagedSettingDefaults(&config.ManagedSettings)
 	setKeyVaultSettingsDefaults(&config.KeyVaultSettings)
+	setAZRSettingsDefaults(&config.AZRSettings)
 
 	if config.ChannelMode == "" {
 		config.ChannelMode = cns.Direct
@@ -188,10 +201,6 @@ func SetCNSConfigDefaults(config *CNSConfig) {
 	}
 	if config.SyncHostNCTimeoutMs == 0 {
 		config.SyncHostNCTimeoutMs = 500 //nolint:gomnd // default times
-	}
-	if config.PopulateHomeAzCacheRetryIntervalSecs == 0 {
-		// set the default PopulateHomeAzCache retry interval to 30 seconds
-		config.PopulateHomeAzCacheRetryIntervalSecs = 30
 	}
 	if config.WireserverIP == "" {
 		config.WireserverIP = "168.63.129.16"

--- a/cns/configuration/configuration_test.go
+++ b/cns/configuration/configuration_test.go
@@ -83,6 +83,10 @@ func TestReadConfigFromFile(t *testing.T) {
 					TelemetryBatchIntervalInSecs: 15,
 					TelemetryBatchSizeBytes:      16384,
 				},
+				AZRSettings: AZRSettings{
+					EnableAZR:                            true,
+					PopulateHomeAzCacheRetryIntervalSecs: 60,
+				},
 				UseHTTPS:     true,
 				WireserverIP: "168.63.129.16",
 			},
@@ -206,8 +210,10 @@ func TestSetCNSConfigDefaults(t *testing.T) {
 				KeyVaultSettings: KeyVaultSettings{
 					RefreshIntervalInHrs: 12,
 				},
-				PopulateHomeAzCacheRetryIntervalSecs: 30,
-				WireserverIP:                         "168.63.129.16",
+				AZRSettings: AZRSettings{
+					PopulateHomeAzCacheRetryIntervalSecs: 60,
+				},
+				WireserverIP: "168.63.129.16",
 			},
 		},
 		{
@@ -230,7 +236,10 @@ func TestSetCNSConfigDefaults(t *testing.T) {
 				KeyVaultSettings: KeyVaultSettings{
 					RefreshIntervalInHrs: 3,
 				},
-				PopulateHomeAzCacheRetryIntervalSecs: 10,
+				AZRSettings: AZRSettings{
+					EnableAZR:                            true,
+					PopulateHomeAzCacheRetryIntervalSecs: 10,
+				},
 			},
 			want: CNSConfig{
 				ChannelMode: "Other",
@@ -250,8 +259,11 @@ func TestSetCNSConfigDefaults(t *testing.T) {
 				KeyVaultSettings: KeyVaultSettings{
 					RefreshIntervalInHrs: 3,
 				},
-				PopulateHomeAzCacheRetryIntervalSecs: 10,
-				WireserverIP:                         "168.63.129.16",
+				AZRSettings: AZRSettings{
+					EnableAZR:                            true,
+					PopulateHomeAzCacheRetryIntervalSecs: 10,
+				},
+				WireserverIP: "168.63.129.16",
 			},
 		},
 	}

--- a/cns/configuration/testdata/good.json
+++ b/cns/configuration/testdata/good.json
@@ -30,5 +30,9 @@
         "TelemetryBatchSizeBytes": 16384
     },
     "UseHTTPS": true,
-    "WireserverIP": "168.63.129.16"
+    "WireserverIP": "168.63.129.16",
+    "AZRSettings": {
+        "EnableAZR": true,
+        "PopulateHomeAzCacheRetryIntervalSecs": 60
+    }
 }

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -567,9 +567,11 @@ func main() {
 		return
 	}
 
-	homeAzMonitor := restserver.NewHomeAzMonitor(nmaClient, time.Duration(cnsconfig.PopulateHomeAzCacheRetryIntervalSecs)*time.Second)
-	logger.Printf("start the goroutine for refreshing homeAz")
-	homeAzMonitor.Start()
+	homeAzMonitor := restserver.NewHomeAzMonitor(nmaClient, time.Duration(cnsconfig.AZRSettings.PopulateHomeAzCacheRetryIntervalSecs)*time.Second)
+	if cnsconfig.AZRSettings.EnableAZR {
+		logger.Printf("start the goroutine for refreshing homeAz")
+		homeAzMonitor.Start()
+	}
 
 	if cnsconfig.ChannelMode == cns.Managed {
 		config.ChannelMode = cns.Managed
@@ -903,8 +905,10 @@ func main() {
 		}
 	}
 
-	logger.Printf("end the goroutine for refreshing homeAz")
-	homeAzMonitor.Stop()
+	if cnsconfig.AZRSettings.EnableAZR {
+		logger.Printf("end the goroutine for refreshing homeAz")
+		homeAzMonitor.Stop()
+	}
 
 	logger.Printf("stop cns service")
 	// Cleanup.


### PR DESCRIPTION
-  add EnableAZR flag to make home az goroutine as an opt-in feature
-  change PopulateHomeAzCacheRetryIntervalSecs default to 60

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] relevant PR labels added

**Notes**:
