### PR TITLE
fix: block pod to wireserver port 80 traffic on windows multitenancy

### DIFF
--- a/cni/azure-windows-multitenancy.conflist
+++ b/cni/azure-windows-multitenancy.conflist
@@ -42,6 +42,19 @@
                         "DestinationPrefix": "10.0.0.0/8",
                         "NeedEncap": true
                     }
+                },
+                {
+                    "Name": "EndpointPolicy",
+                    "Value": {
+                        "Type": "ACL",
+                        "Protocols": "6",
+                        "Action": "Block",
+                        "Direction": "Out",
+                        "RemoteAddresses": "168.63.129.16",
+                        "RemotePorts": "80",
+                        "Priority": 200,
+                        "RuleType": "Switch"
+                    }
                 }
             ],
              "windowsSettings": {


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Traffic from the pod to the wireserver on port 80 should not leave the VM.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
See above.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
Tested Windows Container on Windows 2022. After rule is added, wgets from the pod to websites such as google.com are still seen leaving the pod destined towards the 12:34... MAC. After the rule is added, traffic is still detected when pinging other pods (confirming the rule does not block pod-pod traffic). Tested routing wireserver requests to the eth0 and apipa eth inside the pod and confirmed that for hyper-v isolation containers, the vfp filter counter increases when requests to the wireserver are made (no traffic on the node is detected going to the wireserver from the pod either). Without the rule, traffic is detected on the node from the pod to the wireserver.