### PR TITLE
Draft: POC changes for dualstack Vnet Prefix

### DIFF
--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -319,18 +319,18 @@ func (service *HTTPRestService) ReleaseIPConfigHandler(w http.ResponseWriter, r 
 	}
 
 	// check to make sure there is only one NC
-	if len(service.state.ContainerStatus) != 1 {
-		reserveResp := &cns.IPConfigResponse{
-			Response: cns.Response{
-				ReturnCode: types.InvalidRequest,
-				Message:    fmt.Sprintf("Expected 1 NC when calling this API but found %d NCs", len(service.state.ContainerStatus)),
-			},
-		}
-		w.Header().Set(cnsReturnCode, reserveResp.Response.ReturnCode.String())
-		err = common.Encode(w, &reserveResp)
-		logger.ResponseEx(service.Name, ipconfigRequest, reserveResp, reserveResp.Response.ReturnCode, err)
-		return
-	}
+	// if len(service.state.ContainerStatus) != 1 {
+	// 	reserveResp := &cns.IPConfigResponse{
+	// 		Response: cns.Response{
+	// 			ReturnCode: types.InvalidRequest,
+	// 			Message:    fmt.Sprintf("Expected 1 NC when calling this API but found %d NCs", len(service.state.ContainerStatus)),
+	// 		},
+	// 	}
+	// 	w.Header().Set(cnsReturnCode, reserveResp.Response.ReturnCode.String())
+	// 	err = common.Encode(w, &reserveResp)
+	// 	logger.ResponseEx(service.Name, ipconfigRequest, reserveResp, reserveResp.Response.ReturnCode, err)
+	// 	return
+	// }
 
 	ipconfigsRequest := cns.IPConfigsRequest{
 		DesiredIPAddresses: []string{
@@ -876,36 +876,38 @@ func (service *HTTPRestService) AssignAvailableIPConfigs(podInfo cns.PodInfo) ([
 	service.Lock()
 	defer service.Unlock()
 	// Creates a slice of PodIpInfo with the size as number of NCs to hold the result for assigned IP configs
-	podIPInfo := make([]cns.PodIpInfo, numOfNCs)
+	//hard coding to 2 for POC
+	numOfIPs := 2
+	podIPInfo := make([]cns.PodIpInfo, numOfIPs)
 	// This map is used to store whether or not we have found an available IP from an NC when looping through the pool
-	ipsToAssign := make(map[string]cns.IPConfigurationStatus)
+	ipsToAssign := make(map[bool]cns.IPConfigurationStatus)
 
 	// Searches for available IPs in the pool
 	for _, ipState := range service.PodIPConfigState {
 		// check if an IP from this NC is already set side for assignment.
-		if _, ncAlreadyMarkedForAssignment := ipsToAssign[ipState.NCID]; ncAlreadyMarkedForAssignment {
+		// check if the IP with the same family type exists already
+		if _, IPFamilyAlreadyMarkedForAssignment := ipsToAssign[net.ParseIP(ipState.IPAddress).To4() == nil]; IPFamilyAlreadyMarkedForAssignment {
 			continue
 		}
 		// Checks if the current IP is available
 		if ipState.GetState() != types.Available {
 			continue
 		}
-		ipsToAssign[ipState.NCID] = ipState
+		ipsToAssign[net.ParseIP(ipState.IPAddress).To4() == nil] = ipState
 		// Once one IP per container is found break out of the loop and stop searching
-		if len(ipsToAssign) == numOfNCs {
+		if len(ipsToAssign) == numOfIPs {
 			break
 		}
 	}
 
 	// Checks to make sure we found one IP for each NC
-	if len(ipsToAssign) != numOfNCs {
-		for ncID := range service.state.ContainerStatus {
-			if _, found := ipsToAssign[ncID]; found {
-				continue
-			}
-			return podIPInfo, errors.Errorf("not enough IPs available for %s, waiting on Azure CNS to allocate more with NC Status: %s",
-				ncID, string(service.state.ContainerStatus[ncID].CreateNetworkContainerRequest.NCStatus))
-		}
+	if len(ipsToAssign) != numOfIPs {
+		// for ncID := range service.state.ContainerStatus {
+		// 	if _, found := ipsToAssign[ncID]; found {
+		// 		continue
+		// 	}
+		return podIPInfo, errors.Errorf("not enough IPs available")
+		// }
 	}
 
 	failedToAssignIP := false

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -131,7 +131,7 @@ func (service *HTTPRestService) saveNetworkContainerGoalState(req cns.CreateNetw
 	if hostVersion == "" {
 		// Host version is the NC version from NMAgent, set it -1 to indicate no result from NMAgent yet.
 		// TODO, query NMAgent and with aggresive time out and assign latest host version.
-		hostVersion = "-1"
+		hostVersion = "1"
 	}
 
 	// Remove the auth token before saving the containerStatus to cns json file


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Just testing out a way to force 2 IPs of different families in from the same vnet/NC. 

The current solution for dualstack in overlay is to check for two IPs from two different NCs. For dualstack Vnet Prefix we are seeing what it would be like if we added all of the IPs to the same NC since the v4 and v6 IPs will be on the same Vnet.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
