### PR TITLE
Adding availability zone to nnc spec

### DIFF
--- a/crd/nodenetworkconfig/api/v1alpha/nodenetworkconfig.go
+++ b/crd/nodenetworkconfig/api/v1alpha/nodenetworkconfig.go
@@ -48,6 +48,7 @@ type NodeNetworkConfigSpec struct {
 	RequestedIPCount int64    `json:"requestedIPCount"`
 	IPsNotInUse      []string `json:"ipsNotInUse,omitempty"`
 	// AvailabilityZone contains the Azure availability zone for the virtual machine where network containers are placed.
+	// +kubebuilder:validation:Optional
 	AvailabilityZone string `json:"availabilityZone,omitempty"`
 }
 

--- a/crd/nodenetworkconfig/api/v1alpha/nodenetworkconfig.go
+++ b/crd/nodenetworkconfig/api/v1alpha/nodenetworkconfig.go
@@ -16,6 +16,7 @@ import (
 // +kubebuilder:resource:shortName=nnc
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Requested IPs",type=integer,priority=1,JSONPath=`.spec.requestedIPCount`
+// +kubebuilder:printcolumn:name="Availability Zone",type=string,priority=1,JSONPath=`.spec.availabilityZone`
 // +kubebuilder:printcolumn:name="Allocated IPs",type=integer,priority=0,JSONPath=`.status.assignedIPCount`
 // +kubebuilder:printcolumn:name="Subnet",type=string,priority=1,JSONPath=`.status.networkContainers[*].subnetName`
 // +kubebuilder:printcolumn:name="Subnet CIDR",type=string,priority=1,JSONPath=`.status.networkContainers[*].subnetAddressSpace`
@@ -46,6 +47,8 @@ type NodeNetworkConfigSpec struct {
 	// +kubebuilder:validation:Optional
 	RequestedIPCount int64    `json:"requestedIPCount"`
 	IPsNotInUse      []string `json:"ipsNotInUse,omitempty"`
+	// AvailabilityZone contains the Azure availability zone for the virtual machine where network containers are placed.
+	AvailabilityZone string `json:"availabilityZone,omitempty"`
 }
 
 // Status indicates the NNC reconcile status

--- a/crd/nodenetworkconfig/manifests/acn.azure.com_nodenetworkconfigs.yaml
+++ b/crd/nodenetworkconfig/manifests/acn.azure.com_nodenetworkconfigs.yaml
@@ -21,6 +21,10 @@ spec:
       name: Requested IPs
       priority: 1
       type: integer
+    - jsonPath: .spec.availabilityZone
+      name: Availability Zone
+      priority: 1
+      type: string
     - jsonPath: .status.assignedIPCount
       name: Allocated IPs
       type: integer
@@ -71,6 +75,10 @@ spec:
           spec:
             description: NodeNetworkConfigSpec defines the desired state of NetworkConfig
             properties:
+              availabilityZone:
+                description: AvailabilityZone contains the Azure availability zone
+                  for the virtual machine where network containers are placed.
+                type: string
               ipsNotInUse:
                 items:
                   type: string


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

In order to communicate the availability zone for ncs from the virtual machine where they are placed, we first need to expand the nnc definition to include the az in its status. Population will be handled in a subsequent PR.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
