### PR TITLE
add a new container type for l1vh singularity container request

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -51,7 +51,7 @@ const (
 	Basic                  = "Basic"
 	JobObject              = "JobObject"
 	COW                    = "COW" // Container on Windows
-	BackendNIC             = "BackendNIC"
+	BackendNICNC           = "BackendNICNC"
 )
 
 // Orchestrator Types
@@ -78,6 +78,8 @@ const (
 	InfraNIC NICType = "InfraNIC"
 	// Delegated VM NICs are projected from VM to container network namespace
 	DelegatedVMNIC NICType = "DelegatedVMNIC"
+	// BackendNIC NICs are used for infiniband nics on a VM
+	BackendNIC NICType = "BackendNIC"
 )
 
 // ChannelMode :- CNS channel modes
@@ -107,7 +109,7 @@ type CreateNetworkContainerRequest struct {
 	AllowNCToHostCommunication bool
 	EndpointPolicies           []NetworkContainerRequestPolicies
 	NCStatus                   v1alpha.NCStatus
-	backendNICInfo             BackendNICInfo //nolint // introducing new field for backendnic, to be used later by cni code
+	networkInterfaceInfo       NetworkInterfaceInfo //nolint // introducing new field for backendnic, to be used later by cni code
 }
 
 // CreateNetworkContainerRequest implements fmt.Stringer for logging
@@ -319,7 +321,7 @@ type MultiTenancyInfo struct {
 	ID        int // This can be vlanid, vxlanid, gre-key etc. (depends on EnacapType).
 }
 
