### PR TITLE
fix: don't print stack trace of error for certain logs to prevent spam

### DIFF
--- a/cni/log/logger_error.go
+++ b/cni/log/logger_error.go
@@ -1,12 +1,41 @@
 package log
 
+import (
+	"fmt"
+	"io"
+)
+
 type ErrorWithoutStackTrace struct {
-	Err error
+	error
 }
 
-func (se ErrorWithoutStackTrace) Error() string {
-	if se.Err == nil {
+func (l *ErrorWithoutStackTrace) Error() string {
+	if l.error == nil {
 		return ""
 	}
-	return se.Err.Error()
+	return l.error.Error()
+}
+func (l *ErrorWithoutStackTrace) Format(s fmt.State, verb rune) {
+	// if the error is nil, nothing should happen
+	if l.error == nil {
+		return
+	}
+	v := verb
+	// replace uses of %v with %s
+	if v == 'v' {
+		v = 's'
+	}
+	// if the error implements formatter (which it should)
+	if fm, ok := l.error.(fmt.Formatter); ok {
+		fm.Format(s, v)
+	} else {
+		io.WriteString(s, l.error.Error())
+	}
+}
+func (l *ErrorWithoutStackTrace) Unwrap() error {
+	return l.error
+}
+
+func NewErrorWithoutStackTrace(err error) *ErrorWithoutStackTrace {
+	return &ErrorWithoutStackTrace{err}
 }

--- a/cni/log/logger_error.go
+++ b/cni/log/logger_error.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"errors"
 	"fmt"
 	"io"
 )
@@ -15,6 +16,7 @@ func (l *ErrorWithoutStackTrace) Error() string {
 	}
 	return l.error.Error()
 }
