### PR TITLE
use renamewithnetsh for nc rename

### DIFF
--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -48,7 +48,10 @@ type CNSConfig struct {
 	WatchPods                   bool
 	EnableAsyncPodDelete        bool
 	AsyncPodDeletePath          string
+	EnableRenameWithNetSh       bool
 }
+
+var CnsConfig CNSConfig
 
 type TelemetrySettings struct {
 	// Flag to disable the telemetry.
@@ -133,11 +136,12 @@ func readConfigFromFile(f string) (*CNSConfig, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read config file %s", f)
 	}
-	var config CNSConfig
-	if err := json.Unmarshal(content, &config); err != nil {
+
+	if err := json.Unmarshal(content, &CnsConfig); err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal config")
 	}
-	return &config, nil
+
+	return &CnsConfig, nil
 }
 
 // set telmetry setting defaults

--- a/cns/configuration/configuration_test.go
+++ b/cns/configuration/configuration_test.go
@@ -57,6 +57,7 @@ func TestReadConfigFromFile(t *testing.T) {
 				InitializeFromCNI:    true,
 				EnablePprof:          true,
 				EnableSubnetScarcity: true,
+				EnableRenameWithNetSh: true,
 				ManagedSettings: ManagedSettings{
 					PrivateEndpoint:           "abc",
 					InfrastructureNetworkID:   "abc",

--- a/cns/configuration/testdata/good.json
+++ b/cns/configuration/testdata/good.json
@@ -3,6 +3,7 @@
     "InitializeFromCNI": true,
     "EnablePprof": true,
     "EnableSubnetScarcity": true,
+    "EnableRenameWithNetSh": true,
     "ManagedSettings": {
         "InfrastructureNetworkID": "abc",
         "NodeID": "abc",

--- a/cns/networkcontainers/networkcontainers_windows.go
+++ b/cns/networkcontainers/networkcontainers_windows.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 
 	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/configuration"
 	"github.com/Azure/azure-container-networking/cns/logger"
 	"github.com/Azure/azure-container-networking/common"
 	"github.com/Azure/azure-container-networking/log"
@@ -161,7 +162,7 @@ func createOrUpdateWithOperation(adapterName string, ipConfig cns.IPConfiguratio
 		"/weakhostreceive",
 		"true",
 		"/renamewithnetsh",
-		"true",
+		fmt.Sprintf("%t", configuration.CnsConfig.EnableRenameWithNetSh),
 	}
 
 	c := exec.Command("cmd", args...)

--- a/cns/networkcontainers/networkcontainers_windows.go
+++ b/cns/networkcontainers/networkcontainers_windows.go
@@ -160,6 +160,8 @@ func createOrUpdateWithOperation(adapterName string, ipConfig cns.IPConfiguratio
 		"true",
 		"/weakhostreceive",
 		"true",
+		"/renamewithnetsh",
+		"true",
 	}
 
 	c := exec.Command("cmd", args...)


### PR DESCRIPTION
**Reason for Change**:
Use netsh when creating NC instead of powershell to improve overall create time.