### PR TITLE
[CNS] refactor: remove redundant check for TLSSettings.TLSPort

### DIFF
--- a/cns/service.go
+++ b/cns/service.go
@@ -103,23 +103,21 @@ func (service *Service) AddListener(config *common.ServiceConfig) error {
 
 	// only use TLS connection for DNC/CNS listener:
 	if config.TLSSettings.TLSPort != "" {
-		if config.TLSSettings.TLSPort != "" {
-			// listener.URL.Host will always be hostname:port, passed in to CNS via CNS command
-			// else it will default to localhost
-			// extract hostname and override tls port.
-			hostParts := strings.Split(nodeListener.URL.Host, ":")
-			tlsAddress := net.JoinHostPort(hostParts[0], config.TLSSettings.TLSPort)
+		// listener.URL.Host will always be hostname:port, passed in to CNS via CNS command
+		// else it will default to localhost
+		// extract hostname and override tls port.
+		hostParts := strings.Split(nodeListener.URL.Host, ":")
+		tlsAddress := net.JoinHostPort(hostParts[0], config.TLSSettings.TLSPort)
 
-			// Start the listener and HTTP and HTTPS server.
-			tlsConfig, err := getTLSConfig(config.TLSSettings, config.ErrChan) //nolint
-			if err != nil {
-				log.Printf("Failed to compose Tls Configuration with error: %+v", err)
-				return errors.Wrap(err, "could not get tls config")
-			}
+		// Start the listener and HTTP and HTTPS server.
+		tlsConfig, err := getTLSConfig(config.TLSSettings, config.ErrChan) //nolint
+		if err != nil {
+			log.Printf("Failed to compose Tls Configuration with error: %+v", err)
+			return errors.Wrap(err, "could not get tls config")
+		}
 
-			if err := nodeListener.StartTLS(config.ErrChan, tlsConfig, tlsAddress); err != nil {
-				return errors.Wrap(err, "could not start tls")
-			}
+		if err := nodeListener.StartTLS(config.ErrChan, tlsConfig, tlsAddress); err != nil {
+			return errors.Wrap(err, "could not start tls")
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

- small refactor to remove redundant check for TLSSettings.TLSPort in CNS

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