+
 func (l *ErrorWithoutStackTrace) Format(s fmt.State, verb rune) {
 	// if the error is nil, nothing should happen
 	if l.error == nil {
@@ -26,12 +28,14 @@ func (l *ErrorWithoutStackTrace) Format(s fmt.State, verb rune) {
 		v = 's'
 	}
 	// if the error implements formatter (which it should)
-	if fm, ok := l.error.(fmt.Formatter); ok {
-		fm.Format(s, v)
+	var formatter fmt.Formatter
+	if errors.As(l.error, &formatter) {
+		formatter.Format(s, v)
 	} else {
-		io.WriteString(s, l.error.Error())
+		_, _ = io.WriteString(s, l.error.Error())
 	}
 }
+
 func (l *ErrorWithoutStackTrace) Unwrap() error {
 	return l.error
 }

--- a/cni/log/logger_error.go
+++ b/cni/log/logger_error.go
@@ -1,0 +1,12 @@
+package log
+
+type ErrorWithoutStackTrace struct {
+	Err error
+}
+
+func (se ErrorWithoutStackTrace) Error() string {
+	if se.Err == nil {
+		return ""
+	}
+	return se.Err.Error()
+}

--- a/cni/log/logger_test.go
+++ b/cni/log/logger_test.go
@@ -1,0 +1,51 @@
+package log
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+var internalError = errors.New("internal error")
+
+func TestLoggerError(t *testing.T) {
+	require := require.New(t) //nolint:gocritic
+
+	var buf bytes.Buffer
+
+	// Create a zap core that writes logs to the buffer
+	core := zapcore.NewCore(
+		zapcore.NewJSONEncoder(zapcore.EncoderConfig{}),
+		zapcore.AddSync(&buf),
+		zapcore.DebugLevel,
+	)
+	logger := zap.New(core)
+
+	wrappedError := errors.Wrap(internalError, "wrapped message")
+	errorNoStack := &ErrorWithoutStackTrace{wrappedError}
+
+	logger.Info("Error", zap.Error(wrappedError))
+	require.Contains(buf.String(), "errorVerbose")
+	buf.Reset()
+
+	// Error verbose field should be omitted from the error without stack trace error
+	logger.Info("ErrorWithoutStackTrace", zap.Error(errorNoStack))
+	require.NotContains(buf.String(), "errorVerbose")
+	require.Contains(buf.String(), "wrapped message")
+	require.Contains(buf.String(), "internal error")
+	buf.Reset()
+
+	// Even if the embedded error is nil, the error should still display an empty string and not panic
+	logger.Info("ErrorWithoutStackTrace nil internal error", zap.Error(&ErrorWithoutStackTrace{error: nil}))
+	require.Contains(buf.String(), "\"error\":\"\"")
+	buf.Reset()
+
+	// should be able to unwrap the error without a stack trace
+	require.ErrorIs(errorNoStack, internalError)
+	// Even if the embedded error is nil, should function properly
+	require.NotErrorIs(&ErrorWithoutStackTrace{error: nil}, errorNoStack)
+}

--- a/cni/log/logger_test.go
+++ b/cni/log/logger_test.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -10,7 +11,7 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-var internalError = errors.New("internal error")
+var errInternal = errors.New("internal error")
 
 func TestLoggerError(t *testing.T) {
 	require := require.New(t) //nolint:gocritic
@@ -25,11 +26,12 @@ func TestLoggerError(t *testing.T) {
 	)
 	logger := zap.New(core)
 
-	wrappedError := errors.Wrap(internalError, "wrapped message")
-	errorNoStack := &ErrorWithoutStackTrace{wrappedError}
+	wrappedError := errors.Wrap(errInternal, "wrapped message")
+	errorNoStack := NewErrorWithoutStackTrace(wrappedError)
 
 	logger.Info("Error", zap.Error(wrappedError))
 	require.Contains(buf.String(), "errorVerbose")
+	fmt.Println(buf.String())
 	buf.Reset()
 
 	// Error verbose field should be omitted from the error without stack trace error
@@ -37,15 +39,17 @@ func TestLoggerError(t *testing.T) {
 	require.NotContains(buf.String(), "errorVerbose")
 	require.Contains(buf.String(), "wrapped message")
 	require.Contains(buf.String(), "internal error")
+	fmt.Println(buf.String())
 	buf.Reset()
 
 	// Even if the embedded error is nil, the error should still display an empty string and not panic
-	logger.Info("ErrorWithoutStackTrace nil internal error", zap.Error(&ErrorWithoutStackTrace{error: nil}))
+	logger.Info("ErrorWithoutStackTrace nil internal error", zap.Error(NewErrorWithoutStackTrace(nil)))
 	require.Contains(buf.String(), "\"error\":\"\"")
+	fmt.Println(buf.String())
 	buf.Reset()
 
 	// should be able to unwrap the error without a stack trace
-	require.ErrorIs(errorNoStack, internalError)
+	require.ErrorIs(errorNoStack, errInternal)
 	// Even if the embedded error is nil, should function properly
 	require.NotErrorIs(&ErrorWithoutStackTrace{error: nil}, errorNoStack)
 }

--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -7,6 +7,7 @@ import (
 	"net"
 
 	"github.com/Azure/azure-container-networking/cni"
+	"github.com/Azure/azure-container-networking/cni/log"
 	"github.com/Azure/azure-container-networking/cni/util"
 	"github.com/Azure/azure-container-networking/cns"
 	cnscli "github.com/Azure/azure-container-networking/cns/client"
@@ -321,7 +322,7 @@ func (invoker *CNSIPAMInvoker) Delete(address *net.IPNet, nwCfg *cni.NetworkConf
 					addErr := fsnotify.AddFile(ipConfigs.PodInterfaceID, args.ContainerID, watcherPath)
 					if addErr != nil {
 						logger.Error("Failed to add file to watcher (unsupported api path)",
-							zap.String("podInterfaceID", ipConfigs.PodInterfaceID), zap.String("containerID", args.ContainerID), zap.Error(simpleError{e: addErr}))
+							zap.String("podInterfaceID", ipConfigs.PodInterfaceID), zap.String("containerID", args.ContainerID), zap.Error(log.ErrorWithoutStackTrace{Err: addErr}))
 						return errors.Wrap(addErr, fmt.Sprintf("failed to add file to watcher with containerID %s and podInterfaceID %s (unsupported api path)", args.ContainerID, ipConfigs.PodInterfaceID))
 					}
 				} else {
@@ -336,7 +337,8 @@ func (invoker *CNSIPAMInvoker) Delete(address *net.IPNet, nwCfg *cni.NetworkConf
 			if errors.As(err, &connectionErr) {
 				addErr := fsnotify.AddFile(ipConfigs.PodInterfaceID, args.ContainerID, watcherPath)
 				if addErr != nil {
-					logger.Error("Failed to add file to watcher", zap.String("podInterfaceID", ipConfigs.PodInterfaceID), zap.String("containerID", args.ContainerID), zap.Error(simpleError{e: addErr}))
+					logger.Error("Failed to add file to watcher", zap.String("podInterfaceID", ipConfigs.PodInterfaceID), zap.String("containerID", args.ContainerID),
+						zap.Error(log.ErrorWithoutStackTrace{Err: addErr}))
 					return errors.Wrap(addErr, fmt.Sprintf("failed to add file to watcher with containerID %s and podInterfaceID %s", args.ContainerID, ipConfigs.PodInterfaceID))
 				}
 			} else {

--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -320,8 +320,9 @@ func (invoker *CNSIPAMInvoker) Delete(address *net.IPNet, nwCfg *cni.NetworkConf
 				if errors.As(err, &connectionErr) {
 					addErr := fsnotify.AddFile(ipConfigs.PodInterfaceID, args.ContainerID, watcherPath)
 					if addErr != nil {
-						logger.Error("Failed to add file to watcher", zap.String("podInterfaceID", ipConfigs.PodInterfaceID), zap.String("containerID", args.ContainerID), zap.Error(simpleError{e: addErr}))
-						return errors.Wrap(addErr, fmt.Sprintf("failed to add file to watcher with containerID %s and podInterfaceID %s", args.ContainerID, ipConfigs.PodInterfaceID))
+						logger.Error("Failed to add file to watcher (unsupported api path)",
+							zap.String("podInterfaceID", ipConfigs.PodInterfaceID), zap.String("containerID", args.ContainerID), zap.Error(simpleError{e: addErr}))
+						return errors.Wrap(addErr, fmt.Sprintf("failed to add file to watcher with containerID %s and podInterfaceID %s (unsupported api path)", args.ContainerID, ipConfigs.PodInterfaceID))
 					}
 				} else {
 					logger.Error("Failed to release IP address from CNS using ReleaseIPAddress ",

--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -322,7 +322,7 @@ func (invoker *CNSIPAMInvoker) Delete(address *net.IPNet, nwCfg *cni.NetworkConf
 					addErr := fsnotify.AddFile(ipConfigs.PodInterfaceID, args.ContainerID, watcherPath)
 					if addErr != nil {
 						logger.Error("Failed to add file to watcher (unsupported api path)",
-							zap.String("podInterfaceID", ipConfigs.PodInterfaceID), zap.String("containerID", args.ContainerID), zap.Error(log.ErrorWithoutStackTrace{Err: addErr}))
+							zap.String("podInterfaceID", ipConfigs.PodInterfaceID), zap.String("containerID", args.ContainerID), zap.Error(log.NewErrorWithoutStackTrace(addErr)))
 						return errors.Wrap(addErr, fmt.Sprintf("failed to add file to watcher with containerID %s and podInterfaceID %s (unsupported api path)", args.ContainerID, ipConfigs.PodInterfaceID))
 					}
 				} else {
@@ -338,7 +338,7 @@ func (invoker *CNSIPAMInvoker) Delete(address *net.IPNet, nwCfg *cni.NetworkConf
 				addErr := fsnotify.AddFile(ipConfigs.PodInterfaceID, args.ContainerID, watcherPath)
 				if addErr != nil {
 					logger.Error("Failed to add file to watcher", zap.String("podInterfaceID", ipConfigs.PodInterfaceID), zap.String("containerID", args.ContainerID),
-						zap.Error(log.ErrorWithoutStackTrace{Err: addErr}))
+						zap.Error(log.NewErrorWithoutStackTrace(addErr)))
 					return errors.Wrap(addErr, fmt.Sprintf("failed to add file to watcher with containerID %s and podInterfaceID %s", args.ContainerID, ipConfigs.PodInterfaceID))
 				}
 			} else {

--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -136,7 +136,6 @@ func (invoker *CNSIPAMInvoker) Add(addConfig IPAMAddConfig) (IPAMAddResult, erro
 			}
 		} else {
 			logger.Info("Failed to get IP address from CNS",
-				zap.Error(err),
 				zap.Any("response", response))
 			return IPAMAddResult{}, errors.Wrap(err, "Failed to get IP address from CNS")
 		}
@@ -321,7 +320,7 @@ func (invoker *CNSIPAMInvoker) Delete(address *net.IPNet, nwCfg *cni.NetworkConf
 				if errors.As(err, &connectionErr) {
 					addErr := fsnotify.AddFile(ipConfigs.PodInterfaceID, args.ContainerID, watcherPath)
 					if addErr != nil {
-						logger.Error("Failed to add file to watcher", zap.String("podInterfaceID", ipConfigs.PodInterfaceID), zap.String("containerID", args.ContainerID), zap.Error(addErr))
+						logger.Error("Failed to add file to watcher", zap.String("podInterfaceID", ipConfigs.PodInterfaceID), zap.String("containerID", args.ContainerID), zap.Error(simpleError{e: addErr}))
 						return errors.Wrap(addErr, fmt.Sprintf("failed to add file to watcher with containerID %s and podInterfaceID %s", args.ContainerID, ipConfigs.PodInterfaceID))
 					}
 				} else {
@@ -336,7 +335,7 @@ func (invoker *CNSIPAMInvoker) Delete(address *net.IPNet, nwCfg *cni.NetworkConf
 			if errors.As(err, &connectionErr) {
 				addErr := fsnotify.AddFile(ipConfigs.PodInterfaceID, args.ContainerID, watcherPath)
 				if addErr != nil {
-					logger.Error("Failed to add file to watcher", zap.String("podInterfaceID", ipConfigs.PodInterfaceID), zap.String("containerID", args.ContainerID), zap.Error(addErr))
+					logger.Error("Failed to add file to watcher", zap.String("podInterfaceID", ipConfigs.PodInterfaceID), zap.String("containerID", args.ContainerID), zap.Error(simpleError{e: addErr}))
 					return errors.Wrap(addErr, fmt.Sprintf("failed to add file to watcher with containerID %s and podInterfaceID %s", args.ContainerID, ipConfigs.PodInterfaceID))
 				}
 			} else {

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/azure-container-networking/aitelemetry"
 	"github.com/Azure/azure-container-networking/cni"
 	"github.com/Azure/azure-container-networking/cni/api"
+	"github.com/Azure/azure-container-networking/cni/log"
 	"github.com/Azure/azure-container-networking/cni/util"
 	"github.com/Azure/azure-container-networking/cns"
 	cnscli "github.com/Azure/azure-container-networking/cns/client"
@@ -71,17 +72,6 @@ const (
 const (
 	jsonFileExtension = ".json"
 )
-
-type simpleError struct {
-	e error
-}
-
-func (se simpleError) Error() string {
-	if se.e == nil {
-		return ""
-	}
-	return se.e.Error()
-}
 
 // NetPlugin represents the CNI network plugin.
 type NetPlugin struct {
@@ -485,7 +475,7 @@ func (plugin *NetPlugin) Add(args *cniSkel.CmdArgs) error {
 		logger.Info("ADD command completed for",
 			zap.String("pod", k8sPodName),
 			zap.Any("IPs", cniResult.IPs),
-			zap.Error(simpleError{e: err}))
+			zap.Error(log.ErrorWithoutStackTrace{Err: err}))
 	}()
 
 	ipamAddResult = IPAMAddResult{interfaceInfo: make(map[string]network.InterfaceInfo)}
@@ -942,7 +932,7 @@ func (plugin *NetPlugin) Get(args *cniSkel.CmdArgs) error {
 		}
 
 		logger.Info("GET command completed", zap.Any("result", result),
-			zap.Error(simpleError{e: err}))
+			zap.Error(log.ErrorWithoutStackTrace{Err: err}))
 	}()
 
 	// Parse network configuration from stdin.
@@ -1031,7 +1021,7 @@ func (plugin *NetPlugin) Delete(args *cniSkel.CmdArgs) error {
 	defer func() {
 		logger.Info("DEL command completed",
 			zap.String("pod", k8sPodName),
-			zap.Error(simpleError{e: err}))
+			zap.Error(log.ErrorWithoutStackTrace{Err: err}))
 	}()
 
 	// Parse network configuration from stdin.
@@ -1275,7 +1265,7 @@ func (plugin *NetPlugin) Update(args *cniSkel.CmdArgs) error {
 
 		logger.Info("UPDATE command completed",
 			zap.Any("result", result),
-			zap.Error(simpleError{e: err}))
+			zap.Error(log.ErrorWithoutStackTrace{Err: err}))
 	}()
 
 	// Parse Pod arguments.

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -72,6 +72,17 @@ const (
 	jsonFileExtension = ".json"
 )
 
+type simpleError struct {
+	e error
+}
+
+func (se simpleError) Error() string {
+	if se.e == nil {
+		return ""
+	}
+	return se.e.Error()
+}
+
 // NetPlugin represents the CNI network plugin.
 type NetPlugin struct {
 	*cni.Plugin
@@ -474,7 +485,7 @@ func (plugin *NetPlugin) Add(args *cniSkel.CmdArgs) error {
 		logger.Info("ADD command completed for",
 			zap.String("pod", k8sPodName),
 			zap.Any("IPs", cniResult.IPs),
-			zap.Error(err))
+			zap.Error(simpleError{e: err}))
 	}()
 
 	ipamAddResult = IPAMAddResult{interfaceInfo: make(map[string]network.InterfaceInfo)}
@@ -931,7 +942,7 @@ func (plugin *NetPlugin) Get(args *cniSkel.CmdArgs) error {
 		}
 
 		logger.Info("GET command completed", zap.Any("result", result),
-			zap.Error(err))
+			zap.Error(simpleError{e: err}))
 	}()
 
 	// Parse network configuration from stdin.
@@ -1020,7 +1031,7 @@ func (plugin *NetPlugin) Delete(args *cniSkel.CmdArgs) error {
 	defer func() {
 		logger.Info("DEL command completed",
 			zap.String("pod", k8sPodName),
-			zap.Error(err))
+			zap.Error(simpleError{e: err}))
 	}()
 
 	// Parse network configuration from stdin.
@@ -1264,7 +1275,7 @@ func (plugin *NetPlugin) Update(args *cniSkel.CmdArgs) error {
 
 		logger.Info("UPDATE command completed",
 			zap.Any("result", result),
-			zap.Error(err))
+			zap.Error(simpleError{e: err}))
 	}()
 
 	// Parse Pod arguments.

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -475,7 +475,7 @@ func (plugin *NetPlugin) Add(args *cniSkel.CmdArgs) error {
 		logger.Info("ADD command completed for",
 			zap.String("pod", k8sPodName),
 			zap.Any("IPs", cniResult.IPs),
-			zap.Error(log.ErrorWithoutStackTrace{Err: err}))
+			zap.Error(log.NewErrorWithoutStackTrace(err)))
 	}()
 
 	ipamAddResult = IPAMAddResult{interfaceInfo: make(map[string]network.InterfaceInfo)}
@@ -932,7 +932,7 @@ func (plugin *NetPlugin) Get(args *cniSkel.CmdArgs) error {
 		}
 
 		logger.Info("GET command completed", zap.Any("result", result),
-			zap.Error(log.ErrorWithoutStackTrace{Err: err}))
+			zap.Error(log.NewErrorWithoutStackTrace(err)))
 	}()
 
 	// Parse network configuration from stdin.
@@ -1021,7 +1021,7 @@ func (plugin *NetPlugin) Delete(args *cniSkel.CmdArgs) error {
 	defer func() {
 		logger.Info("DEL command completed",
 			zap.String("pod", k8sPodName),
-			zap.Error(log.ErrorWithoutStackTrace{Err: err}))
+			zap.Error(log.NewErrorWithoutStackTrace(err)))
 	}()
 
 	// Parse network configuration from stdin.
@@ -1265,7 +1265,7 @@ func (plugin *NetPlugin) Update(args *cniSkel.CmdArgs) error {
 
 		logger.Info("UPDATE command completed",
 			zap.Any("result", result),
-			zap.Error(log.ErrorWithoutStackTrace{Err: err}))
+			zap.Error(log.NewErrorWithoutStackTrace(err)))
 	}()
 
 	// Parse Pod arguments.


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
zap.Error inserts an unwanted field verboseError that contains a stack trace when we don't want it

For example, this is one of the log statements when logging error
```
{"level":"info","ts":"2024-08-06T21:56:57.995Z","caller":"network/network.go:381","msg":"ADD command completed for","pid":10680,"component":"cni-net","pod":"ama-metrics-win-node-2plpb","IPs":null,"error":"Failed to get IP address from CNS: http request failed: Post \"
[http://localhost:10090/network/requestipconfigs\":](http://localhost:10090/network/requestipconfigs/%22:)
dial tcp [::1]:10090: connectex: No connection could be made because the target machine actively refused it.","errorVerbose":"Post \"
[http://localhost:10090/network/requestipconfigs\":](http://localhost:10090/network/requestipconfigs/%22:)
dial tcp [::1]:10090: connectex: No connection could be made because the target machine actively refused it.\nhttp request failed\ngithub.com/Azure/azure-container-networking/cns/client.(*Client).RequestIPs\n\t/mnt/vss/_work/1/s/cns/client/client.go:415\ngithub.com/Azure/azure-container-networking/cni/network.(*CNSIPAMInvoker).Add\n\t/mnt/vss/_work/1/s/cni/network/invoker_cns.go:110\ngithub.com/Azure/azure-container-networking/cni/network.(*NetPlugin).Add\n\t/mnt/vss/_work/1/s/cni/network/network.go:521\ngithub.com/containernetworking/cni/pkg/skel.(*dispatcher).checkVersionAndCall\n\t/home/cloudtest/go/pkg/mod/github.com/containernetworking/cni@v1.1.2/pkg/skel/skel.go:166\ngithub.com/containernetworking/cni/pkg/skel.(*dispatcher).pluginMain\n\t/home/cloudtest/go/pkg/mod/github.com/containernetworking/cni@v1.1.2/pkg/skel/skel.go:219\ngithub.com/containernetworking/cni/pkg/skel.PluginMainWithError\n\t/home/cloudtest/go/pkg/mod/github.com/containernetworking/cni@v1.1.2/pkg/skel/skel.go:273\ngithub.com/Azure/azure-container-networking/cni.(*Plugin).Execute\n\t/mnt/vss/_work/1/s/cni/plugin.go:93\nmain.rootExecute\n\t/mnt/vss/_work/1/s/cni/network/plugin/main.go:182\nmain.main\n\t/mnt/vss/_work/1/s/cni/network/plugin/main.go:210\nruntime.main\n\t/opt/hostedtoolcache/go/1.21.9/x64/src/runtime/proc.go:267\nruntime.goexit\n\t/opt/hostedtoolcache/go/1.21.9/x64/src/runtime/asm_amd64.s:1650\nFailed to get IP address from CNS\ngithub.com/Azure/azure-container-networking/cni/network.(*CNSIPAMInvoker).Add\n\t/mnt/vss/_work/1/s/cni/network/invoker_cns.go:140\ngithub.com/Azure/azure-container-networking/cni/network.(*NetPlugin).Add\n\t/mnt/vss/_work/1/s/cni/network/network.go:521\ngithub.com/containernetworking/cni/pkg/skel.(*dispatcher).checkVersionAndCall\n\t/home/cloudtest/go/pkg/mod/github.com/containernetworking/cni@v1.1.2/pkg/skel/skel.go:166\ngithub.com/containernetworking/cni/pkg/skel.(*dispatcher).pluginMain\n\t/home/cloudtest/go/pkg/mod/github.com/containernetworking/cni@v1.1.2/pkg/skel/skel.go:219\ngithub.com/containernetworking/cni/pkg/skel.PluginMainWithError\n\t/home/cloudtest/go/pkg/mod/github.com/containernetworking/cni@v1.1.2/pkg/skel/skel.go:273\ngithub.com/Azure/azure-container-networking/cni.(*Plugin).Execute\n\t/mnt/vss/_work/1/s/cni/plugin.go:93\nmain.rootExecute\n\t/mnt/vss/_work/1/s/cni/network/plugin/main.go:182\nmain.main\n\t/mnt/vss/_work/1/s/cni/network/plugin/main.go:210\nruntime.main\n\t/opt/hostedtoolcache/go/1.21.9/x64/src/runtime/proc.go:267\nruntime.goexit\n\t/opt/hostedtoolcache/go/1.21.9/x64/src/runtime/asm_amd64.s:1650"}
```
**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [X] relevant PR labels added

**Notes**:
