### PR TITLE
fix: disable v4overlay scale tests while we investigate the flakiness

### DIFF
--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-step-template.yaml
@@ -143,40 +143,40 @@ steps:
     displayName: "Cleanup artifact dir"
     condition: always()
 
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
-      scriptLocation: "inlineScript"
-      scriptType: "bash"
-      addSpnToEnvironment: true
-      inlineScript: |
-        set -e
-        make -C ./hack/aks windows-nodepool-up AZCLI=az SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }}
-        echo "Windows node are successfully added to v4 Overlay Cluster"
-        kubectl cluster-info
-        kubectl get node -owide
-        kubectl get po -owide -A
-    name: "Add_Windows_Node"
-    displayName: "Add windows node on v4 overlay cluster"
+  # - task: AzureCLI@2
+  #   inputs:
+  #     azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+  #     scriptLocation: "inlineScript"
+  #     scriptType: "bash"
+  #     addSpnToEnvironment: true
+  #     inlineScript: |
+  #       set -e
+  #       make -C ./hack/aks windows-nodepool-up AZCLI=az SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }}
+  #       echo "Windows node are successfully added to v4 Overlay Cluster"
+  #       kubectl cluster-info
+  #       kubectl get node -owide
+  #       kubectl get po -owide -A
+  #   name: "Add_Windows_Node"
+  #   displayName: "Add windows node on v4 overlay cluster"
 
-  - script: |
-      nodeList=`kubectl get node -owide | grep Windows | awk '{print $1}'`
-      for node in $nodeList; do
-          taint=`kubectl describe node $node | grep Taints | awk '{print $2}'`
-          if [ $taint == "node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule" ]; then
-              kubectl taint nodes $node node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule-
-          fi
-      done
-      CNS=$(make cns-version)
-      sudo -E env "PATH=$PATH" make test-load SCALE_UP=32 OS_TYPE=windows CNI_TYPE=cniv2 VALIDATE_STATEFILE=true INSTALL_CNS=true INSTALL_AZURE_CNI_OVERLAY=true VALIDATE_V4OVERLAY=true CNS_VERSION=${CNS} CNI_DROPGZ_VERSION=$(dropgzVersion) TEST_DROPGZ=${{ parameters.testDropgz }} CLEANUP=true
-    name: "WindowsOverlayControlPlaneScaleTests"
-    displayName: "Windows v4Overlay ControlPlane Scale Tests"
-    retryCountOnTaskFailure: 3
+  # - script: |
+  #     nodeList=`kubectl get node -owide | grep Windows | awk '{print $1}'`
+  #     for node in $nodeList; do
+  #         taint=`kubectl describe node $node | grep Taints | awk '{print $2}'`
+  #         if [ $taint == "node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule" ]; then
+  #             kubectl taint nodes $node node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule-
+  #         fi
+  #     done
+  #     CNS=$(make cns-version)
+  #     sudo -E env "PATH=$PATH" make test-load SCALE_UP=32 OS_TYPE=windows CNI_TYPE=cniv2 VALIDATE_STATEFILE=true INSTALL_CNS=true INSTALL_AZURE_CNI_OVERLAY=true VALIDATE_V4OVERLAY=true CNS_VERSION=${CNS} CNI_DROPGZ_VERSION=$(dropgzVersion) TEST_DROPGZ=${{ parameters.testDropgz }} CLEANUP=true
+  #   name: "WindowsOverlayControlPlaneScaleTests"
+  #   displayName: "Windows v4Overlay ControlPlane Scale Tests"
+  #   retryCountOnTaskFailure: 3
 
