### PR TITLE
fix: change artifact naming convention

### DIFF
--- a/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
+++ b/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
@@ -146,8 +146,8 @@ stages:
             retryCountOnTaskFailure: 6
             name: "CiliumConnectivityTests"
             displayName: "Run Cilium Connectivity Tests"
-      - job: logs
-        displayName: "Log Failure"
+      - job: failedE2ELogs
+        displayName: "Failure Logs"
         dependsOn:
           - deploy_cilium_components
           - deploy_pods

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -89,7 +89,7 @@ stages:
             testDropgz: ""
             clusterName: ciliumnightly-$(commitID)
       - job: logs
-        displayName: "Log Failure"
+        displayName: "Failure Logs"
         dependsOn:
           - cilium_nightly
         condition: failed()

--- a/.pipelines/cni/load-test-templates/pod-deployment-template.yaml
+++ b/.pipelines/cni/load-test-templates/pod-deployment-template.yaml
@@ -5,6 +5,7 @@ parameters:
   iterations: 4
   nodeCount: 10
   cni: ""
+  jobName: "deploy_pods"
 
 steps:
   - task: AzureCLI@1
@@ -28,3 +29,4 @@ steps:
       logType: scaleTest
       os: ${{ parameters.os }}
       cni: ${{ parameters.cni }}
+      jobName: ${{ parameters.jobName }}

--- a/.pipelines/cni/load-test-templates/restart-cns-template.yaml
+++ b/.pipelines/cni/load-test-templates/restart-cns-template.yaml
@@ -4,6 +4,7 @@ parameters:
   scaleup: 100
   nodeCount: 10
   os: ""
+  jobName: "restart_cns"
 
 steps:
   - task: AzureCLI@1
@@ -40,3 +41,4 @@ steps:
       logType: restartCNS
       os: ${{ parameters.os }}
       cni: ${{ parameters.cni }}
+      jobName: ${{ parameters.jobName }}

--- a/.pipelines/cni/load-test-templates/restart-node-template.yaml
+++ b/.pipelines/cni/load-test-templates/restart-node-template.yaml
@@ -4,6 +4,7 @@ parameters:
   scaleup: 100
   os: "linux"
   cni: ""
+  jobName: "restart_nodes"
 
 steps:
   - task: AzureCLI@1
@@ -38,3 +39,4 @@ steps:
       logType: restartNode
       os: ${{ parameters.os }}
       cni: ${{ parameters.cni }}
+      jobName: ${{ parameters.jobName }}

--- a/.pipelines/cni/singletenancy/cniv1-template.yaml
+++ b/.pipelines/cni/singletenancy/cniv1-template.yaml
@@ -158,8 +158,8 @@ stages:
           hybridWin: true
           service: true
           hostport: true
-      - job: logs
-        displayName: "Log Failure"
+      - job: failedE2ELogs
+        displayName: "Failure Logs"
         dependsOn:
           - update_cni
           - npm_k8se2e
@@ -195,7 +195,7 @@ stages:
               parameters:
                 clusterName: ${{ parameters.clusterName }}-$(commitID)
                 cni: cniv1
-        - job: deploy_pods
+        - job: deploy_podsHNS
           displayName: "Scale Test"
           dependsOn: restart_hns
           steps:
@@ -211,9 +211,9 @@ stages:
                 clusterName: ${{ parameters.clusterName }}-$(commitID)
                 os: ${{ parameters.os }}
                 cni: cniv1
-        - job: restart_nodes
+        - job: restart_nodesHNS
           displayName: "Restart Test"
-          dependsOn: deploy_pods
+          dependsOn: deploy_podsHNS
           steps:
             - template: ../load-test-templates/restart-node-template.yaml
               parameters:
@@ -229,7 +229,7 @@ stages:
                 restartCase: "true"
         - job: recover
           displayName: "Recover Resources"
-          dependsOn: restart_nodes
+          dependsOn: restart_nodesHNS
           steps:
             - task: AzureCLI@1
               inputs:
@@ -257,12 +257,12 @@ stages:
             hybridWin: true
             service: true
             hostport: true
-        - job: logs
-          displayName: "Log Failure"
+        - job: failedE2ELogsHNS
+          displayName: "Failure Logs"
           dependsOn:
             - restart_hns
-            - restart_nodes
-            - deploy_pods
+            - restart_nodesHNS
+            - deploy_podsHNS
             - recover
             - cni_${{ parameters.os }}
           condition: failed()

--- a/.pipelines/cni/singletenancy/cniv1-template.yaml
+++ b/.pipelines/cni/singletenancy/cniv1-template.yaml
@@ -206,6 +206,7 @@ stages:
                 os: ${{ parameters.os }}
                 iterations: ${{ parameters.iterations }}
                 nodeCount: ${{ parameters.nodeCount }}
+                jobName: deploy_podsHNS
             - template: ../load-test-templates/validate-state-template.yaml
               parameters:
                 clusterName: ${{ parameters.clusterName }}-$(commitID)
@@ -221,6 +222,7 @@ stages:
                 os: ${{ parameters.os }}
                 nodeCount: ${{ parameters.nodeCount }}
                 scaleup: ${{ parameters.scaleup }}
+                jobName: restart_nodesHNS
             - template: ../load-test-templates/validate-state-template.yaml
               parameters:
                 clusterName: ${{ parameters.clusterName }}-$(commitID)
@@ -271,3 +273,4 @@ stages:
               parameters:
                 clusterName: ${{ parameters.clusterName }}-$(commitID)
                 os: ${{ parameters.os }}
+                jobName: failedE2ELogsHNS

--- a/.pipelines/cni/singletenancy/cniv1-template.yaml
+++ b/.pipelines/cni/singletenancy/cniv1-template.yaml
@@ -141,7 +141,9 @@ stages:
               inlineScript: |
                 echo "Delete load-test Namespace"
                 make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(commitID)
-                kubectl delete ns load-test
+                kubectl get ns --no-headers | grep -v 'kube\|default' | awk '{print $1}'
+                delete=`kubectl get ns --no-headers | grep -v 'kube\|default' | awk '{print $1}'`
+                kubectl delete ns $delete
                 kubectl cluster-info
                 kubectl get po -owide -A
             name: "recover"
@@ -242,7 +244,9 @@ stages:
                 inlineScript: |
                   echo "Delete load-test Namespace"
                   make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(commitID)
-                  kubectl delete ns load-test
+                  kubectl get ns --no-headers | grep -v 'kube\|default' | awk '{print $1}'
+                  delete=`kubectl get ns --no-headers | grep -v 'kube\|default' | awk '{print $1}'`
+                  kubectl delete ns $delete
                   kubectl cluster-info
                   kubectl get po -owide -A
               name: "recover"

--- a/.pipelines/cni/singletenancy/linux-cniv2-template.yaml
+++ b/.pipelines/cni/singletenancy/linux-cniv2-template.yaml
@@ -166,8 +166,8 @@ stages:
           portforward: true
           service: true
           hostport: true
-      - job: logs
-        displayName: "Log Failure"
+      - job: failedE2ELogs
+        displayName: "Failure Logs"
         dependsOn:
           - integration
           - npm_k8se2e

--- a/.pipelines/cni/singletenancy/linux-cniv2-template.yaml
+++ b/.pipelines/cni/singletenancy/linux-cniv2-template.yaml
@@ -150,7 +150,9 @@ stages:
               inlineScript: |
                 echo "Delete load-test Namespace"
                 make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(commitID)
-                kubectl delete ns load-test
+                kubectl get ns --no-headers | grep -v 'kube\|default' | awk '{print $1}'
+                delete=`kubectl get ns --no-headers | grep -v 'kube\|default' | awk '{print $1}'`
+                kubectl delete ns $delete
                 kubectl cluster-info
                 kubectl get po -owide -A
             name: "recover"

--- a/.pipelines/singletenancy/aks-swift/e2e-job-template.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e-job-template.yaml
@@ -63,8 +63,8 @@ stages:
               testDropgz: ${{ parameters.testDropgz }}
               clusterName: ${{ parameters.clusterName }}-$(commitID)
 
-      - job: logs
-        displayName: "Log Failure"
+      - job: failedE2ELogs
+        displayName: "Failure Logs"
         dependsOn:
           - ${{ parameters.name }}
         condition: failed()

--- a/.pipelines/singletenancy/aks/e2e-job-template.yaml
+++ b/.pipelines/singletenancy/aks/e2e-job-template.yaml
@@ -82,8 +82,8 @@ stages:
           hostport: true
           dependsOn: ${{ parameters.name }}
 
-      - job: logs
-        displayName: "Log Failure"
+      - job: failedE2ELogs
+        displayName: "Failure Logs"
         dependsOn:
           - ${{ parameters.name }}
           - cni_${{ parameters.os }}

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
@@ -84,8 +84,8 @@ stages:
           hybridWin: true
           datapath: true
 
-      - job: logs
-        displayName: "Log Failure"
+      - job: failedE2ELogs
+        displayName: "Failure Logs"
         dependsOn:
           - ${{ parameters.name }}
           - cni_${{ parameters.os }}

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-job-template.yaml
@@ -59,8 +59,8 @@ stages:
               testDropgz: ${{ parameters.testDropgz }}
               clusterName: ${{ parameters.clusterName }}-$(commitID)
 
-      - job: logs
-        displayName: "Log Failure"
+      - job: failedE2ELogs
+        displayName: "Failure Logs"
         dependsOn:
           - ${{ parameters.name }}
         condition: failed()

--- a/.pipelines/singletenancy/cilium/cilium-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-job-template.yaml
@@ -63,8 +63,8 @@ stages:
               testDropgz: ${{ parameters.testDropgz }}
               clusterName: ${{ parameters.clusterName }}-$(commitID)
 
-      - job: logs
-        displayName: "Log Failure"
+      - job: failedE2ELogs
+        displayName: "Failure Logs"
         dependsOn:
           - ${{ parameters.name }}
         condition: failed()

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
@@ -83,8 +83,8 @@ stages:
           service: true
           hybridWin: true
 
-      - job: logs
-        displayName: "Log Failure"
+      - job: failedE2ELogs
+        displayName: "Failure Logs"
         dependsOn:
           - ${{ parameters.name }}
           - cni_${{ parameters.os }}

--- a/.pipelines/templates/log-template.yaml
+++ b/.pipelines/templates/log-template.yaml
@@ -10,7 +10,7 @@
 # CNS ConfigMap | "ManageEndpointState"
 # -- Generates --
 # Logs on a per-node basis
-# Outputs a singluar unique artifact per template call | ${{ parameters.clusterName }}_${{ parameters.logType }}_Attempt_#$(System.StageAttempt)
+# Outputs a singluar unique artifact per template call | ${{ parameters.clusterName }}_$(System.JobName)_Attempt_#$(System.StageAttempt)
 # Each artifact is divided into sub-directories
 # -- Intent --
 # Provide through debugging information to understand why CNI test scenarios are failing without having to blindly reproduce
@@ -269,6 +269,6 @@ steps:
 
   - publish: $(System.DefaultWorkingDirectory)/${{ parameters.clusterName }}_${{ parameters.logType }}_Attempt_#$(System.StageAttempt)
     condition: always()
-    artifact: ${{ parameters.clusterName }}_${{ parameters.logType }}_Attempt_#$(System.StageAttempt)
+    artifact: ${{ parameters.clusterName }}_$(System.JobName)_Attempt_#$(System.StageAttempt)
     name: acnLogs_${{ parameters.logType }}
     displayName: Publish Cluster logs

--- a/.pipelines/templates/log-template.yaml
+++ b/.pipelines/templates/log-template.yaml
@@ -10,7 +10,7 @@
 # CNS ConfigMap | "ManageEndpointState"
 # -- Generates --
 # Logs on a per-node basis
-# Outputs a singluar unique artifact per template call | ${{ parameters.clusterName }}_$(System.JobName)_Attempt_#$(System.StageAttempt)
+# Outputs a singluar unique artifact per template call | ${{ parameters.clusterName }}_${{ parameters.jobName }}_Attempt_#$(System.StageAttempt)
 # Each artifact is divided into sub-directories
 # -- Intent --
 # Provide through debugging information to understand why CNI test scenarios are failing without having to blindly reproduce
@@ -20,6 +20,7 @@ parameters:
   logType: "failure"
   os: ""
   cni: ""
+  jobName: "failedE2ELogs"
 
 steps:
   - task: AzureCLI@1
@@ -269,6 +270,6 @@ steps:
 
   - publish: $(System.DefaultWorkingDirectory)/${{ parameters.clusterName }}_${{ parameters.logType }}_Attempt_#$(System.StageAttempt)
     condition: always()
-    artifact: ${{ parameters.clusterName }}_$(System.JobName)_Attempt_#$(System.StageAttempt)
+    artifact: ${{ parameters.clusterName }}_${{ parameters.jobName }}_Attempt_#$(System.StageAttempt)
     name: acnLogs_${{ parameters.logType }}
     displayName: Publish Cluster logs


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Fixes #2264 : artifacts having matching names due to calling the same template in separate stages. I.E. HNS restart calling the same suite of templated tests.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
