### PR TITLE
zap: change cni component structure

### DIFF
--- a/cni/ipam/ipam.go
+++ b/cni/ipam/ipam.go
@@ -62,29 +62,25 @@ func (plugin *ipamPlugin) Start(config *common.PluginConfig) error {
 	// Initialize base plugin.
 	err := plugin.Initialize(config)
 	if err != nil {
-		log.Logger.Error("Failed to initialize base plugin.",
-			zap.Error(err), zap.String("component", "cni-ipam"))
+		log.Logger.Error("Failed to initialize base plugin.", zap.Error(err))
 		return err
 	}
 
 	// Log platform information.
 	log.Logger.Info("Plugin version.", zap.String("name", plugin.Name),
-		zap.String("version", plugin.Version),
-		zap.String("component", "cni-ipam"))
+		zap.String("version", plugin.Version))
 	log.Logger.Info("Running on",
-		zap.String("platform", platform.GetOSInfo()),
-		zap.String("component", "cni-ipam"))
+		zap.String("platform", platform.GetOSInfo()))
 
 	// Initialize address manager. rehyrdration not required on reboot for cni ipam plugin
 	err = plugin.am.Initialize(config, false, plugin.Options)
 	if err != nil {
 		log.Logger.Error("Failed to initialize address manager",
-			zap.String("error", err.Error()),
-			zap.String("component", "cni-ipam"))
+			zap.String("error", err.Error()))
 		return err
 	}
 
-	log.Logger.Info("Plugin started", zap.String("component", "cni-ipam"))
+	log.Logger.Info("Plugin started")
 
 	return nil
 }
@@ -93,7 +89,7 @@ func (plugin *ipamPlugin) Start(config *common.PluginConfig) error {
 func (plugin *ipamPlugin) Stop() {
 	plugin.am.Uninitialize()
 	plugin.Uninitialize()
-	log.Logger.Info("Plugin stopped", zap.String("component", "cni-ipam"))
+	log.Logger.Info("Plugin stopped")
 }
 
 // Configure parses and applies the given network configuration.
@@ -105,8 +101,7 @@ func (plugin *ipamPlugin) Configure(stdinData []byte) (*cni.NetworkConfig, error
 	}
 
 	log.Logger.Info("Read network configuration",
-		zap.Any("config", nwCfg),
-		zap.String("component", "cni-ipam"))
+		zap.Any("config", nwCfg))
 
 	// Apply IPAM configuration.
 
@@ -151,14 +146,12 @@ func (plugin *ipamPlugin) Add(args *cniSkel.CmdArgs) error {
 		zap.String("IfName", args.IfName),
 		zap.String("Args", args.Args),
 		zap.String("Path", args.Path),
-		zap.ByteString("StdinData", args.StdinData),
-		zap.String("component", "cni-ipam"))
+		zap.ByteString("StdinData", args.StdinData))
 
 	defer func() {
 		log.Logger.Info("ADD command completed",
 			zap.Any("result", result),
-			zap.Any("error:", err),
-			zap.String("component", "cni-ipam"))
+			zap.Any("error:", err))
 	}()
 
 	// Parse network configuration from stdin.
@@ -196,8 +189,7 @@ func (plugin *ipamPlugin) Add(args *cniSkel.CmdArgs) error {
 		defer func() {
 			if err != nil && poolID != "" {
 				log.Logger.Info("Releasing pool",
-					zap.String("poolId", poolID),
-					zap.String("component", "cni-ipam"))
+					zap.String("poolId", poolID))
 				_ = plugin.am.ReleasePool(nwCfg.IPAM.AddrSpace, poolID)
 			}
 		}()
@@ -205,8 +197,7 @@ func (plugin *ipamPlugin) Add(args *cniSkel.CmdArgs) error {
 		nwCfg.IPAM.Subnet = subnet
 		log.Logger.Info("Allocated address with subnet",
 			zap.String("poolId", poolID),
-			zap.String("subnet", subnet),
-			zap.String("component", "cni-ipam"))
+			zap.String("subnet", subnet))
 	}
 
 	// Allocate an address for the endpoint.
