### PR TITLE
Fix missing Wireserver IP configuration in Wireserver Client

### DIFF
--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -678,6 +678,7 @@ func main() {
 	}
 
 	wsclient := &wireserver.Client{
+		HostPort:   cnsconfig.WireserverIP,
 		HTTPClient: &http.Client{},
 		Logger:     logger.Log,
 	}

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -677,7 +677,12 @@ func main() {
 		HTTPClient: &http.Client{},
 	}
 
-	httpRestService, err := restserver.NewHTTPRestService(&config, &wireserver.Client{HTTPClient: &http.Client{}}, &wsProxy, nmaClient,
+	wsclient := &wireserver.Client{
+		HTTPClient: &http.Client{},
+		Logger:     logger.Log,
+	}
+
+	httpRestService, err := restserver.NewHTTPRestService(&config, wsclient, &wsProxy, nmaClient,
 		endpointStateStore, conflistGenerator, homeAzMonitor)
 	if err != nil {
 		logger.Errorf("Failed to create CNS object, err:%v.\n", err)

--- a/cns/wireserver/client.go
+++ b/cns/wireserver/client.go
@@ -54,7 +54,7 @@ func (c *Client) GetInterfaces(ctx context.Context) (*GetInterfacesResult, error
 		RawQuery: q.Encode(),
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL.String(), http.NoBody)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to construct request")
 	}

--- a/cns/wireserver/client.go
+++ b/cns/wireserver/client.go
@@ -5,10 +5,8 @@ import (
 	"context"
 	"encoding/xml"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
-	"strconv"
 
 	"github.com/pkg/errors"
 )
@@ -29,8 +27,7 @@ type do interface {
 }
 
 type Client struct {
-	Host string
-	Port uint16
+	HostPort string
 
 	HTTPClient do
 	Logger     interface {
@@ -39,11 +36,7 @@ type Client struct {
 }
 
 func (c *Client) hostport() string {
-	if c.Port != 0 {
-		port := strconv.FormatUint(uint64(c.Port), 10)
-		return net.JoinHostPort(c.Host, port)
-	}
-	return c.Host
+	return c.HostPort
 }
 
 // GetInterfaces queries interfaces from the wireserver.

--- a/cns/wireserver/client.go
+++ b/cns/wireserver/client.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/Azure/azure-container-networking/cns/logger"
 	"github.com/pkg/errors"
 )
 
@@ -26,11 +25,14 @@ type do interface {
 
 type Client struct {
 	HTTPClient do
+	Logger     interface {
+		Printf(string, ...any)
+	}
 }
 
 // GetInterfaces queries interfaces from the wireserver.
 func (c *Client) GetInterfaces(ctx context.Context) (*GetInterfacesResult, error) {
-	logger.Printf("[Azure CNS] GetPrimaryInterfaceInfoFromHost")
+	c.Logger.Printf("[Azure CNS] GetPrimaryInterfaceInfoFromHost")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, hostQueryURL, nil)
 	if err != nil {
@@ -46,7 +48,7 @@ func (c *Client) GetInterfaces(ctx context.Context) (*GetInterfacesResult, error
 		return nil, errors.Wrap(err, "failed to read response body")
 	}
 
-	logger.Printf("[Azure CNS] Response received from NMAgent for get interface details: %s", string(b))
+	c.Logger.Printf("[Azure CNS] Response received from NMAgent for get interface details: %s", string(b))
 
 	var res GetInterfacesResult
 	if err := xml.NewDecoder(bytes.NewReader(b)).Decode(&res); err != nil {

--- a/cns/wireserver/client_test.go
+++ b/cns/wireserver/client_test.go
@@ -1,0 +1,63 @@
+package wireserver_test
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-container-networking/cns/wireserver"
+)
+
+var _ http.RoundTripper = &TestTripper{}
+
+// TestTripper is a mock implementation of a round tripper that allows clients
+// to substitute their own implementation, so that HTTP requests can be
+// asserted against and stub responses can be generated.
+type TestTripper struct {
+	RoundTripF func(*http.Request) (*http.Response, error)
+}
+
+func (t *TestTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return t.RoundTripF(req)
+}
+
+type NOPLogger struct{}
+
+func (m *NOPLogger) Printf(_ string, _ ...any) {}
+
+func TestGetInterfaces(t *testing.T) {
+	// create a wireserver client using a test tripper so that it can be asserted
+	// that the correct requests are sent.
+	expURL := "http://168.63.129.16/machine/plugins?comp=nmagent&type=getinterfaceinfov1"
+	var reqURL string
+	client := &wireserver.Client{
+		Logger: &NOPLogger{},
+		HTTPClient: &http.Client{
+			Transport: &TestTripper{
+				RoundTripF: func(req *http.Request) (*http.Response, error) {
+					reqURL = req.URL.String()
+					rr := httptest.NewRecorder()
+					resp := wireserver.GetInterfacesResult{}
+					err := xml.NewEncoder(rr).Encode(&resp)
+					if err != nil {
+						t.Fatal("unexpected error encoding mock wireserver response: err:", err)
+					}
+
+					return rr.Result(), nil
+				},
+			},
+		},
+	}
+
+	// invoke the endpoint on Wireserver
+	_, err := client.GetInterfaces(context.TODO())
+	if err != nil {
+		t.Fatal("unexpected error invoking GetInterfaces: err:", err)
+	}
+
+	if expURL != reqURL {
+		t.Error("received request URL to wireserve does not match expectation:\n\texp:", expURL, "\n\tgot:", reqURL)
+	}
+}

--- a/cns/wireserver/client_test.go
+++ b/cns/wireserver/client_test.go
@@ -29,21 +29,18 @@ func (m *NOPLogger) Printf(_ string, _ ...any) {}
 
 func TestGetInterfaces(t *testing.T) {
 	tests := []struct {
-		name   string
-		host   string
-		port   uint16
-		expURL string
+		name     string
+		hostport string
+		expURL   string
 	}{
 		{
 			"real ws url",
 			"168.63.129.16",
-			0, // a.k.a. "no port"
 			"http://168.63.129.16/machine/plugins?comp=nmagent&type=getinterfaceinfov1",
 		},
 		{
 			"local ws url",
-			"127.0.0.1",
-			9001, // a.k.a. "no port"
+			"127.0.0.1:9001",
 			"http://127.0.0.1:9001/machine/plugins?comp=nmagent&type=getinterfaceinfov1",
 		},
 	}
@@ -56,9 +53,8 @@ func TestGetInterfaces(t *testing.T) {
 			// that the correct requests are sent.
 			var gotURL string
 			client := &wireserver.Client{
-				Host:   test.host,
-				Port:   test.port,
-				Logger: &NOPLogger{},
+				HostPort: test.hostport,
+				Logger:   &NOPLogger{},
 				HTTPClient: &http.Client{
 					Transport: &TestTripper{
 						RoundTripF: func(req *http.Request) (*http.Response, error) {


### PR DESCRIPTION
Previously, the Wireserver Client used a hardcoded IP, which made starting CNS locally impossible. This is because it attempted to make requests to a Wireserver that wasn't there. There is already a configuration for a WireserverIP, with the intention that that be used to redirect those requests to a mock server for local testing.

This makes the host to which those Wireserver requests are directed configurable so that this configuration is respected by the Wireserver client.

No configuration changes are necessary to end users since no configuration has changed.

To use this locally, any mocks that are in use will need to add an endpoint responding to `/machine/plugins?comp=nmagent&getinterfaceinfov1`  responding with XML in the form:

```xml
<Result>
  <Interfaces MacAddress="{{mac}}" IsPrimary="true">
    <IPSubnet Prefix="{{prefix}}">
      <IPAddress Address="{{addr}}" IsPrimary="true"></IPAddress>
    </IPSubnet>
  </Interfaces>
</Result>
```