### PR TITLE
Add NotFound error handling to NMAgent client

### DIFF
--- a/nmagent/client.go
+++ b/nmagent/client.go
@@ -69,7 +69,7 @@ func (c *Client) JoinNetwork(ctx context.Context, jnr JoinNetworkRequest) error 
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			return die(resp.StatusCode, resp.Header, resp.Body)
+			return die(resp.StatusCode, resp.Header, resp.Body, req.URL.Path)
 		}
 		return nil
 	})
@@ -90,14 +90,8 @@ func (c *Client) DeleteNetwork(ctx context.Context, dnr DeleteNetworkRequest) er
 	}
 	defer resp.Body.Close()
 
-	// NMAgent returns 400 Bad Request if the network ID is invalid or does not
-	// exist, but we wish to return this as a NotFound error.
-	if resp.StatusCode == http.StatusBadRequest {
-		resp.StatusCode = http.StatusNotFound
-	}
-
 	if resp.StatusCode != http.StatusOK {
-		return die(resp.StatusCode, resp.Header, resp.Body)
+		return die(resp.StatusCode, resp.Header, resp.Body, req.URL.Path)
 	}
 	return nil
 }
@@ -120,7 +114,7 @@ func (c *Client) GetNetworkConfiguration(ctx context.Context, gncr GetNetworkCon
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			return die(resp.StatusCode, resp.Header, resp.Body)
+			return die(resp.StatusCode, resp.Header, resp.Body, req.URL.Path)
 		}
 
 		ct := resp.Header.Get(internal.HeaderContentType)
@@ -158,7 +152,7 @@ func (c *Client) GetNCVersion(ctx context.Context, ncvr NCVersionRequest) (NCVer
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return NCVersion{}, die(resp.StatusCode, resp.Header, resp.Body)
+		return NCVersion{}, die(resp.StatusCode, resp.Header, resp.Body, req.URL.Path)
 	}
 
 	var out NCVersion
@@ -185,7 +179,7 @@ func (c *Client) PutNetworkContainer(ctx context.Context, pncr *PutNetworkContai
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return die(resp.StatusCode, resp.Header, resp.Body)
+		return die(resp.StatusCode, resp.Header, resp.Body, req.URL.Path)
 	}
 	return nil
 }
@@ -229,7 +223,7 @@ func (c *Client) DeleteNetworkContainer(ctx context.Context, dcr DeleteContainer
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return die(resp.StatusCode, resp.Header, resp.Body)
+		return die(resp.StatusCode, resp.Header, resp.Body, req.URL.Path)
 	}
 
 	return nil
@@ -248,7 +242,7 @@ func (c *Client) GetNCVersionList(ctx context.Context) (NCVersionList, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return NCVersionList{}, die(resp.StatusCode, resp.Header, resp.Body)
+		return NCVersionList{}, die(resp.StatusCode, resp.Header, resp.Body, req.URL.Path)
 	}
 
 	var out NCVersionList
@@ -276,7 +270,7 @@ func (c *Client) GetHomeAz(ctx context.Context) (AzResponse, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return homeAzResponse, die(resp.StatusCode, resp.Header, resp.Body)
+		return homeAzResponse, die(resp.StatusCode, resp.Header, resp.Body, req.URL.Path)
 	}
 
 	err = json.NewDecoder(resp.Body).Decode(&homeAzResponse)
@@ -287,7 +281,7 @@ func (c *Client) GetHomeAz(ctx context.Context) (AzResponse, error) {
 	return homeAzResponse, nil
 }
 
-func die(code int, headers http.Header, body io.ReadCloser) error {
+func die(code int, headers http.Header, body io.ReadCloser, path string) error {
 	// nolint:errcheck // make a best effort to return whatever information we can
 	// returning an error here without the code and source would
 	// be less helpful
@@ -298,6 +292,7 @@ func die(code int, headers http.Header, body io.ReadCloser) error {
 		// consumers to depend on an internal type (which they can't anyway)
 		Source: internal.GetErrorSource(headers).String(),
 		Body:   bodyContent,
+		Path:   path,
 	}
 }
 

--- a/nmagent/client.go
+++ b/nmagent/client.go
@@ -90,6 +90,12 @@ func (c *Client) DeleteNetwork(ctx context.Context, dnr DeleteNetworkRequest) er
 	}
 	defer resp.Body.Close()
 
+	// NMAgent returns 400 Bad Request if the network ID is invalid or does not
+	// exist, but we wish to return this as a NotFound error.
+	if resp.StatusCode == http.StatusBadRequest {
+		resp.StatusCode = http.StatusNotFound
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		return die(resp.StatusCode, resp.Header, resp.Body)
 	}

--- a/nmagent/client_test.go
+++ b/nmagent/client_test.go
@@ -151,6 +151,13 @@ func TestNMAgentClientDeleteNetwork(t *testing.T) {
 			http.StatusInternalServerError,
 			true,
 		},
+		{
+			"network does not exist",
+			"00000000-0000-0000-0000-000000000000",
+			"/machine/plugins?comp=nmagent&type=NetworkManagement%2FjoinedVirtualNetworks%2F00000000-0000-0000-0000-000000000000%2Fapi-version%2F1%2Fmethod%2FDELETE",
+			http.StatusBadRequest,
+			true,
+		},
 	}
 
 	for _, test := range deleteNetTests {

--- a/nmagent/error.go
+++ b/nmagent/error.go
@@ -11,6 +11,8 @@ import (
 	pkgerrors "github.com/pkg/errors"
 )
 
+var deleteNetworkPattern = regexp.MustCompile(`/NetworkManagement/joinedVirtualNetworks/[^/]+/api-version/\d+/method/DELETE`)
+
 // ContentError is encountered when an unexpected content type is obtained from
 // NMAgent.
 type ContentError struct {
@@ -109,7 +111,6 @@ func (e Error) Unauthorized() bool {
 // NotFound reports whether the error was produced as a result of the resource
 // not existing.
 func (e Error) NotFound() bool {
-	deleteNetworkPattern := regexp.MustCompile(`/NetworkManagement/joinedVirtualNetworks/[^/]+/api-version/\d+/method/DELETE`)
 	if deleteNetworkPattern.MatchString(e.Path) {
 		return e.Code == http.StatusBadRequest || e.Code == http.StatusNotFound
 	}

--- a/nmagent/error.go
+++ b/nmagent/error.go
@@ -103,3 +103,9 @@ func (e Error) StatusCode() int {
 func (e Error) Unauthorized() bool {
 	return e.Code == http.StatusUnauthorized
 }
+
+// NotFound reports whether the error was produced as a result of the resource
+// not existing.
+func (e Error) NotFound() bool {
+	return e.Code == http.StatusNotFound
+}


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
This PR makes some minor changes to the NMAgent client package as a part of a larger work item. This commit adds a NotFound method to the error returned by the NMAgent client. It also adds special handling to treat a 400 BadRequest as a NotFound when returned by the DeleteNetwork API call, since this case should be interpreted as a NotFound by the caller.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
