### PR TITLE
fix: fixing toolbox-lite dockerfile

### DIFF
--- a/hack/toolbox/server/Dockerfile.lite
+++ b/hack/toolbox/server/Dockerfile.lite
@@ -1,5 +1,6 @@
 FROM mcr.microsoft.com/oss/go/microsoft/golang:1.21 as build
 ADD ./server/server.go /
+ADD ./server/go.mod /
 WORKDIR /
 RUN CGO_ENABLED=0 GOOS=linux go build -o server .
 


### PR DESCRIPTION
Was getting this:
```
root[toolbox](master) docker build -t acnpublic.azurecr.io/toolbox-lite:v3 -f server/Dockerfile.lite --no-cache .
[+] Building 27.6s (7/8)                                                                                                                                                                                                                                                                                                                                                                                       docker:default
 => [internal] load build definition from Dockerfile.lite                                                                                                                                                                                                                                                                                                                                                                0.0s
 => => transferring dockerfile: 249B                                                                                                                                                                                                                                                                                                                                                                                     0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                                                                                                                                          0.0s
 => [internal] load metadata for mcr.microsoft.com/oss/go/microsoft/golang:1.21                                                                                                                                                                                                                                                                                                                                          0.4s
 => [build 1/4] FROM mcr.microsoft.com/oss/go/microsoft/golang:1.21@sha256:f5e962fc0e36314548301b1b9380368f34dbff8f23c50d4a0f22a0be64da2552                                                                                                                                                                                                                                                                             25.8s
 => => resolve mcr.microsoft.com/oss/go/microsoft/golang:1.21@sha256:f5e962fc0e36314548301b1b9380368f34dbff8f23c50d4a0f22a0be64da2552                                                                                                                                                                                                                                                                                    0.0s
 => => sha256:f5e962fc0e36314548301b1b9380368f34dbff8f23c50d4a0f22a0be64da2552 1.11kB / 1.11kB                                                                                                                                                                                                                                                                                                                           0.0s
 => => sha256:bb4d32ec2ee9e89cdc36dcb83a58fe1496a6fd0cac11b324ee27f125da17202a 1.58kB / 1.58kB                                                                                                                                                                                                                                                                                                                           0.0s
 => => sha256:0247b6edbe800f07fb4e853edd49cef3397c0840783546cab8abb7d17a0869bb 6.49kB / 6.49kB                                                                                                                                                                                                                                                                                                                           0.0s
 => => sha256:1c74526957fc2157e8b0989072dc99b9582b398c12d1dcd40270fd76231bab0c 24.05MB / 24.05MB                                                                                                                                                                                                                                                                                                                         2.8s
 => => sha256:1b13d4e1a46e5e969702ec92b7c787c1b6891bff7c21ad378ff6dbc9e751d5d4 49.56MB / 49.56MB                                                                                                                                                                                                                                                                                                                         7.3s
 => => sha256:8d55d1cb1ffb0c7e0438b372a96cc0f23a76c21571fa3e7b7b38e3fbc66a8c3a 64.14MB / 64.14MB                                                                                                                                                                                                                                                                                                                         8.1s
 => => sha256:c9017d20e8cf324fc59eeedd89ad1f7b5df80d05f58e2b656e35fb77176d9cab 92.15MB / 92.15MB                                                                                                                                                                                                                                                                                                                         9.6s
 => => sha256:a7349e1dc46a26f739d4c64436c408fe85decd08af41b8f013300bd304faf737 69.24MB / 69.24MB                                                                                                                                                                                                                                                                                                                        17.2s
 => => extracting sha256:1b13d4e1a46e5e969702ec92b7c787c1b6891bff7c21ad378ff6dbc9e751d5d4                                                                                                                                                                                                                                                                                                                                4.1s
 => => sha256:839a46d615b95f8a0b5b8b76d855f9f2551c372da25831c1bfdd71dc7d807b3c 125B / 125B                                                                                                                                                                                                                                                                                                                               8.4s
 => => extracting sha256:1c74526957fc2157e8b0989072dc99b9582b398c12d1dcd40270fd76231bab0c                                                                                                                                                                                                                                                                                                                                0.8s
 => => extracting sha256:8d55d1cb1ffb0c7e0438b372a96cc0f23a76c21571fa3e7b7b38e3fbc66a8c3a                                                                                                                                                                                                                                                                                                                                3.8s
 => => extracting sha256:c9017d20e8cf324fc59eeedd89ad1f7b5df80d05f58e2b656e35fb77176d9cab                                                                                                                                                                                                                                                                                                                                3.1s
 => => extracting sha256:a7349e1dc46a26f739d4c64436c408fe85decd08af41b8f013300bd304faf737                                                                                                                                                                                                                                                                                                                                5.6s
 => => extracting sha256:839a46d615b95f8a0b5b8b76d855f9f2551c372da25831c1bfdd71dc7d807b3c                                                                                                                                                                                                                                                                                                                                0.0s
 => [internal] load build context                                                                                                                                                                                                                                                                                                                                                                                        0.0s
 => => transferring context: 3.28kB                                                                                                                                                                                                                                                                                                                                                                                      0.0s
 => [build 2/4] ADD ./server/server.go /                                                                                                                                                                                                                                                                                                                                                                                 1.0s
 => ERROR [build 3/4] RUN CGO_ENABLED=0 GOOS=linux go build -o server .                                                                                                                                                                                                                                                                                                                                                  0.4s
------                                                                                                                                                                                                                                                                                                                                                                                                                        
 > [build 3/4] RUN CGO_ENABLED=0 GOOS=linux go build -o server .:
0.337 go: go.mod file not found in current directory or any parent directory; see 'go help modules'
------
Dockerfile.lite:4
--------------------
   2 |     ADD ./server/server.go /
   3 |     WORKDIR /
   4 | >>> RUN CGO_ENABLED=0 GOOS=linux go build -o server .
   5 |     
   6 |     FROM scratch
--------------------
ERROR: failed to solve: process "/bin/sh -c CGO_ENABLED=0 GOOS=linux go build -o server ." did not complete successfully: exit code: 1
```

Now it builds and runs:
```
root[toolbox](master) docker build -t acnpublic.azurecr.io/toolbox-lite:v3 -f server/Dockerfile.lite --no-cache .
[+] Building 8.8s (10/10) FINISHED                                                                                                                                                                                                                                                                                                                                                                             docker:default
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                                                                                                                                          0.0s
 => [internal] load build definition from Dockerfile.lite                                                                                                                                                                                                                                                                                                                                                                0.0s
 => => transferring dockerfile: 271B                                                                                                                                                                                                                                                                                                                                                                                     0.0s
 => [internal] load metadata for mcr.microsoft.com/oss/go/microsoft/golang:1.21                                                                                                                                                                                                                                                                                                                                          0.1s
 => CACHED [build 1/5] FROM mcr.microsoft.com/oss/go/microsoft/golang:1.21@sha256:f5e962fc0e36314548301b1b9380368f34dbff8f23c50d4a0f22a0be64da2552                                                                                                                                                                                                                                                                       0.0s
 => [internal] load build context                                                                                                                                                                                                                                                                                                                                                                                        0.0s
 => => transferring context: 186B                                                                                                                                                                                                                                                                                                                                                                                        0.0s
 => [build 2/5] ADD ./server/server.go /                                                                                                                                                                                                                                                                                                                                                                                 0.0s
 => [build 3/5] ADD ./server/go.mod /                                                                                                                                                                                                                                                                                                                                                                                    0.0s
 => [build 4/5] RUN CGO_ENABLED=0 GOOS=linux go build -o server .                                                                                                                                                                                                                                                                                                                                                        8.0s
 => [stage-1 1/1] COPY --from=build /server .                                                                                                                                                                                                                                                                                                                                                                            0.0s
 => exporting to image                                                                                                                                                                                                                                                                                                                                                                                                   0.1s
 => => exporting layers                                                                                                                                                                                                                                                                                                                                                                                                  0.0s
 => => writing image sha256:7911bd7f27e1ef7aab3872f075b4a033b226d6e65bbd77443cd3526ad3fffcf4                                                                                                                                                                                                                                                                                                                             0.0s
 => => naming to acnpublic.azurecr.io/toolbox-lite:v3                                                                                                                                                                                                                                                                                                                                                                    0.0s

What's Next?
  View a summary of image vulnerabilities and recommendations → docker scout quickview
root[toolbox](master) docker run acnpublic.azurecr.io/toolbox-lite:v3
TCP_PORT not set, defaulting to port 8085
UDP_PORT not set, defaulting to port 8086
HTTP_PORT not set, defaulting to port 8080
[HTTP] Listening on 8080
[UDP] Listening on [::]:8086
[TCP] Listening on [::]:8085
```