### PR TITLE
ci: add date to cilium nightly cluster name

### DIFF
--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -11,7 +11,7 @@ stages:
           name: "$(BUILD_POOL_NAME_DEFAULT)"
         steps:
           - script: |
-              echo "##vso[task.setvariable variable=commitID;isOutput=true]$(make revision)"
+              echo "##vso[task.setvariable variable=commitID;isOutput=true]$(echo $(make revision)-$(date "+%d%H%M"))"
             name: "EnvironmentalVariables"
             displayName: "Set environmental variables"
             condition: always()
@@ -86,11 +86,11 @@ stages:
         pool:
           name: $(BUILD_POOL_NAME_DEFAULT)
         steps:
-        - template: ../../singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
-          parameters:
-            name: "cilium_nightly"
-            clusterName: ciliumnightly-$(commitID)
-            testHubble: true
+          - template: ../../singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
+            parameters:
+              name: "cilium_nightly"
+              clusterName: ciliumnightly-$(commitID)
+              testHubble: true
       - job: logs
         displayName: "Failure Logs"
         dependsOn:


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
Adding timestamp for the nightly cilium pipeline.\

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