@@ -219,16 +210,12 @@ func (plugin *ipamPlugin) Add(args *cniSkel.CmdArgs) error {
 	// On failure, release the address.
 	defer func() {
 		if err != nil && address != "" {
-			log.Logger.Info("Releasing address",
-				zap.String("address", address),
-				zap.String("component", "cni-ipam"))
+			log.Logger.Info("Releasing address", zap.String("address", address))
 			_ = plugin.am.ReleaseAddress(nwCfg.IPAM.AddrSpace, nwCfg.IPAM.Subnet, address, options)
 		}
 	}()
 
-	log.Logger.Info("Allocated address",
-		zap.String("address", address),
-		zap.String("component", "cni-ipam"))
+	log.Logger.Info("Allocated address", zap.String("address", address))
 
 	// Parse IP address.
 	ipAddress, err := platform.ConvertStringToIPNet(address)

--- a/cni/ipam/plugin/main.go
+++ b/cni/ipam/plugin/main.go
@@ -20,6 +20,7 @@ const (
 	name               = "azure-vnet-ipam"
 	maxLogFileSizeInMb = 5
 	maxLogFileCount    = 8
+	component          = "cni"
 )
 
 // Version is populated by make during build.
@@ -48,6 +49,7 @@ func main() {
 		MaxSizeInMB: maxLogFileSizeInMb,
 		MaxBackups:  maxLogFileCount,
 		Name:        name,
+		Component:   component,
 	}
 	zaplog.Initialize(ctx, loggerCfg)
 

--- a/cni/ipam/pluginv6/main.go
+++ b/cni/ipam/pluginv6/main.go
@@ -20,6 +20,7 @@ const (
 	name               = "azure-vnet-ipamv6"
 	maxLogFileSizeInMb = 5
 	maxLogFileCount    = 8
+	component          = "cni"
 )
 
 // Version is populated by make during build.
@@ -48,6 +49,7 @@ func main() {
 		MaxSizeInMB: maxLogFileSizeInMb,
 		MaxBackups:  maxLogFileCount,
 		Name:        name,
+		Component:   component,
 	}
 	zaplog.Initialize(ctx, loggerCfg)
 

--- a/cni/log/logger.go
+++ b/cni/log/logger.go
@@ -16,6 +16,7 @@ type Config struct {
 	MaxSizeInMB int
 	MaxBackups  int
 	Name        string
+	Component   string
 }
 
 var Logger *zap.Logger
@@ -48,6 +49,7 @@ func newFileLogger(cfg *Config) *zap.Logger {
 	core := zapcore.NewCore(jsonEncoder, logFileWriter, logLevel)
 	Logger = zap.New(core)
 	Logger = Logger.With(zap.Int("pid", os.Getpid()))
+	Logger = Logger.With(zap.String("component", cfg.Component))
 
 	return Logger
 }

--- a/cni/log/logger.go
+++ b/cni/log/logger.go
@@ -3,7 +3,6 @@ package log
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -48,7 +47,6 @@ func newFileLogger(cfg *Config) *zap.Logger {
 
 	core := zapcore.NewCore(jsonEncoder, logFileWriter, logLevel)
 	Logger = zap.New(core)
-	Logger = Logger.With(zap.Int("pid", os.Getpid()))
 	Logger = Logger.With(zap.String("component", cfg.Component))
 
 	return Logger

--- a/cni/log/logger.go
+++ b/cni/log/logger.go
@@ -3,6 +3,8 @@ package log
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -47,7 +49,8 @@ func newFileLogger(cfg *Config) *zap.Logger {
 
 	core := zapcore.NewCore(jsonEncoder, logFileWriter, logLevel)
 	Logger = zap.New(core)
+	Logger = Logger.With(zap.Int("pid", os.Getpid()))
 	Logger = Logger.With(zap.String("component", cfg.Component))
 
-	return Logger
+	return Logger.Named("pid").Named(strconv.Itoa(os.Getpid()))
 }

--- a/cni/log/logger.go
+++ b/cni/log/logger.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -52,5 +51,5 @@ func newFileLogger(cfg *Config) *zap.Logger {
 	Logger = Logger.With(zap.Int("pid", os.Getpid()))
 	Logger = Logger.With(zap.String("component", cfg.Component))
 
-	return Logger.Named("pid").Named(strconv.Itoa(os.Getpid()))
+	return Logger
 }

--- a/cni/network/invoker_azure.go
+++ b/cni/network/invoker_azure.go
@@ -104,9 +104,7 @@ func (invoker *AzureIPAMInvoker) Add(addConfig IPAMAddConfig) (IPAMAddResult, er
 func (invoker *AzureIPAMInvoker) deleteIpamState() {
 	cniStateExists, err := platform.CheckIfFileExists(platform.CNIStateFilePath)
 	if err != nil {
-		log.Logger.Error("Error checking CNI state exist",
-			zap.Error(err),
-			zap.String("component", "cni"))
+		log.Logger.Error("Error checking CNI state exist", zap.Error(err))
 		return
 	}
 
@@ -116,15 +114,15 @@ func (invoker *AzureIPAMInvoker) deleteIpamState() {
 
 	ipamStateExists, err := platform.CheckIfFileExists(platform.CNIIpamStatePath)
 	if err != nil {
-		log.Logger.Error("Error checking IPAM state exist", zap.Error(err), zap.String("component", "cni"))
+		log.Logger.Error("Error checking IPAM state exist", zap.Error(err))
 		return
 	}
 
 	if ipamStateExists {
-		log.Logger.Info("Deleting IPAM state file", zap.String("component", "cni"))
+		log.Logger.Info("Deleting IPAM state file")
 		err = os.Remove(platform.CNIIpamStatePath)
 		if err != nil {
-			log.Logger.Error("Error deleting state file", zap.Error(err), zap.String("component", "cni"))
+			log.Logger.Error("Error deleting state file", zap.Error(err))
 			return
 		}
 	}

--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -137,8 +137,7 @@ func (invoker *CNSIPAMInvoker) Add(addConfig IPAMAddConfig) (IPAMAddResult, erro
 
 		log.Logger.Info("Received info for pod",
 			zap.Any("ipv4info", info),
-			zap.Any("podInfo", podInfo),
-			zap.String("component", "cni-invoker-cns"))
+			zap.Any("podInfo", podInfo))
 		ip, ncIPNet, err := net.ParseCIDR(info.podIPAddress + "/" + fmt.Sprint(info.ncSubnetPrefix))
 		if ip == nil {
 			return IPAMAddResult{}, errors.Wrap(err, "Unable to parse IP from response: "+info.podIPAddress+" with err %w")

--- a/cni/network/multitenancy.go
+++ b/cni/network/multitenancy.go
@@ -89,8 +89,7 @@ func (m *Multitenancy) DetermineSnatFeatureOnHost(snatFile, nmAgentSupportedApis
 		jsonFile.Close()
 		if retrieveSnatConfigErr = json.Unmarshal(bytes, &snatConfig); retrieveSnatConfigErr != nil {
 			log.Logger.Error("failed to unmarshal to snatConfig with error %v",
-				zap.Error(retrieveSnatConfigErr),
-				zap.String("component", "cni-net"))
+				zap.Error(retrieveSnatConfigErr))
 		}
 	}
 
@@ -128,8 +127,7 @@ func (m *Multitenancy) DetermineSnatFeatureOnHost(snatFile, nmAgentSupportedApis
 					} else {
 						log.Logger.Error("failed to save snat settings",
 							zap.String("snatConfgFile", snatConfigFile),
-							zap.Error(err),
-							zap.String("component", "cni-net"))
+							zap.Error(err))
 					}
 				}
 			} else {
@@ -141,26 +139,21 @@ func (m *Multitenancy) DetermineSnatFeatureOnHost(snatFile, nmAgentSupportedApis
 	// Log and return the error when we fail acquire snat configuration for host and dns
 	if retrieveSnatConfigErr != nil {
 		log.Logger.Error("failed to acquire SNAT configuration with error %v",
-			zap.Error(retrieveSnatConfigErr),
-			zap.String("component", "cni-net"))
+			zap.Error(retrieveSnatConfigErr))
 		return snatConfig.EnableSnatForDns, snatConfig.EnableSnatOnHost, retrieveSnatConfigErr
 	}
 
 	log.Logger.Info("saved snat settings",
 		zap.Any("snatConfig", snatConfig),
-		zap.String("snatConfigfile", snatConfigFile),
-		zap.String("component", "cni-net"))
+		zap.String("snatConfigfile", snatConfigFile))
 	if snatConfig.EnableSnatOnHost {
-		log.Logger.Info("enabling SNAT on container host for outbound connectivity",
-			zap.String("component", "cni-net"))
+		log.Logger.Info("enabling SNAT on container host for outbound connectivity")
 	}
 	if snatConfig.EnableSnatForDns {
-		log.Logger.Info("enabling SNAT on container host for DNS traffic",
-			zap.String("component", "cni-net"))
+		log.Logger.Info("enabling SNAT on container host for DNS traffic")
 	}
 	if !snatConfig.EnableSnatForDns && !snatConfig.EnableSnatOnHost {
-		log.Logger.Info("disabling SNAT on container host",
-			zap.String("component", "cni-net"))
+		log.Logger.Info("disabling SNAT on container host")
 	}
 
 	return snatConfig.EnableSnatForDns, snatConfig.EnableSnatOnHost, nil

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -150,19 +150,16 @@ func (plugin *NetPlugin) Start(config *common.PluginConfig) error {
 	// Log platform information.
 	log.Logger.Info("Plugin Info",
 		zap.String("name", plugin.Name),
-		zap.String("version", plugin.Version),
-		zap.String("component", "cni-net"))
+		zap.String("version", plugin.Version))
 
 	// Initialize network manager. rehyrdration not required on reboot for cni plugin
 	err = plugin.nm.Initialize(config, false)
 	if err != nil {
-		log.Logger.Error("Failed to initialize network manager",
-			zap.Error(err),
-			zap.String("component", "cni-net"))
+		log.Logger.Error("Failed to initialize network manager", zap.Error(err))
 		return err
 	}
 
-	log.Logger.Info("Plugin started", zap.String("component", "cni-net"))
+	log.Logger.Info("Plugin started")
 
 	return nil
 }
@@ -206,7 +203,7 @@ func (plugin *NetPlugin) GetAllEndpointState(networkid string) (*api.AzureCNISta
 func (plugin *NetPlugin) Stop() {
 	plugin.nm.Uninitialize()
 	plugin.Uninitialize()
-	log.Logger.Info("Plugin stopped", zap.String("component", "cni-net"))
+	log.Logger.Info("Plugin stopped")
 }
 
 // FindMasterInterface returns the name of the master interface.
@@ -270,8 +267,7 @@ func (plugin *NetPlugin) getPodInfo(args string) (name, ns string, err error) {
 
 func SetCustomDimensions(cniMetric *telemetry.AIMetric, nwCfg *cni.NetworkConfig, err error) {
 	if cniMetric == nil {
-		log.Logger.Error("Unable to set custom dimension. Report is nil",
-			zap.String("component", "cni"))
+		log.Logger.Error("Unable to set custom dimension. Report is nil")
 		return
 	}
 
@@ -313,7 +309,7 @@ func addNatIPV6SubnetInfo(nwCfg *cni.NetworkConfig,
 			Gateway: resultV6.IPs[0].Gateway,
 		}
 		log.Logger.Info("ipv6 subnet info",
-			zap.Any("ipv6SubnetInfo", ipv6SubnetInfo), zap.String("component", "net"))
+			zap.Any("ipv6SubnetInfo", ipv6SubnetInfo))
 		nwInfo.Subnets = append(nwInfo.Subnets, ipv6SubnetInfo)
 	}
 }

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -54,23 +54,20 @@ func (plugin *NetPlugin) handleConsecutiveAdd(args *cniSkel.CmdArgs, endpointId 
 	hnsEndpoint, err := network.Hnsv1.GetHNSEndpointByName(endpointId)
 	if hnsEndpoint != nil {
 		log.Logger.Info("Found existing endpoint through hcsshim",
-			zap.Any("endpoint", hnsEndpoint),
-			zap.String("component", "net"))
+			zap.Any("endpoint", hnsEndpoint))
 		endpoint, _ := network.Hnsv1.GetHNSEndpointByID(hnsEndpoint.Id)
 		isAttached, _ := network.Hnsv1.IsAttached(endpoint, args.ContainerID)
 		// Attach endpoint if it's not attached yet.
 		if !isAttached {
 			log.Logger.Info("Attaching endpoint to container",
 				zap.String("endpoint", hnsEndpoint.Id),
-				zap.String("container", args.ContainerID),
-				zap.String("component", "net"))
+				zap.String("container", args.ContainerID))
 			err := network.Hnsv1.HotAttachEndpoint(args.ContainerID, hnsEndpoint.Id)
 			if err != nil {
 				log.Logger.Error("Failed to hot attach shared endpoint to container",
 					zap.String("endpoint", hnsEndpoint.Id),
 					zap.String("container", args.ContainerID),
-					zap.Error(err),
-					zap.String("component", "cni-net"))
+					zap.Error(err))
 				return nil, err
 			}
 		}
@@ -254,8 +251,7 @@ func getEndpointDNSSettings(nwCfg *cni.NetworkConfig, result *cniTypesCurr.Resul
 // getPoliciesFromRuntimeCfg returns network policies from network config.
 func getPoliciesFromRuntimeCfg(nwCfg *cni.NetworkConfig, isIPv6Enabled bool) []policy.Policy {
 	log.Logger.Info("Runtime Info",
-		zap.Any("config", nwCfg.RuntimeConfig),
-		zap.String("component", "net"))
+		zap.Any("config", nwCfg.RuntimeConfig))
 	var policies []policy.Policy
 	var protocol uint32
 
@@ -290,8 +286,7 @@ func getPoliciesFromRuntimeCfg(nwCfg *cni.NetworkConfig, isIPv6Enabled bool) []p
 		}
 
 		log.Logger.Info("Creating port mapping policyv4",
-			zap.Any("policy", policyv4),
-			zap.String("component", "net"))
+			zap.Any("policy", policyv4))
 		policies = append(policies, policyv4)
 
 		// add port mapping policy for v6 if we have IPV6 enabled
@@ -317,8 +312,7 @@ func getPoliciesFromRuntimeCfg(nwCfg *cni.NetworkConfig, isIPv6Enabled bool) []p
 			}
 
 			log.Logger.Info("Creating port mapping policyv6",
-				zap.Any("policy", policyv6),
-				zap.String("component", "net"))
+				zap.Any("policy", policyv6))
 			policies = append(policies, policyv6)
 		}
 	}

--- a/cni/network/plugin/main.go
+++ b/cni/network/plugin/main.go
@@ -39,6 +39,7 @@ const (
 	name                            = "azure-vnet"
 	maxLogFileSizeInMb              = 5
 	maxLogFileCount                 = 8
+	component                       = "cni"
 )
 
 // Version is populated by make during build.
@@ -311,6 +312,7 @@ func main() {
 		MaxSizeInMB: maxLogFileSizeInMb,
 		MaxBackups:  maxLogFileCount,
 		Name:        name,
+		Component:   component,
 	}
 	zaplog.Initialize(ctx, loggerCfg)
 

--- a/cni/plugin.go
+++ b/cni/plugin.go
@@ -77,8 +77,7 @@ func (plugin *Plugin) Execute(api PluginApi) (err error) {
 
 			log.Logger.Info("Recovered panic",
 				zap.String("error", cniErr.Msg),
-				zap.String("details", cniErr.Details),
-				zap.String("component", "cni"))
+				zap.String("details", cniErr.Details))
 		}
 	}()
 
@@ -100,13 +99,12 @@ func (plugin *Plugin) DelegateAdd(pluginName string, nwCfg *NetworkConfig) (*cni
 	var result *cniTypesCurr.Result
 	var err error
 
-	log.Logger.Info("Calling ADD", zap.String("plugin", pluginName), zap.String("component", "cni"))
+	log.Logger.Info("Calling ADD", zap.String("plugin", pluginName))
 	defer func() {
 		log.Logger.Info("Plugin returned",
 			zap.String("plugin", pluginName),
 			zap.Any("result", result),
-			zap.Error(err),
-			zap.String("component", "cni"))
+			zap.Error(err))
 	}()
 
 	os.Setenv(Cmd, CmdAdd)
