### PR TITLE
fix: add ipv6 port policy in addition to ipv4 policy if no host ip and ipv6 enabled

### DIFF
--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -201,7 +201,8 @@ func getPoliciesFromRuntimeCfg(nwCfg *cni.NetworkConfig, isIPv6Enabled bool) ([]
 		// To support hostport policy mapping for ipv6 in dualstack overlay mode
 		// uint32 NatFlagsIPv6 = 2
 
-		flag := hnsv2.NatFlagsLocalRoutedVip
+		// if host ip is specified, we create a policy to match that ip only (ipv4 or ipv6), or ipv4 if no host ip
+		flag := hnsv2.NatFlagsLocalRoutedVip // ipv4 flag
 		if mapping.HostIp != "" {
 			hostIP, err := netip.ParseAddr(mapping.HostIp)
 			if err != nil {
@@ -217,36 +218,55 @@ func getPoliciesFromRuntimeCfg(nwCfg *cni.NetworkConfig, isIPv6Enabled bool) ([]
 			}
 		}
 
-		rawPolicy, err := json.Marshal(&hnsv2.PortMappingPolicySetting{
-			ExternalPort: uint16(mapping.HostPort),
-			InternalPort: uint16(mapping.ContainerPort),
-			VIP:          mapping.HostIp,
-			Protocol:     protocol,
-			Flags:        flag,
-		})
+		hnsPortMappingPolicy, err := createPortMappingPolicy(mapping.HostPort, mapping.ContainerPort, mapping.HostIp, protocol, flag)
+
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to marshal HNS portMappingPolicySetting")
+			return nil, err
 		}
 
-		hnsv2Policy, err := json.Marshal(&hnsv2.EndpointPolicy{
-			Type:     hnsv2.PortMapping,
-			Settings: rawPolicy,
-		})
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to marshal HNS endpointPolicy")
+		logger.Info("Creating port mapping policy", zap.Any("policy", hnsPortMappingPolicy))
+		policies = append(policies, *hnsPortMappingPolicy)
+
+		// if no host ip specified and ipv6 enabled, we also create an identical ipv6 policy in addition to the previous ipv4 policy
+		if mapping.HostIp == "" && isIPv6Enabled {
+			ipv6HnsPortMappingPolicy, err := createPortMappingPolicy(mapping.HostPort, mapping.ContainerPort, mapping.HostIp, protocol, hnsv2.NatFlagsIPv6)
+			if err != nil {
+				return nil, err
+			}
+			logger.Info("Creating ipv6 port mapping policy", zap.Any("policy", ipv6HnsPortMappingPolicy))
+			policies = append(policies, *ipv6HnsPortMappingPolicy)
 		}
-
-		hnsPolicy := policy.Policy{
-			Type: policy.EndpointPolicy,
-			Data: hnsv2Policy,
-		}
-
-		logger.Info("Creating port mapping policy", zap.Any("policy", hnsPolicy))
-
-		policies = append(policies, hnsPolicy)
 	}
 
 	return policies, nil
+}
+
+func createPortMappingPolicy(hostPort, containerPort int, hostIP string, protocol uint32, flags hnsv2.NatFlags) (*policy.Policy, error) {
+	rawPolicy, err := json.Marshal(&hnsv2.PortMappingPolicySetting{
+		ExternalPort: uint16(hostPort),
+		InternalPort: uint16(containerPort),
+		VIP:          hostIP,
+		Protocol:     protocol,
+		Flags:        flags,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal HNS portMappingPolicySetting")
+	}
+
+	hnsv2Policy, err := json.Marshal(&hnsv2.EndpointPolicy{
+		Type:     hnsv2.PortMapping,
+		Settings: rawPolicy,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal HNS endpointPolicy")
+	}
+
+	hnsPolicy := policy.Policy{
+		Type: policy.EndpointPolicy,
+		Data: hnsv2Policy,
+	}
+
+	return &hnsPolicy, nil
 }
 
 func getEndpointPolicies(args PolicyArgs) ([]policy.Policy, error) {

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -180,7 +180,18 @@ func getEndpointDNSSettings(nwCfg *cni.NetworkConfig, dns network.DNSInfo, names
 	return epDNS, nil
 }
 
-// getPoliciesFromRuntimeCfg returns network policies from network config.
+/*
+getPoliciesFromRuntimeCfg returns network policies from network config.
+
+Windows
+test-netconnection to --->    to node ipv4    to node ipv6    to localhost ipv4    to localhost ipv6
+host port mapping w/
+no host ip                     ok             ok              fail                 fail
+localhost ipv4 host ip         fail           fail            fail                 fail
+node ipv6 host ip              fail           ok              fail                 fail
+localhost ipv6 host ip         fail           fail            fail                 fail
+node ipv4 host ip              ok             fail            fail                 fail
+*/
 func getPoliciesFromRuntimeCfg(nwCfg *cni.NetworkConfig, isIPv6Enabled bool) ([]policy.Policy, error) {
 	logger.Info("Runtime Info", zap.Any("config", nwCfg.RuntimeConfig))
 	var policies []policy.Policy
@@ -219,7 +230,6 @@ func getPoliciesFromRuntimeCfg(nwCfg *cni.NetworkConfig, isIPv6Enabled bool) ([]
 		}
 
 		hnsPortMappingPolicy, err := createPortMappingPolicy(mapping.HostPort, mapping.ContainerPort, mapping.HostIp, protocol, flag)
-
 		if err != nil {
 			return nil, err
 		}

--- a/cni/network/network_windows_test.go
+++ b/cni/network/network_windows_test.go
@@ -224,6 +224,7 @@ func TestSetPoliciesFromNwCfg(t *testing.T) {
 		expected      []hnsv2.PortMappingPolicySetting
 	}{
 		{
+			// ipv6 disabled, ipv4 host ip --> ipv4 host ip policy only
 			name: "Runtime network polices",
 			nwCfg: cni.NetworkConfig{
 				RuntimeConfig: cni.RuntimeConfig{
@@ -249,6 +250,7 @@ func TestSetPoliciesFromNwCfg(t *testing.T) {
 			},
 		},
 		{
+			// ipv6 disabled, no host ip --> ipv4 policy only
 			name: "Runtime hostPort mapping polices without hostIP",
 			nwCfg: cni.NetworkConfig{
 				RuntimeConfig: cni.RuntimeConfig{
@@ -272,6 +274,7 @@ func TestSetPoliciesFromNwCfg(t *testing.T) {
 			},
 		},
 		{
+			// ipv6 enabled, ipv6 host ip --> ipv6 host ip policy only
 			name: "Runtime hostPort mapping polices with ipv6 hostIP",
 			nwCfg: cni.NetworkConfig{
 				RuntimeConfig: cni.RuntimeConfig{
@@ -297,6 +300,7 @@ func TestSetPoliciesFromNwCfg(t *testing.T) {
 			},
 		},
 		{
+			// ipv6 enabled, ipv4 host ip --> ipv4 host ip policy only
 			name: "Runtime hostPort mapping polices with ipv4 hostIP on ipv6 enabled cluster",
 			nwCfg: cni.NetworkConfig{
 				RuntimeConfig: cni.RuntimeConfig{
@@ -322,6 +326,7 @@ func TestSetPoliciesFromNwCfg(t *testing.T) {
 			},
 		},
 		{
+			// ipv6 enabled, no host ip --> ipv4 and ipv6 policies
 			name: "Runtime hostPort mapping polices with ipv6 without hostIP",
 			nwCfg: cni.NetworkConfig{
 				RuntimeConfig: cni.RuntimeConfig{
@@ -347,6 +352,32 @@ func TestSetPoliciesFromNwCfg(t *testing.T) {
 					ExternalPort: uint16(44000),
 					InternalPort: uint16(80),
 					VIP:          "",
+					Protocol:     policy.ProtocolTcp,
+					Flags:        hnsv2.NatFlagsIPv6,
+				},
+			},
+		},
+		{
+			// ipv6 enabled, ipv6 localhost ip --> ipv6 host ip policy only
+			name: "Runtime hostPort mapping polices with ipv6 localhost hostIP on ipv6 enabled cluster",
+			nwCfg: cni.NetworkConfig{
+				RuntimeConfig: cni.RuntimeConfig{
+					PortMappings: []cni.PortMapping{
+						{
+							Protocol:      "tcp",
+							HostPort:      44000,
+							ContainerPort: 80,
+							HostIp:        "::1",
+						},
+					},
+				},
+			},
+			isIPv6Enabled: true,
+			expected: []hnsv2.PortMappingPolicySetting{
+				{
+					ExternalPort: uint16(44000),
+					InternalPort: uint16(80),
+					VIP:          "::1",
 					Protocol:     policy.ProtocolTcp,
 					Flags:        hnsv2.NatFlagsIPv6,
 				},

--- a/cni/network/network_windows_test.go
+++ b/cni/network/network_windows_test.go
@@ -4,6 +4,7 @@
 package network
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	"github.com/Azure/azure-container-networking/network/hnswrapper"
 	"github.com/Azure/azure-container-networking/network/policy"
 	"github.com/Azure/azure-container-networking/telemetry"
+	hnsv2 "github.com/Microsoft/hcsshim/hcn"
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -219,6 +221,7 @@ func TestSetPoliciesFromNwCfg(t *testing.T) {
 		name          string
 		nwCfg         cni.NetworkConfig
 		isIPv6Enabled bool
+		expected      []hnsv2.PortMappingPolicySetting
 	}{
 		{
 			name: "Runtime network polices",
@@ -235,9 +238,18 @@ func TestSetPoliciesFromNwCfg(t *testing.T) {
 				},
 			},
 			isIPv6Enabled: false,
+			expected: []hnsv2.PortMappingPolicySetting{
+				{
+					ExternalPort: uint16(8000),
+					InternalPort: uint16(80),
+					VIP:          "192.168.0.4",
+					Protocol:     policy.ProtocolTcp,
+					Flags:        hnsv2.NatFlagsLocalRoutedVip,
+				},
+			},
 		},
 		{
-			name: "Runtime hostPort mapping polices",
+			name: "Runtime hostPort mapping polices without hostIP",
 			nwCfg: cni.NetworkConfig{
 				RuntimeConfig: cni.RuntimeConfig{
 					PortMappings: []cni.PortMapping{
@@ -250,6 +262,14 @@ func TestSetPoliciesFromNwCfg(t *testing.T) {
 				},
 			},
 			isIPv6Enabled: false,
+			expected: []hnsv2.PortMappingPolicySetting{
+				{
+					ExternalPort: uint16(44000),
+					InternalPort: uint16(80),
+					Protocol:     policy.ProtocolTcp,
+					Flags:        hnsv2.NatFlagsLocalRoutedVip,
+				},
+			},
 		},
 		{
 			name: "Runtime hostPort mapping polices with ipv6 hostIP",
@@ -266,6 +286,71 @@ func TestSetPoliciesFromNwCfg(t *testing.T) {
 				},
 			},
 			isIPv6Enabled: true,
+			expected: []hnsv2.PortMappingPolicySetting{
+				{
+					ExternalPort: uint16(44000),
+					InternalPort: uint16(80),
+					VIP:          "2001:2002:2003::1",
+					Protocol:     policy.ProtocolTcp,
+					Flags:        hnsv2.NatFlagsIPv6,
+				},
+			},
+		},
+		{
+			name: "Runtime hostPort mapping polices with ipv4 hostIP on ipv6 enabled cluster",
+			nwCfg: cni.NetworkConfig{
+				RuntimeConfig: cni.RuntimeConfig{
+					PortMappings: []cni.PortMapping{
+						{
+							Protocol:      "tcp",
+							HostPort:      44000,
+							ContainerPort: 80,
+							HostIp:        "192.168.0.4",
+						},
+					},
+				},
+			},
+			isIPv6Enabled: true,
+			expected: []hnsv2.PortMappingPolicySetting{
+				{
+					ExternalPort: uint16(44000),
+					InternalPort: uint16(80),
+					VIP:          "192.168.0.4",
+					Protocol:     policy.ProtocolTcp,
+					Flags:        hnsv2.NatFlagsLocalRoutedVip,
+				},
+			},
+		},
+		{
+			name: "Runtime hostPort mapping polices with ipv6 without hostIP",
+			nwCfg: cni.NetworkConfig{
+				RuntimeConfig: cni.RuntimeConfig{
+					PortMappings: []cni.PortMapping{
+						{
+							Protocol:      "tcp",
+							HostPort:      44000,
+							ContainerPort: 80,
+						},
+					},
+				},
+			},
+			isIPv6Enabled: true,
+			expected: []hnsv2.PortMappingPolicySetting{
+				{
+					ExternalPort: uint16(44000),
+					InternalPort: uint16(80),
+					VIP:          "",
+					Protocol:     policy.ProtocolTcp,
+					Flags:        hnsv2.NatFlagsLocalRoutedVip,
+				},
+				{
+					ExternalPort: uint16(44000),
+					InternalPort: uint16(80),
+					VIP:          "",
+					Protocol:     policy.ProtocolTcp,
+					Flags:        hnsv2.NatFlagsIPv6,
+				},
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -276,6 +361,18 @@ func TestSetPoliciesFromNwCfg(t *testing.T) {
 			require.Condition(t, assert.Comparison(func() bool {
 				return len(policies) > 0 && policies[0].Type == policy.EndpointPolicy
 			}))
+			require.Equal(t, len(tt.expected), len(policies), "expected number of policies not equal to actual")
+			for index, policy := range policies {
+				var hnsv2Policy hnsv2.EndpointPolicy
+				err = json.Unmarshal(policy.Data, &hnsv2Policy)
+				require.NoError(t, err, "failed to unmarshal hnsv2 policy")
+
+				var rawPolicy hnsv2.PortMappingPolicySetting
+				err = json.Unmarshal(hnsv2Policy.Settings, &rawPolicy)
+				require.NoError(t, err, "failed to unmarshal hnsv2 port mapping policy")
+
+				require.Equal(t, tt.expected[index], rawPolicy, "policies are not expected")
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Currently if a port mapping is specified in windows, if no host ip is specified, an ipv6 port mapping policy would not be created (only an ipv4 one). This pr makes it so that if no host ip is specified, and dualstack/ipv6 is enabled, we will create two policies, one for ipv6 and one for ipv4. If the host ip is specified, we will create only a single policy based on whether the host ip is ipv4 or ipv6.

Summary:
host port defined with host ip ipv4 (with or without ipv6 enabled) --> ipv4 port mapping policy only
host port defined with host ip ipv6 --> ipv6 port mapping policy only
host port defined without host ip (with ipv6 enabled) --> ipv4 and ipv6 port mapping policy created
host port defined without host ip (without ipv6 enabled) --> ipv4 port mapping policy created only

Updates tests to reflect the above behavior.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests
- [X] relevant PR labels added

**Notes**:
Tested creating a port mapping on a windows dualstack cluster with no host ip and saw two port mapping policies (ipv4 and ipv6) created as expected. Also tested creating a pod with an ipv4 host ip and saw a single ipv4 policy created, even though the cluster was ipv6 enabled.