### PR TITLE
ci: Adding the Vnet Scale Integration Tests to the E2E pipeline 

### DIFF
--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -393,6 +393,17 @@ stages:
       k8sVersion: ""
       dependsOn: "test"
 
+  # AKS Swift Vnet Scale E2E tests
+  - template: singletenancy/aks-swift/e2e-job-template.yaml
+    parameters:
+      name: "aks_swift_vnetscale_e2e"
+      displayName: AKS Swift Vnet Scale Ubuntu
+      clusterType: vnetscale-swift-byocni-up
+      clusterName: "vnetscaleswifte2e"
+      vmSize: Standard_B2s
+      k8sVersion: "1.28"
+      dependsOn: "test"
+
   # CNIv1 E2E tests
   - template: singletenancy/aks/e2e-job-template.yaml
     parameters:

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -77,6 +77,11 @@ swift-net-up: ## Create vnet, nodenet and podnet subnets
 	$(AZCLI) network vnet subnet create -g $(GROUP) --vnet-name $(VNET) --name nodenet --address-prefixes 10.240.0.0/16 -o none
 	$(AZCLI) network vnet subnet create -g $(GROUP) --vnet-name $(VNET) --name podnet --address-prefixes 10.241.0.0/16 -o none
 
+vnetscale-swift-net-up: ## Create vnet, nodenet and podnet subnets for vnet scale
+	$(AZCLI) network vnet create -g $(GROUP) -l $(REGION) --name $(VNET) --address-prefixes 10.0.0.0/8 -o none
+	$(AZCLI) network vnet subnet create -g $(GROUP) --vnet-name $(VNET) --name nodenet --address-prefixes 10.240.0.0/16 -o none
+	$(AZCLI) network vnet subnet create -g $(GROUP) --vnet-name $(VNET) --name podnet --address-prefixes 10.45.0.0/13 -o none
+
 overlay-net-up: ## Create vnet, nodenet subnets
 	$(AZCLI) network vnet create -g $(GROUP) -l $(REGION) --name $(VNET) --address-prefixes 10.0.0.0/8 -o none
 	$(AZCLI) network vnet subnet create -g $(GROUP) --vnet-name $(VNET) --name nodenet --address-prefix 10.10.0.0/16 -o none
@@ -206,6 +211,71 @@ swift-up: rg-up swift-net-up ## Bring up a SWIFT AzCNI cluster
 		--node-vm-size $(VM_SIZE) \
 		--load-balancer-sku basic \
 		--network-plugin azure \
+		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
+		--pod-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/podnet \
+		--no-ssh-key \
+		--yes
+	@$(MAKE) set-kubeconf
+
+vnetscale-swift-byocni-up: rg-up vnetscale-swift-net-up ## Bring up a Vnet Scale SWIFT BYO CNI cluster
+	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
+		--auto-upgrade-channel $(AUTOUPGRADE) \
+		--node-os-upgrade-channel $(NODEUPGRADE) \
+		--node-count $(NODE_COUNT) \
+		--node-vm-size $(VM_SIZE) \
+		--load-balancer-sku basic \
+		--network-plugin none \
+		--kubernetes-version $(K8S_VER) \
+		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
+		--pod-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/podnet \
+		--no-ssh-key \
+		--os-sku $(OS_SKU) \
+		--yes
+	@$(MAKE) set-kubeconf
+
+vnetscale-swift-byocni-nokubeproxy-up: rg-up vnetscale-swift-net-up ## Bring up a Vnet Scale SWIFT BYO CNI cluster without kube-proxy
+	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
+		--auto-upgrade-channel $(AUTOUPGRADE) \
+		--node-os-upgrade-channel $(NODEUPGRADE) \
+		--node-count $(NODE_COUNT) \
+		--node-vm-size $(VM_SIZE) \
+		--load-balancer-sku basic \
+		--network-plugin none \
+		--kubernetes-version $(K8S_VER) \
+		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
+		--pod-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/podnet \
+		--no-ssh-key \
+		--os-sku $(OS_SKU) \
+		--kube-proxy-config ./kube-proxy.json \
+		--yes
+	@$(MAKE) set-kubeconf
+
+vnetscale-swift-cilium-up: rg-up vnetscale-swift-net-up ## Bring up a Vnet Scale SWIFT Cilium cluster
+	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
+		--auto-upgrade-channel $(AUTOUPGRADE) \
+		--node-os-upgrade-channel $(NODEUPGRADE) \
+		--node-count $(NODE_COUNT) \
+		--node-vm-size $(VM_SIZE) \
+		--load-balancer-sku basic \
+		--network-plugin azure \
+		--network-dataplane cilium \
+		--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/CiliumDataplanePreview \
+		--kubernetes-version $(K8S_VER) \
+		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
+		--pod-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/podnet \
+		--no-ssh-key \
+		--yes
+	@$(MAKE) set-kubeconf
+
+vnetscale-swift-up: rg-up vnetscale-swift-net-up ## Bring up a Vnet Scale SWIFT AzCNI cluster
+	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
+		--auto-upgrade-channel $(AUTOUPGRADE) \
+		--node-os-upgrade-channel $(NODEUPGRADE) \
+		--node-count $(NODE_COUNT) \
+		--node-vm-size $(VM_SIZE) \
+		--load-balancer-sku basic \
+		--network-plugin azure \
+		--kubernetes-version $(K8S_VER) \
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
 		--pod-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/podnet \
 		--no-ssh-key \

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -80,7 +80,7 @@ swift-net-up: ## Create vnet, nodenet and podnet subnets
 vnetscale-swift-net-up: ## Create vnet, nodenet and podnet subnets for vnet scale
 	$(AZCLI) network vnet create -g $(GROUP) -l $(REGION) --name $(VNET) --address-prefixes 10.0.0.0/8 -o none
 	$(AZCLI) network vnet subnet create -g $(GROUP) --vnet-name $(VNET) --name nodenet --address-prefixes 10.240.0.0/16 -o none
-	$(AZCLI) network vnet subnet create -g $(GROUP) --vnet-name $(VNET) --name podnet --address-prefixes 10.45.0.0/13 -o none
+	$(AZCLI) network vnet subnet create -g $(GROUP) --vnet-name $(VNET) --name podnet --address-prefixes 10.40.0.0/13 -o none
 
 overlay-net-up: ## Create vnet, nodenet subnets
 	$(AZCLI) network vnet create -g $(GROUP) -l $(REGION) --name $(VNET) --address-prefixes 10.0.0.0/8 -o none

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -217,6 +217,9 @@ swift-up: rg-up swift-net-up ## Bring up a SWIFT AzCNI cluster
 		--yes
 	@$(MAKE) set-kubeconf
 
+# The below Vnet Scale clusters are currently only in private preview and available with Kubernetes 1.28
+# These AKS clusters can only be created in a limited subscription listed here: 
+# https://dev.azure.com/msazure/CloudNativeCompute/_git/aks-rp?path=/resourceprovider/server/microsoft.com/containerservice/flags/network_flags.go&version=GBmaster&line=134&lineEnd=135&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents
 vnetscale-swift-byocni-up: rg-up vnetscale-swift-net-up ## Bring up a Vnet Scale SWIFT BYO CNI cluster
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
 		--auto-upgrade-channel $(AUTOUPGRADE) \

--- a/hack/aks/README.md
+++ b/hack/aks/README.md
@@ -21,23 +21,27 @@ SWIFT Infra
   net-up           Create required swift vnet/subnets
 
 AKS Clusters
-  byocni-up                       Alias to swift-byocni-up
-  cilium-up                       Alias to swift-cilium-up
-  up                              Alias to swift-up
-  overlay-byocni-up               Bring up a Overlay BYO CNI cluster
-  overlay-byocni-nokubeproxy-up   Bring up a Overlay BYO CNI cluster without kube-proxy
-  overlay-cilium-up               Bring up a Overlay Cilium cluster
-  overlay-up                      Bring up a Overlay AzCNI cluster
-  swift-byocni-up                 Bring up a SWIFT BYO CNI cluster
-  swift-byocni-nokubeproxy-up     Bring up a SWIFT BYO CNI cluster without kube-proxy
-  swift-cilium-up                 Bring up a SWIFT Cilium cluster
-  swift-up                        Bring up a SWIFT AzCNI cluster
-  windows-cniv1-up                Bring up a Windows AzCNIv1 cluster
-  linux-cniv1-up                  Bring up a Linux AzCNIv1 cluster
-  dualstack-overlay-byocni-up     Bring up an dualstack overlay cluster without CNS and CNI installed
-  cilium-dualstack-up             Brings up a Cilium Dualstack Overlay cluster with Linux node only
-  dualstack-byocni-nokubeproxy-up Brings up a Dualstack overlay BYOCNI cluster with Linux node only and no kube-proxy
-  windows-nodepool-up             Add windows node pool
-  down                            Delete the cluster
-  vmss-restart                    Restart the nodes of the cluster
+  byocni-up                                 Alias to swift-byocni-up
+  cilium-up                                 Alias to swift-cilium-up
+  up                                        Alias to swift-up
+  overlay-byocni-up                         Bring up a Overlay BYO CNI cluster
+  overlay-byocni-nokubeproxy-up             Bring up a Overlay BYO CNI cluster without kube-proxy
+  overlay-cilium-up                         Bring up a Overlay Cilium cluster
+  overlay-up                                Bring up a Overlay AzCNI cluster
+  swift-byocni-up                           Bring up a SWIFT BYO CNI cluster
+  swift-byocni-nokubeproxy-up               Bring up a SWIFT BYO CNI cluster without kube-proxy
+  swift-cilium-up                           Bring up a SWIFT Cilium cluster
+  swift-up                                  Bring up a SWIFT AzCNI cluster
+  vnetscale-swift-byocni-up                 Bring up a Vnet Scale SWIFT BYO CNI cluster
+  vnetscale-swift-byocni-nokubeproxy-up     Bring up a Vnet Scale SWIFT BYO CNI cluster without kube-proxy
+  vnetscale-swift-cilium-up                 Bring up a Vnet Scale SWIFT Cilium cluster
+  vnetscale-swift-up                        Bring up a Vnet Scale SWIFT AzCNI cluster
+  windows-cniv1-up                          Bring up a Windows AzCNIv1 cluster
+  linux-cniv1-up                            Bring up a Linux AzCNIv1 cluster
+  dualstack-overlay-byocni-up               Bring up an dualstack overlay cluster without CNS and CNI installed
+  cilium-dualstack-up                       Brings up a Cilium Dualstack Overlay cluster with Linux node only
+  dualstack-byocni-nokubeproxy-up           Brings up a Dualstack overlay BYOCNI cluster with Linux node only and no kube-proxy
+  windows-nodepool-up                       Add windows node pool
+  down                                      Delete the cluster
+  vmss-restart                              Restart the nodes of the cluster
 ```


### PR DESCRIPTION
**Reason for Change**:
Added the Vnet Scale Integration Test to the E2E Pipeline and set it up with Kubernetes version 1.28 as the feature is only supported with CNS 1.5x and above which are correlated versions.

**Issue Fixed**:
N/A


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [x] relevant PR labels added

**Notes**:
