### PR TITLE
hotfix: set hcnNetwork flag as non-persistent mode

### DIFF
--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -300,15 +300,17 @@ func (nm *networkManager) configureHcnNetwork(nwInfo *EndpointInfo, extIf *exter
 	// DelegatedNIC flag: hcn.DisableHostPort(1024)
 	if nwInfo.NICType == cns.NodeNetworkInterfaceFrontendNIC {
 		hcnNetwork.Type = hcn.Transparent
-		hcnNetwork.Flags = hcn.DisableHostPort
+		// set transparent network as non-persistent so that networks will be gone after the node gets rebooted
+		// hcnNetwork.flags = hcn.DisableHostPort | hcn.EnableNonPersistent (1024 + 8 = 1032)
+		hcnNetwork.Flags = hcn.DisableHostPort | hcn.EnableNonPersistent
 	}
 
 	// AccelnetNIC flag: hcn.EnableIov(9216)
 	// For L1VH with accelnet, hcn.DisableHostPort and hcn.EnableIov must be configured
-	// To set this, need do OR operation: hcnNetwork.flags = hcn.DisableHostPort | hcn.EnableIov: (1024 + 8192 = 9216)
 	if nwInfo.NICType == cns.NodeNetworkInterfaceAccelnetFrontendNIC {
 		hcnNetwork.Type = hcn.Transparent
-		hcnNetwork.Flags = hcn.DisableHostPort | hcn.EnableIov
+		// hcnNetwork.flags = hcn.DisableHostPort | hcn.EnableIov | hcn.EnableNonPersistent (1024 + 8192 + 8 = 9224)
+		hcnNetwork.Flags = hcn.DisableHostPort | hcn.EnableIov | hcn.EnableNonPersistent
 	}
 
 	// Populate subnets.

--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -309,6 +309,7 @@ func (nm *networkManager) configureHcnNetwork(nwInfo *EndpointInfo, extIf *exter
 	// For L1VH with accelnet, hcn.DisableHostPort and hcn.EnableIov must be configured
 	if nwInfo.NICType == cns.NodeNetworkInterfaceAccelnetFrontendNIC {
 		hcnNetwork.Type = hcn.Transparent
+		// set transparent network as non-persistent so that networks will be gone after the node gets rebooted
 		// hcnNetwork.flags = hcn.DisableHostPort | hcn.EnableIov | hcn.EnableNonPersistent (1024 + 8192 + 8 = 9224)
 		hcnNetwork.Flags = hcn.DisableHostPort | hcn.EnableIov | hcn.EnableNonPersistent
 	}

--- a/network/network_windows_test.go
+++ b/network/network_windows_test.go
@@ -592,3 +592,75 @@ func TestTransparentNetworkCreationForDelegated(t *testing.T) {
 		t.Fatal("network creation does not return error")
 	}
 }
+
+// Test Configure HCN Network for Swiftv2 DelegatedNIC HostComputeNetwork fields
+func TestConfigureHCNNetworkSwiftv2DelegatedNIC(t *testing.T) {
+	expectedSwiftv2NetworkMode := hcn.Transparent
+	expectedSwifv2NetworkFlags := hcn.EnableNonPersistent | hcn.DisableHostPort
+
+	nm := &networkManager{
+		ExternalInterfaces: map[string]*externalInterface{},
+	}
+
+	extIf := externalInterface{
+		Name: "eth1",
+	}
+
+	nwInfo := &EndpointInfo{
+		AdapterName:  "eth1",
+		NetworkID:    "d3e97a83-ba4c-45d5-ba88-dc56757ece28",
+		MasterIfName: "eth1",
+		Mode:         "bridge",
+		NICType:      cns.NodeNetworkInterfaceFrontendNIC,
+	}
+
+	hostComputeNetwork, err := nm.configureHcnNetwork(nwInfo, &extIf)
+	if err != nil {
+		t.Fatalf("Failed to configure hcn network for delegatedVMNIC interface due to: %v", err)
+	}
+
+	if hostComputeNetwork.Type != expectedSwiftv2NetworkMode {
+		t.Fatalf("host network mode is not configured as %v mode when interface NIC type is delegatedVMNIC", expectedSwiftv2NetworkMode)
+	}
+
+	// make sure network type is transparent and flags is 1032
+	if hostComputeNetwork.Flags != expectedSwifv2NetworkFlags {
+		t.Fatalf("host network flags is not configured as %v when interface NIC type is delegatedVMNIC", expectedSwifv2NetworkFlags)
+	}
+}
+
+// Test Configure HCN Network for Swiftv2 AccelnetNIC HostComputeNetwork fields
+func TestConfigureHCNNetworkSwiftv2AccelnetNIC(t *testing.T) {
+	expectedSwiftv2NetworkMode := hcn.Transparent
+	expectedSwifv2NetworkFlags := hcn.EnableNonPersistent | hcn.DisableHostPort | hcn.EnableIov
+
+	nm := &networkManager{
+		ExternalInterfaces: map[string]*externalInterface{},
+	}
+
+	extIf := externalInterface{
+		Name: "eth1",
+	}
+
+	nwInfo := &EndpointInfo{
+		AdapterName:  "eth1",
+		NetworkID:    "d3e97a83-ba4c-45d5-ba88-dc56757ece28",
+		MasterIfName: "eth1",
+		Mode:         "bridge",
+		NICType:      cns.NodeNetworkInterfaceAccelnetFrontendNIC,
+	}
+
+	hostComputeNetwork, err := nm.configureHcnNetwork(nwInfo, &extIf)
+	if err != nil {
+		t.Fatalf("Failed to configure hcn network for accelnetNIC interface due to: %v", err)
+	}
+
+	if hostComputeNetwork.Type != expectedSwiftv2NetworkMode {
+		t.Fatalf("host network mode is not configured as %v mode when interface NIC type is accelnetNIC", expectedSwiftv2NetworkMode)
+	}
+
+	// make sure network type is transparent and flags is 9224
+	if hostComputeNetwork.Flags != expectedSwifv2NetworkFlags {
+		t.Fatalf("host network flags is not configured as %v when interface NIC type is accelnetNIC", expectedSwifv2NetworkFlags)
+	}
+}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
After windows VM bootup, the transparent networks are not deleted;
To cleanup transparent hns networks, set hnsNetwork Flags as non-persistent so that networks will be gone after nodes get rebooted

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
