### PR TITLE
feat: Add NMAgent Delete Network toggle to UnpublishNetworkContainer path

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -554,6 +554,10 @@ type UnpublishNetworkContainerRequest struct {
 	JoinNetworkURL                    string
 	DeleteNetworkContainerURL         string
 	DeleteNetworkContainerRequestBody []byte
+
+	// ShouldDeleteNetwork specifies whether the virtual network should be deleted via
+	// NMAgent after the network container has been unpublished.
+	ShouldDeleteNetwork bool
 }
 
 func (u UnpublishNetworkContainerRequest) String() string {

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -555,7 +555,7 @@ type UnpublishNetworkContainerRequest struct {
 	DeleteNetworkContainerURL         string
 	DeleteNetworkContainerRequestBody []byte
 
-	// ShouldDeleteNetwork specifies whether the virtual network should be deleted via
+	// ShouldDeleteNetwork specifies whether the virtual network should be deleted from
 	// NMAgent after the network container has been unpublished.
 	ShouldDeleteNetwork bool
 }

--- a/cns/fakes/nmagentclientfake.go
+++ b/cns/fakes/nmagentclientfake.go
@@ -17,7 +17,7 @@ type NMAgentClientFake struct {
 	SupportedAPIsF    func(context.Context) ([]string, error)
 	GetNCVersionListF func(context.Context) (nmagent.NCVersionList, error)
 	GetHomeAzF        func(context.Context) (nmagent.AzResponse, error)
-	DeleteNetworkf    func(context.Context, nmagent.DeleteNetworkRequest) error
+	DeleteNetworkF    func(context.Context, nmagent.DeleteNetworkRequest) error
 }
 
 func (n *NMAgentClientFake) SupportedAPIs(ctx context.Context) ([]string, error) {
@@ -33,5 +33,5 @@ func (n *NMAgentClientFake) GetHomeAz(ctx context.Context) (nmagent.AzResponse, 
 }
 
 func (n *NMAgentClientFake) DeleteNetwork(ctx context.Context, req nmagent.DeleteNetworkRequest) error {
-	return n.DeleteNetworkf(ctx, req)
+	return n.DeleteNetworkF(ctx, req)
 }

--- a/cns/fakes/nmagentclientfake.go
+++ b/cns/fakes/nmagentclientfake.go
@@ -17,6 +17,7 @@ type NMAgentClientFake struct {
 	SupportedAPIsF    func(context.Context) ([]string, error)
 	GetNCVersionListF func(context.Context) (nmagent.NCVersionList, error)
 	GetHomeAzF        func(context.Context) (nmagent.AzResponse, error)
+	DeleteNetworkf    func(context.Context, nmagent.DeleteNetworkRequest) error
 }
 
 func (n *NMAgentClientFake) SupportedAPIs(ctx context.Context) ([]string, error) {
@@ -29,4 +30,8 @@ func (n *NMAgentClientFake) GetNCVersionList(ctx context.Context) (nmagent.NCVer
 
 func (n *NMAgentClientFake) GetHomeAz(ctx context.Context) (nmagent.AzResponse, error) {
 	return n.GetHomeAzF(ctx)
+}
+
+func (n *NMAgentClientFake) DeleteNetwork(ctx context.Context, req nmagent.DeleteNetworkRequest) error {
+	return n.DeleteNetworkf(ctx, req)
 }

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -43,6 +43,7 @@ type nmagentClient interface {
 	SupportedAPIs(context.Context) ([]string, error)
 	GetNCVersionList(context.Context) (nma.NCVersionList, error)
 	GetHomeAz(context.Context) (nma.AzResponse, error)
+	DeleteNetwork(context.Context, nma.DeleteNetworkRequest) error
 }
 
 type wireserverProxy interface {

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -718,6 +718,14 @@ func (service *HTTPRestService) setNetworkStateJoined(networkID string) {
 	service.state.joinedNetworks[networkID] = struct{}{}
 }
 
+// Set the network as unjoined (deleted)
+func (service *HTTPRestService) setNetworkStateUnjoined(networkID string) {
+	namedLock.LockAcquire(stateJoinedNetworks)
+	defer namedLock.LockRelease(stateJoinedNetworks)
+
+	delete(service.state.joinedNetworks, networkID)
+}
+
 func logNCSnapshot(createNetworkContainerRequest cns.CreateNetworkContainerRequest) {
 	aiEvent := aitelemetry.Event{
 		EventName:  logger.CnsNCSnapshotEventStr,


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
NMAgent is currently rolling out a change that exposes a Delete Network endpoint to clean up vnet subscriptions. This PR is part of larger change with the end goal of invoking the NMAgent Delete Network endpoint after all NCs in a vnet have been deleted from the node. 

This change adds a `shouldDeleteNetwork` toggle to the UnpublishNetworkContainer API route which will allow DNC to tell CNS if a NMAgent Delete Network request should be made after the NC has been unpublished. Determining whether this is the final NC (meaning the vnet can/should be deleted) will be handled by DNC in a subsequent PR.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
