### PR TITLE
ci: Improve Cilium nightly pipeline

### DIFF
--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -28,6 +28,9 @@ stages:
               cd .pipelines/
               git clone https://github.com/cilium/cilium.git
               cd cilium
+              if [ ! -z $CILIUM_COMMIT_ID ]; then
+                git reset --hard $CILIUM_COMMIT_ID
+              fi
               make docker-cilium-image
               make docker-operator-generic-image
             name: BuildCiliumImage

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -100,12 +100,18 @@ stages:
               clusterName: ciliumnightly-$(commitID)
               os: linux
               cni: cilium
+
+  - stage: delete
+    displayName: Delete Clusters
+    condition: always()
+    dependsOn:
+      - setup
+      - cilium_nightly
+    variables:
+      commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
+    jobs:
       - job: delete
         displayName: Delete Cluster
-        condition: always()
-        dependsOn:
-          - cilium_nightly
-          - logs
         pool:
           name: "$(BUILD_POOL_NAME_DEFAULT)"
         strategy:
@@ -119,4 +125,3 @@ stages:
               name: $(name)
               clusterName: $(clusterName)-$(commitID)
               region: $(LOCATION)
-


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Adds:
- commit ID parameter to cilium git checkout. Allowing us to specify the nightly version of cilium we want to test
- extract cluster deletion into its own stage to enable using the pipeline for exclusively cilium cluster creation

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
