### PR TITLE
Add default routes k8s windows

### DIFF
--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -208,11 +208,6 @@ stages:
                 name: azure-ipam
                 os: windows
                 os_version: ltsc2022
-              cni_dropgz_windows2025_amd64:
-                arch: amd64
-                name: cni-dropgz
-                os: windows
-                os_version: ltsc2022-KB5035857
               cni_linux_amd64:
                 arch: amd64
                 name: cni
@@ -255,11 +250,6 @@ stages:
                 name: cns
                 os: windows
                 os_version: ltsc2022
-              cns_windows2025_amd64:
-                arch: amd64
-                name: cns
-                os: windows
-                os_version: ltsc2022-KB5035857
               ipv6_hp_bpf_linux_amd64:
                 arch: amd64
                 name: ipv6-hp-bpf
@@ -375,11 +365,11 @@ stages:
                 platforms: linux/amd64 linux/arm64 windows/amd64
               cni_dropgz:
                 name: cni-dropgz
-                os_versions: ltsc2019 ltsc2022 ltsc2022-KB5035857
+                os_versions: ltsc2019 ltsc2022
                 platforms: linux/amd64 linux/arm64 windows/amd64
               cns:
                 name: cns
-                os_versions: ltsc2019 ltsc2022 ltsc2022-KB5035857
+                os_versions: ltsc2019 ltsc2022
                 platforms: linux/amd64 linux/arm64 windows/amd64
               ipv6_hp_bpf:
                 name: ipv6-hp-bpf

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -208,6 +208,11 @@ stages:
                 name: azure-ipam
                 os: windows
                 os_version: ltsc2022
+              cni_dropgz_windows2025_amd64:
+                arch: amd64
+                name: cni-dropgz
+                os: windows
+                os_version: ltsc2022-KB5035857
               cni_linux_amd64:
                 arch: amd64
                 name: cni
@@ -250,6 +255,11 @@ stages:
                 name: cns
                 os: windows
                 os_version: ltsc2022
+              cns_windows2025_amd64:
+                arch: amd64
+                name: cns
+                os: windows
+                os_version: win2025
               ipv6_hp_bpf_linux_amd64:
                 arch: amd64
                 name: ipv6-hp-bpf
@@ -599,7 +609,7 @@ stages:
                 clusterName: "mtcluster"
               swiftv2_dummy_e2e:
                 name: swiftv2_dummy_e2e
-                clusterName: "swiftv2dummy"              
+                clusterName: "swiftv2dummy"
           steps:
             - template: templates/delete-cluster.yaml
               parameters:

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -259,7 +259,7 @@ stages:
                 arch: amd64
                 name: cns
                 os: windows
-                os_version: win2025
+                os_version: ltsc2022-KB5035857
               ipv6_hp_bpf_linux_amd64:
                 arch: amd64
                 name: ipv6-hp-bpf
@@ -379,7 +379,7 @@ stages:
                 platforms: linux/amd64 linux/arm64 windows/amd64
               cns:
                 name: cns
-                os_versions: ltsc2019 ltsc2022 win2025
+                os_versions: ltsc2019 ltsc2022 ltsc2022-KB5035857
                 platforms: linux/amd64 linux/arm64 windows/amd64
               ipv6_hp_bpf:
                 name: ipv6-hp-bpf

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -375,11 +375,11 @@ stages:
                 platforms: linux/amd64 linux/arm64 windows/amd64
               cni_dropgz:
                 name: cni-dropgz
-                os_versions: ltsc2019 ltsc2022
+                os_versions: ltsc2019 ltsc2022 ltsc2022-KB5035857
                 platforms: linux/amd64 linux/arm64 windows/amd64
               cns:
                 name: cns
-                os_versions: ltsc2019 ltsc2022
+                os_versions: ltsc2019 ltsc2022 win2025
                 platforms: linux/amd64 linux/arm64 windows/amd64
               ipv6_hp_bpf:
                 name: ipv6-hp-bpf

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ GOOSES   ?= "linux windows" # To override at the cli do: GOOSES="\"darwin bsd\""
 GOARCHES ?= "amd64 arm64" # To override at the cli do: GOARCHES="\"ppc64 mips\""
 ltsc2019  = "10.0.17763.4010"
 ltsc2022  = "10.0.20348.643"
+ltsc2022-KB5035857   = "10.0.26100.1"
+win2025 = "10.0.26100.1"
 
 # Windows specific extensions
 # set these based on the GOOS, not the OS
@@ -183,11 +185,11 @@ azure-ipam-binary:
 
 # Build the ipv6-hp-bpf binary.
 ipv6-hp-bpf-binary:
-	cd $(IPV6_HP_BPF_DIR) && CGO_ENABLED=0 go generate ./... 
+	cd $(IPV6_HP_BPF_DIR) && CGO_ENABLED=0 go generate ./...
 	cd $(IPV6_HP_BPF_DIR)/cmd/ipv6-hp-bpf && CGO_ENABLED=0 go build -v -o $(IPV6_HP_BPF_BUILD_DIR)/ipv6-hp-bpf$(EXE_EXT) -ldflags "-X main.version=$(IPV6_HP_BPF_VERSION)" -gcflags="-dwarflocationlists=true"
 
 # Libraries for ipv6-hp-bpf
-ipv6-hp-bpf-lib: 
+ipv6-hp-bpf-lib:
 ifeq ($(GOARCH),amd64)
 	sudo apt-get update && sudo apt-get install -y llvm clang linux-libc-dev linux-headers-generic libbpf-dev libc6-dev nftables iproute2 gcc-multilib
 	for dir in /usr/include/x86_64-linux-gnu/*; do sudo ln -sfn "$$dir" /usr/include/$$(basename "$$dir"); done

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,6 @@ GOOSES   ?= "linux windows" # To override at the cli do: GOOSES="\"darwin bsd\""
 GOARCHES ?= "amd64 arm64" # To override at the cli do: GOARCHES="\"ppc64 mips\""
 ltsc2019  = "10.0.17763.4010"
 ltsc2022  = "10.0.20348.643"
-ltsc2022-KB5035857   = "10.0.26100.1"
-win2025 = "10.0.26100.1"
 
 # Windows specific extensions
 # set these based on the GOOS, not the OS

--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -28,7 +28,6 @@ FROM mcr.microsoft.com/windows/servercore@sha256:6fdf140282a2f809dae9b13fe441635
 # intermediate for win-ltsc2022
 FROM mcr.microsoft.com/windows/servercore@sha256:45952938708fbde6ec0b5b94de68bcdec3f8c838be018536b1e9e5bd95e6b943 as ltsc2022
 
-# FROM mcr.microsoft.com/windows/server/insider:10.0.26080.1 as
 FROM mcr.microsoft.com/windows/servercore:ltsc2022-KB5035857-amd64 as win2025
 
 FROM ${OS_VERSION} as windows

--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -28,8 +28,6 @@ FROM mcr.microsoft.com/windows/servercore@sha256:6fdf140282a2f809dae9b13fe441635
 # intermediate for win-ltsc2022
 FROM mcr.microsoft.com/windows/servercore@sha256:45952938708fbde6ec0b5b94de68bcdec3f8c838be018536b1e9e5bd95e6b943 as ltsc2022
 
-FROM mcr.microsoft.com/windows/servercore:ltsc2022-KB5035857-amd64 as win2025
-
 FROM ${OS_VERSION} as windows
 COPY --from=builder /azure-container-networking/cns/kubeconfigtemplate.yaml kubeconfigtemplate.yaml
 COPY --from=builder /azure-container-networking/npm/examples/windows/setkubeconfigpath.ps1 setkubeconfigpath.ps1

--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -28,6 +28,9 @@ FROM mcr.microsoft.com/windows/servercore@sha256:6fdf140282a2f809dae9b13fe441635
 # intermediate for win-ltsc2022
 FROM mcr.microsoft.com/windows/servercore@sha256:45952938708fbde6ec0b5b94de68bcdec3f8c838be018536b1e9e5bd95e6b943 as ltsc2022
 
+# FROM mcr.microsoft.com/windows/server/insider:10.0.26080.1 as
+FROM mcr.microsoft.com/windows/servercore:ltsc2022-KB5035857-amd64 as win2025
+
 FROM ${OS_VERSION} as windows
 COPY --from=builder /azure-container-networking/cns/kubeconfigtemplate.yaml kubeconfigtemplate.yaml
 COPY --from=builder /azure-container-networking/npm/examples/windows/setkubeconfigpath.ps1 setkubeconfigpath.ps1

--- a/cns/middlewares/k8sSwiftV2_windows.go
+++ b/cns/middlewares/k8sSwiftV2_windows.go
@@ -5,11 +5,10 @@ import (
 	"github.com/Azure/azure-container-networking/cns/logger"
 )
 
-// setRoutes sets the routes for podIPInfo used in SWIFT V2 scenario. 
 // for AKS L1VH, do not set default route on infraNIC to avoid customer pod reaching all infra vnet services
-// default route is set for secondary interface NIC
+// default route is set for secondary interface NIC(i.e,delegatedNIC)
 func (k *K8sSWIFTv2Middleware) setRoutes(podIPInfo *cns.PodIpInfo) error {
-	logger.Printf("[SWIFTv2Middleware] setRoutes: only skipDefaultRoutes for InfraNIC")
+	logger.Printf("[SWIFTv2Middleware] setRoutes: only set skipDefaultRoutes flag to true for InfraNIC")
 	if podIPInfo.NICType == cns.InfraNIC {
 		podIPInfo.SkipDefaultRoutes = true
 	}

--- a/cns/middlewares/k8sSwiftV2_windows.go
+++ b/cns/middlewares/k8sSwiftV2_windows.go
@@ -6,7 +6,12 @@ import (
 )
 
 // setRoutes sets the routes for podIPInfo used in SWIFT V2 scenario. This is a no-op as route setting is not applicable for Windows.
-func (k *K8sSWIFTv2Middleware) setRoutes(_ *cns.PodIpInfo) error {
-	logger.Printf("[SWIFTv2Middleware] setRoutes is a no-op on Windows")
+// for AKS L1VH, do not set default route on infraNIC to avoid customer pod reaching all infra vnet services
+// default route is set for secondary interface NIC
+func (k *K8sSWIFTv2Middleware) setRoutes(podIPInfo *cns.PodIpInfo) error {
+	logger.Printf("[SWIFTv2Middleware] setRoutes: only skipDefaultRoutes for InfraNIC")
+	if podIPInfo.NICType == cns.InfraNIC {
+		podIPInfo.SkipDefaultRoutes = true
+	}
 	return nil
 }

--- a/cns/middlewares/k8sSwiftV2_windows.go
+++ b/cns/middlewares/k8sSwiftV2_windows.go
@@ -8,8 +8,8 @@ import (
 // for AKS L1VH, do not set default route on infraNIC to avoid customer pod reaching all infra vnet services
 // default route is set for secondary interface NIC(i.e,delegatedNIC)
 func (k *K8sSWIFTv2Middleware) setRoutes(podIPInfo *cns.PodIpInfo) error {
-	logger.Printf("[SWIFTv2Middleware] setRoutes: only set skipDefaultRoutes flag to true for InfraNIC")
 	if podIPInfo.NICType == cns.InfraNIC {
+		logger.Printf("[SWIFTv2Middleware] skip setting default route on InfraNIC interface")
 		podIPInfo.SkipDefaultRoutes = true
 	}
 	return nil

--- a/cns/middlewares/k8sSwiftV2_windows.go
+++ b/cns/middlewares/k8sSwiftV2_windows.go
@@ -5,7 +5,7 @@ import (
 	"github.com/Azure/azure-container-networking/cns/logger"
 )
 
-// setRoutes sets the routes for podIPInfo used in SWIFT V2 scenario. This is a no-op as route setting is not applicable for Windows.
+// setRoutes sets the routes for podIPInfo used in SWIFT V2 scenario. 
 // for AKS L1VH, do not set default route on infraNIC to avoid customer pod reaching all infra vnet services
 // default route is set for secondary interface NIC
 func (k *K8sSWIFTv2Middleware) setRoutes(podIPInfo *cns.PodIpInfo) error {

--- a/cns/middlewares/k8sSwiftV2_windows_test.go
+++ b/cns/middlewares/k8sSwiftV2_windows_test.go
@@ -1,0 +1,41 @@
+package middlewares
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/middlewares/mock"
+	"gotest.tools/v3/assert"
+)
+
+func TestSetRoutesSuccess(t *testing.T) {
+	middleware := K8sSWIFTv2Middleware{Cli: mock.NewClient()}
+
+	podIPInfo := []cns.PodIpInfo{
+		{
+			PodIPConfig: cns.IPSubnet{
+				IPAddress:    "10.0.1.10",
+				PrefixLength: 32,
+			},
+			NICType: cns.InfraNIC,
+		},
+		{
+			PodIPConfig: cns.IPSubnet{
+				IPAddress:    "20.240.1.242",
+				PrefixLength: 32,
+			},
+			NICType:    cns.DelegatedVMNIC,
+			MacAddress: "12:34:56:78:9a:bc",
+		},
+	}
+	for i := range podIPInfo {
+		ipInfo := &podIPInfo[i]
+		err := middleware.setRoutes(ipInfo)
+		assert.Equal(t, err, nil)
+		if ipInfo.NICType == cns.InfraNIC {
+			assert.Equal(t, ipInfo.SkipDefaultRoutes, true)
+		} else {
+			assert.Equal(t, ipInfo.SkipDefaultRoutes, false)
+		}
+	}
+}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Add default routes k8s windows

In Swiftv2 Windows scenario, we need to set default route on delegatedNIC interface instead of infraNIC interface, so we need to set skpDefaultRoutes to true for infraNIC interface

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
