### PR TITLE
ci: add wait before adding windows nodepool if cluster is in updating state

### DIFF
--- a/.pipelines/singletenancy/azure-cni-overlay-stateless/azure-cni-overlay-stateless-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay-stateless/azure-cni-overlay-stateless-e2e-job-template.yaml
@@ -28,31 +28,11 @@ stages:
           k8sVersion: ${{ parameters.k8sVersion }}
           dependsOn: ${{ parameters.dependsOn }}
           region: $(REGION_AKS_CLUSTER_TEST)
-      - job: windows_nodepool
-        displayName: Add Windows Nodepool
-        dependsOn: ${{ parameters.name }}
-        pool:
-          name: $(BUILD_POOL_NAME_DEFAULT)
-          demands:
-          - agent.os -equals Linux
-          - Role -equals $(CUSTOM_E2E_ROLE)
-        steps:
-          - task: AzureCLI@2
-            inputs:
-              azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
-              scriptLocation: "inlineScript"
-              scriptType: "bash"
-              addSpnToEnvironment: true
-              inlineScript: |
-                set -e
-                make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(commitID)
-                make -C ./hack/aks windows-nodepool-up AZCLI=az SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }}-$(commitID) VM_SIZE_WIN=${{ parameters.vmSize }}
-                echo "Windows node are successfully added to v4 Overlay Cluster"
-                kubectl cluster-info
-                kubectl get node -owide
-                kubectl get po -owide -A
-            name: "Add_Windows_Node"
-            displayName: "Add windows node on v4 overlay cluster"
+      - template: ../../templates/add-windows-nodepool-job.yaml
+        parameters:
+          depend: ${{ parameters.name }}
+          clusterName: ${{ parameters.clusterName }}-$(commitID)
+          vmSize: ${{ parameters.vmSize }}
 
   - stage: ${{ parameters.name }}
     displayName: E2E - ${{ parameters.displayName }}

--- a/.pipelines/singletenancy/azure-cni-overlay-stateless/azure-cni-overlay-stateless-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay-stateless/azure-cni-overlay-stateless-e2e-job-template.yaml
@@ -11,6 +11,7 @@ stages:
   - stage: ${{ parameters.clusterName }}
     displayName: Create Cluster - ${{ parameters.displayName }}
     dependsOn:
+      - ${{ parameters.dependsOn }}
       - setup
     pool:
       name: $(BUILD_POOL_NAME_DEFAULT)

--- a/.pipelines/singletenancy/azure-cni-overlay-stateless/azure-cni-overlay-stateless-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay-stateless/azure-cni-overlay-stateless-e2e-job-template.yaml
@@ -11,7 +11,6 @@ stages:
   - stage: ${{ parameters.clusterName }}
     displayName: Create Cluster - ${{ parameters.displayName }}
     dependsOn:
-      - ${{ parameters.dependsOn }}
       - setup
     pool:
       name: $(BUILD_POOL_NAME_DEFAULT)

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
@@ -58,34 +58,11 @@ stages:
               clusterName: ${{ parameters.clusterName }}-$(commitID)
               os: linux
               scaleup: 100
-
-      - job: windows_nodepool
-        displayName: Add Windows Nodepool
-        dependsOn: ${{ parameters.name }}_linux
-        pool:
-          name: $(BUILD_POOL_NAME_DEFAULT)
-          demands:
-          - agent.os -equals Linux
-          - Role -equals $(CUSTOM_E2E_ROLE)
-        steps:
-          - task: AzureCLI@2
-            inputs:
-              azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
-              scriptLocation: "inlineScript"
-              scriptType: "bash"
-              addSpnToEnvironment: true
-              inlineScript: |
-                set -e
-                make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(commitID)
-                make -C ./hack/aks windows-nodepool-up AZCLI=az SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }}-$(commitID) VM_SIZE_WIN=${{ parameters.vmSize }}
-                echo "Windows node are successfully added to v4 Overlay Cluster"
-                kubectl cluster-info
-                kubectl get node -owide
-                kubectl get po -owide -A
-            name: "Add_Windows_Node"
-            displayName: "Add windows node on v4 overlay cluster"
-
-
+      - template: ../../templates/add-windows-nodepool-job.yaml
+        parameters:
+          depend: ${{ parameters.name }}_linux
+          clusterName: ${{ parameters.clusterName }}-$(commitID)
+          vmSize: ${{ parameters.vmSize }}
       - job: ${{ parameters.name }}_windows
         displayName: Azure CNI Overlay Test Suite | Windows - (${{ parameters.name }})
         timeoutInMinutes: 120

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
@@ -59,33 +59,11 @@ stages:
               clusterName: ${{ parameters.clusterName }}-$(commitID)
               os: linux
               scaleup: 100
