### PR TITLE
feat: Dev stateless cni

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ ZAPAI_VERSION			?= $(notdir $(shell git describe --match "zapai*" --tags --alway
 AZURE_IPAM_DIR = $(REPO_ROOT)/azure-ipam
 CNM_DIR = $(REPO_ROOT)/cnm/plugin
 CNI_NET_DIR = $(REPO_ROOT)/cni/network/plugin
+STATELESS_CNI_NET_DIR = $(REPO_ROOT)/cni/network/stateless
 CNI_IPAM_DIR = $(REPO_ROOT)/cni/ipam/plugin
 CNI_IPAMV6_DIR = $(REPO_ROOT)/cni/ipam/pluginv6
 CNI_TELEMETRY_DIR = $(REPO_ROOT)/cni/telemetry/service
@@ -58,11 +59,13 @@ AZURE_IPAM_BUILD_DIR = $(BUILD_DIR)/azure-ipam
 IMAGE_DIR  = $(OUTPUT_DIR)/images
 CNM_BUILD_DIR = $(BUILD_DIR)/cnm
 CNI_BUILD_DIR = $(BUILD_DIR)/cni
+STATELESS_CNI_BUILD_DIR = $(CNI_BUILD_DIR)/stateless
 ACNCLI_BUILD_DIR = $(BUILD_DIR)/acncli
 CNI_MULTITENANCY_BUILD_DIR = $(BUILD_DIR)/cni-multitenancy
 CNI_MULTITENANCY_TRANSPARENT_VLAN_BUILD_DIR = $(BUILD_DIR)/cni-multitenancy-transparent-vlan
 CNI_SWIFT_BUILD_DIR = $(BUILD_DIR)/cni-swift
 CNI_OVERLAY_BUILD_DIR = $(BUILD_DIR)/cni-overlay
+STATELESS_CNI_OVERLAY_BUILD_DIR = $(CNI_OVERLAY_BUILD_DIR)/stateless
 CNI_BAREMETAL_BUILD_DIR = $(BUILD_DIR)/cni-baremetal
 CNI_DUALSTACK_BUILD_DIR = $(BUILD_DIR)/cni-dualstack
 CNS_BUILD_DIR = $(BUILD_DIR)/cns
@@ -130,7 +133,7 @@ endif
 
 # Shorthand target names for convenience.
 azure-cnm-plugin: cnm-binary cnm-archive
-azure-cni-plugin: azure-vnet-binary azure-vnet-ipam-binary azure-vnet-ipamv6-binary azure-vnet-telemetry-binary cni-archive
+azure-cni-plugin: azure-vnet-binary azure-vnet-stateless-binary azure-vnet-ipam-binary azure-vnet-ipamv6-binary azure-vnet-telemetry-binary cni-archive
 azure-cns: azure-cns-binary cns-archive
 acncli: acncli-binary acncli-archive
 azure-cnms: azure-cnms-binary cnms-archive
@@ -179,6 +182,10 @@ cnm-binary:
 # Build the Azure CNI network binary.
 azure-vnet-binary:
 	cd $(CNI_NET_DIR) && CGO_ENABLED=0 go build -v -o $(CNI_BUILD_DIR)/azure-vnet$(EXE_EXT) -ldflags "-X main.version=$(CNI_VERSION)" -gcflags="-dwarflocationlists=true"
+
+# Build the Azure CNI stateless network binary
+azure-vnet-stateless-binary:
+	cd $(STATELESS_CNI_NET_DIR) && CGO_ENABLED=0 go build -v -o $(STATELESS_CNI_BUILD_DIR)/azure-vnet$(EXE_EXT) -ldflags "-X main.version=$(CNI_VERSION)" -gcflags="-dwarflocationlists=true"
 
 # Build the Azure CNI IPAM binary.
 azure-vnet-ipam-binary:
@@ -681,6 +688,8 @@ endif
 	cp cni/azure-$(GOOS)-swift-overlay.conflist $(CNI_OVERLAY_BUILD_DIR)/10-azure.conflist
 	cp telemetry/azure-vnet-telemetry.config $(CNI_OVERLAY_BUILD_DIR)/azure-vnet-telemetry.config
 	cp $(CNI_BUILD_DIR)/azure-vnet$(EXE_EXT) $(CNI_BUILD_DIR)/azure-vnet-ipam$(EXE_EXT) $(CNI_BUILD_DIR)/azure-vnet-telemetry$(EXE_EXT) $(CNI_OVERLAY_BUILD_DIR)
+	$(MKDIR) $(STATELESS_CNI_OVERLAY_BUILD_DIR)
+	cp $(STATELESS_CNI_BUILD_DIR)/azure-vnet$(EXE_EXT) $(STATELESS_CNI_OVERLAY_BUILD_DIR)
 	cd $(CNI_OVERLAY_BUILD_DIR) && $(ARCHIVE_CMD) $(CNI_OVERLAY_ARCHIVE_NAME) azure-vnet$(EXE_EXT) azure-vnet-ipam$(EXE_EXT) azure-vnet-telemetry$(EXE_EXT) 10-azure.conflist azure-vnet-telemetry.config
 
 	$(MKDIR) $(CNI_DUALSTACK_BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ ACNCLI_BUILD_DIR = $(BUILD_DIR)/acncli
 CNI_MULTITENANCY_BUILD_DIR = $(BUILD_DIR)/cni-multitenancy
 CNI_MULTITENANCY_TRANSPARENT_VLAN_BUILD_DIR = $(BUILD_DIR)/cni-multitenancy-transparent-vlan
 CNI_SWIFT_BUILD_DIR = $(BUILD_DIR)/cni-swift
+STATELESS_CNI_SWIFT_BUILD_DIR = $(CNI_SWIFT_BUILD_DIR)/stateless
 CNI_OVERLAY_BUILD_DIR = $(BUILD_DIR)/cni-overlay
 STATELESS_CNI_OVERLAY_BUILD_DIR = $(CNI_OVERLAY_BUILD_DIR)/stateless
 CNI_BAREMETAL_BUILD_DIR = $(BUILD_DIR)/cni-baremetal
@@ -682,6 +683,8 @@ endif
 	cp cni/azure-$(GOOS)-swift.conflist $(CNI_SWIFT_BUILD_DIR)/10-azure.conflist
 	cp telemetry/azure-vnet-telemetry.config $(CNI_SWIFT_BUILD_DIR)/azure-vnet-telemetry.config
 	cp $(CNI_BUILD_DIR)/azure-vnet$(EXE_EXT) $(CNI_BUILD_DIR)/azure-vnet-ipam$(EXE_EXT) $(CNI_BUILD_DIR)/azure-vnet-telemetry$(EXE_EXT) $(CNI_SWIFT_BUILD_DIR)
+	$(MKDIR) $(STATELESS_CNI_SWIFT_BUILD_DIR)
+	cp $(STATELESS_CNI_BUILD_DIR)/azure-vnet$(EXE_EXT) $(STATELESS_CNI_SWIFT_BUILD_DIR)
 	cd $(CNI_SWIFT_BUILD_DIR) && $(ARCHIVE_CMD) $(CNI_SWIFT_ARCHIVE_NAME) azure-vnet$(EXE_EXT) azure-vnet-ipam$(EXE_EXT) azure-vnet-telemetry$(EXE_EXT) 10-azure.conflist azure-vnet-telemetry.config
 
 	$(MKDIR) $(CNI_OVERLAY_BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,6 @@ ZAPAI_VERSION			?= $(notdir $(shell git describe --match "zapai*" --tags --alway
 AZURE_IPAM_DIR = $(REPO_ROOT)/azure-ipam
 CNM_DIR = $(REPO_ROOT)/cnm/plugin
 CNI_NET_DIR = $(REPO_ROOT)/cni/network/plugin
-STATELESS_CNI_NET_DIR = $(REPO_ROOT)/cni/network/stateless
 CNI_IPAM_DIR = $(REPO_ROOT)/cni/ipam/plugin
 CNI_IPAMV6_DIR = $(REPO_ROOT)/cni/ipam/pluginv6
 CNI_TELEMETRY_DIR = $(REPO_ROOT)/cni/telemetry/service
@@ -59,14 +58,11 @@ AZURE_IPAM_BUILD_DIR = $(BUILD_DIR)/azure-ipam
 IMAGE_DIR  = $(OUTPUT_DIR)/images
 CNM_BUILD_DIR = $(BUILD_DIR)/cnm
 CNI_BUILD_DIR = $(BUILD_DIR)/cni
-STATELESS_CNI_BUILD_DIR = $(CNI_BUILD_DIR)/stateless
 ACNCLI_BUILD_DIR = $(BUILD_DIR)/acncli
 CNI_MULTITENANCY_BUILD_DIR = $(BUILD_DIR)/cni-multitenancy
 CNI_MULTITENANCY_TRANSPARENT_VLAN_BUILD_DIR = $(BUILD_DIR)/cni-multitenancy-transparent-vlan
 CNI_SWIFT_BUILD_DIR = $(BUILD_DIR)/cni-swift
-STATELESS_CNI_SWIFT_BUILD_DIR = $(CNI_SWIFT_BUILD_DIR)/stateless
 CNI_OVERLAY_BUILD_DIR = $(BUILD_DIR)/cni-overlay
-STATELESS_CNI_OVERLAY_BUILD_DIR = $(CNI_OVERLAY_BUILD_DIR)/stateless
 CNI_BAREMETAL_BUILD_DIR = $(BUILD_DIR)/cni-baremetal
 CNI_DUALSTACK_BUILD_DIR = $(BUILD_DIR)/cni-dualstack
 CNS_BUILD_DIR = $(BUILD_DIR)/cns
@@ -134,7 +130,7 @@ endif
 
 # Shorthand target names for convenience.
 azure-cnm-plugin: cnm-binary cnm-archive
-azure-cni-plugin: azure-vnet-binary azure-vnet-stateless-binary azure-vnet-ipam-binary azure-vnet-ipamv6-binary azure-vnet-telemetry-binary cni-archive
+azure-cni-plugin: azure-vnet-binary azure-vnet-ipam-binary azure-vnet-ipamv6-binary azure-vnet-telemetry-binary cni-archive
 azure-cns: azure-cns-binary cns-archive
 acncli: acncli-binary acncli-archive
 azure-cnms: azure-cnms-binary cnms-archive
@@ -183,10 +179,6 @@ cnm-binary:
 # Build the Azure CNI network binary.
 azure-vnet-binary:
 	cd $(CNI_NET_DIR) && CGO_ENABLED=0 go build -v -o $(CNI_BUILD_DIR)/azure-vnet$(EXE_EXT) -ldflags "-X main.version=$(CNI_VERSION)" -gcflags="-dwarflocationlists=true"
-
-# Build the Azure CNI stateless network binary
-azure-vnet-stateless-binary:
-	cd $(STATELESS_CNI_NET_DIR) && CGO_ENABLED=0 go build -v -o $(STATELESS_CNI_BUILD_DIR)/azure-vnet$(EXE_EXT) -ldflags "-X main.version=$(CNI_VERSION)" -gcflags="-dwarflocationlists=true"
 
 # Build the Azure CNI IPAM binary.
 azure-vnet-ipam-binary:
@@ -683,16 +675,12 @@ endif
 	cp cni/azure-$(GOOS)-swift.conflist $(CNI_SWIFT_BUILD_DIR)/10-azure.conflist
 	cp telemetry/azure-vnet-telemetry.config $(CNI_SWIFT_BUILD_DIR)/azure-vnet-telemetry.config
 	cp $(CNI_BUILD_DIR)/azure-vnet$(EXE_EXT) $(CNI_BUILD_DIR)/azure-vnet-ipam$(EXE_EXT) $(CNI_BUILD_DIR)/azure-vnet-telemetry$(EXE_EXT) $(CNI_SWIFT_BUILD_DIR)
-	$(MKDIR) $(STATELESS_CNI_SWIFT_BUILD_DIR)
-	cp $(STATELESS_CNI_BUILD_DIR)/azure-vnet$(EXE_EXT) $(STATELESS_CNI_SWIFT_BUILD_DIR)
 	cd $(CNI_SWIFT_BUILD_DIR) && $(ARCHIVE_CMD) $(CNI_SWIFT_ARCHIVE_NAME) azure-vnet$(EXE_EXT) azure-vnet-ipam$(EXE_EXT) azure-vnet-telemetry$(EXE_EXT) 10-azure.conflist azure-vnet-telemetry.config
 
 	$(MKDIR) $(CNI_OVERLAY_BUILD_DIR)
 	cp cni/azure-$(GOOS)-swift-overlay.conflist $(CNI_OVERLAY_BUILD_DIR)/10-azure.conflist
 	cp telemetry/azure-vnet-telemetry.config $(CNI_OVERLAY_BUILD_DIR)/azure-vnet-telemetry.config
 	cp $(CNI_BUILD_DIR)/azure-vnet$(EXE_EXT) $(CNI_BUILD_DIR)/azure-vnet-ipam$(EXE_EXT) $(CNI_BUILD_DIR)/azure-vnet-telemetry$(EXE_EXT) $(CNI_OVERLAY_BUILD_DIR)
-	$(MKDIR) $(STATELESS_CNI_OVERLAY_BUILD_DIR)
-	cp $(STATELESS_CNI_BUILD_DIR)/azure-vnet$(EXE_EXT) $(STATELESS_CNI_OVERLAY_BUILD_DIR)
 	cd $(CNI_OVERLAY_BUILD_DIR) && $(ARCHIVE_CMD) $(CNI_OVERLAY_ARCHIVE_NAME) azure-vnet$(EXE_EXT) azure-vnet-ipam$(EXE_EXT) azure-vnet-telemetry$(EXE_EXT) 10-azure.conflist azure-vnet-telemetry.config
 
 	$(MKDIR) $(CNI_DUALSTACK_BUILD_DIR)

--- a/cni/linux.Dockerfile
+++ b/cni/linux.Dockerfile
@@ -11,6 +11,7 @@ COPY . .
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/plugin/main.go
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-telemetry -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/telemetry/service/telemetrymain.go
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-ipam -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/ipam/plugin/main.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azurecni-stateless -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/stateless/main.go
 
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS compressor
 ARG OS

--- a/cni/network/common.go
+++ b/cni/network/common.go
@@ -1,0 +1,98 @@
+package network
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"reflect"
+
+	"github.com/Azure/azure-container-networking/cni"
+	"github.com/Azure/azure-container-networking/telemetry"
+	"github.com/containernetworking/cni/pkg/skel"
+	cniTypes "github.com/containernetworking/cni/pkg/types"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+)
+
+// send error report to hostnetagent if CNI encounters any error.
+func ReportPluginError(reportManager *telemetry.ReportManager, tb *telemetry.TelemetryBuffer, err error) {
+	logger.Error("Report plugin error")
+	reflect.ValueOf(reportManager.Report).Elem().FieldByName("ErrorMessage").SetString(err.Error())
+
+	if err := reportManager.SendReport(tb); err != nil {
+		logger.Error("SendReport failed", zap.Error(err))
+	}
+}
+
+func validateConfig(jsonBytes []byte) error {
+	var conf struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(jsonBytes, &conf); err != nil {
+		return errors.Wrapf(err, "error reading network config")
+	}
+	if conf.Name == "" {
+		return errors.New("missing network name")
+	}
+	return nil
+}
+
+func getCmdArgsFromEnv() (string, *skel.CmdArgs, error) {
+	logger.Info("Going to read from stdin")
+	stdinData, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return "", nil, errors.Wrapf(err, "error reading from stdin")
+	}
+
+	cmdArgs := &skel.CmdArgs{
+		ContainerID: os.Getenv("CNI_CONTAINERID"),
+		Netns:       os.Getenv("CNI_NETNS"),
+		IfName:      os.Getenv("CNI_IFNAME"),
+		Args:        os.Getenv("CNI_ARGS"),
+		Path:        os.Getenv("CNI_PATH"),
+		StdinData:   stdinData,
+	}
+
+	cmd := os.Getenv("CNI_COMMAND")
+	return cmd, cmdArgs, nil
+}
+
+func HandleIfCniUpdate(update func(*skel.CmdArgs) error) (bool, error) {
+	isupdate := true
+
+	if os.Getenv("CNI_COMMAND") != cni.CmdUpdate {
+		return false, nil
+	}
+
+	logger.Info("CNI UPDATE received")
+
+	_, cmdArgs, err := getCmdArgsFromEnv()
+	if err != nil {
+		logger.Error("Received error while retrieving cmds from environment", zap.Error(err))
+		return isupdate, err
+	}
+
+	logger.Info("Retrieved command args for update", zap.Any("args", cmdArgs))
+	err = validateConfig(cmdArgs.StdinData)
+	if err != nil {
+		logger.Error("Failed to handle CNI UPDATE", zap.Error(err))
+		return isupdate, err
+	}
+
+	err = update(cmdArgs)
+	if err != nil {
+		logger.Error("Failed to handle CNI UPDATE", zap.Error(err))
+		return isupdate, err
+	}
+
+	return isupdate, nil
+}
+
+func PrintCNIError(msg string) {
+	logger.Error(msg)
+	cniErr := &cniTypes.Error{
+		Code: cniTypes.ErrTryAgainLater,
+		Msg:  msg,
+	}
+	cniErr.Print()
+}

--- a/cni/network/plugin/main.go
+++ b/cni/network/plugin/main.go
@@ -4,11 +4,8 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
 	"os"
-	"reflect"
 	"time"
 
 	"github.com/Azure/azure-container-networking/aitelemetry"
@@ -21,8 +18,6 @@ import (
 	"github.com/Azure/azure-container-networking/platform"
 	"github.com/Azure/azure-container-networking/store"
 	"github.com/Azure/azure-container-networking/telemetry"
-	"github.com/containernetworking/cni/pkg/skel"
-	cniTypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
@@ -57,89 +52,6 @@ func printVersion() {
 	fmt.Printf("Azure CNI Version %v\n", version)
 }
 
-// send error report to hostnetagent if CNI encounters any error.
-func reportPluginError(reportManager *telemetry.ReportManager, tb *telemetry.TelemetryBuffer, err error) {
-	logger.Error("Report plugin error")
-	reflect.ValueOf(reportManager.Report).Elem().FieldByName("ErrorMessage").SetString(err.Error())
-
-	if err := reportManager.SendReport(tb); err != nil {
-		logger.Error("SendReport failed", zap.Error(err))
-	}
-}
-
-func validateConfig(jsonBytes []byte) error {
-	var conf struct {
-		Name string `json:"name"`
-	}
-	if err := json.Unmarshal(jsonBytes, &conf); err != nil {
-		return fmt.Errorf("error reading network config: %s", err)
-	}
-	if conf.Name == "" {
-		return fmt.Errorf("missing network name")
-	}
-	return nil
-}
-
-func getCmdArgsFromEnv() (string, *skel.CmdArgs, error) {
-	logger.Info("Going to read from stdin")
-	stdinData, err := io.ReadAll(os.Stdin)
-	if err != nil {
-		return "", nil, fmt.Errorf("error reading from stdin: %v", err)
-	}
-
-	cmdArgs := &skel.CmdArgs{
-		ContainerID: os.Getenv("CNI_CONTAINERID"),
-		Netns:       os.Getenv("CNI_NETNS"),
-		IfName:      os.Getenv("CNI_IFNAME"),
-		Args:        os.Getenv("CNI_ARGS"),
-		Path:        os.Getenv("CNI_PATH"),
-		StdinData:   stdinData,
-	}
-
-	cmd := os.Getenv("CNI_COMMAND")
-	return cmd, cmdArgs, nil
-}
-
-func handleIfCniUpdate(update func(*skel.CmdArgs) error) (bool, error) {
-	isupdate := true
-
-	if os.Getenv("CNI_COMMAND") != cni.CmdUpdate {
-		return false, nil
-	}
-
-	logger.Info("CNI UPDATE received")
-
-	_, cmdArgs, err := getCmdArgsFromEnv()
-	if err != nil {
-		logger.Error("Received error while retrieving cmds from environment", zap.Error(err))
-		return isupdate, err
-	}
-
-	logger.Info("Retrieved command args for update", zap.Any("args", cmdArgs))
-	err = validateConfig(cmdArgs.StdinData)
-	if err != nil {
-		logger.Error("Failed to handle CNI UPDATE", zap.Error(err))
-		return isupdate, err
-	}
-
-	err = update(cmdArgs)
-	if err != nil {
-		logger.Error("Failed to handle CNI UPDATE", zap.Error(err))
-		return isupdate, err
-	}
-
-	return isupdate, nil
-}
-
-func printCNIError(msg string) {
-	logger.Error(msg)
-	cniErr := &cniTypes.Error{
-		Code: cniTypes.ErrTryAgainLater,
-		Msg:  msg,
-	}
-	cniErr.Print()
-}
-
 func rootExecute() error {
 	var (
 		config common.PluginConfig
@@ -147,6 +59,7 @@ func rootExecute() error {
 	)
 
 	config.Version = version
+
 	reportManager := &telemetry.ReportManager{
 		HostNetAgentURL: hostNetAgentURL,
 		ContentType:     telemetry.ContentType,
@@ -169,7 +82,7 @@ func rootExecute() error {
 		&network.Multitenancy{},
 	)
 	if err != nil {
-		printCNIError(fmt.Sprintf("Failed to create network plugin, err:%v.\n", err))
+		network.PrintCNIError(fmt.Sprintf("Failed to create network plugin, err:%v.\n", err))
 		return errors.Wrap(err, "Create plugin error")
 	}
 
@@ -190,7 +103,7 @@ func rootExecute() error {
 
 		// CNI Acquires lock
 		if err = netPlugin.Plugin.InitializeKeyValueStore(&config); err != nil {
-			printCNIError(fmt.Sprintf("Failed to initialize key-value store of network plugin: %v", err))
+			network.PrintCNIError(fmt.Sprintf("Failed to initialize key-value store of network plugin: %v", err))
 
 			tb = telemetry.NewTelemetryBuffer(logger)
 			if tberr := tb.Connect(); tberr != nil {
@@ -198,7 +111,7 @@ func rootExecute() error {
 				return errors.Wrap(err, "lock acquire error")
 			}
 
-			reportPluginError(reportManager, tb, err)
+			network.ReportPluginError(reportManager, tb, err)
 
 			if errors.Is(err, store.ErrTimeoutLockingStore) {
 				var cniMetric telemetry.AIMetric
@@ -239,8 +152,8 @@ func rootExecute() error {
 		cniReport.Timestamp = t.Format("2006-01-02 15:04:05")
 
 		if err = netPlugin.Start(&config); err != nil {
-			printCNIError(fmt.Sprintf("Failed to start network plugin, err:%v.\n", err))
-			reportPluginError(reportManager, tb, err)
+			network.PrintCNIError(fmt.Sprintf("Failed to start network plugin, err:%v.\n", err))
+			network.ReportPluginError(reportManager, tb, err)
 			panic("network plugin start fatal error")
 		}
 
@@ -263,7 +176,7 @@ func rootExecute() error {
 		}
 	}
 
-	handled, _ := handleIfCniUpdate(netPlugin.Update)
+	handled, _ := network.HandleIfCniUpdate(netPlugin.Update)
 	if handled {
 		logger.Info("CNI UPDATE finished.")
 	} else if err = netPlugin.Execute(cni.PluginApi(netPlugin)); err != nil {
@@ -277,7 +190,7 @@ func rootExecute() error {
 	netPlugin.Stop()
 
 	if err != nil {
-		reportPluginError(reportManager, tb, err)
+		network.ReportPluginError(reportManager, tb, err)
 	}
 
 	return errors.Wrap(err, "Execute netplugin failure")

--- a/cni/network/stateless/main.go
+++ b/cni/network/stateless/main.go
@@ -1,0 +1,160 @@
+// Copyright 2017 Microsoft. All rights reserved.
+// MIT License
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/Azure/azure-container-networking/cni"
+	zapLog "github.com/Azure/azure-container-networking/cni/log"
+	"github.com/Azure/azure-container-networking/cni/network"
+	"github.com/Azure/azure-container-networking/common"
+	"github.com/Azure/azure-container-networking/log"
+	"github.com/Azure/azure-container-networking/nns"
+	"github.com/Azure/azure-container-networking/platform"
+	"github.com/Azure/azure-container-networking/telemetry"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+)
+
+var logger = zapLog.CNILogger.With(zap.String("component", "cni-main"))
+
+const (
+	hostNetAgentURL = "http://168.63.129.16/machine/plugins?comp=netagent&type=cnireport"
+	ipamQueryURL    = "http://168.63.129.16/machine/plugins?comp=nmagent&type=getinterfaceinfov1"
+	pluginName      = "CNI"
+	name            = "azure-vnet"
+	stateless       = true
+)
+
+// Version is populated by make during build.
+var version string
+
+// Command line arguments for CNI plugin.
+var args = common.ArgumentList{
+	{
+		Name:         common.OptVersion,
+		Shorthand:    common.OptVersionAlias,
+		Description:  "Print version information",
+		Type:         "bool",
+		DefaultValue: false,
+	},
+}
+
+// Prints version information.
+func printVersion() {
+	fmt.Printf("Azure CNI Version %v\n", version)
+}
+
+func rootExecute() error {
+	var (
+		config common.PluginConfig
+		tb     *telemetry.TelemetryBuffer
+	)
+
+	log.SetName(name)
+	log.SetLevel(log.LevelInfo)
+	if err := log.SetTargetLogDirectory(log.TargetLogfile, ""); err != nil {
+		fmt.Printf("Failed to setup cni logging: %v\n", err)
+	}
+	defer log.Close()
+
+	config.Version = version
+	config.Stateless = stateless
+
+	reportManager := &telemetry.ReportManager{
+		HostNetAgentURL: hostNetAgentURL,
+		ContentType:     telemetry.ContentType,
+		Report: &telemetry.CNIReport{
+			Context:          "AzureCNI",
+			SystemDetails:    telemetry.SystemInfo{},
+			InterfaceDetails: telemetry.InterfaceInfo{},
+			BridgeDetails:    telemetry.BridgeInfo{},
+			Version:          version,
+		},
+	}
+
+	cniReport := reportManager.Report.(*telemetry.CNIReport)
+
+	netPlugin, err := network.NewPlugin(
+		name,
+		&config,
+		&nns.GrpcClient{},
+		&network.Multitenancy{},
+	)
+	if err != nil {
+		network.PrintCNIError(fmt.Sprintf("Failed to create network plugin, err:%v.\n", err))
+		return errors.Wrap(err, "Create plugin error")
+	}
+
+	// Check CNI_COMMAND value
+	cniCmd := os.Getenv(cni.Cmd)
+
+	if cniCmd != cni.CmdVersion {
+		logger.Info("Environment variable set", zap.String("CNI_COMMAND", cniCmd))
+
+		cniReport.GetReport(pluginName, version, ipamQueryURL)
+
+		var upTime time.Time
+		upTime, err = platform.GetLastRebootTime()
+		if err == nil {
+			cniReport.VMUptime = upTime.Format("2006-01-02 15:04:05")
+		}
+
+		defer func() {
+			if recover() != nil {
+				os.Exit(1)
+			}
+		}()
+
+		// Connect to the telemetry process.
+		tb = telemetry.NewTelemetryBuffer()
+		tb.ConnectToTelemetry()
+		defer tb.Close()
+
+		netPlugin.SetCNIReport(cniReport, tb)
+
+		t := time.Now()
+		cniReport.Timestamp = t.Format("2006-01-02 15:04:05")
+
+		if err = netPlugin.Start(&config); err != nil {
+			network.PrintCNIError(fmt.Sprintf("Failed to start network plugin, err:%v.\n", err))
+			network.ReportPluginError(reportManager, tb, err)
+			panic("network plugin start fatal error")
+		}
+	}
+
+	if cniCmd == cni.CmdVersion {
+		return errors.Wrap(err, "Execute netplugin failure")
+	}
+
+	if err = netPlugin.Execute(cni.PluginApi(netPlugin)); err != nil {
+		return errors.Wrap(err, "Failed to execute network plugin")
+	}
+	netPlugin.Stop()
+
+	if err != nil {
+		network.ReportPluginError(reportManager, tb, err)
+	}
+
+	return errors.Wrap(err, "Execute netplugin failure")
+}
+
+// Main is the entry point for CNI network plugin.
+func main() {
+	// Initialize and parse command line arguments.
+	common.ParseArgs(&args, printVersion)
+	vers := common.GetArg(common.OptVersion).(bool)
+
+	if vers {
+		printVersion()
+		os.Exit(0)
+	}
+
+	if rootExecute() != nil {
+		os.Exit(1)
+	}
+}

--- a/cni/network/stateless/main.go
+++ b/cni/network/stateless/main.go
@@ -111,7 +111,7 @@ func rootExecute() error {
 		}()
 
 		// Connect to the telemetry process.
-		tb = telemetry.NewTelemetryBuffer()
+		tb = telemetry.NewTelemetryBuffer(logger)
 		tb.ConnectToTelemetry()
 		defer tb.Close()
 

--- a/cni/network/stateless/main.go
+++ b/cni/network/stateless/main.go
@@ -99,7 +99,8 @@ func rootExecute() error {
 		cniReport.GetReport(pluginName, version, ipamQueryURL)
 
 		var upTime time.Time
-		upTime, err = platform.GetLastRebootTime()
+		p := platform.NewExecClient(logger)
+		upTime, err = p.GetLastRebootTime()
 		if err == nil {
 			cniReport.VMUptime = upTime.Format("2006-01-02 15:04:05")
 		}

--- a/cni/windows.Dockerfile
+++ b/cni/windows.Dockerfile
@@ -11,6 +11,7 @@ COPY . .
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/plugin/main.go
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-telemetry -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/telemetry/service/telemetrymain.go
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-ipam -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/ipam/plugin/main.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azurecni-stateless -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/stateless/main.go
 
 FROM --platform=linux/${ARCH} mcr.microsoft.com/cbl-mariner/base/core:2.0 AS compressor
 ARG OS

--- a/cnm/network/network.go
+++ b/cnm/network/network.go
@@ -272,7 +272,7 @@ func (plugin *netPlugin) deleteEndpoint(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Process request.
-	err = plugin.nm.DeleteEndpoint(req.NetworkID, req.EndpointID)
+	err = plugin.nm.DeleteEndpoint(req.NetworkID, req.EndpointID, nil)
 	if err != nil {
 		plugin.SendErrorResponse(w, err)
 		return

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -37,6 +37,7 @@ const (
 	PathDebugRestData                        = "/debug/restdata"
 	NumberOfCPUCores                         = NumberOfCPUCoresPath
 	NMAgentSupportedAPIs                     = NmAgentSupportedApisPath
+	EndpointApi                              = EndpointPath
 )
 
 // NetworkContainer Prefixes

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -37,7 +37,7 @@ const (
 	PathDebugRestData                        = "/debug/restdata"
 	NumberOfCPUCores                         = NumberOfCPUCoresPath
 	NMAgentSupportedAPIs                     = NmAgentSupportedApisPath
-	EndpointApi                              = EndpointPath
+	EndpointAPI                              = EndpointPath
 )
 
 // NetworkContainer Prefixes

--- a/cns/api.go
+++ b/cns/api.go
@@ -34,6 +34,7 @@ const (
 	NmAgentSupportedApisPath      = "/network/nmagentsupportedapis"
 	V1Prefix                      = "/v0.1"
 	V2Prefix                      = "/v0.2"
+	EndpointPath                  = "/network/endpoints/"
 )
 
 // HTTPService describes the min API interface that every service should have.
@@ -356,4 +357,10 @@ type HomeAzResponse struct {
 type GetHomeAzResponse struct {
 	Response       Response       `json:"response"`
 	HomeAzResponse HomeAzResponse `json:"homeAzResponse"`
+}
+
+// Used by EndpointHandler API to update endpoint state.
+type EndpointRequest struct {
+	HnsEndpointID string `json:"hnsEndpointID"`
+	HostVethName  string `json:"hostVethName"`
 }

--- a/cns/client/client.go
+++ b/cns/client/client.go
@@ -45,7 +45,7 @@ var clientPaths = []string{
 	cns.DeleteNetworkContainer,
 	cns.NetworkContainersURLPath,
 	cns.GetHomeAz,
-	cns.EndpointApi,
+	cns.EndpointAPI,
 }
 
 type do interface {
@@ -1026,7 +1026,7 @@ func (c *Client) GetHomeAz(ctx context.Context) (*cns.GetHomeAzResponse, error) 
 // GetEndpoint calls the EndpointHandlerAPI in CNS to retrieve the state of a given EndpointID
 func (c *Client) GetEndpoint(ctx context.Context, endpointID string) (*restserver.GetEndpointResponse, error) {
 	// build the request
-	u := c.routes[cns.EndpointApi]
+	u := c.routes[cns.EndpointAPI]
 	uString := u.String() + endpointID
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uString, http.NoBody)
 	if err != nil {
@@ -1071,7 +1071,7 @@ func (c *Client) UpdateEndpoint(ctx context.Context, endpointID, hnsID, vethName
 		return nil, errors.Wrap(err, "failed to encode updateEndpoint")
 	}
 
-	u := c.routes[cns.EndpointApi]
+	u := c.routes[cns.EndpointAPI]
 	uString := u.String() + endpointID
 	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, uString, &body)
 	if err != nil {

--- a/cns/client/client.go
+++ b/cns/client/client.go
@@ -45,6 +45,7 @@ var clientPaths = []string{
 	cns.DeleteNetworkContainer,
 	cns.NetworkContainersURLPath,
 	cns.GetHomeAz,
+	cns.EndpointApi,
 }
 
 type do interface {
@@ -1020,4 +1021,83 @@ func (c *Client) GetHomeAz(ctx context.Context) (*cns.GetHomeAzResponse, error) 
 	}
 
 	return &getHomeAzResponse, nil
+}
+
+// GetEndpoint calls the EndpointHandlerAPI in CNS to retrieve the state of a given EndpointID
+func (c *Client) GetEndpoint(ctx context.Context, endpointID string) (*restserver.GetEndpointResponse, error) {
+	// build the request
+	u := c.routes[cns.EndpointApi]
+	uString := u.String() + endpointID
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uString, http.NoBody)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build request")
+	}
+	req.Header.Set(headerContentType, contentTypeJSON)
+	res, err := c.client.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "http request failed")
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("http response %d", res.StatusCode)
+	}
+
+	var response restserver.GetEndpointResponse
+	err = json.NewDecoder(res.Body).Decode(&response)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to decode GetEndpointResponse")
+	}
+
+	if response.Response.ReturnCode != 0 {
+		return nil, errors.New(response.Response.Message)
+	}
+
+	return &response, nil
+}
+
+// UpdateEndpoint calls the EndpointHandlerAPI in CNS
+// to update the state of a given EndpointID with either HNSEndpointID or HostVethName
+func (c *Client) UpdateEndpoint(ctx context.Context, endpointID, hnsID, vethName string) (*cns.Response, error) {
+	// build the request
+	updateEndpoint := cns.EndpointRequest{
+		HnsEndpointID: hnsID,
+		HostVethName:  vethName,
+	}
+	var body bytes.Buffer
+
+	if err := json.NewEncoder(&body).Encode(updateEndpoint); err != nil {
+		return nil, errors.Wrap(err, "failed to encode updateEndpoint")
+	}
+
+	u := c.routes[cns.EndpointApi]
+	uString := u.String() + endpointID
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, uString, &body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build request")
+	}
+	req.Header.Set(headerContentType, contentTypeJSON)
+	res, err := c.client.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "http request failed with error from server")
+	}
+
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("http response %d", res.StatusCode)
+	}
+
+	var response cns.Response
+	err = json.NewDecoder(res.Body).Decode(&response)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to decode CNS Response")
+	}
+
+	if response.ReturnCode != 0 {
+		return nil, errors.New(response.Message)
+	}
+
+	return &response, nil
 }

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -9,19 +9,23 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/filter"
 	"github.com/Azure/azure-container-networking/cns/logger"
 	"github.com/Azure/azure-container-networking/cns/types"
 	"github.com/Azure/azure-container-networking/common"
+	"github.com/Azure/azure-container-networking/store"
 	"github.com/pkg/errors"
 )
 
 var (
-	ErrStoreEmpty       = errors.New("empty endpoint state store")
-	ErrParsePodIPFailed = errors.New("failed to parse pod's ip")
-	ErrNoNCs            = errors.New("No NCs found in the CNS internal state")
+	ErrStoreEmpty             = errors.New("empty endpoint state store")
+	ErrParsePodIPFailed       = errors.New("failed to parse pod's ip")
+	ErrNoNCs                  = errors.New("No NCs found in the CNS internal state")
+	ErrOptManageEndpointState = errors.New("CNS is not set to manage the endpoint state")
+	ErrEndpointStateNotFound  = errors.New("Endpoint state could not be found in the statefile")
 )
 
 // requestIPConfigHandlerHelper validates the request, assign IPs and return the IPConfigs
@@ -941,4 +945,172 @@ func validateDesiredIPAddresses(desiredIPs []string) error {
 		}
 	}
 	return nil
+}
+
+// EndpointHandlerAPI forwards the endpoint related APIs to GetEndpointHandler or UpdateEndpointHandler based on the http method
+func (service *HTTPRestService) EndpointHandlerAPI(w http.ResponseWriter, r *http.Request) {
+	logger.Printf("[EndpointHandlerAPI] EndpointHandlerAPI received request with http Method %s", r.Method)
+	service.Lock()
+	defer service.Unlock()
+	// Check if CNS is managing the CNI statefile
+	if service.Options[common.OptManageEndpointState] == false {
+		response := cns.Response{
+			ReturnCode: types.UnexpectedError,
+			Message:    fmt.Sprintf("[EndpointHandlerAPI] EndpointHandlerAPI failed with error: %s", ErrOptManageEndpointState),
+		}
+		err := service.Listener.Encode(w, &response)
+		logger.Response(service.Name, response, response.ReturnCode, err)
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		service.GetEndpointHandler(w, r)
+	case http.MethodPatch:
+		service.UpdateEndpointHandler(w, r)
+	default:
+		logger.Errorf("[EndpointHandlerAPI] EndpointHandler API expect http Get or Patch method")
+	}
+}
+
+// GetEndpointHandler handles the incoming GetEndpoint requests with http Get method
+func (service *HTTPRestService) GetEndpointHandler(w http.ResponseWriter, r *http.Request) {
+	logger.Printf("[GetEndpointState] GetEndpoint for %s", r.URL.Path)
+
+	endpointID := strings.TrimPrefix(r.URL.Path, cns.EndpointPath)
+	endpointInfo, err := service.GetEndpointHelper(endpointID)
+	if err != nil {
+		response := GetEndpointResponse{
+			Response: Response{
+				ReturnCode: types.UnexpectedError,
+				Message:    fmt.Sprintf("[GetEndpointState] GetEndpoint failed with error: %s", err.Error()),
+			},
+		}
+		if errors.Is(err, ErrEndpointStateNotFound) {
+			response = GetEndpointResponse{
+				Response: Response{
+					ReturnCode: types.NotFound,
+					Message:    fmt.Sprintf("[GetEndpointState] %s", err.Error()),
+				},
+			}
+		}
+		w.Header().Set(cnsReturnCode, response.Response.ReturnCode.String())
+		err = service.Listener.Encode(w, &response)
+		logger.Response(service.Name, response, response.Response.ReturnCode, err)
+		return
+	}
+	response := GetEndpointResponse{
+		Response: Response{
+			ReturnCode: types.Success,
+			Message:    "[GetEndpointState] GetEndpoint retruned successfully",
+		},
+		EndpointInfo: *endpointInfo,
+	}
+	w.Header().Set(cnsReturnCode, response.Response.ReturnCode.String())
+	err = service.Listener.Encode(w, &response)
+	logger.Response(service.Name, response, response.Response.ReturnCode, err)
+}
+
+// GetEndpointHelper returns the state of the given endpointId
+func (service *HTTPRestService) GetEndpointHelper(endpointID string) (*EndpointInfo, error) {
+	logger.Printf("[GetEndpointState] Get endpoint state for infra container %s", endpointID)
+
+	// Skip if a store is not provided.
+	if service.EndpointStateStore == nil {
+		logger.Printf("[GetEndpointState]  store not initialized.")
+		return nil, ErrStoreEmpty
+	}
+
+	err := service.EndpointStateStore.Read(EndpointStoreKey, &service.EndpointState)
+	if err != nil {
+
+		if errors.Is(err, store.ErrKeyNotFound) {
+			// Nothing to retrieve.
+			logger.Printf("[GetEndpointState]  No endpoint state to retrieve.\n")
+		} else {
+			logger.Errorf("[GetEndpointState]  Failed to retrieve state, err:%v", err)
+		}
+		return nil, errors.Wrap(err, "[GetEndpointState]  Failed to retrieve state")
+	}
+	if endpointInfo, ok := service.EndpointState[endpointID]; ok {
+		logger.Warnf("[GetEndpointState] Found existing endpoint state for container %s", endpointID)
+		return endpointInfo, nil
+	}
+	return nil, ErrEndpointStateNotFound
+}
+
+// UpdateEndpointHandler handles the incoming UpdateEndpoint requests with http Patch method
+func (service *HTTPRestService) UpdateEndpointHandler(w http.ResponseWriter, r *http.Request) {
+	logger.Printf("[updateEndpoint] updateEndpoint for %s", r.URL.Path)
+
+	var req cns.EndpointRequest
+	err := service.Listener.Decode(w, r, &req)
+	endpointID := strings.TrimPrefix(r.URL.Path, cns.EndpointPath)
+	logger.Request(service.Name, &req, err)
+	// Check if the request is valid
+	if err != nil {
+		response := cns.Response{
+			ReturnCode: types.InvalidRequest,
+			Message:    fmt.Sprintf("[updateEndpoint] updateEndpoint failed with error: %s", err.Error()),
+		}
+		w.Header().Set(cnsReturnCode, response.ReturnCode.String())
+		err = service.Listener.Encode(w, &response)
+		logger.Response(service.Name, response, response.ReturnCode, err)
+		return
+	}
+	if req.HostVethName == "" && req.HnsEndpointID == "" {
+		logger.Warnf("[updateEndpoint] No HnsEndpointID or HostVethName has been provided")
+		response := cns.Response{
+			ReturnCode: types.InvalidRequest,
+			Message:    "[updateEndpoint] No HnsEndpointID or HostVethName has been provided",
+		}
+		w.Header().Set(cnsReturnCode, response.ReturnCode.String())
+		err = service.Listener.Encode(w, &response)
+		logger.Response(service.Name, response, response.ReturnCode, err)
+		return
+	}
+	// Update the endpoint state
+	err = service.UpdateEndpointHelper(endpointID, req)
+	if err != nil {
+		response := cns.Response{
+			ReturnCode: types.UnexpectedError,
+			Message:    fmt.Sprintf("[updateEndpoint] updateEndpoint failed with error: %s", err.Error()),
+		}
+		w.Header().Set(cnsReturnCode, response.ReturnCode.String())
+		err = service.Listener.Encode(w, &response)
+		logger.Response(service.Name, response, response.ReturnCode, err)
+		return
+	}
+	response := cns.Response{
+		ReturnCode: types.Success,
+		Message:    "[updateEndpoint] updateEndpoint retruned successfully",
+	}
+	w.Header().Set(cnsReturnCode, response.ReturnCode.String())
+	err = service.Listener.Encode(w, &response)
+	logger.Response(service.Name, response, response.ReturnCode, err)
+}
+
+// UpdateEndpointHelper updates the state of the given endpointId with HNSId or VethName
+func (service *HTTPRestService) UpdateEndpointHelper(endpointID string, req cns.EndpointRequest) error {
+	if service.EndpointStateStore == nil {
+		return ErrStoreEmpty
+	}
+	logger.Printf("[updateEndpoint] Updating endpoint state for infra container %s", endpointID)
+	if endpointInfo, ok := service.EndpointState[endpointID]; ok {
+		logger.Printf("[updateEndpoint] Found existing endpoint state for infra container %s", endpointID)
+		if req.HnsEndpointID != "" {
+			service.EndpointState[endpointID].HnsEndpointID = req.HnsEndpointID
+			logger.Printf("[updateEndpoint] update the endpoint %s with HNSID  %s", endpointID, req.HnsEndpointID)
+		}
+		if req.HostVethName != "" {
+			service.EndpointState[endpointID].HostVethName = req.HostVethName
+			logger.Printf("[updateEndpoint] update the endpoint %s with vethName  %s", endpointID, req.HostVethName)
+		}
+
+		err := service.EndpointStateStore.Write(EndpointStoreKey, service.EndpointState)
+		if err != nil {
+			return fmt.Errorf("[updateEndpoint] failed to write endpoint state to store for pod %s :  %w", endpointInfo.PodName, err)
+		}
+		return nil
+	}
+	return errors.New("[updateEndpoint] endpoint could not be found in the statefile")
 }

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -23,9 +23,9 @@ import (
 var (
 	ErrStoreEmpty             = errors.New("empty endpoint state store")
 	ErrParsePodIPFailed       = errors.New("failed to parse pod's ip")
-	ErrNoNCs                  = errors.New("No NCs found in the CNS internal state")
+	ErrNoNCs                  = errors.New("no NCs found in the CNS internal state")
 	ErrOptManageEndpointState = errors.New("CNS is not set to manage the endpoint state")
-	ErrEndpointStateNotFound  = errors.New("Endpoint state could not be found in the statefile")
+	ErrEndpointStateNotFound  = errors.New("endpoint state could not be found in the statefile")
 )
 
 // requestIPConfigHandlerHelper validates the request, assign IPs and return the IPConfigs

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -95,6 +95,8 @@ type EndpointInfo struct {
 	PodName       string
 	PodNamespace  string
 	IfnameToIPMap map[string]*IPInfo // key : interface name, value : IPInfo
+	HnsEndpointID string
+	HostVethName  string
 }
 
 type IPInfo struct {
@@ -117,6 +119,12 @@ type HTTPRestServiceData struct {
 type Response struct {
 	ReturnCode types.ResponseCode
 	Message    string
+}
+
+// GetEndpointResponse describes response from the The GetEndpoint API.
+type GetEndpointResponse struct {
+	Response     Response     `json:"response"`
+	EndpointInfo EndpointInfo `json:"endpointInfo"`
 }
 
 // containerstatus is used to save status of an existing container
@@ -267,7 +275,7 @@ func (service *HTTPRestService) Init(config *common.ServiceConfig) error {
 	listener.AddHandler(cns.PathDebugRestData, service.handleDebugRestData)
 	listener.AddHandler(cns.NetworkContainersURLPath, service.getOrRefreshNetworkContainers)
 	listener.AddHandler(cns.GetHomeAz, service.getHomeAz)
-
+	listener.AddHandler(cns.EndpointPath, service.EndpointHandlerAPI)
 	// handlers for v0.2
 	listener.AddHandler(cns.V2Prefix+cns.SetEnvironmentPath, service.setEnvironment)
 	listener.AddHandler(cns.V2Prefix+cns.CreateNetworkPath, service.createNetwork)
@@ -292,6 +300,7 @@ func (service *HTTPRestService) Init(config *common.ServiceConfig) error {
 	listener.AddHandler(cns.V2Prefix+cns.DeleteHostNCApipaEndpointPath, service.deleteHostNCApipaEndpoint)
 	listener.AddHandler(cns.V2Prefix+cns.NmAgentSupportedApisPath, service.nmAgentSupportedApisHandler)
 	listener.AddHandler(cns.V2Prefix+cns.GetHomeAz, service.getHomeAz)
+	listener.AddHandler(cns.V2Prefix+cns.EndpointPath, service.EndpointHandlerAPI)
 
 	// Initialize HTTP client to be reused in CNS
 	connectionTimeout, _ := service.GetOption(acn.OptHttpConnectionTimeout).(int)

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -658,7 +658,12 @@ func main() {
 		}
 		defer endpointStoreLock.Unlock() // nolint
 
-		err = platform.CreateDirectory(endpointStoreLocation)
+		endpointStorePath := endpointStoreLocation
+		if runtime.GOOS == "windows" {
+			endpointStorePath = os.Getenv("CNSStoreFilePath")
+		}
+		logger.Printf("EndpointState path is %s", endpointStorePath)
+		err = platform.CreateDirectory(endpointStorePath)
 		if err != nil {
 			logger.Errorf("Failed to create File Store directory %s, due to Error:%v", storeFileLocation, err.Error())
 			return

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -305,7 +305,7 @@ var args = acn.ArgumentList{
 		Shorthand:    acn.OptTelemetryServiceAlias,
 		Description:  "Flag to start telemetry service to receive telemetry events from CNI. Default, disabled.",
 		Type:         "bool",
-		DefaultValue: true,
+		DefaultValue: false,
 	},
 	{
 		Name:         acn.OptCNIConflistFilepath,
@@ -621,8 +621,8 @@ func main() {
 			logger.InitAI(aiConfig, ts.DisableTrace, ts.DisableMetric, ts.DisableEvent)
 		}
 	}
-	telemetryDaemonEnabled = disableTelemetry
-	if !telemetryDaemonEnabled {
+	if telemetryDaemonEnabled {
+		log.Printf("CNI Telemtry is enabled")
 		go startTelemetryService(rootCtx)
 	}
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -305,7 +305,7 @@ var args = acn.ArgumentList{
 		Shorthand:    acn.OptTelemetryServiceAlias,
 		Description:  "Flag to start telemetry service to receive telemetry events from CNI. Default, disabled.",
 		Type:         "bool",
-		DefaultValue: false,
+		DefaultValue: true,
 	},
 	{
 		Name:         acn.OptCNIConflistFilepath,

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -443,6 +443,7 @@ func startTelemetryService(ctx context.Context) {
 	tbtemp.Cleanup(telemetry.FdName)
 
 	err = tb.StartServer()
+	log.Printf("Telemetry service for CNI started")
 	if err != nil {
 		log.Errorf("Telemetry service failed to start: %w", err)
 		return
@@ -620,8 +621,8 @@ func main() {
 			logger.InitAI(aiConfig, ts.DisableTrace, ts.DisableMetric, ts.DisableEvent)
 		}
 	}
-
-	if telemetryDaemonEnabled {
+	telemetryDaemonEnabled = disableTelemetry
+	if !telemetryDaemonEnabled {
 		go startTelemetryService(rootCtx)
 	}
 
@@ -662,14 +663,14 @@ func main() {
 		if runtime.GOOS == "windows" {
 			endpointStorePath = os.Getenv("CNSStoreFilePath")
 		}
-		logger.Printf("EndpointState path is %s", endpointStorePath)
 		err = platform.CreateDirectory(endpointStorePath)
 		if err != nil {
 			logger.Errorf("Failed to create File Store directory %s, due to Error:%v", storeFileLocation, err.Error())
 			return
 		}
 		// Create the key value store.
-		storeFileName := endpointStoreLocation + endpointStoreName + ".json"
+		storeFileName := endpointStorePath + endpointStoreName + ".json"
+		logger.Printf("EndpointStoreState path is %s", storeFileName)
 		endpointStateStore, err = store.NewJsonFileStore(storeFileName, endpointStoreLock, nil)
 		if err != nil {
 			logger.Errorf("Failed to create endpoint state store file: %s, due to error %v\n", storeFileName, err)

--- a/common/plugin.go
+++ b/common/plugin.go
@@ -9,11 +9,12 @@ import (
 
 // Plugin is the parent class that implements behavior common to all plugins.
 type Plugin struct {
-	Name    string
-	Version string
-	Options map[string]interface{}
-	ErrChan chan error
-	Store   store.KeyValueStore
+	Name      string
+	Version   string
+	Options   map[string]interface{}
+	ErrChan   chan error
+	Store     store.KeyValueStore
+	Stateless bool
 }
 
 // Plugin base interface.
@@ -34,12 +35,13 @@ type IpamApi interface{}
 
 // Plugin common configuration.
 type PluginConfig struct {
-	Version  string
-	NetApi   NetApi
-	IpamApi  IpamApi
-	Listener *Listener
-	ErrChan  chan error
-	Store    store.KeyValueStore
+	Version   string
+	NetApi    NetApi  // nolint
+	IpamApi   IpamApi // nolint
+	Listener  *Listener
+	ErrChan   chan error
+	Store     store.KeyValueStore
+	Stateless bool
 }
 
 // NewPlugin creates a new Plugin object.
@@ -55,6 +57,7 @@ func NewPlugin(name, version string) (*Plugin, error) {
 func (plugin *Plugin) Initialize(config *PluginConfig) error {
 	plugin.ErrChan = config.ErrChan
 	plugin.Store = config.Store
+	plugin.Stateless = config.Stateless
 
 	return nil
 }

--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -91,6 +91,7 @@ type EndpointInfo struct {
 	NATInfo                  []policy.NATInfo
 	NICType                  cns.NICType
 	SkipDefaultRoutes        bool
+	HNSEndpointID            string
 }
 
 // RouteInfo contains information about an IP route.

--- a/network/manager.go
+++ b/network/manager.go
@@ -98,7 +98,7 @@ type NetworkManager interface {
 	FindNetworkIDFromNetNs(netNs string) (string, error)
 	GetNumEndpointsByContainerID(containerID string) int
 
-	CreateEndpoint(client apipaClient, networkID string, epInfo *EndpointInfo) error
+	CreateEndpoint(client apipaClient, networkID string, epInfo []*EndpointInfo) error
 	DeleteEndpoint(networkID string, endpointID string, epInfo *EndpointInfo) error
 	GetEndpointInfo(networkID string, endpointID string) (*EndpointInfo, error)
 	GetAllEndpoints(networkID string) (map[string]*EndpointInfo, error)
@@ -386,8 +386,7 @@ func (nm *networkManager) CreateEndpoint(cli apipaClient, networkID string, epIn
 			epInfo[0].Data[VlanIDKey] = nw.VlanId
 		}
 	}
-
-	_, err = nw.newEndpoint(cli, nm.netlink, nm.plClient, nm.netio, nm.nsClient, epInfo)
+	ep, err := nw.newEndpoint(cli, nm.netlink, nm.plClient, nm.netio, nm.nsClient, epInfo)
 	if err != nil {
 		return err
 	}
@@ -467,7 +466,7 @@ func (nm *networkManager) DeleteEndpointState(networkID string, epInfo *Endpoint
 		NetworkContainerID:       epInfo.Id,
 	}
 	logger.Info("Deleting endpoint with", zap.String("Endpoint Info: ", epInfo.PrettyString()), zap.String("HNISID : ", ep.HnsId))
-	return nw.deleteEndpointImpl(netlink.NewNetlink(), platform.NewExecClient(logger), nil, ep)
+	return nw.deleteEndpointImpl(netlink.NewNetlink(), platform.NewExecClient(logger), nil, nil, nil, ep)
 }
 
 // GetEndpointInfo returns information about the given endpoint.

--- a/network/manager.go
+++ b/network/manager.go
@@ -465,7 +465,7 @@ func (nm *networkManager) DeleteEndpointState(networkID string, epInfo *Endpoint
 		NetworkContainerID:       epInfo.Id,
 	}
 	logger.Info("Deleting endpoint with", zap.String("Endpoint Info: ", epInfo.PrettyString()), zap.String("HNISID : ", ep.HnsId))
-	return nw.deleteEndpointImpl(netlink.NewNetlink(), platform.NewExecClient(), nil, ep)
+	return nw.deleteEndpointImpl(netlink.NewNetlink(), platform.NewExecClient(logger), nil, ep)
 }
 
 // GetEndpointInfo returns information about the given endpoint.

--- a/network/manager.go
+++ b/network/manager.go
@@ -479,6 +479,9 @@ func (nm *networkManager) GetEndpointInfo(networkId string, endpointId string) (
 		if err != nil {
 			return nil, errors.Wrapf(err, "Get endpoint API returend with error")
 		}
+		if endpointResponse.EndpointInfo.HnsEndpointID == "" && endpointResponse.EndpointInfo.HostVethName == "" {
+			return nil, errors.New("Get endpoint API returend with empty HNSEndpointID and HostVethName")
+		}
 		epInfo := &EndpointInfo{
 			Id:                 endpointId,
 			IfIndex:            EndpointIfIndex, // Azure CNI supports only one interface

--- a/network/manager.go
+++ b/network/manager.go
@@ -4,29 +4,39 @@
 package network
 
 import (
+	"context"
 	"net"
 	"sync"
 	"time"
 
 	cnms "github.com/Azure/azure-container-networking/cnms/cnmspackage"
+	cnsclient "github.com/Azure/azure-container-networking/cns/client"
 	"github.com/Azure/azure-container-networking/common"
+	"github.com/Azure/azure-container-networking/log"
 	"github.com/Azure/azure-container-networking/netio"
 	"github.com/Azure/azure-container-networking/netlink"
 	"github.com/Azure/azure-container-networking/platform"
 	"github.com/Azure/azure-container-networking/store"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
 const (
 	// Network store key.
-	storeKey        = "Network"
-	VlanIDKey       = "VlanID"
-	AzureCNS        = "azure-cns"
-	SNATIPKey       = "NCPrimaryIPKey"
-	RoutesKey       = "RoutesKey"
-	IPTablesKey     = "IPTablesKey"
-	genericData     = "com.docker.network.generic"
-	ipv6AddressMask = 128
+	storeKey             = "Network"
+	VlanIDKey            = "VlanID"
+	AzureCNS             = "azure-cns"
+	SNATIPKey            = "NCPrimaryIPKey"
+	RoutesKey            = "RoutesKey"
+	IPTablesKey          = "IPTablesKey"
+	genericData          = "com.docker.network.generic"
+	ipv6AddressMask      = 128
+	cnsBaseURL           = "" // fallback to default http://localhost:10090
+	cnsReqTimeout        = 15 * time.Second
+	StateLessCNIIsNotSet = "StateLess CNI mode is not enabled"
+	InfraInterfaceName   = "eth0"
+	ContainerIDLength    = 8
+	EndpointIfIndex      = 0 // Azure CNI supports only one interface
 )
 
 var Ipv4DefaultRouteDstPrefix = net.IPNet{
@@ -61,6 +71,8 @@ type EndpointClient interface {
 
 // NetworkManager manages the set of container networking resources.
 type networkManager struct {
+	StatelessCniMode   bool
+	CnsClient          *cnsclient.Client
 	Version            string
 	TimeStamp          time.Time
 	ExternalInterfaces map[string]*externalInterface
@@ -86,8 +98,8 @@ type NetworkManager interface {
 	FindNetworkIDFromNetNs(netNs string) (string, error)
 	GetNumEndpointsByContainerID(containerID string) int
 
-	CreateEndpoint(client apipaClient, networkID string, epInfo []*EndpointInfo) error
-	DeleteEndpoint(networkID string, endpointID string) error
+	CreateEndpoint(client apipaClient, networkID string, epInfo *EndpointInfo) error
+	DeleteEndpoint(networkID string, endpointID string, epInfo *EndpointInfo) error
 	GetEndpointInfo(networkID string, endpointID string) (*EndpointInfo, error)
 	GetAllEndpoints(networkID string) (map[string]*EndpointInfo, error)
 	GetEndpointInfoBasedOnPODDetails(networkID string, podName string, podNameSpace string, doExactMatchForPodName bool) (*EndpointInfo, error)
@@ -96,6 +108,8 @@ type NetworkManager interface {
 	UpdateEndpoint(networkID string, existingEpInfo *EndpointInfo, targetEpInfo *EndpointInfo) error
 	GetNumberOfEndpoints(ifName string, networkID string) int
 	SetupNetworkUsingState(networkMonitor *cnms.NetworkMonitor) error
+	GetEndpointID(containerID, ifName string) string
+	IsStatelessCNIMode() bool
 }
 
 // Creates a new network manager.
@@ -115,6 +129,10 @@ func NewNetworkManager(nl netlink.NetlinkInterface, plc platform.ExecClient, net
 func (nm *networkManager) Initialize(config *common.PluginConfig, isRehydrationRequired bool) error {
 	nm.Version = config.Version
 	nm.store = config.Store
+	if config.Stateless {
+		err := nm.SetStatelessCNIMode()
+		return errors.Wrapf(err, "Failed to initialize stateles CNI")
+	}
 
 	// Restore persisted state.
 	err := nm.restore(isRehydrationRequired)
@@ -123,6 +141,23 @@ func (nm *networkManager) Initialize(config *common.PluginConfig, isRehydrationR
 
 // Uninitialize cleans up network manager.
 func (nm *networkManager) Uninitialize() {
+}
+
+// SetStatelessCNIMode enable the statelessCNI falg and inititlizes a CNSClient
+func (nm *networkManager) SetStatelessCNIMode() error {
+	nm.StatelessCniMode = true
+	// Create CNS client
+	client, err := cnsclient.New(cnsBaseURL, cnsReqTimeout)
+	if err != nil {
+		return errors.Wrapf(err, "failed to initialize CNS client")
+	}
+	nm.CnsClient = client
+	return nil
+}
+
+// IsStatelessCNIMode checks if the Stateless CNI mode has been enabled or not
+func (nm *networkManager) IsStatelessCNIMode() bool {
+	return nm.StatelessCniMode
 }
 
 // Restore reads network manager state from persistent store.
@@ -223,6 +258,10 @@ func (nm *networkManager) restore(isRehydrationRequired bool) error {
 
 // Save writes network manager state to persistent store.
 func (nm *networkManager) save() error {
+	// CNI is not maintaining the state in Steless Mode.
+	if nm.IsStatelessCNIMode() {
+		return nil
+	}
 	// Skip if a store is not provided.
 	if nm.store == nil {
 		return nil
@@ -351,6 +390,10 @@ func (nm *networkManager) CreateEndpoint(cli apipaClient, networkID string, epIn
 		return err
 	}
 
+	if nm.IsStatelessCNIMode() {
+		return nm.UpdateEndpointState(ep)
+	}
+
 	err = nm.save()
 	if err != nil {
 		return err
@@ -359,10 +402,26 @@ func (nm *networkManager) CreateEndpoint(cli apipaClient, networkID string, epIn
 	return nil
 }
 
+// UpdateEndpointState will make a call to CNS updatEndpointState API in the stateless CNI mode
+// It will add HNSEndpointID or HostVeth name to the endpoint state
+func (nm *networkManager) UpdateEndpointState(ep *endpoint) error {
+	logger.Info("Calling cns updateEndpoint API with ", zap.String("containerID: ", ep.ContainerID), zap.String("HnsId: ", ep.HnsId), zap.String("HostIfName: ", ep.HostIfName))
+	response, err := nm.CnsClient.UpdateEndpoint(context.TODO(), ep.ContainerID, ep.HnsId, ep.HostIfName)
+	if err != nil {
+		return errors.Wrapf(err, "Update endpoint API returend with error")
+	}
+	logger.Info("Update endpoint API returend ", zap.String("podname: ", response.ReturnCode.String()))
+	return nil
+}
+
 // DeleteEndpoint deletes an existing container endpoint.
-func (nm *networkManager) DeleteEndpoint(networkID, endpointID string) error {
+func (nm *networkManager) DeleteEndpoint(networkID, endpointID string, epInfo *EndpointInfo) error {
 	nm.Lock()
 	defer nm.Unlock()
+
+	if nm.IsStatelessCNIMode() {
+		return nm.DeleteEndpointState(networkID, epInfo)
+	}
 
 	nw, err := nm.getNetwork(networkID)
 	if err != nil {
@@ -382,10 +441,63 @@ func (nm *networkManager) DeleteEndpoint(networkID, endpointID string) error {
 	return nil
 }
 
+func (nm *networkManager) DeleteEndpointState(networkID string, epInfo *EndpointInfo) error {
+	nw := &network{
+		Id:           networkID,
+		Mode:         opModeTransparentVlan,
+		SnatBridgeIP: "",
+		extIf: &externalInterface{
+			Name:       InfraInterfaceName,
+			MacAddress: nil,
+		},
+	}
+
+	ep := &endpoint{
+		Id:                       epInfo.Id,
+		HnsId:                    epInfo.HNSEndpointID,
+		HostIfName:               epInfo.IfName,
+		LocalIP:                  "",
+		VlanID:                   0,
+		AllowInboundFromHostToNC: false,
+		AllowInboundFromNCToHost: false,
+		EnableSnatOnHost:         false,
+		EnableMultitenancy:       false,
+		NetworkContainerID:       epInfo.Id,
+	}
+	logger.Info("Deleting endpoint with", zap.String("Endpoint Info: ", epInfo.PrettyString()), zap.String("HNISID : ", ep.HnsId))
+	return nw.deleteEndpointImpl(netlink.NewNetlink(), platform.NewExecClient(), nil, ep)
+}
+
 // GetEndpointInfo returns information about the given endpoint.
 func (nm *networkManager) GetEndpointInfo(networkId string, endpointId string) (*EndpointInfo, error) {
 	nm.Lock()
 	defer nm.Unlock()
+
+	if nm.IsStatelessCNIMode() {
+		logger.Info("calling cns getEndpoint API")
+		endpointResponse, err := nm.CnsClient.GetEndpoint(context.TODO(), endpointId)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Get endpoint API returend with error")
+		}
+		epInfo := &EndpointInfo{
+			Id:                 endpointId,
+			IfIndex:            EndpointIfIndex, // Azure CNI supports only one interface
+			IfName:             endpointResponse.EndpointInfo.HostVethName,
+			ContainerID:        endpointId,
+			PODName:            endpointResponse.EndpointInfo.PodName,
+			PODNameSpace:       endpointResponse.EndpointInfo.PodNamespace,
+			NetworkContainerID: endpointId,
+			HNSEndpointID:      endpointResponse.EndpointInfo.HnsEndpointID,
+		}
+
+		for _, ip := range endpointResponse.EndpointInfo.IfnameToIPMap {
+			epInfo.IPAddresses = ip.IPv4
+			epInfo.IPAddresses = append(epInfo.IPAddresses, ip.IPv6...)
+
+		}
+		logger.Info("returning getEndpoint API with", zap.String("Endpoint Info: ", epInfo.PrettyString()), zap.String("HNISID : ", epInfo.HNSEndpointID))
+		return epInfo, nil
+	}
 
 	nw, err := nm.getNetwork(networkId)
 	if err != nil {
@@ -545,4 +657,18 @@ func (nm *networkManager) GetNumberOfEndpoints(ifName string, networkId string) 
 
 func (nm *networkManager) SetupNetworkUsingState(networkMonitor *cnms.NetworkMonitor) error {
 	return nm.monitorNetworkState(networkMonitor)
+}
+
+// GetEndpointID returns a unique endpoint ID based on the CNI mode.
+func (nm *networkManager) GetEndpointID(containerID, ifName string) string {
+	if nm.IsStatelessCNIMode() {
+		return containerID
+	}
+	if len(containerID) > ContainerIDLength {
+		containerID = containerID[:ContainerIDLength]
+	} else {
+		log.Printf("Container ID is not greater than 8 ID: %v", containerID)
+		return ""
+	}
+	return containerID + "-" + ifName
 }

--- a/network/manager.go
+++ b/network/manager.go
@@ -130,8 +130,10 @@ func (nm *networkManager) Initialize(config *common.PluginConfig, isRehydrationR
 	nm.Version = config.Version
 	nm.store = config.Store
 	if config.Stateless {
-		err := nm.SetStatelessCNIMode()
-		return errors.Wrapf(err, "Failed to initialize stateles CNI")
+		if err := nm.SetStatelessCNIMode(); err != nil {
+			return errors.Wrapf(err, "Failed to initialize stateles CNI")
+		}
+		return nil
 	}
 
 	// Restore persisted state.

--- a/network/manager_mock.go
+++ b/network/manager_mock.go
@@ -66,7 +66,7 @@ func (nm *MockNetworkManager) CreateEndpoint(_ apipaClient, _ string, epInfos []
 }
 
 // DeleteEndpoint mock
-func (nm *MockNetworkManager) DeleteEndpoint(networkID string, endpointID string, ep *EndpointInfo) error {
+func (nm *MockNetworkManager) DeleteEndpoint(_, endpointID string, _ *EndpointInfo) error {
 	delete(nm.TestEndpointInfoMap, endpointID)
 	return nil
 }

--- a/network/manager_mock.go
+++ b/network/manager_mock.go
@@ -66,9 +66,32 @@ func (nm *MockNetworkManager) CreateEndpoint(_ apipaClient, _ string, epInfos []
 }
 
 // DeleteEndpoint mock
-func (nm *MockNetworkManager) DeleteEndpoint(networkID, endpointID string) error {
+func (nm *MockNetworkManager) DeleteEndpoint(networkID string, endpointID string, ep *EndpointInfo) error {
 	delete(nm.TestEndpointInfoMap, endpointID)
 	return nil
+}
+
+// SetStatelessCNIMode enable the statelessCNI falg and inititlizes a CNSClient
+func (nm *MockNetworkManager) SetStatelessCNIMode() error {
+	return nil
+}
+
+// IsStatelessCNIMode checks if the Stateless CNI mode has been enabled or not
+func (nm *MockNetworkManager) IsStatelessCNIMode() bool {
+	return false
+}
+
+// GetEndpointID returns the ContainerID value
+func (nm *MockNetworkManager) GetEndpointID(containerID, ifName string) string {
+	if nm.IsStatelessCNIMode() {
+		return containerID
+	}
+	if len(containerID) > ContainerIDLength {
+		containerID = containerID[:ContainerIDLength]
+	} else {
+		return ""
+	}
+	return containerID + "-" + ifName
 }
 
 func (nm *MockNetworkManager) GetAllEndpoints(networkID string) (map[string]*EndpointInfo, error) {

--- a/telemetry/telemetrybuffer.go
+++ b/telemetry/telemetrybuffer.go
@@ -390,6 +390,16 @@ func (tb *TelemetryBuffer) ConnectToTelemetryService(telemetryNumRetries, teleme
 	}
 }
 
+// ConnectToTelemetry - attempt to connect to telemetry service
+func (tb *TelemetryBuffer) ConnectToTelemetry() {
+	if err := tb.Connect(); err != nil {
+		log.Logf("Connection to telemetry socket failed: %v", err)
+		return
+	}
+	tb.Connected = true
+	log.Logf("Connected to telemetry service")
+}
+
 // getTelemetryServiceDirectory - check CNI install directory and Executable location for telemetry binary
 func getTelemetryServiceDirectory() (path string, dir string) {
 	path = filepath.Join(CniInstallDir, TelemetryServiceProcessName)


### PR DESCRIPTION
This PR includes all changes related to Stateless CNI in which CNS will manage and maintain the endpoint states.

- There are changes related to CNS to add two new APIs with respect of endpoint state management.
GetEndpoint() is used to return the state of a given endpointId. UpdateEndpoint() is used to update the HNSId and VethName field within the endpoint state.
- The other changes are related to CNI and network package so the ADD/Del calls can be done without the use of statefile on Store package and instead use CNS and aformenetioned APIs.

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [X] includes documentation
- [X] adds unit tests
- [X] relevant PR labels added

**Notes**:
[Stateless Azure cni Design Doc- P1.docx](https://github.com/Azure/azure-container-networking/files/13620367/Stateless.Azure.cni.Design.Doc-.P1.docx)

