### PR TITLE
fix: wait for vnet ns to create and ensure veths are inside namespace instead of assuming

### DIFF
--- a/network/endpoint_snatroute_linux.go
+++ b/network/endpoint_snatroute_linux.go
@@ -37,7 +37,7 @@ func AddSnatEndpointRules(snatClient *snat.Client, hostToNC, ncToHost bool, nl n
 		return errors.Wrap(err, "failed to block ip addresses on snat bridge")
 	}
 	nuc := networkutils.NewNetworkUtils(nl, plc)
-	if err := nuc.EnableIPForwarding(snat.SnatBridgeName); err != nil {
+	if err := nuc.EnableIPForwarding(); err != nil {
 		return errors.Wrap(err, "failed to enable ip forwarding")
 	}
 

--- a/network/networkutils/networkutils_linux.go
+++ b/network/networkutils/networkutils_linux.go
@@ -201,7 +201,7 @@ func BlockIPAddresses(bridgeName, action string) error {
 }
 
 // This fucntion enables ip forwarding in VM and allow forwarding packets from the interface
-func (nu NetworkUtils) EnableIPForwarding(ifName string) error {
+func (nu NetworkUtils) EnableIPForwarding() error {
 	// Enable ip forwading on linux vm.
 	// sysctl -w net.ipv4.ip_forward=1
 	cmd := fmt.Sprint(enableIPForwardCmd)

--- a/network/networkutils/networkutils_linux.go
+++ b/network/networkutils/networkutils_linux.go
@@ -200,7 +200,7 @@ func BlockIPAddresses(bridgeName, action string) error {
 	return nil
 }
 
-// This fucntion enables ip forwarding in VM and allow forwarding packets from the interface
+// This function enables ip forwarding in VM and allow forwarding packets from the interface
 func (nu NetworkUtils) EnableIPForwarding() error {
 	// Enable ip forwading on linux vm.
 	// sysctl -w net.ipv4.ip_forward=1

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -195,7 +195,7 @@ func (client *TransparentVlanEndpointClient) setLinkNetNSAndConfirm(name string,
 	// confirm veth was moved successfully
 	err = RunWithRetries(func() error {
 		// retry checking in the namespace if the interface is not detected
-		return client.executeInNSFn(client.vnetNSName, func() error {
+		return ExecuteInNS(client.nsClient, client.vnetNSName, func() error {
 			_, ifDetectedErr := client.netioshim.GetNetworkInterfaceByName(client.vlanIfName)
 			return errors.Wrap(ifDetectedErr, "failed to get vlan veth in namespace")
 		})

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -136,7 +136,7 @@ func (client *TransparentVlanEndpointClient) ensureCleanPopulateVM() error {
 		vlanIfNotFoundErr := ExecuteInNS(client.nsClient, client.vnetNSName, func() error {
 			// Ensure the vlan interface exists in the namespace
 			_, err := client.netioshim.GetNetworkInterfaceByName(client.vlanIfName)
-			return err
+			return errors.Wrap(err, "failed to get vlan interface in namespace")
 		})
 		if vlanIfNotFoundErr != nil {
 			logger.Info("Vlan interface doesn't exist even though network namespace exists, deleting network namespace...")
@@ -197,7 +197,7 @@ func (client *TransparentVlanEndpointClient) setLinkNetNSAndConfirm(name string,
 		// retry checking in the namespace if the interface is not detected
 		return client.executeInNSFn(client.vnetNSName, func() error {
 			_, ifDetectedErr := client.netioshim.GetNetworkInterfaceByName(client.vlanIfName)
-			return ifDetectedErr
+			return errors.Wrap(ifDetectedErr, "failed to get vlan veth in namespace")
 		})
 	}, numRetries, sleepInMs)
 	if err != nil {
@@ -280,7 +280,7 @@ func (client *TransparentVlanEndpointClient) PopulateVM(epInfo *EndpointInfo) er
 		// sometimes there is slight delay in interface creation. check if it exists
 		err = RunWithRetries(func() error {
 			_, err = client.netioshim.GetNetworkInterfaceByName(client.vlanIfName)
-			return err
+			return errors.Wrap(err, "failed to get vlan veth")
 		}, numRetries, sleepInMs)
 
 		if err != nil {
@@ -316,20 +316,19 @@ func (client *TransparentVlanEndpointClient) PopulateVM(epInfo *EndpointInfo) er
 
 	// Ensure vnet veth is created, as there may be a slight delay
 	err = RunWithRetries(func() error {
-		var getErr error
-		_, getErr = client.netioshim.GetNetworkInterfaceByName(client.vnetVethName)
-		return getErr
+		_, getErr := client.netioshim.GetNetworkInterfaceByName(client.vnetVethName)
+		return errors.Wrap(getErr, "failed to get vnet veth")
 	}, numRetries, sleepInMs)
 	if err != nil {
 		return errors.Wrap(err, "vnet veth does not exist")
 	}
 
 	// Ensure container veth is created, as there may be a slight delay
-	var containerIf *net.Interface = nil
+	var containerIf *net.Interface
 	err = RunWithRetries(func() error {
 		var getErr error
 		containerIf, getErr = client.netioshim.GetNetworkInterfaceByName(client.containerVethName)
-		return getErr
+		return errors.Wrap(getErr, "failed to get container veth")
 	}, numRetries, sleepInMs)
 	if err != nil {
 		return errors.Wrap(err, "container veth does not exist")
@@ -708,8 +707,8 @@ func ExecuteInNS(nsc NamespaceClientInterface, nsName string, f func() error) er
 	return f()
 }
 
-func RunWithRetries(f func() error, maxRuns int, sleepMs int) error {
-	var err error = nil
+func RunWithRetries(f func() error, maxRuns, sleepMs int) error {
+	var err error
 	for i := 0; i < maxRuns; i++ {
 		err = f()
 		if err == nil {

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -123,10 +123,8 @@ func (client *TransparentVlanEndpointClient) AddEndpoints(epInfo *EndpointInfo) 
 	})
 }
 
-func (client *TransparentVlanEndpointClient) createNetworkNamespace(vmNS, numRetries int) error {
-	var isNamespaceUnique bool
-
-	for i := 0; i < numRetries; i++ {
+func (client *TransparentVlanEndpointClient) createNetworkNamespace(vmNS int) error {
+	createNsImpl := func() error {
 		vnetNS, err := client.netnsClient.NewNamed(client.vnetNSName)
 		if err != nil {
 			return errors.Wrap(err, "failed to create vnet ns")
@@ -134,22 +132,19 @@ func (client *TransparentVlanEndpointClient) createNetworkNamespace(vmNS, numRet
 		logger.Info("Vnet Namespace created", zap.String("vnetNS", client.netnsClient.NamespaceUniqueID(vnetNS)))
 		if !client.netnsClient.IsNamespaceEqual(vnetNS, vmNS) {
 			client.vnetNSFileDescriptor = vnetNS
-			isNamespaceUnique = true
-			break
+			return nil
 		}
+		// the vnet and vm namespace are the same by this point
 		logger.Info("Vnet Namespace is the same as VM namespace. Deleting and retrying...")
 		delErr := client.netnsClient.DeleteNamed(client.vnetNSName)
 		if delErr != nil {
 			logger.Error("failed to cleanup/delete ns after failing to create vlan veth", zap.Any("error:", delErr.Error()))
 		}
-		time.Sleep(time.Duration(sleepInMs) * time.Millisecond)
+		return errors.Wrap(errNamespaceCreation, "vnet and vm namespace are the same")
 	}
+	err := RunWithRetries(createNsImpl, numRetries, sleepInMs)
 
-	if !isNamespaceUnique {
-		return errors.Wrap(errNamespaceCreation, "vnet and vm namespace are same")
-	}
-
-	return nil
+	return err
 }
 
 // Called from AddEndpoints, Namespace: VM
@@ -168,7 +163,7 @@ func (client *TransparentVlanEndpointClient) PopulateVM(epInfo *EndpointInfo) er
 		// We assume the only possible error is that the namespace doesn't exist
 		logger.Info("No existing NS detected. Creating the vnet namespace and switching to it")
 
-		if err = client.createNetworkNamespace(vmNS, numRetries); err != nil {
+		if err = client.createNetworkNamespace(vmNS); err != nil {
 			return errors.Wrap(err, "")
 		}
 
@@ -222,12 +217,11 @@ func (client *TransparentVlanEndpointClient) PopulateVM(epInfo *EndpointInfo) er
 		}()
 
 		// sometimes there is slight delay in interface creation. check if it exists
-		for i := 0; i < numRetries; i++ {
-			if _, err = client.netioshim.GetNetworkInterfaceByName(client.vlanIfName); err == nil {
-				break
-			}
-			time.Sleep(time.Duration(sleepInMs) * time.Millisecond)
-		}
+		err = RunWithRetries(func() error {
+			_, err = client.netioshim.GetNetworkInterfaceByName(client.vlanIfName)
+			return err
+		}, numRetries, sleepInMs)
+
 		if err != nil {
 			deleteNSIfNotNilErr = errors.Wrapf(err, "failed to get vlan veth interface:%s", client.vlanIfName)
 			return deleteNSIfNotNilErr

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -123,6 +123,42 @@ func (client *TransparentVlanEndpointClient) AddEndpoints(epInfo *EndpointInfo) 
 	})
 }
 
+// Called from PopulateVM, Namespace: VM and Vnet
+func (client *TransparentVlanEndpointClient) ensureCleanPopulateVM() error {
+	// Clean up vlan interface in the VM namespace and ensure the network namespace (if it exists) has a vlan interface
+	logger.Info("Checking if NS and vlan veth exists...")
+	var existingErr error
+	client.vnetNSFileDescriptor, existingErr = client.netnsClient.GetFromName(client.vnetNSName)
+	if existingErr == nil {
+		// The namespace exists
+		vlanIfNotFoundErr := ExecuteInNS(client.vnetNSName, func() error {
+			// Ensure the vlan interface exists in the namespace
+			_, err := client.netioshim.GetNetworkInterfaceByName(client.vlanIfName)
+			return err
+		})
+		if vlanIfNotFoundErr != nil {
+			logger.Info("Vlan interface doesn't exist even though network namespace exists, deleting network namespace...")
+			delErr := client.netnsClient.DeleteNamed(client.vnetNSName)
+			if delErr != nil {
+				return errors.Wrap(delErr, "failed to cleanup/delete ns after noticing vlan veth does not exist")
+			}
+		}
+		logger.Info("Veth interface was found in namespace")
+	}
+	// Delete the vlan interface in the VM namespace if it exists
+	_, vlanIfInVMErr := client.netioshim.GetNetworkInterfaceByName(client.vlanIfName)
+	if vlanIfInVMErr == nil {
+		// The vlan interface exists in the VM ns because it failed to move into the network ns previously and needs to be cleaned up
+		logger.Info("Vlan interface exists on the VM namespace, deleting", zap.String("vlanIfName", client.vlanIfName))
+		// TODO: Failing to clean up the vlan interface isn't necessarily fatal is it?
+		if delErr := client.netlink.DeleteLink(client.vlanIfName); delErr != nil {
+			return errors.Wrap(delErr, "failed to clean up vlan interface")
+		}
+	}
+	return nil
+}
+
+// Called from PopulateVM, Namespace: VM
 func (client *TransparentVlanEndpointClient) createNetworkNamespace(vmNS int) error {
 	createNsImpl := func() error {
 		vnetNS, err := client.netnsClient.NewNamed(client.vnetNSName)
@@ -152,6 +188,9 @@ func (client *TransparentVlanEndpointClient) PopulateVM(epInfo *EndpointInfo) er
 	vmNS, err := client.netnsClient.Get()
 	if err != nil {
 		return errors.Wrap(err, "failed to get vm ns handle")
+	}
+	if err := client.ensureCleanPopulateVM(); err != nil {
+		return errors.Wrap(err, "failed to ensure both network namespace and vlan veth were both present or both absent")
 	}
 
 	logger.Info("Checking if NS exists...")
@@ -237,8 +276,22 @@ func (client *TransparentVlanEndpointClient) PopulateVM(epInfo *EndpointInfo) er
 		if deleteNSIfNotNilErr != nil {
 			return errors.Wrap(deleteNSIfNotNilErr, "deleting vlan veth in vm ns due to addendpoint failure")
 		}
+
+		// confirm vlan veth was moved successfully
+		deleteNSIfNotNilErr = RunWithRetries(func() error {
+			// retry checking in the namespace if the vlan interface is not detected
+			return ExecuteInNS(client.vnetNSName, func() error {
+				_, vlanIfExistsErr := client.netioshim.GetNetworkInterfaceByName(client.vlanIfName)
+				// errors if the vlan interface does not exist
+				return vlanIfExistsErr
+			})
+		}, numRetries, sleepInMs)
+		if deleteNSIfNotNilErr != nil {
+			return errors.Wrap(deleteNSIfNotNilErr, "failed to detect vlan veth inside vnet namespace")
+		}
+		logger.Info("Moving vlan veth into namespace confirmed")
 	} else {
-		logger.Info("Existing NS detected. Assuming exists too", zap.String("vnetNSName", client.vnetNSName), zap.String("vlanIfName", client.vlanIfName))
+		logger.Info("Existing NS detected. Vlan interface should exist or namespace would've been deleted.", zap.String("vnetNSName", client.vnetNSName), zap.String("vlanIfName", client.vlanIfName))
 	}
 
 	// Get the default constant host veth mac

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -145,13 +145,12 @@ func (client *TransparentVlanEndpointClient) ensureCleanPopulateVM() error {
 			var ev *os.SyscallError
 			if errors.As(vlanIfErr, &ev) {
 				return errors.Wrap(vlanIfErr, "could not determine if vlan veth exists in vnet namespace")
-			} else {
-				// Assume any other error is the vlan interface not found
-				logger.Info("Vlan interface doesn't exist even though network namespace exists, deleting network namespace...", zap.String("message", vlanIfErr.Error()))
-				delErr := client.netnsClient.DeleteNamed(client.vnetNSName)
-				if delErr != nil {
-					return errors.Wrap(delErr, "failed to cleanup/delete ns after noticing vlan veth does not exist")
-				}
+			}
+			// Assume any other error is the vlan interface not found
+			logger.Info("Vlan interface doesn't exist even though network namespace exists, deleting network namespace...", zap.String("message", vlanIfErr.Error()))
+			delErr := client.netnsClient.DeleteNamed(client.vnetNSName)
+			if delErr != nil {
+				return errors.Wrap(delErr, "failed to cleanup/delete ns after noticing vlan veth does not exist")
 			}
 		}
 	}

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -151,7 +151,6 @@ func (client *TransparentVlanEndpointClient) ensureCleanPopulateVM() error {
 	if vlanIfInVMErr == nil {
 		// The vlan interface exists in the VM ns because it failed to move into the network ns previously and needs to be cleaned up
 		logger.Info("Vlan interface exists on the VM namespace, deleting", zap.String("vlanIfName", client.vlanIfName))
-		// TODO: Failing to clean up the vlan interface isn't necessarily fatal is it?
 		if delErr := client.netlink.DeleteLink(client.vlanIfName); delErr != nil {
 			return errors.Wrap(delErr, "failed to clean up vlan interface")
 		}
@@ -183,6 +182,28 @@ func (client *TransparentVlanEndpointClient) createNetworkNamespace(vmNS int) er
 	err := RunWithRetries(createNsImpl, numRetries, sleepInMs)
 
 	return err
+}
+
+// Called from PopulateVM, Namespace: VM and namespace represented by fd
+func (client *TransparentVlanEndpointClient) setLinkNetNSAndConfirm(name string, fd uintptr) error {
+	logger.Info("Move link to NS", zap.String("ifName", name), zap.Any("NSFileDescriptor", fd))
+	err := client.netlink.SetLinkNetNs(name, fd)
+	if err != nil {
+		return errors.Wrapf(err, "failed to set %v inside namespace %v", name, fd)
+	}
+
+	// confirm veth was moved successfully
+	err = RunWithRetries(func() error {
+		// retry checking in the namespace if the interface is not detected
+		return client.executeInNSFn(client.vnetNSName, func() error {
+			_, ifDetectedErr := client.netioshim.GetNetworkInterfaceByName(client.vlanIfName)
+			return ifDetectedErr
+		})
+	}, numRetries, sleepInMs)
+	if err != nil {
+		return errors.Wrapf(err, "failed to detect %v inside namespace %v", name, fd)
+	}
+	return nil
 }
 
 // Called from AddEndpoints, Namespace: VM
@@ -273,22 +294,9 @@ func (client *TransparentVlanEndpointClient) PopulateVM(epInfo *EndpointInfo) er
 		}
 		// vlan veth was created successfully, so move the vlan veth you created
 		logger.Info("Move vlan link to vnet NS", zap.String("vlanIfName", client.vlanIfName), zap.Any("vnetNSFileDescriptor", uintptr(client.vnetNSFileDescriptor)))
-		deleteNSIfNotNilErr = client.netlink.SetLinkNetNs(client.vlanIfName, uintptr(client.vnetNSFileDescriptor))
+		deleteNSIfNotNilErr = client.setLinkNetNSAndConfirm(client.vlanIfName, uintptr(client.vnetNSFileDescriptor))
 		if deleteNSIfNotNilErr != nil {
-			return errors.Wrap(deleteNSIfNotNilErr, "deleting vlan veth in vm ns due to addendpoint failure")
-		}
-
-		// confirm vlan veth was moved successfully
-		deleteNSIfNotNilErr = RunWithRetries(func() error {
-			// retry checking in the namespace if the vlan interface is not detected
-			return ExecuteInNS(client.nsClient, client.vnetNSName, func() error {
-				_, vlanIfExistsErr := client.netioshim.GetNetworkInterfaceByName(client.vlanIfName)
-				// errors if the vlan interface does not exist
-				return vlanIfExistsErr
-			})
-		}, numRetries, sleepInMs)
-		if deleteNSIfNotNilErr != nil {
-			return errors.Wrap(deleteNSIfNotNilErr, "failed to detect vlan veth inside vnet namespace")
+			return errors.Wrap(deleteNSIfNotNilErr, "failed to move or detect vlan veth inside vnet namespace")
 		}
 		logger.Info("Moving vlan veth into namespace confirmed")
 	} else {
@@ -341,13 +349,12 @@ func (client *TransparentVlanEndpointClient) PopulateVM(epInfo *EndpointInfo) er
 		return errors.Wrap(err, "failed to disable RA on container veth, deleting")
 	}
 
-	if err = client.netlink.SetLinkNetNs(client.vnetVethName, uintptr(client.vnetNSFileDescriptor)); err != nil {
+	if err = client.setLinkNetNSAndConfirm(client.vnetVethName, uintptr(client.vnetNSFileDescriptor)); err != nil {
 		if delErr := client.netlink.DeleteLink(client.vnetVethName); delErr != nil {
 			logger.Error("Deleting vnet veth failed on addendpoint failure with", zap.Error(delErr))
 		}
-		return errors.Wrap(err, "failed to move vnetVethName into vnet ns, deleting")
+		return errors.Wrap(err, "failed to move or detect vnetVethName in vnet ns, deleting")
 	}
-
 	client.containerMac = containerIf.HardwareAddr
 	return nil
 }
@@ -555,7 +562,7 @@ func (client *TransparentVlanEndpointClient) GetVnetRoutes(ipAddresses []net.IPN
 
 // Helper that creates routing rules for the current NS which direct packets
 // to the virtual gateway ip on linkToName device interface
-// Route 1: 169.254.1.1 dev <linkToName>
+// Route 1: 169.254.2.1 dev <linkToName>
 // Route 2: default via 169.254.2.1 dev <linkToName>
 func (client *TransparentVlanEndpointClient) addDefaultRoutes(linkToName string, table int) error {
 	// Add route for virtualgwip (ip route add 169.254.2.1/32 dev eth0)

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -147,7 +147,7 @@ func (client *TransparentVlanEndpointClient) ensureCleanPopulateVM() error {
 				return errors.Wrap(vlanIfErr, "could not determine if vlan veth exists in vnet namespace")
 			}
 			// Assume any other error is the vlan interface not found
-			logger.Info("Vlan interface doesn't exist even though network namespace exists, deleting network namespace...", zap.String("message", vlanIfErr.Error()))
+			logger.Info("vlan interface doesn't exist even though network namespace exists, deleting network namespace...", zap.String("message", vlanIfErr.Error()))
 			delErr := client.netnsClient.DeleteNamed(client.vnetNSName)
 			if delErr != nil {
 				return errors.Wrap(delErr, "failed to cleanup/delete ns after noticing vlan veth does not exist")
@@ -158,7 +158,7 @@ func (client *TransparentVlanEndpointClient) ensureCleanPopulateVM() error {
 	_, vlanIfInVMErr := client.netioshim.GetNetworkInterfaceByName(client.vlanIfName)
 	if vlanIfInVMErr == nil {
 		// The vlan interface exists in the VM ns because it failed to move into the network ns previously and needs to be cleaned up
-		logger.Info("Vlan interface exists on the VM namespace, deleting", zap.String("vlanIfName", client.vlanIfName))
+		logger.Info("vlan interface exists on the VM namespace, deleting", zap.String("vlanIfName", client.vlanIfName))
 		if delErr := client.netlink.DeleteLink(client.vlanIfName); delErr != nil {
 			return errors.Wrap(delErr, "failed to clean up vlan interface")
 		}
@@ -306,7 +306,7 @@ func (client *TransparentVlanEndpointClient) PopulateVM(epInfo *EndpointInfo) er
 		}
 		logger.Info("Moving vlan veth into namespace confirmed")
 	} else {
-		logger.Info("Existing NS detected. Vlan interface should exist or namespace would've been deleted.", zap.String("vnetNSName", client.vnetNSName), zap.String("vlanIfName", client.vlanIfName))
+		logger.Info("Existing NS detected. vlan interface should exist or namespace would've been deleted.", zap.String("vnetNSName", client.vnetNSName), zap.String("vlanIfName", client.vlanIfName))
 	}
 
 	// Get the default constant host veth mac

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -310,6 +310,11 @@ func (client *TransparentVlanEndpointClient) PopulateVnet(epInfo *EndpointInfo) 
 	if err != nil {
 		return errors.Wrap(err, "transparent vlan failed to disable rp filter vlan interface in vnet")
 	}
+	// Ensure ip forwarding is enabled (even though it should be enabled on network create already)
+	err = client.netUtilsClient.EnableIPForwarding()
+	if err != nil {
+		return errors.Wrap(err, "transparent vlan failed to enable ip forwarding in vnet")
+	}
 	return nil
 }
 

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -143,7 +143,7 @@ func (client *TransparentVlanEndpointClient) ensureCleanPopulateVM() error {
 				return errors.Wrap(delErr, "failed to cleanup/delete ns after noticing vlan veth does not exist")
 			}
 		}
-		logger.Info("Veth interface was found in namespace")
+		logger.Info("Vlan veth interface was found in namespace")
 	}
 	// Delete the vlan interface in the VM namespace if it exists
 	_, vlanIfInVMErr := client.netioshim.GetNetworkInterfaceByName(client.vlanIfName)

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -166,7 +166,7 @@ func (client *TransparentVlanEndpointClient) createNetworkNamespace(vmNS int) er
 		if err != nil {
 			return errors.Wrap(err, "failed to create vnet ns")
 		}
-		logger.Info("Vnet Namespace created", zap.String("vnetNS", client.netnsClient.NamespaceUniqueID(vnetNS)))
+		logger.Info("Vnet Namespace created", zap.String("vnetNS", client.netnsClient.NamespaceUniqueID(vnetNS)), zap.String("vmNS", client.netnsClient.NamespaceUniqueID(vmNS)))
 		if !client.netnsClient.IsNamespaceEqual(vnetNS, vmNS) {
 			client.vnetNSFileDescriptor = vnetNS
 			return nil

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -3,7 +3,6 @@ package network
 import (
 	"fmt"
 	"net"
-	"os"
 	"strings"
 	"time"
 
@@ -139,14 +138,8 @@ func (client *TransparentVlanEndpointClient) ensureCleanPopulateVM() error {
 			_, err := client.netioshim.GetNetworkInterfaceByName(client.vlanIfName)
 			return errors.Wrap(err, "failed to get vlan interface in namespace")
 		})
-
-		// If the vlan veth for sure doesn't exist, we delete the vnet ns, but if we can't query, we can't delete the ns (the vlan veth might exist!)
 		if vlanIfErr != nil {
-			var ev *os.SyscallError
-			if errors.As(vlanIfErr, &ev) {
-				return errors.Wrap(vlanIfErr, "could not determine if vlan veth exists in vnet namespace")
-			}
-			// Assume any other error is the vlan interface not found
+			// Assume any error is the vlan interface not found
 			logger.Info("vlan interface doesn't exist even though network namespace exists, deleting network namespace...", zap.String("message", vlanIfErr.Error()))
 			delErr := client.netnsClient.DeleteNamed(client.vnetNSName)
 			if delErr != nil {

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -251,6 +251,28 @@ func (client *TransparentVlanEndpointClient) PopulateVM(epInfo *EndpointInfo) er
 	if err = client.netUtilsClient.CreateEndpoint(client.vnetVethName, client.containerVethName, mac); err != nil {
 		return errors.Wrap(err, "failed to create veth pair")
 	}
+
+	// Ensure vnet veth is created, as there may be a slight delay
+	err = RunWithRetries(func() error {
+		var getErr error
+		_, getErr = client.netioshim.GetNetworkInterfaceByName(client.vnetVethName)
+		return getErr
+	}, numRetries, sleepInMs)
+	if err != nil {
+		return errors.Wrap(err, "vnet veth does not exist")
+	}
+
+	// Ensure container veth is created, as there may be a slight delay
+	var containerIf *net.Interface = nil
+	err = RunWithRetries(func() error {
+		var getErr error
+		containerIf, getErr = client.netioshim.GetNetworkInterfaceByName(client.containerVethName)
+		return getErr
+	}, numRetries, sleepInMs)
+	if err != nil {
+		return errors.Wrap(err, "container veth does not exist")
+	}
+
 	// Disable RA for veth pair, and delete if any failure
 	if err = client.netUtilsClient.DisableRAForInterface(client.vnetVethName); err != nil {
 		if delErr := client.netlink.DeleteLink(client.vnetVethName); delErr != nil {
@@ -272,10 +294,6 @@ func (client *TransparentVlanEndpointClient) PopulateVM(epInfo *EndpointInfo) er
 		return errors.Wrap(err, "failed to move vnetVethName into vnet ns, deleting")
 	}
 
-	containerIf, err := client.netioshim.GetNetworkInterfaceByName(client.containerVethName)
-	if err != nil {
-		return errors.Wrap(err, "container veth does not exist")
-	}
 	client.containerMac = containerIf.HardwareAddr
 	return nil
 }

--- a/network/transparent_vlan_endpointclient_linux_test.go
+++ b/network/transparent_vlan_endpointclient_linux_test.go
@@ -5,6 +5,7 @@ package network
 
 import (
 	"net"
+	"os"
 	"testing"
 
 	"github.com/Azure/azure-container-networking/netio"
@@ -17,7 +18,8 @@ import (
 
 var errNetnsMock = errors.New("mock netns error")
 var errMockNetIOFail = errors.New("netio fail")
-var errMockNetIONoIfFail = errors.New("no such network interface")
+var errMockNetIOSyscallFail = &net.OpError{Op: "route", Net: "ip+net", Source: nil, Addr: nil, Err: os.NewSyscallError("syscall error", errMockNetIOFail)}
+var errMockNetIONoIfFail = &net.OpError{Op: "route", Net: "ip+net", Source: nil, Addr: nil, Err: errors.New("no such network interface")}
 
 func newNetnsErrorMock(errStr string) error {
 	return errors.Wrap(errNetnsMock, errStr)
@@ -276,7 +278,7 @@ func TestTransparentVlanAddEndpoints(t *testing.T) {
 				netUtilsClient: networkutils.NewNetworkUtils(nl, plc),
 				netioshim: &mockNetIO{
 					existingInterfaces: map[string]bool{},
-					err:                errMockNetIOFail,
+					err:                errMockNetIOSyscallFail,
 				},
 				nsClient: NewMockNamespaceClient(),
 			},

--- a/network/transparent_vlan_endpointclient_linux_test.go
+++ b/network/transparent_vlan_endpointclient_linux_test.go
@@ -121,6 +121,83 @@ func TestTransparentVlanAddEndpoints(t *testing.T) {
 		wantErr    bool
 		wantErrMsg string
 	}{
+		// Set the link network namespace and confirm that it was moved inside
+		{
+			name: "Set link netns good path",
+			client: &TransparentVlanEndpointClient{
+				primaryHostIfName: "eth0",
+				vlanIfName:        "eth0.1",
+				vnetVethName:      "A1veth0",
+				containerVethName: "B1veth0",
+				vnetNSName:        "az_ns_1",
+				netlink:           netlink.NewMockNetlink(false, ""),
+				plClient:          platform.NewMockExecClient(false),
+				netUtilsClient:    networkutils.NewNetworkUtils(nl, plc),
+				netioshim:         netio.NewMockNetIO(false, 0),
+				executeInNSFn:     defaultExecuteInNSFn,
+			},
+			epInfo:  &EndpointInfo{},
+			wantErr: false,
+		},
+		{
+			name: "Set link netns fail to set",
+			client: &TransparentVlanEndpointClient{
+				primaryHostIfName: "eth0",
+				vlanIfName:        "eth0.1",
+				vnetVethName:      "A1veth0",
+				containerVethName: "B1veth0",
+				vnetNSName:        "az_ns_1",
+				netlink:           netlink.NewMockNetlink(true, "netlink fail"),
+				plClient:          platform.NewMockExecClient(false),
+				netUtilsClient:    networkutils.NewNetworkUtils(nl, plc),
+				netioshim:         netio.NewMockNetIO(false, 0),
+				executeInNSFn:     defaultExecuteInNSFn,
+			},
+			epInfo:     &EndpointInfo{},
+			wantErr:    true,
+			wantErrMsg: "failed to set eth0.1",
+		},
+		{
+			name: "Set link netns fail to detect",
+			client: &TransparentVlanEndpointClient{
+				primaryHostIfName: "eth0",
+				vlanIfName:        "eth0.1",
+				vnetVethName:      "A1veth0",
+				containerVethName: "B1veth0",
+				vnetNSName:        "az_ns_1",
+				netlink:           netlink.NewMockNetlink(false, ""),
+				plClient:          platform.NewMockExecClient(false),
+				netUtilsClient:    networkutils.NewNetworkUtils(nl, plc),
+				netioshim: &mockNetIO{
+					existingInterfaces: map[string]bool{},
+				},
+				executeInNSFn: defaultExecuteInNSFn,
+			},
+			epInfo:     &EndpointInfo{},
+			wantErr:    true,
+			wantErrMsg: "failed to detect eth0.1",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.client.setLinkNetNSAndConfirm(tt.client.vlanIfName, 1)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErrMsg, "Expected:%v actual:%v", tt.wantErrMsg, err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+
+	tests = []struct {
+		name       string
+		client     *TransparentVlanEndpointClient
+		epInfo     *EndpointInfo
+		wantErr    bool
+		wantErrMsg string
+	}{
 		// Ensuring vnet namespace and vlan both exist or are both absent before populating the vm
 		{
 			name: "Ensure clean populate VM neither vnet ns nor vlan if exists",
@@ -236,6 +313,7 @@ func TestTransparentVlanAddEndpoints(t *testing.T) {
 				plClient:       platform.NewMockExecClient(false),
 				netUtilsClient: networkutils.NewNetworkUtils(nl, plc),
 				netioshim:      netio.NewMockNetIO(false, 0),
+				executeInNSFn:  defaultExecuteInNSFn,
 			},
 			epInfo:  &EndpointInfo{},
 			wantErr: false,
@@ -262,7 +340,7 @@ func TestTransparentVlanAddEndpoints(t *testing.T) {
 			},
 			epInfo:     &EndpointInfo{},
 			wantErr:    true,
-			wantErrMsg: "failed to move vnetVethName into vnet ns, deleting: " + netlink.ErrorMockNetlink.Error() + " : netlink fail",
+			wantErrMsg: "failed to move or detect vnetVethName in vnet ns, deleting: failed to set A1veth0 inside namespace 1: " + netlink.ErrorMockNetlink.Error() + " : netlink fail",
 		},
 		{
 			name: "Add endpoints get interface fail for primary interface (eth0)",
@@ -342,7 +420,7 @@ func TestTransparentVlanAddEndpoints(t *testing.T) {
 			wantErrMsg: "failed to get vm ns handle: netns failure: " + errNetnsMock.Error(),
 		},
 		{
-			name: "Add endpoints NetNS Set fail",
+			name: "Add endpoints no vnet ns NetNS Set fail",
 			client: &TransparentVlanEndpointClient{
 				primaryHostIfName: "eth0",
 				vlanIfName:        "eth0.1",

--- a/network/transparent_vlan_endpointclient_linux_test.go
+++ b/network/transparent_vlan_endpointclient_linux_test.go
@@ -84,7 +84,7 @@ type mockNetIO struct {
 }
 
 func (ns *mockNetIO) GetNetworkInterfaceByName(name string) (*net.Interface, error) {
-	var ErrMockNetIOFail = errors.New("netio fail")
+	ErrMockNetIOFail := errors.New("netio fail")
 	if ns.existingInterfaces[name] {
 		hwAddr, _ := net.ParseMAC("ab:cd:ef:12:34:56")
 		return &net.Interface{
@@ -95,11 +95,11 @@ func (ns *mockNetIO) GetNetworkInterfaceByName(name string) (*net.Interface, err
 			//nolint:gomnd // Dummy interface index
 			Index: 2,
 		}, nil
-	} else {
-		return nil, errors.Wrap(ErrMockNetIOFail, name)
 	}
+	return nil, errors.Wrap(ErrMockNetIOFail, name)
 }
-func (ns *mockNetIO) GetNetworkInterfaceAddrs(iface *net.Interface) ([]net.Addr, error) {
+
+func (ns *mockNetIO) GetNetworkInterfaceAddrs(_ *net.Interface) ([]net.Addr, error) {
 	return []net.Addr{}, nil
 }
 
@@ -110,6 +110,7 @@ func defaultExecuteInNSFn(nsName string, f func() error) error {
 	}()
 	return f()
 }
+
 func TestTransparentVlanAddEndpoints(t *testing.T) {
 	nl := netlink.NewMockNetlink(false, "")
 	plc := platform.NewMockExecClient(false)
@@ -395,7 +396,7 @@ func TestTransparentVlanAddEndpoints(t *testing.T) {
 			},
 			epInfo:     &EndpointInfo{},
 			wantErr:    true,
-			wantErrMsg: "container veth does not exist: B1veth0: " + netio.ErrMockNetIOFail.Error() + "",
+			wantErrMsg: "container veth does not exist: failed to get container veth: B1veth0: " + netio.ErrMockNetIOFail.Error() + "",
 		},
 		{
 			name: "Add endpoints NetNS Get fail",
@@ -874,6 +875,7 @@ func TestTransparentVlanConfigureContainerInterfacesAndRoutes(t *testing.T) {
 		})
 	}
 }
+
 func createFunctionWithFailurePattern(errorPattern []error) func() error {
 	s := 0
 	return func() error {
@@ -881,13 +883,14 @@ func createFunctionWithFailurePattern(errorPattern []error) func() error {
 			return nil
 		}
 		result := errorPattern[s]
-		s += 1
+		s++
 		return result
 	}
 }
+
 func TestRunWithRetries(t *testing.T) {
-	var errMock = errors.New("mock error")
-	var runs = 4
+	errMock := errors.New("mock error")
+	runs := 4
 
 	tests := []struct {
 		name    string

--- a/network/transparent_vlan_endpointclient_linux_test.go
+++ b/network/transparent_vlan_endpointclient_linux_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Azure/azure-container-networking/platform"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 var errNetnsMock = errors.New("mock netns error")
@@ -77,11 +78,112 @@ func defaultDeleteNamed(name string) error {
 	return nil
 }
 
+// This mock netioshim provides more flexbility in when it errors compared to the one in the netio package
+type mockNetIO struct {
+	existingInterfaces map[string]bool
+}
+
+func (ns *mockNetIO) GetNetworkInterfaceByName(name string) (*net.Interface, error) {
+	var ErrMockNetIOFail = errors.New("netio fail")
+	if ns.existingInterfaces[name] {
+		hwAddr, _ := net.ParseMAC("ab:cd:ef:12:34:56")
+		return &net.Interface{
+			//nolint:gomnd // Dummy MTU
+			MTU:          1000,
+			Name:         name,
+			HardwareAddr: hwAddr,
+			//nolint:gomnd // Dummy interface index
+			Index: 2,
+		}, nil
+	} else {
+		return nil, errors.Wrap(ErrMockNetIOFail, name)
+	}
+}
+func (ns *mockNetIO) GetNetworkInterfaceAddrs(iface *net.Interface) ([]net.Addr, error) {
+	return []net.Addr{}, nil
+}
+
+func defaultExecuteInNSFn(nsName string, f func() error) error {
+	logger.Info("[MockExecuteInNS] Entering ns", zap.String("nsName", nsName))
+	defer func() {
+		logger.Info("[MockExecuteInNS] Exiting ns", zap.String("nsName", nsName))
+	}()
+	return f()
+}
 func TestTransparentVlanAddEndpoints(t *testing.T) {
 	nl := netlink.NewMockNetlink(false, "")
 	plc := platform.NewMockExecClient(false)
 
 	tests := []struct {
+		name       string
+		client     *TransparentVlanEndpointClient
+		epInfo     *EndpointInfo
+		wantErr    bool
+		wantErrMsg string
+	}{
+		// Ensuring vnet namespace and vlan both exist or are both absent before populating the vm
+		{
+			name: "Ensure clean populate VM neither vnet ns nor vlan if exists",
+			client: &TransparentVlanEndpointClient{
+				primaryHostIfName: "eth0",
+				vlanIfName:        "eth0.1",
+				vnetVethName:      "A1veth0",
+				containerVethName: "B1veth0",
+				vnetNSName:        "az_ns_1",
+				netnsClient: &mockNetns{
+					get: defaultGet,
+					getFromName: func(name string) (fileDescriptor int, err error) {
+						return 0, newNetnsErrorMock("netns failure")
+					},
+				},
+				netlink:        netlink.NewMockNetlink(false, ""),
+				plClient:       platform.NewMockExecClient(false),
+				netUtilsClient: networkutils.NewNetworkUtils(nl, plc),
+				netioshim:      netio.NewMockNetIO(false, 0),
+				executeInNSFn:  defaultExecuteInNSFn,
+			},
+			epInfo:  &EndpointInfo{},
+			wantErr: false,
+		},
+		{
+			name: "Ensure clean populate VM vnet ns but vlan if does not",
+			client: &TransparentVlanEndpointClient{
+				primaryHostIfName: "eth0",
+				vlanIfName:        "eth0.1",
+				vnetVethName:      "A1veth0",
+				containerVethName: "B1veth0",
+				vnetNSName:        "az_ns_1",
+				netnsClient: &mockNetns{
+					get:         defaultGet,
+					getFromName: defaultGetFromName,
+					deleteNamed: func(name string) (err error) {
+						return newNetnsErrorMock("netns failure")
+					},
+				},
+				netlink:        netlink.NewMockNetlink(false, ""),
+				plClient:       platform.NewMockExecClient(false),
+				netUtilsClient: networkutils.NewNetworkUtils(nl, plc),
+				netioshim:      netio.NewMockNetIO(true, 1),
+				executeInNSFn:  defaultExecuteInNSFn,
+			},
+			epInfo:     &EndpointInfo{},
+			wantErr:    true,
+			wantErrMsg: "failed to cleanup/delete ns after noticing vlan veth does not exist: netns failure: " + errNetnsMock.Error(),
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.client.ensureCleanPopulateVM()
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErrMsg, "Expected:%v actual:%v", tt.wantErrMsg, err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+	tests = []struct {
 		name       string
 		client     *TransparentVlanEndpointClient
 		epInfo     *EndpointInfo
@@ -206,11 +308,16 @@ func TestTransparentVlanAddEndpoints(t *testing.T) {
 				netlink:        netlink.NewMockNetlink(false, ""),
 				plClient:       platform.NewMockExecClient(false),
 				netUtilsClient: networkutils.NewNetworkUtils(nl, plc),
-				netioshim:      netio.NewMockNetIO(true, 1),
+				netioshim: &mockNetIO{
+					existingInterfaces: map[string]bool{
+						"A1veth0": true,
+					},
+				},
+				executeInNSFn: defaultExecuteInNSFn,
 			},
 			epInfo:     &EndpointInfo{},
 			wantErr:    true,
-			wantErrMsg: "container veth does not exist: " + netio.ErrMockNetIOFail.Error() + ":B1veth0",
+			wantErrMsg: "container veth does not exist: B1veth0: " + netio.ErrMockNetIOFail.Error() + "",
 		},
 		{
 			name: "Add endpoints NetNS Get fail",
@@ -703,6 +810,7 @@ func createFunctionWithFailurePattern(errorPattern []error) func() error {
 func TestRunWithRetries(t *testing.T) {
 	var errMock = errors.New("mock error")
 	var runs = 4
+
 	tests := []struct {
 		name    string
 		wantErr bool


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

In the transparent vlan endpoint client add endpoint path, detecting the vnet network namespace would previously assume the vlan interface was already inside the namespace. However, this was not always the case (the vlan interface may not exist or may be in the vm namespace). The fix removes any stray vlan interface pertaining to the container in the vm if it exists and also deletes the network namespace if it does not have a valid vlan interface. Then, the code can proceed as though the vnet namespace never existed. Deleting the vnet namespace will not cause existing endpoints to become inaccessible because they must have errored (and been cleaned up) previously to enter this state. 

Additionally, we also explicitly confirm the vlan interface as well as the vnet interface are successfully created and moved into the vnet namespace. If the vlan interface fails to move, we delete the vnet namespace and the vlan interface. If the vnet interface fails to move into the vnet namespace, we only delete the vnet interface.

Code changes have been made to create unit tests.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
See above.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests
- [X] relevant PR labels added

**Notes**:
The following were manually tested (against commit "Address feedback"):
- create pod when its vnet namespace does not exist
- create pod when its vnet namespace and vlan interface does exist
- create pod when its vnet namespace exists but the vlan interface does not exist
- create pod when its vlan interface is in the vm namespace (as if it failed to move into the vnet namespace)
- in all scenarios, we test pod-pod same vnet same vm connectivity, pod-pod same vnet different vm connectivity, pod-internet connectivity, pod-pod same vm different vnet with no connectivity