-
-      - job: windows_nodepool
-        displayName: Add Windows Nodepool
-        dependsOn: ${{ parameters.name }}_linux
-        pool:
-          name: $(BUILD_POOL_NAME_DEFAULT)
-          demands:
-          - agent.os -equals Linux
-          - Role -equals $(CUSTOM_E2E_ROLE)
-        steps:
-          - task: AzureCLI@2
-            inputs:
-              azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
-              scriptLocation: "inlineScript"
-              scriptType: "bash"
-              addSpnToEnvironment: true
-              inlineScript: |
-                set -e
-                make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(commitID)
-                make -C ./hack/aks windows-nodepool-up AZCLI=az SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }}-$(commitID) VM_SIZE_WIN=${{ parameters.vmSize }}
-                echo "Windows nodes have been successfully added to DualStack Overlay Cluster"
-                kubectl cluster-info
-                kubectl get node -owide
-                kubectl get po -owide -A
-            name: "Add_Windows_Node"
-            displayName: "Add windows node"
-
+      - template: ../../templates/add-windows-nodepool-job.yaml
+        parameters:
+          depend: ${{ parameters.name }}_linux
+          clusterName: ${{ parameters.clusterName }}-$(commitID)
+          vmSize: "Standard_D2_v3"
       - job: ${{ parameters.name }}_windows
         displayName: DualStack Overlay Test Suite | Windows - (${{ parameters.name }})
         timeoutInMinutes: 120

--- a/.pipelines/templates/add-windows-nodepool-job.yaml
+++ b/.pipelines/templates/add-windows-nodepool-job.yaml
@@ -13,6 +13,7 @@ jobs:
     demands:
     - agent.os -equals Linux
     - Role -equals $(CUSTOM_E2E_ROLE)
+  timeoutInMinutes: 30
   steps:
     - task: AzureCLI@2
       inputs:
@@ -31,7 +32,22 @@ jobs:
 
           if [ -z "$windows_nodepool" ]; then
             echo "No Windows node pool found in the AKS cluster."
-          
+
+            # wait for cluster to update
+            while true; do
+              cluster_state=$(az aks show \
+              --name "${{ parameters.clusterName }}" \
+              --resource-group "${{ parameters.clusterName }}" \
+              --query provisioningState)
+              
+              if echo "$cluster_state" | grep -q "Updating"; then
+                echo "Cluster is updating. Sleeping for 30 seconds..."
+                sleep 30
+              else
+                break
+              fi
+            done
+
             make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
             make -C ./hack/aks windows-nodepool-up AZCLI=az SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }} VM_SIZE_WIN=${{ parameters.vmSize }}
             echo "Windows node was successfully added to v4 Overlay Cluster"

--- a/.pipelines/templates/add-windows-nodepool-job.yaml
+++ b/.pipelines/templates/add-windows-nodepool-job.yaml
@@ -2,7 +2,6 @@ parameters:
   depend: ""
   clusterName: "" # unique identifier
   vmSize: ""
-  retryCount: 5
 
 jobs:
 - job: windows_nodepool
@@ -47,6 +46,8 @@ jobs:
                 break
               fi
             done
