### PR TITLE
CNS - Ensuring no stale NCs during NNC reconcile

### DIFF
--- a/cns/kubecontroller/nodenetworkconfig/reconciler.go
+++ b/cns/kubecontroller/nodenetworkconfig/reconciler.go
@@ -24,7 +24,7 @@ import (
 
 type cnsClient interface {
 	CreateOrUpdateNetworkContainerInternal(*cns.CreateNetworkContainerRequest) cnstypes.ResponseCode
-	EnsureNoStaleNCs(validNCIDs []string)
+	MustEnsureNoStaleNCs(validNCIDs []string)
 }
 
 type nodeNetworkConfigListener interface {
@@ -82,7 +82,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	for i := range nnc.Status.NetworkContainers {
 		validNCIDs[i] = nnc.Status.NetworkContainers[i].ID
 	}
-	r.cnscli.EnsureNoStaleNCs(validNCIDs)
+	r.cnscli.MustEnsureNoStaleNCs(validNCIDs)
 
 	// for each NC, parse it in to a CreateNCRequest and forward it to the appropriate Listener
 	for i := range nnc.Status.NetworkContainers {

--- a/cns/kubecontroller/nodenetworkconfig/reconciler.go
+++ b/cns/kubecontroller/nodenetworkconfig/reconciler.go
@@ -24,6 +24,7 @@ import (
 
 type cnsClient interface {
 	CreateOrUpdateNetworkContainerInternal(*cns.CreateNetworkContainerRequest) cnstypes.ResponseCode
+	EnsureNoStaleNCs(validNCIDs []string)
 }
 
 type nodeNetworkConfigListener interface {
@@ -73,6 +74,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	logger.Printf("[cns-rc] CRD Spec: %+v", nnc.Spec)
 
 	ipAssignments := 0
+
+	// during node upgrades, an nnc may be updated with new ncs. at any given time, only the ncs
+	// that exist in the nnc are valid. any others that may have been previously created and no
+	// longer exist in the nnc should be considered stale.
+	validNCIDs := make([]string, len(nnc.Status.NetworkContainers))
+	for i := range nnc.Status.NetworkContainers {
+		validNCIDs[i] = nnc.Status.NetworkContainers[i].ID
+	}
+	r.cnscli.EnsureNoStaleNCs(validNCIDs)
 
 	// for each NC, parse it in to a CreateNCRequest and forward it to the appropriate Listener
 	for i := range nnc.Status.NetworkContainers {

--- a/cns/kubecontroller/nodenetworkconfig/reconciler_test.go
+++ b/cns/kubecontroller/nodenetworkconfig/reconciler_test.go
@@ -33,7 +33,7 @@ func (m *mockCNSClient) CreateOrUpdateNetworkContainerInternal(req *cns.CreateNe
 	return m.createOrUpdateNC(req)
 }
 
-func (m *mockCNSClient) EnsureNoStaleNCs(validNCIDs []string) {
+func (m *mockCNSClient) MustEnsureNoStaleNCs(validNCIDs []string) {
 	valid := make(map[string]struct{})
 	for _, ncID := range validNCIDs {
 		valid[ncID] = struct{}{}

--- a/cns/kubecontroller/nodenetworkconfig/reconciler_test.go
+++ b/cns/kubecontroller/nodenetworkconfig/reconciler_test.go
@@ -18,8 +18,8 @@ import (
 )
 
 type cnsClientState struct {
-	req *cns.CreateNetworkContainerRequest
-	nnc *v1alpha.NodeNetworkConfig
+	reqsByNCID map[string]*cns.CreateNetworkContainerRequest
+	nnc        *v1alpha.NodeNetworkConfig
 }
 
 type mockCNSClient struct {
@@ -29,8 +29,21 @@ type mockCNSClient struct {
 }
 
 func (m *mockCNSClient) CreateOrUpdateNetworkContainerInternal(req *cns.CreateNetworkContainerRequest) cnstypes.ResponseCode {
-	m.state.req = req
+	m.state.reqsByNCID[req.NetworkContainerid] = req
 	return m.createOrUpdateNC(req)
+}
+
+func (m *mockCNSClient) EnsureNoStaleNCs(validNCIDs []string) {
+	valid := make(map[string]struct{})
+	for _, ncID := range validNCIDs {
+		valid[ncID] = struct{}{}
+	}
+
+	for ncID := range m.state.reqsByNCID {
+		if _, ok := valid[ncID]; !ok {
+			delete(m.state.reqsByNCID, ncID)
+		}
+	}
 }
 
 func (m *mockCNSClient) Update(nnc *v1alpha.NodeNetworkConfig) error {
@@ -112,7 +125,7 @@ func TestReconcile(t *testing.T) {
 			},
 			wantErr: true,
 			wantCNSClientState: cnsClientState{
-				req: validSwiftRequest,
+				reqsByNCID: map[string]*cns.CreateNetworkContainerRequest{validSwiftRequest.NetworkContainerid: validSwiftRequest},
 			},
 		},
 		{
@@ -137,7 +150,7 @@ func TestReconcile(t *testing.T) {
 			},
 			wantErr: false,
 			wantCNSClientState: cnsClientState{
-				req: validSwiftRequest,
+				reqsByNCID: map[string]*cns.CreateNetworkContainerRequest{validSwiftRequest.NetworkContainerid: validSwiftRequest},
 				nnc: &v1alpha.NodeNetworkConfig{
 					Status: validSwiftStatus,
 					Spec: v1alpha.NodeNetworkConfigSpec{
@@ -173,6 +186,11 @@ func TestReconcile(t *testing.T) {
 	}
 	for _, tt := range tests {
 		tt := tt
+		tt.cnsClient.state.reqsByNCID = make(map[string]*cns.CreateNetworkContainerRequest)
+		if tt.wantCNSClientState.reqsByNCID == nil {
+			tt.wantCNSClientState.reqsByNCID = make(map[string]*cns.CreateNetworkContainerRequest)
+		}
+
 		t.Run(tt.name, func(t *testing.T) {
 			r := NewReconciler(&tt.cnsClient, &tt.cnsClient, tt.nodeIP)
 			r.nnccli = &tt.ncGetter
@@ -186,4 +204,65 @@ func TestReconcile(t *testing.T) {
 			assert.Equal(t, tt.wantCNSClientState, tt.cnsClient.state)
 		})
 	}
+}
+
+func TestReconcileStaleNCs(t *testing.T) {
+	logger.InitLogger("", 0, 0, "")
+
+	cnsClient := mockCNSClient{
+		state:            cnsClientState{reqsByNCID: make(map[string]*cns.CreateNetworkContainerRequest)},
+		createOrUpdateNC: func(*cns.CreateNetworkContainerRequest) cnstypes.ResponseCode { return cnstypes.Success },
+		update:           func(*v1alpha.NodeNetworkConfig) error { return nil },
+	}
+
+	nodeIP := "10.0.0.10"
+
+	nncv1 := v1alpha.NodeNetworkConfig{
+		Status: v1alpha.NodeNetworkConfigStatus{
+			NetworkContainers: []v1alpha.NetworkContainer{
+				{ID: "nc1", PrimaryIP: "10.1.0.10", SubnetAddressSpace: "10.1.0.0/24", NodeIP: nodeIP},
+				{ID: "nc2", PrimaryIP: "10.1.0.11", SubnetAddressSpace: "10.1.0.0/24", NodeIP: nodeIP},
+			},
+		},
+		Spec: v1alpha.NodeNetworkConfigSpec{RequestedIPCount: 10},
+	}
+
+	nncv2 := v1alpha.NodeNetworkConfig{
+		Status: v1alpha.NodeNetworkConfigStatus{
+			NetworkContainers: []v1alpha.NetworkContainer{
+				{ID: "nc3", PrimaryIP: "10.1.0.12", SubnetAddressSpace: "10.1.0.0/24", NodeIP: nodeIP},
+				{ID: "nc4", PrimaryIP: "10.1.0.13", SubnetAddressSpace: "10.1.0.0/24", NodeIP: nodeIP},
+			},
+		},
+		Spec: v1alpha.NodeNetworkConfigSpec{RequestedIPCount: 10},
+	}
+
+	i := 0
+	nncIterator := func(context.Context, types.NamespacedName) (*v1alpha.NodeNetworkConfig, error) {
+		nncLog := []v1alpha.NodeNetworkConfig{nncv1, nncv2}
+		for i < len(nncLog) {
+			j := i
+			i++
+			return &nncLog[j], nil
+		}
+
+		return &nncLog[len(nncLog)-1], nil
+	}
+
+	r := NewReconciler(&cnsClient, &cnsClient, nodeIP)
+	r.nnccli = &mockNCGetter{get: nncIterator}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{})
+	require.NoError(t, err)
+
+	assert.Contains(t, cnsClient.state.reqsByNCID, "nc1")
+	assert.Contains(t, cnsClient.state.reqsByNCID, "nc2")
+
+	_, err = r.Reconcile(context.Background(), reconcile.Request{})
+	require.NoError(t, err)
+
+	assert.NotContains(t, cnsClient.state.reqsByNCID, "nc1")
+	assert.NotContains(t, cnsClient.state.reqsByNCID, "nc2")
+	assert.Contains(t, cnsClient.state.reqsByNCID, "nc3")
+	assert.Contains(t, cnsClient.state.reqsByNCID, "nc4")
 }

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -475,7 +475,7 @@ func (service *HTTPRestService) DeleteNetworkContainerInternal(
 	return types.Success
 }
 
-func (service *HTTPRestService) EnsureNoStaleNCs(validNCIDs []string) {
+func (service *HTTPRestService) MustEnsureNoStaleNCs(validNCIDs []string) {
 	valid := make(map[string]struct{})
 	for _, ncID := range validNCIDs {
 		valid[ncID] = struct{}{}
@@ -484,10 +484,24 @@ func (service *HTTPRestService) EnsureNoStaleNCs(validNCIDs []string) {
 	service.Lock()
 	defer service.Unlock()
 
+	ncIDToAssignedIPs := make(map[string][]cns.IPConfigurationStatus)
+	for _, ipInfo := range service.PodIPConfigState { // nolint:gocritic // copy is fine; it's a larger change to modify the map to hold pointers
+		if ipInfo.GetState() == types.Assigned {
+			ncIDToAssignedIPs[ipInfo.NCID] = append(ncIDToAssignedIPs[ipInfo.NCID], ipInfo)
+		}
+	}
+
 	mutated := false
 	for ncID := range service.state.ContainerStatus {
 		if _, ok := valid[ncID]; !ok {
-			logger.Errorf("[Azure CNS] Found stale network container id %s in CNS state. Removing...", ncID)
+			// stale NCs with assigned IPs are an unexpected CNS state which we need to alert on.
+			if assignedIPs, hasAssignedIPs := ncIDToAssignedIPs[ncID]; hasAssignedIPs {
+				msg := fmt.Sprintf("Unexpected state: found stale NC ID %s in CNS state with %d assigned IPs: %+v", ncID, len(assignedIPs), assignedIPs)
+				logger.Errorf(msg)
+				panic(msg)
+			}
+
+			logger.Errorf("[Azure CNS] Found stale NC ID %s in CNS state. Removing...", ncID)
 			delete(service.state.ContainerStatus, ncID)
 			mutated = true
 		}

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -484,14 +484,18 @@ func (service *HTTPRestService) EnsureNoStaleNCs(validNCIDs []string) {
 	service.Lock()
 	defer service.Unlock()
 
+	mutated := false
 	for ncID := range service.state.ContainerStatus {
 		if _, ok := valid[ncID]; !ok {
 			logger.Errorf("[Azure CNS] Found stale network container id %s in CNS state. Removing...", ncID)
 			delete(service.state.ContainerStatus, ncID)
+			mutated = true
 		}
 	}
 
-	_ = service.saveState()
+	if mutated {
+		_ = service.saveState()
+	}
 }
 
 // This API will be called by CNS RequestController on CRD update.


### PR DESCRIPTION
**Reason for Change**:
There may be occasions where node upgrades may not result in delete and re-create events for an NNC, rather a new set of NCs will be available in the NNC as an update. The current reconcile logic only adds NCs to CNS, so in these cases stale NCs would remain. This PR attempts to ensure there are no stale NCs during NNC reconciles.
