### PR TITLE
ci: Add vnetscale cluster delete

### DIFF
--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -399,7 +399,7 @@ stages:
       name: "aks_swift_vnetscale_e2e"
       displayName: AKS Swift Vnet Scale Ubuntu
       clusterType: vnetscale-swift-byocni-up
-      clusterName: "vnetscaleswifte2e"
+      clusterName: "vscaleswifte2e"
       vmSize: Standard_B2s
       k8sVersion: "1.28"
       dependsOn: "test"
@@ -475,6 +475,9 @@ stages:
             aks_swift_e2e:
               name: aks_swift_e2e
               clusterName: "swifte2e"
+            aks_swift_vnetscale_e2e:
+              name: aks_swift_vnetscale_e2e
+              clusterName: "vscaleswifte2e"
             azure_overlay_cni_e2e:
               name: "azure_overlay_cni_e2e"
               clusterName: "azovercnie2e"


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Adds in a cluster delete step for vnetscale e2e and renames the cluster to be under 14 characters to prevent AKS cluster name overflow of 80 characters.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
