### PR TITLE
Return error if hns network exists for transparent network

### DIFF
--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -389,7 +389,7 @@ func (nm *networkManager) newNetworkImplHnsV2(nwInfo *EndpointInfo, extIf *exter
 			// CNI triggers Add() for new pod first and then delete older pod later
 			// for transparent network type, do not ignore network creation if network already exists
 			// return error to avoid creating second endpoint
-			return nil, fmt.Errorf("Do not create endpoint for transparent network if network already exists")
+			return nil, fmt.Errorf("Do not create endpoint for transparent network if hcn network %s already exists", hcnNetwork.Name)
 		}
 		logger.Info("Network with name already exists", zap.String("name", hcnNetwork.Name))
 	}

--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -388,8 +388,8 @@ func (nm *networkManager) newNetworkImplHnsV2(nwInfo *EndpointInfo, extIf *exter
 			// CNI triggers Add() for new pod first and then delete older pod later
 			// for transparent network type, do not ignore network creation if network already exists
 			// return error to avoid creating second endpoint
-			logger.Error("Do not create endpoint for transparent network if hcn network already exists")
-			return nil, fmt.Errorf("Do not create endpoint for transparent network if hcn network %s already exists", hcnNetwork.Name) //nolint
+			logger.Error("HNS network with name already exists. Returning error for transparent network", zap.String("networkName", hcnNetwork.Name))
+			return nil, fmt.Errorf("HNS network with name:%s already exists. Returning error for transparent network", hcnNetwork.Name) //nolint
 		}
 		logger.Info("Network with name already exists", zap.String("name", hcnNetwork.Name))
 	}

--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -384,12 +384,13 @@ func (nm *networkManager) newNetworkImplHnsV2(nwInfo *EndpointInfo, extIf *exter
 			// we can't validate if the network already exists, don't continue
 			return nil, fmt.Errorf("Failed to create hcn network: %s, failed to query for existing network with error: %v", hcnNetwork.Name, err)
 		}
-	} else if hcnNetwork.Type == hcn.Transparent {
-		// CNI triggers Add() for new pod first and then delete older pod later
-		// for transparent network type, do not ignore network creation if network already exists
-		// return error to avoid creating second endpoint
-		return nil, fmt.Errorf("Do not create endpoint for transparent network if network already exists")
 	} else {
+		if hcnNetwork.Type == hcn.Transparent {
+			// CNI triggers Add() for new pod first and then delete older pod later
+			// for transparent network type, do not ignore network creation if network already exists
+			// return error to avoid creating second endpoint
+			return nil, fmt.Errorf("Do not create endpoint for transparent network if network already exists")
+		}
 		logger.Info("Network with name already exists", zap.String("name", hcnNetwork.Name))
 	}
 

--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -384,6 +384,11 @@ func (nm *networkManager) newNetworkImplHnsV2(nwInfo *EndpointInfo, extIf *exter
 			// we can't validate if the network already exists, don't continue
 			return nil, fmt.Errorf("Failed to create hcn network: %s, failed to query for existing network with error: %v", hcnNetwork.Name, err)
 		}
+	} else if hcnNetwork.Type == hcn.Transparent {
+		// CNI triggers Add() for new pod first and then delete older pod later
+		// for transparent network type, do not ignore network creation if network already exists
+		// return error to avoid creating second endpoint
+		return nil, fmt.Errorf("Do not create endpoint for transparent network if network already exists")
 	} else {
 		logger.Info("Network with name already exists", zap.String("name", hcnNetwork.Name))
 	}

--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -378,7 +378,6 @@ func (nm *networkManager) newNetworkImplHnsV2(nwInfo *EndpointInfo, extIf *exter
 			if err != nil {
 				return nil, fmt.Errorf("Failed to create hcn network: %s due to error: %v", hcnNetwork.Name, err)
 			}
-
 			logger.Info("Successfully created hcn network with response", zap.Any("hnsResponse", hnsResponse))
 		} else {
 			// we can't validate if the network already exists, don't continue
@@ -389,7 +388,8 @@ func (nm *networkManager) newNetworkImplHnsV2(nwInfo *EndpointInfo, extIf *exter
 			// CNI triggers Add() for new pod first and then delete older pod later
 			// for transparent network type, do not ignore network creation if network already exists
 			// return error to avoid creating second endpoint
-			return nil, fmt.Errorf("Do not create endpoint for transparent network if hcn network %s already exists", hcnNetwork.Name)
+			logger.Error("Do not create endpoint for transparent network if hcn network already exists")
+			return nil, fmt.Errorf("Do not create endpoint for transparent network if hcn network %s already exists", hcnNetwork.Name) //nolint
 		}
 		logger.Info("Network with name already exists", zap.String("name", hcnNetwork.Name))
 	}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
The PR is to not ignore network exist if network type is transparent to avoid creating a second endpoint

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
