### PR TITLE
Revert "fix: Modified the value of DelegatedVMNIC to resolve compatibility issue in Version 1.5"

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -79,7 +79,7 @@ type NICType string
 const (
 	InfraNIC NICType = "InfraNIC"
 	// DelegatedVMNIC are projected from VM to container network namespace
-	DelegatedVMNIC NICType = "DelegatedVMNIC"
+	DelegatedVMNIC NICType = "FrontendNIC"
 	// BackendNIC are used for infiniband NICs on a VM
 	BackendNIC NICType = "BackendNIC"
 	// NodeNetworkInterfaceAccelnetFrontendNIC is a type of front-end nic that offers accelerated networking performance


### PR DESCRIPTION
Reverts Azure/azure-container-networking#2808
breaks changes in 1.5.32 release rollout due to accelnet not being fully supported. 