### PR TITLE
Removed os.Exec'ing code

### DIFF
--- a/platform/osRegistryInterface.go
+++ b/platform/osRegistryInterface.go
@@ -1,0 +1,46 @@
+//go:build windows
+// +build windows
+
+package platform
+
+import "golang.org/x/sys/windows/registry"
+
+// Registry interface for interacting with the Windows registry
+type Registry interface {
+	OpenKey(k registry.Key, path string, access uint32) (RegistryKey, error)
+}
+
+// RegistryKey interface to represent an open registry key
+type RegistryKey interface {
+	GetStringValue(name string) (string, uint32, error)
+	SetStringValue(name, value string) error
+	Close() error
+}
+
+type WindowsRegistry struct{}
+
+// WindowsRegistryKey implements the RegistryKey interface
+type WindowsRegistryKey struct {
+	key registry.Key
+}
+
+func (r *WindowsRegistry) OpenKey(k registry.Key, path string, access uint32) (RegistryKey, error) {
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE, path, access)
+	if err != nil {
+		return nil, err
+	}
+	return &WindowsRegistryKey{key}, nil
+}
+
+func (k *WindowsRegistryKey) GetStringValue(name string) (val string, valtype uint32, err error) {
+	value, valType, err := k.key.GetStringValue(name)
+	return value, valType, err
+}
+
+func (k *WindowsRegistryKey) SetStringValue(name, value string) error {
+	return k.key.SetStringValue(name, value)
+}
+
+func (k *WindowsRegistryKey) Close() error {
+	return k.key.Close()
+}

--- a/platform/os_windows.go
+++ b/platform/os_windows.go
@@ -20,6 +20,9 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/mgr"
 )
 
 const (
@@ -61,23 +64,11 @@ const (
 	// for vlan tagged arp requests
 	SDNRemoteArpMacAddress = "12-34-56-78-9a-bc"
 
-	// Command to get SDNRemoteArpMacAddress registry key
-	GetSdnRemoteArpMacAddressCommand = "(Get-ItemProperty " +
-		"-Path HKLM:\\SYSTEM\\CurrentControlSet\\Services\\hns\\State -Name SDNRemoteArpMacAddress).SDNRemoteArpMacAddress"
-
-	// Command to set SDNRemoteArpMacAddress registry key
-	SetSdnRemoteArpMacAddressCommand = "Set-ItemProperty " +
-		"-Path HKLM:\\SYSTEM\\CurrentControlSet\\Services\\hns\\State -Name SDNRemoteArpMacAddress -Value \"12-34-56-78-9a-bc\""
-
-	// Command to check if system has hns state path or not
-	CheckIfHNSStatePathExistsCommand = "Test-Path " +
-		"-Path HKLM:\\SYSTEM\\CurrentControlSet\\Services\\hns\\State"
-
 	// Command to fetch netadapter and pnp id
+	//TODO can we replace this (and things in endpoint_windows) with "golang.org/x/sys/windows"
+	//var adapterInfo windows.IpAdapterInfo
+	//var bufferSize uint32 = uint32(unsafe.Sizeof(adapterInfo))
 	GetMacAddressVFPPnpIDMapping = "Get-NetAdapter | Select-Object MacAddress, PnpDeviceID| Format-Table -HideTableHeaders"
-
-	// Command to restart HNS service
-	RestartHnsServiceCommand = "Restart-Service -Name hns"
 
 	// Interval between successive checks for mellanox adapter's PriorityVLANTag value
 	defaultMellanoxMonitorInterval = 30 * time.Second
@@ -257,38 +248,89 @@ func (p *execClient) ExecutePowershellCommandWithContext(ctx context.Context, co
 }
 
 // SetSdnRemoteArpMacAddress sets the regkey for SDNRemoteArpMacAddress needed for multitenancy if hns is enabled
-func SetSdnRemoteArpMacAddress(execClient ExecClient) error {
-	exists, err := execClient.ExecutePowershellCommand(CheckIfHNSStatePathExistsCommand)
+func SetSdnRemoteArpMacAddress(reg Registry) error {
+	key, err := reg.OpenKey(registry.LOCAL_MACHINE, "SYSTEM\\CurrentControlSet\\Services\\hns\\State", registry.READ|registry.SET_VALUE)
 	if err != nil {
+		if err == registry.ErrNotExist {
+			log.Printf("hns state path does not exist, skip setting SdnRemoteArpMacAddress")
+			return nil
+		}
 		errMsg := fmt.Sprintf("Failed to check the existent of hns state path due to error %s", err.Error())
 		log.Printf(errMsg)
 		return errors.Errorf(errMsg)
 	}
-	if strings.EqualFold(exists, "false") {
-		log.Printf("hns state path does not exist, skip setting SdnRemoteArpMacAddress")
-		return nil
-	}
+
 	if sdnRemoteArpMacAddressSet == false {
-		result, err := execClient.ExecutePowershellCommand(GetSdnRemoteArpMacAddressCommand)
+
+		//Was (Get-ItemProperty -Path HKLM:\\SYSTEM\\CurrentControlSet\\Services\\hns\\State -Name SDNRemoteArpMacAddress).SDNRemoteArpMacAddress"
+		result, _, err := key.GetStringValue("SDNRemoteArpMacAddress")
 		if err != nil {
 			return err
 		}
 
 		// Set the reg key if not already set or has incorrect value
 		if result != SDNRemoteArpMacAddress {
-			if _, err = execClient.ExecutePowershellCommand(SetSdnRemoteArpMacAddressCommand); err != nil {
+
+			//was "Set-ItemProperty -Path HKLM:\\SYSTEM\\CurrentControlSet\\Services\\hns\\State -Name SDNRemoteArpMacAddress -Value \"12-34-56-78-9a-bc\""
+
+			if err := key.SetStringValue("SDNRemoteArpMacAddress", SDNRemoteArpMacAddress); err != nil {
 				log.Printf("Failed to set SDNRemoteArpMacAddress due to error %s", err.Error())
 				return err
 			}
-
 			log.Printf("[Azure CNS] SDNRemoteArpMacAddress regKey set successfully. Restarting hns service.")
-			if _, err := execClient.ExecutePowershellCommand(RestartHnsServiceCommand); err != nil {
+
+			//	was "Restart-Service -Name hns"
+			if err := restartService("hns"); err != nil {
 				log.Printf("Failed to Restart HNS Service due to error %s", err.Error())
 				return err
 			}
 		}
 
 		sdnRemoteArpMacAddressSet = true
+	}
+
+	return nil
+}
+
+// straight out of chat gpt
+func restartService(serviceName string) error {
+	// Connect to the service manager
+	m, err := mgr.Connect()
+	if err != nil {
+		return fmt.Errorf("could not connect to service manager: %v", err)
+	}
+	defer m.Disconnect()
+
+	// Open the service by name
+	service, err := m.OpenService(serviceName)
+	if err != nil {
+		return fmt.Errorf("could not access service: %v", err)
+	}
+	defer service.Close()
+
+	// Stop the service
+	_, err = service.Control(svc.Stop)
+	if err != nil {
+		return fmt.Errorf("could not stop service: %v", err)
+	}
+
+	// Wait for the service to stop
+	status, err := service.Query()
+	if err != nil {
+		return fmt.Errorf("could not query service status: %v", err)
+	}
+	for status.State != svc.Stopped {
+		time.Sleep(500 * time.Millisecond)
+		status, err = service.Query()
+		if err != nil {
+			return fmt.Errorf("could not query service status: %v", err)
+		}
+	}
+
+	// Start the service again
+	err = service.Start()
+	if err != nil {
+		return fmt.Errorf("could not start service: %v", err)
 	}
 
 	return nil
@@ -364,6 +406,7 @@ func GetProcessNameByID(pidstr string) (string, error) {
 	pidstr = strings.Trim(pidstr, "\r\n")
 	cmd := fmt.Sprintf("Get-Process -Id %s|Format-List", pidstr)
 	p := NewExecClient(nil)
+	//TODO not riemovign this because it seems to only be called in test?
 	out, err := p.ExecutePowershellCommand(cmd)
 	if err != nil {
 		log.Printf("Process is not running. Output:%v, Error %v", out, err)


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
There was a CRI recently where it appears that when CNS is shelling out to PowerShell, spooling up the whole PowerShell env is quite heavy; thus, we are OOMing the CNS pod. There could be other contributing factors that haven't been identified yet as well.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
This pr gets rid of os.Exec'ing a shell (creating a whole new instance of PowerShell) each time and instead replacing the code with calling into windows registry. 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ X] adds unit tests
- [ ] relevant PR labels added

**Notes**:


Work Item: https://msazure.visualstudio.com/One/_workitems/edit/29254102
