### PR TITLE
fix zap logger rotation issues

### DIFF
--- a/cni/ipam/plugin/main.go
+++ b/cni/ipam/plugin/main.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-container-networking/cni"
 	"github.com/Azure/azure-container-networking/cni/ipam"
 	"github.com/Azure/azure-container-networking/common"
-	"github.com/Azure/azure-container-networking/log"
 )
 
 const name = "azure-vnet-ipam"
@@ -22,17 +21,6 @@ var version string
 func main() {
 	var config common.PluginConfig
 	config.Version = version
-
-	logDirectory := "" // Sets the current location as log directory
-
-	log.SetName(name)
-	log.SetLevel(log.LevelInfo)
-	if err := log.SetTargetLogDirectory(log.TargetLogfile, logDirectory); err != nil {
-		fmt.Printf("Failed to setup cni logging: %v\n", err)
-		return
-	}
-
-	defer log.Close()
 
 	ipamPlugin, err := ipam.NewPlugin(name, &config)
 	if err != nil {

--- a/cni/ipam/pluginv6/main.go
+++ b/cni/ipam/pluginv6/main.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-container-networking/cni"
 	"github.com/Azure/azure-container-networking/cni/ipam"
 	"github.com/Azure/azure-container-networking/common"
-	"github.com/Azure/azure-container-networking/log"
 )
 
 const name = "azure-vnet-ipamv6"
@@ -22,17 +21,6 @@ var version string
 func main() {
 	var config common.PluginConfig
 	config.Version = version
-
-	logDirectory := "" // Sets the current location as log directory
-
-	log.SetName(name)
-	log.SetLevel(log.LevelInfo)
-	if err := log.SetTargetLogDirectory(log.TargetLogfile, logDirectory); err != nil {
-		fmt.Printf("Failed to setup cni logging: %v\n", err)
-		return
-	}
-
-	defer log.Close()
 
 	ipamPlugin, err := ipam.NewPlugin(name, &config)
 	if err != nil {

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -903,7 +903,7 @@ func (plugin *NetPlugin) Get(args *cniSkel.CmdArgs) error {
 
 	// Query the endpoint.
 	if epInfo, err = plugin.nm.GetEndpointInfo(networkID, endpointID); err != nil {
-		plugin.Errorf("Failed to query endpoint: %v", err)
+		logger.Error("Failed to query endpoint", zap.Error(err))
 		return err
 	}
 

--- a/cni/network/plugin/main.go
+++ b/cni/network/plugin/main.go
@@ -17,7 +17,6 @@ import (
 	zaplog "github.com/Azure/azure-container-networking/cni/log"
 	"github.com/Azure/azure-container-networking/cni/network"
 	"github.com/Azure/azure-container-networking/common"
-	"github.com/Azure/azure-container-networking/log"
 	"github.com/Azure/azure-container-networking/nns"
 	"github.com/Azure/azure-container-networking/platform"
 	"github.com/Azure/azure-container-networking/store"
@@ -294,15 +293,6 @@ func main() {
 		printVersion()
 		os.Exit(0)
 	}
-
-	log.SetName(name)
-	log.SetLevel(log.LevelInfo)
-	if err := log.SetTargetLogDirectory(log.TargetLogfile, ""); err != nil {
-		fmt.Printf("Failed to setup cni logging: %v\n", err)
-		return
-	}
-
-	defer log.Close()
 
 	if rootExecute() != nil {
 		os.Exit(1)


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
This PR is to fix log rotation issue that is crashed after windows nodes are restarted.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
