### PR TITLE
ci: [NPM] add bash directive to scale scripts

### DIFF
--- a/test/scale/connectivity/test-connectivity.sh
+++ b/test/scale/connectivity/test-connectivity.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # exit on error
 set -e
 

--- a/test/scale/test-scale.sh
+++ b/test/scale/test-scale.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #exit on error
 set -e
 


### PR DESCRIPTION
**Reason for Change**:
Runs scheduled for master branch have failed since the `/bin/sh` interpreter does not support double bracket syntax:
```
./test-scale.sh: 62: [[: not found
```

Now we explicitly direct these scripts to use `/bin/bash`.

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added
