### PR TITLE
fix: CNS should ignore NNCs that are being deleted (#2798)

### DIFF
--- a/cns/kubecontroller/nodenetworkconfig/reconciler.go
+++ b/cns/kubecontroller/nodenetworkconfig/reconciler.go
@@ -175,6 +175,10 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, node *v1.Node) error {
 				return ue.ObjectOld.GetGeneration() == ue.ObjectNew.GetGeneration()
 			},
 		}).
+		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
+			// only process events on objects that are not being deleted.
+			return object.GetDeletionTimestamp().IsZero()
+		})).
 		Complete(r)
 	if err != nil {
 		return errors.Wrap(err, "failed to set up reconciler with manager")

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1058,6 +1058,9 @@ func reconcileInitialCNSState(ctx context.Context, cli nodeNetworkConfigGetter, 
 	}
 
 	logger.Printf("Retrieved NNC: %+v", nnc)
+	if !nnc.DeletionTimestamp.IsZero() {
+		return errors.New("failed to init CNS state: NNC is being deleted")
+	}
 
 	// If there are no NCs, we can't initialize our state and we should fail out.
 	if len(nnc.Status.NetworkContainers) == 0 {


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Backport #2798
If an NNC is marked for deletion, CNS should not use it to reinitialize state or ingest any events for it.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
