### PR TITLE
ci: Agent pool default set at stage level

### DIFF
--- a/.pipelines/singletenancy/aks-swift/e2e-job-template.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e-job-template.yaml
@@ -41,6 +41,8 @@ stages:
       CURRENT_VERSION: $[ stagedependencies.containerize.check_tag.outputs['CurrentTagManifests.currentTagManifests'] ]
       commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
     condition: and(succeeded(), eq(variables.TAG, variables.CURRENT_VERSION))
+    pool:
+      name: $(BUILD_POOL_NAME_DEFAULT)
     jobs:
       - job: ${{ parameters.name }}
         displayName: Singletenancy AKS Swift Suite - (${{ parameters.name }})

--- a/.pipelines/singletenancy/aks/e2e-job-template.yaml
+++ b/.pipelines/singletenancy/aks/e2e-job-template.yaml
@@ -47,6 +47,8 @@ stages:
     - setup
     - publish
     - ${{ parameters.clusterName }}
+    pool:
+      name: $(BUILD_POOL_NAME_DEFAULT)
     jobs:
       - job: ${{ parameters.name }}
         displayName: Singletenancy AKS - (${{ parameters.name }})

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
@@ -38,6 +38,8 @@ stages:
     - ${{ parameters.clusterName }}
     variables:
       commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
+    pool:
+      name: $(BUILD_POOL_NAME_DEFAULT)
     jobs:
       - job: ${{ parameters.name }}
         displayName: Azure CNI Overlay Test Suite - (${{ parameters.name }})

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-job-template.yaml
@@ -36,6 +36,8 @@ stages:
     - setup
     - publish
     - ${{ parameters.clusterName }}
+    pool:
+      name: $(BUILD_POOL_NAME_DEFAULT)
     jobs:
       - job: ${{ parameters.name }}
         displayName: Cilium Overlay Test Suite - (${{ parameters.name }})

--- a/.pipelines/singletenancy/cilium/cilium-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-job-template.yaml
@@ -41,6 +41,8 @@ stages:
       CURRENT_VERSION: $[ stagedependencies.containerize.check_tag.outputs['CurrentTagManifests.currentTagManifests'] ]
       commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
     condition: and(succeeded(), eq(variables.TAG, variables.CURRENT_VERSION))
+    pool:
+      name: $(BUILD_POOL_NAME_DEFAULT)
     jobs:
       - job: ${{ parameters.name }}
         displayName: Cilium Test Suite - (${{ parameters.name }})

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
@@ -42,6 +42,8 @@ stages:
       GOBIN: "$(GOPATH)/bin" # Go binaries path
       modulePath: "$(GOPATH)/src/github.com/Azure/azure-container-networking"
       commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
+    pool:
+      name: $(BUILD_POOL_NAME_DEFAULT)
     jobs:
       - job: ${{ parameters.name }}
         displayName: DualStack Overlay Test Suite - (${{ parameters.name }})


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Ensures that E2E templates in PR pipeline use `Networking-ContainerNetworking-VMSS` build pool by setting it at the stage level, which is passed to the individual jobs and can be overwritten. This is to prevent using the default build pool that can call old images that no longer exist or are depreciated. 

```
##[warning]An image label with the label Ubuntu16 does not exist.
,##[error]The remote provider was unable to process the request.
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
