### PR TITLE
fix: [NPM] [Linux] panic if applyIPSets continues to fail

### DIFF
--- a/npm/pkg/dataplane/ipsets/ipsetmanager.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager.go
@@ -51,6 +51,9 @@ type IPSetManager struct {
 	setMap     map[string]*IPSet
 	dirtyCache dirtyCacheInterface
 	ioShim     *common.IOShim
+	// consecutiveApplyFailures is used in Linux to count the number of consecutive failures to apply ipsets
+	// if this count exceeds a threshold, we will panic
+	consecutiveApplyFailures int
 	sync.RWMutex
 }
 
@@ -71,6 +74,8 @@ func NewIPSetManager(iMgrCfg *IPSetManagerCfg, ioShim *common.IOShim) *IPSetMana
 		setMap:     make(map[string]*IPSet),
 		dirtyCache: newDirtyCache(),
 		ioShim:     ioShim,
+		// set to 0 to avoid lint error for windows
+		consecutiveApplyFailures: 0,
 	}
 }
 


### PR DESCRIPTION
**Reason for Change**:
This PR causes NPM to panic/restart if `applyIPSets()` continues to fail, a symptom of non-retriable errors like those in #2963, an issue which is mitigated by an NPM restart. #2480 was another race condition where this logic could have helped (although #2480 was fixed directly in #2841).

**Issue Fixed**:
Fixes #2963 with NPM restart

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:

New panic from the first error to the 100th:
```
E0828 00:46:15.242859       1 dataplane.go:431] [DataPlane] [BACKGROUND] failed to add policies. will retry one policy at a time. err: [DataPlane] [ADD-NETPOL] error while applying IPSets: ipset restore failed when applying ipsets: Operation [RunCommandWithFile] failed with error code [999], full cmd [], full error after 5 tries, failed to run command [ipset restore] with error: error running command [ipset restore] with err [exit status 1] and stdErr [ipset v7.5: Error in line 4: The set with the given name does not exist
]
...
I0828 00:46:39.734773       1 restore.go:188] running this restore command: [ipset restore]
2024/08/28 00:46:39 [1] error: on try number 4, failed to run command [ipset restore]. Rerunning with updated file. err: [line-number error for line [-F azure-npm-3728449650]: error running command [ipset restore] with err [exit status 1] and stdErr [ipset v7.5: Error in line 2: The set with the given name does not exist
]]
2024/08/28 00:46:39 [1] exceeded max consecutive failures (100) when applying ipsets. final error: Operation [RunCommandWithFile] failed with error code [999], full cmd [], full error after 5 tries, failed to run command [ipset restore] with error: error running command [ipset restore] with err [exit status 1] and stdErr [ipset v7.5: Error in line 6: The set with the given name does not exist
]
E0828 00:46:39.736905       1 ipsetmanager_linux.go:419] exceeded max consecutive failures (100) when applying ipsets. final error: Operation [RunCommandWithFile] failed with error code [999], full cmd [], full error after 5 tries, failed to run command [ipset restore] with error: error running command [ipset restore] with err [exit status 1] and stdErr [ipset v7.5: Error in line 6: The set with the given name does not exist
]
panic: exceeded max consecutive failures (100) when applying ipsets. final error: Operation [RunCommandWithFile] failed with error code [999], full cmd [], full error after 5 tries, failed to run command [ipset restore] with error: error running command [ipset restore] with err [exit status 1] and stdErr [ipset v7.5: Error in line 6: The set with the given name does not exist
]

goroutine 26 [running]:
github.com/Azure/azure-container-networking/npm/pkg/dataplane/ipsets.(*IPSetManager).applyIPSets(0xc0002a9a90)
        /usr/local/src/npm/pkg/dataplane/ipsets/ipsetmanager_linux.go:421 +0x285
github.com/Azure/azure-container-networking/npm/pkg/dataplane/ipsets.(*IPSetManager).ApplyIPSets(0xc0002a9a90)
        /usr/local/src/npm/pkg/dataplane/ipsets/ipsetmanager.go:467 +0x1ec
github.com/Azure/azure-container-networking/npm/pkg/dataplane.(*DataPlane).applyDataPlaneNow(0xc0001b0b80, {0x1d36b9d, 0xa})
        /usr/local/src/npm/pkg/dataplane/dataplane.go:331 +0xa5
github.com/Azure/azure-container-networking/npm/pkg/dataplane.(*DataPlane).addPolicies(0xc0001b0b80, {0xc00045b638?, 0x1, 0x1})
        /usr/local/src/npm/pkg/dataplane/dataplane.go:518 +0x5be
github.com/Azure/azure-container-networking/npm/pkg/dataplane.(*DataPlane).addPoliciesWithRetry(0xc0001b0b80, {0x1d36b93, 0xa})
        /usr/local/src/npm/pkg/dataplane/dataplane.go:423 +0x1f2
github.com/Azure/azure-container-networking/npm/pkg/dataplane.(*DataPlane).RunPeriodicTasks.func2()
        /usr/local/src/npm/pkg/dataplane/dataplane.go:188 +0x149
created by github.com/Azure/azure-container-networking/npm/pkg/dataplane.(*DataPlane).RunPeriodicTasks in goroutine 1
        /usr/local/src/npm/pkg/dataplane/dataplane.go:170 +0x9f
```