### PR TITLE
fix: remove pool monitor from debug api response

### DIFF
--- a/cns/cmd/cli/cli.go
+++ b/cns/cmd/cli/cli.go
@@ -95,7 +95,7 @@ func getInMemory(ctx context.Context, client *client.Client) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("PodIPIDByOrchestratorContext: %v\nPodIPConfigState: %v\nIPAMPoolMonitor: %v\n",
-		data.HTTPRestServiceData.PodIPIDByPodInterfaceKey, data.HTTPRestServiceData.PodIPConfigState, data.HTTPRestServiceData.IPAMPoolMonitor)
+	fmt.Printf("PodIPIDByOrchestratorContext: %v\nPodIPConfigState: %v\n",
+		data.HTTPRestServiceData.PodIPIDByPodInterfaceKey, data.HTTPRestServiceData.PodIPConfigState)
 	return nil
 }

--- a/cns/restserver/api_test.go
+++ b/cns/restserver/api_test.go
@@ -1686,7 +1686,6 @@ func startService() error {
 	svc = service.(*HTTPRestService)
 	svc.Name = "cns-test-server"
 
-	svc.IPAMPoolMonitor = &fakes.MonitorFake{}
 	nmagentClient.GetNCVersionListF = func(context.Context) (nmagent.NCVersionList, error) {
 		var hostVersionNeedsUpdateContainers []string
 		for idx := range svc.state.ContainerStatus {

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -835,18 +835,6 @@ func createAndValidateNCRequest(t *testing.T, secondaryIPConfigs map[string]cns.
 	if returnCode != 0 {
 		t.Fatalf("Failed to createNetworkContainerRequest, req: %+v, err: %d", req, returnCode)
 	}
-	_ = svc.IPAMPoolMonitor.Update(&v1alpha.NodeNetworkConfig{
-		Status: v1alpha.NodeNetworkConfigStatus{
-			Scaler: v1alpha.Scaler{
-				BatchSize:               batchSize,
-				ReleaseThresholdPercent: releasePercent,
-				RequestThresholdPercent: requestPercent,
-			},
-		},
-		Spec: v1alpha.NodeNetworkConfigSpec{
-			RequestedIPCount: initPoolSize,
-		},
-	})
 	validateNetworkRequest(t, *req)
 }
 
@@ -1061,18 +1049,6 @@ func createNCReqInternal(t *testing.T, secondaryIPConfigs map[string]cns.Seconda
 	if returnCode != 0 {
 		t.Fatalf("Failed to createNetworkContainerRequest, req: %+v, err: %d", req, returnCode)
 	}
-	_ = svc.IPAMPoolMonitor.Update(&v1alpha.NodeNetworkConfig{
-		Status: v1alpha.NodeNetworkConfigStatus{
-			Scaler: v1alpha.Scaler{
-				BatchSize:               batchSize,
-				ReleaseThresholdPercent: releasePercent,
-				RequestThresholdPercent: requestPercent,
-			},
-		},
-		Spec: v1alpha.NodeNetworkConfigSpec{
-			RequestedIPCount: initPoolSize,
-		},
-	})
 	return *req
 }
 

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -573,15 +573,10 @@ func (service *HTTPRestService) handleDebugPodContext(w http.ResponseWriter, r *
 func (service *HTTPRestService) handleDebugRestData(w http.ResponseWriter, r *http.Request) {
 	service.RLock()
 	defer service.RUnlock()
-	if service.IPAMPoolMonitor == nil {
-		http.Error(w, "not ready", http.StatusServiceUnavailable)
-		return
-	}
 	resp := GetHTTPServiceDataResponse{
 		HTTPRestServiceData: HTTPRestServiceData{
 			PodIPIDByPodInterfaceKey: service.PodIPIDByPodInterfaceKey,
 			PodIPConfigState:         service.PodIPConfigState,
-			IPAMPoolMonitor:          service.IPAMPoolMonitor.GetStateSnapshot(),
 		},
 	}
 	err := service.Listener.Encode(w, &resp)

--- a/cns/restserver/ipam_test.go
+++ b/cns/restserver/ipam_test.go
@@ -1,6 +1,3 @@
-// Copyright 2020 Microsoft. All rights reserved.
-// MIT License
-
 package restserver
 
 import (
@@ -18,7 +15,6 @@ import (
 	"github.com/Azure/azure-container-networking/cns/middlewares"
 	"github.com/Azure/azure-container-networking/cns/middlewares/mock"
 	"github.com/Azure/azure-container-networking/cns/types"
-	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	"github.com/Azure/azure-container-networking/store"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -69,7 +65,6 @@ func getTestService() *HTTPRestService {
 	var config common.ServiceConfig
 	httpsvc, _ := NewHTTPRestService(&config, &fakes.WireserverClientFake{}, &fakes.WireserverProxyFake{}, &fakes.NMAgentClientFake{}, store.NewMockStore(""), nil, nil)
 	svc = httpsvc
-	httpsvc.IPAMPoolMonitor = &fakes.MonitorFake{}
 	setOrchestratorTypeInternal(cns.KubernetesCRD)
 
 	return httpsvc
@@ -1192,20 +1187,6 @@ func TestIPAMMarkIPAsPendingWithPendingProgrammingIPs(t *testing.T) {
 	if returnCode != 0 {
 		t.Fatalf("Failed to createNetworkContainerRequest, req: %+v, err: %d", req, returnCode)
 	}
-	svc.IPAMPoolMonitor.Update(
-		&v1alpha.NodeNetworkConfig{
-			Status: v1alpha.NodeNetworkConfigStatus{
-				Scaler: v1alpha.Scaler{
-					BatchSize:               batchSize,
-					ReleaseThresholdPercent: releasePercent,
-					RequestThresholdPercent: requestPercent,
-				},
-			},
-			Spec: v1alpha.NodeNetworkConfigSpec{
-				RequestedIPCount: initPoolSize,
-			},
-		},
-	)
 	// Release pending programming IPs
 	ips, err := svc.MarkIPAsPendingRelease(2)
 	if err != nil {

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -61,7 +61,6 @@ type HTTPRestService struct {
 	networkContainer         *networkcontainers.NetworkContainers
 	PodIPIDByPodInterfaceKey map[string][]string                  // PodInterfaceId is key and value is slice of Pod IP (SecondaryIP) uuids.
 	PodIPConfigState         map[string]cns.IPConfigurationStatus // Secondary IP ID(uuid) is key
-	IPAMPoolMonitor          cns.IPAMPoolMonitor
 	routingTable             *routes.RoutingTable
 	store                    store.KeyValueStore
 	state                    *httpRestServiceState
@@ -113,7 +112,6 @@ type GetHTTPServiceDataResponse struct {
 type HTTPRestServiceData struct { //nolint:musttag // not tagging struct for revert-PR
 	PodIPIDByPodInterfaceKey map[string][]string                  // PodInterfaceId is key and value is slice of Pod IP uuids.
 	PodIPConfigState         map[string]cns.IPConfigurationStatus // secondaryipid(uuid) is key
-	IPAMPoolMonitor          cns.IpamPoolMonitorStateSnapshot
 }
 
 type Response struct {


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Removes the IPAM Pool Monitor reference from the HTTPRestService, debug API, and tests. 
It is not a functional requirement and does not get initialized anymore since https://github.com/Azure/azure-container-networking/pull/2422.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