-  - script: |
-      echo "IPv4 Overlay DataPath Test"
-      cd test/integration/datapath
-      sudo -E env "PATH=$PATH" go test -count=1 datapath_windows_test.go -timeout 3m -tags connection -restartKubeproxy true -run ^TestDatapathWin$
-    name: "WindowsV4OverlayDatapathTests"
-    displayName: "Windows v4Overlay Datapath Tests"
-    retryCountOnTaskFailure: 3
+  # - script: |
+  #     echo "IPv4 Overlay DataPath Test"
+  #     cd test/integration/datapath
+  #     sudo -E env "PATH=$PATH" go test -count=1 datapath_windows_test.go -timeout 3m -tags connection -restartKubeproxy true -run ^TestDatapathWin$
+  #   name: "WindowsV4OverlayDatapathTests"
+  #   displayName: "Windows v4Overlay Datapath Tests"
+  #   retryCountOnTaskFailure: 3

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-step-template.yaml
@@ -123,40 +123,40 @@ steps:
     displayName: "Restart CNS and Validate Pod State"
     retryCountOnTaskFailure: 3
 
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
-      scriptLocation: "inlineScript"
-      scriptType: "bash"
-      addSpnToEnvironment: true
-      inlineScript: |
-        set -e
-        make -C ./hack/aks windows-nodepool-up AZCLI=az SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }}
-        echo "Windows nodes have been successfully added to DualStack Overlay Cluster"
-        kubectl cluster-info
-        kubectl get node -owide
-        kubectl get po -owide -A
-    name: "Add_Windows_Node"
-    displayName: "Add windows node"
+  # - task: AzureCLI@2
+  #   inputs:
+  #     azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+  #     scriptLocation: "inlineScript"
+  #     scriptType: "bash"
+  #     addSpnToEnvironment: true
+  #     inlineScript: |
+  #       set -e
+  #       make -C ./hack/aks windows-nodepool-up AZCLI=az SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }}
+  #       echo "Windows nodes have been successfully added to DualStack Overlay Cluster"
+  #       kubectl cluster-info
+  #       kubectl get node -owide
+  #       kubectl get po -owide -A
+  #   name: "Add_Windows_Node"
+  #   displayName: "Add windows node"
 
-  - script: |
-      nodeList=`kubectl get node -owide | grep Windows | awk '{print $1}'`
-      for node in $nodeList; do
-          taint=`kubectl describe node $node | grep Taints | awk '{print $2}'`
-          if [ $taint == "node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule" ]; then
-              kubectl taint nodes $node node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule-
-          fi
-      done
-      CNS=$(make cns-version)
-      sudo -E env "PATH=$PATH" make test-load SCALE_UP=32 OS_TYPE=windows CNI_TYPE=cniv2 VALIDATE_STATEFILE=true INSTALL_CNS=true INSTALL_DUALSTACK_OVERLAY=true VALIDATE_DUALSTACK=true CNS_VERSION=${CNS} CNI_DROPGZ_VERSION=$(dropgzVersion) TEST_DROPGZ=${{ parameters.testDropgz }} CLEANUP=true
-    name: "WindowsDualStackOverlayControlPlaneScaleTests"
-    displayName: "Windows DualStack Overlay ControlPlane Scale Tests"
-    retryCountOnTaskFailure: 3
+  # - script: |
+  #     nodeList=`kubectl get node -owide | grep Windows | awk '{print $1}'`
+  #     for node in $nodeList; do
+  #         taint=`kubectl describe node $node | grep Taints | awk '{print $2}'`
+  #         if [ $taint == "node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule" ]; then
+  #             kubectl taint nodes $node node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule-
+  #         fi
+  #     done
+  #     CNS=$(make cns-version)
+  #     sudo -E env "PATH=$PATH" make test-load SCALE_UP=32 OS_TYPE=windows CNI_TYPE=cniv2 VALIDATE_STATEFILE=true INSTALL_CNS=true INSTALL_DUALSTACK_OVERLAY=true VALIDATE_DUALSTACK=true CNS_VERSION=${CNS} CNI_DROPGZ_VERSION=$(dropgzVersion) TEST_DROPGZ=${{ parameters.testDropgz }} CLEANUP=true
+  #   name: "WindowsDualStackOverlayControlPlaneScaleTests"
+  #   displayName: "Windows DualStack Overlay ControlPlane Scale Tests"
+  #   retryCountOnTaskFailure: 3
 
-  - script: |
-      echo "DualStack Overlay DataPath Test"
-      cd test/integration/datapath
-      sudo -E env "PATH=$PATH" go test -count=1 datapath_windows_test.go -timeout 3m -tags connection -restartKubeproxy true -run ^TestDatapathWin$
-    name: "WindowsDualStackOverlayDatapathTests"
-    displayName: "Windows DaulStack Overlay Datapath Tests"
-    retryCountOnTaskFailure: 3
+  # - script: |
+  #     echo "DualStack Overlay DataPath Test"
+  #     cd test/integration/datapath
+  #     sudo -E env "PATH=$PATH" go test -count=1 datapath_windows_test.go -timeout 3m -tags connection -restartKubeproxy true -run ^TestDatapathWin$
+  #   name: "WindowsDualStackOverlayDatapathTests"
+  #   displayName: "Windows DaulStack Overlay Datapath Tests"
+  #   retryCountOnTaskFailure: 3


### PR DESCRIPTION
While we investigate the flakiness of the v4 overlay windows tests, disable them to unblock others