### PR TITLE
[CNS] Add unit tests to Standalone SwiftV2 scenario

### DIFF
--- a/cns/middlewares/standaloneSwiftV2.go
+++ b/cns/middlewares/standaloneSwiftV2.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/Azure/azure-container-networking/cns"
-	"github.com/Azure/azure-container-networking/cns/types"
 	"github.com/pkg/errors"
 )
 
@@ -16,7 +15,6 @@ func (m *StandaloneSWIFTv2Middleware) IPConfigsRequestHandlerWrapper(ipRequestHa
 	return func(ctx context.Context, req cns.IPConfigsRequest) (*cns.IPConfigsResponse, error) {
 		ipConfigsResp, err := ipRequestHandler(ctx, req)
 		if err != nil {
-			ipConfigsResp.Response.ReturnCode = types.UnexpectedError
 			return ipConfigsResp, errors.Wrapf(err, "Failed to requestIPConfigs for Standalone SwiftV2 from IPConfigsRequest %+v", req)
 		}
 

--- a/cns/middlewares/standaloneSwiftV2.go
+++ b/cns/middlewares/standaloneSwiftV2.go
@@ -17,7 +17,7 @@ func (m *StandaloneSWIFTv2Middleware) IPConfigsRequestHandlerWrapper(ipRequestHa
 		ipConfigsResp, err := ipRequestHandler(ctx, req)
 		if err != nil {
 			ipConfigsResp.Response.ReturnCode = types.UnexpectedError
-			return ipConfigsResp, errors.Wrapf(err, "Failed to requestIPConfigs for Standalone-SwiftV2 from IPConfigsRequest %v", req)
+			return ipConfigsResp, errors.Wrapf(err, "Failed to requestIPConfigs for Standalone SwiftV2 from IPConfigsRequest %+v", req)
 		}
 
 		return ipConfigsResp, nil

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -138,7 +138,7 @@ func (service *HTTPRestService) requestIPConfigHandlerHelperStandalone(ctx conte
 		return &cns.IPConfigsResponse{
 			Response: cns.Response{
 				ReturnCode: types.FailedToAllocateIPConfig,
-				Message:    fmt.Sprintf("AllocateIPConfig failed due to not getting NC Response from statefile, IP config request is %v", ipconfigsRequest),
+				Message:    fmt.Sprintf("AllocateIPConfig failed due to not getting NC Response from statefile, IP config request is %+v", ipconfigsRequest),
 			},
 		}, ErrGetAllNCResponseEmpty
 	}
@@ -166,7 +166,7 @@ func (service *HTTPRestService) requestIPConfigHandlerHelperStandalone(ctx conte
 		return &cns.IPConfigsResponse{
 			Response: cns.Response{
 				ReturnCode: types.FailedToAllocateIPConfig,
-				Message:    fmt.Sprintf("AllocateIPConfig failed while updating pod with interfaces: %v, IP config request is %v", err, ipconfigsRequest),
+				Message:    fmt.Sprintf("AllocateIPConfig failed while updating pod with interfaces: %v, IP config request is %+v", err, ipconfigsRequest),
 			},
 		}, err
 	}

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -132,6 +132,10 @@ func (service *HTTPRestService) requestIPConfigHandlerHelperStandalone(ctx conte
 		return &cns.IPConfigsResponse{}, fmt.Errorf("error getting orchestrator context from PodInfo %w", err)
 	}
 	cnsRequest := cns.GetNetworkContainerRequest{OrchestratorContext: orchestratorContext}
+
+	// IMPORTANT: although SwiftV2 reuses the concept of NCs, NMAgent doesn't program NCs for SwiftV2, but
+	// instead programs NICs. When getting SwiftV2 NCs, we want the NIC type and MAC address of the NCs.
+	// TODO: we need another way to verify and sync NMAgent's NIC programming status. pending new NMAgent API or NIC programming status to be passed in the SwiftV2 create NC request.
 	resp := service.getAllNetworkContainerResponses(cnsRequest) //nolint:contextcheck // not passed in any methods, appease linter
 	// return err if returned list has no NCs
 	if len(resp) == 0 {
@@ -143,6 +147,7 @@ func (service *HTTPRestService) requestIPConfigHandlerHelperStandalone(ctx conte
 		}, ErrGetAllNCResponseEmpty
 	}
 
+	// assign NICType and MAC Address for SwiftV2. we assume that there won't be any SwiftV1 NCs here
 	podIPInfoList := make([]cns.PodIpInfo, 0, len(resp))
 	for i := range resp {
 		podIPInfo := cns.PodIpInfo{

--- a/cns/restserver/ipam_test.go
+++ b/cns/restserver/ipam_test.go
@@ -70,13 +70,13 @@ type ncState struct {
 	ips  []string
 }
 
-func getTestService() *HTTPRestService {
+func getTestService(orchestratorType string) *HTTPRestService {
 	var config common.ServiceConfig
 	httpsvc, _ := NewHTTPRestService(&config, &fakes.WireserverClientFake{}, &fakes.WireserverProxyFake{},
 		&fakes.NMAgentClientFake{}, store.NewMockStore(""), nil, nil,
 		fakes.NewMockIMDSClient())
 	svc = httpsvc
-	setOrchestratorTypeInternal(cns.KubernetesCRD)
+	setOrchestratorTypeInternal(orchestratorType)
 
 	return httpsvc
 }
@@ -207,7 +207,7 @@ func TestEndpointStateReadAndWriteMultipleNCs(t *testing.T) {
 
 // Tests the creation of an endpoint using the NCs and IPs as input and then tests the deletion of that endpoint
 func EndpointStateReadAndWrite(t *testing.T, ncStates []ncState) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 	ipconfigs := make(map[string]cns.IPConfigurationStatus, 0)
 	for i := range ncStates {
 		state := NewPodState(ncStates[i].ips[0], ipIDs[i][0], ncStates[i].ncID, types.Available, 0)
@@ -310,7 +310,7 @@ func TestIPAMGetAvailableIPConfigMultipleNCs(t *testing.T) {
 
 // Add one IP per NC to the pool and request those IPs
 func IPAMGetAvailableIPConfig(t *testing.T, ncStates []ncState) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 
 	for i := range ncStates {
 		ipconfigs := make(map[string]cns.IPConfigurationStatus, 0)
@@ -389,7 +389,7 @@ func TestIPAMGetNextAvailableIPConfigMultipleNCs(t *testing.T) {
 
 // First IP is already assigned to a pod, want second IP
 func IPAMGetNextAvailableIPConfig(t *testing.T, ncStates []ncState) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 
 	// Add already assigned pod ip to state
 	for i := range ncStates {
@@ -468,7 +468,7 @@ func TestIPAMGetAlreadyAssignedIPConfigForSamePodMultipleNCs(t *testing.T) {
 }
 
 func IPAMGetAlreadyAssignedIPConfigForSamePod(t *testing.T, ncStates []ncState) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 
 	// Add Assigned Pod IP to state
 	for i := range ncStates {
@@ -546,7 +546,7 @@ func TestIPAMAttemptToRequestIPNotFoundInPoolMultipleNCs(t *testing.T) {
 }
 
 func IPAMAttemptToRequestIPNotFoundInPool(t *testing.T, ncStates []ncState) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 
 	// Add Available Pod IP to state
 	for i := range ncStates {
@@ -606,7 +606,7 @@ func TestIPAMGetDesiredIPConfigWithSpecfiedIPMultipleNCs(t *testing.T) {
 }
 
 func IPAMGetDesiredIPConfigWithSpecfiedIP(t *testing.T, ncStates []ncState) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 
 	// Add Available Pod IP to state
 	for i := range ncStates {
@@ -685,7 +685,7 @@ func TestIPAMFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIPMultipleNCs(t 
 }
 
 func IPAMFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIP(t *testing.T, ncStates []ncState) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 
 	// set state as already assigned
 	ipconfigs := make(map[string]cns.IPConfigurationStatus, 0)
@@ -749,7 +749,7 @@ func TestIPAMFailToGetIPWhenAllIPsAreAssignedMultipleNCs(t *testing.T) {
 }
 
 func IPAMFailToGetIPWhenAllIPsAreAssigned(t *testing.T, ncStates []ncState) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 
 	ipconfigs := make(map[string]cns.IPConfigurationStatus, 0)
 	// Add already assigned pod ip to state
@@ -810,7 +810,7 @@ func TestIPAMRequestThenReleaseThenRequestAgainMultipleNCs(t *testing.T) {
 // Release PodInfo1
 // Request 10.0.0.1 with PodInfo2 (Success)
 func IPAMRequestThenReleaseThenRequestAgain(t *testing.T, ncStates []ncState) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 
 	// set state as already assigned
 	for i := range ncStates {
@@ -915,7 +915,7 @@ func TestIPAMReleaseIPIdempotencyMultipleNCs(t *testing.T) {
 }
 
 func IPAMReleaseIPIdempotency(t *testing.T, ncStates []ncState) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 	// set state as already assigned
 	ipconfigs := make(map[string]cns.IPConfigurationStatus, 0)
 	for i := range ncStates {
@@ -971,7 +971,7 @@ func TestIPAMAllocateIPIdempotencyMultipleNCs(t *testing.T) {
 }
 
 func IPAMAllocateIPIdempotency(t *testing.T, ncStates []ncState) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 	// set state as already assigned
 	ipconfigs := make(map[string]cns.IPConfigurationStatus, 0)
 	for i := range ncStates {
@@ -1026,7 +1026,7 @@ func TestAvailableIPConfigsMultipleNCs(t *testing.T) {
 }
 
 func AvailableIPConfigs(t *testing.T, ncStates []ncState) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 
 	IDsToBeDeleted := make([]string, len(ncStates))
 	ipconfigs := make(map[string]cns.IPConfigurationStatus, 0)
@@ -1139,7 +1139,7 @@ func TestIPAMMarkIPCountAsPendingMultipleNCs(t *testing.T) {
 }
 
 func IPAMMarkIPCountAsPending(t *testing.T, ncStates []ncState) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 	// set state as already assigned
 	ipconfigs := make(map[string]cns.IPConfigurationStatus, 0)
 	for i := range ncStates {
@@ -1188,7 +1188,7 @@ func IPAMMarkIPCountAsPending(t *testing.T, ncStates []ncState) {
 }
 
 func TestIPAMMarkIPAsPendingWithPendingProgrammingIPs(t *testing.T) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 
 	secondaryIPConfigs := make(map[string]cns.SecondaryIPConfig)
 	// Default Programmed NC version is -1, set nc version as 0 will result in pending programming state.
@@ -1301,7 +1301,7 @@ func TestIPAMMarkExistingIPConfigAsPendingMultipleNCs(t *testing.T) {
 }
 
 func IPAMMarkExistingIPConfigAsPending(t *testing.T, ncStates []ncState) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 
 	// Add already assigned pod ip to state
 	for i := range ncStates {
@@ -1363,7 +1363,7 @@ func IPAMMarkExistingIPConfigAsPending(t *testing.T, ncStates []ncState) {
 }
 
 func TestIPAMFailToRequestIPsWithNoNCsSpecificIP(t *testing.T) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 	req := cns.IPConfigsRequest{
 		PodInterfaceID:   testPod1Info.InterfaceID(),
 		InfraContainerID: testPod1Info.InfraContainerID(),
@@ -1381,7 +1381,7 @@ func TestIPAMFailToRequestIPsWithNoNCsSpecificIP(t *testing.T) {
 }
 
 func TestIPAMFailToRequestIPsWithNoNCsAnyIP(t *testing.T) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 	req := cns.IPConfigsRequest{
 		PodInterfaceID:   testPod1Info.InterfaceID(),
 		InfraContainerID: testPod1Info.InfraContainerID(),
@@ -1397,7 +1397,7 @@ func TestIPAMFailToRequestIPsWithNoNCsAnyIP(t *testing.T) {
 }
 
 func TestIPAMReleaseOneIPWhenExpectedToHaveTwo(t *testing.T) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 
 	// set state as already assigned
 	testState, _ := NewPodStateWithOrchestratorContext(testIP1, testPod1GUID, testNCID, types.Assigned, 24, 0, testPod1Info)
@@ -1427,7 +1427,7 @@ func TestIPAMReleaseOneIPWhenExpectedToHaveTwo(t *testing.T) {
 }
 
 func TestIPAMFailToRequestOneIPWhenExpectedToHaveTwo(t *testing.T) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 
 	// set state as already assigned
 	testState := NewPodState(testIP1, ipIDs[0][0], testNCID, types.Available, 0)
@@ -1463,7 +1463,7 @@ func TestIPAMFailToRequestOneIPWhenExpectedToHaveTwo(t *testing.T) {
 }
 
 func TestIPAMFailToReleasePartialIPsInPool(t *testing.T) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 
 	// set state as already assigned
 	testState, _ := NewPodStateWithOrchestratorContext(testIP1, testIPID1, testNCID, types.Assigned, 24, 0, testPod1Info)
@@ -1493,7 +1493,7 @@ func TestIPAMFailToReleasePartialIPsInPool(t *testing.T) {
 }
 
 func TestIPAMFailToRequestPartialIPsInPool(t *testing.T) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 
 	// set state as already assigned
 	testState := NewPodState(testIP1, testIPID1, testNCID, types.Available, 0)
@@ -1533,7 +1533,7 @@ func TestIPAMFailToRequestPartialIPsInPool(t *testing.T) {
 }
 
 func TestIPAMReleaseSWIFTV2PodIPSuccess(t *testing.T) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 	middleware := middlewares.K8sSWIFTv2Middleware{Cli: mock.NewClient()}
 	svc.AttachIPConfigsHandlerMiddleware(&middleware)
 
@@ -1584,7 +1584,7 @@ func TestIPAMReleaseSWIFTV2PodIPSuccess(t *testing.T) {
 }
 
 func TestIPAMGetK8sSWIFTv2IPSuccess(t *testing.T) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 	middleware := middlewares.K8sSWIFTv2Middleware{Cli: mock.NewClient()}
 	svc.AttachIPConfigsHandlerMiddleware(&middleware)
 
@@ -1647,7 +1647,7 @@ func TestIPAMGetK8sSWIFTv2IPSuccess(t *testing.T) {
 }
 
 func TestIPAMGetK8sSWIFTv2IPFailure(t *testing.T) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 	middleware := middlewares.K8sSWIFTv2Middleware{Cli: mock.NewClient()}
 	svc.AttachIPConfigsHandlerMiddleware(&middleware)
 	ncStates := []ncState{
@@ -1717,7 +1717,7 @@ func TestIPAMGetK8sSWIFTv2IPFailure(t *testing.T) {
 }
 
 func TestIPAMGetK8sInfinibandSuccess(t *testing.T) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 	middleware := middlewares.K8sSWIFTv2Middleware{Cli: mock.NewClient()}
 	svc.AttachIPConfigsHandlerMiddleware(&middleware)
 	updatePnpIDMacAddressState(svc)
@@ -1782,7 +1782,7 @@ func TestIPAMGetK8sInfinibandSuccess(t *testing.T) {
 
 // Test intednd to check for on single backend nic without the delegaed nic
 func TestIPAMGetK8sInfinibandSuccessOneNic(t *testing.T) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 	middleware := middlewares.K8sSWIFTv2Middleware{Cli: mock.NewClient()}
 	svc.AttachIPConfigsHandlerMiddleware(&middleware)
 	updatePnpIDMacAddressState(svc)
@@ -1842,7 +1842,7 @@ func TestIPAMGetK8sInfinibandSuccessOneNic(t *testing.T) {
 }
 
 func TestIPAMGetK8sInfinibandFailure(t *testing.T) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 	middleware := middlewares.K8sSWIFTv2Middleware{Cli: mock.NewClient()}
 	svc.AttachIPConfigsHandlerMiddleware(&middleware)
 	updatePnpIDMacAddressState(svc)

--- a/cns/restserver/ipam_test.go
+++ b/cns/restserver/ipam_test.go
@@ -1921,9 +1921,10 @@ func TestIPAMGetStandaloneSWIFTv2(t *testing.T) {
 			},
 			mockNMAgent: &fakes.NMAgentClientFake{
 				GetNCVersionListF: func(_ context.Context) (nma.NCVersionList, error) {
+					// NMAgent returns an error, eg. NC is not programmed
 					return nma.NCVersionList{
 						Containers: []nma.NCVersion{},
-					}, errors.New("error")
+					}, errors.New("any NMAgent error")
 				},
 			},
 			expectedResponse: &cns.IPConfigsResponse{
@@ -1962,6 +1963,7 @@ func TestIPAMGetStandaloneSWIFTv2(t *testing.T) {
 			},
 			mockNMAgent: &fakes.NMAgentClientFake{
 				GetNCVersionListF: func(_ context.Context) (nma.NCVersionList, error) {
+					// NMAgent returns an empty response with no error
 					return nma.NCVersionList{
 						Containers: []nma.NCVersion{},
 					}, nil
@@ -2003,6 +2005,7 @@ func TestIPAMGetStandaloneSWIFTv2(t *testing.T) {
 			},
 			mockNMAgent: &fakes.NMAgentClientFake{
 				GetNCVersionListF: func(_ context.Context) (nma.NCVersionList, error) {
+					// NMAgent returns an NC even if it's not programmed
 					return nma.NCVersionList{
 						Containers: []nma.NCVersion{
 							{
@@ -2070,12 +2073,7 @@ func TestIPAMGetStandaloneSWIFTv2(t *testing.T) {
 				assert.Equal(t, expected.MacAddress, actualPodIPInfo[i].MacAddress)
 				assert.Equal(t, expected.NICType, actualPodIPInfo[i].NICType)
 
-				// assert that PodIPInfo contains HostIPInfo
-				assert.Equal(t, expected.HostPrimaryIPInfo.Gateway, actualPodIPInfo[i].HostPrimaryIPInfo.Gateway)
-				assert.Equal(t, expected.HostPrimaryIPInfo.PrimaryIP, actualPodIPInfo[i].HostPrimaryIPInfo.PrimaryIP)
-				assert.Equal(t, expected.HostPrimaryIPInfo.Subnet, actualPodIPInfo[i].HostPrimaryIPInfo.Subnet)
-			}
-
+					// assert that PodIPInfo contains interface information
 		})
 	}
 }

--- a/cns/restserver/util_test.go
+++ b/cns/restserver/util_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-container-networking/cns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -163,7 +164,7 @@ func TestDeleteNCs(t *testing.T) {
 }
 
 func TestGetPnpIDMapping(t *testing.T) {
-	svc := getTestService()
+	svc := getTestService(cns.KubernetesCRD)
 	svc.state.PnpIDByMacAddress = map[string]string{
 		"macaddress1": "value1",
 	}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

This adds unit tests for PR #2634 for Standalone SwiftV2.


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [x] relevant PR labels added

**Notes**: 
- This implementation has some assumptions being made with NC programming on NMAgent that will be addressed in a future PR, once NMagent exposes an API to query for NIC programming.
