### PR TITLE
fix: disable ipv6 on transparent vlan mode network create

### DIFF
--- a/network/network_linux.go
+++ b/network/network_linux.go
@@ -98,6 +98,10 @@ func (nm *networkManager) newNetworkImpl(nwInfo *NetworkInfo, extIf *externalInt
 			return nil, errors.Wrap(err, "ipv4 forwarding failed")
 		}
 		logger.Info("Ipv4 forwarding enabled")
+		if err := nu.UpdateIPV6Setting(1); err != nil {
+			return nil, errors.Wrap(err, "failed to disable ipv6 on vm")
+		}
+		logger.Info("Disabled ipv6")
 		// Blocks wireserver traffic from apipa nic
 		if err := networkutils.BlockEgressTrafficFromContainer(iptables.V4, networkutils.AzureDNS, iptables.TCP, iptables.HTTPPort); err != nil {
 			return nil, errors.Wrap(err, "unable to insert vm iptables rule drop wireserver packets")


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Ipv6 traffic from within the pod should not be able to reach eth0 on the vm from eth1 in the container. To enforce this, we disable ipv6 on all interfaces in the vm namespace. The vnet namespace has ipv6 forwarding disabled by default so no modification is required on that datapath.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
See above.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
- Network utils failure is already tested when we test "enable ipv4 forwarding"