### PR TITLE
CNS - consider multiple IPs for a pod in reconciliation after restart

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -295,8 +295,6 @@ func KubePodsToPodInfoByIP(pods []corev1.Pod) (map[string]PodInfo, error) {
 			return nil, errors.Wrap(ErrDuplicateIP, pods[i].Status.PodIP)
 		}
 		// record the PodInfo by assigned IP.
-		// todo: this will not work for dual stack since we need to reconcile based on interface id
-		// todo: does this path work for since CNS internal state is keyed with interface id?
 		podInfoByIP[pods[i].Status.PodIP] = NewPodInfo("", "", pods[i].Name, pods[i].Namespace)
 	}
 	return podInfoByIP, nil

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -295,6 +295,8 @@ func KubePodsToPodInfoByIP(pods []corev1.Pod) (map[string]PodInfo, error) {
 			return nil, errors.Wrap(ErrDuplicateIP, pods[i].Status.PodIP)
 		}
 		// record the PodInfo by assigned IP.
+		// todo: this will not work for dual stack since we need to reconcile based on interface id
+		// todo: does this path work for since CNS internal state is keyed with interface id?
 		podInfoByIP[pods[i].Status.PodIP] = NewPodInfo("", "", pods[i].Name, pods[i].Namespace)
 	}
 	return podInfoByIP, nil

--- a/cns/client/client_test.go
+++ b/cns/client/client_test.go
@@ -314,7 +314,7 @@ func TestCNSClientPodContextApi(t *testing.T) {
 
 	addTestStateToRestServer(t, secondaryIps)
 
-	podInfo := cns.NewPodInfo("", "", podName, podNamespace)
+	podInfo := cns.NewPodInfo("some-guid-1", "abc-eth0", podName, podNamespace)
 	orchestratorContext, err := json.Marshal(podInfo)
 	assert.NoError(t, err)
 
@@ -344,7 +344,7 @@ func TestCNSClientDebugAPI(t *testing.T) {
 
 	addTestStateToRestServer(t, secondaryIps)
 
-	podInfo := cns.NewPodInfo("", "", podName, podNamespace)
+	podInfo := cns.NewPodInfo("some-guid-1", "abc-eth0", podName, podNamespace)
 	orchestratorContext, err := json.Marshal(podInfo)
 	assert.NoError(t, err)
 

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -396,6 +396,8 @@ func newPodKeyToPodIPsMap(podInfoByIP map[string]cns.PodInfo) (map[string]podIPs
 
 		ip := net.ParseIP(ipStr)
 		switch {
+		case ip == nil:
+			return nil, errors.Wrapf(errIPParse, "could not parse ip string %q on pod %+v", ipStr, podInfo)
 		case ip.To4() != nil:
 			if ips.v4IP != nil {
 				return nil, errors.Wrapf(errMultipleIPPerFamily, "multiple ipv4 addresses (%v, %v) associated to pod %+v", ips.v4IP, ip, podInfo)
@@ -408,8 +410,6 @@ func newPodKeyToPodIPsMap(podInfoByIP map[string]cns.PodInfo) (map[string]podIPs
 			}
 
 			ips.v6IP = ip
-		default:
-			return nil, errors.Wrapf(errIPParse, "could not parse ip string %q on pod %+v", ipStr, podInfo)
 		}
 
 		podKeyToPodIPs[id] = ips

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -317,7 +317,7 @@ func (service *HTTPRestService) ReconcileIPAMState(ncReqs []*cns.CreateNetworkCo
 	// to pod IPs indexed by pod key (interface or name+namespace, depending on scenario):
 	//
 	//   {
-	//     "aaa-eth0": podIPs{IPs:["10.0.0.1","fe80::1"]}
+	//     "aaa-eth0": podIPs{v4IP: 10.0.0.1, v6IP: fe80::1}
 	//   }
 	//
 	// such that we can iterate over pod interfaces, and assign all IPs for it at once.
@@ -346,7 +346,7 @@ func (service *HTTPRestService) ReconcileIPAMState(ncReqs []*cns.CreateNetworkCo
 		}
 
 		if len(desiredIPs) == 0 {
-			// this may happen for system pods
+			// this may happen for pods in the host network
 			continue
 		}
 

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -333,7 +333,16 @@ func (service *HTTPRestService) ReconcileIPAMState(ncReqs []*cns.CreateNetworkCo
 			ncIDs      []string
 		)
 
-		for _, ip := range []net.IP{podIPs.v4IP, podIPs.v6IP} {
+		var ips []net.IP
+		if podIPs.v4IP != nil {
+			ips = append(ips, podIPs.v4IP)
+		}
+
+		if podIPs.v6IP != nil {
+			ips = append(ips, podIPs.v6IP)
+		}
+
+		for _, ip := range ips {
 			if ncReq, ok := allSecIPsIdx[ip.String()]; ok {
 				logger.Printf("secondary ip %s is assigned to pod %+v, ncId: %s ncVersion: %s", ip, podIPs, ncReq.NetworkContainerid, ncReq.Version)
 				desiredIPs = append(desiredIPs, ip.String())

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -333,6 +333,7 @@ func (service *HTTPRestService) ReconcileIPAMState(ncReqs []*cns.CreateNetworkCo
 				desiredIPs = append(desiredIPs, ip)
 				ncIDs = append(ncIDs, ncReq.NetworkContainerid)
 			} else {
+				// todo: confirm if this is a valid scenario for system pods
 				logger.Errorf("ip %s assigned to pod %+v but not found in any nc", ip, podIPs)
 			}
 		}
@@ -341,6 +342,11 @@ func (service *HTTPRestService) ReconcileIPAMState(ncReqs []*cns.CreateNetworkCo
 		if err != nil {
 			logger.Errorf("Failed to marshal KubernetesPodInfo, error: %v", err)
 			return types.UnexpectedError
+		}
+
+		if len(desiredIPs) == 0 {
+			// this may happen for system pods
+			continue
 		}
 
 		ipconfigsRequest := cns.IPConfigsRequest{

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -733,7 +733,7 @@ func TestReconcileCNSIPAMWithKubePodInfoProvider(t *testing.T) {
 	expectedAssignedPods := make(map[string]cns.PodInfo)
 	expectedAssignedPods["10.0.0.6"] = cns.NewPodInfo("", "", "customerpod1", "PodNS1")
 
-	// allocate non-vnet IP for system  pod
+	// allocate non-vnet IP for pod in host network
 	expectedAssignedPods["192.168.0.1"] = cns.NewPodInfo("", "", "systempod", "kube-system")
 
 	expectedNcCount := len(svc.state.ContainerStatus)

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -86,7 +86,7 @@ func TestReconcileNCStatePrimaryIPChangeShouldFail(t *testing.T) {
 	}
 
 	// now try to reconcile the state where the NC primary IP has changed
-	resp := svc.ReconcileNCState(ncReqs, map[string]cns.PodInfo{}, &v1alpha.NodeNetworkConfig{})
+	resp := svc.ReconcileIPAMState(ncReqs, map[string]cns.PodInfo{}, &v1alpha.NodeNetworkConfig{})
 
 	assert.Equal(t, types.PrimaryCANotSame, resp)
 }
@@ -133,7 +133,7 @@ func TestReconcileNCStateGatewayChange(t *testing.T) {
 	}
 
 	// now try to reconcile the state where the NC gateway has changed
-	resp := svc.ReconcileNCState(ncReqs, map[string]cns.PodInfo{}, &v1alpha.NodeNetworkConfig{})
+	resp := svc.ReconcileIPAMState(ncReqs, map[string]cns.PodInfo{}, &v1alpha.NodeNetworkConfig{})
 
 	assert.Equal(t, types.Success, resp)
 	// assert the new state reflects the gateway update
@@ -330,7 +330,7 @@ func TestReconcileNCWithEmptyState(t *testing.T) {
 
 	expectedNcCount := len(svc.state.ContainerStatus)
 	expectedAssignedPods := make(map[string]cns.PodInfo)
-	returnCode := svc.ReconcileNCState(nil, expectedAssignedPods, &v1alpha.NodeNetworkConfig{
+	returnCode := svc.ReconcileIPAMState(nil, expectedAssignedPods, &v1alpha.NodeNetworkConfig{
 		Status: v1alpha.NodeNetworkConfigStatus{
 			Scaler: v1alpha.Scaler{
 				BatchSize:               batchSize,
@@ -380,7 +380,7 @@ func TestReconcileNCWithEmptyStateAndPendingRelease(t *testing.T) {
 		return pendingIPs
 	}()
 	req := generateNetworkContainerRequest(secondaryIPConfigs, "reconcileNc1", "-1")
-	returnCode := svc.ReconcileNCState([]*cns.CreateNetworkContainerRequest{req}, expectedAssignedPods, &v1alpha.NodeNetworkConfig{
+	returnCode := svc.ReconcileIPAMState([]*cns.CreateNetworkContainerRequest{req}, expectedAssignedPods, &v1alpha.NodeNetworkConfig{
 		Spec: v1alpha.NodeNetworkConfigSpec{
 			IPsNotInUse: pending,
 		},
@@ -427,7 +427,7 @@ func TestReconcileNCWithExistingStateAndPendingRelease(t *testing.T) {
 	req := generateNetworkContainerRequest(secondaryIPConfigs, "reconcileNc1", "-1")
 
 	expectedNcCount := len(svc.state.ContainerStatus)
-	returnCode := svc.ReconcileNCState([]*cns.CreateNetworkContainerRequest{req}, expectedAssignedPods, &v1alpha.NodeNetworkConfig{
+	returnCode := svc.ReconcileIPAMState([]*cns.CreateNetworkContainerRequest{req}, expectedAssignedPods, &v1alpha.NodeNetworkConfig{
 		Spec: v1alpha.NodeNetworkConfigSpec{
 			IPsNotInUse: maps.Keys(pendingIPIDs),
 		},
@@ -464,7 +464,7 @@ func TestReconcileNCWithExistingState(t *testing.T) {
 	}
 
 	expectedNcCount := len(svc.state.ContainerStatus)
-	returnCode := svc.ReconcileNCState([]*cns.CreateNetworkContainerRequest{req}, expectedAssignedPods, &v1alpha.NodeNetworkConfig{
+	returnCode := svc.ReconcileIPAMState([]*cns.CreateNetworkContainerRequest{req}, expectedAssignedPods, &v1alpha.NodeNetworkConfig{
 		Status: v1alpha.NodeNetworkConfigStatus{
 			Scaler: v1alpha.Scaler{
 				BatchSize:               batchSize,
@@ -508,7 +508,7 @@ func TestReconcileNCWithExistingStateFromInterfaceID(t *testing.T) {
 	}
 
 	expectedNcCount := len(svc.state.ContainerStatus)
-	returnCode := svc.ReconcileNCState([]*cns.CreateNetworkContainerRequest{req}, expectedAssignedPods, &v1alpha.NodeNetworkConfig{
+	returnCode := svc.ReconcileIPAMState([]*cns.CreateNetworkContainerRequest{req}, expectedAssignedPods, &v1alpha.NodeNetworkConfig{
 		Status: v1alpha.NodeNetworkConfigStatus{
 			Scaler: v1alpha.Scaler{
 				BatchSize:               batchSize,
@@ -551,7 +551,7 @@ func TestReconcileNCWithSystemPods(t *testing.T) {
 	expectedAssignedPods["192.168.0.1"] = cns.NewPodInfo("", "", "systempod", "kube-system")
 
 	expectedNcCount := len(svc.state.ContainerStatus)
-	returnCode := svc.ReconcileNCState([]*cns.CreateNetworkContainerRequest{req}, expectedAssignedPods, &v1alpha.NodeNetworkConfig{
+	returnCode := svc.ReconcileIPAMState([]*cns.CreateNetworkContainerRequest{req}, expectedAssignedPods, &v1alpha.NodeNetworkConfig{
 		Status: v1alpha.NodeNetworkConfigStatus{
 			Scaler: v1alpha.Scaler{
 				BatchSize:               batchSize,

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -406,8 +406,8 @@ func TestReconcileNCWithExistingStateAndPendingRelease(t *testing.T) {
 		secondaryIPConfigs[ipID.String()] = secIPConfig
 	}
 	expectedAssignedPods := map[string]cns.PodInfo{
-		"10.0.0.6": cns.NewPodInfo("", "", "reconcilePod1", "PodNS1"),
-		"10.0.0.7": cns.NewPodInfo("", "", "reconcilePod2", "PodNS1"),
+		"10.0.0.6": cns.NewPodInfo("some-guid-1", "58a0b427-eth0", "reconcilePod1", "PodNS1"),
+		"10.0.0.7": cns.NewPodInfo("some-guid-2", "45b9b555-eth0", "reconcilePod2", "PodNS1"),
 	}
 	pendingIPIDs := func() map[string]cns.PodInfo {
 		numPending := rand.Intn(len(secondaryIPConfigs)) + 1 //nolint:gosec // weak rand is sufficient in test
@@ -459,8 +459,8 @@ func TestReconcileNCWithExistingState(t *testing.T) {
 	req := generateNetworkContainerRequest(secondaryIPConfigs, "reconcileNc1", "-1")
 
 	expectedAssignedPods := map[string]cns.PodInfo{
-		"10.0.0.6": cns.NewPodInfo("", "", "reconcilePod1", "PodNS1"),
-		"10.0.0.7": cns.NewPodInfo("", "", "reconcilePod2", "PodNS1"),
+		"10.0.0.6": cns.NewPodInfo("some-guid-1", "abc-eth0", "reconcilePod1", "PodNS1"),
+		"10.0.0.7": cns.NewPodInfo("some-guid-2", "def-eth0", "reconcilePod2", "PodNS1"),
 	}
 
 	expectedNcCount := len(svc.state.ContainerStatus)
@@ -545,10 +545,10 @@ func TestReconcileNCWithSystemPods(t *testing.T) {
 	req := generateNetworkContainerRequest(secondaryIPConfigs, uuid.New().String(), "-1")
 
 	expectedAssignedPods := make(map[string]cns.PodInfo)
-	expectedAssignedPods["10.0.0.6"] = cns.NewPodInfo("", "", "customerpod1", "PodNS1")
+	expectedAssignedPods["10.0.0.6"] = cns.NewPodInfo("some-guid-1", "abc-eth0", "customerpod1", "PodNS1")
 
 	// Allocate non-vnet IP for system  pod
-	expectedAssignedPods["192.168.0.1"] = cns.NewPodInfo("", "", "systempod", "kube-system")
+	expectedAssignedPods["192.168.0.1"] = cns.NewPodInfo("some-guid-2", "def-eth0", "systempod", "kube-system")
 
 	expectedNcCount := len(svc.state.ContainerStatus)
 	returnCode := svc.ReconcileIPAMState([]*cns.CreateNetworkContainerRequest{req}, expectedAssignedPods, &v1alpha.NodeNetworkConfig{

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1017,13 +1017,13 @@ type nodeNetworkConfigGetter interface {
 	Get(context.Context) (*v1alpha.NodeNetworkConfig, error)
 }
 
-type ncStateReconciler interface {
-	ReconcileNCState(ncRequests []*cns.CreateNetworkContainerRequest, podInfoByIP map[string]cns.PodInfo, nnc *v1alpha.NodeNetworkConfig) cnstypes.ResponseCode
+type ipamStateReconciler interface {
+	ReconcileIPAMState(ncRequests []*cns.CreateNetworkContainerRequest, podInfoByIP map[string]cns.PodInfo, nnc *v1alpha.NodeNetworkConfig) cnstypes.ResponseCode
 }
 
 // TODO(rbtr) where should this live??
 // reconcileInitialCNSState initializes cns by passing pods and a CreateNetworkContainerRequest
-func reconcileInitialCNSState(ctx context.Context, cli nodeNetworkConfigGetter, ncReconciler ncStateReconciler, podInfoByIPProvider cns.PodInfoByIPProvider) error {
+func reconcileInitialCNSState(ctx context.Context, cli nodeNetworkConfigGetter, ipamReconciler ipamStateReconciler, podInfoByIPProvider cns.PodInfoByIPProvider) error {
 	// Get nnc using direct client
 	nnc, err := cli.Get(ctx)
 	if err != nil {
@@ -1073,8 +1073,8 @@ func reconcileInitialCNSState(ctx context.Context, cli nodeNetworkConfigGetter, 
 	}
 
 	// Call cnsclient init cns passing those two things.
-	if err := restserver.ResponseCodeToError(ncReconciler.ReconcileNCState(ncReqs, podInfoByIP, nnc)); err != nil {
-		return errors.Wrap(err, "failed to reconcile NC state")
+	if err := restserver.ResponseCodeToError(ipamReconciler.ReconcileIPAMState(ncReqs, podInfoByIP, nnc)); err != nil {
+		return errors.Wrap(err, "failed to reconcile CNS IPAM state")
 	}
 
 	return nil


### PR DESCRIPTION
**Reason for Change**:

Reconciliation after CNS restart is currently not handling dual stack scenarios correctly. There's 2 bugs:
- the information fetched from CNI currently filters out ipv6 addresses.
- reconciliation after restart processes multiple NCs separately, but pod info in CNS (or at least one representation of it) is not able to be patched after first insertion, meaning, a pod will be reconciliated with ipv4 first, and then skip the update with ipv6.

This PR modifies the main reconciliation function such that it takes multiple NCs as input, and processes all IPs for a single pod key (interface or name+namespace, depending on reconcile flow) at the same time, such that both ipv4 and ipv6 can be inserted once as `DesiredIPAddresses`.