### PR TITLE
chore: log process id instead of logging name

### DIFF
--- a/cni/log/logger.go
+++ b/cni/log/logger.go
@@ -47,7 +47,7 @@ func newFileLogger(cfg *Config) *zap.Logger {
 
 	core := zapcore.NewCore(jsonEncoder, logFileWriter, logLevel)
 	Logger = zap.New(core)
-	Logger = Logger.With(zap.Int("pid", os.Getgid()))
+	Logger = Logger.With(zap.Int("pid", os.Getpid()))
 
 	return Logger.Named("")
 }

--- a/cni/log/logger.go
+++ b/cni/log/logger.go
@@ -3,6 +3,7 @@ package log
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -46,6 +47,7 @@ func newFileLogger(cfg *Config) *zap.Logger {
 
 	core := zapcore.NewCore(jsonEncoder, logFileWriter, logLevel)
 	Logger = zap.New(core)
+	Logger = Logger.With(zap.Int("pid", os.Getgid()))
 
-	return Logger.Named(cfg.Name)
+	return Logger.Named("")
 }

--- a/cni/log/logger.go
+++ b/cni/log/logger.go
@@ -49,5 +49,5 @@ func newFileLogger(cfg *Config) *zap.Logger {
 	Logger = zap.New(core)
 	Logger = Logger.With(zap.Int("pid", os.Getpid()))
 
-	return Logger.Named("")
+	return Logger
 }


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
This PR is to get rid of repeated "logger: azure-vnet" name. Instead, it will print the process id, such as : "pid":301

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**New logs on Linux:**
```
{"level":"info","ts":"2023-08-11T02:14:30.471Z","msg":"Plugin Info","pid":299160,"name":"azure-vnet","version":"v1.5.9-9-gd589d7df","component":"cni-net"}
2023/08/11 02:14:30 [299160] [net] Restored state
{"level":"info","ts":"2023-08-11T02:14:30.471Z","msg":"Plugin started","pid":299160,"component":"cni-net"}
{"level":"info","ts":"2023-08-11T02:14:30.471Z","msg":"[cni-net] Processing ADD command","pid":299160,"containerId":"0ffde0741e3e96ac0394991ae0fa86f01ffdcb39acdd0877c04843de7a8f7a6d","netNS":"/var/run/netns/cni-039e1fc6-101e-4e19-692d-645048038cb0","ifName":"eth0","args":"K8S_POD_UID=38b85cf6-29ea-4357-90ef-45a3360717d8;IgnoreUnknown=1;K8S_POD_NAMESPACE=default;K8S_POD_NAME=linux-pod2;K8S_POD_INFRA_CONTAINER_ID=0ffde0741e3e96ac0394991ae0fa86f01ffdcb39acdd0877c04843de7a8f7a6d","path":"/opt/cni/bin","stdinData":"{\"cniVersion\":\"0.3.0\",\"ipam\":{\"mode\":\"overlay\",\"type\":\"azure-cns\"},\"ipsToRouteViaHost\":[\"169.254.20.10\"],\"mode\":\"transparent\",\"name\":\"azure\",\"type\":\"azure-vnet\"}"}
{"level":"info","ts":"2023-08-11T02:14:30.472Z","msg":"[cni-net] Found network with subnet","pid":299160,"network":"azure","subnet":"10.244.0.0/16"}
{"level":"info","ts":"2023-08-11T02:14:30.472Z","msg":"linux-pod2","pid":299160}
{"level":"info","ts":"2023-08-11T02:14:30.472Z","msg":"Requesting IP for pod using ipconfig","pid":299160,"pod":{"PodName":"linux-pod2","PodNamespace":"default"},"ipconfig":{"desiredIPAddresses":null,"podInterfaceID":"0ffde074-eth0","infraContainerID":"0ffde0741e3e96ac0394991ae0fa86f01ffdcb39acdd0877c04843de7a8f7a6d","orchestratorContext":{"PodName":"linux-pod2","PodNamespace":"default"},"ifname":""}}
{"level":"info","ts":"2023-08-11T02:14:30.476Z","msg":"Received info for pod",**"pid":299160**,"ipv4info":{},"podInfo":{"PodName":"linux-pod2","PodNamespace":"default"},"component":"cni-invoker-cns"}
{"level":"info","ts":"2023-08-11T02:14:30.476Z","msg":"Received info for pod","pid":299160,"ipv4info":{},"podInfo":{"PodName":"linux-pod2","PodNamespace":"default"},"component":"cni-invoker-cns"}
{"level":"info","ts":"2023-08-11T02:14:30.477Z","msg":"[cni-net] Creating endpoint","pid":299160,"endpointInfo":"Id:0ffde074-eth0 ContainerID:0ffde0741e3e96ac0394991ae0fa86f01ffdcb39acdd0877c04843de7a8f7a6d NetNsPath:/var/run/netns/cni-039e1fc6-101e-4e19-692d-645048038cb0 IfName:eth0 IfIndex:0 MacAddr: IPAddrs:[{10.244.1.71 ffff0000} {fdad:db03:a8b6:1a06::154 ffffffffffffffff0000000000000000}] Gateways:[] Data:map[vethname:default.linux-pod2]"}
```

