### PR TITLE
fix: az pipeline output within Merqe Queue Check

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -38,22 +38,22 @@ jobs:
           echo ${{ secrets.AZURE_DEVOPS_EXT_PAT }} | az devops login --org ${{ secrets.AZURE_PIPELINE_ORG }}
 
           echo "Sanity check recently triggered Merge Queue Pipeline runs"
-          az pipelines runs list --pipeline-ids ${{ secrets.AZURE_PIPELINE_ID }} --org ${{ secrets.AZURE_PIPELINE_ORG }} --project ${{ secrets.AZURE_PIPELINE_PROJECT }} --reason individualCI --top 10 --output json | jq -r .[].sourceBranch
-          status=`az pipelines runs list --pipeline-ids ${{ secrets.AZURE_PIPELINE_ID }} --org ${{ secrets.AZURE_PIPELINE_ORG }} --project ${{ secrets.AZURE_PIPELINE_PROJECT }} --top 1 --branch $GITHUB_REF --output json | jq -r .[].status`
+          az pipelines runs list --pipeline-ids ${{ secrets.AZURE_PIPELINE_ID }} --org ${{ secrets.AZURE_PIPELINE_ORG }} --project ${{ secrets.AZURE_PIPELINE_PROJECT }} --reason individualCI --top 10 --query-order QueueTimeDesc --output json | jq -r .[].sourceBranch
+          status=`az pipelines runs list --pipeline-ids ${{ secrets.AZURE_PIPELINE_ID }} --org ${{ secrets.AZURE_PIPELINE_ORG }} --project ${{ secrets.AZURE_PIPELINE_PROJECT }} --top 1 --branch $GITHUB_REF --query-order QueueTimeDesc --output json | jq -r .[].status`
           echo "Triggered CI Status - $status"
           echo "Branch Ref - $GITHUB_REF"
 
           echo "Checking for AZP triggered CI for 60s"
           end=$((SECONDS+60)) # Stop checking if not queued within a minute
           while [ $SECONDS -lt $end ]; do
+            echo "Waiting for 5 seconds for AZP to trigger run and show inProgress or notStarted"
+            sleep 5s
+            status=`az pipelines runs list --pipeline-ids ${{ secrets.AZURE_PIPELINE_ID }} --org ${{ secrets.AZURE_PIPELINE_ORG }} --project ${{ secrets.AZURE_PIPELINE_PROJECT }} --top 1 --branch $GITHUB_REF --query-order QueueTimeDesc --output json | jq -r .[].status`
+            echo "Current CI Status - $status"
             if [ $status = 'inProgress' ] || [ $status = 'notStarted' ]; then
               echo "AZP triggered pipeline queued successfully"
               exit 0
             fi
-            echo "Waiting for 15 seconds for AZP to trigger run and show inProgress or notStarted"
-            sleep 15s
-            status=`az pipelines runs list --pipeline-ids ${{ secrets.AZURE_PIPELINE_ID }} --org ${{ secrets.AZURE_PIPELINE_ORG }} --project ${{ secrets.AZURE_PIPELINE_PROJECT }} --top 1 --branch $GITHUB_REF --output json | jq -r .[].status`
-            echo "Current CI Status - $status"
           done
           echo "AZP did not trigger CI"
 
@@ -66,7 +66,7 @@ jobs:
           while [ $SECONDS -lt $end ]; do
             echo "Waiting for 5 seconds for pipeline to show inProgress or notStarted on AZP"
             sleep 5s
-            status=`az pipelines runs list --pipeline-ids ${{ secrets.AZURE_PIPELINE_ID }} --org ${{ secrets.AZURE_PIPELINE_ORG }} --project ${{ secrets.AZURE_PIPELINE_PROJECT }} --top 1 --branch $GITHUB_REF --output json | jq -r .[].status`
+            status=`az pipelines runs list --pipeline-ids ${{ secrets.AZURE_PIPELINE_ID }} --org ${{ secrets.AZURE_PIPELINE_ORG }} --project ${{ secrets.AZURE_PIPELINE_PROJECT }} --top 1 --branch $GITHUB_REF --query-order QueueTimeDesc --output json | jq -r .[].status`
             echo "Current CI Status - $status"
             if [ $status = 'inProgress' ] || [ $status = 'notStarted' ]; then
               echo "Manually triggered pipeline queued successfully"


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Output of `az pipeline` commands without the use of `--query-order QueueTimeDesc` was pulling old information on merge queue branches and missing recent runs. This meant that any new runs that were added to the merge queue without the merge commit sha changing were showing up as `completed` within the [ github action ](https://github.com/Azure/azure-container-networking/actions/runs/7788304422/job/21237437223#step:4:77).

Also changed the sleep for the automatically queued runs to be 5 seconds **AND** moved it to be before the checks to ensure that an automated queued run does not get skipped and then manually triggered. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
For the merge commit sha to change you need:
- a change to master
- merge commits in front of you in the merge queue
- a change to your PR in the form of a rebase or new commit