-type BackendNICInfo struct {
+type NetworkInterfaceInfo struct {
 	NICType    string
 	MACAddress string
 }
@@ -422,7 +424,7 @@ type PodIpInfo struct {
 	PodIPConfig                     IPSubnet
 	NetworkContainerPrimaryIPConfig IPConfiguration
 	HostPrimaryIPInfo               HostIPInfo
-	// NICType defines whether NIC is InfraNIC or DelegatedVMNIC
+	// NICType defines whether NIC is InfraNIC or DelegatedVMNIC or BackendNIC
 	NICType       NICType
 	InterfaceName string
 	// MacAddress of interface

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -107,7 +107,7 @@ type CreateNetworkContainerRequest struct {
 	AllowNCToHostCommunication bool
 	EndpointPolicies           []NetworkContainerRequestPolicies
 	NCStatus                   v1alpha.NCStatus
-	backendNICInfo             BackendNICInfo
+	backendNICInfo             BackendNICInfo //nolint // introducing new field for backendnic, to be used later by cni code
 }
 
 // CreateNetworkContainerRequest implements fmt.Stringer for logging
@@ -320,9 +320,8 @@ type MultiTenancyInfo struct {
 }
 
 type BackendNICInfo struct {
-	NICType                   string
-	BackendNetworkInterfaceID string
-	MACAddress                string
+	NICType    string
+	MACAddress string
 }
 
 // IPConfiguration contains details about ip config to provision in the VM.

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -109,7 +109,7 @@ type CreateNetworkContainerRequest struct {
 	AllowNCToHostCommunication bool
 	EndpointPolicies           []NetworkContainerRequestPolicies
 	NCStatus                   v1alpha.NCStatus
-	networkInterfaceInfo       NetworkInterfaceInfo //nolint // introducing new field for backendnic, to be used later by cni code
+	NetworkInterfaceInfo       NetworkInterfaceInfo //nolint // introducing new field for backendnic, to be used later by cni code
 }
 
 // CreateNetworkContainerRequest implements fmt.Stringer for logging
@@ -117,9 +117,10 @@ func (req *CreateNetworkContainerRequest) String() string {
 	return fmt.Sprintf("CreateNetworkContainerRequest"+
 		"{Version: %s, NetworkContainerType: %s, NetworkContainerid: %s, PrimaryInterfaceIdentifier: %s, "+
 		"LocalIPConfiguration: %+v, IPConfiguration: %+v, SecondaryIPConfigs: %+v, MultitenancyInfo: %+v, "+
-		"AllowHostToNCCommunication: %t, AllowNCToHostCommunication: %t, NCStatus: %s}",
+		"AllowHostToNCCommunication: %t, AllowNCToHostCommunication: %t, NCStatus: %s, NetworkInterfaceInfo: %+v}",
 		req.Version, req.NetworkContainerType, req.NetworkContainerid, req.PrimaryInterfaceIdentifier, req.LocalIPConfiguration,
-		req.IPConfiguration, req.SecondaryIPConfigs, req.MultiTenancyInfo, req.AllowHostToNCCommunication, req.AllowNCToHostCommunication, string(req.NCStatus))
+		req.IPConfiguration, req.SecondaryIPConfigs, req.MultiTenancyInfo, req.AllowHostToNCCommunication, req.AllowNCToHostCommunication,
+		string(req.NCStatus), req.NetworkInterfaceInfo)
 }
 
 // NetworkContainerRequestPolicies - specifies policies associated with create network request
@@ -322,7 +323,7 @@ type MultiTenancyInfo struct {
 }
 
 type NetworkInterfaceInfo struct {
-	NICType    string
+	NICType    NICType
 	MACAddress string
 }
 
@@ -418,6 +419,7 @@ type GetNetworkContainerResponse struct {
 	Response                   Response
 	AllowHostToNCCommunication bool
 	AllowNCToHostCommunication bool
+	NetworkInterfaceInfo       NetworkInterfaceInfo
 }
 
 type PodIpInfo struct {

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -107,8 +107,7 @@ type CreateNetworkContainerRequest struct {
 	AllowNCToHostCommunication bool
 	EndpointPolicies           []NetworkContainerRequestPolicies
 	NCStatus                   v1alpha.NCStatus
-	BackendNetworkInterfaceID  string
-	MACAddress                 string
+	backendNICInfo             BackendNICInfo
 }
 
 // CreateNetworkContainerRequest implements fmt.Stringer for logging
@@ -318,6 +317,12 @@ func KubePodsToPodInfoByIP(pods []corev1.Pod) (map[string]PodInfo, error) {
 type MultiTenancyInfo struct {
 	EncapType string
 	ID        int // This can be vlanid, vxlanid, gre-key etc. (depends on EnacapType).
+}
+
+type BackendNICInfo struct {
+	NICType                   string
+	BackendNetworkInterfaceID string
+	MACAddress                string
 }
 
 // IPConfiguration contains details about ip config to provision in the VM.

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -51,6 +51,7 @@ const (
 	Basic                  = "Basic"
 	JobObject              = "JobObject"
 	COW                    = "COW" // Container on Windows
+	BackendNIC             = "BackendNIC"
 )
 
 // Orchestrator Types

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -107,6 +107,8 @@ type CreateNetworkContainerRequest struct {
 	AllowNCToHostCommunication bool
 	EndpointPolicies           []NetworkContainerRequestPolicies
 	NCStatus                   v1alpha.NCStatus
+	BackendNetworkInterfaceID  string
+	MACAddress                 string
 }
 
 // CreateNetworkContainerRequest implements fmt.Stringer for logging

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -501,6 +501,7 @@ func (service *HTTPRestService) getAllNetworkContainerResponses(
 			LocalIPConfiguration:       savedReq.LocalIPConfiguration,
 			AllowHostToNCCommunication: savedReq.AllowHostToNCCommunication,
 			AllowNCToHostCommunication: savedReq.AllowNCToHostCommunication,
+			NetworkInterfaceInfo:       savedReq.NetworkInterfaceInfo,
 		}
 
 		// If the NC version check wasn't skipped, take into account the VFP programming status when returning the response

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -163,9 +163,7 @@ func (service *HTTPRestService) saveNetworkContainerGoalState(
 		fallthrough
 	case cns.JobObject:
 		fallthrough
-	case cns.COW:
-		fallthrough
-	case cns.BackendNIC:
+	case cns.COW, cns.BackendNIC:
 		fallthrough
 	case cns.WebApps:
 		switch service.state.OrchestratorType {

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -165,6 +165,8 @@ func (service *HTTPRestService) saveNetworkContainerGoalState(
 		fallthrough
 	case cns.COW:
 		fallthrough
+	case cns.BackendNIC:
+		fallthrough
 	case cns.WebApps:
 		switch service.state.OrchestratorType {
 		case cns.Kubernetes:

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -163,7 +163,7 @@ func (service *HTTPRestService) saveNetworkContainerGoalState(
 		fallthrough
 	case cns.JobObject:
 		fallthrough
-	case cns.COW, cns.BackendNIC:
+	case cns.COW, cns.BackendNICNC:
 		fallthrough
 	case cns.WebApps:
 		switch service.state.OrchestratorType {
@@ -177,7 +177,7 @@ func (service *HTTPRestService) saveNetworkContainerGoalState(
 			fallthrough
 		case cns.AzureFirstParty:
 			fallthrough
-		case cns.WebApps, cns.BackendNIC: // todo: Is WebApps an OrchastratorType or ContainerType?
+		case cns.WebApps, cns.BackendNICNC: // todo: Is WebApps an OrchastratorType or ContainerType?
 			podInfo, err := cns.UnmarshalPodInfo(req.OrchestratorContext)
 			if err != nil {
 				errBuf := fmt.Sprintf("Unmarshalling %s failed with error %v", req.NetworkContainerType, err)

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -177,7 +177,7 @@ func (service *HTTPRestService) saveNetworkContainerGoalState(
 			fallthrough
 		case cns.AzureFirstParty:
 			fallthrough
-		case cns.WebApps: // todo: Is WebApps an OrchastratorType or ContainerType?
+		case cns.WebApps, cns.BackendNIC: // todo: Is WebApps an OrchastratorType or ContainerType?
 			podInfo, err := cns.UnmarshalPodInfo(req.OrchestratorContext)
 			if err != nil {
 				errBuf := fmt.Sprintf("Unmarshalling %s failed with error %v", req.NetworkContainerType, err)


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
- we need a new containerType as per new NC request type in DNC for the Singularity L1VH APIs for create/delete backend-nic NC, so the goal state to be sent to CNS & used by CNI should have the new containerType for it. Also adding 2 fields required to program a backendNIC to the createNetworkContainerRequest object to send the goal state.
design doc - https://microsoft.sharepoint.com/:w:/t/Aznet/EQqTVNaVUBJDsRbhxwlMFP4BPAqGRM_9-RQiOkoMt7FyxA?e=kYTEJZ



**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
