### PR TITLE
feat: make OverlayExtensionConfig `ExtensionIPRange` field immutable

### DIFF
--- a/crd/overlayextensionconfig/api/v1alpha1/overlayextensionconfig_types.go
+++ b/crd/overlayextensionconfig/api/v1alpha1/overlayextensionconfig_types.go
@@ -31,9 +31,13 @@ type OverlayExtensionConfigList struct {
 }
 
 // OverlayExtensionConfigSpec defines the desired state of OverlayExtensionConfig.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.extensionIPRange) || has(self.extensionIPRange)", message="ExtensionIPRange is required once set"
 type OverlayExtensionConfigSpec struct {
 	// ExtensionIPRange field defines a CIDR that should be able to reach routing domain ip addresses.
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
+	// +kubebuilder:validation:MaxLength=43
+	// 43 is max length of IPv6 CIDR string
 	ExtensionIPRange string `json:"extensionIPRange,omitempty"`
 }
 

--- a/crd/overlayextensionconfig/manifests/acn.azure.com_overlayextensionconfigs.yaml
+++ b/crd/overlayextensionconfig/manifests/acn.azure.com_overlayextensionconfigs.yaml
@@ -48,10 +48,18 @@ spec:
             description: OverlayExtensionConfigSpec defines the desired state of OverlayExtensionConfig.
             properties:
               extensionIPRange:
-                description: ExtensionIPRange field defines a CIDR that should be
-                  able to reach routing domain ip addresses.
+                description: |-
+                  ExtensionIPRange field defines a CIDR that should be able to reach routing domain ip addresses.
+                  43 is max length of IPv6 CIDR string
+                maxLength: 43
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
             type: object
+            x-kubernetes-validations:
+            - message: ExtensionIPRange is required once set
+              rule: '!has(oldSelf.extensionIPRange) || has(self.extensionIPRange)'
           status:
             description: OverlayExtensionConfigStatus defines the observed state of
               OverlayExtensionConfig


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
We want to make OverlayExtensionConfig `extensionIPRange` field immutable to prevent accidental changes to the field. Network Containers are getting programmed for every IP address in this field's CIDR range, and DNC/DNC-RC will not support updating this field.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
