### PR TITLE
chore: must* functions should panic

### DIFF
--- a/test/integration/datapath/datapath_windows_test.go
+++ b/test/integration/datapath/datapath_windows_test.go
@@ -51,13 +51,10 @@ func setupWindowsEnvironment(t *testing.T) {
 	ctx := context.Background()
 
 	t.Log("Get REST config")
-	restConfig := kubernetes.MustGetRestConfig(t)
+	restConfig := kubernetes.MustGetRestConfig()
 
 	t.Log("Create Clientset")
-	clientset, err := kubernetes.MustGetClientset()
-	if err != nil {
-		t.Fatal(err)
-	}
+	clientset := kubernetes.MustGetClientset()
 
 	if *restartKubeproxy {
 		validator, err := validate.CreateValidator(ctx, clientset, restConfig, *podNamespace, "cniv2", false, "windows")
@@ -85,16 +82,10 @@ func setupWindowsEnvironment(t *testing.T) {
 	if !namespaceExists {
 		// Test Namespace
 		t.Log("Create Namespace")
-		err := kubernetes.MustCreateNamespace(ctx, clientset, *podNamespace)
-		if err != nil {
-			t.Fatalf("failed to create pod namespace %s due to: %v", *podNamespace, err)
-		}
+		kubernetes.MustCreateNamespace(ctx, clientset, *podNamespace)
 
 		t.Log("Creating Windows pods through deployment")
-		deployment, err := kubernetes.MustParseDeployment(WindowsDeployYamlPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		deployment := kubernetes.MustParseDeployment(WindowsDeployYamlPath)
 
 		// Fields for overwritting existing deployment yaml.
 		// Defaults from flags will not change anything
@@ -105,10 +96,7 @@ func setupWindowsEnvironment(t *testing.T) {
 		deployment.Namespace = *podNamespace
 
 		deploymentsClient := clientset.AppsV1().Deployments(*podNamespace)
-		err = kubernetes.MustCreateDeployment(ctx, deploymentsClient, deployment)
-		if err != nil {
-			t.Fatal(err)
-		}
+		kubernetes.MustCreateDeployment(ctx, deploymentsClient, deployment)
 
 		t.Log("Waiting for pods to be running state")
 		err = kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector)
@@ -145,13 +133,10 @@ func TestDatapathWin(t *testing.T) {
 	ctx := context.Background()
 
 	t.Log("Get REST config")
-	restConfig := kubernetes.MustGetRestConfig(t)
+	restConfig := kubernetes.MustGetRestConfig()
 
 	t.Log("Create Clientset")
-	clientset, err := kubernetes.MustGetClientset()
-	if err != nil {
-		t.Fatalf("could not get k8s clientset: %v", err)
-	}
+	clientset := kubernetes.MustGetClientset()
 
 	setupWindowsEnvironment(t)
 	podLabelSelector := kubernetes.CreateLabelSelector(podLabelKey, podPrefix)

--- a/test/integration/load/setup_test.go
+++ b/test/integration/load/setup_test.go
@@ -56,10 +56,7 @@ func TestMain(m *testing.M) {
 		os.Exit(exitCode)
 	}()
 
-	clientset, err := kubernetes.MustGetClientset()
-	if err != nil {
-		return
-	}
+	clientset := kubernetes.MustGetClientset()
 
 	ctx := context.Background()
 	installopt := os.Getenv(kubernetes.EnvInstallCNS)

--- a/test/integration/setup_test.go
+++ b/test/integration/setup_test.go
@@ -49,10 +49,7 @@ func TestMain(m *testing.M) {
 		os.Exit(exitCode)
 	}()
 
-	clientset, err := kubernetes.MustGetClientset()
-	if err != nil {
-		return
-	}
+	clientset := kubernetes.MustGetClientset()
 
 	ctx := context.Background()
 	installopt := os.Getenv(kubernetes.EnvInstallCNS)

--- a/test/internal/kubernetes/utils.go
+++ b/test/internal/kubernetes/utils.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/Azure/azure-container-networking/test/internal/retry"
@@ -40,40 +39,39 @@ const (
 
 var Kubeconfig = flag.String("test-kubeconfig", filepath.Join(homedir.HomeDir(), ".kube", "config"), "(optional) absolute path to the kubeconfig file")
 
-func MustGetClientset() (*kubernetes.Clientset, error) {
+func MustGetClientset() *kubernetes.Clientset {
 	config, err := clientcmd.BuildConfigFromFlags("", *Kubeconfig)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to build config from flags")
+		panic(errors.Wrap(err, "failed to build config from flags"))
 	}
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get clientset")
+		panic(errors.Wrap(err, "failed to get clientset"))
 	}
-	return clientset, nil
+	return clientset
 }
 
-func MustGetRestConfig(t *testing.T) *rest.Config {
+func MustGetRestConfig() *rest.Config {
 	config, err := clientcmd.BuildConfigFromFlags("", *Kubeconfig)
 	if err != nil {
-		t.Fatal(err)
+		panic(err)
 	}
 	return config
 }
 
-func mustParseResource(path string, out interface{}) error {
+func mustParseResource(path string, out interface{}) {
 	f, err := os.Open(path)
 	if err != nil {
-		return errors.Wrap(err, "failed to open path")
+		panic(errors.Wrap(err, "failed to open path"))
 	}
 	defer func() { _ = f.Close() }()
 
 	if err := yaml.NewYAMLOrJSONDecoder(f, 0).Decode(out); err != nil {
-		return errors.Wrap(err, "failed to decode")
+		panic(errors.Wrap(err, "failed to decode"))
 	}
-	return nil
 }
 
-func MustLabelSwiftNodes(ctx context.Context, t *testing.T, clientset *kubernetes.Clientset, delegatedSubnetID, delegatedSubnetName string) {
+func MustLabelSwiftNodes(ctx context.Context, clientset *kubernetes.Clientset, delegatedSubnetID, delegatedSubnetName string) {
 	swiftNodeLabels := map[string]string{
 		DelegatedSubnetIDLabel: delegatedSubnetID,
 		SubnetNameLabel:        delegatedSubnetName,
@@ -81,37 +79,27 @@ func MustLabelSwiftNodes(ctx context.Context, t *testing.T, clientset *kubernete
 
 	res, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		t.Fatalf("could not list nodes: %v", err)
+		panic(errors.Wrap(err, "could not list nodes"))
 	}
 	for index := range res.Items {
 		node := res.Items[index]
 		_, err := AddNodeLabels(ctx, clientset.CoreV1().Nodes(), node.Name, swiftNodeLabels)
 		if err != nil {
-			t.Fatalf("could not add labels to node: %v", err)
+			panic(errors.Wrap(err, "could not add labels to node"))
 		}
-		t.Logf("labels added to node %s", node.Name)
 	}
 }
 
-func MustSetUpClusterRBAC(ctx context.Context, clientset *kubernetes.Clientset, clusterRolePath, clusterRoleBindingPath, serviceAccountPath string) (func(), error) {
+func MustSetUpClusterRBAC(ctx context.Context, clientset *kubernetes.Clientset, clusterRolePath, clusterRoleBindingPath, serviceAccountPath string) func() {
 	var (
-		err                error
 		clusterRole        v1.ClusterRole
 		clusterRoleBinding v1.ClusterRoleBinding
 		serviceAccount     corev1.ServiceAccount
 	)
 
-	if clusterRole, err = mustParseClusterRole(clusterRolePath); err != nil {
-		return nil, err
-	}
-
-	if clusterRoleBinding, err = mustParseClusterRoleBinding(clusterRoleBindingPath); err != nil {
-		return nil, err
-	}
-
-	if serviceAccount, err = mustParseServiceAccount(serviceAccountPath); err != nil {
-		return nil, err
-	}
+	mustParseClusterRole(clusterRolePath)
+	mustParseClusterRoleBinding(clusterRoleBindingPath)
+	mustParseServiceAccount(serviceAccountPath)
 
 	clusterRoles := clientset.RbacV1().ClusterRoles()
 	clusterRoleBindings := clientset.RbacV1().ClusterRoleBindings()
@@ -133,59 +121,35 @@ func MustSetUpClusterRBAC(ctx context.Context, clientset *kubernetes.Clientset, 
 		log.Print("rbac cleaned up")
 	}
 
-	if err := mustCreateServiceAccount(ctx, serviceAccounts, serviceAccount); err != nil {
-		return cleanupFunc, err
-	}
+	mustCreateServiceAccount(ctx, serviceAccounts, serviceAccount)
+	mustCreateClusterRole(ctx, clusterRoles, clusterRole)
+	mustCreateClusterRoleBinding(ctx, clusterRoleBindings, clusterRoleBinding)
 
-	if err := mustCreateClusterRole(ctx, clusterRoles, clusterRole); err != nil {
-		return cleanupFunc, err
-	}
-
-	if err := mustCreateClusterRoleBinding(ctx, clusterRoleBindings, clusterRoleBinding); err != nil {
-		return cleanupFunc, err
-	}
-
-	return cleanupFunc, nil
+	return cleanupFunc
 }
 
-func MustSetUpRBAC(ctx context.Context, clientset *kubernetes.Clientset, rolePath, roleBindingPath string) error {
+func MustSetUpRBAC(ctx context.Context, clientset *kubernetes.Clientset, rolePath, roleBindingPath string) {
 	var (
-		err         error
 		role        v1.Role
 		roleBinding v1.RoleBinding
 	)
 
-	if role, err = mustParseRole(rolePath); err != nil {
-		return err
-	}
-
-	if roleBinding, err = mustParseRoleBinding(roleBindingPath); err != nil {
-		return err
-	}
+	mustParseRole(rolePath)
+	mustParseRoleBinding(roleBindingPath)
 
 	roles := clientset.RbacV1().Roles(role.Namespace)
 	roleBindings := clientset.RbacV1().RoleBindings(roleBinding.Namespace)
 
-	if err := mustCreateRole(ctx, roles, role); err != nil {
-		return err
-	}
-
-	return mustCreateRoleBinding(ctx, roleBindings, roleBinding)
+	mustCreateRole(ctx, roles, role)
+	mustCreateRoleBinding(ctx, roleBindings, roleBinding)
 }
 
-func MustSetupConfigMap(ctx context.Context, clientset *kubernetes.Clientset, configMapPath string) error {
-	var (
-		err error
-		cm  corev1.ConfigMap
-	)
+func MustSetupConfigMap(ctx context.Context, clientset *kubernetes.Clientset, configMapPath string) {
+	var cm corev1.ConfigMap
 
-	if cm, err = mustParseConfigMap(configMapPath); err != nil {
-		return err
-	}
-
+	mustParseConfigMap(configMapPath)
 	configmaps := clientset.CoreV1().ConfigMaps(cm.Namespace)
-
-	return mustCreateConfigMap(ctx, configmaps, cm)
+	mustCreateConfigMap(ctx, configmaps, cm)
 }
 
 func Int32ToPtr(i int32) *int32 { return &i }
@@ -319,15 +283,16 @@ func WaitForPodDaemonset(ctx context.Context, clientset *kubernetes.Clientset, n
 	return errors.Wrapf(retrier.Do(ctx, checkPodDaemonsetFn), "could not wait for daemonset %s", daemonsetName)
 }
 
-func MustUpdateReplica(ctx context.Context, deploymentsClient typedappsv1.DeploymentInterface, deploymentName string, replicas int32) error {
+func MustUpdateReplica(ctx context.Context, deploymentsClient typedappsv1.DeploymentInterface, deploymentName string, replicas int32) {
 	deployment, err := deploymentsClient.Get(ctx, deploymentName, metav1.GetOptions{})
 	if err != nil {
-		return errors.Wrapf(err, "could not get deployment %s", deploymentName)
+		panic(errors.Wrapf(err, "could not get deployment %s", deploymentName))
 	}
 
 	deployment.Spec.Replicas = Int32ToPtr(replicas)
-	_, err = deploymentsClient.Update(ctx, deployment, metav1.UpdateOptions{})
-	return errors.Wrapf(err, "could not update deployment %s", deploymentName)
+	if _, err := deploymentsClient.Update(ctx, deployment, metav1.UpdateOptions{}); err != nil {
+		panic(errors.Wrapf(err, "could not update deployment %s", deploymentName))
+	}
 }
 
 func ExportLogsByLabelSelector(ctx context.Context, clientset *kubernetes.Clientset, namespace, labelselector, logDir string) error {

--- a/test/internal/kubernetes/utils.go
+++ b/test/internal/kubernetes/utils.go
@@ -97,9 +97,9 @@ func MustSetUpClusterRBAC(ctx context.Context, clientset *kubernetes.Clientset, 
 		serviceAccount     corev1.ServiceAccount
 	)
 
-	mustParseClusterRole(clusterRolePath)
-	mustParseClusterRoleBinding(clusterRoleBindingPath)
-	mustParseServiceAccount(serviceAccountPath)
+	clusterRole = mustParseClusterRole(clusterRolePath)
+	clusterRoleBinding = mustParseClusterRoleBinding(clusterRoleBindingPath)
+	serviceAccount = mustParseServiceAccount(serviceAccountPath)
 
 	clusterRoles := clientset.RbacV1().ClusterRoles()
 	clusterRoleBindings := clientset.RbacV1().ClusterRoleBindings()
@@ -134,8 +134,8 @@ func MustSetUpRBAC(ctx context.Context, clientset *kubernetes.Clientset, rolePat
 		roleBinding v1.RoleBinding
 	)
 
-	mustParseRole(rolePath)
-	mustParseRoleBinding(roleBindingPath)
+	role = mustParseRole(rolePath)
+	roleBinding = mustParseRoleBinding(roleBindingPath)
 
 	roles := clientset.RbacV1().Roles(role.Namespace)
 	roleBindings := clientset.RbacV1().RoleBindings(roleBinding.Namespace)
@@ -145,9 +145,7 @@ func MustSetUpRBAC(ctx context.Context, clientset *kubernetes.Clientset, rolePat
 }
 
 func MustSetupConfigMap(ctx context.Context, clientset *kubernetes.Clientset, configMapPath string) {
-	var cm corev1.ConfigMap
-
-	mustParseConfigMap(configMapPath)
+	cm := mustParseConfigMap(configMapPath)
 	configmaps := clientset.CoreV1().ConfigMaps(cm.Namespace)
 	mustCreateConfigMap(ctx, configmaps, cm)
 }

--- a/test/internal/kubernetes/utils_create.go
+++ b/test/internal/kubernetes/utils_create.go
@@ -61,125 +61,92 @@ var (
 	ErrNoCNSScenarioDefined   = errors.New("no CNSScenario set to true as env var")
 )
 
-func MustCreateOrUpdatePod(ctx context.Context, podI typedcorev1.PodInterface, pod corev1.Pod) error {
-	if err := MustDeletePod(ctx, podI, pod); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return errors.Wrap(err, "failed to delete pod")
-		}
-	}
-	if _, err := podI.Create(ctx, &pod, metav1.CreateOptions{}); err != nil {
-		return errors.Wrapf(err, "failed to create pod %v", pod.Name)
-	}
-
-	return nil
-}
-
-func MustCreateDaemonset(ctx context.Context, daemonsets typedappsv1.DaemonSetInterface, ds appsv1.DaemonSet) error {
-	if err := MustDeleteDaemonset(ctx, daemonsets, ds); err != nil {
-		return errors.Wrap(err, "failed to delete daemonset")
-	}
+func MustCreateDaemonset(ctx context.Context, daemonsets typedappsv1.DaemonSetInterface, ds appsv1.DaemonSet) {
+	MustDeleteDaemonset(ctx, daemonsets, ds)
 	log.Printf("Creating Daemonset %v", ds.Name)
 	if _, err := daemonsets.Create(ctx, &ds, metav1.CreateOptions{}); err != nil {
-		return errors.Wrap(err, "failed to create daemonset")
+		panic(errors.Wrap(err, "failed to create daemonset"))
 	}
-
-	return nil
 }
 
-func MustCreateDeployment(ctx context.Context, deployments typedappsv1.DeploymentInterface, d appsv1.Deployment) error {
-	if err := MustDeleteDeployment(ctx, deployments, d); err != nil {
-		return errors.Wrap(err, "failed to delete deployment")
-	}
+func MustCreateDeployment(ctx context.Context, deployments typedappsv1.DeploymentInterface, d appsv1.Deployment) {
+	MustDeleteDeployment(ctx, deployments, d)
 	log.Printf("Creating Deployment %v", d.Name)
 	if _, err := deployments.Create(ctx, &d, metav1.CreateOptions{}); err != nil {
-		return errors.Wrap(err, "failed to create deployment")
+		panic(errors.Wrap(err, "failed to create deployment"))
 	}
-
-	return nil
 }
 
-func mustCreateServiceAccount(ctx context.Context, svcAccounts typedcorev1.ServiceAccountInterface, s corev1.ServiceAccount) error {
+func mustCreateServiceAccount(ctx context.Context, svcAccounts typedcorev1.ServiceAccountInterface, s corev1.ServiceAccount) {
 	if err := svcAccounts.Delete(ctx, s.Name, metav1.DeleteOptions{}); err != nil {
 		if !apierrors.IsNotFound(err) {
-			return errors.Wrap(err, "failed to delete svc account")
+			panic(errors.Wrap(err, "failed to delete svc account"))
 		}
 	}
 	log.Printf("Creating ServiceAccount %v", s.Name)
 	if _, err := svcAccounts.Create(ctx, &s, metav1.CreateOptions{}); err != nil {
-		return errors.Wrap(err, "failed to create svc account")
+		panic(errors.Wrap(err, "failed to create svc account"))
 	}
-
-	return nil
 }
 
-func mustCreateClusterRole(ctx context.Context, clusterRoles typedrbacv1.ClusterRoleInterface, cr rbacv1.ClusterRole) error {
+func mustCreateClusterRole(ctx context.Context, clusterRoles typedrbacv1.ClusterRoleInterface, cr rbacv1.ClusterRole) {
 	if err := clusterRoles.Delete(ctx, cr.Name, metav1.DeleteOptions{}); err != nil {
 		if !apierrors.IsNotFound(err) {
-			return errors.Wrap(err, "failed to delete cluster role")
+			panic(errors.Wrap(err, "failed to delete cluster role"))
 		}
 	}
 	log.Printf("Creating ClusterRoles %v", cr.Name)
 	if _, err := clusterRoles.Create(ctx, &cr, metav1.CreateOptions{}); err != nil {
-		return errors.Wrap(err, "failed to create cluster role")
+		panic(errors.Wrap(err, "failed to create cluster role"))
 	}
-
-	return nil
 }
 
-func mustCreateClusterRoleBinding(ctx context.Context, crBindings typedrbacv1.ClusterRoleBindingInterface, crb rbacv1.ClusterRoleBinding) error {
+func mustCreateClusterRoleBinding(ctx context.Context, crBindings typedrbacv1.ClusterRoleBindingInterface, crb rbacv1.ClusterRoleBinding) {
 	if err := crBindings.Delete(ctx, crb.Name, metav1.DeleteOptions{}); err != nil {
 		if !apierrors.IsNotFound(err) {
-			return errors.Wrap(err, "failed to delete cluster role binding")
+			panic(errors.Wrap(err, "failed to delete cluster role binding"))
 		}
 	}
 	log.Printf("Creating RoleBinding %v", crb.Name)
 	if _, err := crBindings.Create(ctx, &crb, metav1.CreateOptions{}); err != nil {
-		return errors.Wrap(err, "failed to create role binding")
+		panic(errors.Wrap(err, "failed to create role binding"))
 	}
-
-	return nil
 }
 
-func mustCreateRole(ctx context.Context, rs typedrbacv1.RoleInterface, r rbacv1.Role) error {
+func mustCreateRole(ctx context.Context, rs typedrbacv1.RoleInterface, r rbacv1.Role) {
 	if err := rs.Delete(ctx, r.Name, metav1.DeleteOptions{}); err != nil {
 		if !apierrors.IsNotFound(err) {
-			return errors.Wrap(err, "failed to delete role")
+			panic(errors.Wrap(err, "failed to delete role"))
 		}
 	}
 	log.Printf("Creating Role %v", r.Name)
 	if _, err := rs.Create(ctx, &r, metav1.CreateOptions{}); err != nil {
-		return errors.Wrap(err, "failed to create role")
+		panic(errors.Wrap(err, "failed to create role"))
 	}
-
-	return nil
 }
 
-func mustCreateRoleBinding(ctx context.Context, rbi typedrbacv1.RoleBindingInterface, rb rbacv1.RoleBinding) error {
+func mustCreateRoleBinding(ctx context.Context, rbi typedrbacv1.RoleBindingInterface, rb rbacv1.RoleBinding) {
 	if err := rbi.Delete(ctx, rb.Name, metav1.DeleteOptions{}); err != nil {
 		if !apierrors.IsNotFound(err) {
-			return errors.Wrap(err, "failed to delete role binding")
+			panic(errors.Wrap(err, "failed to delete role binding"))
 		}
 	}
 	log.Printf("Creating RoleBinding %v", rb.Name)
 	if _, err := rbi.Create(ctx, &rb, metav1.CreateOptions{}); err != nil {
-		return errors.Wrap(err, "failed to create role binding")
+		panic(errors.Wrap(err, "failed to create role binding"))
 	}
-
-	return nil
 }
 
-func mustCreateConfigMap(ctx context.Context, cmi typedcorev1.ConfigMapInterface, cm corev1.ConfigMap) error {
+func mustCreateConfigMap(ctx context.Context, cmi typedcorev1.ConfigMapInterface, cm corev1.ConfigMap) {
 	if err := cmi.Delete(ctx, cm.Name, metav1.DeleteOptions{}); err != nil {
 		if !apierrors.IsNotFound(err) {
-			return errors.Wrap(err, "failed to delete configmap")
+			panic(errors.Wrap(err, "failed to delete configmap"))
 		}
 	}
 	log.Printf("Creating ConfigMap %v", cm.Name)
 	if _, err := cmi.Create(ctx, &cm, metav1.CreateOptions{}); err != nil {
-		return errors.Wrap(err, "failed to create configmap")
+		panic(errors.Wrap(err, "failed to create configmap"))
 	}
-
-	return nil
 }
 
 func MustScaleDeployment(ctx context.Context,
@@ -190,33 +157,28 @@ func MustScaleDeployment(ctx context.Context,
 	podLabelSelector string,
 	replicas int,
 	skipWait bool,
-) error {
+) {
 	log.Printf("Scaling deployment %v to %v replicas", deployment.Name, replicas)
-	err := MustUpdateReplica(ctx, deploymentsClient, deployment.Name, int32(replicas))
-	if err != nil {
-		return errors.Wrap(err, "failed to scale deployment")
-	}
+	MustUpdateReplica(ctx, deploymentsClient, deployment.Name, int32(replicas))
 
 	if !skipWait {
 		log.Printf("Waiting for pods to be ready..")
-		err = WaitForPodDeployment(ctx, clientset, namespace, deployment.Name, podLabelSelector, replicas)
+		err := WaitForPodDeployment(ctx, clientset, namespace, deployment.Name, podLabelSelector, replicas)
 		if err != nil {
-			return errors.Wrap(err, "failed to wait for pod deployment")
+			panic(errors.Wrap(err, "failed to wait for pod deployment"))
 		}
 	}
-	return nil
 }
 
-func MustCreateNamespace(ctx context.Context, clienset *kubernetes.Clientset, namespace string) error {
+func MustCreateNamespace(ctx context.Context, clienset *kubernetes.Clientset, namespace string) {
 	_, err := clienset.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namespace,
 		},
 	}, metav1.CreateOptions{})
 	if err != nil {
-		return errors.Wrapf(err, "failed to create namespace %v", namespace)
+		panic(errors.Wrapf(err, "failed to create namespace %v", namespace))
 	}
-	return nil
 }
 
 func InstallCNSDaemonset(ctx context.Context, clientset *kubernetes.Clientset, logDir string) (func() error, error) {
@@ -471,23 +433,14 @@ func setupCNSDaemonset(
 	cnsDaemonsetClient := clientset.AppsV1().DaemonSets(cns.Namespace)
 
 	// setup the CNS configmap
-	if err := MustSetupConfigMap(ctx, clientset, cnsScenarioDetails.configMapPath); err != nil {
-		return cns, cnsDetails{}, errors.Wrapf(err, "failed to setup CNS %s configMap", cnsScenarioDetails.configMapPath)
-	}
+	MustSetupConfigMap(ctx, clientset, cnsScenarioDetails.configMapPath)
 
 	// setup common RBAC, ClusteerRole, ClusterRoleBinding, ServiceAccount
-	if _, err := MustSetUpClusterRBAC(ctx, clientset, cnsScenarioDetails.clusterRolePath, cnsScenarioDetails.clusterRoleBindingPath, cnsScenarioDetails.serviceAccountPath); err != nil {
-		return appsv1.DaemonSet{}, cnsDetails{}, errors.Wrap(err, "failed to setup common RBAC, ClusteerRole, ClusterRoleBinding and ServiceAccount")
-	}
+	MustSetUpClusterRBAC(ctx, clientset, cnsScenarioDetails.clusterRolePath, cnsScenarioDetails.clusterRoleBindingPath, cnsScenarioDetails.serviceAccountPath)
 
 	// setup RBAC, Role, RoleBinding
-	if err := MustSetUpRBAC(ctx, clientset, cnsScenarioDetails.rolePath, cnsScenarioDetails.roleBindingPath); err != nil {
-		return appsv1.DaemonSet{}, cnsDetails{}, errors.Wrap(err, "failed to setup RBAC, Role and RoleBinding")
-	}
-
-	if err := MustCreateDaemonset(ctx, cnsDaemonsetClient, cns); err != nil {
-		return appsv1.DaemonSet{}, cnsDetails{}, errors.Wrap(err, "failed to create daemonset")
-	}
+	MustSetUpRBAC(ctx, clientset, cnsScenarioDetails.rolePath, cnsScenarioDetails.roleBindingPath)
+	MustCreateDaemonset(ctx, cnsDaemonsetClient, cns)
 
 	if err := WaitForPodDaemonset(ctx, clientset, cns.Namespace, cns.Name, cnsScenarioDetails.labelSelector); err != nil {
 		return appsv1.DaemonSet{}, cnsDetails{}, errors.Wrap(err, "failed to check daemonset running")
@@ -513,10 +466,7 @@ func parseCNSDaemonset(cnsVersion, cniDropgzVersion string,
 			return appsv1.DaemonSet{}, cnsScenarioDetails, errors.Wrapf(ErrUnsupportedCNSScenario, "the combination of %s and %s is not supported", scenario, nodeOS)
 		}
 
-		cns, err := MustParseDaemonSet(cnsScenarioDetails.daemonsetPath) //nolint:govet // return this anyways
-		if err != nil {
-			return appsv1.DaemonSet{}, cnsDetails{}, errors.Wrapf(err, "failed to parse daemonset")
-		}
+		cns := MustParseDaemonSet(cnsScenarioDetails.daemonsetPath)
 
 		image, _ := ParseImageString(cns.Spec.Template.Spec.Containers[0].Image)
 		cns.Spec.Template.Spec.Containers[0].Image = GetImageString(image, cnsVersion)

--- a/test/internal/kubernetes/utils_delete.go
+++ b/test/internal/kubernetes/utils_delete.go
@@ -13,40 +13,34 @@ import (
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-func MustDeletePod(ctx context.Context, podI typedcorev1.PodInterface, pod corev1.Pod) error {
+func MustDeletePod(ctx context.Context, podI typedcorev1.PodInterface, pod corev1.Pod) {
 	if err := podI.Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil {
 		if !apierrors.IsNotFound(err) {
-			return errors.Wrap(err, "failed to delete pod")
+			panic(errors.Wrap(err, "failed to delete pod"))
 		}
 	}
-	return nil
 }
 
-func MustDeleteDaemonset(ctx context.Context, daemonsets typedappsv1.DaemonSetInterface, ds appsv1.DaemonSet) error {
+func MustDeleteDaemonset(ctx context.Context, daemonsets typedappsv1.DaemonSetInterface, ds appsv1.DaemonSet) {
 	if err := daemonsets.Delete(ctx, ds.Name, metav1.DeleteOptions{}); err != nil {
 		if !apierrors.IsNotFound(err) {
-			return errors.Wrap(err, "failed to delete daemonset")
+			panic(errors.Wrap(err, "failed to delete daemonset"))
 		}
 	}
-
-	return nil
 }
 
-func MustDeleteDeployment(ctx context.Context, deployments typedappsv1.DeploymentInterface, d appsv1.Deployment) error {
+func MustDeleteDeployment(ctx context.Context, deployments typedappsv1.DeploymentInterface, d appsv1.Deployment) {
 	if err := deployments.Delete(ctx, d.Name, metav1.DeleteOptions{}); err != nil {
 		if !apierrors.IsNotFound(err) {
-			return errors.Wrap(err, "failed to delete deployment")
+			panic(errors.Wrap(err, "failed to delete deployment"))
 		}
 	}
-
-	return nil
 }
 
-func MustDeleteNamespace(ctx context.Context, clienset *kubernetes.Clientset, namespace string) error {
+func MustDeleteNamespace(ctx context.Context, clienset *kubernetes.Clientset, namespace string) {
 	if err := clienset.CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{}); err != nil {
 		if !apierrors.IsNotFound(err) {
-			return errors.Wrapf(err, "failed to delete namespace %v", namespace)
+			panic(errors.Wrapf(err, "failed to delete namespace %v", namespace))
 		}
 	}
-	return nil
 }

--- a/test/internal/kubernetes/utils_parse.go
+++ b/test/internal/kubernetes/utils_parse.go
@@ -6,57 +6,50 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
-// ParsePod parses a corev1.Pod from the provided yaml or json file path.
-func MustParsePod(path string) (corev1.Pod, error) {
-	var pod corev1.Pod
-	err := mustParseResource(path, &pod)
-	return pod, err
-}
-
-func MustParseDaemonSet(path string) (appsv1.DaemonSet, error) {
+func MustParseDaemonSet(path string) appsv1.DaemonSet {
 	var ds appsv1.DaemonSet
-	err := mustParseResource(path, &ds)
-	return ds, err
+	mustParseResource(path, &ds)
+	return ds
 }
 
-func MustParseDeployment(path string) (appsv1.Deployment, error) {
+func MustParseDeployment(path string) appsv1.Deployment {
 	var depl appsv1.Deployment
-	err := mustParseResource(path, &depl)
-	return depl, err
+	mustParseResource(path, &depl)
+	return depl
 }
 
-func mustParseServiceAccount(path string) (corev1.ServiceAccount, error) {
+func mustParseServiceAccount(path string) corev1.ServiceAccount {
 	var svcAcct corev1.ServiceAccount
-	err := mustParseResource(path, &svcAcct)
-	return svcAcct, err
+	mustParseResource(path, &svcAcct)
+	return svcAcct
 }
 
-func mustParseClusterRole(path string) (rbacv1.ClusterRole, error) {
+func mustParseClusterRole(path string) rbacv1.ClusterRole {
 	var cr rbacv1.ClusterRole
-	err := mustParseResource(path, &cr)
-	return cr, err
+	mustParseResource(path, &cr)
+	return cr
 }
 
-func mustParseClusterRoleBinding(path string) (rbacv1.ClusterRoleBinding, error) {
+func mustParseClusterRoleBinding(path string) rbacv1.ClusterRoleBinding {
 	var crb rbacv1.ClusterRoleBinding
-	err := mustParseResource(path, &crb)
-	return crb, err
+	mustParseResource(path, &crb)
+	return crb
 }
 
-func mustParseRole(path string) (rbacv1.Role, error) {
+func mustParseRole(path string) rbacv1.Role {
 	var r rbacv1.Role
-	err := mustParseResource(path, &r)
-	return r, err
+	mustParseResource(path, &r)
+	return r
 }
 
-func mustParseRoleBinding(path string) (rbacv1.RoleBinding, error) {
+func mustParseRoleBinding(path string) rbacv1.RoleBinding {
 	var rb rbacv1.RoleBinding
-	err := mustParseResource(path, &rb)
-	return rb, err
+	mustParseResource(path, &rb)
+	return rb
 }
 
-func mustParseConfigMap(path string) (corev1.ConfigMap, error) {
+func mustParseConfigMap(path string) corev1.ConfigMap {
 	var cm corev1.ConfigMap
-	err := mustParseResource(path, &cm)
-	return cm, err
+	mustParseResource(path, &cm)
+	return cm
 }


### PR DESCRIPTION
`must*` functions should panic, not return `err`

Targeting the `test/internal/kubernetes` package in this PR