### PR TITLE
fix: Fixing Vnet Scale For Cillium to set IMDS NAT using HostPrimaryIP during Cluster Creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ endif
 # Interrogate the git repo and set some variables
 REPO_ROOT				 = $(shell git rev-parse --show-toplevel)
 REVISION				?= $(shell git rev-parse --short HEAD)
-ACN_VERSION				?= $(shell git describe --exclude "azure-ipam*" --exclude "dropgz*" --exclude "zapai*" --tags --always)-asn
+ACN_VERSION				?= $(shell git describe --exclude "azure-ipam*" --exclude "dropgz*" --exclude "zapai*" --tags --always)
 AZURE_IPAM_VERSION		?= $(notdir $(shell git describe --match "azure-ipam*" --tags --always))
 CNI_VERSION				?= $(ACN_VERSION)
 CNI_DROPGZ_VERSION		?= $(notdir $(shell git describe --match "dropgz*" --tags --always))

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ endif
 # Interrogate the git repo and set some variables
 REPO_ROOT				 = $(shell git rev-parse --show-toplevel)
 REVISION				?= $(shell git rev-parse --short HEAD)
-ACN_VERSION				?= $(shell git describe --exclude "azure-ipam*" --exclude "dropgz*" --exclude "zapai*" --tags --always)
+ACN_VERSION				?= $(shell git describe --exclude "azure-ipam*" --exclude "dropgz*" --exclude "zapai*" --tags --always)-asn
 AZURE_IPAM_VERSION		?= $(notdir $(shell git describe --match "azure-ipam*" --tags --always))
 CNI_VERSION				?= $(ACN_VERSION)
 CNI_DROPGZ_VERSION		?= $(notdir $(shell git describe --match "dropgz*" --tags --always))

--- a/cns/kubecontroller/nodenetworkconfig/conversion.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion.go
@@ -93,8 +93,8 @@ func CreateNCRequestFromStaticNC(nc v1alpha.NetworkContainer) (*cns.CreateNetwor
 	}
 
 	if nc.Type == v1alpha.VNETBlock {
-		nodeIP, err := netip.ParsePrefix(nc.NodeIP)
-		if err != nil {
+		nodeIP, nerr := netip.ParsePrefix(nc.NodeIP)
+		if nerr != nil {
 			return nil, errors.Wrapf(err, "IP: %s", nc.NodeIP)
 		}
 		subnet.IPAddress = nodeIP.Addr().String()

--- a/cns/kubecontroller/nodenetworkconfig/conversion.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion.go
@@ -92,6 +92,15 @@ func CreateNCRequestFromStaticNC(nc v1alpha.NetworkContainer) (*cns.CreateNetwor
 		PrefixLength: uint8(subnetPrefix.Bits()),
 	}
 
+	if nc.Type == v1alpha.VNETBlock {
+		nodeIP, err := netip.ParsePrefix(nc.NodeIP)
+		if err != nil {
+			return nil, errors.Wrapf(err, "IP: %s", nc.NodeIP)
+		}
+		subnet.IPAddress = nodeIP.Addr().String()
+		subnet.PrefixLength = uint8(nodeIP.Bits())
+	}
+
 	req, err := createNCRequestFromStaticNCHelper(nc, primaryPrefix, subnet)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error while creating NC request from static NC")

--- a/cns/kubecontroller/nodenetworkconfig/conversion.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion.go
@@ -92,15 +92,6 @@ func CreateNCRequestFromStaticNC(nc v1alpha.NetworkContainer) (*cns.CreateNetwor
 		PrefixLength: uint8(subnetPrefix.Bits()),
 	}
 
-	// if nc.Type == v1alpha.VNETBlock {
-	// 	nodeIP, nerr := netip.ParsePrefix(nc.NodeIP)
-	// 	if nerr != nil {
-	// 		return nil, errors.Wrapf(err, "IP: %s", nc.NodeIP)
-	// 	}
-	// 	subnet.IPAddress = nodeIP.Addr().String()
-	// 	subnet.PrefixLength = uint8(nodeIP.Bits())
-	// }
-
 	req, err := createNCRequestFromStaticNCHelper(nc, primaryPrefix, subnet)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error while creating NC request from static NC")

--- a/cns/kubecontroller/nodenetworkconfig/conversion.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion.go
@@ -92,18 +92,23 @@ func CreateNCRequestFromStaticNC(nc v1alpha.NetworkContainer) (*cns.CreateNetwor
 		PrefixLength: uint8(subnetPrefix.Bits()),
 	}
 
-	if nc.Type == v1alpha.VNETBlock {
-		nodeIP, nerr := netip.ParsePrefix(nc.NodeIP)
-		if nerr != nil {
-			return nil, errors.Wrapf(err, "IP: %s", nc.NodeIP)
-		}
-		subnet.IPAddress = nodeIP.Addr().String()
-		subnet.PrefixLength = uint8(nodeIP.Bits())
-	}
+	// if nc.Type == v1alpha.VNETBlock {
+	// 	nodeIP, nerr := netip.ParsePrefix(nc.NodeIP)
+	// 	if nerr != nil {
+	// 		return nil, errors.Wrapf(err, "IP: %s", nc.NodeIP)
+	// 	}
+	// 	subnet.IPAddress = nodeIP.Addr().String()
+	// 	subnet.PrefixLength = uint8(nodeIP.Bits())
+	// }
 
 	req, err := createNCRequestFromStaticNCHelper(nc, primaryPrefix, subnet)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error while creating NC request from static NC")
 	}
+
+	if nc.Type == v1alpha.VNETBlock {
+		req.HostPrimaryIP = nc.NodeIP
+	}
+
 	return req, err
 }

--- a/cns/kubecontroller/nodenetworkconfig/conversion_linux_test.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_linux_test.go
@@ -37,7 +37,8 @@ var validOverlayRequest = &cns.CreateNetworkContainerRequest{
 }
 
 var validVNETBlockRequest = &cns.CreateNetworkContainerRequest{
-	Version: strconv.FormatInt(version, 10),
+	Version:       strconv.FormatInt(version, 10),
+	HostPrimaryIP: vnetBlockNodeIP,
 	IPConfiguration: cns.IPConfiguration{
 		GatewayIPAddress: vnetBlockDefaultGateway,
 		IPSubnet: cns.IPSubnet{


### PR DESCRIPTION
fix: Fixing Vnet Scale For Cillium to set IMDS NAT using HostPrimaryIP during Cluster Creation

**Reason for Change**:
fix: Fixing Vnet Scale For Cillium to set IMDS NAT using HostPrimaryIP during Cluster Creation


**Issue Fixed**:
https://dev.azure.com/msazure/One/_workitems/edit/27315294



**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [X] includes documentation
- [X] adds unit tests
- [X] relevant PR labels added

**Notes**:
