### PR TITLE
[refactor] make podname optional

### DIFF
--- a/crd/multitenancy/api/v1alpha1/multitenantpodnetworkconfig.go
+++ b/crd/multitenancy/api/v1alpha1/multitenantpodnetworkconfig.go
@@ -48,7 +48,7 @@ type MultitenantPodNetworkConfigSpec struct {
 	// name of PN object from requesting cx pod
 	PodNetwork string `json:"podNetwork"`
 	// name of the requesting cx pod
-	PodName string `json:"podName"`
+	PodName string `json:"podName,omitempty"`
 }
 
 // MultitenantPodNetworkConfigStatus defines the observed state of PodNetworkConfig

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_multitenantpodnetworkconfigs.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_multitenantpodnetworkconfigs.yaml
@@ -73,7 +73,6 @@ spec:
                 description: name of PNI object from requesting cx pod
                 type: string
             required:
-            - podName
             - podNetwork
             type: object
           status:

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_multitenantpodnetworkconfigs.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_multitenantpodnetworkconfigs.yaml
@@ -73,6 +73,7 @@ spec:
                 description: name of PNI object from requesting cx pod
                 type: string
             required:
+            - podName
             - podNetwork
             type: object
           status:


### PR DESCRIPTION
**Reason for Change**:
PodName field in MTPNC CRD is not used. Make the field optional as a first step. Once the references to the filed are moved from the underlay, remove the field from the CRD in a subsequent PR.

**Issue Fixed**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added
