### PR TITLE
fix: enable ip forward on transparent vlan network create

### DIFF
--- a/dropgz/build/cniTest_linux.Dockerfile
+++ b/dropgz/build/cniTest_linux.Dockerfile
@@ -20,6 +20,7 @@ COPY --from=azure-ipam /azure-ipam/*.conflist pkg/embed/fs
 COPY --from=azure-ipam /azure-ipam/bin/* pkg/embed/fs
 COPY --from=azure-vnet /azure-container-networking/cni/azure-$OS.conflist pkg/embed/fs/azure.conflist
 COPY --from=azure-vnet /azure-container-networking/cni/azure-$OS-swift.conflist pkg/embed/fs/azure-swift.conflist
+COPY --from=azure-vnet /azure-container-networking/cni/azure-$OS-multitenancy-transparent-vlan.conflist pkg/embed/fs/azure-multitenancy-transparent-vlan.conflist
 COPY --from=azure-vnet /azure-container-networking/cni/azure-$OS-swift-overlay.conflist pkg/embed/fs/azure-swift-overlay.conflist
 COPY --from=azure-vnet /azure-container-networking/cni/azure-$OS-swift-overlay-dualstack.conflist pkg/embed/fs/azure-swift-overlay-dualstack.conflist
 COPY --from=azure-vnet /azure-container-networking/bin/* pkg/embed/fs

--- a/network/network_linux.go
+++ b/network/network_linux.go
@@ -93,6 +93,11 @@ func (nm *networkManager) newNetworkImpl(nwInfo *NetworkInfo, extIf *externalInt
 	case opModeTransparentVlan:
 		logger.Info("Transparent vlan mode")
 		ifName = extIf.Name
+		nu := networkutils.NewNetworkUtils(nm.netlink, nm.plClient)
+		if err := nu.EnableIPV4Forwarding(); err != nil {
+			return nil, fmt.Errorf("Ipv4 forwarding failed: %w", err)
+		}
+		logger.Info("Ipv4 forwarding enabled")
 	default:
 		return nil, errNetworkModeInvalid
 	}

--- a/network/networkutils/networkutils_linux.go
+++ b/network/networkutils/networkutils_linux.go
@@ -222,14 +222,8 @@ func (nu NetworkUtils) EnableIPForwarding(ifName string) error {
 }
 
 func (nu NetworkUtils) EnableIPV4Forwarding() error {
-	cmd := fmt.Sprint(enableIPV4ForwardCmd)
-	_, err := nu.plClient.ExecuteCommand(cmd)
-	if err != nil {
-		logger.Error("Enable ipv4 forwarding failed with", zap.Error(err))
-		return err
-	}
-
-	return nil
+	_, err := nu.plClient.ExecuteCommand(enableIPV4ForwardCmd)
+	return errors.Wrap(err, "enable ipv4 forwarding failed")
 }
 
 func (nu NetworkUtils) EnableIPV6Forwarding() error {

--- a/network/networkutils/networkutils_linux.go
+++ b/network/networkutils/networkutils_linux.go
@@ -34,6 +34,7 @@ const (
 	enableIPForwardCmd   = "sysctl -w net.ipv4.ip_forward=1"
 	toggleIPV6Cmd        = "sysctl -w net.ipv6.conf.all.disable_ipv6=%d"
 	enableIPV6ForwardCmd = "sysctl -w net.ipv6.conf.all.forwarding=1"
+	enableIPV4ForwardCmd = "sysctl -w net.ipv4.conf.all.forwarding=1"
 	disableRACmd         = "sysctl -w net.ipv6.conf.%s.accept_ra=0"
 	acceptRAV6File       = "/proc/sys/net/ipv6/conf/%s/accept_ra"
 )
@@ -214,6 +215,17 @@ func (nu NetworkUtils) EnableIPForwarding(ifName string) error {
 	if err := iptables.AppendIptableRule(iptables.V4, iptables.Filter, iptables.Forward, "", iptables.Accept); err != nil {
 		logger.Error("Appending forward chain rule: allow traffic coming from snatbridge failed with",
 			zap.Error(err))
+		return err
+	}
+
+	return nil
+}
+
+func (nu NetworkUtils) EnableIPV4Forwarding() error {
+	cmd := fmt.Sprint(enableIPV4ForwardCmd)
+	_, err := nu.plClient.ExecuteCommand(cmd)
+	if err != nil {
+		logger.Error("Enable ipv4 forwarding failed with", zap.Error(err))
 		return err
 	}
 

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -308,6 +308,9 @@ func (client *TransparentVlanEndpointClient) PopulateVnet(epInfo *EndpointInfo) 
 	if err != nil {
 		return errors.Wrap(err, "transparent vlan failed to disable rp filter vlan interface in vnet")
 	}
+	if err := client.netUtilsClient.EnableIPV4Forwarding(); err != nil {
+		return errors.Wrap(err, "transparent vlan failed to enable ipv4 forwarding in vnet namespace")
+	}
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

IP forwarding may not be enabled on the vm when transparent vlan endpoint client first starts (for the first time on this new vm). When namespaces are created, they would have ip forwarding disabled, leading to connectivity issues. This change runs a command to enable forwarding in each namespace on creation, as well as on the vm when the network is first created. Enabling IP forwarding on the namespace may be redundant but is useful for testing (can be removed if necessary). Does not use the existing enable ip forwarding function because that function seems to add additional iptable rules.

Adds transparent vlan multitenancy conflist to dropgz for testing.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
See above.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
