### PR TITLE
backport "feat: Consume the NCStatus to be able to append subnet is full error to Pod IP reservation failures" to release/v1.4

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-container-networking/cns/types"
+	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -92,6 +93,7 @@ type CreateNetworkContainerRequest struct {
 	AllowHostToNCCommunication bool
 	AllowNCToHostCommunication bool
 	EndpointPolicies           []NetworkContainerRequestPolicies
+	NCStatus                   v1alpha.NCStatus
 }
 
 // CreateNetworkContainerRequest implements fmt.Stringer for logging
@@ -99,9 +101,9 @@ func (req *CreateNetworkContainerRequest) String() string {
 	return fmt.Sprintf("CreateNetworkContainerRequest"+
 		"{Version: %s, NetworkContainerType: %s, NetworkContainerid: %s, PrimaryInterfaceIdentifier: %s, "+
 		"LocalIPConfiguration: %+v, IPConfiguration: %+v, SecondaryIPConfigs: %+v, MultitenancyInfo: %+v, "+
-		"AllowHostToNCCommunication: %t, AllowNCToHostCommunication: %t}",
+		"AllowHostToNCCommunication: %t, AllowNCToHostCommunication: %t, NCStatus: %s}",
 		req.Version, req.NetworkContainerType, req.NetworkContainerid, req.PrimaryInterfaceIdentifier, req.LocalIPConfiguration,
-		req.IPConfiguration, req.SecondaryIPConfigs, req.MultiTenancyInfo, req.AllowHostToNCCommunication, req.AllowNCToHostCommunication)
+		req.IPConfiguration, req.SecondaryIPConfigs, req.MultiTenancyInfo, req.AllowHostToNCCommunication, req.AllowNCToHostCommunication, string(req.NCStatus))
 }
 
 // NetworkContainerRequestPolicies - specifies policies associated with create network request

--- a/cns/kubecontroller/nodenetworkconfig/conversion.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion.go
@@ -66,6 +66,7 @@ func CreateNCRequestFromDynamicNC(nc v1alpha.NetworkContainer) (*cns.CreateNetwo
 			IPSubnet:         subnet,
 			GatewayIPAddress: nc.DefaultGateway,
 		},
+		NCStatus: nc.Status,
 	}, nil
 }
 

--- a/cns/kubecontroller/nodenetworkconfig/conversion_linux.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_linux.go
@@ -33,5 +33,5 @@ func createNCRequestFromStaticNCHelper(nc v1alpha.NetworkContainer, primaryIPPre
 			GatewayIPAddress: nc.DefaultGateway,
 		},
 		NCStatus: nc.Status,
-	}, nil
+	}
 }

--- a/cns/kubecontroller/nodenetworkconfig/conversion_linux.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_linux.go
@@ -32,5 +32,6 @@ func createNCRequestFromStaticNCHelper(nc v1alpha.NetworkContainer, primaryIPPre
 			IPSubnet:         subnet,
 			GatewayIPAddress: nc.DefaultGateway,
 		},
-	}
+		NCStatus: nc.Status,
+	}, nil
 }

--- a/cns/kubecontroller/nodenetworkconfig/conversion_windows.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_windows.go
@@ -44,5 +44,6 @@ func createNCRequestFromStaticNCHelper(nc v1alpha.NetworkContainer, primaryIPPre
 			IPSubnet:         subnet,
 			GatewayIPAddress: nc.DefaultGateway,
 		},
-	}
+		NCStatus: nc.Status,
+	}, nil
 }

--- a/cns/kubecontroller/nodenetworkconfig/conversion_windows.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_windows.go
@@ -45,5 +45,5 @@ func createNCRequestFromStaticNCHelper(nc v1alpha.NetworkContainer, primaryIPPre
 			GatewayIPAddress: nc.DefaultGateway,
 		},
 		NCStatus: nc.Status,
-	}, nil
+	}
 }

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -542,7 +542,9 @@ func (service *HTTPRestService) AssignAnyAvailableIPConfig(podInfo cns.PodInfo) 
 	service.Lock()
 	defer service.Unlock()
 
+	var ncID string
 	for _, ipState := range service.PodIPConfigState {
+		ncID = ipState.NCID
 		if ipState.GetState() == types.Available {
 			if err := service.assignIPConfig(ipState, podInfo); err != nil {
 				return cns.PodIpInfo{}, err
@@ -557,7 +559,8 @@ func (service *HTTPRestService) AssignAnyAvailableIPConfig(podInfo cns.PodInfo) 
 		}
 	}
 	//nolint:goerr113
-	return cns.PodIpInfo{}, fmt.Errorf("no IPs available, waiting on Azure CNS to allocate more")
+	return cns.PodIpInfo{}, errors.Errorf("not enough IPs available for %s, waiting on Azure CNS to allocate more with NC Status: %s",
+		ncID, string(service.state.ContainerStatus[ncID].CreateNetworkContainerRequest.NCStatus))
 }
 
 // If IPConfig is already assigned to pod, it returns that else it returns one of the available ipconfigs.

--- a/crd/nodenetworkconfig/api/v1alpha/nodenetworkconfig.go
+++ b/crd/nodenetworkconfig/api/v1alpha/nodenetworkconfig.go
@@ -59,12 +59,16 @@ const (
 )
 
 // NCStatus indicates the latest NC request status
-// +kubebuilder:validation:Enum=SubnetFull
+// +kubebuilder:validation:Enum=NCUpdateSubnetFullError;NCUpdateInternalServerError;NCUpdateUnauthorizedError;NCUpdateSuccess;NCUpdateFailed
 // +kubebuilder:validation:Optional
 type NCStatus string
 
 const (
-	NCStatusSubnetFull NCStatus = "SubnetFull"
+	NCUpdateSubnetFull          NCStatus = "NCUpdateSubnetFullError"
+	NCUpdateInternalServerError NCStatus = "NCUpdateInternalServerError"
+	NCUpdateUnauthorizedError   NCStatus = "NCUpdateUnauthorizedError"
+	NCUpdateSuccess             NCStatus = "NCUpdateSuccess"
+	NCUpdateFailed              NCStatus = "NCUpdateFailed"
 )
 
 // NodeNetworkConfigStatus defines the observed state of NetworkConfig

--- a/crd/nodenetworkconfig/api/v1alpha/nodenetworkconfig.go
+++ b/crd/nodenetworkconfig/api/v1alpha/nodenetworkconfig.go
@@ -58,6 +58,15 @@ const (
 	Error    Status = "Error"
 )
 
+// NCStatus indicates the latest NC request status
+// +kubebuilder:validation:Enum=SubnetFull
+// +kubebuilder:validation:Optional
+type NCStatus string
+
+const (
+	NCStatusSubnetFull NCStatus = "SubnetFull"
+)
+
 // NodeNetworkConfigStatus defines the observed state of NetworkConfig
 type NodeNetworkConfigStatus struct {
 	// +kubebuilder:default=0
@@ -107,12 +116,13 @@ type NetworkContainer struct {
 	SubnetAddressSpace string         `json:"subnetAddressSpace,omitempty"`
 	// +kubebuilder:default=0
 	// +kubebuilder:validation:Optional
-	Version         int64  `json:"version"`
-	NodeIP          string `json:"nodeIP,omitempty"`
-	SubscriptionID  string `json:"subcriptionID,omitempty"`
-	ResourceGroupID string `json:"resourceGroupID,omitempty"`
-	VNETID          string `json:"vnetID,omitempty"`
-	SubnetID        string `json:"subnetID,omitempty"`
+	Version         int64    `json:"version"`
+	NodeIP          string   `json:"nodeIP,omitempty"`
+	SubscriptionID  string   `json:"subcriptionID,omitempty"`
+	ResourceGroupID string   `json:"resourceGroupID,omitempty"`
+	VNETID          string   `json:"vnetID,omitempty"`
+	SubnetID        string   `json:"subnetID,omitempty"`
+	Status          NCStatus `json:"status,omitempty"`
 }
 
 // IPAssignment groups an IP address and Name. Name is a UUID set by the the IP address assigner.

--- a/crd/nodenetworkconfig/manifests/acn.azure.com_nodenetworkconfigs.yaml
+++ b/crd/nodenetworkconfig/manifests/acn.azure.com_nodenetworkconfigs.yaml
@@ -118,7 +118,11 @@ spec:
                     status:
                       description: NCStatus indicates the latest NC request status
                       enum:
-                      - SubnetFull
+                      - NCUpdateSubnetFullError
+                      - NCUpdateInternalServerError
+                      - NCUpdateUnauthorizedError
+                      - NCUpdateSuccess
+                      - NCUpdateFailed
                       type: string
                     subcriptionID:
                       type: string

--- a/crd/nodenetworkconfig/manifests/acn.azure.com_nodenetworkconfigs.yaml
+++ b/crd/nodenetworkconfig/manifests/acn.azure.com_nodenetworkconfigs.yaml
@@ -115,6 +115,11 @@ spec:
                       type: string
                     resourceGroupID:
                       type: string
+                    status:
+                      description: NCStatus indicates the latest NC request status
+                      enum:
+                      - SubnetFull
+                      type: string
                     subcriptionID:
                       type: string
                     subnetAddressSpace:


### PR DESCRIPTION
**Reason for Change**:
Cherry-pick of #2202 and #2193 into the release/v1.4


**Issue Fixed**:


**Requirements**:


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
