### PR TITLE
ci: add OS scale timeout

### DIFF
--- a/test/integration/load/load_test.go
+++ b/test/integration/load/load_test.go
@@ -40,6 +40,13 @@ var noopDeploymentMap = map[string]string{
 	"linux":   manifestDir + "/noop-deployment-linux.yaml",
 }
 
+// This map is used exclusively for TestLoad. Windows is expected to take 10-15 minutes per iteration.
+// Will change this as scale testing results are verified. This will ensure we keep a standard performance metric.
+var scaleTimeoutMap = map[string]time.Duration{
+	"windows": 15 * time.Minute,
+	"linux":   10 * time.Minute,
+}
+
 /*
 In order to run the scale tests, you need a k8s cluster and its kubeconfig.
 If no kubeconfig is passed, the test will attempt to find one in the default location for kubectl config.
@@ -64,8 +71,7 @@ todo: consider adding the following scenarios
 */
 func TestLoad(t *testing.T) {
 	clientset := kubernetes.MustGetClientset()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(testConfig.Iterations)*scaleTimeoutMap[testConfig.OSType])
 	defer cancel()
 
 	// Create namespace if it doesn't exist


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Set a standard time for `TestLoad()` per iteration for each OS type. Setting arbitrary to a default 30 limited the amount of iterations and did not take into account the performance differences between OS.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
