### PR TITLE
fix: build imds compute url correctly and give a default retryAttempts

### DIFF
--- a/cns/imds/client.go
+++ b/cns/imds/client.go
@@ -6,9 +6,7 @@ package imds
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 
 	"github.com/avast/retry-go/v4"
@@ -118,9 +116,6 @@ func (c *Client) getInstanceComputeMetadata(ctx context.Context) (map[string]any
 
 	// IMDS requires the "Metadata: true" header
 	req.Header.Add(metadataHeaderKey, metadataHeaderValue)
-
-	reqDump, _ := httputil.DumpRequestOut(req, false)
-	fmt.Printf("REQUEST:\n%s", string(reqDump))
 	resp, err := c.cli.Do(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "error querying IMDS")

--- a/cns/imds/client_test.go
+++ b/cns/imds/client_test.go
@@ -23,6 +23,12 @@ func TestGetVMUniqueID(t *testing.T) {
 		// request header "Metadata: true" must be present
 		metadataHeader := r.Header.Get("Metadata")
 		assert.Equal(t, "true", metadataHeader)
+
+		// query params should include apiversion and json format
+		apiVersion := r.URL.Query().Get("api-version")
+		assert.Equal(t, "2021-01-01", apiVersion)
+		format := r.URL.Query().Get("format")
+		assert.Equal(t, "json", format)
 		w.WriteHeader(http.StatusOK)
 		_, writeErr := w.Write(computeMetadata)
 		require.NoError(t, writeErr, "error writing response")


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
IMDS client was incorrectly building the URL for the compute json doc by adding the query params into the url path by urlencoding them instead of making them query params. Also, there was no default retry attempts in the client, causing it to retry forever. Instead we'll set the default to three.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [x] relevant PR labels added

**Notes**:
