### PR TITLE
fix: Add SubnetGUID to MT PodNetwork CRD

### DIFF
--- a/crd/multitenancy/api/v1alpha1/podnetwork.go
+++ b/crd/multitenancy/api/v1alpha1/podnetwork.go
@@ -17,7 +17,8 @@ import (
 // +kubebuilder:printcolumn:name="Status",type=string,priority=1,JSONPath=`.status.status`
 // +kubebuilder:printcolumn:name="Address Prefixes",type=string,priority=1,JSONPath=`.status.addressPrefixes`
 // +kubebuilder:printcolumn:name="Network",type=string,priority=1,JSONPath=`.spec.vnetGUID`
-// +kubebuilder:printcolumn:name="Subnet",type=string,priority=1,JSONPath=`.spec.subnetGUID`
+// +kubebuilder:printcolumn:name="Subnet",type=string,priority=1,JSONPath=`.spec.subnetResourceID`
+// +kubebuilder:printcolumn:name="SubnetGUID",type=string,priority=1,JSONPath=`.spec.subnetGUID`
 type PodNetwork struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -40,6 +41,8 @@ type PodNetworkSpec struct {
 	// +kubebuilder:validation:Optional
 	// customer vnet guid
 	VnetGUID string `json:"vnetGUID,omitempty"`
+	// customer subnet id
+	SubnetResourceID string `json:"subnetResourceID,omitempty"`
 	// customer subnet guid
 	SubnetGUID string `json:"subnetGUID,omitempty"`
 }

--- a/crd/multitenancy/api/v1alpha1/podnetwork.go
+++ b/crd/multitenancy/api/v1alpha1/podnetwork.go
@@ -17,7 +17,7 @@ import (
 // +kubebuilder:printcolumn:name="Status",type=string,priority=1,JSONPath=`.status.status`
 // +kubebuilder:printcolumn:name="Address Prefixes",type=string,priority=1,JSONPath=`.status.addressPrefixes`
 // +kubebuilder:printcolumn:name="Network",type=string,priority=1,JSONPath=`.spec.vnetGUID`
-// +kubebuilder:printcolumn:name="Subnet",type=string,priority=1,JSONPath=`.spec.subnetResourceID`
+// +kubebuilder:printcolumn:name="Subnet",type=string,priority=1,JSONPath=`.spec.subnetGUID`
 type PodNetwork struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -40,8 +40,8 @@ type PodNetworkSpec struct {
 	// +kubebuilder:validation:Optional
 	// customer vnet guid
 	VnetGUID string `json:"vnetGUID,omitempty"`
-	// customer subnet id
-	SubnetResourceID string `json:"subnetResourceID,omitempty"`
+	// customer subnet guid
+	SubnetGUID string `json:"subnetGUID,omitempty"`
 }
 
 // Status indicates the status of PN

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_podnetworks.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_podnetworks.yaml
@@ -57,11 +57,11 @@ spec:
           spec:
             description: PodNetworkSpec defines the desired state of PodNetwork
             properties:
-              subnetResourceID:
-                description: customer subnet id
-                type: string
               subnetGUID:
                 description: customer subnet guid
+                type: string
+              subnetResourceID:
+                description: customer subnet id
                 type: string
               vnetGUID:
                 description: customer vnet guid

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_podnetworks.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_podnetworks.yaml
@@ -29,8 +29,12 @@ spec:
       name: Network
       priority: 1
       type: string
-    - jsonPath: .spec.subnetGUID
+    - jsonPath: .spec.subnetResourceID
       name: Subnet
+      priority: 1
+      type: string
+    - jsonPath: .spec.subnetGUID
+      name: SubnetGUID
       priority: 1
       type: string
     name: v1alpha1
@@ -53,6 +57,9 @@ spec:
           spec:
             description: PodNetworkSpec defines the desired state of PodNetwork
             properties:
+              subnetResourceID:
+                description: customer subnet id
+                type: string
               subnetGUID:
                 description: customer subnet guid
                 type: string

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_podnetworks.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_podnetworks.yaml
@@ -29,7 +29,7 @@ spec:
       name: Network
       priority: 1
       type: string
-    - jsonPath: .spec.subnetResourceID
+    - jsonPath: .spec.subnetGUID
       name: Subnet
       priority: 1
       type: string
@@ -53,8 +53,8 @@ spec:
           spec:
             description: PodNetworkSpec defines the desired state of PodNetwork
             properties:
-              subnetResourceID:
-                description: customer subnet id
+              subnetGUID:
+                description: customer subnet guid
                 type: string
               vnetGUID:
                 description: customer vnet guid


### PR DESCRIPTION
**Reason for Change**:
Multi-tenancy orchestrator needs to submit Azure Subnet ResourceGUID to PN CRD, in addition to ARM Resource ID.

**Issue Fixed**:

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
