### PR TITLE
refactor: remove cniTypesCurr.Result dependency in InterfaceInfo

### DIFF
--- a/cni/network/invoker.go
+++ b/cni/network/invoker.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/Azure/azure-container-networking/cni"
 	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/network"
 	cniSkel "github.com/containernetworking/cni/pkg/skel"
-	cniTypesCurr "github.com/containernetworking/cni/pkg/types/100"
 )
 
 // IPAMInvoker is used by the azure-vnet CNI plugin to call different sources for IPAM.
@@ -28,17 +28,10 @@ type IPAMAddConfig struct {
 
 type IPAMAddResult struct {
 	// Splitting defaultInterfaceInfo from secondaryInterfacesInfo so we don't need to loop for default CNI result every time
-	defaultInterfaceInfo    InterfaceInfo
-	secondaryInterfacesInfo []InterfaceInfo
+	defaultInterfaceInfo    network.InterfaceInfo
+	secondaryInterfacesInfo []network.InterfaceInfo
 	// ncResponse is used for Swift 1.0 multitenancy
 	ncResponse       *cns.GetNetworkContainerResponse
 	hostSubnetPrefix net.IPNet
 	ipv6Enabled      bool
-}
-
-type InterfaceInfo struct {
-	ipResult          *cniTypesCurr.Result
-	nicType           cns.NICType
-	macAddress        net.HardwareAddr
-	skipDefaultRoutes bool
 }

--- a/cni/network/invoker_azure_test.go
+++ b/cni/network/invoker_azure_test.go
@@ -103,10 +103,10 @@ func getSingleResult(ip string) []*cniTypesCurr.Result {
 }
 
 // getResult will return a slice of IPConfigs
-func getResult(ips ...string) *cniTypesCurr.Result {
-	res := &cniTypesCurr.Result{}
+func getResult(ips ...string) []*network.IPConfig {
+	res := make([]*network.IPConfig, 0)
 	for _, ip := range ips {
-		res.IPs = append(res.IPs, &cniTypesCurr.IPConfig{Address: *getCIDRNotationForAddress(ip)})
+		res = append(res, &network.IPConfig{Address: *getCIDRNotationForAddress(ip)})
 	}
 	return res
 }
@@ -142,7 +142,7 @@ func TestAzureIPAMInvoker_Add(t *testing.T) {
 		name    string
 		fields  fields
 		args    args
-		want    *cniTypesCurr.Result
+		want    []*network.IPConfig
 		wantErr bool
 	}{
 		{
@@ -238,8 +238,8 @@ func TestAzureIPAMInvoker_Add(t *testing.T) {
 				require.Nil(err)
 			}
 
-			fmt.Printf("want:%+v\nrest:%+v\n", tt.want, ipamAddResult.defaultInterfaceInfo.ipResult)
-			require.Exactly(tt.want, ipamAddResult.defaultInterfaceInfo.ipResult)
+			fmt.Printf("want:%+v\nrest:%+v\n", tt.want, ipamAddResult.defaultInterfaceInfo.IPConfigs)
+			require.Exactly(tt.want, ipamAddResult.defaultInterfaceInfo.IPConfigs)
 		})
 	}
 }
@@ -395,8 +395,7 @@ func TestRemoveIpamState_Add(t *testing.T) {
 		name       string
 		fields     fields
 		args       args
-		want       *cniTypesCurr.Result
-		want1      *cniTypesCurr.Result
+		want       []*network.IPConfig
 		wantErrMsg string
 		wantErr    bool
 	}{

--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -15,8 +15,6 @@ import (
 	"github.com/Azure/azure-container-networking/network"
 	"github.com/Azure/azure-container-networking/network/networkutils"
 	cniSkel "github.com/containernetworking/cni/pkg/skel"
-	cniTypes "github.com/containernetworking/cni/pkg/types"
-	cniTypesCurr "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -178,8 +176,8 @@ func (invoker *CNSIPAMInvoker) Add(addConfig IPAMAddConfig) (IPAMAddResult, erro
 			}
 		default:
 			// only count dualstack interface once
-			if addResult.defaultInterfaceInfo.ipResult == nil {
-				addResult.defaultInterfaceInfo.ipResult = &cniTypesCurr.Result{}
+			if addResult.defaultInterfaceInfo.IPConfigs == nil {
+				addResult.defaultInterfaceInfo.IPConfigs = make([]*network.IPConfig, 0)
 				if !info.skipDefaultRoutes {
 					numInterfacesWithDefaultRoutes++
 				}
@@ -331,8 +329,8 @@ func (invoker *CNSIPAMInvoker) Delete(address *net.IPNet, nwCfg *cni.NetworkConf
 	return nil
 }
 
-func getRoutes(cnsRoutes []cns.Route, skipDefaultRoutes bool) ([]*cniTypes.Route, error) {
-	routes := make([]*cniTypes.Route, 0)
+func getRoutes(cnsRoutes []cns.Route, skipDefaultRoutes bool) ([]network.RouteInfo, error) {
+	routes := make([]network.RouteInfo, 0)
 	for _, route := range cnsRoutes {
 		_, dst, routeErr := net.ParseCIDR(route.IPAddress)
 		if routeErr != nil {
@@ -345,9 +343,9 @@ func getRoutes(cnsRoutes []cns.Route, skipDefaultRoutes bool) ([]*cniTypes.Route
 		}
 
 		routes = append(routes,
-			&cniTypes.Route{
+			network.RouteInfo{
 				Dst: *dst,
-				GW:  gw,
+				Gw:  gw,
 			})
 	}
 
@@ -386,15 +384,15 @@ func configureDefaultAddResult(info *IPResultInfo, addConfig *IPAMAddConfig, add
 	}
 
 	if ip := net.ParseIP(info.podIPAddress); ip != nil {
-		defaultInterfaceInfo := addResult.defaultInterfaceInfo.ipResult
+		defaultInterfaceInfo := &addResult.defaultInterfaceInfo
 		defaultRouteDstPrefix := network.Ipv4DefaultRouteDstPrefix
 		if ip.To4() == nil {
 			defaultRouteDstPrefix = network.Ipv6DefaultRouteDstPrefix
 			addResult.ipv6Enabled = true
 		}
 
-		defaultInterfaceInfo.IPs = append(defaultInterfaceInfo.IPs,
-			&cniTypesCurr.IPConfig{
+		defaultInterfaceInfo.IPConfigs = append(defaultInterfaceInfo.IPConfigs,
+			&network.IPConfig{
 				Address: net.IPNet{
 					IP:   ip,
 					Mask: ncIPNet.Mask,
@@ -410,14 +408,13 @@ func configureDefaultAddResult(info *IPResultInfo, addConfig *IPAMAddConfig, add
 		if len(routes) > 0 {
 			defaultInterfaceInfo.Routes = append(defaultInterfaceInfo.Routes, routes...)
 		} else { // add default routes if none are provided
-			defaultInterfaceInfo.Routes = append(defaultInterfaceInfo.Routes, &cniTypes.Route{
+			defaultInterfaceInfo.Routes = append(defaultInterfaceInfo.Routes, network.RouteInfo{
 				Dst: defaultRouteDstPrefix,
-				GW:  ncgw,
+				Gw:  ncgw,
 			})
 		}
 
-		addResult.defaultInterfaceInfo.ipResult = defaultInterfaceInfo
-		addResult.defaultInterfaceInfo.skipDefaultRoutes = info.skipDefaultRoutes
+		addResult.defaultInterfaceInfo.SkipDefaultRoutes = info.skipDefaultRoutes
 	}
 
 	// get the name of the primary IP address
@@ -427,7 +424,7 @@ func configureDefaultAddResult(info *IPResultInfo, addConfig *IPAMAddConfig, add
 	}
 
 	addResult.hostSubnetPrefix = *hostIPNet
-	addResult.defaultInterfaceInfo.nicType = cns.InfraNIC
+	addResult.defaultInterfaceInfo.NICType = cns.InfraNIC
 
 	// set subnet prefix for host vm
 	// setHostOptions will execute if IPAM mode is not v4 overlay and not dualStackOverlay mode
@@ -452,28 +449,26 @@ func configureSecondaryAddResult(info *IPResultInfo, addResult *IPAMAddResult, p
 		return errors.Wrap(err, "Invalid mac address")
 	}
 
-	result := InterfaceInfo{
-		ipResult: &cniTypesCurr.Result{
-			IPs: []*cniTypesCurr.IPConfig{
-				{
-					Address: net.IPNet{
-						IP:   ip,
-						Mask: ipnet.Mask,
-					},
-				},
-			},
-		},
-		nicType:           info.nicType,
-		macAddress:        macAddress,
-		skipDefaultRoutes: info.skipDefaultRoutes,
-	}
-
 	routes, err := getRoutes(info.routes, info.skipDefaultRoutes)
 	if err != nil {
 		return err
 	}
 
-	result.ipResult.Routes = append(result.ipResult.Routes, routes...)
+	result := network.InterfaceInfo{
+		IPConfigs: []*network.IPConfig{
+			{
+				Address: net.IPNet{
+					IP:   ip,
+					Mask: ipnet.Mask,
+				},
+			},
+		},
+		Routes:            routes,
+		NICType:           info.nicType,
+		MacAddress:        macAddress,
+		SkipDefaultRoutes: info.skipDefaultRoutes,
+	}
+
 	addResult.secondaryInterfacesInfo = append(addResult.secondaryInterfacesInfo, result)
 
 	return nil

--- a/cni/network/invoker_mock.go
+++ b/cni/network/invoker_mock.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/Azure/azure-container-networking/cni"
 	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/network"
 	"github.com/containernetworking/cni/pkg/skel"
-	current "github.com/containernetworking/cni/pkg/types/100"
 )
 
 const (
@@ -60,11 +60,11 @@ func (invoker *MockIpamInvoker) Add(opt IPAMAddConfig) (ipamAddResult IPAMAddRes
 	ip := net.ParseIP(ipv4Str)
 	ipnet := net.IPNet{IP: ip, Mask: net.CIDRMask(subnetBits, ipv4Bits)}
 	gwIP := net.ParseIP("10.240.0.1")
-	ipamAddResult.defaultInterfaceInfo = InterfaceInfo{
-		ipResult: &current.Result{
-			IPs: []*current.IPConfig{{Address: ipnet, Gateway: gwIP}},
+	ipamAddResult.defaultInterfaceInfo = network.InterfaceInfo{
+		IPConfigs: []*network.IPConfig{
+			{Address: ipnet, Gateway: gwIP},
 		},
-		nicType: cns.InfraNIC,
+		NICType: cns.InfraNIC,
 	}
 	invoker.ipMap[ipnet.String()] = true
 	if invoker.v6Fail {
@@ -80,7 +80,7 @@ func (invoker *MockIpamInvoker) Add(opt IPAMAddConfig) (ipamAddResult IPAMAddRes
 		ip := net.ParseIP(ipv6Str)
 		ipnet := net.IPNet{IP: ip, Mask: net.CIDRMask(subnetv6Bits, ipv6Bits)}
 		gwIP := net.ParseIP("fc00::1")
-		ipamAddResult.defaultInterfaceInfo.ipResult.IPs = append(ipamAddResult.defaultInterfaceInfo.ipResult.IPs, &current.IPConfig{Address: ipnet, Gateway: gwIP})
+		ipamAddResult.defaultInterfaceInfo.IPConfigs = append(ipamAddResult.defaultInterfaceInfo.IPConfigs, &network.IPConfig{Address: ipnet, Gateway: gwIP})
 		invoker.ipMap[ipnet.String()] = true
 	}
 
@@ -91,11 +91,11 @@ func (invoker *MockIpamInvoker) Add(opt IPAMAddConfig) (ipamAddResult IPAMAddRes
 
 		ipStr := "20.20.20.20/32"
 		_, ipnet, _ := net.ParseCIDR(ipStr)
-		ipamAddResult.secondaryInterfacesInfo = append(ipamAddResult.secondaryInterfacesInfo, InterfaceInfo{
-			ipResult: &current.Result{
-				IPs: []*current.IPConfig{{Address: *ipnet}},
+		ipamAddResult.secondaryInterfacesInfo = append(ipamAddResult.secondaryInterfacesInfo, network.InterfaceInfo{
+			IPConfigs: []*network.IPConfig{
+				{Address: *ipnet},
 			},
-			nicType: cns.DelegatedVMNIC,
+			NICType: cns.DelegatedVMNIC,
 		})
 	}
 

--- a/cni/network/multitenancy_mock.go
+++ b/cni/network/multitenancy_mock.go
@@ -38,7 +38,7 @@ func (m *MockMultitenancy) SetupRoutingForMultitenancy(
 	cnsNetworkConfig *cns.GetNetworkContainerResponse,
 	azIpamResult *current.Result,
 	epInfo *network.EndpointInfo,
-	result *current.Result) {
+	_ *network.InterfaceInfo) {
 }
 
 func (m *MockMultitenancy) DetermineSnatFeatureOnHost(snatFile, nmAgentSupportedApisURL string) (snatDNS, snatHost bool, err error) {
@@ -158,8 +158,10 @@ func (m *MockMultitenancy) GetAllNetworkContainers(
 	for i := 0; i < len(cnsResponses); i++ {
 		ipamResults[i].ncResponse = &cnsResponses[i]
 		ipamResults[i].hostSubnetPrefix = ipNets[i]
-		ipamResults[i].defaultInterfaceInfo.ipResult = convertToCniResult(ipamResults[i].ncResponse, ifName)
-		ipamResults[i].defaultInterfaceInfo.nicType = cns.InfraNIC
+		ipconfig, routes := convertToIPConfigAndRouteInfo(ipamResults[i].ncResponse)
+		ipamResults[i].defaultInterfaceInfo.IPConfigs = []*network.IPConfig{ipconfig}
+		ipamResults[i].defaultInterfaceInfo.Routes = routes
+		ipamResults[i].defaultInterfaceInfo.NICType = cns.InfraNIC
 	}
 
 	return ipamResults, nil

--- a/cni/network/multitenancy_test.go
+++ b/cni/network/multitenancy_test.go
@@ -194,7 +194,7 @@ func TestSetupRoutingForMultitenancy(t *testing.T) {
 		cnsNetworkConfig *cns.GetNetworkContainerResponse
 		azIpamResult     *cniTypesCurr.Result
 		epInfo           *network.EndpointInfo
-		result           *cniTypesCurr.Result
+		result           *network.InterfaceInfo
 	}
 
 	tests := []struct {
@@ -218,7 +218,7 @@ func TestSetupRoutingForMultitenancy(t *testing.T) {
 					},
 				},
 				epInfo: &network.EndpointInfo{},
-				result: &cniTypesCurr.Result{},
+				result: &network.InterfaceInfo{},
 			},
 			expected: args{
 				nwCfg: &cni.NetworkConfig{
@@ -240,11 +240,11 @@ func TestSetupRoutingForMultitenancy(t *testing.T) {
 						},
 					},
 				},
-				result: &cniTypesCurr.Result{
-					Routes: []*cniTypes.Route{
+				result: &network.InterfaceInfo{
+					Routes: []network.RouteInfo{
 						{
 							Dst: net.IPNet{IP: net.ParseIP("0.0.0.0"), Mask: defaultIPNet().Mask},
-							GW:  net.ParseIP("10.0.0.1"),
+							Gw:  net.ParseIP("10.0.0.1"),
 						},
 					},
 				},

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -362,11 +362,7 @@ func (plugin *NetPlugin) Add(args *cniSkel.CmdArgs) error {
 		telemetry.SendCNIMetric(&cniMetric, plugin.tb)
 
 		// Add Interfaces to result.
-		defaultCniResult := convertInterfaceInfoToCniResult(ipamAddResult.defaultInterfaceInfo)
-		iface := &cniTypesCurr.Interface{
-			Name: args.IfName,
-		}
-		defaultCniResult.Interfaces = append(defaultCniResult.Interfaces, iface)
+		defaultCniResult := convertInterfaceInfoToCniResult(ipamAddResult.defaultInterfaceInfo, args.IfName)
 
 		addSnatInterface(nwCfg, defaultCniResult)
 
@@ -1359,8 +1355,13 @@ func convertNnsToIPConfigs(
 	return ipConfigs
 }
 
-func convertInterfaceInfoToCniResult(info network.InterfaceInfo) *cniTypesCurr.Result {
+func convertInterfaceInfoToCniResult(info network.InterfaceInfo, ifName string) *cniTypesCurr.Result {
 	result := &cniTypesCurr.Result{
+		Interfaces: []*cniTypesCurr.Interface{
+			{
+				Name: ifName,
+			},
+		},
 		DNS: cniTypes.DNS{
 			Domain:      info.DNS.Suffix,
 			Nameservers: info.DNS.Servers,

--- a/cni/network/network_linux_test.go
+++ b/cni/network/network_linux_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/network"
-	current "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -114,7 +113,7 @@ func TestAddDefaultRoute(t *testing.T) {
 		name   string
 		gwIP   string
 		epInfo network.EndpointInfo
-		result current.Result
+		result network.InterfaceInfo
 	}{
 		{
 			name: "add default route multitenancy",
@@ -140,7 +139,7 @@ func TestAddSnatForDns(t *testing.T) {
 		name   string
 		gwIP   string
 		epInfo network.EndpointInfo
-		result current.Result
+		result network.InterfaceInfo
 	}{
 		{
 			name: "add snat for dns",

--- a/cni/network/network_test.go
+++ b/cni/network/network_test.go
@@ -742,131 +742,131 @@ func TestPluginMultitenancyDelete(t *testing.T) {
 /*
 Baremetal scenarios
 */
-// func TestPluginBaremetalAdd(t *testing.T) {
-// 	plugin, _ := cni.NewPlugin("test", "0.3.0")
+func TestPluginBaremetalAdd(t *testing.T) {
+	plugin, _ := cni.NewPlugin("test", "0.3.0")
 
-// 	localNwCfg := cni.NetworkConfig{
-// 		CNIVersion:                 "0.3.0",
-// 		Name:                       "baremetal-net",
-// 		ExecutionMode:              string(util.Baremetal),
-// 		EnableExactMatchForPodName: true,
-// 		Master:                     "eth0",
-// 	}
+	localNwCfg := cni.NetworkConfig{
+		CNIVersion:                 "0.3.0",
+		Name:                       "baremetal-net",
+		ExecutionMode:              string(util.Baremetal),
+		EnableExactMatchForPodName: true,
+		Master:                     "eth0",
+	}
 
-// 	tests := []struct {
-// 		name       string
-// 		plugin     *NetPlugin
-// 		args       *cniSkel.CmdArgs
-// 		wantErr    bool
-// 		wantErrMsg string
-// 	}{
-// 		{
-// 			name: "Baremetal Add Happy path",
-// 			plugin: &NetPlugin{
-// 				Plugin:    plugin,
-// 				nm:        acnnetwork.NewMockNetworkmanager(acnnetwork.NewMockEndpointClient(nil)),
-// 				tb:        &telemetry.TelemetryBuffer{},
-// 				report:    &telemetry.CNIReport{},
-// 				nnsClient: &nns.MockGrpcClient{},
-// 			},
-// 			args: &cniSkel.CmdArgs{
-// 				StdinData:   localNwCfg.Serialize(),
-// 				ContainerID: "test-container",
-// 				Netns:       "test-container",
-// 				Args:        fmt.Sprintf("K8S_POD_NAME=%v;K8S_POD_NAMESPACE=%v", "test-pod", "test-pod-ns"),
-// 				IfName:      eth0IfName,
-// 			},
-// 			wantErr: false,
-// 		},
-// 		{
-// 			name: "Baremetal Add Fail",
-// 			plugin: &NetPlugin{
-// 				Plugin:    plugin,
-// 				nm:        acnnetwork.NewMockNetworkmanager(acnnetwork.NewMockEndpointClient(nil)),
-// 				tb:        &telemetry.TelemetryBuffer{},
-// 				report:    &telemetry.CNIReport{},
-// 				nnsClient: &nns.MockGrpcClient{Fail: true},
-// 			},
-// 			args: &cniSkel.CmdArgs{
-// 				StdinData:   localNwCfg.Serialize(),
-// 				ContainerID: "test-container",
-// 				Netns:       "test-container",
-// 				Args:        fmt.Sprintf("K8S_POD_NAME=%v;K8S_POD_NAMESPACE=%v", "test-pod", "test-pod-ns"),
-// 				IfName:      eth0IfName,
-// 			},
-// 			wantErr:    true,
-// 			wantErrMsg: nns.ErrMockNnsAdd.Error(),
-// 		},
-// 	}
+	tests := []struct {
+		name       string
+		plugin     *NetPlugin
+		args       *cniSkel.CmdArgs
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			name: "Baremetal Add Happy path",
+			plugin: &NetPlugin{
+				Plugin:    plugin,
+				nm:        acnnetwork.NewMockNetworkmanager(acnnetwork.NewMockEndpointClient(nil)),
+				tb:        &telemetry.TelemetryBuffer{},
+				report:    &telemetry.CNIReport{},
+				nnsClient: &nns.MockGrpcClient{},
+			},
+			args: &cniSkel.CmdArgs{
+				StdinData:   localNwCfg.Serialize(),
+				ContainerID: "test-container",
+				Netns:       "test-container",
+				Args:        fmt.Sprintf("K8S_POD_NAME=%v;K8S_POD_NAMESPACE=%v", "test-pod", "test-pod-ns"),
+				IfName:      eth0IfName,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Baremetal Add Fail",
+			plugin: &NetPlugin{
+				Plugin:    plugin,
+				nm:        acnnetwork.NewMockNetworkmanager(acnnetwork.NewMockEndpointClient(nil)),
+				tb:        &telemetry.TelemetryBuffer{},
+				report:    &telemetry.CNIReport{},
+				nnsClient: &nns.MockGrpcClient{Fail: true},
+			},
+			args: &cniSkel.CmdArgs{
+				StdinData:   localNwCfg.Serialize(),
+				ContainerID: "test-container",
+				Netns:       "test-container",
+				Args:        fmt.Sprintf("K8S_POD_NAME=%v;K8S_POD_NAMESPACE=%v", "test-pod", "test-pod-ns"),
+				IfName:      eth0IfName,
+			},
+			wantErr:    true,
+			wantErrMsg: nns.ErrMockNnsAdd.Error(),
+		},
+	}
 
-// 	for _, tt := range tests {
-// 		tt := tt
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			err := tt.plugin.Add(tt.args)
-// 			if tt.wantErr {
-// 				require.Error(t, err)
-// 				assert.Contains(t, err.Error(), tt.wantErrMsg, "Expected %v but got %+v", tt.wantErrMsg, err.Error())
-// 			} else {
-// 				require.NoError(t, err)
-// 			}
-// 		})
-// 	}
-// }
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.plugin.Add(tt.args)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg, "Expected %v but got %+v", tt.wantErrMsg, err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
 
-// func TestPluginBaremetalDelete(t *testing.T) {
-// 	plugin := GetTestResources()
-// 	plugin.nnsClient = &nns.MockGrpcClient{}
-// 	localNwCfg := cni.NetworkConfig{
-// 		CNIVersion:                 "0.3.0",
-// 		Name:                       "baremetal-net",
-// 		ExecutionMode:              string(util.Baremetal),
-// 		EnableExactMatchForPodName: true,
-// 		Master:                     "eth0",
-// 	}
+func TestPluginBaremetalDelete(t *testing.T) {
+	plugin := GetTestResources()
+	plugin.nnsClient = &nns.MockGrpcClient{}
+	localNwCfg := cni.NetworkConfig{
+		CNIVersion:                 "0.3.0",
+		Name:                       "baremetal-net",
+		ExecutionMode:              string(util.Baremetal),
+		EnableExactMatchForPodName: true,
+		Master:                     "eth0",
+	}
 
-// 	tests := []struct {
-// 		name       string
-// 		methods    []string
-// 		args       *cniSkel.CmdArgs
-// 		wantErr    bool
-// 		wantErrMsg string
-// 	}{
-// 		{
-// 			name:    "Baremetal delete success",
-// 			methods: []string{CNI_ADD, CNI_DEL},
-// 			args: &cniSkel.CmdArgs{
-// 				StdinData:   localNwCfg.Serialize(),
-// 				ContainerID: "test-container",
-// 				Netns:       "test-container",
-// 				Args:        fmt.Sprintf("K8S_POD_NAME=%v;K8S_POD_NAMESPACE=%v", "test-pod", "test-pod-ns"),
-// 				IfName:      eth0IfName,
-// 			},
-// 			wantErr: false,
-// 		},
-// 	}
+	tests := []struct {
+		name       string
+		methods    []string
+		args       *cniSkel.CmdArgs
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			name:    "Baremetal delete success",
+			methods: []string{CNI_ADD, CNI_DEL},
+			args: &cniSkel.CmdArgs{
+				StdinData:   localNwCfg.Serialize(),
+				ContainerID: "test-container",
+				Netns:       "test-container",
+				Args:        fmt.Sprintf("K8S_POD_NAME=%v;K8S_POD_NAMESPACE=%v", "test-pod", "test-pod-ns"),
+				IfName:      eth0IfName,
+			},
+			wantErr: false,
+		},
+	}
 
-// 	for _, tt := range tests {
-// 		tt := tt
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			var err error
-// 			for _, method := range tt.methods {
-// 				if method == CNI_ADD {
-// 					err = plugin.Add(tt.args)
-// 				} else if method == CNI_DEL {
-// 					err = plugin.Delete(tt.args)
-// 				}
-// 			}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			for _, method := range tt.methods {
+				if method == CNI_ADD {
+					err = plugin.Add(tt.args)
+				} else if method == CNI_DEL {
+					err = plugin.Delete(tt.args)
+				}
+			}
 
-// 			if tt.wantErr {
-// 				require.Error(t, err)
-// 			} else {
-// 				require.NoError(t, err)
-// 				endpoints, _ := plugin.nm.GetAllEndpoints(localNwCfg.Name)
-// 				require.Condition(t, assert.Comparison(func() bool { return len(endpoints) == 0 }))
-// 			}
-// 		})
-// 	}
-// }
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				endpoints, _ := plugin.nm.GetAllEndpoints(localNwCfg.Name)
+				require.Condition(t, assert.Comparison(func() bool { return len(endpoints) == 0 }))
+			}
+		})
+	}
+}
 
 /*
 AKS-Swift scenario

--- a/cni/network/network_test.go
+++ b/cni/network/network_test.go
@@ -742,131 +742,131 @@ func TestPluginMultitenancyDelete(t *testing.T) {
 /*
 Baremetal scenarios
 */
-func TestPluginBaremetalAdd(t *testing.T) {
-	plugin, _ := cni.NewPlugin("test", "0.3.0")
+// func TestPluginBaremetalAdd(t *testing.T) {
+// 	plugin, _ := cni.NewPlugin("test", "0.3.0")
 
-	localNwCfg := cni.NetworkConfig{
-		CNIVersion:                 "0.3.0",
-		Name:                       "baremetal-net",
-		ExecutionMode:              string(util.Baremetal),
-		EnableExactMatchForPodName: true,
-		Master:                     "eth0",
-	}
+// 	localNwCfg := cni.NetworkConfig{
+// 		CNIVersion:                 "0.3.0",
+// 		Name:                       "baremetal-net",
+// 		ExecutionMode:              string(util.Baremetal),
+// 		EnableExactMatchForPodName: true,
+// 		Master:                     "eth0",
+// 	}
 
-	tests := []struct {
-		name       string
-		plugin     *NetPlugin
-		args       *cniSkel.CmdArgs
-		wantErr    bool
-		wantErrMsg string
-	}{
-		{
-			name: "Baremetal Add Happy path",
-			plugin: &NetPlugin{
-				Plugin:    plugin,
-				nm:        acnnetwork.NewMockNetworkmanager(acnnetwork.NewMockEndpointClient(nil)),
-				tb:        &telemetry.TelemetryBuffer{},
-				report:    &telemetry.CNIReport{},
-				nnsClient: &nns.MockGrpcClient{},
-			},
-			args: &cniSkel.CmdArgs{
-				StdinData:   localNwCfg.Serialize(),
-				ContainerID: "test-container",
-				Netns:       "test-container",
-				Args:        fmt.Sprintf("K8S_POD_NAME=%v;K8S_POD_NAMESPACE=%v", "test-pod", "test-pod-ns"),
-				IfName:      eth0IfName,
-			},
-			wantErr: false,
-		},
-		{
-			name: "Baremetal Add Fail",
-			plugin: &NetPlugin{
-				Plugin:    plugin,
-				nm:        acnnetwork.NewMockNetworkmanager(acnnetwork.NewMockEndpointClient(nil)),
-				tb:        &telemetry.TelemetryBuffer{},
-				report:    &telemetry.CNIReport{},
-				nnsClient: &nns.MockGrpcClient{Fail: true},
-			},
-			args: &cniSkel.CmdArgs{
-				StdinData:   localNwCfg.Serialize(),
-				ContainerID: "test-container",
-				Netns:       "test-container",
-				Args:        fmt.Sprintf("K8S_POD_NAME=%v;K8S_POD_NAMESPACE=%v", "test-pod", "test-pod-ns"),
-				IfName:      eth0IfName,
-			},
-			wantErr:    true,
-			wantErrMsg: nns.ErrMockNnsAdd.Error(),
-		},
-	}
+// 	tests := []struct {
+// 		name       string
+// 		plugin     *NetPlugin
+// 		args       *cniSkel.CmdArgs
+// 		wantErr    bool
+// 		wantErrMsg string
+// 	}{
+// 		{
+// 			name: "Baremetal Add Happy path",
+// 			plugin: &NetPlugin{
+// 				Plugin:    plugin,
+// 				nm:        acnnetwork.NewMockNetworkmanager(acnnetwork.NewMockEndpointClient(nil)),
+// 				tb:        &telemetry.TelemetryBuffer{},
+// 				report:    &telemetry.CNIReport{},
+// 				nnsClient: &nns.MockGrpcClient{},
+// 			},
+// 			args: &cniSkel.CmdArgs{
+// 				StdinData:   localNwCfg.Serialize(),
+// 				ContainerID: "test-container",
+// 				Netns:       "test-container",
+// 				Args:        fmt.Sprintf("K8S_POD_NAME=%v;K8S_POD_NAMESPACE=%v", "test-pod", "test-pod-ns"),
+// 				IfName:      eth0IfName,
+// 			},
+// 			wantErr: false,
+// 		},
+// 		{
+// 			name: "Baremetal Add Fail",
+// 			plugin: &NetPlugin{
+// 				Plugin:    plugin,
+// 				nm:        acnnetwork.NewMockNetworkmanager(acnnetwork.NewMockEndpointClient(nil)),
+// 				tb:        &telemetry.TelemetryBuffer{},
+// 				report:    &telemetry.CNIReport{},
+// 				nnsClient: &nns.MockGrpcClient{Fail: true},
+// 			},
+// 			args: &cniSkel.CmdArgs{
+// 				StdinData:   localNwCfg.Serialize(),
+// 				ContainerID: "test-container",
+// 				Netns:       "test-container",
+// 				Args:        fmt.Sprintf("K8S_POD_NAME=%v;K8S_POD_NAMESPACE=%v", "test-pod", "test-pod-ns"),
+// 				IfName:      eth0IfName,
+// 			},
+// 			wantErr:    true,
+// 			wantErrMsg: nns.ErrMockNnsAdd.Error(),
+// 		},
+// 	}
 
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.plugin.Add(tt.args)
-			if tt.wantErr {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErrMsg, "Expected %v but got %+v", tt.wantErrMsg, err.Error())
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
+// 	for _, tt := range tests {
+// 		tt := tt
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			err := tt.plugin.Add(tt.args)
+// 			if tt.wantErr {
+// 				require.Error(t, err)
+// 				assert.Contains(t, err.Error(), tt.wantErrMsg, "Expected %v but got %+v", tt.wantErrMsg, err.Error())
+// 			} else {
+// 				require.NoError(t, err)
+// 			}
+// 		})
+// 	}
+// }
 
-func TestPluginBaremetalDelete(t *testing.T) {
-	plugin := GetTestResources()
-	plugin.nnsClient = &nns.MockGrpcClient{}
-	localNwCfg := cni.NetworkConfig{
-		CNIVersion:                 "0.3.0",
-		Name:                       "baremetal-net",
-		ExecutionMode:              string(util.Baremetal),
-		EnableExactMatchForPodName: true,
-		Master:                     "eth0",
-	}
+// func TestPluginBaremetalDelete(t *testing.T) {
+// 	plugin := GetTestResources()
+// 	plugin.nnsClient = &nns.MockGrpcClient{}
+// 	localNwCfg := cni.NetworkConfig{
+// 		CNIVersion:                 "0.3.0",
+// 		Name:                       "baremetal-net",
+// 		ExecutionMode:              string(util.Baremetal),
+// 		EnableExactMatchForPodName: true,
+// 		Master:                     "eth0",
+// 	}
 
-	tests := []struct {
-		name       string
-		methods    []string
-		args       *cniSkel.CmdArgs
-		wantErr    bool
-		wantErrMsg string
-	}{
-		{
-			name:    "Baremetal delete success",
-			methods: []string{CNI_ADD, CNI_DEL},
-			args: &cniSkel.CmdArgs{
-				StdinData:   localNwCfg.Serialize(),
-				ContainerID: "test-container",
-				Netns:       "test-container",
-				Args:        fmt.Sprintf("K8S_POD_NAME=%v;K8S_POD_NAMESPACE=%v", "test-pod", "test-pod-ns"),
-				IfName:      eth0IfName,
-			},
-			wantErr: false,
-		},
-	}
+// 	tests := []struct {
+// 		name       string
+// 		methods    []string
+// 		args       *cniSkel.CmdArgs
+// 		wantErr    bool
+// 		wantErrMsg string
+// 	}{
+// 		{
+// 			name:    "Baremetal delete success",
+// 			methods: []string{CNI_ADD, CNI_DEL},
+// 			args: &cniSkel.CmdArgs{
+// 				StdinData:   localNwCfg.Serialize(),
+// 				ContainerID: "test-container",
+// 				Netns:       "test-container",
+// 				Args:        fmt.Sprintf("K8S_POD_NAME=%v;K8S_POD_NAMESPACE=%v", "test-pod", "test-pod-ns"),
+// 				IfName:      eth0IfName,
+// 			},
+// 			wantErr: false,
+// 		},
+// 	}
 
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			var err error
-			for _, method := range tt.methods {
-				if method == CNI_ADD {
-					err = plugin.Add(tt.args)
-				} else if method == CNI_DEL {
-					err = plugin.Delete(tt.args)
-				}
-			}
+// 	for _, tt := range tests {
+// 		tt := tt
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			var err error
+// 			for _, method := range tt.methods {
+// 				if method == CNI_ADD {
+// 					err = plugin.Add(tt.args)
+// 				} else if method == CNI_DEL {
+// 					err = plugin.Delete(tt.args)
+// 				}
+// 			}
 
-			if tt.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				endpoints, _ := plugin.nm.GetAllEndpoints(localNwCfg.Name)
-				require.Condition(t, assert.Comparison(func() bool { return len(endpoints) == 0 }))
-			}
-		})
-	}
-}
+// 			if tt.wantErr {
+// 				require.Error(t, err)
+// 			} else {
+// 				require.NoError(t, err)
+// 				endpoints, _ := plugin.nm.GetAllEndpoints(localNwCfg.Name)
+// 				require.Condition(t, assert.Comparison(func() bool { return len(endpoints) == 0 }))
+// 			}
+// 		})
+// 	}
+// }
 
 /*
 AKS-Swift scenario

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -110,13 +110,10 @@ func (plugin *NetPlugin) handleConsecutiveAdd(args *cniSkel.CmdArgs, endpointId 
 	return nil, err
 }
 
-func addDefaultRoute(gwIPString string, epInfo *network.EndpointInfo, result *cniTypesCurr.Result) {
+func addDefaultRoute(_ string, _ *network.EndpointInfo, _ *network.InterfaceInfo) {
 }
 
-func addSnatForDNS(gwIPString string, epInfo *network.EndpointInfo, result *cniTypesCurr.Result) {
-}
-
-func addInfraRoutes(azIpamResult *cniTypesCurr.Result, result *cniTypesCurr.Result, epInfo *network.EndpointInfo) {
+func addSnatForDNS(_ string, _ *network.EndpointInfo, _ *network.InterfaceInfo) {
 }
 
 func setNetworkOptions(cnsNwConfig *cns.GetNetworkContainerResponse, nwInfo *network.NetworkInfo) {
@@ -161,7 +158,7 @@ func (plugin *NetPlugin) getNetworkName(netNs string, ipamAddResult *IPAMAddResu
 	// This will happen during ADD call
 	if ipamAddResult != nil && ipamAddResult.ncResponse != nil {
 		// networkName will look like ~ azure-vlan1-172-28-1-0_24
-		ipAddrNet := ipamAddResult.defaultInterfaceInfo.ipResult.IPs[0].Address
+		ipAddrNet := ipamAddResult.defaultInterfaceInfo.IPConfigs[0].Address
 		prefix, err := netip.ParsePrefix(ipAddrNet.String())
 		if err != nil {
 			logger.Error("Error parsing network CIDR",
@@ -191,11 +188,10 @@ func (plugin *NetPlugin) getNetworkName(netNs string, ipamAddResult *IPAMAddResu
 func setupInfraVnetRoutingForMultitenancy(
 	_ *cni.NetworkConfig,
 	_ *cniTypesCurr.Result,
-	_ *network.EndpointInfo,
-	_ *cniTypesCurr.Result) {
+	_ *network.EndpointInfo) {
 }
 
-func getNetworkDNSSettings(nwCfg *cni.NetworkConfig, _ *cniTypesCurr.Result) (network.DNSInfo, error) {
+func getNetworkDNSSettings(nwCfg *cni.NetworkConfig, _ network.DNSInfo) (network.DNSInfo, error) {
 	var nwDNS network.DNSInfo
 
 	// use custom dns if present
@@ -216,7 +212,7 @@ func getNetworkDNSSettings(nwCfg *cni.NetworkConfig, _ *cniTypesCurr.Result) (ne
 	return nwDNS, nil
 }
 
-func getEndpointDNSSettings(nwCfg *cni.NetworkConfig, result *cniTypesCurr.Result, namespace string) (network.DNSInfo, error) {
+func getEndpointDNSSettings(nwCfg *cni.NetworkConfig, dns network.DNSInfo, namespace string) (network.DNSInfo, error) {
 	var epDNS network.DNSInfo
 
 	// use custom dns if present
@@ -237,11 +233,8 @@ func getEndpointDNSSettings(nwCfg *cni.NetworkConfig, result *cniTypesCurr.Resul
 			Options: nwCfg.DNS.Options,
 		}
 	} else {
-		epDNS = network.DNSInfo{
-			Servers: result.DNS.Nameservers,
-			Suffix:  result.DNS.Domain,
-			Options: nwCfg.DNS.Options,
-		}
+		epDNS = dns
+		epDNS.Options = nwCfg.DNS.Options
 	}
 
 	return epDNS, nil

--- a/cni/network/network_windows_test.go
+++ b/cni/network/network_windows_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/Azure/azure-container-networking/network/policy"
 	"github.com/Azure/azure-container-networking/telemetry"
 	"github.com/containernetworking/cni/pkg/skel"
-	cniTypesCurr "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -228,7 +227,7 @@ func TestSetPoliciesFromNwCfg(t *testing.T) {
 					PortMappings: []cni.PortMapping{
 						{
 							Protocol:      "tcp",
-							HostIp:        "19.268.0.4",
+							HostIp:        "192.168.0.4",
 							HostPort:      8000,
 							ContainerPort: 80,
 						},
@@ -296,7 +295,7 @@ func TestDSRPolciy(t *testing.T) {
 					},
 				},
 				nwInfo: &network.NetworkInfo{},
-				ipconfigs: []*cniTypesCurr.IPConfig{
+				ipconfigs: []*network.IPConfig{
 					{
 						Address: func() net.IPNet {
 							_, ipnet, _ := net.ParseCIDR("10.0.0.5/24")
@@ -312,7 +311,7 @@ func TestDSRPolciy(t *testing.T) {
 			args: PolicyArgs{
 				nwCfg:  &cni.NetworkConfig{},
 				nwInfo: &network.NetworkInfo{},
-				ipconfigs: []*cniTypesCurr.IPConfig{
+				ipconfigs: []*network.IPConfig{
 					{
 						Address: func() net.IPNet {
 							_, ipnet, _ := net.ParseCIDR("10.0.0.5/24")
@@ -367,14 +366,12 @@ func TestGetNetworkNameFromCNS(t *testing.T) {
 						ID: 1,
 					},
 				},
-				defaultInterfaceInfo: InterfaceInfo{
-					ipResult: &cniTypesCurr.Result{
-						IPs: []*cniTypesCurr.IPConfig{
-							{
-								Address: net.IPNet{
-									IP:   net.ParseIP("10.240.0.5"),
-									Mask: net.CIDRMask(24, 32),
-								},
+				defaultInterfaceInfo: network.InterfaceInfo{
+					IPConfigs: []*network.IPConfig{
+						{
+							Address: net.IPNet{
+								IP:   net.ParseIP("10.240.0.5"),
+								Mask: net.CIDRMask(24, 32),
 							},
 						},
 					},
@@ -404,14 +401,12 @@ func TestGetNetworkNameFromCNS(t *testing.T) {
 						ID: 1,
 					},
 				},
-				defaultInterfaceInfo: InterfaceInfo{
-					ipResult: &cniTypesCurr.Result{
-						IPs: []*cniTypesCurr.IPConfig{
-							{
-								Address: net.IPNet{
-									IP:   net.ParseIP(""),
-									Mask: net.CIDRMask(24, 32),
-								},
+				defaultInterfaceInfo: network.InterfaceInfo{
+					IPConfigs: []*network.IPConfig{
+						{
+							Address: net.IPNet{
+								IP:   net.ParseIP(""),
+								Mask: net.CIDRMask(24, 32),
 							},
 						},
 					},
@@ -441,14 +436,12 @@ func TestGetNetworkNameFromCNS(t *testing.T) {
 						ID: 1,
 					},
 				},
-				defaultInterfaceInfo: InterfaceInfo{
-					ipResult: &cniTypesCurr.Result{
-						IPs: []*cniTypesCurr.IPConfig{
-							{
-								Address: net.IPNet{
-									IP:   net.ParseIP("10.0.00.6"),
-									Mask: net.CIDRMask(24, 32),
-								},
+				defaultInterfaceInfo: network.InterfaceInfo{
+					IPConfigs: []*network.IPConfig{
+						{
+							Address: net.IPNet{
+								IP:   net.ParseIP("10.0.00.6"),
+								Mask: net.CIDRMask(24, 32),
 							},
 						},
 					},
@@ -478,14 +471,12 @@ func TestGetNetworkNameFromCNS(t *testing.T) {
 						ID: 1,
 					},
 				},
-				defaultInterfaceInfo: InterfaceInfo{
-					ipResult: &cniTypesCurr.Result{
-						IPs: []*cniTypesCurr.IPConfig{
-							{
-								Address: net.IPNet{
-									IP:   net.ParseIP("10.0.0.6"),
-									Mask: net.CIDRMask(24, 32),
-								},
+				defaultInterfaceInfo: network.InterfaceInfo{
+					IPConfigs: []*network.IPConfig{
+						{
+							Address: net.IPNet{
+								IP:   net.ParseIP("10.0.0.6"),
+								Mask: net.CIDRMask(24, 32),
 							},
 						},
 					},
@@ -511,14 +502,12 @@ func TestGetNetworkNameFromCNS(t *testing.T) {
 			},
 			ipamAddResult: &IPAMAddResult{
 				ncResponse: &cns.GetNetworkContainerResponse{},
-				defaultInterfaceInfo: InterfaceInfo{
-					ipResult: &cniTypesCurr.Result{
-						IPs: []*cniTypesCurr.IPConfig{
-							{
-								Address: net.IPNet{
-									IP:   net.ParseIP("10.0.0.6"),
-									Mask: net.CIDRMask(24, 32),
-								},
+				defaultInterfaceInfo: network.InterfaceInfo{
+					IPConfigs: []*network.IPConfig{
+						{
+							Address: net.IPNet{
+								IP:   net.ParseIP("10.0.0.6"),
+								Mask: net.CIDRMask(24, 32),
 							},
 						},
 					},

--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -109,10 +109,16 @@ type RouteInfo struct {
 type InterfaceInfo struct {
 	Name              string
 	MacAddress        net.HardwareAddr
-	IPAddress         []net.IPNet
+	IPConfigs         []*IPConfig
 	Routes            []RouteInfo
+	DNS               DNSInfo
 	NICType           cns.NICType
 	SkipDefaultRoutes bool
+}
+
+type IPConfig struct {
+	Address net.IPNet
+	Gateway net.IP
 }
 
 type apipaClient interface {

--- a/network/secondary_endpoint_client_linux.go
+++ b/network/secondary_endpoint_client_linux.go
@@ -57,10 +57,16 @@ func (client *SecondaryEndpointClient) AddEndpoints(epInfo *EndpointInfo) error 
 	if _, exists := client.ep.SecondaryInterfaces[iface.Name]; exists {
 		return newErrorSecondaryEndpointClient(errors.New(iface.Name + " already exists"))
 	}
+
+	ipconfigs := make([]*IPConfig, len(epInfo.IPAddresses))
+	for i, ipconfig := range epInfo.IPAddresses {
+		ipconfigs[i] = &IPConfig{Address: ipconfig}
+	}
+
 	client.ep.SecondaryInterfaces[iface.Name] = &InterfaceInfo{
 		Name:              iface.Name,
 		MacAddress:        epInfo.MacAddress,
-		IPAddress:         epInfo.IPAddresses,
+		IPConfigs:         ipconfigs,
 		NICType:           epInfo.NICType,
 		SkipDefaultRoutes: epInfo.SkipDefaultRoutes,
 	}

--- a/network/secondary_endpoint_client_linux.go
+++ b/network/secondary_endpoint_client_linux.go
@@ -114,6 +114,13 @@ func (client *SecondaryEndpointClient) ConfigureContainerInterfacesAndRoutes(epI
 		return newErrorSecondaryEndpointClient(errors.New("routes expected for " + epInfo.IfName))
 	}
 
+	// virtual gw route needs to be scope link
+	for i := range epInfo.Routes {
+		if epInfo.Routes[i].Gw == nil {
+			epInfo.Routes[i].Scope = netlink.RT_SCOPE_LINK
+		}
+	}
+
 	if err := addRoutes(client.netlink, client.netioshim, epInfo.IfName, epInfo.Routes); err != nil {
 		return newErrorSecondaryEndpointClient(err)
 	}


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
removing cniTypesCurr.Result dependency in InterfaceInfo

adding scope link for swiftv2 gateway route

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
