### PR TITLE
ci: scope scenario parameters instead of whole job

### DIFF
--- a/test/e2e/framework/kubernetes/create-agnhost-statefulset.go
+++ b/test/e2e/framework/kubernetes/create-agnhost-statefulset.go
@@ -120,6 +120,9 @@ func (c *CreateAgnhostStatefulSet) getAgnhostDeployment() *appsv1.StatefulSet {
 							},
 						},
 					},
+					NodeSelector: map[string]string{
+						"kubernetes.io/os": "linux",
+					},
 					Containers: []v1.Container{
 						{
 							Name:  c.AgnhostName,

--- a/test/e2e/framework/kubernetes/create-resource.go
+++ b/test/e2e/framework/kubernetes/create-resource.go
@@ -202,6 +202,22 @@ func CreateResource(ctx context.Context, obj runtime.Object, clientset *kubernet
 			return fmt.Errorf("failed to create/update NetworkPolicy \"%s\" in namespace \"%s\": %w", o.Name, o.Namespace, err)
 		}
 
+	case *v1.Secret:
+		log.Printf("Creating/Updating Secret \"%s\" in namespace \"%s\"...\n", o.Name, o.Namespace)
+		client := clientset.CoreV1().Secrets(o.Namespace)
+		_, err := client.Get(ctx, o.Name, metaV1.GetOptions{})
+		if errors.IsNotFound(err) {
+			_, err = client.Create(ctx, o, metaV1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to create Secret \"%s\" in namespace \"%s\": %w", o.Name, o.Namespace, err)
+			}
+			return nil
+		}
+		_, err = client.Update(ctx, o, metaV1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to create/update Secret \"%s\" in namespace \"%s\": %w", o.Name, o.Namespace, err)
+		}
+
 	default:
 		return fmt.Errorf("unknown object type: %T, err: %w", obj, ErrUnknownResourceType)
 	}

--- a/test/e2e/framework/kubernetes/delete-resource.go
+++ b/test/e2e/framework/kubernetes/delete-resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -13,9 +14,190 @@ import (
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
-var ErrDeleteNilResource = fmt.Errorf("cannot create nil resource")
+var (
+	ErrDeleteNilResource = fmt.Errorf("cannot create nil resource")
+)
+
+type ResourceType string
+
+const (
+	DaemonSet          ResourceType = "DaemonSet"
+	Deployment         ResourceType = "Deployment"
+	StatefulSet        ResourceType = "StatefulSet"
+	Service            ResourceType = "Service"
+	ServiceAccount     ResourceType = "ServiceAccount"
+	Role               ResourceType = "Role"
+	RoleBinding        ResourceType = "RoleBinding"
+	ClusterRole        ResourceType = "ClusterRole"
+	ClusterRoleBinding ResourceType = "ClusterRoleBinding"
+	ConfigMap          ResourceType = "ConfigMap"
+	NetworkPolicy      ResourceType = "NetworkPolicy"
+	Secret             ResourceType = "Secret"
+	Unknown            ResourceType = "Unknown"
+)
+
+// Parameters can only be strings, heres to help add guardrails
+func TypeString(resourceType ResourceType) string {
+	ResourceTypes := map[ResourceType]string{
+		DaemonSet:          "DaemonSet",
+		Deployment:         "Deployment",
+		StatefulSet:        "StatefulSet",
+		Service:            "Service",
+		ServiceAccount:     "ServiceAccount",
+		Role:               "Role",
+		RoleBinding:        "RoleBinding",
+		ClusterRole:        "ClusterRole",
+		ClusterRoleBinding: "ClusterRoleBinding",
+		ConfigMap:          "ConfigMap",
+		NetworkPolicy:      "NetworkPolicy",
+		Secret:             "Secret",
+		Unknown:            "Unknown",
+	}
+	str, ok := ResourceTypes[resourceType]
+	if !ok {
+		return ResourceTypes[Unknown]
+	}
+	return str
+}
+
+type DeleteKubernetesResource struct {
+	ResourceType       string // can't use enum, breaks parameter parsing, all must be strings
+	ResourceName       string
+	ResourceNamespace  string
+	KubeConfigFilePath string
+}
+
+func (d *DeleteKubernetesResource) Run() error {
+	config, err := clientcmd.BuildConfigFromFlags("", d.KubeConfigFilePath)
+	if err != nil {
+		return fmt.Errorf("error building kubeconfig: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("error creating Kubernetes client: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeoutSeconds*time.Second)
+	defer cancel()
+
+	res := ResourceType(d.ResourceType)
+
+	var resource runtime.Object
+
+	switch res {
+	case DaemonSet:
+		resource = &appsv1.DaemonSet{
+			ObjectMeta: metaV1.ObjectMeta{
+				Name:      d.ResourceName,
+				Namespace: d.ResourceNamespace,
+			},
+		}
+	case Deployment:
+		resource = &appsv1.Deployment{
+			ObjectMeta: metaV1.ObjectMeta{
+				Name:      d.ResourceName,
+				Namespace: d.ResourceNamespace,
+			},
+		}
+	case StatefulSet:
+		resource = &appsv1.StatefulSet{
+			ObjectMeta: metaV1.ObjectMeta{
+				Name:      d.ResourceName,
+				Namespace: d.ResourceNamespace,
+			},
+		}
+	case Service:
+		resource = &v1.Service{
+			ObjectMeta: metaV1.ObjectMeta{
+				Name:      d.ResourceName,
+				Namespace: d.ResourceNamespace,
+			},
+		}
+	case ServiceAccount:
+		resource = &v1.ServiceAccount{
+			ObjectMeta: metaV1.ObjectMeta{
+				Name:      d.ResourceName,
+				Namespace: d.ResourceNamespace,
+			},
+		}
+	case Role:
+		resource = &rbacv1.Role{
+			ObjectMeta: metaV1.ObjectMeta{
+				Name:      d.ResourceName,
+				Namespace: d.ResourceNamespace,
+			},
+		}
+	case RoleBinding:
+		resource = &rbacv1.RoleBinding{
+			ObjectMeta: metaV1.ObjectMeta{
+				Name:      d.ResourceName,
+				Namespace: d.ResourceNamespace,
+			},
+		}
+	case ClusterRole:
+		resource = &rbacv1.ClusterRole{
+			ObjectMeta: metaV1.ObjectMeta{
+				Name: d.ResourceName,
+			},
+		}
+	case ClusterRoleBinding:
+		resource = &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metaV1.ObjectMeta{
+				Name: d.ResourceName,
+			},
+		}
+	case ConfigMap:
+		resource = &v1.ConfigMap{
+			ObjectMeta: metaV1.ObjectMeta{
+				Name:      d.ResourceName,
+				Namespace: d.ResourceNamespace,
+			},
+		}
+	case NetworkPolicy:
+		resource = &networkingv1.NetworkPolicy{
+			ObjectMeta: metaV1.ObjectMeta{
+				Name:      d.ResourceName,
+				Namespace: d.ResourceNamespace,
+			},
+		}
+	case Secret:
+		resource = &v1.Secret{
+			ObjectMeta: metaV1.ObjectMeta{
+
+				Name:      d.ResourceName,
+				Namespace: d.ResourceNamespace,
+			},
+		}
+	case Unknown:
+		return fmt.Errorf("unknown resource type: %s: %w", d.ResourceType, ErrUnknownResourceType)
+	default:
+		return ErrUnknownResourceType
+	}
+
+	err = DeleteResource(ctx, resource, clientset)
+	if err != nil {
+		return fmt.Errorf("error deleting resource: %w", err)
+	}
+
+	return nil
+}
+
+func (d *DeleteKubernetesResource) Stop() error {
+	return nil
+}
+
+func (d *DeleteKubernetesResource) Prevalidate() error {
+	restype := ResourceType(d.ResourceType)
+	if restype == Unknown {
+		return ErrUnknownResourceType
+	}
+
+	return nil
+}
 
 func DeleteResource(ctx context.Context, obj runtime.Object, clientset *kubernetes.Clientset) error { //nolint:gocyclo //this is just boilerplate code
 	if obj == nil {
@@ -36,7 +218,7 @@ func DeleteResource(ctx context.Context, obj runtime.Object, clientset *kubernet
 		}
 
 	case *appsv1.Deployment:
-		log.Printf("Creating/Updating Deployment \"%s\" in namespace \"%s\"...\n", o.Name, o.Namespace)
+		log.Printf("Deleting Deployment \"%s\" in namespace \"%s\"...\n", o.Name, o.Namespace)
 		client := clientset.AppsV1().Deployments(o.Namespace)
 		err := client.Delete(ctx, o.Name, metaV1.DeleteOptions{})
 		if err != nil {
@@ -48,7 +230,7 @@ func DeleteResource(ctx context.Context, obj runtime.Object, clientset *kubernet
 		}
 
 	case *appsv1.StatefulSet:
-		log.Printf("Creating/Updating StatefulSet \"%s\" in namespace \"%s\"...\n", o.Name, o.Namespace)
+		log.Printf("Deleting StatefulSet \"%s\" in namespace \"%s\"...\n", o.Name, o.Namespace)
 		client := clientset.AppsV1().StatefulSets(o.Namespace)
 		err := client.Delete(ctx, o.Name, metaV1.DeleteOptions{})
 		if err != nil {
@@ -60,7 +242,7 @@ func DeleteResource(ctx context.Context, obj runtime.Object, clientset *kubernet
 		}
 
 	case *v1.Service:
-		log.Printf("Creating/Updating Service \"%s\" in namespace \"%s\"...\n", o.Name, o.Namespace)
+		log.Printf("Deleting Service \"%s\" in namespace \"%s\"...\n", o.Name, o.Namespace)
 		client := clientset.CoreV1().Services(o.Namespace)
 		err := client.Delete(ctx, o.Name, metaV1.DeleteOptions{})
 		if err != nil {
@@ -72,7 +254,7 @@ func DeleteResource(ctx context.Context, obj runtime.Object, clientset *kubernet
 		}
 
 	case *v1.ServiceAccount:
-		log.Printf("Creating/Updating ServiceAccount \"%s\" in namespace \"%s\"...\n", o.Name, o.Namespace)
+		log.Printf("Deleting ServiceAccount \"%s\" in namespace \"%s\"...\n", o.Name, o.Namespace)
 		client := clientset.CoreV1().ServiceAccounts(o.Namespace)
 		err := client.Delete(ctx, o.Name, metaV1.DeleteOptions{})
 		if err != nil {
@@ -84,7 +266,7 @@ func DeleteResource(ctx context.Context, obj runtime.Object, clientset *kubernet
 		}
 
 	case *rbacv1.Role:
-		log.Printf("Creating/Updating Role \"%s\" in namespace \"%s\"...\n", o.Name, o.Namespace)
+		log.Printf("Deleting Role \"%s\" in namespace \"%s\"...\n", o.Name, o.Namespace)
 		client := clientset.RbacV1().Roles(o.Namespace)
 		err := client.Delete(ctx, o.Name, metaV1.DeleteOptions{})
 		if err != nil {
@@ -96,7 +278,7 @@ func DeleteResource(ctx context.Context, obj runtime.Object, clientset *kubernet
 		}
 
 	case *rbacv1.RoleBinding:
-		log.Printf("Creating/Updating RoleBinding \"%s\" in namespace \"%s\"...\n", o.Name, o.Namespace)
+		log.Printf("Deleting RoleBinding \"%s\" in namespace \"%s\"...\n", o.Name, o.Namespace)
 		client := clientset.RbacV1().RoleBindings(o.Namespace)
 		err := client.Delete(ctx, o.Name, metaV1.DeleteOptions{})
 		if err != nil {
@@ -108,7 +290,7 @@ func DeleteResource(ctx context.Context, obj runtime.Object, clientset *kubernet
 		}
 
 	case *rbacv1.ClusterRole:
-		log.Printf("Creating/Updating ClusterRole \"%s\"...\n", o.Name)
+		log.Printf("Deleting ClusterRole \"%s\"...\n", o.Name)
 		client := clientset.RbacV1().ClusterRoles()
 		err := client.Delete(ctx, o.Name, metaV1.DeleteOptions{})
 		if err != nil {
@@ -120,7 +302,7 @@ func DeleteResource(ctx context.Context, obj runtime.Object, clientset *kubernet
 		}
 
 	case *rbacv1.ClusterRoleBinding:
-		log.Printf("Creating/Updating ClusterRoleBinding \"%s\"...\n", o.Name)
+		log.Printf("Deleting ClusterRoleBinding \"%s\"...\n", o.Name)
 		client := clientset.RbacV1().ClusterRoleBindings()
 		err := client.Delete(ctx, o.Name, metaV1.DeleteOptions{})
 		if err != nil {
@@ -132,7 +314,7 @@ func DeleteResource(ctx context.Context, obj runtime.Object, clientset *kubernet
 		}
 
 	case *v1.ConfigMap:
-		log.Printf("Creating/Updating ConfigMap \"%s\" in namespace \"%s\"...\n", o.Name, o.Namespace)
+		log.Printf("Deleting ConfigMap \"%s\" in namespace \"%s\"...\n", o.Name, o.Namespace)
 		client := clientset.CoreV1().ConfigMaps(o.Namespace)
 		err := client.Delete(ctx, o.Name, metaV1.DeleteOptions{})
 		if err != nil {
@@ -144,7 +326,7 @@ func DeleteResource(ctx context.Context, obj runtime.Object, clientset *kubernet
 		}
 
 	case *networkingv1.NetworkPolicy:
-		log.Printf("Creating/Updating NetworkPolicy \"%s\" in namespace \"%s\"...\n", o.Name, o.Namespace)
+		log.Printf("Deleting NetworkPolicy \"%s\" in namespace \"%s\"...\n", o.Name, o.Namespace)
 		client := clientset.NetworkingV1().NetworkPolicies(o.Namespace)
 		err := client.Delete(ctx, o.Name, metaV1.DeleteOptions{})
 		if err != nil {
@@ -153,6 +335,18 @@ func DeleteResource(ctx context.Context, obj runtime.Object, clientset *kubernet
 				return nil
 			}
 			return fmt.Errorf("failed to delete NetworkPolicy \"%s\" in namespace \"%s\": %w", o.Name, o.Namespace, err)
+		}
+
+	case *v1.Secret:
+		log.Printf("Deleting Secret \"%s\" in namespace \"%s\"...\n", o.Name, o.Namespace)
+		client := clientset.CoreV1().Secrets(o.Namespace)
+		err := client.Delete(ctx, o.Name, metaV1.DeleteOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				log.Printf("Secret \"%s\" in namespace \"%s\" does not exist\n", o.Name, o.Namespace)
+				return nil
+			}
+			return fmt.Errorf("failed to delete Secret \"%s\" in namespace \"%s\": %w", o.Name, o.Namespace, err)
 		}
 
 	default:

--- a/test/e2e/framework/kubernetes/delete-resource.go
+++ b/test/e2e/framework/kubernetes/delete-resource.go
@@ -17,9 +17,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-var (
-	ErrDeleteNilResource = fmt.Errorf("cannot create nil resource")
-)
+var ErrDeleteNilResource = fmt.Errorf("cannot create nil resource")
 
 type ResourceType string
 
@@ -167,7 +165,6 @@ func (d *DeleteKubernetesResource) Run() error {
 	case Secret:
 		resource = &v1.Secret{
 			ObjectMeta: metaV1.ObjectMeta{
-
 				Name:      d.ResourceName,
 				Namespace: d.ResourceNamespace,
 			},

--- a/test/e2e/framework/kubernetes/port-forward.go
+++ b/test/e2e/framework/kubernetes/port-forward.go
@@ -72,7 +72,6 @@ func (p *PortForward) Run() error {
 	}
 
 	portForwardFn := func() error {
-
 		// if we have a pod name (likely from affinity above), use it, otherwise use label selector
 		opts := k8s.PortForwardingOpts{
 			Namespace: p.Namespace,

--- a/test/e2e/framework/types/background_test.go
+++ b/test/e2e/framework/types/background_test.go
@@ -6,27 +6,25 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/Azure/azure-container-networking/test/e2e/framework/types"
 )
 
 func TestFramework(t *testing.T) {
-	job := types.NewJob("Validate that drop metrics are present in the prometheus endpoint")
-	runner := types.NewRunner(t, job)
+	job := NewJob("Validate that drop metrics are present in the prometheus endpoint")
+	runner := NewRunner(t, job)
 	defer runner.Run()
 
 	job.AddStep(&TestBackground{
 		CounterName: "Example Counter",
-	}, &types.StepOptions{
+	}, &StepOptions{
 		ExpectError:           false,
 		RunInBackgroundWithID: "TestStep",
 	})
 
-	job.AddStep(&types.Sleep{
+	job.AddStep(&Sleep{
 		Duration: 1 * time.Second,
 	}, nil)
 
-	job.AddStep(&types.Stop{
+	job.AddStep(&Stop{
 		BackgroundID: "TestStep",
 	}, nil)
 }

--- a/test/e2e/framework/types/job.go
+++ b/test/e2e/framework/types/job.go
@@ -107,7 +107,6 @@ func (j *Job) AddStep(step Step, opts *StepOptions) {
 }
 
 func (j *Job) GetValue(stepw *StepWrapper, key string) (string, bool) {
-
 	// if step exists in a scenario, use the scenario's values
 	// if the value isn't in the scenario's values, get the root job's value
 	if scenario, exists := j.Scenarios[stepw]; exists {

--- a/test/e2e/framework/types/job.go
+++ b/test/e2e/framework/types/job.go
@@ -297,7 +297,7 @@ func (j *Job) validateStep(step *StepWrapper) error {
 
 					if passedvalue == "" {
 						if retrievedvalue == "" {
-							return fmt.Errorf("parameter \"%s\" is empty; %w", parameter, ErrNoValue)
+							return fmt.Errorf("parameter \"%s\" is empty in step \"%s\"; %w", parameter, j.GetPrettyStepName(step), ErrNoValue)
 						}
 						value = retrievedvalue
 					} else {

--- a/test/e2e/framework/types/scenarios_test.go
+++ b/test/e2e/framework/types/scenarios_test.go
@@ -1,0 +1,51 @@
+package types
+
+import (
+	"fmt"
+	"testing"
+)
+
+// Test against a BYO cluster with Cilium and Hubble enabled,
+// create a pod with a deny all network policy and validate
+// that the drop metrics are present in the prometheus endpoint
+func TestScenarioValues(t *testing.T) {
+	job := NewJob("Validate that drop metrics are present in the prometheus endpoint")
+	runner := NewRunner(t, job)
+	defer runner.Run()
+
+	job.AddStep(&DummyStep{
+		Parameter1: "Top Level Step 1",
+		Parameter2: "Top Level Step 2",
+	}, nil)
+
+	job.AddScenario(NewDummyScenario())
+
+	job.AddStep(&DummyStep{}, nil)
+}
+
+func NewDummyScenario() *Scenario {
+	return NewScenario("Dummy Scenario",
+		&StepWrapper{
+			Step: &DummyStep{
+				Parameter2: "Scenario Parameter 2",
+			},
+		},
+	)
+}
+
+type DummyStep struct {
+	Parameter1 string
+	Parameter2 string
+}
+
+func (d *DummyStep) Run() error {
+	fmt.Printf("Running DummyStep with parameter 1 as: %s\n", d.Parameter1)
+	fmt.Printf("Running DummyStep with parameter 2 as: %s\n", d.Parameter2)
+	return nil
+}
+func (d *DummyStep) Stop() error {
+	return nil
+}
+func (d *DummyStep) Prevalidate() error {
+	return nil
+}

--- a/test/e2e/framework/types/scenarios_test.go
+++ b/test/e2e/framework/types/scenarios_test.go
@@ -50,7 +50,6 @@ func TestScenarioValuesWithSkip(t *testing.T) {
 		Parameter1: "Other Level Step 1",
 		Parameter2: "Other Level Step 2",
 	}, nil)
-
 }
 
 func TestScenarioValuesWithScenarioSkip(t *testing.T) {
@@ -117,9 +116,11 @@ func (d *DummyStep) Run() error {
 	fmt.Printf("Running DummyStep with parameter 2 as: %s\n", d.Parameter2)
 	return nil
 }
+
 func (d *DummyStep) Stop() error {
 	return nil
 }
+
 func (d *DummyStep) Prevalidate() error {
 	return nil
 }

--- a/test/e2e/framework/types/scenarios_test.go
+++ b/test/e2e/framework/types/scenarios_test.go
@@ -13,13 +13,62 @@ func TestScenarioValues(t *testing.T) {
 	runner := NewRunner(t, job)
 	defer runner.Run()
 
+	// Add top level step
 	job.AddStep(&DummyStep{
 		Parameter1: "Top Level Step 1",
 		Parameter2: "Top Level Step 2",
 	}, nil)
 
+	// Add scenario to ensure that the parameters are set correctly
+	// and inherited without overriding
 	job.AddScenario(NewDummyScenario())
 
+	job.AddStep(&DummyStep{}, nil)
+}
+
+// Test against a BYO cluster with Cilium and Hubble enabled,
+// create a pod with a deny all network policy and validate
+// that the drop metrics are present in the prometheus endpoint
+func TestScenarioValuesWithSkip(t *testing.T) {
+	job := NewJob("Validate that drop metrics are present in the prometheus endpoint")
+	runner := NewRunner(t, job)
+	defer runner.Run()
+
+	// Add top level step
+	job.AddStep(&DummyStep{
+		Parameter1: "Top Level Step 1",
+		Parameter2: "Top Level Step 2",
+	}, &StepOptions{
+		SkipSavingParamatersToJob: true,
+	})
+
+	// top level step skips saving parameters, so we should error here
+	// that parameters are missing
+	job.AddScenario(NewDummyScenario())
+
+	job.AddStep(&DummyStep{
+		Parameter1: "Other Level Step 1",
+		Parameter2: "Other Level Step 2",
+	}, nil)
+
+}
+
+func TestScenarioValuesWithScenarioSkip(t *testing.T) {
+	job := NewJob("Validate that drop metrics are present in the prometheus endpoint")
+	runner := NewRunner(t, job)
+	defer runner.Run()
+
+	// Add top level step
+	job.AddStep(&DummyStep{
+		Parameter1: "Kubeconfig path 1",
+		Parameter2: "Kubeconfig path 2",
+	}, nil)
+
+	// top level step skips saving parameters, so we should error here
+	// that parameters are missing
+	job.AddScenario(NewDummyScenarioWithSkipSave())
+
+	// Add top level step
 	job.AddStep(&DummyStep{}, nil)
 }
 
@@ -27,7 +76,32 @@ func NewDummyScenario() *Scenario {
 	return NewScenario("Dummy Scenario",
 		&StepWrapper{
 			Step: &DummyStep{
-				Parameter2: "Scenario Parameter 2",
+				Parameter1: "Something in Scenario 1",
+				Parameter2: "Something in Scenario 1",
+			},
+		},
+	)
+}
+
+func NewDummyScenario2() *Scenario {
+	return NewScenario("Dummy Scenario",
+		&StepWrapper{
+			Step: &DummyStep{
+				Parameter1: "Something 2 in Scenario 1",
+				Parameter2: "Something 2 in Scenario 1",
+			},
+		},
+	)
+}
+
+func NewDummyScenarioWithSkipSave() *Scenario {
+	return NewScenario("Dummy Scenario",
+		&StepWrapper{
+			Step: &DummyStep{
+				Parameter1: "",
+				Parameter2: "",
+			}, Opts: &StepOptions{
+				SkipSavingParamatersToJob: true,
 			},
 		},
 	)

--- a/test/e2e/scenarios/hubble/azuremonitor/scenario.go
+++ b/test/e2e/scenarios/hubble/azuremonitor/scenario.go
@@ -7,29 +7,33 @@ import (
 
 // todo: once AMA is rolled out
 func ValidateAMATargets() *types.Scenario {
-	return &types.Scenario{
-		Steps: []*types.StepWrapper{
-			{
-				Step: &k8s.PortForward{
-					Namespace:     "kube-system",
-					LabelSelector: "k8s-app=cilium",
-					LocalPort:     "9965",
-					RemotePort:    "9965",
-				},
-				Opts: &types.StepOptions{
-					RunInBackgroundWithID: "validate-ama-targets",
-				},
+
+	steps := []*types.StepWrapper{
+		{
+			Step: &k8s.PortForward{
+				Namespace:     "kube-system",
+				LabelSelector: "k8s-app=cilium",
+				LocalPort:     "9965",
+				RemotePort:    "9965",
 			},
-			{
-				Step: &VerifyPrometheusMetrics{
-					Address: "http://localhost:9090",
-				},
+			Opts: &types.StepOptions{
+				RunInBackgroundWithID: "validate-ama-targets",
 			},
-			{
-				Step: &types.Stop{
-					BackgroundID: "validate-ama-targets",
-				},
+		},
+		{
+			Step: &VerifyPrometheusMetrics{
+				Address: "http://localhost:9090",
+			},
+		},
+		{
+			Step: &types.Stop{
+				BackgroundID: "validate-ama-targets",
 			},
 		},
 	}
+
+	return types.NewScenario(
+		"Validate that drop metrics are present in the prometheus endpoint",
+		steps...,
+	)
 }

--- a/test/e2e/scenarios/hubble/azuremonitor/scenario.go
+++ b/test/e2e/scenarios/hubble/azuremonitor/scenario.go
@@ -7,7 +7,6 @@ import (
 
 // todo: once AMA is rolled out
 func ValidateAMATargets() *types.Scenario {
-
 	steps := []*types.StepWrapper{
 		{
 			Step: &k8s.PortForward{

--- a/test/e2e/scenarios/hubble/drop/scenario.go
+++ b/test/e2e/scenarios/hubble/drop/scenario.go
@@ -91,5 +91,4 @@ func ValidateDropMetric() *types.Scenario {
 		},
 	}
 	return types.NewScenario(Name, Steps...)
-
 }

--- a/test/e2e/scenarios/hubble/drop/scenario.go
+++ b/test/e2e/scenarios/hubble/drop/scenario.go
@@ -16,79 +16,80 @@ const (
 )
 
 func ValidateDropMetric() *types.Scenario {
-	return &types.Scenario{
-		Steps: []*types.StepWrapper{
-			{
-				Step: &k8s.CreateKapingerDeployment{
-					KapingerNamespace: "kube-system",
-					KapingerReplicas:  "1",
-				},
+	Name := "Validate that drop metrics are present in the prometheus endpoint"
+	Steps := []*types.StepWrapper{
+		{
+			Step: &k8s.CreateKapingerDeployment{
+				KapingerNamespace: "kube-system",
+				KapingerReplicas:  "1",
 			},
-			{
-				Step: &k8s.CreateDenyAllNetworkPolicy{
-					NetworkPolicyNamespace: "kube-system",
-					DenyAllLabelSelector:   "app=agnhost-a",
-				},
+		},
+		{
+			Step: &k8s.CreateDenyAllNetworkPolicy{
+				NetworkPolicyNamespace: "kube-system",
+				DenyAllLabelSelector:   "app=agnhost-a",
 			},
-			{
-				Step: &k8s.CreateAgnhostStatefulSet{
-					AgnhostName:      "agnhost-a",
-					AgnhostNamespace: "kube-system",
-				},
+		},
+		{
+			Step: &k8s.CreateAgnhostStatefulSet{
+				AgnhostName:      "agnhost-a",
+				AgnhostNamespace: "kube-system",
 			},
-			{
-				Step: &k8s.ExecInPod{
-					PodName:      "agnhost-a-0",
-					PodNamespace: "kube-system",
-					Command:      "curl -s -m 5 bing.com",
-				},
-				Opts: &types.StepOptions{
-					ExpectError:               true,
-					SkipSavingParamatersToJob: true,
-				},
+		},
+		{
+			Step: &k8s.ExecInPod{
+				PodName:      "agnhost-a-0",
+				PodNamespace: "kube-system",
+				Command:      "curl -s -m 5 bing.com",
 			},
-			{
-				Step: &types.Sleep{
-					Duration: sleepDelay,
-				},
+			Opts: &types.StepOptions{
+				ExpectError:               true,
+				SkipSavingParamatersToJob: true,
 			},
-			// run curl again
-			{
-				Step: &k8s.ExecInPod{
-					PodName:      "agnhost-a-0",
-					PodNamespace: "kube-system",
-					Command:      "curl -s -m 5 bing.com",
-				},
-				Opts: &types.StepOptions{
-					ExpectError:               true,
-					SkipSavingParamatersToJob: true,
-				},
+		},
+		{
+			Step: &types.Sleep{
+				Duration: sleepDelay,
 			},
-			{
-				Step: &k8s.PortForward{
-					Namespace:             "kube-system",
-					LabelSelector:         "k8s-app=cilium",
-					LocalPort:             "9965",
-					RemotePort:            "9965",
-					OptionalLabelAffinity: "app=agnhost-a", // port forward to a pod on a node that also has this pod with this label, assuming same namespace
-				},
-				Opts: &types.StepOptions{
-					RunInBackgroundWithID: "hubble-drop-port-forward",
-				},
+		},
+		// run curl again
+		{
+			Step: &k8s.ExecInPod{
+				PodName:      "agnhost-a-0",
+				PodNamespace: "kube-system",
+				Command:      "curl -s -m 5 bing.com",
 			},
-			{
-				Step: &ValidateHubbleDropMetric{
-					PortForwardedHubblePort: "9965",
-					Source:                  "agnhost-a",
-					Reason:                  PolicyDenied,
-					Protocol:                UDP,
-				},
+			Opts: &types.StepOptions{
+				ExpectError:               true,
+				SkipSavingParamatersToJob: true,
 			},
-			{
-				Step: &types.Stop{
-					BackgroundID: "hubble-drop-port-forward",
-				},
+		},
+		{
+			Step: &k8s.PortForward{
+				Namespace:             "kube-system",
+				LabelSelector:         "k8s-app=cilium",
+				LocalPort:             "9965",
+				RemotePort:            "9965",
+				OptionalLabelAffinity: "app=agnhost-a", // port forward to a pod on a node that also has this pod with this label, assuming same namespace
+			},
+			Opts: &types.StepOptions{
+				RunInBackgroundWithID: "hubble-drop-port-forward",
+			},
+		},
+		{
+			Step: &ValidateHubbleDropMetric{
+				PortForwardedHubblePort: "9965",
+				Source:                  "agnhost-a",
+				Reason:                  PolicyDenied,
+				Protocol:                UDP,
+			},
+		},
+		{
+			Step: &types.Stop{
+				BackgroundID: "hubble-drop-port-forward",
 			},
 		},
 	}
+	return types.NewScenario(Name, Steps...)
+
 }

--- a/test/e2e/scenarios/hubble/flow/scenario.go
+++ b/test/e2e/scenarios/hubble/flow/scenario.go
@@ -4,13 +4,14 @@ import "github.com/Azure/azure-container-networking/test/e2e/framework/types"
 
 // todo: once AMA is rolled out
 func ValidateAMATargets() *types.Scenario {
-	return &types.Scenario{
-		Steps: []*types.StepWrapper{
-			{
-				Step: &ValidateHubbleFlowMetric{
-					LocalPort: "9090",
-				},
+	name := "Validate that flow metrics are present in the prometheus endpoint"
+	steps := []*types.StepWrapper{
+
+		{
+			Step: &ValidateHubbleFlowMetric{
+				LocalPort: "9090",
 			},
 		},
 	}
+	return types.NewScenario(name, steps...)
 }

--- a/test/e2e/scenarios/hubble/flow/scenario.go
+++ b/test/e2e/scenarios/hubble/flow/scenario.go
@@ -6,7 +6,6 @@ import "github.com/Azure/azure-container-networking/test/e2e/framework/types"
 func ValidateAMATargets() *types.Scenario {
 	name := "Validate that flow metrics are present in the prometheus endpoint"
 	steps := []*types.StepWrapper{
-
 		{
 			Step: &ValidateHubbleFlowMetric{
 				LocalPort: "9090",


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

Parameter injection for scenarios are now scoped to the scenario, and can inherit from top level job, but don't impede parameters for other subsequent scenarios

See: 

test/e2e/framework/types/scenarios_test.go

in this pr for usage


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
