### PR TITLE
fix: Change cluster name for cilium nightly pipeline

### DIFF
--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -98,8 +98,8 @@ stages:
         strategy:
           matrix:
             cilium_nightly:
-              name: ciliumnightly
-              clusterName: overlaynightly
+              name: cilium_overlay_nightly
+              clusterName: ciliumnightly
         steps:
           - template: ../../templates/delete-cluster.yaml
             parameters:


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Cilium Nightly Pipeline was not deleting clusters at the end of its run due to mismatched cluster names. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
Fixed the version input variables for pipeline within ADO. There is an updated policy that auto removes images after 30d that do not match `v*` . Included with that was an initial deletion of all images >30d, leading to the loss of older versions that matched the regex.