### PR TITLE
ci: create template for cilium cli install

### DIFF
--- a/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
+++ b/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
@@ -88,11 +88,11 @@ stages:
                   else
                     kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-config/cilium-config.yaml
                   fi
-                  
+
                   # Passes Cilium image to daemonset and deployment
                   kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-agent/files
                   kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-operator/files
-                            
+
                   envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-agent/templates/daemonset.yaml | kubectl apply -f -
                   envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-operator/templates/deployment.yaml | kubectl apply -f -
                   kubectl get po -owide -A
@@ -119,7 +119,7 @@ stages:
                   pwd
                   kubectl cluster-info
                   kubectl get po -owide -A
-                  
+
                   echo "install Cilium onto Overlay Cluster with hubble enabled"
                   export CILIUM_VERSION_TAG=${CILIUM_HUBBLE_VERSION_TAG}
                   export DIR=${CILIUM_VERSION_TAG%.*}
@@ -134,7 +134,7 @@ stages:
                   echo "Deploy Azure-CNS"
                   sudo -E env "PATH=$PATH" make test-integration AZURE_IPAM_VERSION=$(make azure-ipam-version) CNS_VERSION=$(make cns-version) INSTALL_CNS=true INSTALL_OVERLAY=true CNS_IMAGE_REPO=$(CNS_IMAGE_REPO)
                   kubectl get po -owide -A
-          
+
       - job: deploy_pods
         condition: and( and( not(canceled()), not(failed()) ), or( contains(variables.CONTROL_SCENARIO, 'scaleTest') , contains(variables.CONTROL_SCENARIO, 'all') ) )
         displayName: "Scale Test"
@@ -183,24 +183,7 @@ stages:
         displayName: "Cilium Test"
         dependsOn: restart_cns
         steps:
-          - script: |
-              echo "install cilium CLI"
-              if [[ ${CILIUM_VERSION_TAG} =~ ^1.1[1-3].[0-9]{1,2} ]]; then
-                echo "Cilium Agent Version ${BASH_REMATCH[0]}"
-                CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable-v0.14.txt)
-              else
-                echo "Cilium Agent Version ${CILIUM_VERSION_TAG}"
-                CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
-              fi
-              CLI_ARCH=amd64
-              curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-linux-${CLI_ARCH}.tar.gz{,.sha256sum}
-              sha256sum --check cilium-linux-${CLI_ARCH}.tar.gz.sha256sum
-              sudo tar xzvfC cilium-linux-${CLI_ARCH}.tar.gz /usr/local/bin
-              rm cilium-linux-${CLI_ARCH}.tar.gz{,.sha256sum}
-              cilium status
-              cilium version
-            name: "InstallCiliumCli"
-            displayName: "Install Cilium CLI"
+          - template: ../../templates/cilium-cli.yaml
           - task: AzureCLI@1
             inputs:
               azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)

--- a/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-step-template.yaml
@@ -40,7 +40,7 @@ steps:
         # Passes Cilium image to daemonset and deployment
         kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-agent/files
         kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-operator/files
-                  
+
         export CILIUM_VERSION_TAG=${CILIUM_DUALSTACK_VERSION}
         echo "install Cilium ${CILIUM_DUALSTACK_VERSION} onto Overlay Cluster"
         envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-agent/templates/daemonset.yaml | kubectl apply -f -
@@ -49,25 +49,7 @@ steps:
     name: "installCilium"
     displayName: "Install Cilium on AKS Dualstack Overlay"
 
-  - script: |
-      echo "install cilium CLI"
-      if [[ ${CILIUM_VERSION_TAG} =~ ^1.1[1-3].[0-9]{1,2} ]]; then
-        echo "Cilium Agent Version ${BASH_REMATCH[0]}"
-        CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable-v0.14.txt)
-      else
-        echo "Cilium Agent Version ${CILIUM_VERSION_TAG}"
-        CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
-      fi
-      CLI_ARCH=amd64
-      if [ "$(uname -m)" = "aarch64" ]; then CLI_ARCH=arm64; fi
-      curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-linux-${CLI_ARCH}.tar.gz{,.sha256sum}
-      sha256sum --check cilium-linux-${CLI_ARCH}.tar.gz.sha256sum
-      sudo tar xzvfC cilium-linux-${CLI_ARCH}.tar.gz /usr/local/bin
-      rm cilium-linux-${CLI_ARCH}.tar.gz{,.sha256sum}
-      cilium status
-      cilium version
-    name: "installCiliumCLI"
-    displayName: "Install Cilium CLI"
+  - template: ../../templates/cilium-cli.yaml
 
   - script: |
       echo "Start Azilium E2E Tests on Overlay Cluster"
@@ -93,17 +75,17 @@ steps:
     name: "ciliumConnectivityTests"
     displayName: "Run Cilium Connectivity Tests"
 
-  - script: | 
-      set -e 
-      kubectl get po -owide -A 
-      cd test/integration/datapath 
-      echo "Dualstack Overlay Linux datapath IPv6 test" 
-      go test -count=1 datapath_linux_test.go -timeout 3m -tags connection -run ^TestDatapathLinux$ -tags=connection,integration -isDualStack=true 
-      echo "Dualstack Overlay Linux datapath IPv4 test" 
-      go test -count=1 datapath_linux_test.go -timeout 3m -tags connection -run ^TestDatapathLinux$ -tags=connection,integration 
-    retryCountOnTaskFailure: 3 
-    name: "DualStack_Overlay_Linux_Tests" 
-    displayName: "DualStack Overlay Linux Tests" 
+  - script: |
+      set -e
+      kubectl get po -owide -A
+      cd test/integration/datapath
+      echo "Dualstack Overlay Linux datapath IPv6 test"
+      go test -count=1 datapath_linux_test.go -timeout 3m -tags connection -run ^TestDatapathLinux$ -tags=connection,integration -isDualStack=true
+      echo "Dualstack Overlay Linux datapath IPv4 test"
+      go test -count=1 datapath_linux_test.go -timeout 3m -tags connection -run ^TestDatapathLinux$ -tags=connection,integration
+    retryCountOnTaskFailure: 3
+    name: "DualStack_Overlay_Linux_Tests"
+    displayName: "DualStack Overlay Linux Tests"
 
   - script: |
       echo "validate pod IP assignment and check systemd-networkd restart"

--- a/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-step-template.yaml
@@ -48,25 +48,7 @@ steps:
     name: "installCilium"
     displayName: "Install Cilium on AKS Overlay"
 
-  - script: |
-      echo "install cilium CLI"
-      if [[ ${CILIUM_VERSION_TAG} =~ ^1.1[1-3].[0-9]{1,2} ]]; then
-        echo "Cilium Agent Version ${BASH_REMATCH[0]}"
-        CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable-v0.14.txt)
-      else
-        echo "Cilium Agent Version ${CILIUM_VERSION_TAG}"
-        CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
-      fi
-      CLI_ARCH=amd64
-      if [ "$(uname -m)" = "aarch64" ]; then CLI_ARCH=arm64; fi
-      curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-linux-${CLI_ARCH}.tar.gz{,.sha256sum}
-      sha256sum --check cilium-linux-${CLI_ARCH}.tar.gz.sha256sum
-      sudo tar xzvfC cilium-linux-${CLI_ARCH}.tar.gz /usr/local/bin
-      rm cilium-linux-${CLI_ARCH}.tar.gz{,.sha256sum}
-      cilium status
-      cilium version
-    name: "installCiliumCLI"
-    displayName: "Install Cilium CLI"
+  - template: ../../templates/cilium-cli.yaml
 
   - script: |
       echo "Start Azilium E2E Tests on Overlay Cluster"

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
@@ -39,7 +39,7 @@ steps:
         pwd
         kubectl cluster-info
         kubectl get po -owide -A
-        if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]; then 
+        if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]; then
           FILE_PATH=-nightly
           echo "Running nightly"
           echo "deploy Cilium ConfigMap"
@@ -59,34 +59,16 @@ steps:
           # Passes Cilium image to daemonset and deployment
           kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-agent/files
           kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-operator/files
-                    
+
           envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-agent/templates/daemonset.yaml | kubectl apply -f -
           envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-operator/templates/deployment.yaml | kubectl apply -f -
         fi
-        
+
         kubectl get po -owide -A
     name: "installCilium"
     displayName: "Install Cilium on AKS Overlay"
 
-  - script: |
-      echo "install cilium CLI"
-      if [[ ${CILIUM_VERSION_TAG} =~ ^1.1[1-3].[0-9]{1,2} ]]; then
-        echo "Cilium Agent Version ${BASH_REMATCH[0]}"
-        CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable-v0.14.txt)
-      else
-        echo "Cilium Agent Version ${CILIUM_VERSION_TAG}"
-        CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
-      fi
-      CLI_ARCH=amd64
-      if [ "$(uname -m)" = "aarch64" ]; then CLI_ARCH=arm64; fi
-      curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-linux-${CLI_ARCH}.tar.gz{,.sha256sum}
-      sha256sum --check cilium-linux-${CLI_ARCH}.tar.gz.sha256sum
-      sudo tar xzvfC cilium-linux-${CLI_ARCH}.tar.gz /usr/local/bin
-      rm cilium-linux-${CLI_ARCH}.tar.gz{,.sha256sum}
-      cilium status
-      cilium version
-    name: "installCiliumCLI"
-    displayName: "Install Cilium CLI"
+  - template: ../../templates/cilium-cli.yaml
 
   - script: |
       echo "Start Azilium E2E Tests on Overlay Cluster"

--- a/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
@@ -46,32 +46,14 @@ steps:
         # Passes Cilium image to daemonset and deployment
         kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-agent/files
         kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-operator/files
-                  
+
         envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-agent/templates/daemonset.yaml | kubectl apply -f -
         envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-operator/templates/deployment.yaml | kubectl apply -f -
         kubectl get po -owide -A
     name: "installCilium"
     displayName: "Install Cilium"
 
-  - script: |
-      echo "install cilium CLI"
-      if [[ ${CILIUM_VERSION_TAG} =~ ^1.1[1-3].[0-9]{1,2} ]]; then
-        echo "Cilium Agent Version ${BASH_REMATCH[0]}"
-        CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable-v0.14.txt)
-      else
-        echo "Cilium Agent Version ${CILIUM_VERSION_TAG}"
-        CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
-      fi
-      CLI_ARCH=amd64
-      if [ "$(uname -m)" = "aarch64" ]; then CLI_ARCH=arm64; fi
-      curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-linux-${CLI_ARCH}.tar.gz{,.sha256sum}
-      sha256sum --check cilium-linux-${CLI_ARCH}.tar.gz.sha256sum
-      sudo tar xzvfC cilium-linux-${CLI_ARCH}.tar.gz /usr/local/bin
-      rm cilium-linux-${CLI_ARCH}.tar.gz{,.sha256sum}
-      cilium status
-      cilium version
-    name: "installCiliumCLI"
-    displayName: "Install Cilium CLI"
+  - template: ../../templates/cilium-cli.yaml
 
   - script: |
       echo "Start Azilium E2E Tests"

--- a/.pipelines/templates/cilium-cli.yaml
+++ b/.pipelines/templates/cilium-cli.yaml
@@ -1,0 +1,23 @@
+steps:
+  - script: |
+      echo "install cilium CLI"
+      if [[ ${CILIUM_VERSION_TAG} =~ ^1.1[1-3].[0-9]{1,2} ]]; then
+        echo "Cilium Agent Version ${BASH_REMATCH[0]}"
+        CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable-v0.14.txt)
+      elif [[ ${CILIUM_VERSION_TAG} =~ ^1.14.[0-9]{1,2} ]]; then
+        echo "Cilium Agent Version ${BASH_REMATCH[0]}"
+        CILIUM_CLI_VERSION=v0.15.22
+      else
+        echo "Cilium Agent Version ${CILIUM_VERSION_TAG}"
+        CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
+      fi
+      CLI_ARCH=amd64
+      if [ "$(uname -m)" = "aarch64" ]; then CLI_ARCH=arm64; fi
+      curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-linux-${CLI_ARCH}.tar.gz{,.sha256sum}
+      sha256sum --check cilium-linux-${CLI_ARCH}.tar.gz.sha256sum
+      sudo tar xzvfC cilium-linux-${CLI_ARCH}.tar.gz /usr/local/bin
+      rm cilium-linux-${CLI_ARCH}.tar.gz{,.sha256sum}
+      cilium status
+      cilium version
+    name: "installCiliumCLI"
+    displayName: "Install Cilium CLI"


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Creates a template for Cilium CLI install to ensure that all CLI installs are the same.

Provides Cilium 1.14.X a supported CLI version of v0.15.22.



**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
Changes in Cilium CLI github prompted this change. https://github.com/cilium/cilium-cli?tab=readme-ov-file#releases.

Broken cilium connectivity test when going from v0.16.6 -> v0.16.7 when using Cilium v1.14.9 