### PR TITLE
fix: fixing CNS IP releae for azure CNI in case of managed endpoint s…

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -180,6 +180,7 @@ type podInfoScheme int
 const (
 	KubernetesPodInfoScheme podInfoScheme = iota
 	InterfaceIDPodInfoScheme
+	InfraIDPodInfoScheme
 )
 
 // PodInfo represents the object that we are providing network for.
@@ -249,11 +250,18 @@ func (p *podInfo) InterfaceID() string {
 // orchestrator pod name and namespace. if the Version is interfaceID, key is
 // composed of the CNI interfaceID, which is generated from the CRI infra
 // container ID and the pod net ns primary interface name.
+// If the version in InfraContainerID then the key is containerID.
 func (p *podInfo) Key() string {
-	if p.Version == InterfaceIDPodInfoScheme {
+	switch p.Version {
+	case InfraIDPodInfoScheme:
+		return p.PodInfraContainerID
+	case InterfaceIDPodInfoScheme:
 		return p.PodInterfaceID
+	case KubernetesPodInfoScheme:
+		return p.PodName + ":" + p.PodNamespace
+	default:
+		return p.PodName + ":" + p.PodNamespace
 	}
-	return p.PodName + ":" + p.PodNamespace
 }
 
 func (p *podInfo) Name() string {

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -713,13 +713,8 @@ func (service *HTTPRestService) releaseIPConfigs(podInfo cns.PodInfo) error {
 	service.Lock()
 	defer service.Unlock()
 	ipsToBeReleased := make([]cns.IPConfigurationStatus, 0)
-	key := podInfo.Key()
-	if _, isMapContainsKey := service.PodIPIDByPodInterfaceKey[podInfo.Key()]; !isMapContainsKey {
-		// the special case for azure CNI with managed endpoint state since the podInfo.Key() is in containeID-eth0 format and we need to use full ContainerID as well
-		key = podInfo.InfraContainerID()
-	}
-	logger.Printf("[releaseIPConfigs] Released pod with key %s", key)
-	for i, ipID := range service.PodIPIDByPodInterfaceKey[key] {
+	logger.Printf("[releaseIPConfigs] Releasing pod with key %s", podInfo.Key())
+	for i, ipID := range service.PodIPIDByPodInterfaceKey[podInfo.Key()] {
 		if ipID != "" {
 			if ipconfig, isExist := service.PodIPConfigState[ipID]; isExist {
 				ipsToBeReleased = append(ipsToBeReleased, ipconfig)

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -713,8 +713,13 @@ func (service *HTTPRestService) releaseIPConfigs(podInfo cns.PodInfo) error {
 	service.Lock()
 	defer service.Unlock()
 	ipsToBeReleased := make([]cns.IPConfigurationStatus, 0)
-
-	for i, ipID := range service.PodIPIDByPodInterfaceKey[podInfo.Key()] {
+	key := podInfo.Key()
+	if _, isMapContainsKey := service.PodIPIDByPodInterfaceKey[podInfo.Key()]; !isMapContainsKey {
+		// the special case for azure CNI with managed endpoint state since the podInfo.Key() is in containeID-eth0 format and we need to use full ContainerID as well
+		key = podInfo.InfraContainerID()
+	}
+	logger.Printf("[releaseIPConfigs] Released pod with key %s", key)
+	for i, ipID := range service.PodIPIDByPodInterfaceKey[key] {
 		if ipID != "" {
 			if ipconfig, isExist := service.PodIPConfigState[ipID]; isExist {
 				ipsToBeReleased = append(ipsToBeReleased, ipconfig)

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -843,7 +843,7 @@ func main() {
 		// in this case, cns maintains state with containerid as key and so in-memory cache can lookup
 		// and update based on container id.
 		if cnsconfig.ManageEndpointState {
-			cns.GlobalPodInfoScheme = cns.InterfaceIDPodInfoScheme
+			cns.GlobalPodInfoScheme = cns.InfraIDPodInfoScheme
 		}
 
 		logger.Printf("Set GlobalPodInfoScheme %v (InitializeFromCNI=%t)", cns.GlobalPodInfoScheme, cnsconfig.InitializeFromCNI)
@@ -1244,8 +1244,9 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 		if err = PopulateCNSEndpointState(httpRestServiceImplementation.EndpointStateStore); err != nil {
 			return errors.Wrap(err, "failed to create CNS EndpointState From CNI")
 		}
+		// endpoint state needs tobe loaded in memory so the subsequent Delete calls remove the state and release the IPs.
 		if err = httpRestServiceImplementation.EndpointStateStore.Read(restserver.EndpointStoreKey, &httpRestServiceImplementation.EndpointState); err != nil {
-			return errors.Wrap(err, "Failed to restore endpoint state")
+			return errors.Wrap(err, "failed to restore endpoint state")
 		}
 	}
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1244,6 +1244,9 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 		if err = PopulateCNSEndpointState(httpRestServiceImplementation.EndpointStateStore); err != nil {
 			return errors.Wrap(err, "failed to create CNS EndpointState From CNI")
 		}
+		if err = httpRestServiceImplementation.EndpointStateStore.Read(restserver.EndpointStoreKey, &httpRestServiceImplementation.EndpointState); err != nil {
+			return errors.Wrap(err, "Failed to restore endpoint state")
+		}
 	}
 
 	var podInfoByIPProvider cns.PodInfoByIPProvider


### PR DESCRIPTION



**Issue Fixed**:
CNS is using [first 8 digit of containerID]-eth0 format to release IPs for azure CNI. However, when CNS Manage endpoint state is enable it should also use the full containerID as the key.


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
