### PR TITLE
expose MinTLSVersion config for TLS handshake

### DIFF
--- a/cns/configuration/cns_config.json
+++ b/cns/configuration/cns_config.json
@@ -33,5 +33,6 @@
     "MellanoxMonitorIntervalSecs": 30,
     "AZRSettings": {
         "PopulateHomeAzCacheRetryIntervalSecs": 60
-    }
+    },
+    "MinTLSVersion": "TLS 1.2"
 }

--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -54,6 +54,7 @@ type CNSConfig struct {
 	WatchPods                   bool `json:"-"`
 	WireserverIP                string
 	GRPCSettings                GRPCSettings
+	MinTLSVersion               string
 }
 
 type TelemetrySettings struct {
@@ -228,6 +229,10 @@ func SetCNSConfigDefaults(config *CNSConfig) {
 	}
 	if config.GRPCSettings.Port == 0 {
 		config.GRPCSettings.Port = 8080
+	}
+
+	if config.MinTLSVersion == "" {
+		config.MinTLSVersion = "TLS 1.2"
 	}
 	config.GRPCSettings.Enable = false
 	config.WatchPods = config.EnableIPAMv2 || config.EnableSwiftV2

--- a/cns/configuration/configuration_test.go
+++ b/cns/configuration/configuration_test.go
@@ -86,9 +86,10 @@ func TestReadConfigFromFile(t *testing.T) {
 				AZRSettings: AZRSettings{
 					PopulateHomeAzCacheRetryIntervalSecs: 60,
 				},
-				UseHTTPS:     true,
-				UseMTLS:      true,
-				WireserverIP: "168.63.129.16",
+				UseHTTPS:      true,
+				UseMTLS:       true,
+				WireserverIP:  "168.63.129.16",
+				MinTLSVersion: "TLS 1.1",
 			},
 			wantErr: false,
 		},
@@ -220,6 +221,7 @@ func TestSetCNSConfigDefaults(t *testing.T) {
 					IPAddress: "localhost",
 					Port:      8080,
 				},
+				MinTLSVersion: "TLS 1.2",
 			},
 		},
 		{
@@ -250,6 +252,7 @@ func TestSetCNSConfigDefaults(t *testing.T) {
 					IPAddress: "192.168.1.1",
 					Port:      9090,
 				},
+				MinTLSVersion: "TLS 1.3",
 			},
 			want: CNSConfig{
 				ChannelMode: "Other",
@@ -279,6 +282,7 @@ func TestSetCNSConfigDefaults(t *testing.T) {
 					IPAddress: "192.168.1.1",
 					Port:      9090,
 				},
+				MinTLSVersion: "TLS 1.3",
 			},
 		},
 	}

--- a/cns/configuration/configuration_test.go
+++ b/cns/configuration/configuration_test.go
@@ -89,7 +89,7 @@ func TestReadConfigFromFile(t *testing.T) {
 				UseHTTPS:      true,
 				UseMTLS:       true,
 				WireserverIP:  "168.63.129.16",
-				MinTLSVersion: "TLS 1.1",
+				MinTLSVersion: "TLS 1.3",
 			},
 			wantErr: false,
 		},

--- a/cns/configuration/testdata/good.json
+++ b/cns/configuration/testdata/good.json
@@ -34,5 +34,6 @@
     "WireserverIP": "168.63.129.16",
     "AZRSettings": {
         "PopulateHomeAzCacheRetryIntervalSecs": 60
-    }
+    },
+    "MinTLSVersion": "TLS 1.1"
 }

--- a/cns/configuration/testdata/good.json
+++ b/cns/configuration/testdata/good.json
@@ -35,5 +35,5 @@
     "AZRSettings": {
         "PopulateHomeAzCacheRetryIntervalSecs": 60
     },
-    "MinTLSVersion": "TLS 1.1"
+    "MinTLSVersion": "TLS 1.3"
 }

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -776,6 +776,7 @@ func main() {
 				MSIResourceID:                      cnsconfig.MSISettings.ResourceID,
 				KeyVaultCertificateRefreshInterval: time.Duration(cnsconfig.KeyVaultSettings.RefreshIntervalInHrs) * time.Hour,
 				UseMTLS:                            cnsconfig.UseMTLS,
+				MinTLSVersion:                      cnsconfig.MinTLSVersion,
 			}
 		}
 

--- a/cns/service_test.go
+++ b/cns/service_test.go
@@ -76,6 +76,7 @@ func TestNewService(t *testing.T) {
 			TLSPort:            "10091",
 			TLSSubjectName:     "localhost",
 			TLSCertificatePath: testCertFilePath,
+			MinTLSVersion:      "TLS 1.2",
 		}
 
 		svc, err := NewService(config.Name, config.Version, config.ChannelMode, config.Store)