+            # cluster state is always set and visible outside the loop
+            echo "Cluster state is: $cluster_state"
 
             make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
             make -C ./hack/aks windows-nodepool-up AZCLI=az SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }} VM_SIZE_WIN=${{ parameters.vmSize }}
@@ -59,4 +60,4 @@ jobs:
           fi
       name: "Add_Windows_Node"
       displayName: "Add windows node to cluster"
-      retryCountOnTaskFailure: ${{ parameters.retryCount }}
+      retryCountOnTaskFailure: 5

--- a/.pipelines/templates/add-windows-nodepool-job.yaml
+++ b/.pipelines/templates/add-windows-nodepool-job.yaml
@@ -50,7 +50,7 @@ jobs:
 
             make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
             make -C ./hack/aks windows-nodepool-up AZCLI=az SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }} VM_SIZE_WIN=${{ parameters.vmSize }}
-            echo "Windows node was successfully added to v4 Overlay Cluster"
+            echo "Windows node was successfully added"
             kubectl cluster-info
             kubectl get node -owide
             kubectl get po -owide -A
@@ -58,5 +58,5 @@ jobs:
             echo "Windows node pool already exists in the AKS cluster."
           fi
       name: "Add_Windows_Node"
-      displayName: "Add windows node on v4 overlay cluster"
+      displayName: "Add windows node to cluster"
       retryCountOnTaskFailure: ${{ parameters.retryCount }}

--- a/.pipelines/templates/add-windows-nodepool-job.yaml
+++ b/.pipelines/templates/add-windows-nodepool-job.yaml
@@ -1,0 +1,46 @@
+parameters:
+  depend: ""
+  clusterName: "" # unique identifier
+  vmSize: ""
+  retryCount: 5
+
+jobs:
+- job: windows_nodepool
+  displayName: Add Windows Nodepool
+  dependsOn: ${{ parameters.depend }}
+  pool:
+    name: $(BUILD_POOL_NAME_DEFAULT)
+    demands:
+    - agent.os -equals Linux
+    - Role -equals $(CUSTOM_E2E_ROLE)
+  steps:
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+        scriptLocation: "inlineScript"
+        scriptType: "bash"
+        addSpnToEnvironment: true
+        inlineScript: |
+          set -e
+          
+          windows_nodepool=$(az aks nodepool list \
+          --resource-group ${{ parameters.clusterName }} \
+          --cluster-name ${{ parameters.clusterName }} \
+          --query "[?osType=='Windows']" \
+          --output tsv)
+
+          if [ -z "$windows_nodepool" ]; then
+            echo "No Windows node pool found in the AKS cluster."
+          
+            make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
+            make -C ./hack/aks windows-nodepool-up AZCLI=az SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=${{ parameters.clusterName }} VM_SIZE_WIN=${{ parameters.vmSize }}
+            echo "Windows node was successfully added to v4 Overlay Cluster"
+            kubectl cluster-info
+            kubectl get node -owide
+            kubectl get po -owide -A
+          else
+            echo "Windows node pool already exists in the AKS cluster."
+          fi
+      name: "Add_Windows_Node"
+      displayName: "Add windows node on v4 overlay cluster"
+      retryCountOnTaskFailure: ${{ parameters.retryCount }}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
If a windows nodepool is added to a newly created aks cluster, the aks cluster may be in "Updating" state, causing the job to fail. This PR adds a check to see if the cluster is in updating state and sleeps until the cluster is no longer in the updating state. Also refactors adding windows nodepool into a common template and adds a check if the windows nodepool is already created (so we don't error if the nodepool is already added).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->



**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
On detecting updating state, we wait, see line 54:
https://msazure.visualstudio.com/One/_build/results?buildId=105433502&view=logs&j=66af8358-44a8-5a80-90ff-77e03c31665a&t=8f8dc4ee-a8ef-5fc9-ab65-cc330785c488
When not detecting updating state, we proceed:
https://msazure.visualstudio.com/One/_build/results?buildId=105437613&view=logs&s=46b305b8-7ec3-51e0-83b8-e4b201974b98&j=66af8358-44a8-5a80-90ff-77e03c31665a