### PR TITLE
feat: build cni installer image with cni builds

### DIFF
--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -159,6 +159,20 @@ stages:
           name: "$(BUILD_POOL_NAME_LINUX_AMD64)"
         strategy:
           matrix:
+            cni_linux_amd64:
+              arch: amd64
+              name: cni
+              os: linux
+            cni_windows2019_amd64:
+              arch: amd64
+              name: cni
+              os: windows
+              os_version: ltsc2019
+            cni_windows2022_amd64:
+              arch: amd64
+              name: cni
+              os: windows
+              os_version: ltsc2022
             cni_dropgz_linux_amd64:
               arch: amd64
               name: cni-dropgz
@@ -225,6 +239,10 @@ stages:
           name: "$(BUILD_POOL_NAME_LINUX_ARM64)"
         strategy:
           matrix:
+            cni_linux_arm64:
+              arch: arm64
+              name: cni
+              os: linux
             cni_dropgz_linux_arm64:
               arch: arm64
               name: cni-dropgz
@@ -294,6 +312,10 @@ stages:
           name: "$(BUILD_POOL_NAME_DEFAULT)"
         strategy:
           matrix:
+            cni:
+              name: cni
+              os_versions: ltsc2019 ltsc2022
+              platforms: linux/amd64 linux/arm64 windows/amd64
             cni_dropgz:
               name: cni-dropgz
               os_versions: ltsc2019 ltsc2022

--- a/Makefile
+++ b/Makefile
@@ -32,16 +32,16 @@ EXE_EXT 	= .exe
 endif
 
 # Interrogate the git repo and set some variables
-REPO_ROOT 		   		 = $(shell git rev-parse --show-toplevel)
-REVISION 		   		?= $(shell git rev-parse --short HEAD)
-ACN_VERSION  	   		?= $(shell git describe --exclude "azure-ipam*" --exclude "dropgz*" --exclude "zapai*" --tags --always)
-AZURE_IPAM_VERSION 		?= $(notdir $(shell git describe --match "azure-ipam*" --tags --always))
-CNI_VERSION        		?= $(ACN_VERSION)
-CNI_DROPGZ_VERSION 		?= $(notdir $(shell git describe --match "dropgz*" --tags --always))
-CNI_DROPGZ_TEST_VERSION ?= $(notdir $(shell git describe --match "dropgz-test*" --tags --always))
-CNS_VERSION  	   		?= $(ACN_VERSION)
-NPM_VERSION        		?= $(ACN_VERSION)
-ZAPAI_VERSION  	   		?= $(notdir $(shell git describe --match "zapai*" --tags --always))
+REPO_ROOT				 = $(shell git rev-parse --show-toplevel)
+REVISION				?= $(shell git rev-parse --short HEAD)
+ACN_VERSION				?= $(shell git describe --exclude "azure-ipam*" --exclude "dropgz*" --exclude "zapai*" --tags --always)
+AZURE_IPAM_VERSION		?= $(notdir $(shell git describe --match "azure-ipam*" --tags --always))
+CNI_VERSION				?= $(ACN_VERSION)
+CNI_DROPGZ_VERSION		?= $(notdir $(shell git describe --match "dropgz*" --tags --always))
+CNI_DROPGZ_TEST_VERSION	?= $(notdir $(shell git describe --match "dropgz-test*" --tags --always))
+CNS_VERSION				?= $(ACN_VERSION)
+NPM_VERSION				?= $(ACN_VERSION)
+ZAPAI_VERSION			?= $(notdir $(shell git describe --match "zapai*" --tags --always))
 
 # Build directories.
 AZURE_IPAM_DIR = $(REPO_ROOT)/azure-ipam
@@ -102,9 +102,10 @@ NPM_ARCHIVE_NAME = azure-npm-$(GOOS)-$(GOARCH)-$(NPM_VERSION).$(ARCHIVE_EXT)
 AZURE_IPAM_ARCHIVE_NAME = azure-ipam-$(GOOS)-$(GOARCH)-$(AZURE_IPAM_VERSION).$(ARCHIVE_EXT)
 
 # Image info file names.
-CNI_DROPGZ_IMAGE_INFO_FILE = cni-dropgz-$(CNI_DROPGZ_VERSION).txt
-CNS_IMAGE_INFO_FILE 	   = azure-cns-$(CNS_VERSION).txt
-NPM_IMAGE_INFO_FILE 	   = azure-npm-$(NPM_VERSION).txt
+CNI_IMAGE_INFO_FILE			= azure-cni-$(CNI_VERSION).txt
+CNI_DROPGZ_IMAGE_INFO_FILE	= cni-dropgz-$(CNI_DROPGZ_VERSION).txt
+CNS_IMAGE_INFO_FILE			= azure-cns-$(CNS_VERSION).txt
+NPM_IMAGE_INFO_FILE			= azure-npm-$(NPM_VERSION).txt
 
 # Docker libnetwork (CNM) plugin v2 image parameters.
 CNM_PLUGIN_IMAGE ?= microsoft/azure-vnet-plugin
@@ -246,19 +247,22 @@ CONTAINER_TRANSPORT = docker
 endif
 
 ## Image name definitions.
-ACNCLI_IMAGE     	  = acncli
-CNI_DROPGZ_IMAGE 	  = cni-dropgz
-CNI_DROPGZ_TEST_IMAGE = cni-dropgz-test
-CNS_IMAGE        	  = azure-cns
-NPM_IMAGE        	  = azure-npm
+ACNCLI_IMAGE			= acncli
+CNI_IMAGE				= azure-cni
+CNI_DROPGZ_IMAGE		= cni-dropgz
+CNI_DROPGZ_TEST_IMAGE	= cni-dropgz-test
+CNS_IMAGE				= azure-cns
+NPM_IMAGE				= azure-npm
 
 ## Image platform tags.
-ACNCLI_PLATFORM_TAG    		 ?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(ACN_VERSION)
-CNI_DROPGZ_PLATFORM_TAG 	 ?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(CNI_DROPGZ_VERSION)
-CNI_DROPGZ_TEST_PLATFORM_TAG ?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(CNI_DROPGZ_TEST_VERSION)
-CNS_PLATFORM_TAG        	 ?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(CNS_VERSION)
-CNS_WINDOWS_PLATFORM_TAG 	 ?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(CNS_VERSION)-$(OS_SKU_WIN)
-NPM_PLATFORM_TAG        	 ?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(NPM_VERSION)
+ACNCLI_PLATFORM_TAG				?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(ACN_VERSION)
+CNI_PLATFORM_TAG				?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(CNI_VERSION)
+CNI_WINDOWS_PLATFORM_TAG		?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(CNI_VERSION)-$(OS_SKU_WIN)
+CNI_DROPGZ_PLATFORM_TAG			?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(CNI_DROPGZ_VERSION)
+CNI_DROPGZ_TEST_PLATFORM_TAG	?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(CNI_DROPGZ_TEST_VERSION)
+CNS_PLATFORM_TAG				?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(CNS_VERSION)
+CNS_WINDOWS_PLATFORM_TAG		?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(CNS_VERSION)-$(OS_SKU_WIN)
+NPM_PLATFORM_TAG				?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(NPM_VERSION)
 
 
 qemu-user-static: ## Set up the host to run qemu multiplatform container builds.
@@ -329,6 +333,37 @@ acncli-image-pull: ## pull cni-manager container image.
 	$(MAKE) container-pull \
 		IMAGE=$(ACNCLI_IMAGE) \
 		TAG=$(ACNCLI_PLATFORM_TAG)
+
+
+# cni
+
+cni-image-name: # util target to print the CNI image name.
+	@echo $(CNI_IMAGE)
+
+cni-image-name-and-tag: # util target to print the CNI image name and tag.
+	@echo $(IMAGE_REGISTRY)/$(CNI_IMAGE):$(CNI_PLATFORM_TAG)
+
+cni-image: ## build cni container image.
+	$(MAKE) container \
+		DOCKERFILE=cni/$(OS).Dockerfile \
+		IMAGE=$(CNI_IMAGE) \
+		EXTRA_BUILD_ARGS='--build-arg OS=$(OS) --build-arg ARCH=$(ARCH) --build-arg OS_VERSION=$(OS_VERSION)' \
+		PLATFORM=$(PLATFORM) \
+		TAG=$(CNI_PLATFORM_TAG) \
+		OS=$(OS) \
+		ARCH=$(ARCH) \
+		OS_VERSION=$(OS_VERSION)
+
+cni-image-push: ## push cni container image.
+	$(MAKE) container-push \
+		IMAGE=$(CNI_IMAGE) \
+		TAG=$(CNI_PLATFORM_TAG)
+
+cni-image-pull: ## pull cni container image.
+	$(MAKE) container-pull \
+		IMAGE=$(CNI_IMAGE) \
+		TAG=$(CNI_PLATFORM_TAG)
+
 
 # cni-dropgz
 
@@ -518,6 +553,23 @@ acncli-skopeo-archive: ## export tar archive of acncli multiplat container manif
 	$(MAKE) manifest-skopeo-archive \
 		IMAGE=$(ACNCLI_IMAGE) \
 		TAG=$(ACN_VERSION)
+
+cni-manifest-build: ## build cni multiplat container manifest.
+	$(MAKE) manifest-build \
+		PLATFORMS="$(PLATFORMS)" \
+		IMAGE=$(CNI_IMAGE) \
+		TAG=$(CNI_VERSION) \
+		OS_VERSIONS="$(OS_VERSIONS)"
+
+cni-manifest-push: ## push cni multiplat container manifest
+	$(MAKE) manifest-push \
+		IMAGE=$(CNI_IMAGE) \
+		TAG=$(CNI_VERSION)
+
+cni-skopeo-archive: ## export tar archive of cni multiplat container manifest.
+	$(MAKE) manifest-skopeo-archive \
+		IMAGE=$(CNI_IMAGE) \
+		TAG=$(CNI_VERSION)
 
 cni-dropgz-manifest-build: ## build cni-dropgz multiplat container manifest.
 	$(MAKE) manifest-build \

--- a/cni/linux.Dockerfile
+++ b/cni/linux.Dockerfile
@@ -1,0 +1,38 @@
+ARG ARCH
+ARG DROPGZ_VERSION=v0.0.12
+ARG OS_VERSION
+ARG OS
+
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.21 AS azure-vnet
+ARG OS
+ARG VERSION
+WORKDIR /azure-container-networking
+COPY . .
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/plugin/main.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-telemetry -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/telemetry/service/telemetrymain.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-ipam -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/ipam/plugin/main.go
+
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS compressor
+ARG OS
+WORKDIR /payload
+COPY --from=azure-vnet /go/bin/* /payload
+COPY --from=azure-vnet /azure-container-networking/cni/azure-$OS.conflist /payload/azure.conflist
+COPY --from=azure-vnet /azure-container-networking/cni/azure-$OS-swift.conflist /payload/azure-swift.conflist
+COPY --from=azure-vnet /azure-container-networking/cni/azure-$OS-swift-overlay.conflist /payload/azure-swift-overlay.conflist
+COPY --from=azure-vnet /azure-container-networking/cni/azure-$OS-swift-overlay-dualstack.conflist /payload/azure-swift-overlay-dualstack.conflist
+COPY --from=azure-vnet /azure-container-networking/telemetry/azure-vnet-telemetry.config /payload/azure-vnet-telemetry.config
+RUN cd /payload && sha256sum * > sum.txt
+RUN gzip --verbose --best --recursive /payload && for f in /payload/*.gz; do mv -- "$f" "${f%%.gz}"; done
+
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.21 AS dropgz
+ARG DROPGZ_VERSION
+ARG OS
+ARG VERSION
+RUN go mod download github.com/azure/azure-container-networking/dropgz@$DROPGZ_VERSION
+WORKDIR /go/pkg/mod/github.com/azure/azure-container-networking/dropgz\@$DROPGZ_VERSION
+COPY --from=compressor /payload/* /pkg/embed/fs/
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/dropgz -trimpath -ldflags "-X github.com/Azure/azure-container-networking/dropgz/internal/buildinfo.Version="$VERSION"" -gcflags="-dwarflocationlists=true" main.go
+
+FROM scratch
+COPY --from=dropgz /go/bin/dropgz dropgz
+ENTRYPOINT [ "dropgz" ]

--- a/cni/windows.Dockerfile
+++ b/cni/windows.Dockerfile
@@ -1,0 +1,38 @@
+ARG ARCH
+ARG DROPGZ_VERSION=v0.0.12
+ARG OS
+ARG OS_VERSION
+
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.21 AS azure-vnet
+ARG OS
+ARG VERSION
+WORKDIR /azure-container-networking
+COPY . .
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/plugin/main.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-telemetry -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/telemetry/service/telemetrymain.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-ipam -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/ipam/plugin/main.go
+
+FROM --platform=linux/${ARCH} mcr.microsoft.com/cbl-mariner/base/core:2.0 AS compressor
+ARG OS
+WORKDIR /payload
+COPY --from=azure-vnet /go/bin/* /payload/
+COPY --from=azure-vnet /azure-container-networking/cni/azure-$OS.conflist /payload/azure.conflist
+COPY --from=azure-vnet /azure-container-networking/cni/azure-$OS-swift.conflist /payload/azure-swift.conflist
+COPY --from=azure-vnet /azure-container-networking/cni/azure-$OS-swift-overlay.conflist /payload/azure-swift-overlay.conflist
+COPY --from=azure-vnet /azure-container-networking/cni/azure-$OS-swift-overlay-dualstack.conflist /payload/azure-swift-overlay-dualstack.conflist
+COPY --from=azure-vnet /azure-container-networking/telemetry/azure-vnet-telemetry.config /payload/azure-vnet-telemetry.config
+RUN cd /payload && sha256sum * > sum.txt
+RUN gzip --verbose --best --recursive /payload && for f in /payload/*.gz; do mv -- "$f" "${f%%.gz}"; done
+
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.21 AS dropgz
+ARG DROPGZ_VERSION
+ARG OS
+ARG VERSION
+RUN go mod download github.com/azure/azure-container-networking/dropgz@$DROPGZ_VERSION
+WORKDIR /go/pkg/mod/github.com/azure/azure-container-networking/dropgz\@$DROPGZ_VERSION
+COPY --from=compressor /payload/* /pkg/embed/fs/
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/dropgz -trimpath -ldflags "-X github.com/Azure/azure-container-networking/dropgz/internal/buildinfo.Version="$VERSION"" -gcflags="-dwarflocationlists=true" main.go
+
+FROM mcr.microsoft.com/windows/nanoserver:${OS_VERSION}
+COPY --from=dropgz /go/bin/dropgz dropgz
+ENTRYPOINT [ "dropgz" ]


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Up until now, we have released the CNI installer image as a separately versioned component from the CNI releases themselves. This has created a bit of versioning hell, as we struggle to maintain multiple release trains of the CNI (and thus CNI installer) when the CNI and installer version are not correlated. 

This change flips the CNI installer image builder architecture. Previously, `dropgz` pulled in the released CNI tarballs as dependencies and produced a "dropgz-vX" omnibus image which contained uncorrelated CNI versions.
Here, we migrate instead to a CNI Dockerfile which _imports `dropgz` as the dependency_ and is built in lockstep with (at least) azure-vnet builds, and versioned the same as them. Instead of deploying a "dropgz:v0.0.4" with unknown (at least, non-obvious) CNI payload versions, we produce a "cni-installer:v1.5.11" during the CNI release process with no ambiguity.

This is part 1 of this migration:
- [x] Build CNI installer images
- [ ] Build azure-ipam installer images
- [ ] Set up MCR publishing and syndication on new images
- [ ] Migrate pipelines to new images
- [ ] Migrate downstreams (AKS) to new images
- [ ] Remove existing dropgz image infra (Dockerfiles, pipelines, etc)


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
