### PR TITLE
ci: Add k8s network conformance tests to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ azure-ipam: azure-ipam-binary azure-ipam-archive
 
 revision: ## print the current git revision
 	@echo $(REVISION)
-	
+
 version: ## prints the root version
 	@echo $(ACN_VERSION)
 
@@ -161,15 +161,15 @@ cni-dropgz-test-version: ## prints the cni-dropgz version
 	@echo $(CNI_DROPGZ_TEST_VERSION)
 
 cns-version:
-	@echo $(CNS_VERSION) 
+	@echo $(CNS_VERSION)
 
 npm-version:
-	@echo $(NPM_VERSION) 
+	@echo $(NPM_VERSION)
 
 zapai-version: ## prints the zapai version
 	@echo $(ZAPAI_VERSION)
 
-##@ Binaries 
+##@ Binaries
 
 # Build the delegated IPAM plugin binary.
 azure-ipam-binary:
@@ -509,8 +509,8 @@ manifest-build: # util target to compose multiarch container manifests from plat
 			$(MAKE) manifest-add PLATFORM=$(PLATFORM);\
 		)\
 	)\
-		
-			
+
+
 
 manifest-push: # util target to push multiarch container manifest.
 	$(CONTAINER_BUILDER) manifest push --all $(IMAGE_REGISTRY)/$(IMAGE):$(TAG) docker://$(IMAGE_REGISTRY)/$(IMAGE):$(TAG)
@@ -534,7 +534,7 @@ acncli-manifest-push: ## push acncli multiplat container manifest
 acncli-skopeo-archive: ## export tar archive of acncli multiplat container manifest.
 	$(MAKE) manifest-skopeo-archive \
 		IMAGE=$(ACNCLI_IMAGE) \
-		TAG=$(ACN_VERSION) 
+		TAG=$(ACN_VERSION)
 
 cni-dropgz-manifest-build: ## build cni-dropgz multiplat container manifest.
 	$(MAKE) manifest-build \
@@ -692,7 +692,7 @@ ifeq ($(GOOS),linux)
 endif
 
 
-##@ Utils 
+##@ Utils
 
 clean: ## Clean build artifacts.
 	$(RMDIR) $(OUTPUT_DIR)
@@ -723,7 +723,7 @@ workspace: ## Set up the Go workspace.
 	go work use ./dropgz
 	go work use ./zapai
 
-##@ Test 
+##@ Test
 
 COVER_PKG ?= .
 #Restart case is used for cni load test pipeline for restarting the nodes cluster.
@@ -762,6 +762,15 @@ test-azure-ipam: ## run the unit test for azure-ipam
 kind:
 	kind create cluster --config ./test/kind/kind.yaml
 
+test-k8se2e: test-k8se2e-build test-k8se2e-only ## Alias to run build and test
+
+test-k8se2e-build: ## Build k8s e2e test suite
+	cd hack/scripts && bash ./k8se2e.sh $(GROUP) $(CLUSTER)
+	cd ../..
+
+test-k8se2e-only: ## Run k8s network conformance test, use TYPE=basic for only datapath tests
+	cd hack/scripts && bash ./k8se2e-tests.sh $(OS) $(TYPE)
+	cd ../..
 
 ##@ Utilities
 
@@ -781,7 +790,7 @@ gitconfig: ## configure the local git repository
 setup: tools install-hooks gitconfig ## performs common required repo setup
 
 
-##@ Tools 
+##@ Tools
 
 $(TOOLS_DIR)/go.mod:
 	cd $(TOOLS_DIR); go mod init && go mod tidy
@@ -791,7 +800,7 @@ $(CONTROLLER_GEN): $(TOOLS_DIR)/go.mod
 
 controller-gen: $(CONTROLLER_GEN) ## Build controller-gen
 
-protoc: 
+protoc:
 	source ${REPO_ROOT}/scripts/install-protoc.sh
 
 $(GOCOV): $(TOOLS_DIR)/go.mod
@@ -824,13 +833,13 @@ $(MOCKGEN): $(TOOLS_DIR)/go.mod
 
 mockgen: $(MOCKGEN) ## Build mockgen
 
-clean-tools: 
+clean-tools:
 	rm -r build/tools/bin
 
 tools: acncli gocov gocov-xml go-junit-report golangci-lint gofumpt protoc ## Build bins for build tools
 
 
-##@ Help 
+##@ Help
 
 help: ## Display this help
