### PR TITLE
fix: add legacy IPAM metrics back to IPAMv2

### DIFF
--- a/cns/ipampool/metrics/metrics.go
+++ b/cns/ipampool/metrics/metrics.go
@@ -1,4 +1,4 @@
-package ipampool
+package metrics
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
@@ -6,12 +6,12 @@ import (
 )
 
 const (
-	subnetLabel                = "subnet"
-	subnetCIDRLabel            = "subnet_cidr"
-	podnetARMIDLabel           = "podnet_arm_id"
+	SubnetLabel                = "subnet"
+	SubnetCIDRLabel            = "subnet_cidr"
+	PodnetARMIDLabel           = "podnet_arm_id"
 	customerMetricLabel        = "customer_metric"
 	customerMetricLabelValue   = "customer metric"
-	subnetExhaustionStateLabel = "subnet_exhaustion_state"
+	SubnetExhaustionStateLabel = "subnet_exhaustion_state"
 	SubnetIPExhausted          = 1
 	SubnetIPNotExhausted       = 0
 )
@@ -23,7 +23,7 @@ var (
 			Help:        "IPs currently in use by Pods on this CNS Node.",
 			ConstLabels: prometheus.Labels{customerMetricLabel: customerMetricLabelValue},
 		},
-		[]string{subnetLabel, subnetCIDRLabel, podnetARMIDLabel},
+		[]string{SubnetLabel, SubnetCIDRLabel, PodnetARMIDLabel},
 	)
 	IpamAvailableIPCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -31,7 +31,7 @@ var (
 			Help:        "IPs available on this CNS Node for use by a Pod.",
 			ConstLabels: prometheus.Labels{customerMetricLabel: customerMetricLabelValue},
 		},
-		[]string{subnetLabel, subnetCIDRLabel, podnetARMIDLabel},
+		[]string{SubnetLabel, SubnetCIDRLabel, PodnetARMIDLabel},
 	)
 	IpamBatchSize = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -39,7 +39,7 @@ var (
 			Help:        "IPAM IP pool scaling batch size.",
 			ConstLabels: prometheus.Labels{customerMetricLabel: customerMetricLabelValue},
 		},
-		[]string{subnetLabel, subnetCIDRLabel, podnetARMIDLabel},
+		[]string{SubnetLabel, SubnetCIDRLabel, PodnetARMIDLabel},
 	)
 	IpamCurrentAvailableIPcount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -47,7 +47,7 @@ var (
 			Help:        "Current available IP count.",
 			ConstLabels: prometheus.Labels{customerMetricLabel: customerMetricLabelValue},
 		},
-		[]string{subnetLabel, subnetCIDRLabel, podnetARMIDLabel},
+		[]string{SubnetLabel, SubnetCIDRLabel, PodnetARMIDLabel},
 	)
 	IpamExpectedAvailableIPCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -55,7 +55,7 @@ var (
 			Help:        "Expected future available IP count assuming the Requested IP count is honored.",
 			ConstLabels: prometheus.Labels{customerMetricLabel: customerMetricLabelValue},
 		},
-		[]string{subnetLabel, subnetCIDRLabel, podnetARMIDLabel},
+		[]string{SubnetLabel, SubnetCIDRLabel, PodnetARMIDLabel},
 	)
 	IpamMaxIPCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -63,7 +63,7 @@ var (
 			Help:        "Maximum Secondary IPs allowed on this Node.",
 			ConstLabels: prometheus.Labels{customerMetricLabel: customerMetricLabelValue},
 		},
-		[]string{subnetLabel, subnetCIDRLabel, podnetARMIDLabel},
+		[]string{SubnetLabel, SubnetCIDRLabel, PodnetARMIDLabel},
 	)
 	IpamPendingProgramIPCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -71,7 +71,7 @@ var (
 			Help:        "IPs reserved but not yet available (Pending Programming).",
 			ConstLabels: prometheus.Labels{customerMetricLabel: customerMetricLabelValue},
 		},
-		[]string{subnetLabel, subnetCIDRLabel, podnetARMIDLabel},
+		[]string{SubnetLabel, SubnetCIDRLabel, PodnetARMIDLabel},
 	)
 	IpamPendingReleaseIPCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -79,7 +79,7 @@ var (
 			Help:        "IPs reserved but not available anymore (Pending Release).",
 			ConstLabels: prometheus.Labels{customerMetricLabel: customerMetricLabelValue},
 		},
-		[]string{subnetLabel, subnetCIDRLabel, podnetARMIDLabel},
+		[]string{SubnetLabel, SubnetCIDRLabel, PodnetARMIDLabel},
 	)
 	IpamPrimaryIPCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -87,7 +87,7 @@ var (
 			Help:        "NC Primary IP count (reserved from Pod Subnet for DNS and IMDS SNAT).",
 			ConstLabels: prometheus.Labels{customerMetricLabel: customerMetricLabelValue},
 		},
-		[]string{subnetLabel, subnetCIDRLabel, podnetARMIDLabel},
+		[]string{SubnetLabel, SubnetCIDRLabel, PodnetARMIDLabel},
 	)
 	IpamRequestedIPConfigCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -95,7 +95,7 @@ var (
 			Help:        "Secondary Pod Subnet IPs requested by this CNS Node (for Pods).",
 			ConstLabels: prometheus.Labels{customerMetricLabel: customerMetricLabelValue},
 		},
-		[]string{subnetLabel, subnetCIDRLabel, podnetARMIDLabel},
+		[]string{SubnetLabel, SubnetCIDRLabel, PodnetARMIDLabel},
 	)
 	IpamSecondaryIPCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -103,7 +103,7 @@ var (
 			Help:        "Node NC Secondary IP count (reserved usable by Pods).",
 			ConstLabels: prometheus.Labels{customerMetricLabel: customerMetricLabelValue},
 		},
-		[]string{subnetLabel, subnetCIDRLabel, podnetARMIDLabel},
+		[]string{SubnetLabel, SubnetCIDRLabel, PodnetARMIDLabel},
 	)
 	IpamTotalIPCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -111,7 +111,7 @@ var (
 			Help:        "Count of total IP pool size allocated to CNS by DNC.",
 			ConstLabels: prometheus.Labels{customerMetricLabel: customerMetricLabelValue},
 		},
-		[]string{subnetLabel, subnetCIDRLabel, podnetARMIDLabel},
+		[]string{SubnetLabel, SubnetCIDRLabel, PodnetARMIDLabel},
 	)
 	IpamSubnetExhaustionState = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -119,14 +119,14 @@ var (
 			Help:        "IPAM view of subnet exhaustion state",
 			ConstLabels: prometheus.Labels{customerMetricLabel: customerMetricLabelValue},
 		},
-		[]string{subnetLabel, subnetCIDRLabel, podnetARMIDLabel},
+		[]string{SubnetLabel, SubnetCIDRLabel, PodnetARMIDLabel},
 	)
 	IpamSubnetExhaustionCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "cx_ipam_subnet_exhaustion_state_count_total",
 			Help: "Count of the number of times the ipam pool monitor sees subnet exhaustion",
 		},
-		[]string{subnetLabel, subnetCIDRLabel, podnetARMIDLabel, subnetExhaustionStateLabel},
+		[]string{SubnetLabel, SubnetCIDRLabel, PodnetARMIDLabel, SubnetExhaustionStateLabel},
 	)
 )
 
@@ -147,25 +147,4 @@ func init() {
 		IpamSubnetExhaustionState,
 		IpamSubnetExhaustionCount,
 	)
-}
-
-func observeIPPoolState(state ipPoolState, meta metaState) {
-	labels := []string{meta.subnet, meta.subnetCIDR, meta.subnetARMID}
-	IpamAllocatedIPCount.WithLabelValues(labels...).Set(float64(state.allocatedToPods))
-	IpamAvailableIPCount.WithLabelValues(labels...).Set(float64(state.available))
-	IpamBatchSize.WithLabelValues(labels...).Set(float64(meta.batch))
-	IpamCurrentAvailableIPcount.WithLabelValues(labels...).Set(float64(state.currentAvailableIPs))
-	IpamExpectedAvailableIPCount.WithLabelValues(labels...).Set(float64(state.expectedAvailableIPs))
-	IpamMaxIPCount.WithLabelValues(labels...).Set(float64(meta.max))
-	IpamPendingProgramIPCount.WithLabelValues(labels...).Set(float64(state.pendingProgramming))
-	IpamPendingReleaseIPCount.WithLabelValues(labels...).Set(float64(state.pendingRelease))
-	IpamPrimaryIPCount.WithLabelValues(labels...).Set(float64(len(meta.primaryIPAddresses)))
-	IpamRequestedIPConfigCount.WithLabelValues(labels...).Set(float64(state.requestedIPs))
-	IpamSecondaryIPCount.WithLabelValues(labels...).Set(float64(state.secondaryIPs))
-	IpamTotalIPCount.WithLabelValues(labels...).Set(float64(state.secondaryIPs + int64(len(meta.primaryIPAddresses))))
-	if meta.exhausted {
-		IpamSubnetExhaustionState.WithLabelValues(labels...).Set(float64(SubnetIPExhausted))
-	} else {
-		IpamSubnetExhaustionState.WithLabelValues(labels...).Set(float64(SubnetIPNotExhausted))
-	}
 }

--- a/cns/ipampool/metrics/observer.go
+++ b/cns/ipampool/metrics/observer.go
@@ -1,0 +1,157 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/types"
+	"github.com/Azure/azure-container-networking/crd/clustersubnetstate/api/v1alpha1"
+	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
+	"github.com/pkg/errors"
+)
+
+// Subnet ARM ID /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/$(SUBNET)
+const subnetARMIDTemplate = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/%s/subnets/%s"
+
+// ipPoolState is the current actual state of the CNS IP pool.
+type ipPoolState struct {
+	// allocatedToPods are the IPs CNS gives to Pods.
+	allocatedToPods int64
+	// available are the IPs in state "Available".
+	available int64
+	// currentAvailableIPs are the current available IPs: allocated - assigned - pendingRelease.
+	currentAvailableIPs int64
+	// expectedAvailableIPs are the "future" available IPs, if the requested IP count is honored: requested - assigned.
+	expectedAvailableIPs int64
+	// pendingProgramming are the IPs in state "PendingProgramming".
+	pendingProgramming int64
+	// pendingRelease are the IPs in state "PendingRelease".
+	pendingRelease int64
+	// requestedIPs are the IPs CNS has requested that it be allocated by DNC.
+	requestedIPs int64
+	// secondaryIPs are all the IPs given to CNS by DNC, not including the primary IP of the NC.
+	secondaryIPs int64
+}
+
+// metaState is the Monitor's configuration state for the IP pool.
+type metaState struct {
+	batch              int64
+	exhausted          bool
+	max                int64
+	primaryIPAddresses map[string]struct{}
+	subnet             string
+	subnetARMID        string
+	subnetCIDR         string
+}
+
+// NewLegacyMetricsObserver creates a closed functional scope which can be invoked to
+// observe the legacy IPAM pool metrics.
+//
+//nolint:lll // ignore line length
+func NewLegacyMetricsObserver(ctx context.Context, ipcli func() map[string]cns.IPConfigurationStatus, nnccli func(context.Context) (*v1alpha.NodeNetworkConfig, error), csscli func(context.Context) ([]v1alpha1.ClusterSubnetState, error)) func() error {
+	return func() error {
+		return observeMetrics(ctx, ipcli, nnccli, csscli)
+	}
+}
+
+// generateARMID uses the Subnet ARM ID format to populate the ARM ID with the metadata.
+// If either of the metadata attributes are empty, then the ARM ID will be an empty string.
+func generateARMID(nc *v1alpha.NetworkContainer) string {
+	subscription := nc.SubscriptionID
+	resourceGroup := nc.ResourceGroupID
+	vnetID := nc.VNETID
+	subnetID := nc.SubnetID
+
+	if subscription == "" || resourceGroup == "" || vnetID == "" || subnetID == "" {
+		return ""
+	}
+	return fmt.Sprintf(subnetARMIDTemplate, subscription, resourceGroup, vnetID, subnetID)
+}
+
+// observeMetrics observes the IP pool and updates the metrics. Blocking.
+//
+//nolint:lll // ignore line length
+func observeMetrics(ctx context.Context, ipcli func() map[string]cns.IPConfigurationStatus, nnccli func(context.Context) (*v1alpha.NodeNetworkConfig, error), csscli func(context.Context) ([]v1alpha1.ClusterSubnetState, error)) error {
+	csslist, err := csscli(ctx)
+	if err != nil {
+		return err
+	}
+	nnc, err := nnccli(ctx)
+	if err != nil {
+		return err
+	}
+	ips := ipcli()
+
+	var meta metaState
+	for i := range csslist {
+		if csslist[i].Status.Exhausted {
+			meta.exhausted = true
+			break
+		}
+	}
+	if len(nnc.Status.NetworkContainers) > 0 {
+		// Set SubnetName, SubnetAddressSpace and Pod Network ARM ID values to the global subnet, subnetCIDR and subnetARM variables.
+		meta.subnet = nnc.Status.NetworkContainers[0].SubnetName
+		meta.subnetCIDR = nnc.Status.NetworkContainers[0].SubnetAddressSpace
+		meta.subnetARMID = generateARMID(&nnc.Status.NetworkContainers[0])
+	}
+	meta.primaryIPAddresses = make(map[string]struct{})
+	// Add Primary IP to Map, if not present.
+	// This is only for Swift i.e. if NC Type is vnet.
+	for i := 0; i < len(nnc.Status.NetworkContainers); i++ {
+		nc := nnc.Status.NetworkContainers[i]
+		if nc.Type == "" || nc.Type == v1alpha.VNET {
+			meta.primaryIPAddresses[nc.PrimaryIP] = struct{}{}
+		}
+
+		if nc.Type == v1alpha.VNETBlock {
+			primaryPrefix, err := netip.ParsePrefix(nc.PrimaryIP)
+			if err != nil {
+				return errors.Wrapf(err, "unable to parse ip prefix: %s", nc.PrimaryIP)
+			}
+			meta.primaryIPAddresses[primaryPrefix.Addr().String()] = struct{}{}
+		}
+	}
+
+	state := ipPoolState{
+		secondaryIPs: int64(len(ips)),
+		requestedIPs: nnc.Spec.RequestedIPCount,
+	}
+	for i := range ips {
+		ip := ips[i]
+		switch ip.GetState() {
+		case types.Assigned:
+			state.allocatedToPods++
+		case types.Available:
+			state.available++
+		case types.PendingProgramming:
+			state.pendingProgramming++
+		case types.PendingRelease:
+			state.pendingRelease++
+		}
+	}
+	state.currentAvailableIPs = state.secondaryIPs - state.allocatedToPods - state.pendingRelease
+	state.expectedAvailableIPs = state.requestedIPs - state.allocatedToPods
+
+	labels := []string{meta.subnet, meta.subnetCIDR, meta.subnetARMID}
+	IpamAllocatedIPCount.WithLabelValues(labels...).Set(float64(state.allocatedToPods))
+	IpamAvailableIPCount.WithLabelValues(labels...).Set(float64(state.available))
+	IpamBatchSize.WithLabelValues(labels...).Set(float64(meta.batch))
+	IpamCurrentAvailableIPcount.WithLabelValues(labels...).Set(float64(state.currentAvailableIPs))
+	IpamExpectedAvailableIPCount.WithLabelValues(labels...).Set(float64(state.expectedAvailableIPs))
+	IpamMaxIPCount.WithLabelValues(labels...).Set(float64(meta.max))
+	IpamPendingProgramIPCount.WithLabelValues(labels...).Set(float64(state.pendingProgramming))
+	IpamPendingReleaseIPCount.WithLabelValues(labels...).Set(float64(state.pendingRelease))
+	IpamPrimaryIPCount.WithLabelValues(labels...).Set(float64(len(meta.primaryIPAddresses)))
+	IpamRequestedIPConfigCount.WithLabelValues(labels...).Set(float64(state.requestedIPs))
+	IpamSecondaryIPCount.WithLabelValues(labels...).Set(float64(state.secondaryIPs))
+	IpamTotalIPCount.WithLabelValues(labels...).Set(float64(state.secondaryIPs + int64(len(meta.primaryIPAddresses))))
+	if meta.exhausted {
+		IpamSubnetExhaustionState.WithLabelValues(labels...).Set(float64(SubnetIPExhausted))
+	} else {
+		IpamSubnetExhaustionState.WithLabelValues(labels...).Set(float64(SubnetIPNotExhausted))
+	}
+	return nil
+}

--- a/crd/clustersubnetstate/client.go
+++ b/crd/clustersubnetstate/client.go
@@ -103,3 +103,9 @@ func (c *Client) Get(ctx context.Context, key types.NamespacedName) (*v1alpha1.C
 	err := c.cli.Get(ctx, key, clusterSubnetState)
 	return clusterSubnetState, errors.Wrapf(err, "failed to get css %v", key)
 }
+
+func (c *Client) List(ctx context.Context) ([]v1alpha1.ClusterSubnetState, error) {
+	clusterSubnetStateList := &v1alpha1.ClusterSubnetStateList{}
+	err := c.cli.List(ctx, clusterSubnetStateList)
+	return clusterSubnetStateList.Items, errors.Wrap(err, "failed to list css")
+}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
IPAM metrics that were set by the old IPAM PoolMonitor were not set in the v2 monitor. This breaks the AMA workbooks for subnet usage monitoring on AKS 1.30+ where CNS 1.6 with v2 IPAM is deployed.

The metrics were missing because the v2 PoolMonitor does not use most of that source data anymore - it depends only on Pod count and Batch size, not the full IPAM utilization buckets and previous NNC state that the v1 implementation needed to scale up/down.

This fix creates a "metrics observer" which functionally performs what the IPAM v1 monitor used to do WRT the metrics in a portable closed scope. It is injected into the v2 monitor so that the v2 monitor does not need to be polluted with the data pulls that the v1 monitor needed and can still trigger the metrics updates.

TODO: As the v1 monitor is phased-out (hopefully in the 1.7 release of CNS), these metrics should be removed to more appropriate locations, such as moving the Allocated/Available/Assigned/etc IP state metrics in to the CNS core datastore IPConfig paths where those IP states are mutated.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
