### PR TITLE
fix: serviceAccount must be specified at pod spec level in dual stack goldpinger deployments

### DIFF
--- a/test/integration/manifests/datapath/linux-deployment-ipv6.yaml
+++ b/test/integration/manifests/datapath/linux-deployment-ipv6.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: goldpinger
     spec:
+        serviceAccount: goldpinger-serviceaccount
         containers:
           - name: goldpinger
             env:
@@ -41,7 +42,6 @@ spec:
               - name: HOSTS_TO_RESOLVE
                 value: "2001:4860:4860::8888 www.bing.com"
             image: "docker.io/bloomberg/goldpinger:v3.7.0"
-            serviceAccount: goldpinger-serviceaccount
             tolerations:
               - key: node-role.kubernetes.io/master
                 effect: NoSchedule

--- a/test/integration/manifests/datapath/linux-deployment.yaml
+++ b/test/integration/manifests/datapath/linux-deployment.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: goldpinger
     spec:
+        serviceAccount: goldpinger-serviceaccount
         containers:
           - name: goldpinger
             env:
@@ -39,7 +40,6 @@ spec:
               - name: HOSTS_TO_RESOLVE
                 value: "1.1.1.1 8.8.8.8 www.bing.com"
             image: "docker.io/bloomberg/goldpinger:v3.7.0"
-            serviceAccount: goldpinger-serviceaccount
             tolerations:
               - key: node-role.kubernetes.io/master
                 effect: NoSchedule


### PR DESCRIPTION
**Reason for Change**:
Goldpinger pods in dual stack tests are not able to query apiserver to discover what pod IPs to ping, due to RBAC being incorrectly set up for these deployments.