### PR TITLE
fix: add windows async delete mounts

### DIFF
--- a/test/integration/manifests/cns/daemonset-windows.yaml
+++ b/test/integration/manifests/cns/daemonset-windows.yaml
@@ -74,6 +74,8 @@ spec:
               mountPath: /etc/azure-cns
             - name: cni-conflist
               mountPath: /k/azurecni/netconf
+            - name: azure-vnet
+              mountPath: /var/run/azure-vnet
           ports:
             - containerPort: 10090
               hostPort: 10090
@@ -130,5 +132,9 @@ spec:
           hostPath:
             path: /k/azurecni/bin
             type: Directory # // TODO: add windows cni conflist when ready
+        - name: azure-vnet
+          hostPath:
+            path: /var/run/azure-vnet
+            type: DirectoryOrCreate
       serviceAccount: azure-cns
       serviceAccountName: azure-cns

--- a/test/integration/manifests/cnsconfig/azurecnidualstackoverlaylinuxconfigmap.yaml
+++ b/test/integration/manifests/cnsconfig/azurecnidualstackoverlaylinuxconfigmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cns-win-config
+  name: cns-config
   namespace: kube-system
 data:
   cns_config.json: |
@@ -21,15 +21,13 @@ data:
           "NodeID": "",
           "NodeSyncIntervalInSeconds": 30
       },
-      "EnableSubnetScarcity": false,
       "ChannelMode": "CRD",
       "InitializeFromCNI": true,
       "ManageEndpointState": false,
       "ProgramSNATIPTables" : false,
-      "MetricsBindAddress": ":10092",
-      "EnableCNIConflistGeneration": false,
-      "CNIConflistFilepath": "C:\\k\\azurecni\\netconf\\10-azure.conflist",
-      "CNIConflistScenario": "v4overlay",
-      "EnableAsyncPodDelete": true,
+      "EnableCNIConflistGeneration": true,
+      "CNIConflistFilepath": "/etc/cni/net.d/15-azure-swift-overlay.conflist",
+      "CNIConflistScenario": "overlay",
+      "EnableAsyncPodDelete": false,
       "AsyncPodDeletePath": "/var/run/azure-vnet/deleteIDs"
     }

--- a/test/integration/manifests/cnsconfig/azurecnidualstackoverlaywindowsconfigmap.yaml
+++ b/test/integration/manifests/cnsconfig/azurecnidualstackoverlaywindowsconfigmap.yaml
@@ -29,5 +29,7 @@ data:
       "MetricsBindAddress": ":10092",
       "EnableCNIConflistGeneration": false,
       "CNIConflistFilepath": "C:\\k\\azurecni\\netconf\\10-azure.conflist",
-      "CNIConflistScenario": "dualStackOverlay"
+      "CNIConflistScenario": "dualStackOverlay",
+      "EnableAsyncPodDelete": false,
+      "AsyncPodDeletePath": "/var/run/azure-vnet/deleteIDs"
     }

--- a/test/integration/manifests/cnsconfig/azurecnioverlaylinuxconfigmap.yaml
+++ b/test/integration/manifests/cnsconfig/azurecnioverlaylinuxconfigmap.yaml
@@ -27,5 +27,7 @@ data:
       "ProgramSNATIPTables" : false,
       "EnableCNIConflistGeneration": true,
       "CNIConflistFilepath": "/etc/cni/net.d/15-azure-swift-overlay.conflist",
-      "CNIConflistScenario": "v4overlay"
+      "CNIConflistScenario": "v4overlay",
+      "EnableAsyncPodDelete": true,
+      "AsyncPodDeletePath": "/var/run/azure-vnet/deleteIDs"
     }

--- a/test/internal/kubernetes/utils_create.go
+++ b/test/internal/kubernetes/utils_create.go
@@ -316,6 +316,7 @@ func initCNSScenarioVars() (map[CNSScenario]map[corev1.OSName]cnsDetails, error)
 	cnsOverlayConfigMapPath := cnsConfigFolder + "/overlayconfigmap.yaml"
 	cnsAzureCNIOverlayLinuxConfigMapPath := cnsConfigFolder + "/azurecnioverlaylinuxconfigmap.yaml"
 	cnsAzureCNIOverlayWindowsConfigMapPath := cnsConfigFolder + "/azurecnioverlaywindowsconfigmap.yaml"
+	cnsAzureCNIDualStackLinuxConfigMapPath := cnsConfigFolder + "/azurecnidualstackoverlaylinuxconfigmap.yaml"
 	cnsAzureCNIDualStackWindowsConfigMapPath := cnsConfigFolder + "/azurecnidualstackoverlaywindowsconfigmap.yaml"
 	cnsRolePath := cnsManifestFolder + "/role.yaml"
 	cnsRoleBindingPath := cnsManifestFolder + "/rolebinding.yaml"
@@ -439,7 +440,7 @@ func initCNSScenarioVars() (map[CNSScenario]map[corev1.OSName]cnsDetails, error)
 					"azure-swift-overlay-dualstack.conflist", "-o", "/etc/cni/net.d/10-azure.conflist",
 				},
 				initContainerName:  initContainerNameCNI,
-				configMapPath:      cnsSwiftConfigMapPath,
+				configMapPath:      cnsAzureCNIDualStackLinuxConfigMapPath,
 				installIPMasqAgent: true,
 			},
 			corev1.Windows: {

--- a/test/internal/kubernetes/utils_create.go
+++ b/test/internal/kubernetes/utils_create.go
@@ -674,6 +674,15 @@ func volumesForAzureCNIOverlayWindows() []corev1.Volume {
 				},
 			},
 		}, // TODO: add windows cni conflist when ready
+		{
+			Name: "azure-vnet",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/var/run/azure-vnet",
+					Type: hostPathTypePtr(corev1.HostPathDirectoryOrCreate),
+				},
+			},
+		},
 	}
 }
 
@@ -746,5 +755,9 @@ func cnsVolumeMountsForAzureCNIOverlayWindows() []corev1.VolumeMount {
 			Name:      "cni-bin",
 			MountPath: "/k/azurecni/bin",
 		}, // TODO: add windows cni conflist when ready
+		{
+			Name:      "azure-vnet",
+			MountPath: "/var/run/azure-vnet",
+		},
 	}
 }


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Updates the windows CNS daemonset to include the async delete path `/var/run/azure-vnet` in its volume mounts. Without the mount, windows CNS would OOM even if `EnableAsyncPodDelete: false` is read from the configmap. 

Add the appropriate async delete fields to CNS configmaps

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
