### PR TITLE
test: add uts for cni add function

### DIFF
--- a/cni/network/invoker_mock.go
+++ b/cni/network/invoker_mock.go
@@ -47,7 +47,7 @@ func NewMockIpamInvoker(ipv6, v4Fail, v6Fail, delegatedVMNIC, delegatedVMNICFail
 
 func NewCustomMockIpamInvoker(customReturn map[string]network.InterfaceInfo) *MockIpamInvoker {
 	return &MockIpamInvoker{
-		add: func(opt IPAMAddConfig) (ipamAddResult IPAMAddResult, err error) {
+		add: func(_ IPAMAddConfig) (ipamAddResult IPAMAddResult, err error) {
 			ipamAddResult = IPAMAddResult{interfaceInfo: make(map[string]network.InterfaceInfo)}
 			ipamAddResult.interfaceInfo = customReturn
 			return ipamAddResult, nil

--- a/cni/network/invoker_mock.go
+++ b/cni/network/invoker_mock.go
@@ -31,7 +31,7 @@ type MockIpamInvoker struct {
 	delegatedVMNIC     bool
 	delegatedVMNICFail bool
 	ipMap              map[string]bool
-	customReturn       map[string]network.InterfaceInfo
+	add                func(opt IPAMAddConfig) (ipamAddResult IPAMAddResult, err error)
 }
 
 func NewMockIpamInvoker(ipv6, v4Fail, v6Fail, delegatedVMNIC, delegatedVMNICFail bool) *MockIpamInvoker {
@@ -47,8 +47,11 @@ func NewMockIpamInvoker(ipv6, v4Fail, v6Fail, delegatedVMNIC, delegatedVMNICFail
 
 func NewCustomMockIpamInvoker(customReturn map[string]network.InterfaceInfo) *MockIpamInvoker {
 	return &MockIpamInvoker{
-		customReturn: customReturn,
-
+		add: func(opt IPAMAddConfig) (ipamAddResult IPAMAddResult, err error) {
+			ipamAddResult = IPAMAddResult{interfaceInfo: make(map[string]network.InterfaceInfo)}
+			ipamAddResult.interfaceInfo = customReturn
+			return ipamAddResult, nil
+		},
 		ipMap: make(map[string]bool),
 	}
 }
@@ -112,9 +115,8 @@ func (invoker *MockIpamInvoker) Add(opt IPAMAddConfig) (ipamAddResult IPAMAddRes
 		}
 	}
 
-	if invoker.customReturn != nil {
-		ipamAddResult.interfaceInfo = invoker.customReturn
-		return ipamAddResult, nil
+	if invoker.add != nil {
+		return invoker.add(opt)
 	}
 
 	return ipamAddResult, nil

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -46,6 +46,7 @@ func setNetworkOptions(cnsNwConfig *cns.GetNetworkContainerResponse, nwInfo *net
 	}
 }
 
+// update epInfo data field, allow host to nc, allow nc to host, and network container id
 func setEndpointOptions(cnsNwConfig *cns.GetNetworkContainerResponse, epInfo *network.EndpointInfo, vethName string) {
 	if cnsNwConfig != nil && cnsNwConfig.MultiTenancyInfo.ID != 0 {
 		logger.Info("Setting Endpoint Options")

--- a/cni/network/network_linux_test.go
+++ b/cni/network/network_linux_test.go
@@ -5,7 +5,6 @@ package network
 
 import (
 	"fmt"
-	"log"
 	"net"
 	"regexp"
 	"testing"
@@ -511,26 +510,26 @@ func TestPluginLinuxAdd(t *testing.T) {
 
 			// compare contents
 			for _, wantedEndpointEntry := range tt.want {
-				epId := "none"
+				epID := "none"
 				for _, endpointInfo := range allEndpoints {
-					log.Printf("%v", endpointInfo.NetworkID)
-					if tt.match(wantedEndpointEntry.epInfo, endpointInfo) {
-						// save the endpoint id before removing it
-						epId = endpointInfo.EndpointID
-						require.Regexp(t, regexp.MustCompile(wantedEndpointEntry.epIDRegex), epId)
-
-						// omit endpoint id and ifname fields as they are nondeterministic
-						endpointInfo.EndpointID = ""
-						endpointInfo.IfName = ""
-
-						require.Equal(t, wantedEndpointEntry.epInfo, endpointInfo)
-						break
+					if !tt.match(wantedEndpointEntry.epInfo, endpointInfo) {
+						continue
 					}
+					// save the endpoint id before removing it
+					epID = endpointInfo.EndpointID
+					require.Regexp(t, regexp.MustCompile(wantedEndpointEntry.epIDRegex), epID)
+
+					// omit endpoint id and ifname fields as they are nondeterministic
+					endpointInfo.EndpointID = ""
+					endpointInfo.IfName = ""
+
+					require.Equal(t, wantedEndpointEntry.epInfo, endpointInfo)
 				}
-				if epId == "none" {
+				if epID == "none" {
 					t.Fail()
 				}
-				tt.plugin.nm.DeleteEndpoint("", epId, nil)
+				err = tt.plugin.nm.DeleteEndpoint("", epID, nil)
+				require.NoError(t, err)
 			}
 
 			// confirm separate entities

--- a/cni/network/network_linux_test.go
+++ b/cni/network/network_linux_test.go
@@ -235,6 +235,12 @@ func TestPluginLinuxAdd(t *testing.T) {
 		MultiTenancy:               false,
 		EnableExactMatchForPodName: true,
 		// test auto finding master interface
+		DNS: types.DNS{
+			Nameservers: []string{
+				"ns1", "ns2",
+			},
+			Domain: "myDomain",
+		},
 	}
 	macAddress := "60:45:bd76:f6:44"
 	parsedMACAddress, _ := net.ParseMAC(macAddress)
@@ -405,6 +411,12 @@ func TestPluginLinuxAdd(t *testing.T) {
 						NetNsPath:         "bc526fae-4ba0-4e80-bc90-ad721e5850bf",
 						NetNs:             "bc526fae-4ba0-4e80-bc90-ad721e5850bf",
 						HostSubnetPrefix:  "10.224.0.0/16",
+						EndpointDNS: network.DNSInfo{
+							Servers: []string{
+								"ns1", "ns2",
+							},
+							Suffix: "myDomain",
+						},
 						Options: map[string]interface{}{
 							"testflag": "copy",
 						},
@@ -456,6 +468,12 @@ func TestPluginLinuxAdd(t *testing.T) {
 						NetNsPath:         "bc526fae-4ba0-4e80-bc90-ad721e5850bf",
 						NetNs:             "bc526fae-4ba0-4e80-bc90-ad721e5850bf",
 						HostSubnetPrefix:  "<nil>",
+						EndpointDNS: network.DNSInfo{
+							Servers: []string{
+								"ns1", "ns2",
+							},
+							Suffix: "myDomain",
+						},
 						Options: map[string]interface{}{
 							"testflag": "copy",
 						},

--- a/cni/network/network_linux_test.go
+++ b/cni/network/network_linux_test.go
@@ -508,6 +508,8 @@ func TestPluginLinuxAdd(t *testing.T) {
 			require.NoError(t, err)
 			allEndpoints, _ := tt.plugin.nm.GetAllEndpoints("")
 			require.Len(t, allEndpoints, len(tt.want))
+
+			// compare contents
 			for _, wantedEndpointEntry := range tt.want {
 				epId := "none"
 				for _, endpointInfo := range allEndpoints {
@@ -531,6 +533,23 @@ func TestPluginLinuxAdd(t *testing.T) {
 				tt.plugin.nm.DeleteEndpoint("", epId, nil)
 			}
 
+			// confirm separate entities
+			// that is, if one is modified, the other should not be modified
+			epInfos := []*network.EndpointInfo{}
+			for _, val := range allEndpoints {
+				epInfos = append(epInfos, val)
+			}
+			if len(epInfos) > 1 {
+				epInfo1 := epInfos[0]
+				epInfo2 := epInfos[1]
+				epInfo1.Data["dummy"] = "dummy value"
+				epInfo1.Options["dummy"] = "another dummy value"
+				require.NotEqual(t, epInfo1.Data, epInfo2.Data)
+				require.NotEqual(t, epInfo1.Options, epInfo2.Options)
+			}
+
+			// ensure deleted
+			require.Empty(t, allEndpoints)
 		})
 	}
 }

--- a/cni/network/network_linux_test.go
+++ b/cni/network/network_linux_test.go
@@ -4,10 +4,18 @@
 package network
 
 import (
+	"fmt"
+	"log"
+	"net"
+	"regexp"
 	"testing"
 
+	"github.com/Azure/azure-container-networking/cni"
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/network"
+	"github.com/Azure/azure-container-networking/platform"
+	"github.com/Azure/azure-container-networking/telemetry"
+	cniSkel "github.com/containernetworking/cni/pkg/skel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -157,6 +165,144 @@ func TestAddSnatForDns(t *testing.T) {
 					tt.epInfo.Routes[0].Gw.String() == "192.168.0.1" &&
 					tt.epInfo.Routes[0].Dst.String() == "168.63.129.16/32"
 			}))
+		})
+	}
+}
+
+// Happy path scenario for add and delete
+func TestPluginLinuxAdd(t *testing.T) {
+	resources := GetTestResources()
+	localNwCfg := cni.NetworkConfig{
+		CNIVersion:                 "0.3.0",
+		Name:                       "mulnet",
+		MultiTenancy:               true,
+		EnableExactMatchForPodName: true,
+		Master:                     "eth0",
+	}
+	type endpointEntry struct {
+		epInfo    *network.EndpointInfo
+		epIDRegex string
+	}
+
+	tests := []struct {
+		name   string
+		plugin *NetPlugin
+		args   *cniSkel.CmdArgs
+		want   []endpointEntry
+		match  func(*network.EndpointInfo, *network.EndpointInfo) bool
+	}{
+		{
+			// in swiftv1 linux multitenancy, we only get 1 response from cns at a time
+			name: "Add Happy Path Swiftv1 Multitenancy",
+			plugin: &NetPlugin{
+				Plugin:             resources.Plugin,
+				nm:                 network.NewMockNetworkmanager(network.NewMockEndpointClient(nil)),
+				tb:                 &telemetry.TelemetryBuffer{},
+				report:             &telemetry.CNIReport{},
+				multitenancyClient: NewMockMultitenancy(false, []*cns.GetNetworkContainerResponse{GetTestCNSResponse3()}),
+			},
+			args: &cniSkel.CmdArgs{
+				StdinData:   localNwCfg.Serialize(),
+				ContainerID: "test-container",
+				Netns:       "bc526fae-4ba0-4e80-bc90-ad721e5850bf",
+				Args:        fmt.Sprintf("K8S_POD_NAME=%v;K8S_POD_NAMESPACE=%v", "test-pod", "test-pod-ns"),
+				IfName:      eth0IfName,
+			},
+			match: func(ei1, ei2 *network.EndpointInfo) bool {
+				return ei1.NetworkContainerID == ei2.NetworkContainerID
+			},
+			want: []endpointEntry{
+				// should match with GetTestCNSResponse3
+				{
+					epInfo: &network.EndpointInfo{
+						ContainerID: "test-container",
+						Data: map[string]interface{}{
+							"VlanID":       1, // Vlan ID used here
+							"localIP":      "168.254.0.4/17",
+							"snatBridgeIP": "168.254.0.1/17",
+							"vethname":     "mulnettest-containereth0",
+						},
+						Routes: []network.RouteInfo{
+							{
+								Dst: *parseCIDR("192.168.0.4/24"),
+								Gw:  net.ParseIP("192.168.0.1"),
+								// interface to use is NOT propagated to ep info
+							},
+						},
+						AllowInboundFromHostToNC: true,
+						EnableSnatOnHost:         true,
+						EnableMultiTenancy:       true,
+						EnableSnatForDns:         true,
+						PODName:                  "test-pod",
+						PODNameSpace:             "test-pod-ns",
+						NICType:                  cns.InfraNIC,
+						MasterIfName:             eth0IfName,
+						NetworkContainerID:       "Swift_74b34111-6e92-49ee-a82a-8881c850ce0e",
+						NetworkID:                "mulnet",
+						NetNsPath:                "bc526fae-4ba0-4e80-bc90-ad721e5850bf",
+						NetNs:                    "bc526fae-4ba0-4e80-bc90-ad721e5850bf",
+						HostSubnetPrefix:         "20.240.0.0/24",
+						Options: map[string]interface{}{
+							dockerNetworkOption: map[string]interface{}{
+								"VlanID":       "1", // doesn't seem to be used in linux
+								"snatBridgeIP": "168.254.0.1/17",
+							},
+						},
+						// matches with cns ip configuration
+						IPAddresses: []net.IPNet{
+							{
+								IP:   net.ParseIP("20.0.0.10"),
+								Mask: getIPNetWithString("20.0.0.10/24").Mask,
+							},
+						},
+						NATInfo: nil,
+						// ip config pod ip + mask(s) from cns > interface info > subnet info
+						Subnets: []network.SubnetInfo{
+							{
+								Family: platform.AfINET,
+								// matches cns ip configuration (20.0.0.1/24 == 20.0.0.0/24)
+								Prefix: *getIPNetWithString("20.0.0.0/24"),
+								// matches cns ip configuration gateway ip address
+								Gateway: net.ParseIP("20.0.0.1"),
+							},
+						},
+					},
+					epIDRegex: `test-con-eth0`,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.plugin.Add(tt.args)
+			require.NoError(t, err)
+			allEndpoints, _ := tt.plugin.nm.GetAllEndpoints("")
+			require.Len(t, allEndpoints, len(tt.want))
+			for _, wantedEndpointEntry := range tt.want {
+				epId := "none"
+				for _, endpointInfo := range allEndpoints {
+					log.Printf("%v", endpointInfo.NetworkID)
+					if tt.match(wantedEndpointEntry.epInfo, endpointInfo) {
+						// save the endpoint id before removing it
+						epId = endpointInfo.EndpointID
+						require.Regexp(t, regexp.MustCompile(wantedEndpointEntry.epIDRegex), epId)
+
+						// omit endpoint id and ifname fields as they are nondeterministic
+						endpointInfo.EndpointID = ""
+						endpointInfo.IfName = ""
+
+						require.Equal(t, wantedEndpointEntry.epInfo, endpointInfo)
+						break
+					}
+				}
+				if epId == "none" {
+					t.Fail()
+				}
+				tt.plugin.nm.DeleteEndpoint("", epId, nil)
+			}
+
 		})
 	}
 }

--- a/cni/network/network_test.go
+++ b/cni/network/network_test.go
@@ -688,6 +688,44 @@ func GetTestCNSResponse2() *cns.GetNetworkContainerResponse {
 	}
 }
 
+// For use with GetAllNetworkContainers in linux multitenancy
+func GetTestCNSResponse3() *cns.GetNetworkContainerResponse {
+	return &cns.GetNetworkContainerResponse{
+		NetworkContainerID: "Swift_74b34111-6e92-49ee-a82a-8881c850ce0e",
+		IPConfiguration: cns.IPConfiguration{
+			IPSubnet: cns.IPSubnet{
+				IPAddress:    "20.0.0.10",
+				PrefixLength: ipPrefixLen,
+			},
+			DNSServers: []string{
+				"168.63.129.16",
+			},
+			GatewayIPAddress: "20.0.0.1",
+		},
+		Routes: []cns.Route{
+			// dummy route
+			{
+				IPAddress:        "192.168.0.4/24",
+				GatewayIPAddress: "192.168.0.1",
+			},
+		},
+		MultiTenancyInfo: cns.MultiTenancyInfo{
+			EncapType: cns.Vlan,
+			ID:        multiTenancyVlan1,
+		},
+		PrimaryInterfaceIdentifier: "20.240.0.4/24",
+		LocalIPConfiguration: cns.IPConfiguration{
+			IPSubnet: cns.IPSubnet{
+				IPAddress:    "168.254.0.4",
+				PrefixLength: localIPPrefixLen,
+			},
+			GatewayIPAddress: "168.254.0.1",
+		},
+		AllowHostToNCCommunication: true,
+		AllowNCToHostCommunication: false,
+	}
+}
+
 // Test Multitenancy Add
 func TestPluginMultitenancyAdd(t *testing.T) {
 	plugin, _ := cni.NewPlugin("test", "0.3.0")

--- a/cni/network/network_windows_test.go
+++ b/cni/network/network_windows_test.go
@@ -955,7 +955,7 @@ func TestPluginWindowsAdd(t *testing.T) {
 					epInfo: &network.EndpointInfo{
 						ContainerID: "test-container",
 						Data: map[string]interface{}{
-							"cnetAddressSpace": ([]string)(nil),
+							"cnetAddressSpace": []string(nil),
 						},
 						Routes:             []network.RouteInfo{},
 						EnableSnatOnHost:   true,
@@ -1010,7 +1010,7 @@ func TestPluginWindowsAdd(t *testing.T) {
 					epInfo: &network.EndpointInfo{
 						ContainerID: "test-container",
 						Data: map[string]interface{}{
-							"cnetAddressSpace": ([]string)(nil),
+							"cnetAddressSpace": []string(nil),
 						},
 						Routes:             []network.RouteInfo{},
 						EnableSnatOnHost:   true,
@@ -1189,25 +1189,26 @@ func TestPluginWindowsAdd(t *testing.T) {
 			allEndpoints, _ := tt.plugin.nm.GetAllEndpoints("")
 			require.Len(t, allEndpoints, len(tt.want))
 			for _, wantedEndpointEntry := range tt.want {
-				epId := "none"
+				epID := "none"
 				for _, endpointInfo := range allEndpoints {
-					if tt.match(wantedEndpointEntry.epInfo, endpointInfo) {
-						// save the endpoint id before removing it
-						epId = endpointInfo.EndpointID
-						require.Regexp(t, regexp.MustCompile(wantedEndpointEntry.epIDRegex), epId)
-
-						// omit endpoint id and ifname fields as they are nondeterministic
-						endpointInfo.EndpointID = ""
-						endpointInfo.IfName = ""
-
-						require.Equal(t, wantedEndpointEntry.epInfo, endpointInfo)
-						break
+					if !tt.match(wantedEndpointEntry.epInfo, endpointInfo) {
+						continue
 					}
+					// save the endpoint id before removing it
+					epID = endpointInfo.EndpointID
+					require.Regexp(t, regexp.MustCompile(wantedEndpointEntry.epIDRegex), epID)
+
+					// omit endpoint id and ifname fields as they are nondeterministic
+					endpointInfo.EndpointID = ""
+					endpointInfo.IfName = ""
+
+					require.Equal(t, wantedEndpointEntry.epInfo, endpointInfo)
 				}
-				if epId == "none" {
+				if epID == "none" {
 					t.Fail()
 				}
-				tt.plugin.nm.DeleteEndpoint("", epId, nil)
+				err = tt.plugin.nm.DeleteEndpoint("", epID, nil)
+				require.NoError(t, err)
 			}
 
 			// ensure deleted

--- a/cni/network/network_windows_test.go
+++ b/cni/network/network_windows_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"regexp"
 	"testing"
 
 	"github.com/Azure/azure-container-networking/cni"
@@ -14,6 +15,7 @@ import (
 	"github.com/Azure/azure-container-networking/network"
 	"github.com/Azure/azure-container-networking/network/hnswrapper"
 	"github.com/Azure/azure-container-networking/network/policy"
+	"github.com/Azure/azure-container-networking/platform"
 	"github.com/Azure/azure-container-networking/telemetry"
 	hnsv2 "github.com/Microsoft/hcsshim/hcn"
 	cniSkel "github.com/containernetworking/cni/pkg/skel"
@@ -852,6 +854,185 @@ func TestPluginMultitenancyWindowsDelete(t *testing.T) {
 				endpoints, _ := plugin.nm.GetAllEndpoints(localNwCfg.Name)
 				require.Condition(t, assert.Comparison(func() bool { return len(endpoints) == 0 }))
 			}
+		})
+	}
+}
+
+// Happy path scenario for add and delete
+func TestPluginWindowsAdd(t *testing.T) {
+	resources := GetTestResources()
+	localNwCfg := cni.NetworkConfig{
+		CNIVersion:                 "0.3.0",
+		Name:                       "mulnet",
+		MultiTenancy:               true,
+		EnableExactMatchForPodName: true,
+		Master:                     "eth0",
+	}
+	type endpointEntry struct {
+		epInfo    *network.EndpointInfo
+		epIDRegex string
+	}
+
+	tests := []struct {
+		name   string
+		plugin *NetPlugin
+		args   *cniSkel.CmdArgs
+		want   []endpointEntry
+		match  func(*network.EndpointInfo, *network.EndpointInfo) bool
+	}{
+		{
+			name: "Add Happy Path Dual NIC",
+			plugin: &NetPlugin{
+				Plugin:             resources.Plugin,
+				nm:                 network.NewMockNetworkmanager(network.NewMockEndpointClient(nil)),
+				tb:                 &telemetry.TelemetryBuffer{},
+				report:             &telemetry.CNIReport{},
+				multitenancyClient: NewMockMultitenancy(false, []*cns.GetNetworkContainerResponse{GetTestCNSResponse1(), GetTestCNSResponse2()}),
+			},
+			args: &cniSkel.CmdArgs{
+				StdinData:   localNwCfg.Serialize(),
+				ContainerID: "test-container",
+				Netns:       "bc526fae-4ba0-4e80-bc90-ad721e5850bf",
+				Args:        fmt.Sprintf("K8S_POD_NAME=%v;K8S_POD_NAMESPACE=%v", "test-pod", "test-pod-ns"),
+				IfName:      eth0IfName,
+			},
+			match: func(ei1, ei2 *network.EndpointInfo) bool {
+				return ei1.NetworkID == ei2.NetworkID
+			},
+			want: []endpointEntry{
+				// should match with GetTestCNSResponse1
+				{
+					epInfo: &network.EndpointInfo{
+						ContainerID: "test-container",
+						Data: map[string]interface{}{
+							"cnetAddressSpace": ([]string)(nil),
+						},
+						Routes:             []network.RouteInfo{},
+						EnableSnatOnHost:   true,
+						EnableMultiTenancy: true,
+						EnableSnatForDns:   true,
+						PODName:            "test-pod",
+						PODNameSpace:       "test-pod-ns",
+						NICType:            cns.InfraNIC,
+						MasterIfName:       eth0IfName,
+						NetworkID:          "mulnet-vlan1-20-0-0-0_24",
+						NetNsPath:          "bc526fae-4ba0-4e80-bc90-ad721e5850bf",
+						NetNs:              "bc526fae-4ba0-4e80-bc90-ad721e5850bf",
+						HostSubnetPrefix:   "20.240.0.0/24",
+						Options: map[string]interface{}{
+							dockerNetworkOption: map[string]interface{}{
+								"VlanID": "1",
+							},
+						},
+						// matches with cns ip configuration
+						IPAddresses: []net.IPNet{
+							{
+								IP:   net.ParseIP("20.0.0.10"),
+								Mask: getIPNetWithString("20.0.0.10/24").Mask,
+							},
+						},
+						// LocalIPConfiguration doesn't seem used in windows
+						// Constant, in windows, NAT Info comes from
+						// options > ipamAddConfig >
+						// cns invoker may populate network.SNATIPKey with the default response received >
+						// getNATInfo (with nwCfg) > adds nat info based on condition
+						// typically adds azure dns (168.63.129.16)
+						NATInfo: []policy.NATInfo{
+							{
+								Destinations: []string{"168.63.129.16"},
+							},
+						},
+						// ip config pod ip + mask(s) from cns > interface info > subnet info
+						Subnets: []network.SubnetInfo{
+							{
+								Family: platform.AfINET,
+								// matches cns ip configuration (20.0.0.1/24 == 20.0.0.0/24)
+								Prefix: *getIPNetWithString("20.0.0.0/24"),
+								// matches cns ip configuration gateway ip address
+								Gateway: net.ParseIP("20.0.0.1"),
+							},
+						},
+					},
+					epIDRegex: `.*`,
+				},
+				// should match with GetTestCNSResponse2
+				{
+					epInfo: &network.EndpointInfo{
+						ContainerID: "test-container",
+						Data: map[string]interface{}{
+							"cnetAddressSpace": ([]string)(nil),
+						},
+						Routes:             []network.RouteInfo{},
+						EnableSnatOnHost:   true,
+						EnableMultiTenancy: true,
+						EnableSnatForDns:   true,
+						PODName:            "test-pod",
+						PODNameSpace:       "test-pod-ns",
+						NICType:            cns.InfraNIC,
+						MasterIfName:       eth0IfName,
+						NetworkID:          "mulnet-vlan2-10-0-0-0_24",
+						NetNsPath:          "bc526fae-4ba0-4e80-bc90-ad721e5850bf",
+						NetNs:              "bc526fae-4ba0-4e80-bc90-ad721e5850bf",
+						HostSubnetPrefix:   "10.240.0.0/24",
+						Options: map[string]interface{}{
+							dockerNetworkOption: map[string]interface{}{
+								"VlanID": "2",
+							},
+						},
+						IPAddresses: []net.IPNet{
+							{
+								IP:   net.ParseIP("10.0.0.10"),
+								Mask: getIPNetWithString("10.0.0.10/24").Mask,
+							},
+						},
+						NATInfo: []policy.NATInfo{
+							{
+								Destinations: []string{"168.63.129.16"},
+							},
+						},
+						Subnets: []network.SubnetInfo{
+							{
+								Family:  platform.AfINET,
+								Prefix:  *getIPNetWithString("10.0.0.0/24"),
+								Gateway: net.ParseIP("10.0.0.1"),
+							},
+						},
+					},
+					epIDRegex: `.*`,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.plugin.Add(tt.args)
+			require.NoError(t, err)
+			allEndpoints, _ := tt.plugin.nm.GetAllEndpoints("")
+			require.Len(t, allEndpoints, len(tt.want))
+			for _, wantedEndpointEntry := range tt.want {
+				epId := "none"
+				for _, endpointInfo := range allEndpoints {
+					if tt.match(wantedEndpointEntry.epInfo, endpointInfo) {
+						// save the endpoint id before removing it
+						epId = endpointInfo.EndpointID
+						require.Regexp(t, regexp.MustCompile(wantedEndpointEntry.epIDRegex), epId)
+
+						// omit endpoint id and ifname fields as they are nondeterministic
+						endpointInfo.EndpointID = ""
+						endpointInfo.IfName = ""
+
+						require.Equal(t, wantedEndpointEntry.epInfo, endpointInfo)
+						break
+					}
+				}
+				if epId == "none" {
+					t.Fail()
+				}
+				tt.plugin.nm.DeleteEndpoint("", epId, nil)
+			}
+
 		})
 	}
 }

--- a/cni/network/network_windows_test.go
+++ b/cni/network/network_windows_test.go
@@ -858,6 +858,39 @@ func TestPluginMultitenancyWindowsDelete(t *testing.T) {
 	}
 }
 
+// windows swiftv2 example
+func GetTestCNSResponseSecondary() map[string]network.InterfaceInfo {
+	macAddress := "60:45:bd76:f6:44"
+	parsedMAC, _ := net.ParseMAC(macAddress)
+	return map[string]network.InterfaceInfo{
+		string(cns.InfraNIC): {
+			IPConfigs: []*network.IPConfig{
+				{
+					Address: *getCIDRNotationForAddress("10.244.2.107/16"),
+					Gateway: net.ParseIP("10.244.2.1"),
+				},
+			},
+			Routes: []network.RouteInfo{
+				{
+					Gw: net.ParseIP("10.244.2.1"),
+				},
+			},
+			SkipDefaultRoutes: true,
+			NICType:           cns.InfraNIC,
+		},
+		"60:45:bd76:f6:44": {
+			MacAddress: parsedMAC,
+			IPConfigs: []*network.IPConfig{
+				{
+					Address: *getCIDRNotationForAddress("10.241.0.21/16"),
+					Gateway: net.ParseIP("10.241.0.1"),
+				},
+			},
+			NICType: cns.NodeNetworkInterfaceFrontendNIC,
+		},
+	}
+}
+
 // Happy path scenario for add and delete
 func TestPluginWindowsAdd(t *testing.T) {
 	resources := GetTestResources()

--- a/cni/network/network_windows_test.go
+++ b/cni/network/network_windows_test.go
@@ -1210,6 +1210,8 @@ func TestPluginWindowsAdd(t *testing.T) {
 				tt.plugin.nm.DeleteEndpoint("", epId, nil)
 			}
 
+			// ensure deleted
+			require.Empty(t, allEndpoints)
 		})
 	}
 }

--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -93,7 +93,7 @@ type EndpointInfo struct {
 	IPV6Mode                 string
 	VnetCidrs                string
 	ServiceCidrs             string
-	NATInfo                  []policy.NATInfo
+	NATInfo                  []policy.NATInfo // windows only
 	NICType                  cns.NICType
 	SkipDefaultRoutes        bool
 	HNSEndpointID            string

--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -66,7 +66,7 @@ type EndpointInfo struct {
 	EndpointID               string
 	ContainerID              string
 	NetNsPath                string
-	IfName                   string // value differs during creation vs. deletion flow
+	IfName                   string // value differs during creation vs. deletion flow; used in statefile, not necessarily the nic name
 	SandboxKey               string
 	IfIndex                  int
 	MacAddress               net.HardwareAddr

--- a/network/secondary_endpoint_linux_test.go
+++ b/network/secondary_endpoint_linux_test.go
@@ -79,6 +79,7 @@ func TestSecondaryAddEndpoints(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tt.client.ep.SecondaryInterfaces["eth1"].MacAddress, tt.epInfo.MacAddress)
+				require.Equal(t, "eth1", tt.epInfo.IfName, "interface name should update based on mac address here before being referenced later")
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Adds unit tests to test that endpoint info struct creation is as expected based on args, cns/ipam invoker response, and network configuration for the following scenarios:
- swiftv2 linux ipam response (infra + delegated) -> endpoint info
- swiftv2 windows ipam response (infra + delegated) -> endpoint info
- swiftv1 windows multitenancy dual nic ipam response  (infra + infra) -> endpoint info
- swiftv1 linux multitenancy (infra) ipam response -> endpoint info

Each scenario tests the `Add` method from ipam response until we call an `EndpointCreate`, given args, ipam response, and network configuration and ensure the endpoint info struct generated _exactly matches_ what is expected (so all fields are checked) **except** for the interface name and endpoint id as they are nondeterministic identifiers generated during runtime.

Adds a check to ensure each endpoint info's Option and Data fields are separate.
Adds a check to ensure swiftv2 linux's endpoint info interface name is overwritten with the correct interface name.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests
- [X] relevant PR labels added

**Notes**:
This does not add tests for swiftv2 ib. It also does not explicitly add tests for swiftv1 non multitenancy scenarios as they are mostly covered by the multitenancy ones (singletenancy is just a single ipam response). This does not test anything that happens inside `EndpointCreate`.
