### PR TITLE
ci: Bypass Dualstack E2E on cluster creation failure

### DIFF
--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
@@ -19,16 +19,26 @@ stages:
     variables:
       commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
     jobs:
-      - template: ../../templates/create-cluster.yaml
-        parameters:
-          name: ${{ parameters.name }}
-          displayName: ${{ parameters.displayName }}
-          clusterType: ${{ parameters.clusterType }}
-          clusterName: ${{ parameters.clusterName }}-$(commitID)
-          vmSize: ${{ parameters.vmSize }}
-          k8sVersion: ${{ parameters.k8sVersion }}
-          dependsOn: ${{ parameters.dependsOn }}
-          region: $(REGION_DUALSTACKOVERLAY_CLUSTER_TEST) # Dualstack has a specific region requirement
+      - job: temp
+        pool:
+          name: "$(BUILD_POOL_NAME_DEFAULT)"
+        steps:
+          - script: |
+              # To use the variables below, you must make the respective stage's dependsOn have - setup or it will not retain context of this stage
+              echo you did it
+            name: "EnvironmentalVariables"
+            displayName: "Set environmental variables"
+
+      # - template: ../../templates/create-cluster.yaml
+      #   parameters:
+      #     name: ${{ parameters.name }}
+      #     displayName: ${{ parameters.displayName }}
+      #     clusterType: ${{ parameters.clusterType }}
+      #     clusterName: ${{ parameters.clusterName }}-$(commitID)
+      #     vmSize: ${{ parameters.vmSize }}
+      #     k8sVersion: ${{ parameters.k8sVersion }}
+      #     dependsOn: ${{ parameters.dependsOn }}
+      #     region: $(REGION_DUALSTACKOVERLAY_CLUSTER_TEST) # Dualstack has a specific region requirement
 
   - stage: ${{ parameters.name }}
     condition: and( succeeded(), not(eq(dependencies.dualstackoverlaye2e.result,'SucceededWithIssues')) ) # Cant use parameters in dependencies

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
@@ -19,26 +19,16 @@ stages:
     variables:
       commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
     jobs:
-      - job: temp
-        pool:
-          name: "$(BUILD_POOL_NAME_DEFAULT)"
-        steps:
-          - script: |
-              # To use the variables below, you must make the respective stage's dependsOn have - setup or it will not retain context of this stage
-              echo you did it
-            name: "EnvironmentalVariables"
-            displayName: "Set environmental variables"
-
-      # - template: ../../templates/create-cluster.yaml
-      #   parameters:
-      #     name: ${{ parameters.name }}
-      #     displayName: ${{ parameters.displayName }}
-      #     clusterType: ${{ parameters.clusterType }}
-      #     clusterName: ${{ parameters.clusterName }}-$(commitID)
-      #     vmSize: ${{ parameters.vmSize }}
-      #     k8sVersion: ${{ parameters.k8sVersion }}
-      #     dependsOn: ${{ parameters.dependsOn }}
-      #     region: $(REGION_DUALSTACKOVERLAY_CLUSTER_TEST) # Dualstack has a specific region requirement
+      - template: ../../templates/create-cluster.yaml
+        parameters:
+          name: ${{ parameters.name }}
+          displayName: ${{ parameters.displayName }}
+          clusterType: ${{ parameters.clusterType }}
+          clusterName: ${{ parameters.clusterName }}-$(commitID)
+          vmSize: ${{ parameters.vmSize }}
+          k8sVersion: ${{ parameters.k8sVersion }}
+          dependsOn: ${{ parameters.dependsOn }}
+          region: $(REGION_DUALSTACKOVERLAY_CLUSTER_TEST) # Dualstack has a specific region requirement
 
   - stage: ${{ parameters.name }}
     condition: and( succeeded(), not(eq(dependencies.dualstackoverlaye2e.result,'SucceededWithIssues')) ) # Cant use parameters in dependencies

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
@@ -31,7 +31,7 @@ stages:
           region: $(REGION_DUALSTACKOVERLAY_CLUSTER_TEST) # Dualstack has a specific region requirement
 
   - stage: ${{ parameters.name }}
-    condition: succeededOrFailed()
+    condition: and( succeeded(), not(eq(dependencies.dualstackoverlaye2e.result,'SucceededWithIssues')) ) # Cant use parameters in dependencies
     displayName: E2E - ${{ parameters.displayName }}
     dependsOn:
     - setup

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
@@ -31,6 +31,7 @@ stages:
           region: $(REGION_DUALSTACKOVERLAY_CLUSTER_TEST) # Dualstack has a specific region requirement
 
   - stage: ${{ parameters.name }}
+    condition: succeededOrFailed()
     displayName: E2E - ${{ parameters.displayName }}
     dependsOn:
     - setup

--- a/.pipelines/templates/create-cluster.yaml
+++ b/.pipelines/templates/create-cluster.yaml
@@ -34,3 +34,4 @@ jobs:
             make -C ./hack/aks ${{ parameters.clusterType }} AZCLI=az REGION=${{ parameters.region }} SUB=$(SUB_AZURE_NETWORK_AGENT_TEST) CLUSTER=${{ parameters.clusterName }} K8S_VER=${{ parameters.k8sVersion }} VM_SIZE=${{ parameters.vmSize }} WINDOWS_OS_SKU=${{ parameters.windowsOsSku }} WINDOWS_VM_SKU=${{ parameters.vmSize }} WINDOWS_USERNAME=${WINDOWS_USERNAME} WINDOWS_PASSWORD=${WINDOWS_PASSWORD}
             echo "Cluster successfully created"
         displayName: Cluster - ${{ parameters.clusterType }}
+        continueOnError: ${{ contains(parameters.clusterType, 'dualstack') }}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
This allows for the Dualstack E2E on the PR pipeline to run if cluster creation succeeds and skip it if it does not.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**: