### PR TITLE
ci: Add node restart to cniv2 E2E

### DIFF
--- a/.pipelines/singletenancy/aks-swift/e2e-job-template.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e-job-template.yaml
@@ -59,7 +59,6 @@ stages:
             parameters:
               name: ${{ parameters.name }}
               clusterName: ${{ parameters.clusterName }}-$(commitID)
-              os: linux
               scaleup: 100
 
       - template: ../../cni/k8s-e2e/k8s-e2e-job-template.yaml

--- a/.pipelines/singletenancy/aks-swift/e2e-job-template.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e-job-template.yaml
@@ -59,6 +59,8 @@ stages:
             parameters:
               name: ${{ parameters.name }}
               clusterName: ${{ parameters.clusterName }}-$(commitID)
+              os: linux
+              scaleup: 100
 
       - template: ../../cni/k8s-e2e/k8s-e2e-job-template.yaml
         parameters:

--- a/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
@@ -47,6 +47,42 @@ steps:
     name: "aksswifte2e"
     displayName: "Run AKS Swift E2E"
 
+  - task: AzureCLI@1
+    inputs:
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+      scriptLocation: "inlineScript"
+      scriptType: "bash"
+      addSpnToEnvironment: true
+      inlineScript: |
+        set -e
+        kubectl get po -owide -A
+        clusterName=${{ parameters.clusterName }}
+        echo "Restarting nodes"
+        for val in $(az vmss list -g MC_${clusterName}_${clusterName}_$(REGION_AKS_CLUSTER_TEST) --query "[].name" -o tsv); do
+          make -C ./hack/aks restart-vmss AZCLI=az CLUSTER=${clusterName} REGION=$(REGION_AKS_CLUSTER_TEST) VMSS_NAME=${val}
+        done
+    displayName: "Restart Nodes"
+
+  - task: AzureCLI@1
+    inputs:
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+      scriptLocation: "inlineScript"
+      scriptType: "bash"
+      addSpnToEnvironment: true
+      inlineScript: |
+        cd test/integration/load
+        clusterName=${{ parameters.clusterName }}
+        make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${clusterName}
+        make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
+
+        # Scale Cluster Up/Down to confirm functioning CNS
+        ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
+        kubectl get pods -owide -A
+        echo "Validating Node Restart"
+        make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
+    displayName: "Validate Node Restart"
+    retryCountOnTaskFailure: 3
+
   - script: |
       echo "Run wireserver and metadata connectivity Tests"
       bash test/network/wireserver_metadata_test.sh

--- a/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
@@ -1,6 +1,7 @@
 parameters:
   name: ""
   clusterName: ""
+  scaleup: ""
 
 steps:
   - bash: |
@@ -71,17 +72,14 @@ steps:
       addSpnToEnvironment: true
       inlineScript: |
         cd test/integration/load
-        clusterName=${{ parameters.clusterName }}
-        make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${clusterName}
-        make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
 
         # Scale Cluster Up/Down to confirm functioning CNS
-        ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
+        ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=linux go test -count 1 -timeout 30m -tags load -run ^TestLoad$
         kubectl get pods -owide -A
 
         cd ../../..
         echo "Validating Node Restart"
-        make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
+        make test-validate-state OS_TYPE=linux RESTART_CASE=true CNI_TYPE=cniv2
         kubectl delete ns load-test
     displayName: "Validate Node Restart"
     retryCountOnTaskFailure: 3

--- a/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
@@ -78,6 +78,8 @@ steps:
         # Scale Cluster Up/Down to confirm functioning CNS
         ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
         kubectl get pods -owide -A
+
+        cd ../../..
         echo "Validating Node Restart"
         make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
     displayName: "Validate Node Restart"

--- a/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
@@ -82,6 +82,7 @@ steps:
         cd ../../..
         echo "Validating Node Restart"
         make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
+        kubectl delete ns load-test
     displayName: "Validate Node Restart"
     retryCountOnTaskFailure: 3
 

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
@@ -76,7 +76,7 @@ stages:
               addSpnToEnvironment: true
               inlineScript: |
                 set -e
-                make -C ./hack/aks windows-nodepool-up AZCLI=az SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }} VM_SIZE_WIN=${{ parameters.vmSizeWin }}
+                make -C ./hack/aks windows-nodepool-up AZCLI=az SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }}-$(commitID) VM_SIZE_WIN=${{ parameters.vmSizeWin }}
                 echo "Windows node are successfully added to v4 Overlay Cluster"
                 kubectl cluster-info
                 kubectl get node -owide

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
@@ -45,6 +45,7 @@ stages:
     jobs:
       - job: ${{ parameters.name }}_linux
         displayName: Azure CNI Overlay Test Suite | Linux - (${{ parameters.name }})
+        timeoutInMinutes: 120
         pool:
           name: $(BUILD_POOL_NAME_DEFAULT)
           demands:
@@ -56,10 +57,38 @@ stages:
               name: ${{ parameters.name }}
               clusterName: ${{ parameters.clusterName }}-$(commitID)
               os: linux
+              scaleup: 100
+
+      - job: windows_nodepool
+        displayName: Add Windows Nodepool
+        dependsOn: ${{ parameters.name }}_linux
+        pool:
+          name: $(BUILD_POOL_NAME_DEFAULT)
+          demands:
+          - agent.os -equals Linux
+          - Role -equals $(CUSTOM_E2E_ROLE)
+        steps:
+          - task: AzureCLI@2
+            inputs:
+              azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+              scriptLocation: "inlineScript"
+              scriptType: "bash"
+              addSpnToEnvironment: true
+              inlineScript: |
+                set -e
+                make -C ./hack/aks windows-nodepool-up AZCLI=az SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }} VM_SIZE_WIN=${{ parameters.vmSizeWin }}
+                echo "Windows node are successfully added to v4 Overlay Cluster"
+                kubectl cluster-info
+                kubectl get node -owide
+                kubectl get po -owide -A
+            name: "Add_Windows_Node"
+            displayName: "Add windows node on v4 overlay cluster"
+
 
       - job: ${{ parameters.name }}_windows
         displayName: Azure CNI Overlay Test Suite | Windows - (${{ parameters.name }})
-        dependsOn: ${{ parameters.name }}_linux
+        timeoutInMinutes: 120
+        dependsOn: windows_nodepool
         pool:
           name: $(BUILD_POOL_NAME_DEFAULT)
           demands:
@@ -71,7 +100,7 @@ stages:
               name: ${{ parameters.name }}
               clusterName: ${{ parameters.clusterName }}-$(commitID)
               os: windows
-              vmSizeWin: ${{ parameters.vmSize }} # Matching linux vmSize
+              scaleup: 50
 
       - template: ../../cni/k8s-e2e/k8s-e2e-job-template.yaml
         parameters:

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
@@ -76,7 +76,8 @@ stages:
               addSpnToEnvironment: true
               inlineScript: |
                 set -e
-                make -C ./hack/aks windows-nodepool-up AZCLI=az SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }}-$(commitID) VM_SIZE_WIN=${{ parameters.vmSizeWin }}
+                make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(commitID)
+                make -C ./hack/aks windows-nodepool-up AZCLI=az SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }}-$(commitID) VM_SIZE_WIN=${{ parameters.vmSize }}
                 echo "Windows node are successfully added to v4 Overlay Cluster"
                 kubectl cluster-info
                 kubectl get node -owide

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-step-template.yaml
@@ -67,25 +67,13 @@ steps:
           clusterName=${{ parameters.clusterName }}
           make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${clusterName}
           make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
+
+          # Scale Cluster Up/Down to confirm functioning CNS
+          ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
           kubectl get pods -owide -A
           echo "Validating Node Restart"
-          CNI_TYPE=cniv2 RESTART_CASE=true go test -timeout 30m -tags load -run ^TestValidateState$
+          make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
       displayName: "Validate Node Restart"
-      retryCountOnTaskFailure: 3
-
-    - script: |
-        echo "validate pod IP assignment before CNS restart"
-        kubectl get pod -owide -A
-        echo "validate pod state before CNS restarts"
-        cd test/integration/load
-        CNI_TYPE=cniv2 go test -timeout 30m -tags load -run ^TestValidateState$
-        kubectl rollout restart ds azure-cns -n kube-system
-        kubectl rollout status ds azure-cns -n kube-system
-        kubectl get pod -owide -A
-        echo "validate pods after CNS restart"
-        CNI_TYPE=cniv2 go test -timeout 30m -tags load -run ^TestValidateState$
-      name: "restartCNS_ValidatePodState"
-      displayName: "Restart CNS and validate pod state"
       retryCountOnTaskFailure: 3
 
     - script: |
@@ -96,22 +84,6 @@ steps:
       displayName: "Run Wireserver and Metadata Connectivity Tests"
 
   - ${{ if eq(parameters.os, 'windows') }}:
-    - task: AzureCLI@2
-      inputs:
-        azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
-        scriptLocation: "inlineScript"
-        scriptType: "bash"
-        addSpnToEnvironment: true
-        inlineScript: |
-          set -e
-          make -C ./hack/aks windows-nodepool-up AZCLI=az SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }} VM_SIZE_WIN=${{ parameters.vmSizeWin }}
-          echo "Windows node are successfully added to v4 Overlay Cluster"
-          kubectl cluster-info
-          kubectl get node -owide
-          kubectl get po -owide -A
-      name: "Add_Windows_Node"
-      displayName: "Add windows node on v4 overlay cluster"
-
     - script: |
         nodeList=`kubectl get node -owide | grep Windows | awk '{print $1}'`
         for node in $nodeList; do
@@ -131,4 +103,40 @@ steps:
         sudo -E env "PATH=$PATH" go test -count=1 datapath_windows_test.go -timeout 3m -tags connection -restartKubeproxy true -run ^TestDatapathWin$
       name: "WindowsV4OverlayDatapathTests"
       displayName: "Windows v4Overlay Datapath Tests"
+      retryCountOnTaskFailure: 3
+
+    - task: AzureCLI@1
+      inputs:
+        azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+        scriptLocation: "inlineScript"
+        scriptType: "bash"
+        addSpnToEnvironment: true
+        inlineScript: |
+          set -e
+          kubectl get po -owide -A
+          clusterName=${{ parameters.clusterName }}
+          echo "Restarting nodes"
+          for val in $(az vmss list -g MC_${clusterName}_${clusterName}_$(REGION_AKS_CLUSTER_TEST) --query "[].name" -o tsv); do
+            make -C ./hack/aks restart-vmss AZCLI=az CLUSTER=${clusterName} REGION=$(REGION_AKS_CLUSTER_TEST) VMSS_NAME=${val}
+          done
+      displayName: "Restart Nodes"
+
+    - task: AzureCLI@1
+      inputs:
+        azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+        scriptLocation: "inlineScript"
+        scriptType: "bash"
+        addSpnToEnvironment: true
+        inlineScript: |
+          cd test/integration/load
+          clusterName=${{ parameters.clusterName }}
+          make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${clusterName}
+          make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
+
+          # Scale Cluster Up/Down to confirm functioning CNS
+          ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
+          kubectl get pods -owide -A
+          echo "Validating Node Restart"
+          make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
+      displayName: "Validate Node Restart"
       retryCountOnTaskFailure: 3

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-step-template.yaml
@@ -75,6 +75,7 @@ steps:
           cd ../../..
           echo "Validating Node Restart"
           make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
+          kubectl delete ns load-test
       displayName: "Validate Node Restart"
       retryCountOnTaskFailure: 3
 
@@ -140,5 +141,6 @@ steps:
           kubectl get pods -owide -A
           echo "Validating Node Restart"
           make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
+          kubectl delete ns load-test
       displayName: "Validate Node Restart"
       retryCountOnTaskFailure: 3

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-step-template.yaml
@@ -2,6 +2,7 @@ parameters:
   name: ""
   clusterName: ""
   os: ""
+  scaleup: ""
 
 steps:
   - bash: |
@@ -64,17 +65,14 @@ steps:
         addSpnToEnvironment: true
         inlineScript: |
           cd test/integration/load
-          clusterName=${{ parameters.clusterName }}
-          make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${clusterName}
-          make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
 
           # Scale Cluster Up/Down to confirm functioning CNS
-          ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
+          ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=linux go test -count 1 -timeout 30m -tags load -run ^TestLoad$
           kubectl get pods -owide -A
 
           cd ../../..
           echo "Validating Node Restart"
-          make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
+          make test-validate-state OS_TYPE=linux RESTART_CASE=true CNI_TYPE=cniv2
           kubectl delete ns load-test
       displayName: "Validate Node Restart"
       retryCountOnTaskFailure: 3
@@ -132,15 +130,14 @@ steps:
         addSpnToEnvironment: true
         inlineScript: |
           cd test/integration/load
-          clusterName=${{ parameters.clusterName }}
-          make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${clusterName}
-          make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
 
           # Scale Cluster Up/Down to confirm functioning CNS
-          ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
+          ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=windows go test -count 1 -timeout 30m -tags load -run ^TestLoad$
           kubectl get pods -owide -A
+
+          cd ../../..
           echo "Validating Node Restart"
-          make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
+          make test-validate-state OS_TYPE=windows RESTART_CASE=true CNI_TYPE=cniv2
           kubectl delete ns load-test
       displayName: "Validate Node Restart"
       retryCountOnTaskFailure: 3

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-step-template.yaml
@@ -71,6 +71,8 @@ steps:
           # Scale Cluster Up/Down to confirm functioning CNS
           ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
           kubectl get pods -owide -A
+
+          cd ../../..
           echo "Validating Node Restart"
           make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
       displayName: "Validate Node Restart"

--- a/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-job-template.yaml
@@ -55,6 +55,8 @@ stages:
             parameters:
               name: ${{ parameters.name }}
               clusterName: ${{ parameters.clusterName }}-$(commitID)
+              os: linux
+              scaleup: 100
 
       - template: ../../cni/k8s-e2e/k8s-e2e-job-template.yaml
         parameters:

--- a/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-job-template.yaml
@@ -55,7 +55,6 @@ stages:
             parameters:
               name: ${{ parameters.name }}
               clusterName: ${{ parameters.clusterName }}-$(commitID)
-              os: linux
               scaleup: 100
 
       - template: ../../cni/k8s-e2e/k8s-e2e-job-template.yaml

--- a/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-step-template.yaml
@@ -102,7 +102,8 @@ steps:
 
         cd ../../..
         echo "Validating Node Restart"
-        make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
+        make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true
+        kubectl delete ns load-test
     displayName: "Validate Node Restart"
     retryCountOnTaskFailure: 3
 

--- a/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-step-template.yaml
@@ -68,6 +68,42 @@ steps:
     name: "CiliumStatus"
     displayName: "Cilium Status"
 
+  - task: AzureCLI@1
+    inputs:
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+      scriptLocation: "inlineScript"
+      scriptType: "bash"
+      addSpnToEnvironment: true
+      inlineScript: |
+        set -e
+        kubectl get po -owide -A
+        clusterName=${{ parameters.clusterName }}
+        echo "Restarting nodes"
+        for val in $(az vmss list -g MC_${clusterName}_${clusterName}_$(REGION_AKS_CLUSTER_TEST) --query "[].name" -o tsv); do
+          make -C ./hack/aks restart-vmss AZCLI=az CLUSTER=${clusterName} REGION=$(REGION_AKS_CLUSTER_TEST) VMSS_NAME=${val}
+        done
+    displayName: "Restart Nodes"
+
+  - task: AzureCLI@1
+    inputs:
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+      scriptLocation: "inlineScript"
+      scriptType: "bash"
+      addSpnToEnvironment: true
+      inlineScript: |
+        cd test/integration/load
+        clusterName=${{ parameters.clusterName }}
+        make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${clusterName}
+        make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
+
+        # Scale Cluster Up/Down to confirm functioning CNS
+        ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
+        kubectl get pods -owide -A
+        echo "Validating Node Restart"
+        make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
+    displayName: "Validate Node Restart"
+    retryCountOnTaskFailure: 3
+
   - script: |
       echo "Run Cilium Connectivity Tests"
       cilium status
@@ -109,7 +145,7 @@ steps:
     retryCountOnTaskFailure: 3
     name: "WireserverMetadataConnectivityTests"
     displayName: "Run Wireserver and Metadata Connectivity Tests"
-  
+
   - script: |
       cd hack/scripts
       chmod +x async-delete-test.sh

--- a/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-step-template.yaml
@@ -1,6 +1,7 @@
 parameters:
   name: ""
   clusterName: ""
+  scaleup: ""
 
 steps:
 
@@ -92,17 +93,14 @@ steps:
       addSpnToEnvironment: true
       inlineScript: |
         cd test/integration/load
-        clusterName=${{ parameters.clusterName }}
-        make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${clusterName}
-        make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
 
         # Scale Cluster Up/Down to confirm functioning CNS
-        ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
+        ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=linux go test -count 1 -timeout 30m -tags load -run ^TestLoad$
         kubectl get pods -owide -A
 
         cd ../../..
         echo "Validating Node Restart"
-        make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true
+        make test-validate-state OS_TYPE=linux RESTART_CASE=true CNI_TYPE=cilium_dualstack
         kubectl delete ns load-test
     displayName: "Validate Node Restart"
     retryCountOnTaskFailure: 3

--- a/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-step-template.yaml
@@ -99,6 +99,8 @@ steps:
         # Scale Cluster Up/Down to confirm functioning CNS
         ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
         kubectl get pods -owide -A
+
+        cd ../../..
         echo "Validating Node Restart"
         make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
     displayName: "Validate Node Restart"

--- a/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-job-template.yaml
@@ -59,7 +59,6 @@ stages:
               name: ${{ parameters.name }}
               clusterName: ${{ parameters.clusterName }}-$(commitID)
               testHubble: ${{ parameters.testHubble }}
-              os: linux
               scaleup: 100
 
       - template: ../../cni/k8s-e2e/k8s-e2e-job-template.yaml

--- a/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-job-template.yaml
@@ -59,6 +59,8 @@ stages:
               name: ${{ parameters.name }}
               clusterName: ${{ parameters.clusterName }}-$(commitID)
               testHubble: ${{ parameters.testHubble }}
+              os: linux
+              scaleup: 100
 
       - template: ../../cni/k8s-e2e/k8s-e2e-job-template.yaml
         parameters:

--- a/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-step-template.yaml
@@ -2,6 +2,7 @@ parameters:
   name: ""
   clusterName: ""
   testHubble: false
+  scaleup: ""
 
 steps:
   - bash: |
@@ -96,17 +97,14 @@ steps:
       addSpnToEnvironment: true
       inlineScript: |
         cd test/integration/load
-        clusterName=${{ parameters.clusterName }}
-        make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${clusterName}
-        make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
 
         # Scale Cluster Up/Down to confirm functioning CNS
-        ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
+        ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=linux go test -count 1 -timeout 30m -tags load -run ^TestLoad$
         kubectl get pods -owide -A
 
         cd ../../..
         echo "Validating Node Restart"
-        make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true
+        make test-validate-state OS_TYPE=linux RESTART_CASE=true
         kubectl delete ns load-test
     displayName: "Validate Node Restart"
     retryCountOnTaskFailure: 3

--- a/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-step-template.yaml
@@ -106,7 +106,8 @@ steps:
 
         cd ../../..
         echo "Validating Node Restart"
-        make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
+        make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true
+        kubectl delete ns load-test
     displayName: "Validate Node Restart"
     retryCountOnTaskFailure: 3
 

--- a/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-step-template.yaml
@@ -72,6 +72,42 @@ steps:
     name: "CiliumStatus"
     displayName: "Cilium Status"
 
+  - task: AzureCLI@1
+    inputs:
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+      scriptLocation: "inlineScript"
+      scriptType: "bash"
+      addSpnToEnvironment: true
+      inlineScript: |
+        set -e
+        kubectl get po -owide -A
+        clusterName=${{ parameters.clusterName }}
+        echo "Restarting nodes"
+        for val in $(az vmss list -g MC_${clusterName}_${clusterName}_$(REGION_AKS_CLUSTER_TEST) --query "[].name" -o tsv); do
+          make -C ./hack/aks restart-vmss AZCLI=az CLUSTER=${clusterName} REGION=$(REGION_AKS_CLUSTER_TEST) VMSS_NAME=${val}
+        done
+    displayName: "Restart Nodes"
+
+  - task: AzureCLI@1
+    inputs:
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+      scriptLocation: "inlineScript"
+      scriptType: "bash"
+      addSpnToEnvironment: true
+      inlineScript: |
+        cd test/integration/load
+        clusterName=${{ parameters.clusterName }}
+        make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${clusterName}
+        make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
+
+        # Scale Cluster Up/Down to confirm functioning CNS
+        ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
+        kubectl get pods -owide -A
+        echo "Validating Node Restart"
+        make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
+    displayName: "Validate Node Restart"
+    retryCountOnTaskFailure: 3
+
   - script: |
       echo "Run Cilium Connectivity Tests"
       cilium status
@@ -147,7 +183,7 @@ steps:
     retryCountOnTaskFailure: 3
     name: "WireserverMetadataConnectivityTests"
     displayName: "Run Wireserver and Metadata Connectivity Tests"
-  
+
   - script: |
       cd hack/scripts
       chmod +x async-delete-test.sh

--- a/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-step-template.yaml
@@ -103,6 +103,8 @@ steps:
         # Scale Cluster Up/Down to confirm functioning CNS
         ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
         kubectl get pods -owide -A
+
+        cd ../../..
         echo "Validating Node Restart"
         make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
     displayName: "Validate Node Restart"

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-job-template.yaml
@@ -57,7 +57,6 @@ stages:
             parameters:
               name: ${{ parameters.name }}
               clusterName: ${{ parameters.clusterName }}-$(commitID)
-              os: linux
               scaleup: 100
 
       - template: ../../cni/k8s-e2e/k8s-e2e-job-template.yaml

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-job-template.yaml
@@ -57,6 +57,8 @@ stages:
             parameters:
               name: ${{ parameters.name }}
               clusterName: ${{ parameters.clusterName }}-$(commitID)
+              os: linux
+              scaleup: 100
 
       - template: ../../cni/k8s-e2e/k8s-e2e-job-template.yaml
         parameters:

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
@@ -2,6 +2,8 @@ parameters:
   name: ""
   clusterName: ""
   testHubble: false
+  scaleup: ""
+
 
 steps:
   - bash: |
@@ -117,17 +119,14 @@ steps:
       addSpnToEnvironment: true
       inlineScript: |
         cd test/integration/load
-        clusterName=${{ parameters.clusterName }}
-        make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${clusterName}
-        make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
 
         # Scale Cluster Up/Down to confirm functioning CNS
-        ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
+        ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=linux go test -count 1 -timeout 30m -tags load -run ^TestLoad$
         kubectl get pods -owide -A
 
         cd ../../..
         echo "Validating Node Restart"
-        make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true
+        make test-validate-state OS_TYPE=linux RESTART_CASE=true
         kubectl delete ns load-test
     displayName: "Validate Node Restart"
     retryCountOnTaskFailure: 3

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
@@ -93,6 +93,42 @@ steps:
     name: "CiliumStatus"
     displayName: "Cilium Status"
 
+  - task: AzureCLI@1
+    inputs:
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+      scriptLocation: "inlineScript"
+      scriptType: "bash"
+      addSpnToEnvironment: true
+      inlineScript: |
+        set -e
+        kubectl get po -owide -A
+        clusterName=${{ parameters.clusterName }}
+        echo "Restarting nodes"
+        for val in $(az vmss list -g MC_${clusterName}_${clusterName}_$(REGION_AKS_CLUSTER_TEST) --query "[].name" -o tsv); do
+          make -C ./hack/aks restart-vmss AZCLI=az CLUSTER=${clusterName} REGION=$(REGION_AKS_CLUSTER_TEST) VMSS_NAME=${val}
+        done
+    displayName: "Restart Nodes"
+
+  - task: AzureCLI@1
+    inputs:
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+      scriptLocation: "inlineScript"
+      scriptType: "bash"
+      addSpnToEnvironment: true
+      inlineScript: |
+        cd test/integration/load
+        clusterName=${{ parameters.clusterName }}
+        make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${clusterName}
+        make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
+
+        # Scale Cluster Up/Down to confirm functioning CNS
+        ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
+        kubectl get pods -owide -A
+        echo "Validating Node Restart"
+        make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
+    displayName: "Validate Node Restart"
+    retryCountOnTaskFailure: 3
+
   - script: |
       echo "Run Cilium Connectivity Tests"
       cilium status
@@ -186,7 +222,7 @@ steps:
     retryCountOnTaskFailure: 3
     name: "WireserverMetadataConnectivityTests"
     displayName: "Run Wireserver and Metadata Connectivity Tests"
-  
+
   - script: |
       if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]; then
         echo "Running nightly, skip async delete test"

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
@@ -127,7 +127,8 @@ steps:
 
         cd ../../..
         echo "Validating Node Restart"
-        make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
+        make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true
+        kubectl delete ns load-test
     displayName: "Validate Node Restart"
     retryCountOnTaskFailure: 3
 

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
@@ -124,6 +124,8 @@ steps:
         # Scale Cluster Up/Down to confirm functioning CNS
         ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
         kubectl get pods -owide -A
+
+        cd ../../..
         echo "Validating Node Restart"
         make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
     displayName: "Validate Node Restart"

--- a/.pipelines/singletenancy/cilium/cilium-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-job-template.yaml
@@ -60,6 +60,8 @@ stages:
             parameters:
               name: ${{ parameters.name }}
               clusterName: ${{ parameters.clusterName }}-$(commitID)
+              os: linux
+              scaleup: 100
 
       - template: ../../cni/k8s-e2e/k8s-e2e-job-template.yaml
         parameters:

--- a/.pipelines/singletenancy/cilium/cilium-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-job-template.yaml
@@ -60,7 +60,6 @@ stages:
             parameters:
               name: ${{ parameters.name }}
               clusterName: ${{ parameters.clusterName }}-$(commitID)
-              os: linux
               scaleup: 100
 
       - template: ../../cni/k8s-e2e/k8s-e2e-job-template.yaml

--- a/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
@@ -72,6 +72,42 @@ steps:
     name: "CiliumStatus"
     displayName: "Cilium Status"
 
+  - task: AzureCLI@1
+    inputs:
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+      scriptLocation: "inlineScript"
+      scriptType: "bash"
+      addSpnToEnvironment: true
+      inlineScript: |
+        set -e
+        kubectl get po -owide -A
+        clusterName=${{ parameters.clusterName }}
+        echo "Restarting nodes"
+        for val in $(az vmss list -g MC_${clusterName}_${clusterName}_$(REGION_AKS_CLUSTER_TEST) --query "[].name" -o tsv); do
+          make -C ./hack/aks restart-vmss AZCLI=az CLUSTER=${clusterName} REGION=$(REGION_AKS_CLUSTER_TEST) VMSS_NAME=${val}
+        done
+    displayName: "Restart Nodes"
+
+  - task: AzureCLI@1
+    inputs:
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+      scriptLocation: "inlineScript"
+      scriptType: "bash"
+      addSpnToEnvironment: true
+      inlineScript: |
+        cd test/integration/load
+        clusterName=${{ parameters.clusterName }}
+        make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${clusterName}
+        make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
+
+        # Scale Cluster Up/Down to confirm functioning CNS
+        ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
+        kubectl get pods -owide -A
+        echo "Validating Node Restart"
+        make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
+    displayName: "Validate Node Restart"
+    retryCountOnTaskFailure: 3
+
   - script: |
       echo "Run Cilium Connectivity Tests"
       cilium status
@@ -95,25 +131,12 @@ steps:
     displayName: "Validate Pods"
 
   - script: |
-      echo "validate pod IP assignment before CNS restart"
-      kubectl get pod -owide -A
-      make test-validate-state
-      echo "restart CNS"
-      kubectl rollout restart ds azure-cns -n kube-system
-      kubectl rollout status ds azure-cns -n kube-system
-      kubectl get pod -owide -A
-      echo "validate pods after CNS restart"
-      make test-validate-state
-    name: "restartCNS"
-    displayName: "Restart CNS and validate pods"
-
-  - script: |
       echo "Run wireserver and metadata connectivity Tests"
       bash test/network/wireserver_metadata_test.sh
     retryCountOnTaskFailure: 3
     name: "WireserverMetadataConnectivityTests"
     displayName: "Run Wireserver and Metadata Connectivity Tests"
-  
+
   - script: |
       cd hack/scripts
       chmod +x async-delete-test.sh

--- a/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
@@ -106,7 +106,8 @@ steps:
 
         cd ../../..
         echo "Validating Node Restart"
-        make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
+        make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true
+        kubectl delete ns load-test
     displayName: "Validate Node Restart"
     retryCountOnTaskFailure: 3
 

--- a/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
@@ -1,6 +1,7 @@
 parameters:
   name: ""
   clusterName: ""
+  scaleup: ""
 
 steps:
   - bash: |
@@ -96,17 +97,14 @@ steps:
       addSpnToEnvironment: true
       inlineScript: |
         cd test/integration/load
-        clusterName=${{ parameters.clusterName }}
-        make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${clusterName}
-        make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
 
         # Scale Cluster Up/Down to confirm functioning CNS
-        ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
+        ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=linux go test -count 1 -timeout 30m -tags load -run ^TestLoad$
         kubectl get pods -owide -A
 
         cd ../../..
         echo "Validating Node Restart"
-        make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true
+        make test-validate-state OS_TYPE=linux RESTART_CASE=true
         kubectl delete ns load-test
     displayName: "Validate Node Restart"
     retryCountOnTaskFailure: 3

--- a/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
@@ -103,6 +103,8 @@ steps:
         # Scale Cluster Up/Down to confirm functioning CNS
         ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
         kubectl get pods -owide -A
+
+        cd ../../..
         echo "Validating Node Restart"
         make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
     displayName: "Validate Node Restart"

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
@@ -46,6 +46,7 @@ stages:
     jobs:
       - job: ${{ parameters.name }}_linux
         displayName: DualStack Overlay Test Suite | Linux - (${{ parameters.name }})
+        timeoutInMinutes: 120
         pool:
           name: $(BUILD_POOL_NAME_DEFAULT)
           demands:
@@ -57,10 +58,37 @@ stages:
               name: ${{ parameters.name }}
               clusterName: ${{ parameters.clusterName }}-$(commitID)
               os: linux
+              scaleup: 100
+
+      - job: windows_nodepool
+        displayName: Add Windows Nodepool
+        dependsOn: ${{ parameters.name }}_linux
+        pool:
+          name: $(BUILD_POOL_NAME_DEFAULT)
+          demands:
+          - agent.os -equals Linux
+          - Role -equals $(CUSTOM_E2E_ROLE)
+        steps:
+          - task: AzureCLI@2
+            inputs:
+              azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+              scriptLocation: "inlineScript"
+              scriptType: "bash"
+              addSpnToEnvironment: true
+              inlineScript: |
+                set -e
+                make -C ./hack/aks windows-nodepool-up AZCLI=az SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }} VM_SIZE_WIN=${{ parameters.vmSizeWin }}
+                echo "Windows nodes have been successfully added to DualStack Overlay Cluster"
+                kubectl cluster-info
+                kubectl get node -owide
+                kubectl get po -owide -A
+            name: "Add_Windows_Node"
+            displayName: "Add windows node"
 
       - job: ${{ parameters.name }}_windows
         displayName: DualStack Overlay Test Suite | Windows - (${{ parameters.name }})
-        dependsOn: ${{ parameters.name }}_linux
+        timeoutInMinutes: 120
+        dependsOn: windows_nodepool
         pool:
           name: $(BUILD_POOL_NAME_DEFAULT)
           demands:
@@ -72,7 +100,7 @@ stages:
               name: ${{ parameters.name }}
               clusterName: ${{ parameters.clusterName }}-$(commitID)
               os: windows
-              vmSizeWin: ${{ parameters.vmSize }} # Matching linux vmSize
+              scaleup: 50
 
       - template: ../../cni/k8s-e2e/k8s-e2e-job-template.yaml
         parameters:

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
@@ -77,7 +77,8 @@ stages:
               addSpnToEnvironment: true
               inlineScript: |
                 set -e
-                make -C ./hack/aks windows-nodepool-up AZCLI=az SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }}-$(commitID) VM_SIZE_WIN=${{ parameters.vmSizeWin }}
+                make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(commitID)
+                make -C ./hack/aks windows-nodepool-up AZCLI=az SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }}-$(commitID) VM_SIZE_WIN=${{ parameters.vmSize }}
                 echo "Windows nodes have been successfully added to DualStack Overlay Cluster"
                 kubectl cluster-info
                 kubectl get node -owide

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
@@ -77,7 +77,7 @@ stages:
               addSpnToEnvironment: true
               inlineScript: |
                 set -e
-                make -C ./hack/aks windows-nodepool-up AZCLI=az SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }} VM_SIZE_WIN=${{ parameters.vmSizeWin }}
+                make -C ./hack/aks windows-nodepool-up AZCLI=az SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }}-$(commitID) VM_SIZE_WIN=${{ parameters.vmSizeWin }}
                 echo "Windows nodes have been successfully added to DualStack Overlay Cluster"
                 kubectl cluster-info
                 kubectl get node -owide

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-step-template.yaml
@@ -3,6 +3,7 @@ parameters:
   clusterName: ""
   cni: "dualstack"
   os: ""
+  scaleup: ""
 
 steps:
   - bash: |
@@ -37,7 +38,7 @@ steps:
         kubectl cluster-info
         kubectl get node
         kubectl get po -owide -A
-        sudo -E env "PATH=$PATH" make test-load SCALE_UP=32 OS_TYPE=linux CNI_TYPE=cniv2 VALIDATE_STATEFILE=true INSTALL_CNS=true INSTALL_DUALSTACK_OVERLAY=true VALIDATE_DUALSTACK=true CNI_VERSION=$(make cni-version) CNS_VERSION=$(make cns-version) CLEANUP=true
+        sudo -E env "PATH=$PATH" make test-load SCALE_UP=32 OS_TYPE=linux CNI_TYPE=dualstack VALIDATE_STATEFILE=true INSTALL_CNS=true INSTALL_DUALSTACK_OVERLAY=true VALIDATE_DUALSTACK=true CNI_VERSION=$(make cni-version) CNS_VERSION=$(make cns-version) CLEANUP=true
       retryCountOnTaskFailure: 3
       name: "integrationTest"
       displayName: "Run CNS Integration Tests on AKS DualStack Overlay"
@@ -77,17 +78,14 @@ steps:
         addSpnToEnvironment: true
         inlineScript: |
           cd test/integration/load
-          clusterName=${{ parameters.clusterName }}
-          make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${clusterName}
-          make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_DUALSTACKOVERLAY_CLUSTER_TEST)
 
           # Scale Cluster Up/Down to confirm functioning CNS
-          ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
+          ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=linux go test -count 1 -timeout 30m -tags load -run ^TestLoad$
           kubectl get pods -owide -A
 
           cd ../../..
           echo "Validating Node Restart"
-          make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
+          make test-validate-state OS_TYPE=linux RESTART_CASE=true CNI_TYPE=dualstack
           kubectl delete ns load-test
       displayName: "Validate Node Restart"
       retryCountOnTaskFailure: 3
@@ -137,17 +135,14 @@ steps:
         addSpnToEnvironment: true
         inlineScript: |
           cd test/integration/load
-          clusterName=${{ parameters.clusterName }}
-          make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${clusterName}
-          make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_DUALSTACKOVERLAY_CLUSTER_TEST)
 
           # Scale Cluster Up/Down to confirm functioning CNS
-          ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
+          ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=windows go test -count 1 -timeout 30m -tags load -run ^TestLoad$
           kubectl get pods -owide -A
 
           cd ../../..
           echo "Validating Node Restart"
-          make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
+          make test-validate-state OS_TYPE=windows RESTART_CASE=true CNI_TYPE=cniv2
           kubectl delete ns load-test
       displayName: "Validate Node Restart"
       retryCountOnTaskFailure: 3

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-step-template.yaml
@@ -80,44 +80,16 @@ steps:
           clusterName=${{ parameters.clusterName }}
           make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${clusterName}
           make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_DUALSTACKOVERLAY_CLUSTER_TEST)
-          kubectl get pods -A
+
+          # Scale Cluster Up/Down to confirm functioning CNS
+          ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
+          kubectl get pods -owide -A
           echo "Validating Node Restart"
-          CNI_TYPE=dualstack RESTART_CASE=true go test -timeout 30m -tags load -run ^TestValidateState$
+          make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
       displayName: "Validate Node Restart"
       retryCountOnTaskFailure: 3
 
-    - script: |
-        echo "validate pod IP assignment before CNS restart"
-        kubectl get pod -owide -A
-        echo "validate pod state before CNS restarts"
-        cd test/integration/load
-        CNI_TYPE=dualstack go test -timeout 30m -tags load -run ^TestValidateState$
-        kubectl rollout restart ds azure-cns -n kube-system
-        kubectl rollout status ds azure-cns -n kube-system
-        kubectl get pod -owide -A
-        echo "validate pods after CNS restarts"
-        CNI_TYPE=dualstack go test -timeout 30m -tags load -run ^TestValidateState$
-      name: "restartCNS_ValidatePodState"
-      displayName: "Restart CNS and Validate Pod State"
-      retryCountOnTaskFailure: 3
-
   - ${{ if eq(parameters.os, 'windows') }}:
-    - task: AzureCLI@2
-      inputs:
-        azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
-        scriptLocation: "inlineScript"
-        scriptType: "bash"
-        addSpnToEnvironment: true
-        inlineScript: |
-          set -e
-          make -C ./hack/aks windows-nodepool-up AZCLI=az SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }} VM_SIZE_WIN=${{ parameters.vmSizeWin }}
-          echo "Windows nodes have been successfully added to DualStack Overlay Cluster"
-          kubectl cluster-info
-          kubectl get node -owide
-          kubectl get po -owide -A
-      name: "Add_Windows_Node"
-      displayName: "Add windows node"
-
     - script: |
         nodeList=`kubectl get node -owide | grep Windows | awk '{print $1}'`
         for node in $nodeList; do
@@ -137,4 +109,39 @@ steps:
         sudo -E env "PATH=$PATH" go test -count=1 datapath_windows_test.go -timeout 3m -tags connection -restartKubeproxy true -run ^TestDatapathWin$
       name: "WindowsDualStackOverlayDatapathTests"
       displayName: "Windows DualStack Overlay Datapath Tests"
+      retryCountOnTaskFailure: 3
+
+    - task: AzureCLI@1
+      inputs:
+        azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+        scriptLocation: "inlineScript"
+        scriptType: "bash"
+        addSpnToEnvironment: true
+        inlineScript: |
+          set -e
+          clusterName=${{ parameters.clusterName }}
+          echo "Restarting nodes"
+          for val in $(az vmss list -g MC_${clusterName}_${clusterName}_$(REGION_DUALSTACKOVERLAY_CLUSTER_TEST) --query "[].name" -o tsv); do
+            make -C ./hack/aks restart-vmss AZCLI=az CLUSTER=${clusterName} REGION=$(REGION_DUALSTACKOVERLAY_CLUSTER_TEST) VMSS_NAME=${val}
+          done
+      displayName: "Restart Nodes"
+
+    - task: AzureCLI@1
+      inputs:
+        azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+        scriptLocation: "inlineScript"
+        scriptType: "bash"
+        addSpnToEnvironment: true
+        inlineScript: |
+          cd test/integration/load
+          clusterName=${{ parameters.clusterName }}
+          make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${clusterName}
+          make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_DUALSTACKOVERLAY_CLUSTER_TEST)
+
+          # Scale Cluster Up/Down to confirm functioning CNS
+          ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
+          kubectl get pods -owide -A
+          echo "Validating Node Restart"
+          make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
+      displayName: "Validate Node Restart"
       retryCountOnTaskFailure: 3

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-step-template.yaml
@@ -84,6 +84,8 @@ steps:
           # Scale Cluster Up/Down to confirm functioning CNS
           ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
           kubectl get pods -owide -A
+
+          cd ../../..
           echo "Validating Node Restart"
           make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
       displayName: "Validate Node Restart"
@@ -141,6 +143,8 @@ steps:
           # Scale Cluster Up/Down to confirm functioning CNS
           ITERATIONS=2 SCALE_UP=${{ parameters.scaleup }} OS_TYPE=${{ parameters.os }} go test -count 1 -timeout 30m -tags load -run ^TestLoad$
           kubectl get pods -owide -A
+
+          cd ../../..
           echo "Validating Node Restart"
           make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
       displayName: "Validate Node Restart"

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-step-template.yaml
@@ -88,6 +88,7 @@ steps:
           cd ../../..
           echo "Validating Node Restart"
           make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
+          kubectl delete ns load-test
       displayName: "Validate Node Restart"
       retryCountOnTaskFailure: 3
 
@@ -147,5 +148,6 @@ steps:
           cd ../../..
           echo "Validating Node Restart"
           make test-validate-state OS_TYPE=${{ parameters.os }} RESTART_CASE=true CNI_TYPE=cniv2
+          kubectl delete ns load-test
       displayName: "Validate Node Restart"
       retryCountOnTaskFailure: 3


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Adds test coverage to validate CNI binary install occurs correctly on all scenarios. Additionally, refreshes current E2E to remove duplicate testing, pull out windows nodepool creation, and leverages existing makefile commands for validation testing.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Contributes to CI/CD to cover #2818 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