-	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[0-9a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -61,6 +61,16 @@ vars: ## Show the input vars configured for the cluster commands
 	@echo NODE_COUNT=$(NODE_COUNT)
 	@echo VMSS_NAME=$(VMSS_NAME)
 
+##@ k8s Network conformance tests
+
+k8se2e: k8se2e-build k8se2e-test ## Alias to run build and test
+
+k8se2e-build: ## Build k8s e2e test suite
+	cd ../scripts && bash ./k8se2e.sh $(GROUP) $(CLUSTER)
+
+k8se2e-test: ## Run k8s network conformance test
+	cd ../scripts && bash ./k8se2e-tests.sh $(OS) $(TYPE)
+
 
 ##@ SWIFT Infra
 

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -25,16 +25,16 @@ VNET       ?= $(CLUSTER)
 ##@ Help
 
 help:  ## Display this help
-	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[0-9a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 
 ##@ Utilities
 
-azlogin:
+azlogin: ## Login and set account to $SUB
 	@$(AZCLI) login
 	@$(AZCLI) account set -s $(SUB)
 
-azcfg:
+azcfg: ## Set the $AZCLI to use aks-preview
 	@$(AZCLI) extension add --name aks-preview --yes
 	@$(AZCLI) extension update --name aks-preview
 
@@ -222,7 +222,7 @@ windows-cniv1-up: rg-up overlay-net-up ## Bring up a Windows CNIv1 cluster
 
 	@$(MAKE) set-kubeconf
 
-linux-cniv1-up: rg-up overlay-net-up
+linux-cniv1-up: rg-up overlay-net-up ## Bring up a Linux CNIv1 cluster
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
 		--node-count $(NODE_COUNT) \
 		--node-vm-size $(VM_SIZE) \

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -50,6 +50,14 @@ unset-kubeconf: ## Deletes the kubeconf for $CLUSTER
 shell: ## print $AZCLI so it can be used outside of make
 	@echo $(AZCLI)
 
+k8se2e: k8se2e-build k8se2e-test ## Alias to run build and test
+
+k8se2e-build: ## Build k8s e2e test suite
+	cd ../scripts && bash ./k8se2e.sh $(GROUP) $(CLUSTER)
+
+k8se2e-test: ## Run k8s network conformance test, use TYPE=basic for only datapath tests
+	cd ../scripts && bash ./k8se2e-tests.sh $(OS) $(TYPE)
+
 vars: ## Show the input vars configured for the cluster commands
 	@echo CLUSTER=$(CLUSTER)
 	@echo GROUP=$(GROUP)
@@ -60,16 +68,6 @@ vars: ## Show the input vars configured for the cluster commands
 	@echo VM_SIZE=$(VM_SIZE)
 	@echo NODE_COUNT=$(NODE_COUNT)
 	@echo VMSS_NAME=$(VMSS_NAME)
-
-##@ k8s Network conformance tests
-
-k8se2e: k8se2e-build k8se2e-test ## Alias to run build and test
-
-k8se2e-build: ## Build k8s e2e test suite
-	cd ../scripts && bash ./k8se2e.sh $(GROUP) $(CLUSTER)
-
-k8se2e-test: ## Run k8s network conformance test
-	cd ../scripts && bash ./k8se2e-tests.sh $(OS) $(TYPE)
 
 
 ##@ SWIFT Infra

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -50,14 +50,6 @@ unset-kubeconf: ## Deletes the kubeconf for $CLUSTER
 shell: ## print $AZCLI so it can be used outside of make
 	@echo $(AZCLI)
 
-k8se2e: k8se2e-build k8se2e-test ## Alias to run build and test
-
-k8se2e-build: ## Build k8s e2e test suite
-	cd ../scripts && bash ./k8se2e.sh $(GROUP) $(CLUSTER)
-
-k8se2e-test: ## Run k8s network conformance test, use TYPE=basic for only datapath tests
-	cd ../scripts && bash ./k8se2e-tests.sh $(OS) $(TYPE)
-
 vars: ## Show the input vars configured for the cluster commands
 	@echo CLUSTER=$(CLUSTER)
 	@echo GROUP=$(GROUP)

--- a/hack/aks/README.md
+++ b/hack/aks/README.md
@@ -13,6 +13,9 @@ Utilities
   set-kubeconf     Adds the kubeconf for $CLUSTER
   unset-kubeconf   Deletes the kubeconf for $CLUSTER
   shell            print $AZCLI so it can be used outside of make
+  k8se2e           Alias for single command to build and test k8se2e
+  k8se2e-build     Build k8se2e tests based off $CLUSTER
+  k8se2e-test      Run k8se2e tests based off $CLUSTER and $OS
 
 SWIFT Infra
   vars             Show the env vars configured for the swift command

--- a/hack/aks/README.md
+++ b/hack/aks/README.md
@@ -13,9 +13,6 @@ Utilities
   set-kubeconf     Adds the kubeconf for $CLUSTER
   unset-kubeconf   Deletes the kubeconf for $CLUSTER
   shell            print $AZCLI so it can be used outside of make
-  k8se2e           Alias for single command to build and test k8se2e
-  k8se2e-build     Build k8se2e tests based off $CLUSTER
-  k8se2e-test      Run k8se2e tests based off $CLUSTER and $OS
 
 SWIFT Infra
   vars             Show the env vars configured for the swift command

--- a/hack/scripts/k8se2e-tests.sh
+++ b/hack/scripts/k8se2e-tests.sh
@@ -1,0 +1,61 @@
+# Taint Linux nodes so that windows tests do not run on them and ensure no LinuxOnly tests run on windows nodes
+if [[ 'windows' == $OS ]]
+then
+SKIP="|LinuxOnly"
+kubectl taint nodes -l kubernetes.azure.com/mode=system node-role.kubernetes.io/control-plane:NoSchedule
+fi
+
+
+
+if [[ 'basic' == $TYPE ]]
+then
+echo "Testing Datapath"
+echo "./ginkgo --nodes=4 \
+./e2e.test -- \
+--num-nodes=2 \
+--provider=skeleton \
+--ginkgo.focus='(.*).Networking.should|(.*).Networking.Granular|(.*)kubernetes.api' \
+--ginkgo.skip='SCTP|Disruptive|Slow|hostNetwork|kube-proxy|IPv6' \
+--ginkgo.flakeAttempts=3 \
+--ginkgo.v \
+--node-os-distro=$OS \
+--kubeconfig=$HOME/.kube/config"
+./ginkgo --nodes=4 \
+./e2e.test -- \
+--num-nodes=2 \
+--provider=skeleton \
+--ginkgo.focus='(.*).Networking.should|(.*).Networking.Granular|(.*)kubernetes.api' \
+--ginkgo.skip='SCTP|Disruptive|Slow|hostNetwork|kube-proxy|IPv6' \
+--ginkgo.flakeAttempts=3 \
+--ginkgo.v \
+--node-os-distro=$OS \
+--kubeconfig=$HOME/.kube/config
+else
+echo "Testing Datapath, DNS, PortForward, Service, and Hostport"
+echo "./ginkgo --nodes=4 \
+./e2e.test -- \
+--num-nodes=2 \
+--provider=skeleton \
+--ginkgo.focus='(.*).Networking.should|(.*).Networking.Granular|(.*)kubernetes.api|\[sig-network\].DNS.should|\[sig-cli\].Kubectl.Port|Services.*\[Conformance\].*|\[sig-network\](.*)HostPort|\[sig-scheduling\](.*)hostPort' \
+--ginkgo.skip='SCTP|Disruptive|Slow|hostNetwork|kube-proxy|IPv6|resolv|exists conflict$SKIP' \
+--ginkgo.flakeAttempts=3 \
+--ginkgo.v \
+--node-os-distro=$OS \
+--kubeconfig=$HOME/.kube/config"
+./ginkgo --nodes=4 \
+./e2e.test -- \
+--num-nodes=2 \
+--provider=skeleton \
+--ginkgo.focus='(.*).Networking.should|(.*).Networking.Granular|(.*)kubernetes.api|\[sig-network\].DNS.should|\[sig-cli\].Kubectl.Port|Services.*\[Conformance\].*|\[sig-network\](.*)HostPort|\[sig-scheduling\](.*)hostPort' \
+--ginkgo.skip="SCTP|Disruptive|Slow|hostNetwork|kube-proxy|IPv6|resolv|exists conflict$SKIP" \
+--ginkgo.flakeAttempts=3 \
+--ginkgo.v \
+--node-os-distro=$OS \
+--kubeconfig=$HOME/.kube/config
+fi
+
+# Untaint Linux nodes once testing is complete
+if [[ 'windows' == $OS ]]
+then
+kubectl taint nodes -l kubernetes.azure.com/mode=system node-role.kubernetes.io/control-plane:NoSchedule-
+fi

--- a/hack/scripts/k8se2e.sh
+++ b/hack/scripts/k8se2e.sh
@@ -1,7 +1,7 @@
-echo "-g $GROUP -n $CLUSTER"
+echo "Cluster -g $GROUP -n $CLUSTER"
 
 eval k8sVersion="v"$( az aks show -g $GROUP -n $CLUSTER --query "currentKubernetesVersion")
-echo "$k8sversion e2e Test Suite"
+echo $k8sVersion "e2e Test Suite"
 
 curl -L https://dl.k8s.io/$k8sVersion/kubernetes-test-linux-amd64.tar.gz -o ./kubernetes-test-linux-amd64.tar.gz
 

--- a/hack/scripts/k8se2e.sh
+++ b/hack/scripts/k8se2e.sh
@@ -1,0 +1,8 @@
+echo "-g $GROUP -n $CLUSTER"
+
+eval k8sVersion="v"$( az aks show -g $GROUP -n $CLUSTER --query "currentKubernetesVersion")
+echo "$k8sversion e2e Test Suite"
+
+curl -L https://dl.k8s.io/$k8sVersion/kubernetes-test-linux-amd64.tar.gz -o ./kubernetes-test-linux-amd64.tar.gz
+
+tar -xvzf kubernetes-test-linux-amd64.tar.gz --strip-components=3 kubernetes/test/bin/ginkgo kubernetes/test/bin/e2e.test


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Allows for users to test cluster network conformance from the command line and give a single command to test network conformance in future CI.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
-  [x] relevant PR labels added

**Notes**:
Example commands:
 - make -C ./hack/aks/ test-k8se2e CLUSTER=yourClusterName GROUP=resourceGroup OS=windows TYPE=basic
 - make -C ./hack/aks/ test-k8se2e CLUSTER=yourClusterName GROUP=resourceGroup