### PR TITLE
fix: move CNS to distroless-iptables base image

### DIFF
--- a/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
+++ b/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
@@ -205,7 +205,7 @@ stages:
               cd hack/scripts
               chmod +x async-delete-test.sh
               ./async-delete-test.sh
-              if ! [ -z $(kubectl -n kube-system get ds  azure-cns | grep non-existing) ]; then
+              if ! [ -z $(kubectl -n kube-system get ds azure-cns | grep non-existing) ]; then
                 kubectl -n kube-system patch daemonset azure-cns --type json -p='[{"op": "remove", "path": "/spec/template/spec/nodeSelector/non-existing"}]'
               fi
             name: "testAsyncDelete"

--- a/cns/linux.Dockerfile
+++ b/cns/linux.Dockerfile
@@ -1,4 +1,13 @@
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.21 AS builder
+# mcr.microsoft.com/oss/go/microsoft/golang:1.22.3-1-cbl-mariner2.0
+FROM mcr.microsoft.com/oss/go/microsoft/golang@sha256:8253def0216b87b2994b7ad689aeec7440f6eb67f981e438071d8d67e36ff69f as golang
+
+# mcr.microsoft.com/cbl-mariner/base/core:2.0
+FROM mcr.microsoft.com/cbl-mariner/base/core@sha256:77651116f2e83cf50fddd8a0316945499f8ce6521ff8e94e67539180d1e5975a as mariner-core
+
+# mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
+FROM mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:63a0a70ceaa1320bc6eb98b81106667d43e46b674731ea8d28e4de1b87e0747f as mariner-distroless
+
+FROM golang AS builder
 ARG VERSION
 ARG CNS_AI_PATH
 ARG CNS_AI_ID
@@ -7,13 +16,15 @@ COPY . .
 RUN CGO_ENABLED=0 go build -a -o /usr/local/bin/azure-cns -ldflags "-X main.version="$VERSION" -X "$CNS_AI_PATH"="$CNS_AI_ID"" -gcflags="-dwarflocationlists=true" cns/service/*.go
 RUN CGO_ENABLED=0 go build -a -o /usr/local/bin/azure-vnet-telemetry -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/telemetry/service/*.go
 
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
-RUN tdnf upgrade -y && tdnf install -y ca-certificates iptables
-COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder /etc/group /etc/group
+FROM mariner-core as iptables
+RUN tdnf install -y iptables
+
+FROM mariner-distroless
+COPY --from=iptables /usr/sbin/*tables* /usr/sbin/
+COPY --from=iptables /usr/lib/iptables /usr/lib/iptables
+COPY --from=iptables /usr/lib/libip* /usr/lib/
+COPY --from=iptables /usr/lib/libxtables* /usr/lib/
 COPY --from=builder /usr/local/bin/azure-cns \
 	/usr/local/bin/azure-cns
-COPY --from=builder /usr/local/bin/azure-vnet-telemetry \
-	/usr/local/bin/azure-vnet-telemetry
 ENTRYPOINT [ "/usr/local/bin/azure-cns" ]
 EXPOSE 10090

--- a/cns/linux.Dockerfile
+++ b/cns/linux.Dockerfile
@@ -21,9 +21,7 @@ RUN tdnf install -y iptables
 
 FROM mariner-distroless
 COPY --from=iptables /usr/sbin/*tables* /usr/sbin/
-COPY --from=iptables /usr/lib/iptables /usr/lib/iptables
-COPY --from=iptables /usr/lib/libip* /usr/lib/
-COPY --from=iptables /usr/lib/libxtables* /usr/lib/
+COPY --from=iptables /usr/lib /usr/lib
 COPY --from=builder /usr/local/bin/azure-cns \
 	/usr/local/bin/azure-cns
 ENTRYPOINT [ "/usr/local/bin/azure-cns" ]

--- a/hack/scripts/async-delete-test.sh
+++ b/hack/scripts/async-delete-test.sh
@@ -24,11 +24,11 @@ do
 
         echo "check directory for pending delete"
         cns_pod=$(kubectl get pods -l k8s-app=azure-cns -n kube-system -o wide | grep "$node_name" | awk '{print $1}')
-        file=$(kubectl exec -it $cns_pod -n kube-system -- ls var/run/azure-vnet/deleteIDs)
+        file=$(kubectl exec -it $cns_pod -c debug -n kube-system -- ls var/run/azure-vnet/deleteIDs)
         if [ -z $file ]; then
             while [ -z $file ]; 
             do
-                file=$(kubectl exec -i $cns_pod -n kube-system -- ls var/run/azure-vnet/deleteIDs)
+                file=$(kubectl exec -i $cns_pod -c debug -n kube-system -- ls var/run/azure-vnet/deleteIDs)
             done
         fi
         echo "pending deletes"
@@ -37,7 +37,7 @@ do
         echo "wait 30s for filesystem delete to occur"
         sleep 30s
         echo "check directory is now empty"
-        check_directory=$(kubectl exec -i $cns_pod -n kube-system -- ls var/run/azure-vnet/deleteIDs)
+        check_directory=$(kubectl exec -i $cns_pod -c debug -n kube-system -- ls var/run/azure-vnet/deleteIDs)
         if [ -z $check_directory ]; then
             echo "async delete success"
             break

--- a/test/integration/manifests/cns/daemonset-linux.yaml
+++ b/test/integration/manifests/cns/daemonset-linux.yaml
@@ -83,6 +83,33 @@ spec:
                   fieldRef:
                     apiVersion: v1
                     fieldPath: spec.nodeName
+        - name: debug
+          image: mcr.microsoft.com/cbl-mariner/base/core:2.0
+          imagePullPolicy: IfNotPresent
+          command: ["sleep", "3600"]
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+          volumeMounts:
+            - name: log
+              mountPath: /var/log
+            - name: cns-state
+              mountPath: /var/lib/azure-network
+            - name: azure-endpoints
+              mountPath: /var/run/azure-cns/
+            - name: cns-config
+              mountPath: /etc/azure-cns
+            - name: cni-bin
+              mountPath: /opt/cni/bin
+            - name: azure-vnet
+              mountPath: /var/run/azure-vnet
+            - name: legacy-cni-state
+              mountPath: /var/run/azure-vnet.json
+            - name: xtables-lock
+              mountPath: /run/xtables.lock
+            - name: cni-conflist
+              mountPath: /etc/cni/net.d
       initContainers:
         - name: cni-installer
           image: acnpublic.azurecr.io/cni-dropgz:latest

--- a/test/integration/swiftv2/swiftv2_test.go
+++ b/test/integration/swiftv2/swiftv2_test.go
@@ -154,7 +154,7 @@ func TestSwiftv2PodToPod(t *testing.T) {
 	for _, pod := range allPods.Items {
 		for _, ip := range ipsToPing {
 			t.Logf("ping from pod %q to %q", pod.Name, ip)
-			result := podTest(t, ctx, clientset, pod, []string{"ping", "-c", "3", ip}, restConfig)
+			result := podTest(t, ctx, clientset, pod, "", []string{"ping", "-c", "3", ip}, restConfig)
 			if result != nil {
 				t.Errorf("ping %q failed: error: %s", ip, result)
 			}
@@ -163,8 +163,8 @@ func TestSwiftv2PodToPod(t *testing.T) {
 	return
 }
 
-func podTest(t *testing.T, ctx context.Context, clientset *kuberneteslib.Clientset, srcPod v1.Pod, cmd []string, rc *restclient.Config) error {
-	output, err := kubernetes.ExecCmdOnPod(ctx, clientset, srcPod.Namespace, srcPod.Name, cmd, rc)
+func podTest(t *testing.T, ctx context.Context, clientset *kuberneteslib.Clientset, srcPod v1.Pod, container string, cmd []string, rc *restclient.Config) error {
+	output, err := kubernetes.ExecCmdOnPod(ctx, clientset, srcPod.Namespace, srcPod.Name, container, cmd, rc)
 	t.Logf(string(output))
 	if err != nil {
 		t.Errorf("failed to execute command on pod: %v", srcPod.Name)

--- a/test/internal/datapath/datapath_win.go
+++ b/test/internal/datapath/datapath_win.go
@@ -19,7 +19,7 @@ var ipv6PrefixPolicy = []string{"powershell", "-c", "curl.exe", "-6", "-v", "www
 
 func podTest(ctx context.Context, clientset *kubernetes.Clientset, srcPod *apiv1.Pod, cmd []string, rc *restclient.Config, passFunc func(string) error) error {
 	logrus.Infof("podTest() - %v %v", srcPod.Name, cmd)
-	output, err := acnk8s.ExecCmdOnPod(ctx, clientset, srcPod.Namespace, srcPod.Name, cmd, rc)
+	output, err := acnk8s.ExecCmdOnPod(ctx, clientset, srcPod.Namespace, srcPod.Name, "", cmd, rc)
 	if err != nil {
 		return errors.Wrapf(err, "failed to execute command on pod: %v", srcPod.Name)
 	}

--- a/test/internal/kubernetes/utils_create.go
+++ b/test/internal/kubernetes/utils_create.go
@@ -77,7 +77,7 @@ func MustCreateDaemonset(ctx context.Context, daemonsets typedappsv1.DaemonSetIn
 	MustDeleteDaemonset(ctx, daemonsets, ds)
 	log.Printf("Creating Daemonset %v", ds.Name)
 	if _, err := daemonsets.Create(ctx, &ds, metav1.CreateOptions{}); err != nil {
-		panic(errors.Wrap(err, "failed to create daemonset"))
+		log.Fatal(errors.Wrap(err, "failed to create daemonset"))
 	}
 }
 
@@ -85,79 +85,79 @@ func MustCreateDeployment(ctx context.Context, deployments typedappsv1.Deploymen
 	MustDeleteDeployment(ctx, deployments, d)
 	log.Printf("Creating Deployment %v", d.Name)
 	if _, err := deployments.Create(ctx, &d, metav1.CreateOptions{}); err != nil {
-		panic(errors.Wrap(err, "failed to create deployment"))
+		log.Fatal(errors.Wrap(err, "failed to create deployment"))
 	}
 }
 
 func mustCreateServiceAccount(ctx context.Context, svcAccounts typedcorev1.ServiceAccountInterface, s corev1.ServiceAccount) {
 	if err := svcAccounts.Delete(ctx, s.Name, metav1.DeleteOptions{}); err != nil {
 		if !apierrors.IsNotFound(err) {
-			panic(errors.Wrap(err, "failed to delete svc account"))
+			log.Fatal(errors.Wrap(err, "failed to delete svc account"))
 		}
 	}
 	log.Printf("Creating ServiceAccount %v", s.Name)
 	if _, err := svcAccounts.Create(ctx, &s, metav1.CreateOptions{}); err != nil {
-		panic(errors.Wrap(err, "failed to create svc account"))
+		log.Fatal(errors.Wrap(err, "failed to create svc account"))
 	}
 }
 
 func mustCreateClusterRole(ctx context.Context, clusterRoles typedrbacv1.ClusterRoleInterface, cr rbacv1.ClusterRole) {
 	if err := clusterRoles.Delete(ctx, cr.Name, metav1.DeleteOptions{}); err != nil {
 		if !apierrors.IsNotFound(err) {
-			panic(errors.Wrap(err, "failed to delete cluster role"))
+			log.Fatal(errors.Wrap(err, "failed to delete cluster role"))
 		}
 	}
 	log.Printf("Creating ClusterRoles %v", cr.Name)
 	if _, err := clusterRoles.Create(ctx, &cr, metav1.CreateOptions{}); err != nil {
-		panic(errors.Wrap(err, "failed to create cluster role"))
+		log.Fatal(errors.Wrap(err, "failed to create cluster role"))
 	}
 }
 
 func mustCreateClusterRoleBinding(ctx context.Context, crBindings typedrbacv1.ClusterRoleBindingInterface, crb rbacv1.ClusterRoleBinding) {
 	if err := crBindings.Delete(ctx, crb.Name, metav1.DeleteOptions{}); err != nil {
 		if !apierrors.IsNotFound(err) {
-			panic(errors.Wrap(err, "failed to delete cluster role binding"))
+			log.Fatal(errors.Wrap(err, "failed to delete cluster role binding"))
 		}
 	}
 	log.Printf("Creating RoleBinding %v", crb.Name)
 	if _, err := crBindings.Create(ctx, &crb, metav1.CreateOptions{}); err != nil {
-		panic(errors.Wrap(err, "failed to create role binding"))
+		log.Fatal(errors.Wrap(err, "failed to create role binding"))
 	}
 }
 
 func mustCreateRole(ctx context.Context, rs typedrbacv1.RoleInterface, r rbacv1.Role) {
 	if err := rs.Delete(ctx, r.Name, metav1.DeleteOptions{}); err != nil {
 		if !apierrors.IsNotFound(err) {
-			panic(errors.Wrap(err, "failed to delete role"))
+			log.Fatal(errors.Wrap(err, "failed to delete role"))
 		}
 	}
 	log.Printf("Creating Role %v", r.Name)
 	if _, err := rs.Create(ctx, &r, metav1.CreateOptions{}); err != nil {
-		panic(errors.Wrap(err, "failed to create role"))
+		log.Fatal(errors.Wrap(err, "failed to create role"))
 	}
 }
 
 func mustCreateRoleBinding(ctx context.Context, rbi typedrbacv1.RoleBindingInterface, rb rbacv1.RoleBinding) {
 	if err := rbi.Delete(ctx, rb.Name, metav1.DeleteOptions{}); err != nil {
 		if !apierrors.IsNotFound(err) {
-			panic(errors.Wrap(err, "failed to delete role binding"))
+			log.Fatal(errors.Wrap(err, "failed to delete role binding"))
 		}
 	}
 	log.Printf("Creating RoleBinding %v", rb.Name)
 	if _, err := rbi.Create(ctx, &rb, metav1.CreateOptions{}); err != nil {
-		panic(errors.Wrap(err, "failed to create role binding"))
+		log.Fatal(errors.Wrap(err, "failed to create role binding"))
 	}
 }
 
 func mustCreateConfigMap(ctx context.Context, cmi typedcorev1.ConfigMapInterface, cm corev1.ConfigMap) {
 	if err := cmi.Delete(ctx, cm.Name, metav1.DeleteOptions{}); err != nil {
 		if !apierrors.IsNotFound(err) {
-			panic(errors.Wrap(err, "failed to delete configmap"))
+			log.Fatal(errors.Wrap(err, "failed to delete configmap"))
 		}
 	}
 	log.Printf("Creating ConfigMap %v", cm.Name)
 	if _, err := cmi.Create(ctx, &cm, metav1.CreateOptions{}); err != nil {
-		panic(errors.Wrap(err, "failed to create configmap"))
+		log.Fatal(errors.Wrap(err, "failed to create configmap"))
 	}
 }
 
@@ -177,7 +177,7 @@ func MustScaleDeployment(ctx context.Context,
 		log.Printf("Waiting for pods to be ready..")
 		err := WaitForPodDeployment(ctx, clientset, namespace, deployment.Name, podLabelSelector, replicas)
 		if err != nil {
-			panic(errors.Wrap(err, "failed to wait for pod deployment"))
+			log.Fatal(errors.Wrap(err, "failed to wait for pod deployment"))
 		}
 	}
 }
@@ -189,7 +189,7 @@ func MustCreateNamespace(ctx context.Context, clienset *kubernetes.Clientset, na
 		},
 	}, metav1.CreateOptions{})
 	if err != nil {
-		panic(errors.Wrapf(err, "failed to create namespace %v", namespace))
+		log.Fatal(errors.Wrapf(err, "failed to create namespace %v", namespace))
 	}
 }
 
@@ -615,6 +615,15 @@ func hostPathTypePtr(h corev1.HostPathType) *corev1.HostPathType {
 func volumesForAzureCNIOverlayLinux() []corev1.Volume {
 	return []corev1.Volume{
 		{
+			Name: "azure-endpoints",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/var/run/azure-cns/",
+					Type: hostPathTypePtr(corev1.HostPathDirectoryOrCreate),
+				},
+			},
+		},
+		{
 			Name: "log",
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
@@ -684,6 +693,15 @@ func volumesForAzureCNIOverlayLinux() []corev1.Volume {
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: "cns-config",
 					},
+				},
+			},
+		},
+		{
+			Name: "xtables-lock",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/run/xtables.lock",
+					Type: hostPathTypePtr(corev1.HostPathFile),
 				},
 			},
 		},

--- a/test/validate/windows_validate.go
+++ b/test/validate/windows_validate.go
@@ -33,14 +33,50 @@ var (
 
 var windowsChecksMap = map[string][]check{
 	"cniv1": {
-		{"hns", hnsStateFileIps, privilegedLabelSelector, privilegedNamespace, hnsEndPointCmd},
-		{"azure-vnet", azureVnetIps, privilegedLabelSelector, privilegedNamespace, azureVnetCmd},
-		{"azure-vnet-ipam", azureVnetIpamIps, privilegedLabelSelector, privilegedNamespace, azureVnetIpamCmd},
+		{
+			name:             "hns",
+			stateFileIPs:     hnsStateFileIPs,
+			podLabelSelector: privilegedLabelSelector,
+			podNamespace:     privilegedNamespace,
+			cmd:              hnsEndPointCmd,
+		},
+		{
+			name:             "azure-vnet",
+			stateFileIPs:     azureVnetIps,
+			podLabelSelector: privilegedLabelSelector,
+			podNamespace:     privilegedNamespace,
+			cmd:              azureVnetCmd,
+		},
+		{
+			name:             "azure-vnet-ipam",
+			stateFileIPs:     azureVnetIpamIps,
+			podLabelSelector: privilegedLabelSelector,
+			podNamespace:     privilegedNamespace,
+			cmd:              azureVnetIpamCmd,
+		},
 	},
 	"cniv2": {
-		{"hns", hnsStateFileIps, privilegedLabelSelector, privilegedNamespace, hnsEndPointCmd},
-		{"azure-vnet", azureVnetIps, privilegedLabelSelector, privilegedNamespace, azureVnetCmd},
-		{"cns cache", cnsCacheStateFileIps, cnsWinLabelSelector, privilegedNamespace, cnsWinCachedAssignedIPStateCmd},
+		{
+			name:             "hns",
+			stateFileIPs:     hnsStateFileIPs,
+			podLabelSelector: privilegedLabelSelector,
+			podNamespace:     privilegedNamespace,
+			cmd:              hnsEndPointCmd,
+		},
+		{
+			name:             "azure-vnet",
+			stateFileIPs:     azureVnetIps,
+			podLabelSelector: privilegedLabelSelector,
+			podNamespace:     privilegedNamespace,
+			cmd:              azureVnetCmd,
+		},
+		{
+			name:             "cns cache",
+			stateFileIPs:     cnsCacheStateFileIps,
+			podLabelSelector: cnsWinLabelSelector,
+			podNamespace:     privilegedNamespace,
+			cmd:              cnsWinCachedAssignedIPStateCmd,
+		},
 	},
 }
 
@@ -101,7 +137,7 @@ type AddressRecord struct {
 	InUse bool
 }
 
-func hnsStateFileIps(result []byte) (map[string]string, error) {
+func hnsStateFileIPs(result []byte) (map[string]string, error) {
 	jsonType := bytes.TrimLeft(result, " \t\r\n")
 	isObject := jsonType[0] == '{'
 	isArray := jsonType[0] == '['
@@ -209,7 +245,7 @@ func validateHNSNetworkState(ctx context.Context, nodes *corev1.NodeList, client
 		}
 		podName := pod.Items[0].Name
 		// exec into the pod to get the state file
-		result, err := acnk8s.ExecCmdOnPod(ctx, clientset, privilegedNamespace, podName, hnsNetworkCmd, restConfig)
+		result, err := acnk8s.ExecCmdOnPod(ctx, clientset, privilegedNamespace, podName, "", hnsNetworkCmd, restConfig)
 		if err != nil {
 			return errors.Wrap(err, "failed to exec into privileged pod")
 		}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
CNS was moved from `scratch` to `mariner` in [this change](https://github.com/Azure/azure-container-networking/pull/1499/files#diff-505c5d2f3910d5791524e206cc08abca53a8eefac1094baf678cd5d2b5dbf9e0) where we migrated responsibility to CNS to write some iptables rules.

This change moves CNS to the `mariner distroless` base image and adds `iptables`, in an effort to reduce the image size while maintaining the required iptables functionality.
