### PR TITLE
fix: Add back cluster create/delete for Cilium Nightly Pipeline

### DIFF
--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -2,6 +2,20 @@ pr: none
 trigger: none
 
 stages:
+  - stage: setup
+    displayName: Setup
+    jobs:
+      - job: env
+        displayName: Setup
+        pool:
+          name: "$(BUILD_POOL_NAME_DEFAULT)"
+        steps:
+          - script: |
+              echo "##vso[task.setvariable variable=commitID;isOutput=true]$(make revision)"
+            name: "EnvironmentalVariables"
+            displayName: "Set environmental variables"
+            condition: always()
+
   - stage: init
     displayName: "Build and Push Cilium Image"
     jobs:
@@ -40,14 +54,31 @@ stages:
             inputs:
               containerRegistry: $(CONTAINER_REGISTRY)
               command: "logout"
+
   - stage: cilium_nightly
     displayName: E2E - Cilium Nightly
+    dependsOn:
+      - init
+      - setup
     variables:
       GOPATH: "$(Agent.TempDirectory)/go" # Go workspace path
       GOBIN: "$(GOPATH)/bin" # Go binaries path
       modulePath: "$(GOPATH)/src/github.com/Azure/azure-container-networking"
+      commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
     jobs:
+      - template: ../../templates/create-cluster.yaml
+        parameters:
+          name: cilium_overlay_nightly
+          displayName: Cilium on AKS Overlay
+          clusterType: cilium-overlay-up
+          clusterName: ciliumnightly-$(commitID)
+          vmSize: Standard_B2ms
+          k8sVersion: ""
+          dependsOn: ""
+          region: $(LOCATION)
       - job: cilium_nightly
+        dependsOn:
+          - cilium_overlay_nightly
         pool:
           name: $(BUILD_POOL_NAME_DEFAULT)
         steps:
@@ -55,4 +86,22 @@ stages:
           parameters:
             name: "cilium_nightly"
             testDropgz: ""
-            clusterName: "ciliumnightly"
+            clusterName: ciliumnightly-$(commitID)
+      - job: delete
+        displayName: Delete Cluster
+        dependsOn:
+          - cilium_nightly
+        pool:
+          name: "$(BUILD_POOL_NAME_DEFAULT)"
+        strategy:
+          matrix:
+            cilium_nightly:
+              name: ciliumnightly
+              clusterName: overlaynightly
+        steps:
+          - template: ../../templates/delete-cluster.yaml
+            parameters:
+              name: $(name)
+              clusterName: $(clusterName)-$(commitID)
+              region: $(LOCATION)
+

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -77,6 +77,7 @@ stages:
           dependsOn: ""
           region: $(LOCATION)
       - job: cilium_nightly
+        displayName: Cilium Overlay Nightly E2E
         dependsOn:
           - cilium_overlay_nightly
         pool:
@@ -89,6 +90,7 @@ stages:
             clusterName: ciliumnightly-$(commitID)
       - job: delete
         displayName: Delete Cluster
+        condition: always()
         dependsOn:
           - cilium_nightly
         pool:


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Fixes Cilium Nightly Pipeline by adding back in the cluster creation and deletion steps. They were removed in #2077 when the cluster creation process was changed for the PR pipeline.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