**New logs on Windows:**
{"level":"info","ts":"2023-08-11T02:27:30.090Z","msg":"Plugin started","pid":5112,"component":"cni-net"}
{"level":"info","ts":"2023-08-11T02:27:30.090Z","msg":"[cni-net] Processing DEL command","pid":5112,"containerId":"a02bd997aaec32e8356286bc6411eb7ba6ed273bf7140716eacf35965233e46a","netNS":"c46f1949-30b1-4d44-be62-6ac58263d28c","ifName":"eth0","args":"IgnoreUnknown=1;K8S_POD_NAMESPACE=kube-system;K8S_POD_NAME=csi-azurefile-node-win-5xrfh;K8S_POD_INFRA_CONTAINER_ID=a02bd997aaec32e8356286bc6411eb7ba6ed273bf7140716eacf35965233e46a;K8S_POD_UID=e9aa3235-0205-4372-871e-56ada83c6ae0","path":"c:/k/azurecni/bin","stdinData":"{\"AdditionalArgs\":[{\"Name\":\"EndpointPolicy\",\"Value\":{\"ExceptionList\":[\"10.244.0.0/16\"],\"Type\":\"OutBoundNAT\"}},{\"Name\":\"EndpointPolicy\",\"Value\":{\"ExceptionList\":[\"fdad:db03:a8b6:1a06::/64\"],\"Type\":\"OutBoundNAT\"}},{\"Name\":\"EndpointPolicy\",\"Value\":{\"Action\":\"Block\",\"Direction\":\"Out\",\"Priority\":200,\"Protocols\":\"6\",\"RemoteAddresses\":\"168.63.129.16/32\",\"RemotePorts\":\"80\",\"RuleType\":\"Switch\",\"Type\":\"ACL\"}},{\"Name\":\"EndpointPolicy\",\"Value\":{\"Action\":\"Allow\",\"Direction\":\"In\",\"Priority\":65500,\"Type\":\"ACL\"}},{\"Name\":\"EndpointPolicy\",\"Value\":{\"Action\":\"Allow\",\"Direction\":\"Out\",\"Priority\":65500,\"Type\":\"ACL\"}}],\"bridge\":\"azure0\",\"capabilities\":{\"dns\":true,\"portMappings\":true},\"cniVersion\":\"0.3.0\",\"dns\":{\"Nameservers\":[\"10.0.0.10\",\"168.63.129.16\"],\"Search\":[\"svc.cluster.local\"]},\"executionMode\":\"v4swift\",\"ipam\":{\"mode\":\"v4overlay\",\"type\":\"azure-cns\"},\"mode\":\"bridge\",\"name\":\"azure\",\"runtimeConfig\":{\"dns\":{\"Servers\":[\"10.0.0.10\"],\"Searches\":[\"kube-system.svc.cluster.local\",\"svc.cluster.local\",\"cluster.local\"],\"Options\":[\"ndots:5\"]}},\"type\":\"azure-vnet\",\"windowsSettings\":{\"enableLoopbackDSR\":true}}"}
{"level":"info","ts":"2023-08-11T02:27:30.091Z","msg":"Execution mode","pid":5112,"mode":"v4swift"}
{"level":"info","ts":"2023-08-11T02:27:30.091Z","msg":"[cni-net] Endpoints to be deleted","pid":5112,"count":1}
{"level":"error","ts":"2023-08-11T02:27:30.091Z","msg":"[cni-net] Failed to query network","pid":5112,"network":"azure","error":"Network not found"}
{"level":"info","ts":"2023-08-11T02:27:30.091Z","msg":"[cni-net] DEL command completed","pid":5112,"pod":"csi-azurefile-node-win-5xrfh"}
{"level":"info","ts":"2023-08-11T02:27:30.091Z","msg":"Plugin stopped","pid":5112,"component":"cni-net"}
2023/08/11 02:27:30 [5112] Released process lock


the nonsense <"logger": "azure-vnet"> is gone and "pid": <number> is added

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
