### PR TITLE
fix: dualnic options to avoid overwritting vlanMaps

### DIFF
--- a/cni/network/invoker.go
+++ b/cni/network/invoker.go
@@ -31,6 +31,15 @@ type IPAMAddResult struct {
 	ipv6Enabled bool
 }
 
+func (ipamAddConfig IPAMAddConfig) getOptions() *map[string]interface{} {
+	res := map[string]interface{}{}
+	for k, v := range ipamAddConfig.options {
+		// only support permittive type
+		res[k] = v
+	}
+	return &res
+}
+
 func (ipamAddResult IPAMAddResult) PrettyString() string {
 	pStr := "InterfaceInfo: "
 	for key := range ipamAddResult.interfaceInfo {

--- a/cni/network/invoker.go
+++ b/cni/network/invoker.go
@@ -31,15 +31,6 @@ type IPAMAddResult struct {
 	ipv6Enabled bool
 }
 
-func (ipamAddConfig IPAMAddConfig) getOptions() *map[string]interface{} {
-	res := map[string]interface{}{}
-	for k, v := range ipamAddConfig.options {
-		// only support permittive type
-		res[k] = v
-	}
-	return &res
-}
-
 func (ipamAddResult IPAMAddResult) PrettyString() string {
 	pStr := "InterfaceInfo: "
 	for key := range ipamAddResult.interfaceInfo {
@@ -47,4 +38,14 @@ func (ipamAddResult IPAMAddResult) PrettyString() string {
 		pStr += val.PrettyString()
 	}
 	return pStr
+}
+
+// shallow copy options from one map to a new options map
+func (ipamAddConfig IPAMAddConfig) shallowCopyIpamAddConfigOptions() map[string]interface{} {
+	res := map[string]interface{}{}
+	for k, v := range ipamAddConfig.options {
+		// only support primitive type
+		res[k] = v
+	}
+	return res
 }

--- a/cni/network/invoker_cns_test.go
+++ b/cni/network/invoker_cns_test.go
@@ -2112,19 +2112,30 @@ func TestShallowCopyIpamAddConfigOptions(t *testing.T) {
 	require.Equal(t, opts.options, res)
 
 	// modified copied res and make sure original opts is not changed
-	res[network.SNATIPKey] = "100"
-	res[dockerNetworkOption] = "200"
-	require.NotEqual(t, opts.options, res)
+	newSnapIPKeyValue := "100"
+	newDockerNetworkOptionValue := "200"
+
+	res[network.SNATIPKey] = newSnapIPKeyValue
+	res[dockerNetworkOption] = newDockerNetworkOptionValue
+
+	expectedOpts := map[string]interface{}{
+		network.SNATIPKey:   newSnapIPKeyValue,
+		dockerNetworkOption: newDockerNetworkOptionValue,
+		"intType":           10,
+		"floatType":         0.51,
+		"byteType":          byte('A'),
+	}
+	require.Equal(t, expectedOpts, res)
 
 	// make sure original object is equal to expected opts after copied res is changed
-	expectedOpts := map[string]interface{}{
+	expectedOriginalOpts := map[string]interface{}{
 		network.SNATIPKey:   "10",
 		dockerNetworkOption: "20",
 		"intType":           10,
 		"floatType":         0.51,
 		"byteType":          byte('A'),
 	}
-	require.Equal(t, opts.options, expectedOpts)
+	require.Equal(t, expectedOriginalOpts, opts.options)
 
 	// shallow copy empty opts and make sure it does not break anything
 	emptyOpts := IPAMAddConfig{

--- a/cni/network/invoker_cns_test.go
+++ b/cni/network/invoker_cns_test.go
@@ -2097,7 +2097,7 @@ func TestCNSIPAMInvoker_Add_SwiftV2(t *testing.T) {
 
 func TestShallowCopyIpamAddConfigOptions(t *testing.T) {
 	opts := IPAMAddConfig{
-		// mock all optios' fields
+		// mock different types of map value
 		options: map[string]interface{}{
 			network.SNATIPKey:   "10",
 			dockerNetworkOption: "20",

--- a/cni/network/invoker_cns_test.go
+++ b/cni/network/invoker_cns_test.go
@@ -2108,20 +2108,20 @@ func TestShallowCopyIpamAddConfigOptions(t *testing.T) {
 	}
 
 	// shallow copy all ipamAddConfig options
-	res1 := opts.shallowCopyIpamAddConfigOptions()
-	require.Equal(t, opts.options, res1)
+	res := opts.shallowCopyIpamAddConfigOptions()
+	require.Equal(t, opts.options, res)
 
 	// create a second opts for reference representing expected outputs
-	copyRes := res1
-	// modify res1 fields and make sure expectedOpts has not changed
-	res1[network.SNATIPKey] = "100"
-	res1[dockerNetworkOption] = "200"
-	require.Equal(t, copyRes, res1)
+	copyRes := res
+	// modify res1 fields and make sure copied res has changed
+	res[network.SNATIPKey] = "100"
+	res[dockerNetworkOption] = "200"
+	require.Equal(t, copyRes, res)
 
 	// shallow copy empty opts and make sure it does not break anything
 	emptyOpts := IPAMAddConfig{
 		options: map[string]interface{}{},
 	}
-	res3 := emptyOpts.shallowCopyIpamAddConfigOptions()
-	require.Equal(t, emptyOpts.options, res3)
+	emptyRes := emptyOpts.shallowCopyIpamAddConfigOptions()
+	require.Equal(t, emptyOpts.options, emptyRes)
 }

--- a/cni/network/invoker_cns_test.go
+++ b/cni/network/invoker_cns_test.go
@@ -2111,12 +2111,20 @@ func TestShallowCopyIpamAddConfigOptions(t *testing.T) {
 	res := opts.shallowCopyIpamAddConfigOptions()
 	require.Equal(t, opts.options, res)
 
-	// create a second opts for reference representing expected outputs
-	copyRes := res
-	// modify res1 fields and make sure copied res has changed
+	// modified copied res and make sure original opts is not changed
 	res[network.SNATIPKey] = "100"
 	res[dockerNetworkOption] = "200"
-	require.Equal(t, copyRes, res)
+	require.NotEqual(t, opts.options, res)
+
+	// make sure original object is equal to expected opts after copied res is changed
+	expectedOpts := map[string]interface{}{
+		network.SNATIPKey:   "10",
+		dockerNetworkOption: "20",
+		"intType":           10,
+		"floatType":         0.51,
+		"byteType":          byte('A'),
+	}
+	require.Equal(t, opts.options, expectedOpts)
 
 	// shallow copy empty opts and make sure it does not break anything
 	emptyOpts := IPAMAddConfig{
@@ -2124,4 +2132,11 @@ func TestShallowCopyIpamAddConfigOptions(t *testing.T) {
 	}
 	emptyRes := emptyOpts.shallowCopyIpamAddConfigOptions()
 	require.Equal(t, emptyOpts.options, emptyRes)
+
+	// shallow copy null opts and make sure it does not break anything
+	nullOpts := IPAMAddConfig{
+		options: nil,
+	}
+	nullRes := nullOpts.shallowCopyIpamAddConfigOptions()
+	require.Equal(t, map[string]interface{}{}, nullRes)
 }

--- a/cni/network/invoker_cns_test.go
+++ b/cni/network/invoker_cns_test.go
@@ -2108,6 +2108,20 @@ func TestShallowCopyIpamAddConfigOptions(t *testing.T) {
 	}
 
 	// shallow copy all ipamAddConfig options
-	res := opts.shallowCopyIpamAddConfigOptions()
-	require.Equal(t, opts.options, res)
+	res1 := opts.shallowCopyIpamAddConfigOptions()
+	require.Equal(t, opts.options, res1)
+
+	// create a second opts for reference representing expected outputs
+	copyRes := res1
+	// modify res1 fields and make sure expectedOpts has not changed
+	res1[network.SNATIPKey] = "100"
+	res1[dockerNetworkOption] = "200"
+	require.Equal(t, copyRes, res1)
+
+	// shallow copy empty opts and make sure it does not break anything
+	emptyOpts := IPAMAddConfig{
+		options: map[string]interface{}{},
+	}
+	res3 := emptyOpts.shallowCopyIpamAddConfigOptions()
+	require.Equal(t, emptyOpts.options, res3)
 }

--- a/cni/network/invoker_cns_test.go
+++ b/cni/network/invoker_cns_test.go
@@ -2112,14 +2112,14 @@ func TestShallowCopyIpamAddConfigOptions(t *testing.T) {
 	require.Equal(t, opts.options, res)
 
 	// modified copied res and make sure original opts is not changed
-	newSnapIPKeyValue := "100"
+	newSNATIPKeyValue := "100"
 	newDockerNetworkOptionValue := "200"
 
-	res[network.SNATIPKey] = newSnapIPKeyValue
+	res[network.SNATIPKey] = newSNATIPKeyValue
 	res[dockerNetworkOption] = newDockerNetworkOptionValue
 
 	expectedOpts := map[string]interface{}{
-		network.SNATIPKey:   newSnapIPKeyValue,
+		network.SNATIPKey:   newSNATIPKeyValue,
 		dockerNetworkOption: newDockerNetworkOptionValue,
 		"intType":           10,
 		"floatType":         0.51,

--- a/cni/network/invoker_cns_test.go
+++ b/cni/network/invoker_cns_test.go
@@ -2094,3 +2094,20 @@ func TestCNSIPAMInvoker_Add_SwiftV2(t *testing.T) {
 		})
 	}
 }
+
+func TestShallowCopyIpamAddConfigOptions(t *testing.T) {
+	opts := IPAMAddConfig{
+		// mock all optios' fields
+		options: map[string]interface{}{
+			network.SNATIPKey:   "10",
+			dockerNetworkOption: "20",
+			"intType":           10,
+			"floatType":         0.51,
+			"byteType":          byte('A'),
+		},
+	}
+
+	// shallow copy all ipamAddConfig options
+	res := opts.shallowCopyIpamAddConfigOptions()
+	require.Equal(t, opts.options, res)
+}

--- a/cni/network/multitenancy_test.go
+++ b/cni/network/multitenancy_test.go
@@ -346,6 +346,10 @@ func TestGetMultiTenancyCNIResult(t *testing.T) {
 				GatewayIPAddress: "10.1.0.1",
 			},
 		},
+		MultiTenancyInfo: cns.MultiTenancyInfo{
+			EncapType: "1", // vlanID 1
+			ID:        1,
+		},
 	}
 
 	ncResponseTwo := cns.GetNetworkContainerResponse{
@@ -376,6 +380,10 @@ func TestGetMultiTenancyCNIResult(t *testing.T) {
 				IPAddress:        "20.1.0.0/16",
 				GatewayIPAddress: "20.1.0.1",
 			},
+		},
+		MultiTenancyInfo: cns.MultiTenancyInfo{
+			EncapType: "2", // vlanID 2
+			ID:        2,
 		},
 	}
 	ncResponses = append(ncResponses, ncResponseOne, ncResponseTwo)
@@ -484,6 +492,10 @@ func TestGetMultiTenancyCNIResult(t *testing.T) {
 						GatewayIPAddress: "10.1.0.1",
 					},
 				},
+				MultiTenancyInfo: cns.MultiTenancyInfo{
+					EncapType: "1",
+					ID:        1,
+				},
 			},
 			want2: &cns.GetNetworkContainerResponse{
 				PrimaryInterfaceIdentifier: "20.0.0.0/16",
@@ -513,6 +525,10 @@ func TestGetMultiTenancyCNIResult(t *testing.T) {
 						IPAddress:        "20.1.0.0/16",
 						GatewayIPAddress: "20.1.0.1",
 					},
+				},
+				MultiTenancyInfo: cns.MultiTenancyInfo{
+					EncapType: "2",
+					ID:        2,
 				},
 			},
 			want3: *getCIDRNotationForAddress("10.0.0.0/16"),

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -764,7 +764,6 @@ func (plugin *NetPlugin) createEpInfo(opt *createEpInfoOpt) (*network.EndpointIn
 		endpointID = plugin.nm.GetEndpointID(opt.args.ContainerID, ifName)
 	}
 
-	option := opt.ipamAddConfig.getOptions()
 	endpointInfo := network.EndpointInfo{
 		NetworkID:                     opt.networkID,
 		Mode:                          opt.ipamAddConfig.nwCfg.Mode,
@@ -773,7 +772,7 @@ func (plugin *NetPlugin) createEpInfo(opt *createEpInfoOpt) (*network.EndpointIn
 		BridgeName:                    opt.ipamAddConfig.nwCfg.Bridge,
 		NetworkPolicies:               networkPolicies, // nw and ep policies separated to avoid possible conflicts
 		NetNs:                         opt.ipamAddConfig.args.Netns,
-		Options:                       *option,
+		Options:                       opt.ipamAddConfig.shallowCopyIpamAddConfigOptions(),
 		DisableHairpinOnHostInterface: opt.ipamAddConfig.nwCfg.DisableHairpinOnHostInterface,
 		IsIPv6Enabled:                 opt.ipv6Enabled, // present infra only
 

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -435,6 +435,7 @@ func (plugin *NetPlugin) Add(args *cniSkel.CmdArgs) error {
 		// previously we had a default interface info to select which interface info was the one to be returned from cni add
 		cniResult := &cniTypesCurr.Result{}
 		for key := range ipamAddResult.interfaceInfo {
+			logger.Info("Exiting add, interface info retrieved", zap.Any("ifInfo", ipamAddResult.interfaceInfo[key]))
 			// now we have to infer which interface info should be returned
 			// we assume that we want to return the infra nic always, and if that is not found, return any one of the secondary interfaces
 			// if there is an infra nic + secondary, we will always return the infra nic (linux swift v2)

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -764,6 +764,7 @@ func (plugin *NetPlugin) createEpInfo(opt *createEpInfoOpt) (*network.EndpointIn
 		endpointID = plugin.nm.GetEndpointID(opt.args.ContainerID, ifName)
 	}
 
+	option := opt.ipamAddConfig.getOptions()
 	endpointInfo := network.EndpointInfo{
 		NetworkID:                     opt.networkID,
 		Mode:                          opt.ipamAddConfig.nwCfg.Mode,
@@ -772,7 +773,7 @@ func (plugin *NetPlugin) createEpInfo(opt *createEpInfoOpt) (*network.EndpointIn
 		BridgeName:                    opt.ipamAddConfig.nwCfg.Bridge,
 		NetworkPolicies:               networkPolicies, // nw and ep policies separated to avoid possible conflicts
 		NetNs:                         opt.ipamAddConfig.args.Netns,
-		Options:                       opt.ipamAddConfig.options,
+		Options:                       *option,
 		DisableHairpinOnHostInterface: opt.ipamAddConfig.nwCfg.DisableHairpinOnHostInterface,
 		IsIPv6Enabled:                 opt.ipv6Enabled, // present infra only
 

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -435,7 +435,6 @@ func (plugin *NetPlugin) Add(args *cniSkel.CmdArgs) error {
 		// previously we had a default interface info to select which interface info was the one to be returned from cni add
 		cniResult := &cniTypesCurr.Result{}
 		for key := range ipamAddResult.interfaceInfo {
-			logger.Info("Exiting add, interface info retrieved", zap.Any("ifInfo", ipamAddResult.interfaceInfo[key]))
 			// now we have to infer which interface info should be returned
 			// we assume that we want to return the infra nic always, and if that is not found, return any one of the secondary interfaces
 			// if there is an infra nic + secondary, we will always return the infra nic (linux swift v2)
@@ -609,6 +608,7 @@ func (plugin *NetPlugin) Add(args *cniSkel.CmdArgs) error {
 	endpointIndex := 1
 	for key := range ipamAddResult.interfaceInfo {
 		ifInfo := ipamAddResult.interfaceInfo[key]
+		logger.Info("retrieving interfaceInfo:", zap.Any("ifInfo", ifInfo))
 
 		natInfo := getNATInfo(nwCfg, options[network.SNATIPKey], enableSnatForDNS)
 		networkID, _ := plugin.getNetworkID(args.Netns, &ifInfo, nwCfg)

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -608,7 +608,7 @@ func (plugin *NetPlugin) Add(args *cniSkel.CmdArgs) error {
 	endpointIndex := 1
 	for key := range ipamAddResult.interfaceInfo {
 		ifInfo := ipamAddResult.interfaceInfo[key]
-		logger.Info("retrieving interfaceInfo:", zap.Any("ifInfo", ifInfo))
+		logger.Info("Processing interfaceInfo:", zap.Any("ifInfo", ifInfo))
 
 		natInfo := getNATInfo(nwCfg, options[network.SNATIPKey], enableSnatForDNS)
 		networkID, _ := plugin.getNetworkID(args.Netns, &ifInfo, nwCfg)

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-container-networking/network"
 	"github.com/Azure/azure-container-networking/network/policy"
 	cniTypesCurr "github.com/containernetworking/cni/pkg/types/100"
+	"go.uber.org/zap"
 )
 
 const (
@@ -40,6 +41,8 @@ func setNetworkOptions(cnsNwConfig *cns.GetNetworkContainerResponse, nwInfo *net
 		vlanMap := make(map[string]interface{})
 		vlanMap[network.VlanIDKey] = strconv.Itoa(cnsNwConfig.MultiTenancyInfo.ID)
 		vlanMap[network.SnatBridgeIPKey] = cnsNwConfig.LocalIPConfiguration.GatewayIPAddress + "/" + strconv.Itoa(int(cnsNwConfig.LocalIPConfiguration.IPSubnet.PrefixLength))
+		logger.Info("Add %s and %s with %d to", zap.String("vlanIDKey", network.VlanIDKey), zap.String("SnatBridgeIPKey", network.SnatBridgeIPKey),
+			zap.Int("vlanID", cnsNwConfig.MultiTenancyInfo.ID), zap.Any("vlanMap", vlanMap))
 		nwInfo.Options[dockerNetworkOption] = vlanMap
 	}
 }

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -38,12 +38,11 @@ func addSnatForDNS(gwIPString string, epInfo *network.EndpointInfo, result *netw
 func setNetworkOptions(cnsNwConfig *cns.GetNetworkContainerResponse, nwInfo *network.EndpointInfo) {
 	if cnsNwConfig != nil && cnsNwConfig.MultiTenancyInfo.ID != 0 {
 		logger.Info("Setting Network Options")
-		vlanMap := make(map[string]interface{})
-		vlanMap[network.VlanIDKey] = strconv.Itoa(cnsNwConfig.MultiTenancyInfo.ID)
-		vlanMap[network.SnatBridgeIPKey] = cnsNwConfig.LocalIPConfiguration.GatewayIPAddress + "/" + strconv.Itoa(int(cnsNwConfig.LocalIPConfiguration.IPSubnet.PrefixLength))
-		logger.Info("Add vlanIDkey and SnatBridgeIPKey with vlanID to vlanMap", zap.String("vlanIDKey", network.VlanIDKey), zap.String("SnatBridgeIPKey", network.SnatBridgeIPKey),
-			zap.Int("vlanID", cnsNwConfig.MultiTenancyInfo.ID), zap.Any("vlanMap", vlanMap))
-		nwInfo.Options[dockerNetworkOption] = vlanMap
+		optionsMap := make(map[string]interface{})
+		optionsMap[network.VlanIDKey] = strconv.Itoa(cnsNwConfig.MultiTenancyInfo.ID)
+		optionsMap[network.SnatBridgeIPKey] = cnsNwConfig.LocalIPConfiguration.GatewayIPAddress + "/" + strconv.Itoa(int(cnsNwConfig.LocalIPConfiguration.IPSubnet.PrefixLength))
+		logger.Info("Add vlanIDkey and SnatBridgeIPKey to optionsMap", zap.String("vlanIDKey", network.VlanIDKey), zap.String("SnatBridgeIPKey", network.SnatBridgeIPKey))
+		nwInfo.Options[dockerNetworkOption] = optionsMap
 	}
 }
 

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -41,7 +41,7 @@ func setNetworkOptions(cnsNwConfig *cns.GetNetworkContainerResponse, nwInfo *net
 		vlanMap := make(map[string]interface{})
 		vlanMap[network.VlanIDKey] = strconv.Itoa(cnsNwConfig.MultiTenancyInfo.ID)
 		vlanMap[network.SnatBridgeIPKey] = cnsNwConfig.LocalIPConfiguration.GatewayIPAddress + "/" + strconv.Itoa(int(cnsNwConfig.LocalIPConfiguration.IPSubnet.PrefixLength))
-		logger.Info("Add %s and %s with %d to", zap.String("vlanIDKey", network.VlanIDKey), zap.String("SnatBridgeIPKey", network.SnatBridgeIPKey),
+		logger.Info("Add vlanIDkey and SnatBridgeIPKey with vlanID to vlanMap", zap.String("vlanIDKey", network.VlanIDKey), zap.String("SnatBridgeIPKey", network.SnatBridgeIPKey),
 			zap.Int("vlanID", cnsNwConfig.MultiTenancyInfo.ID), zap.Any("vlanMap", vlanMap))
 		nwInfo.Options[dockerNetworkOption] = vlanMap
 	}

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -43,6 +43,7 @@ func setNetworkOptions(cnsNwConfig *cns.GetNetworkContainerResponse, nwInfo *net
 		logger.Info("Setting Network Options")
 		vlanMap := make(map[string]interface{})
 		vlanMap[network.VlanIDKey] = strconv.Itoa(cnsNwConfig.MultiTenancyInfo.ID)
+		logger.Info("Add %s with %d to", zap.String("vlanIDKey", network.VlanIDKey), zap.Int("vlanID", cnsNwConfig.MultiTenancyInfo.ID), zap.Any("vlanMap", vlanMap))
 		nwInfo.Options[dockerNetworkOption] = vlanMap
 	}
 }

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -43,7 +43,7 @@ func setNetworkOptions(cnsNwConfig *cns.GetNetworkContainerResponse, nwInfo *net
 		logger.Info("Setting Network Options")
 		vlanMap := make(map[string]interface{})
 		vlanMap[network.VlanIDKey] = strconv.Itoa(cnsNwConfig.MultiTenancyInfo.ID)
-		logger.Info("Add %s with %d to", zap.String("vlanIDKey", network.VlanIDKey), zap.Int("vlanID", cnsNwConfig.MultiTenancyInfo.ID), zap.Any("vlanMap", vlanMap))
+		logger.Info("Add vlanIDKey with vlanID to vlanMap", zap.String("vlanIDKey", network.VlanIDKey), zap.Int("vlanID", cnsNwConfig.MultiTenancyInfo.ID), zap.Any("vlanMap", vlanMap))
 		nwInfo.Options[dockerNetworkOption] = vlanMap
 	}
 }

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -41,10 +41,10 @@ func addSnatForDNS(_ string, _ *network.EndpointInfo, _ *network.InterfaceInfo) 
 func setNetworkOptions(cnsNwConfig *cns.GetNetworkContainerResponse, nwInfo *network.EndpointInfo) {
 	if cnsNwConfig != nil && cnsNwConfig.MultiTenancyInfo.ID != 0 {
 		logger.Info("Setting Network Options")
-		vlanMap := make(map[string]interface{})
-		vlanMap[network.VlanIDKey] = strconv.Itoa(cnsNwConfig.MultiTenancyInfo.ID)
-		logger.Info("Add vlanIDKey with vlanID to vlanMap", zap.String("vlanIDKey", network.VlanIDKey), zap.Int("vlanID", cnsNwConfig.MultiTenancyInfo.ID), zap.Any("vlanMap", vlanMap))
-		nwInfo.Options[dockerNetworkOption] = vlanMap
+		optionsMap := make(map[string]interface{})
+		optionsMap[network.VlanIDKey] = strconv.Itoa(cnsNwConfig.MultiTenancyInfo.ID)
+		logger.Info("Add vlanIDKey to optionsMap", zap.String("vlanIDKey", network.VlanIDKey))
+		nwInfo.Options[dockerNetworkOption] = optionsMap
 	}
 }
 

--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -151,9 +151,9 @@ type apipaClient interface {
 }
 
 func (epInfo *EndpointInfo) PrettyString() string {
-	return fmt.Sprintf("Id:%s ContainerID:%s NetNsPath:%s IfName:%s IfIndex:%d MacAddr:%s IPAddrs:%v Gateways:%v Data:%+v NICType: %s NetworkContainerID: %s HostIfName: %s NetNs: %s",
+	return fmt.Sprintf("Id:%s ContainerID:%s NetNsPath:%s IfName:%s IfIndex:%d MacAddr:%s IPAddrs:%v Gateways:%v Data:%+v NICType: %s NetworkContainerID: %s HostIfName: %s NetNs: %s Options: %v",
 		epInfo.EndpointID, epInfo.ContainerID, epInfo.NetNsPath, epInfo.IfName, epInfo.IfIndex, epInfo.MacAddress.String(), epInfo.IPAddresses,
-		epInfo.Gateways, epInfo.Data, epInfo.NICType, epInfo.NetworkContainerID, epInfo.HostIfName, epInfo.NetNs)
+		epInfo.Gateways, epInfo.Data, epInfo.NICType, epInfo.NetworkContainerID, epInfo.HostIfName, epInfo.NetNs, epInfo.Options)
 }
 
 func (ifInfo *InterfaceInfo) PrettyString() string {


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
This PR is to fix dualnic options to avoid overwritting vlanMaps
In the windows dualnic multitenancy case, we receive two interface infos from cns and should create two corresponding networks and endpoints. The first and second endpoints created by hns should have vlan id 1 and vlan id 2, respectively. It is CNI's job to parse the cns input and send a request to hns to create the endpoints. 

However, during testing both endpoints have vlan id 2. This is because the ipamAddConfig's `options` field is unintentionally **shared** between each `EndpointInfo` struct. Modifying the vlan id of one options field in an endpoint info struct inadvertently modifies every other endpoint info struct's options. So, the vlan id reflected during endpoint creation is of the last endpoint info's vlan id only, as all endpoint info option fields point to the same underlying object in memory.

The proposed solution is to, for each endpoint info we create, we shallow copy the `ipamAddConfig`'s options field. So, every endpoint info gets its own copy of the options field which it can modify and store without modifying the other endpoint infos.

If the options field of type map[string]interface{} ever holds anything other than primitives before we perform the shallow copy (ex: if we store pointers to another object as a value in the map) the copied pointer will still be pointing to the same object and we will have the same issue, but as of now we have only identified a single instance where we write to the options field in `invoker_cns.go` (`ncPrimaryIP`) where the value is of type string, which is immutable.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
To be tested by partner team(s) before being merged.