### PR TITLE
ci: Remove AKS Engine storage account usage

### DIFF
--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -184,17 +184,6 @@ stages:
                 pathtoPublish: "$(Build.ArtifactStagingDirectory)"
               condition: succeeded()
 
-            - task: AzureCLI@1
-              inputs:
-                azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
-                scriptLocation: "inlineScript"
-                inlineScript: |
-                  echo Creating storage container with name acn-$(STORAGE_ID) and account name $(STORAGE_ACCOUNT_NAME)
-                  az storage container create -n acn-$(STORAGE_ID) --account-name $(STORAGE_ACCOUNT_NAME) --public-access container
-                  az storage blob upload-batch -d acn-$(STORAGE_ID) -s ./output/bins/  --account-name $(STORAGE_ACCOUNT_NAME)
-              displayName: Create artifact storage container
-              condition: succeeded()
-
     - stage: containerize
       displayName: Build Images
       dependsOn:
@@ -606,34 +595,3 @@ stages:
                 echo $TAG
                 echo $CURRENT_VERSION
                 echo "Checking if branch is up to date with master"
-
-    - stage: cleanup
-      displayName: Cleanup
-      dependsOn:
-        - azure_overlay_e2e
-        - aks_swift_e2e
-        - cilium_e2e
-        - cilium_overlay_e2e
-        - cilium_h_overlay_e2e
-        - aks_ubuntu_22_linux_e2e
-        - aks_windows_22_e2e
-        - dualstackoverlay_e2e
-        - cilium_dualstackoverlay_e2e
-      jobs:
-        - job: delete_remote_artifacts
-          displayName: Delete remote artifacts
-          pool:
-            name: $(BUILD_POOL_NAME_DEFAULT)
-            demands: agent.os -equals Linux
-          steps:
-            - checkout: none
-            - task: AzureCLI@1
-              inputs:
-                azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
-                scriptLocation: "inlineScript"
-                inlineScript: |
-                  BUILD_NUMBER=$(Build.BuildNumber)
-                  BUILD_NUMBER=${BUILD_NUMBER//./-}
-                  echo Deleting storage container with name acn-$BUILD_NUMBER and account name $(STORAGE_ACCOUNT_NAME)
-                  az storage container delete -n acn-$BUILD_NUMBER --account-name $(STORAGE_ACCOUNT_NAME)
-              displayName: Cleanup remote Azure storage container


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
We no longer utilize this storage account for AKS engine or Jenkins. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
