### PR TITLE
ci: Backport CI dependency changes

### DIFF
--- a/.pipelines/cni/cilium/cilium-cni-load-test.yaml
+++ b/.pipelines/cni/cilium/cilium-cni-load-test.yaml
@@ -28,7 +28,7 @@ stages:
           - task: AzureCLI@1
             displayName: "Install Cilium, CNS, and ip-masq-agent"
             inputs:
-              azureSubscription: $(TEST_SUB_SERVICE_CONNECTION)
+              azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"
               scriptType: "bash"
               addSpnToEnvironment: true
@@ -164,7 +164,7 @@ stages:
         steps:
           - task: AzureCLI@1
             inputs:
-              azureSubscription: $(TEST_SUB_SERVICE_CONNECTION)
+              azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"
               scriptType: "bash"
               addSpnToEnvironment: true
@@ -175,7 +175,7 @@ stages:
                   echo "Deleting Cluster and resource group"
                   make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(make revision)
                   make -C ./hack/aks azcfg AZCLI=az REGION=$(LOCATION)
-                  make -C ./hack/aks down AZCLI=az REGION=$(LOCATION) SUB=$(SUBSCRIPTION_ID) CLUSTER=${{ parameters.clusterName }}-$(make revision)
+                  make -C ./hack/aks down AZCLI=az REGION=$(LOCATION) SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }}-$(make revision)
                   echo "Cluster and resources down"
                 else
                   echo "Deletion of resources is False"

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -52,3 +52,40 @@ stages:
             name: "cilium_nightly"
             testDropgz: ""
             clusterName: "ciliumnightly"
+
+      - template: ../../cni/k8s-e2e/k8s-e2e-job-template.yaml
+        parameters:
+          sub: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+          clusterName: ciliumnightly-$(commitID)
+          os: linux
+          cni: cilium
+          dependsOn: cilium_nightly
+          datapath: true
+          dns: true
+          portforward: true
+          service: true
+
+  - stage: delete
+    displayName: Delete Clusters
+    condition: always()
+    dependsOn:
+      - setup
+      - cilium_nightly
+    variables:
+      commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
+    jobs:
+      - job: delete
+        displayName: Delete Cluster
+        pool:
+          name: "$(BUILD_POOL_NAME_DEFAULT)"
+        strategy:
+          matrix:
+            cilium_nightly:
+              name: cilium_overlay_nightly
+              clusterName: ciliumnightly
+        steps:
+          - template: ../../templates/delete-cluster.yaml
+            parameters:
+              name: $(name)
+              clusterName: $(clusterName)-$(commitID)
+              region: $(LOCATION)

--- a/.pipelines/cni/k8s-e2e/k8s-e2e-job-template.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e-job-template.yaml
@@ -3,6 +3,7 @@ parameters:
   os: ""
   dependsOn: ""
   sub: ""
+  cni: cni
 
 
 jobs:
@@ -63,13 +64,23 @@ jobs:
             os: ${{ parameters.os }}
             processes: 8
             attempts: 3
-      - ${{ if eq(parameters.service, true) }}:
+      - ${{ if and( eq(parameters.service, true), contains(parameters.cni, 'cni') ) }}:
         - template: ../k8s-e2e/k8s-e2e-step-template.yaml
           parameters:
             testName: Service Conformance
             name: service
             ginkgoFocus: 'Services.*\[Conformance\].*'
             ginkgoSkip: ''
+            os: ${{ parameters.os }}
+            processes: 8
+            attempts: 3
+      - ${{ if and( eq(parameters.service, true), contains(parameters.cni, 'cilium') ) }}:
+        - template: ../k8s-e2e/k8s-e2e-step-template.yaml
+          parameters:
+            testName: Service Conformance|Cilium
+            name: service
+            ginkgoFocus: 'Services.*\[Conformance\].*'
+            ginkgoSkip: 'should serve endpoints on same port and different protocols' # Cilium does not support this feature. For more info on test: https://github.com/kubernetes/kubernetes/blame/e602e9e03cd744c23dde9fee09396812dd7bdd93/test/conformance/testdata/conformance.yaml#L1780-L1788
             os: ${{ parameters.os }}
             processes: 8
             attempts: 3

--- a/.pipelines/cni/k8s-e2e/k8s-e2e-job-template.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e-job-template.yaml
@@ -20,11 +20,12 @@ jobs:
           addSpnToEnvironment: true
           inlineScript: |
             set -e
-            make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(make revision)
+            make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
 
             # sig-release provides test suite tarball(s) per k8s release. Just need to provide k8s version "v1.xx.xx"
             # pulling k8s version from AKS.
-            eval k8sVersion="v"$( az aks show -g ${{ parameters.clusterName }}-$(make revision) -n ${{ parameters.clusterName }}-$(make revision) --query "currentKubernetesVersion")
+            eval k8sVersion="v"$( az aks show -g ${{ parameters.clusterName }} -n ${{ parameters.clusterName }} --query "currentKubernetesVersion")
+            echo $k8sVersion
             curl -L https://dl.k8s.io/$k8sVersion/kubernetes-test-linux-amd64.tar.gz -o ./kubernetes-test-linux-amd64.tar.gz
 
             # https://github.com/kubernetes/sig-release/blob/master/release-engineering/artifacts.md#content-of-kubernetes-test-system-archtargz-on-example-of-kubernetes-test-linux-amd64targz-directories-removed-from-list
@@ -37,7 +38,6 @@ jobs:
           parameters:
             testName: Datapath
             name: datapath
-            clusterName: ${{ parameters.clusterName }}
             ginkgoFocus: '(.*).Networking.should|(.*).Networking.Granular|(.*)kubernetes.api'
             ginkgoSkip: 'SCTP|Disruptive|Slow|hostNetwork|kube-proxy|IPv6'
             os: ${{ parameters.os }}
@@ -48,7 +48,6 @@ jobs:
           parameters:
             testName: DNS
             name: dns
-            clusterName: ${{ parameters.clusterName }}
             ginkgoFocus: '\[sig-network\].DNS.should'
             ginkgoSkip: 'resolv|256 search'
             os: ${{ parameters.os }}
@@ -59,7 +58,6 @@ jobs:
           parameters:
             testName: Kubectl Portforward
             name: portforward
-            clusterName: ${{ parameters.clusterName }}
             ginkgoFocus: '\[sig-cli\].Kubectl.Port'
             ginkgoSkip: ''
             os: ${{ parameters.os }}
@@ -70,7 +68,6 @@ jobs:
           parameters:
             testName: Service Conformance
             name: service
-            clusterName: ${{ parameters.clusterName }}
             ginkgoFocus: 'Services.*\[Conformance\].*'
             ginkgoSkip: ''
             os: ${{ parameters.os }}
@@ -81,7 +78,6 @@ jobs:
           parameters:
             testName: Host Port
             name: hostport
-            clusterName: ${{ parameters.clusterName }}
             ginkgoFocus: '\[sig-network\](.*)HostPort|\[sig-scheduling\](.*)hostPort'
             ginkgoSkip: 'SCTP|exists conflict' # Skip slow 5 minute test
             os: ${{ parameters.os }}
@@ -92,7 +88,6 @@ jobs:
           parameters:
             testName: Hybrid Network
             name: hybrid
-            clusterName: ${{ parameters.clusterName }}
             ginkgoFocus: '\[sig-windows\].Hybrid'
             ginkgoSkip: ''
             os: ${{ parameters.os }}

--- a/.pipelines/cni/k8s-e2e/k8s-e2e-step-template.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e-step-template.yaml
@@ -1,7 +1,6 @@
 parameters:
   testName: ""
   name: ""
-  clusterName: ""
   ginkgoFocus: ""
   ginkgoSkip: ""
   os: ""

--- a/.pipelines/cni/load-test-templates/create-cluster-template.yaml
+++ b/.pipelines/cni/load-test-templates/create-cluster-template.yaml
@@ -8,13 +8,13 @@ parameters:
 steps:
   - task: AzureCLI@1
     inputs:
-      azureSubscription: $(TEST_SUB_SERVICE_CONNECTION)
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"
       scriptType: "bash"
       addSpnToEnvironment: true
       inlineScript: |
         set -ex
         make -C ./hack/aks azcfg AZCLI=az REGION=$(LOCATION)
-        make -C ./hack/aks ${{ parameters.clusterType }} AZCLI=az REGION=$(LOCATION) SUB=$(SUBSCRIPTION_ID) CLUSTER=${{ parameters.clusterName }}-$(make revision) NODE_COUNT=${{ parameters.nodeCount }} VM_SIZE=${{ parameters.vmSize }} WINDOWS_VM_SKU=${{ parameters.windowsVMSize }} WINDOWS_USERNAME=${WINDOWS_USERNAME} WINDOWS_PASSWORD=${WINDOWS_PASSWORD}
+        make -C ./hack/aks ${{ parameters.clusterType }} AZCLI=az REGION=$(LOCATION) SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }}-$(make revision) NODE_COUNT=${{ parameters.nodeCount }} VM_SIZE=${{ parameters.vmSize }} WINDOWS_VM_SKU=${{ parameters.windowsVMSize }} WINDOWS_USERNAME=${WINDOWS_USERNAME} WINDOWS_PASSWORD=${WINDOWS_PASSWORD}
     name: "CreateAksCluster"
     displayName: "Create AKS Cluster"

--- a/.pipelines/cni/load-test-templates/pod-deployment-template.yaml
+++ b/.pipelines/cni/load-test-templates/pod-deployment-template.yaml
@@ -8,7 +8,7 @@ steps:
   - task: AzureCLI@1
     displayName: "Pod Deployment"
     inputs:
-      azureSubscription: $(TEST_SUB_SERVICE_CONNECTION)
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"
       scriptType: "bash"
       addSpnToEnvironment: true

--- a/.pipelines/cni/load-test-templates/restart-node-template.yaml
+++ b/.pipelines/cni/load-test-templates/restart-node-template.yaml
@@ -4,7 +4,7 @@ parameters:
 steps:
   - task: AzureCLI@1
     inputs:
-      azureSubscription: $(TEST_SUB_SERVICE_CONNECTION)
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"
       scriptType: "bash"
       addSpnToEnvironment: true

--- a/.pipelines/cni/load-test-templates/validate-state-template.yaml
+++ b/.pipelines/cni/load-test-templates/validate-state-template.yaml
@@ -6,7 +6,7 @@ parameters:
 steps:
   - task: AzureCLI@1
     inputs:
-      azureSubscription: $(TEST_SUB_SERVICE_CONNECTION)
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"
       scriptType: "bash"
       addSpnToEnvironment: true

--- a/.pipelines/cni/singletenancy/windows-cni-load-test-template.yaml
+++ b/.pipelines/cni/singletenancy/windows-cni-load-test-template.yaml
@@ -64,7 +64,7 @@ stages:
         steps:
           - task: AzureCLI@1
             inputs:
-              azureSubscription: $(TEST_SUB_SERVICE_CONNECTION)
+              azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"
               scriptType: "bash"
               addSpnToEnvironment: true
@@ -84,6 +84,23 @@ stages:
               kubectl get pods -A
             name: "WaitForCNI"
             displayName: "Wait For CNI"
+  - stage: datapath_tests
+    pool:
+      name: $(BUILD_POOL_NAME_DEFAULT)
+    dependsOn: update_cni
+    displayName: "Datapath Test - Windows"
+    jobs:
+      - template: ../k8s-e2e/k8s-e2e-job-template.yaml
+        parameters:
+          sub: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+          clusterName: ${{ parameters.clusterName }}-$(make revision)
+          os: ${{ parameters.os }}
+          datapath: true
+          dns: true
+          portforward: true
+          hybridWin: true
+          service: true
+          hostport: true
   - stage: pod_deployment_windows
     dependsOn: update_cni
     displayName: "Pod Deployment"
@@ -112,6 +129,23 @@ stages:
               clusterName: ${{ parameters.clusterName }}
               os: ${{ parameters.os }}
               cni: ${{ parameters.cni }}
+
+  - stage: npm
+    dependsOn:
+      - validate_state_windows
+      - setup
+    displayName: NPM|CNI Release Test
+    variables:
+      npmVersion: $[ stagedependencies.setup.env.outputs['SetEnvVars.npmVersion'] ]
+    jobs:
+      - template: ../../npm/npm-cni-integration-test.yaml
+        parameters:
+          clusterName: ${{ parameters.clusterName }}
+          os: ${{ parameters.os }}
+          sub: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+          os_version: 'ltsc2022'
+          tag: $(npmVersion)
+
   - stage: delete_resources
     displayName: "Delete Resources"
     dependsOn:
@@ -123,7 +157,7 @@ stages:
         steps:
           - task: AzureCLI@1
             inputs:
-              azureSubscription: $(TEST_SUB_SERVICE_CONNECTION)
+              azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"
               scriptType: "bash"
               addSpnToEnvironment: true
@@ -134,7 +168,7 @@ stages:
                   echo "Deleting Cluster and resource group"
                   make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(make revision)
                   make -C ./hack/aks azcfg AZCLI=az REGION=$(LOCATION)
-                  make -C ./hack/aks down AZCLI=az REGION=$(LOCATION) SUB=$(SUBSCRIPTION_ID) CLUSTER=${{ parameters.clusterName }}-$(make revision)
+                  make -C ./hack/aks down AZCLI=az REGION=$(LOCATION) SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }}-$(make revision)
                   echo "Cluster and resources down"
                 else
                   echo "Deletion of resources is False"

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -340,14 +340,15 @@ stages:
 
   - template: singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
     parameters:
-      name: "azure_cni_overlay_e2e"
-      displayName: Azure CNI Overlay
+      name: "azure_overlay_e2e"
+      displayName: Azure Overlay
+      os: linux
       testDropgz: ""
       clusterType: overlay-byocni-up
       clusterName: "azurecnioverlaye2e"
       vmSize: Standard_B2ms
       k8sVersion: ""
-      dependsOn: 'containerize'
+      dependsOn: "containerize"
 
   - template: singletenancy/aks-swift/e2e-job-template.yaml
     parameters:
@@ -392,7 +393,7 @@ stages:
     condition: always()
     dependsOn:
       - setup
-      - "azure_cni_overlay_e2e"
+      - "azure_overlay_e2e"
       - "aks_swift_e2e"
       - "cilium_e2e"
       - "cilium_overlay_cilium_e2e"
@@ -413,8 +414,8 @@ stages:
             cilium_overlay_cilium_e2e:
               name: cilium_overlay_cilium_e2e
               clusterName: 'overlaye2e'
-            azure_cni_overlay_e2e:
-              name: azure_cni_overlay_e2e
+            azure_overlay_e2e:
+              name: azure_overlay_e2e
               clusterName: 'azurecnioverlaye2e'
             aks_swift_e2e:
               name: aks_swift_e2e
@@ -455,7 +456,7 @@ stages:
   - stage: cleanup
     displayName: Cleanup
     dependsOn:
-      - "azure_cni_overlay_e2e"
+      - "azure_overlay_e2e"
       - "aks_swift_e2e"
       - "cilium_e2e"
       - "cilium_overlay_cilium_e2e"

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -353,6 +353,7 @@ stages:
     parameters:
       name: "aks_swift_e2e"
       displayName: AKS Swift Ubuntu
+      os: linux
       testDropgz: ""
       clusterType: swift-byocni-up
       clusterName: "swifte2e"

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -32,8 +32,10 @@ stages:
           name: "$(BUILD_POOL_NAME_DEFAULT)"
         steps:
           - script: |
+              # To use the variables below, you must make the respective stage's dependsOn have - setup or it will not retain context of this stage
               BUILD_NUMBER=$(Build.BuildNumber)
               echo "##vso[task.setvariable variable=StorageID;isOutput=true]$(echo ${BUILD_NUMBER//./-})"
+              echo "##vso[task.setvariable variable=commitID;isOutput=true]$(make revision)"
               echo "##vso[task.setvariable variable=Tag;isOutput=true]$(make version)"
               echo "##vso[task.setvariable variable=cniVersion;isOutput=true]$(make cni-version)"
               echo "##vso[task.setvariable variable=npmVersion;isOutput=true]$(make npm-version)"
@@ -318,34 +320,45 @@ stages:
     parameters:
       name: "cilium_e2e"
       displayName: Cilium
-      pipelineBuildImage: "$(BUILD_IMAGE)"
       testDropgz: ""
+      clusterType: cilium-podsubnet-up
       clusterName: "ciliume2e"
+      vmSize: Standard_B2ms
+      k8sVersion: ""
+      dependsOn: 'containerize'
 
   - template: singletenancy/cilium-overlay/cilium-overlay-e2e-job-template.yaml
     parameters:
       name: "cilium_overlay_cilium_e2e"
       displayName: Cilium on AKS Overlay
-      pipelineBuildImage: "$(BUILD_IMAGE)"
       testDropgz: ""
+      clusterType: cilium-overlay-up
       clusterName: "overlaye2e"
+      vmSize: Standard_B2ms
+      k8sVersion: ""
+      dependsOn: 'containerize'
 
   - template: singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
     parameters:
       name: "azure_cni_overlay_e2e"
       displayName: Azure CNI Overlay
-      pipelineBuildImage: "$(BUILD_IMAGE)"
       testDropgz: ""
+      clusterType: overlay-byocni-up
       clusterName: "azurecnioverlaye2e"
+      vmSize: Standard_B2ms
+      k8sVersion: ""
+      dependsOn: 'containerize'
 
   - template: singletenancy/aks-swift/e2e-job-template.yaml
     parameters:
       name: "aks_swift_e2e"
       displayName: AKS Swift Ubuntu
-      pipelineBuildImage: "$(BUILD_IMAGE)"
       testDropgz: ""
+      clusterType: swift-byocni-up
       clusterName: "swifte2e"
-      osSku: "Ubuntu"
+      vmSize: Standard_B2s
+      k8sVersion: ""
+      dependsOn: 'containerize'
 
   - template: singletenancy/aks/e2e-job-template.yaml
     parameters:
@@ -358,6 +371,7 @@ stages:
       vmSize: Standard_B2s
       k8sVersion: 1.25
       scaleup: 100
+      dependsOn: 'containerize'
 
   - template: singletenancy/aks/e2e-job-template.yaml
     parameters:
@@ -368,9 +382,54 @@ stages:
       clusterType: windows-cniv1-up
       clusterName: 'win22e2e'
       vmSize: Standard_B2ms
-      windowsOsSku: 'Windows2022'
       os_version: 'ltsc2022'
-      scaleup: 100
+      scaleup: 50
+      dependsOn: 'containerize'
+
+  - stage: delete
+    displayName: Delete Clusters
+    condition: always()
+    dependsOn:
+      - setup
+      - "azure_cni_overlay_e2e"
+      - "aks_swift_e2e"
+      - "cilium_e2e"
+      - "cilium_overlay_cilium_e2e"
+      - "aks_ubuntu_22_linux_e2e"
+      - "aks_windows_22_e2e"
+    variables:
+      commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
+    jobs:
+      - job: delete
+        displayName: Delete Cluster
+        pool:
+          name: "$(BUILD_POOL_NAME_DEFAULT)"
+        strategy:
+          matrix:
+            cilium_e2e:
+              name: cilium_e2e
+              clusterName: 'ciliume2e'
+            cilium_overlay_cilium_e2e:
+              name: cilium_overlay_cilium_e2e
+              clusterName: 'overlaye2e'
+            azure_cni_overlay_e2e:
+              name: azure_cni_overlay_e2e
+              clusterName: 'azurecnioverlaye2e'
+            aks_swift_e2e:
+              name: aks_swift_e2e
+              clusterName: 'swifte2e'
+            aks_ubuntu_22_linux_e2e:
+              name: aks_ubuntu_22_linux_e2e
+              clusterName: 'ubuntu22e2e'
+            aks_windows_22_e2e:
+              name: aks_windows_22_e2e
+              clusterName: 'win22e2e'
+        steps:
+          - template: templates/delete-cluster.yaml
+            parameters:
+              name: $(name)
+              clusterName: $(clusterName)-$(commitID)
+              region: $(REGION_AKS_CLUSTER_TEST)
 
   - stage: validate2
     displayName: Validate Tags
@@ -395,6 +454,7 @@ stages:
   - stage: cleanup
     displayName: Cleanup
     dependsOn:
+      - "azure_cni_overlay_e2e"
       - "aks_swift_e2e"
       - "cilium_e2e"
       - "cilium_overlay_cilium_e2e"

--- a/.pipelines/singletenancy/aks-swift/e2e-job-template.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e-job-template.yaml
@@ -1,19 +1,45 @@
 parameters:
   name: ""
   displayName: ""
-  pipelineBuildImage: "$(BUILD_IMAGE)"
   testDropgz: ""
+  clusterType: ""
   clusterName: ""
-  osSku: ""
+  vmSize: ""
+  k8sVersion: ""
+  dependsOn: ""
+
 stages:
+  - stage: ${{ parameters.clusterName }}
+    displayName: Create Cluster - ${{ parameters.displayName }}
+    dependsOn:
+      - ${{ parameters.dependsOn }}
+      - setup
+    pool:
+      name: $(BUILD_POOL_NAME_DEFAULT)
+    variables:
+      commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
+    jobs:
+      - template: ../../templates/create-cluster.yaml
+        parameters:
+          name: ${{ parameters.name }}
+          displayName: ${{ parameters.displayName }}
+          clusterType: ${{ parameters.clusterType }}
+          clusterName: ${{ parameters.clusterName }}-$(commitID)
+          vmSize: ${{ parameters.vmSize }}
+          k8sVersion: ${{ parameters.k8sVersion }}
+          dependsOn: ${{ parameters.dependsOn }}
+          region: $(REGION_AKS_CLUSTER_TEST)
+
   - stage: ${{ parameters.name }}
     displayName: E2E - ${{ parameters.displayName }}
-    dependsOn: 
+    dependsOn:
     - setup
     - publish
+    - ${{ parameters.clusterName }}
     variables:
       TAG: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.Tag'] ]
       CURRENT_VERSION: $[ stagedependencies.containerize.check_tag.outputs['CurrentTagManifests.currentTagManifests'] ]
+      commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
     condition: and(succeeded(), eq(variables.TAG, variables.CURRENT_VERSION))
     jobs:
       - job: ${{ parameters.name }}
@@ -21,7 +47,7 @@ stages:
         timeoutInMinutes: 120
         pool:
           name: $(BUILD_POOL_NAME_DEFAULT)
-          demands: 
+          demands:
           - agent.os -equals Linux
           - Role -equals $(CUSTOM_E2E_ROLE)
         variables:
@@ -33,5 +59,4 @@ stages:
             parameters:
               name: ${{ parameters.name }}
               testDropgz: ${{ parameters.testDropgz }}
-              clusterName: ${{ parameters.clusterName }}
-              osSku: ${{ parameters.osSku }}
+              clusterName: ${{ parameters.clusterName }}-$(commitID)

--- a/.pipelines/singletenancy/aks-swift/e2e-job-template.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e-job-template.yaml
@@ -60,3 +60,15 @@ stages:
               name: ${{ parameters.name }}
               testDropgz: ${{ parameters.testDropgz }}
               clusterName: ${{ parameters.clusterName }}-$(commitID)
+
+      - template: ../../cni/k8s-e2e/k8s-e2e-job-template.yaml
+        parameters:
+          sub: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+          clusterName: ${{ parameters.clusterName }}-$(commitID)
+          os: ${{ parameters.os }}
+          dependsOn: ${{ parameters.name }}
+          datapath: true
+          dns: true
+          portforward: true
+          hostport: true
+          service: true

--- a/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
@@ -24,7 +24,7 @@ steps:
 
   - task: AzureCLI@1
     inputs:
-      azureSubscription: $(AZURE_TEST_AGENT_SERVICE_CONNECTION)
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"
       scriptType: "bash"
       addSpnToEnvironment: true

--- a/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
@@ -2,7 +2,6 @@ parameters:
   name: ""
   testDropgz: ""
   clusterName: ""
-  osSku: ""
 
 steps:
   - bash: |
@@ -31,25 +30,17 @@ steps:
       addSpnToEnvironment: true
       inlineScript: |
         set -e
-        mkdir -p ~/.kube/
-        echo "Create AKS cluster"
-        make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
-        make -C ./hack/aks byocni-up AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST) SUB=$(SUB_AZURE_NETWORK_AGENT_TEST) CLUSTER=${{ parameters.clusterName }}-${{ parameters.osSku }}-$(make revision) OSSKU=${{ parameters.osSku }}
-        echo "Cluster successfully created"
-    displayName: Create test cluster
-    condition: succeeded()
-
-  - script: |
-      echo "install kubetest2 and gsutils"
-      go get github.com/onsi/ginkgo/ginkgo
-      go get github.com/onsi/gomega/...
-      go install github.com/onsi/ginkgo/ginkgo@latest
-      go install sigs.k8s.io/kubetest2@latest
-      go install sigs.k8s.io/kubetest2/kubetest2-noop@latest
-      go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest
-      wget https://storage.googleapis.com/pub/gsutil.tar.gz
-      tar xfz gsutil.tar.gz
-      sudo mv gsutil /usr/local/bin
+        make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
+        echo "install kubetest2 and gsutils"
+        go get github.com/onsi/ginkgo/ginkgo
+        go get github.com/onsi/gomega/...
+        go install github.com/onsi/ginkgo/ginkgo@latest
+        go install sigs.k8s.io/kubetest2@latest
+        go install sigs.k8s.io/kubetest2/kubetest2-noop@latest
+        go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest
+        wget https://storage.googleapis.com/pub/gsutil.tar.gz
+        tar xfz gsutil.tar.gz
+        sudo mv gsutil /usr/local/bin
     name: "installKubetest"
     displayName: "Set up Conformance Tests"
 
@@ -115,20 +106,4 @@ steps:
       sudo rm -rf test/integration/logs
     name: "Cleanupartifactdir"
     displayName: "Cleanup artifact dir"
-    condition: always()
-
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: "$(AZURE_TEST_AGENT_SERVICE_CONNECTION)"
-      scriptLocation: "inlineScript"
-      scriptType: "bash"
-      addSpnToEnvironment: true
-      inlineScript: |
-        set -e
-        echo "Deleting cluster"
-        make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
-        make -C ./hack/aks down AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST) SUB=$(SUB_AZURE_NETWORK_AGENT_TEST) CLUSTER=${{ parameters.clusterName }}-${{ parameters.osSku }}-$(make revision)
-        echo "Cluster and resources down"
-    name: "Cleanupcluster"
-    displayName: "Cleanup cluster"
     condition: always()

--- a/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
@@ -35,18 +35,8 @@ steps:
       inlineScript: |
         set -e
         make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
-        echo "install kubetest2 and gsutils"
-        go get github.com/onsi/ginkgo/ginkgo
-        go get github.com/onsi/gomega/...
-        go install github.com/onsi/ginkgo/ginkgo@latest
-        go install sigs.k8s.io/kubetest2@latest
-        go install sigs.k8s.io/kubetest2/kubetest2-noop@latest
-        go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest
-        wget https://storage.googleapis.com/pub/gsutil.tar.gz
-        tar xfz gsutil.tar.gz
-        sudo mv gsutil /usr/local/bin
-    name: "installKubetest"
-    displayName: "Set up Conformance Tests"
+    name: "kubeconfig"
+    displayName: "Set Kubeconfig"
 
   - script: |
       ls -lah
@@ -74,24 +64,6 @@ steps:
       artifactName: aks-swift-output
       pathtoPublish: "$(Build.ArtifactStagingDirectory)/aks-swift-output"
     condition: always()
-
-  - script: |
-      echo "Run Service Conformance E2E"
-      export PATH=${PATH}:/usr/local/bin/gsutil
-      KUBECONFIG=~/.kube/config kubetest2 noop \
-        --test ginkgo -- \
-        --focus-regex "Services.*\[Conformance\].*"
-    name: "servicesConformance"
-    displayName: "Run Services Conformance Tests"
-
-  - script: |
-      echo "Run HostPort Conformance E2E"
-      export PATH=${PATH}:/usr/local/bin/gsutil
-      KUBECONFIG=~/.kube/config kubetest2 noop \
-        --test ginkgo -- \
-        --focus-regex "HostPort.*\[Conformance\].*"
-    name: "hostportConformance"
-    displayName: "Run HostPort Conformance Tests"
 
   - script: |
       echo "Run wireserver and metadata connectivity Tests"

--- a/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
@@ -22,6 +22,10 @@ steps:
     name: "GoEnv"
     displayName: "Set up the Go environment"
 
+  - task: KubectlInstaller@0
+    inputs:
+      kubectlVersion: latest
+
   - task: AzureCLI@1
     inputs:
       azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
@@ -47,9 +51,6 @@ steps:
   - script: |
       ls -lah
       pwd
-      echo "installing kubectl"
-      curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-      sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
       kubectl cluster-info
       kubectl get po -owide -A
       sudo -E env "PATH=$PATH" make test-integration CNS_VERSION=$(make cns-version) CNI_DROPGZ_VERSION=$(make cni-dropgz-version) INSTALL_CNS=true INSTALL_AZURE_VNET=true TEST_DROPGZ=${{ parameters.testDropgz }}

--- a/.pipelines/singletenancy/aks/e2e-job-template.yaml
+++ b/.pipelines/singletenancy/aks/e2e-job-template.yaml
@@ -7,11 +7,32 @@ parameters:
   clusterName: ""
   vmSize: ""
   k8sVersion: ""
-  windowsOsSku: ""
   os_version: ""
   scaleup: ""
+  dependsOn: ""
 
 stages:
+  - stage: ${{ parameters.clusterName }}
+    displayName: Create Cluster - ${{ parameters.displayName }}
+    dependsOn:
+      - ${{ parameters.dependsOn }}
+      - setup
+    pool:
+      name: $(BUILD_POOL_NAME_DEFAULT)
+    variables:
+      commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
+    jobs:
+      - template: ../../templates/create-cluster.yaml
+        parameters:
+          name: ${{ parameters.name }}
+          displayName: ${{ parameters.displayName }}
+          clusterType: ${{ parameters.clusterType }}
+          clusterName: ${{ parameters.clusterName }}-$(commitID)
+          vmSize: ${{ parameters.vmSize }}
+          k8sVersion: ${{ parameters.k8sVersion }}
+          dependsOn: ${{ parameters.dependsOn }}
+          region: $(REGION_AKS_CLUSTER_TEST)
+
   - stage: ${{ parameters.name }}
     displayName: E2E - ${{ parameters.displayName }}
     variables:
@@ -20,9 +41,11 @@ stages:
       modulePath: "$(GOPATH)/src/github.com/Azure/azure-container-networking"
       dropgzVersion: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.dropgzVersion'] ]
       cniVersion: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.cniVersion'] ]
+      commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
     dependsOn:
     - setup
     - publish
+    - ${{ parameters.clusterName }}
     jobs:
       - job: ${{ parameters.name }}
         displayName: Singletenancy AKS - (${{ parameters.name }})
@@ -35,13 +58,9 @@ stages:
           - template: e2e-step-template.yaml
             parameters:
               name: ${{ parameters.name }}
-              clusterType: ${{ parameters.clusterType }}
-              clusterName: ${{ parameters.clusterName }}
-              vmSize: ${{ parameters.vmSize }}
+              clusterName: ${{ parameters.clusterName }}-$(commitID)
               arch: ${{ parameters.arch }}
               os: ${{ parameters.os }}
-              k8sVersion: ${{ parameters.k8sVersion }}
-              windowsOsSku: ${{ parameters.windowsOsSku }}
               os_version: ${{ parameters.os_version }}
               version: $(dropgzVersion)
               cniVersion: $(cniVersion)
@@ -50,7 +69,7 @@ stages:
       - template: ../../cni/k8s-e2e/k8s-e2e-job-template.yaml
         parameters:
           sub: $(AZURE_TEST_AGENT_SERVICE_CONNECTION)
-          clusterName: ${{ parameters.clusterName }}
+          clusterName: ${{ parameters.clusterName }}-$(commitID)
           os: ${{ parameters.os }}
           datapath: true
           dns: true
@@ -59,29 +78,3 @@ stages:
           service: true
           hostport: true
           dependsOn: ${{ parameters.name }}
-
-      - job: cleanup
-        displayName: "Cleanup"
-        dependsOn:
-        - ${{ parameters.name }}
-        - "cni_k8se2e"
-        pool:
-          name: $(BUILD_POOL_NAME_DEFAULT)
-        condition: always()
-        steps:
-          - task: AzureCLI@1
-            inputs:
-              azureSubscription: $(AZURE_TEST_AGENT_SERVICE_CONNECTION)
-              scriptLocation: "inlineScript"
-              scriptType: "bash"
-              addSpnToEnvironment: true
-              inlineScript: |
-                set -e
-                echo "Deleting cluster"
-                make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
-                make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(make revision)
-                make -C ./hack/aks down AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST) SUB=$(SUB_AZURE_NETWORK_AGENT_TEST) CLUSTER=${{ parameters.clusterName }}-$(make revision)
-                echo "Cluster and resources down"
-            displayName: "Delete test cluster"
-
-

--- a/.pipelines/singletenancy/aks/e2e-job-template.yaml
+++ b/.pipelines/singletenancy/aks/e2e-job-template.yaml
@@ -68,7 +68,7 @@ stages:
 
       - template: ../../cni/k8s-e2e/k8s-e2e-job-template.yaml
         parameters:
-          sub: $(AZURE_TEST_AGENT_SERVICE_CONNECTION)
+          sub: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
           clusterName: ${{ parameters.clusterName }}-$(commitID)
           os: ${{ parameters.os }}
           datapath: true

--- a/.pipelines/singletenancy/aks/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks/e2e-step-template.yaml
@@ -1,14 +1,8 @@
 parameters:
   name: ""
-  clusterType: ""
   clusterName: ""
-  nodeCount: ""
-  vmSize: ""
-  k8sVersion: ""
-  version: ""
+  arch: ""
   os: ""
-  windowsOsSku: ""
-  cniVersion: ""
   os_version: ""
   scaleup: ""
 
@@ -31,28 +25,21 @@ steps:
       addSpnToEnvironment: true
       inlineScript: |
         set -e
-        mkdir -p ~/.kube/
-        echo "Create AKS cluster"
-        echo "parameters ${{ parameters.windowsOsSku }}"
-        make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
-        make -C ./hack/aks ${{ parameters.clusterType }} AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST) SUB=$(SUB_AZURE_NETWORK_AGENT_TEST) CLUSTER=${{ parameters.clusterName }}-$(make revision) K8S_VER=${{ parameters.k8sVersion }} VM_SIZE=${{ parameters.vmSize }} WINDOWS_OS_SKU=${{ parameters.windowsOsSku }} WINDOWS_VM_SKU=${{ parameters.vmSize }} WINDOWS_USERNAME=${WINDOWS_USERNAME} WINDOWS_PASSWORD=${WINDOWS_PASSWORD}
-        echo "Cluster successfully created"
-    displayName: Create test cluster
-  - script: |
-      echo "Upload CNI"
-      if [ "${{parameters.os}}" == "windows" ]; then
-        export DROP_GZ_URL=$( make cni-dropgz-test-image-name-and-tag OS='linux' ARCH=${{ parameters.arch }} CNI_DROPGZ_VERSION=${{ parameters.version }})
-        envsubst < ./test/integration/manifests/cni/cni-installer-v1.yaml | kubectl apply -f -
-        kubectl rollout status daemonset/azure-cni -n kube-system
-        echo "Deploying on windows nodes"
-        export DROP_GZ_URL=$( make cni-dropgz-test-image-name-and-tag OS='windows' ARCH=${{ parameters.arch }}  OS_VERSION=${{ parameters.os_version }} CNI_DROPGZ_VERSION=${{ parameters.version }})
-        envsubst < ./test/integration/manifests/cni/cni-installer-v1-windows.yaml | kubectl apply -f -
-        kubectl rollout status daemonset/azure-cni-windows -n kube-system
-      else
-        export DROP_GZ_URL=$( make cni-dropgz-test-image-name-and-tag OS=${{ parameters.os }} ARCH=${{ parameters.arch }} CNI_DROPGZ_VERSION=${{ parameters.version }})
-        envsubst < ./test/integration/manifests/cni/cni-installer-v1.yaml | kubectl apply -f -
-        kubectl rollout status daemonset/azure-cni -n kube-system
-      fi
+        make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
+        echo "Upload CNI"
+        if [ "${{parameters.os}}" == "windows" ]; then
+          export DROP_GZ_URL=$( make cni-dropgz-test-image-name-and-tag OS='linux' ARCH=${{ parameters.arch }} CNI_DROPGZ_VERSION=${{ parameters.version }})
+          envsubst < ./test/integration/manifests/cni/cni-installer-v1.yaml | kubectl apply -f -
+          kubectl rollout status daemonset/azure-cni -n kube-system
+          echo "Deploying on windows nodes"
+          export DROP_GZ_URL=$( make cni-dropgz-test-image-name-and-tag OS='windows' ARCH=${{ parameters.arch }}  OS_VERSION=${{ parameters.os_version }} CNI_DROPGZ_VERSION=${{ parameters.version }})
+          envsubst < ./test/integration/manifests/cni/cni-installer-v1-windows.yaml | kubectl apply -f -
+          kubectl rollout status daemonset/azure-cni-windows -n kube-system
+        else
+          export DROP_GZ_URL=$( make cni-dropgz-test-image-name-and-tag OS=${{ parameters.os }} ARCH=${{ parameters.arch }} CNI_DROPGZ_VERSION=${{ parameters.version }})
+          envsubst < ./test/integration/manifests/cni/cni-installer-v1.yaml | kubectl apply -f -
+          kubectl rollout status daemonset/azure-cni -n kube-system
+        fi
     name: "UploadCni"
     displayName: "Upload CNI"
   - task: AzureCLI@1
@@ -63,7 +50,7 @@ steps:
       addSpnToEnvironment: true
       inlineScript: |
         set -e
-        clusterName=${{ parameters.clusterName }}-$(make revision)
+        clusterName=${{ parameters.clusterName }}
         echo "Restarting nodes"
         for val in $(az vmss list -g MC_${clusterName}_${clusterName}_$(REGION_AKS_CLUSTER_TEST) --query "[].name" -o tsv); do
           make -C ./hack/aks restart-vmss AZCLI=az CLUSTER=${clusterName} REGION=$(REGION_AKS_CLUSTER_TEST) VMSS_NAME=${val}

--- a/.pipelines/singletenancy/aks/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks/e2e-step-template.yaml
@@ -19,7 +19,7 @@ steps:
     displayName: "Set up the Go environment"
   - task: AzureCLI@1
     inputs:
-      azureSubscription: $(AZURE_TEST_AGENT_SERVICE_CONNECTION)
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"
       scriptType: "bash"
       addSpnToEnvironment: true
@@ -44,7 +44,7 @@ steps:
     displayName: "Upload CNI"
   - task: AzureCLI@1
     inputs:
-      azureSubscription: $(AZURE_TEST_AGENT_SERVICE_CONNECTION)
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"
       scriptType: "bash"
       addSpnToEnvironment: true

--- a/.pipelines/singletenancy/aks/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks/e2e-step-template.yaml
@@ -17,6 +17,9 @@ steps:
       echo '##vso[task.prependpath]$(GOROOT)/bin'
     name: "GoEnv"
     displayName: "Set up the Go environment"
+  - task: KubectlInstaller@0
+    inputs:
+      kubectlVersion: latest
   - task: AzureCLI@1
     inputs:
       azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
@@ -1,23 +1,50 @@
 parameters:
   name: ""
   displayName: ""
-  pipelineBuildImage: "$(BUILD_IMAGE)"
   testDropgz: ""
+  clusterType: ""
   clusterName: ""
+  vmSize: ""
+  k8sVersion: ""
+  dependsOn: ""
 
 stages:
+  - stage: ${{ parameters.clusterName }}
+    displayName: Create Cluster - ${{ parameters.displayName }}
+    dependsOn:
+      - ${{ parameters.dependsOn }}
+      - setup
+    pool:
+      name: $(BUILD_POOL_NAME_DEFAULT)
+    variables:
+      commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
+    jobs:
+      - template: ../../templates/create-cluster.yaml
+        parameters:
+          name: ${{ parameters.name }}
+          displayName: ${{ parameters.displayName }}
+          clusterType: ${{ parameters.clusterType }}
+          clusterName: ${{ parameters.clusterName }}-$(commitID)
+          vmSize: ${{ parameters.vmSize }}
+          k8sVersion: ${{ parameters.k8sVersion }}
+          dependsOn: ${{ parameters.dependsOn }}
+          region: $(REGION_AKS_CLUSTER_TEST)
+
   - stage: ${{ parameters.name }}
     displayName: E2E - ${{ parameters.displayName }}
-    dependsOn: 
+    dependsOn:
     - setup
     - publish
+    - ${{ parameters.clusterName }}
+    variables:
+      commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
     jobs:
       - job: ${{ parameters.name }}
         displayName: Azure CNI Overlay Test Suite - (${{ parameters.name }})
         timeoutInMinutes: 120
         pool:
           name: $(BUILD_POOL_NAME_DEFAULT)
-          demands: 
+          demands:
           - agent.os -equals Linux
           - Role -equals $(CUSTOM_E2E_ROLE)
         variables:
@@ -29,4 +56,4 @@ stages:
             parameters:
               name: ${{ parameters.name }}
               testDropgz: ${{ parameters.testDropgz }}
-              clusterName: ${{ parameters.clusterName }}
+              clusterName: ${{ parameters.clusterName }}-$(commitID)

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
@@ -57,3 +57,15 @@ stages:
               name: ${{ parameters.name }}
               testDropgz: ${{ parameters.testDropgz }}
               clusterName: ${{ parameters.clusterName }}-$(commitID)
+
+      - template: ../../cni/k8s-e2e/k8s-e2e-job-template.yaml
+        parameters:
+          sub: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+          clusterName: ${{ parameters.clusterName }}-$(commitID)
+          os: ${{ parameters.os }}
+          dependsOn: ${{ parameters.name }}
+          datapath: true
+          dns: true
+          portforward: true
+          hostport: true
+          service: true

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-step-template.yaml
@@ -30,22 +30,14 @@ steps:
       addSpnToEnvironment: true
       inlineScript: |
         set -e
-        mkdir -p ~/.kube/
-        echo "Create AKS Overlay cluster"
-        make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_OVERLAY_CLUSTER_TEST)
-        make -C ./hack/aks overlay-byocni-up AZCLI=az REGION=$(REGION_OVERLAY_CLUSTER_TEST) SUB=$(SUB_AZURE_NETWORK_AGENT_TEST) CLUSTER=${{ parameters.clusterName }}-$(make revision) VM_SIZE=Standard_B2ms
-        echo "Cluster successfully created"
-    displayName: Create Overlay cluster
-    condition: succeeded()
-
-  - script: |
-      ls -lah
-      pwd
-      echo "installing kubectl"
-      curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-      sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-      kubectl cluster-info
-      kubectl get po -owide -A
+        make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
+        ls -lah
+        pwd
+        echo "installing kubectl"
+        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+        sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+        kubectl cluster-info
+        kubectl get po -owide -A
     name: "installKubectl"
     displayName: "Install Kubectl"
 
@@ -121,20 +113,4 @@ steps:
       sudo rm -rf test/integration/logs
     name: "Cleanupartifactdir"
     displayName: "Cleanup artifact dir"
-    condition: always()
-
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: $(AZURE_TEST_AGENT_SERVICE_CONNECTION)
-      scriptLocation: "inlineScript"
-      scriptType: "bash"
-      addSpnToEnvironment: true
-      inlineScript: |
-        set -e
-        echo "Deleting cluster"
-        make -C ./hack/aks azcfg AZCLI=az
-        make -C ./hack/aks down SUB=$(SUB_AZURE_NETWORK_AGENT_TEST) AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(make revision)
-        echo "Cluster and resources down"
-    name: "Cleanupcluster"
-    displayName: "Cleanup cluster"
     condition: always()

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-step-template.yaml
@@ -24,7 +24,7 @@ steps:
 
   - task: AzureCLI@1
     inputs:
-      azureSubscription: $(AZURE_TEST_AGENT_SERVICE_CONNECTION)
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"
       scriptType: "bash"
       addSpnToEnvironment: true

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-step-template.yaml
@@ -39,20 +39,6 @@ steps:
     displayName: "Set Kubeconfig"
 
   - script: |
-      echo "install kubetest2 and gsutils"
-      go get github.com/onsi/ginkgo/ginkgo
-      go get github.com/onsi/gomega/...
-      go install github.com/onsi/ginkgo/ginkgo@latest
-      go install sigs.k8s.io/kubetest2@latest
-      go install sigs.k8s.io/kubetest2/kubetest2-noop@latest
-      go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest
-      wget https://storage.googleapis.com/pub/gsutil.tar.gz
-      tar xfz gsutil.tar.gz
-      sudo mv gsutil /usr/local/bin
-    name: "installKubetest"
-    displayName: "Set up Conformance Tests"
-
-  - script: |
       echo "Start Integration Tests on Overlay Cluster"
       echo "deploy ip-masq-agent for overlay"
       kubectl apply -f test/integration/manifests/ip-masq-agent/ip-masq-agent.yaml --validate=false
@@ -86,15 +72,6 @@ steps:
       artifactName: test-output
       pathtoPublish: "$(Build.ArtifactStagingDirectory)/test-output"
     condition: always()
-
-  - script: |
-      echo "Run Service Conformance E2E"
-      export PATH=${PATH}:/usr/local/bin/gsutil
-      KUBECONFIG=~/.kube/config kubetest2 noop \
-        --test ginkgo -- \
-        --focus-regex "Services.*\[Conformance\].*"
-    name: "servicesConformance"
-    displayName: "Run Services Conformance Tests"
 
   - script: |
       echo "Run wireserver and metadata connectivity Tests"

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-step-template.yaml
@@ -22,6 +22,10 @@ steps:
     name: "GoEnv"
     displayName: "Set up the Go environment"
 
+  - task: KubectlInstaller@0
+    inputs:
+      kubectlVersion: latest
+
   - task: AzureCLI@1
     inputs:
       azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
@@ -31,15 +35,8 @@ steps:
       inlineScript: |
         set -e
         make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
-        ls -lah
-        pwd
-        echo "installing kubectl"
-        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-        sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-        kubectl cluster-info
-        kubectl get po -owide -A
-    name: "installKubectl"
-    displayName: "Install Kubectl"
+    name: "kubeconfig"
+    displayName: "Set Kubeconfig"
 
   - script: |
       echo "install kubetest2 and gsutils"

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-job-template.yaml
@@ -1,32 +1,58 @@
 parameters:
   name: ""
   displayName: ""
-  pipelineBuildImage: "$(BUILD_IMAGE)"
   testDropgz: ""
+  clusterType: ""
   clusterName: ""
+  vmSize: ""
+  k8sVersion: ""
+  dependsOn: ""
 
 stages:
+  - stage: ${{ parameters.clusterName }}
+    displayName: Create Cluster - ${{ parameters.displayName }}
+    dependsOn:
+      - ${{ parameters.dependsOn }}
+      - setup
+    pool:
+      name: $(BUILD_POOL_NAME_DEFAULT)
+    variables:
+      commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
+    jobs:
+      - template: ../../templates/create-cluster.yaml
+        parameters:
+          name: ${{ parameters.name }}
+          displayName: ${{ parameters.displayName }}
+          clusterType: ${{ parameters.clusterType }}
+          clusterName: ${{ parameters.clusterName }}-$(commitID)
+          vmSize: ${{ parameters.vmSize }}
+          k8sVersion: ${{ parameters.k8sVersion }}
+          dependsOn: ${{ parameters.dependsOn }}
+          region: $(REGION_AKS_CLUSTER_TEST)
+
   - stage: ${{ parameters.name }}
     displayName: E2E - ${{ parameters.displayName }}
-    dependsOn: 
+    dependsOn:
     - setup
     - publish
+    - ${{ parameters.clusterName }}
     jobs:
       - job: ${{ parameters.name }}
         displayName: Cilium Overlay Test Suite - (${{ parameters.name }})
         timeoutInMinutes: 120
         pool:
           name: $(BUILD_POOL_NAME_DEFAULT)
-          demands: 
+          demands:
           - agent.os -equals Linux
           - Role -equals $(CUSTOM_E2E_ROLE)
         variables:
           GOPATH: "$(Agent.TempDirectory)/go" # Go workspace path
           GOBIN: "$(GOPATH)/bin" # Go binaries path
           modulePath: "$(GOPATH)/src/github.com/Azure/azure-container-networking"
+          commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
         steps:
           - template: cilium-overlay-e2e-step-template.yaml
             parameters:
               name: ${{ parameters.name }}
               testDropgz: ${{ parameters.testDropgz }}
-              clusterName: ${{ parameters.clusterName }}
+              clusterName: ${{ parameters.clusterName }}-$(commitID)

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-job-template.yaml
@@ -7,6 +7,7 @@ parameters:
   vmSize: ""
   k8sVersion: ""
   dependsOn: ""
+  os: "linux"
 
 stages:
   - stage: ${{ parameters.clusterName }}
@@ -36,6 +37,8 @@ stages:
     - setup
     - publish
     - ${{ parameters.clusterName }}
+    variables:
+      commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
     jobs:
       - job: ${{ parameters.name }}
         displayName: Cilium Overlay Test Suite - (${{ parameters.name }})
@@ -56,3 +59,15 @@ stages:
               name: ${{ parameters.name }}
               testDropgz: ${{ parameters.testDropgz }}
               clusterName: ${{ parameters.clusterName }}-$(commitID)
+
+      - template: ../../cni/k8s-e2e/k8s-e2e-job-template.yaml
+        parameters:
+          sub: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+          clusterName: ${{ parameters.clusterName }}-$(commitID)
+          os: ${{ parameters.os }}
+          cni: cilium
+          dependsOn: ${{ parameters.name }}
+          datapath: true
+          dns: true
+          portforward: true
+          service: true

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
@@ -24,7 +24,7 @@ steps:
 
   - task: AzureCLI@1
     inputs:
-      azureSubscription: $(AZURE_TEST_AGENT_SERVICE_CONNECTION)
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"
       scriptType: "bash"
       addSpnToEnvironment: true

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
@@ -22,6 +22,10 @@ steps:
     name: "GoEnv"
     displayName: "Set up the Go environment"
 
+  - task: KubectlInstaller@0
+    inputs:
+      kubectlVersion: latest
+
   - task: AzureCLI@1
     inputs:
       azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
@@ -33,9 +37,6 @@ steps:
         make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
         ls -lah
         pwd
-        echo "installing kubectl"
-        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-        sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
         kubectl cluster-info
         kubectl get po -owide -A
         if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]; then FILE_PATH=-nightly && echo "Running nightly"; fi

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
@@ -30,34 +30,26 @@ steps:
       addSpnToEnvironment: true
       inlineScript: |
         set -e
-        mkdir -p ~/.kube/
-        echo "Create AKS Overlay cluster"
-        make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_OVERLAY_CLUSTER_TEST)
-        make -C ./hack/aks overlay-no-kube-proxy-up AZCLI=az REGION=$(REGION_OVERLAY_CLUSTER_TEST) SUB=$(SUB_AZURE_NETWORK_AGENT_TEST) CLUSTER=${{ parameters.clusterName }}-$(make revision) VM_SIZE=Standard_B2ms
-        echo "Cluster successfully created"
-    displayName: Create Overlay cluster
-    condition: succeeded()
-
-  - script: |
-      ls -lah
-      pwd
-      echo "installing kubectl"
-      curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-      sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-      kubectl cluster-info
-      kubectl get po -owide -A
-      if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]; then FILE_PATH=-nightly && echo "Running nightly"; fi
-      echo "deploy Cilium ConfigMap"
-      kubectl apply -f cilium/configmap.yaml
-      kubectl apply -f test/integration/manifests/cilium/cilium${FILE_PATH}-config.yaml
-      echo "install Cilium ${CILIUM_VERSION_TAG}"
-      # Passes Cilium image to daemonset and deployment
-      envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/daemonset.yaml | kubectl apply -f -
-      envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/deployment.yaml | kubectl apply -f -
-      # Use different file directories for nightly and current cilium version
-      kubectl apply -f test/integration/manifests/cilium/cilium${FILE_PATH}-agent
-      kubectl apply -f test/integration/manifests/cilium/cilium${FILE_PATH}-operator
-      kubectl get po -owide -A
+        make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
+        ls -lah
+        pwd
+        echo "installing kubectl"
+        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+        sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+        kubectl cluster-info
+        kubectl get po -owide -A
+        if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]; then FILE_PATH=-nightly && echo "Running nightly"; fi
+        echo "deploy Cilium ConfigMap"
+        kubectl apply -f cilium/configmap.yaml
+        kubectl apply -f test/integration/manifests/cilium/cilium${FILE_PATH}-config.yaml
+        echo "install Cilium ${CILIUM_VERSION_TAG}"
+        # Passes Cilium image to daemonset and deployment
+        envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/daemonset.yaml | kubectl apply -f -
+        envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/deployment.yaml | kubectl apply -f -
+        # Use different file directories for nightly and current cilium version
+        kubectl apply -f test/integration/manifests/cilium/cilium${FILE_PATH}-agent
+        kubectl apply -f test/integration/manifests/cilium/cilium${FILE_PATH}-operator
+        kubectl get po -owide -A
     name: "installCilium"
     displayName: "Install Cilium on AKS Overlay"
 
@@ -158,6 +150,14 @@ steps:
   - script: |
       echo "validate pod IP assignment and check systemd-networkd restart"
       kubectl get pod -owide -A
+      # Deleting echo-external-node deployment until cilium version matches TODO. https://github.com/cilium/cilium-cli/issues/67 is addressing the change.
+      # Saves 17 minutes
+      kubectl delete deploy -n cilium-test echo-external-node
+      if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]; then
+        echo "Check cilium identities in cilium-test namepsace during nightly run"
+        echo "expect the identities to be deleted when the namespace is deleted"
+        kubectl get ciliumidentity | grep cilium-test
+      fi
       make test-validate-state
       echo "delete cilium connectivity test resources and re-validate state"
       kubectl delete ns cilium-test
@@ -165,6 +165,33 @@ steps:
       make test-validate-state
     name: "validatePods"
     displayName: "Validate Pods"
+
+  - script: |
+      if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]; then
+        kubectl get pod -owide -n cilium-test
+        echo "wait for pod and cilium identity deletion in cilium-test namespace"
+        ns="cilium-test"
+        while true; do
+          pods=$(kubectl get pods -n $ns --no-headers=true 2>/dev/null)
+          if [[ -z "$pods" ]]; then
+            echo "No pods found"
+              break
+          fi
+          sleep 2s
+        done
+        sleep 20s
+        echo "Verify cilium identities are deleted from cilium-test"
+        checkIdentity="$(kubectl get ciliumidentity -o json | grep cilium-test | jq -e 'length == 0')"
+        if [[ -n $checkIdentity ]]; then
+          echo "##[error]Cilium Identities still present in cilium-test namespace"
+        else
+          printf -- "Identities deleted from cilium-test namespace\n"
+        fi
+      else
+        echo "skip cilium identities check for PR pipeline"
+      fi
+    name: "CiliumIdentities"
+    displayName: "Verify Cilium Identities Deletion"
 
   - script: |
       echo "validate pod IP assignment before CNS restart"
@@ -195,18 +222,3 @@ steps:
     displayName: "Cleanup artifact dir"
     condition: always()
 
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: "$(AZURE_TEST_AGENT_SERVICE_CONNECTION)"
-      scriptLocation: "inlineScript"
-      scriptType: "bash"
-      addSpnToEnvironment: true
-      inlineScript: |
-        set -e
-        echo "Deleting cluster"
-        make -C ./hack/aks azcfg AZCLI=az
-        make -C ./hack/aks down SUB=$(SUB_AZURE_NETWORK_AGENT_TEST) AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(make revision)
-        echo "Cluster and resources down"
-    name: "Cleanupcluster"
-    displayName: "Cleanup cluster"
-    condition: always()

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
@@ -56,7 +56,13 @@ steps:
 
   - script: |
       echo "install cilium CLI"
-      CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
+      if [[ ${CILIUM_VERSION_TAG} =~ ^1.1[1-3].[0-9]{1,2} ]]; then
+        echo "Cilium Agent Version ${BASH_REMATCH[0]}"
+        CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable-v0.14.txt)
+      else
+        echo "Cilium Agent Version ${CILIUM_VERSION_TAG}"
+        CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
+      fi
       CLI_ARCH=amd64
       if [ "$(uname -m)" = "aarch64" ]; then CLI_ARCH=arm64; fi
       curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-linux-${CLI_ARCH}.tar.gz{,.sha256sum}
@@ -64,6 +70,7 @@ steps:
       sudo tar xzvfC cilium-linux-${CLI_ARCH}.tar.gz /usr/local/bin
       rm cilium-linux-${CLI_ARCH}.tar.gz{,.sha256sum}
       cilium status
+      cilium version
     name: "installCiliumCLI"
     displayName: "Install Cilium CLI"
 

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
@@ -68,20 +68,6 @@ steps:
     displayName: "Install Cilium CLI"
 
   - script: |
-      echo "install kubetest2 and gsutils"
-      go get github.com/onsi/ginkgo/ginkgo
-      go get github.com/onsi/gomega/...
-      go install github.com/onsi/ginkgo/ginkgo@latest
-      go install sigs.k8s.io/kubetest2@latest
-      go install sigs.k8s.io/kubetest2/kubetest2-noop@latest
-      go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest
-      wget https://storage.googleapis.com/pub/gsutil.tar.gz
-      tar xfz gsutil.tar.gz
-      sudo mv gsutil /usr/local/bin
-    name: "installKubetest"
-    displayName: "Set up Conformance Tests"
-
-  - script: |
       echo "Start Azilium E2E Tests on Overlay Cluster"
       echo "deploy ip-masq-agent for overlay"
       kubectl create -f test/integration/manifests/ip-masq-agent/ip-masq-agent.yaml --validate=false
@@ -130,16 +116,6 @@ steps:
     retryCountOnTaskFailure: 3
     name: "CiliumStatus"
     displayName: "Cilium Status"
-
-  - script: |
-      echo "Run Service Conformance E2E"
-      export PATH=${PATH}:/usr/local/bin/gsutil
-      KUBECONFIG=~/.kube/config kubetest2 noop \
-        --test ginkgo -- \
-        --focus-regex "Services.*\[Conformance\].*" \
-        --skip-regex "should serve endpoints on same port and different protocols" # Cilium does not support this feature. For more info on test: https://github.com/kubernetes/kubernetes/blame/e602e9e03cd744c23dde9fee09396812dd7bdd93/test/conformance/testdata/conformance.yaml#L1780-L1788
-    name: "servicesConformance"
-    displayName: "Run Services Conformance Tests"
 
   - script: |
       echo "Run Cilium Connectivity Tests"

--- a/.pipelines/singletenancy/cilium/cilium-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-job-template.yaml
@@ -1,19 +1,45 @@
 parameters:
   name: ""
   displayName: ""
-  pipelineBuildImage: "$(BUILD_IMAGE)"
   testDropgz: ""
+  clusterType: ""
   clusterName: ""
+  vmSize: ""
+  k8sVersion: ""
+  dependsOn: ""
 
 stages:
+  - stage: ${{ parameters.clusterName }}
+    displayName: Create Cluster - ${{ parameters.displayName }}
+    dependsOn:
+      - ${{ parameters.dependsOn }}
+      - setup
+    pool:
+      name: $(BUILD_POOL_NAME_DEFAULT)
+    variables:
+      commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
+    jobs:
+      - template: ../../templates/create-cluster.yaml
+        parameters:
+          name: ${{ parameters.name }}
+          displayName: ${{ parameters.displayName }}
+          clusterType: ${{ parameters.clusterType }}
+          clusterName: ${{ parameters.clusterName }}-$(commitID)
+          vmSize: ${{ parameters.vmSize }}
+          k8sVersion: ${{ parameters.k8sVersion }}
+          dependsOn: ${{ parameters.dependsOn }}
+          region: $(REGION_AKS_CLUSTER_TEST)
+
   - stage: ${{ parameters.name }}
     displayName: E2E - ${{ parameters.displayName }}
-    dependsOn: 
+    dependsOn:
     - setup
     - publish
+    - ${{ parameters.clusterName }}
     variables:
       TAG: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.Tag'] ]
       CURRENT_VERSION: $[ stagedependencies.containerize.check_tag.outputs['CurrentTagManifests.currentTagManifests'] ]
+      commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
     condition: and(succeeded(), eq(variables.TAG, variables.CURRENT_VERSION))
     jobs:
       - job: ${{ parameters.name }}
@@ -21,7 +47,7 @@ stages:
         timeoutInMinutes: 120
         pool:
           name: $(BUILD_POOL_NAME_DEFAULT)
-          demands: 
+          demands:
           - agent.os -equals Linux
           - Role -equals $(CUSTOM_E2E_ROLE)
         variables:
@@ -33,4 +59,4 @@ stages:
             parameters:
               name: ${{ parameters.name }}
               testDropgz: ${{ parameters.testDropgz }}
-              clusterName: ${{ parameters.clusterName }}
+              clusterName: ${{ parameters.clusterName }}-$(commitID)

--- a/.pipelines/singletenancy/cilium/cilium-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-job-template.yaml
@@ -7,6 +7,7 @@ parameters:
   vmSize: ""
   k8sVersion: ""
   dependsOn: ""
+  os: "linux"
 
 stages:
   - stage: ${{ parameters.clusterName }}
@@ -60,3 +61,16 @@ stages:
               name: ${{ parameters.name }}
               testDropgz: ${{ parameters.testDropgz }}
               clusterName: ${{ parameters.clusterName }}-$(commitID)
+
+      - template: ../../cni/k8s-e2e/k8s-e2e-job-template.yaml
+        parameters:
+          sub: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+          clusterName: ${{ parameters.clusterName }}-$(commitID)
+          os: ${{ parameters.os }}
+          cni: cilium
+          dependsOn: ${{ parameters.name }}
+          datapath: true
+          dns: true
+          portforward: true
+          service: true
+

--- a/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
@@ -24,7 +24,7 @@ steps:
 
   - task: AzureCLI@1
     inputs:
-      azureSubscription: $(AZURE_TEST_AGENT_SERVICE_CONNECTION)
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"
       scriptType: "bash"
       addSpnToEnvironment: true

--- a/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
@@ -22,6 +22,10 @@ steps:
     name: "GoEnv"
     displayName: "Set up the Go environment"
 
+  - task: KubectlInstaller@0
+    inputs:
+      kubectlVersion: latest
+
   - task: AzureCLI@1
     inputs:
       azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
@@ -33,9 +37,6 @@ steps:
         make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
         ls -lah
         pwd
-        echo "installing kubectl"
-        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-        sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
         kubectl cluster-info
         kubectl get po -owide -A
         echo "deploy Cilium ConfigMap"

--- a/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
@@ -30,31 +30,23 @@ steps:
       addSpnToEnvironment: true
       inlineScript: |
         set -e
-        mkdir -p ~/.kube/
-        echo "Create AKS cluster"
-        make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
-        make -C ./hack/aks swift-no-kube-proxy-up AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST) SUB=$(SUB_AZURE_NETWORK_AGENT_TEST) CLUSTER=${{ parameters.clusterName }}-$(make revision) VM_SIZE=Standard_B2ms
-        echo "Cluster successfully created"
-    displayName: Create test cluster
-    condition: succeeded()
-
-  - script: |
-      ls -lah
-      pwd
-      echo "installing kubectl"
-      curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-      sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-      kubectl cluster-info
-      kubectl get po -owide -A
-      echo "deploy Cilium ConfigMap"
-      kubectl apply -f cilium/configmap.yaml
-      kubectl apply -f test/integration/manifests/cilium/cilium-config.yaml
-      echo "install Cilium ${CILIUM_VERSION_TAG}"
-      envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/daemonset.yaml | kubectl apply -f -
-      envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/deployment.yaml | kubectl apply -f -
-      kubectl apply -f test/integration/manifests/cilium/cilium-agent
-      kubectl apply -f test/integration/manifests/cilium/cilium-operator
-      kubectl get po -owide -A
+        make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
+        ls -lah
+        pwd
+        echo "installing kubectl"
+        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+        sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+        kubectl cluster-info
+        kubectl get po -owide -A
+        echo "deploy Cilium ConfigMap"
+        kubectl apply -f cilium/configmap.yaml
+        kubectl apply -f test/integration/manifests/cilium/cilium-config.yaml
+        echo "install Cilium ${CILIUM_VERSION_TAG}"
+        envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/daemonset.yaml | kubectl apply -f -
+        envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/deployment.yaml | kubectl apply -f -
+        kubectl apply -f test/integration/manifests/cilium/cilium-agent
+        kubectl apply -f test/integration/manifests/cilium/cilium-operator
+        kubectl get po -owide -A
     name: "installCilium"
     displayName: "Install Cilium"
 
