### PR TITLE
ci: align cilium charts with AKS

### DIFF
--- a/test/integration/manifests/cilium/v1.13/cilium-config/cilium-config.yaml
+++ b/test/integration/manifests/cilium/v1.13/cilium-config/cilium-config.yaml
@@ -16,6 +16,7 @@ data:
   debug: "false"
   disable-cnp-status-updates: "true"
   disable-endpoint-crd: "false"
+  dnsproxy-enable-transparent-mode: "false"
   enable-auto-protect-node-port-range: "true"
   enable-bgp-control-plane: "false"
   enable-bpf-clock-probe: "true"

--- a/test/integration/manifests/cilium/v1.14/cilium-agent/templates/daemonset-dualstack.yaml
+++ b/test/integration/manifests/cilium/v1.14/cilium-agent/templates/daemonset-dualstack.yaml
@@ -308,35 +308,6 @@ spec:
           name: cilium-cgroup
         - mountPath: /var/run/cilium
           name: cilium-run
-      - command:
-        - bash
-        - -cex
-        - |
-          export LD_LIBRARY_PATH=/host/lib/systemd:/host/usr/lib/aarch64-linux-gnu:/host/usr/lib/x86_64-linux-gnu
-          export SYSTEMD_VERSION="$(/host/lib/systemd/systemd --version | head -n 1 | cut -d' ' -f2)"
-          [[ $SYSTEMD_VERSION -ge 249 ]] && {
-              mkdir -p /host/etc/systemd/networkd.conf.d
-              echo -e "[Network]\nManageForeignRoutes=no\nManageForeignRoutingPolicyRules=no\n" \
-                >/host/etc/systemd/networkd.conf.d/99-cilium-foreign-routes.conf
-              chmod -R u+rwX,go+rX /host/etc/systemd/networkd.conf.d
-            } || exit 0
-        image: mcr.microsoft.com/cbl-mariner/base/core:2.0
-        imagePullPolicy: IfNotPresent
-        name: systemd-networkd-overrides
-        resources: {}
-        securityContext:
-          privileged: true
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /host/etc/systemd
-          name: host-etc-systemd
-        - mountPath: /host/lib/systemd
-          name: host-lib-systemd
-          readOnly: true
-        - mountPath: /host/usr/lib
-          name: host-usr-lib
-          readOnly: true
       - name: start-ipv6-hp-bpf
         image: acnpublic.azurecr.io/ipv6-hp-bpf:$IPV6_HP_BPF_VERSION
         imagePullPolicy: IfNotPresent

--- a/test/integration/manifests/cilium/v1.14/cilium-agent/templates/daemonset-dualstack.yaml
+++ b/test/integration/manifests/cilium/v1.14/cilium-agent/templates/daemonset-dualstack.yaml
@@ -313,7 +313,13 @@ spec:
         imagePullPolicy: IfNotPresent
         command: [/ipv6-hp-bpf]
         securityContext:
-          privileged: true
+          capabilities:
+            add:
+            - NET_ADMIN
+            - IPC_LOCK
+            - SYS_ADMIN
+            drop:
+            - ALL
         volumeMounts:
         - mountPath: /var/log
           name: ipv6-hp-bpf

--- a/test/integration/manifests/cilium/v1.14/cilium-agent/templates/daemonset.yaml
+++ b/test/integration/manifests/cilium/v1.14/cilium-agent/templates/daemonset.yaml
@@ -308,35 +308,6 @@ spec:
           name: cilium-cgroup
         - mountPath: /var/run/cilium
           name: cilium-run
-      - command:
-        - bash
-        - -cex
-        - |
-          export LD_LIBRARY_PATH=/host/lib/systemd:/host/usr/lib/aarch64-linux-gnu:/host/usr/lib/x86_64-linux-gnu
-          export SYSTEMD_VERSION="$(/host/lib/systemd/systemd --version | head -n 1 | cut -d' ' -f2)"
-          [[ $SYSTEMD_VERSION -ge 249 ]] && {
-              mkdir -p /host/etc/systemd/networkd.conf.d
-              echo -e "[Network]\nManageForeignRoutes=no\nManageForeignRoutingPolicyRules=no\n" \
-                >/host/etc/systemd/networkd.conf.d/99-cilium-foreign-routes.conf
-              chmod -R u+rwX,go+rX /host/etc/systemd/networkd.conf.d
-            } || exit 0
-        image: mcr.microsoft.com/cbl-mariner/base/core:2.0
-        imagePullPolicy: IfNotPresent
-        name: systemd-networkd-overrides
-        resources: {}
-        securityContext:
-          privileged: true
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /host/etc/systemd
-          name: host-etc-systemd
-        - mountPath: /host/lib/systemd
-          name: host-lib-systemd
-          readOnly: true
-        - mountPath: /host/usr/lib
-          name: host-usr-lib
-          readOnly: true
       - name: block-wireserver
         image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
         imagePullPolicy: IfNotPresent

--- a/test/integration/manifests/cilium/v1.14/cilium-config/cilium-config-dualstack.yaml
+++ b/test/integration/manifests/cilium/v1.14/cilium-config/cilium-config-dualstack.yaml
@@ -17,6 +17,7 @@ data:
   debug: "false"
   disable-cnp-status-updates: "true"
   disable-endpoint-crd: "false"
+  dnsproxy-enable-transparent-mode: "false"
   enable-auto-protect-node-port-range: "true"
   enable-bgp-control-plane: "false"
   enable-bpf-clock-probe: "true"

--- a/test/integration/manifests/cilium/v1.14/cilium-config/cilium-config-hubble.yaml
+++ b/test/integration/manifests/cilium/v1.14/cilium-config/cilium-config-hubble.yaml
@@ -16,6 +16,7 @@ data:
   debug: "false"
   disable-cnp-status-updates: "true"
   disable-endpoint-crd: "false"
+  dnsproxy-enable-transparent-mode: "false"
   enable-auto-protect-node-port-range: "true"
   enable-bgp-control-plane: "false"
   enable-bpf-clock-probe: "true"

--- a/test/integration/manifests/cilium/v1.14/cilium-config/cilium-config.yaml
+++ b/test/integration/manifests/cilium/v1.14/cilium-config/cilium-config.yaml
@@ -16,6 +16,7 @@ data:
   debug: "false"
   disable-cnp-status-updates: "true"
   disable-endpoint-crd: "false"
+  dnsproxy-enable-transparent-mode: "false"
   enable-auto-protect-node-port-range: "true"
   enable-bgp-control-plane: "false"
   enable-bpf-clock-probe: "true"


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
- systemd-netword-overrides init container was removed in charts for cilium 1.14 since this was fixed upstream
- adding new config value `dnsproxy-enable-transparent-mode: "false"` which is present in 1.13 and 1.14


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
