### PR TITLE
chore: delete podAntiAffinity from cilium daemonsets in test

### DIFF
--- a/test/integration/manifests/cilium/v1.13/cilium-agent/templates/daemonset.yaml
+++ b/test/integration/manifests/cilium/v1.13/cilium-agent/templates/daemonset.yaml
@@ -42,12 +42,6 @@ spec:
                 operator: In
                 values:
                 - linux
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                k8s-app: cilium
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map

--- a/test/integration/manifests/cilium/v1.14/cilium-agent/templates/daemonset-dualstack.yaml
+++ b/test/integration/manifests/cilium/v1.14/cilium-agent/templates/daemonset-dualstack.yaml
@@ -42,12 +42,6 @@ spec:
                 operator: In
                 values:
                 - linux
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                k8s-app: cilium
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map

--- a/test/integration/manifests/cilium/v1.14/cilium-agent/templates/daemonset.yaml
+++ b/test/integration/manifests/cilium/v1.14/cilium-agent/templates/daemonset.yaml
@@ -42,12 +42,6 @@ spec:
                 operator: In
                 values:
                 - linux
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                k8s-app: cilium
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map

--- a/test/integration/manifests/cilium/v1.16/cilium-agent/templates/daemonset-dualstack.yaml
+++ b/test/integration/manifests/cilium/v1.16/cilium-agent/templates/daemonset-dualstack.yaml
@@ -43,12 +43,6 @@ spec:
                 operator: In
                 values:
                 - linux
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                k8s-app: cilium
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map

--- a/test/integration/manifests/cilium/v1.16/cilium-agent/templates/daemonset.yaml
+++ b/test/integration/manifests/cilium/v1.16/cilium-agent/templates/daemonset.yaml
@@ -43,12 +43,6 @@ spec:
                 operator: In
                 values:
                 - linux
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                k8s-app: cilium
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
PodAntiAffinity slows down pod startup in large scale clusters. Removing this from daemonsets for all cilium versions


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
