### PR TITLE
chore: upgrade go toolchain to 1.23

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT="1.22"
+ARG VARIANT="1.23"
 FROM mcr.microsoft.com/vscode/devcontainers/go:${VARIANT}
 RUN apt-get update && \
     export DEBIAN_FRONTEND=noninteractive && \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			"VARIANT": "1.22-bullseye",
+			"VARIANT": "1.23-bullseye",
 			"NODE_VERSION": "none"
 		}
 	},

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.23"
           check-latest: true
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/crdgen.yaml
+++ b/.github/workflows/crdgen.yaml
@@ -14,7 +14,7 @@ jobs:
   crdgen:
     strategy:
       matrix:
-        go-version: ['1.21', '1.22']
+        go-version: ['1.22', '1.23']
         os: [ubuntu-latest]
     name: CRDs are Generated
     runs-on: ${{ matrix.os }}
@@ -31,5 +31,9 @@ jobs:
       run: make -C crd/multitenantnetworkcontainer
     - name: Regenerate Multitenancy CRDs
       run: make -C crd/multitenancy
+    - name: Regenerate ClusterSubnetState CRD
+      run: make -C crd/clustersubnetstate
+    - name: Regenerate OverlayExtensionConfig CRD
+      run: make -C crd/overlayextensionconfig
     - name: Fail if the tree is dirty
       run: test -z "$(git status --porcelain)"

--- a/.github/workflows/cyclonus-netpol-extended-nightly-test.yaml
+++ b/.github/workflows/cyclonus-netpol-extended-nightly-test.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "^1.22"
+          go-version: "^1.23"
 
       - name: Setup Kind
         uses: engineerd/setup-kind@v0.5.0

--- a/.github/workflows/cyclonus-netpol-test.yaml
+++ b/.github/workflows/cyclonus-netpol-test.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '^1.22'
+          go-version: '^1.23'
 
       - name: Setup Kind
         uses: helm/kind-action@v1

--- a/.github/workflows/golangci.yaml
+++ b/.github/workflows/golangci.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.21.x', '1.22.x']
+        go-version: ['1.22.x', '1.23.x']
         os: [ubuntu-latest, windows-latest]
     name: Lint
     runs-on: ${{ matrix.os }}
@@ -29,5 +29,5 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.55
+        version: v1.61
         args: --new-from-rev=origin/master --config=.golangci.yml --timeout=25m 

--- a/azure-ipam/Dockerfile
+++ b/azure-ipam/Dockerfile
@@ -3,8 +3,8 @@ ARG DROPGZ_VERSION=v0.0.12
 ARG OS_VERSION
 ARG OS
 
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.22-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:c062e5e23f2d172a8fd590adcd171499af7005cae344a36284255f26e5ce4f8a AS go
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.23.2-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:f8613198423d5cb702961f1547f9cb061f8da1c6ca9ce8da4824eb47db663cd7 AS go
 
 # skopeo inspect docker://mcr.microsoft.com/cbl-mariner/base/core:2.0 --format "{{.Name}}@{{.Digest}}"
 FROM --platform=linux/${ARCH} mcr.microsoft.com/cbl-mariner/base/core@sha256:a490e0b0869dc570ae29782c2bc17643aaaad1be102aca83ce0b96e0d0d2d328 AS mariner-core

--- a/azure-ipam/go.mod
+++ b/azure-ipam/go.mod
@@ -1,6 +1,8 @@
 module github.com/Azure/azure-container-networking/azure-ipam
 
-go 1.22
+go 1.23
+
+toolchain go1.23.2
 
 require (
 	github.com/Azure/azure-container-networking v1.5.21

--- a/bpf-prog/ipv6-hp-bpf/go.mod
+++ b/bpf-prog/ipv6-hp-bpf/go.mod
@@ -1,6 +1,8 @@
 module github.com/Azure/azure-container-networking/bpf-prog/ipv6-hp-bpf
 
-go 1.21.6
+go 1.23
+
+toolchain go1.23.2
 
 require (
 	github.com/cilium/ebpf v0.15.0

--- a/bpf-prog/ipv6-hp-bpf/linux.Dockerfile
+++ b/bpf-prog/ipv6-hp-bpf/linux.Dockerfile
@@ -1,5 +1,5 @@
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.23-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:46967b18b274559caafd0b3555676fc044037358d8103f4c44567cd4d0620ed7 AS builder
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.23.2 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:86c5b00bbed2a6e7157052d78bf4b45c0bf26545ed6e8fd7dbad51ac9415f534 AS builder
 ARG VERSION
 ARG DEBUG
 ARG OS

--- a/bpf-prog/ipv6-hp-bpf/linux.Dockerfile
+++ b/bpf-prog/ipv6-hp-bpf/linux.Dockerfile
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.22 AS builder
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.23-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:46967b18b274559caafd0b3555676fc044037358d8103f4c44567cd4d0620ed7 AS builder
 ARG VERSION
 ARG DEBUG
 ARG OS

--- a/build/tools/go.mod
+++ b/build/tools/go.mod
@@ -1,6 +1,8 @@
 module github.com/Azure/azure-container-networking/build/tools
 
-go 1.22
+go 1.23
+
+toolchain go1.23.2
 
 require (
 	github.com/AlekSi/gocov-xml v1.1.0

--- a/cni/Dockerfile
+++ b/cni/Dockerfile
@@ -3,8 +3,8 @@ ARG DROPGZ_VERSION=v0.0.12
 ARG OS_VERSION
 ARG OS
 
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.22-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:c062e5e23f2d172a8fd590adcd171499af7005cae344a36284255f26e5ce4f8a AS go
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.23.2-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:f8613198423d5cb702961f1547f9cb061f8da1c6ca9ce8da4824eb47db663cd7 AS go
 
 # skopeo inspect docker://mcr.microsoft.com/cbl-mariner/base/core:2.0 --format "{{.Name}}@{{.Digest}}"
 FROM --platform=linux/${ARCH} mcr.microsoft.com/cbl-mariner/base/core@sha256:a490e0b0869dc570ae29782c2bc17643aaaad1be102aca83ce0b96e0d0d2d328 AS mariner-core

--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -2,8 +2,8 @@ ARG ARCH
 ARG OS_VERSION
 ARG OS
 
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.22-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:c062e5e23f2d172a8fd590adcd171499af7005cae344a36284255f26e5ce4f8a AS go
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.23.2-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:f8613198423d5cb702961f1547f9cb061f8da1c6ca9ce8da4824eb47db663cd7 AS go
 
 # skopeo inspect docker://mcr.microsoft.com/cbl-mariner/base/core:2.0 --format "{{.Name}}@{{.Digest}}"
 FROM mcr.microsoft.com/cbl-mariner/base/core@sha256:a490e0b0869dc570ae29782c2bc17643aaaad1be102aca83ce0b96e0d0d2d328 AS mariner-core

--- a/dropgz/go.mod
+++ b/dropgz/go.mod
@@ -1,6 +1,8 @@
 module github.com/Azure/azure-container-networking/dropgz
 
-go 1.22
+go 1.23
+
+toolchain go1.23.2
 
 require (
 	github.com/jsternberg/zap-logfmt v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/Azure/azure-container-networking
 
-go 1.22.0
+go 1.23
 
-toolchain go1.22.7
+toolchain go1.23.2
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.14.0

--- a/hack/toolbox/Dockerfile.windows
+++ b/hack/toolbox/Dockerfile.windows
@@ -1,5 +1,5 @@
 # Build cns
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.22 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23 AS builder
 # Build args
 ARG VERSION
 ARG CNS_AI_PATH

--- a/hack/toolbox/server/Dockerfile.heavy
+++ b/hack/toolbox/server/Dockerfile.heavy
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.22 as build
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23 as build
 ADD ./ /
 WORKDIR /
 RUN CGO_ENABLED=0 GOOS=linux go build -o server .

--- a/hack/toolbox/server/Dockerfile.lite
+++ b/hack/toolbox/server/Dockerfile.lite
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.22 as build
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23 as build
 ADD ./server/server.go /
 ADD ./server/go.mod /
 WORKDIR /

--- a/npm/linux.Dockerfile
+++ b/npm/linux.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.22 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23 AS builder
 ARG VERSION
 ARG NPM_AI_PATH
 ARG NPM_AI_ID

--- a/npm/windows.Dockerfile
+++ b/npm/windows.Dockerfile
@@ -1,5 +1,5 @@
 ARG OS_VERSION
-FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.22 AS builder
+FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.23 AS builder
 ARG VERSION
 ARG NPM_AI_PATH
 ARG NPM_AI_ID

--- a/tools/acncli/Dockerfile
+++ b/tools/acncli/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.22 as build
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23 as build
 WORKDIR /go/src/github.com/Azure/azure-container-networking/
 ARG VERSION
 ADD . . 

--- a/zapai/go.mod
+++ b/zapai/go.mod
@@ -1,6 +1,8 @@
 module github.com/Azure/azure-container-networking/zapai
 
-go 1.22
+go 1.23
+
+toolchain go1.23.2
 
 require (
 	github.com/jsternberg/zap-logfmt v1.3.0


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Updates the Go version to v1.23.1 for various improvements, fixes to stdlib, and toolchain upgrades.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
