### PR TITLE
Adding dualstack overlay support to azure-ipam plugin for Cilium

### DIFF
--- a/azure-ipam/const.go
+++ b/azure-ipam/const.go
@@ -13,7 +13,8 @@ const (
 // plugin specific error codes
 // https://www.cni.dev/docs/spec/#error
 const (
-	ErrCreateIPConfigRequest uint = iota + 100
+	ErrCreateIPConfigRequest  uint = iota + 100
+	ErrCreateIPConfigsRequest uint = iota + 200
 	ErrRequestIPConfigFromCNS
 	ErrProcessIPConfigResponse
 )

--- a/azure-ipam/ipam.go
+++ b/azure-ipam/ipam.go
@@ -181,7 +181,6 @@ func (p *IPAMPlugin) CmdDel(args *cniSkel.CmdArgs) error {
 			}
 			err = p.cnsClient.ReleaseIPAddress(context.TODO(), ipconfigReq)
 
-			// if the old API fails as well then we just return the error
 			if err != nil {
 				if errors.As(err, &connectionErr) {
 					p.logger.Info("Failed to release IP address from CNS due to connection failure, saving to watcher to delete")

--- a/azure-ipam/ipam.go
+++ b/azure-ipam/ipam.go
@@ -36,6 +36,8 @@ type IPAMPlugin struct {
 
 type cnsClient interface {
 	RequestIPAddress(context.Context, cns.IPConfigRequest) (*cns.IPConfigResponse, error)
+	RequestIPs(context.Context, cns.IPConfigsRequest) (*cns.IPConfigsResponse, error)
+	ReleaseIPs(context.Context, cns.IPConfigsRequest) error
 	ReleaseIPAddress(context.Context, cns.IPConfigRequest) error
 }
 
@@ -69,40 +71,69 @@ func (p *IPAMPlugin) CmdAdd(args *cniSkel.CmdArgs) error {
 	p.logger.Debug("Parsed network config", zap.Any("netconf", nwCfg))
 
 	// Create ip config request from args
-	req, err := ipconfig.CreateIPConfigReq(args)
+	req, err := ipconfig.CreateIPConfigsReq(args)
 	if err != nil {
-		p.logger.Error("Failed to create CNS IP config request", zap.Error(err))
-		return cniTypes.NewError(ErrCreateIPConfigRequest, err.Error(), "failed to create CNS IP config request")
+		p.logger.Error("Failed to create CNS IP configs request", zap.Error(err))
+		return cniTypes.NewError(ErrCreateIPConfigRequest, err.Error(), "failed to create CNS IP configs request")
 	}
 	p.logger.Debug("Created CNS IP config request", zap.Any("request", req))
 
 	p.logger.Debug("Making request to CNS")
 	// if this fails, the caller plugin should execute again with cmdDel before returning error.
 	// https://www.cni.dev/docs/spec/#delegated-plugin-execution-procedure
-	resp, err := p.cnsClient.RequestIPAddress(context.TODO(), req)
+	resp, err := p.cnsClient.RequestIPs(context.TODO(), req)
 	if err != nil {
-		p.logger.Error("Failed to request IP address from CNS", zap.Error(err), zap.Any("request", req))
-		return cniTypes.NewError(ErrRequestIPConfigFromCNS, err.Error(), "failed to request IP address from CNS")
+		if cnscli.IsUnsupportedAPI(err) {
+			p.logger.Error("Failed to request IPs using RequestIPs from CNS, going to try RequestIPAddress", zap.Error(err), zap.Any("request", req))
+			ipconfigReq, err := ipconfig.CreateIPConfigReq(args)
+			if err != nil {
+				p.logger.Error("Failed to create CNS IP config request", zap.Error(err))
+				return cniTypes.NewError(ErrCreateIPConfigRequest, err.Error(), "failed to create CNS IP config request")
+			}
+			res, err := p.cnsClient.RequestIPAddress(context.TODO(), ipconfigReq)
+
+			// if the old API fails as well then we just return the error
+			if err != nil {
+				p.logger.Error("Failed to request IP address from CNS using RequestIPAddress", zap.Error(err), zap.Any("request", ipconfigReq))
+				return cniTypes.NewError(ErrRequestIPConfigFromCNS, err.Error(), "failed to request IP address from CNS using RequestIPAddress")
+			}
+			// takes values from the IPConfigResponse struct and puts them in a IPConfigsResponse struct
+			resp = &cns.IPConfigsResponse{
+				Response: res.Response,
+				PodIPInfo: []cns.PodIpInfo{
+					res.PodIpInfo,
+				},
+			}
+		} else {
+			p.logger.Error("Failed to request IP address from CNS", zap.Error(err), zap.Any("request", req))
+			return cniTypes.NewError(ErrRequestIPConfigFromCNS, err.Error(), "failed to request IP address from CNS")
+		}
 	}
 	p.logger.Debug("Received CNS IP config response", zap.Any("response", resp))
 
 	// Get Pod IP and gateway IP from ip config response
-	podIPNet, err := ipconfig.ProcessIPConfigResp(resp)
+	podIPNet, err := ipconfig.ProcessIPConfigsResp(resp)
 	if err != nil {
 		p.logger.Error("Failed to interpret CNS IPConfigResponse", zap.Error(err), zap.Any("response", resp))
 		return cniTypes.NewError(ErrProcessIPConfigResponse, err.Error(), "failed to interpret CNS IPConfigResponse")
 	}
-	p.logger.Debug("Parsed pod IP", zap.String("podIPNet", podIPNet.String()))
-
-	cniResult := &types100.Result{
-		IPs: []*types100.IPConfig{
-			{
-				Address: net.IPNet{
-					IP:   net.ParseIP(podIPNet.Addr().String()),
-					Mask: net.CIDRMask(podIPNet.Bits(), 32), // nolint
-				},
-			},
-		},
+	cniResult := &types100.Result{}
+	cniResult.IPs = make([]*types100.IPConfig, len(*podIPNet))
+	for i, ipNet := range *podIPNet {
+		p.logger.Debug("Parsed pod IP", zap.String("podIPNet", ipNet.String()))
+		ipConfig := &types100.IPConfig{}
+		if ipNet.Addr().Is4() {
+			ipConfig.Address = net.IPNet{
+				IP:   net.ParseIP(ipNet.Addr().String()),
+				Mask: net.CIDRMask(ipNet.Bits(), 32), // nolint
+			}
+		} else {
+			ipConfig.Address = net.IPNet{
+				IP:   net.ParseIP(ipNet.Addr().String()),
+				Mask: net.CIDRMask(ipNet.Bits(), 128), // nolint
+			}
+		}
+		cniResult.IPs[i] = ipConfig
 	}
 
 	// Get versioned result
@@ -130,18 +161,44 @@ func (p *IPAMPlugin) CmdDel(args *cniSkel.CmdArgs) error {
 	p.logger.Info("DEL called", zap.Any("args", args))
 
 	// Create ip config request from args
-	req, err := ipconfig.CreateIPConfigReq(args)
+	req, err := ipconfig.CreateIPConfigsReq(args)
 	if err != nil {
-		p.logger.Error("Failed to create CNS IP config request", zap.Error(err))
-		return cniTypes.NewError(cniTypes.ErrTryAgainLater, err.Error(), "failed to create CNS IP config request")
+		p.logger.Error("Failed to create CNS IP configs request", zap.Error(err))
+		return cniTypes.NewError(cniTypes.ErrTryAgainLater, err.Error(), "failed to create CNS IP configs request")
 	}
 	p.logger.Debug("Created CNS IP config request", zap.Any("request", req))
 
 	p.logger.Debug("Making request to CNS")
 	// cnsClient enforces it own timeout
-	if err := p.cnsClient.ReleaseIPAddress(context.TODO(), req); err != nil {
-		if errors.As(err, &connectionErr) {
-			p.logger.Info("Failed to release IP address from CNS due to connection failure, saving to watcher to delete")
+	if err := p.cnsClient.ReleaseIPs(context.TODO(), req); err != nil {
+		// if we fail a request with a 404 error try using the old API
+		if cnscli.IsUnsupportedAPI(err) {
+			p.logger.Error("Failed to release IPs using ReleaseIPs from CNS, going to try ReleaseIPAddress", zap.Error(err), zap.Any("request", req))
+			ipconfigReq, err := ipconfig.CreateIPConfigReq(args)
+			if err != nil {
+				p.logger.Error("Failed to create CNS IP config request", zap.Error(err))
+				return cniTypes.NewError(ErrCreateIPConfigRequest, err.Error(), "failed to create CNS IP config request")
+			}
+			err = p.cnsClient.ReleaseIPAddress(context.TODO(), ipconfigReq)
+
+			// if the old API fails as well then we just return the error
+			if err != nil {
+				if errors.As(err, &connectionErr) {
+					p.logger.Info("Failed to release IP address from CNS due to connection failure, saving to watcher to delete")
+					addErr := fsnotify.AddFile(args.ContainerID, args.ContainerID, watcherPath)
+					if addErr != nil {
+						p.logger.Error("Failed to add file to watcher", zap.String("containerID", args.ContainerID), zap.Error(addErr))
+						return cniTypes.NewError(cniTypes.ErrTryAgainLater, addErr.Error(), fmt.Sprintf("failed to add file to watcher with containerID %s", args.ContainerID))
+					} else {
+						p.logger.Info("File successfully added to watcher directory")
+					}
+				} else {
+					p.logger.Error("Failed to release IP address to CNS using ReleaseIPAddress", zap.Error(err), zap.Any("request", ipconfigReq))
+					return cniTypes.NewError(ErrRequestIPConfigFromCNS, err.Error(), "failed to release IP address from CNS using ReleaseIPAddress")
+				}
+			}
+		} else if errors.As(err, &connectionErr) {
+			p.logger.Info("Failed to release IP addresses from CNS due to connection failure, saving to watcher to delete")
 			addErr := fsnotify.AddFile(args.ContainerID, args.ContainerID, watcherPath)
 			if addErr != nil {
 				p.logger.Error("Failed to add file to watcher", zap.String("containerID", args.ContainerID), zap.Error(addErr))
@@ -150,8 +207,8 @@ func (p *IPAMPlugin) CmdDel(args *cniSkel.CmdArgs) error {
 				p.logger.Info("File successfully added to watcher directory")
 			}
 		} else {
-			p.logger.Error("Failed to release IP address from CNS", zap.Error(err), zap.Any("request", req))
-			return cniTypes.NewError(cniTypes.ErrTryAgainLater, err.Error(), "failed to release IP address from CNS")
+			p.logger.Error("Failed to release IP addresses from CNS", zap.Error(err), zap.Any("request", req))
+			return cniTypes.NewError(cniTypes.ErrTryAgainLater, err.Error(), "failed to release IP addresses from CNS")
 		}
 	}
 

--- a/azure-ipam/ipam_test.go
+++ b/azure-ipam/ipam_test.go
@@ -85,6 +85,120 @@ func (c *MockCNSClient) RequestIPAddress(ctx context.Context, ipconfig cns.IPCon
 	}
 }
 
+func (c *MockCNSClient) RequestIPs(ctx context.Context, ipconfig cns.IPConfigsRequest) (*cns.IPConfigsResponse, error) {
+	switch ipconfig.InfraContainerID {
+	case "failRequestCNSArgs":
+		return nil, errFoo
+	case "failProcessCNSResp":
+		result := &cns.IPConfigsResponse{
+			PodIPInfo: []cns.PodIpInfo{
+				{
+					{
+						PodIPConfig: cns.IPSubnet{
+							IPAddress:    "10.0.1.10.2", // invalid ip address
+							PrefixLength: 24,
+						},
+
+					},
+					NetworkContainerPrimaryIPConfig: cns.IPConfiguration{
+						IPSubnet: cns.IPSubnet{
+							IPAddress:    "10.0.1.0",
+							PrefixLength: 24,
+						},
+						DNSServers:       nil,
+						GatewayIPAddress: "10.0.0.1",
+					},
+					HostPrimaryIPInfo: cns.HostIPInfo{
+						Gateway:   "10.0.0.1",
+						PrimaryIP: "10.0.0.1",
+						Subnet:    "10.0.0.0/24",
+					},
+				},
+				{
+					{
+						PodIPConfig: cns.IPSubnet{
+							IPAddress:    "2001:db8:abcd:0015::10A::0", // invalid ip address
+							PrefixLength: 120,
+						},
+
+					},
+					NetworkContainerPrimaryIPConfig: cns.IPConfiguration{
+						IPSubnet: cns.IPSubnet{
+							IPAddress:    "2001:db8:abcd:0015::100",
+							PrefixLength: 8,
+						},
+						DNSServers:       nil,
+						GatewayIPAddress: "2001:db8:abcd:0015::1",
+					},
+					HostPrimaryIPInfo: cns.HostIPInfo{
+						Gateway:   "2001:db8:abcd:0015::1",
+						PrimaryIP: "2001:db8:abcd:0015::1",
+						Subnet:    "2001:db8:abcd:0015::0/120",
+					},
+				}
+			},
+			Response: cns.Response{
+				ReturnCode: 0,
+				Message:    "",
+			},
+		}
+		return result, nil
+	default:
+		result := &cns.IPConfigResponse{
+			PodIPInfo: []cns.PodIpInfo{
+				{
+					{
+						PodIPConfig: cns.IPSubnet{
+							IPAddress:    "10.0.1.10",
+							PrefixLength: 24,
+						},
+					},
+					NetworkContainerPrimaryIPConfig: cns.IPConfiguration{
+						IPSubnet: cns.IPSubnet{
+							IPAddress:    "10.0.1.0",
+							PrefixLength: 24,
+						},
+						DNSServers:       nil,
+						GatewayIPAddress: "10.0.0.1",
+					},
+					HostPrimaryIPInfo: cns.HostIPInfo{
+						Gateway:   "10.0.0.1",
+						PrimaryIP: "10.0.0.1",
+						Subnet:    "10.0.0.0/24",
+					},
+				},
+				{
+					{
+						PodIPConfig: cns.IPSubnet{
+							IPAddress:    "2001:db8:abcd:0015::10A", // invalid ip address
+							PrefixLength: 120,
+						},
+
+					},
+					NetworkContainerPrimaryIPConfig: cns.IPConfiguration{
+						IPSubnet: cns.IPSubnet{
+							IPAddress:    "2001:db8:abcd:0015::100",
+							PrefixLength: 8,
+						},
+						DNSServers:       nil,
+						GatewayIPAddress: "2001:db8:abcd:0015::1",
+					},
+					HostPrimaryIPInfo: cns.HostIPInfo{
+						Gateway:   "2001:db8:abcd:0015::1",
+						PrimaryIP: "2001:db8:abcd:0015::1",
+						Subnet:    "2001:db8:abcd:0015::0/120",
+					},
+				}
+			},
+			Response: cns.Response{
+				ReturnCode: 0,
+				Message:    "",
+			},
+		}
+		return result, nil
+	}
+}
+
 func (c *MockCNSClient) ReleaseIPAddress(ctx context.Context, ipconfig cns.IPConfigRequest) error {
 	switch ipconfig.InfraContainerID {
 	case "failRequestCNSReleaseIPArgs":

--- a/azure-ipam/ipconfig/ipconfig.go
+++ b/azure-ipam/ipconfig/ipconfig.go
@@ -38,19 +38,50 @@ func CreateIPConfigReq(args *cniSkel.CmdArgs) (cns.IPConfigRequest, error) {
 	return req, nil
 }
 
-// ProcessIPConfigResp processes the IPConfigResponse from the CNS.
-func ProcessIPConfigResp(resp *cns.IPConfigResponse) (*netip.Prefix, error) {
-	podCIDR := fmt.Sprintf(
-		"%s/%d",
-		resp.PodIpInfo.PodIPConfig.IPAddress,
-		resp.PodIpInfo.NetworkContainerPrimaryIPConfig.IPSubnet.PrefixLength,
-	)
-	podIPNet, err := netip.ParsePrefix(podCIDR)
+// CreateIPConfigReq creates an IPConfigsRequest from the given CNI args.
+func CreateIPConfigsReq(args *cniSkel.CmdArgs) (cns.IPConfigsRequest, error) {
+	podConf, err := parsePodConf(args.Args)
 	if err != nil {
-		return nil, errors.Wrapf(err, "cns returned invalid pod CIDR %q", podCIDR)
+		return cns.IPConfigsRequest{}, errors.Wrapf(err, "failed to parse pod config from CNI args")
 	}
 
-	return &podIPNet, nil
+	podInfo := cns.KubernetesPodInfo{
+		PodName:      string(podConf.K8S_POD_NAME),
+		PodNamespace: string(podConf.K8S_POD_NAMESPACE),
+	}
+
+	orchestratorContext, err := json.Marshal(podInfo)
+	if err != nil {
+		return cns.IPConfigsRequest{}, errors.Wrapf(err, "failed to marshal podInfo to JSON")
+	}
+
+	req := cns.IPConfigsRequest{
+		PodInterfaceID:      args.ContainerID,
+		InfraContainerID:    args.ContainerID,
+		OrchestratorContext: orchestratorContext,
+		Ifname:              args.IfName,
+	}
+
+	return req, nil
+}
+
+func ProcessIPConfigsResp(resp *cns.IPConfigsResponse) (*[]netip.Prefix, error) {
+	podIPNets := make([]netip.Prefix, len(resp.PodIPInfo))
+
+	for i := range resp.PodIPInfo {
+		podCIDR := fmt.Sprintf(
+			"%s/%d",
+			resp.PodIPInfo[i].PodIPConfig.IPAddress,
+			resp.PodIPInfo[i].NetworkContainerPrimaryIPConfig.IPSubnet.PrefixLength,
+		)
+		podIPNet, err := netip.ParsePrefix(podCIDR)
+		if err != nil {
+			return nil, errors.Wrapf(err, "cns returned invalid pod CIDR %q", podCIDR)
+		}
+		podIPNets[i] = podIPNet
+	}
+
+	return &podIPNets, nil
 }
 
 type k8sPodEnvArgs struct {

--- a/cilium/cilium_helm_values.yaml
+++ b/cilium/cilium_helm_values.yaml
@@ -26,6 +26,7 @@ extraArgs:
 # kubenet pod CIDR
 ipv4NativeRoutingCIDR: 10.241.0.0/16
 enableIPv4Masquerade: false
+enableIPv6Masquerade: false
 install-no-conntrack-iptables-rules: false
 installIptablesRules: true
 l7Proxy: false

--- a/cilium/cilium_helm_values.yaml
+++ b/cilium/cilium_helm_values.yaml
@@ -26,7 +26,6 @@ extraArgs:
 # kubenet pod CIDR
 ipv4NativeRoutingCIDR: 10.241.0.0/16
 enableIPv4Masquerade: false
-enableIPv6Masquerade: false
 install-no-conntrack-iptables-rules: false
 installIptablesRules: true
 l7Proxy: false


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Adds support in the azure-ipam plugin to use new APIs created for CNS to allow for passing multiple IPs on Add and Delete commands which is needed to create dualstack clusters.

Here's where the new APIs were added.
https://github.com/Azure/azure-container-networking/pull/1773

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
