### PR TITLE
Update atomic fs writer to delay tempfile creation until Write() is called

### DIFF
--- a/internal/fs/atomic_test.go
+++ b/internal/fs/atomic_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAtomicWriterFileExists(t *testing.T) {
-	file := "testdata/data.txt"
+	file := "./testdata/data.txt"
 	w, err := fs.NewAtomicWriter(file)
 	require.NoError(t, err, "error creating atomic writer")
 
@@ -37,7 +37,7 @@ func TestAtomicWriterFileExists(t *testing.T) {
 }
 
 func TestAtomicWriterNewFile(t *testing.T) {
-	file := "testdata/newdata.txt"
+	file := "./testdata/newdata.txt"
 
 	// if the file exists before running this test, remove it
 	err := os.Remove(file)


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
The atomic fs writer currently opens the tempfile when it is instantiated. This can lead to many tempfiles being created if CNS fails during initiliazation.
This moves the tempfile creation in to the Write() method, so early exits after initialization will not clutter up the host filesystem with empty tempfiles.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
