### PR TITLE
feat: bumping dropGZ to 1.6.0 and adding stateless CNI to Windows

### DIFF
--- a/dropgz/build/linux.Dockerfile
+++ b/dropgz/build/linux.Dockerfile
@@ -12,7 +12,7 @@ COPY ./azure-ipam .
 RUN curl -LO --cacert /etc/ssl/certs/ca-certificates.crt https://github.com/Azure/azure-container-networking/releases/download/azure-ipam%2F$AZIPAM_VERSION/azure-ipam-$OS-$ARCH-$AZIPAM_VERSION.tgz && tar -xvf azure-ipam-$OS-$ARCH-$AZIPAM_VERSION.tgz
 
 FROM tar AS azure-vnet
-ARG AZCNI_VERSION=v1.5.28
+ARG AZCNI_VERSION=v1.6.0
 ARG VERSION
 ARG OS
 ARG ARCH

--- a/dropgz/build/windows.Dockerfile
+++ b/dropgz/build/windows.Dockerfile
@@ -6,7 +6,7 @@ RUN tdnf install -y unzip
 RUN tdnf upgrade -y && tdnf install -y ca-certificates
 
 FROM tar AS azure-vnet
-ARG AZCNI_VERSION=v1.5.28
+ARG AZCNI_VERSION=v1.6.0
 ARG VERSION
 ARG OS
 ARG ARCH
@@ -21,6 +21,7 @@ COPY dropgz .
 COPY --from=azure-vnet /azure-container-networking/cni/azure-$OS-swift-overlay.conflist pkg/embed/fs/azure-swift-overlay.conflist
 COPY --from=azure-vnet /azure-container-networking/cni/azure-$OS-swift-overlay-dualstack.conflist pkg/embed/fs/azure-swift-overlay-dualstack.conflist
 COPY --from=azure-vnet /azure-container-networking/azure-vnet.exe pkg/embed/fs
+COPY --from=azure-vnet /azure-container-networking/azure-vnet-stateless.exe pkg/embed/fs
 COPY --from=azure-vnet /azure-container-networking/azure-vnet-telemetry.exe pkg/embed/fs
 COPY --from=azure-vnet /azure-container-networking/azure-vnet-ipam.exe pkg/embed/fs
 COPY --from=azure-vnet /azure-container-networking/azure-vnet-telemetry.config pkg/embed/fs


### PR DESCRIPTION


**Reason for Change**:
bumping dropGZ to 1.6.0 and adding stateless CNI to Windows

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
