### PR TITLE
chore: [NPM] Updated NPM to Not Use Privileged containers and to Mount Container's Root Filesystem as Read Only

### DIFF
--- a/npm/azure-npm.yaml
+++ b/npm/azure-npm.yaml
@@ -87,7 +87,11 @@ spec:
             requests:
               cpu: 250m
           securityContext:
-            privileged: true
+            privileged: false
+            capabilities:
+              add:
+              - NET_ADMIN
+            readOnlyRootFilesystem: true
           env:
             - name: HOSTNAME
               valueFrom:
@@ -105,6 +109,8 @@ spec:
               mountPath: /etc/protocols
             - name: azure-npm-config
               mountPath: /etc/azure-npm
+            - name: tmp
+              mountPath: /tmp
       hostNetwork: true
       hostUsers: false
       nodeSelector:
@@ -125,6 +131,8 @@ spec:
         - name: azure-npm-config
           configMap:
             name: azure-npm-config
+        - name: tmp
+          emptyDir: {}
       serviceAccountName: azure-npm
 ---
 apiVersion: v1


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Addresses NPM Linux vulnerabilities from security scan by customer.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
- Do not use privileged containers
  - set securityContext.privileged=false
  - Added NET_ADMIN capabilities securityContext.capabilities.add=- NET_ADMIN as netadmin profile is able to view/modify iptables rules without privilege
- Mount container's root filesystem as read only
  - set securityContext.readOnlyRootFilesystem=true
  - Mounted an emptyDir volume on the mount /tmp instead of writing to the root volume as we need to write for app insights telemetry

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added