### PR TITLE
chore: refactor load test suite

### DIFF
--- a/.pipelines/cni/load-test-templates/pod-deployment-template.yaml
+++ b/.pipelines/cni/load-test-templates/pod-deployment-template.yaml
@@ -19,4 +19,4 @@ steps:
         make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
         cd test/integration/load
         scale=$(( ${{ parameters.scaleup }} * ${{ parameters.nodeCount }} ))
-        go test -timeout 30m -tags load -run ^TestLoad$ -tags=load -iterations=${{ parameters.iterations }} -scaleup=$scale -os=${{ parameters.os }}
+        ITERATIONS=${{ parameters.iterations }} SCALE_UP=$scale OS_TYPE=${{ parameters.os }} go test -timeout 30m -tags load -run ^TestLoad$

--- a/.pipelines/cni/load-test-templates/restart-cns-template.yaml
+++ b/.pipelines/cni/load-test-templates/restart-cns-template.yaml
@@ -18,7 +18,7 @@ steps:
         echo "Ensure there are pods scheduled on each node"
         cd test/integration/load
         scale=$(( ${{ parameters.scaleup }} * ${{ parameters.nodeCount }} ))
-        go test -count 1 -timeout 30m -tags load -run ^TestScaleDeployment$ -tags=load -replicas=$scale
+        REPLICAS=$scale go test -count 1 -timeout 30m -tags load -run ^TestScaleDeployment$ -tags=load
         cd ../../../
 
         echo "Validate pod IP assignment before CNS restart"

--- a/.pipelines/cni/load-test-templates/restart-node-template.yaml
+++ b/.pipelines/cni/load-test-templates/restart-node-template.yaml
@@ -25,6 +25,6 @@ steps:
         vmss_name=$(az vmss list -g MC_${clusterName}_${clusterName}_$(LOCATION) --query "[].name" -o tsv)
         make -C ./hack/aks restart-vmss AZCLI=az CLUSTER=${clusterName} REGION=$(LOCATION) VMSS_NAME=$vmss_name
         cd test/integration/load
-        REPLICAS=$scale go test -count 1 -timeout 30m -tags load -run ^TestScaleDeployment$ -tags=load
+        REPLICAS=$scale go test -count 1 -timeout 30m -tags load -run ^TestScaleDeployment$
     name: "RestartNodes"
     displayName: "Restart Nodes"

--- a/.pipelines/cni/load-test-templates/restart-node-template.yaml
+++ b/.pipelines/cni/load-test-templates/restart-node-template.yaml
@@ -19,12 +19,12 @@ steps:
         # Capture a scaledown, scaling down to 50% of initial value
         scale=$(( ${{ parameters.scaleup }} * ${{ parameters.nodeCount }} / 2))
         echo "Scaling the pods down to $(( $scale / ${{ parameters.nodeCount }} )) per node"
-        go test -count 1 -timeout 30m -tags load -run ^TestScaleDeployment$ -tags=load -replicas=$scale -skip-wait=true
+        REPLICAS=$scale SKIP_WAIT=true go test -count 1 -timeout 30m -tags load -run ^TestScaleDeployment$ -tags=load
         cd ../../../
         echo "Restarting the nodes"
         vmss_name=$(az vmss list -g MC_${clusterName}_${clusterName}_$(LOCATION) --query "[].name" -o tsv)
         make -C ./hack/aks restart-vmss AZCLI=az CLUSTER=${clusterName} REGION=$(LOCATION) VMSS_NAME=$vmss_name
         cd test/integration/load
-        go test -count 1 -timeout 30m -tags load -run ^TestScaleDeployment$ -tags=load -replicas=$scale
+        REPLICAS=$scale go test -count 1 -timeout 30m -tags load -run ^TestScaleDeployment$ -tags=load
     name: "RestartNodes"
     displayName: "Restart Nodes"

--- a/.pipelines/cni/load-test-templates/validate-state-template.yaml
+++ b/.pipelines/cni/load-test-templates/validate-state-template.yaml
@@ -25,7 +25,7 @@ steps:
 
         make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
         kubectl get pods -A
-        make test-validate-state OS=${{ parameters.os }} RESTART_CASE=${{ parameters.restartCase }} CNI_TYPE=${{ parameters.cni }}
+        make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=${{ parameters.restartCase }} CNI_TYPE=${{ parameters.cni }}
     name: "ValidateState"
     displayName: "Validate State"
     retryCountOnTaskFailure: 3

--- a/.pipelines/singletenancy/aks/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks/e2e-step-template.yaml
@@ -60,7 +60,7 @@ steps:
       kubectl get pods -A -o wide
       echo "Deploying test pods"
       cd test/integration/load
-      go test -count 1 -timeout 30m -tags load -run ^TestLoad$ -iterations=2 -scaleup=${{ parameters.scaleup }} -os=${{ parameters.os }}
+      ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
       cd ../../..
       # Remove this once we have cniv1 support for validating the test cluster
       echo "Validate State skipped for linux cniv1 for now"
@@ -70,5 +70,3 @@ steps:
       kubectl delete ns load-test
     displayName: "Validate State"
     retryCountOnTaskFailure: 3
-
-

--- a/.pipelines/singletenancy/aks/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks/e2e-step-template.yaml
@@ -65,7 +65,7 @@ steps:
       # Remove this once we have cniv1 support for validating the test cluster
       echo "Validate State skipped for linux cniv1 for now"
       if [ "${{parameters.os}}" == "windows" ]; then
-        make test-validate-state OS=${{ parameters.os }} CNI_TYPE=cniv1
+        make test-validate-state OS_TYPE=${{ parameters.os }} CNI_TYPE=cniv1
       fi
       kubectl delete ns load-test
     displayName: "Validate State"

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-step-template.yaml
@@ -123,7 +123,7 @@ steps:
         make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
         kubectl get pods -owide -A
         echo "Validating Node Restart"
-        sudo go test -timeout 30m -tags load -cni cniv2 -run ^TestValidateState$ -restart-case=true
+        sudo CNI_TYPE=cniv2 RESTART_CASE=true go test -timeout 30m -tags load -run ^TestValidateState$
     displayName: "Validate Node Restart"
     retryCountOnTaskFailure: 3
 
@@ -132,12 +132,12 @@ steps:
       kubectl get pod -owide -A
       echo "validate pod state before CNS restarts"
       cd test/integration/load
-      sudo go test -timeout 30m -tags load -cni cniv2 -run ^TestValidateState$
+      sudo CNI_TYPE=cniv2 go test -timeout 30m -tags load -run ^TestValidateState$
       kubectl rollout restart ds azure-cns -n kube-system
       kubectl rollout status ds azure-cns -n kube-system
       kubectl get pod -owide -A
       echo "validate pods after CNS restart"
-      sudo go test -timeout 30m -tags load -cni cniv2 -run ^TestValidateState$
+      sudo CNI_TYPE=cniv2 go test -timeout 30m -tags load -run ^TestValidateState$
     name: "restartCNS_ValidatePodState"
     displayName: "Restart CNS and validate pod state"
     retryCountOnTaskFailure: 3

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-step-template.yaml
@@ -55,11 +55,11 @@ steps:
       set -e
       cd test/integration/load
       echo "DualStack Overlay Linux control plane Node properties test"
-      sudo go test -timeout 30m -tags load -run ^TestDualStackProperties$
+      sudo CNI_TYPE=dualstack go test -timeout 30m -tags load -run ^TestDualStackProperties$
       echo "DualStack Overlay Linux control plane Load test"
       sudo go test -timeout 30m -tags load -run ^TestLoad$
       echo "DualStack Overlay Linux control plane CNS validation test"
-      sudo go test -timeout 30m -tags load -cni dualstack -run ^TestValidateState$
+      sudo CNI_TYPE=dualstack go test -timeout 30m -tags load -run ^TestValidateState$
       cd ../datapath
       echo "Dualstack Overlay Linux datapath IPv6 test"
       sudo go test -count=1 datapath_linux_test.go -timeout 3m -tags connection -run ^TestDatapathLinux$ -tags=connection,integration -isDualStack=true
@@ -97,7 +97,7 @@ steps:
         make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_DUALSTACKOVERLAY_CLUSTER_TEST)
         kubectl get pods -A
         echo "Validating Node Restart"
-        sudo go test -timeout 30m -tags load -cni dualstack -run ^TestValidateState$ -restart-case=true
+        sudo CNI_TYPE=dualstack RESTART_CASE=true go test -timeout 30m -tags load -run ^TestValidateState$
     displayName: "Validate Node Restart"
     retryCountOnTaskFailure: 3
 
@@ -106,12 +106,12 @@ steps:
       kubectl get pod -owide -A
       echo "validate pod state before CNS restarts"
       cd test/integration/load
-      sudo go test -timeout 30m -tags load -cni dualstack -run ^TestValidateState$
+      sudo CNI_TYPE=dualstack go test -timeout 30m -tags load -run ^TestValidateState$
       kubectl rollout restart ds azure-cns -n kube-system
       kubectl rollout status ds azure-cns -n kube-system
       kubectl get pod -owide -A
       echo "validate pods after CNS restarts"
-      sudo go test -timeout 30m -tags load -cni dualstack -run ^TestValidateState$
+      sudo CNI_TYPE=dualstack go test -timeout 30m -tags load -run ^TestValidateState$
     name: "restartCNS_ValidatePodState"
     displayName: "Restart CNS and Validate Pod State"
     retryCountOnTaskFailure: 3

--- a/Makefile
+++ b/Makefile
@@ -733,7 +733,7 @@ test-load: ## run all load tests
 		go test -timeout 30m -race -tags=load ./test/integration/load...
 
 test-validate-state:
-	cd test/integration/load && OS_TYPE=$(OS) go test -mod=readonly -count=1 -timeout 30m -tags load -run ^TestValidateState
+	cd test/integration/load && go test -mod=readonly -count=1 -timeout 30m -tags load -run ^TestValidateState
 	cd ../../..
 
 test-cyclonus: ## run the cyclonus test for npm.

--- a/Makefile
+++ b/Makefile
@@ -733,7 +733,7 @@ test-load: ## run all load tests
 		go test -timeout 30m -race -tags=load ./test/integration/load...
 
 test-validate-state:
-	cd test/integration/load && go test -mod=readonly -count=1 -timeout 30m -tags load -run ^TestValidateState -restart-case=$(RESTART_CASE) -os=$(OS) -cni=$(CNI_TYPE)
+	cd test/integration/load && OS_TYPE=$(OS) go test -mod=readonly -count=1 -timeout 30m -tags load -run ^TestValidateState
 	cd ../../..
 
 test-cyclonus: ## run the cyclonus test for npm.

--- a/Makefile
+++ b/Makefile
@@ -727,6 +727,11 @@ test-integration: ## run all integration tests.
 		CNS_VERSION=$(CNS_VERSION) \
 		go test -mod=readonly -buildvcs=false -timeout 1h -coverpkg=./... -race -covermode atomic -coverprofile=coverage.out -tags=integration ./test/integration...
 
+test-load: ## run all load tests
+	CNI_DROPGZ_VERSION=$(CNI_DROPGZ_VERSION) \
+		CNS_VERSION=$(CNS_VERSION) \
+		go test -timeout 30m -race -tags=load ./test/integration/load...
+
 test-validate-state:
 	cd test/integration/load && go test -mod=readonly -count=1 -timeout 30m -tags load -run ^TestValidateState -restart-case=$(RESTART_CASE) -os=$(OS) -cni=$(CNI_TYPE)
 	cd ../../..

--- a/test/integration/load/load_test.go
+++ b/test/integration/load/load_test.go
@@ -92,7 +92,7 @@ func TestLoad(t *testing.T) {
 	for i := 0; i < testConfig.Iterations; i++ {
 		t.Log("Iteration ", i)
 		t.Log("Scale down deployment")
-		err = kubernetes.MustScaleDeployment(ctx, deploymentsClient, deployment, clientset, namespace, podLabelSelector, testConfig.Iterations, testConfig.SkipWait)
+		err = kubernetes.MustScaleDeployment(ctx, deploymentsClient, deployment, clientset, namespace, podLabelSelector, testConfig.ScaleDownReplicas, testConfig.SkipWait)
 		require.NoError(t, err)
 
 		t.Log("Scale up deployment")

--- a/test/integration/load/load_test.go
+++ b/test/integration/load/load_test.go
@@ -4,32 +4,35 @@ package load
 
 import (
 	"context"
-	"flag"
 	"testing"
 	"time"
 
 	"github.com/Azure/azure-container-networking/test/internal/kubernetes"
 	"github.com/Azure/azure-container-networking/test/validate"
+	"github.com/stretchr/testify/require"
 )
+
+type TestConfig struct {
+	OSType            string `env:"OS_TYPE" default:"linux"`
+	CNIType           string `env:"CNI_TYPE" default:"cilium"`
+	Iterations        int    `env:"ITERATIONS" default:"2"`
+	ScaleUpReplicas   int    `env:"SCALE_UP" default:"10"`
+	ScaleDownReplicas int    `env:"SCALE_DOWN" default:"1"`
+	Replicas          int    `env:"REPLICAS" default:"1"`
+	ValidateStateFile bool   `env:"VALIDATE_STATEFILE" default:"false"`
+	ValidateDualStack bool   `env:"VALIDATE_DUALSTACK" default:"false"`
+	SkipWait          bool   `env:"SKIP_WAIT" default:"false"`
+	RestartCase       bool   `env:"RESTART_CASE" default:"false"`
+	Cleanup           bool   `env:"CLEANUP" default:"false"`
+}
 
 const (
 	manifestDir      = "../manifests"
 	podLabelSelector = "load-test=true"
+	namespace        = "load-test"
 )
 
-var (
-	osType            = flag.String("os", "linux", "Operating system to run the test on")
-	cniType           = flag.String("cni", "cilium", "CNI to run the test on")
-	iterations        = flag.Int("iterations", 2, "Number of iterations to run the test for")
-	scaleUpReplicas   = flag.Int("scaleup", 10, "Number of replicas to scale up to")
-	scaleDownReplicas = flag.Int("scaledown", 1, "Number of replicas to scale down to")
-	replicas          = flag.Int("replicas", 1, "Number of replicas to scale up/down to")
-	validateStateFile = flag.Bool("validate-statefile", false, "Validate the state file")
-	validateDualStack = flag.Bool("validate-dualstack", false, "Validate the dualstack overlay")
-	skipWait          = flag.Bool("skip-wait", false, "Skip waiting for pods to be ready")
-	restartCase       = flag.Bool("restart-case", false, "In restart case, skip if we don't find state file")
-	namespace         = "load-test"
-)
+var testConfig = &TestConfig{}
 
 var noopDeploymentMap = map[string]string{
 	"windows": manifestDir + "/noop-deployment-windows.yaml",
@@ -41,7 +44,7 @@ In order to run the scale tests, you need a k8s cluster and its kubeconfig.
 If no kubeconfig is passed, the test will attempt to find one in the default location for kubectl config.
 Run the tests as follows:
 
-go test -timeout 30m -tags load -run ^TestLoad$ -tags=load
+go test -timeout 30m -tags load -run ^TestLoad$
 
 The Load test scale the pods up/down on the cluster and validates the pods have IP. By default it runs the
 cycle for 2 iterations.
@@ -60,142 +63,138 @@ todo: consider adding the following scenarios
 */
 func TestLoad(t *testing.T) {
 	clientset, err := kubernetes.MustGetClientset()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
 
 	// Create namespace if it doesn't exist
 	namespaceExists, err := kubernetes.NamespaceExists(ctx, clientset, namespace)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if !namespaceExists {
 		err = kubernetes.MustCreateNamespace(ctx, clientset, namespace)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 	}
 
-	deployment, err := kubernetes.MustParseDeployment(noopDeploymentMap[*osType])
-	if err != nil {
-		t.Fatal(err)
-	}
+	deployment, err := kubernetes.MustParseDeployment(noopDeploymentMap[testConfig.OSType])
+	require.NoError(t, err)
 
 	deploymentsClient := clientset.AppsV1().Deployments(namespace)
 	err = kubernetes.MustCreateDeployment(ctx, deploymentsClient, deployment)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	t.Log("Checking pods are running")
 	err = kubernetes.WaitForPodsRunning(ctx, clientset, namespace, podLabelSelector)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	t.Log("Repeating the scale up/down cycle")
-	for i := 0; i < *iterations; i++ {
+	for i := 0; i < testConfig.Iterations; i++ {
 		t.Log("Iteration ", i)
 		t.Log("Scale down deployment")
-		err = kubernetes.MustScaleDeployment(ctx, deploymentsClient, deployment, clientset, namespace, podLabelSelector, *scaleDownReplicas, *skipWait)
-		if err != nil {
-			t.Fatal(err)
-		}
+		err = kubernetes.MustScaleDeployment(ctx, deploymentsClient, deployment, clientset, namespace, podLabelSelector, testConfig.Iterations, testConfig.SkipWait)
+		require.NoError(t, err)
+
 		t.Log("Scale up deployment")
-		err = kubernetes.MustScaleDeployment(ctx, deploymentsClient, deployment, clientset, namespace, podLabelSelector, *scaleUpReplicas, *skipWait)
-		if err != nil {
-			t.Fatal(err)
-		}
+		err = kubernetes.MustScaleDeployment(ctx, deploymentsClient, deployment, clientset, namespace, podLabelSelector, testConfig.ScaleUpReplicas, testConfig.SkipWait)
+		require.NoError(t, err)
 	}
 	t.Log("Checking pods are running and IP assigned")
 	err = kubernetes.WaitForPodsRunning(ctx, clientset, "", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if *validateStateFile {
+	if testConfig.ValidateStateFile {
 		t.Run("Validate state file", TestValidateState)
 	}
 
-	if *validateDualStack {
+	if testConfig.ValidateDualStack {
 		t.Run("Validate dualstack overlay", TestDualStackProperties)
+	}
+
+	if testConfig.Cleanup {
+		err = kubernetes.MustDeleteDeployment(ctx, deploymentsClient, deployment)
+		require.NoError(t, err, "error deleteing load deployment")
 	}
 }
 
 // TestValidateState validates the state file based on the os and cni type.
 func TestValidateState(t *testing.T) {
 	clientset, err := kubernetes.MustGetClientset()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	config := kubernetes.MustGetRestConfig(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
 
-	validator, err := validate.CreateValidator(ctx, clientset, config, namespace, *cniType, *restartCase, *osType)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := validator.Validate(ctx); err != nil {
-		t.Fatal(err)
+	validator, err := validate.CreateValidator(ctx, clientset, config, namespace, testConfig.CNIType, testConfig.RestartCase, testConfig.OSType)
+	require.NoError(t, err)
+
+	err = validator.Validate(ctx)
+	require.NoError(t, err)
+
+	if testConfig.Cleanup {
+		err = validator.Cleanup(ctx)
+		require.NoError(t, err, "failed to cleanup validator")
 	}
 }
 
 // TestScaleDeployment scales the deployment up/down based on the replicas passed.
-// go test -timeout 30m -tags load -run ^TestScaleDeployment$ -tags=load -replicas 10
+// REPLICAS=10 go test -timeout 30m -tags load -run ^TestScaleDeployment$ -tags=load
 func TestScaleDeployment(t *testing.T) {
 	t.Log("Scale deployment")
 	clientset, err := kubernetes.MustGetClientset()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	ctx := context.Background()
 	// Create namespace if it doesn't exist
 	namespaceExists, err := kubernetes.NamespaceExists(ctx, clientset, namespace)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if !namespaceExists {
 		err = kubernetes.MustCreateNamespace(ctx, clientset, namespace)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 	}
 
-	deployment, err := kubernetes.MustParseDeployment(noopDeploymentMap[*osType])
-	if err != nil {
-		t.Fatal(err)
+	deployment, err := kubernetes.MustParseDeployment(noopDeploymentMap[testConfig.OSType])
+	require.NoError(t, err)
+
+	if testConfig.Cleanup {
+		deploymentsClient := clientset.AppsV1().Deployments(namespace)
+		err = kubernetes.MustCreateDeployment(ctx, deploymentsClient, deployment)
+		require.NoError(t, err)
 	}
+
 	deploymentsClient := clientset.AppsV1().Deployments(namespace)
-	err = kubernetes.MustScaleDeployment(ctx, deploymentsClient, deployment, clientset, namespace, podLabelSelector, *replicas, *skipWait)
-	if err != nil {
-		t.Fatal(err)
+	err = kubernetes.MustScaleDeployment(ctx, deploymentsClient, deployment, clientset, namespace, podLabelSelector, testConfig.Replicas, testConfig.SkipWait)
+	require.NoError(t, err)
+
+	if testConfig.Cleanup {
+		err = kubernetes.MustDeleteDeployment(ctx, deploymentsClient, deployment)
+		require.NoError(t, err, "error deleteing load deployment")
 	}
 }
 
 func TestDualStackProperties(t *testing.T) {
-	clientset, err := kubernetes.MustGetClientset()
-	if err != nil {
-		t.Fatal(err)
+	if !testConfig.ValidateDualStack {
+		return
 	}
+	clientset, err := kubernetes.MustGetClientset()
+	require.NoError(t, err)
+
 	config := kubernetes.MustGetRestConfig(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
 
 	t.Log("Validating the dualstack node labels")
-	validator, err := validate.CreateValidator(ctx, clientset, config, namespace, *cniType, *restartCase, *osType)
-	if err != nil {
-		t.Fatal(err)
-	}
+	validator, err := validate.CreateValidator(ctx, clientset, config, namespace, testConfig.CNIType, testConfig.RestartCase, testConfig.OSType)
+	require.NoError(t, err)
 
 	// validate dualstack overlay scenarios
 	err = validator.ValidateDualStackControlPlane(ctx)
-	if err != nil {
-		t.Fatal(err)
+	require.NoError(t, err)
+
+	if testConfig.Cleanup {
+		err = validator.Cleanup(ctx)
+		require.NoError(t, err, "failed to cleanup validator")
 	}
 }

--- a/test/integration/load/setup_test.go
+++ b/test/integration/load/setup_test.go
@@ -1,0 +1,110 @@
+//go:build load
+
+package load
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"reflect"
+	"runtime/debug"
+	"strconv"
+	"testing"
+
+	"github.com/Azure/azure-container-networking/test/internal/kubernetes"
+)
+
+const (
+	exitFail = 1
+
+	// relative log directory
+	logDir = "logs/"
+)
+
+func TestMain(m *testing.M) {
+	var (
+		err        error
+		exitCode   int
+		cnicleanup func() error
+		cnscleanup func() error
+	)
+
+	LoadEnvironment(testConfig)
+
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println(string(debug.Stack()))
+			exitCode = exitFail
+		}
+
+		if err != nil {
+			log.Print(err)
+			exitCode = exitFail
+		} else {
+			if cnicleanup != nil {
+				cnicleanup()
+			}
+			if cnscleanup != nil {
+				cnscleanup()
+			}
+		}
+
+		os.Exit(exitCode)
+	}()
+
+	clientset, err := kubernetes.MustGetClientset()
+	if err != nil {
+		return
+	}
+
+	ctx := context.Background()
+	installopt := os.Getenv(kubernetes.EnvInstallCNS)
+	// create dirty cns ds
+	if installCNS, err := strconv.ParseBool(installopt); err == nil && installCNS == true {
+		if cnscleanup, err = kubernetes.InstallCNSDaemonset(ctx, clientset, logDir); err != nil {
+			log.Print(err)
+			exitCode = 2
+			return
+		}
+	} else {
+		log.Printf("Env %v not set to true, skipping", kubernetes.EnvInstallCNS)
+	}
+
+	exitCode = m.Run()
+}
+
+func LoadEnvironment(obj interface{}) {
+	val := reflect.ValueOf(obj).Elem()
+	typ := reflect.TypeOf(obj).Elem()
+
+	for i := 0; i < val.NumField(); i++ {
+		fieldVal := val.Field(i)
+		fieldTyp := typ.Field(i)
+
+		env := fieldTyp.Tag.Get("env")
+		defaultVal := fieldTyp.Tag.Get("default")
+		envVal := os.Getenv(env)
+
+		if envVal == "" {
+			envVal = defaultVal
+		}
+
+		switch fieldVal.Kind() {
+		case reflect.Int:
+			intVal, err := strconv.Atoi(envVal)
+			if err != nil {
+				panic(fmt.Sprintf("environment variable %q must be an integer", env))
+			}
+			fieldVal.SetInt(int64(intVal))
+		case reflect.String:
+			fieldVal.SetString(envVal)
+		case reflect.Bool:
+			boolVal, err := strconv.ParseBool(envVal)
+			if err != nil {
+				panic(fmt.Sprintf("environment variable %s must be a bool", env))
+			}
+			fieldVal.SetBool(boolVal)
+		}
+	}
+}

--- a/test/integration/load/setup_test.go
+++ b/test/integration/load/setup_test.go
@@ -4,6 +4,7 @@ package load
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -21,6 +22,8 @@ const (
 	// relative log directory
 	logDir = "logs/"
 )
+
+var ErrInvalidVariableType = errors.New("variable type not supported")
 
 func TestMain(m *testing.M) {
 	var (
@@ -61,7 +64,7 @@ func TestMain(m *testing.M) {
 	ctx := context.Background()
 	installopt := os.Getenv(kubernetes.EnvInstallCNS)
 	// create dirty cns ds
-	if installCNS, err := strconv.ParseBool(installopt); err == nil && installCNS == true {
+	if installCNS, err := strconv.ParseBool(installopt); err == nil && installCNS {
 		if cnscleanup, err = kubernetes.InstallCNSDaemonset(ctx, clientset, logDir); err != nil {
 			log.Print(err)
 			exitCode = 2
@@ -105,6 +108,8 @@ func LoadEnvironment(obj interface{}) {
 				panic(fmt.Sprintf("environment variable %s must be a bool", env))
 			}
 			fieldVal.SetBool(boolVal)
+		default:
+			panic(ErrInvalidVariableType)
 		}
 	}
 }

--- a/test/integration/setup_test.go
+++ b/test/integration/setup_test.go
@@ -57,7 +57,7 @@ func TestMain(m *testing.M) {
 	ctx := context.Background()
 	installopt := os.Getenv(kubernetes.EnvInstallCNS)
 	// create dirty cns ds
-	if installCNS, err := strconv.ParseBool(installopt); err == nil && installCNS == true {
+	if installCNS, err := strconv.ParseBool(installopt); err == nil && installCNS {
 		if cnscleanup, err = kubernetes.InstallCNSDaemonset(ctx, clientset, logDir); err != nil {
 			log.Print(err)
 			exitCode = 2

--- a/test/internal/kubernetes/utils_create.go
+++ b/test/internal/kubernetes/utils_create.go
@@ -2,7 +2,6 @@ package kubernetes
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"path"
@@ -299,7 +298,7 @@ func loadCNSDaemonset(ctx context.Context, clientset *kubernetes.Clientset, cnsV
 	for cnsScenario := range cnsScenarioMap {
 		cns, err = setupCNSDaemonset(ctx, clientset, cns, cnsScenarioMap, cnsScenario)
 		if err != nil {
-			return appsv1.DaemonSet{}, errors.Wrap(err, fmt.Sprintf("failed to setup %s cns scenario", cnsScenario))
+			return appsv1.DaemonSet{}, errors.Wrapf(err, "failed to setup %s cns scenario", cnsScenario)
 		}
 	}
 
@@ -331,7 +330,7 @@ func loadCNSDaemonset(ctx context.Context, clientset *kubernetes.Clientset, cnsV
 func setupCNSDaemonset(ctx context.Context, clientset *kubernetes.Clientset, cns appsv1.DaemonSet, cnsScenarioMap map[string]cnsScenario, flag string) (appsv1.DaemonSet, error) {
 	cnsScenarioConfig, ok := cnsScenarioMap[flag]
 	if !ok {
-		return cns, errors.Wrap(ErrUnsupportedCNSScenario, fmt.Sprintf("%s not a supported cns scneario", flag))
+		return cns, errors.Wrapf(ErrUnsupportedCNSScenario, "%s not a supported cns scneario", flag)
 	}
 
 	flagValue := os.Getenv(flag)
@@ -355,7 +354,7 @@ func setupCNSDaemonset(ctx context.Context, clientset *kubernetes.Clientset, cns
 
 		// setup the CNS configmap
 		if err := MustSetupConfigMap(ctx, clientset, cnsScenarioConfig.configMapPath); err != nil {
-			return cns, errors.Wrap(err, fmt.Sprintf("failed to setup CNS %s configMap", cnsScenarioConfig.configMapPath))
+			return cns, errors.Wrapf(err, "failed to setup CNS %s configMap", cnsScenarioConfig.configMapPath)
 		}
 	} else {
 		log.Printf("Env %v not set to true, skipping", flag)

--- a/test/internal/kubernetes/utils_create.go
+++ b/test/internal/kubernetes/utils_create.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path"
+	"path/filepath"
+	"runtime"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -37,62 +40,12 @@ const (
 	envInstallOverlay          = "INSTALL_OVERLAY"
 	envInstallAzureCNIOverlay  = "INSTALL_AZURE_CNI_OVERLAY"
 	envInstallDualStackOverlay = "INSTALL_DUALSTACK_OVERLAY"
-
-	// relative cns manifest paths
-	cnsManifestFolder               = "manifests/cns"
-	cnsConfigFolder                 = "manifests/cnsconfig"
-	cnsDaemonSetPath                = cnsManifestFolder + "/daemonset.yaml"
-	cnsClusterRolePath              = cnsManifestFolder + "/clusterrole.yaml"
-	cnsClusterRoleBindingPath       = cnsManifestFolder + "/clusterrolebinding.yaml"
-	cnsSwiftConfigMapPath           = cnsConfigFolder + "/swiftconfigmap.yaml"
-	cnsCiliumConfigMapPath          = cnsConfigFolder + "/ciliumconfigmap.yaml"
-	cnsOverlayConfigMapPath         = cnsConfigFolder + "/overlayconfigmap.yaml"
-	cnsAzureCNIOverlayConfigMapPath = cnsConfigFolder + "/azurecnioverlayconfigmap.yaml"
-	cnsRolePath                     = cnsManifestFolder + "/role.yaml"
-	cnsRoleBindingPath              = cnsManifestFolder + "/rolebinding.yaml"
-	cnsServiceAccountPath           = cnsManifestFolder + "/serviceaccount.yaml"
-	cnsLabelSelector                = "k8s-app=azure-cns"
+	cnsLabelSelector           = "k8s-app=azure-cns"
 )
 
 var (
-	ErrUnsupportedCNSScenario = errors.New("Unsupported CNS scenario")
-	cnsScenarioMap            = map[string]cnsScenario{
-		envInstallAzureVnet: {
-			initContainerArgs: []string{
-				"deploy", "azure-vnet", "-o", "/opt/cni/bin/azure-vnet", "azure-vnet-telemetry",
-				"-o", "/opt/cni/bin/azure-vnet-telemetry", "azure-vnet-ipam", "-o", "/opt/cni/bin/azure-vnet-ipam",
-				"azure-swift.conflist", "-o", "/etc/cni/net.d/10-azure.conflist",
-			},
-			configMapPath: cnsSwiftConfigMapPath,
-		},
-		envInstallAzilium: {
-			initContainerArgs: []string{
-				"deploy", "azure-ipam", "-o", "/opt/cni/bin/azure-ipam",
-			},
-			configMapPath: cnsCiliumConfigMapPath,
-		},
-		envInstallOverlay: {
-			initContainerArgs: []string{"deploy", "azure-ipam", "-o", "/opt/cni/bin/azure-ipam"},
-			configMapPath:     cnsOverlayConfigMapPath,
-		},
-		envInstallAzureCNIOverlay: {
-			initContainerArgs: []string{
-				"deploy", "azure-vnet", "-o", "/opt/cni/bin/azure-vnet", "azure-vnet-telemetry", "-o", "/opt/cni/bin/azure-vnet-telemetry",
-			},
-			volumes:                   volumesForAzureCNIOverlay(),
-			initContainerVolumeMounts: dropgzVolumeMountsForAzureCNIOverlay(),
-			containerVolumeMounts:     cnsVolumeMountsForAzureCNIOverlay(),
-			configMapPath:             cnsAzureCNIOverlayConfigMapPath,
-		},
-		envInstallDualStackOverlay: {
-			initContainerArgs: []string{
-				"deploy", "azure-vnet", "-o", "/opt/cni/bin/azure-vnet",
-				"azure-vnet-telemetry", "-o", "/opt/cni/bin/azure-vnet-telemetry", "azure-vnet-ipam", "-o",
-				"/opt/cni/bin/azure-vnet-ipam", "azure-swift-overlay-dualstack.conflist", "-o", "/etc/cni/net.d/10-azure.conflist",
-			},
-			configMapPath: cnsSwiftConfigMapPath,
-		},
-	}
+	ErrUnsupportedCNSScenario = errors.New("unsupported CNS scenario")
+	ErrPathNotFound           = errors.New("failed to get the absolute path to directory")
 )
 
 func MustCreateOrUpdatePod(ctx context.Context, podI typedcorev1.PodInterface, pod corev1.Pod) error {
@@ -109,7 +62,7 @@ func MustCreateOrUpdatePod(ctx context.Context, podI typedcorev1.PodInterface, p
 }
 
 func MustCreateDaemonset(ctx context.Context, daemonsets typedappsv1.DaemonSetInterface, ds appsv1.DaemonSet) error {
-	if err := mustDeleteDaemonset(ctx, daemonsets, ds); err != nil {
+	if err := MustDeleteDaemonset(ctx, daemonsets, ds); err != nil {
 		return errors.Wrap(err, "failed to delete daemonset")
 	}
 	log.Printf("Creating Daemonset %v", ds.Name)
@@ -121,7 +74,7 @@ func MustCreateDaemonset(ctx context.Context, daemonsets typedappsv1.DaemonSetIn
 }
 
 func MustCreateDeployment(ctx context.Context, deployments typedappsv1.DeploymentInterface, d appsv1.Deployment) error {
-	if err := mustDeleteDeployment(ctx, deployments, d); err != nil {
+	if err := MustDeleteDeployment(ctx, deployments, d); err != nil {
 		return errors.Wrap(err, "failed to delete deployment")
 	}
 	log.Printf("Creating Deployment %v", d.Name)
@@ -272,6 +225,158 @@ func InstallCNSDaemonset(ctx context.Context, clientset *kubernetes.Clientset, l
 	return cleanupds, nil
 }
 
+func loadCNSDaemonset(ctx context.Context, clientset *kubernetes.Clientset, cnsVersion, cniDropgzVersion string) (appsv1.DaemonSet, error) {
+	_, b, _, ok := runtime.Caller(0)
+	if !ok {
+		return appsv1.DaemonSet{}, errors.Wrap(ErrPathNotFound, "could not get path to caller")
+	}
+	basepath := filepath.Dir(b)
+	cnsManifestFolder := path.Join(basepath, "../../integration/manifests/cns")
+	cnsConfigFolder := path.Join(basepath, "../../integration/manifests/cnsconfig")
+
+	// relative cns manifest paths
+	cnsDaemonSetPath := cnsManifestFolder + "/daemonset.yaml"
+	cnsClusterRolePath := cnsManifestFolder + "/clusterrole.yaml"
+	cnsClusterRoleBindingPath := cnsManifestFolder + "/clusterrolebinding.yaml"
+	cnsSwiftConfigMapPath := cnsConfigFolder + "/swiftconfigmap.yaml"
+	cnsCiliumConfigMapPath := cnsConfigFolder + "/ciliumconfigmap.yaml"
+	cnsOverlayConfigMapPath := cnsConfigFolder + "/overlayconfigmap.yaml"
+	cnsAzureCNIOverlayConfigMapPath := cnsConfigFolder + "/azurecnioverlayconfigmap.yaml"
+	cnsRolePath := cnsManifestFolder + "/role.yaml"
+	cnsRoleBindingPath := cnsManifestFolder + "/rolebinding.yaml"
+	cnsServiceAccountPath := cnsManifestFolder + "/serviceaccount.yaml"
+
+	// cns scenario map
+	cnsScenarioMap := map[string]cnsScenario{
+		envInstallAzureVnet: {
+			initContainerArgs: []string{
+				"deploy", "azure-vnet", "-o", "/opt/cni/bin/azure-vnet", "azure-vnet-telemetry",
+				"-o", "/opt/cni/bin/azure-vnet-telemetry", "azure-vnet-ipam", "-o", "/opt/cni/bin/azure-vnet-ipam",
+				"azure-swift.conflist", "-o", "/etc/cni/net.d/10-azure.conflist",
+			},
+			configMapPath: cnsSwiftConfigMapPath,
+		},
+		envInstallAzilium: {
+			initContainerArgs: []string{
+				"deploy", "azure-ipam", "-o", "/opt/cni/bin/azure-ipam",
+			},
+			configMapPath: cnsCiliumConfigMapPath,
+		},
+		envInstallOverlay: {
+			initContainerArgs: []string{"deploy", "azure-ipam", "-o", "/opt/cni/bin/azure-ipam"},
+			configMapPath:     cnsOverlayConfigMapPath,
+		},
+		envInstallAzureCNIOverlay: {
+			initContainerArgs: []string{
+				"deploy", "azure-vnet", "-o", "/opt/cni/bin/azure-vnet", "azure-vnet-telemetry", "-o", "/opt/cni/bin/azure-vnet-telemetry",
+			},
+			volumes:                   volumesForAzureCNIOverlay(),
+			initContainerVolumeMounts: dropgzVolumeMountsForAzureCNIOverlay(),
+			containerVolumeMounts:     cnsVolumeMountsForAzureCNIOverlay(),
+			configMapPath:             cnsAzureCNIOverlayConfigMapPath,
+		},
+		envInstallDualStackOverlay: {
+			initContainerArgs: []string{
+				"deploy", "azure-vnet", "-o", "/opt/cni/bin/azure-vnet",
+				"azure-vnet-telemetry", "-o", "/opt/cni/bin/azure-vnet-telemetry", "azure-vnet-ipam", "-o",
+				"/opt/cni/bin/azure-vnet-ipam", "azure-swift-overlay-dualstack.conflist", "-o", "/etc/cni/net.d/10-azure.conflist",
+			},
+			configMapPath: cnsSwiftConfigMapPath,
+		},
+	}
+
+	cns, err := MustParseDaemonSet(cnsDaemonSetPath)
+	if err != nil {
+		return appsv1.DaemonSet{}, errors.Wrapf(err, "failed to parse daemonset")
+	}
+
+	image, _ := ParseImageString(cns.Spec.Template.Spec.Containers[0].Image)
+	cns.Spec.Template.Spec.Containers[0].Image = GetImageString(image, cnsVersion)
+
+	log.Printf("Checking environment scenario")
+	cns = loadDropgzImage(cns, cniDropgzVersion)
+
+	for cnsScenario := range cnsScenarioMap {
+		cns, err = setupCNSDaemonset(ctx, clientset, cns, cnsScenarioMap, cnsScenario)
+		if err != nil {
+			return appsv1.DaemonSet{}, errors.Wrap(err, fmt.Sprintf("failed to setup %s cns scenario", cnsScenario))
+		}
+	}
+
+	cnsDaemonsetClient := clientset.AppsV1().DaemonSets(cns.Namespace)
+
+	log.Printf("Installing CNS with image %s", cns.Spec.Template.Spec.Containers[0].Image)
+
+	// setup common RBAC, ClusteerRole, ClusterRoleBinding, ServiceAccount
+	if _, err := MustSetUpClusterRBAC(ctx, clientset, cnsClusterRolePath, cnsClusterRoleBindingPath, cnsServiceAccountPath); err != nil {
+		return appsv1.DaemonSet{}, errors.Wrap(err, "failed to setup common RBAC, ClusteerRole, ClusterRoleBinding and ServiceAccount")
+	}
+
+	// setup RBAC, Role, RoleBinding
+	if err := MustSetUpRBAC(ctx, clientset, cnsRolePath, cnsRoleBindingPath); err != nil {
+		return appsv1.DaemonSet{}, errors.Wrap(err, "failed to setup RBAC, Role and RoleBinding")
+	}
+
+	if err := MustCreateDaemonset(ctx, cnsDaemonsetClient, cns); err != nil {
+		return appsv1.DaemonSet{}, errors.Wrap(err, "failed to create daemonset")
+	}
+
+	if err := WaitForPodDaemonset(ctx, clientset, cns.Namespace, cns.Name, cnsLabelSelector); err != nil {
+		return appsv1.DaemonSet{}, errors.Wrap(err, "failed to check daemonset running")
+	}
+
+	return cns, nil
+}
+
+func setupCNSDaemonset(ctx context.Context, clientset *kubernetes.Clientset, cns appsv1.DaemonSet, cnsScenarioMap map[string]cnsScenario, flag string) (appsv1.DaemonSet, error) {
+	cnsScenarioConfig, ok := cnsScenarioMap[flag]
+	if !ok {
+		return cns, errors.Wrap(ErrUnsupportedCNSScenario, fmt.Sprintf("%s not a supported cns scneario", flag))
+	}
+
+	flagValue := os.Getenv(flag)
+
+	if scenario, err := strconv.ParseBool(flagValue); err == nil && scenario {
+		log.Printf("Env %v set to true", flag)
+
+		// override init container args
+		cns.Spec.Template.Spec.InitContainers[0].Args = cnsScenarioConfig.initContainerArgs
+
+		// override the volumes and volume mounts (if present)
+		if len(cnsScenarioConfig.volumes) > 0 {
+			cns.Spec.Template.Spec.Volumes = cnsScenarioConfig.volumes
+		}
+		if len(cnsScenarioConfig.initContainerVolumeMounts) > 0 {
+			cns.Spec.Template.Spec.InitContainers[0].VolumeMounts = cnsScenarioConfig.initContainerVolumeMounts
+		}
+		if len(cnsScenarioConfig.containerVolumeMounts) > 0 {
+			cns.Spec.Template.Spec.Containers[0].VolumeMounts = cnsScenarioConfig.containerVolumeMounts
+		}
+
+		// setup the CNS configmap
+		if err := MustSetupConfigMap(ctx, clientset, cnsScenarioConfig.configMapPath); err != nil {
+			return cns, errors.Wrap(err, fmt.Sprintf("failed to setup CNS %s configMap", cnsScenarioConfig.configMapPath))
+		}
+	} else {
+		log.Printf("Env %v not set to true, skipping", flag)
+	}
+	return cns, nil
+}
+
+func loadDropgzImage(cns appsv1.DaemonSet, dropgzVersion string) appsv1.DaemonSet {
+	installFlag := os.Getenv(envTestDropgz)
+	if testDropgzScenario, err := strconv.ParseBool(installFlag); err == nil && testDropgzScenario {
+		log.Printf("Env %v set to true, deploy cniTest.Dockerfile", envTestDropgz)
+		initImage, _ := ParseImageString("acnpublic.azurecr.io/cni-dropgz-test:latest")
+		cns.Spec.Template.Spec.InitContainers[0].Image = GetImageString(initImage, dropgzVersion)
+	} else {
+		log.Printf("Env %v not set to true, deploying cni.Dockerfile", envTestDropgz)
+		initImage, _ := ParseImageString(cns.Spec.Template.Spec.InitContainers[0].Image)
+		cns.Spec.Template.Spec.InitContainers[0].Image = GetImageString(initImage, dropgzVersion)
+	}
+	return cns
+}
+
 func hostPathTypePtr(h corev1.HostPathType) *corev1.HostPathType {
 	return &h
 }
@@ -398,97 +503,4 @@ func cnsVolumeMountsForAzureCNIOverlay() []corev1.VolumeMount {
 			MountPath: "/etc/cni/net.d",
 		},
 	}
-}
-
-func loadCNSDaemonset(ctx context.Context, clientset *kubernetes.Clientset, cnsVersion, cniDropgzVersion string) (appsv1.DaemonSet, error) {
-	cns, err := MustParseDaemonSet(cnsDaemonSetPath)
-	if err != nil {
-		return appsv1.DaemonSet{}, errors.Wrapf(err, "failed to parse daemonset")
-	}
-
-	image, _ := ParseImageString(cns.Spec.Template.Spec.Containers[0].Image)
-	cns.Spec.Template.Spec.Containers[0].Image = GetImageString(image, cnsVersion)
-
-	log.Printf("Checking environment scenario")
-	cns = loadDropgzImage(cns, cniDropgzVersion)
-
-	for cnsScenario := range cnsScenarioMap {
-		cns, err = setupCNSDaemonset(ctx, clientset, cns, cnsScenario)
-		if err != nil {
-			return appsv1.DaemonSet{}, errors.Wrap(err, fmt.Sprintf("failed to setup %s cns scenario", cnsScenario))
-		}
-	}
-
-	cnsDaemonsetClient := clientset.AppsV1().DaemonSets(cns.Namespace)
-
-	log.Printf("Installing CNS with image %s", cns.Spec.Template.Spec.Containers[0].Image)
-
-	// setup common RBAC, ClusteerRole, ClusterRoleBinding, ServiceAccount
-	if _, err := MustSetUpClusterRBAC(ctx, clientset, cnsClusterRolePath, cnsClusterRoleBindingPath, cnsServiceAccountPath); err != nil {
-		return appsv1.DaemonSet{}, errors.Wrap(err, "failed to setup common RBAC, ClusteerRole, ClusterRoleBinding and ServiceAccount")
-	}
-
-	// setup RBAC, Role, RoleBinding
-	if err := MustSetUpRBAC(ctx, clientset, cnsRolePath, cnsRoleBindingPath); err != nil {
-		return appsv1.DaemonSet{}, errors.Wrap(err, "failed to setup RBAC, Role and RoleBinding")
-	}
-
-	if err := MustCreateDaemonset(ctx, cnsDaemonsetClient, cns); err != nil {
-		return appsv1.DaemonSet{}, errors.Wrap(err, "failed to create daemonset")
-	}
-
-	if err := WaitForPodDaemonset(ctx, clientset, cns.Namespace, cns.Name, cnsLabelSelector); err != nil {
-		return appsv1.DaemonSet{}, errors.Wrap(err, "failed to check daemonset running")
-	}
-
-	return cns, nil
-}
-
-func setupCNSDaemonset(ctx context.Context, clientset *kubernetes.Clientset, cns appsv1.DaemonSet, flag string) (appsv1.DaemonSet, error) {
-	cnsScenarioConfig, ok := cnsScenarioMap[flag]
-	if !ok {
-		return cns, errors.Wrap(ErrUnsupportedCNSScenario, fmt.Sprintf("%s not a supported cns scneario", flag))
-	}
-
-	flagValue := os.Getenv(flag)
-
-	if scenario, err := strconv.ParseBool(flagValue); err == nil && scenario {
-		log.Printf("Env %v set to true", flag)
-
-		// override init container args
-		cns.Spec.Template.Spec.InitContainers[0].Args = cnsScenarioConfig.initContainerArgs
-
-		// override the volumes and volume mounts (if present)
-		if len(cnsScenarioConfig.volumes) > 0 {
-			cns.Spec.Template.Spec.Volumes = cnsScenarioConfig.volumes
-		}
-		if len(cnsScenarioConfig.initContainerVolumeMounts) > 0 {
-			cns.Spec.Template.Spec.InitContainers[0].VolumeMounts = cnsScenarioConfig.initContainerVolumeMounts
-		}
-		if len(cnsScenarioConfig.containerVolumeMounts) > 0 {
-			cns.Spec.Template.Spec.Containers[0].VolumeMounts = cnsScenarioConfig.containerVolumeMounts
-		}
-
-		// setup the CNS configmap
-		if err := MustSetupConfigMap(ctx, clientset, cnsScenarioConfig.configMapPath); err != nil {
-			return cns, errors.Wrap(err, fmt.Sprintf("failed to setup CNS %s configMap", cnsScenarioConfig.configMapPath))
-		}
-	} else {
-		log.Printf("Env %v not set to true, skipping", flag)
-	}
-	return cns, nil
-}
-
-func loadDropgzImage(cns appsv1.DaemonSet, dropgzVersion string) appsv1.DaemonSet {
-	installFlag := os.Getenv(envTestDropgz)
-	if testDropgzScenario, err := strconv.ParseBool(installFlag); err == nil && testDropgzScenario {
-		log.Printf("Env %v set to true, deploy cniTest.Dockerfile", envTestDropgz)
-		initImage, _ := ParseImageString("acnpublic.azurecr.io/cni-dropgz-test:latest")
-		cns.Spec.Template.Spec.InitContainers[0].Image = GetImageString(initImage, dropgzVersion)
-	} else {
-		log.Printf("Env %v not set to true, deploying cni.Dockerfile", envTestDropgz)
-		initImage, _ := ParseImageString(cns.Spec.Template.Spec.InitContainers[0].Image)
-		cns.Spec.Template.Spec.InitContainers[0].Image = GetImageString(initImage, dropgzVersion)
-	}
-	return cns
 }

--- a/test/internal/kubernetes/utils_delete.go
+++ b/test/internal/kubernetes/utils_delete.go
@@ -22,7 +22,7 @@ func MustDeletePod(ctx context.Context, podI typedcorev1.PodInterface, pod corev
 	return nil
 }
 
-func mustDeleteDaemonset(ctx context.Context, daemonsets typedappsv1.DaemonSetInterface, ds appsv1.DaemonSet) error {
+func MustDeleteDaemonset(ctx context.Context, daemonsets typedappsv1.DaemonSetInterface, ds appsv1.DaemonSet) error {
 	if err := daemonsets.Delete(ctx, ds.Name, metav1.DeleteOptions{}); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return errors.Wrap(err, "failed to delete daemonset")
@@ -32,7 +32,7 @@ func mustDeleteDaemonset(ctx context.Context, daemonsets typedappsv1.DaemonSetIn
 	return nil
 }
 
-func mustDeleteDeployment(ctx context.Context, deployments typedappsv1.DeploymentInterface, d appsv1.Deployment) error {
+func MustDeleteDeployment(ctx context.Context, deployments typedappsv1.DeploymentInterface, d appsv1.Deployment) error {
 	if err := deployments.Delete(ctx, d.Name, metav1.DeleteOptions{}); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return errors.Wrap(err, "failed to delete deployment")

--- a/test/validate/validate.go
+++ b/test/validate/validate.go
@@ -224,3 +224,16 @@ func (v *Validator) ValidateDualStackControlPlane(ctx context.Context) error {
 
 	return nil
 }
+
+func (v *Validator) Cleanup(ctx context.Context) error {
+	// deploy privileged pod
+	privilegedDaemonSet, err := acnk8s.MustParseDaemonSet(privilegedDaemonSetPathMap[v.os])
+	if err != nil {
+		return errors.Wrap(err, "unable to parse daemonset")
+	}
+	daemonsetClient := v.clientset.AppsV1().DaemonSets(privilegedNamespace)
+	if err := acnk8s.MustDeleteDaemonset(ctx, daemonsetClient, privilegedDaemonSet); err != nil {
+		return errors.Wrap(err, "unable to create daemonset")
+	}
+	return nil
+}

--- a/test/validate/validate.go
+++ b/test/validate/validate.go
@@ -233,7 +233,7 @@ func (v *Validator) Cleanup(ctx context.Context) error {
 	}
 	daemonsetClient := v.clientset.AppsV1().DaemonSets(privilegedNamespace)
 	if err := acnk8s.MustDeleteDaemonset(ctx, daemonsetClient, privilegedDaemonSet); err != nil {
-		return errors.Wrap(err, "unable to create daemonset")
+		return errors.Wrap(err, "unable to delete daemonset")
 	}
 	return nil
 }


### PR DESCRIPTION
**Reason for Change**:
Refactoring the load test suite in preparation for #2187
- Making `env` variables instead of cmd line flags
- Adding a `CLEANUP` option
- Adding `CNS` installation as an option
