### PR TITLE
fix: update azure-vnet directory permissions

### DIFF
--- a/processlock/processlock.go
+++ b/processlock/processlock.go
@@ -32,8 +32,8 @@ func NewFileLock(fileAbsPath string) (Interface, error) {
 		return nil, ErrEmptyFilePath
 	}
 
-	//nolint:gomnd //0o664 - permission to create directory in octal
-	err := os.MkdirAll(filepath.Dir(fileAbsPath), os.FileMode(0o664))
+	//nolint:gomnd //0o755 - permission to create directory in octal
+	err := os.MkdirAll(filepath.Dir(fileAbsPath), os.FileMode(0o755))
 	if err != nil {
 		return nil, errors.Wrap(err, "mkdir lock dir returned error")
 	}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Address race issue in 1.6.x
Now it should not matter if cni or k8s makes the directory since they should both have 0755 permissions.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
#2818 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
Created nodesubnet/legacy cluster (no cns), checked var/run/azure-vnet directory and it has 0644 permissions.
Replaced cni version with this new one and restarted the node. The var/run/azure-vnet directory now has 0755 permissions after the reboot.