### PR TITLE
ci: Add safeguards to prevent race condition resulting from MustRestartDaemonset()

### DIFF
--- a/test/internal/kubernetes/utils.go
+++ b/test/internal/kubernetes/utils.go
@@ -468,6 +468,7 @@ func MustRestartDaemonset(ctx context.Context, clientset *kubernetes.Clientset, 
 		ds.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
 	}
 
+	// gen represents the generation before triggering a restart
 	gen := ds.Status.ObservedGeneration
 	log.Printf("Current generation is %v", gen)
 	ds.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)

--- a/test/internal/kubernetes/utils.go
+++ b/test/internal/kubernetes/utils.go
@@ -38,6 +38,8 @@ const (
 	RetryDelay              = 10 * time.Second
 	DeleteRetryAttempts     = 12
 	DeleteRetryDelay        = 5 * time.Second
+	ShortRetryAttempts      = 8
+	ShortRetryDelay         = 250 * time.Millisecond
 	PrivilegedDaemonSetPath = "../manifests/load/privileged-daemonset-windows.yaml"
 	PrivilegedLabelSelector = "app=privileged-daemonset"
 	PrivilegedNamespace     = "kube-system"
@@ -495,7 +497,7 @@ func MustRestartDaemonset(ctx context.Context, clientset *kubernetes.Clientset, 
 		log.Printf("daemonset %s has updated generation", daemonsetName)
 		return nil
 	}
-	retrier := retry.Retrier{Attempts: 8, Delay: 250 * time.Millisecond}
+	retrier := retry.Retrier{Attempts: ShortRetryAttempts, Delay: ShortRetryDelay}
 	return errors.Wrapf(retrier.Do(ctx, checkDaemonsetGenerationFn), "could not wait for ds %s generation update", daemonsetName)
 }
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

`MustRestartDaemonset()` did not have safeguards to ensure that `WaitForPodDaemonset()` could capture a restart. This was due to the fact that we need not ensure that a restart had actually occurred within `MustRestartDaemonset()` just that the k8sAPI request was sent and received without errors. The safeguard that was introduced is a short lived check for generation update. This is normally the following response after 200-ing the update request. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
