### PR TITLE
feat: Using the Node IP as the Primary IP if the feature flag is enabled for the same

### DIFF
--- a/cns/configuration/cns_config.json
+++ b/cns/configuration/cns_config.json
@@ -33,5 +33,8 @@
     "AZRSettings": {
         "EnableAZR": false,
         "PopulateHomeAzCacheRetryIntervalSecs": 60
+    },
+    "FeatureFlagSettings": {
+        "UseNodeIPAsNCPrimaryIP": false
     }
 }

--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -48,6 +48,7 @@ type CNSConfig struct {
 	WatchPods                   bool
 	EnableAsyncPodDelete        bool
 	AsyncPodDeletePath          string
+	FeatureFlagSettings         FeatureFlagSettings
 }
 
 type TelemetrySettings struct {
@@ -82,6 +83,12 @@ type ManagedSettings struct {
 	InfrastructureNetworkID   string
 	NodeID                    string
 	NodeSyncIntervalInSeconds int
+}
+
+type FeatureFlagSettings struct {
+	// This flag will be used to enable/disable the feature of using node IP as NC primary IP.
+	// This feature is disabled by default. When enabled, DNC will use node IP as NC primary IP instead of one of the IPs from the secondary IP pool.
+	UseNodeIPAsNCPrimaryIP bool
 }
 
 type AZRSettings struct {

--- a/cns/configuration/testdata/good.json
+++ b/cns/configuration/testdata/good.json
@@ -34,5 +34,8 @@
     "AZRSettings": {
         "EnableAZR": true,
         "PopulateHomeAzCacheRetryIntervalSecs": 60
+    },
+    "FeatureFlagSettings": {
+        "UseNodeIPAsNCPrimaryIP": false
     }
 }

--- a/cns/kubecontroller/nodenetworkconfig/conversion.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion.go
@@ -73,7 +73,7 @@ func CreateNCRequestFromDynamicNC(nc v1alpha.NetworkContainer) (*cns.CreateNetwo
 // CreateNCRequestFromStaticNC generates a CreateNetworkContainerRequest from a static NetworkContainer.
 //
 //nolint:gocritic //ignore hugeparam
-func CreateNCRequestFromStaticNC(nc v1alpha.NetworkContainer) (*cns.CreateNetworkContainerRequest, error) {
+func CreateNCRequestFromStaticNC(nc v1alpha.NetworkContainer, useNodeIPAsNCPrimaryIP bool) (*cns.CreateNetworkContainerRequest, error) {
 	if nc.Type == v1alpha.Overlay {
 		nc.Version = 0 // fix for NMA always giving us version 0 for Overlay NCs
 	}
@@ -92,7 +92,7 @@ func CreateNCRequestFromStaticNC(nc v1alpha.NetworkContainer) (*cns.CreateNetwor
 		PrefixLength: uint8(subnetPrefix.Bits()),
 	}
 
-	req, err := createNCRequestFromStaticNCHelper(nc, primaryPrefix, subnet)
+	req, err := createNCRequestFromStaticNCHelper(nc, primaryPrefix, subnet, useNodeIPAsNCPrimaryIP)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error while creating NC request from static NC")
 	}

--- a/cns/kubecontroller/nodenetworkconfig/conversion_linux.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_linux.go
@@ -13,7 +13,7 @@ import (
 // by adding all IPs in the the block to the secondary IP configs list. It does not skip any IPs.
 //
 //nolint:gocritic //ignore hugeparam
-func createNCRequestFromStaticNCHelper(nc v1alpha.NetworkContainer, primaryIPPrefix netip.Prefix, subnet cns.IPSubnet) (*cns.CreateNetworkContainerRequest, error) {
+func createNCRequestFromStaticNCHelper(nc v1alpha.NetworkContainer, primaryIPPrefix netip.Prefix, subnet cns.IPSubnet, useNodeIPAsNCPrimaryIP bool) (*cns.CreateNetworkContainerRequest, error) {
 	secondaryIPConfigs := map[string]cns.SecondaryIPConfig{}
 
 	// iterate through all IP addresses in the subnet described by primaryPrefix and
@@ -42,8 +42,10 @@ func createNCRequestFromStaticNCHelper(nc v1alpha.NetworkContainer, primaryIPPre
 				}
 			}
 		}
-		// Change the primary IP to the Node IP
-		subnet.IPAddress = nc.NodeIP
+		// Change the primary IP to the Node IP if feature flag is set
+		if useNodeIPAsNCPrimaryIP {
+			subnet.IPAddress = nc.NodeIP
+		}
 	}
 
 	return &cns.CreateNetworkContainerRequest{

--- a/cns/kubecontroller/nodenetworkconfig/conversion_linux_test.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_linux_test.go
@@ -42,7 +42,7 @@ var validVNETBlockRequest = &cns.CreateNetworkContainerRequest{
 		GatewayIPAddress: vnetBlockDefaultGateway,
 		IPSubnet: cns.IPSubnet{
 			PrefixLength: uint8(vnetBlockSubnetPrefixLen),
-			IPAddress:    vnetBlockPrimaryIP,
+			IPAddress:    vnetBlockNodeIP,
 		},
 	},
 	NetworkContainerid:   ncID,

--- a/cns/kubecontroller/nodenetworkconfig/conversion_linux_test.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_linux_test.go
@@ -42,6 +42,66 @@ var validVNETBlockRequest = &cns.CreateNetworkContainerRequest{
 		GatewayIPAddress: vnetBlockDefaultGateway,
 		IPSubnet: cns.IPSubnet{
 			PrefixLength: uint8(vnetBlockSubnetPrefixLen),
+			IPAddress:    vnetBlockPrimaryIP,
+		},
+	},
+	NetworkContainerid:   ncID,
+	NetworkContainerType: cns.Docker,
+	// Ignore first IP in first CIDR Block, i.e. 10.224.0.4
+	SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+		"10.224.0.5": {
+			IPAddress: "10.224.0.5",
+			NCVersion: version,
+		},
+		"10.224.0.6": {
+			IPAddress: "10.224.0.6",
+			NCVersion: version,
+		},
+		"10.224.0.7": {
+			IPAddress: "10.224.0.7",
+			NCVersion: version,
+		},
+		"10.224.0.8": {
+			IPAddress: "10.224.0.8",
+			NCVersion: version,
+		},
+		"10.224.0.9": {
+			IPAddress: "10.224.0.9",
+			NCVersion: version,
+		},
+		"10.224.0.10": {
+			IPAddress: "10.224.0.10",
+			NCVersion: version,
+		},
+		"10.224.0.11": {
+			IPAddress: "10.224.0.11",
+			NCVersion: version,
+		},
+		"10.224.0.12": {
+			IPAddress: "10.224.0.12",
+			NCVersion: version,
+		},
+		"10.224.0.13": {
+			IPAddress: "10.224.0.13",
+			NCVersion: version,
+		},
+		"10.224.0.14": {
+			IPAddress: "10.224.0.14",
+			NCVersion: version,
+		},
+		"10.224.0.15": {
+			IPAddress: "10.224.0.15",
+			NCVersion: version,
+		},
+	},
+}
+
+var validVNETBlockRequestUsingNodeIP = &cns.CreateNetworkContainerRequest{
+	Version: strconv.FormatInt(version, 10),
+	IPConfiguration: cns.IPConfiguration{
+		GatewayIPAddress: vnetBlockDefaultGateway,
+		IPSubnet: cns.IPSubnet{
+			PrefixLength: uint8(vnetBlockSubnetPrefixLen),
 			IPAddress:    vnetBlockNodeIP,
 		},
 	},

--- a/cns/kubecontroller/nodenetworkconfig/conversion_test.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_test.go
@@ -228,10 +228,11 @@ func TestCreateNCRequestFromDynamicNC(t *testing.T) {
 
 func TestCreateNCRequestFromStaticNC(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   v1alpha.NetworkContainer
-		want    *cns.CreateNetworkContainerRequest
-		wantErr bool
+		name                   string
+		input                  v1alpha.NetworkContainer
+		want                   *cns.CreateNetworkContainerRequest
+		wantErr                bool
+		useNodeIPAsNCPrimaryIP bool
 	}{
 		{
 			name:    "valid overlay",
@@ -302,10 +303,18 @@ func TestCreateNCRequestFromStaticNC(t *testing.T) {
 		},
 		// VNET Block test cases
 		{
-			name:    "valid VNET Block",
-			input:   validVNETBlockNC,
-			wantErr: false,
-			want:    validVNETBlockRequest,
+			name:                   "valid VNET Block without Node IP as Primary IP",
+			input:                  validVNETBlockNC,
+			wantErr:                false,
+			want:                   validVNETBlockRequest,
+			useNodeIPAsNCPrimaryIP: false,
+		},
+		{
+			name:                   "valid VNET Block with Node IP as Primary IP",
+			input:                  validVNETBlockNC,
+			wantErr:                false,
+			want:                   validVNETBlockRequestUsingNodeIP,
+			useNodeIPAsNCPrimaryIP: false,
 		},
 		{
 			name: "PrimaryIP is not CIDR",
@@ -339,7 +348,7 @@ func TestCreateNCRequestFromStaticNC(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := CreateNCRequestFromStaticNC(tt.input)
+			got, err := CreateNCRequestFromStaticNC(tt.input, tt.useNodeIPAsNCPrimaryIP)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/cns/kubecontroller/nodenetworkconfig/reconciler.go
+++ b/cns/kubecontroller/nodenetworkconfig/reconciler.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/configuration"
 	"github.com/Azure/azure-container-networking/cns/logger"
 	"github.com/Azure/azure-container-networking/cns/restserver"
 	cnstypes "github.com/Azure/azure-container-networking/cns/types"
@@ -43,18 +44,22 @@ type Reconciler struct {
 	once               sync.Once
 	started            chan interface{}
 	nodeIP             string
+	featureFlagConfigs configuration.FeatureFlagSettings
 }
 
 // NewReconciler creates a NodeNetworkConfig Reconciler which will get updates from the Kubernetes
 // apiserver for NNC events.
 // Provided nncListeners are passed the NNC after the Reconcile preprocesses it. Note: order matters! The
 // passed Listeners are notified in the order provided.
-func NewReconciler(cnscli cnsClient, ipampoolmonitorcli nodeNetworkConfigListener, nodeIP string) *Reconciler {
+func NewReconciler(cnscli cnsClient, ipampoolmonitorcli nodeNetworkConfigListener, nodeIP string,
+	featureFlags configuration.FeatureFlagSettings,
+) *Reconciler {
 	return &Reconciler{
 		cnscli:             cnscli,
 		ipampoolmonitorcli: ipampoolmonitorcli,
 		started:            make(chan interface{}),
 		nodeIP:             nodeIP,
+		featureFlagConfigs: featureFlags,
 	}
 }
 
@@ -101,7 +106,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		switch nnc.Status.NetworkContainers[i].AssignmentMode { //nolint:exhaustive // skipping dynamic case
 		// For Overlay and Vnet Scale Scenarios
 		case v1alpha.Static:
-			req, err = CreateNCRequestFromStaticNC(nnc.Status.NetworkContainers[i])
+			req, err = CreateNCRequestFromStaticNC(nnc.Status.NetworkContainers[i], r.featureFlagConfigs.UseNodeIPAsNCPrimaryIP)
 		// For Pod Subnet scenario
 		default: // For backward compatibility, default will be treated as Dynamic too.
 			req, err = CreateNCRequestFromDynamicNC(nnc.Status.NetworkContainers[i])

--- a/cns/kubecontroller/nodenetworkconfig/reconciler_test.go
+++ b/cns/kubecontroller/nodenetworkconfig/reconciler_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/configuration"
 	"github.com/Azure/azure-container-networking/cns/logger"
 	cnstypes "github.com/Azure/azure-container-networking/cns/types"
 	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
@@ -184,6 +185,11 @@ func TestReconcile(t *testing.T) {
 			wantCNSClientState: cnsClientState{}, // state should be empty since we should skip this NC
 		},
 	}
+
+	featureFlags := configuration.FeatureFlagSettings{
+		UseNodeIPAsNCPrimaryIP: false,
+	}
+
 	for _, tt := range tests {
 		tt := tt
 		tt.cnsClient.state.reqsByNCID = make(map[string]*cns.CreateNetworkContainerRequest)
@@ -192,7 +198,7 @@ func TestReconcile(t *testing.T) {
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
-			r := NewReconciler(&tt.cnsClient, &tt.cnsClient, tt.nodeIP)
+			r := NewReconciler(&tt.cnsClient, &tt.cnsClient, tt.nodeIP, featureFlags)
 			r.nnccli = &tt.ncGetter
 			got, err := r.Reconcile(context.Background(), tt.in)
 			if tt.wantErr {
@@ -249,7 +255,11 @@ func TestReconcileStaleNCs(t *testing.T) {
 		return &nncLog[len(nncLog)-1], nil
 	}
 
-	r := NewReconciler(&cnsClient, &cnsClient, nodeIP)
+	featureFlags := configuration.FeatureFlagSettings{
+		UseNodeIPAsNCPrimaryIP: false,
+	}
+
+	r := NewReconciler(&cnsClient, &cnsClient, nodeIP, featureFlags)
 	r.nnccli = &mockNCGetter{get: nncIterator}
 
 	_, err := r.Reconcile(context.Background(), reconcile.Request{})

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1056,7 +1056,9 @@ type ipamStateReconciler interface {
 
 // TODO(rbtr) where should this live??
 // reconcileInitialCNSState initializes cns by passing pods and a CreateNetworkContainerRequest
-func reconcileInitialCNSState(ctx context.Context, cli nodeNetworkConfigGetter, ipamReconciler ipamStateReconciler, podInfoByIPProvider cns.PodInfoByIPProvider, cnsconfig *configuration.CNSConfig) error {
+func reconcileInitialCNSState(ctx context.Context, cli nodeNetworkConfigGetter, ipamReconciler ipamStateReconciler, podInfoByIPProvider cns.PodInfoByIPProvider,
+	cnsconfig *configuration.CNSConfig,
+) error {
 	// Get nnc using direct client
 	nnc, err := cli.Get(ctx)
 	if err != nil {


### PR DESCRIPTION
**Reason for Change**:
Updates to CNS to program the Node IP as the Primary IP instead of one of the IPs from the secondary allocations for SNAT if the feature flag is enabled.

**Issue Fixed**:
This update was needed as we were wasting half the subnet for OpenAI to simply provision one primary IP per node as in the Vnet Scale mode we are wasting one CIDR block for Primary IP when the no. of pods is a multiple of 16


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
