### PR TITLE
fix: update default k8s ver to 1.30

### DIFF
--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -351,7 +351,7 @@ stages:
         clusterType: vnetscale-swift-byocni-up
         clusterName: "vscaleswifte2e"
         vmSize: Standard_B2ms
-        k8sVersion: "1.28"
+        k8sVersion: "1.30"
         dependsOn: "containerize"
 
     # CNIv1 E2E tests

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -9,7 +9,7 @@ AZCLI   ?= docker run --rm -v $(AZCFG):/root/.azure -v $(KUBECFG):/root/.kube -v
 
 # overrideable defaults
 AUTOUPGRADE     ?= patch
-K8S_VER         ?= 1.28
+K8S_VER         ?= 1.30
 NODE_COUNT      ?= 2
 NODE_COUNT_WIN	?= $(NODE_COUNT)
 NODEUPGRADE     ?= NodeImage
@@ -237,7 +237,7 @@ swiftv2-multitenancy-cluster-up: rg-up
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
 		--network-plugin azure \
 		--network-plugin-mode overlay \
-		--kubernetes-version 1.28 \
+		--kubernetes-version $(K8S_VER) \
 		--nodepool-name "mtapool" \
 		--node-vm-size $(VM_SIZE) \
 		--node-count 2 \


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Main branch is for release 1.6.x, which is locked to k8s 1.30. Updates the default cluster for E2Es and development to 1.30.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