@@ -94,10 +95,13 @@ func TestNewService(t *testing.T) {
 		err = svc.StartListener(config)
 		require.NoError(t, err)
 
+		minTLSVersionNumber, err := TLSVersionNumber(config.TLSSettings.MinTLSVersion)
+		require.NoError(t, err)
+
 		tlsClient := &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
-					MinVersion: tls.VersionTLS12,
+					MinVersion: minTLSVersionNumber,
 					MaxVersion: tls.VersionTLS13,
 					ServerName: config.TLSSettings.TLSSubjectName,
 					// #nosec G402 for test purposes only
@@ -134,6 +138,7 @@ func TestNewService(t *testing.T) {
 			TLSSubjectName:     "localhost",
 			TLSCertificatePath: testCertFilePath,
 			UseMTLS:            true,
+			MinTLSVersion:      "TLS 1.2",
 		}
 
 		svc, err := NewService(config.Name, config.Version, config.ChannelMode, config.Store)
@@ -321,4 +326,19 @@ func createTestCertificate(t *testing.T) string {
 	t.Log("Created test certificate file at: ", testCertFilePath)
 
 	return testCertFilePath
+}
+
+func TestTLSVersionNumber(t *testing.T) {
+	t.Run("unsupported ServerSettings.MinTLSVersion", func(t *testing.T) {
+		versionNumber, err := TLSVersionNumber("TLS 1.4")
+		require.Equal(t, uint16(0), versionNumber)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "unsupported TLS version name")
+	})
+
+	t.Run("valid ServerSettings.MinTLSVersion", func(t *testing.T) {
+		versionNumber, err := TLSVersionNumber("TLS 1.2")
+		require.Equal(t, uint16(tls.VersionTLS12), versionNumber)
+		require.NoError(t, err)
+	})
 }

--- a/cns/service_test.go
+++ b/cns/service_test.go
@@ -95,7 +95,7 @@ func TestNewService(t *testing.T) {
 		err = svc.StartListener(config)
 		require.NoError(t, err)
 
-		minTLSVersionNumber, err := TLSVersionNumber(config.TLSSettings.MinTLSVersion)
+		minTLSVersionNumber, err := parseTLSVersionName(config.TLSSettings.MinTLSVersion)
 		require.NoError(t, err)
 
 		tlsClient := &http.Client{
@@ -329,15 +329,28 @@ func createTestCertificate(t *testing.T) string {
 }
 
 func TestTLSVersionNumber(t *testing.T) {
-	t.Run("unsupported ServerSettings.MinTLSVersion", func(t *testing.T) {
-		versionNumber, err := TLSVersionNumber("TLS 1.4")
+	t.Run("unsupported ServerSettings.MinTLSVersion TLS 1.0", func(t *testing.T) {
+		versionNumber, err := parseTLSVersionName("TLS 1.0")
+		require.Equal(t, uint16(0), versionNumber)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "unsupported TLS version name")
+	})
+
+	t.Run("unsupported ServerSettings.MinTLSVersion TLS 1.1", func(t *testing.T) {
+		versionNumber, err := parseTLSVersionName("TLS 1.1")
+		require.Equal(t, uint16(0), versionNumber)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "unsupported TLS version name")
+	})
+	t.Run("unsupported ServerSettings.MinTLSVersion TLS 1.4", func(t *testing.T) {
+		versionNumber, err := parseTLSVersionName("TLS 1.4")
 		require.Equal(t, uint16(0), versionNumber)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "unsupported TLS version name")
 	})
 
 	t.Run("valid ServerSettings.MinTLSVersion", func(t *testing.T) {
-		versionNumber, err := TLSVersionNumber("TLS 1.2")
+		versionNumber, err := parseTLSVersionName("TLS 1.2")
 		require.Equal(t, uint16(tls.VersionTLS12), versionNumber)
 		require.NoError(t, err)
 	})

--- a/server/tls/tlscertificate_retriever.go
+++ b/server/tls/tlscertificate_retriever.go
@@ -14,6 +14,7 @@ type TlsSettings struct {
 	MSIResourceID                      string
 	KeyVaultCertificateRefreshInterval time.Duration
 	UseMTLS                            bool
+	MinTLSVersion                      string
 }
 
 func GetTlsCertificateRetriever(settings TlsSettings) (TlsCertificateRetriever, error) {


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
A configuration change is required in CNS to be able to specify the optional config of minimum TLS version support desired for TLS handshake

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] relevant PR labels added

**Notes**:
