### PR TITLE
fix: check for notStarted

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -46,11 +46,11 @@ jobs:
           echo "Checking for AZP triggered CI for 60s"
           end=$((SECONDS+60)) # Stop checking if not queued within a minute
           while [ $SECONDS -lt $end ]; do
-            if [ $status = 'inProgress' ]; then
-              echo "AZP triggered pipeline started successfully"
+            if [ $status = 'inProgress' ] || [ $status = 'notStarted' ]; then
+              echo "AZP triggered pipeline queued successfully"
               exit 0
             fi
-            echo "Waiting for 15 seconds for AZP to trigger run and show inProgress"
+            echo "Waiting for 15 seconds for AZP to trigger run and show inProgress or notStarted"
             sleep 15s
             status=`az pipelines runs list --pipeline-ids ${{ secrets.AZURE_PIPELINE_ID }} --org ${{ secrets.AZURE_PIPELINE_ORG }} --project ${{ secrets.AZURE_PIPELINE_PROJECT }} --top 1 --branch $GITHUB_REF --output json | jq -r .[].status`
             echo "Current CI Status - $status"
@@ -64,12 +64,12 @@ jobs:
           echo "Checking for Manually triggered CI for 60s"
           end=$((SECONDS+60)) # Stop checking if not queued within a minute
           while [ $SECONDS -lt $end ]; do
-            echo "Waiting for 5 seconds for pipeline to show inProgress on AZP"
+            echo "Waiting for 5 seconds for pipeline to show inProgress or notStarted on AZP"
             sleep 5s
             status=`az pipelines runs list --pipeline-ids ${{ secrets.AZURE_PIPELINE_ID }} --org ${{ secrets.AZURE_PIPELINE_ORG }} --project ${{ secrets.AZURE_PIPELINE_PROJECT }} --top 1 --branch $GITHUB_REF --output json | jq -r .[].status`
             echo "Current CI Status - $status"
-            if [ $status = 'inProgress' ]; then
-              echo "Manually triggered pipeline started successfully"
+            if [ $status = 'inProgress' ] || [ $status = 'notStarted' ]; then
+              echo "Manually triggered pipeline queued successfully"
               exit 0
             fi
           done


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
fixes #2460 double queuing of pipeline runs due to agent provisioning time and missing the `notStarted` status in conditional. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
