### PR TITLE
test: add ut for populating network and endpoint hns id in endpoint and endpoint info structs

### DIFF
--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Azure/azure-container-networking/netlink"
 	"github.com/Azure/azure-container-networking/network/policy"
 	"github.com/Azure/azure-container-networking/platform"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -385,4 +386,25 @@ func (epInfo *EndpointInfo) IsEndpointStateIncomplete() bool {
 		return true
 	}
 	return false
+}
+
+func (ep *endpoint) validateEndpoint() error {
+	if ep.ContainerID == "" || ep.NICType == "" {
+		return errors.New("endpoint struct must contain a container id and nic type")
+	}
+	return nil
+}
+
+func validateEndpoints(eps []*endpoint) error {
+	containerIDs := map[string]bool{}
+	for _, ep := range eps {
+		if err := ep.validateEndpoint(); err != nil {
+			return errors.Wrap(err, "failed to validate endpoint struct")
+		}
+		containerIDs[ep.ContainerID] = true
+	}
+	if len(containerIDs) != 1 {
+		return errors.New("multiple distinct container ids detected")
+	}
+	return nil
 }

--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -402,9 +402,10 @@ func validateEndpoints(eps []*endpoint) error {
 			return errors.Wrap(err, "failed to validate endpoint struct")
 		}
 		containerIDs[ep.ContainerID] = true
-	}
-	if len(containerIDs) != 1 {
-		return errors.New("multiple distinct container ids detected")
+
+		if len(containerIDs) != 1 {
+			return errors.New("multiple distinct container ids detected")
+		}
 	}
 	return nil
 }

--- a/network/endpoint_test.go
+++ b/network/endpoint_test.go
@@ -175,10 +175,11 @@ var _ = Describe("Test Endpoint", func() {
 				Endpoints: map[string]*endpoint{},
 			}
 			epInfo := &EndpointInfo{
-				EndpointID: "768e8deb-eth1",
-				Data:       make(map[string]interface{}),
-				IfName:     eth0IfName,
-				NICType:    cns.InfraNIC,
+				EndpointID:  "768e8deb-eth1",
+				Data:        make(map[string]interface{}),
+				IfName:      eth0IfName,
+				NICType:     cns.InfraNIC,
+				ContainerID: "0ea7476f26d192f067abdc8b3df43ce3cdbe324386e1c010cb48de87eefef480",
 			}
 			epInfo.Data[VlanIDKey] = 100
 
@@ -206,6 +207,7 @@ var _ = Describe("Test Endpoint", func() {
 				Expect(ep.Gateways[0].String()).To(Equal("192.168.0.1"))
 				Expect(ep.VlanID).To(Equal(epInfo.Data[VlanIDKey].(int)))
 				Expect(ep.IfName).To(Equal(epInfo.IfName))
+				Expect(ep.ContainerID).To(Equal(epInfo.ContainerID))
 			})
 			It("Should be not added", func() {
 				// Adding an endpoint with an id.
@@ -371,6 +373,70 @@ var _ = Describe("Test Endpoint", func() {
 					podName := GetPodNameWithoutSuffix(testValue)
 					Expect(podName).To(Equal(expectedPodName))
 				}
+			})
+		})
+	})
+
+	// validation when calling add
+	Describe("Test validateEndpoints", func() {
+		Context("When in a single add call we create two endpoint structs", func() {
+			It("Should have the same container id", func() {
+				eps := []*endpoint{
+					{
+						ContainerID: "0ea7476f26d192f067abdc8b3df43ce3cdbe324386e1c010cb48de87eefef480",
+						NICType:     cns.InfraNIC,
+					},
+					{
+						ContainerID: "0ea7476f26d192f067abdc8b3df43ce3cdbe324386e1c010cb48de87eefef480",
+						NICType:     cns.DelegatedVMNIC,
+					},
+				}
+				Expect(validateEndpoints(eps)).To(BeNil())
+			})
+		})
+		Context("When in a single add call we have different container ids", func() {
+			It("Should error", func() {
+				eps := []*endpoint{
+					{
+						ContainerID: "0ea7476f26d192f067abdc8b3df43ce3cdbe324386e1c010cb48de87eefef480",
+						NICType:     cns.InfraNIC,
+					},
+					{
+						ContainerID: "0ea7476f26d192f067abdc8b3df43ce3cdbe324386e1c010cb48de87eefef481",
+						NICType:     cns.DelegatedVMNIC,
+					},
+				}
+				Expect(validateEndpoints(eps)).ToNot(BeNil())
+			})
+		})
+		Context("When no container id", func() {
+			It("Should error", func() {
+				eps := []*endpoint{
+					{
+						ContainerID: "",
+						NICType:     cns.InfraNIC,
+					},
+					{
+						ContainerID: "",
+						NICType:     cns.DelegatedVMNIC,
+					},
+				}
+				Expect(validateEndpoints(eps)).ToNot(BeNil())
+			})
+		})
+		Context("When missing nic type", func() {
+			It("Should error", func() {
+				eps := []*endpoint{
+					{
+						ContainerID: "0ea7476f26d192f067abdc8b3df43ce3cdbe324386e1c010cb48de87eefef480",
+						NICType:     cns.InfraNIC,
+					},
+					{
+						ContainerID: "0ea7476f26d192f067abdc8b3df43ce3cdbe324386e1c010cb48de87eefef480",
+						NICType:     "",
+					},
+				}
+				Expect(validateEndpoints(eps)).ToNot(BeNil())
 			})
 		})
 	})

--- a/network/endpoint_test.go
+++ b/network/endpoint_test.go
@@ -439,5 +439,16 @@ var _ = Describe("Test Endpoint", func() {
 				Expect(validateEndpoints(eps)).ToNot(BeNil())
 			})
 		})
+		Context("When no container id ib nic", func() {
+			It("Should error", func() {
+				eps := []*endpoint{
+					{
+						ContainerID: "",
+						NICType:     cns.NodeNetworkInterfaceBackendNIC,
+					},
+				}
+				Expect(validateEndpoints(eps)).ToNot(BeNil())
+			})
+		})
 	})
 })

--- a/network/endpoint_windows_test.go
+++ b/network/endpoint_windows_test.go
@@ -35,9 +35,7 @@ func TestNewAndDeleteEndpointImplHnsV2(t *testing.T) {
 
 	// this hnsv2 variable overwrites the package level variable in network
 	// we do this to avoid passing around os specific objects in platform agnostic code
-	Hnsv2 = hnswrapper.Hnsv2wrapperwithtimeout{
-		Hnsv2: hnswrapper.NewHnsv2wrapperFake(),
-	}
+	Hnsv2 = hnswrapper.NewHnsv2wrapperFake()
 
 	epInfo := &EndpointInfo{
 		EndpointID:  "753d3fb6-e9b3-49e2-a109-2acc5dda61f1",
@@ -50,15 +48,35 @@ func TestNewAndDeleteEndpointImplHnsV2(t *testing.T) {
 			Servers: []string{"10.0.0.1, 10.0.0.2"},
 			Options: nil,
 		},
-		MacAddress: net.HardwareAddr("00:00:5e:00:53:01"),
+		MacAddress:   net.HardwareAddr("00:00:5e:00:53:01"),
+		NICType:      cns.InfraNIC,
+		HNSNetworkID: "853d3fb6-e9b3-49e2-a109-2acc5dda61f1",
 	}
-	endpoint, err := nw.newEndpointImplHnsV2(nil, epInfo)
+	ep, err := nw.newEndpointImplHnsV2(nil, epInfo)
 	if err != nil {
 		fmt.Printf("+%v", err)
 		t.Fatal(err)
 	}
 
-	err = nw.deleteEndpointImplHnsV2(endpoint)
+	if err := validateEndpoints([]*endpoint{ep}); err != nil {
+		fmt.Printf("+%v", err)
+		t.Fatal(err)
+	}
+
+	if epInfo.HNSEndpointID == "" {
+		t.Fatal("hns endpoint id not populated inside endpoint info during new endpoint impl call")
+	}
+
+	if ep.HnsId == "" {
+		t.Fatal("hns endpoint id not populated inside endpoint struct during new endpoint impl call")
+	}
+
+	if ep.HNSNetworkID == "" {
+		t.Fatal("hns network id was not copied to the endpoint struct during new endpoint impl call")
+	}
+
+	err = nw.deleteEndpointImplHnsV2(ep)
+
 	if err != nil {
 		fmt.Printf("+%v", err)
 		t.Fatal(err)

--- a/network/endpoint_windows_test.go
+++ b/network/endpoint_windows_test.go
@@ -58,7 +58,7 @@ func TestNewAndDeleteEndpointImplHnsV2(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := validateEndpoints([]*endpoint{ep}); err != nil {
+	if err = validateEndpoints([]*endpoint{ep}); err != nil {
 		fmt.Printf("+%v", err)
 		t.Fatal(err)
 	}

--- a/network/hnswrapper/hnsv2wrapperfake.go
+++ b/network/hnswrapper/hnsv2wrapperfake.go
@@ -50,7 +50,9 @@ func (f Hnsv2wrapperFake) CreateNetwork(network *hcn.HostComputeNetwork) (*hcn.H
 	defer f.Unlock()
 
 	delayHnsCall(f.Delay)
-	network.Id = network.Name // simulate hns creating the network and generating an hns network id
+	if network.Id == "" {
+		network.Id = network.Name // simulate hns creating the network and generating an hns network id
+	}
 	f.Cache.networks[network.Name] = NewFakeHostComputeNetwork(network)
 	return network, nil
 }
@@ -217,8 +219,10 @@ func (f Hnsv2wrapperFake) CreateEndpoint(endpoint *hcn.HostComputeEndpoint) (*hc
 	f.Lock()
 	defer f.Unlock()
 	delayHnsCall(f.Delay)
+	if endpoint.Id == "" {
+		endpoint.Id = endpoint.Name // simulate hns creating the endpoint and generating an hns endpoint id
+	}
 	f.Cache.endpoints[endpoint.Id] = NewFakeHostComputeEndpoint(endpoint)
-	endpoint.Id = endpoint.Name // simulate hns creating the endpoint and generating an hns endpoint id
 	return endpoint, nil
 }
 

--- a/network/hnswrapper/hnsv2wrapperfake.go
+++ b/network/hnswrapper/hnsv2wrapperfake.go
@@ -50,6 +50,7 @@ func (f Hnsv2wrapperFake) CreateNetwork(network *hcn.HostComputeNetwork) (*hcn.H
 	defer f.Unlock()
 
 	delayHnsCall(f.Delay)
+	network.Id = network.Name // simulate hns creating the network and generating an hns network id
 	f.Cache.networks[network.Name] = NewFakeHostComputeNetwork(network)
 	return network, nil
 }
@@ -217,6 +218,7 @@ func (f Hnsv2wrapperFake) CreateEndpoint(endpoint *hcn.HostComputeEndpoint) (*hc
 	defer f.Unlock()
 	delayHnsCall(f.Delay)
 	f.Cache.endpoints[endpoint.Id] = NewFakeHostComputeEndpoint(endpoint)
+	endpoint.Id = endpoint.Name // simulate hns creating the endpoint and generating an hns endpoint id
 	return endpoint, nil
 }
 

--- a/network/manager_test.go
+++ b/network/manager_test.go
@@ -229,6 +229,44 @@ var _ = Describe("Test Manager", func() {
 				Expect(num).To(Equal(3))
 			})
 		})
+
+		Context("When different fields passed to update endpoint state", func() {
+			It("Should error or validate correctly", func() {
+				nm := &networkManager{}
+
+				err := nm.UpdateEndpointState([]*endpoint{
+					{
+						IfName:      "eth0",
+						ContainerID: "2bfc3b23e078f0bea48612d5d081ace587599cdac026d23e4d57bd03c85d357c",
+					},
+					{
+						IfName:      "",
+						ContainerID: "2bfc3b23e078f0bea48612d5d081ace587599cdac026d23e4d57bd03c85d357c",
+					},
+				})
+				Expect(err).To(HaveOccurred())
+
+				err = nm.UpdateEndpointState([]*endpoint{
+					{
+						IfName:      "eth1",
+						ContainerID: "",
+					},
+					{
+						IfName:      "eth0",
+						ContainerID: "",
+					},
+				})
+				Expect(err).To(HaveOccurred())
+
+				err = validateUpdateEndpointState(
+					"2bfc3b23e078f0bea48612d5d081ace587599cdac026d23e4d57bd03c85d357c",
+					map[string]*restserver.IPInfo{
+						"eth1": {},
+						"eth2": {},
+					})
+				Expect(err).To(BeNil())
+			})
+		})
 	})
 	Describe("Test EndpointCreate", func() {
 		Context("When no endpoints provided", func() {

--- a/network/network.go
+++ b/network/network.go
@@ -346,6 +346,10 @@ func (nm *networkManager) EndpointCreate(cnsclient apipaClient, epInfos []*Endpo
 		eps = append(eps, ep)
 	}
 
+	if err := validateEndpoints(eps); err != nil {
+		return err
+	}
+
 	// save endpoints
 	return nm.SaveState(eps)
 }

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -197,7 +197,7 @@ var _ = Describe("Test Network", func() {
 					Mode:         opModeTransparentVlan,
 				}
 				nw, err := nm.newNetwork(nwInfo)
-				Expect(err).To(MatchError(platform.ErrMockExec))
+				Expect(err).NotTo(BeNil())
 				Expect(nw).To(BeNil())
 			})
 		})

--- a/network/network_windows_test.go
+++ b/network/network_windows_test.go
@@ -52,6 +52,13 @@ func TestNewAndDeleteNetworkImplHnsV2(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if network.HnsId == "" {
+		t.Fatal("hns network id not populated in network struct")
+	}
+	if nwInfo.HNSNetworkID == "" {
+		t.Fatal("hns network id not populated")
+	}
+
 	err = nm.deleteNetworkImplHnsV2(network)
 
 	if err != nil {


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Modifies existing uts to confirm the following:
When we create a network, we add the hns network id to the network{} and EndpointInfo{} structs
When we create an endpoint, we add the hns endpoint id to the endpoint{} and EndpointInfo{} structs
When we create an endpoint, we add the hns network id to the endpoint{} struct from the passed in EndpointInfo{} struct

Also validates that `ContainerID` s for a particular ADD call are all the same and are not equal to the empty string and that the endpoint nic type is populated. An error **will now be returned** if the container ids of all endpoint{} structs are not the same, any of the container ids are the empty string, or the nic type field is not populated. This is only checked on add calls.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests
- [X] relevant PR labels added

**Notes**:
