### PR TITLE
fix: block wireserver port 80 traffic in multitenancy

### DIFF
--- a/network/network_linux.go
+++ b/network/network_linux.go
@@ -98,8 +98,8 @@ func (nm *networkManager) newNetworkImpl(nwInfo *NetworkInfo, extIf *externalInt
 			return nil, fmt.Errorf("Ipv4 forwarding failed: %w", err)
 		}
 		logger.Info("Ipv4 forwarding enabled")
-		if err := networkutils.BlockEgressTrafficFromContainer(networkutils.AzureDNS, iptables.HTTPPort); err != nil {
-			return nil, fmt.Errorf("unable to insert vm iptables rule drop all wireserver port 80 packets: %w", err)
+		if err := networkutils.BlockEgressTrafficFromContainer(iptables.V4, networkutils.AzureDNS, iptables.HTTPPort); err != nil {
+			return nil, fmt.Errorf("unable to insert vm iptables rule drop wireserver packets: %w", err)
 		}
 		logger.Info("Block wireserver traffic rule added")
 	default:

--- a/network/network_linux.go
+++ b/network/network_linux.go
@@ -98,6 +98,12 @@ func (nm *networkManager) newNetworkImpl(nwInfo *NetworkInfo, extIf *externalInt
 			return nil, fmt.Errorf("Ipv4 forwarding failed: %w", err)
 		}
 		logger.Info("Ipv4 forwarding enabled")
+		// iptables -t filter -I FORWARD -j DROP -d 168.63.129.16/32 -p tcp -m tcp --dport 80
+		dropWireserver := "-d 168.63.129.16/32 -p tcp -m tcp --dport 80"
+		if err := iptables.InsertIptableRule(iptables.V4, "filter", "FORWARD", dropWireserver, "DROP"); err != nil {
+			return nil, fmt.Errorf("unable to insert vm iptables rule drop all wireserver port 80 packets: %w", err)
+		}
+		logger.Info("Block wireserver traffic rule added")
 	default:
 		return nil, errNetworkModeInvalid
 	}

--- a/network/network_linux.go
+++ b/network/network_linux.go
@@ -95,11 +95,11 @@ func (nm *networkManager) newNetworkImpl(nwInfo *NetworkInfo, extIf *externalInt
 		ifName = extIf.Name
 		nu := networkutils.NewNetworkUtils(nm.netlink, nm.plClient)
 		if err := nu.EnableIPV4Forwarding(); err != nil {
-			return nil, fmt.Errorf("Ipv4 forwarding failed: %w", err)
+			return nil, errors.Wrap(err, "ipv4 forwarding failed")
 		}
 		logger.Info("Ipv4 forwarding enabled")
-		if err := networkutils.BlockEgressTrafficFromContainer(iptables.V4, networkutils.AzureDNS, iptables.HTTPPort); err != nil {
-			return nil, fmt.Errorf("unable to insert vm iptables rule drop wireserver packets: %w", err)
+		if err := networkutils.BlockEgressTrafficFromContainer(iptables.V4, networkutils.AzureDNS, iptables.TCP, iptables.HTTPPort); err != nil {
+			return nil, errors.Wrap(err, "unable to insert vm iptables rule drop wireserver packets")
 		}
 		logger.Info("Block wireserver traffic rule added")
 	default:

--- a/network/network_linux.go
+++ b/network/network_linux.go
@@ -98,8 +98,8 @@ func (nm *networkManager) newNetworkImpl(nwInfo *NetworkInfo, extIf *externalInt
 			return nil, fmt.Errorf("Ipv4 forwarding failed: %w", err)
 		}
 		logger.Info("Ipv4 forwarding enabled")
-		// iptables -t filter -I FORWARD -j DROP -d 168.63.129.16/32 -p tcp -m tcp --dport 80
-		dropWireserver := "-d 168.63.129.16/32 -p tcp -m tcp --dport 80"
+		// iptables -t filter -I FORWARD -j DROP -d <wireserver ip>/32 -p tcp -m tcp --dport 80
+		dropWireserver := fmt.Sprintf("-d %s/32 -p tcp -m tcp --dport 80", networkutils.AzureDNS)
 		if err := iptables.InsertIptableRule(iptables.V4, "filter", "FORWARD", dropWireserver, "DROP"); err != nil {
 			return nil, fmt.Errorf("unable to insert vm iptables rule drop all wireserver port 80 packets: %w", err)
 		}

--- a/network/network_linux.go
+++ b/network/network_linux.go
@@ -98,9 +98,7 @@ func (nm *networkManager) newNetworkImpl(nwInfo *NetworkInfo, extIf *externalInt
 			return nil, fmt.Errorf("Ipv4 forwarding failed: %w", err)
 		}
 		logger.Info("Ipv4 forwarding enabled")
-		// iptables -t filter -I FORWARD -j DROP -d <wireserver ip>/32 -p tcp -m tcp --dport 80
-		dropWireserver := fmt.Sprintf("-d %s/32 -p tcp -m tcp --dport 80", networkutils.AzureDNS)
-		if err := iptables.InsertIptableRule(iptables.V4, "filter", "FORWARD", dropWireserver, "DROP"); err != nil {
+		if err := networkutils.BlockWireserverTraffic(); err != nil {
 			return nil, fmt.Errorf("unable to insert vm iptables rule drop all wireserver port 80 packets: %w", err)
 		}
 		logger.Info("Block wireserver traffic rule added")

--- a/network/network_linux.go
+++ b/network/network_linux.go
@@ -98,7 +98,7 @@ func (nm *networkManager) newNetworkImpl(nwInfo *NetworkInfo, extIf *externalInt
 			return nil, fmt.Errorf("Ipv4 forwarding failed: %w", err)
 		}
 		logger.Info("Ipv4 forwarding enabled")
-		if err := networkutils.BlockWireserverTraffic(); err != nil {
+		if err := networkutils.BlockEgressTrafficFromContainer(networkutils.AzureDNS, iptables.HTTPPort); err != nil {
 			return nil, fmt.Errorf("unable to insert vm iptables rule drop all wireserver port 80 packets: %w", err)
 		}
 		logger.Info("Block wireserver traffic rule added")

--- a/network/network_linux.go
+++ b/network/network_linux.go
@@ -98,6 +98,7 @@ func (nm *networkManager) newNetworkImpl(nwInfo *NetworkInfo, extIf *externalInt
 			return nil, errors.Wrap(err, "ipv4 forwarding failed")
 		}
 		logger.Info("Ipv4 forwarding enabled")
+		// Blocks wireserver traffic from apipa nic
 		if err := networkutils.BlockEgressTrafficFromContainer(iptables.V4, networkutils.AzureDNS, iptables.TCP, iptables.HTTPPort); err != nil {
 			return nil, errors.Wrap(err, "unable to insert vm iptables rule drop wireserver packets")
 		}

--- a/network/networkutils/networkutils_linux.go
+++ b/network/networkutils/networkutils_linux.go
@@ -176,10 +176,10 @@ func AllowIPAddresses(bridgeName string, skipAddresses []string, action string) 
 	return nil
 }
 
-func BlockEgressTrafficFromContainer(ipAddress string, port int) error {
+func BlockEgressTrafficFromContainer(version, ipAddress string, port int) error {
 	// iptables -t filter -I FORWARD -j DROP -d <ip>/32 -p tcp -m tcp --dport <port>
 	dropTraffic := fmt.Sprintf("-d %s/32 -p tcp -m tcp --dport %d", ipAddress, port)
-	return errors.Wrap(iptables.InsertIptableRule(iptables.V4, iptables.Filter, iptables.Forward, dropTraffic, iptables.Drop), "iptables block traffic failed")
+	return errors.Wrap(iptables.InsertIptableRule(version, iptables.Filter, iptables.Forward, dropTraffic, iptables.Drop), "iptables block traffic failed")
 }
 
 func BlockIPAddresses(bridgeName, action string) error {

--- a/network/networkutils/networkutils_linux.go
+++ b/network/networkutils/networkutils_linux.go
@@ -176,6 +176,12 @@ func AllowIPAddresses(bridgeName string, skipAddresses []string, action string) 
 	return nil
 }
 
+func BlockWireserverTraffic() error {
+	// iptables -t filter -I FORWARD -j DROP -d <wireserver ip>/32 -p tcp -m tcp --dport 80
+	dropWireserver := fmt.Sprintf("-d %s/32 -p tcp -m tcp --dport 80", AzureDNS)
+	return errors.Wrap(iptables.InsertIptableRule(iptables.V4, "filter", "FORWARD", dropWireserver, "DROP"), "block wireserver traffic port 80 failed")
+}
+
 func BlockIPAddresses(bridgeName, action string) error {
 	privateIPAddresses := getPrivateIPSpace()
 	chains := getFilterChains()

--- a/network/networkutils/networkutils_linux.go
+++ b/network/networkutils/networkutils_linux.go
@@ -176,10 +176,10 @@ func AllowIPAddresses(bridgeName string, skipAddresses []string, action string) 
 	return nil
 }
 
-func BlockWireserverTraffic() error {
-	// iptables -t filter -I FORWARD -j DROP -d <wireserver ip>/32 -p tcp -m tcp --dport 80
-	dropWireserver := fmt.Sprintf("-d %s/32 -p tcp -m tcp --dport 80", AzureDNS)
-	return errors.Wrap(iptables.InsertIptableRule(iptables.V4, "filter", "FORWARD", dropWireserver, "DROP"), "block wireserver traffic port 80 failed")
+func BlockEgressTrafficFromContainer(ipAddress string, port int) error {
+	// iptables -t filter -I FORWARD -j DROP -d <ip>/32 -p tcp -m tcp --dport <port>
+	dropTraffic := fmt.Sprintf("-d %s/32 -p tcp -m tcp --dport %d", ipAddress, port)
+	return errors.Wrap(iptables.InsertIptableRule(iptables.V4, iptables.Filter, iptables.Forward, dropTraffic, iptables.Drop), "iptables block traffic failed")
 }
 
 func BlockIPAddresses(bridgeName, action string) error {

--- a/network/networkutils/networkutils_linux.go
+++ b/network/networkutils/networkutils_linux.go
@@ -177,8 +177,8 @@ func AllowIPAddresses(bridgeName string, skipAddresses []string, action string) 
 }
 
 func BlockEgressTrafficFromContainer(version, ipAddress, protocol string, port int) error {
-	// iptables -t filter -I FORWARD -j DROP -d <ip>/32 -p <protocol> -m <protocol> --dport <port>
-	dropTraffic := fmt.Sprintf("-d %s/32 -p %s -m %s --dport %d", ipAddress, protocol, protocol, port)
+	// iptables -t filter -I FORWARD -j DROP -d <ip> -p <protocol> -m <protocol> --dport <port>
+	dropTraffic := fmt.Sprintf("-d %s -p %s -m %s --dport %d", ipAddress, protocol, protocol, port)
 	return errors.Wrap(iptables.InsertIptableRule(version, iptables.Filter, iptables.Forward, dropTraffic, iptables.Drop), "iptables block traffic failed")
 }
 

--- a/network/networkutils/networkutils_linux.go
+++ b/network/networkutils/networkutils_linux.go
@@ -176,9 +176,9 @@ func AllowIPAddresses(bridgeName string, skipAddresses []string, action string) 
 	return nil
 }
 
-func BlockEgressTrafficFromContainer(version, ipAddress string, port int) error {
-	// iptables -t filter -I FORWARD -j DROP -d <ip>/32 -p tcp -m tcp --dport <port>
-	dropTraffic := fmt.Sprintf("-d %s/32 -p tcp -m tcp --dport %d", ipAddress, port)
+func BlockEgressTrafficFromContainer(version, ipAddress, protocol string, port int) error {
+	// iptables -t filter -I FORWARD -j DROP -d <ip>/32 -p <protocol> -m <protocol> --dport <port>
+	dropTraffic := fmt.Sprintf("-d %s/32 -p %s -m %s --dport %d", ipAddress, protocol, protocol, port)
 	return errors.Wrap(iptables.InsertIptableRule(version, iptables.Filter, iptables.Forward, dropTraffic, iptables.Drop), "iptables block traffic failed")
 }
 

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -405,7 +405,7 @@ func (client *TransparentVlanEndpointClient) AddVnetRules(epInfo *EndpointInfo) 
 		return errors.Wrap(err, "unable to insert iptables rule accept all incoming from vlan interface")
 	}
 
-	if err := networkutils.BlockWireserverTraffic(); err != nil {
+	if err := networkutils.BlockEgressTrafficFromContainer(networkutils.AzureDNS, iptables.HTTPPort); err != nil {
 		return errors.Wrap(err, "unable to insert iptables rule drop all wireserver port 80 packets")
 	}
 

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -405,7 +405,7 @@ func (client *TransparentVlanEndpointClient) AddVnetRules(epInfo *EndpointInfo) 
 		return errors.Wrap(err, "unable to insert iptables rule accept all incoming from vlan interface")
 	}
 
-	if err := networkutils.BlockEgressTrafficFromContainer(iptables.V4, networkutils.AzureDNS, iptables.HTTPPort); err != nil {
+	if err := networkutils.BlockEgressTrafficFromContainer(iptables.V4, networkutils.AzureDNS, iptables.TCP, iptables.HTTPPort); err != nil {
 		return errors.Wrap(err, "unable to insert iptables rule to drop wireserver packets")
 	}
 

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -404,6 +404,12 @@ func (client *TransparentVlanEndpointClient) AddVnetRules(epInfo *EndpointInfo) 
 	if err := iptables.InsertIptableRule(iptables.V4, "mangle", "PREROUTING", match, "ACCEPT"); err != nil {
 		return errors.Wrap(err, "unable to insert iptables rule accept all incoming from vlan interface")
 	}
+	// iptables -t filter -I FORWARD -j DROP -d 168.63.129.16/32 -p tcp -m tcp --dport 80 -m comment --comment "block traffic to 168.63.129.16 port 80"
+	dropWireserver := "-d 168.63.129.16/32 -p tcp -m tcp --dport 80"
+	if err := iptables.InsertIptableRule(iptables.V4, "filter", "FORWARD", dropWireserver, "DROP"); err != nil {
+		return errors.Wrap(err, "unable to insert iptables rule drop all wireserver port 80 packets")
+	}
+
 	// Packets that are marked should go to the tunneling table
 	newRule := vishnetlink.NewRule()
 	newRule.Mark = tunnelingMark

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -404,9 +404,8 @@ func (client *TransparentVlanEndpointClient) AddVnetRules(epInfo *EndpointInfo) 
 	if err := iptables.InsertIptableRule(iptables.V4, "mangle", "PREROUTING", match, "ACCEPT"); err != nil {
 		return errors.Wrap(err, "unable to insert iptables rule accept all incoming from vlan interface")
 	}
-	// iptables -t filter -I FORWARD -j DROP -d <wireserver ip>/32 -p tcp -m tcp --dport 80
-	dropWireserver := fmt.Sprintf("-d %s/32 -p tcp -m tcp --dport 80", networkutils.AzureDNS)
-	if err := iptables.InsertIptableRule(iptables.V4, "filter", "FORWARD", dropWireserver, "DROP"); err != nil {
+
+	if err := networkutils.BlockWireserverTraffic(); err != nil {
 		return errors.Wrap(err, "unable to insert iptables rule drop all wireserver port 80 packets")
 	}
 

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -404,8 +404,8 @@ func (client *TransparentVlanEndpointClient) AddVnetRules(epInfo *EndpointInfo) 
 	if err := iptables.InsertIptableRule(iptables.V4, "mangle", "PREROUTING", match, "ACCEPT"); err != nil {
 		return errors.Wrap(err, "unable to insert iptables rule accept all incoming from vlan interface")
 	}
-	// iptables -t filter -I FORWARD -j DROP -d 168.63.129.16/32 -p tcp -m tcp --dport 80 -m comment --comment "block traffic to 168.63.129.16 port 80"
-	dropWireserver := "-d 168.63.129.16/32 -p tcp -m tcp --dport 80"
+	// iptables -t filter -I FORWARD -j DROP -d <wireserver ip>/32 -p tcp -m tcp --dport 80
+	dropWireserver := fmt.Sprintf("-d %s/32 -p tcp -m tcp --dport 80", networkutils.AzureDNS)
 	if err := iptables.InsertIptableRule(iptables.V4, "filter", "FORWARD", dropWireserver, "DROP"); err != nil {
 		return errors.Wrap(err, "unable to insert iptables rule drop all wireserver port 80 packets")
 	}

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -404,7 +404,7 @@ func (client *TransparentVlanEndpointClient) AddVnetRules(epInfo *EndpointInfo) 
 	if err := iptables.InsertIptableRule(iptables.V4, "mangle", "PREROUTING", match, "ACCEPT"); err != nil {
 		return errors.Wrap(err, "unable to insert iptables rule accept all incoming from vlan interface")
 	}
-
+	// Blocks wireserver traffic from customer vnet nic
 	if err := networkutils.BlockEgressTrafficFromContainer(iptables.V4, networkutils.AzureDNS, iptables.TCP, iptables.HTTPPort); err != nil {
 		return errors.Wrap(err, "unable to insert iptables rule to drop wireserver packets")
 	}

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -405,8 +405,8 @@ func (client *TransparentVlanEndpointClient) AddVnetRules(epInfo *EndpointInfo) 
 		return errors.Wrap(err, "unable to insert iptables rule accept all incoming from vlan interface")
 	}
 
-	if err := networkutils.BlockEgressTrafficFromContainer(networkutils.AzureDNS, iptables.HTTPPort); err != nil {
-		return errors.Wrap(err, "unable to insert iptables rule drop all wireserver port 80 packets")
+	if err := networkutils.BlockEgressTrafficFromContainer(iptables.V4, networkutils.AzureDNS, iptables.HTTPPort); err != nil {
+		return errors.Wrap(err, "unable to insert iptables rule to drop wireserver packets")
 	}
 
 	// Packets that are marked should go to the tunneling table


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Pods should not be able to communicate with the wireserver on port 80.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
See above.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
- wanted to create a unit test for the iptables command failing but there is no mock interface or way of injecting a mock "iptables" dependency.
- considered placing the code for the vm iptable rule in transparent vlan endpoint client, but this iptable rule only needs to be run once.
- wanted to match the capitalization convention of enabling ipv4 forwarding, but the linter (only now) is giving me warnings about capitalization (not sure why it didn't warn me about the capitalization before).