### PR TITLE
fix: remove PowerShell from Windows registry interactions

### DIFF
--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -788,8 +788,7 @@ func main() {
 	}
 
 	// Setting the remote ARP MAC address to 12-34-56-78-9a-bc on windows for external traffic if HNS is enabled
-	execClient := platform.NewExecClient(nil)
-	err = platform.SetSdnRemoteArpMacAddress(execClient)
+	err = platform.SetSdnRemoteArpMacAddress(rootCtx)
 	if err != nil {
 		logger.Errorf("Failed to set remote ARP MAC address: %v", err)
 		return

--- a/platform/os_linux.go
+++ b/platform/os_linux.go
@@ -179,7 +179,7 @@ func (p *execClient) KillProcessByName(processName string) error {
 
 // SetSdnRemoteArpMacAddress sets the regkey for SDNRemoteArpMacAddress needed for multitenancy
 // This operation is specific to windows OS
-func SetSdnRemoteArpMacAddress(_ ExecClient) error {
+func SetSdnRemoteArpMacAddress(context.Context) error {
 	return nil
 }
 

--- a/platform/os_windows_test.go
+++ b/platform/os_windows_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"os/exec"
-	"strings"
 	"testing"
 	"time"
 
@@ -113,41 +112,6 @@ func TestExecuteCommandError(t *testing.T) {
 	_, err := NewExecClient(nil).ExecuteCommand(context.Background(), "dontaddtopath")
 	require.Error(t, err)
 	require.ErrorIs(t, err, exec.ErrNotFound)
-}
-
-func TestSetSdnRemoteArpMacAddress_hnsNotEnabled(t *testing.T) {
-	mockExecClient := NewMockExecClient(false)
-	// testing skip setting SdnRemoteArpMacAddress when hns not enabled
-	mockExecClient.SetPowershellCommandResponder(func(_ string) (string, error) {
-		return "False", nil
-	})
-	err := SetSdnRemoteArpMacAddress(mockExecClient)
-	assert.NoError(t, err)
-	assert.Equal(t, false, sdnRemoteArpMacAddressSet)
-
-	// testing the scenario when there is an error in checking if hns is enabled or not
-	mockExecClient.SetPowershellCommandResponder(func(_ string) (string, error) {
-		return "", errTestFailure
-	})
-	err = SetSdnRemoteArpMacAddress(mockExecClient)
-	assert.ErrorAs(t, err, &errTestFailure)
-	assert.Equal(t, false, sdnRemoteArpMacAddressSet)
-}
-
-func TestSetSdnRemoteArpMacAddress_hnsEnabled(t *testing.T) {
-	mockExecClient := NewMockExecClient(false)
-	// happy path
-	mockExecClient.SetPowershellCommandResponder(func(cmd string) (string, error) {
-		if strings.Contains(cmd, "Test-Path") {
-			return "True", nil
-		}
-		return "", nil
-	})
-	err := SetSdnRemoteArpMacAddress(mockExecClient)
-	assert.NoError(t, err)
-	assert.Equal(t, true, sdnRemoteArpMacAddressSet)
-	// reset sdnRemoteArpMacAddressSet
-	sdnRemoteArpMacAddressSet = false
 }
 
 func TestFetchPnpIDMapping(t *testing.T) {

--- a/test/validate/validate.go
+++ b/test/validate/validate.go
@@ -124,7 +124,7 @@ func (v *Validator) ValidateStateFile(ctx context.Context) error {
 }
 
 func (v *Validator) validateIPs(ctx context.Context, stateFileIps stateFileIpsFunc, cmd []string, checkType, namespace, labelSelector, containerName string) error {
-	log.Printf("Validating %s state file", checkType)
+	log.Printf("Validating %s state file for %s on %s", checkType, v.cni, v.os)
 	nodes, err := acnk8s.GetNodeListByLabelSelector(ctx, v.clientset, nodeSelectorMap[v.os])
 	if err != nil {
 		return errors.Wrapf(err, "failed to get node list")


### PR DESCRIPTION
**Reason for Change**:
PowerShell is heavy (+30mb of memory footprint per invocation). We don't need to use it to interact with the Windows Registry (or ServiceManager) - the Go stdlib has good native bindings that should use instead.

**Notes**:
This functionality was introduced in #1306. In #2315, it was changed to conditionally set the reg key value only if the HNS path exists. Why? It seems simpler and harmless to always try to set the reg key, so that's what I have done. Unclear if this is problematic - cc @ZetaoZhuang 

Supersedes and closes #2974 and #2961 (and #2949)
