### PR TITLE
test(capz): [WIN-NPM] support containerd 1.7 filesystem

### DIFF
--- a/npm/azure-npm.yaml
+++ b/npm/azure-npm.yaml
@@ -148,14 +148,14 @@ metadata:
 data:
   azure-npm.json: |
     {
-        "ResyncPeriodInMinutes":          15,
-        "ListeningPort":                  10091,
-        "ListeningAddress":               "0.0.0.0",
-        "ApplyIntervalInMilliseconds":    500,
-        "ApplyMaxBatches":                100,
-        "MaxBatchedACLsPerPod":           30,
-        "NetPolInvervalInMilliseconds":   500,
-        "MaxPendingNetPols":              100,
+        "ResyncPeriodInMinutes":        15,
+        "ListeningPort":                10091,
+        "ListeningAddress":             "0.0.0.0",
+        "ApplyIntervalInMilliseconds":  500,
+        "ApplyMaxBatches":              100,
+        "MaxBatchedACLsPerPod":         30,
+        "NetPolInvervalInMilliseconds": 500,
+        "MaxPendingNetPols":            100,
         "Toggles": {
             "EnablePrometheusMetrics": true,
             "EnablePprof":             true,

--- a/npm/examples/windows/azure-npm-capz.yaml
+++ b/npm/examples/windows/azure-npm-capz.yaml
@@ -84,15 +84,14 @@ spec:
       containers:
         - name: azure-npm
           image: mcr.microsoft.com/containernetworking/azure-npm:v1.5.5
-          # workingDir: "$env:CONTAINER_SANDBOX_MOUNT_POINT"
           command: ["powershell.exe"]
           args:
             [
+              # eventually should have the Dockerfile copy npm.exe to /npm.exe instead
               'mv $env:CONTAINER_SANDBOX_MOUNT_POINT/npm.exe /npm.exe',
               ";",
               '.\npm.exe',
               "start",
-              '--kubeconfig=C:\etc\kubernetes\kubelet.conf',
             ]
           resources:
             limits:

--- a/npm/examples/windows/azure-npm-capz.yaml
+++ b/npm/examples/windows/azure-npm-capz.yaml
@@ -84,14 +84,15 @@ spec:
       containers:
         - name: azure-npm
           image: mcr.microsoft.com/containernetworking/azure-npm:v1.5.5
+          # workingDir: "$env:CONTAINER_SANDBOX_MOUNT_POINT"
           command: ["powershell.exe"]
           args:
             [
-              '.\setkubeconfigpath-capz.ps1',
+              'mv $env:CONTAINER_SANDBOX_MOUNT_POINT/npm.exe /npm.exe',
               ";",
               '.\npm.exe',
               "start",
-              '--kubeconfig=.\kubeconfig',
+              '--kubeconfig=C:\etc\kubernetes\kubelet.conf',
             ]
           resources:
             limits:
@@ -106,10 +107,10 @@ spec:
                   apiVersion: v1
                   fieldPath: spec.nodeName
             - name: NPM_CONFIG
-              value: .\\etc\\azure-npm\\azure-npm.json
+              value: /etc/azure-npm/azure-npm.json
           volumeMounts:
             - name: azure-npm-config
-              mountPath: .\\etc\\azure-npm
+              mountPath: /etc/azure-npm
       nodeSelector:
         kubernetes.io/os: windows
       volumes:

--- a/npm/examples/windows/azure-npm-capz.yaml
+++ b/npm/examples/windows/azure-npm-capz.yaml
@@ -140,21 +140,23 @@ metadata:
 data:
   azure-npm.json: |
     {
-        "WindowsNetworkName":          "Calico",
-        "ResyncPeriodInMinutes":       15,
-        "ListeningPort":               10091,
-        "ListeningAddress":            "0.0.0.0",
-        "ApplyIntervalInMilliseconds": 500,
-        "ApplyMaxBatches":             100,
-        "MaxBatchedACLsPerPod":        30,
+        "WindowsNetworkName":           "Calico",
+        "ResyncPeriodInMinutes":        15,
+        "ListeningPort":                10091,
+        "ListeningAddress":             "0.0.0.0",
+        "ApplyIntervalInMilliseconds":  500,
+        "ApplyMaxBatches":              100,
+        "MaxBatchedACLsPerPod":         30,
+        "NetPolInvervalInMilliseconds": 500,
+        "MaxPendingNetPols":            100,
         "Toggles": {
             "EnablePrometheusMetrics": true,
             "EnablePprof":             true,
             "EnableHTTPDebugAPI":      true,
             "EnableV2NPM":             true,
-            "PlaceAzureChainFirst":    true,
+            "PlaceAzureChainFirst":    false,
             "ApplyIPSetsOnNeed":       false,
             "ApplyInBackground":       true,
-            "NetPolInBackground":      false
+            "NetPolInBackground":      true
         }
     }

--- a/npm/examples/windows/azure-npm.yaml
+++ b/npm/examples/windows/azure-npm.yaml
@@ -83,7 +83,7 @@ spec:
       hostNetwork: true
       containers:
         - name: azure-npm
-          image: mcr.microsoft.com/containernetworking/azure-npm:v1.4.45
+          image: mcr.microsoft.com/containernetworking/azure-npm:v1.5.5
           command: ["powershell.exe"]
           args:
             [
@@ -140,14 +140,14 @@ metadata:
 data:
   azure-npm.json: |
     {
-        "ResyncPeriodInMinutes":          15,
-        "ListeningPort":                  10091,
-        "ListeningAddress":               "0.0.0.0",
-        "ApplyIntervalInMilliseconds":    500,
-        "ApplyMaxBatches":                100,
-        "MaxBatchedACLsPerPod":           30,
-        "NetPolInvervalInMilliseconds":   500,
-        "MaxPendingNetPols":              100,
+        "ResyncPeriodInMinutes":        15,
+        "ListeningPort":                10091,
+        "ListeningAddress":             "0.0.0.0",
+        "ApplyIntervalInMilliseconds":  500,
+        "ApplyMaxBatches":              100,
+        "MaxBatchedACLsPerPod":         30,
+        "NetPolInvervalInMilliseconds": 500,
+        "MaxPendingNetPols":            100,
         "Toggles": {
             "EnablePrometheusMetrics": true,
             "EnablePprof":             true,


### PR DESCRIPTION
HostProcess containers have a [change to container mounts](https://github.com/kubernetes/enhancements/tree/master/keps/sig-windows/1981-windows-privileged-container-support#container-mounts) in containerd 1.7.
CAPZ testbed is on containerd 1.7, so current NPM yaml crashes with e.g. `npm.exe not found`.

**Reason for Change**:

**Issue Fixed**:

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
