### PR TITLE
ci: Replace k8s conformance tests within aks-swift CI

### DIFF
--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -461,6 +461,7 @@ stages:
       parameters:
         name: "aks_swift_e2e"
         displayName: AKS Swift Ubuntu
+        os: linux
         clusterType: swift-byocni-up
         clusterName: "swifte2e"
         vmSize: Standard_B2ms
@@ -472,6 +473,7 @@ stages:
       parameters:
         name: "aks_swift_vnetscale_e2e"
         displayName: AKS Swift Vnet Scale Ubuntu
+        os: linux
         clusterType: vnetscale-swift-byocni-up
         clusterName: "vscaleswifte2e"
         vmSize: Standard_B2ms

--- a/.pipelines/singletenancy/aks-swift/e2e-job-template.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e-job-template.yaml
@@ -60,10 +60,23 @@ stages:
               name: ${{ parameters.name }}
               clusterName: ${{ parameters.clusterName }}-$(commitID)
 
+      - template: ../../cni/k8s-e2e/k8s-e2e-job-template.yaml
+        parameters:
+          sub: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+          clusterName: ${{ parameters.clusterName }}-$(commitID)
+          os: ${{ parameters.os }}
+          dependsOn: ${{ parameters.name }}
+          datapath: true
+          dns: true
+          portforward: true
+          hostport: true
+          service: true
+
       - job: failedE2ELogs
         displayName: "Failure Logs"
         dependsOn:
           - ${{ parameters.name }}
+          - cni_linux
         condition: failed()
         steps:
           - template: ../../templates/log-template.yaml

--- a/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
@@ -34,18 +34,8 @@ steps:
       inlineScript: |
         set -e
         make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
-        echo "install kubetest2 and gsutils"
-        go get github.com/onsi/ginkgo/ginkgo
-        go get github.com/onsi/gomega/...
-        go install github.com/onsi/ginkgo/ginkgo@latest
-        go install sigs.k8s.io/kubetest2@latest
-        go install sigs.k8s.io/kubetest2/kubetest2-noop@latest
-        go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest
-        wget https://storage.googleapis.com/pub/gsutil.tar.gz
-        tar xfz gsutil.tar.gz
-        sudo mv gsutil /usr/local/bin
-    name: "installKubetest"
-    displayName: "Set up Conformance Tests"
+    name: "kubeconfig"
+    displayName: "Set Kubeconfig"
 
   - script: |
       ls -lah
@@ -56,25 +46,6 @@ steps:
     retryCountOnTaskFailure: 3
     name: "aksswifte2e"
     displayName: "Run AKS Swift E2E"
-
-  - script: |
-      kubectl get po -owide -A
-      echo "Run Service Conformance E2E"
-      export PATH=${PATH}:/usr/local/bin/gsutil
-      KUBECONFIG=~/.kube/config kubetest2 noop \
-        --test ginkgo -- \
-        --focus-regex "Services.*\[Conformance\].*"
-    name: "servicesConformance"
-    displayName: "Run Services Conformance Tests"
-
-  - script: |
-      echo "Run HostPort Conformance E2E"
-      export PATH=${PATH}:/usr/local/bin/gsutil
-      KUBECONFIG=~/.kube/config kubetest2 noop \
-        --test ginkgo -- \
-        --focus-regex "HostPort.*\[Conformance\].*"
-    name: "hostportConformance"
-    displayName: "Run HostPort Conformance Tests"
 
   - script: |
       echo "Run wireserver and metadata connectivity Tests"


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Replaces kubetest2 to run k8s conformances tests with k8se2e job templates that use exclusively ginkgo. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
Needs to be backported to support future CI runs