### PR TITLE
chore: switch to true enable exact pod name match

### DIFF
--- a/cni/azure-linux-multitenancy-transparent-vlan.conflist
+++ b/cni/azure-linux-multitenancy-transparent-vlan.conflist
@@ -9,7 +9,7 @@
          "multiTenancy":true,
          "infraVnetAddressSpace":"",
          "podNamespaceForDualNetwork":[],
-         "enableExactMatchForPodName": false,
+         "enableExactMatchForPodName": true,
          "enableSnatOnHost":true,
          "ipam":{
             "type":"azure-cns"

--- a/cni/azure-linux-multitenancy.conflist
+++ b/cni/azure-linux-multitenancy.conflist
@@ -9,7 +9,7 @@
          "multiTenancy":true,
          "infraVnetAddressSpace":"",
          "podNamespaceForDualNetwork":[],
-         "enableExactMatchForPodName": false,
+         "enableExactMatchForPodName": true,
          "enableSnatOnHost":true,
          "ipam":{
             "type":"azure-cns"


### PR DESCRIPTION
A while back, this `enableExactPodNameMatch` was made for ACI when they first onboarded to SWIFT
ACI no longer uses kubernetes, so this is not relevant anymore
