### PR TITLE
fix: Using Node IP as the primary IP allowing the use of all the IPs in the subnet for pods in Vnet Scale Mode and added the fix for Vnet Scale Cillium

### DIFF
--- a/cns/kubecontroller/nodenetworkconfig/conversion.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion.go
@@ -88,13 +88,13 @@ func CreateNCRequestFromStaticNC(nc v1alpha.NetworkContainer) (*cns.CreateNetwor
 		return nil, errors.Wrapf(err, "invalid SubnetAddressSpace %s", nc.SubnetAddressSpace)
 	}
 
-	var subnet cns.IPSubnet
+	subnet := cns.IPSubnet{
+		PrefixLength: uint8(subnetPrefix.Bits()),
+	}
 	if nc.Type == v1alpha.VNETBlock {
 		subnet.IPAddress = nc.NodeIP
-		subnet.PrefixLength = uint8(subnetPrefix.Bits())
 	} else {
 		subnet.IPAddress = primaryPrefix.Addr().String()
-		subnet.PrefixLength = uint8(subnetPrefix.Bits())
 	}
 
 	req, err := createNCRequestFromStaticNCHelper(nc, primaryPrefix, subnet)

--- a/cns/kubecontroller/nodenetworkconfig/conversion.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion.go
@@ -102,8 +102,5 @@ func CreateNCRequestFromStaticNC(nc v1alpha.NetworkContainer) (*cns.CreateNetwor
 		return nil, errors.Wrapf(err, "error while creating NC request from static NC")
 	}
 
-	if nc.Type == v1alpha.VNETBlock {
-		req.HostPrimaryIP = nc.NodeIP
-	}
 	return req, err
 }

--- a/cns/kubecontroller/nodenetworkconfig/conversion.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion.go
@@ -87,14 +87,23 @@ func CreateNCRequestFromStaticNC(nc v1alpha.NetworkContainer) (*cns.CreateNetwor
 	if err != nil {
 		return nil, errors.Wrapf(err, "invalid SubnetAddressSpace %s", nc.SubnetAddressSpace)
 	}
-	subnet := cns.IPSubnet{
-		IPAddress:    primaryPrefix.Addr().String(),
-		PrefixLength: uint8(subnetPrefix.Bits()),
+
+	var subnet cns.IPSubnet
+	if nc.Type == v1alpha.VNETBlock {
+		subnet.IPAddress = nc.NodeIP
+		subnet.PrefixLength = uint8(subnetPrefix.Bits())
+	} else {
+		subnet.IPAddress = primaryPrefix.Addr().String()
+		subnet.PrefixLength = uint8(subnetPrefix.Bits())
 	}
 
 	req, err := createNCRequestFromStaticNCHelper(nc, primaryPrefix, subnet)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error while creating NC request from static NC")
+	}
+
+	if nc.Type == v1alpha.VNETBlock {
+		req.HostPrimaryIP = nc.NodeIP
 	}
 	return req, err
 }

--- a/cns/kubecontroller/nodenetworkconfig/conversion_linux.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_linux.go
@@ -46,6 +46,7 @@ func createNCRequestFromStaticNCHelper(nc v1alpha.NetworkContainer, primaryIPPre
 	}
 
 	return &cns.CreateNetworkContainerRequest{
+		HostPrimaryIP:        nc.NodeIP,
 		SecondaryIPConfigs:   secondaryIPConfigs,
 		NetworkContainerid:   nc.ID,
 		NetworkContainerType: cns.Docker,

--- a/cns/kubecontroller/nodenetworkconfig/conversion_linux.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_linux.go
@@ -27,8 +27,6 @@ func createNCRequestFromStaticNCHelper(nc v1alpha.NetworkContainer, primaryIPPre
 
 	// Add IPs from CIDR block to the secondary IPConfigs
 	if nc.Type == v1alpha.VNETBlock {
-		// Delete primary IP reserved for Primary IP for NC
-		delete(secondaryIPConfigs, primaryIPPrefix.Addr().String())
 
 		for _, ipAssignment := range nc.IPAssignments {
 			cidrPrefix, err := netip.ParsePrefix(ipAssignment.IP)

--- a/cns/kubecontroller/nodenetworkconfig/conversion_linux_test.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_linux_test.go
@@ -7,7 +7,8 @@ import (
 )
 
 var validOverlayRequest = &cns.CreateNetworkContainerRequest{
-	Version: strconv.FormatInt(0, 10),
+	HostPrimaryIP: validOverlayNC.NodeIP,
+	Version:       strconv.FormatInt(0, 10),
 	IPConfiguration: cns.IPConfiguration{
 		IPSubnet: cns.IPSubnet{
 			PrefixLength: uint8(subnetPrefixLen),

--- a/cns/kubecontroller/nodenetworkconfig/conversion_linux_test.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_linux_test.go
@@ -37,18 +37,23 @@ var validOverlayRequest = &cns.CreateNetworkContainerRequest{
 }
 
 var validVNETBlockRequest = &cns.CreateNetworkContainerRequest{
-	Version: strconv.FormatInt(version, 10),
+	Version:       strconv.FormatInt(version, 10),
+	HostPrimaryIP: vnetBlockNodeIP,
 	IPConfiguration: cns.IPConfiguration{
 		GatewayIPAddress: vnetBlockDefaultGateway,
 		IPSubnet: cns.IPSubnet{
 			PrefixLength: uint8(vnetBlockSubnetPrefixLen),
-			IPAddress:    vnetBlockPrimaryIP,
+			IPAddress:    vnetBlockNodeIP,
 		},
 	},
 	NetworkContainerid:   ncID,
 	NetworkContainerType: cns.Docker,
 	// Ignore first IP in first CIDR Block, i.e. 10.224.0.4
 	SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+		"10.224.0.4": {
+			IPAddress: "10.224.0.4",
+			NCVersion: version,
+		},
 		"10.224.0.5": {
 			IPAddress: "10.224.0.5",
 			NCVersion: version,


### PR DESCRIPTION
**Reason for Change**:
fix: Using Node IP as the primary IP allowing the use of all the IPs in the subnet for pods in Vnet Scale Mode


**Issue Fixed**:
https://dev.azure.com/msazure/One/_workitems/edit/25432148



**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [X] includes documentation
- [X] adds unit tests
- [X] relevant PR labels added

**Notes**:
