### PR TITLE
ci(scale-script): [NPM] support shared label keys and faster, more reliable labeling

### DIFF
--- a/test/scale/templates/kwok-deployment.yaml
+++ b/test/scale/templates/kwok-deployment.yaml
@@ -11,12 +11,12 @@ spec:
   selector:
     matchLabels:
       app: scale-test
-      is-kwok: "true"OTHER_LABELS_6_SPACES
+      is-kwok: "true"UNIQUE_LABELS_PER_DEPLOYMENT_6_SPACESSHARED_LABELS_6_SPACESSHARED_LABEL_KEYS_PER_DEPLOYMENT_6_SPACES
   template:
     metadata:
       labels:
         app: scale-test
-        is-kwok: "true"OTHER_LABELS_8_SPACES
+        is-kwok: "true"UNIQUE_LABELS_PER_DEPLOYMENT_8_SPACESSHARED_LABELS_8_SPACESSHARED_LABEL_KEYS_PER_DEPLOYMENT_8_SPACES
     spec:
       affinity:
         nodeAffinity:

--- a/test/scale/templates/real-agnhost-deployment.yaml
+++ b/test/scale/templates/real-agnhost-deployment.yaml
@@ -11,13 +11,13 @@ spec:
   selector:
     matchLabels:
       app: scale-test
-      is-real: "true"OTHER_LABELS_6_SPACES
+      is-real: "true"UNIQUE_LABELS_PER_DEPLOYMENT_6_SPACESSHARED_LABELS_6_SPACESSHARED_LABEL_KEYS_PER_DEPLOYMENT_6_SPACES
   template:
     metadata:
       labels:
         app: scale-test
         name: TEMP_NAME
-        is-real: "true"OTHER_LABELS_8_SPACES
+        is-real: "true"UNIQUE_LABELS_PER_DEPLOYMENT_8_SPACESSHARED_LABELS_8_SPACESSHARED_LABEL_KEYS_PER_DEPLOYMENT_8_SPACES
     spec:
       nodeSelector:
         scale-test: "true"

--- a/test/scale/test-scale.sh
+++ b/test/scale/test-scale.sh
@@ -372,13 +372,13 @@ generateDeployments() {
         if [[ $numSharedLabelsPerPod -gt 0 ]]; then
             sharedLabels=""
             for j in $(seq -f "%05g" 1 $numSharedLabelsPerPod); do
-                sharedLabels="$sharedLabels\n      shared-lab-$i=val"
+                sharedLabels="$sharedLabels\n      shared-lab-$i: val"
             done
             perl -pi -e "s/SHARED_LABELS_6_SPACES/$sharedLabels/g" $outFile
 
             sharedLabels=""
             for j in $(seq -f "%05g" 1 $numSharedLabelsPerPod); do
-                sharedLabels="$sharedLabels\n        shared-lab-$i=val"
+                sharedLabels="$sharedLabels\n        shared-lab-$i: val"
             done
             perl -pi -e "s/SHARED_LABELS_8_SPACES/$sharedLabels/g" $outFile
         else
@@ -390,14 +390,14 @@ generateDeployments() {
             sharedKeyLabels=""
             for j in $(seq 1 $numSharedLabelKeysPerDeployment); do
                 k=`printf "%05d" $deployCount`
-                sharedKeyLabels="$sharedKeyLabels\n      shared-key-$j=val-$k"
+                sharedKeyLabels="$sharedKeyLabels\n      shared-key-$j: val-$k"
             done
             perl -pi -e "s/SHARED_LABEL_KEYS_PER_DEPLOYMENT_6_SPACES/$sharedKeyLabels/g" $outFile
 
             sharedKeyLabels=""
             for j in $(seq 1 $numSharedLabelKeysPerDeployment); do
                 k=`printf "%05d" $deployCount`
-                sharedKeyLabels="$sharedKeyLabels\n        shared-key-$j=val-$k"
+                sharedKeyLabels="$sharedKeyLabels\n        shared-key-$j: val-$k"
             done
             perl -pi -e "s/SHARED_LABEL_KEYS_PER_DEPLOYMENT_8_SPACES/$sharedKeyLabels/g" $outFile
         else


### PR DESCRIPTION
**Reason for Change**:
New optional parameter for scale script `--num-shared-label-keys-per-deployment`. This allows you to label all deployments with the same keys but different values (where a label is `key=value`).

Also, labeling is much faster and more reliable because all labels (except `uniqueLabelsPerPod`) are configured in the deployment yamls instead of labeling individual Pods. This saves a lot of time labeling and avoids the following scenario where labeling is inaccurate: since KWOK nodes tend to disappear, KWOK Pods tend to be recreated, in which case labels on the Pod itself no longer exist.

**Issue Fixed**:

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
Validated generated yamls results for different values of `--num-shared-label-keys-per-deployment` and `--num-shared-labels-per-pod`:
```shell
./test-scale.sh \
    --num-kwok-deployments=5 \
    --num-kwok-replicas=1 \
    --max-kwok-pods-per-node=50 \
    --num-real-deployments=2 \
    --num-real-replicas=1 \
    --max-real-pods-per-node=30 \
    --num-network-policies=5 \
    --num-unapplied-network-policies=5 \
    --num-unique-labels-per-pod=0 \
    --num-unique-labels-per-deployment=1 \
    --num-shared-labels-per-pod=5 \
    --num-shared-label-keys-per-deployment=5 \
    --debug-exit-after-generation

```

Example:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: fake-kwok-dep-00002
  namespace: scale-test
  labels:
    app: scale-test
    is-kwok: "true"
spec:
  replicas: 1
  selector:
    matchLabels:
      app: scale-test
      is-kwok: "true"
      kwok-dep-lab-00002-00001: val
      shared-lab-00002: val
      shared-lab-00002: val
      shared-lab-00002: val
      shared-lab-00002: val
      shared-lab-00002: val
      shared-key-1: val-00002
      shared-key-2: val-00002
      shared-key-3: val-00002
      shared-key-4: val-00002
      shared-key-5: val-00002
  template:
    metadata:
      labels:
        app: scale-test
        is-kwok: "true"
        kwok-dep-lab-00002-00001: val
        shared-lab-00002: val
        shared-lab-00002: val
        shared-lab-00002: val
        shared-lab-00002: val
        shared-lab-00002: val
        shared-key-1: val-00002
        shared-key-2: val-00002
        shared-key-3: val-00002
        shared-key-4: val-00002
        shared-key-5: val-00002
    spec:
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
              - matchExpressions:
                  - key: type
                    operator: In
                    values:
                      - kwok
      # A taints was added to an automatically created Node.
      # You can remove taints of Node or add this tolerations.
      tolerations:
        - key: "kwok.x-k8s.io/node"
          operator: "Exists"
          effect: "NoSchedule"
      containers:
        - name: fake-container
          image: fake-image
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: real-agnhost-dep-00001
  namespace: scale-test
  labels:
    app: scale-test
    is-real: "true"
spec:
  replicas: 1
  selector:
    matchLabels:
      app: scale-test
      is-real: "true"
      real-agnhost-dep-lab-00001-00001: val
      shared-lab-00001: val
      shared-lab-00001: val
      shared-lab-00001: val
      shared-lab-00001: val
      shared-lab-00001: val
      shared-key-1: val-00006
      shared-key-2: val-00006
      shared-key-3: val-00006
      shared-key-4: val-00006
      shared-key-5: val-00006
  template:
    metadata:
      labels:
        app: scale-test
        name: real-agnhost-dep-00001
        is-real: "true"
        real-agnhost-dep-lab-00001-00001: val
        shared-lab-00001: val
        shared-lab-00001: val
        shared-lab-00001: val
        shared-lab-00001: val
        shared-lab-00001: val
        shared-key-1: val-00006
        shared-key-2: val-00006
        shared-key-3: val-00006
        shared-key-4: val-00006
        shared-key-5: val-00006
    spec:
      nodeSelector:
        scale-test: "true"
      containers:
      - command:
        - /agnhost
        - serve-hostname
        - --tcp
        - --http=false
        - --port
        - "80"
        image: k8s.gcr.io/e2e-test-images/agnhost:2.33
        imagePullPolicy: IfNotPresent
        name: cont-80-tcp
        ports:
        - containerPort: 80
          protocol: TCP
```