### PR TITLE
normalize NCID by stripping Swift prefix

### DIFF
--- a/cns/restserver/api_test.go
+++ b/cns/restserver/api_test.go
@@ -1311,7 +1311,7 @@ func TestNCIDCaseInSensitive(t *testing.T) {
 	ncVersionList := map[string]string{}
 	// add lower-case NCIDs to ncVersionList
 	for _, ncid := range ncids {
-		ncVersionList[lowerCaseNCGuid(ncid)] = "1"
+		ncVersionList[strings.TrimPrefix(lowerCaseNCGuid(ncid), cns.SwiftPrefix)] = "1"
 	}
 
 	for _, ncid := range ncids {

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -106,7 +106,7 @@ func (service *HTTPRestService) SyncNodeStatus(dncEP, infraVnet, nodeID string, 
 	if !skipNCVersionCheck {
 		nmaNCs := map[string]string{}
 		for _, nc := range ncVersionListResp.Containers {
-			nmaNCs[cns.SwiftPrefix+strings.ToLower(nc.NetworkContainerID)] = nc.Version
+			nmaNCs[strings.TrimPrefix(lowerCaseNCGuid(nc.NetworkContainerID), cns.SwiftPrefix)] = nc.Version
 		}
 
 		// check if the version is valid and save it to service state


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
https://github.com/Azure/azure-container-networking/pull/1767 introduced a bug where, if the NC in state does _not_ have the `Swift_` prefix, when we unconditionally add the prefix we become unable to identify it in the NMA responses which don't have it and are stuck:

```json
{"httpStatusCode":"200","networkContainers":[{"networkContainerId":"de043d23-a135-401c-b6a8-1ab6a09f980a","version":"0"}]}
```

and yet
```
[Azure CNS] Failed to get NC de043d23-a135-401c-b6a8-1ab6a09f980a doesn't exist in NMAgent NC version list Skipping GetNCVersionStatus check from NMAgent
```

After investigating, this it seems like nobody knows where or even if we actually have NCs in the wild with the `Swift_` prefix, but it is possible that we do as a legacy artifact, and it could be unsafe to remove the prefixing entirely.

However, for the purposes of the lookup in the NC version list query, we can strip the prefix when add items to this in-memory map, and strip prefixes when we attempt to look objects up in the map, and unstick ourselves. This additional prefixing is not done anywhere else, and no usages of these objects escape this local map, so it should be safe and back-compat.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
