### PR TITLE
fix: make statless CNI to return an empty state when CNI GET API is …

### DIFF
--- a/cni/network/stateless/main.go
+++ b/cni/network/stateless/main.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-container-networking/cni"
+	"github.com/Azure/azure-container-networking/cni/api"
 	zapLog "github.com/Azure/azure-container-networking/cni/log"
 	"github.com/Azure/azure-container-networking/cni/network"
 	"github.com/Azure/azure-container-networking/common"
@@ -126,6 +127,19 @@ func rootExecute() error {
 			network.ReportPluginError(reportManager, tb, err)
 			panic("network plugin start fatal error")
 		}
+	}
+	// dump an empty state in case the API is called for StateMigration or InitilizeCNS from CNI State
+	if cniCmd == cni.CmdGetEndpointsState {
+		logger.Debug("returning an empty state")
+		simpleState := api.AzureCNIState{
+			ContainerInterfaces: make(map[string]api.PodNetworkInterfaceInfo),
+		}
+		err = simpleState.PrintResult()
+		if err != nil {
+			logger.Error("Failed to print state result to stdout", zap.Error(err))
+		}
+
+		return errors.Wrap(err, "Get cni state printresult error")
 	}
 
 	if cniCmd == cni.CmdVersion {


### PR DESCRIPTION
…invoked

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
This change is needed for a scenario that StateMigration is enabled and dropGZ is using StatelessCNI.
In this scenario Stateles CNI should return an empty satate.
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
