### PR TITLE
ci: remove logger field from portforwarder to avoid race with goroutine

### DIFF
--- a/test/e2e/framework/kubernetes/port-forward.go
+++ b/test/e2e/framework/kubernetes/port-forward.go
@@ -86,7 +86,7 @@ func (p *PortForward) Run() error {
 
 		log.Printf("attempting port forward to pod name \"%s\" with label \"%s\", in namespace \"%s\"...\n", targetPodName, p.LabelSelector, p.Namespace)
 
-		p.pf, err = k8s.NewPortForwarder(config, &logger{}, opts)
+		p.pf, err = k8s.NewPortForwarder(config, opts)
 		if err != nil {
 			return fmt.Errorf("could not create port forwarder: %w", err)
 		}
@@ -160,10 +160,4 @@ func (p *PortForward) Prevalidate() error {
 func (p *PortForward) Stop() error {
 	p.pf.Stop()
 	return nil
-}
-
-type logger struct{}
-
-func (l *logger) Logf(format string, args ...interface{}) {
-	log.Printf(format, args...)
 }

--- a/test/integration/datapath/datapath_linux_test.go
+++ b/test/integration/datapath/datapath_linux_test.go
@@ -221,7 +221,7 @@ func TestDatapathLinux(t *testing.T) {
 				DestPort:      8080,
 			}
 
-			pf, err := k8s.NewPortForwarder(restConfig, t, pfOpts)
+			pf, err := k8s.NewPortForwarder(restConfig, pfOpts)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/test/integration/k8s_test.go
+++ b/test/integration/k8s_test.go
@@ -174,7 +174,7 @@ func TestPodScaling(t *testing.T) {
 			}
 
 			pingCheckFn := func() error {
-				pf, err := NewPortForwarder(restConfig, t, pfOpts)
+				pf, err := NewPortForwarder(restConfig, pfOpts)
 				if err != nil {
 					t.Fatalf("could not build port forwarder: %v", err)
 				}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
When running pipelines, we pass the testing object into the port forwarder struct. Then, we spawn a go routine and from within it, call the test's logger. This causes a data race in the unit tests, which causes various scenarios to flake. The testing logger is not thread safe and should not be called from within a go routine. Instead, this PR modifies these log statements to use the "log" package, which is thread safe, to log messages from the port forwarding file.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
Ran the cni release pipeline (where this issue was detected) three times, and the data race error has not shown up.