### PR TITLE
fix: Remove NLM_F_EXCL flag from Netlink Delete call (#2150)

### DIFF
--- a/netlink/ip_linux.go
+++ b/netlink/ip_linux.go
@@ -43,7 +43,7 @@ func (Netlink) setIPAddress(ifName string, ipAddress net.IP, ipNet *net.IPNet, a
 		flags = unix.NLM_F_CREATE | unix.NLM_F_EXCL | unix.NLM_F_ACK
 	} else {
 		msgType = unix.RTM_DELADDR
-		flags = unix.NLM_F_EXCL | unix.NLM_F_ACK
+		flags = unix.NLM_F_ACK
 	}
 
 	req := newRequest(msgType, flags)
@@ -225,7 +225,7 @@ func setIpRoute(route *Route, add bool) error {
 		flags = unix.NLM_F_CREATE | unix.NLM_F_EXCL | unix.NLM_F_ACK
 	} else {
 		msgType = unix.RTM_DELROUTE
-		flags = unix.NLM_F_EXCL | unix.NLM_F_ACK
+		flags = unix.NLM_F_ACK
 	}
 
 	req := newRequest(msgType, flags)


### PR DESCRIPTION
* fix: Remove unix.NLM_F_EXCL from Netlink Delete Route api call

unix.NLM_F_EXCL is not expected to set in netlink delete route calls. It's no-op in older kernel and didnt return error. From kernel 5.19+, new flag NLM_F_BULK was defined with same value and serves a purpose in delete route call. This changes breaks azure cni and netlink calls fails in 5.19 kernel and onwards.

The fix is to remove setting unix.NLM_F_EXCL in netlink delete route request.

* fix: Remove unix.NLM_F_EXCL from Netlink Delete Route api call

unix.NLM_F_EXCL is not expected to set in netlink delete route calls. It's no-op in older kernel and didnt return error. From kernel 5.19+, new flag NLM_F_BULK was defined with same value and serves a purpose in delete route call. This changes breaks azure cni and netlink calls fails in 5.19 kernel and onwards.

The fix is to remove setting unix.NLM_F_EXCL in netlink delete route request.

* Add unit tests for netlink add/delete address and add/delete routes

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Hot fix over the released version 1.4.39

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
