### PR TITLE
ci: Update Cilium image usage for release/v1.4

### DIFF
--- a/.pipelines/cni/cilium/cilium-cni-load-test.yaml
+++ b/.pipelines/cni/cilium/cilium-cni-load-test.yaml
@@ -49,8 +49,8 @@ stages:
                 kubectl apply -f test/integration/manifests/cilium/cilium-agent
                 kubectl apply -f test/integration/manifests/cilium/cilium-operator
                 # Passes Cilium image to daemonset and deployment
-                envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/daemonset.yaml | kubectl apply -f -
-                envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/deployment.yaml | kubectl apply -f -
+                envsubst '${CILIUM_VERSION_TAG_V1_4},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/daemonset.yaml | kubectl apply -f -
+                envsubst '${CILIUM_VERSION_TAG_V1_4},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/deployment.yaml | kubectl apply -f -
                 kubectl get po -owide -A
                 echo "deploy ip-masq-agent for overlay"
                 kubectl create -f test/integration/manifests/ip-masq-agent/ip-masq-agent.yaml --validate=false

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
@@ -38,14 +38,14 @@ steps:
         pwd
         kubectl cluster-info
         kubectl get po -owide -A
-        if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]; then FILE_PATH=-nightly && echo "Running nightly"; fi
+        if [ "$CILIUM_VERSION_TAG_V1_4" = "cilium-nightly-pipeline" ]; then FILE_PATH=-nightly && echo "Running nightly"; fi
         echo "deploy Cilium ConfigMap"
         kubectl apply -f cilium/configmap.yaml
         kubectl apply -f test/integration/manifests/cilium/cilium${FILE_PATH}-config.yaml
-        echo "install Cilium ${CILIUM_VERSION_TAG}"
+        echo "install Cilium ${CILIUM_VERSION_TAG_V1_4}"
         # Passes Cilium image to daemonset and deployment
-        envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/daemonset.yaml | kubectl apply -f -
-        envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/deployment.yaml | kubectl apply -f -
+        envsubst '${CILIUM_VERSION_TAG_V1_4},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/daemonset.yaml | kubectl apply -f -
+        envsubst '${CILIUM_VERSION_TAG_V1_4},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/deployment.yaml | kubectl apply -f -
         # Use different file directories for nightly and current cilium version
         kubectl apply -f test/integration/manifests/cilium/cilium${FILE_PATH}-agent
         kubectl apply -f test/integration/manifests/cilium/cilium${FILE_PATH}-operator
@@ -55,11 +55,11 @@ steps:
 
   - script: |
       echo "install cilium CLI"
-      if [[ ${CILIUM_VERSION_TAG} =~ ^1.1[1-3].[0-9]{1,2} ]]; then
+      if [[ ${CILIUM_VERSION_TAG_V1_4} =~ ^1.1[1-3].[0-9]{1,2} ]]; then
         echo "Cilium Agent Version ${BASH_REMATCH[0]}"
         CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable-v0.14.txt)
       else
-        echo "Cilium Agent Version ${CILIUM_VERSION_TAG}"
+        echo "Cilium Agent Version ${CILIUM_VERSION_TAG_V1_4}"
         CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
       fi
       CLI_ARCH=amd64
@@ -83,7 +83,7 @@ steps:
       cd ../../../..
       kubectl get po -owide -A
       # Nightly does not build images per commit. Will use existing image.
-      if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]
+      if [ "$CILIUM_VERSION_TAG_V1_4" = "cilium-nightly-pipeline" ]
       then
           CNS=$(CNS_VERSION) CNI=$(CNI_VERSION) && echo "Running nightly"
       else
@@ -136,7 +136,7 @@ steps:
       # Deleting echo-external-node deployment until cilium version matches TODO. https://github.com/cilium/cilium-cli/issues/67 is addressing the change.
       # Saves 17 minutes
       kubectl delete deploy -n cilium-test echo-external-node
-      if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]; then
+      if [ "$CILIUM_VERSION_TAG_V1_4" = "cilium-nightly-pipeline" ]; then
         echo "Check cilium identities in cilium-test namepsace during nightly run"
         echo "expect the identities to be deleted when the namespace is deleted"
         kubectl get ciliumidentity | grep cilium-test
@@ -150,7 +150,7 @@ steps:
     displayName: "Validate Pods"
 
   - script: |
-      if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]; then
+      if [ "$CILIUM_VERSION_TAG_V1_4" = "cilium-nightly-pipeline" ]; then
         kubectl get pod -owide -n cilium-test
         echo "wait for pod and cilium identity deletion in cilium-test namespace"
         ns="cilium-test"

--- a/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
@@ -41,9 +41,9 @@ steps:
         echo "deploy Cilium ConfigMap"
         kubectl apply -f cilium/configmap.yaml
         kubectl apply -f test/integration/manifests/cilium/cilium-config.yaml
-        echo "install Cilium ${CILIUM_VERSION_TAG}"
-        envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/daemonset.yaml | kubectl apply -f -
-        envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/deployment.yaml | kubectl apply -f -
+        echo "install Cilium ${CILIUM_VERSION_TAG_V1_4}"
+        envsubst '${CILIUM_VERSION_TAG_V1_4},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/daemonset.yaml | kubectl apply -f -
+        envsubst '${CILIUM_VERSION_TAG_V1_4},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/deployment.yaml | kubectl apply -f -
         kubectl apply -f test/integration/manifests/cilium/cilium-agent
         kubectl apply -f test/integration/manifests/cilium/cilium-operator
         kubectl get po -owide -A
@@ -52,11 +52,11 @@ steps:
 
   - script: |
       echo "install cilium CLI"
-      if [[ ${CILIUM_VERSION_TAG} =~ ^1.1[1-3].[0-9]{1,2} ]]; then
+      if [[ ${CILIUM_VERSION_TAG_V1_4} =~ ^1.1[1-3].[0-9]{1,2} ]]; then
         echo "Cilium Agent Version ${BASH_REMATCH[0]}"
         CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable-v0.14.txt)
       else
-        echo "Cilium Agent Version ${CILIUM_VERSION_TAG}"
+        echo "Cilium Agent Version ${CILIUM_VERSION_TAG_V1_4}"
         CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
       fi
       CLI_ARCH=amd64

--- a/test/integration/manifests/cilium/daemonset.yaml
+++ b/test/integration/manifests/cilium/daemonset.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: CILIUM_CLUSTERMESH_CONFIG
           value: /var/lib/cilium/clustermesh/
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
@@ -163,7 +163,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: install-cni-binaries
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_4
         imagePullPolicy: IfNotPresent
         command:
           - "/install-plugin.sh"
@@ -192,7 +192,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_4
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         resources: {}
@@ -224,7 +224,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_4
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         resources: {}
@@ -252,7 +252,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_4
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         resources: {}
@@ -279,7 +279,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_4
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -338,7 +338,7 @@ spec:
           name: host-usr-lib
           readOnly: true
       - name: block-wireserver
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_4
         imagePullPolicy: IfNotPresent
         command:
         - /bin/bash

--- a/test/integration/manifests/cilium/deployment.yaml
+++ b/test/integration/manifests/cilium/deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: cilium-operator
-        image: $CILIUM_IMAGE_REGISTRY/cilium/operator-generic:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/operator-generic:$CILIUM_VERSION_TAG_V1_4
         imagePullPolicy: IfNotPresent
         command:
         - cilium-operator-generic


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Updates pipeline variables to allow for a matching of release train and cilium version. Cilium version should match the k8s version being used.

This change came about because of #3089 changes which bumped cilium version from 1.13.13 -> 1.14.15 which exposed a testing gap.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
