### PR TITLE
[NPM] L1Vh Endpoints Fix for NPM Lite

### DIFF
--- a/npm/cmd/start.go
+++ b/npm/cmd/start.go
@@ -130,6 +130,8 @@ func start(config npmconfig.Config, flags npmconfig.Flags) error {
 				options.FieldSelector = "spec.nodeName=" + models.GetNodeName()
 			}),
 		)
+		npmV2DataplaneCfg.IsL1VHNode = config.Toggles.IsL1VHNode
+		npmV2DataplaneCfg.EnableNPMLite = config.Toggles.EnableNPMLite
 	}
 	k8sServerVersion := k8sServerVersion(clientset)
 

--- a/npm/config/config.go
+++ b/npm/config/config.go
@@ -52,6 +52,7 @@ var DefaultConfig = Config{
 		// NetPolInBackground is currently used in Linux to apply NetPol controller Add events in the background
 		NetPolInBackground: true,
 		EnableNPMLite:      false,
+		IsL1VHNode:         false,
 	},
 }
 
@@ -96,6 +97,7 @@ type Toggles struct {
 	// NetPolInBackground
 	NetPolInBackground bool
 	EnableNPMLite      bool
+	IsL1VHNode         bool
 }
 
 type Flags struct {

--- a/npm/examples/windows/azure-npm-lite-win.yaml
+++ b/npm/examples/windows/azure-npm-lite-win.yaml
@@ -154,6 +154,7 @@ data:
             "ApplyIPSetsOnNeed":       false,
             "ApplyInBackground":       true,
             "NetPolInBackground":      true
-            "EnableNPMLite":           true
+            "EnableNPMLite":           true,
+            "IsL1VHNode":              true
         }
     }

--- a/npm/pkg/dataplane/dataplane.go
+++ b/npm/pkg/dataplane/dataplane.go
@@ -45,6 +45,8 @@ type Config struct {
 	NetPolInBackground bool
 	MaxPendingNetPols  int
 	NetPolInterval     time.Duration
+	IsL1VHNode         bool
+	EnableNPMLite      bool
 	*ipsets.IPSetManagerCfg
 	*policies.PolicyManagerCfg
 }

--- a/npm/pkg/dataplane/dataplane_windows.go
+++ b/npm/pkg/dataplane/dataplane_windows.go
@@ -51,7 +51,9 @@ func (dp *DataPlane) initializeDataPlane() error {
 		Flags: hcn.HostComputeQueryFlagsNone,
 	}
 	// Filter out any endpoints that are not in "AttachedShared" State. All running Windows pods with networking must be in this state.
-	filterMap := map[string]uint16{"State": hcnEndpointStateAttachedSharing}
+	//testing
+	filterMap := map[string]uint16{"State": hcnEndpointStateAttached}
+	klog.Info("State: hcnEndpointStateAttachedSharing")
 
 	// if npm lite is enabled and running on l1vh node, filter out any endpoints that are not in "Attached" State
 	if dp.EnableNPMLite && dp.IsL1VHNode {

--- a/npm/pkg/dataplane/dataplane_windows.go
+++ b/npm/pkg/dataplane/dataplane_windows.go
@@ -52,6 +52,12 @@ func (dp *DataPlane) initializeDataPlane() error {
 	}
 	// Filter out any endpoints that are not in "AttachedShared" State. All running Windows pods with networking must be in this state.
 	filterMap := map[string]uint16{"State": hcnEndpointStateAttachedSharing}
+
+	// if npm lite is enabled and running on l1vh node, filter out any endpoints that are not in "Attached" State
+	if dp.EnableNPMLite && dp.IsL1VHNode {
+		filterMap = map[string]uint16{"State": hcnEndpointStateAttached}
+	}
+
 	filter, err := json.Marshal(filterMap)
 	if err != nil {
 		return npmerrors.SimpleErrorWrapper("failed to marshal endpoint filter map", err)

--- a/npm/pkg/dataplane/dataplane_windows.go
+++ b/npm/pkg/dataplane/dataplane_windows.go
@@ -55,6 +55,7 @@ func (dp *DataPlane) initializeDataPlane() error {
 
 	// if npm lite is enabled and running on l1vh node, filter out any endpoints that are not in "Attached" State
 	if dp.EnableNPMLite && dp.IsL1VHNode {
+		klog.Info("NPM lite is running on L1VH Node")
 		filterMap = map[string]uint16{"State": hcnEndpointStateAttached}
 	}
 

--- a/npm/pkg/dataplane/dataplane_windows.go
+++ b/npm/pkg/dataplane/dataplane_windows.go
@@ -51,9 +51,8 @@ func (dp *DataPlane) initializeDataPlane() error {
 		Flags: hcn.HostComputeQueryFlagsNone,
 	}
 	// Filter out any endpoints that are not in "AttachedShared" State. All running Windows pods with networking must be in this state.
-	//testing
-	filterMap := map[string]uint16{"State": hcnEndpointStateAttached}
-	klog.Info("State: hcnEndpointStateAttachedSharing")
+	filterMap := map[string]uint16{"State": hcnEndpointStateAttachedSharing}
+	klog.Info("State:hcnEndpointStateAttachedSharing ")
 
 	// if npm lite is enabled and running on l1vh node, filter out any endpoints that are not in "Attached" State
 	if dp.EnableNPMLite && dp.IsL1VHNode {


### PR DESCRIPTION
…in l1vh node

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Currently when npm lite is enabled and running on an l1vh node, in the npm daemon set logs we see a log stating "ignoring pod update since there is no corresponding endpoints". The endpoints of the pods do exist in the HNS network itself; however, the logs are not able to find them.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
The state of the endpoints in HNS network in L1VH node is 2 which corresponds to state "hcnEndpointStateAttached". In the original windows NPM setup, the state of the endpoints in non-L1VH nodes is 3 which corresponds to state "hcnEndpointStateAttachedSharing". This pr adds a statement which checks if npm lite is enabled and running on L1VH node and if so, the endpoints are filter based on "hcnEndpointStateAttached" rather than "hcnEndpointStateAttachedSharing".

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
