### PR TITLE
ci: Enable /azp run for submodule pipeline

### DIFF
--- a/.pipelines/submodules-pipeline.yaml
+++ b/.pipelines/submodules-pipeline.yaml
@@ -8,6 +8,7 @@ pr:
     - "azure-ipam/*"
     - "dropgz/*"
     - "cni/*"
+    - ".pipelines/submodules-pipeline.yaml" # Enable /azp run Azure Container Networking PR - submodules
     exclude:
     - "*"
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Enables the use of [comment triggers](https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers) for the submodules pipeline. `.pipelines/submodules-pipeline.yaml` was excluded from the triggers and prevented ` /azp run Azure Container Networking PR - submodules ` from being called to run the pipeline.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**: