### PR TITLE
fix: move bufio reader creation out of for loop to fix telemetry unmarshal errors

### DIFF
--- a/telemetry/telemetrybuffer.go
+++ b/telemetry/telemetrybuffer.go
@@ -138,8 +138,8 @@ func (tb *TelemetryBuffer) StartServer() error {
 					}()
 					reader := bufio.NewReader(conn)
 					for {
-						reportStr, err := read(reader)
-						if err != nil {
+						reportStr, readErr := read(reader)
+						if readErr != nil {
 							return
 						}
 						var tmp map[string]interface{}

--- a/telemetry/telemetrybuffer.go
+++ b/telemetry/telemetrybuffer.go
@@ -138,10 +138,12 @@ func (tb *TelemetryBuffer) StartServer() error {
 					}()
 					reader := bufio.NewReader(conn)
 					for {
-						reportStr, readErr := read(reader)
+						reportStr, readErr := reader.ReadBytes(Delimiter)
 						if readErr != nil {
 							return
 						}
+						reportStr = reportStr[:len(reportStr)-1]
+
 						var tmp map[string]interface{}
 						err = json.Unmarshal(reportStr, &tmp)
 						if err != nil {
@@ -226,16 +228,6 @@ func (tb *TelemetryBuffer) PushData(ctx context.Context) {
 			return
 		}
 	}
-}
-
-// read - read from the file descriptor
-func read(reader *bufio.Reader) (b []byte, err error) {
-	b, err = reader.ReadBytes(Delimiter)
-	if err == nil {
-		b = b[:len(b)-1]
-	}
-
-	return
 }
 
 // Write - write to the file descriptor.

--- a/telemetry/telemetrybuffer.go
+++ b/telemetry/telemetrybuffer.go
@@ -136,9 +136,9 @@ func (tb *TelemetryBuffer) StartServer() error {
 							tb.connections = remove(tb.connections, index)
 						}
 					}()
-
+					reader := bufio.NewReader(conn)
 					for {
-						reportStr, err := read(conn)
+						reportStr, err := read(reader)
 						if err != nil {
 							return
 						}
@@ -229,8 +229,8 @@ func (tb *TelemetryBuffer) PushData(ctx context.Context) {
 }
 
 // read - read from the file descriptor
-func read(conn net.Conn) (b []byte, err error) {
-	b, err = bufio.NewReader(conn).ReadBytes(Delimiter)
+func read(reader *bufio.Reader) (b []byte, err error) {
+	b, err = reader.ReadBytes(Delimiter)
 	if err == nil {
 		b = b[:len(b)-1]
 	}

--- a/telemetry/telemetrybuffer_test.go
+++ b/telemetry/telemetrybuffer_test.go
@@ -117,8 +117,8 @@ func TestWrite(t *testing.T) {
 	}{
 		{
 			name:    "write",
-			data:    []byte("testdata"),
-			want:    len("testdata") + 1, // +1 due to Delimiter('\n)
+			data:    []byte("{\"testdata\":1}"),
+			want:    len("{\"testdata\":1}") + 1, // +1 due to Delimiter('\n)
 			wantErr: false,
 		},
 		{

--- a/telemetry/telemetrybuffer_test.go
+++ b/telemetry/telemetrybuffer_test.go
@@ -70,6 +70,36 @@ func TestClientConnClose(t *testing.T) {
 	tbClient.Close()
 }
 
+func TestCloseOnWriteError(t *testing.T) {
+	tbServer, closeTBServer := createTBServer(t)
+	defer closeTBServer()
+
+	tbClient := NewTelemetryBuffer(nil)
+	err := tbClient.Connect()
+	require.NoError(t, err)
+	defer tbClient.Close()
+
+	data := []byte("{\"good\":1}")
+	_, err = tbClient.Write(data)
+	require.NoError(t, err)
+	// need to wait for connection to populate in server
+	time.Sleep(1 * time.Second)
+	tbServer.mutex.Lock()
+	conns := tbServer.connections
+	tbServer.mutex.Unlock()
+	require.Len(t, conns, 1)
+
+	// the connection should be automatically closed on failure
+	badData := []byte("} malformed json }}}")
+	_, err = tbClient.Write(badData)
+	require.NoError(t, err)
+	time.Sleep(1 * time.Second)
+	tbServer.mutex.Lock()
+	conns = tbServer.connections
+	tbServer.mutex.Unlock()
+	require.Empty(t, conns)
+}
+
 func TestWrite(t *testing.T) {
 	_, closeTBServer := createTBServer(t)
 	defer closeTBServer()


### PR DESCRIPTION
If the bufio reader is created in the for loop that handles reads we get unmarshaling errors. Creating a single bufio reader outside of the for loop once the connection is accepted and then repeatedly looping over that single reader fixes this issue.

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
See above

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [X] relevant PR labels added

**Notes**:
