### PR TITLE
fix: Ignore accelnetEnable flag to disable swiftv2 Linux&&Windows for AccelentNIC

### DIFF
--- a/cns/middlewares/k8sSwiftV2.go
+++ b/cns/middlewares/k8sSwiftV2.go
@@ -203,10 +203,11 @@ func (k *K8sSWIFTv2Middleware) getIPConfig(ctx context.Context, podInfo cns.PodI
 				err        error
 			)
 			switch {
-			case interfaceInfo.DeviceType == v1alpha1.DeviceTypeVnetNIC:
+			case interfaceInfo.DeviceType == v1alpha1.DeviceTypeVnetNIC && !interfaceInfo.AccelnetEnabled:
 				nicType = cns.DelegatedVMNIC
-			case interfaceInfo.DeviceType == v1alpha1.DeviceTypeVnetNIC && interfaceInfo.AccelnetEnabled:
-				nicType = cns.NodeNetworkInterfaceAccelnetFrontendNIC
+			// TODO: have it back once Linux supports accelnetNIC
+			// case interfaceInfo.DeviceType == v1alpha1.DeviceTypeVnetNIC && interfaceInfo.AccelnetEnabled:
+			// 	nicType = cns.NodeNetworkInterfaceAccelnetFrontendNIC
 			case interfaceInfo.DeviceType == v1alpha1.DeviceTypeInfiniBandNIC:
 				nicType = cns.NodeNetworkInterfaceBackendNIC
 			default:

--- a/cns/middlewares/k8sSwiftV2.go
+++ b/cns/middlewares/k8sSwiftV2.go
@@ -203,7 +203,7 @@ func (k *K8sSWIFTv2Middleware) getIPConfig(ctx context.Context, podInfo cns.PodI
 				err        error
 			)
 			switch {
-			case interfaceInfo.DeviceType == v1alpha1.DeviceTypeVnetNIC && !interfaceInfo.AccelnetEnabled:
+			case interfaceInfo.DeviceType == v1alpha1.DeviceTypeVnetNIC:
 				nicType = cns.DelegatedVMNIC
 			// TODO: have it back once Linux supports accelnetNIC
 			// case interfaceInfo.DeviceType == v1alpha1.DeviceTypeVnetNIC && interfaceInfo.AccelnetEnabled:

--- a/cns/middlewares/k8sSwiftV2.go
+++ b/cns/middlewares/k8sSwiftV2.go
@@ -203,7 +203,7 @@ func (k *K8sSWIFTv2Middleware) getIPConfig(ctx context.Context, podInfo cns.PodI
 				err        error
 			)
 			switch {
-			case interfaceInfo.DeviceType == v1alpha1.DeviceTypeVnetNIC && !interfaceInfo.AccelnetEnabled:
+			case interfaceInfo.DeviceType == v1alpha1.DeviceTypeVnetNIC:
 				nicType = cns.DelegatedVMNIC
 			case interfaceInfo.DeviceType == v1alpha1.DeviceTypeVnetNIC && interfaceInfo.AccelnetEnabled:
 				nicType = cns.NodeNetworkInterfaceAccelnetFrontendNIC


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
This PR is to disable Swiftv2 Linux and Windows for AccelnetNIC support until they support

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
