### PR TITLE
ci: Remove depreciated values from Cilium nightly config

### DIFF
--- a/test/integration/manifests/cilium/cilium-nightly-config.yaml
+++ b/test/integration/manifests/cilium/cilium-nightly-config.yaml
@@ -61,7 +61,6 @@ data:
   prometheus-serve-addr: :9962
   remove-cilium-node-taints: "true"
   set-cilium-is-up-condition: "true"
-  sidecar-istio-proxy-image: cilium/istio_proxy
   synchronize-k8s-nodes: "true"
   tofqdns-dns-reject-response-code: refused
   tofqdns-enable-dns-compression: "true"

--- a/test/integration/manifests/cilium/cilium-nightly-config.yaml
+++ b/test/integration/manifests/cilium/cilium-nightly-config.yaml
@@ -36,7 +36,6 @@ data:
   enable-local-redirect-policy: "false"
   enable-metrics: "true"
   enable-policy: default
-  enable-remote-node-identity: "true"
   enable-session-affinity: "true"
   enable-svc-source-range-check: "true"
   enable-vtep: "false"


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Updating `cilium-nightly-config.yaml` to be single point of truth of latest relevant cilium config values. 

https://github.com/cilium/cilium/blob/main/Documentation/operations/upgrade.rst#removed-options
> Deprecated Options
> The unused flag sidecar-istio-proxy-image has been removed.
> The enable-remote-node-identity flag has been deprecated and will be removed in Cilium 1.16. This flag is needed for various features to work correctly and has been enabled by default since Cilium 1.7. There is no benefit in disabling it anymore.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
Ensure that these are removed from appropriate cilium-config(s) when applicable. 
- v1.16 remove `sidecar-istio-proxy-image`
- v1.15 remove `enable-remote-node-identity`