### PR TITLE
fix: delete endpoint on cni state save failure

### DIFF
--- a/network/manager.go
+++ b/network/manager.go
@@ -402,6 +402,10 @@ func (nm *networkManager) CreateEndpoint(cli apipaClient, networkID string, epIn
 
 	err = nm.save()
 	if err != nil {
+		delErr := nw.deleteEndpoint(nm.netlink, nm.plClient, nm.netio, nm.nsClient, nm.iptablesClient, ep.Id)
+		if delErr != nil {
+			logger.Error("Deleting endpoint after failing to save state failed with", zap.Error(delErr))
+		}
 		return err
 	}
 

--- a/network/manager.go
+++ b/network/manager.go
@@ -395,25 +395,24 @@ func (nm *networkManager) CreateEndpoint(cli apipaClient, networkID string, epIn
 	if err != nil {
 		return err
 	}
-	var delEndpointErr error
 	// any error after this point should also clean up the endpoint we created above
 	defer func() {
-		if delEndpointErr != nil {
+		if err != nil {
 			delErr := nw.deleteEndpoint(nm.netlink, nm.plClient, nm.netio, nm.nsClient, nm.iptablesClient, ep.Id)
 			if delErr != nil {
-				logger.Error("Deleting endpoint after failing to save state failed with", zap.Error(delErr))
+				logger.Error("Deleting endpoint after create endpoint failure failed with", zap.Error(delErr))
 			}
 		}
 	}()
 
 	if nm.IsStatelessCNIMode() {
-		delEndpointErr = nm.UpdateEndpointState(ep)
-		return delEndpointErr
+		err = nm.UpdateEndpointState(ep)
+		return err
 	}
 
-	delEndpointErr = nm.save()
-	if delEndpointErr != nil {
-		return delEndpointErr
+	err = nm.save()
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/network/manager.go
+++ b/network/manager.go
@@ -395,18 +395,25 @@ func (nm *networkManager) CreateEndpoint(cli apipaClient, networkID string, epIn
 	if err != nil {
 		return err
 	}
+	var delEndpointErr error
+	// any error after this point should also clean up the endpoint we created above
+	defer func() {
+		if delEndpointErr != nil {
+			delErr := nw.deleteEndpoint(nm.netlink, nm.plClient, nm.netio, nm.nsClient, nm.iptablesClient, ep.Id)
+			if delErr != nil {
+				logger.Error("Deleting endpoint after failing to save state failed with", zap.Error(delErr))
+			}
+		}
+	}()
 
 	if nm.IsStatelessCNIMode() {
-		return nm.UpdateEndpointState(ep)
+		delEndpointErr = nm.UpdateEndpointState(ep)
+		return delEndpointErr
 	}
 
-	err = nm.save()
-	if err != nil {
-		delErr := nw.deleteEndpoint(nm.netlink, nm.plClient, nm.netio, nm.nsClient, nm.iptablesClient, ep.Id)
-		if delErr != nil {
-			logger.Error("Deleting endpoint after failing to save state failed with", zap.Error(delErr))
-		}
-		return err
+	delEndpointErr = nm.save()
+	if delEndpointErr != nil {
+		return delEndpointErr
 	}
 
 	return nil

--- a/network/manager.go
+++ b/network/manager.go
@@ -398,6 +398,7 @@ func (nm *networkManager) CreateEndpoint(cli apipaClient, networkID string, epIn
 	// any error after this point should also clean up the endpoint we created above
 	defer func() {
 		if err != nil {
+			logger.Error("Create endpoint failure failed with", zap.Error(err))
 			delErr := nw.deleteEndpoint(nm.netlink, nm.plClient, nm.netio, nm.nsClient, nm.iptablesClient, ep.Id)
 			if delErr != nil {
 				logger.Error("Deleting endpoint after create endpoint failure failed with", zap.Error(delErr))

--- a/network/manager.go
+++ b/network/manager.go
@@ -398,7 +398,8 @@ func (nm *networkManager) CreateEndpoint(cli apipaClient, networkID string, epIn
 	// any error after this point should also clean up the endpoint we created above
 	defer func() {
 		if err != nil {
-			logger.Error("Create endpoint failure failed with", zap.Error(err))
+			logger.Error("Create endpoint failure", zap.Error(err))
+			logger.Info("Cleanup resources")
 			delErr := nw.deleteEndpoint(nm.netlink, nm.plClient, nm.netio, nm.nsClient, nm.iptablesClient, ep.Id)
 			if delErr != nil {
 				logger.Error("Deleting endpoint after create endpoint failure failed with", zap.Error(delErr))


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
In windows, it is possible to successfully create an HNS endpoint and then subsequently fail to write to the CNI statefile. While the CNI call fails, the HNS endpoint is never deleted, causing retries to fail because the HNS endpoint has already been created. As it is not possible to retrieve the existing endpoint on a retried ADD call, we instead opt to delete the HNS endpoint if saving the CNI state fails.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
See above.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
The code change affects both the windows and linux scenarios (if saving fails, deleteEndpoint will call the platform specific version for deletion of the endpoint). On windows, tested triggering a save failure and then examining HNS endpoints-- the endpoint is cleaned up which is confirmed in the logs. Without the fix, the endpoint still shows and produces the endpoint already exists (ip address claimed) error. On linux transparent-vlan mode, tested triggering a save failure, which does call into deleting the endpoint. Subsequent delete/adds for that pod run without erroring.