### PR TITLE
fix: assume invalid semver CNI has the required dump state command

### DIFF
--- a/cni/client/client.go
+++ b/cni/client/client.go
@@ -11,12 +11,15 @@ import (
 	"github.com/Azure/azure-container-networking/log"
 	"github.com/Azure/azure-container-networking/platform"
 	semver "github.com/hashicorp/go-version"
+	"github.com/pkg/errors"
 	utilexec "k8s.io/utils/exec"
 )
 
 type client struct {
 	exec utilexec.Interface
 }
+
+var ErrSemVerParse = errors.New("error parsing version")
 
 func New(exec utilexec.Interface) *client {
 	return &client{exec: exec}
@@ -58,5 +61,10 @@ func (c *client) GetVersion() (*semver.Version, error) {
 		return nil, fmt.Errorf("Unexpected Azure CNI Version formatting: %v", output)
 	}
 
-	return semver.NewVersion(res[3])
+	version, versionErr := semver.NewVersion(res[3])
+	if versionErr != nil {
+		return nil, errors.Wrap(ErrSemVerParse, versionErr.Error())
+	}
+
+	return version, nil
 }

--- a/cns/cnireconciler/version.go
+++ b/cns/cnireconciler/version.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Azure/azure-container-networking/cni/client"
 	semver "github.com/hashicorp/go-version"
+	"github.com/pkg/errors"
 	"k8s.io/utils/exec"
 )
 
@@ -15,7 +16,9 @@ const lastCNIWithoutDumpStateVer = "1.4.6"
 // IsDumpStateVer checks if the CNI executable is a version that
 // has the dump state command required to initialize CNS from CNI
 // state and returns the result of that test or an error. Will always
-// return false when there is an error.
+// return false when there is an error unless the error was caused
+// by the CNI not being a semver, in which case we'll assume we can
+// use the command.
 func IsDumpStateVer() (bool, error) {
 	return isDumpStateVer(exec.New())
 }
@@ -28,6 +31,11 @@ func isDumpStateVer(exec exec.Interface) (bool, error) {
 	cnicli := client.New(exec)
 	ver, err := cnicli.GetVersion()
 	if err != nil {
+		// If the error was that the CNI isn't a valid semver, assume we have the
+		// the dump state command
+		if errors.Is(err, client.ErrSemVerParse) {
+			return true, nil
+		}
 		return false, fmt.Errorf("failed to invoke CNI client.GetVersion(): %w", err)
 	}
 	return ver.GreaterThan(needVer), nil

--- a/cns/cnireconciler/version_test.go
+++ b/cns/cnireconciler/version_test.go
@@ -48,6 +48,18 @@ func TestIsDumpStateVer(t *testing.T) {
 			want:    true,
 			wantErr: false,
 		},
+		{
+			name:    "non-semver",
+			exec:    newCNIVersionFakeExec(`Azure CNI Version v1.4.35_Win2019OverlayFix`),
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "non-semver hotfix ver",
+			exec:    newCNIVersionFakeExec(`Azure CNI Version v1.4.44.4`),
+			want:    true,
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**Reason for Change**:
The CNS will invoke CNI's `version` command to check CNI version, and use it to determine whether it can be used for reconciling CNS state. This is achieved by a semver comparison >= v1.4.7. However, if the CNI was not tagged with a semantic version, this fails. Since CNI v1.4.7 is quite old, it is probably safe to remove this check entirely and just say "CNS >= v1.4.44 can't be used with CNI <=v1.4.6", but for now we'll just ignore the sem ver check if the parsing fails and assume we can use the command.


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [ ] relevant PR labels added

**Notes**:
I'm open to just removing the semver check altogether with the caveat that CNS v1.4.44 and above must be used with CNI >= v1.4.7.
