### PR TITLE
[FIX] ci: Update AzCLI task to v2

### DIFF
--- a/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
+++ b/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
@@ -69,7 +69,7 @@ stages:
         - job: deploy_cilium_components
           displayName: Deploy Cilium
           steps:
-            - task: AzureCLI@1
+            - task: AzureCLI@2
               displayName: "Install Cilium, CNS, and ip-masq-agent"
               inputs:
                 azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
@@ -124,7 +124,7 @@ stages:
         - job: deploy_cilium_components
           displayName: Deploy Cilium with Hubble
           steps:
-            - task: AzureCLI@1
+            - task: AzureCLI@2
               displayName: "Install Cilium, CNS, and ip-masq-agent"
               inputs:
                 azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
@@ -205,7 +205,7 @@ stages:
         dependsOn: restart_cns
         steps:
           - template: ../../templates/cilium-cli.yaml
-          - task: AzureCLI@1
+          - task: AzureCLI@2
             inputs:
               azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"

--- a/.pipelines/cni/cilium/cilium-scale-test.yaml
+++ b/.pipelines/cni/cilium/cilium-scale-test.yaml
@@ -9,7 +9,7 @@ stages:
         pool:
           name: "$(BUILD_POOL_NAME_DEFAULT)"
         steps:
-          - task: AzureCLI@1
+          - task: AzureCLI@2
             inputs:
               azureSubscription: $(TEST_SUB_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"
@@ -27,12 +27,12 @@ stages:
                 kubectl apply -f test/integration/manifests/cilium/cilium-operator
                 echo "Keep CNS version up to date, grabbing pipeline parameter"
                 CNS_IMAGE=${CNS_IMAGE}
-                sed -i '/containers:/{n;n;s/\(image\).*/\1: '"${CNS_IMAGE//\//\\/}"'/}' test/integration/manifests/cns/daemonset.yaml 
-                kubectl apply -f test/integration/manifests/cns/daemonset.yaml 
+                sed -i '/containers:/{n;n;s/\(image\).*/\1: '"${CNS_IMAGE//\//\\/}"'/}' test/integration/manifests/cns/daemonset.yaml
+                kubectl apply -f test/integration/manifests/cns/daemonset.yaml
                 for val in $(az vmss list -g MC_${clusterName}_${clusterName}_$(REGION_AKS_CLUSTER_TEST) --query "[].name" -o tsv); do
                   make -C ./hack/aks restart-vmss AZCLI=az CLUSTER=${clusterName} REGION=$(REGION_AKS_CLUSTER_TEST) VMSS_NAME=${val}
                 done
-                kubectl get node 
+                kubectl get node
                 kubectl get pod -A
             name: "UpdateCiliumandCNSVersion"
             displayName: "Update Cilium and CNS Version"
@@ -43,7 +43,7 @@ stages:
         pool:
           name: "$(BUILD_POOL_NAME_DEFAULT)"
         steps:
-          - task: AzureCLI@1
+          - task: AzureCLI@2
             inputs:
               azureSubscription: $(TEST_SUB_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"
@@ -63,7 +63,7 @@ stages:
         pool:
           name: "$(BUILD_POOL_NAME_DEFAULT)"
         steps:
-          - task: AzureCLI@1
+          - task: AzureCLI@2
             inputs:
               azureSubscription: $(TEST_SUB_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"
@@ -72,7 +72,7 @@ stages:
               inlineScript: |
                 echo "Set node label scale-test=true and connectivity-test=true for testing"
                 az aks get-credentials --resource-group ${CLUSTER} --name ${CLUSTER}
-                cd test/scale 
+                cd test/scale
                 chmod +x label-nodes.sh
                 ./label-nodes.sh
             name: "LabelNodes"
@@ -84,7 +84,7 @@ stages:
         pool:
           name: "$(BUILD_POOL_NAME_DEFAULT)"
         steps:
-          - task: AzureCLI@1
+          - task: AzureCLI@2
             inputs:
               azureSubscription: $(TEST_SUB_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"
@@ -95,14 +95,14 @@ stages:
                 echo "collect cpu and memory usage before scaling for network policies"
                 mkdir test1_1_netpol_cpu_and_mem_before
                 cd test1_1_netpol_cpu_and_mem_before
-                echo "running k top node" 
+                echo "running k top node"
                 kubectl top node >> "node_before_netpol_scale.log"
                 echo "running k top pod"
                 kubectl top pod -A | grep cilium >> "pod_before_netpol_scale.log"
                 echo "Logs will be available as a build artifact"
                 ARTIFACT_DIR=$(Build.ArtifactStagingDirectory)/test1_1_netpol_cpu_and_mem_before/
                 echo $ARTIFACT_DIR
-                sudo rm -rf $ARTIFACT_DIR 
+                sudo rm -rf $ARTIFACT_DIR
                 sudo mkdir $ARTIFACT_DIR
                 cd ..
                 sudo cp ./test1_1_netpol_cpu_and_mem_before/* $ARTIFACT_DIR
@@ -113,7 +113,7 @@ stages:
                 echo "collect cpu and mem results after scaling"
                 mkdir test1_2_netpol_cpu_and_mem_scale
                 cd test1_2_netpol_cpu_and_mem_scale
-                echo "running k top node" 
+                echo "running k top node"
                 kubectl top node >> "node_netpol_scale.log"
                 echo "running k top pod"
                 kubectl top pod -A | grep cilium >> "pod_netpol_scale.log"
@@ -148,7 +148,7 @@ stages:
           name: "$(BUILD_POOL_NAME_DEFAULT)"
         timeoutInMinutes: 120
         steps:
-          - task: AzureCLI@1
+          - task: AzureCLI@2
             inputs:
               azureSubscription: $(TEST_SUB_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"
@@ -163,14 +163,14 @@ stages:
                 echo "collect cpu and mem results after connectivity tests"
                 mkdir test1_3_netpol_cpu_and_mem_after
                 cd test1_3_netpol_cpu_and_mem_after
-                echo "running k top node" 
+                echo "running k top node"
                 kubectl top node >> "node_after_netpol_tests.log"
                 echo "running k top pod"
                 kubectl top pod -A | grep cilium >> "pod_after_netpol_tests.log"
                 echo "Logs will be available as a build artifact"
                 ARTIFACT_DIR=$(Build.ArtifactStagingDirectory)/test1_3_netpol_cpu_and_mem_after/
                 echo $ARTIFACT_DIR
-                sudo rm -rf $ARTIFACT_DIR 
+                sudo rm -rf $ARTIFACT_DIR
                 sudo mkdir $ARTIFACT_DIR
                 cd ..
                 sudo cp ./test1_3_netpol_cpu_and_mem_after/* $ARTIFACT_DIR
@@ -190,7 +190,7 @@ stages:
         pool:
           name: "$(BUILD_POOL_NAME_DEFAULT)"
         steps:
-          - task: AzureCLI@1
+          - task: AzureCLI@2
             inputs:
               azureSubscription: $(TEST_SUB_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"
@@ -201,14 +201,14 @@ stages:
                 echo "collect cpu and mem results before scale for lb tests"
                 mkdir test2_1_lb_cpu_and_mem_before
                 cd test2_1_lb_cpu_and_mem_before
-                echo "running k top node" 
+                echo "running k top node"
                 kubectl top node >> "node_before_lb_scale.log"
                 echo "running k top pod"
                 kubectl top pod -A | grep cilium >> "pod_before_lb_scale.log"
                 echo "Logs will be available as a build artifact"
                 ARTIFACT_DIR=$(Build.ArtifactStagingDirectory)/test2_1_lb_cpu_and_mem_before/
                 echo $ARTIFACT_DIR
-                sudo rm -rf $ARTIFACT_DIR 
+                sudo rm -rf $ARTIFACT_DIR
                 sudo mkdir $ARTIFACT_DIR
                 cd ..
                 sudo cp ./test2_1_lb_cpu_and_mem_before/* $ARTIFACT_DIR
@@ -218,7 +218,7 @@ stages:
                 echo "collect cpu and mem results after scaling"
                 mkdir test2_2_lb_cpu_and_mem_scale
                 cd test2_2_lb_cpu_and_mem_scale
-                echo "running k top node" 
+                echo "running k top node"
                 kubectl top node >> "node_lb_scale.log"
                 echo "running k top pod"
                 kubectl top pod -A | grep cilium >> "pod_lb_scale.log"
@@ -252,7 +252,7 @@ stages:
         pool:
           name: "$(BUILD_POOL_NAME_DEFAULT)"
         steps:
-          - task: AzureCLI@1
+          - task: AzureCLI@2
             inputs:
               azureSubscription: $(TEST_SUB_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"
@@ -274,7 +274,7 @@ stages:
                 cd ..
                 mkdir test2_3_lb_cpu_and_mem_after
                 cd test2_3_lb_cpu_and_mem_after
-                echo "running k top node" 
+                echo "running k top node"
                 kubectl top node >> "node_after_lb_tests.log"
                 echo "running k top pod"
                 kubectl top pod -A | grep cilium >> "pod_after_lb_tests.log"
@@ -312,7 +312,7 @@ stages:
         pool:
           name: "$(BUILD_POOL_NAME_DEFAULT)"
         steps:
-          - task: AzureCLI@1
+          - task: AzureCLI@2
             inputs:
               azureSubscription: $(TEST_SUB_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"
@@ -328,7 +328,7 @@ stages:
                 echo "collect cpu and mem results after netperf tests"
                 mkdir test3_netperf_cpu_and_mem
                 cd test3_netperf_cpu_and_mem
-                echo "running k top node" 
+                echo "running k top node"
                 kubectl top node >> "node_netperf.log"
                 echo "running k top pod"
                 kubectl top pod -A | grep cilium >> "pod_netperf.log"
@@ -337,8 +337,8 @@ stages:
                 ARTIFACT_DIR2=$(Build.ArtifactStagingDirectory)/test3_netperf/
                 echo $ARTIFACT_DIR
                 echo $ARTIFACT_DIR2
-                sudo rm -rf $ARTIFACT_DIR 
-                sudo rm -rf $ARTIFACT_DIR2 
+                sudo rm -rf $ARTIFACT_DIR
+                sudo rm -rf $ARTIFACT_DIR2
                 sudo mkdir $ARTIFACT_DIR
                 sudo mkdir $ARTIFACT_DIR2
                 cd ..
@@ -367,7 +367,7 @@ stages:
         pool:
           name: "$(BUILD_POOL_NAME_DEFAULT)"
         steps:
-          - task: AzureCLI@1
+          - task: AzureCLI@2
             inputs:
               azureSubscription: $(TEST_SUB_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"
@@ -389,7 +389,7 @@ stages:
         pool:
           name: "$(BUILD_POOL_NAME_DEFAULT)"
         steps:
-        - task: AzureCLI@1
+        - task: AzureCLI@2
           inputs:
             azureSubscription: $(TEST_SUB_SERVICE_CONNECTION)
             scriptLocation: "inlineScript"

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -73,12 +73,14 @@ stages:
             inputs:
               azureSubscription: $(ACR_ARM_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"
+              scriptType: "bash"
               inlineScript: |
                 az acr login -n $(ACR)
           - task: AzureCLI@2
             inputs:
               azureSubscription: $(TEST_SUB_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"
+              scriptType: "bash"
               inlineScript: |
                 set -ex
                 docker tag quay.io/cilium/$(image):$(DOCKER_IMAGE_TAG) $(ACR).azurecr.io/cilium/$(image):$(DOCKER_IMAGE_TAG)
@@ -90,6 +92,7 @@ stages:
             inputs:
               azureSubscription: $(ACR_ARM_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"
+              scriptType: "bash"
               inlineScript: |
                 docker logout
 

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -68,14 +68,14 @@ stages:
               make $(type)
             name: BuildCiliumImage
             displayName: "Build Cilium Image"
-          - task: AzureCLI@1
+          - task: AzureCLI@2
             displayName: "Login"
             inputs:
               azureSubscription: $(ACR_ARM_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"
               inlineScript: |
                 az acr login -n $(ACR)
-          - task: AzureCLI@1
+          - task: AzureCLI@2
             inputs:
               azureSubscription: $(TEST_SUB_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"
@@ -85,7 +85,7 @@ stages:
                 docker push $(ACR).azurecr.io/cilium/$(image):$(DOCKER_IMAGE_TAG)
             name: "PushCiliumImage"
             displayName: "Push Cilium Image"
-          - task: AzureCLI@1
+          - task: AzureCLI@2
             displayName: "Logout"
             inputs:
               azureSubscription: $(ACR_ARM_SERVICE_CONNECTION)

--- a/.pipelines/cni/k8s-e2e/k8s-e2e-job-template.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e-job-template.yaml
@@ -14,7 +14,7 @@ jobs:
     pool:
       name: $(BUILD_POOL_NAME_DEFAULT)
     steps:
-      - task: AzureCLI@1
+      - task: AzureCLI@2
         inputs:
           azureSubscription: ${{ parameters.sub }}
           scriptLocation: "inlineScript"

--- a/.pipelines/cni/load-test-templates/create-cluster-template.yaml
+++ b/.pipelines/cni/load-test-templates/create-cluster-template.yaml
@@ -10,7 +10,7 @@ parameters:
   nodeCountWin: 2
 
 steps:
-  - task: AzureCLI@1
+  - task: AzureCLI@2
     inputs:
       azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"

--- a/.pipelines/cni/load-test-templates/pod-deployment-template.yaml
+++ b/.pipelines/cni/load-test-templates/pod-deployment-template.yaml
@@ -8,7 +8,7 @@ parameters:
   jobName: "deploy_pods"
 
 steps:
-  - task: AzureCLI@1
+  - task: AzureCLI@2
     displayName: "Pod Deployment"
     inputs:
       azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)

--- a/.pipelines/cni/load-test-templates/restart-cns-template.yaml
+++ b/.pipelines/cni/load-test-templates/restart-cns-template.yaml
@@ -7,7 +7,7 @@ parameters:
   jobName: "restart_cns"
 
 steps:
-  - task: AzureCLI@1
+  - task: AzureCLI@2
     inputs:
       azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"

--- a/.pipelines/cni/load-test-templates/restart-hns-template.yaml
+++ b/.pipelines/cni/load-test-templates/restart-hns-template.yaml
@@ -3,7 +3,7 @@ parameters:
   cni: "cniv1"
 
 steps:
-  - task: AzureCLI@1
+  - task: AzureCLI@2
     inputs:
       azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"

--- a/.pipelines/cni/load-test-templates/restart-node-template.yaml
+++ b/.pipelines/cni/load-test-templates/restart-node-template.yaml
@@ -6,7 +6,7 @@ parameters:
   region: ""
 
 steps:
-  - task: AzureCLI@1
+  - task: AzureCLI@2
     inputs:
       azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"

--- a/.pipelines/cni/load-test-templates/validate-state-template.yaml
+++ b/.pipelines/cni/load-test-templates/validate-state-template.yaml
@@ -5,7 +5,7 @@ parameters:
   cni: "cilium"
 
 steps:
-  - task: AzureCLI@1
+  - task: AzureCLI@2
     inputs:
       azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"

--- a/.pipelines/cni/lsg/kernel-upgrade-template.yaml
+++ b/.pipelines/cni/lsg/kernel-upgrade-template.yaml
@@ -2,7 +2,7 @@ parameters:
   clusterName: ""
 
 steps:
-  - task: AzureCLI@1
+  - task: AzureCLI@2
     inputs:
       azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"

--- a/.pipelines/cni/lsg/lsg-cni-intergration-template.yaml
+++ b/.pipelines/cni/lsg/lsg-cni-intergration-template.yaml
@@ -21,7 +21,7 @@ stages:
     jobs:
       - job: create_aks_cluster_with_${{ parameters.name }}
         steps:
-          - task: AzureCLI@1
+          - task: AzureCLI@2
             inputs:
               azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"
@@ -55,7 +55,7 @@ stages:
         - job: integration
           displayName: "Integration Test - ${{ parameters.name }}"
           steps:
-            - task: AzureCLI@1
+            - task: AzureCLI@2
               inputs:
                 azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
                 scriptLocation: "inlineScript"
@@ -77,7 +77,7 @@ stages:
         - job: integration
           displayName: "Deploy Cilium Components"
           steps:
-            - task: AzureCLI@1
+            - task: AzureCLI@2
               displayName: "Install Cilium, CNS, and ip-masq-agent"
               retryCountOnTaskFailure: 2
               inputs:
@@ -166,7 +166,7 @@ stages:
         displayName: "Recover Resources"
         dependsOn: restart_cns
         steps:
-          - task: AzureCLI@1
+          - task: AzureCLI@2
             inputs:
               azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"
@@ -205,7 +205,7 @@ stages:
               cilium version
             name: "InstallCiliumCli"
             displayName: "Install Cilium CLI"
-          - task: AzureCLI@1
+          - task: AzureCLI@2
             inputs:
               azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"

--- a/.pipelines/cni/pipeline.yaml
+++ b/.pipelines/cni/pipeline.yaml
@@ -373,7 +373,7 @@ stages:
       arch: amd64
       dualstackVersion: ${CILIUM_DUALSTACK_VERSION}
       cni: "cilium_dualstack"
-  
+
   - template: cilium/cilium-overlay-load-test-template.yaml
     parameters:
       name: cilium_ds_arm
@@ -396,7 +396,7 @@ stages:
       osSKU: AzureLinux
       dualstackVersion: ${CILIUM_DUALSTACK_VERSION}
       cni: "cilium_dualstack"
-  
+
   - template: cilium/cilium-overlay-load-test-template.yaml
     parameters:
       name: cilium_ds_rdma
@@ -501,7 +501,7 @@ stages:
               name: windows19_overlay
               clusterName: w19-amd-ov
         steps:
-          - task: AzureCLI@1
+          - task: AzureCLI@2
             inputs:
               azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"

--- a/.pipelines/cni/singletenancy/cniv1-template.yaml
+++ b/.pipelines/cni/singletenancy/cniv1-template.yaml
@@ -116,7 +116,7 @@ stages:
     jobs:
       - job: update_cni
         steps:
-          - task: AzureCLI@1
+          - task: AzureCLI@2
             inputs:
               azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"
@@ -193,7 +193,7 @@ stages:
         displayName: "Recover Resources"
         dependsOn: restart_nodes
         steps:
-          - task: AzureCLI@1
+          - task: AzureCLI@2
             inputs:
               azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"
@@ -305,7 +305,7 @@ stages:
           displayName: "Recover Resources"
           dependsOn: restart_nodesHNS
           steps:
-            - task: AzureCLI@1
+            - task: AzureCLI@2
               inputs:
                 azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
                 scriptLocation: "inlineScript"

--- a/.pipelines/cni/singletenancy/cniv2-template.yaml
+++ b/.pipelines/cni/singletenancy/cniv2-template.yaml
@@ -125,7 +125,7 @@ stages:
         displayName: "Integration Test - ${{ parameters.name }}"
         steps:
           - ${{ if contains(parameters.clusterType, 'overlay') }}:
-            - task: AzureCLI@1
+            - task: AzureCLI@2
               inputs:
                 azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
                 scriptLocation: "inlineScript"
@@ -144,7 +144,7 @@ stages:
               name: "overlaye2e"
               displayName: "Overlay Integration"
           - ${{ if contains(parameters.clusterType, 'swift') }}:
-            - task: AzureCLI@1
+            - task: AzureCLI@2
               inputs:
                 azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
                 scriptLocation: "inlineScript"
@@ -248,7 +248,7 @@ stages:
         displayName: "Recover Resources"
         dependsOn: restart_cns
         steps:
-          - task: AzureCLI@1
+          - task: AzureCLI@2
             inputs:
               azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"
@@ -371,7 +371,7 @@ stages:
           displayName: "Recover Resources"
           dependsOn: restart_cns
           steps:
-            - task: AzureCLI@1
+            - task: AzureCLI@2
               inputs:
                 azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
                 scriptLocation: "inlineScript"

--- a/.pipelines/containers/container-template.yaml
+++ b/.pipelines/containers/container-template.yaml
@@ -10,6 +10,7 @@ steps:
   inputs:
     azureSubscription: $(ACR_ARM_SERVICE_CONNECTION)
     scriptLocation: "inlineScript"
+    scriptType: "bash"
     inlineScript: |
       az acr login -n $(ACR)
 
@@ -26,5 +27,6 @@ steps:
   inputs:
     azureSubscription: $(ACR_ARM_SERVICE_CONNECTION)
     scriptLocation: "inlineScript"
+    scriptType: "bash"
     inlineScript: |
       docker logout

--- a/.pipelines/containers/container-template.yaml
+++ b/.pipelines/containers/container-template.yaml
@@ -5,7 +5,7 @@ parameters:
   os_version: ""
 
 steps:
-- task: AzureCLI@1
+- task: AzureCLI@2
   displayName: "Login"
   inputs:
     azureSubscription: $(ACR_ARM_SERVICE_CONNECTION)
@@ -21,7 +21,7 @@ steps:
   displayName: Image Build
   retryCountOnTaskFailure: 3
 
-- task: AzureCLI@1
+- task: AzureCLI@2
   displayName: "Logout"
   inputs:
     azureSubscription: $(ACR_ARM_SERVICE_CONNECTION)

--- a/.pipelines/containers/manifest-template.yaml
+++ b/.pipelines/containers/manifest-template.yaml
@@ -10,6 +10,7 @@ steps:
     inputs:
       azureSubscription: $(ACR_ARM_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"
+      scriptType: "bash"
       inlineScript: |
         az acr login -n $(ACR)
 
@@ -41,6 +42,7 @@ steps:
     inputs:
       azureSubscription: $(ACR_ARM_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"
+      scriptType: "bash"
       inlineScript: |
         docker logout
 

--- a/.pipelines/containers/manifest-template.yaml
+++ b/.pipelines/containers/manifest-template.yaml
@@ -5,7 +5,7 @@ parameters:
 
 steps:
 
-  - task: AzureCLI@1
+  - task: AzureCLI@2
     displayName: "Login"
     inputs:
       azureSubscription: $(ACR_ARM_SERVICE_CONNECTION)
@@ -36,7 +36,7 @@ steps:
     displayName: Manifest Push
     retryCountOnTaskFailure: 3
 
-  - task: AzureCLI@1
+  - task: AzureCLI@2
     displayName: "Logout"
     inputs:
       azureSubscription: $(ACR_ARM_SERVICE_CONNECTION)

--- a/.pipelines/multitenancy/swiftv2-e2e-step-template.yaml
+++ b/.pipelines/multitenancy/swiftv2-e2e-step-template.yaml
@@ -19,7 +19,7 @@ steps:
     inputs:
       kubectlVersion: latest
 
-  - task: AzureCLI@1
+  - task: AzureCLI@2
     inputs:
       azureSubscription: $(ACN_TEST_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"

--- a/.pipelines/networkobservability/pipeline.yaml
+++ b/.pipelines/networkobservability/pipeline.yaml
@@ -47,7 +47,7 @@ stages:
           inputs:
               kubectlVersion: latest
 
-        - task: AzureCLI@1
+        - task: AzureCLI@2
           inputs:
               azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
               scriptLocation: "inlineScript"
@@ -70,7 +70,7 @@ stages:
           name: "installCiliumCLI"
           displayName: "Install Cilium CLI"
 
-        - task: AzureCLI@1
+        - task: AzureCLI@2
           inputs:
             azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
             scriptLocation: "inlineScript"
@@ -131,10 +131,10 @@ stages:
           retryCountOnTaskFailure: 3
           name: "HubbleConnectivityTests"
           displayName: "Run Hubble Connectivity Tests"
-          
+
   - stage: deleteCluster
     condition: always()
-    dependsOn: 
+    dependsOn:
      - createCluster
      - setupCluster
     jobs:

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -243,7 +243,7 @@ stages:
               FQDN=`az aks show -n $(AZURE_CLUSTER) -g $(RESOURCE_GROUP) --query fqdn -o tsv`
               echo "##vso[task.setvariable variable=FQDN]$FQDN"
 
-        - task: AzureCLI@1
+        - task: AzureCLI@2
           inputs:
             azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
             scriptLocation: "inlineScript"

--- a/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
@@ -25,7 +25,7 @@ steps:
     inputs:
       kubectlVersion: latest
 
-  - task: AzureCLI@1
+  - task: AzureCLI@2
     inputs:
       azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"

--- a/.pipelines/singletenancy/aks/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks/e2e-step-template.yaml
@@ -20,7 +20,7 @@ steps:
   - task: KubectlInstaller@0
     inputs:
       kubectlVersion: latest
-  - task: AzureCLI@1
+  - task: AzureCLI@2
     inputs:
       azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"
@@ -49,7 +49,7 @@ steps:
         fi
     name: "deployCNI"
     displayName: "Deploy CNI"
-  - task: AzureCLI@1
+  - task: AzureCLI@2
     inputs:
       azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"
@@ -71,7 +71,7 @@ steps:
       cd ../../..
 
       make test-validate-state OS_TYPE=${{ parameters.os }} CNI_TYPE=cniv1
-      
+
       kubectl delete ns load-test
     displayName: "Validate State"
     retryCountOnTaskFailure: 3

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-step-template.yaml
@@ -19,7 +19,7 @@ steps:
     inputs:
       kubectlVersion: latest
 
-  - task: AzureCLI@1
+  - task: AzureCLI@2
     inputs:
       azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"
@@ -40,7 +40,7 @@ steps:
       name: "integrationTest"
       displayName: "Run CNS Integration Tests on AKS Overlay"
 
-    - task: AzureCLI@1
+    - task: AzureCLI@2
       inputs:
         azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
         scriptLocation: "inlineScript"
@@ -56,7 +56,7 @@ steps:
           done
       displayName: "Restart Nodes"
 
-    - task: AzureCLI@1
+    - task: AzureCLI@2
       inputs:
         azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
         scriptLocation: "inlineScript"

--- a/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-step-template.yaml
@@ -19,7 +19,7 @@ steps:
     inputs:
       kubectlVersion: latest
 
-  - task: AzureCLI@1
+  - task: AzureCLI@2
     inputs:
       azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"
@@ -109,7 +109,7 @@ steps:
     retryCountOnTaskFailure: 3
     name: "WireserverMetadataConnectivityTests"
     displayName: "Run Wireserver and Metadata Connectivity Tests"
-  
+
   - script: |
       cd hack/scripts
       chmod +x async-delete-test.sh

--- a/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-step-template.yaml
@@ -26,7 +26,7 @@ steps:
     inputs:
       kubectlVersion: latest
 
-  - task: AzureCLI@1
+  - task: AzureCLI@2
     inputs:
       azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"
@@ -147,7 +147,7 @@ steps:
     retryCountOnTaskFailure: 3
     name: "WireserverMetadataConnectivityTests"
     displayName: "Run Wireserver and Metadata Connectivity Tests"
-  
+
   - script: |
       cd hack/scripts
       chmod +x async-delete-test.sh

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
@@ -26,7 +26,7 @@ steps:
     inputs:
       kubectlVersion: latest
 
-  - task: AzureCLI@1
+  - task: AzureCLI@2
     inputs:
       azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"
@@ -186,7 +186,7 @@ steps:
     retryCountOnTaskFailure: 3
     name: "WireserverMetadataConnectivityTests"
     displayName: "Run Wireserver and Metadata Connectivity Tests"
-  
+
   - script: |
       if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]; then
         echo "Running nightly, skip async delete test"

--- a/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
@@ -25,7 +25,7 @@ steps:
     inputs:
       kubectlVersion: latest
 
-  - task: AzureCLI@1
+  - task: AzureCLI@2
     inputs:
       azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"
@@ -113,7 +113,7 @@ steps:
     retryCountOnTaskFailure: 3
     name: "WireserverMetadataConnectivityTests"
     displayName: "Run Wireserver and Metadata Connectivity Tests"
-  
+
   - script: |
       cd hack/scripts
       chmod +x async-delete-test.sh

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-step-template.yaml
@@ -54,7 +54,7 @@ steps:
       name: "DualStack_Overlay_Linux_Tests"
       displayName: "DualStack Overlay Linux Tests"
 
-    - task: AzureCLI@1
+    - task: AzureCLI@2
       inputs:
         azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
         scriptLocation: "inlineScript"
@@ -69,7 +69,7 @@ steps:
           done
       displayName: "Restart Nodes"
 
-    - task: AzureCLI@1
+    - task: AzureCLI@2
       inputs:
         azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
         scriptLocation: "inlineScript"

--- a/.pipelines/templates/create-cluster-swiftv2.yaml
+++ b/.pipelines/templates/create-cluster-swiftv2.yaml
@@ -6,7 +6,7 @@ jobs:
   - job: ${{ parameters.name }}
     displayName: Cluster - ${{ parameters.name }}
     steps:
-      - task: AzureCLI@1
+      - task: AzureCLI@2
         inputs:
           azureSubscription: $(ACN_TEST_SERVICE_CONNECTION)
           scriptLocation: "inlineScript"

--- a/.pipelines/templates/create-cluster.yaml
+++ b/.pipelines/templates/create-cluster.yaml
@@ -15,7 +15,7 @@ jobs:
   - job: ${{ parameters.name }}
     displayName: Cluster - ${{ parameters.name }}
     steps:
-      - task: AzureCLI@1
+      - task: AzureCLI@2
         inputs:
           azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
           scriptLocation: "inlineScript"

--- a/.pipelines/templates/delete-cluster.yaml
+++ b/.pipelines/templates/delete-cluster.yaml
@@ -4,7 +4,7 @@ parameters:
   region: ""
 
 steps:
-  - task: AzureCLI@1
+  - task: AzureCLI@2
     inputs:
       azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"

--- a/.pipelines/templates/log-template.yaml
+++ b/.pipelines/templates/log-template.yaml
@@ -23,7 +23,7 @@ parameters:
   jobName: "FailedE2ELogs"
 
 steps:
-  - task: AzureCLI@1
+  - task: AzureCLI@2
     inputs:
       azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
       scriptLocation: "inlineScript"


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

Recently pipelines have been randomly failing AzCLI tasks with `AggregateError ETIMEDOUT`. This was noted in https://github.com/microsoft/azure-pipelines-tasks/pull/20277 and was updated only in v2. 

Updating to the v2 task will allow us to take on this fix.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
