### PR TITLE
fix: add placeholder os version value for linux docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,7 +245,8 @@ BUILDX_ACTION  		?= --load
 CONTAINER_BUILDER   ?= buildah
 CONTAINER_RUNTIME   ?= podman
 CONTAINER_TRANSPORT ?= skopeo
-
+# docker wants a value even if it is not used
+DOCKER_OS_VERSION   ?= $(if $(OS_VERSION),$(OS_VERSION),"none")
 
 # prefer buildah, if available, but fall back to docker if that binary is not in the path or on Windows.
 ifeq (, $(shell which $(CONTAINER_BUILDER)))
@@ -321,7 +322,7 @@ container-docker: # util target to build container images using docker buildx. d
 		$(BUILDX_ACTION) \
 		--build-arg ARCH=$(ARCH) \
 		--build-arg OS=$(OS) \
-		--build-arg OS_VERSION=$(OS_VERSION) \
+		--build-arg OS_VERSION=$(DOCKER_OS_VERSION) \
 		--build-arg PLATFORM=$(PLATFORM) \
 		--build-arg VERSION=$(TAG) \
 		$(EXTRA_BUILD_ARGS) \

--- a/azure-ipam/Dockerfile
+++ b/azure-ipam/Dockerfile
@@ -27,10 +27,10 @@ WORKDIR /go/pkg/mod/github.com/azure/azure-container-networking/dropgz\@$DROPGZ_
 COPY --from=compressor /payload/* pkg/embed/fs/
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/dropgz -trimpath -ldflags "-X github.com/Azure/azure-container-networking/dropgz/internal/buildinfo.Version="$VERSION"" -gcflags="-dwarflocationlists=true" main.go
 
-FROM scratch as linux
+FROM scratch AS linux
 COPY --from=dropgz /go/bin/dropgz dropgz
 ENTRYPOINT [ "/dropgz" ]
 
-FROM mcr.microsoft.com/windows/nanoserver:${OS_VERSION} as windows
+FROM mcr.microsoft.com/windows/nanoserver:${OS_VERSION} AS windows
 COPY --from=dropgz /go/bin/dropgz dropgz.exe
 ENTRYPOINT [ "/dropgz.exe" ]

--- a/cni/Dockerfile
+++ b/cni/Dockerfile
@@ -13,7 +13,7 @@ RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-telemetry -trimpath
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-ipam -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/ipam/plugin/main.go
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-stateless -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/stateless/main.go
 
-FROM scratch as bins
+FROM scratch AS bins
 COPY --from=azure-vnet /go/bin/* /
 
 FROM --platform=linux/${ARCH} mcr.microsoft.com/cbl-mariner/base/core:2.0 AS compressor
@@ -39,19 +39,19 @@ WORKDIR /go/pkg/mod/github.com/azure/azure-container-networking/dropgz\@$DROPGZ_
 COPY --from=compressor /payload/* pkg/embed/fs/
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/dropgz -trimpath -ldflags "-X github.com/Azure/azure-container-networking/dropgz/internal/buildinfo.Version="$VERSION"" -gcflags="-dwarflocationlists=true" main.go
 
-FROM scratch as linux
+FROM scratch AS linux
 COPY --from=dropgz /go/bin/dropgz dropgz
 ENTRYPOINT [ "/dropgz" ]
 
 # intermediate for win-ltsc2019
-FROM mcr.microsoft.com/windows/nanoserver@sha256:736f8845da1c7bbc9510b419abddb870230485e74644a96e0001a21e1ca4c172 as ltsc2019
+FROM mcr.microsoft.com/windows/nanoserver@sha256:736f8845da1c7bbc9510b419abddb870230485e74644a96e0001a21e1ca4c172 AS ltsc2019
 
 # intermediate for win-ltsc2022
-FROM mcr.microsoft.com/windows/nanoserver@sha256:cc9f6a1334190c1f18a905f56d285132e562a9a1ce18ff9476cfaf95194aa0b7 as ltsc2022
+FROM mcr.microsoft.com/windows/nanoserver@sha256:cc9f6a1334190c1f18a905f56d285132e562a9a1ce18ff9476cfaf95194aa0b7 AS ltsc2022
 
 # intermediate for win-ltsc2025
-FROM mcr.microsoft.com/windows/nanoserver/insider@sha256:67e0ab7f3a79cd73be4a18bae24659c03b294aed0dbeaa624feb3810931f0bd2 as ltsc2025
+FROM mcr.microsoft.com/windows/nanoserver/insider@sha256:67e0ab7f3a79cd73be4a18bae24659c03b294aed0dbeaa624feb3810931f0bd2 AS ltsc2025
 
-FROM ${OS_VERSION} as windows
+FROM ${OS_VERSION} AS windows
 COPY --from=dropgz /go/bin/dropgz dropgz.exe
 ENTRYPOINT [ "/dropgz.exe" ]

--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -11,10 +11,10 @@ WORKDIR /azure-container-networking
 COPY . .
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-cns -ldflags "-X main.version="$VERSION" -X "$CNS_AI_PATH"="$CNS_AI_ID"" -gcflags="-dwarflocationlists=true" cns/service/*.go
 
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 as iptables
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS iptables
 RUN tdnf install -y iptables
 
-FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 as linux
+FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 AS linux
 COPY --from=iptables /usr/sbin/*tables* /usr/sbin/
 COPY --from=iptables /usr/lib /usr/lib
 COPY --from=builder /go/bin/azure-cns /usr/local/bin/azure-cns
@@ -23,15 +23,15 @@ EXPOSE 10090
 
 
 # intermediate for win-ltsc2019
-FROM mcr.microsoft.com/windows/servercore@sha256:6fdf140282a2f809dae9b13fe441635867f0a27c33a438771673b8da8f3348a4 as ltsc2019
+FROM mcr.microsoft.com/windows/servercore@sha256:6fdf140282a2f809dae9b13fe441635867f0a27c33a438771673b8da8f3348a4 AS ltsc2019
 
 # intermediate for win-ltsc2022
-FROM mcr.microsoft.com/windows/servercore@sha256:45952938708fbde6ec0b5b94de68bcdec3f8c838be018536b1e9e5bd95e6b943 as ltsc2022
+FROM mcr.microsoft.com/windows/servercore@sha256:45952938708fbde6ec0b5b94de68bcdec3f8c838be018536b1e9e5bd95e6b943 AS ltsc2022
 
 # intermediate for win-ltsc2025
-FROM mcr.microsoft.com/windows/servercore/insider@sha256:4daaf3daa404fbdebec9d88783fb343f18009ffd9c8d98c43430ca1f4e615184 as ltsc2025
+FROM mcr.microsoft.com/windows/servercore/insider@sha256:4daaf3daa404fbdebec9d88783fb343f18009ffd9c8d98c43430ca1f4e615184 AS ltsc2025
 
-FROM ${OS_VERSION} as windows
+FROM ${OS_VERSION} AS windows
 COPY --from=builder /azure-container-networking/cns/kubeconfigtemplate.yaml kubeconfigtemplate.yaml
 COPY --from=builder /azure-container-networking/npm/examples/windows/setkubeconfigpath.ps1 setkubeconfigpath.ps1
 COPY --from=builder /go/bin/azure-cns /azure-cns.exe


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
If in the pipelines a linux agent cannot find buildah (for some reason), it falls back to docker. Docker expects non-empty build args. In linux, OS_VERSION is not used, so we don't populate it, but docker needs _some_ value for it, or there will be an error. So, if the value is not set, we put a placeholder value so there is no error in linux. In windows, we DOCKER_OS_VERSION just becomes the value of OS_VERSION like normal. The ARG OS_VERSION=none is not necessary but takes care of some of the dockerfile warnings.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
See above

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
