### PR TITLE
ci: Move E2E runtime variables from job level to stage

### DIFF
--- a/.pipelines/singletenancy/aks-swift/e2e-job-template.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e-job-template.yaml
@@ -40,6 +40,9 @@ stages:
       TAG: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.Tag'] ]
       CURRENT_VERSION: $[ stagedependencies.containerize.check_tag.outputs['CurrentTagManifests.currentTagManifests'] ]
       commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
+      GOPATH: "$(Agent.TempDirectory)/go" # Go workspace path
+      GOBIN: "$(GOPATH)/bin" # Go binaries path
+      modulePath: "$(GOPATH)/src/github.com/Azure/azure-container-networking"
     condition: and(succeeded(), eq(variables.TAG, variables.CURRENT_VERSION))
     pool:
       name: $(BUILD_POOL_NAME_DEFAULT)
@@ -52,10 +55,6 @@ stages:
           demands:
           - agent.os -equals Linux
           - Role -equals $(CUSTOM_E2E_ROLE)
-        variables:
-          GOPATH: "$(Agent.TempDirectory)/go" # Go workspace path
-          GOBIN: "$(GOPATH)/bin" # Go binaries path
-          modulePath: "$(GOPATH)/src/github.com/Azure/azure-container-networking"
         steps:
           - template: e2e-step-template.yaml
             parameters:

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
@@ -38,6 +38,9 @@ stages:
     - ${{ parameters.clusterName }}
     variables:
       commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
+      GOPATH: "$(Agent.TempDirectory)/go" # Go workspace path
+      GOBIN: "$(GOPATH)/bin" # Go binaries path
+      modulePath: "$(GOPATH)/src/github.com/Azure/azure-container-networking"
     pool:
       name: $(BUILD_POOL_NAME_DEFAULT)
     jobs:
@@ -49,10 +52,6 @@ stages:
           demands:
           - agent.os -equals Linux
           - Role -equals $(CUSTOM_E2E_ROLE)
-        variables:
-          GOPATH: "$(Agent.TempDirectory)/go" # Go workspace path
-          GOBIN: "$(GOPATH)/bin" # Go binaries path
-          modulePath: "$(GOPATH)/src/github.com/Azure/azure-container-networking"
         steps:
           - template: azure-cni-overlay-e2e-step-template.yaml
             parameters:

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-job-template.yaml
@@ -36,6 +36,11 @@ stages:
     - setup
     - publish
     - ${{ parameters.clusterName }}
+    variables:
+      commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
+      GOPATH: "$(Agent.TempDirectory)/go" # Go workspace path
+      GOBIN: "$(GOPATH)/bin" # Go binaries path
+      modulePath: "$(GOPATH)/src/github.com/Azure/azure-container-networking"
     pool:
       name: $(BUILD_POOL_NAME_DEFAULT)
     jobs:
@@ -47,11 +52,6 @@ stages:
           demands:
           - agent.os -equals Linux
           - Role -equals $(CUSTOM_E2E_ROLE)
-        variables:
-          GOPATH: "$(Agent.TempDirectory)/go" # Go workspace path
-          GOBIN: "$(GOPATH)/bin" # Go binaries path
-          modulePath: "$(GOPATH)/src/github.com/Azure/azure-container-networking"
-          commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
         steps:
           - template: cilium-overlay-e2e-step-template.yaml
             parameters:

--- a/.pipelines/singletenancy/cilium/cilium-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-job-template.yaml
@@ -40,6 +40,9 @@ stages:
       TAG: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.Tag'] ]
       CURRENT_VERSION: $[ stagedependencies.containerize.check_tag.outputs['CurrentTagManifests.currentTagManifests'] ]
       commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
+      GOPATH: "$(Agent.TempDirectory)/go" # Go workspace path
+      GOBIN: "$(GOPATH)/bin" # Go binaries path
+      modulePath: "$(GOPATH)/src/github.com/Azure/azure-container-networking"
     condition: and(succeeded(), eq(variables.TAG, variables.CURRENT_VERSION))
     pool:
       name: $(BUILD_POOL_NAME_DEFAULT)
@@ -52,10 +55,6 @@ stages:
           demands:
           - agent.os -equals Linux
           - Role -equals $(CUSTOM_E2E_ROLE)
-        variables:
-          GOPATH: "$(Agent.TempDirectory)/go" # Go workspace path
-          GOBIN: "$(GOPATH)/bin" # Go binaries path
-          modulePath: "$(GOPATH)/src/github.com/Azure/azure-container-networking"
         steps:
           - template: cilium-e2e-step-template.yaml
             parameters:


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
E2E did not have consistent assigning of variables. This led to a bug that affected cilium overlay E2E logging because the commitID variable was never passed to the failure logs. This was not showing as a passed run would skip the logging job. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
