### PR TITLE
ci: Improve Validate package

### DIFF
--- a/test/integration/datapath/datapath_windows_test.go
+++ b/test/integration/datapath/datapath_windows_test.go
@@ -15,13 +15,10 @@ import (
 )
 
 const (
-	WindowsDeployYamlPath   = "../manifests/datapath/windows-deployment.yaml"
-	podLabelKey             = "app"
-	podCount                = 2
-	nodepoolKey             = "agentpool"
-	privilegedDaemonSetPath = "../manifests/load/privileged-daemonset-windows.yaml"
-	privilegedLabelSelector = "app=privileged-daemonset"
-	privilegedNamespace     = "kube-system"
+	WindowsDeployYamlPath = "../manifests/datapath/windows-deployment.yaml"
+	podLabelKey           = "app"
+	podCount              = 2
+	nodepoolKey           = "agentpool"
 )
 
 var (
@@ -59,15 +56,15 @@ func setupWindowsEnvironment(t *testing.T) {
 	clientset := kubernetes.MustGetClientset()
 
 	if *restartKubeproxy {
-		privilegedDaemonSet := kubernetes.MustParseDaemonSet(privilegedDaemonSetPath)
-		daemonsetClient := clientset.AppsV1().DaemonSets(privilegedNamespace)
+		privilegedDaemonSet := kubernetes.MustParseDaemonSet(kubernetes.PrivilegedDaemonSetPath)
+		daemonsetClient := clientset.AppsV1().DaemonSets(kubernetes.PrivilegedNamespace)
 		kubernetes.MustCreateDaemonset(ctx, daemonsetClient, privilegedDaemonSet)
 
 		// Ensures that pods have been replaced if test is re-run after failure
-		if err := kubernetes.WaitForPodDaemonset(ctx, clientset, privilegedNamespace, privilegedDaemonSet.Name, privilegedLabelSelector); err != nil {
+		if err := kubernetes.WaitForPodDaemonset(ctx, clientset, kubernetes.PrivilegedNamespace, privilegedDaemonSet.Name, kubernetes.PrivilegedLabelSelector); err != nil {
 			require.NoError(t, err)
 		}
-		err := kubernetes.RestartKubeProxyService(ctx, clientset, privilegedNamespace, privilegedLabelSelector, restConfig)
+		err := kubernetes.RestartKubeProxyService(ctx, clientset, kubernetes.PrivilegedNamespace, kubernetes.PrivilegedLabelSelector, restConfig)
 		require.NoError(t, err)
 	}
 

--- a/test/internal/kubernetes/utils.go
+++ b/test/internal/kubernetes/utils.go
@@ -470,7 +470,7 @@ func MustRestartDaemonset(ctx context.Context, clientset *kubernetes.Clientset, 
 }
 
 // Restarts kubeproxy on windows nodes from an existing privileged daemonset
-func RestartKubeProxyService(ctx context.Context, clientset *kubernetes.Clientset, privilegedNamespace string, privilegedLabelSelector string, config *rest.Config) error {
+func RestartKubeProxyService(ctx context.Context, clientset *kubernetes.Clientset, privilegedNamespace, privilegedLabelSelector string, config *rest.Config) error {
 	restartKubeProxyCmd := []string{"powershell", "Restart-service", "kubeproxy"}
 
 	nodes, err := GetNodeList(ctx, clientset)

--- a/test/internal/kubernetes/utils.go
+++ b/test/internal/kubernetes/utils.go
@@ -34,10 +34,13 @@ const (
 	SubnetNameLabel        = "kubernetes.azure.com/podnetwork-subnet"
 
 	// RetryAttempts is the number of times to retry a test.
-	RetryAttempts       = 90
-	RetryDelay          = 10 * time.Second
-	DeleteRetryAttempts = 12
-	DeleteRetryDelay    = 5 * time.Second
+	RetryAttempts           = 90
+	RetryDelay              = 10 * time.Second
+	DeleteRetryAttempts     = 12
+	DeleteRetryDelay        = 5 * time.Second
+	PrivilegedDaemonSetPath = "../manifests/load/privileged-daemonset-windows.yaml"
+	PrivilegedLabelSelector = "app=privileged-daemonset"
+	PrivilegedNamespace     = "kube-system"
 )
 
 var Kubeconfig = flag.String("test-kubeconfig", filepath.Join(homedir.HomeDir(), ".kube", "config"), "(optional) absolute path to the kubeconfig file")
@@ -489,6 +492,9 @@ func RestartKubeProxyService(ctx context.Context, clientset *kubernetes.Clientse
 			return errors.Wrapf(err, "failed to get privileged pod on node %s", node.Name)
 		}
 
+		if len(pod.Items) == 0 {
+			return errors.Errorf("there are no privileged pods on node - %v", node.Name)
+		}
 		privilegedPod := pod.Items[0]
 		// exec into the pod and restart kubeproxy
 		_, err = ExecCmdOnPod(ctx, clientset, privilegedNamespace, privilegedPod.Name, restartKubeProxyCmd, config)

--- a/test/validate/linux_validate.go
+++ b/test/validate/linux_validate.go
@@ -156,21 +156,6 @@ func ciliumStateFileIps(result []byte) (map[string]string, error) {
 	return ciliumPodIps, nil
 }
 
-func cnsCacheStateFileIps(result []byte) (map[string]string, error) {
-	var cnsLocalCache CNSLocalCache
-
-	err := json.Unmarshal(result, &cnsLocalCache)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal cns local cache")
-	}
-
-	cnsPodIps := make(map[string]string)
-	for index := range cnsLocalCache.IPConfigurationStatus {
-		cnsPodIps[cnsLocalCache.IPConfigurationStatus[index].IPAddress] = cnsLocalCache.IPConfigurationStatus[index].PodInfo.Name()
-	}
-	return cnsPodIps, nil
-}
-
 func azureVnetStateIps(result []byte) (map[string]string, error) {
 	var azureVnetResult AzureCniState
 	err := json.Unmarshal(result, &azureVnetResult)

--- a/test/validate/linux_validate.go
+++ b/test/validate/linux_validate.go
@@ -219,11 +219,11 @@ func (v *Validator) validateRestartNetwork(ctx context.Context) error {
 			return errors.Wrapf(err, "failed to get privileged pod")
 		}
 
-		privelegedPod := pod.Items[0]
+		privilegedPod := pod.Items[0]
 		// exec into the pod to get the state file
-		_, err = acnk8s.ExecCmdOnPod(ctx, v.clientset, privilegedNamespace, privelegedPod.Name, restartNetworkCmd, v.config)
+		_, err = acnk8s.ExecCmdOnPod(ctx, v.clientset, privilegedNamespace, privilegedPod.Name, restartNetworkCmd, v.config)
 		if err != nil {
-			return errors.Wrapf(err, "failed to exec into privileged pod %s on node %s", privelegedPod.Name, node.Name)
+			return errors.Wrapf(err, "failed to exec into privileged pod %s on node %s", privilegedPod.Name, node.Name)
 		}
 		err = acnk8s.WaitForPodsRunning(ctx, v.clientset, "", "")
 		if err != nil {

--- a/test/validate/linux_validate.go
+++ b/test/validate/linux_validate.go
@@ -214,11 +214,13 @@ func (v *Validator) validateRestartNetwork(ctx context.Context) error {
 			continue
 		}
 		// get the privileged pod
-		pod, err := acnk8s.GetPodsByNode(ctx, v.clientset, privilegedNamespace, privilegedLabelSelector, nodes.Items[index].Name)
+		pod, err := acnk8s.GetPodsByNode(ctx, v.clientset, privilegedNamespace, privilegedLabelSelector, node.Name)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get privileged pod")
 		}
-
+		if len(pod.Items) == 0 {
+			return errors.Errorf("there are no privileged pods on node - %v", node.Name)
+		}
 		privilegedPod := pod.Items[0]
 		// exec into the pod to get the state file
 		_, err = acnk8s.ExecCmdOnPod(ctx, v.clientset, privilegedNamespace, privilegedPod.Name, restartNetworkCmd, v.config)

--- a/test/validate/linux_validate.go
+++ b/test/validate/linux_validate.go
@@ -15,12 +15,12 @@ const (
 )
 
 var (
-	restartNetworkCmd      = []string{"bash", "-c", "chroot /host /bin/bash -c systemctl restart systemd-networkd"}
-	cnsManagedStateFileCmd = []string{"bash", "-c", "cat /var/run/azure-cns/azure-endpoints.json"}
-	azureVnetStateFileCmd  = []string{"bash", "-c", "cat /var/run/azure-vnet.json"}
-	azureVnetIpamStateCmd  = []string{"bash", "-c", "cat /var/run/azure-vnet-ipam.json"}
-	ciliumStateFileCmd     = []string{"bash", "-c", "cilium endpoint list -o json"}
-	cnsLocalCacheCmd       = []string{"curl", "localhost:10090/debug/ipaddresses", "-d", "{\"IPConfigStateFilter\":[\"Assigned\"]}"}
+	restartNetworkCmd           = []string{"bash", "-c", "chroot /host /bin/bash -c systemctl restart systemd-networkd"}
+	cnsManagedStateFileCmd      = []string{"bash", "-c", "cat /var/run/azure-cns/azure-endpoints.json"}
+	azureVnetStateFileCmd       = []string{"bash", "-c", "cat /var/run/azure-vnet.json"}
+	azureVnetIpamStateCmd       = []string{"bash", "-c", "cat /var/run/azure-vnet-ipam.json"}
+	ciliumStateFileCmd          = []string{"bash", "-c", "cilium endpoint list -o json"}
+	cnsCachedAssignedIPStateCmd = []string{"curl", "localhost:10090/debug/ipaddresses", "-d", "{\"IPConfigStateFilter\":[\"Assigned\"]}"}
 )
 
 type stateFileIpsFunc func([]byte) (map[string]string, error)
@@ -29,18 +29,18 @@ var linuxChecksMap = map[string][]check{
 	"cilium": {
 		{"cns", cnsManagedStateFileIps, cnsLabelSelector, privilegedNamespace, cnsManagedStateFileCmd}, // cns configmap "ManageEndpointState": true, | Endpoints managed in CNS State File
 		{"cilium", ciliumStateFileIps, ciliumLabelSelector, privilegedNamespace, ciliumStateFileCmd},
-		{"cns cache", cnsCacheStateFileIps, cnsLabelSelector, privilegedNamespace, cnsLocalCacheCmd},
+		{"cns cache", cnsCacheStateFileIps, cnsLabelSelector, privilegedNamespace, cnsCachedAssignedIPStateCmd},
 	},
 	"cniv1": {
 		{"azure-vnet", azureVnetStateIps, privilegedLabelSelector, privilegedNamespace, azureVnetStateFileCmd},
 		{"azure-vnet-ipam", azureVnetIpamStateIps, privilegedLabelSelector, privilegedNamespace, azureVnetIpamStateCmd},
 	},
 	"cniv2": {
-		{"cns cache", cnsCacheStateFileIps, cnsLabelSelector, privilegedNamespace, cnsLocalCacheCmd},
+		{"cns cache", cnsCacheStateFileIps, cnsLabelSelector, privilegedNamespace, cnsCachedAssignedIPStateCmd},
 		{"azure-vnet", azureVnetStateIps, privilegedLabelSelector, privilegedNamespace, azureVnetStateFileCmd}, // cns configmap "ManageEndpointState": false, | Endpoints managed in CNI State File
 	},
 	"dualstack": {
-		{"cns cache", cnsCacheStateFileIps, cnsLabelSelector, privilegedNamespace, cnsLocalCacheCmd},
+		{"cns cache", cnsCacheStateFileIps, cnsLabelSelector, privilegedNamespace, cnsCachedAssignedIPStateCmd},
 		{"azure dualstackoverlay", azureVnetStateIps, privilegedLabelSelector, privilegedNamespace, azureVnetStateFileCmd},
 	},
 }

--- a/test/validate/utils.go
+++ b/test/validate/utils.go
@@ -11,14 +11,16 @@ import (
 )
 
 func compareIPs(expected map[string]string, actual []string) error {
-	if len(expected) != len(actual) {
-		return errors.Errorf("len of expected IPs != len of actual IPs, expected: %+v, actual: %+v", expected, actual)
-	}
+	expectedLen := len(expected)
 
 	for _, ip := range actual {
 		if _, ok := expected[ip]; !ok {
 			return errors.Errorf("actual ip %s is unexpected, expected: %+v, actual: %+v", ip, expected, actual)
 		}
+		delete(expected, ip)
+	}
+	if expectedLen != len(actual) {
+		return errors.Errorf("len of expected IPs != len of actual IPs, expected: %+v, actual: %+v | Remaining expected IP(s) - %v", expectedLen, len(actual), expected)
 	}
 
 	return nil

--- a/test/validate/utils.go
+++ b/test/validate/utils.go
@@ -20,7 +20,7 @@ func compareIPs(expected map[string]string, actual []string) error {
 		delete(expected, ip)
 	}
 	if expectedLen != len(actual) {
-		return errors.Errorf("len of expected IPs != len of actual IPs, expected: %+v, actual: %+v | Remaining expected IP(s) - %v", expectedLen, len(actual), expected)
+		return errors.Errorf("len of expected IPs != len of actual IPs, expected: %+v, actual: %+v | Remaining, potentially leaked, IP(s) on state file - %v", expectedLen, len(actual), expected)
 	}
 
 	return nil

--- a/test/validate/validate.go
+++ b/test/validate/validate.go
@@ -166,7 +166,7 @@ func (v *Validator) validateIPs(ctx context.Context, stateFileIps stateFileIpsFu
 		}
 		filePodIps, err := stateFileIps(result)
 		if err != nil {
-			return errors.Wrapf(err, "failed to get pod ips from state file")
+			return errors.Wrapf(err, "failed to get pod ips from state file on node %v", nodes.Items[index].Name)
 		}
 		if len(filePodIps) == 0 && v.restartCase {
 			log.Printf("No pods found on node %s", nodes.Items[index].Name)

--- a/test/validate/validate.go
+++ b/test/validate/validate.go
@@ -80,7 +80,10 @@ func CreateValidator(ctx context.Context, clientset *kubernetes.Clientset, confi
 	}
 
 	if os == "windows" {
-		acnk8s.RestartKubeProxyService(ctx, clientset, privilegedNamespace, privilegedLabelSelector, config)
+		err := acnk8s.RestartKubeProxyService(ctx, clientset, privilegedNamespace, privilegedLabelSelector, config)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to restart kubeproxy")
+		}
 	}
 
 	return &Validator{

--- a/test/validate/windows_validate.go
+++ b/test/validate/windows_validate.go
@@ -18,12 +18,12 @@ const (
 )
 
 var (
-	hnsEndPointCmd      = []string{"powershell", "-c", "Get-HnsEndpoint | ConvertTo-Json"}
-	hnsNetworkCmd       = []string{"powershell", "-c", "Get-HnsNetwork | ConvertTo-Json"}
-	azureVnetCmd        = []string{"powershell", "-c", "cat ../../k/azure-vnet.json"}
-	azureVnetIpamCmd    = []string{"powershell", "-c", "cat ../../k/azure-vnet-ipam.json"}
-	restartKubeProxyCmd = []string{"powershell", "Restart-service", "kubeproxy"}
-	cnsWinLocalCacheCmd = []string{
+	hnsEndPointCmd                 = []string{"powershell", "-c", "Get-HnsEndpoint | ConvertTo-Json"}
+	hnsNetworkCmd                  = []string{"powershell", "-c", "Get-HnsNetwork | ConvertTo-Json"}
+	azureVnetCmd                   = []string{"powershell", "-c", "cat ../../k/azure-vnet.json"}
+	azureVnetIpamCmd               = []string{"powershell", "-c", "cat ../../k/azure-vnet-ipam.json"}
+	restartKubeProxyCmd            = []string{"powershell", "Restart-service", "kubeproxy"}
+	cnsWinCachedAssignedIPStateCmd = []string{
 		"powershell", "Invoke-WebRequest -Uri 127.0.0.1:10090/debug/ipaddresses",
 		"-Method Post -ContentType application/x-www-form-urlencoded",
 		"-Body \"{`\"IPConfigStateFilter`\":[`\"Assigned`\"]}\"",
@@ -40,7 +40,7 @@ var windowsChecksMap = map[string][]check{
 	"cniv2": {
 		{"hns", hnsStateFileIps, privilegedLabelSelector, privilegedNamespace, hnsEndPointCmd},
 		{"azure-vnet", azureVnetIps, privilegedLabelSelector, privilegedNamespace, azureVnetCmd},
-		{"cns cache", cnsCacheStateFileIps, cnsWinLabelSelector, privilegedNamespace, cnsWinLocalCacheCmd},
+		{"cns cache", cnsCacheStateFileIps, cnsWinLabelSelector, privilegedNamespace, cnsWinCachedAssignedIPStateCmd},
 	},
 }
 

--- a/test/validate/windows_validate.go
+++ b/test/validate/windows_validate.go
@@ -13,12 +13,22 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+const (
+	cnsWinLabelSelector = "k8s-app=azure-cns-win"
+)
+
 var (
 	hnsEndPointCmd      = []string{"powershell", "-c", "Get-HnsEndpoint | ConvertTo-Json"}
 	hnsNetworkCmd       = []string{"powershell", "-c", "Get-HnsNetwork | ConvertTo-Json"}
 	azureVnetCmd        = []string{"powershell", "-c", "cat ../../k/azure-vnet.json"}
 	azureVnetIpamCmd    = []string{"powershell", "-c", "cat ../../k/azure-vnet-ipam.json"}
 	restartKubeProxyCmd = []string{"powershell", "Restart-service", "kubeproxy"}
+	cnsWinLocalCacheCmd = []string{
+		"powershell", "Invoke-WebRequest -Uri 127.0.0.1:10090/debug/ipaddresses",
+		"-Method Post -ContentType application/x-www-form-urlencoded",
+		"-Body \"{`\"IPConfigStateFilter`\":[`\"Assigned`\"]}\"",
+		"-UseBasicParsing | Select-Object -Expand Content",
+	}
 )
 
 var windowsChecksMap = map[string][]check{
@@ -28,7 +38,9 @@ var windowsChecksMap = map[string][]check{
 		{"azure-vnet-ipam", azureVnetIpamIps, privilegedLabelSelector, privilegedNamespace, azureVnetIpamCmd},
 	},
 	"cniv2": {
+		{"hns", hnsStateFileIps, privilegedLabelSelector, privilegedNamespace, hnsEndPointCmd},
 		{"azure-vnet", azureVnetIps, privilegedLabelSelector, privilegedNamespace, azureVnetCmd},
+		{"cns cache", cnsCacheStateFileIps, cnsWinLabelSelector, privilegedNamespace, cnsWinLocalCacheCmd},
 	},
 }
 

--- a/test/validate/windows_validate.go
+++ b/test/validate/windows_validate.go
@@ -47,7 +47,7 @@ var windowsChecksMap = map[string][]check{
 type HNSEndpoint struct {
 	MacAddress       string `json:"MacAddress"`
 	IPAddress        net.IP `json:"IPAddress"`
-	IPv6Address      net.IP `json:",omitempty"`
+	IPv6Address      net.IP `json:"IPv6Address"`
 	IsRemoteEndpoint bool   `json:",omitempty"`
 }
 
@@ -112,6 +112,10 @@ func hnsStateFileIps(result []byte) (map[string]string, error) {
 	for _, v := range hnsResult {
 		if !v.IsRemoteEndpoint {
 			hnsPodIps[v.IPAddress.String()] = v.MacAddress
+			if v.IPv6Address.String() != "<nil>" {
+				hnsPodIps[v.IPv6Address.String()] = v.MacAddress
+			}
+
 		}
 	}
 	return hnsPodIps, nil

--- a/test/validate/windows_validate.go
+++ b/test/validate/windows_validate.go
@@ -204,7 +204,9 @@ func validateHNSNetworkState(ctx context.Context, nodes *corev1.NodeList, client
 		if err != nil {
 			return errors.Wrap(err, "failed to get privileged pod")
 		}
-
+		if len(pod.Items) == 0 {
+			return errors.Errorf("there are no privileged pods on node - %v", nodes.Items[index].Name)
+		}
 		podName := pod.Items[0].Name
 		// exec into the pod to get the state file
 		result, err := acnk8s.ExecCmdOnPod(ctx, clientset, privilegedNamespace, podName, hnsNetworkCmd, restConfig)

--- a/test/validate/windows_validate.go
+++ b/test/validate/windows_validate.go
@@ -23,7 +23,6 @@ var (
 	hnsNetworkCmd                  = []string{"powershell", "-c", "Get-HnsNetwork | ConvertTo-Json"}
 	azureVnetCmd                   = []string{"powershell", "-c", "cat ../../k/azure-vnet.json"}
 	azureVnetIpamCmd               = []string{"powershell", "-c", "cat ../../k/azure-vnet-ipam.json"}
-	restartKubeProxyCmd            = []string{"powershell", "Restart-service", "kubeproxy"}
 	cnsWinCachedAssignedIPStateCmd = []string{
 		"powershell", "Invoke-WebRequest -Uri 127.0.0.1:10090/debug/ipaddresses",
 		"-Method Post -ContentType application/x-www-form-urlencoded",

--- a/test/validate/windows_validate.go
+++ b/test/validate/windows_validate.go
@@ -108,7 +108,8 @@ func hnsStateFileIps(result []byte) (map[string]string, error) {
 	isArray := jsonType[0] == '['
 	hnsPodIps := make(map[string]string)
 
-	if isObject {
+	switch {
+	case isObject:
 		var hnsResult HNSEndpoint
 		err := json.Unmarshal(result, &hnsResult)
 		if err != nil {
@@ -119,10 +120,8 @@ func hnsStateFileIps(result []byte) (map[string]string, error) {
 			if hnsResult.IPv6Address.String() != "<nil>" {
 				hnsPodIps[hnsResult.IPv6Address.String()] = hnsResult.MacAddress
 			}
-
 		}
-
-	} else if isArray {
+	case isArray:
 		var hnsResult []HNSEndpoint
 		err := json.Unmarshal(result, &hnsResult)
 		if err != nil {
@@ -138,9 +137,9 @@ func hnsStateFileIps(result []byte) (map[string]string, error) {
 
 			}
 		}
-	} else {
-		log.Printf("Leading character is - %s", jsonType[0])
-		return nil, errors.New("JSON is malformed and does not have correct leading character.")
+	default:
+		log.Printf("Leading character is - %v", jsonType[0])
+		return nil, errors.New("json is malformed and does not have correct leading character")
 	}
 
 	return hnsPodIps, nil


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
- Adds windows CNIv2 state validation
- Moves `cnsCacheStateFileIps()` to `validate.go` as it is OS agnostic
- Adds in reporting for leaked ips that exist on state files when `compareIPs()` fails due to size difference between actual IPs on the cluster and what exists in the state file. Old functionality reported an entire map of IPs from both current IPs and state file IPs. 
- Adds in reporting when `ExecCmdPod()` has a 0 byte response
- Fixes `validateRestartNetwork()` to work in hybrid clusters and only execute on linux nodes
- Moves `RestartKubeProxyService()` to internal `kubernetes` package as it is a wrapper function for `ExecCmdPod()` and does not validate anything

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
