### PR TITLE
Adding CNS/CNI v1.5.4 for vNetBlock E2E testing

### DIFF
--- a/.pipelines/mdnc/azure-cns-cni-1.5.4.yaml
+++ b/.pipelines/mdnc/azure-cns-cni-1.5.4.yaml
@@ -96,7 +96,7 @@ spec:
           effect: NoSchedule
       initContainers:
         - name: init-cni-dropgz
-          image: "acnpublic.azurecr.io/containernetworking/mdnc-cni-dropgz" # CNI 1.4.35
+          image: "mcr.microsoft.com/containernetworking/cni-dropgz:v0.0.9" # CNI 1.5.4
           imagePullPolicy: IfNotPresent
           command: ["/dropgz"]
           args: ["deploy" , "azure-vnet", "-o", "/opt/cni/bin/azure-vnet", "azure-vnet-telemetry", "-o", "/opt/cni/bin/azure-vnet-telemetry", "azure-swift.conflist", "-o", "/etc/cni/net.d/10-azure.conflist"]
@@ -107,7 +107,7 @@ spec:
               mountPath: /etc/cni/net.d
       containers:
         - name: cns-container
-          image: mcr.microsoft.com/containernetworking/azure-cns:v1.4.32
+          image: mcr.microsoft.com/containernetworking/azure-cns:v1.5.4
           imagePullPolicy: IfNotPresent
           args: [ "-c", "tcp://$(CNSIpAddress):$(CNSPort)", "-t", "$(CNSLogTarget)"]
           volumeMounts:


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
This PR is adding a new yaml file used by our E2E test pipeline in order to be able to test vNetBlock feature e2e (which requires cns changes present in v1.5.4).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
