### PR TITLE
fix: pass ai metadata to telemetry during cni image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -436,7 +436,8 @@ cni-image: ## build cni container image.
 		TARGET=$(OS) \
 		OS=$(OS) \
 		ARCH=$(ARCH) \
-		OS_VERSION=$(OS_VERSION)
+		OS_VERSION=$(OS_VERSION) \
+		EXTRA_BUILD_ARGS='--build-arg CNI_AI_PATH=$(CNI_AI_PATH) --build-arg CNI_AI_ID=$(CNI_AI_ID)'
 
 cni-image-push: ## push cni container image.
 	$(MAKE) container-push \

--- a/Makefile
+++ b/Makefile
@@ -74,11 +74,9 @@ CNS_BUILD_DIR = $(BUILD_DIR)/cns
 NPM_BUILD_DIR = $(BUILD_DIR)/npm
 TOOLS_DIR = $(REPO_ROOT)/build/tools
 TOOLS_BIN_DIR = $(TOOLS_DIR)/bin
-CNI_AI_ID = 5515a1eb-b2bc-406a-98eb-ba462e6f0411
 CNS_AI_ID = ce672799-8f08-4235-8c12-08563dc2acef
 NPM_AI_ID = 014c22bd-4107-459e-8475-67909e96edcb
 ACN_PACKAGE_PATH = github.com/Azure/azure-container-networking
-CNI_AI_PATH=$(ACN_PACKAGE_PATH)/telemetry.aiMetadata
 CNS_AI_PATH=$(ACN_PACKAGE_PATH)/cns/logger.aiMetadata
 NPM_AI_PATH=$(ACN_PACKAGE_PATH)/npm.aiMetadata
 
@@ -205,7 +203,7 @@ azure-vnet-ipamv6-binary:
 
 # Build the Azure CNI telemetry binary.
 azure-vnet-telemetry-binary:
-	cd $(CNI_TELEMETRY_DIR) && CGO_ENABLED=0 go build -v -o $(CNI_BUILD_DIR)/azure-vnet-telemetry$(EXE_EXT) -ldflags "-X main.version=$(CNI_VERSION) -X $(CNI_AI_PATH)=$(CNI_AI_ID)" -gcflags="-dwarflocationlists=true"
+	cd $(CNI_TELEMETRY_DIR) && CGO_ENABLED=0 go build -v -o $(CNI_BUILD_DIR)/azure-vnet-telemetry$(EXE_EXT) -ldflags "-X main.version=$(CNI_VERSION)" -gcflags="-dwarflocationlists=true"
 
 # Build the Azure CLI network binary.
 acncli-binary:
@@ -213,7 +211,7 @@ acncli-binary:
 
 # Build the Azure CNS binary.
 azure-cns-binary:
-	cd $(CNS_DIR) && CGO_ENABLED=0 go build -v -o $(CNS_BUILD_DIR)/azure-cns$(EXE_EXT) -ldflags "-X main.version=$(CNS_VERSION) -X $(CNS_AI_PATH)=$(CNS_AI_ID) -X $(CNI_AI_PATH)=$(CNI_AI_ID)" -gcflags="-dwarflocationlists=true"
+	cd $(CNS_DIR) && CGO_ENABLED=0 go build -v -o $(CNS_BUILD_DIR)/azure-cns$(EXE_EXT) -ldflags "-X main.version=$(CNS_VERSION) -X $(CNS_AI_PATH)=$(CNS_AI_ID)" -gcflags="-dwarflocationlists=true"
 
 # Build the Azure NPM binary.
 azure-npm-binary:
@@ -436,8 +434,7 @@ cni-image: ## build cni container image.
 		TARGET=$(OS) \
 		OS=$(OS) \
 		ARCH=$(ARCH) \
-		OS_VERSION=$(OS_VERSION) \
-		EXTRA_BUILD_ARGS='--build-arg CNI_AI_PATH=$(CNI_AI_PATH) --build-arg CNI_AI_ID=$(CNI_AI_ID)'
+		OS_VERSION=$(OS_VERSION)
 
 cni-image-push: ## push cni container image.
 	$(MAKE) container-push \

--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,11 @@ CNS_BUILD_DIR = $(BUILD_DIR)/cns
 NPM_BUILD_DIR = $(BUILD_DIR)/npm
 TOOLS_DIR = $(REPO_ROOT)/build/tools
 TOOLS_BIN_DIR = $(TOOLS_DIR)/bin
+CNI_AI_ID = 5515a1eb-b2bc-406a-98eb-ba462e6f0411
 CNS_AI_ID = ce672799-8f08-4235-8c12-08563dc2acef
 NPM_AI_ID = 014c22bd-4107-459e-8475-67909e96edcb
 ACN_PACKAGE_PATH = github.com/Azure/azure-container-networking
