### PR TITLE
ci: Enable multiple runs with the same commitID

### DIFF
--- a/.pipelines/cni/pipeline.yaml
+++ b/.pipelines/cni/pipeline.yaml
@@ -13,7 +13,7 @@ stages:
           - script: |
               echo "Setting up environment"
               go version
-              echo "##vso[task.setvariable variable=commitID;isOutput=true]$(make revision)"
+              echo "##vso[task.setvariable variable=commitID;isOutput=true]$(echo $(make revision)-$(date "+%d%H%M"))"
               echo "##vso[task.setvariable variable=npmVersion;isOutput=true]$(make npm-version)"
               echo "##vso[task.setvariable variable=dropgzVersion;isOutput=true]$(make cni-dropgz-test-version)"
               echo "##vso[task.setvariable variable=cnsVersion;isOutput=true]$(CNS_VERSION)"
@@ -138,7 +138,7 @@ stages:
     parameters:
       name: cilium_overlay
       clusterType: overlay-byocni-nokubeproxy-up
-      clusterName: "cilium-overlay"
+      clusterName: "cilium-over"
       nodeCount: ${NODE_COUNT_CILIUM}
       vmSize: ${VM_SIZE_CILIUM}
 
@@ -146,7 +146,7 @@ stages:
     parameters:
       name: win22_cniv1
       clusterType: windows-cniv1-up
-      clusterName: win22-cniv1
+      clusterName: "win22-cniv1"
       nodeCount: ${NODE_COUNT_WIN}
       vmSize: ${VM_SIZE_WINCLUSTER_SYSTEMPOOL}
       vmSizeWin: ${VM_SIZE_WIN}
@@ -160,7 +160,7 @@ stages:
     parameters:
       name: linux_cniv1
       clusterType: linux-cniv1-up
-      clusterName: linux-cniv1
+      clusterName: "linux-cniv1"
       nodeCount: ${NODE_COUNT_LINUX}
       vmSize: ${VM_SIZE}
       os: linux
@@ -172,7 +172,7 @@ stages:
     parameters:
       name: linux_podsubnet
       clusterType: swift-byocni-up
-      clusterName: linux-cniv2-podsubnet
+      clusterName: "linux-podsub"
       nodeCount: ${NODE_COUNT_LINUX}
       vmSize: ${VM_SIZE}
       arch: amd64
@@ -181,7 +181,7 @@ stages:
     parameters:
       name: linux_overlay
       clusterType: overlay-byocni-up
-      clusterName: linux-cniv2-overlay
+      clusterName: "linux-over"
       nodeCount: ${NODE_COUNT_LINUX}
       vmSize: ${VM_SIZE}
       arch: amd64
@@ -190,7 +190,7 @@ stages:
     parameters:
       name: mariner_linux_overlay
       clusterType: overlay-byocni-up
-      clusterName: mariner-cniv2-overlay
+      clusterName: "mariner-over"
       nodeCount: ${NODE_COUNT_LINUX}
       vmSize:  ${VM_SIZE}
       arch: amd64
@@ -200,7 +200,7 @@ stages:
     parameters:
       name: arm_linux_overlay
       clusterType: overlay-byocni-up
-      clusterName: arm-cniv2-overlay
+      clusterName: "arm-over"
       nodeCount: ${NODE_COUNT_LINUX}
       vmSize: Standard_D8ps_v5
       arch: arm64
@@ -209,7 +209,7 @@ stages:
     parameters:
       name: rdma_linux_overlay
       clusterType: overlay-byocni-up
-      clusterName: rdma-cniv2-overlay
+      clusterName: "rdma-over"
       nodeCount: 2
       vmSize: Standard_NC24r
       arch: amd64
@@ -240,28 +240,28 @@ stages:
           matrix:
             cilium_overlay:
               name: cilium_overlay
-              clusterName: cilium-overlay
+              clusterName: "cilium-over"
             win22-cniv1:
               name: win22-cniv1
-              clusterName: win22-cniv1
+              clusterName: "win22-cniv1"
             linux_cniv1:
               name: linux_cniv1
-              clusterName: linux-cniv1
+              clusterName: "linux-cniv1"
             linux_podsubnet:
               name: linux_podsubnet
-              clusterName: linux-cniv2-podsubnet
+              clusterName: "linux-podsub"
             linux_overlay:
               name: linux_overlay
-              clusterName: linux-cniv2-overlay
+              clusterName: "linux-over"
             mariner_linux_overlay:
               name: mariner_linux_overlay
-              clusterName: mariner-cniv2-overlay
+              clusterName: "mariner-over"
             arm_linux_overlay:
               name: arm_linux_overlay
-              clusterName: arm-cniv2-overlay
+              clusterName: "arm-over"
             rdma_linux_overlay:
               name: rdma_linux_overlay
-              clusterName: rdma-cniv2-overlay
+              clusterName: "rdma-over"
         steps:
           - task: AzureCLI@1
             inputs:

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -35,7 +35,7 @@ stages:
               # To use the variables below, you must make the respective stage's dependsOn have - setup or it will not retain context of this stage
               BUILD_NUMBER=$(Build.BuildNumber)
               echo "##vso[task.setvariable variable=StorageID;isOutput=true]$(echo ${BUILD_NUMBER//./-})"
