### PR TITLE
test: validate inputs to acn components

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -36,6 +36,8 @@ import (
 	"go.uber.org/zap"
 )
 
+var validRegexp = regexp.MustCompile(`^[a-zA-Z0-9._\-\(\) ]*$`)
+
 const (
 	dockerNetworkOption = "com.docker.network.generic"
 	OpModeTransparent   = "transparent"
@@ -409,7 +411,8 @@ func (plugin *NetPlugin) Add(args *cniSkel.CmdArgs) error {
 		return err
 	}
 
-	if err = plugin.validateArgs(args, nwCfg); err != nil {
+	if argErr := plugin.validateArgs(args, nwCfg); argErr != nil {
+		err = argErr
 		return err
 	}
 
@@ -938,7 +941,8 @@ func (plugin *NetPlugin) Get(args *cniSkel.CmdArgs) error {
 
 	logger.Info("Read network configuration", zap.Any("config", nwCfg))
 
-	if err = plugin.validateArgs(args, nwCfg); err != nil {
+	if argErr := plugin.validateArgs(args, nwCfg); argErr != nil {
+		err = argErr
 		return err
 	}
 
@@ -1024,7 +1028,8 @@ func (plugin *NetPlugin) Delete(args *cniSkel.CmdArgs) error {
 		return err
 	}
 
-	if err = plugin.validateArgs(args, nwCfg); err != nil {
+	if argErr := plugin.validateArgs(args, nwCfg); argErr != nil {
+		err = argErr
 		return err
 	}
 
@@ -1219,7 +1224,8 @@ func (plugin *NetPlugin) Update(args *cniSkel.CmdArgs) error {
 		return err
 	}
 
-	if err = plugin.validateArgs(args, nwCfg); err != nil {
+	if argErr := plugin.validateArgs(args, nwCfg); argErr != nil {
+		err = argErr
 		return err
 	}
 
@@ -1499,7 +1505,5 @@ func (plugin *NetPlugin) validateArgs(args *cniSkel.CmdArgs, nwCfg *cni.NetworkC
 
 // returns true if the string fully consists of zero or more alphanumeric, dots, dashes, parentheses, or underscores
 func isValidString(value string) bool {
-	pattern := `^[a-zA-Z0-9._\-\(\) ]*$`
-	re := regexp.MustCompile(pattern)
-	return re.MatchString(value)
+	return validRegexp.MatchString(value)
 }

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -36,7 +36,8 @@ import (
 	"go.uber.org/zap"
 )
 
-var validRegexp = regexp.MustCompile(`^[a-zA-Z0-9._\-\(\) ]*$`)
+// matches if the string fully consists of zero or more alphanumeric, dots, dashes, parentheses, spaces, or underscores
+var allowedInput = regexp.MustCompile(`^[a-zA-Z0-9._\-\(\) ]*$`)
 
 const (
 	dockerNetworkOption = "com.docker.network.generic"
@@ -1493,17 +1494,12 @@ func convertCniResultToInterfaceInfo(result *cniTypesCurr.Result) network.Interf
 }
 
 func (plugin *NetPlugin) validateArgs(args *cniSkel.CmdArgs, nwCfg *cni.NetworkConfig) error {
-	if !isValidString(args.ContainerID) || !isValidString(args.IfName) {
+	if !allowedInput.MatchString(args.ContainerID) || !allowedInput.MatchString(args.IfName) {
 		return errors.New("invalid args value")
 	}
-	if !isValidString(nwCfg.Bridge) {
+	if !allowedInput.MatchString(nwCfg.Bridge) {
 		return errors.New("invalid network config value")
 	}
 
 	return nil
-}
-
-// returns true if the string fully consists of zero or more alphanumeric, dots, dashes, parentheses, or underscores
-func isValidString(value string) bool {
-	return validRegexp.MatchString(value)
 }

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -142,10 +142,12 @@ func (req *CreateNetworkContainerRequest) Validate() error {
 }
 
 func isValidIP(ipStr string) bool {
+	// if can parse (i.e. not nil), then valid ip
 	if ip, _, err := net.ParseCIDR(ipStr); err == nil {
 		return ip != nil
 	}
-	return net.ParseIP(ipStr) != nil
+	ip := net.ParseIP(ipStr)
+	return ip != nil
 }
 
 // CreateNetworkContainerRequest implements fmt.Stringer for logging

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -101,6 +101,7 @@ const (
 )
 
 var ErrInvalidNCID = errors.New("invalid NetworkContainerID")
+var ErrInvalidIP = errors.New("invalid IP")
 
 // CreateNetworkContainerRequest specifies request to create a network container or network isolation boundary.
 type CreateNetworkContainerRequest struct {
@@ -131,7 +132,20 @@ func (req *CreateNetworkContainerRequest) Validate() error {
 	if _, err := uuid.Parse(strings.TrimPrefix(req.NetworkContainerid, SwiftPrefix)); err != nil {
 		return errors.Wrapf(ErrInvalidNCID, "NetworkContainerID %s is not a valid UUID: %s", req.NetworkContainerid, err.Error())
 	}
+	if req.PrimaryInterfaceIdentifier != "" && !isValidIP(req.PrimaryInterfaceIdentifier) {
+		return errors.Wrapf(ErrInvalidIP, "PrimaryInterfaceIdentifier %s is not a valid ip address", req.PrimaryInterfaceIdentifier)
+	}
+	if req.IPConfiguration.GatewayIPAddress != "" && !isValidIP(req.IPConfiguration.GatewayIPAddress) {
+		return errors.Wrapf(ErrInvalidIP, "GatewayIPAddress %s is not a valid ip address", req.IPConfiguration.GatewayIPAddress)
+	}
 	return nil
+}
+
+func isValidIP(ipStr string) bool {
+	if ip, _, err := net.ParseCIDR(ipStr); err == nil {
+		return ip != nil
+	}
+	return net.ParseIP(ipStr) != nil
 }
 
 // CreateNetworkContainerRequest implements fmt.Stringer for logging

--- a/cns/NetworkContainerContract_test.go
+++ b/cns/NetworkContainerContract_test.go
@@ -157,7 +157,15 @@ func TestPostNetworkContainersRequest_Validate(t *testing.T) {
 						NetworkContainerid: "f47ac10b-58cc-0372-8567-0e02b2c3d479",
 					},
 					{
-						NetworkContainerid: "f47ac10b-58cc-0372-8567-0e02b2c3d478",
+						NetworkContainerid:         "f47ac10b-58cc-0372-8567-0e02b2c3d478",
+						PrimaryInterfaceIdentifier: "10.240.0.4",
+						IPConfiguration: IPConfiguration{
+							GatewayIPAddress: "10.0.0.1",
+						},
+					},
+					{
+						NetworkContainerid:         "a47ac10b-58cc-0372-8567-0e02b2c3d478",
+						PrimaryInterfaceIdentifier: "10.240.0.4/24",
 					},
 				},
 			},
@@ -186,6 +194,36 @@ func TestPostNetworkContainersRequest_Validate(t *testing.T) {
 					},
 					{
 						NetworkContainerid: "-f47ac10b-58cc-0372-8567-0e02b2c3d478",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid",
+			req: PostNetworkContainersRequest{
+				CreateNetworkContainerRequests: []CreateNetworkContainerRequest{
+					{
+						NetworkContainerid:         "f47ac10b-58cc-0372-8567-0e02b2c3d478",
+						PrimaryInterfaceIdentifier: "10.240.0.4",
+						IPConfiguration: IPConfiguration{
+							GatewayIPAddress: "10.0.0.1;",
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid",
+			req: PostNetworkContainersRequest{
+				CreateNetworkContainerRequests: []CreateNetworkContainerRequest{
+					{
+						NetworkContainerid:         "f47ac10b-58cc-0372-8567-0e02b2c3d478",
+						PrimaryInterfaceIdentifier: "-10.240.0.4",
+						IPConfiguration: IPConfiguration{
+							GatewayIPAddress: "10.0.0.1",
+						},
 					},
 				},
 			},


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Validates some fields in requests to the cns, and also validates some fields in the cni args and network config. 

**This PR modifies the behavior of CNS:**
- If the primary interface ip is not a valid ip or cidr, an error will now be raised
- Same if the gateway ip address is not an ip address

**This PR modifies the behavior of CNI:**
- The container id, ifname, and bridge name passed into cni must fully consists of zero or more alphanumeric, dots, dashes, parentheses, or underscores. Otherwise, an error will be raised

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests
- [X] relevant PR labels added

**Notes**:
Please confirm there are no existing scenarios in cns where we have a primary interface name or gateway ip field that aren't ips.