### PR TITLE
Add join VNET call for every AZR NC unpublish call

### DIFF
--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -1039,6 +1039,10 @@ func (service *HTTPRestService) unpublishNetworkContainer(w http.ResponseWriter,
 		}
 	}
 
+	/* For AZR scenarios, if NMAgent is restarted, it loses state and does not know what VNETs to subscribe to.
+	As it no longer has VNET state, delete nc calls would fail. We need to add join VNET call for all AZR
+	nc unpublish calls just like publish nc calls.
+	*/
 	if unpublishBody.AZREnabled || !service.isNetworkJoined(req.NetworkID) {
 		joinResp, err := service.wsproxy.JoinNetwork(ctx, req.NetworkID) //nolint:govet // ok to shadow
 		if err != nil {

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -14,14 +14,13 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/Azure/azure-container-networking/nmagent"
-
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/hnsclient"
 	"github.com/Azure/azure-container-networking/cns/logger"
 	"github.com/Azure/azure-container-networking/cns/types"
 	"github.com/Azure/azure-container-networking/cns/wireserver"
 	"github.com/Azure/azure-container-networking/common"
+	"github.com/Azure/azure-container-networking/nmagent"
 	"github.com/pkg/errors"
 )
 

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -1036,6 +1036,7 @@ func (service *HTTPRestService) unpublishNetworkContainer(w http.ResponseWriter,
 		err = json.Unmarshal(req.DeleteNetworkContainerRequestBody, &unpublishBody)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("could not unmarshal delete network container body: %v", err), http.StatusBadRequest)
+			return
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
For AZR scenarios, if NMAgent is restarted, it loses state and does not know what VNETs to subscribe to. As it no longer has VNET state, successive put nc or delete nc calls would fail. We, however, always call join VNET before put nc call. This PR adds such a fdlow for delete AZR nc calls as well.

PS: We don't need this flow for regular NCs, as NMAgent there uses NMA swift module to rehydrate VNETs if state is lost.


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
