### PR TITLE
[backport] ci: Update Cilium image usage for release/v1.5

### DIFF
--- a/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
+++ b/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
@@ -91,7 +91,7 @@ stages:
                   fi
 
                   echo "install Cilium ${CILIUM_VERSION_TAG}"
-                  export DIR=${CILIUM_VERSION_TAG%.*}
+                  export DIR=$(echo ${CILIUM_VERSION_TAG#v} | cut -d. -f1,2)
                   echo "installing files from ${DIR}"
 
                   echo "deploy Cilium ConfigMap"

--- a/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
+++ b/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
@@ -87,11 +87,11 @@ stages:
 
                   if [ ! -z ${{ parameters.dualstackVersion }} ]; then
                     echo "Use dualstack version of Cilium"
-                    export CILIUM_VERSION_TAG=${{ parameters.dualstackVersion }}
+                    export CILIUM_VERSION_TAG_V1_5=${{ parameters.dualstackVersion }}
                   fi
 
-                  echo "install Cilium ${CILIUM_VERSION_TAG}"
-                  export DIR=$(echo ${CILIUM_VERSION_TAG#v} | cut -d. -f1,2)
+                  echo "install Cilium ${CILIUM_VERSION_TAG_V1_5}"
+                  export DIR=$(echo ${CILIUM_VERSION_TAG_V1_5#v} | cut -d. -f1,2)
                   echo "installing files from ${DIR}"
 
                   echo "deploy Cilium ConfigMap"
@@ -106,8 +106,8 @@ stages:
                   kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-agent/files
                   kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-operator/files
 
-                    envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-agent/templates/daemonset.yaml | kubectl apply -f -
-                  envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-operator/templates/deployment.yaml | kubectl apply -f -
+                  envsubst '${CILIUM_VERSION_TAG_V1_5},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-agent/templates/daemonset.yaml | kubectl apply -f -
+                  envsubst '${CILIUM_VERSION_TAG_V1_5},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-operator/templates/deployment.yaml | kubectl apply -f -
                   kubectl get po -owide -A
 
                   echo "Deploy Azure-CNS"
@@ -134,14 +134,14 @@ stages:
                   kubectl get po -owide -A
 
                   echo "install Cilium onto Overlay Cluster with hubble enabled"
-                  export CILIUM_VERSION_TAG=${CILIUM_HUBBLE_VERSION_TAG}
-                  export DIR=${CILIUM_VERSION_TAG%.*}
+                  export CILIUM_VERSION_TAG_V1_5=${CILIUM_HUBBLE_VERSION_TAG}
+                  export DIR=${CILIUM_VERSION_TAG_V1_5%.*}
                   echo "installing files from ${DIR}"
                   kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-config/cilium-config-hubble.yaml
                   kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-agent/files
                   kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-operator/files
-                  envsubst '${CILIUM_IMAGE_REGISTRY},${CILIUM_VERSION_TAG}' < test/integration/manifests/cilium/v${DIR}/cilium-agent/templates/daemonset.yaml | kubectl apply -f -
-                  envsubst '${CILIUM_IMAGE_REGISTRY},${CILIUM_VERSION_TAG}' < test/integration/manifests/cilium/v${DIR}/cilium-operator/templates/deployment.yaml | kubectl apply -f -
+                  envsubst '${CILIUM_IMAGE_REGISTRY},${CILIUM_VERSION_TAG_V1_5}' < test/integration/manifests/cilium/v${DIR}/cilium-agent/templates/daemonset.yaml | kubectl apply -f -
+                  envsubst '${CILIUM_IMAGE_REGISTRY},${CILIUM_VERSION_TAG_V1_5}' < test/integration/manifests/cilium/v${DIR}/cilium-operator/templates/deployment.yaml | kubectl apply -f -
                   kubectl get po -owide -A
 
                   echo "Deploy Azure-CNS"

--- a/.pipelines/cni/lsg/lsg-cni-intergration-template.yaml
+++ b/.pipelines/cni/lsg/lsg-cni-intergration-template.yaml
@@ -95,7 +95,7 @@ stages:
                   kubectl get po -owide -A
 
                   echo "install Cilium ${CILIUM_VERSION_TAG}"
-                  export DIR=${CILIUM_VERSION_TAG%.*}
+                  export DIR=$(echo ${CILIUM_VERSION_TAG#v} | cut -d. -f1,2)
                   echo "installing files from ${DIR}"
 
                   echo "deploy Cilium ConfigMap"

--- a/.pipelines/cni/lsg/lsg-cni-intergration-template.yaml
+++ b/.pipelines/cni/lsg/lsg-cni-intergration-template.yaml
@@ -94,8 +94,8 @@ stages:
                   kubectl cluster-info
                   kubectl get po -owide -A
 
-                  echo "install Cilium ${CILIUM_VERSION_TAG}"
-                  export DIR=$(echo ${CILIUM_VERSION_TAG#v} | cut -d. -f1,2)
+                  echo "install Cilium ${CILIUM_VERSION_TAG_V1_5}"
+                  export DIR=$(echo ${CILIUM_VERSION_TAG_V1_5#v} | cut -d. -f1,2)
                   echo "installing files from ${DIR}"
 
                   echo "deploy Cilium ConfigMap"
@@ -105,8 +105,8 @@ stages:
                   kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-agent/files
                   kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-operator/files
 
-                  envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-agent/templates/daemonset.yaml | kubectl apply -f -
-                  envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-operator/templates/deployment.yaml | kubectl apply -f -
+                  envsubst '${CILIUM_VERSION_TAG_V1_5},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-agent/templates/daemonset.yaml | kubectl apply -f -
+                  envsubst '${CILIUM_VERSION_TAG_V1_5},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-operator/templates/deployment.yaml | kubectl apply -f -
                   kubectl get po -owide -A
                   echo "Deploy Azure-CNS"
                   sudo -E env "PATH=$PATH" make test-load CNS_ONLY=true AZURE_IPAM_VERSION=$(ipamVersion) CNS_VERSION=$(cnsVersion) INSTALL_CNS=true INSTALL_OVERLAY=true CNS_IMAGE_REPO=$(CNS_IMAGE_REPO) IPAM_IMAGE_REPO=$(IPAM_IMAGE_REPO)
@@ -189,11 +189,11 @@ stages:
         steps:
           - script: |
               echo "install cilium CLI"
-              if [[ ${CILIUM_VERSION_TAG} =~ ^1.1[1-3].[0-9]{1,2} ]]; then
+              if [[ ${CILIUM_VERSION_TAG_V1_5} =~ ^1.1[1-3].[0-9]{1,2} ]]; then
                 echo "Cilium Agent Version ${BASH_REMATCH[0]}"
                 CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable-v0.14.txt)
               else
-                echo "Cilium Agent Version ${CILIUM_VERSION_TAG}"
+                echo "Cilium Agent Version ${CILIUM_VERSION_TAG_V1_5}"
                 CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
               fi
               CLI_ARCH=amd64

--- a/.pipelines/cni/pipeline.yaml
+++ b/.pipelines/cni/pipeline.yaml
@@ -360,7 +360,7 @@ stages:
       nodeCount: ${NODE_COUNT_CILIUM}
       vmSize: ${VM_SIZE_CILIUM}
       arch: amd64
-      dualstackVersion: ${CILIUM_DUALSTACK_VERSION}
+      dualstackVersion: ${CILIUM_DUALSTACK_VERSION_V1_5}
       cni: "cilium_dualstack"
 
   - stage: delete_resources

--- a/.pipelines/networkobservability/pipeline.yaml
+++ b/.pipelines/networkobservability/pipeline.yaml
@@ -77,7 +77,7 @@ stages:
             scriptType: "bash"
             addSpnToEnvironment: true
             inlineScript: |
-              export DIR=${CILIUM_VERSION_TAG%.*}
+              export DIR=$(echo ${CILIUM_VERSION_TAG#v} | cut -d. -f1,2)
               echo "installing files from ${DIR}"
               kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-config/cilium-config-hubble.yaml
               kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-agent/files

--- a/.pipelines/networkobservability/pipeline.yaml
+++ b/.pipelines/networkobservability/pipeline.yaml
@@ -77,20 +77,20 @@ stages:
             scriptType: "bash"
             addSpnToEnvironment: true
             inlineScript: |
-              export DIR=$(echo ${CILIUM_VERSION_TAG#v} | cut -d. -f1,2)
+              export DIR=$(echo ${CILIUM_VERSION_TAG_V1_5#v} | cut -d. -f1,2)
               echo "installing files from ${DIR}"
               kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-config/cilium-config-hubble.yaml
               kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-agent/files
               kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-operator/files
-              envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-agent/templates/daemonset.yaml | kubectl apply -f -
-              envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-operator/templates/deployment.yaml | kubectl apply -f -
+              envsubst '${CILIUM_VERSION_TAG_V1_5},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-agent/templates/daemonset.yaml | kubectl apply -f -
+              envsubst '${CILIUM_VERSION_TAG_V1_5},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-operator/templates/deployment.yaml | kubectl apply -f -
               # Use different file directories for nightly and current cilium version
           name: "installCilium"
           displayName: "Install Cilium on AKS Overlay"
 
         - script: |
             echo "Start Azilium E2E Tests on Overlay Cluster"
-            if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]
+            if [ "$CILIUM_VERSION_TAG_V1_5" = "cilium-nightly-pipeline" ]
             then
                 CNS=$(CNS_VERSION) IPAM=$(AZURE_IPAM_VERSION) && echo "Running nightly"
             else
@@ -123,7 +123,7 @@ stages:
           enabled: true
 
         - script: |
-            export DIR=${CILIUM_VERSION_TAG%.*}
+            export DIR=${CILIUM_VERSION_TAG_V1_5%.*}
             kubectl apply -f test/integration/manifests/cilium/v${DIR}/hubble/hubble-peer-svc.yaml
             kubectl get pods -Aowide
             echo "verify Hubble metrics endpoint is usable"

--- a/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-step-template.yaml
@@ -34,7 +34,7 @@ steps:
         kubectl cluster-info
         kubectl get po -owide -A
         echo "install Cilium ${CILIUM_DUALSTACK_VERSION}"
-        export DIR=${CILIUM_DUALSTACK_VERSION%.*}
+        export DIR=$(echo ${CILIUM_DUALSTACK_VERSION#v} | cut -d. -f1,2)
         echo "installing files from ${DIR}"
         echo "deploy Cilium ConfigMap"
         kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-config/cilium-config-dualstack.yaml

--- a/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-step-template.yaml
@@ -33,8 +33,8 @@ steps:
         pwd
         kubectl cluster-info
         kubectl get po -owide -A
-        echo "install Cilium ${CILIUM_DUALSTACK_VERSION}"
-        export DIR=$(echo ${CILIUM_DUALSTACK_VERSION#v} | cut -d. -f1,2)
+        echo "install Cilium ${CILIUM_DUALSTACK_VERSION_V1_5}"
+        export DIR=$(echo ${CILIUM_DUALSTACK_VERSION_V1_5#v} | cut -d. -f1,2)
         echo "installing files from ${DIR}"
         echo "deploy Cilium ConfigMap"
         kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-config/cilium-config-dualstack.yaml
@@ -42,11 +42,11 @@ steps:
         kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-agent/files
         kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-operator/files
 
-        export CILIUM_VERSION_TAG=${CILIUM_DUALSTACK_VERSION}
+        export CILIUM_VERSION_TAG_V1_5=${CILIUM_DUALSTACK_VERSION_V1_5}
         export IPV6_HP_BPF_VERSION=$(make ipv6-hp-bpf-version)
-        echo "install Cilium ${CILIUM_DUALSTACK_VERSION} onto Overlay Cluster"
-        envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY},${IPV6_HP_BPF_VERSION}' < test/integration/manifests/cilium/v${DIR}/cilium-agent/templates/daemonset-dualstack.yaml | kubectl apply -f -
-        envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-operator/templates/deployment.yaml | kubectl apply -f -
+        echo "install Cilium ${CILIUM_DUALSTACK_VERSION_V1_5} onto Overlay Cluster"
+        envsubst '${CILIUM_VERSION_TAG_V1_5},${CILIUM_IMAGE_REGISTRY},${IPV6_HP_BPF_VERSION}' < test/integration/manifests/cilium/v${DIR}/cilium-agent/templates/daemonset-dualstack.yaml | kubectl apply -f -
+        envsubst '${CILIUM_VERSION_TAG_V1_5},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-operator/templates/deployment.yaml | kubectl apply -f -
         kubectl get po -owide -A
     name: "installCilium"
     displayName: "Install Cilium on AKS Dualstack Overlay"

--- a/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-step-template.yaml
@@ -38,7 +38,7 @@ steps:
         make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
         ls -lah
         export CILIUM_VERSION_TAG=${CILIUM_HUBBLE_VERSION_TAG}
-        export DIR=${CILIUM_VERSION_TAG%.*}
+        export DIR=$(echo ${CILIUM_VERSION_TAG#v} | cut -d. -f1,2)
         echo "installing files from ${DIR}"
         kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-config/cilium-config-hubble.yaml
         kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-agent/files

--- a/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-step-template.yaml
@@ -37,14 +37,14 @@ steps:
         set -e
         make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
         ls -lah
-        export CILIUM_VERSION_TAG=${CILIUM_HUBBLE_VERSION_TAG}
-        export DIR=$(echo ${CILIUM_VERSION_TAG#v} | cut -d. -f1,2)
+        export CILIUM_VERSION_TAG_V1_5=${CILIUM_HUBBLE_VERSION_TAG}
+        export DIR=$(echo ${CILIUM_VERSION_TAG_V1_5#v} | cut -d. -f1,2)
         echo "installing files from ${DIR}"
         kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-config/cilium-config-hubble.yaml
         kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-agent/files
         kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-operator/files
-        envsubst '${CILIUM_IMAGE_REGISTRY},${CILIUM_VERSION_TAG}' < test/integration/manifests/cilium/v${DIR}/cilium-agent/templates/daemonset.yaml | kubectl apply -f -
-        envsubst '${CILIUM_IMAGE_REGISTRY},${CILIUM_VERSION_TAG}' < test/integration/manifests/cilium/v${DIR}/cilium-operator/templates/deployment.yaml | kubectl apply -f -
+        envsubst '${CILIUM_IMAGE_REGISTRY},${CILIUM_VERSION_TAG_V1_5}' < test/integration/manifests/cilium/v${DIR}/cilium-agent/templates/daemonset.yaml | kubectl apply -f -
+        envsubst '${CILIUM_IMAGE_REGISTRY},${CILIUM_VERSION_TAG_V1_5}' < test/integration/manifests/cilium/v${DIR}/cilium-operator/templates/deployment.yaml | kubectl apply -f -
         # Use different file directories for nightly and current cilium version
     name: "installCilium"
     displayName: "Install Cilium on AKS Overlay"
@@ -53,7 +53,7 @@ steps:
 
   - script: |
       echo "Start Azilium E2E Tests on Overlay Cluster"
-      if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]
+      if [ "$CILIUM_VERSION_TAG_V1_5" = "cilium-nightly-pipeline" ]
       then
           CNS=$(CNS_VERSION) IPAM=$(AZURE_IPAM_VERSION) && echo "Running nightly"
       else
@@ -138,7 +138,7 @@ steps:
       # Deleting echo-external-node deployment until cilium version matches TODO. https://github.com/cilium/cilium-cli/issues/67 is addressing the change.
       # Saves 17 minutes
       kubectl delete deploy -n cilium-test echo-external-node
-      if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]; then
+      if [ "$CILIUM_VERSION_TAG_V1_5" = "cilium-nightly-pipeline" ]; then
         echo "Check cilium identities in cilium-test namepsace during nightly run"
         echo "expect the identities to be deleted when the namespace is deleted"
         kubectl get ciliumidentity | grep cilium-test
@@ -152,7 +152,7 @@ steps:
     displayName: "Validate Pods"
 
   - script: |
-      if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]; then
+      if [ "$CILIUM_VERSION_TAG_V1_5" = "cilium-nightly-pipeline" ]; then
         kubectl get pod -owide -n cilium-test
         echo "wait for pod and cilium identity deletion in cilium-test namespace"
         ns="cilium-test"

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
@@ -54,7 +54,7 @@ steps:
           kubectl apply -f test/integration/manifests/cilium/cilium${FILE_PATH}-operator
         else
           echo "install Cilium ${CILIUM_VERSION_TAG}"
-          export DIR=${CILIUM_VERSION_TAG%.*}
+          export DIR=$(echo ${CILIUM_VERSION_TAG#v} | cut -d. -f1,2)
           echo "installing files from ${DIR}"
           echo "deploy Cilium ConfigMap"
           kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-config/cilium-config.yaml

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
@@ -41,20 +41,20 @@ steps:
         pwd
         kubectl cluster-info
         kubectl get po -owide -A
-        if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]; then
+        if [ "$CILIUM_VERSION_TAG_V1_5" = "cilium-nightly-pipeline" ]; then
           FILE_PATH=-nightly
           echo "Running nightly"
           echo "deploy Cilium ConfigMap"
           kubectl apply -f test/integration/manifests/cilium/cilium${FILE_PATH}-config.yaml
           # Passes Cilium image to daemonset and deployment
-          envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/daemonset.yaml | kubectl apply -f -
-          envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/deployment.yaml | kubectl apply -f -
+          envsubst '${CILIUM_VERSION_TAG_V1_5},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/daemonset.yaml | kubectl apply -f -
+          envsubst '${CILIUM_VERSION_TAG_V1_5},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/deployment.yaml | kubectl apply -f -
           # Use different file directories for nightly and current cilium version
           kubectl apply -f test/integration/manifests/cilium/cilium${FILE_PATH}-agent
           kubectl apply -f test/integration/manifests/cilium/cilium${FILE_PATH}-operator
         else
-          echo "install Cilium ${CILIUM_VERSION_TAG}"
-          export DIR=$(echo ${CILIUM_VERSION_TAG#v} | cut -d. -f1,2)
+          echo "install Cilium ${CILIUM_VERSION_TAG_V1_5}"
+          export DIR=$(echo ${CILIUM_VERSION_TAG_V1_5#v} | cut -d. -f1,2)
           echo "installing files from ${DIR}"
           echo "deploy Cilium ConfigMap"
           kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-config/cilium-config.yaml
@@ -62,8 +62,8 @@ steps:
           kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-agent/files
           kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-operator/files
 
-          envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-agent/templates/daemonset.yaml | kubectl apply -f -
-          envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-operator/templates/deployment.yaml | kubectl apply -f -
+          envsubst '${CILIUM_VERSION_TAG_V1_5},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-agent/templates/daemonset.yaml | kubectl apply -f -
+          envsubst '${CILIUM_VERSION_TAG_V1_5},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-operator/templates/deployment.yaml | kubectl apply -f -
         fi
 
         kubectl get po -owide -A
@@ -74,7 +74,7 @@ steps:
 
   - script: |
       echo "Start Azilium E2E Tests on Overlay Cluster"
-      if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]
+      if [ "$CILIUM_VERSION_TAG_V1_5" = "cilium-nightly-pipeline" ]
       then
           CNS=$(CNS_VERSION) IPAM=$(AZURE_IPAM_VERSION) && echo "Running nightly"
       else
@@ -134,7 +134,7 @@ steps:
   - script: |
       echo "Run Cilium Connectivity Tests"
       cilium status
-      if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]
+      if [ "$CILIUM_VERSION_TAG_V1_5" = "cilium-nightly-pipeline" ]
       then
           cilium connectivity test --connect-timeout 4s --request-timeout 30s --test '!pod-to-pod-encryption,!node-to-node-encryption,!check-log-errors'
       else
@@ -165,7 +165,7 @@ steps:
       # Deleting echo-external-node deployment until cilium version matches TODO. https://github.com/cilium/cilium-cli/issues/67 is addressing the change.
       # Saves 17 minutes
       kubectl delete deploy -n cilium-test echo-external-node
-      if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]; then
+      if [ "$CILIUM_VERSION_TAG_V1_5" = "cilium-nightly-pipeline" ]; then
         echo "Check cilium identities in cilium-test namepsace during nightly run"
         echo "expect the identities to be deleted when the namespace is deleted"
         kubectl get ciliumidentity | grep cilium-test
@@ -179,7 +179,7 @@ steps:
     displayName: "Validate Pods"
 
   - script: |
-      if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]; then
+      if [ "$CILIUM_VERSION_TAG_V1_5" = "cilium-nightly-pipeline" ]; then
         kubectl get pod -owide -n cilium-test
         echo "wait for pod and cilium identity deletion in cilium-test namespace"
         ns="cilium-test"
@@ -226,7 +226,7 @@ steps:
     displayName: "Run Wireserver and Metadata Connectivity Tests"
 
   - script: |
-      if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]; then
+      if [ "$CILIUM_VERSION_TAG_V1_5" = "cilium-nightly-pipeline" ]; then
         echo "Running nightly, skip async delete test"
       else
         cd hack/scripts

--- a/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
@@ -40,7 +40,7 @@ steps:
         kubectl cluster-info
         kubectl get po -owide -A
         echo "install Cilium ${CILIUM_VERSION_TAG}"
-        export DIR=${CILIUM_VERSION_TAG%.*}
+        export DIR=$(echo ${CILIUM_VERSION_TAG#v} | cut -d. -f1,2)
         echo "installing files from ${DIR}"
         echo "deploy Cilium ConfigMap"
         kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-config/cilium-config.yaml

--- a/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
@@ -39,8 +39,8 @@ steps:
         pwd
         kubectl cluster-info
         kubectl get po -owide -A
-        echo "install Cilium ${CILIUM_VERSION_TAG}"
-        export DIR=$(echo ${CILIUM_VERSION_TAG#v} | cut -d. -f1,2)
+        echo "install Cilium ${CILIUM_VERSION_TAG_V1_5}"
+        export DIR=$(echo ${CILIUM_VERSION_TAG_V1_5#v} | cut -d. -f1,2)
         echo "installing files from ${DIR}"
         echo "deploy Cilium ConfigMap"
         kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-config/cilium-config.yaml
@@ -48,8 +48,8 @@ steps:
         kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-agent/files
         kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-operator/files
 
-        envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-agent/templates/daemonset.yaml | kubectl apply -f -
-        envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-operator/templates/deployment.yaml | kubectl apply -f -
+        envsubst '${CILIUM_VERSION_TAG_V1_5},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-agent/templates/daemonset.yaml | kubectl apply -f -
+        envsubst '${CILIUM_VERSION_TAG_V1_5},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-operator/templates/deployment.yaml | kubectl apply -f -
         kubectl get po -owide -A
     name: "installCilium"
     displayName: "Install Cilium"

--- a/.pipelines/templates/cilium-cli.yaml
+++ b/.pipelines/templates/cilium-cli.yaml
@@ -1,14 +1,14 @@
 steps:
   - script: |
       echo "install cilium CLI"
-      if [[ ${CILIUM_VERSION_TAG} =~ ^1.1[1-3].[0-9]{1,2} ]]; then
+      if [[ ${CILIUM_VERSION_TAG_V1_5} =~ ^1.1[1-3].[0-9]{1,2} ]]; then
         echo "Cilium Agent Version ${BASH_REMATCH[0]}"
         CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable-v0.14.txt)
-      elif [[ ${CILIUM_VERSION_TAG} =~ ^1.14.[0-9]{1,2} ]]; then
+      elif [[ ${CILIUM_VERSION_TAG_V1_5} =~ ^1.14.[0-9]{1,2} ]]; then
         echo "Cilium Agent Version ${BASH_REMATCH[0]}"
         CILIUM_CLI_VERSION=v0.15.22
       else
-        echo "Cilium Agent Version ${CILIUM_VERSION_TAG}"
+        echo "Cilium Agent Version ${CILIUM_VERSION_TAG_V1_5}"
         CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
       fi
       CLI_ARCH=amd64

--- a/test/integration/manifests/cilium/daemonset.yaml
+++ b/test/integration/manifests/cilium/daemonset.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: CILIUM_CLUSTERMESH_CONFIG
           value: /var/lib/cilium/clustermesh/
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
@@ -163,7 +163,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: install-cni-binaries
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         command:
           - "/install-plugin.sh"
@@ -192,7 +192,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         resources: {}
@@ -224,7 +224,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         resources: {}
@@ -252,7 +252,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         resources: {}
@@ -279,7 +279,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -338,7 +338,7 @@ spec:
           name: host-usr-lib
           readOnly: true
       - name: block-wireserver
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         command:
         - /bin/bash

--- a/test/integration/manifests/cilium/deployment.yaml
+++ b/test/integration/manifests/cilium/deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: cilium-operator
-        image: $CILIUM_IMAGE_REGISTRY/cilium/operator-generic:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/operator-generic:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         command:
         - cilium-operator-generic

--- a/test/integration/manifests/cilium/v1.12/cilium-agent/templates/daemonset.yaml
+++ b/test/integration/manifests/cilium/v1.12/cilium-agent/templates/daemonset.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: CILIUM_CLUSTERMESH_CONFIG
           value: /var/lib/cilium/clustermesh/
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
@@ -163,7 +163,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: install-cni-binaries
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         command:
           - "/install-plugin.sh"
@@ -192,7 +192,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         resources: {}
@@ -224,7 +224,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         resources: {}
@@ -252,7 +252,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         resources: {}
@@ -279,7 +279,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -338,7 +338,7 @@ spec:
           name: host-usr-lib
           readOnly: true
       - name: block-wireserver
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         command:
         - /bin/bash

--- a/test/integration/manifests/cilium/v1.12/cilium-operator/templates/deployment.yaml
+++ b/test/integration/manifests/cilium/v1.12/cilium-operator/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: cilium-operator
-        image: $CILIUM_IMAGE_REGISTRY/cilium/operator-generic:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/operator-generic:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         command:
         - cilium-operator-generic

--- a/test/integration/manifests/cilium/v1.13/cilium-agent/templates/daemonset.yaml
+++ b/test/integration/manifests/cilium/v1.13/cilium-agent/templates/daemonset.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: CILIUM_CLUSTERMESH_CONFIG
           value: /var/lib/cilium/clustermesh/
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
@@ -163,7 +163,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: install-cni-binaries
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         command:
           - "/install-plugin.sh"
@@ -192,7 +192,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         resources: {}
@@ -224,7 +224,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         resources: {}
@@ -252,7 +252,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         resources: {}
@@ -279,7 +279,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -338,7 +338,7 @@ spec:
           name: host-usr-lib
           readOnly: true
       - name: block-wireserver
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         command:
         - /bin/bash

--- a/test/integration/manifests/cilium/v1.13/cilium-operator/templates/deployment.yaml
+++ b/test/integration/manifests/cilium/v1.13/cilium-operator/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: cilium-operator
-        image: $CILIUM_IMAGE_REGISTRY/cilium/operator-generic:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/operator-generic:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         command:
         - cilium-operator-generic

--- a/test/integration/manifests/cilium/v1.14/cilium-agent/templates/daemonset-dualstack.yaml
+++ b/test/integration/manifests/cilium/v1.14/cilium-agent/templates/daemonset-dualstack.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: CILIUM_CLUSTERMESH_CONFIG
           value: /var/lib/cilium/clustermesh/
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
@@ -163,7 +163,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: install-cni-binaries
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         command:
           - "/install-plugin.sh"
@@ -192,7 +192,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         resources: {}
@@ -224,7 +224,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         resources: {}
@@ -252,7 +252,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         resources: {}
@@ -279,7 +279,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -347,7 +347,7 @@ spec:
         - mountPath: /var/log
           name: ipv6-hp-bpf
       - name: block-wireserver
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         command:
         - /bin/bash

--- a/test/integration/manifests/cilium/v1.14/cilium-agent/templates/daemonset.yaml
+++ b/test/integration/manifests/cilium/v1.14/cilium-agent/templates/daemonset.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: CILIUM_CLUSTERMESH_CONFIG
           value: /var/lib/cilium/clustermesh/
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
@@ -163,7 +163,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: install-cni-binaries
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         command:
           - "/install-plugin.sh"
@@ -192,7 +192,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         resources: {}
@@ -224,7 +224,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         resources: {}
@@ -252,7 +252,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         resources: {}
@@ -279,7 +279,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -338,7 +338,7 @@ spec:
           name: host-usr-lib
           readOnly: true
       - name: block-wireserver
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         command:
         - /bin/bash

--- a/test/integration/manifests/cilium/v1.14/cilium-operator/templates/deployment.yaml
+++ b/test/integration/manifests/cilium/v1.14/cilium-operator/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: cilium-operator
-        image: $CILIUM_IMAGE_REGISTRY/cilium/operator-generic:$CILIUM_VERSION_TAG
+        image: $CILIUM_IMAGE_REGISTRY/cilium/operator-generic:$CILIUM_VERSION_TAG_V1_5
         imagePullPolicy: IfNotPresent
         command:
         - cilium-operator-generic


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Updates pipeline variables to allow for a matching of release train and cilium version. Cilium version should match the k8s version being used.

This change came about because of https://github.com/Azure/azure-container-networking/pull/3089 changes which bumped cilium version from 1.13.13 -> 1.14.15 which exposed a testing gap.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
