### PR TITLE
security issue: only bind private ip and localhost address

### DIFF
--- a/cns/service.go
+++ b/cns/service.go
@@ -77,7 +77,7 @@ func (service *Service) Initialize(config *common.ServiceConfig) error {
 
 		host, _, err := net.SplitHostPort(u.Host)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "failed to split hostPort")
 		}
 
 		if !net.ParseIP(host).IsPrivate() || host != "localhost" {

--- a/cns/service.go
+++ b/cns/service.go
@@ -75,6 +75,15 @@ func (service *Service) Initialize(config *common.ServiceConfig) error {
 			return err
 		}
 
+		host, _, err := net.SplitHostPort(u.Host)
+		if err != nil {
+			return err
+		}
+
+		if !net.ParseIP(host).IsPrivate() || host != "localhost" {
+			return errors.Wrap(err, "only private IP or localhost can be used")
+		}
+
 		listener, err := acn.NewListener(u)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
This PR is to solve the security issue that:
CNS main service is bound to localhost and doesn't need to change. but it is additionally binding the metrics service on *:10092; In AKS, we already bind CNS to localhost 127.0.0.1;
We need to only bind to the interfaces with private IPs

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
