### PR TITLE
fix: update pipeline to handle an extra character 'v' in version tag

### DIFF
--- a/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
+++ b/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
@@ -91,7 +91,7 @@ stages:
                   fi
 
                   echo "install Cilium ${CILIUM_VERSION_TAG}"
-                  export DIR=${CILIUM_VERSION_TAG%.*}
+                  export DIR=$(echo ${CILIUM_VERSION_TAG#v} | cut -d. -f1,2)
                   echo "installing files from ${DIR}"
 
                   echo "deploy Cilium ConfigMap"

--- a/.pipelines/cni/cilium/cilium-scale-test.yaml
+++ b/.pipelines/cni/cilium/cilium-scale-test.yaml
@@ -47,7 +47,7 @@ stages:
                 pwd
 
                 echo "install Cilium ${CILIUM_VERSION_TAG}"
-                export DIR=${CILIUM_VERSION_TAG%.*}
+                export DIR=$(echo ${CILIUM_VERSION_TAG#v} | cut -d. -f1,2)
                 echo "installing files from ${DIR}"
 
                 echo "deploy Cilium ConfigMap"

--- a/.pipelines/cni/lsg/lsg-cni-intergration-template.yaml
+++ b/.pipelines/cni/lsg/lsg-cni-intergration-template.yaml
@@ -95,7 +95,7 @@ stages:
                   kubectl get po -owide -A
 
                   echo "install Cilium ${CILIUM_VERSION_TAG}"
-                  export DIR=${CILIUM_VERSION_TAG%.*}
+                  export DIR=$(echo ${CILIUM_VERSION_TAG#v} | cut -d. -f1,2)
                   echo "installing files from ${DIR}"
 
                   echo "deploy Cilium ConfigMap"

--- a/.pipelines/networkobservability/pipeline.yaml
+++ b/.pipelines/networkobservability/pipeline.yaml
@@ -77,7 +77,7 @@ stages:
             scriptType: "bash"
             addSpnToEnvironment: true
             inlineScript: |
-              export DIR=${CILIUM_VERSION_TAG%.*}
+              export DIR=$(echo ${CILIUM_VERSION_TAG#v} | cut -d. -f1,2)
               echo "installing files from ${DIR}"
               kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-config/cilium-config-hubble.yaml
               kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-agent/files

--- a/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-step-template.yaml
@@ -34,7 +34,7 @@ steps:
         kubectl cluster-info
         kubectl get po -owide -A
         echo "install Cilium ${CILIUM_DUALSTACK_VERSION}"
-        export DIR=${CILIUM_DUALSTACK_VERSION%.*}
+        export DIR=$(echo ${CILIUM_DUALSTACK_VERSION#v} | cut -d. -f1,2)
         echo "installing files from ${DIR}"
         echo "deploy Cilium ConfigMap"
         kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-config/cilium-config-dualstack.yaml

--- a/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e.steps.yaml
+++ b/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e.steps.yaml
@@ -35,7 +35,7 @@ steps:
         kubectl cluster-info
         kubectl get po -owide -A
         echo "install Cilium ${CILIUM_DUALSTACK_VERSION}"
-        export DIR=${CILIUM_DUALSTACK_VERSION%.*}
+        export DIR=$(echo ${CILIUM_DUALSTACK_VERSION#v} | cut -d. -f1,2)
         echo "installing files from ${DIR}"
         echo "deploy Cilium ConfigMap"
         kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-config/cilium-config-dualstack.yaml

--- a/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-step-template.yaml
@@ -38,7 +38,7 @@ steps:
         make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
         ls -lah
         export CILIUM_VERSION_TAG=${CILIUM_HUBBLE_VERSION_TAG}
-        export DIR=${CILIUM_VERSION_TAG%.*}
+        export DIR=$(echo ${CILIUM_VERSION_TAG#v} | cut -d. -f1,2)
         echo "installing files from ${DIR}"
         kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-config/cilium-config-hubble.yaml
         kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-agent/files

--- a/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e.steps.yaml
+++ b/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e.steps.yaml
@@ -32,7 +32,7 @@ steps:
         make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
         ls -lah
         export CILIUM_VERSION_TAG=${CILIUM_HUBBLE_VERSION_TAG}
-        export DIR=${CILIUM_VERSION_TAG%.*}
+        export DIR=$(echo ${CILIUM_VERSION_TAG#v} | cut -d. -f1,2)
         echo "installing files from ${DIR}"
         kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-config/cilium-config-hubble.yaml
         kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-agent/files

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
@@ -54,7 +54,7 @@ steps:
           kubectl apply -f test/integration/manifests/cilium/cilium${FILE_PATH}-operator
         else
           echo "install Cilium ${CILIUM_VERSION_TAG}"
-          export DIR=${CILIUM_VERSION_TAG%.*}
+          export DIR=$(echo ${CILIUM_VERSION_TAG#v} | cut -d. -f1,2)
           echo "installing files from ${DIR}"
           echo "deploy Cilium ConfigMap"
           kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-config/cilium-config.yaml

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e.steps.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e.steps.yaml
@@ -48,7 +48,7 @@ steps:
           kubectl apply -f test/integration/manifests/cilium/cilium${FILE_PATH}-operator
         else
           echo "install Cilium ${CILIUM_VERSION_TAG}"
-          export DIR=${CILIUM_VERSION_TAG%.*}
+          export DIR=$(echo ${CILIUM_VERSION_TAG#v} | cut -d. -f1,2)
           echo "installing files from ${DIR}"
           echo "deploy Cilium ConfigMap"
           kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-config/cilium-config.yaml

--- a/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
@@ -40,7 +40,7 @@ steps:
         kubectl cluster-info
         kubectl get po -owide -A
         echo "install Cilium ${CILIUM_VERSION_TAG}"
-        export DIR=${CILIUM_VERSION_TAG%.*}
+        export DIR=$(echo ${CILIUM_VERSION_TAG#v} | cut -d. -f1,2)
         echo "installing files from ${DIR}"
         echo "deploy Cilium ConfigMap"
         kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-config/cilium-config.yaml

--- a/.pipelines/singletenancy/cilium/cilium-e2e.steps.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e.steps.yaml
@@ -34,7 +34,7 @@ steps:
         kubectl cluster-info
         kubectl get po -owide -A
         echo "install Cilium ${CILIUM_VERSION_TAG}"
-        export DIR=${CILIUM_VERSION_TAG%.*}
+        export DIR=$(echo ${CILIUM_VERSION_TAG#v} | cut -d. -f1,2)
         echo "installing files from ${DIR}"
         echo "deploy Cilium ConfigMap"
         kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-config/cilium-config.yaml


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
ACN pipelines used Cilium version tags that didn't include the letter 'v'. This PR updates the pipelines to handle private fork version tags, which include the letter 'v'. This will allow us to set ADO pipeline variables to point to ACN private fork images for Cilium.


**Issue Fixed**:
Lack of support for ACN Cilium private fork images


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
