### PR TITLE
fix: HTTPRemoteRestService config missing Direct ChannelMode

### DIFF
--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -652,19 +652,22 @@ func main() {
 	}
 
 	// copy ChannelMode from cnsconfig to HTTPRemoteRestService config
-	if cnsconfig.ChannelMode == cns.Direct {
+	switch cnsconfig.ChannelMode {
+	case cns.Direct:
 		config.ChannelMode = cns.Direct
-	} else if cnsconfig.ChannelMode == cns.Managed {
+	case cns.Managed:
 		config.ChannelMode = cns.Managed
 		privateEndpoint = cnsconfig.ManagedSettings.PrivateEndpoint
 		infravnet = cnsconfig.ManagedSettings.InfrastructureNetworkID
 		nodeID = cnsconfig.ManagedSettings.NodeID
-	} else if cnsconfig.ChannelMode == cns.CRD {
+	case cns.CRD:
 		config.ChannelMode = cns.CRD
-	} else if cnsconfig.ChannelMode == cns.MultiTenantCRD {
+	case cns.MultiTenantCRD:
 		config.ChannelMode = cns.MultiTenantCRD
-	} else if acn.GetArg(acn.OptManaged).(bool) {
-		config.ChannelMode = cns.Managed
+	default:
+		if acn.GetArg(acn.OptManaged).(bool) {
+			config.ChannelMode = cns.Managed
+		}
 	}
 
 	homeAzMonitor := restserver.NewHomeAzMonitor(nmaClient, time.Duration(cnsconfig.AZRSettings.PopulateHomeAzCacheRetryIntervalSecs)*time.Second)

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -658,7 +658,7 @@ func main() {
 		infravnet = cnsconfig.ManagedSettings.InfrastructureNetworkID
 		nodeID = cnsconfig.ManagedSettings.NodeID
 	}
-	if acn.GetArg(acn.OptManaged).(bool) {
+	if isManaged, ok := acn.GetArg(acn.OptManaged).(bool); ok && isManaged {
 		config.ChannelMode = cns.Managed
 	}
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -652,22 +652,14 @@ func main() {
 	}
 
 	// copy ChannelMode from cnsconfig to HTTPRemoteRestService config
-	switch cnsconfig.ChannelMode {
-	case cns.Direct:
-		config.ChannelMode = cns.Direct
-	case cns.Managed:
-		config.ChannelMode = cns.Managed
+	config.ChannelMode = cnsconfig.ChannelMode
+	if cnsconfig.ChannelMode == cns.Managed {
 		privateEndpoint = cnsconfig.ManagedSettings.PrivateEndpoint
 		infravnet = cnsconfig.ManagedSettings.InfrastructureNetworkID
 		nodeID = cnsconfig.ManagedSettings.NodeID
-	case cns.CRD:
-		config.ChannelMode = cns.CRD
-	case cns.MultiTenantCRD:
-		config.ChannelMode = cns.MultiTenantCRD
-	default:
-		if acn.GetArg(acn.OptManaged).(bool) {
-			config.ChannelMode = cns.Managed
-		}
+	}
+	if acn.GetArg(acn.OptManaged).(bool) {
+		config.ChannelMode = cns.Managed
 	}
 
 	homeAzMonitor := restserver.NewHomeAzMonitor(nmaClient, time.Duration(cnsconfig.AZRSettings.PopulateHomeAzCacheRetryIntervalSecs)*time.Second)

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -651,7 +651,10 @@ func main() {
 		return
 	}
 
-	if cnsconfig.ChannelMode == cns.Managed {
+	// copy ChannelMode from cnsconfig to HTTPRemoteRestService config
+	if cnsconfig.ChannelMode == cns.Direct {
+		config.ChannelMode = cns.Direct
+	} else if cnsconfig.ChannelMode == cns.Managed {
 		config.ChannelMode = cns.Managed
 		privateEndpoint = cnsconfig.ManagedSettings.PrivateEndpoint
 		infravnet = cnsconfig.ManagedSettings.InfrastructureNetworkID


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:

There is an [if-check for `ChannelMode: Direct` in HTTPRemoteRestService to add the `GetVMUniqueID` handler to it's listener that was not being added](https://github.com/Azure/azure-container-networking/blob/251959ac63e361898baa5089f29a548a120fc044/cns/restserver/restserver.go#L279-L281) because the channel mode was not copied from `cnsconfig` like the rest of the channel modes.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
- validated manually in ACI environment
- it doesn't appear to be trivial to add unit test here because it's in `main()`, any thoughts or suggestions?