### PR TITLE
fix: close connection on any return from azure-vnet-telemetry

### DIFF
--- a/telemetry/telemetrybuffer.go
+++ b/telemetry/telemetrybuffer.go
@@ -116,6 +116,27 @@ func (tb *TelemetryBuffer) StartServer() error {
 				tb.connections = append(tb.connections, conn)
 				tb.mutex.Unlock()
 				go func() {
+					defer func() {
+						var index int
+						var value net.Conn
+						var found bool
+
+						tb.mutex.Lock()
+						defer tb.mutex.Unlock()
+
+						for index, value = range tb.connections {
+							if value == conn {
+								conn.Close()
+								found = true
+								break
+							}
+						}
+
+						if found {
+							tb.connections = remove(tb.connections, index)
+						}
+					}()
+
 					for {
 						reportStr, err := read(conn)
 						if err == nil {
@@ -145,25 +166,6 @@ func (tb *TelemetryBuffer) StartServer() error {
 								}
 							}
 						} else {
-							var index int
-							var value net.Conn
-							var found bool
-
-							tb.mutex.Lock()
-							defer tb.mutex.Unlock()
-
-							for index, value = range tb.connections {
-								if value == conn {
-									conn.Close()
-									found = true
-									break
-								}
-							}
-
-							if found {
-								tb.connections = remove(tb.connections, index)
-							}
-
 							return
 						}
 					}

--- a/telemetry/telemetrybuffer.go
+++ b/telemetry/telemetrybuffer.go
@@ -154,11 +154,17 @@ func (tb *TelemetryBuffer) StartServer() error {
 						}
 						if _, ok := tmp["CniSucceeded"]; ok {
 							var cniReport CNIReport
-							json.Unmarshal([]byte(reportStr), &cniReport)
+							err = json.Unmarshal([]byte(reportStr), &cniReport)
+							if err != nil {
+								return
+							}
 							tb.data <- cniReport
 						} else if _, ok := tmp["Metric"]; ok {
 							var aiMetric AIMetric
-							json.Unmarshal([]byte(reportStr), &aiMetric)
+							err = json.Unmarshal([]byte(reportStr), &aiMetric)
+							if err != nil {
+								return
+							}
 							tb.data <- aiMetric
 						} else {
 							if tb.logger != nil {

--- a/telemetry/telemetrybuffer.go
+++ b/telemetry/telemetrybuffer.go
@@ -139,34 +139,33 @@ func (tb *TelemetryBuffer) StartServer() error {
 
 					for {
 						reportStr, err := read(conn)
-						if err == nil {
-							var tmp map[string]interface{}
-							err = json.Unmarshal(reportStr, &tmp)
-							if err != nil {
-								if tb.logger != nil {
-									tb.logger.Error("StartServer: unmarshal error", zap.Error(err))
-								} else {
-									log.Logf("StartServer: unmarshal error:%v", err)
-								}
-								return
-							}
-							if _, ok := tmp["CniSucceeded"]; ok {
-								var cniReport CNIReport
-								json.Unmarshal([]byte(reportStr), &cniReport)
-								tb.data <- cniReport
-							} else if _, ok := tmp["Metric"]; ok {
-								var aiMetric AIMetric
-								json.Unmarshal([]byte(reportStr), &aiMetric)
-								tb.data <- aiMetric
-							} else {
-								if tb.logger != nil {
-									tb.logger.Info("StartServer: default", zap.Any("case", tmp))
-								} else {
-									log.Logf("StartServer: default case:%+v...", tmp)
-								}
-							}
-						} else {
+						if err != nil {
 							return
+						}
+						var tmp map[string]interface{}
+						err = json.Unmarshal(reportStr, &tmp)
+						if err != nil {
+							if tb.logger != nil {
+								tb.logger.Error("StartServer: unmarshal error", zap.Error(err))
+							} else {
+								log.Logf("StartServer: unmarshal error:%v", err)
+							}
+							return
+						}
+						if _, ok := tmp["CniSucceeded"]; ok {
+							var cniReport CNIReport
+							json.Unmarshal([]byte(reportStr), &cniReport)
+							tb.data <- cniReport
+						} else if _, ok := tmp["Metric"]; ok {
+							var aiMetric AIMetric
+							json.Unmarshal([]byte(reportStr), &aiMetric)
+							tb.data <- aiMetric
+						} else {
+							if tb.logger != nil {
+								tb.logger.Info("StartServer: default", zap.Any("case", tmp))
+							} else {
+								log.Logf("StartServer: default case:%+v...", tmp)
+							}
 						}
 					}
 				}()

--- a/telemetry/telemetrybuffer_test.go
+++ b/telemetry/telemetrybuffer_test.go
@@ -70,30 +70,6 @@ func TestClientConnClose(t *testing.T) {
 	tbClient.Close()
 }
 
-func TestCloseOnWriteError(t *testing.T) {
-	tbServer, closeTBServer := createTBServer(t)
-	defer closeTBServer()
-
-	tbClient := NewTelemetryBuffer(nil)
-	err := tbClient.Connect()
-	require.NoError(t, err)
-	defer tbClient.Close()
-
-	data := []byte("{\"good\":1}")
-	_, err = tbClient.Write(data)
-	require.NoError(t, err)
-	// need to wait for connection to populate in server
-	time.Sleep(1 * time.Second)
-	require.Len(t, tbServer.connections, 1)
-
-	// the connection should be automatically closed on failure
-	badData := []byte("} malformed json }}}")
-	_, err = tbClient.Write(badData)
-	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	require.Empty(t, tbServer.connections)
-}
-
 func TestWrite(t *testing.T) {
 	_, closeTBServer := createTBServer(t)
 	defer closeTBServer()


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Prevents leaking of sockets when azure-vnet-telemetry errors and fails to unmarshal mentioned in #2703 (this pr does not fix the unmarshaling error itself)

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [X] relevant PR labels added

**Notes**:
The unit test uses time.sleep to ensure the connection populates in the server, and we will be rewriting these tests later anyway with stateless cni.