### PR TITLE
fix: [WIN-NPM] HNS Remote Endpoint Fix

### DIFF
--- a/npm/pkg/dataplane/dataplane_windows.go
+++ b/npm/pkg/dataplane/dataplane_windows.go
@@ -98,7 +98,7 @@ func (dp *DataPlane) bootupDataPlane() error {
 	}
 
 	// for backwards compatibility, get remote allEndpoints to delete as well
-	allEndpoints, err := dp.getAllPodEndpoints()
+	allEndpoints, err := dp.getLocalPodEndpoints()
 	if err != nil {
 		return err
 	}

--- a/npm/pkg/dataplane/dataplane_windows.go
+++ b/npm/pkg/dataplane/dataplane_windows.go
@@ -97,7 +97,6 @@ func (dp *DataPlane) bootupDataPlane() error {
 		return npmerrors.SimpleErrorWrapper("failed to initialize dataplane", err)
 	}
 
-	// for backwards compatibility, get remote allEndpoints to delete as well
 	allEndpoints, err := dp.getLocalPodEndpoints()
 	if err != nil {
 		return err

--- a/npm/pkg/dataplane/dataplane_windows.go
+++ b/npm/pkg/dataplane/dataplane_windows.go
@@ -327,23 +327,6 @@ func (dp *DataPlane) getEndpointsToApplyPolicies(netPols []*policies.NPMNetworkP
 	return endpointList, nil
 }
 
-func (dp *DataPlane) getAllPodEndpoints() ([]*hcn.HostComputeEndpoint, error) {
-	klog.Infof("getting all endpoints for network ID %s", dp.networkID)
-	timer := metrics.StartNewTimer()
-	endpoints, err := dp.ioShim.Hns.ListEndpointsOfNetwork(dp.networkID)
-	metrics.RecordListEndpointsLatency(timer)
-	if err != nil {
-		metrics.IncListEndpointsFailures()
-		return nil, npmerrors.SimpleErrorWrapper("failed to get all pod endpoints", err)
-	}
-
-	epPointers := make([]*hcn.HostComputeEndpoint, 0, len(endpoints))
-	for k := range endpoints {
-		epPointers = append(epPointers, &endpoints[k])
-	}
-	return epPointers, nil
-}
-
 func (dp *DataPlane) getLocalPodEndpoints() ([]*hcn.HostComputeEndpoint, error) {
 	klog.Info("getting local endpoints")
 	timer := metrics.StartNewTimer()


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
As we were booting up npm agent on windows, we saw ~4K endpoints on a node with 16 pods, when there should be a 1:1 endpoint to pod ratio.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Changed logic: When booting up the data plane, instead of getting all remote endpoints, we only get local endpoints which will be the endpoints for the pods in the node.
Testing:
Took a node with 11 non-system pods on it.
Ran windows NPM with new image and saw total of 12 endpoints getting reset vs ~4K that were getting reset originally. 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
