### PR TITLE
test: validate secondary endpoint client failure

### DIFF
--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -463,7 +463,7 @@ func configureSecondaryAddResult(info *IPResultInfo, addResult *IPAMAddResult, p
 				},
 			},
 		},
-		nicType:           cns.DelegatedVMNIC,
+		nicType:           info.nicType,
 		macAddress:        macAddress,
 		skipDefaultRoutes: info.skipDefaultRoutes,
 	}

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -819,7 +819,7 @@ func (plugin *NetPlugin) createEndpointInternal(opt *createEndpointInternalOpt) 
 				IPAddresses:       addresses,
 				Routes:            routes,
 				MacAddress:        secondaryCniResult.macAddress,
-				NICType:           cns.DelegatedVMNIC,
+				NICType:           secondaryCniResult.nicType,
 				SkipDefaultRoutes: secondaryCniResult.skipDefaultRoutes,
 			})
 	}

--- a/netlink/mocknetlink.go
+++ b/netlink/mocknetlink.go
@@ -6,6 +6,8 @@ import (
 	"net"
 )
 
+const BadEth = "badeth"
+
 // ErrorMockNetlink - netlink mock error
 var ErrorMockNetlink = errors.New("Mock Netlink Error")
 
@@ -60,7 +62,11 @@ func (f *MockNetlink) SetLinkName(string, string) error {
 	return f.error()
 }
 
-func (f *MockNetlink) SetLinkState(string, bool) error {
+func (f *MockNetlink) SetLinkState(name string, _ bool) error {
+	if name == BadEth {
+		return ErrorMockNetlink
+	}
+
 	return f.error()
 }
 

--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -157,7 +157,7 @@ func (nw *network) newEndpoint(
 }
 
 // DeleteEndpoint deletes an existing endpoint from the network.
-func (nw *network) deleteEndpoint(nl netlink.NetlinkInterface, plc platform.ExecClient, nsc NamespaceClientInterface, endpointID string) error {
+func (nw *network) deleteEndpoint(nl netlink.NetlinkInterface, plc platform.ExecClient, nioc netio.NetIOInterface, nsc NamespaceClientInterface, endpointID string) error {
 	var err error
 
 	logger.Info("Deleting endpoint from network", zap.String("endpointID", endpointID), zap.String("id", nw.Id))
@@ -176,7 +176,7 @@ func (nw *network) deleteEndpoint(nl netlink.NetlinkInterface, plc platform.Exec
 
 	// Call the platform implementation.
 	// Pass nil for epClient and will be initialized in deleteEndpointImpl
-	err = nw.deleteEndpointImpl(nl, plc, nil, nsc, ep)
+	err = nw.deleteEndpointImpl(nl, plc, nil, nioc, nsc, ep)
 	if err != nil {
 		return err
 	}

--- a/network/endpoint_test.go
+++ b/network/endpoint_test.go
@@ -227,11 +227,11 @@ var _ = Describe("Test Endpoint", func() {
 				Expect(len(mockCli.endpoints)).To(Equal(1))
 				// Deleting the endpoint
 				//nolint:errcheck // ignore error
-				nw.deleteEndpointImpl(netlink.NewMockNetlink(false, ""), platform.NewMockExecClient(false), mockCli, NewMockNamespaceClient(), ep2)
+				nw.deleteEndpointImpl(netlink.NewMockNetlink(false, ""), platform.NewMockExecClient(false), mockCli, netio.NewMockNetIO(false, 0), NewMockNamespaceClient(), ep2)
 				Expect(len(mockCli.endpoints)).To(Equal(0))
 				// Deleting same endpoint with same id should not fail
 				//nolint:errcheck // ignore error
-				nw.deleteEndpointImpl(netlink.NewMockNetlink(false, ""), platform.NewMockExecClient(false), mockCli, NewMockNamespaceClient(), ep2)
+				nw.deleteEndpointImpl(netlink.NewMockNetlink(false, ""), platform.NewMockExecClient(false), mockCli, netio.NewMockNetIO(false, 0), NewMockNamespaceClient(), ep2)
 				Expect(len(mockCli.endpoints)).To(Equal(0))
 			})
 		})
@@ -259,6 +259,37 @@ var _ = Describe("Test Endpoint", func() {
 					netio.NewMockNetIO(false, 0), NewMockEndpointClient(nil), NewMockNamespaceClient(), []*EndpointInfo{epInfo})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(ep).NotTo(BeNil())
+				Expect(ep.Id).To(Equal(epInfo.Id))
+			})
+		})
+		Context("When secondary endpoint add failed", func() {
+			It("Should not be added to the network", func() {
+				_, ipnet, _ := net.ParseCIDR("0.0.0.0/0")
+				nw := &network{
+					Endpoints: map[string]*endpoint{},
+					Mode:      opModeTransparent,
+					extIf:     &externalInterface{BridgeName: "testbridge"},
+				}
+				epInfo := &EndpointInfo{
+					Id:      "768e8deb-eth1",
+					IfName:  eth0IfName,
+					NICType: cns.InfraNIC,
+				}
+				secondaryEpInfo := &EndpointInfo{
+					MacAddress: netio.BadHwAddr, // mock netlink will fail to set link state on bad eth
+					NICType:    cns.DelegatedVMNIC,
+					Routes:     []RouteInfo{{Dst: *ipnet}},
+				}
+				ep, err := nw.newEndpointImpl(nil, netlink.NewMockNetlink(false, ""), platform.NewMockExecClient(false),
+					netio.NewMockNetIO(false, 0), nil, NewMockNamespaceClient(), []*EndpointInfo{epInfo, secondaryEpInfo})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("SecondaryEndpointClient Error: " + netlink.ErrorMockNetlink.Error()))
+				Expect(ep).To(BeNil())
+
+				secondaryEpInfo.MacAddress = netio.HwAddr
+				ep, err = nw.newEndpointImpl(nil, netlink.NewMockNetlink(false, ""), platform.NewMockExecClient(false),
+					netio.NewMockNetIO(false, 0), nil, NewMockNamespaceClient(), []*EndpointInfo{epInfo, secondaryEpInfo})
+				Expect(err).ToNot(HaveOccurred())
 				Expect(ep.Id).To(Equal(epInfo.Id))
 			})
 		})

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -409,7 +409,7 @@ func (nw *network) newEndpointImplHnsV2(cli apipaClient, epInfo *EndpointInfo) (
 }
 
 // deleteEndpointImpl deletes an existing endpoint from the network.
-func (nw *network) deleteEndpointImpl(_ netlink.NetlinkInterface, _ platform.ExecClient, _ EndpointClient, _ NamespaceClientInterface, ep *endpoint) error {
+func (nw *network) deleteEndpointImpl(_ netlink.NetlinkInterface, _ platform.ExecClient, _ EndpointClient, _ netio.NetIOInterface, _ NamespaceClientInterface, ep *endpoint) error {
 	if useHnsV2, err := UseHnsV2(ep.NetNs); useHnsV2 {
 		if err != nil {
 			return err

--- a/network/manager.go
+++ b/network/manager.go
@@ -369,7 +369,7 @@ func (nm *networkManager) DeleteEndpoint(networkID, endpointID string) error {
 		return err
 	}
 
-	err = nw.deleteEndpoint(nm.netlink, nm.plClient, nm.nsClient, endpointID)
+	err = nw.deleteEndpoint(nm.netlink, nm.plClient, nm.netio, nm.nsClient, endpointID)
 	if err != nil {
 		return err
 	}

--- a/network/secondary_endpoint_client_linux.go
+++ b/network/secondary_endpoint_client_linux.go
@@ -30,13 +30,14 @@ type SecondaryEndpointClient struct {
 
 func NewSecondaryEndpointClient(
 	nl netlink.NetlinkInterface,
+	nioc netio.NetIOInterface,
 	plc platform.ExecClient,
 	nsc NamespaceClientInterface,
 	endpoint *endpoint,
 ) *SecondaryEndpointClient {
 	client := &SecondaryEndpointClient{
 		netlink:        nl,
-		netioshim:      &netio.NetIO{},
+		netioshim:      nioc,
 		plClient:       plc,
 		netUtilsClient: networkutils.NewNetworkUtils(nl, plc),
 		nsClient:       nsc,

--- a/network/transparent_endpointclient_linux.go
+++ b/network/transparent_endpointclient_linux.go
@@ -52,6 +52,7 @@ func NewTransparentEndpointClient(
 	containerVethName string,
 	mode string,
 	nl netlink.NetlinkInterface,
+	nioc netio.NetIOInterface,
 	plc platform.ExecClient,
 ) *TransparentEndpointClient {
 	client := &TransparentEndpointClient{
@@ -62,7 +63,7 @@ func NewTransparentEndpointClient(
 		hostPrimaryMac:    extIf.MacAddress,
 		mode:              mode,
 		netlink:           nl,
-		netioshim:         &netio.NetIO{},
+		netioshim:         nioc,
 		plClient:          plc,
 		netUtilsClient:    networkutils.NewNetworkUtils(nl, plc),
 	}


### PR DESCRIPTION
**Reason for Change**:
Add a test to validate that endpoint will not be created if SecondaryEndpointClient fails

Passing NIC Type var from CNS response down instead of hardcoding


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] relevant PR labels added

**Notes**:
