### PR TITLE
feat: 🌈 StatelessCNI: Adding getEndpoint and UpdateEndpoint API to CNS

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -36,6 +36,7 @@ const (
 	PathDebugRestData                        = "/debug/restdata"
 	NumberOfCPUCores                         = NumberOfCPUCoresPath
 	NMAgentSupportedAPIs                     = NmAgentSupportedApisPath
+	EndpointsPath                            = EndpointPath
 )
 
 // NetworkContainer Prefixes

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -36,7 +36,7 @@ const (
 	PathDebugRestData                        = "/debug/restdata"
 	NumberOfCPUCores                         = NumberOfCPUCoresPath
 	NMAgentSupportedAPIs                     = NmAgentSupportedApisPath
-	EndpointsPath                            = EndpointPath
+	EndpointApi                              = EndpointPath
 )
 
 // NetworkContainer Prefixes

--- a/cns/api.go
+++ b/cns/api.go
@@ -34,7 +34,7 @@ const (
 	NmAgentSupportedApisPath      = "/network/nmagentsupportedapis"
 	V1Prefix                      = "/v0.1"
 	V2Prefix                      = "/v0.2"
-	EndpointPath                  = "/network/endpoints"
+	EndpointPath                  = "/network/endpoints/"
 )
 
 // HTTPService describes the min API interface that every service should have.
@@ -351,12 +351,6 @@ type GetHomeAzResponse struct {
 
 // UpdateEndpoint describes request to update the state.
 type EndpointRequest struct {
-	EndpointID    string `json:"endpointID"`
 	HnsEndpointID string `json:"hnsEndpointID"`
 	HostVethName  string `json:"hostVethName"`
-}
-
-// UpdateEndpointResponse describes response to the UpdateEndpoint request.
-type UpdateEndpointResponse struct {
-	Response Response `json:"response"`
 }

--- a/cns/api.go
+++ b/cns/api.go
@@ -34,6 +34,7 @@ const (
 	NmAgentSupportedApisPath      = "/network/nmagentsupportedapis"
 	V1Prefix                      = "/v0.1"
 	V2Prefix                      = "/v0.2"
+	EndpointPath                  = "/network/endpoints"
 )
 
 // HTTPService describes the min API interface that every service should have.
@@ -346,4 +347,21 @@ type HomeAzResponse struct {
 type GetHomeAzResponse struct {
 	Response       Response       `json:"response"`
 	HomeAzResponse HomeAzResponse `json:"homeAzResponse"`
+}
+
+// UpdateEndpoint describes request to update the state.
+type UpdateEndpoint struct {
+	EndpointID string `json:"EndpointID"`
+	HnsID      string `json:"HnsID"`
+	VethName   string `json:"VethName"`
+}
+
+// UpdateEndpointResponse describes response to the UpdateEndpoint request.
+type UpdateEndpointResponse struct {
+	Response Response `json:"Response"`
+}
+
+// EndpointID describes request to get the state.
+type GetEndpoint struct {
+	EndpointID string `json:"EndpointID"`
 }

--- a/cns/api.go
+++ b/cns/api.go
@@ -351,9 +351,9 @@ type GetHomeAzResponse struct {
 
 // UpdateEndpoint describes request to update the state.
 type EndpointRequest struct {
-	EndpointID string `json:"endpointID"`
-	HnsID      string `json:"hnsID"`
-	VethName   string `json:"vethName"`
+	EndpointID    string `json:"endpointID"`
+	HnsEndpointID string `json:"hnsEndpointID"`
+	HostVethName  string `json:"hostVethName"`
 }
 
 // UpdateEndpointResponse describes response to the UpdateEndpoint request.

--- a/cns/api.go
+++ b/cns/api.go
@@ -350,18 +350,13 @@ type GetHomeAzResponse struct {
 }
 
 // UpdateEndpoint describes request to update the state.
-type UpdateEndpoint struct {
-	EndpointID string `json:"EndpointID"`
-	HnsID      string `json:"HnsID"`
-	VethName   string `json:"VethName"`
+type EndpointRequest struct {
+	EndpointID string `json:"endpointID"`
+	HnsID      string `json:"hnsID"`
+	VethName   string `json:"vethName"`
 }
 
 // UpdateEndpointResponse describes response to the UpdateEndpoint request.
 type UpdateEndpointResponse struct {
-	Response Response `json:"Response"`
-}
-
-// EndpointID describes request to get the state.
-type GetEndpoint struct {
-	EndpointID string `json:"EndpointID"`
+	Response Response `json:"response"`
 }

--- a/cns/api.go
+++ b/cns/api.go
@@ -349,7 +349,7 @@ type GetHomeAzResponse struct {
 	HomeAzResponse HomeAzResponse `json:"homeAzResponse"`
 }
 
-// UpdateEndpoint describes request to update the state.
+// Used by EndpointHandler API to update endpoint state.
 type EndpointRequest struct {
 	HnsEndpointID string `json:"hnsEndpointID"`
 	HostVethName  string `json:"hostVethName"`

--- a/cns/client/client.go
+++ b/cns/client/client.go
@@ -1047,7 +1047,7 @@ func (c *Client) GetEndpoint(ctx context.Context, endpointID string) (*restserve
 	var response restserver.GetEndpointResponse
 	err = json.NewDecoder(res.Body).Decode(&response)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to decode IPConfigResponse")
+		return nil, errors.Wrap(err, "failed to decode GetEndpointResponse")
 	}
 
 	if response.Response.ReturnCode != 0 {
@@ -1092,7 +1092,7 @@ func (c *Client) UpdateEndpoint(ctx context.Context, endpointID, hnsID, vethName
 	err = json.NewDecoder(res.Body).Decode(&response)
 
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to decode IPConfigResponse")
+		return nil, errors.Wrap(err, "failed to decode GetEndpointResponse")
 	}
 
 	if response.ReturnCode != 0 {

--- a/cns/client/client.go
+++ b/cns/client/client.go
@@ -45,6 +45,7 @@ var clientPaths = []string{
 	cns.DeleteNetworkContainer,
 	cns.NetworkContainersURLPath,
 	cns.GetHomeAz,
+	cns.EndpointsPath,
 }
 
 type do interface {
@@ -1020,4 +1021,90 @@ func (c *Client) GetHomeAz(ctx context.Context) (*cns.GetHomeAzResponse, error) 
 	}
 
 	return &getHomeAzResponse, nil
+}
+
+// GetEndpoint calls the GetEndpoint in CNS
+func (c *Client) GetEndpoint(ctx context.Context, endpointID string) (*restserver.GetEndpointResponse, error) {
+	var err error
+	getEndpoint := cns.GetEndpoint{
+		EndpointID: endpointID,
+	}
+	var body bytes.Buffer
+	err = json.NewEncoder(&body).Encode(getEndpoint)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to encode getEndpoint")
+	}
+
+	u := c.routes[cns.EndpointsPath]
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), &body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build request")
+	}
+	req.Header.Set(headerContentType, contentTypeJSON)
+	res, err := c.client.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "http request failed")
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("http response %d", res.StatusCode)
+	}
+
+	var response restserver.GetEndpointResponse
+	err = json.NewDecoder(res.Body).Decode(&response)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to decode IPConfigResponse")
+	}
+
+	if response.Response.ReturnCode != 0 {
+		return nil, errors.New(response.Response.Message)
+	}
+
+	return &response, nil
+}
+
+// UpdateEndpoint calls the UpdateEndpoint in CNS
+func (c *Client) UpdateEndpoint(ctx context.Context, endpointID, hnsID, vethName string) (*cns.UpdateEndpointResponse, error) {
+	var err error
+	updateEndpoint := cns.UpdateEndpoint{
+		EndpointID: endpointID,
+		HnsID:      hnsID,
+		VethName:   vethName,
+	}
+	var body bytes.Buffer
+	err = json.NewEncoder(&body).Encode(updateEndpoint)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to encode updateEndpoint")
+	}
+
+	u := c.routes[cns.EndpointsPath]
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, u.String(), &body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build request")
+	}
+	req.Header.Set(headerContentType, contentTypeJSON)
+	res, err := c.client.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "http request failed with error from server")
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("http response %d", res.StatusCode)
+	}
+
+	var response cns.UpdateEndpointResponse
+	err = json.NewDecoder(res.Body).Decode(&response)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to decode IPConfigResponse")
+	}
+
+	if response.Response.ReturnCode != 0 {
+		return nil, errors.New(response.Response.Message)
+	}
+
+	return &response, nil
 }

--- a/cns/client/client.go
+++ b/cns/client/client.go
@@ -1023,19 +1023,12 @@ func (c *Client) GetHomeAz(ctx context.Context) (*cns.GetHomeAzResponse, error) 
 	return &getHomeAzResponse, nil
 }
 
-// GetEndpoint calls the EndpointHandlerAPI in CNS to retrive the state of a given EndpointID
+// GetEndpoint calls the EndpointHandlerAPI in CNS to retrieve the state of a given EndpointID
 func (c *Client) GetEndpoint(ctx context.Context, endpointID string) (*restserver.GetEndpointResponse, error) {
-	getEndpoint := cns.EndpointRequest{
-		EndpointID: endpointID,
-	}
-	var body bytes.Buffer
-
-	if err := json.NewEncoder(&body).Encode(getEndpoint); err != nil {
-		return nil, errors.Wrap(err, "failed to encode getEndpoint")
-	}
-
+	// build the request
 	u := c.routes[cns.EndpointsPath]
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), &body)
+	uString := u.String() + endpointID
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uString, http.NoBody)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to build request")
 	}
@@ -1064,10 +1057,11 @@ func (c *Client) GetEndpoint(ctx context.Context, endpointID string) (*restserve
 	return &response, nil
 }
 
-// UpdateEndpoint calls the EndpointHandlerAPI in CNS to update the state of a given EndpointID with either HNSEndpointID or HostVethName
-func (c *Client) UpdateEndpoint(ctx context.Context, endpointID, hnsID, vethName string) (*cns.UpdateEndpointResponse, error) {
+// UpdateEndpoint calls the EndpointHandlerAPI in CNS
+// to update the state of a given EndpointID with either HNSEndpointID or HostVethName
+func (c *Client) UpdateEndpoint(ctx context.Context, endpointID, hnsID, vethName string) (*cns.Response, error) {
+	// build the request
 	updateEndpoint := cns.EndpointRequest{
-		EndpointID:    endpointID,
 		HnsEndpointID: hnsID,
 		HostVethName:  vethName,
 	}
@@ -1078,7 +1072,8 @@ func (c *Client) UpdateEndpoint(ctx context.Context, endpointID, hnsID, vethName
 	}
 
 	u := c.routes[cns.EndpointsPath]
-	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, u.String(), &body)
+	uString := u.String() + endpointID
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, uString, &body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to build request")
 	}
@@ -1089,19 +1084,19 @@ func (c *Client) UpdateEndpoint(ctx context.Context, endpointID, hnsID, vethName
 	}
 
 	defer res.Body.Close()
-
 	if res.StatusCode != http.StatusOK {
 		return nil, errors.Errorf("http response %d", res.StatusCode)
 	}
 
-	var response cns.UpdateEndpointResponse
+	var response cns.Response
 	err = json.NewDecoder(res.Body).Decode(&response)
+
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to decode IPConfigResponse")
 	}
 
-	if response.Response.ReturnCode != 0 {
-		return nil, errors.New(response.Response.Message)
+	if response.ReturnCode != 0 {
+		return nil, errors.New(response.Message)
 	}
 
 	return &response, nil

--- a/cns/client/client.go
+++ b/cns/client/client.go
@@ -1023,7 +1023,7 @@ func (c *Client) GetHomeAz(ctx context.Context) (*cns.GetHomeAzResponse, error) 
 	return &getHomeAzResponse, nil
 }
 
