### PR TITLE
ci; Improve package kubernetes and load

### DIFF
--- a/test/integration/load/load_test.go
+++ b/test/integration/load/load_test.go
@@ -195,7 +195,7 @@ func TestValidCNSStateDuringScaleAndCNSRestartToTriggerDropgzInstall(t *testing.
 	kubernetes.MustScaleDeployment(ctx, deploymentsClient, deployment, clientset, namespace, podLabelSelector, testConfig.ScaleUpReplicas, skipWait)
 
 	// restart linux CNS (linux, windows)
-	err = kubernetes.RestartCNSDaemonset(ctx, clientset)
+	err = kubernetes.RestartCNSDaemonset(ctx, clientset, true)
 	require.NoError(t, err)
 
 	// wait for pods to settle before checking cns state (otherwise, race between getting pods in creating state, and getting CNS state file)
@@ -210,7 +210,7 @@ func TestValidCNSStateDuringScaleAndCNSRestartToTriggerDropgzInstall(t *testing.
 	kubernetes.MustScaleDeployment(ctx, deploymentsClient, deployment, clientset, namespace, podLabelSelector, testConfig.ScaleDownReplicas, skipWait)
 
 	// restart linux CNS (linux, windows)
-	err = kubernetes.RestartCNSDaemonset(ctx, clientset)
+	err = kubernetes.RestartCNSDaemonset(ctx, clientset, true)
 	require.NoError(t, err)
 
 	// wait for pods to settle before checking cns state (otherwise, race between getting pods in terminating state, and getting CNS state file)

--- a/test/integration/load/load_test.go
+++ b/test/integration/load/load_test.go
@@ -186,6 +186,13 @@ func TestValidCNSStateDuringScaleAndCNSRestartToTriggerDropgzInstall(t *testing.
 	deploymentsClient := clientset.AppsV1().Deployments(namespace)
 
 	if testConfig.Cleanup {
+		// Create namespace if it doesn't exist
+		namespaceExists, err := kubernetes.NamespaceExists(ctx, clientset, namespace)
+		require.NoError(t, err)
+		if !namespaceExists {
+			kubernetes.MustCreateNamespace(ctx, clientset, namespace)
+		}
+
 		// Create a deployment
 		kubernetes.MustCreateDeployment(ctx, deploymentsClient, deployment)
 	}

--- a/test/internal/kubernetes/utils.go
+++ b/test/internal/kubernetes/utils.go
@@ -259,10 +259,14 @@ func WaitForPodDaemonset(ctx context.Context, clientset *kubernetes.Clientset, n
 		if err != nil {
 			return errors.Wrapf(err, "could not get daemonset %s", daemonsetName)
 		}
+		if daemonset.Status.UpdatedNumberScheduled != daemonset.Status.DesiredNumberScheduled {
+			log.Printf("daemonset %s is updating, %v of %v pods updated", daemonsetName, daemonset.Status.UpdatedNumberScheduled, daemonset.Status.DesiredNumberScheduled)
+			return errors.New("daemonset failed to update all pods")
+		}
 
 		if daemonset.Status.NumberReady == 0 && daemonset.Status.DesiredNumberScheduled == 0 {
 			// Capture daemonset restart. Restart sets every numerical status to 0.
-			log.Printf("daemonset %s is in restart phase, no pods should be ready or scheduled", daemonsetName)
+			log.Printf("daemonset %s is fresh, no pods should be ready or scheduled", daemonsetName)
 			return errors.New("daemonset did not set any pods to be scheduled")
 		}
 
@@ -277,7 +281,7 @@ func WaitForPodDaemonset(ctx context.Context, clientset *kubernetes.Clientset, n
 			return errors.Wrapf(err, "could not list pods with label selector %s", podLabelSelector)
 		}
 
-		log.Printf("daemonset %s has %d pods in ready status, expected %d", daemonsetName, len(podList.Items), daemonset.Status.CurrentNumberScheduled)
+		log.Printf("daemonset %s has %d pods in ready status | %d pods up-to-date status, expected %d", daemonsetName, len(podList.Items), daemonset.Status.UpdatedNumberScheduled, daemonset.Status.CurrentNumberScheduled)
 		if len(podList.Items) != int(daemonset.Status.NumberReady) {
 			return errors.New("some pods of the daemonset are still not ready")
 		}

--- a/test/internal/kubernetes/utils.go
+++ b/test/internal/kubernetes/utils.go
@@ -281,7 +281,8 @@ func WaitForPodDaemonset(ctx context.Context, clientset *kubernetes.Clientset, n
 			return errors.Wrapf(err, "could not list pods with label selector %s", podLabelSelector)
 		}
 
-		log.Printf("daemonset %s has %d pods in ready status | %d pods up-to-date status, expected %d", daemonsetName, len(podList.Items), daemonset.Status.UpdatedNumberScheduled, daemonset.Status.CurrentNumberScheduled)
+		log.Printf("daemonset %s has %d pods in ready status | %d pods up-to-date status, expected %d",
+			daemonsetName, len(podList.Items), daemonset.Status.UpdatedNumberScheduled, daemonset.Status.CurrentNumberScheduled)
 		if len(podList.Items) != int(daemonset.Status.NumberReady) {
 			return errors.New("some pods of the daemonset are still not ready")
 		}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Calls for package `kubernetes - WaitForPodDaemonset()` would result in a race condition if an update command was used to restart the Daemonset. This resulted in `make test-load` having a built in race condition every time `TestValidCNSStateDuringScaleAndCNSRestartToTriggerDropgzInstall()` test was called. 

To ensure that functionality is gained, `RestartCNSDaemonset()` has a new flag `waitForReady` that then calls `WaitForPodDaemonset()` to ensure that all pods within the daemonset are ready and updated to the newest revision.  

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
