### PR TITLE
CNI must add static route for ipv6 default gateway

### DIFF
--- a/.pipelines/cni/k8s-e2e/k8s-e2e-job-template.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e-job-template.yaml
@@ -34,6 +34,21 @@ jobs:
             tar -xvzf kubernetes-test-linux-amd64.tar.gz --strip-components=3 kubernetes/test/bin/ginkgo kubernetes/test/bin/e2e.test
 
         displayName: "Setup Environment"
+      - ${{ if contains(parameters.os, 'windows') }}:
+        - script: |
+            set -e
+            kubectl apply -f test/integration/manifests/load/privileged-daemonset-windows.yaml
+            kubectl rollout status -n kube-system ds privileged-daemonset
+
+            kubectl get pod -n kube-system -l app=privileged-daemonset,os=windows -owide
+            pods=`kubectl get pod -n kube-system -l app=privileged-daemonset,os=windows --no-headers | awk '{print $1}'`
+            for pod in $pods; do
+              kubectl exec -i -n kube-system $pod -- powershell "Restart-Service kubeproxy"
+              kubectl exec -i -n kube-system $pod -- powershell "Get-Service kubeproxy"
+            done
+          name: kubeproxy
+          displayName: Restart Kubeproxy on Windows nodes
+          retryCountOnTaskFailure: 3
       - ${{ if eq(parameters.datapath, true) }}:
         - template: ../k8s-e2e/k8s-e2e-step-template.yaml
           parameters:

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -196,7 +196,7 @@ func (nw *network) addIPv6DefaultRoute(plc platform.ExecClient) error {
 		out string
 	)
 	// the default ipv6 route is missing sometimes due to ARP issue
-	// need to add ipv6 default route if it does not exist in dualstack overlay windows
+	// need to add ipv6 default route if it does not exist in dualstack overlay windows node
 	if len(nw.Subnets) < 2 {
 		return fmt.Errorf("Ipv6 subnet not found in network state")
 	}

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -32,7 +32,7 @@ const (
 	defaultGwMac = "12-34-56-78-9a-bc"
 
 	// Default IPv6 Route
-	defaultIPv6Route = "::/1"
+	defaultIPv6Route = "::/0"
 
 	// Default IPv6 nextHop
 	defaultIPv6NextHop = "fe80::1234:5678:9abc"

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -31,6 +31,12 @@ const (
 	// Default gateway Mac
 	defaultGwMac = "12-34-56-78-9a-bc"
 
+	// Default IPv6 Route
+	defaultIPv6Route = "::/1"
+
+	// Default IPv6 nextHop
+	defaultIPv6NextHop = "fe80::1234:5678:9abc"
+
 	// Container interface name prefix
 	containerIfNamePrefix = "vEthernet"
 
@@ -77,6 +83,11 @@ func (nw *network) newEndpointImpl(
 	// there is only 1 epInfo for windows, multiple interfaces will be added in the future
 	if useHnsV2, err := UseHnsV2(epInfo[0].NetNsPath); useHnsV2 {
 		if err != nil {
+			return nil, err
+		}
+
+		// check if ipv6 default gateway route is missing before windows endpoint creation
+		if err := nw.addIPv6DefaultRoute(plc); err != nil {
 			return nil, err
 		}
 
@@ -177,6 +188,38 @@ func (nw *network) newEndpointImplHnsV1(epInfo *EndpointInfo, plc platform.ExecC
 	ep.MacAddress, _ = net.ParseMAC(hnsResponse.MacAddress)
 
 	return ep, nil
+}
+
+func (nw *network) addIPv6DefaultRoute(plc platform.ExecClient) error {
+	var (
+		err error
+		out string
+	)
+	// the default ipv6 route is missing sometimes due to ARP issue
+	// need to add ipv6 default route if it does not exist in dualstack overlay windows
+	if len(nw.Subnets) < 2 {
+		return fmt.Errorf("Ipv6 subnet not found in network state")
+	}
+
+	cmd := fmt.Sprintf(`Get-NetAdapter | Where-Object { $_.InterfaceDescription -like 'Hyper-V*' } | Select-Object -ExpandProperty ifIndex`)
+	ifIndex, err := plc.ExecutePowershellCommand(cmd)
+	if err != nil {
+		return fmt.Errorf("error while executing powershell command to get ipv6 Hyper-V interface: %w", err)
+	}
+
+	getIPv6RouteCmd := fmt.Sprintf("Get-NetRoute -DestinationPrefix %s", defaultIPv6Route)
+	if out, err = plc.ExecutePowershellCommand(getIPv6RouteCmd); err != nil {
+		logger.Info("ipv6 default route is not found, adding it to the system", zap.Any("out", out))
+		// run powershell cmd to add ipv6 default route
+		addCmd := fmt.Sprintf("New-NetRoute -DestinationPrefix %s -InterfaceIndex %s -NextHop %s",
+			defaultIPv6Route, ifIndex, defaultIPv6NextHop)
+		if out, err = plc.ExecutePowershellCommand(addCmd); err != nil {
+			logger.Error("Failed to add ipv6 default gateway route", zap.Any("out", out), zap.Error(err))
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (nw *network) addIPv6NeighborEntryForGateway(epInfo *EndpointInfo, plc platform.ExecClient) error {

--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -327,6 +327,8 @@ func (nm *networkManager) addIPv6DefaultRoute() error {
 		err error
 		out string
 	)
+
+	logger.Info("Adding default ipv6 route to windows node")
 	// the default ipv6 route is missing sometimes due to ARP issue
 	// need to add ipv6 default route if it does not exist in dualstack overlay windows node
 	cmd := fmt.Sprintf(`Get-NetAdapter | Where-Object { $_.InterfaceDescription -like 'Hyper-V*' } | Select-Object -ExpandProperty ifIndex`)

--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -329,7 +329,7 @@ func (nm *networkManager) addIPv6DefaultRoute() error {
 	)
 
 	logger.Info("Adding default ipv6 route to windows node")
-	// the default ipv6 route is missing sometimes due to ARP issue
+	// the default ipv6 route is missing sometimes
 	// need to add ipv6 default route if it does not exist in dualstack overlay windows node
 	cmd := fmt.Sprintf(`Get-NetAdapter | Where-Object { $_.InterfaceDescription -like 'Hyper-V*' } | Select-Object -ExpandProperty ifIndex`)
 	ifIndex, err := nm.plClient.ExecutePowershellCommand(cmd)

--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -5,7 +5,6 @@ package network
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -16,6 +15,7 @@ import (
 	"github.com/Microsoft/hcsshim"
 	"github.com/Microsoft/hcsshim/hcn"
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 

--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -43,6 +43,8 @@ const (
 	defaultIPv6Route = "::/0"
 	// Default IPv6 nextHop
 	defaultIPv6NextHop = "fe80::1234:5678:9abc"
+	// Default ipv6 adding command attempt times
+	addIPv6DefaultRouteAttemps = 3
 )
 
 // Windows implementation of route.
@@ -324,29 +326,36 @@ func (nm *networkManager) configureHcnNetwork(nwInfo *NetworkInfo, extIf *extern
 }
 
 func (nm *networkManager) addIPv6DefaultRoute() error {
-	var (
-		err error
-		out string
-	)
-
-	logger.Info("Adding default ipv6 route to windows node")
 	// the default ipv6 route is missing sometimes
-	// need to add ipv6 default route if it does not exist in dualstack overlay windows node
+	// need to add ipv6 default route if it does not exist in dualstack overlay windows node from persistentstore
 	cmd := `Get-NetAdapter | Where-Object { $_.InterfaceDescription -like 'Hyper-V*' } | Select-Object -ExpandProperty ifIndex`
 	ifIndex, err := nm.plClient.ExecutePowershellCommand(cmd)
 	if err != nil {
 		return fmt.Errorf("error while executing powershell command to get ipv6 Hyper-V interface: %w", err)
 	}
 
-	getIPv6RouteCmd := fmt.Sprintf("Get-NetRoute -DestinationPrefix %s", defaultIPv6Route)
-	if out, err = nm.plClient.ExecutePowershellCommand(getIPv6RouteCmd); err != nil {
-		logger.Info("ipv6 default route is not found, adding it to the system", zap.Any("out", out))
+	getIPv6RouteActiveCmd := fmt.Sprintf("Get-NetRoute -DestinationPrefix %s", defaultIPv6Route)
+	getIPv6RoutePersistentCmd := fmt.Sprintf("Get-NetRoute -DestinationPrefix %s -PolicyStore Persistentstore", defaultIPv6Route)
+	if out, err := nm.plClient.ExecutePowershellCommand(getIPv6RoutePersistentCmd); err != nil {
+		logger.Info("ipv6 default route is not found from persistentstore, adding default ipv6 route to the windows node", zap.Any("out", out))
 		// run powershell cmd to add ipv6 default route
-		addCmd := fmt.Sprintf("New-NetRoute -DestinationPrefix %s -InterfaceIndex %s -NextHop %s",
-			defaultIPv6Route, ifIndex, defaultIPv6NextHop)
-		if out, err = nm.plClient.ExecutePowershellCommand(addCmd); err != nil {
-			logger.Error("Failed to add ipv6 default gateway route", zap.Any("out", out), zap.Error(err))
-			return errors.Wrapf(err, "Failed to add ipv6 default gateway route")
+		addCmd := fmt.Sprintf("Remove-NetRoute -DestinationPrefix %s -InterfaceIndex %s -NextHop %s -confirm:$false;New-NetRoute -DestinationPrefix %s -InterfaceIndex %s -NextHop %s -confirm:$false",
+			defaultIPv6Route, ifIndex, defaultIPv6NextHop, defaultIPv6Route, ifIndex, defaultIPv6NextHop)
+
+		// if command is failed to execute, then attempt times
+		for i := 0; i <= addIPv6DefaultRouteAttemps; i++ {
+			if out, err := nm.plClient.ExecutePowershellCommand(addCmd); err != nil {
+				logger.Error("Failed to add ipv6 default gateway route, retrying after error", zap.Any("out", out), zap.Error(err))
+			} else {
+				if out, err := nm.plClient.ExecutePowershellCommand(getIPv6RoutePersistentCmd); err != nil {
+					logger.Error("default Route is not added to windows persistent store", zap.Any("out", out))
+					return errors.Wrapf(err, "Failed to add ipv6 default gateway route")
+				}
+				if out, err := nm.plClient.ExecutePowershellCommand(getIPv6RouteActiveCmd); err != nil {
+					logger.Error("default Route is not added to windows active store", zap.Any("out", out))
+					return errors.Wrapf(err, "Failed to add ipv6 default gateway route")
+				}
+			}
 		}
 	}
 

--- a/test/integration/load/load_test.go
+++ b/test/integration/load/load_test.go
@@ -40,6 +40,13 @@ var noopDeploymentMap = map[string]string{
 	"linux":   manifestDir + "/noop-deployment-linux.yaml",
 }
 
+// This map is used exclusively for TestLoad. Windows is expected to take 10-15 minutes per iteration.
+// Will change this as scale testing results are verified. This will ensure we keep a standard performance metric.
+var scaleTimeoutMap = map[string]time.Duration{
+	"windows": 15 * time.Minute,
+	"linux":   10 * time.Minute,
+}
+
 /*
 In order to run the scale tests, you need a k8s cluster and its kubeconfig.
 If no kubeconfig is passed, the test will attempt to find one in the default location for kubectl config.
@@ -64,8 +71,7 @@ todo: consider adding the following scenarios
 */
 func TestLoad(t *testing.T) {
 	clientset := kubernetes.MustGetClientset()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(testConfig.Iterations)*scaleTimeoutMap[testConfig.OSType])
 	defer cancel()
 
 	// Create namespace if it doesn't exist

--- a/test/internal/kubernetes/utils.go
+++ b/test/internal/kubernetes/utils.go
@@ -418,6 +418,18 @@ func NamespaceExists(ctx context.Context, clientset *kubernetes.Clientset, names
 	return true, nil
 }
 
+func DeploymentExists(ctx context.Context, deploymentsClient typedappsv1.DeploymentInterface, deploymentName string) (bool, error) {
+	_, err := deploymentsClient.Get(ctx, deploymentName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, errors.Wrapf(err, "error in getting deployment %s", deploymentName)
+	}
+
+	return true, nil
+}
+
 // return a label selector
 func CreateLabelSelector(key string, selector *string) string {
 	return fmt.Sprintf("%s=%s", key, *selector)

--- a/test/internal/kubernetes/utils_get.go
+++ b/test/internal/kubernetes/utils_get.go
@@ -7,6 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	typedappsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 )
 
 func GetNodeList(ctx context.Context, clientset *kubernetes.Clientset) (*corev1.NodeList, error) {
@@ -50,4 +51,13 @@ func GetPodsIpsByNode(ctx context.Context, clientset *kubernetes.Clientset, name
 		}
 	}
 	return ips, nil
+}
+
+func GetDeploymentAvailableReplicas(ctx context.Context, deploymentsClient typedappsv1.DeploymentInterface, deploymentName string) (int32, error) {
+	deployment, err := deploymentsClient.Get(ctx, deploymentName, metav1.GetOptions{})
+	if err != nil {
+		return -1, errors.Wrapf(err, "could not get deployment %s", deploymentName)
+	}
+
+	return deployment.Status.AvailableReplicas, nil
 }


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
This PR is associated with ADO 26116186; 
The PR is to fix in dualstack overlay cluster windows node that in the rare cases, windows nodes are missing ipv6 default route gateway; so from CNI side, it should check if ipv6 default route is missing; if not, then do not do anything, otherwise add the default route(::/0 and nextHop is fe80::1234:5678:9abc)
We add ipv6 default route once when HNs network is created

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Successfully added the routes:
Active Routes:
 If Metric Network Destination      Gateway
 10    266 ::/0                     fe80::1234:5678:9abc
 10    266 ::/1                     fe80::1234:5678:9abc

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