@@ -130,13 +128,11 @@ func (plugin *Plugin) DelegateDel(pluginName string, nwCfg *NetworkConfig) error
 
 	log.Logger.Info("Calling DEL",
 		zap.String("plugin", pluginName),
-		zap.Any("config", nwCfg),
-		zap.String("component", "cni"))
+		zap.Any("config", nwCfg))
 	defer func() {
 		log.Logger.Info("Plugin eturned",
 			zap.String("plugin", pluginName),
-			zap.Error(err),
-			zap.String("component", "cni"))
+			zap.Error(err))
 	}()
 
 	os.Setenv(Cmd, CmdDel)
@@ -186,14 +182,13 @@ func (plugin *Plugin) InitializeKeyValueStore(config *common.PluginConfig) error
 	if plugin.Store == nil {
 		lockclient, err := processlock.NewFileLock(platform.CNILockPath + plugin.Name + store.LockExtension)
 		if err != nil {
-			log.Logger.Error("Error initializing file lock",
-				zap.Error(err), zap.String("component", "cni"))
+			log.Logger.Error("Error initializing file lock", zap.Error(err))
 			return errors.Wrap(err, "error creating new filelock")
 		}
 
 		plugin.Store, err = store.NewJsonFileStore(platform.CNIRuntimePath+plugin.Name+".json", lockclient)
 		if err != nil {
-			log.Logger.Error("Failed to create store", zap.Error(err), zap.String("component", "cni"))
+			log.Logger.Error("Failed to create store", zap.Error(err))
 			return err
 		}
 	}
@@ -219,7 +214,7 @@ func (plugin *Plugin) UninitializeKeyValueStore() error {
 	if plugin.Store != nil {
 		err := plugin.Store.Unlock()
 		if err != nil {
-			log.Logger.Error("Failed to unlock store", zap.Error(err), zap.String("component", "cni"))
+			log.Logger.Error("Failed to unlock store", zap.Error(err))
 			return err
 		}
 	}

--- a/cni/telemetry/service/telemetrymain.go
+++ b/cni/telemetry/service/telemetrymain.go
@@ -29,7 +29,7 @@ const (
 	configExtension                   = ".config"
 	maxLogFileSizeInMb                = 5
 	maxLogFileCount                   = 8
-	component                         = "telemetry"
+	component                         = "cni"
 )
 
 var version string

--- a/cni/telemetry/service/telemetrymain.go
+++ b/cni/telemetry/service/telemetrymain.go
@@ -29,6 +29,7 @@ const (
 	configExtension                   = ".config"
 	maxLogFileSizeInMb                = 5
 	maxLogFileCount                   = 8
+	component                         = "telemetry"
 )
 
 var version string
@@ -123,6 +124,7 @@ func main() {
 		MaxSizeInMB: maxLogFileSizeInMb,
 		MaxBackups:  maxLogFileCount,
 		Name:        azureVnetTelemetry,
+		Component:   component,
 	}
 	log.Initialize(ctx, loggerCfg)
 
@@ -134,14 +136,11 @@ func main() {
 		configPath = fmt.Sprintf("%s\\%s%s", configDirectory, azureVnetTelemetry, configExtension)
 	}
 
-	log.Logger.Info("Config path",
-		zap.String("path", configPath), zap.String("component", "telemetry"))
+	log.Logger.Info("Config path", zap.String("path", configPath))
 
 	config, err = telemetry.ReadConfigFile(configPath)
 	if err != nil {
-		log.Logger.Error("Error reading telemetry config",
-			zap.Error(err),
-			zap.String("component", "telemetry"))
+		log.Logger.Error("Error reading telemetry config", zap.Error(err))
 	}
 
 	log.Logger.Info("read config returned", zap.Any("config", config))
@@ -157,14 +156,13 @@ func main() {
 	for {
 		tb = telemetry.NewTelemetryBuffer()
 
-		log.Logger.Info("Starting telemetry server", zap.String("component", "telemetry"))
+		log.Logger.Info("Starting telemetry server")
 		err = tb.StartServer()
 		if err == nil || tb.FdExists {
 			break
 		}
 
-		log.Logger.Error("Telemetry service starting failed",
-			zap.Error(err), zap.String("component", "telemetry"))
+		log.Logger.Error("Telemetry service starting failed", zap.Error(err))
 		tb.Cleanup(telemetry.FdName)
 		time.Sleep(time.Millisecond * 200)
 	}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
This PR is to change the CNI zap logging component structure. Instead of putting component:cni everywhere, we provide component name globally.

**Example logs in Linux:**
{"level":"info","ts":"2023-08-15T20:44:48.779Z","msg":"Plugin started","pid":3139991,"component":"cni"}
{"level":"info","ts":"2023-08-15T20:44:48.779Z","msg":"[cni-net] Processing ADD command","pid":3139991,"component":"cni","containerId":"9ac1b7e2429d7d2ad36a6b497d6756279fd074d7974910a1c281afeb16e00f6c","netNS":"/var/run/netns/cni-55d04a42-99a4-c2aa-ff40-383dff9d1efb","ifName":"eth0","args":"K8S_POD_NAME=linux-pod2;K8S_POD_INFRA_CONTAINER_ID=9ac1b7e2429d7d2ad36a6b497d6756279fd074d7974910a1c281afeb16e00f6c;K8S_POD_UID=ed43fc0a-e04c-4876-ba1d-be581f99ee39;IgnoreUnknown=1;K8S_POD_NAMESPACE=default","path":"/opt/cni/bin","stdinData":"{\"cniVersion\":\"0.3.0\",\"ipam\":{\"mode\":\"overlay\",\"type\":\"azure-cns\"},\"ipsToRouteViaHost\":[\"169.254.20.10\"],\"mode\":\"transparent\",\"name\":\"azure\",\"type\":\"azure-vnet\"}"}
{"level":"info","ts":"2023-08-15T20:44:48.780Z","msg":"[cni-net] Found network with subnet","pid":3139991,"component":"cni","network":"azure","subnet":"10.244.0.0/16"}
{"level":"info","ts":"2023-08-15T20:44:48.780Z","msg":"linux-pod2","pid":3139991,"component":"cni"}
{"level":"info","ts":"2023-08-15T20:44:48.780Z","msg":"Requesting IP for pod using ipconfig","pid":3139991,"component":"cni","pod":{"PodName":"linux-pod2","PodNamespace":"default"},"ipconfig":{"desiredIPAddresses":null,"podInterfaceID":"9ac1b7e2-eth0","infraContainerID":"9ac1b7e2429d7d2ad36a6b497d6756279fd074d7974910a1c281afeb16e00f6c","orchestratorContext":{"PodName":"linux-pod2","PodNamespace":"default"},"ifname":""}}
{"level":"info","ts":"2023-08-15T20:44:48.783Z","msg":"Received info for pod","pid":3139991,"component":"cni","ipv4info":{},"podInfo":{"PodName":"linux-pod2","PodNamespace":"default"}}
{"level":"info","ts":"2023-08-15T20:44:48.783Z","msg":"Received info for pod","pid":3139991,"component":"cni","ipv4info":{},"podInfo":{"PodName":"linux-pod2","PodNamespace":"default"}}
{"level":"info","ts":"2023-08-15T20:44:48.783Z","msg":"[cni-net] Creating endpoint","pid":3139991,"component":"cni","endpointInfo":"Id:9ac1b7e2-eth0 ContainerID:9ac1b7e2429d7d2ad36a6b497d6756279fd074d7974910a1c281afeb16e00f6c NetNsPath:/var/run/netns/cni-55d04a42-99a4-c2aa-ff40-383dff9d1efb IfName:eth0 IfIndex:0 MacAddr: IPAddrs:[{10.244.0.84 ffff0000} {fd9a:2e13:4857:dd28::18 ffffffffffffffff0000000000000000}] Gateways:[] Data:map[vethname:default.linux-pod2]"}
2023/08/15 20:44:48 [3139991] Generate veth name based on the key provided default.linux-pod2
2023/08/15 20:44:48 [3139991] Transparent client
2023/08/15 20:44:48 [3139991] [net] Creating veth pair azvf1dc5516897 azvf1dc55168972.
2023/08/15 20:44:48 [3139991] [net] Setting link azvf1dc5516897 state up.
2023/08/15 20:44:48 [3139991] [Azure-Utils] sysctl -w net.ipv6.conf.azvf1dc5516897.accept_ra=0
2023/08/15 20:44:48 [3139991] Setting mtu 1500 on veth interface azvf1dc5516897
2023/08/15 20:44:48 [3139991] [net] Adding route for the ip 10.244.0.84/32
2023/08/15 20:44:48 [3139991] [net] Adding IP route {Dst:{IP:10.244.0.84 Mask:ffffffff} Src:<nil> Gw:<nil> Protocol:0 DevName: Scope:0 Priority:0 Table:0} to link azvf1dc5516897.
2023/08/15 20:44:48 [3139991] [net] Adding route for the ip fd9a:2e13:4857:dd28::18/128
2023/08/15 20:44:48 [3139991] [net] Adding IP route {Dst:{IP:10.244.0.84 Mask:ffffffff} Src:<nil> Gw:<nil> Protocol:0 DevName: Scope:0 Priority:0 Table:0} to link azvf1dc5516897.
2023/08/15 20:44:48 [3139991] [netlink] Received {NlMsghdr:{Len:64 Type:2 Flags:0 Seq:6 Pid:3139991} data:[239 255 255 255 44 0 0 0 24 0 5 6 6 0 0 0 151 233 47 0 2 32 0 0 0 4 0 1 0 0 0 0 8 0 1 0 10 244 0 84 8 0 4 0 155 0 0 0] payload:[]}, err=file exists
2023/08/15 20:44:48 [3139991] [net] route already exists
2023/08/15 20:44:48 [3139991] [net] Adding IP route {Dst:{IP:fd9a:2e13:4857:dd28::18 Mask:ffffffffffffffffffffffffffffffff} Src:<nil> Gw:<nil> Protocol:0 DevName: Scope:0 Priority:0 Table:0} to link azvf1dc5516897.
2023/08/15 20:44:48 [3139991] calling setArpProxy for azvf1dc5516897
2023/08/15 20:44:48 [3139991] [Azure-Utils] echo 1 > /proc/sys/net/ipv4/conf/azvf1dc5516897/proxy_arp
2023/08/15 20:44:48 [3139991] [net] Opening netns /var/run/netns/cni-55d04a42-99a4-c2aa-ff40-383dff9d1efb.
2023/08/15 20:44:48 [3139991] [net] Setting link azvf1dc55168972 netns /var/run/netns/cni-55d04a42-99a4-c2aa-ff40-383dff9d1efb.
2023/08/15 20:44:48 [3139991] [net] Entering netns /var/run/netns/cni-55d04a42-99a4-c2aa-ff40-383dff9d1efb.
2023/08/15 20:44:48 [3139991] Enable ipv6 setting in container.
2023/08/15 20:44:48 [3139991] [Azure-Utils] sysctl -w net.ipv6.conf.all.disable_ipv6=0
2023/08/15 20:44:48 [3139991] [net] Setting link azvf1dc55168972 state down.
2023/08/15 20:44:48 [3139991] [net] Setting link azvf1dc55168972 name eth0.
2023/08/15 20:44:48 [3139991] [Azure-Utils] sysctl -w net.ipv6.conf.eth0.accept_ra=0
2023/08/15 20:44:48 [3139991] [net] Setting link eth0 state up.
2023/08/15 20:44:48 [3139991] [net] Adding IP address 10.244.0.84/16 to link eth0.
2023/08/15 20:44:48 [3139991] [net] Adding IP address fd9a:2e13:4857:dd28::18/64 to link eth0.
2023/08/15 20:44:48 [3139991] [net] Deleting IP route {Dst:{IP:10.244.0.0 Mask:ffff0000} Src:<nil> Gw:<nil> Protocol:2 DevName: Scope:253 Priority:0 Table:0} from link eth0.
2023/08/15 20:44:48 [3139991] [net] Deleting IP route {Dst:{IP:fd9a:2e13:4857:dd28:: Mask:ffffffffffffffff0000000000000000} Src:<nil> Gw:<nil> Protocol:2 DevName: Scope:253 Priority:0 Table:0} from link eth0.
2023/08/15 20:44:48 [3139991] [net] Adding IP route {Dst:{IP:169.254.1.1 Mask:ffffffff} Src:<nil> Gw:<nil> Protocol:0 DevName: Scope:253 Priority:0 Table:0} to link eth0.
2023/08/15 20:44:48 [3139991] [net] Adding IP route {Dst:{IP:0.0.0.0 Mask:00000000} Src:<nil> Gw:169.254.1.1 Protocol:0 DevName: Scope:0 Priority:0 Table:0} to link eth0.
2023/08/15 20:44:48 [3139991] [net] Adding static arp for IP address 169.254.1.1/32 and MAC aa:aa:aa:aa:aa:aa in Container namespace
2023/08/15 20:44:48 [3139991] Setting up ipv6 routes in container
2023/08/15 20:44:48 [3139991] defaultv6ipnet :::/0
2023/08/15 20:44:48 [3139991] [net] Adding IP route {Dst:{IP:fe80::1234:5678:9abc Mask:ffffffffffffffffffffffffffffffff} Src:<nil> Gw:<nil> Protocol:0 DevName: Scope:253 Priority:0 Table:0} to link eth0.
2023/08/15 20:44:48 [3139991] [net] Adding IP route {Dst:{IP::: Mask:00000000000000000000000000000000} Src:<nil> Gw:fe80::1234:5678:9abc Protocol:0 DevName: Scope:0 Priority:0 Table:0} to link eth0.
2023/08/15 20:44:48 [3139991] [net] Add v6 neigh entry for default gw ip
2023/08/15 20:44:48 [3139991] [net] Exiting netns /var/run/netns/cni-55d04a42-99a4-c2aa-ff40-383dff9d1efb.
2023/08/15 20:44:48 [3139991] [net] Created endpoint &{Id:9ac1b7e2-eth0 HnsId: SandboxKey: IfName:azvf1dc55168972 HostIfName:azvf1dc5516897 MacAddress:3e:1f:c8:7e:8b:14 InfraVnetIP:{IP:<nil> Mask:<nil>} LocalIP: IPAddresses:[{IP:10.244.0.84 Mask:ffff0000} {IP:fd9a:2e13:4857:dd28::18 Mask:ffffffffffffffff0000000000000000}] Gateways:[0.0.0.0] DNS:{Suffix: Servers:[] Options:[]} Routes:[{Dst:{IP:0.0.0.0 Mask:00000000} Src:<nil> Gw:169.254.1.1 Protocol:0 DevName: Scope:0 Priority:0 Table:0}] VlanID:0 EnableSnatOnHost:false EnableInfraVnet:false EnableMultitenancy:false AllowInboundFromHostToNC:false AllowInboundFromNCToHost:false NetworkContainerID: NetworkNameSpace:/var/run/netns/cni-55d04a42-99a4-c2aa-ff40-383dff9d1efb ContainerID:9ac1b7e2429d7d2ad36a6b497d6756279fd074d7974910a1c281afeb16e00f6c PODName:linux-pod2 PODNameSpace:default InfraVnetAddressSpace: NetNs:}. Num of endpoints:2
2023/08/15 20:44:48 [3139991] [net] Save succeeded.
{"level":"info","ts":"2023-08-15T20:44:48.843Z","msg":"[cni-net] ADD command completed for pod %v with IPs:%+v err:%v.","pid":3139991,"component":"cni","pod":"linux-pod2","IPs":[{"address":"10.244.0.84/16","gateway":"169.254.1.1"},{"address":"fd9a:2e13:4857:dd28::18/64","gateway":"fe80::1234:5678:9abc"}]}
{"level":"info","ts":"2023-08-15T20:44:48.843Z","msg":"Plugin stopped","pid":3139991,"component":"cni"}
2023/08/15 20:44:48 [3139991] Released process lock
{"level":"info","ts":"2023-08-15T20:46:09.224Z","msg":"Environment variable set","pid":3142512,"component":"cni","CNI_COMMAND":"DEL"}
2023/08/15 20:46:09 [3142512] Acquiring process lock
2023/08/15 20:46:09 [3142512] Acquired process lock with timeout value of 10s
2023/08/15 20:46:09 [3142512] Connected to telemetry service
{"level":"info","ts":"2023-08-15T20:46:09.227Z","msg":"Plugin Info","pid":3142512,"component":"cni","name":"azure-vnet","version":"v1.5.9-19-ge338f17e"}
2023/08/15 20:46:09 [3142512] [net] Restored state
{"level":"info","ts":"2023-08-15T20:46:09.228Z","msg":"Plugin started","pid":3142512,"component":"cni"}
{"level":"info","ts":"2023-08-15T20:46:09.228Z","msg":"[cni-net] Processing DEL command","pid":3142512,"component":"cni","containerId":"9ac1b7e2429d7d2ad36a6b497d6756279fd074d7974910a1c281afeb16e00f6c","netNS":"/var/run/netns/cni-55d04a42-99a4-c2aa-ff40-383dff9d1efb","ifName":"eth0","args":"K8S_POD_UID=ed43fc0a-e04c-4876-ba1d-be581f99ee39;IgnoreUnknown=1;K8S_POD_NAMESPACE=default;K8S_POD_NAME=linux-pod2;K8S_POD_INFRA_CONTAINER_ID=9ac1b7e2429d7d2ad36a6b497d6756279fd074d7974910a1c281afeb16e00f6c","path":"/opt/cni/bin","stdinData":"{\"cniVersion\":\"0.3.0\",\"ipam\":{\"mode\":\"overlay\",\"type\":\"azure-cns\"},\"ipsToRouteViaHost\":[\"169.254.20.10\"],\"mode\":\"transparent\",\"name\":\"azure\",\"type\":\"azure-vnet\"}"}
{"level":"info","ts":"2023-08-15T20:46:09.228Z","msg":"Execution mode","pid":3142512,"component":"cni","mode":""}
{"level":"info","ts":"2023-08-15T20:46:09.228Z","msg":"[cni-net] Endpoints to be deleted","pid":3142512,"component":"cni","count":1}
{"level":"info","ts":"2023-08-15T20:46:09.228Z","msg":"Deleting endpoint","pid":3142512,"component":"cni","endpointID":"9ac1b7e2-eth0"}
2023/08/15 20:46:09 [3142512] [net] Deleting endpoint 9ac1b7e2-eth0 from network azure.
2023/08/15 20:46:09 [3142512] [net] Deleting route for the ip 10.244.0.84/32
2023/08/15 20:46:09 [3142512] [net] Deleting IP route {Dst:{IP:10.244.0.84 Mask:ffffffff} Src:<nil> Gw:<nil> Protocol:0 DevName: Scope:0 Priority:0 Table:0} from link azvf1dc5516897.
2023/08/15 20:46:09 [3142512] [net] Deleting route for the ip fd9a:2e13:4857:dd28::18/128
2023/08/15 20:46:09 [3142512] [net] Deleting IP route {Dst:{IP:fd9a:2e13:4857:dd28::18 Mask:ffffffffffffffffffffffffffffffff} Src:<nil> Gw:<nil> Protocol:0 DevName: Scope:0 Priority:0 Table:0} from link azvf1dc5516897.
2023/08/15 20:46:09 [3142512] [net] Deleted endpoint &{Id:9ac1b7e2-eth0 HnsId: SandboxKey: IfName:azvf1dc55168972 HostIfName:azvf1dc5516897 MacAddress:3e:1f:c8:7e:8b:14 InfraVnetIP:{IP:<nil> Mask:<nil>} LocalIP: IPAddresses:[{IP:10.244.0.84 Mask:ffff0000} {IP:fd9a:2e13:4857:dd28::18 Mask:ffffffffffffffff0000000000000000}] Gateways:[0.0.0.0] DNS:{Suffix: Servers:[] Options:[]} Routes:[{Dst:{IP:0.0.0.0 Mask:00000000} Src:<nil> Gw:169.254.1.1 Protocol:0 DevName: Scope:0 Priority:0 Table:0}] VlanID:0 EnableSnatOnHost:false EnableInfraVnet:false EnableMultitenancy:false AllowInboundFromHostToNC:false AllowInboundFromNCToHost:false NetworkContainerID: NetworkNameSpace:/var/run/netns/cni-55d04a42-99a4-c2aa-ff40-383dff9d1efb ContainerID:9ac1b7e2429d7d2ad36a6b497d6756279fd074d7974910a1c281afeb16e00f6c PODName:linux-pod2 PODNameSpace:default InfraVnetAddressSpace: NetNs:}. Num of endpoints:1
2023/08/15 20:46:09 [3142512] [net] Save succeeded.
{"level":"info","ts":"2023-08-15T20:46:09.229Z","msg":"Release ip","pid":3142512,"component":"cni","ip":"10.244.0.84"}
{"level":"info","ts":"2023-08-15T20:46:09.232Z","msg":"Release ip","pid":3142512,"component":"cni","ip":"fd9a:2e13:4857:dd28::18"}
{"level":"info","ts":"2023-08-15T20:46:09.232Z","msg":"[cni-net] DEL command completed","pid":3142512,"component":"cni","pod":"linux-pod2"}
{"level":"info","ts":"2023-08-15T20:46:09.232Z","msg":"Plugin stopped","pid":3142512,"component":"cni"}


**Example of Windows Log:**
{"level":"info","ts":"2023-08-15T20:51:20.379Z","msg":"Plugin Info","pid":11200,"component":"cni","name":"azure-vnet","version":"v1.5.9-19-ge338f17e"}
2023/08/15 20:51:20 [11200] [net] Restored state
{"level":"info","ts":"2023-08-15T20:51:20.380Z","msg":"Plugin started","pid":11200,"component":"cni"}
{"level":"info","ts":"2023-08-15T20:51:20.380Z","msg":"[cni-net] Processing ADD command","pid":11200,"component":"cni","containerId":"45dce45f6be6bbcbdbf95275743763425abe026a690153b287365f5d4aaa9e61","netNS":"31b673d2-2b52-480a-8ca2-ffd04ffb4a68","ifName":"eth0","args":"K8S_POD_NAMESPACE=default;K8S_POD_NAME=windows-pod23;K8S_POD_INFRA_CONTAINER_ID=45dce45f6be6bbcbdbf95275743763425abe026a690153b287365f5d4aaa9e61;K8S_POD_UID=f2d54c55-bdb2-478a-95ec-bff490a4df37;IgnoreUnknown=1","path":"c:/k/azurecni/bin","stdinData":"{\"AdditionalArgs\":[{\"Name\":\"EndpointPolicy\",\"Value\":{\"ExceptionList\":[\"10.244.0.0/16\"],\"Type\":\"OutBoundNAT\"}},{\"Name\":\"EndpointPolicy\",\"Value\":{\"ExceptionList\":[\"fd9a:2e13:4857:dd28::/64\"],\"Type\":\"OutBoundNAT\"}},{\"Name\":\"EndpointPolicy\",\"Value\":{\"Action\":\"Block\",\"Direction\":\"Out\",\"Priority\":200,\"Protocols\":\"6\",\"RemoteAddresses\":\"168.63.129.16/32\",\"RemotePorts\":\"80\",\"RuleType\":\"Switch\",\"Type\":\"ACL\"}},{\"Name\":\"EndpointPolicy\",\"Value\":{\"Action\":\"Allow\",\"Direction\":\"In\",\"Priority\":65500,\"Type\":\"ACL\"}},{\"Name\":\"EndpointPolicy\",\"Value\":{\"Action\":\"Allow\",\"Direction\":\"Out\",\"Priority\":65500,\"Type\":\"ACL\"}}],\"bridge\":\"azure0\",\"capabilities\":{\"dns\":true,\"portMappings\":true},\"cniVersion\":\"0.3.0\",\"dns\":{\"Nameservers\":[\"10.0.0.10\",\"168.63.129.16\"],\"Search\":[\"svc.cluster.local\"]},\"executionMode\":\"v4swift\",\"ipam\":{\"mode\":\"v4overlay\",\"type\":\"azure-cns\"},\"mode\":\"bridge\",\"name\":\"azure\",\"runtimeConfig\":{\"dns\":{\"Servers\":[\"10.0.0.10\"],\"Searches\":[\"default.svc.cluster.local\",\"svc.cluster.local\",\"cluster.local\"],\"Options\":[\"ndots:5\"]}},\"type\":\"azure-vnet\",\"windowsSettings\":{\"enableLoopbackDSR\":true}}"}
{"level":"info","ts":"2023-08-15T20:51:20.382Z","msg":"[cni-net] Found network with subnet","pid":11200,"component":"cni","network":"azure","subnet":"10.244.0.0/16"}
{"level":"info","ts":"2023-08-15T20:51:20.382Z","msg":"windows-pod23","pid":11200,"component":"cni"}
{"level":"info","ts":"2023-08-15T20:51:20.382Z","msg":"Requesting IP for pod using ipconfig","pid":11200,"component":"cni","pod":{"PodName":"windows-pod23","PodNamespace":"default"},"ipconfig":{"desiredIPAddresses":null,"podInterfaceID":"45dce45f-eth0","infraContainerID":"45dce45f6be6bbcbdbf95275743763425abe026a690153b287365f5d4aaa9e61","orchestratorContext":{"PodName":"windows-pod23","PodNamespace":"default"},"ifname":""}}
{"level":"info","ts":"2023-08-15T20:51:20.694Z","msg":"Received info for pod","pid":11200,"component":"cni","ipv4info":{},"podInfo":{"PodName":"windows-pod23","PodNamespace":"default"}}
{"level":"info","ts":"2023-08-15T20:51:20.694Z","msg":"Received info for pod","pid":11200,"component":"cni","ipv4info":{},"podInfo":{"PodName":"windows-pod23","PodNamespace":"default"}}
{"level":"info","ts":"2023-08-15T20:51:20.694Z","msg":"Runtime Info","pid":11200,"component":"cni","config":{"dns":{"servers":["10.0.0.10"],"searches":["default.svc.cluster.local","svc.cluster.local","cluster.local"],"options":["ndots:5"]}}}
{"level":"info","ts":"2023-08-15T20:51:20.694Z","msg":"[cni-net] Creating endpoint","pid":11200,"component":"cni","endpointInfo":"Id:45dce45f-eth0 ContainerID:45dce45f6be6bbcbdbf95275743763425abe026a690153b287365f5d4aaa9e61 NetNsPath:31b673d2-2b52-480a-8ca2-ffd04ffb4a68 IfName:eth0 IfIndex:0 MacAddr: IPAddrs:[{10.244.3.80 ffff0000} {fd9a:2e13:4857:dd28::390 ffffffffffffffff0000000000000000}] Gateways:[] Data:map[]"}
2023/08/15 20:51:20 [11200] Successfully retrieve endpoint policy: OutBoundNAT
2023/08/15 20:51:20 [11200] Successfully retrieve endpoint policy: OutBoundNAT
2023/08/15 20:51:20 [11200] Successfully retrieve endpoint policy: ACL
2023/08/15 20:51:20 [11200] Successfully retrieve endpoint policy: ACL
2023/08/15 20:51:20 [11200] Successfully retrieve endpoint policy: ACL
2023/08/15 20:51:20 [11200] DSR policy for ip:10.244.3.80
2023/08/15 20:51:20 [11200] Successfully retrieve endpoint policy: OutBoundNAT
2023/08/15 20:51:20 [11200] [net] Creating hcn endpoint: 45dce45f-eth0 computenetwork:6e43a293-6c18-4b33-8a59-89f513759934
2023/08/15 20:51:20 [11200] [net] Successfully created hcn endpoint with response: &{Id:76489afa-8616-4656-813b-e8ef4898324c Name:45dce45f-eth0 HostComputeNetwork:6e43a293-6c18-4b33-8a59-89f513759934 HostComputeNamespace: Policies:[{Type:OutBoundNAT Settings:[123 34 69 120 99 101 112 116 105 111 110 115 34 58 91 34 49 48 46 50 52 52 46 48 46 48 47 49 54 34 93 125]} {Type:OutBoundNAT Settings:[123 34 69 120 99 101 112 116 105 111 110 115 34 58 91 34 102 100 57 97 58 50 101 49 51 58 52 56 53 55 58 100 100 50 56 58 58 47 54 52 34 93 125]} {Type:ACL Settings:[123 34 80 114 111 116 111 99 111 108 115 34 58 34 54 34 44 34 82 101 109 111 116 101 65 100 100 114 101 115 115 101 115 34 58 34 49 54 56 46 54 51 46 49 50 57 46 49 54 47 51 50 34 44 34 82 101 109 111 116 101 80 111 114 116 115 34 58 34 56 48 34 44 34 80 114 105 111 114 105 116 121 34 58 50 48 48 44 34 65 99 116 105 111 110 34 58 34 66 108 111 99 107 34 44 34 68 105 114 101 99 116 105 111 110 34 58 34 79 117 116 34 44 34 82 117 108 101 84 121 112 101 34 58 34 83 119 105 116 99 104 34 125]} {Type:ACL Settings:[123 34 80 114 105 111 114 105 116 121 34 58 54 53 53 48 48 44 34 65 99 116 105 111 110 34 58 34 65 108 108 111 119 34 44 34 68 105 114 101 99 116 105 111 110 34 58 34 73 110 34 125]} {Type:ACL Settings:[123 34 80 114 105 111 114 105 116 121 34 58 54 53 53 48 48 44 34 65 99 116 105 111 110 34 58 34 65 108 108 111 119 34 44 34 68 105 114 101 99 116 105 111 110 34 58 34 79 117 116 34 125]} {Type:OutBoundNAT Settings:[123 34 68 101 115 116 105 110 97 116 105 111 110 115 34 58 91 34 49 48 46 50 52 52 46 51 46 56 48 34 93 125]} {Type:L2Driver Settings:[]} {Type:EncapOverhead Settings:[123 34 79 118 101 114 104 101 97 100 34 58 53 48 125]}] IpConfigurations:[{IpAddress:10.244.3.80 PrefixLength:16} {IpAddress:fd9a:2e13:4857:dd28::390 PrefixLength:64}] Dns:{Domain:kube-system.svc.cluster.local,svc.cluster.local,cluster.local Search:[default.svc.cluster.local svc.cluster.local cluster.local] ServerList:[10.0.0.10] Options:[]} Routes:[{NextHop:10.244.3.1 DestinationPrefix:0.0.0.0/0 Metric:0} {NextHop:fd9a:2e13:4857:dd28::301 DestinationPrefix:::/0 Metric:0}] MacAddress:00-15-5D-D0-01-80 Flags:0 Health:{Data:<nil> Extra:{Resources:[] SharedContainers:[91 93] LayeredOn: SwitchGuid: UtilityVM: VirtualMachine:}} SchemaVersion:{Major:2 Minor:0}}
2023/08/15 20:51:20 [11200] [net] Created endpoint &{Id:45dce45f-eth0 HnsId:76489afa-8616-4656-813b-e8ef4898324c SandboxKey:45dce45f6be6bbcbdbf95275743763425abe026a690153b287365f5d4aaa9e61 IfName:eth0 HostIfName: MacAddress:00:15:5d:d0:01:80 InfraVnetIP:{IP:<nil> Mask:<nil>} LocalIP: IPAddresses:[{IP:10.244.3.80 Mask:ffff0000} {IP:fd9a:2e13:4857:dd28::390 Mask:ffffffffffffffff0000000000000000}] Gateways:[10.244.3.1] DNS:{Suffix:default.svc.cluster.local,svc.cluster.local,cluster.local Servers:[10.0.0.10] Options:[ndots:5]} Routes:[{Dst:{IP:0.0.0.0 Mask:00000000} Src:<nil> Gw:10.244.3.1 Protocol:0 DevName: Scope:0 Priority:0 Table:0}] VlanID:0 EnableSnatOnHost:false EnableInfraVnet:false EnableMultitenancy:false AllowInboundFromHostToNC:false AllowInboundFromNCToHost:false NetworkContainerID: NetworkNameSpace: ContainerID:45dce45f6be6bbcbdbf95275743763425abe026a690153b287365f5d4aaa9e61 PODName:windows-pod23 PODNameSpace:default InfraVnetAddressSpace: NetNs:31b673d2-2b52-480a-8ca2-ffd04ffb4a68}. Num of endpoints:10
2023/08/15 20:51:20 [11200] [net] Save succeeded.
{"level":"info","ts":"2023-08-15T20:51:20.716Z","msg":"[cni-net] ADD command completed for pod %v with IPs:%+v err:%v.","pid":11200,"component":"cni","pod":"windows-pod23","IPs":[{"address":"10.244.3.80/16","gateway":"10.244.3.1"},{"address":"fd9a:2e13:4857:dd28::390/64","gateway":"fd9a:2e13:4857:dd28::301"}]}
{"level":"info","ts":"2023-08-15T20:51:20.716Z","msg":"Plugin stopped","pid":11200,"component":"cni"}
2023/08/15 20:51:20 [11200] Released process lock

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
