### PR TITLE
chore: wait for deployment to completely delete before proceeding

### DIFF
--- a/test/internal/kubernetes/utils.go
+++ b/test/internal/kubernetes/utils.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Azure/azure-container-networking/test/internal/retry"
 	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -33,8 +34,9 @@ const (
 	SubnetNameLabel        = "kubernetes.azure.com/podnetwork-subnet"
 
 	// RetryAttempts is the number of times to retry a test.
-	RetryAttempts = 90
-	RetryDelay    = 10 * time.Second
+	RetryAttempts       = 90
+	DeleteRetryAttempts = 6
+	RetryDelay          = 10 * time.Second
 )
 
 var Kubeconfig = flag.String("test-kubeconfig", filepath.Join(homedir.HomeDir(), ".kube", "config"), "(optional) absolute path to the kubeconfig file")
@@ -245,6 +247,19 @@ func WaitForPodDeployment(ctx context.Context, clientset *kubernetes.Clientset, 
 
 	retrier := retry.Retrier{Attempts: RetryAttempts, Delay: RetryDelay}
 	return errors.Wrapf(retrier.Do(ctx, checkPodDeploymentFn), "could not wait for deployment %s", deploymentName)
+}
+
+func WaitForDeploymentToDelete(ctx context.Context, deploymentsClient typedappsv1.DeploymentInterface, d appsv1.Deployment) error {
+	assertDeploymentNotFound := func() error {
+		_, err := deploymentsClient.Get(ctx, d.Name, metav1.GetOptions{})
+		// only if the error is "isNotFound", do we say, the deployment is deleted
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.New(fmt.Sprintf("expected isNotFound error when getting deployment, but got %+v", err))
+	}
+	retrier := retry.Retrier{Attempts: DeleteRetryAttempts, Delay: RetryDelay}
+	return errors.Wrapf(retrier.Do(ctx, assertDeploymentNotFound), "could not assert deployment %s isNotFound", d.Name)
 }
 
 func WaitForPodDaemonset(ctx context.Context, clientset *kubernetes.Clientset, namespace, daemonsetName, podLabelSelector string) error {

--- a/test/internal/kubernetes/utils.go
+++ b/test/internal/kubernetes/utils.go
@@ -35,8 +35,9 @@ const (
 
 	// RetryAttempts is the number of times to retry a test.
 	RetryAttempts       = 90
-	DeleteRetryAttempts = 6
 	RetryDelay          = 10 * time.Second
+	DeleteRetryAttempts = 12
+	DeleteRetryDelay    = 5 * time.Second
 )
 
 var Kubeconfig = flag.String("test-kubeconfig", filepath.Join(homedir.HomeDir(), ".kube", "config"), "(optional) absolute path to the kubeconfig file")
@@ -256,7 +257,7 @@ func WaitForDeploymentToDelete(ctx context.Context, deploymentsClient typedappsv
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
-		return errors.New(fmt.Sprintf("expected isNotFound error when getting deployment, but got %+v", err))
+		return errors.Errorf(fmt.Sprintf("expected isNotFound error when getting deployment, but got %+v", err))
 	}
 	retrier := retry.Retrier{Attempts: DeleteRetryAttempts, Delay: RetryDelay}
 	return errors.Wrapf(retrier.Do(ctx, assertDeploymentNotFound), "could not assert deployment %s isNotFound", d.Name)

--- a/test/internal/kubernetes/utils.go
+++ b/test/internal/kubernetes/utils.go
@@ -259,7 +259,7 @@ func WaitForDeploymentToDelete(ctx context.Context, deploymentsClient typedappsv
 		}
 		return errors.Errorf(fmt.Sprintf("expected isNotFound error when getting deployment, but got %+v", err))
 	}
-	retrier := retry.Retrier{Attempts: DeleteRetryAttempts, Delay: RetryDelay}
+	retrier := retry.Retrier{Attempts: DeleteRetryAttempts, Delay: DeleteRetryDelay}
 	return errors.Wrapf(retrier.Do(ctx, assertDeploymentNotFound), "could not assert deployment %s isNotFound", d.Name)
 }
 

--- a/test/internal/kubernetes/utils_delete.go
+++ b/test/internal/kubernetes/utils_delete.go
@@ -35,6 +35,9 @@ func MustDeleteDeployment(ctx context.Context, deployments typedappsv1.Deploymen
 			panic(errors.Wrap(err, "failed to delete deployment"))
 		}
 	}
+	if err := WaitForDeploymentToDelete(ctx, deployments, d); err != nil {
+		panic(errors.Wrap(err, "failed to wait for deployment to delete"))
+	}
 }
 
 func MustDeleteNamespace(ctx context.Context, clienset *kubernetes.Clientset, namespace string) {


### PR DESCRIPTION
The windows overlay tests kept hitting:
```
--- FAIL: TestScaleDeployment (0.30s)
    load_test.go:141: Scale deployment
panic: could not update deployment win-load-test: Operation cannot be fulfilled on deployments.apps "win-load-test": the object has been modified; please apply your changes to the latest version and try again [recovered]
	panic: could not update deployment win-load-test: Operation cannot be fulfilled on deployments.apps "win-load-test": the object has been modified; please apply your changes to the latest version and try again
```

This was most likely because the deployment was not being completely deleted, before each test run
Now we wait for the deployment to be deleted before proceeding