### PR TITLE
feat: Add CNS API to retrieve VMUniqueID from IMDS

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -18,6 +18,7 @@ import (
 const (
 	SetOrchestratorType                      = "/network/setorchestratortype"
 	GetHomeAz                                = "/homeaz"
+	GetVMUniqueID                            = "/vmuniqueid"
 	CreateOrUpdateNetworkContainer           = "/network/createorupdatenetworkcontainer"
 	DeleteNetworkContainer                   = "/network/deletenetworkcontainer"
 	PublishNetworkContainer                  = "/network/publishnetworkcontainer"

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -18,7 +18,7 @@ import (
 const (
 	SetOrchestratorType                      = "/network/setorchestratortype"
 	GetHomeAz                                = "/homeaz"
-	GetVMUniqueID                            = "/vmuniqueid"
+	GetVMUniqueID                            = "/metadata/vmuniqueid"
 	CreateOrUpdateNetworkContainer           = "/network/createorupdatenetworkcontainer"
 	DeleteNetworkContainer                   = "/network/deletenetworkcontainer"
 	PublishNetworkContainer                  = "/network/publishnetworkcontainer"

--- a/cns/api.go
+++ b/cns/api.go
@@ -373,3 +373,8 @@ type EndpointRequest struct {
 	HostVethName  string `json:"hostVethName"`
 	InterfaceName string `json:"InterfaceName"`
 }
+
+type GetVMUniqueIDResponse struct {
+	Response   Response `json:"response"`
+	VMUniqueID string   `json:"VMUniqueID"`
+}

--- a/cns/api.go
+++ b/cns/api.go
@@ -306,8 +306,8 @@ type IpamPoolMonitorStateSnapshot struct {
 
 // Response describes generic response from CNS.
 type Response struct {
-	ReturnCode types.ResponseCode
-	Message    string
+	ReturnCode types.ResponseCode `json:"ReturnCode"`
+	Message    string             `json:"Message"`
 }
 
 // NumOfCPUCoresResponse describes num of cpu cores present on host.

--- a/cns/api.go
+++ b/cns/api.go
@@ -376,5 +376,5 @@ type EndpointRequest struct {
 
 type GetVMUniqueIDResponse struct {
 	Response   Response `json:"response"`
-	VMUniqueID string   `json:"VMUniqueID"`
+	VMUniqueID string   `json:"vmuniqueid"`
 }

--- a/cns/client/client_test.go
+++ b/cns/client/client_test.go
@@ -151,7 +151,9 @@ func TestMain(m *testing.M) {
 	logger.InitLogger(logName, 0, 0, tmpLogDir+"/")
 	config := common.ServiceConfig{}
 
-	httpRestService, err := restserver.NewHTTPRestService(&config, &fakes.WireserverClientFake{}, &fakes.WireserverProxyFake{}, &fakes.NMAgentClientFake{}, nil, nil, nil)
+	httpRestService, err := restserver.NewHTTPRestService(&config, &fakes.WireserverClientFake{},
+		&fakes.WireserverProxyFake{}, &fakes.NMAgentClientFake{}, nil, nil, nil,
+		fakes.NewMockIMDSClient())
 	svc = httpRestService
 	httpRestService.Name = "cns-test-server"
 

--- a/cns/fakes/imdsclientfake.go
+++ b/cns/fakes/imdsclientfake.go
@@ -9,6 +9,7 @@ package fakes
 import (
 	"context"
 
+	"github.com/Azure/azure-container-networking/cns/imds"
 	"github.com/Azure/azure-container-networking/cns/wireserver"
 )
 
@@ -16,10 +17,13 @@ const (
 	// HostPrimaryIP 10.0.0.4
 	HostPrimaryIP = "10.0.0.4"
 	// HostSubnet 10.0.0.0/24
-	HostSubnet = "10.0.0.0/24"
+	HostSubnet    = "10.0.0.0/24"
+	SimulateError = "simulate-error"
 )
 
 type WireserverClientFake struct{}
+type MockIMDSCtxKey string
+type MockIMDSClient struct{}
 
 func (c *WireserverClientFake) GetInterfaces(ctx context.Context) (*wireserver.GetInterfacesResult, error) {
 	return &wireserver.GetInterfacesResult{
@@ -40,4 +44,17 @@ func (c *WireserverClientFake) GetInterfaces(ctx context.Context) (*wireserver.G
 			},
 		},
 	}, nil
+}
+
+func NewMockIMDSClient() *MockIMDSClient {
+	return &MockIMDSClient{}
+}
+
+func (m *MockIMDSClient) GetVMUniqueID(ctx context.Context) (string, error) {
+	key := MockIMDSCtxKey(SimulateError)
+	if ctx.Value(key) != nil {
+		return "", imds.ErrUnexpectedStatusCode
+	}
+
+	return "55b8499d-9b42-4f85-843f-24ff69f4a643", nil
 }

--- a/cns/fakes/imdsclientfake.go
+++ b/cns/fakes/imdsclientfake.go
@@ -17,8 +17,8 @@ const (
 	// HostPrimaryIP 10.0.0.4
 	HostPrimaryIP = "10.0.0.4"
 	// HostSubnet 10.0.0.0/24
-	HostSubnet    = "10.0.0.0/24"
-	SimulateError = "simulate-error"
+	HostSubnet                   = "10.0.0.0/24"
+	SimulateError MockIMDSCtxKey = "simulate-error"
 )
 
 type WireserverClientFake struct{}
@@ -51,8 +51,7 @@ func NewMockIMDSClient() *MockIMDSClient {
 }
 
 func (m *MockIMDSClient) GetVMUniqueID(ctx context.Context) (string, error) {
-	key := MockIMDSCtxKey(SimulateError)
-	if ctx.Value(key) != nil {
+	if ctx.Value(SimulateError) != nil {
 		return "", imds.ErrUnexpectedStatusCode
 	}
 

--- a/cns/imds/client_test.go
+++ b/cns/imds/client_test.go
@@ -91,7 +91,7 @@ func TestInvalidVMUniqueID(t *testing.T) {
 		assert.Equal(t, "json", format)
 		w.WriteHeader(http.StatusOK)
 		_, writeErr := w.Write(computeMetadata)
-		assert.NoError(t, writeErr, "error writing response")
+		require.NoError(t, writeErr, "error writing response")
 	}))
 	defer mockIMDSServer.Close()
 

--- a/cns/imds/client_test.go
+++ b/cns/imds/client_test.go
@@ -74,3 +74,29 @@ func TestIMDSInvalidJSON(t *testing.T) {
 	_, err := imdsClient.GetVMUniqueID(context.Background())
 	require.Error(t, err, "expected json decoding error")
 }
+
+func TestInvalidVMUniqueID(t *testing.T) {
+	computeMetadata, err := os.ReadFile("testdata/invalidComputeMetadata.json")
+	require.NoError(t, err, "error reading testdata compute metadata file")
+
+	mockIMDSServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// request header "Metadata: true" must be present
+		metadataHeader := r.Header.Get("Metadata")
+		assert.Equal(t, "true", metadataHeader)
+
+		// query params should include apiversion and json format
+		apiVersion := r.URL.Query().Get("api-version")
+		assert.Equal(t, "2021-01-01", apiVersion)
+		format := r.URL.Query().Get("format")
+		assert.Equal(t, "json", format)
+		w.WriteHeader(http.StatusOK)
+		_, writeErr := w.Write(computeMetadata)
+		assert.NoError(t, writeErr, "error writing response")
+	}))
+	defer mockIMDSServer.Close()
+
+	imdsClient := imds.NewClient(imds.Endpoint(mockIMDSServer.URL))
+	vmUniqueID, err := imdsClient.GetVMUniqueID(context.Background())
+	require.Error(t, err, "error querying testserver")
+	require.Equal(t, "", vmUniqueID)
+}

--- a/cns/imds/testdata/invalidComputeMetadata.json
+++ b/cns/imds/testdata/invalidComputeMetadata.json
@@ -1,0 +1,5 @@
+{
+  "azEnvironment": "AzurePublicCloud",
+  "location": "westus2",
+  "vmId": ""
+}

--- a/cns/restserver/api_test.go
+++ b/cns/restserver/api_test.go
@@ -1783,8 +1783,7 @@ func TestGetVMUniqueIDSuccess(t *testing.T) {
 // Testing GetVMUniqueID API handler with failure
 func TestGetVMUniqueIDFailed(t *testing.T) {
 	ctx := context.TODO()
-	key := fakes.MockIMDSCtxKey(fakes.SimulateError)
-	ctx = context.WithValue(ctx, key, Interface{})
+	ctx = context.WithValue(ctx, fakes.SimulateError, Interface{})
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cns.GetVMUniqueID, http.NoBody)
 	if err != nil {
 		t.Fatal(err)

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -16,6 +16,8 @@ import (
 	"time"
 
 	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/common"
+	"github.com/Azure/azure-container-networking/cns/configuration"
 	"github.com/Azure/azure-container-networking/cns/fakes"
 	"github.com/Azure/azure-container-networking/cns/types"
 	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
@@ -1056,7 +1058,7 @@ func restartService() {
 	fmt.Println("Restart Service")
 
 	service.Stop()
-	if err := startService(); err != nil {
+	if err := startService(common.ServiceConfig{}, configuration.CNSConfig{}); err != nil {
 		fmt.Printf("Failed to restart CNS Service. Error: %v", err)
 		os.Exit(1)
 	}

--- a/cns/restserver/ipam_test.go
+++ b/cns/restserver/ipam_test.go
@@ -72,7 +72,9 @@ type ncState struct {
 
 func getTestService() *HTTPRestService {
 	var config common.ServiceConfig
-	httpsvc, _ := NewHTTPRestService(&config, &fakes.WireserverClientFake{}, &fakes.WireserverProxyFake{}, &fakes.NMAgentClientFake{}, store.NewMockStore(""), nil, nil)
+	httpsvc, _ := NewHTTPRestService(&config, &fakes.WireserverClientFake{}, &fakes.WireserverProxyFake{},
+		&fakes.NMAgentClientFake{}, store.NewMockStore(""), nil, nil,
+		fakes.NewMockIMDSClient())
 	svc = httpsvc
 	setOrchestratorTypeInternal(cns.KubernetesCRD)
 

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -287,7 +287,10 @@ func (service *HTTPRestService) Init(config *common.ServiceConfig) error {
 	listener.AddHandler(cns.NetworkContainersURLPath, service.getOrRefreshNetworkContainers)
 	listener.AddHandler(cns.GetHomeAz, service.getHomeAz)
 	listener.AddHandler(cns.EndpointPath, service.EndpointHandlerAPI)
-	listener.AddHandler(cns.GetVMUniqueID, service.getVMUniqueID)
+	// This API is only needed for Direct channel mode with Swift v2.
+	if config.ChannelMode == cns.Direct {
+		listener.AddHandler(cns.GetVMUniqueID, service.getVMUniqueID)
+	}
 
 	// handlers for v0.2
 	listener.AddHandler(cns.V2Prefix+cns.SetEnvironmentPath, service.setEnvironment)
@@ -314,7 +317,10 @@ func (service *HTTPRestService) Init(config *common.ServiceConfig) error {
 	listener.AddHandler(cns.V2Prefix+cns.NmAgentSupportedApisPath, service.nmAgentSupportedApisHandler)
 	listener.AddHandler(cns.V2Prefix+cns.GetHomeAz, service.getHomeAz)
 	listener.AddHandler(cns.V2Prefix+cns.EndpointPath, service.EndpointHandlerAPI)
-	listener.AddHandler(cns.V2Prefix+cns.GetVMUniqueID, service.getVMUniqueID)
+	// This API is only needed for Direct channel mode with Swift v2.
+	if config.ChannelMode == cns.Direct {
+		listener.AddHandler(cns.V2Prefix+cns.GetVMUniqueID, service.getVMUniqueID)
+	}
 
 	// Initialize HTTP client to be reused in CNS
 	connectionTimeout, _ := service.GetOption(acn.OptHttpConnectionTimeout).(int)

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -49,6 +49,10 @@ type wireserverProxy interface {
 	UnpublishNC(ctx context.Context, ncParams cns.NetworkContainerParameters, payload []byte) (*http.Response, error)
 }
 
+type IMDSClient interface {
+	GetVMUniqueID(ctx context.Context) (string, error)
+}
+
 // HTTPRestService represents http listener for CNS - Container Networking Service.
 type HTTPRestService struct {
 	*cns.Service
@@ -73,6 +77,7 @@ type HTTPRestService struct {
 	generateCNIConflistOnce    sync.Once
 	IPConfigsHandlerMiddleware cns.IPConfigsHandlerMiddleware
 	PnpIDByMacAddress          map[string]string
+	imdsClient                 IMDSClient
 }
 
 type CNIConflistGenerator interface {
@@ -163,6 +168,7 @@ type networkInfo struct {
 // NewHTTPRestService creates a new HTTP Service object.
 func NewHTTPRestService(config *common.ServiceConfig, wscli interfaceGetter, wsproxy wireserverProxy, nmagentClient nmagentClient,
 	endpointStateStore store.KeyValueStore, gen CNIConflistGenerator, homeAzMonitor *HomeAzMonitor,
+	imdsClient IMDSClient,
 ) (*HTTPRestService, error) {
 	service, err := cns.NewService(config.Name, config.Version, config.ChannelMode, config.Store)
 	if err != nil {
@@ -225,6 +231,7 @@ func NewHTTPRestService(config *common.ServiceConfig, wscli interfaceGetter, wsp
 		EndpointState:            make(map[string]*EndpointInfo),
 		homeAzMonitor:            homeAzMonitor,
 		cniConflistGenerator:     gen,
+		imdsClient:               imdsClient,
 	}, nil
 }
 

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -280,6 +280,8 @@ func (service *HTTPRestService) Init(config *common.ServiceConfig) error {
 	listener.AddHandler(cns.NetworkContainersURLPath, service.getOrRefreshNetworkContainers)
 	listener.AddHandler(cns.GetHomeAz, service.getHomeAz)
 	listener.AddHandler(cns.EndpointPath, service.EndpointHandlerAPI)
+	listener.AddHandler(cns.GetVMUniqueID, service.getVMUniqueID)
+
 	// handlers for v0.2
 	listener.AddHandler(cns.V2Prefix+cns.SetEnvironmentPath, service.setEnvironment)
 	listener.AddHandler(cns.V2Prefix+cns.CreateNetworkPath, service.createNetwork)
@@ -305,6 +307,7 @@ func (service *HTTPRestService) Init(config *common.ServiceConfig) error {
 	listener.AddHandler(cns.V2Prefix+cns.NmAgentSupportedApisPath, service.nmAgentSupportedApisHandler)
 	listener.AddHandler(cns.V2Prefix+cns.GetHomeAz, service.getHomeAz)
 	listener.AddHandler(cns.V2Prefix+cns.EndpointPath, service.EndpointHandlerAPI)
+	listener.AddHandler(cns.V2Prefix+cns.GetVMUniqueID, service.getVMUniqueID)
 
 	// Initialize HTTP client to be reused in CNS
 	connectionTimeout, _ := service.GetOption(acn.OptHttpConnectionTimeout).(int)

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -49,7 +49,7 @@ type wireserverProxy interface {
 	UnpublishNC(ctx context.Context, ncParams cns.NetworkContainerParameters, payload []byte) (*http.Response, error)
 }
 
-type IMDSClient interface {
+type imdsClient interface {
 	GetVMUniqueID(ctx context.Context) (string, error)
 }
 
@@ -77,7 +77,7 @@ type HTTPRestService struct {
 	generateCNIConflistOnce    sync.Once
 	IPConfigsHandlerMiddleware cns.IPConfigsHandlerMiddleware
 	PnpIDByMacAddress          map[string]string
-	imdsClient                 IMDSClient
+	imdsClient                 imdsClient
 }
 
 type CNIConflistGenerator interface {
@@ -168,7 +168,7 @@ type networkInfo struct {
 // NewHTTPRestService creates a new HTTP Service object.
 func NewHTTPRestService(config *common.ServiceConfig, wscli interfaceGetter, wsproxy wireserverProxy, nmagentClient nmagentClient,
 	endpointStateStore store.KeyValueStore, gen CNIConflistGenerator, homeAzMonitor *HomeAzMonitor,
-	imdsClient IMDSClient,
+	imdsClient imdsClient,
 ) (*HTTPRestService, error) {
 	service, err := cns.NewService(config.Name, config.Version, config.ChannelMode, config.Store)
 	if err != nil {

--- a/cns/restserver/v2/server_test.go
+++ b/cns/restserver/v2/server_test.go
@@ -49,7 +49,9 @@ func startService(cnsPort, cnsURL string) error {
 	config := common.ServiceConfig{}
 
 	nmagentClient := &fakes.NMAgentClientFake{}
-	service, err := restserver.NewHTTPRestService(&config, &fakes.WireserverClientFake{}, &fakes.WireserverProxyFake{}, nmagentClient, nil, nil, nil)
+	service, err := restserver.NewHTTPRestService(&config, &fakes.WireserverClientFake{},
+		&fakes.WireserverProxyFake{}, nmagentClient, nil, nil, nil,
+		fakes.NewMockIMDSClient())
 	if err != nil {
 		return errors.Wrap(err, "Failed to initialize service")
 	}

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -748,8 +748,10 @@ func main() {
 		Logger:     logger.Log,
 	}
 
+	imdsClient := imds.NewClient()
+
 	httpRemoteRestService, err := restserver.NewHTTPRestService(&config, wsclient, &wsProxy, nmaClient,
-		endpointStateStore, conflistGenerator, homeAzMonitor)
+		endpointStateStore, conflistGenerator, homeAzMonitor, imdsClient)
 	if err != nil {
 		logger.Errorf("Failed to create CNS object, err:%v.\n", err)
 		return


### PR DESCRIPTION
**Reason for Change**:
Adding a new CNS API to retrieve vmuniqueID of the VM where CNS is running. This uses the existing imdsclient in CNS which already has a method to retrieve vmUniqueID.

This API will invoked by DNC for Swift v2 scenario for ACI/standalone to discover VMUniqueID for the node.


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [x] relevant PR labels added

**Notes**:
