### PR TITLE
ci: add cilium identities check to nightly pipeline

### DIFF
--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
@@ -158,6 +158,10 @@ steps:
   - script: |
       echo "validate pod IP assignment and check systemd-networkd restart"
       kubectl get pod -owide -A
+      if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]; then
+        echo "Check cilium identities during nightly run"
+        kubectl get ciliumidentity | grep cilium-test
+      fi
       make test-validate-state
       echo "delete cilium connectivity test resources and re-validate state"
       kubectl delete ns cilium-test
@@ -165,6 +169,33 @@ steps:
       make test-validate-state
     name: "validatePods"
     displayName: "Validate Pods"
+
+  - script: |
+      if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]; then 
+        kubectl get pod -owide -n cilium-test
+        echo "wait for pod and cilium identity deletion"
+        ns="cilium-test"
+        while true; do
+          pods=$(kubectl get pods -n $ns --no-headers=true 2>/dev/null)
+          if [[ -z "$pods" ]]; then
+            echo "No pods found"
+              break
+          fi
+          sleep 2s
+        done
+        sleep 20s
+        echo "Verify cilium identities are deleted"
+        checkIdentity="$(kubectl get ciliumidentity -o json | grep cilium-test | jq -e 'length == 0')"
+        if [[ -n $checkIdentity ]]; then
+          echo "##[error]Cilium Identities still present"
+        else
+          printf -- "Identities deleted\n"
+        fi 
+      else
+        echo "skip cilium identities check for PR pipeline"
+      fi
+    name: "CiliumIdentites"
+    displayName: "Verify Cilium Identity Deletion"
 
   - script: |
       echo "validate pod IP assignment before CNS restart"

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
@@ -159,7 +159,8 @@ steps:
       echo "validate pod IP assignment and check systemd-networkd restart"
       kubectl get pod -owide -A
       if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]; then
-        echo "Check cilium identities during nightly run"
+        echo "Check cilium identities in cilium-test namepsace during nightly run"
+        echo "expect the identities to be deleted when the namespace is deleted"
         kubectl get ciliumidentity | grep cilium-test
       fi
       make test-validate-state
@@ -173,7 +174,7 @@ steps:
   - script: |
       if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]; then 
         kubectl get pod -owide -n cilium-test
-        echo "wait for pod and cilium identity deletion"
+        echo "wait for pod and cilium identity deletion in cilium-test namespace"
         ns="cilium-test"
         while true; do
           pods=$(kubectl get pods -n $ns --no-headers=true 2>/dev/null)
@@ -184,18 +185,18 @@ steps:
           sleep 2s
         done
         sleep 20s
-        echo "Verify cilium identities are deleted"
+        echo "Verify cilium identities are deleted from cilium-test"
         checkIdentity="$(kubectl get ciliumidentity -o json | grep cilium-test | jq -e 'length == 0')"
         if [[ -n $checkIdentity ]]; then
-          echo "##[error]Cilium Identities still present"
+          echo "##[error]Cilium Identities still present in cilium-test namespace"
         else
-          printf -- "Identities deleted\n"
+          printf -- "Identities deleted from cilium-test namespace\n"
         fi 
       else
         echo "skip cilium identities check for PR pipeline"
       fi
-    name: "CiliumIdentites"
-    displayName: "Verify Cilium Identity Deletion"
+    name: "CiliumIdentities"
+    displayName: "Verify Cilium Identities Deletion"
 
   - script: |
       echo "validate pod IP assignment before CNS restart"

--- a/test/integration/manifests/cilium/deployment.yaml
+++ b/test/integration/manifests/cilium/deployment.yaml
@@ -36,6 +36,8 @@ spec:
         args:
         - --config-dir=/tmp/cilium/config-map
         - --debug=$(CILIUM_DEBUG)
+        - --identity-gc-interval=0m20s
+        - --identity-heartbeat-timeout=0m20s
         env:
         - name: K8S_NODE_NAME
           valueFrom:


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
- This PR updates cilium operator arguments for cilium identities to lower the garbage collection interval. 
- Adding a stage in the nightly pipeline to verify that cilium identities are removed once the cilium endpoint is deleted. 

This check will only run for the nightly pipeline and will be skipped in the PR runs. It was previously added to the old version of our nightly pipeline.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