@@ -143,6 +135,9 @@ steps:
   - script: |
       echo "validate pod IP assignment and check systemd-networkd restart"
       kubectl get pod -owide -A
+      # Deleting echo-external-node deployment until cilium version matches TODO. https://github.com/cilium/cilium-cli/issues/67 is addressing the change.
+      # Saves 17 minutes
+      kubectl delete deploy -n cilium-test echo-external-node
       make test-validate-state
       echo "delete cilium connectivity test resources and re-validate state"
       kubectl delete ns cilium-test
@@ -178,20 +173,4 @@ steps:
       sudo rm -rf test/integration/logs
     name: "Cleanupartifactdir"
     displayName: "Cleanup artifact dir"
-    condition: always()
-
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: "$(AZURE_TEST_AGENT_SERVICE_CONNECTION)"
-      scriptLocation: "inlineScript"
-      scriptType: "bash"
-      addSpnToEnvironment: true
-      inlineScript: |
-        set -e
-        echo "Deleting cluster"
-        make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
-        make -C ./hack/aks down AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST) SUB=$(SUB_AZURE_NETWORK_AGENT_TEST) CLUSTER=${{ parameters.clusterName }}-$(make revision)
-        echo "Cluster and resources down"
-    name: "Cleanupcluster"
-    displayName: "Cleanup cluster"
     condition: always()

--- a/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
@@ -65,20 +65,6 @@ steps:
     displayName: "Install Cilium CLI"
 
   - script: |
-      echo "install kubetest2 and gsutils"
-      go get github.com/onsi/ginkgo/ginkgo
-      go get github.com/onsi/gomega/...
-      go install github.com/onsi/ginkgo/ginkgo@latest
-      go install sigs.k8s.io/kubetest2@latest
-      go install sigs.k8s.io/kubetest2/kubetest2-noop@latest
-      go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest
-      wget https://storage.googleapis.com/pub/gsutil.tar.gz
-      tar xfz gsutil.tar.gz
-      sudo mv gsutil /usr/local/bin
-    name: "installKubetest"
-    displayName: "Set up Conformance Tests"
-
-  - script: |
       echo "Start Azilium E2E Tests"
       kubectl get po -owide -A
       sudo -E env "PATH=$PATH" make test-integration CNS_VERSION=$(make cns-version) CNI_DROPGZ_VERSION=$(make cni-dropgz-version) INSTALL_CNS=true INSTALL_AZILIUM=true TEST_DROPGZ=${{ parameters.testDropgz }}
@@ -114,16 +100,6 @@ steps:
     retryCountOnTaskFailure: 3
     name: "CiliumStatus"
     displayName: "Cilium Status"
-
-  - script: |
-      echo "Run Service Conformance E2E"
-      export PATH=${PATH}:/usr/local/bin/gsutil
-      KUBECONFIG=~/.kube/config kubetest2 noop \
-        --test ginkgo -- \
-        --focus-regex "Services.*\[Conformance\].*" \
-        --skip-regex "should serve endpoints on same port and different protocols" # Cilium does not support this feature. For more info on test: https://github.com/kubernetes/kubernetes/blame/e602e9e03cd744c23dde9fee09396812dd7bdd93/test/conformance/testdata/conformance.yaml#L1780-L1788
-    name: "servicesConformance"
-    displayName: "Run Services Conformance Tests"
 
   - script: |
       echo "Run Cilium Connectivity Tests"

--- a/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
@@ -53,7 +53,13 @@ steps:
 
   - script: |
       echo "install cilium CLI"
-      CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
+      if [[ ${CILIUM_VERSION_TAG} =~ ^1.1[1-3].[0-9]{1,2} ]]; then
+        echo "Cilium Agent Version ${BASH_REMATCH[0]}"
+        CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable-v0.14.txt)
+      else
+        echo "Cilium Agent Version ${CILIUM_VERSION_TAG}"
+        CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
+      fi
       CLI_ARCH=amd64
       if [ "$(uname -m)" = "aarch64" ]; then CLI_ARCH=arm64; fi
       curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-linux-${CLI_ARCH}.tar.gz{,.sha256sum}
@@ -61,6 +67,7 @@ steps:
       sudo tar xzvfC cilium-linux-${CLI_ARCH}.tar.gz /usr/local/bin
       rm cilium-linux-${CLI_ARCH}.tar.gz{,.sha256sum}
       cilium status
+      cilium version
     name: "installCiliumCLI"
     displayName: "Install Cilium CLI"
 

--- a/.pipelines/submodules-pipeline.yaml
+++ b/.pipelines/submodules-pipeline.yaml
@@ -57,8 +57,10 @@ stages:
           name: "$(BUILD_POOL_NAME_DEFAULT)"
         steps:
           - script: |
+              # To use the variables below, you must make the respective stage's dependsOn have - setup or it will not retain context of this stage
               BUILD_NUMBER=$(Build.BuildNumber)
               echo "##vso[task.setvariable variable=StorageID;isOutput=true]$(echo ${BUILD_NUMBER//./-})"
+              echo "##vso[task.setvariable variable=commitID;isOutput=true]$(make revision)"
               echo "##vso[task.setvariable variable=Tag;isOutput=true]$(make version)"
               echo "##vso[task.setvariable variable=cniVersion;isOutput=true]$(make cni-version)"
               echo "##vso[task.setvariable variable=npmVersion;isOutput=true]$(make npm-version)"
@@ -265,32 +267,77 @@ stages:
     parameters:
       name: "cilium_e2e"
       displayName: Cilium
-      pipelineBuildImage: "$(BUILD_IMAGE)"
       testDropgz: true
-      clusterName: "submodules-ciliume2e"
+      clusterType: cilium-podsubnet-up
+      clusterName: "submodciliume2e"
+      vmSize: Standard_B2ms
+      k8sVersion: ""
+      windowsOsSku: ""
+      dependsOn: 'containerize'
 
   - template: singletenancy/cilium-overlay/cilium-overlay-e2e-job-template.yaml
     parameters:
       name: "cilium_overlay_e2e"
       displayName: Cilium on AKS Overlay
-      pipelineBuildImage: "$(BUILD_IMAGE)"
       testDropgz: true
-      clusterName: "submodules-overlaye2e"
+      clusterType: cilium-overlay-up
+      clusterName: "submodoverlaye2e"
+      vmSize: Standard_B2ms
+      k8sVersion: ""
+      windowsOsSku: ""
+      dependsOn: 'containerize'
 
   - template: singletenancy/aks-swift/e2e-job-template.yaml
     parameters:
       name: "aks_swift_e2e"
       displayName: AKS Swift
-      pipelineBuildImage: "$(BUILD_IMAGE)"
       testDropgz: true
+      clusterType: swift-byocni-up
       clusterName: "submodswift"
-      osSku: "Ubuntu"
+      vmSize: Standard_B2ms
+      k8sVersion: ""
+      windowsOsSku: ""
+      dependsOn: 'containerize'
+
+  - stage: delete
+    displayName: Delete Clusters
+    condition: always()
+    dependsOn:
+      - setup
+      - "aks_swift_e2e"
+      - "cilium_e2e"
+      - "cilium_overlay_e2e"
+    variables:
+      commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
+    jobs:
+      - job: delete
+        displayName: Delete Cluster
+        pool:
+          name: "$(BUILD_POOL_NAME_DEFAULT)"
+        strategy:
+          matrix:
+            cilium_e2e:
+              name: cilium_e2e
+              clusterName: 'submodciliume2e'
+            cilium_overlay_e2e:
+              name: cilium_overlay_e2e
+              clusterName: 'submodoverlaye2e'
+            aks_swift_e2e:
+              name: aks_swift_e2e
+              clusterName: 'submodswift'
+        steps:
+          - template: templates/delete-cluster.yaml
+            parameters:
+              name: $(name)
+              clusterName: $(clusterName)-$(commitID)
+              region: $(REGION_AKS_CLUSTER_TEST)
 
   - stage: cleanup
     displayName: Cleanup
     dependsOn:
       - cilium_e2e
       - aks_swift_e2e
+      - cilium_overlay_e2e
     jobs:
       - job: delete_remote_artifacts
         displayName: Delete remote artifacts

--- a/.pipelines/templates/create-cluster.yaml
+++ b/.pipelines/templates/create-cluster.yaml
@@ -1,0 +1,36 @@
+parameters:
+  name: ""
+  displayName: ""
+  clusterType: ""
+  clusterName: "" # Recommended to pass in unique identifier
+  vmSize: ""
+  k8sVersion: ""
+  windowsOsSku: "Windows2022" # Currently we only support Windows2022
+  dependsOn: ""
+  region: ""
+
+jobs:
+  - job: ${{ parameters.name }}
+    displayName: Cluster - ${{ parameters.name }}
+    steps:
+      - task: AzureCLI@1
+        inputs:
+          azureSubscription: $(AZURE_TEST_AGENT_SERVICE_CONNECTION)
+          scriptLocation: "inlineScript"
+          scriptType: "bash"
+          addSpnToEnvironment: true
+          inlineScript: |
+            set -e
+            echo "Check az version"
+            az version
+            if ${{ lower(contains(parameters.clusterType, 'dualstack')) }}
+            then
+              echo "Install az cli extension preview"
+              az extension add --name aks-preview
+              az extension update --name aks-preview
+            fi
+            mkdir -p ~/.kube/
+            make -C ./hack/aks azcfg AZCLI=az REGION=${{ parameters.region }}
+            make -C ./hack/aks ${{ parameters.clusterType }} AZCLI=az REGION=${{ parameters.region }} SUB=$(SUB_AZURE_NETWORK_AGENT_TEST) CLUSTER=${{ parameters.clusterName }} K8S_VER=${{ parameters.k8sVersion }} VM_SIZE=${{ parameters.vmSize }} WINDOWS_OS_SKU=${{ parameters.windowsOsSku }} WINDOWS_VM_SKU=${{ parameters.vmSize }} WINDOWS_USERNAME=${WINDOWS_USERNAME} WINDOWS_PASSWORD=${WINDOWS_PASSWORD}
+            echo "Cluster successfully created"
+        displayName: Cluster - ${{ parameters.clusterType }}

--- a/.pipelines/templates/create-cluster.yaml
+++ b/.pipelines/templates/create-cluster.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - task: AzureCLI@1
         inputs:
-          azureSubscription: $(AZURE_TEST_AGENT_SERVICE_CONNECTION)
+          azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
           scriptLocation: "inlineScript"
           scriptType: "bash"
           addSpnToEnvironment: true
@@ -31,6 +31,6 @@ jobs:
             fi
             mkdir -p ~/.kube/
             make -C ./hack/aks azcfg AZCLI=az REGION=${{ parameters.region }}
-            make -C ./hack/aks ${{ parameters.clusterType }} AZCLI=az REGION=${{ parameters.region }} SUB=$(SUB_AZURE_NETWORK_AGENT_TEST) CLUSTER=${{ parameters.clusterName }} K8S_VER=${{ parameters.k8sVersion }} VM_SIZE=${{ parameters.vmSize }} WINDOWS_OS_SKU=${{ parameters.windowsOsSku }} WINDOWS_VM_SKU=${{ parameters.vmSize }} WINDOWS_USERNAME=${WINDOWS_USERNAME} WINDOWS_PASSWORD=${WINDOWS_PASSWORD}
+            make -C ./hack/aks ${{ parameters.clusterType }} AZCLI=az REGION=${{ parameters.region }} SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }} K8S_VER=${{ parameters.k8sVersion }} VM_SIZE=${{ parameters.vmSize }} WINDOWS_OS_SKU=${{ parameters.windowsOsSku }} WINDOWS_VM_SKU=${{ parameters.vmSize }} WINDOWS_USERNAME=${WINDOWS_USERNAME} WINDOWS_PASSWORD=${WINDOWS_PASSWORD}
             echo "Cluster successfully created"
         displayName: Cluster - ${{ parameters.clusterType }}

--- a/.pipelines/templates/delete-cluster.yaml
+++ b/.pipelines/templates/delete-cluster.yaml
@@ -1,0 +1,20 @@
+parameters:
+  name: ""
+  clusterName: ""
+  region: ""
+
+steps:
+  - task: AzureCLI@1
+    inputs:
+      azureSubscription: $(AZURE_TEST_AGENT_SERVICE_CONNECTION)
+      scriptLocation: "inlineScript"
+      scriptType: "bash"
+      addSpnToEnvironment: true
+      inlineScript: |
+        echo "Deleting cluster"
+        make -C ./hack/aks azcfg AZCLI=az REGION=${{ parameters.region }}
+        make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
+        make -C ./hack/aks down AZCLI=az REGION=${{ parameters.region }} SUB=$(SUB_AZURE_NETWORK_AGENT_TEST) CLUSTER=${{ parameters.clusterName }}
+        echo "Cluster and resources down"
+    name: delete
+    displayName: Delete - ${{ parameters.name }}

--- a/.pipelines/templates/delete-cluster.yaml
+++ b/.pipelines/templates/delete-cluster.yaml
@@ -6,7 +6,7 @@ parameters:
 steps:
   - task: AzureCLI@1
     inputs:
-      azureSubscription: $(AZURE_TEST_AGENT_SERVICE_CONNECTION)
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"
       scriptType: "bash"
       addSpnToEnvironment: true
@@ -14,7 +14,7 @@ steps:
         echo "Deleting cluster"
         make -C ./hack/aks azcfg AZCLI=az REGION=${{ parameters.region }}
         make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
-        make -C ./hack/aks down AZCLI=az REGION=${{ parameters.region }} SUB=$(SUB_AZURE_NETWORK_AGENT_TEST) CLUSTER=${{ parameters.clusterName }}
+        make -C ./hack/aks down AZCLI=az REGION=${{ parameters.region }} SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }}
         echo "Cluster and resources down"
     name: delete
     displayName: Delete - ${{ parameters.name }}

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -99,21 +99,7 @@ overlay-byocni-up: rg-up overlay-net-up ## Brings up an Overlay BYO CNI cluster
 		--yes
 	@$(MAKE) set-kubeconf
 
-overlay-no-kube-proxy-up: rg-up overlay-net-up ## Brings up an Overlay BYO CNI cluster without kube-proxy for Cilium
-	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
-		--node-count $(NODE_COUNT) \
-		--node-vm-size $(VM_SIZE) \
-		--load-balancer-sku basic \
-		--network-plugin none \
-		--network-plugin-mode overlay \
-		--pod-cidr 192.168.0.0/16 \
-		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
-		--no-ssh-key \
-		--kube-proxy-config ./kube-proxy.json \
-		--yes
-	@$(MAKE) set-kubeconf
-
-overlay-cilium-up: rg-up overlay-net-up ## Brings up an Overlay AzCNI cluster
+overlay-cilium-up: rg-up overlay-net-up ## Brings up an Overlay Cilium cluster
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
 		--node-count $(NODE_COUNT) \
 		--node-vm-size $(VM_SIZE) \
@@ -153,19 +139,6 @@ swift-byocni-up: rg-up swift-net-up ## Bring up a SWIFT BYO CNI cluster
 		--yes
 	@$(MAKE) set-kubeconf
 
-swift-no-kube-proxy-up: rg-up swift-net-up ## Bring up a SWIFT BYO CNI cluster without kube-proxy for Cilium
-	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
-		--node-count $(NODE_COUNT) \
-		--node-vm-size $(VM_SIZE) \
-		--load-balancer-sku basic \
-		--network-plugin none \
-		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
-		--pod-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/podnet \
-		--no-ssh-key \
-		--os-sku $(OS_SKU) \
-		--kube-proxy-config ./kube-proxy.json \
-		--yes
-	@$(MAKE) set-kubeconf
 
 swift-cilium-up: rg-up swift-net-up ## Bring up a SWIFT Cilium cluster
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
@@ -190,6 +163,34 @@ swift-up: rg-up swift-net-up ## Bring up a SWIFT AzCNI cluster
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
 		--pod-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/podnet \
 		--no-ssh-key \
+		--yes
+	@$(MAKE) set-kubeconf
+
+cilium-overlay-up: rg-up overlay-net-up ## Brings up an Overlay BYO CNI cluster without kube-proxy for Cilium
+	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
+		--node-count $(NODE_COUNT) \
+		--node-vm-size $(VM_SIZE) \
+		--load-balancer-sku basic \
+		--network-plugin none \
+		--network-plugin-mode overlay \
+		--pod-cidr 192.168.0.0/16 \
+		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
+		--no-ssh-key \
+		--kube-proxy-config ./kube-proxy.json \
+		--yes
+	@$(MAKE) set-kubeconf
+
+cilium-podsubnet-up: rg-up swift-net-up ## Bring up a SWIFT BYO CNI cluster without kube-proxy for Cilium
+	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
+		--node-count $(NODE_COUNT) \
+		--node-vm-size $(VM_SIZE) \
+		--load-balancer-sku basic \
+		--network-plugin none \
+		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
+		--pod-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/podnet \
+		--no-ssh-key \
+		--os-sku $(OS_SKU) \
+		--kube-proxy-config ./kube-proxy.json \
 		--yes
 	@$(MAKE) set-kubeconf
 

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -13,7 +13,7 @@ OS_SKU          ?= Ubuntu
 WINDOWS_OS_SKU  ?= Windows2022
 VM_SIZE	        ?= Standard_B2s
 NODE_COUNT      ?= 2
-K8S_VER         ?= 1.25 # Used only for ubuntu 18 as K8S 1.24.9, as K8S > 1.25 have Ubuntu 22
+K8S_VER         ?= 1.27 # Designated for Long Term Support, July 2025 | Only Ubuntu 22.04 is supported
 WINDOWS_VM_SKU  ?= Standard_B2s
 
 # overrideable variables
@@ -222,7 +222,6 @@ linux-cniv1-up: rg-up overlay-net-up
 		--max-pods 250 \
 		--network-plugin azure \
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
-		--kubernetes-version $(K8S_VER) \
 		--os-sku $(OS_SKU) \
 		--no-ssh-key \
 		--yes

--- a/hack/aks/README.md
+++ b/hack/aks/README.md
@@ -21,14 +21,20 @@ SWIFT Infra
   net-up           Create required swift vnet/subnets
 
 AKS Clusters
-  byocni-up        Alias to swift-byocni-up
-  cilium-up        Alias to swift-cilium-up
-  up               Alias to swift-up
-  overlay-up       Brings up an Overlay AzCNI cluster
-  swift-byocni-up  Bring up a SWIFT BYO CNI cluster
-  swift-cilium-up  Bring up a SWIFT Cilium cluster
-  swift-up         Bring up a SWIFT AzCNI cluster
-  windows-cniv1-up Bring up a Windows AzCNIv1 cluster
-  down             Delete the cluster
-  vmss-restart     Restart the nodes of the cluster
+  byocni-up                    Alias to swift-byocni-up
+  cilium-up                    Alias to swift-cilium-up
+  up                           Alias to swift-up
+  overlay-byocni-up            Bring up a Overlay BYO CNI cluster
+  overlay-cilium-up            Bring up a Overlay Cilium cluster
+  overlay-up                   Bring up a Overlay AzCNI cluster
+  swift-byocni-up              Bring up a SWIFT BYO CNI cluster
+  swift-cilium-up              Bring up a SWIFT Cilium cluster
+  swift-up                     Bring up a SWIFT AzCNI cluster
+  cilium-overlay-up            Bring up a Overlay BYO CNI cluster without kube-proxy for Cilium
+  cilium-podsubnet-up          Bring up a SWIFT BYO CNI cluster without kube-proxy for Cilium
+  windows-cniv1-up             Bring up a Windows AzCNIv1 cluster
+  linux-cniv1-up               Bring up a Linux AzCNIv1 cluster
+  dualstack-overlay-byocni-up  Bring up an dualstack overlay cluster without CNS and CNI installed
+  down                         Delete the cluster
+  vmss-restart                 Restart the nodes of the cluster
 ```

--- a/test/internal/k8sutils/utils.go
+++ b/test/internal/k8sutils/utils.go
@@ -35,8 +35,8 @@ const (
 	SubnetNameLabel        = "kubernetes.azure.com/podnetwork-subnet"
 
 	// RetryAttempts is the number of times to retry a test.
-	RetryAttempts = 30
-	RetryDelay    = 30 * time.Second
+	RetryAttempts = 90
+	RetryDelay    = 10 * time.Second
 )
 
 var Kubeconfig = flag.String("test-kubeconfig", filepath.Join(homedir.HomeDir(), ".kube", "config"), "(optional) absolute path to the kubeconfig file")


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

These CI changes impact all uses of AZP. Needed to be backported to ensure that v1.4 runs are smooth.

Update include:
- Removal of kubetest2 in favor of purely ginkgo
- Moving from ACN Test Sub to Build Validation 
- Using Kubectl installer task instead of manually installing

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