+CNI_AI_PATH=$(ACN_PACKAGE_PATH)/telemetry.aiMetadata
 CNS_AI_PATH=$(ACN_PACKAGE_PATH)/cns/logger.aiMetadata
 NPM_AI_PATH=$(ACN_PACKAGE_PATH)/npm.aiMetadata
 
@@ -203,7 +205,7 @@ azure-vnet-ipamv6-binary:
 
 # Build the Azure CNI telemetry binary.
 azure-vnet-telemetry-binary:
-	cd $(CNI_TELEMETRY_DIR) && CGO_ENABLED=0 go build -v -o $(CNI_BUILD_DIR)/azure-vnet-telemetry$(EXE_EXT) -ldflags "-X main.version=$(CNI_VERSION)" -gcflags="-dwarflocationlists=true"
+	cd $(CNI_TELEMETRY_DIR) && CGO_ENABLED=0 go build -v -o $(CNI_BUILD_DIR)/azure-vnet-telemetry$(EXE_EXT) -ldflags "-X main.version=$(CNI_VERSION) -X $(CNI_AI_PATH)=$(CNI_AI_ID)" -gcflags="-dwarflocationlists=true"
 
 # Build the Azure CLI network binary.
 acncli-binary:
@@ -211,7 +213,7 @@ acncli-binary:
 
 # Build the Azure CNS binary.
 azure-cns-binary:
-	cd $(CNS_DIR) && CGO_ENABLED=0 go build -v -o $(CNS_BUILD_DIR)/azure-cns$(EXE_EXT) -ldflags "-X main.version=$(CNS_VERSION) -X $(CNS_AI_PATH)=$(CNS_AI_ID)" -gcflags="-dwarflocationlists=true"
+	cd $(CNS_DIR) && CGO_ENABLED=0 go build -v -o $(CNS_BUILD_DIR)/azure-cns$(EXE_EXT) -ldflags "-X main.version=$(CNS_VERSION) -X $(CNS_AI_PATH)=$(CNS_AI_ID) -X $(CNI_AI_PATH)=$(CNI_AI_ID)" -gcflags="-dwarflocationlists=true"
 
 # Build the Azure NPM binary.
 azure-npm-binary:
@@ -434,7 +436,8 @@ cni-image: ## build cni container image.
 		TARGET=$(OS) \
 		OS=$(OS) \
 		ARCH=$(ARCH) \
-		OS_VERSION=$(OS_VERSION)
+		OS_VERSION=$(OS_VERSION) \
+		EXTRA_BUILD_ARGS='--build-arg CNI_AI_PATH=$(CNI_AI_PATH) --build-arg CNI_AI_ID=$(CNI_AI_ID)'
 
 cni-image-push: ## push cni container image.
 	$(MAKE) container-push \

--- a/cni/Dockerfile
+++ b/cni/Dockerfile
@@ -12,10 +12,12 @@ FROM --platform=linux/${ARCH} mcr.microsoft.com/cbl-mariner/base/core@sha256:a49
 FROM go AS azure-vnet
 ARG OS
 ARG VERSION
+ARG CNI_AI_PATH
+ARG CNI_AI_ID
 WORKDIR /azure-container-networking
 COPY . .
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/plugin/main.go
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-telemetry -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/telemetry/service/telemetrymain.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-telemetry -trimpath -ldflags "-X main.version="$VERSION" -X "$CNI_AI_PATH"="$CNI_AI_ID"" -gcflags="-dwarflocationlists=true" cni/telemetry/service/telemetrymain.go
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-ipam -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/ipam/plugin/main.go
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-stateless -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/stateless/main.go
 

--- a/cni/Dockerfile
+++ b/cni/Dockerfile
@@ -12,12 +12,10 @@ FROM --platform=linux/${ARCH} mcr.microsoft.com/cbl-mariner/base/core@sha256:a49
 FROM go AS azure-vnet
 ARG OS
 ARG VERSION
-ARG CNI_AI_PATH
-ARG CNI_AI_ID
 WORKDIR /azure-container-networking
 COPY . .
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/plugin/main.go
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-telemetry -trimpath -ldflags "-X main.version="$VERSION" -X "$CNI_AI_PATH"="$CNI_AI_ID"" -gcflags="-dwarflocationlists=true" cni/telemetry/service/telemetrymain.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-telemetry -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/telemetry/service/telemetrymain.go
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-ipam -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/ipam/plugin/main.go
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-stateless -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/stateless/main.go
 

--- a/cni/telemetry/service/telemetrymain.go
+++ b/cni/telemetry/service/telemetrymain.go
@@ -167,8 +167,8 @@ func main() {
 		GetEnvRetryWaitTimeInSecs:    config.GetEnvRetryWaitTimeInSecs,
 	}
 
-	if aiCreationErr := tb.CreateAITelemetryHandle(aiConfig, config.DisableAll, config.DisableTrace, config.DisableMetric); aiCreationErr != nil {
-		logger.Error("AI Handle creation error:", zap.Error(aiCreationErr))
+	if err := tb.CreateAITelemetryHandle(aiConfig, config.DisableAll, config.DisableTrace, config.DisableMetric); err != nil { // nolint
+		logger.Error("AI Handle creation error:", zap.Error(err))
 	}
 	logger.Info("Report to host interval", zap.Duration("seconds", config.ReportToHostIntervalInSeconds))
 	tb.PushData(context.Background())

--- a/cni/telemetry/service/telemetrymain.go
+++ b/cni/telemetry/service/telemetrymain.go
@@ -167,8 +167,8 @@ func main() {
 		GetEnvRetryWaitTimeInSecs:    config.GetEnvRetryWaitTimeInSecs,
 	}
 
-	if tb.CreateAITelemetryHandle(aiConfig, config.DisableAll, config.DisableTrace, config.DisableMetric) != nil {
-		logger.Error("AI Handle creation error", zap.Error(err))
+	if aiCreationErr := tb.CreateAITelemetryHandle(aiConfig, config.DisableAll, config.DisableTrace, config.DisableMetric); aiCreationErr != nil {
+		logger.Error("AI Handle creation error:", zap.Error(aiCreationErr))
 	}
 	logger.Info("Report to host interval", zap.Duration("seconds", config.ReportToHostIntervalInSeconds))
 	tb.PushData(context.Background())

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -672,7 +672,7 @@ func main() {
 	}
 
 	if telemetryDaemonEnabled {
-		logger.Printf("CNI Telemtry is enabled")
+		logger.Printf("CNI Telemetry is enabled")
 		go startTelemetryService(rootCtx)
 	}
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -672,7 +672,7 @@ func main() {
 	}
 
 	if telemetryDaemonEnabled {
-		logger.Printf("CNI Telemetry is enabled")
+		logger.Printf("CNI Telemtry is enabled")
 		go startTelemetryService(rootCtx)
 	}
 

--- a/telemetry/aiwrapper.go
+++ b/telemetry/aiwrapper.go
@@ -9,6 +9,7 @@ import (
 )
 
 var (
+	aiMetadata           string
 	th                   aitelemetry.TelemetryHandle
 	gDisableTrace        bool
 	gDisableMetric       bool
@@ -16,7 +17,6 @@ var (
 )
 
 const (
-	aiMetadata = "5515a1eb-b2bc-406a-98eb-ba462e6f0411"
 	// Wait time for AI to gracefully close AI telemetry session
 	waitTimeInSecs = 10
 )

--- a/telemetry/aiwrapper.go
+++ b/telemetry/aiwrapper.go
@@ -9,7 +9,6 @@ import (
 )
 
 var (
-	aiMetadata           string
 	th                   aitelemetry.TelemetryHandle
 	gDisableTrace        bool
 	gDisableMetric       bool
@@ -17,6 +16,7 @@ var (
 )
 
 const (
+	aiMetadata = "5515a1eb-b2bc-406a-98eb-ba462e6f0411"
 	// Wait time for AI to gracefully close AI telemetry session
 	waitTimeInSecs = 10
 )

--- a/telemetry/aiwrapper_test.go
+++ b/telemetry/aiwrapper_test.go
@@ -17,15 +17,7 @@ func TestCreateAITelemetryHandle(t *testing.T) {
 		wantErr       bool
 	}{
 		{
-			name:          "disable telemetry",
-			aiConfig:      aitelemetry.AIConfig{},
-			disableAll:    false,
-			disableMetric: true,
-			disableTrace:  true,
-			wantErr:       true,
-		},
-		{
-			name:          "empty aiconfig",
+			name:          "disabled telemetry with empty aiconfig",
 			aiConfig:      aitelemetry.AIConfig{},
 			disableAll:    true,
 			disableMetric: true,


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->
Updates the cni dockerfile to take in arguments for the ai metadata, similar to the cns dockerfile.

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
The ai instrumentation key previously was not passed when building the azure vnet telemetry binary when making a *cni image*. The instrumentation key was passed when making the binary with the make file command, however.

Also fixed an error message not logging which hid the above error.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
See above

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
Tested on podsubnet cluster. No logs were found to be uploaded, and noticed telemetry logs showed an ai handle creation error. However, after applying the cni image with the fix using the cni installer, we started to receive logs. The telemetry logs also no longer produced the error message.