### PR TITLE
ci: add kubeproxy restart before windows k8s conformance testing

### DIFF
--- a/.pipelines/cni/k8s-e2e/k8s-e2e-job-template.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e-job-template.yaml
@@ -36,6 +36,7 @@ jobs:
         displayName: "Setup Environment"
       - ${{ if contains(parameters.os, 'windows') }}:
         - script: |
+            set -e
             kubectl apply -f test/integration/manifests/load/privileged-daemonset-windows.yaml
             kubectl rollout status -n kube-system ds privileged-daemonset
 

--- a/.pipelines/cni/k8s-e2e/k8s-e2e-job-template.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e-job-template.yaml
@@ -34,6 +34,20 @@ jobs:
             tar -xvzf kubernetes-test-linux-amd64.tar.gz --strip-components=3 kubernetes/test/bin/ginkgo kubernetes/test/bin/e2e.test
 
         displayName: "Setup Environment"
+      - ${{ if contains(parameters.os, 'windows') }}:
+        - script: |
+            kubectl apply -f test/integration/manifests/load/privileged-daemonset-windows.yaml
+            kubectl rollout status -n kube-system ds privileged-daemonset
+
+            kubectl get pod -n kube-system -l app=privileged-daemonset,os=windows -owide
+            pods=`kubectl get pod -n kube-system -l app=privileged-daemonset,os=windows --no-headers | awk '{print $1}'`
+            for pod in $pods; do
+              kubectl exec -i -n kube-system $pod -- powershell "Restart-Service kubeproxy"
+              kubectl exec -i -n kube-system $pod -- powershell "Get-Service kubeproxy"
+            done
+          name: kubeproxy
+          displayName: Restart Kubeproxy on Windows nodes
+          retryCountOnTaskFailure: 3
       - ${{ if eq(parameters.datapath, true) }}:
         - template: ../k8s-e2e/k8s-e2e-step-template.yaml
           parameters:


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Windows byocni clusters have kubeproxy turned off by default. Ensuring that kubeproxy is restarted before k8s conformance testing occurs ensures that edge cases do not impact windows testing.  

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