-              echo "##vso[task.setvariable variable=commitID;isOutput=true]$(make revision)"
+              echo "##vso[task.setvariable variable=commitID;isOutput=true]$(echo $(make revision)-$(date "+%d-%H-%M"))"
               echo "##vso[task.setvariable variable=Tag;isOutput=true]$(make version)"
               echo "##vso[task.setvariable variable=cniVersion;isOutput=true]$(make cni-version)"
               echo "##vso[task.setvariable variable=npmVersion;isOutput=true]$(make npm-version)"

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -35,7 +35,7 @@ stages:
               # To use the variables below, you must make the respective stage's dependsOn have - setup or it will not retain context of this stage
               BUILD_NUMBER=$(Build.BuildNumber)
               echo "##vso[task.setvariable variable=StorageID;isOutput=true]$(echo ${BUILD_NUMBER//./-})"
-              echo "##vso[task.setvariable variable=commitID;isOutput=true]$(echo $(make revision)-$(date "+%d-%H-%M"))"
+              echo "##vso[task.setvariable variable=commitID;isOutput=true]$(echo $(make revision)-$(date "+%d%H%M"))"
               echo "##vso[task.setvariable variable=Tag;isOutput=true]$(make version)"
               echo "##vso[task.setvariable variable=cniVersion;isOutput=true]$(make cni-version)"
               echo "##vso[task.setvariable variable=npmVersion;isOutput=true]$(make npm-version)"
@@ -346,7 +346,7 @@ stages:
       displayName: CNI - Cilium Podsubnet
       testDropgz: true
       clusterType: swift-byocni-nokubeproxy-up
-      clusterName: "ciliumpodsubnetcnie2e"
+      clusterName: "cilpodcnie2e"
       vmSize: Standard_B2ms
       k8sVersion: ""
       dependsOn: "containerize"
@@ -358,7 +358,7 @@ stages:
       displayName: Cilium on AKS Overlay
       testDropgz: ""
       clusterType: overlay-byocni-nokubeproxy-up
-      clusterName: "ciliumoverlaye2e"
+      clusterName: "cilovere2e"
       vmSize: Standard_B2ms
       k8sVersion: ""
       dependsOn: "containerize"
@@ -369,7 +369,7 @@ stages:
       displayName: CNI - Cilium on AKS Overlay
       testDropgz: true
       clusterType: overlay-byocni-nokubeproxy-up
-      clusterName: "ciliumoverlaycnie2e"
+      clusterName: "cilovercnie2e"
       vmSize: Standard_B2ms
       k8sVersion: ""
       dependsOn: "containerize"
@@ -382,7 +382,7 @@ stages:
       os: linux
       testDropgz: ""
       clusterType: overlay-byocni-up
-      clusterName: "azureoverlaye2e"
+      clusterName: "azovere2e"
       vmSize: Standard_B2ms
       k8sVersion: ""
       dependsOn: "containerize"
@@ -394,7 +394,7 @@ stages:
       os: linux
       testDropgz: true
       clusterType: overlay-byocni-up
-      clusterName: "azureoverlaycnie2e"
+      clusterName: "azovercnie2e"
       vmSize: Standard_B2ms
       k8sVersion: ""
       dependsOn: "containerize"
@@ -456,7 +456,7 @@ stages:
       displayName: AKS DualStack Overlay
       os: linux
       clusterType: dualstack-overlay-byocni-up
-      clusterName: "dualstackoverlaye2e"
+      clusterName: "dsovere2e"
       vmSize: Standard_B2ms
       dependsOn: "containerize"
       testDropgz: true
@@ -491,22 +491,22 @@ stages:
               clusterName: "ciliume2e"
             cilium_overlay_e2e:
               name: cilium_overlay_e2e
-              clusterName: "ciliumoverlaye2e"
+              clusterName: "cilovere2e"
             azure_overlay_e2e:
               name: azure_overlay_e2e
-              clusterName: "azureoverlaye2e"
+              clusterName: "azovere2e"
             aks_swift_e2e:
               name: aks_swift_e2e
               clusterName: "swifte2e"
             azure_overlay_cni_e2e:
-              name: azure_overlay_cni_e2e
+              name: "azovercnie2e"
               clusterName: "azureoverlaycnie2e"
             cilium_podsubnet_cni_e2e:
               name: cilium_podsubnet_cni_e2e
-              clusterName: "ciliumpodsubnetcnie2e"
+              clusterName: "cilpodcnie2e"
             cilium_overlay_cni_e2e:
               name: cilium_overlay_cni_e2e
-              clusterName: "ciliumoverlaycnie2e"
+              clusterName: "cilovercnie2e"
             aks_swift_cni_e2e:
               name: aks_swift_cni_e2e
               clusterName: "swiftcnie2e"
@@ -518,7 +518,7 @@ stages:
               clusterName: "win22e2e"
             dualstackoverlay_e2e:
               name: dualstackoverlay_e2e
-              clusterName: "dualstackoverlaye2e"
+              clusterName: "dsovere2e"
         steps:
           - template: templates/delete-cluster.yaml
             parameters:


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Having multiple runs on the same commit ID was causing conflicts from cluster creation/deletion. This change makes each run unique by giving it a time stamp of DDHHMM (DayHourMinute). Expected clusterName  `<unique cluster name>-<commitID>-<Timestamp>` | `cilium-over-ebdde6c1-132228`

Adding 7 additional characters at the end of the clusterName resulted in having to change the unique cluster names due to the max character limit being 80. Generally the max length for a cluster name should be 14 characters as 32 characters are reserved by the commit hash + timestamp and prefix/suffix can be up to 18 characters (based on region selection).

ex. `MC_ciliovercnie2e-67b2ede2-132124_ciliovercnie2e-67b2ede2-132124_centraluseuap` 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
