### PR TITLE
ci: Shift E2E cluster creation

### DIFF
--- a/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
+++ b/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
@@ -27,7 +27,8 @@ stages:
         location: $(LOCATION_AMD64)
       commitID: $[ stagedependencies.setup.env.outputs['SetEnvVars.commitID'] ]
     dependsOn:
-      - binaries
+      - setup
+      - build_images
     displayName: "Create Cluster - ${{ parameters.clusterName }}"
     jobs:
       - job: create_aks_cluster_with_${{ parameters.name }}

--- a/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
+++ b/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
@@ -27,7 +27,7 @@ stages:
         location: $(LOCATION_AMD64)
       commitID: $[ stagedependencies.setup.env.outputs['SetEnvVars.commitID'] ]
     dependsOn:
-      - setup
+      - binaries
     displayName: "Create Cluster - ${{ parameters.clusterName }}"
     jobs:
       - job: create_aks_cluster_with_${{ parameters.name }}
@@ -112,7 +112,7 @@ stages:
                   else
                     envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-agent/templates/daemonset.yaml | kubectl apply -f -
                   fi
-                  
+
                   envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-operator/templates/deployment.yaml | kubectl apply -f -
                   kubectl get po -owide -A
 

--- a/.pipelines/cni/singletenancy/cniv1-template.yaml
+++ b/.pipelines/cni/singletenancy/cniv1-template.yaml
@@ -42,7 +42,8 @@ stages:
       pool:
         name: $(BUILD_POOL_NAME_DEFAULT)
       dependsOn:
-        - binaries
+        - setup
+        - build_images
       displayName: "Create Cluster - ${{ parameters.clusterName }}"
       jobs:
         - job: create_aks_cluster_with_${{ parameters.name }}
@@ -74,7 +75,8 @@ stages:
       pool:
         name: $(BUILD_POOL_NAME_DEFAULT)
       dependsOn:
-        - binaries
+        - setup
+        - build_images
       displayName: "Create Cluster - ${{ parameters.clusterName }}"
       jobs:
         - job: create_aks_cluster_with_${{ parameters.name }}

--- a/.pipelines/cni/singletenancy/cniv1-template.yaml
+++ b/.pipelines/cni/singletenancy/cniv1-template.yaml
@@ -42,7 +42,7 @@ stages:
       pool:
         name: $(BUILD_POOL_NAME_DEFAULT)
       dependsOn:
-        - setup
+        - binaries
       displayName: "Create Cluster - ${{ parameters.clusterName }}"
       jobs:
         - job: create_aks_cluster_with_${{ parameters.name }}
@@ -74,7 +74,7 @@ stages:
       pool:
         name: $(BUILD_POOL_NAME_DEFAULT)
       dependsOn:
-        - setup
+        - binaries
       displayName: "Create Cluster - ${{ parameters.clusterName }}"
       jobs:
         - job: create_aks_cluster_with_${{ parameters.name }}

--- a/.pipelines/cni/singletenancy/cniv2-template.yaml
+++ b/.pipelines/cni/singletenancy/cniv2-template.yaml
@@ -42,7 +42,8 @@ stages:
       pool:
         name: $(BUILD_POOL_NAME_DEFAULT)
       dependsOn:
-        - binaries
+        - setup
+        - build_images
       displayName: "Create Cluster - ${{ parameters.clusterName }}"
       jobs:
         - job: create_aks_cluster_with_${{ parameters.name }}
@@ -74,7 +75,8 @@ stages:
       pool:
         name: $(BUILD_POOL_NAME_DEFAULT)
       dependsOn:
-        - binaries
+        - setup
+        - build_images
       displayName: "Create Cluster - ${{ parameters.clusterName }}"
       jobs:
         - job: create_aks_cluster_with_${{ parameters.name }}

--- a/.pipelines/cni/singletenancy/cniv2-template.yaml
+++ b/.pipelines/cni/singletenancy/cniv2-template.yaml
@@ -42,7 +42,7 @@ stages:
       pool:
         name: $(BUILD_POOL_NAME_DEFAULT)
       dependsOn:
-        - setup
+        - binaries
       displayName: "Create Cluster - ${{ parameters.clusterName }}"
       jobs:
         - job: create_aks_cluster_with_${{ parameters.name }}
@@ -74,7 +74,7 @@ stages:
       pool:
         name: $(BUILD_POOL_NAME_DEFAULT)
       dependsOn:
-        - setup
+        - binaries
       displayName: "Create Cluster - ${{ parameters.clusterName }}"
       jobs:
         - job: create_aks_cluster_with_${{ parameters.name }}

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -405,7 +405,7 @@ stages:
         clusterName: "ciliume2e"
         vmSize: Standard_B2ms
         k8sVersion: ""
-        dependsOn: "test"
+        dependsOn: "containerize"
 
     # Cilium Overlay E2E tests
     - template: singletenancy/cilium-overlay/cilium-overlay-e2e-job-template.yaml
@@ -416,7 +416,7 @@ stages:
         clusterName: "cilovere2e"
         vmSize: Standard_B2ms
         k8sVersion: ""
-        dependsOn: "test"
+        dependsOn: "containerize"
 
     # Cilium Dualstack Overlay E2E tests
     - template: singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-job-template.yaml
@@ -428,7 +428,7 @@ stages:
         clusterName: "cildsovere2e"
         vmSize: Standard_B2ms
         k8sVersion: ""
-        dependsOn: "test"
+        dependsOn: "containerize"
 
         # Cilium Overlay with hubble E2E tests
     - template: singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-job-template.yaml
@@ -439,7 +439,7 @@ stages:
         clusterName: "cilwhleovere2e"
         vmSize: Standard_B2ms
         k8sVersion: ""
-        dependsOn: "test"
+        dependsOn: "containerize"
         testHubble: true
 
     # Azure Overlay E2E tests
@@ -452,7 +452,7 @@ stages:
         clusterName: "azovere2e"
         vmSize: Standard_B2ms
         k8sVersion: ""
-        dependsOn: "test"
+        dependsOn: "containerize"
 
     # AKS Swift E2E tests
     - template: singletenancy/aks-swift/e2e-job-template.yaml
@@ -464,7 +464,7 @@ stages:
         clusterName: "swifte2e"
         vmSize: Standard_B2ms
         k8sVersion: ""
-        dependsOn: "test"
+        dependsOn: "containerize"
 
     # AKS Swift Vnet Scale E2E tests
     - template: singletenancy/aks-swift/e2e-job-template.yaml
@@ -476,7 +476,7 @@ stages:
         clusterName: "vscaleswifte2e"
         vmSize: Standard_B2ms
         k8sVersion: "1.28"
-        dependsOn: "test"
+        dependsOn: "containerize"
 
     # CNIv1 E2E tests
     - template: singletenancy/aks/e2e-job-template.yaml
@@ -490,7 +490,7 @@ stages:
         vmSize: Standard_B2s
         k8sVersion: 1.25
         scaleup: 100
-        dependsOn: "test"
+        dependsOn: "containerize"
 
     - template: singletenancy/aks/e2e-job-template.yaml
       parameters:
@@ -503,7 +503,7 @@ stages:
         vmSize: Standard_B2ms
         os_version: "ltsc2022"
         scaleup: 50
-        dependsOn: "test"
+        dependsOn: "containerize"
 
     # CNI dual stack overlay E2E tests
     - template: singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
@@ -514,7 +514,7 @@ stages:
         clusterType: dualstack-overlay-byocni-up
         clusterName: "dsovere2e"
         vmSize: Standard_B2ms
-        dependsOn: "test"
+        dependsOn: "containerize"
 
     # Swiftv2 E2E tests with multitenancy cluster start up
     - template: multitenancy/swiftv2-e2e-job-template.yaml
@@ -526,7 +526,7 @@ stages:
         clusterName: "mtacluster"
         nodePoolName: "mtapool"
         vmSize: $(SWIFTV2_MT_CLUSTER_SKU)
-        dependsOn: "test"
+        dependsOn: "containerize"
         dummyClusterName: "swiftv2dummy"
         dummyClusterType: "swiftv2-dummy-cluster-up"
         dummyClusterDisplayName: Swiftv2 Multitenancy Dummy Cluster


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

Image and Manifest generation has begun to take longer and Clusters are left in `NotReady` for longer than 15 minutes after they are successfully created. Resulting node restarts that occur in the middle of E2E.

RCA: After 15 minutes of being left in `NotReady` status nodes will begin a reboot rollout of the entire cluster.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
