### PR TITLE
fix: pass right interface name to generate hns endpoint name as expected

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -732,7 +732,6 @@ func (plugin *NetPlugin) createEpInfo(opt *createEpInfoOpt) (*network.EndpointIn
 	// populate endpoint info
 	epDNSInfo, err := getEndpointDNSSettings(opt.nwCfg, opt.ifInfo.DNS, opt.k8sNamespace) // Probably won't panic if given bad values
 	if err != nil {
-
 		err = plugin.Errorf("Failed to getEndpointDNSSettings: %v", err)
 		return nil, err
 	}
@@ -753,13 +752,16 @@ func (plugin *NetPlugin) createEpInfo(opt *createEpInfoOpt) (*network.EndpointIn
 	}
 
 	// generate endpoint info
-	var endpointID string
+	var endpointID, ifName string
+
 	if opt.ifInfo.NICType == cns.InfraNIC && !*opt.infraSeen {
 		// so we do not break existing scenarios, only the first infra gets the original endpoint id generation
-		endpointID = plugin.nm.GetEndpointID(opt.args.ContainerID, opt.args.IfName)
+		ifName = opt.args.IfName
+		endpointID = plugin.nm.GetEndpointID(opt.args.ContainerID, ifName)
 		*opt.infraSeen = true
 	} else {
-		endpointID = plugin.nm.GetEndpointID(opt.args.ContainerID, strconv.Itoa(opt.endpointIndex))
+		ifName = "eth" + strconv.Itoa(opt.endpointIndex)
+		endpointID = plugin.nm.GetEndpointID(opt.args.ContainerID, ifName)
 	}
 
 	endpointInfo := network.EndpointInfo{
@@ -777,7 +779,7 @@ func (plugin *NetPlugin) createEpInfo(opt *createEpInfoOpt) (*network.EndpointIn
 		EndpointID:  endpointID,
 		ContainerID: opt.args.ContainerID,
 		NetNsPath:   opt.args.Netns, // probably same value as epInfo.NetNs
-		IfName:      "eth" + strconv.Itoa(opt.endpointIndex),
+		IfName:      ifName,
 		Data:        make(map[string]interface{}),
 		EndpointDNS: epDNSInfo,
 		// endpoint policies are populated later

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -605,7 +605,7 @@ func (plugin *NetPlugin) Add(args *cniSkel.CmdArgs) error {
 	}()
 
 	infraSeen := false
-	endpointIndex := 0
+	endpointIndex := 1
 	for key := range ipamAddResult.interfaceInfo {
 		ifInfo := ipamAddResult.interfaceInfo[key]
 

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -777,7 +777,7 @@ func (plugin *NetPlugin) createEpInfo(opt *createEpInfoOpt) (*network.EndpointIn
 		EndpointID:  endpointID,
 		ContainerID: opt.args.ContainerID,
 		NetNsPath:   opt.args.Netns, // probably same value as epInfo.NetNs
-		IfName:      opt.args.IfName,
+		IfName:      "eth" + strconv.Itoa(opt.endpointIndex),
 		Data:        make(map[string]interface{}),
 		EndpointDNS: epDNSInfo,
 		// endpoint policies are populated later

--- a/cni/network/network_test.go
+++ b/cni/network/network_test.go
@@ -1392,11 +1392,11 @@ func TestPluginSwiftV2MultipleAddDelete(t *testing.T) {
 				Plugin: plugin,
 				nm:     acnnetwork.NewMockNetworkmanager(acnnetwork.NewMockEndpointClient(nil)),
 				ipamInvoker: NewCustomMockIpamInvoker(map[string]acnnetwork.InterfaceInfo{
-					"eth0-1": {
-						NICType: cns.NodeNetworkInterfaceFrontendNIC,
-					},
 					"eth0": {
 						NICType: cns.InfraNIC,
+					},
+					"eth2": {
+						NICType: cns.NodeNetworkInterfaceFrontendNIC,
 					},
 				}),
 				report: &telemetry.CNIReport{},
@@ -1417,7 +1417,7 @@ func TestPluginSwiftV2MultipleAddDelete(t *testing.T) {
 				Plugin: plugin,
 				nm:     acnnetwork.NewMockNetworkmanager(acnnetwork.NewMockEndpointClient(nil)),
 				ipamInvoker: NewCustomMockIpamInvoker(map[string]acnnetwork.InterfaceInfo{
-					"eth0-1": {
+					"eth1": {
 						NICType: cns.NodeNetworkInterfaceAccelnetFrontendNIC,
 					},
 					"eth0": {
@@ -1442,14 +1442,14 @@ func TestPluginSwiftV2MultipleAddDelete(t *testing.T) {
 				Plugin: plugin,
 				nm:     acnnetwork.NewMockNetworkmanager(acnnetwork.NewMockEndpointClient(nil)),
 				ipamInvoker: NewCustomMockIpamInvoker(map[string]acnnetwork.InterfaceInfo{
-					"eth0-2": {
-						NICType: cns.NodeNetworkInterfaceAccelnetFrontendNIC,
-					},
-					"eth0-1": {
-						NICType: cns.NodeNetworkInterfaceFrontendNIC,
-					},
 					"eth0": {
 						NICType: cns.InfraNIC,
+					},
+					"eth1": {
+						NICType: cns.NodeNetworkInterfaceAccelnetFrontendNIC,
+					},
+					"eth2": {
+						NICType: cns.NodeNetworkInterfaceFrontendNIC,
 					},
 				}),
 				report: &telemetry.CNIReport{},
@@ -1470,11 +1470,11 @@ func TestPluginSwiftV2MultipleAddDelete(t *testing.T) {
 				Plugin: plugin,
 				nm:     acnnetwork.NewMockNetworkmanager(acnnetwork.NewMockEndpointClient(nil)),
 				ipamInvoker: NewCustomMockIpamInvoker(map[string]acnnetwork.InterfaceInfo{
-					"eth0-1": {
-						NICType: cns.BackendNIC,
-					},
 					"eth0": {
 						NICType: cns.InfraNIC,
+					},
+					"eth1": {
+						NICType: cns.BackendNIC,
 					},
 				}),
 				report: &telemetry.CNIReport{},
@@ -1495,10 +1495,10 @@ func TestPluginSwiftV2MultipleAddDelete(t *testing.T) {
 				Plugin: plugin,
 				nm:     acnnetwork.NewMockNetworkmanager(acnnetwork.NewMockEndpointClient(nil)),
 				ipamInvoker: NewCustomMockIpamInvoker(map[string]acnnetwork.InterfaceInfo{
-					"eth0": {
+					"eth1": {
 						NICType: cns.NodeNetworkInterfaceFrontendNIC,
 					},
-					"eth0-1": {
+					"eth2": {
 						NICType: cns.NodeNetworkInterfaceFrontendNIC,
 					},
 				}),
@@ -1520,10 +1520,10 @@ func TestPluginSwiftV2MultipleAddDelete(t *testing.T) {
 				Plugin: plugin,
 				nm:     acnnetwork.NewMockNetworkmanager(acnnetwork.NewMockEndpointClient(nil)),
 				ipamInvoker: NewCustomMockIpamInvoker(map[string]acnnetwork.InterfaceInfo{
-					"eth0": {
+					"eth1": {
 						NICType: cns.NodeNetworkInterfaceAccelnetFrontendNIC,
 					},
-					"eth0-1": {
+					"eth2": {
 						NICType: cns.NodeNetworkInterfaceAccelnetFrontendNIC,
 					},
 				}),
@@ -1556,7 +1556,7 @@ func TestPluginSwiftV2MultipleAddDelete(t *testing.T) {
 					"eth0": {
 						NICType: cns.InfraNIC,
 					},
-					"eth0-1": {
+					"eth1": {
 						NICType: cns.NodeNetworkInterfaceFrontendNIC,
 					},
 				}),
@@ -1588,7 +1588,7 @@ func TestPluginSwiftV2MultipleAddDelete(t *testing.T) {
 					"eth0": {
 						NICType: cns.NodeNetworkInterfaceFrontendNIC,
 					},
-					"eth0-1": {
+					"eth1": {
 						NICType: cns.NodeNetworkInterfaceAccelnetFrontendNIC,
 					},
 				}),
@@ -1620,7 +1620,7 @@ func TestPluginSwiftV2MultipleAddDelete(t *testing.T) {
 					"eth0": {
 						NICType: cns.InfraNIC,
 					},
-					"eth0-1": {
+					"eth1": {
 						NICType: cns.NodeNetworkInterfaceAccelnetFrontendNIC,
 					},
 				}),
@@ -1655,7 +1655,7 @@ func TestPluginSwiftV2MultipleAddDelete(t *testing.T) {
 				if ep.NICType == cns.InfraNIC {
 					require.Equal(t, "test-con-"+tt.args.IfName, ep.EndpointID, "infra nic must use ifname for its endpoint id")
 				} else {
-					require.Regexp(t, `test-con-\d+$`, ep.EndpointID, "other nics must use an index for their endpoint ids")
+					require.Regexp(t, `\d+$`, ep.EndpointID, "other nics must use an index for their endpoint ids")
 				}
 			}
 

--- a/cni/network/network_test.go
+++ b/cni/network/network_test.go
@@ -1676,7 +1676,7 @@ func TestPluginGenerateEndpointNames(t *testing.T) {
 	accelnetAddress := "ab:cd:ef:12:34:56"
 	infraSeen := false
 	endpointIndex := 0
-	epInfos := []*network.EndpointInfo{}
+	epInfos := []*acnnetwork.EndpointInfo{}
 
 	type args struct {
 		nwCfg            *cni.NetworkConfig
@@ -1697,16 +1697,16 @@ func TestPluginGenerateEndpointNames(t *testing.T) {
 	}
 
 	// create createEpInfo
-	interfaceInfos := map[string]network.InterfaceInfo{
+	interfaceInfos := map[string]acnnetwork.InterfaceInfo{
 		infraAddress: {
-			IPConfigs: []*network.IPConfig{
+			IPConfigs: []*acnnetwork.IPConfig{
 				{
 					Address: *getCIDRNotationForAddress("10.1.1.10/24"),
 				},
 			},
-			Routes: []network.RouteInfo{
+			Routes: []acnnetwork.RouteInfo{
 				{
-					Dst: network.Ipv4DefaultRouteDstPrefix,
+					Dst: acnnetwork.Ipv4DefaultRouteDstPrefix,
 					Gw:  net.ParseIP("10.0.0.1"),
 				},
 			},
@@ -1714,12 +1714,12 @@ func TestPluginGenerateEndpointNames(t *testing.T) {
 			HostSubnetPrefix: *parseCIDR("10.0.0.0/24"),
 		},
 		accelnetAddress: {
-			IPConfigs: []*network.IPConfig{
+			IPConfigs: []*acnnetwork.IPConfig{
 				{
 					Address: *getCIDRNotationForAddress("20.1.1.10/24"),
 				},
 			},
-			Routes:     []network.RouteInfo{},
+			Routes:     []acnnetwork.RouteInfo{},
 			NICType:    cns.NodeNetworkInterfaceAccelnetFrontendNIC,
 			MacAddress: net.HardwareAddr(accelnetAddress),
 		},

--- a/cni/network/network_test.go
+++ b/cni/network/network_test.go
@@ -1727,7 +1727,7 @@ func TestPluginGenerateEndpointNames(t *testing.T) {
 	for key := range interfaceInfos {
 		ifInfo := interfaceInfos[key]
 
-		createEpInfoOpt := createEpInfoOpt{
+		epInfoOpt := createEpInfoOpt{
 			args:          argsInfo.args,
 			k8sPodName:    "test-pod",
 			k8sNamespace:  "test-pod-ns",
@@ -1740,19 +1740,19 @@ func TestPluginGenerateEndpointNames(t *testing.T) {
 		// generate endpoint info
 		var endpointID, ifName string
 
-		if createEpInfoOpt.ifInfo.NICType == cns.InfraNIC && !*createEpInfoOpt.infraSeen {
-			ifName = createEpInfoOpt.args.IfName
-			endpointID = plugin.nm.GetEndpointID(createEpInfoOpt.args.ContainerID, ifName)
-			*createEpInfoOpt.infraSeen = true
+		if epInfoOpt.ifInfo.NICType == cns.InfraNIC && !*epInfoOpt.infraSeen {
+			ifName = epInfoOpt.args.IfName
+			endpointID = plugin.nm.GetEndpointID(epInfoOpt.args.ContainerID, ifName)
+			*epInfoOpt.infraSeen = true
 		} else {
-			ifName = "eth" + strconv.Itoa(createEpInfoOpt.endpointIndex)
-			endpointID = plugin.nm.GetEndpointID(createEpInfoOpt.args.ContainerID, ifName)
+			ifName = "eth" + strconv.Itoa(epInfoOpt.endpointIndex)
+			endpointID = plugin.nm.GetEndpointID(epInfoOpt.args.ContainerID, ifName)
 		}
 
 		endpointInfo := acnnetwork.EndpointInfo{
 			IfName:     ifName,
 			EndpointID: endpointID,
-			NICType:    createEpInfoOpt.ifInfo.NICType,
+			NICType:    epInfoOpt.ifInfo.NICType,
 		}
 
 		epInfos = append(epInfos, &endpointInfo)

--- a/cni/network/network_test.go
+++ b/cni/network/network_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Azure/azure-container-networking/cni/util"
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/common"
-	"github.com/Azure/azure-container-networking/network"
 	acnnetwork "github.com/Azure/azure-container-networking/network"
 	"github.com/Azure/azure-container-networking/network/networkutils"
 	"github.com/Azure/azure-container-networking/network/policy"
@@ -1750,7 +1749,7 @@ func TestPluginGenerateEndpointNames(t *testing.T) {
 			endpointID = plugin.nm.GetEndpointID(createEpInfoOpt.args.ContainerID, ifName)
 		}
 
-		endpointInfo := network.EndpointInfo{
+		endpointInfo := acnnetwork.EndpointInfo{
 			IfName:     ifName,
 			EndpointID: endpointID,
 			NICType:    createEpInfoOpt.ifInfo.NICType,


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
CNI always returns endpoint names as xxx-eth**0** that cannot identify if this interface is primary or secondary;
To create reasonable endpoint names, we need to pass non-eth0 as secondary interface names

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
**Examples of endpoints now:**
ID                 : 9fec3b82-8d49-456b-9590-e380d41197a0
Name               : **841bd4b7-eth1**
Version            : 64424509443
AdditionalParams   : @{SwitchId=7F827C62-F4FB-4BE9-8C33-1BF415650187;
                     SwitchPortId=9FEC3B82-8D49-456B-9590-E380D41197A0;
                     VmSwitchNicName=7782EA20-E476-54D6-9A48-95E01CCCDA3B--8CCC5ED3-0EFE-4128-AC3D-44B01F85C813}
Resources          : @{AdditionalParams=; AllocationOrder=2; Allocators=System.Object[]; CompartmentOperationTime=0;
                     Flags=0; Health=; ID=9209FC4F-6861-4CCD-8A0E-06349DE51834; PortOperationTime=0; State=1;
                     SwitchOperationTime=0; VfpOperationTime=0; parentId=89BADB65-CCF1-46A9-8594-6707489CA752}
State              : 2
VirtualNetwork     : 7f827c62-f4fb-4be9-8c33-1bf415650187
VirtualNetworkName : **azure-00:22:48:bc:ed:a3**

Name               : **d71e513f-eth1**
Version            : 64424509443
AdditionalParams   : @{SwitchId=A369473C-73B0-4327-84D3-7C5394AAC3A0;
                     SwitchPortId=D75AA635-B249-464A-B353-49DBBA40F3CA;
                     VmSwitchNicName=37E88AFE-2B5A-5CC8-812B-69753AEC85FD--D6DA3396-3472-40E9-B5A7-3E9D9020C086}
Resources          : @{AdditionalParams=; AllocationOrder=2; Allocators=System.Object[]; CompartmentOperationTime=0;
                     Flags=0; Health=; ID=A16529F4-BAD6-42B0-AFDA-190AA1BCE705; PortOperationTime=0; State=1;
                     SwitchOperationTime=0; VfpOperationTime=0; parentId=91672D1B-01E7-4EFD-BF91-9A5F82727014}
State              : 2
VirtualNetwork     : a369473c-73b0-4327-84d3-7c5394aac3a0
VirtualNetworkName : **azure-00:22:48:bc:e5:9d**

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
