### PR TITLE
feat: plumb accelnet bool through interfaceinfo

### DIFF
--- a/crd/multitenancy/api/v1alpha1/multitenantpodnetworkconfig.go
+++ b/crd/multitenancy/api/v1alpha1/multitenantpodnetworkconfig.go
@@ -60,6 +60,9 @@ type InterfaceInfo struct {
 	GatewayIP string `json:"gatewayIP,omitempty"`
 	// DeviceType is the device type that this NC was created for
 	DeviceType DeviceType `json:"deviceType,omitempty"`
+	// AccelnetEnabled determines if the CNI will provision the NIC with accelerated networking enabled
+	// +kubebuilder:validation:Optional
+	AccelnetEnabled bool `json:"accelnetEnabled,omitempty"`
 }
 
 // MultitenantPodNetworkConfigStatus defines the observed state of PodNetworkConfig

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_multitenantpodnetworkconfigs.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_multitenantpodnetworkconfigs.yaml
@@ -75,6 +75,10 @@ spec:
                   goal state for this Pod
                 items:
                   properties:
+                    accelnetEnabled:
+                      description: AccelnetEnabled determines if the CNI will provision
+                        the NIC with accelerated networking enabled
+                      type: boolean
                     deviceType:
                       description: DeviceType is the device type that this NC was
                         created for


### PR DESCRIPTION
**Reason for Change**:
Adds a property to `InterfaceInfo` to tell CNI whether the NIC should be programmed with accelnet enabled or not


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
