### PR TITLE
fix: NPM Changed Allow All Policy for Ingress and Egress

### DIFF
--- a/npm/pkg/controlplane/translation/translatePolicy.go
+++ b/npm/pkg/controlplane/translation/translatePolicy.go
@@ -491,9 +491,13 @@ func allowAllPolicy(npmNetPol *policies.NPMNetworkPolicy, direction policies.Dir
 // isAllowAllToIngress returns true if this network policy allows all traffic from internal (i.e,. K8s cluster) and external (i.e., internet)
 // Otherwise, it returns false.
 func isAllowAllToIngress(ingress []networkingv1.NetworkPolicyIngressRule) bool {
-	return len(ingress) == 1 &&
-		len(ingress[0].Ports) == 0 &&
-		len(ingress[0].From) == 0
+	for _, ingressRule := range ingress {
+		// Allow all if any of the ingress rules are allow all.
+		if len(ingressRule.Ports) == 0 && len(ingressRule.From) == 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // ingressPolicy traslates NetworkPolicyIngressRule in NetworkPolicy object
@@ -530,9 +534,13 @@ func ingressPolicy(npmNetPol *policies.NPMNetworkPolicy, netPolName string, ingr
 // isAllowAllToEgress returns true if this network policy allows all traffic to internal (i.e,. K8s cluster) and external (i.e., internet)
 // Otherwise, it returns false.
 func isAllowAllToEgress(egress []networkingv1.NetworkPolicyEgressRule) bool {
-	return len(egress) == 1 &&
-		len(egress[0].Ports) == 0 &&
-		len(egress[0].To) == 0
+	for _, egressRule := range egress {
+		// Allow all if any of the egress rules are allow all.
+		if len(egressRule.Ports) == 0 && len(egressRule.To) == 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // egressPolicy traslates NetworkPolicyEgressRule in networkpolicy object

--- a/npm/pkg/controlplane/translation/translatePolicy_test.go
+++ b/npm/pkg/controlplane/translation/translatePolicy_test.go
@@ -1462,6 +1462,7 @@ func TestIngressPolicy(t *testing.T) {
 	targetPodMatchType := policies.EitherMatch
 	peerMatchType := policies.SrcMatch
 	emptyString := intstr.FromString("")
+	port443 := intstr.FromInt(443)
 	// TODO(jungukcho): add test cases with more complex rules
 	tests := []struct {
 		name                  string
@@ -1787,6 +1788,45 @@ func TestIngressPolicy(t *testing.T) {
 				},
 			},
 			rules: []networkingv1.NetworkPolicyIngressRule{
+				{},
+			},
+			npmNetPol: &policies.NPMNetworkPolicy{
+				Namespace:   "default",
+				PolicyKey:   "default/serve-tcp",
+				ACLPolicyID: "azure-acl-default-serve-tcp",
+				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
+					ipsets.NewTranslatedIPSet("label:src", ipsets.KeyValueLabelOfPod),
+					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
+				},
+				ChildPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
+				PodSelectorList: []policies.SetInfo{
+					policies.NewSetInfo("label:src", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
+					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
+				},
+				ACLs: []*policies.ACLPolicy{
+					{
+						Target:    policies.Allowed,
+						Direction: policies.Ingress,
+					},
+				},
+			},
+		},
+		{
+			name: "allow all ingress rules works with ports rules",
+			targetSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"label": "src",
+				},
+			},
+			rules: []networkingv1.NetworkPolicyIngressRule{
+				{
+					Ports: []networkingv1.NetworkPolicyPort{
+						{
+							Protocol: &tcp,
+							Port:     &port443,
+						},
+					},
+				},
 				{},
 			},
 			npmNetPol: &policies.NPMNetworkPolicy{
@@ -2152,6 +2192,7 @@ func TestIngressPolicy(t *testing.T) {
 func TestEgressPolicy(t *testing.T) {
 	tcp := v1.ProtocolTCP
 	emptyString := intstr.FromString("")
+	port443 := intstr.FromInt(443)
 	targetPodMatchType := policies.EitherMatch
 	peerMatchType := policies.DstMatch
 	tests := []struct {
@@ -2387,6 +2428,45 @@ func TestEgressPolicy(t *testing.T) {
 				},
 			},
 			rules: []networkingv1.NetworkPolicyEgressRule{
+				{},
+			},
+			npmNetPol: &policies.NPMNetworkPolicy{
+				Namespace:   "default",
+				PolicyKey:   "default/serve-tcp",
+				ACLPolicyID: "azure-acl-default-serve-tcp",
+				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
+					ipsets.NewTranslatedIPSet("label:dst", ipsets.KeyValueLabelOfPod),
+					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
+				},
+				ChildPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
+				PodSelectorList: []policies.SetInfo{
+					policies.NewSetInfo("label:dst", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
+					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
+				},
+				ACLs: []*policies.ACLPolicy{
+					{
+						Target:    policies.Allowed,
+						Direction: policies.Egress,
+					},
+				},
+			},
+		},
+		{
+			name: "allow all egress rules works with ports rules",
+			targetSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"label": "dst",
+				},
+			},
+			rules: []networkingv1.NetworkPolicyEgressRule{
+				{
+					Ports: []networkingv1.NetworkPolicyPort{
+						{
+							Protocol: &tcp,
+							Port:     &port443,
+						},
+					},
+				},
 				{},
 			},
 			npmNetPol: &policies.NPMNetworkPolicy{


### PR DESCRIPTION
 Changed allow all policy for ingress and egress for npm to allow all even with other rules in the network policy and added new test cases to confirm the changes work. 

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**: This change is in alignment with functionality of other network policy tools such as Calico.
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**: https://portal.microsofticm.com/imp/v3/incidents/incident/442655848/summary
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests: Added unit tests "allow all ingress rules works with ports rules" and "allow all egress rules works with ports rules"
- [ ] relevant PR labels added