### PR TITLE
Adding IPV6 NC conversion tests for CNS

### DIFF
--- a/cns/kubecontroller/nodenetworkconfig/conversion_linux_test.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_linux_test.go
@@ -36,6 +36,36 @@ var validOverlayRequest = &cns.CreateNetworkContainerRequest{
 	},
 }
 
+var validDualstackOverlayRequest = &cns.CreateNetworkContainerRequest{
+	Version: strconv.FormatInt(0, 10),
+	IPConfiguration: cns.IPConfiguration{
+		IPSubnet: cns.IPSubnet{
+			PrefixLength: uint8(subnetPrefixLenV6),
+			IPAddress:    primaryIPV6,
+		},
+	},
+	NetworkContainerid:   ncID,
+	NetworkContainerType: cns.Docker,
+	SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+		"fd12:1234::": {
+			IPAddress: "fd12:1234::",
+			NCVersion: 0,
+		},
+		"fd12:1234::1": {
+			IPAddress: "fd12:1234::1",
+			NCVersion: 0,
+		},
+		"fd12:1234::2": {
+			IPAddress: "fd12:1234::2",
+			NCVersion: 0,
+		},
+		"fd12:1234::3": {
+			IPAddress: "fd12:1234::3",
+			NCVersion: 0,
+		},
+	},
+}
+
 var validVNETBlockRequest = &cns.CreateNetworkContainerRequest{
 	Version: strconv.FormatInt(version, 10),
 	IPConfiguration: cns.IPConfiguration{
@@ -91,6 +121,66 @@ var validVNETBlockRequest = &cns.CreateNetworkContainerRequest{
 		},
 		"10.224.0.15": {
 			IPAddress: "10.224.0.15",
+			NCVersion: version,
+		},
+	},
+}
+
+var validVNETBlockDualstackRequest = &cns.CreateNetworkContainerRequest{
+	Version: strconv.FormatInt(version, 10),
+	IPConfiguration: cns.IPConfiguration{
+		GatewayIPAddress: vnetBlockDefaultGatewayV6,
+		IPSubnet: cns.IPSubnet{
+			PrefixLength: uint8(vnetBlockSubnetPrefixLenV6),
+			IPAddress:    vnetBlockPrimaryIPV6,
+		},
+	},
+	NetworkContainerid:   ncID,
+	NetworkContainerType: cns.Docker,
+	// Ignore first IP in first CIDR Block, i.e. fd12:1234::4
+	SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+		"fd12:1234::5": {
+			IPAddress: "fd12:1234::5",
+			NCVersion: version,
+		},
+		"fd12:1234::6": {
+			IPAddress: "fd12:1234::6",
+			NCVersion: version,
+		},
+		"fd12:1234::7": {
+			IPAddress: "fd12:1234::7",
+			NCVersion: version,
+		},
+		"fd12:1234::8": {
+			IPAddress: "fd12:1234::8",
+			NCVersion: version,
+		},
+		"fd12:1234::9": {
+			IPAddress: "fd12:1234::9",
+			NCVersion: version,
+		},
+		"fd12:1234::a": {
+			IPAddress: "fd12:1234::a",
+			NCVersion: version,
+		},
+		"fd12:1234::b": {
+			IPAddress: "fd12:1234::b",
+			NCVersion: version,
+		},
+		"fd12:1234::c": {
+			IPAddress: "fd12:1234::c",
+			NCVersion: version,
+		},
+		"fd12:1234::d": {
+			IPAddress: "fd12:1234::d",
+			NCVersion: version,
+		},
+		"fd12:1234::e": {
+			IPAddress: "fd12:1234::e",
+			NCVersion: version,
+		},
+		"fd12:1234::f": {
+			IPAddress: "fd12:1234::f",
 			NCVersion: version,
 		},
 	},

--- a/cns/kubecontroller/nodenetworkconfig/conversion_test.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_test.go
@@ -10,19 +10,24 @@ import (
 )
 
 const (
-	uuid                        = "539970a2-c2dd-11ea-b3de-0242ac130004"
-	defaultGateway              = "10.0.0.2"
-	ipIsCIDR                    = "10.0.0.1/32"
-	ipMalformed                 = "10.0.0.0.0"
-	ncID                        = "160005ba-cd02-11ea-87d0-0242ac130003"
-	primaryIP                   = "10.0.0.1"
-	overlayPrimaryIP            = "10.0.0.1/30"
-	subnetAddressSpace          = "10.0.0.0/24"
-	subnetName                  = "subnet1"
-	subnetPrefixLen             = 24
-	testSecIP                   = "10.0.0.2"
-	version                     = 1
-	nodeIP                      = "10.1.0.5"
+	uuid                 = "539970a2-c2dd-11ea-b3de-0242ac130004"
+	defaultGateway       = "10.0.0.2"
+	ipIsCIDR             = "10.0.0.1/32"
+	ipMalformed          = "10.0.0.0.0"
+	ncID                 = "160005ba-cd02-11ea-87d0-0242ac130003"
+	primaryIP            = "10.0.0.1"
+	primaryIPV6          = "fd12:1234::1"
+	overlayPrimaryIP     = "10.0.0.1/30"
+	overlayPrimaryIPv6   = "fd12:1234::1/126"
+	subnetAddressSpace   = "10.0.0.0/24"
+	subnetAddressSpacev6 = "fd12:1234::/120"
+	subnetName           = "subnet1"
+	subnetPrefixLen      = 24
+	subnetPrefixLenV6    = 120
+	testSecIP            = "10.0.0.2"
+	version              = 1
+	nodeIP               = "10.1.0.5"
+
 	vnetBlockPrimaryIP          = "10.224.0.4"
 	vnetBlockPrimaryIPPrefix    = "10.224.0.4/30"
 	vnetBlockSubnetAddressSpace = "10.224.0.0/14"
@@ -31,6 +36,15 @@ const (
 	vnetBlockDefaultGateway     = "10.224.0.1"
 	vnetBlockCIDR1              = "10.224.0.8/30"
 	vnetBlockCIDR2              = "10.224.0.12/30"
+
+	vnetBlockPrimaryIPV6          = "fd12:1234::4"
+	vnetBlockPrimaryIPPrefixV6    = "fd12:1234::4/126"
+	vnetBlockSubnetAddressSpaceV6 = "fd12:1234::1/110"
+	vnetBlockSubnetPrefixLenV6    = 110
+	vnetBlockNodeIPV6             = "fd12:1238::1"
+	vnetBlockDefaultGatewayV6     = "fd12:1234::1"
+	vnetBlockCIDR1V6              = "fd12:1234::8/126"
+	vnetBlockCIDR2V6              = "fd12:1234::c/126"
 )
 
 var invalidStatusMultiNC = v1alpha.NodeNetworkConfigStatus{
@@ -95,6 +109,17 @@ var validOverlayNC = v1alpha.NetworkContainer{
 	Version:            version,
 }
 
+var validDualstackOverlayNC = v1alpha.NetworkContainer{
+	ID:                 ncID,
+	AssignmentMode:     v1alpha.Static,
+	Type:               v1alpha.Overlay,
+	PrimaryIP:          overlayPrimaryIPv6,
+	NodeIP:             nodeIP,
+	SubnetName:         subnetName,
+	SubnetAddressSpace: subnetAddressSpacev6,
+	Version:            version,
+}
+
 var validVNETBlockNC = v1alpha.NetworkContainer{
 	ID:             ncID,
 	AssignmentMode: v1alpha.Static,
@@ -114,6 +139,28 @@ var validVNETBlockNC = v1alpha.NetworkContainer{
 	SubnetName:         subnetName,
 	SubnetAddressSpace: vnetBlockSubnetAddressSpace,
 	DefaultGateway:     vnetBlockDefaultGateway,
+	Version:            version,
+}
+
+var validDualstackVNETBlockNC = v1alpha.NetworkContainer{
+	ID:             ncID,
+	AssignmentMode: v1alpha.Static,
+	Type:           v1alpha.VNETBlock,
+	IPAssignments: []v1alpha.IPAssignment{
+		{
+			Name: uuid,
+			IP:   vnetBlockCIDR1V6,
+		},
+		{
+			Name: uuid,
+			IP:   vnetBlockCIDR2V6,
+		},
+	},
+	NodeIP:             vnetBlockNodeIPV6,
+	PrimaryIP:          vnetBlockPrimaryIPPrefixV6,
+	SubnetName:         subnetName,
+	SubnetAddressSpace: vnetBlockSubnetAddressSpaceV6,
+	DefaultGateway:     vnetBlockDefaultGatewayV6,
 	Version:            version,
 }
 
@@ -240,6 +287,12 @@ func TestCreateNCRequestFromStaticNC(t *testing.T) {
 			want:    validOverlayRequest,
 		},
 		{
+			name:    "valid overlay V6",
+			input:   validDualstackOverlayNC,
+			wantErr: false,
+			want:    validDualstackOverlayRequest,
+		},
+		{
 			name: "malformed primary IP",
 			input: v1alpha.NetworkContainer{
 				PrimaryIP: ipMalformed,
@@ -306,6 +359,12 @@ func TestCreateNCRequestFromStaticNC(t *testing.T) {
 			input:   validVNETBlockNC,
 			wantErr: false,
 			want:    validVNETBlockRequest,
+		},
+		{
+			name:    "valid VNET Block V6",
+			input:   validDualstackVNETBlockNC,
+			wantErr: false,
+			want:    validVNETBlockDualstackRequest,
 		},
 		{
 			name: "PrimaryIP is not CIDR",

--- a/cns/kubecontroller/nodenetworkconfig/conversion_windows_test.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_windows_test.go
@@ -25,6 +25,25 @@ var validOverlayRequest = &cns.CreateNetworkContainerRequest{
 	},
 }
 
+var validDualstackOverlayRequest = &cns.CreateNetworkContainerRequest{
+	Version: strconv.FormatInt(0, 10),
+	IPConfiguration: cns.IPConfiguration{
+		IPSubnet: cns.IPSubnet{
+			PrefixLength: uint8(subnetPrefixLenV6),
+			IPAddress:    primaryIPV6,
+		},
+		GatewayIPAddress: "fd12:1234::1",
+	},
+	NetworkContainerid:   ncID,
+	NetworkContainerType: cns.Docker,
+	SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+		"fd12:1234::2": {
+			IPAddress: "fd12:1234::2",
+			NCVersion: 0,
+		},
+	},
+}
+
 var validVNETBlockRequest = &cns.CreateNetworkContainerRequest{
 	Version: strconv.FormatInt(version, 10),
 	IPConfiguration: cns.IPConfiguration{
@@ -76,6 +95,62 @@ var validVNETBlockRequest = &cns.CreateNetworkContainerRequest{
 		},
 		"10.224.0.14": {
 			IPAddress: "10.224.0.14",
+			NCVersion: version,
+		},
+	},
+}
+
+var validVNETBlockDualstackRequest = &cns.CreateNetworkContainerRequest{
+	Version: strconv.FormatInt(version, 10),
+	IPConfiguration: cns.IPConfiguration{
+		GatewayIPAddress: vnetBlockDefaultGatewayV6,
+		IPSubnet: cns.IPSubnet{
+			PrefixLength: uint8(vnetBlockSubnetPrefixLenV6),
+			IPAddress:    vnetBlockPrimaryIPV6,
+		},
+	},
+	NetworkContainerid:   ncID,
+	NetworkContainerType: cns.Docker,
+	// Ignore first IP in first CIDR Block, i.e. fd12:1234::4
+	SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+		"fd12:1234::5": {
+			IPAddress: "fd12:1234::5",
+			NCVersion: version,
+		},
+		"fd12:1234::6": {
+			IPAddress: "fd12:1234::6",
+			NCVersion: version,
+		},
+		"fd12:1234::7": {
+			IPAddress: "fd12:1234::7",
+			NCVersion: version,
+		},
+		"fd12:1234::8": {
+			IPAddress: "fd12:1234::8",
+			NCVersion: version,
+		},
+		"fd12:1234::9": {
+			IPAddress: "fd12:1234::9",
+			NCVersion: version,
+		},
+		"fd12:1234::a": {
+			IPAddress: "fd12:1234::a",
+			NCVersion: version,
+		},
+		"fd12:1234::b": {
+			IPAddress: "fd12:1234::b",
+			NCVersion: version,
+		},
+		"fd12:1234::c": {
+			IPAddress: "fd12:1234::c",
+			NCVersion: version,
+		},
+		"fd12:1234::d": {
+			IPAddress: "fd12:1234::d",
+			NCVersion: version,
+		},
+		"fd12:1234::e": {
+			IPAddress: "fd12:1234::e",
 			NCVersion: version,
 		},
 	},


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Adding tests to make sure that NCs with V6 IPs for both Overlay and VNET Prefix can flatten out V6 CIDRs and populate the ipam pool in CNS.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