-// GetEndpoint calls the GetEndpoint in CNS
+// GetEndpoint calls the EndpointHandlerAPI in CNS to retrive the state of a given EndpointID
 func (c *Client) GetEndpoint(ctx context.Context, endpointID string) (*restserver.GetEndpointResponse, error) {
 	getEndpoint := cns.EndpointRequest{
 		EndpointID: endpointID,
@@ -1064,12 +1064,12 @@ func (c *Client) GetEndpoint(ctx context.Context, endpointID string) (*restserve
 	return &response, nil
 }
 
-// UpdateEndpoint calls the UpdateEndpoint in CNS
+// UpdateEndpoint calls the EndpointHandlerAPI in CNS to update the state of a given EndpointID with either HNSEndpointID or HostVethName
 func (c *Client) UpdateEndpoint(ctx context.Context, endpointID, hnsID, vethName string) (*cns.UpdateEndpointResponse, error) {
 	updateEndpoint := cns.EndpointRequest{
-		EndpointID: endpointID,
-		HnsID:      hnsID,
-		VethName:   vethName,
+		EndpointID:    endpointID,
+		HnsEndpointID: hnsID,
+		HostVethName:  vethName,
 	}
 	var body bytes.Buffer
 

--- a/cns/client/client.go
+++ b/cns/client/client.go
@@ -45,7 +45,7 @@ var clientPaths = []string{
 	cns.DeleteNetworkContainer,
 	cns.NetworkContainersURLPath,
 	cns.GetHomeAz,
-	cns.EndpointsPath,
+	cns.EndpointApi,
 }
 
 type do interface {
@@ -1026,7 +1026,7 @@ func (c *Client) GetHomeAz(ctx context.Context) (*cns.GetHomeAzResponse, error) 
 // GetEndpoint calls the EndpointHandlerAPI in CNS to retrieve the state of a given EndpointID
 func (c *Client) GetEndpoint(ctx context.Context, endpointID string) (*restserver.GetEndpointResponse, error) {
 	// build the request
-	u := c.routes[cns.EndpointsPath]
+	u := c.routes[cns.EndpointApi]
 	uString := u.String() + endpointID
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uString, http.NoBody)
 	if err != nil {
@@ -1071,7 +1071,7 @@ func (c *Client) UpdateEndpoint(ctx context.Context, endpointID, hnsID, vethName
 		return nil, errors.Wrap(err, "failed to encode updateEndpoint")
 	}
 
-	u := c.routes[cns.EndpointsPath]
+	u := c.routes[cns.EndpointApi]
 	uString := u.String() + endpointID
 	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, uString, &body)
 	if err != nil {
@@ -1092,7 +1092,7 @@ func (c *Client) UpdateEndpoint(ctx context.Context, endpointID, hnsID, vethName
 	err = json.NewDecoder(res.Body).Decode(&response)
 
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to decode GetEndpointResponse")
+		return nil, errors.Wrap(err, "failed to decode CNS Response")
 	}
 
 	if response.ReturnCode != 0 {

--- a/cns/client/client.go
+++ b/cns/client/client.go
@@ -1025,13 +1025,12 @@ func (c *Client) GetHomeAz(ctx context.Context) (*cns.GetHomeAzResponse, error) 
 
 // GetEndpoint calls the GetEndpoint in CNS
 func (c *Client) GetEndpoint(ctx context.Context, endpointID string) (*restserver.GetEndpointResponse, error) {
-	var err error
-	getEndpoint := cns.GetEndpoint{
+	getEndpoint := cns.EndpointRequest{
 		EndpointID: endpointID,
 	}
 	var body bytes.Buffer
-	err = json.NewEncoder(&body).Encode(getEndpoint)
-	if err != nil {
+
+	if err := json.NewEncoder(&body).Encode(getEndpoint); err != nil {
 		return nil, errors.Wrap(err, "failed to encode getEndpoint")
 	}
 
@@ -1067,15 +1066,14 @@ func (c *Client) GetEndpoint(ctx context.Context, endpointID string) (*restserve
 
 // UpdateEndpoint calls the UpdateEndpoint in CNS
 func (c *Client) UpdateEndpoint(ctx context.Context, endpointID, hnsID, vethName string) (*cns.UpdateEndpointResponse, error) {
-	var err error
-	updateEndpoint := cns.UpdateEndpoint{
+	updateEndpoint := cns.EndpointRequest{
 		EndpointID: endpointID,
 		HnsID:      hnsID,
 		VethName:   vethName,
 	}
 	var body bytes.Buffer
-	err = json.NewEncoder(&body).Encode(updateEndpoint)
-	if err != nil {
+
+	if err := json.NewEncoder(&body).Encode(updateEndpoint); err != nil {
 		return nil, errors.Wrap(err, "failed to encode updateEndpoint")
 	}
 

--- a/cns/client/client_test.go
+++ b/cns/client/client_test.go
@@ -2778,7 +2778,7 @@ func TestUpdateEndpoint(t *testing.T) {
 		hnsID       string
 		vethName    string
 		response    *RequestCapture
-		expReq      *cns.UpdateEndpoint
+		expReq      *cns.EndpointRequest
 		shouldErr   bool
 	}{
 		{
@@ -2802,7 +2802,7 @@ func TestUpdateEndpoint(t *testing.T) {
 					httpStatusCodeToReturn: http.StatusOK,
 				},
 			},
-			&cns.UpdateEndpoint{
+			&cns.EndpointRequest{
 				EndpointID: "foo",
 				HnsID:      "bar",
 			},
@@ -2818,7 +2818,7 @@ func TestUpdateEndpoint(t *testing.T) {
 					httpStatusCodeToReturn: http.StatusOK,
 				},
 			},
-			&cns.UpdateEndpoint{
+			&cns.EndpointRequest{
 				EndpointID: "foo",
 				VethName:   "bar",
 			},
@@ -2855,7 +2855,93 @@ func TestUpdateEndpoint(t *testing.T) {
 			// if a request was expected to be sent, decode it and ensure that it
 			// matches expectations
 			if test.expReq != nil {
-				var gotReq cns.UpdateEndpoint
+				var gotReq cns.EndpointRequest
+				err = json.NewDecoder(test.response.Request.Body).Decode(&gotReq)
+				if err != nil {
+					t.Fatal("error decoding the received request: err:", err)
+				}
+
+				// a nil expReq is semantically meaningful (i.e. "no request"), but in
+				// order for cmp to work properly, the outer types should be identical.
+				// Thus we have to dereference it explicitly:
+				expReq := *test.expReq
+
+				// ensure that the received request is what was expected
+				if !cmp.Equal(gotReq, expReq) {
+					t.Error("received request differs from expectation: diff", cmp.Diff(gotReq, expReq))
+				}
+			}
+		})
+	}
+}
+
+func TestGetEndpoint(t *testing.T) {
+	// the CNS client has to be provided with routes going somewhere, so create a
+	// bunch of routes mapped to the localhost
+	emptyRoutes, _ := buildRoutes(defaultBaseURL, clientPaths)
+
+	// define our test cases
+	getEndpointTests := []struct {
+		name        string
+		containerID string
+		response    *RequestCapture
+		expReq      *cns.EndpointRequest
+		shouldErr   bool
+	}{
+		{
+			"empty",
+			"",
+			&RequestCapture{
+				Next: &mockdo{},
+			},
+			nil,
+			true,
+		},
+		{
+			"with EndpointID",
+			"foo",
+			&RequestCapture{
+				Next: &mockdo{
+					httpStatusCodeToReturn: http.StatusOK,
+				},
+			},
+			&cns.EndpointRequest{
+				EndpointID: "foo",
+			},
+			false,
+		},
+	}
+
+	for _, test := range getEndpointTests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// create a new client with the mock routes and the mock doer
+			client := Client{
+				client: test.response,
+				routes: emptyRoutes,
+			}
+
+			// execute the method under test
+			res, err := client.GetEndpoint(context.TODO(), test.containerID)
+			if err != nil && !test.shouldErr {
+				t.Fatal("unexpected error: err: ", err, res.Response.Message)
+			}
+
+			if err == nil && test.shouldErr {
+				t.Fatal("expected test to error, but no error was produced", res.Response.Message)
+			}
+
+			// make sure a request was actually sent
+			if test.expReq != nil && test.response.Request == nil {
+				t.Fatal("expected a request to be sent, but none was", res.Response.Message)
+			}
+
+			// if a request was expected to be sent, decode it and ensure that it
+			// matches expectations
+			if test.expReq != nil {
+				var gotReq cns.EndpointRequest
 				err = json.NewDecoder(test.response.Request.Body).Decode(&gotReq)
 				if err != nil {
 					t.Fatal("error decoding the received request: err:", err)

--- a/cns/client/client_test.go
+++ b/cns/client/client_test.go
@@ -2765,3 +2765,112 @@ func TestGetHomeAz(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateEndpoint(t *testing.T) {
+	// the CNS client has to be provided with routes going somewhere, so create a
+	// bunch of routes mapped to the localhost
+	emptyRoutes, _ := buildRoutes(defaultBaseURL, clientPaths)
+
+	// define our test cases
+	updateEndpointTests := []struct {
+		name        string
+		containerID string
+		hnsID       string
+		vethName    string
+		response    *RequestCapture
+		expReq      *cns.UpdateEndpoint
+		shouldErr   bool
+	}{
+		{
+			"empty",
+			"",
+			"",
+			"",
+			&RequestCapture{
+				Next: &mockdo{},
+			},
+			nil,
+			true,
+		},
+		{
+			"with HNSId",
+			"foo",
+			"bar",
+			"",
+			&RequestCapture{
+				Next: &mockdo{
+					httpStatusCodeToReturn: http.StatusOK,
+				},
+			},
+			&cns.UpdateEndpoint{
+				EndpointID: "foo",
+				HnsID:      "bar",
+			},
+			false,
+		},
+		{
+			"with vethName",
+			"foo",
+			"",
+			"bar",
+			&RequestCapture{
+				Next: &mockdo{
+					httpStatusCodeToReturn: http.StatusOK,
+				},
+			},
+			&cns.UpdateEndpoint{
+				EndpointID: "foo",
+				VethName:   "bar",
+			},
+			false,
+		},
+	}
+
+	for _, test := range updateEndpointTests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// create a new client with the mock routes and the mock doer
+			client := Client{
+				client: test.response,
+				routes: emptyRoutes,
+			}
+
+			// execute the method under test
+			res, err := client.UpdateEndpoint(context.TODO(), test.containerID, test.hnsID, test.vethName)
+			if err != nil && !test.shouldErr {
+				t.Fatal("unexpected error: err: ", err, res.Response.Message)
+			}
+
+			if err == nil && test.shouldErr {
+				t.Fatal("expected test to error, but no error was produced", res.Response.Message)
+			}
+
+			// make sure a request was actually sent
+			if test.expReq != nil && test.response.Request == nil {
+				t.Fatal("expected a request to be sent, but none was", res.Response.Message)
+			}
+
+			// if a request was expected to be sent, decode it and ensure that it
+			// matches expectations
+			if test.expReq != nil {
+				var gotReq cns.UpdateEndpoint
+				err = json.NewDecoder(test.response.Request.Body).Decode(&gotReq)
+				if err != nil {
+					t.Fatal("error decoding the received request: err:", err)
+				}
+
+				// a nil expReq is semantically meaningful (i.e. "no request"), but in
+				// order for cmp to work properly, the outer types should be identical.
+				// Thus we have to dereference it explicitly:
+				expReq := *test.expReq
+
+				// ensure that the received request is what was expected
+				if !cmp.Equal(gotReq, expReq) {
+					t.Error("received request differs from expectation: diff", cmp.Diff(gotReq, expReq))
+				}
+			}
+		})
+	}
+}

--- a/cns/client/client_test.go
+++ b/cns/client/client_test.go
@@ -2803,8 +2803,8 @@ func TestUpdateEndpoint(t *testing.T) {
 				},
 			},
 			&cns.EndpointRequest{
-				EndpointID: "foo",
-				HnsID:      "bar",
+				EndpointID:    "foo",
+				HnsEndpointID: "bar",
 			},
 			false,
 		},
@@ -2819,10 +2819,26 @@ func TestUpdateEndpoint(t *testing.T) {
 				},
 			},
 			&cns.EndpointRequest{
-				EndpointID: "foo",
-				VethName:   "bar",
+				EndpointID:   "foo",
+				HostVethName: "bar",
 			},
 			false,
+		},
+		{
+			"bad request error",
+			"foo",
+			"",
+			"bar",
+			&RequestCapture{
+				Next: &mockdo{
+					httpStatusCodeToReturn: http.StatusBadRequest,
+				},
+			},
+			&cns.EndpointRequest{
+				EndpointID:   "foo",
+				HostVethName: "bar",
+			},
+			true,
 		},
 	}
 
@@ -2909,6 +2925,19 @@ func TestGetEndpoint(t *testing.T) {
 				EndpointID: "foo",
 			},
 			false,
+		},
+		{
+			"with EndpointID",
+			"foo",
+			&RequestCapture{
+				Next: &mockdo{
+					httpStatusCodeToReturn: http.StatusBadRequest,
+				},
+			},
+			&cns.EndpointRequest{
+				EndpointID: "foo",
+			},
+			true,
 		},
 	}
 

--- a/cns/client/client_test.go
+++ b/cns/client/client_test.go
@@ -2919,7 +2919,7 @@ func TestGetEndpoint(t *testing.T) {
 			false,
 		},
 		{
-			"with EndpointID",
+			"Bad Request",
 			"foo",
 			&RequestCapture{
 				Next: &mockdo{

--- a/cns/client/client_test.go
+++ b/cns/client/client_test.go
@@ -2803,7 +2803,6 @@ func TestUpdateEndpoint(t *testing.T) {
 				},
 			},
 			&cns.EndpointRequest{
-				EndpointID:    "foo",
 				HnsEndpointID: "bar",
 			},
 			false,
@@ -2819,7 +2818,6 @@ func TestUpdateEndpoint(t *testing.T) {
 				},
 			},
 			&cns.EndpointRequest{
-				EndpointID:   "foo",
 				HostVethName: "bar",
 			},
 			false,
@@ -2835,7 +2833,6 @@ func TestUpdateEndpoint(t *testing.T) {
 				},
 			},
 			&cns.EndpointRequest{
-				EndpointID:   "foo",
 				HostVethName: "bar",
 			},
 			true,
@@ -2856,16 +2853,16 @@ func TestUpdateEndpoint(t *testing.T) {
 			// execute the method under test
 			res, err := client.UpdateEndpoint(context.TODO(), test.containerID, test.hnsID, test.vethName)
 			if err != nil && !test.shouldErr {
-				t.Fatal("unexpected error: err: ", err, res.Response.Message)
+				t.Fatal("unexpected error: err: ", err, res.Message)
 			}
 
 			if err == nil && test.shouldErr {
-				t.Fatal("expected test to error, but no error was produced", res.Response.Message)
+				t.Fatal("expected test to error, but no error was produced", res.Message)
 			}
 
 			// make sure a request was actually sent
 			if test.expReq != nil && test.response.Request == nil {
-				t.Fatal("expected a request to be sent, but none was", res.Response.Message)
+				t.Fatal("expected a request to be sent, but none was", res.Message)
 			}
 
 			// if a request was expected to be sent, decode it and ensure that it
@@ -2901,7 +2898,6 @@ func TestGetEndpoint(t *testing.T) {
 		name        string
 		containerID string
 		response    *RequestCapture
-		expReq      *cns.EndpointRequest
 		shouldErr   bool
 	}{
 		{
@@ -2910,7 +2906,6 @@ func TestGetEndpoint(t *testing.T) {
 			&RequestCapture{
 				Next: &mockdo{},
 			},
-			nil,
 			true,
 		},
 		{
@@ -2921,9 +2916,6 @@ func TestGetEndpoint(t *testing.T) {
 					httpStatusCodeToReturn: http.StatusOK,
 				},
 			},
-			&cns.EndpointRequest{
-				EndpointID: "foo",
-			},
 			false,
 		},
 		{
@@ -2933,9 +2925,6 @@ func TestGetEndpoint(t *testing.T) {
 				Next: &mockdo{
 					httpStatusCodeToReturn: http.StatusBadRequest,
 				},
-			},
-			&cns.EndpointRequest{
-				EndpointID: "foo",
 			},
 			true,
 		},
@@ -2960,31 +2949,6 @@ func TestGetEndpoint(t *testing.T) {
 
 			if err == nil && test.shouldErr {
 				t.Fatal("expected test to error, but no error was produced", res.Response.Message)
-			}
-
-			// make sure a request was actually sent
-			if test.expReq != nil && test.response.Request == nil {
-				t.Fatal("expected a request to be sent, but none was", res.Response.Message)
-			}
-
-			// if a request was expected to be sent, decode it and ensure that it
-			// matches expectations
-			if test.expReq != nil {
-				var gotReq cns.EndpointRequest
-				err = json.NewDecoder(test.response.Request.Body).Decode(&gotReq)
-				if err != nil {
-					t.Fatal("error decoding the received request: err:", err)
-				}
-
-				// a nil expReq is semantically meaningful (i.e. "no request"), but in
-				// order for cmp to work properly, the outer types should be identical.
-				// Thus we have to dereference it explicitly:
-				expReq := *test.expReq
-
-				// ensure that the received request is what was expected
-				if !cmp.Equal(gotReq, expReq) {
-					t.Error("received request differs from expectation: diff", cmp.Diff(gotReq, expReq))
-				}
 			}
 		})
 	}

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -903,14 +903,14 @@ func validateDesiredIPAddresses(desiredIPs []string) error {
 
 // EndpointHandlerAPI forwards the endpoint related APIs to GetEndpointHandler or UpdateEndpointHandler based on the http method
 func (service *HTTPRestService) EndpointHandlerAPI(w http.ResponseWriter, r *http.Request) {
-	logger.Printf("[Azure CNS] EndpointHandlerAPI received request with http Method %s", r.Method)
+	logger.Printf("[EndpointHandlerAPI] EndpointHandlerAPI received request with http Method %s", r.Method)
 	service.Lock()
 	defer service.Unlock()
 	// Check if CNS is managing the CNI statefile
 	if service.Options[common.OptManageEndpointState] == false {
 		response := cns.Response{
 			ReturnCode: types.UnexpectedError,
-			Message:    fmt.Sprintf("[updateEndpoint] updateEndpoint failed with error: %s", ErrOptManageEndpointState),
+			Message:    fmt.Sprintf("[EndpointHandlerAPI] EndpointHandlerAPI failed with error: %s", ErrOptManageEndpointState),
 		}
 		err := service.Listener.Encode(w, &response)
 		logger.Response(service.Name, response, response.ReturnCode, err)
@@ -922,7 +922,7 @@ func (service *HTTPRestService) EndpointHandlerAPI(w http.ResponseWriter, r *htt
 	case http.MethodPatch:
 		service.UpdateEndpointHandler(w, r)
 	default:
-		logger.Errorf("[Azure CNS] EndpointHandler API expect http Get or Patch method")
+		logger.Errorf("[EndpointHandlerAPI] EndpointHandler API expect http Get or Patch method")
 	}
 }
 

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/filter"
@@ -23,6 +24,7 @@ var (
 	ErrParsePodIPFailed       = errors.New("failed to parse pod's ip")
 	ErrNoNCs                  = errors.New("No NCs found in the CNS internal state")
 	ErrOptManageEndpointState = errors.New("CNS is not set to manage the endpoint state")
+	ErrEndpointStateNotFound  = errors.New("Endpoint state could not be found in the statefile")
 )
 
 // requestIPConfigHandlerHelper validates the request, assigns IPs, and returns a response
@@ -901,10 +903,19 @@ func validateDesiredIPAddresses(desiredIPs []string) error {
 
 // EndpointHandlerAPI forwards the endpoint related APIs to GetEndpointHandler or UpdateEndpointHandler based on the http method
 func (service *HTTPRestService) EndpointHandlerAPI(w http.ResponseWriter, r *http.Request) {
-	logger.Printf("[Azure CNS] EndpointHandlerAPI")
+	logger.Printf("[Azure CNS] EndpointHandlerAPI received request with http Method %s", r.Method)
 	service.Lock()
 	defer service.Unlock()
-
+	// Check if CNS is managing the CNI statefile
+	if service.Options[common.OptManageEndpointState] == false {
+		response := cns.Response{
+			ReturnCode: types.UnexpectedError,
+			Message:    fmt.Sprintf("[updateEndpoint] updateEndpoint failed with error: %s", ErrOptManageEndpointState),
+		}
+		err := service.Listener.Encode(w, &response)
+		logger.Response(service.Name, response, response.ReturnCode, err)
+		return
+	}
 	switch r.Method {
 	case http.MethodGet:
 		service.GetEndpointHandler(w, r)
@@ -917,45 +928,40 @@ func (service *HTTPRestService) EndpointHandlerAPI(w http.ResponseWriter, r *htt
 
 // GetEndpointHandler handles the incoming GetEndpoint requests with http Get method
 func (service *HTTPRestService) GetEndpointHandler(w http.ResponseWriter, r *http.Request) {
-	logger.Printf("[Azure CNS] GetEndpoint")
+	logger.Printf("[GetEndpointState] GetEndpoint for %s", r.URL.Path)
 
-	var req cns.EndpointRequest
-	err := service.Listener.Decode(w, r, &req)
-
-	logger.Request(service.Name, &req, err)
+	endpointID := strings.TrimPrefix(r.URL.Path, cns.EndpointPath)
+	endpointInfo, err := service.GetEndpointHelper(endpointID)
 	if err != nil {
 		response := GetEndpointResponse{
 			Response: Response{
-				ReturnCode: types.InvalidRequest,
-				Message:    fmt.Sprintf("[Azure CNS] GetEndpoint failed with error: %s", err.Error()),
+				ReturnCode: types.UnexpectedError,
+				Message:    fmt.Sprintf("[GetEndpointState] GetEndpoint failed with error: %s", err.Error()),
 			},
 		}
+		if errors.Is(err, ErrEndpointStateNotFound) {
+			response = GetEndpointResponse{
+				Response: Response{
+					ReturnCode: types.NotFound,
+					Message:    fmt.Sprintf("[GetEndpointState] %s", err.Error()),
+				},
+			}
+		}
+		w.Header().Set(cnsReturnCode, response.Response.ReturnCode.String())
 		err = service.Listener.Encode(w, &response)
 		logger.Response(service.Name, response, response.Response.ReturnCode, err)
 		return
 	}
-
-	endpointInfo, err := service.GetEndpointHelper(req.EndpointID)
-	if err != nil {
-		response := GetEndpointResponse{
-			Response: Response{
-				ReturnCode: types.InvalidRequest,
-				Message:    fmt.Sprintf("[Azure CNS] GetEndpoint failed with error: %s", err.Error()),
-			},
-		}
-		err = service.Listener.Encode(w, &response)
-		logger.Response(service.Name, response, response.Response.ReturnCode, err)
-	}
 	response := GetEndpointResponse{
 		Response: Response{
 			ReturnCode: types.Success,
-			Message:    "[Azure CNS] GetEndpoint retruned successfully",
+			Message:    "[GetEndpointState] GetEndpoint retruned successfully",
 		},
 		EndpointInfo: *endpointInfo,
 	}
+	w.Header().Set(cnsReturnCode, response.Response.ReturnCode.String())
 	err = service.Listener.Encode(w, &response)
 	logger.Response(service.Name, response, response.Response.ReturnCode, err)
-
 }
 
 // GetEndpointHelper returns the state of the given endpointId
@@ -968,100 +974,97 @@ func (service *HTTPRestService) GetEndpointHelper(endpointID string) (*EndpointI
 		return nil, ErrStoreEmpty
 	}
 
-	if service.Options[common.OptManageEndpointState] == true {
-		err := service.EndpointStateStore.Read(EndpointStoreKey, &service.EndpointState)
-		if err != nil {
+	err := service.EndpointStateStore.Read(EndpointStoreKey, &service.EndpointState)
+	if err != nil {
 
-			if errors.Is(err, store.ErrKeyNotFound) {
-				// Nothing to retrieve.
-				logger.Printf("[GetEndpointState]  No endpoint state to retrieve.\n")
-			} else {
-				logger.Errorf("[GetEndpointState]  Failed to retrieve state, err:%v", err)
-			}
-			return nil, errors.Wrap(err, "[GetEndpointState]  Failed to retrieve state")
+		if errors.Is(err, store.ErrKeyNotFound) {
+			// Nothing to retrieve.
+			logger.Printf("[GetEndpointState]  No endpoint state to retrieve.\n")
+		} else {
+			logger.Errorf("[GetEndpointState]  Failed to retrieve state, err:%v", err)
 		}
-		if endpointInfo, ok := service.EndpointState[endpointID]; ok {
-			logger.Warnf("[GetEndpointState] Found existing endpoint state for container %s", endpointID)
-			return endpointInfo, nil
-		}
-		return nil, errors.New("endpoint could not be found in the statefile")
-
+		return nil, errors.Wrap(err, "[GetEndpointState]  Failed to retrieve state")
 	}
-	return nil, ErrOptManageEndpointState
+	if endpointInfo, ok := service.EndpointState[endpointID]; ok {
+		logger.Warnf("[GetEndpointState] Found existing endpoint state for container %s", endpointID)
+		return endpointInfo, nil
+	}
+	return nil, ErrEndpointStateNotFound
 }
 
 // UpdateEndpointHandler handles the incoming UpdateEndpoint requests with http Patch method
 func (service *HTTPRestService) UpdateEndpointHandler(w http.ResponseWriter, r *http.Request) {
-	logger.Printf("[Azure CNS] updateEndpoint")
+	logger.Printf("[updateEndpoint] updateEndpoint for %s", r.URL.Path)
 
 	var req cns.EndpointRequest
 	err := service.Listener.Decode(w, r, &req)
-
+	endpointID := strings.TrimPrefix(r.URL.Path, cns.EndpointPath)
 	logger.Request(service.Name, &req, err)
+	// Check if the request is valid
 	if err != nil {
-		response := cns.UpdateEndpointResponse{
-			Response: cns.Response{
-				ReturnCode: types.InvalidRequest,
-				Message:    fmt.Sprintf("[Azure CNS] updateEndpoint failed with error: %s", err.Error()),
-			},
+		response := cns.Response{
+			ReturnCode: types.InvalidRequest,
+			Message:    fmt.Sprintf("[updateEndpoint] updateEndpoint failed with error: %s", err.Error()),
 		}
+		w.Header().Set(cnsReturnCode, response.ReturnCode.String())
 		err = service.Listener.Encode(w, &response)
-		logger.Response(service.Name, response, response.Response.ReturnCode, err)
+		logger.Response(service.Name, response, response.ReturnCode, err)
 		return
 	}
-
-	err = service.UpdateEndpointHelper(req)
-	if err != nil {
-		response := cns.UpdateEndpointResponse{
-			Response: cns.Response{
-				ReturnCode: types.UnexpectedError,
-				Message:    fmt.Sprintf("[Azure CNS] updateEndpoint failed with error: %s", err.Error()),
-			},
+	if req.HostVethName == "" && req.HnsEndpointID == "" {
+		logger.Warnf("[updateEndpoint] No HnsEndpointID or HostVethName has been provided")
+		response := cns.Response{
+			ReturnCode: types.InvalidRequest,
+			Message:    "[updateEndpoint] No HnsEndpointID or HostVethName has been provided",
 		}
+		w.Header().Set(cnsReturnCode, response.ReturnCode.String())
 		err = service.Listener.Encode(w, &response)
-		logger.Response(service.Name, response, response.Response.ReturnCode, err)
+		logger.Response(service.Name, response, response.ReturnCode, err)
+		return
 	}
-	response := cns.UpdateEndpointResponse{
-		Response: cns.Response{
-			ReturnCode: types.Success,
-			Message:    "[Azure CNS] updateEndpoint retruned successfully",
-		},
+	// Update the endpoint state
+	err = service.UpdateEndpointHelper(endpointID, req)
+	if err != nil {
+		response := cns.Response{
+			ReturnCode: types.UnexpectedError,
+			Message:    fmt.Sprintf("[updateEndpoint] updateEndpoint failed with error: %s", err.Error()),
+		}
+		w.Header().Set(cnsReturnCode, response.ReturnCode.String())
+		err = service.Listener.Encode(w, &response)
+		logger.Response(service.Name, response, response.ReturnCode, err)
+		return
 	}
+	response := cns.Response{
+		ReturnCode: types.Success,
+		Message:    "[updateEndpoint] updateEndpoint retruned successfully",
+	}
+	w.Header().Set(cnsReturnCode, response.ReturnCode.String())
 	err = service.Listener.Encode(w, &response)
-	logger.Response(service.Name, response, response.Response.ReturnCode, err)
+	logger.Response(service.Name, response, response.ReturnCode, err)
 }
 
 // UpdateEndpointHelper updates the state of the given endpointId with HNSId or VethName
-func (service *HTTPRestService) UpdateEndpointHelper(req cns.EndpointRequest) error {
+func (service *HTTPRestService) UpdateEndpointHelper(endpointID string, req cns.EndpointRequest) error {
 	if service.EndpointStateStore == nil {
 		return ErrStoreEmpty
 	}
-	logger.Printf("[UpdateEndpointState] Updating endpoint state for infra container %s", req.EndpointID)
-	if service.Options[common.OptManageEndpointState] == true {
-		if endpointInfo, ok := service.EndpointState[req.EndpointID]; ok {
-			logger.Printf("[UpdateEndpointState] Found existing endpoint state for infra container %s", req.EndpointID)
-			if req.HostVethName == "" && req.HnsEndpointID != "" {
-				logger.Warnf("[UpdateEndpointState] No HnsEndpointID or HostVethName has been provided")
-				return nil
-			}
-			if req.HnsEndpointID != "" {
-				service.EndpointState[req.EndpointID].HnsEndpointID = req.HnsEndpointID
-				logger.Errorf("[UpdateEndpointState] update the endpoint %s with HNSID  %s", req.EndpointID, req.HnsEndpointID)
-				return nil
-			}
-			if req.HostVethName != "" {
-				service.EndpointState[req.EndpointID].HostVethName = req.HostVethName
-				logger.Errorf("[UpdateEndpointState] update the endpoint %s with vethName  %s", req.EndpointID, req.HostVethName)
-				return nil
-			}
-
-			err := service.EndpointStateStore.Write(EndpointStoreKey, service.EndpointState)
-			if err != nil {
-				return fmt.Errorf("failed to write endpoint state to store for pod %s :  %w", endpointInfo.PodName, err)
-			}
-
+	logger.Printf("[updateEndpoint] Updating endpoint state for infra container %s", endpointID)
+	if endpointInfo, ok := service.EndpointState[endpointID]; ok {
+		logger.Printf("[updateEndpoint] Found existing endpoint state for infra container %s", endpointID)
+		if req.HnsEndpointID != "" {
+			service.EndpointState[endpointID].HnsEndpointID = req.HnsEndpointID
+			logger.Printf("[updateEndpoint] update the endpoint %s with HNSID  %s", endpointID, req.HnsEndpointID)
 		}
-		return errors.New("endpoint could not be found in the statefile")
+		if req.HostVethName != "" {
+			service.EndpointState[endpointID].HostVethName = req.HostVethName
+			logger.Printf("[updateEndpoint] update the endpoint %s with vethName  %s", endpointID, req.HostVethName)
+		}
+
+		err := service.EndpointStateStore.Write(EndpointStoreKey, service.EndpointState)
+		if err != nil {
+			return fmt.Errorf("[updateEndpoint] failed to write endpoint state to store for pod %s :  %w", endpointInfo.PodName, err)
+		}
+		return nil
 	}
-	return ErrOptManageEndpointState
+	return errors.New("[updateEndpoint] endpoint could not be found in the statefile")
 }

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -920,7 +920,7 @@ func (service *HTTPRestService) EndpointHandlerAPI(w http.ResponseWriter, r *htt
 func (service *HTTPRestService) GetEndpointHandler(w http.ResponseWriter, r *http.Request) {
 	logger.Printf("[Azure CNS] GetEndpoint")
 
-	var req cns.GetEndpoint
+	var req cns.EndpointRequest
 	err := service.Listener.Decode(w, r, &req)
 
 	logger.Request(service.Name, &req, err)
@@ -1010,7 +1010,7 @@ func (service *HTTPRestService) GetEndpointHelper(endpointID string) (*EndpointI
 func (service *HTTPRestService) UpdateEndpointHandler(w http.ResponseWriter, r *http.Request) {
 	logger.Printf("[Azure CNS] updateEndpoint")
 
-	var req cns.UpdateEndpoint
+	var req cns.EndpointRequest
 	err := service.Listener.Decode(w, r, &req)
 
 	logger.Request(service.Name, &req, err)

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -14,13 +14,15 @@ import (
 	"github.com/Azure/azure-container-networking/cns/logger"
 	"github.com/Azure/azure-container-networking/cns/types"
 	"github.com/Azure/azure-container-networking/common"
+	"github.com/Azure/azure-container-networking/store"
 	"github.com/pkg/errors"
 )
 
 var (
-	ErrStoreEmpty       = errors.New("empty endpoint state store")
-	ErrParsePodIPFailed = errors.New("failed to parse pod's ip")
-	ErrNoNCs            = errors.New("No NCs found in the CNS internal state")
+	ErrStoreEmpty             = errors.New("empty endpoint state store")
+	ErrParsePodIPFailed       = errors.New("failed to parse pod's ip")
+	ErrNoNCs                  = errors.New("No NCs found in the CNS internal state")
+	ErrOptManageEndpointState = errors.New("CNS is not set to manage the endpoint state")
 )
 
 // requestIPConfigHandlerHelper validates the request, assigns IPs, and returns a response
@@ -895,4 +897,182 @@ func validateDesiredIPAddresses(desiredIPs []string) error {
 		}
 	}
 	return nil
+}
+
+// EndpointHandlerAPI forwards the endpoint related APIs to GetEndpointHandler or UpdateEndpointHandler based on the http method
+func (service *HTTPRestService) EndpointHandlerAPI(w http.ResponseWriter, r *http.Request) {
+	logger.Printf("[Azure CNS] EndpointHandlerAPI")
+
+	service.Lock()
+	defer service.Unlock()
+
+	switch r.Method {
+	case http.MethodGet:
+		service.GetEndpointHandler(w, r)
+	case http.MethodPatch:
+		service.UpdateEndpointHandler(w, r)
+	default:
+		logger.Errorf("[Azure CNS] EndpointHandler API expect http Get or Patch method")
+	}
+}
+
+// GetEndpointHandler handles the incoming GetEndpoint requests with http Get method
+func (service *HTTPRestService) GetEndpointHandler(w http.ResponseWriter, r *http.Request) {
+	logger.Printf("[Azure CNS] GetEndpoint")
+
+	var req cns.GetEndpoint
+	err := service.Listener.Decode(w, r, &req)
+
+	logger.Request(service.Name, &req, err)
+	if err != nil {
+		response := GetEndpointResponse{
+			Response: Response{
+				ReturnCode: types.InvalidRequest,
+				Message:    fmt.Sprintf("[Azure CNS] GetEndpoint failed with error: %s", err.Error()),
+			},
+		}
+		err = service.Listener.Encode(w, &response)
+		logger.Response(service.Name, response, response.Response.ReturnCode, err)
+		return
+	}
+
+	endpointInfo, err := service.GetEndpointHelper(req.EndpointID)
+	if err != nil {
+		response := GetEndpointResponse{
+			Response: Response{
+				ReturnCode: types.InvalidRequest,
+				Message:    fmt.Sprintf("[Azure CNS] GetEndpoint failed with error: %s", err.Error()),
+			},
+		}
+		err = service.Listener.Encode(w, &response)
+		logger.Response(service.Name, response, response.Response.ReturnCode, err)
+	} else {
+		response := GetEndpointResponse{
+			Response: Response{
+				ReturnCode: types.Success,
+				Message:    "[Azure CNS] GetEndpoint retruned successfully",
+			},
+			EndpointInfo: *endpointInfo,
+		}
+		err = service.Listener.Encode(w, &response)
+		logger.Response(service.Name, response, response.Response.ReturnCode, err)
+	}
+}
+
+// GetEndpointHelper returns the state of the given endpointId
+func (service *HTTPRestService) GetEndpointHelper(endpointID string) (*EndpointInfo, error) {
+	logger.Printf("[GetEndpointState] Get endpoint state for infra container %s", endpointID)
+
+	// Skip if a store is not provided.
+	if service.store == nil {
+		logger.Printf("[GetEndpointState]  store not initialized.")
+		return nil, ErrStoreEmpty
+	}
+
+	// Read any persisted state.
+	err := service.store.Read(storeKey, &service.state)
+	if err != nil {
+		if errors.Is(err, store.ErrKeyNotFound) {
+			// Nothing to restore.
+			logger.Printf("[GetEndpointState]  No state to restore.\n")
+		} else {
+			logger.Errorf("[GetEndpointState]  Failed to restore state, err:%v", err)
+			service.store.Remove()
+		}
+
+		return nil, errors.Wrap(err, "[GetEndpointState]  Failed to retrieve state")
+	}
+
+	logger.Printf("[GetEndpointState]  retrieve state, %+v\n", service.state)
+
+	if service.Options[common.OptManageEndpointState] == true {
+		err := service.EndpointStateStore.Read(EndpointStoreKey, &service.EndpointState)
+		if err != nil {
+
+			if errors.Is(err, store.ErrKeyNotFound) {
+				// Nothing to restore.
+				logger.Printf("[GetEndpointState]  No endpoint state to restore.\n")
+			} else {
+				logger.Errorf("[GetEndpointState]  Failed to retrieve state, err:%v", err)
+			}
+			return nil, errors.Wrap(err, "[GetEndpointState]  Failed to retrieve state")
+		} else if endpointInfo, ok := service.EndpointState[endpointID]; ok {
+			logger.Warnf("[GetEndpointState] Found existing endpoint state for container %s", endpointID)
+			return endpointInfo, nil
+		} else {
+			return nil, errors.New("endpoint could not be found in the statefile")
+		}
+	}
+	return nil, ErrOptManageEndpointState
+}
+
+// UpdateEndpointHandler handles the incoming UpdateEndpoint requests with http Patch method
+func (service *HTTPRestService) UpdateEndpointHandler(w http.ResponseWriter, r *http.Request) {
+	logger.Printf("[Azure CNS] updateEndpoint")
+
+	var req cns.UpdateEndpoint
+	err := service.Listener.Decode(w, r, &req)
+
+	logger.Request(service.Name, &req, err)
+	if err != nil {
+		response := cns.UpdateEndpointResponse{
+			Response: cns.Response{
+				ReturnCode: types.InvalidRequest,
+				Message:    fmt.Sprintf("[Azure CNS] updateEndpoint failed with error: %s", err.Error()),
+			},
+		}
+		err = service.Listener.Encode(w, &response)
+		logger.Response(service.Name, response, response.Response.ReturnCode, err)
+		return
+	}
+
+	err = service.UpdateEndpointHelper(req.EndpointID, req.HnsID, req.VethName)
+	if err != nil {
+		response := cns.UpdateEndpointResponse{
+			Response: cns.Response{
+				ReturnCode: types.UnexpectedError,
+				Message:    fmt.Sprintf("[Azure CNS] updateEndpoint failed with error: %s", err.Error()),
+			},
+		}
+		err = service.Listener.Encode(w, &response)
+		logger.Response(service.Name, response, response.Response.ReturnCode, err)
+	} else {
+		response := cns.UpdateEndpointResponse{
+			Response: cns.Response{
+				ReturnCode: types.Success,
+				Message:    "[Azure CNS] updateEndpoint retruned successfully",
+			},
+		}
+		err = service.Listener.Encode(w, &response)
+		logger.Response(service.Name, response, response.Response.ReturnCode, err)
+	}
+}
+
+// UpdateEndpointHelper updates the state of the given endpointId with HNSId or VethName
+func (service *HTTPRestService) UpdateEndpointHelper(endpointID, hnsID, vethName string) error {
+	if service.EndpointStateStore == nil {
+		return ErrStoreEmpty
+	}
+	logger.Printf("[UpdateEndpointState] Updating endpoint state for infra container %s", endpointID)
+	if service.Options[common.OptManageEndpointState] == true {
+		if endpointInfo, ok := service.EndpointState[endpointID]; ok {
+			logger.Printf("[UpdateEndpointState] Found existing endpoint state for infra container %s", endpointID)
+			if hnsID != "" {
+				service.EndpointState[endpointID].HnsID = hnsID
+				logger.Errorf("[UpdateEndpointState] update the endpoint %s with HNSID  %s", endpointID, hnsID)
+				return nil
+			} else if vethName != "" {
+				service.EndpointState[endpointID].VethName = vethName
+				logger.Errorf("[UpdateEndpointState] update the endpoint %s with vethName  %s", endpointID, vethName)
+				return nil
+			}
+			err := service.EndpointStateStore.Write(EndpointStoreKey, service.EndpointState)
+			if err != nil {
+				return fmt.Errorf("failed to write endpoint state to store for pod %s :  %w", endpointInfo.PodName, err)
+			}
+
+		}
+		return errors.New("endpoint could not be found in the statefile")
+	}
+	return ErrOptManageEndpointState
 }

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -902,7 +902,6 @@ func validateDesiredIPAddresses(desiredIPs []string) error {
 // EndpointHandlerAPI forwards the endpoint related APIs to GetEndpointHandler or UpdateEndpointHandler based on the http method
 func (service *HTTPRestService) EndpointHandlerAPI(w http.ResponseWriter, r *http.Request) {
 	logger.Printf("[Azure CNS] EndpointHandlerAPI")
-
 	service.Lock()
 	defer service.Unlock()
 
@@ -946,17 +945,17 @@ func (service *HTTPRestService) GetEndpointHandler(w http.ResponseWriter, r *htt
 		}
 		err = service.Listener.Encode(w, &response)
 		logger.Response(service.Name, response, response.Response.ReturnCode, err)
-	} else {
-		response := GetEndpointResponse{
-			Response: Response{
-				ReturnCode: types.Success,
-				Message:    "[Azure CNS] GetEndpoint retruned successfully",
-			},
-			EndpointInfo: *endpointInfo,
-		}
-		err = service.Listener.Encode(w, &response)
-		logger.Response(service.Name, response, response.Response.ReturnCode, err)
 	}
+	response := GetEndpointResponse{
+		Response: Response{
+			ReturnCode: types.Success,
+			Message:    "[Azure CNS] GetEndpoint retruned successfully",
+		},
+		EndpointInfo: *endpointInfo,
+	}
+	err = service.Listener.Encode(w, &response)
+	logger.Response(service.Name, response, response.Response.ReturnCode, err)
+
 }
 
 // GetEndpointHelper returns the state of the given endpointId
@@ -964,44 +963,29 @@ func (service *HTTPRestService) GetEndpointHelper(endpointID string) (*EndpointI
 	logger.Printf("[GetEndpointState] Get endpoint state for infra container %s", endpointID)
 
 	// Skip if a store is not provided.
-	if service.store == nil {
+	if service.EndpointStateStore == nil {
 		logger.Printf("[GetEndpointState]  store not initialized.")
 		return nil, ErrStoreEmpty
 	}
-
-	// Read any persisted state.
-	err := service.store.Read(storeKey, &service.state)
-	if err != nil {
-		if errors.Is(err, store.ErrKeyNotFound) {
-			// Nothing to restore.
-			logger.Printf("[GetEndpointState]  No state to restore.\n")
-		} else {
-			logger.Errorf("[GetEndpointState]  Failed to restore state, err:%v", err)
-			service.store.Remove()
-		}
-
-		return nil, errors.Wrap(err, "[GetEndpointState]  Failed to retrieve state")
-	}
-
-	logger.Printf("[GetEndpointState]  retrieve state, %+v\n", service.state)
 
 	if service.Options[common.OptManageEndpointState] == true {
 		err := service.EndpointStateStore.Read(EndpointStoreKey, &service.EndpointState)
 		if err != nil {
 
 			if errors.Is(err, store.ErrKeyNotFound) {
-				// Nothing to restore.
-				logger.Printf("[GetEndpointState]  No endpoint state to restore.\n")
+				// Nothing to retrieve.
+				logger.Printf("[GetEndpointState]  No endpoint state to retrieve.\n")
 			} else {
 				logger.Errorf("[GetEndpointState]  Failed to retrieve state, err:%v", err)
 			}
 			return nil, errors.Wrap(err, "[GetEndpointState]  Failed to retrieve state")
-		} else if endpointInfo, ok := service.EndpointState[endpointID]; ok {
+		}
+		if endpointInfo, ok := service.EndpointState[endpointID]; ok {
 			logger.Warnf("[GetEndpointState] Found existing endpoint state for container %s", endpointID)
 			return endpointInfo, nil
-		} else {
-			return nil, errors.New("endpoint could not be found in the statefile")
 		}
+		return nil, errors.New("endpoint could not be found in the statefile")
+
 	}
 	return nil, ErrOptManageEndpointState
 }
@@ -1026,7 +1010,7 @@ func (service *HTTPRestService) UpdateEndpointHandler(w http.ResponseWriter, r *
 		return
 	}
 
-	err = service.UpdateEndpointHelper(req.EndpointID, req.HnsID, req.VethName)
+	err = service.UpdateEndpointHelper(req)
 	if err != nil {
 		response := cns.UpdateEndpointResponse{
 			Response: cns.Response{
@@ -1036,36 +1020,41 @@ func (service *HTTPRestService) UpdateEndpointHandler(w http.ResponseWriter, r *
 		}
 		err = service.Listener.Encode(w, &response)
 		logger.Response(service.Name, response, response.Response.ReturnCode, err)
-	} else {
-		response := cns.UpdateEndpointResponse{
-			Response: cns.Response{
-				ReturnCode: types.Success,
-				Message:    "[Azure CNS] updateEndpoint retruned successfully",
-			},
-		}
-		err = service.Listener.Encode(w, &response)
-		logger.Response(service.Name, response, response.Response.ReturnCode, err)
 	}
+	response := cns.UpdateEndpointResponse{
+		Response: cns.Response{
+			ReturnCode: types.Success,
+			Message:    "[Azure CNS] updateEndpoint retruned successfully",
+		},
+	}
+	err = service.Listener.Encode(w, &response)
+	logger.Response(service.Name, response, response.Response.ReturnCode, err)
 }
 
 // UpdateEndpointHelper updates the state of the given endpointId with HNSId or VethName
-func (service *HTTPRestService) UpdateEndpointHelper(endpointID, hnsID, vethName string) error {
+func (service *HTTPRestService) UpdateEndpointHelper(req cns.EndpointRequest) error {
 	if service.EndpointStateStore == nil {
 		return ErrStoreEmpty
 	}
-	logger.Printf("[UpdateEndpointState] Updating endpoint state for infra container %s", endpointID)
+	logger.Printf("[UpdateEndpointState] Updating endpoint state for infra container %s", req.EndpointID)
 	if service.Options[common.OptManageEndpointState] == true {
-		if endpointInfo, ok := service.EndpointState[endpointID]; ok {
-			logger.Printf("[UpdateEndpointState] Found existing endpoint state for infra container %s", endpointID)
-			if hnsID != "" {
-				service.EndpointState[endpointID].HnsID = hnsID
-				logger.Errorf("[UpdateEndpointState] update the endpoint %s with HNSID  %s", endpointID, hnsID)
-				return nil
-			} else if vethName != "" {
-				service.EndpointState[endpointID].VethName = vethName
-				logger.Errorf("[UpdateEndpointState] update the endpoint %s with vethName  %s", endpointID, vethName)
+		if endpointInfo, ok := service.EndpointState[req.EndpointID]; ok {
+			logger.Printf("[UpdateEndpointState] Found existing endpoint state for infra container %s", req.EndpointID)
+			if req.HostVethName == "" && req.HnsEndpointID != "" {
+				logger.Warnf("[UpdateEndpointState] No HnsEndpointID or HostVethName has been provided")
 				return nil
 			}
+			if req.HnsEndpointID != "" {
+				service.EndpointState[req.EndpointID].HnsEndpointID = req.HnsEndpointID
+				logger.Errorf("[UpdateEndpointState] update the endpoint %s with HNSID  %s", req.EndpointID, req.HnsEndpointID)
+				return nil
+			}
+			if req.HostVethName != "" {
+				service.EndpointState[req.EndpointID].HostVethName = req.HostVethName
+				logger.Errorf("[UpdateEndpointState] update the endpoint %s with vethName  %s", req.EndpointID, req.HostVethName)
+				return nil
+			}
+
 			err := service.EndpointStateStore.Write(EndpointStoreKey, service.EndpointState)
 			if err != nil {
 				return fmt.Errorf("failed to write endpoint state to store for pod %s :  %w", endpointInfo.PodName, err)

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -95,6 +95,8 @@ type EndpointInfo struct {
 	PodName       string
 	PodNamespace  string
 	IfnameToIPMap map[string]*IPInfo // key : interface name, value : IPInfo
+	HnsID         string
+	VethName      string
 }
 
 type IPInfo struct {
@@ -117,6 +119,12 @@ type HTTPRestServiceData struct {
 type Response struct {
 	ReturnCode types.ResponseCode
 	Message    string
+}
+
+// GetEndpointResponse describes response from the The GetEndpoint API.
+type GetEndpointResponse struct {
+	Response     Response     `json:"Response"`
+	EndpointInfo EndpointInfo `json:"EndpointInfo"`
 }
 
 // containerstatus is used to save status of an existing container
@@ -264,7 +272,7 @@ func (service *HTTPRestService) Init(config *common.ServiceConfig) error {
 	listener.AddHandler(cns.PathDebugRestData, service.handleDebugRestData)
 	listener.AddHandler(cns.NetworkContainersURLPath, service.getOrRefreshNetworkContainers)
 	listener.AddHandler(cns.GetHomeAz, service.getHomeAz)
-
+	listener.AddHandler(cns.EndpointPath, service.EndpointHandlerAPI)
 	// handlers for v0.2
 	listener.AddHandler(cns.V2Prefix+cns.SetEnvironmentPath, service.setEnvironment)
 	listener.AddHandler(cns.V2Prefix+cns.CreateNetworkPath, service.createNetwork)
@@ -289,6 +297,7 @@ func (service *HTTPRestService) Init(config *common.ServiceConfig) error {
 	listener.AddHandler(cns.V2Prefix+cns.DeleteHostNCApipaEndpointPath, service.deleteHostNCApipaEndpoint)
 	listener.AddHandler(cns.V2Prefix+cns.NmAgentSupportedApisPath, service.nmAgentSupportedApisHandler)
 	listener.AddHandler(cns.V2Prefix+cns.GetHomeAz, service.getHomeAz)
+	listener.AddHandler(cns.V2Prefix+cns.EndpointPath, service.EndpointHandlerAPI)
 
 	// Initialize HTTP client to be reused in CNS
 	connectionTimeout, _ := service.GetOption(acn.OptHttpConnectionTimeout).(int)

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -95,8 +95,8 @@ type EndpointInfo struct {
 	PodName       string
 	PodNamespace  string
 	IfnameToIPMap map[string]*IPInfo // key : interface name, value : IPInfo
-	HnsID         string
-	VethName      string
+	HnsEndpointID string
+	HostVethName  string
 }
 
 type IPInfo struct {
@@ -123,8 +123,8 @@ type Response struct {
 
 // GetEndpointResponse describes response from the The GetEndpoint API.
 type GetEndpointResponse struct {
-	Response     Response     `json:"Response"`
-	EndpointInfo EndpointInfo `json:"EndpointInfo"`
+	Response     Response     `json:"response"`
+	EndpointInfo EndpointInfo `json:"endpointInfo"`
 }
 
 // containerstatus is used to save status of an existing container

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -77,11 +77,10 @@ import (
 
 const (
 	// Service name.
-	name                  = "azure-cns"
-	pluginName            = "azure-vnet"
-	endpointStoreName     = "azure-endpoints"
-	endpointStoreLocation = "/var/run/azure-cns/"
-	//endpointStoreLocationWindows      = "C:\\Temp\\"
+	name                              = "azure-cns"
+	pluginName                        = "azure-vnet"
+	endpointStoreName                 = "azure-endpoints"
+	endpointStoreLocation             = "/var/run/azure-cns/"
 	defaultCNINetworkConfigFileName   = "10-azure.conflist"
 	dncApiVersion                     = "?api-version=2018-03-01"
 	poolIPAMRefreshRateInMilliseconds = 1000
@@ -661,7 +660,6 @@ func main() {
 		endpointStorePath := endpointStoreLocation
 		if runtime.GOOS == "windows" {
 			endpointStorePath = os.Getenv("CNSStoreFilePath")
-			//endpointStorePath = endpointStoreLocationWindows
 		}
 		logger.Printf("EndpointState path is %s", endpointStorePath)
 		err = platform.CreateDirectory(endpointStorePath)

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -77,10 +77,11 @@ import (
 
 const (
 	// Service name.
-	name                              = "azure-cns"
-	pluginName                        = "azure-vnet"
-	endpointStoreName                 = "azure-endpoints"
-	endpointStoreLocation             = "/var/run/azure-cns/"
+	name                  = "azure-cns"
+	pluginName            = "azure-vnet"
+	endpointStoreName     = "azure-endpoints"
+	endpointStoreLocation = "/var/run/azure-cns/"
+	//endpointStoreLocationWindows      = "C:\\Temp\\"
 	defaultCNINetworkConfigFileName   = "10-azure.conflist"
 	dncApiVersion                     = "?api-version=2018-03-01"
 	poolIPAMRefreshRateInMilliseconds = 1000
@@ -657,7 +658,13 @@ func main() {
 		}
 		defer endpointStoreLock.Unlock() // nolint
 
-		err = platform.CreateDirectory(endpointStoreLocation)
+		endpointStorePath := endpointStoreLocation
+		if runtime.GOOS == "windows" {
+			endpointStorePath = os.Getenv("CNSStoreFilePath")
+			//endpointStorePath = endpointStoreLocationWindows
+		}
+		logger.Printf("EndpointState path is %s", endpointStorePath)
+		err = platform.CreateDirectory(endpointStorePath)
 		if err != nil {
 			logger.Errorf("Failed to create File Store directory %s, due to Error:%v", storeFileLocation, err.Error())
 			return


### PR DESCRIPTION
Reason for Change:
In the stateless CNI design two new APIs on CNS side with respect of endpoint state management is needed.
GetEndpoint() is used to return the state of a given endpointId
UpdateEndpoint() is used to update the HNSId and VethName field within the endpoint state.

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests
- [X] relevant PR labels added

**Notes**:
