### PR TITLE
Add join VNET call for every AZR NC unpublish call with fixed UTs

### DIFF
--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -1035,7 +1035,9 @@ func (service *HTTPRestService) unpublishNetworkContainer(w http.ResponseWriter,
 	var azrNC bool
 	err = json.Unmarshal(req.DeleteNetworkContainerRequestBody, &unpublishBody)
 	if err != nil {
-		// If the body contains only `""\n`, it is a non-AZR NC
+		// If the body contains only `""\n`, it is non-AZR NC
+		// In this case, we should not return an error
+		// However, if the body is not `""\n`, it is invalid and therefore, we must return an error
 		if !bytes.Equal(req.DeleteNetworkContainerRequestBody, []byte(`""`+"\n")) {
 			http.Error(w, fmt.Sprintf("could not unmarshal delete network container body: %v", err), http.StatusBadRequest)
 			return

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -1038,7 +1038,8 @@ func (service *HTTPRestService) unpublishNetworkContainer(w http.ResponseWriter,
 		// If the body contains only `""\n`, it is non-AZR NC
 		// In this case, we should not return an error
 		// However, if the body is not `""\n`, it is invalid and therefore, we must return an error
-		if !bytes.Equal(req.DeleteNetworkContainerRequestBody, []byte(`""`+"\n")) {
+		// []byte{34, 34, 10} here represents []byte(`""`+"\n")
+		if !bytes.Equal(req.DeleteNetworkContainerRequestBody, []byte{34, 34, 10}) {
 			http.Error(w, fmt.Sprintf("could not unmarshal delete network container body: %v", err), http.StatusBadRequest)
 			return
 		}

--- a/cns/restserver/api_test.go
+++ b/cns/restserver/api_test.go
@@ -1085,6 +1085,7 @@ func TestUnpublishNCViaCNS(t *testing.T) {
 func TestUnpublishViaCNSRequestBody(t *testing.T) {
 	createNetworkContainerURL := "http://" + nmagentEndpoint + "/machine/plugins/?comp=nmagent&type=NetworkManagement/interfaces/dummyIntf/networkContainers/dummyNCURL/authenticationToken/dummyT/api-version/1"
 	deleteNetworkContainerURL := "http://" + nmagentEndpoint + "/machine/plugins/?comp=nmagent&type=NetworkManagement/interfaces/dummyIntf/networkContainers/dummyNCURL/authenticationToken/dummyT/api-version/1/method/DELETE"
+	vnet := "vnet1"
 	wsProxy := fakes.WireserverProxyFake{}
 	cleanup := setWireserverProxy(svc, &wsProxy)
 	defer cleanup()
@@ -1118,9 +1119,9 @@ func TestUnpublishViaCNSRequestBody(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			errPublish := publishNCViaCNS("vnet1", tt.ncID, createNetworkContainerURL)
+			errPublish := publishNCViaCNS(vnet, tt.ncID, createNetworkContainerURL)
 			require.NoError(t, errPublish)
-			errUnpublish := unpublishNCViaCNS("vnet1", tt.ncID, deleteNetworkContainerURL, tt.body)
+			errUnpublish := unpublishNCViaCNS(vnet, tt.ncID, deleteNetworkContainerURL, tt.body)
 			if tt.requireError {
 				require.Error(t, errUnpublish)
 			} else {

--- a/cns/restserver/api_test.go
+++ b/cns/restserver/api_test.go
@@ -1057,7 +1057,7 @@ func TestUnpublishNCViaCNS(t *testing.T) {
 		"/machine/plugins/?comp=nmagent&type=NetworkManagement/interfaces/dummyIntf/networkContainers/dummyNCURL/authenticationToke/" +
 		"8636c99d-7861-401f-b0d3-7e5b7dc8183c" +
 		"/api-version/1/method/DELETE"
-	err = unpublishNCViaCNS("vnet1", "ethWebApp", deleteNetworkContainerURL)
+	err = unpublishNCViaCNS("vnet1", "ethWebApp", deleteNetworkContainerURL, []byte(`""`+"\n"))
 	if err == nil {
 		t.Fatal("Expected a bad request error due to delete network url being incorrect")
 	}
@@ -1068,7 +1068,7 @@ func TestUnpublishNCViaCNS(t *testing.T) {
 		"/machine/plugins/?comp=nmagent&NetworkManagement/interfaces/dummyIntf/networkContainers/dummyNCURL/authenticationToken/" +
 		"8636c99d-7861-401f-b0d3-7e5b7dc8183c8636c99d-7861-401f-b0d3-7e5b7dc8183c" +
 		"/api-version/1/method/DELETE"
-	err = unpublishNCViaCNS("vnet1", "ethWebApp", deleteNetworkContainerURL)
+	err = unpublishNCViaCNS("vnet1", "ethWebApp", deleteNetworkContainerURL, []byte(`""`+"\n"))
 	if err == nil {
 		t.Fatal("Expected a bad request error due to create network url having more characters than permitted in auth token")
 	}
@@ -1076,9 +1076,57 @@ func TestUnpublishNCViaCNS(t *testing.T) {
 	// now actually perform the deletion:
 	deleteNetworkContainerURL = "http://" + nmagentEndpoint +
 		"/machine/plugins/?comp=nmagent&type=NetworkManagement/interfaces/dummyIntf/networkContainers/dummyNCURL/authenticationToken/dummyT/api-version/1/method/DELETE"
-	err = unpublishNCViaCNS("vnet1", "ethWebApp", deleteNetworkContainerURL)
+	err = unpublishNCViaCNS("vnet1", "ethWebApp", deleteNetworkContainerURL, []byte(`""`+"\n"))
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestUnpublishViaCNSRequestBody(t *testing.T) {
+	createNetworkContainerURL := "http://" + nmagentEndpoint + "/machine/plugins/?comp=nmagent&type=NetworkManagement/interfaces/dummyIntf/networkContainers/dummyNCURL/authenticationToken/dummyT/api-version/1"
+	deleteNetworkContainerURL := "http://" + nmagentEndpoint + "/machine/plugins/?comp=nmagent&type=NetworkManagement/interfaces/dummyIntf/networkContainers/dummyNCURL/authenticationToken/dummyT/api-version/1/method/DELETE"
+	wsProxy := fakes.WireserverProxyFake{}
+	cleanup := setWireserverProxy(svc, &wsProxy)
+	defer cleanup()
+
+	tests := []struct {
+		name         string
+		ncID         string
+		body         []byte
+		requireError bool
+	}{
+		{
+			name:         "Delete NC with invalid body",
+			ncID:         "ncID1",
+			body:         []byte(`invalid` + "\n"),
+			requireError: true,
+		},
+		{
+			name:         "Delete NC with valid non-AZR body",
+			ncID:         "ncID2",
+			body:         []byte(`""` + "\n"),
+			requireError: false,
+		},
+		{
+			name:         "Delete NC with valid AZR body",
+			ncID:         "ncID3",
+			body:         []byte(`{"azID":1,"azrEnabled":true}`),
+			requireError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			errPublish := publishNCViaCNS("vnet1", tt.ncID, createNetworkContainerURL)
+			require.NoError(t, errPublish)
+			errUnpublish := unpublishNCViaCNS("vnet1", tt.ncID, deleteNetworkContainerURL, tt.body)
+			if tt.requireError {
+				require.Error(t, errUnpublish)
+			} else {
+				require.NoError(t, errUnpublish)
+			}
+		})
 	}
 }
 
@@ -1161,7 +1209,7 @@ func TestUnpublishNCViaCNS401(t *testing.T) {
 	}
 }
 
-func unpublishNCViaCNS(networkID, networkContainerID, deleteNetworkContainerURL string) error {
+func unpublishNCViaCNS(networkID, networkContainerID, deleteNetworkContainerURL string, bodyBytes []byte) error {
 	joinNetworkURL := "http://" + nmagentEndpoint + "/dummyVnetURL"
 
 	unpublishNCRequest := &cns.UnpublishNetworkContainerRequest{
@@ -1169,7 +1217,7 @@ func unpublishNCViaCNS(networkID, networkContainerID, deleteNetworkContainerURL 
 		NetworkContainerID:                networkContainerID,
 		JoinNetworkURL:                    joinNetworkURL,
 		DeleteNetworkContainerURL:         deleteNetworkContainerURL,
-		DeleteNetworkContainerRequestBody: []byte("{}"),
+		DeleteNetworkContainerRequestBody: bodyBytes,
 	}
 
 	var body bytes.Buffer

--- a/cns/restserver/api_test.go
+++ b/cns/restserver/api_test.go
@@ -1126,6 +1126,7 @@ func TestUnpublishViaCNSRequestBody(t *testing.T) {
 			errUnpublish := unpublishNCViaCNS(vnet, tt.ncID, deleteNetworkContainerURL, tt.body)
 			if tt.requireError {
 				require.Error(t, errUnpublish)
+				require.Contains(t, errUnpublish.Error(), "error decoding json")
 			} else {
 				require.NoError(t, errUnpublish)
 			}

--- a/cns/restserver/api_test.go
+++ b/cns/restserver/api_test.go
@@ -1083,8 +1083,10 @@ func TestUnpublishNCViaCNS(t *testing.T) {
 }
 
 func TestUnpublishViaCNSRequestBody(t *testing.T) {
-	createNetworkContainerURL := "http://" + nmagentEndpoint + "/machine/plugins/?comp=nmagent&type=NetworkManagement/interfaces/dummyIntf/networkContainers/dummyNCURL/authenticationToken/dummyT/api-version/1"
-	deleteNetworkContainerURL := "http://" + nmagentEndpoint + "/machine/plugins/?comp=nmagent&type=NetworkManagement/interfaces/dummyIntf/networkContainers/dummyNCURL/authenticationToken/dummyT/api-version/1/method/DELETE"
+	createNetworkContainerURL := "http://" + nmagentEndpoint +
+		"/machine/plugins/?comp=nmagent&type=NetworkManagement/interfaces/dummyIntf/networkContainers/dummyNCURL/authenticationToken/dummyT/api-version/1"
+	deleteNetworkContainerURL := "http://" + nmagentEndpoint +
+		"/machine/plugins/?comp=nmagent&type=NetworkManagement/interfaces/dummyIntf/networkContainers/dummyNCURL/authenticationToken/dummyT/api-version/1/method/DELETE"
 	vnet := "vnet1"
 	wsProxy := fakes.WireserverProxyFake{}
 	cleanup := setWireserverProxy(svc, &wsProxy)


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
For AZR scenarios, if NMAgent is restarted, it loses state and does not know what VNETs to subscribe to. As it no longer has VNET state, successive put nc or delete nc calls would fail. We, however, always call join VNET before put nc call. This PR adds such a flow for delete AZR nc calls as well.

PS: We don't need this flow for regular NCs, as NMAgent there uses NMA swift module to rehydrate VNETs if state is lost.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [x] relevant PR labels added

**Notes**:
