### PR TITLE
feat: Windows HPC base image

### DIFF
--- a/.pipelines/cni/pipeline.yaml
+++ b/.pipelines/cni/pipeline.yaml
@@ -39,30 +39,18 @@ stages:
               arch: amd64
               name: azure-ipam
               os: linux
-            azure_ipam_windows2019_amd64:
+            azure_ipam_windows_amd64:
               arch: amd64
               name: azure-ipam
               os: windows
-              os_version: ltsc2019
-            azure_ipam_windows2022_amd64:
-              arch: amd64
-              name: azure-ipam
-              os: windows
-              os_version: ltsc2022
             cni_linux_amd64:
               arch: amd64
               name: cni
               os: linux
-            cni_windows2019_amd64:
+            cni_windows_amd64:
               arch: amd64
               name: cni
               os: windows
-              os_version: ltsc2019
-            cni_windows2022_amd64:
-              arch: amd64
-              name: cni
-              os: windows
-              os_version: ltsc2022
             ipv6_hp_bpf_linux_amd64:
               arch: amd64
               name: ipv6-hp-bpf
@@ -71,18 +59,16 @@ stages:
               arch: amd64
               name: npm
               os: linux
-            npm_windows2022_amd64:
+            npm_windows_amd64:
               arch: amd64
               name: npm
               os: windows
-              os_version: ltsc2022
         steps:
           - template: ../containers/container-template.yaml
             parameters:
               arch: $(arch)
               name: $(name)
               os: $(os)
-              os_version: $(os_version)
       - job: containerize_linux_arm64
         displayName: Build Images
         pool:
@@ -160,14 +146,12 @@ stages:
               platforms: linux/amd64 linux/arm64 windows/amd64
             cni:
               name: cni
-              os_versions: ltsc2019 ltsc2022
               platforms: linux/amd64 linux/arm64 windows/amd64
             ipv6-hp-bpf:
               name: ipv6-hp-bpf
               platforms: linux/amd64 linux/arm64
             npm:
               name: npm
-              os_versions: ltsc2022
               platforms: linux/amd64 linux/arm64 windows/amd64
         steps:
           - template: ../containers/manifest-template.yaml

--- a/.pipelines/containers/container-template.steps.yaml
+++ b/.pipelines/containers/container-template.steps.yaml
@@ -2,7 +2,6 @@ parameters:
   arch: ""
   name: ""
   os: ""
-  os_version: ""
 
 steps:
 - task: AzureCLI@2
@@ -17,7 +16,7 @@ steps:
 - script: |
     set -e
     if [ "$IN_OS" = 'windows' ]; then export BUILDX_ACTION='--push'; fi
-    make "$IMGNAME" OS="$IN_OS" ARCH="$IN_ARCH" OS_VERSION="$IN_OS_VERSION"
+    make "$IMGNAME" OS="$IN_OS" ARCH="$IN_ARCH" 
   name: image_build
   displayName: Image Build
   workingDirectory: $(ACN_DIR)
@@ -26,7 +25,6 @@ steps:
     IMGNAME: '${{ parameters.name }}-image'
     IN_OS: '${{ parameters.os }}'
     IN_ARCH: '${{ parameters.arch }}'
-    IN_OS_VERSION: '${{ parameters.os_version }}'
 
 - task: AzureCLI@2
   displayName: "Logout"

--- a/.pipelines/containers/container-template.yaml
+++ b/.pipelines/containers/container-template.yaml
@@ -2,7 +2,6 @@ parameters:
   arch: ""
   name: ""
   os: ""
-  os_version: ""
 
 steps:
 - task: AzureCLI@2
@@ -17,7 +16,7 @@ steps:
 - script: |
     set -e
     if [ ${{ parameters.os }} = 'windows' ]; then export BUILDX_ACTION='--push'; fi
-    make ${{ parameters.name }}-image OS=${{ parameters.os }} ARCH=${{ parameters.arch }} OS_VERSION=${{ parameters.os_version }}
+    make ${{ parameters.name }}-image OS=${{ parameters.os }} ARCH=${{ parameters.arch }}
   name: image_build
   displayName: Image Build
   retryCountOnTaskFailure: 3

--- a/.pipelines/containers/manifest-template.steps.yaml
+++ b/.pipelines/containers/manifest-template.steps.yaml
@@ -1,7 +1,6 @@
 parameters:
   name: ""
   platforms: ""
-  os_versions: ""
 
 steps:
 
@@ -16,7 +15,7 @@ steps:
 
   - script: |
       set -e
-      make ${{ parameters.name }}-manifest-build PLATFORMS="${{ parameters.platforms }}" OS_VERSIONS="${{ parameters.os_versions }}"
+      make ${{ parameters.name }}-manifest-build PLATFORMS="${{ parameters.platforms }}"
     workingDirectory: $(ACN_DIR)
     name: manifest_build
     displayName: Manifest Build

--- a/.pipelines/containers/manifest-template.yaml
+++ b/.pipelines/containers/manifest-template.yaml
@@ -1,7 +1,6 @@
 parameters:
   name: ""
   platforms: ""
-  os_versions: ""
 
 steps:
 
@@ -16,7 +15,7 @@ steps:
 
   - script: |
       set -e
-      make ${{ parameters.name }}-manifest-build PLATFORMS="${{ parameters.platforms }}" OS_VERSIONS="${{ parameters.os_versions }}"
+      make ${{ parameters.name }}-manifest-build PLATFORMS="${{ parameters.platforms }}" 
     name: manifest_build
     displayName: Manifest Build
     retryCountOnTaskFailure: 3

--- a/.pipelines/npm/npm-cni-integration-test.yaml
+++ b/.pipelines/npm/npm-cni-integration-test.yaml
@@ -69,7 +69,7 @@ jobs:
               # deploy azure-npm-win
               # Windows
               kubectl apply -f npm/examples/windows/azure-npm.yaml
-              kubectl set image daemonset/azure-npm-win -n kube-system azure-npm=$IMAGE_REGISTRY/azure-npm:windows-amd64-ltsc2022-${{ parameters.tag }}
+              kubectl set image daemonset/azure-npm-win -n kube-system azure-npm=$IMAGE_REGISTRY/azure-npm:windows-amd64-${{ parameters.tag }}
               kubectl rollout status -n kube-system daemonset/azure-npm-win
 
               # konnectivity agent tends to fail after rollout. Give it time to recover

--- a/.pipelines/npm/npm-conformance-tests-latest-release.yaml
+++ b/.pipelines/npm/npm-conformance-tests-latest-release.yaml
@@ -179,7 +179,7 @@ jobs:
 
               az aks get-credentials -n $(AZURE_CLUSTER) -g $(RESOURCE_GROUP) --file ./kubeconfig
               ./kubectl --kubeconfig=./kubeconfig apply -f https://raw.githubusercontent.com/Azure/azure-container-networking/master/npm/examples/windows/azure-npm.yaml
-              ./kubectl --kubeconfig=./kubeconfig set image daemonset/azure-npm-win -n kube-system azure-npm=$IMAGE_REGISTRY/azure-npm:windows-amd64-ltsc2022-$(TAG)
+              ./kubectl --kubeconfig=./kubeconfig set image daemonset/azure-npm-win -n kube-system azure-npm=$IMAGE_REGISTRY/azure-npm:windows-amd64-$(TAG)
 
             else
               echo "Creating Linux Cluster";
@@ -409,7 +409,7 @@ jobs:
   #           ./kubectl --kubeconfig=./kubeconfig apply -f https://raw.githubusercontent.com/Azure/azure-container-networking/master/npm/examples/windows/azure-npm.yaml
 
   #           # swap azure-npm image with one built during run
-  #           ./kubectl --kubeconfig=./kubeconfig set image daemonset/azure-npm-win -n kube-system azure-npm=$IMAGE_REGISTRY/azure-npm:windows-amd64-ltsc2022-$(TAG)
+  #           ./kubectl --kubeconfig=./kubeconfig set image daemonset/azure-npm-win -n kube-system azure-npm=$IMAGE_REGISTRY/azure-npm:windows-amd64-$(TAG)
 
   #           echo "sleeping 3 minutes to allow NPM pods to restart"
   #           sleep 180

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -74,18 +74,16 @@ stages:
             arch: amd64
             name: npm
             os: linux
-          npm_windows2022_amd64:
+          npm_windows_amd64:
             arch: amd64
             name: npm
             os: windows
-            os_version: ltsc2022
       steps:
         - template: ../containers/container-template.yaml
           parameters:
             arch: $(arch)
             name: $(name)
             os: $(os)
-            os_version: $(os_version)
 
   - stage: Create_Cluster_and_Run_Test
     displayName: NPM Conformance
@@ -204,7 +202,7 @@ stages:
 
                 az aks get-credentials -n $(AZURE_CLUSTER) -g $(RESOURCE_GROUP) --file ./kubeconfig
                 ./kubectl --kubeconfig=./kubeconfig apply -f $(Pipeline.Workspace)/s/npm/examples/windows/azure-npm.yaml
-                ./kubectl --kubeconfig=./kubeconfig set image daemonset/azure-npm-win -n kube-system azure-npm=$IMAGE_REGISTRY/azure-npm:windows-amd64-ltsc2022-$(TAG)
+                ./kubectl --kubeconfig=./kubeconfig set image daemonset/azure-npm-win -n kube-system azure-npm=$IMAGE_REGISTRY/azure-npm:windows-amd64-$(TAG)
 
               else
                 echo "Creating Linux Cluster";
@@ -515,7 +513,7 @@ stages:
   #             ./kubectl --kubeconfig=./kubeconfig apply -f $(Pipeline.Workspace)/s/npm/examples/windows/azure-npm.yaml
 
   #             # swap azure-npm image with one built during run
-  #             ./kubectl --kubeconfig=./kubeconfig set image daemonset/azure-npm-win -n kube-system azure-npm=$IMAGE_REGISTRY/azure-npm:windows-amd64-ltsc2022-$(TAG)
+  #             ./kubectl --kubeconfig=./kubeconfig set image daemonset/azure-npm-win -n kube-system azure-npm=$IMAGE_REGISTRY/azure-npm:windows-amd64-$(TAG)
 
   #             echo "sleeping and waiting for NPM pods to be ready..."
   #             sleep 1m

--- a/.pipelines/npm/npm-cyc-win-tests-latest-release.yaml
+++ b/.pipelines/npm/npm-cyc-win-tests-latest-release.yaml
@@ -153,7 +153,7 @@ jobs:
             ./kubectl --kubeconfig=./kubeconfig apply -f https://raw.githubusercontent.com/Azure/azure-container-networking/master/npm/examples/windows/azure-npm.yaml
 
             # swap azure-npm image with one built during run
-            ./kubectl --kubeconfig=./kubeconfig set image daemonset/azure-npm-win -n kube-system azure-npm=$IMAGE_REGISTRY/azure-npm:windows-amd64-ltsc2022-$(TAG)
+            ./kubectl --kubeconfig=./kubeconfig set image daemonset/azure-npm-win -n kube-system azure-npm=$IMAGE_REGISTRY/azure-npm:windows-amd64-$(TAG)
 
             echo "sleeping 3 minutes to allow NPM pods to restart"
             sleep 180

--- a/.pipelines/npm/npm-scale-test.yaml
+++ b/.pipelines/npm/npm-scale-test.yaml
@@ -67,18 +67,16 @@ jobs:
             arch: amd64
             name: npm
             os: linux
-        npm_windows2022_amd64:
+        npm_windows_amd64:
           arch: amd64
           name: npm
           os: windows
-          os_version: ltsc2022
     steps:
       - template: ../containers/container-template.yaml
         parameters:
           arch: $(arch)
           name: $(name)
           os: $(os)
-          os_version: $(os_version)
 
   - job: Create_Cluster_and_Run_Test
     timeoutInMinutes: 360
@@ -204,7 +202,7 @@ jobs:
 
             # swap azure-npm image with one built during run
             kubectl set image daemonset/azure-npm -n kube-system azure-npm=$IMAGE_REGISTRY/azure-npm:linux-amd64-$(TAG)
-            kubectl set image daemonset/azure-npm-win -n kube-system azure-npm=$IMAGE_REGISTRY/azure-npm:windows-amd64-ltsc2022-$(TAG)
+            kubectl set image daemonset/azure-npm-win -n kube-system azure-npm=$IMAGE_REGISTRY/azure-npm:windows-amd64-$(TAG)
 
             sleep 30s
             echo "waiting for NPM to start running..."

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -110,54 +110,26 @@ stages:
                 arch: amd64
                 name: azure-ipam
                 os: linux
-              azure_ipam_windows2019_amd64:
+              azure_ipam_windows:
                 arch: amd64
                 name: azure-ipam
                 os: windows
-                os_version: ltsc2019
-              azure_ipam_windows2022_amd64:
-                arch: amd64
-                name: azure-ipam
-                os: windows
-                os_version: ltsc2022
               cni_linux_amd64:
                 arch: amd64
                 name: cni
                 os: linux
-              cni_windows2019_amd64:
+              cni_windows_amd64:
                 arch: amd64
                 name: cni
                 os: windows
-                os_version: ltsc2019
-              cni_windows2022_amd64:
-                arch: amd64
-                name: cni
-                os: windows
-                os_version: ltsc2022
-              cni_windows2025_amd64:
-                arch: amd64
-                name: cni
-                os: windows
-                os_version: ltsc2025
               cns_linux_amd64:
                 arch: amd64
                 name: cns
                 os: linux
-              cns_windows2019_amd64:
+              cns_windows_amd64:
                 arch: amd64
                 name: cns
                 os: windows
-                os_version: ltsc2019
-              cns_windows2022_amd64:
-                arch: amd64
-                name: cns
-                os: windows
-                os_version: ltsc2022
-              cns_windows2025_amd64:
-                arch: amd64
-                name: cns
-                os: windows
-                os_version: ltsc2025
               ipv6_hp_bpf_linux_amd64:
                 arch: amd64
                 name: ipv6-hp-bpf
@@ -166,11 +138,10 @@ stages:
                 arch: amd64
                 name: npm
                 os: linux
-              npm_windows2022_amd64:
+              npm_windows_amd64:
                 arch: amd64
                 name: npm
                 os: windows
-                os_version: ltsc2022
           steps:
             - template: containers/container-template.yaml
               parameters:
@@ -226,28 +197,23 @@ stages:
             matrix:
               azure_ipam:
                 name: azure-ipam
-                os_versions: ltsc2019 ltsc2022
                 platforms: linux/amd64 linux/arm64 windows/amd64
               cni:
                 name: cni
-                os_versions: ltsc2019 ltsc2022 ltsc2025
                 platforms: linux/amd64 linux/arm64 windows/amd64
               cns:
                 name: cns
-                os_versions: ltsc2019 ltsc2022 ltsc2025
                 platforms: linux/amd64 linux/arm64 windows/amd64
               ipv6_hp_bpf:
                 name: ipv6-hp-bpf
                 platforms: linux/amd64 linux/arm64
               npm:
                 name: npm
-                os_versions: ltsc2022
                 platforms: linux/amd64 linux/arm64 windows/amd64
           steps:
             - template: containers/manifest-template.yaml
               parameters:
                 name: $(name)
-                os_versions: $(os_versions)
                 platforms: $(platforms)
 
     # Cilium Podsubnet E2E tests

--- a/.pipelines/run-pipeline.yaml
+++ b/.pipelines/run-pipeline.yaml
@@ -122,64 +122,31 @@ stages:
                 arch: amd64
                 name: azure-ipam
                 os: linux
-              azure_ipam_windows2019_amd64:
-                Suffix: azure_ipam_windows2019_amd64
+              azure_ipam_windows_amd64:
+                Suffix: azure_ipam_windows_amd64
                 arch: amd64
                 name: azure-ipam
                 os: windows
-                os_version: ltsc2019
-              azure_ipam_windows2022_amd64:
-                Suffix: azure_ipam_windows2022_amd64
-                arch: amd64
-                name: azure-ipam
-                os: windows
-                os_version: ltsc2022
               cni_linux_amd64:
                 Suffix: cni_linux_amd64
                 arch: amd64
                 name: cni
                 os: linux
-              cni_windows2019_amd64:
-                Suffix: cni_windows2019_amd64
+              cni_windows_amd64:
+                Suffix: cni_windows_amd64
                 arch: amd64
                 name: cni
                 os: windows
-                os_version: ltsc2019
-              cni_windows2022_amd64:
-                Suffix: cni_windows2022_amd64
-                arch: amd64
-                name: cni
-                os: windows
-                os_version: ltsc2022
-              cni_windows2025_amd64:
-                Suffix: cni_windows2025_amd64
-                arch: amd64
-                name: cni
-                os: windows
-                os_version: ltsc2025
               cns_linux_amd64:
                 Suffix: cns_linux_amd64
                 arch: amd64
                 name: cns
                 os: linux
-              cns_windows2019_amd64:
-                Suffix: cns_windows2019_amd64
+              cns_windows_amd64:
+                Suffix: cns_windows_amd64
                 arch: amd64
                 name: cns
                 os: windows
-                os_version: ltsc2019
-              cns_windows2022_amd64:
-                Suffix: cns_windows2022_amd64
-                arch: amd64
-                name: cns
-                os: windows
-                os_version: ltsc2022
-              cns_windows2025_amd64:
-                Suffix: cns_windows2025_amd64
-                arch: amd64
-                name: cns
-                os: windows
-                os_version: ltsc2025
               ipv6_hp_bpf_linux_amd64:
                 Suffix: ipv6_hp_bpf_linux_amd64
                 arch: amd64
@@ -190,12 +157,11 @@ stages:
                 arch: amd64
                 name: npm
                 os: linux
-              npm_windows2022_amd64:
-                Suffix: npm_windows2022_amd64
+              npm_windows_amd64:
+                Suffix: npm_windows_amd64
                 arch: amd64
                 name: npm
                 os: windows
-                os_version: ltsc2022
           variables:
             ob_git_checkout: true
             ob_artifactSuffix: $(Suffix) # this is needed to not collide published artifact containers
@@ -209,7 +175,6 @@ stages:
                 arch: $(arch)
                 name: $(name)
                 os: $(os)
-                os_version: $(os_version)
 
         - job: containerize_linux_arm64
           displayName: Build Images
@@ -280,17 +245,14 @@ stages:
             matrix:
               azure_ipam:
                 name: azure-ipam
-                os_versions: ltsc2019 ltsc2022
                 platforms: linux/amd64 linux/arm64 windows/amd64
                 Suffix: azure-ipam
               cni:
                 name: cni
-                os_versions: ltsc2019 ltsc2022 ltsc2025
                 platforms: linux/amd64 linux/arm64 windows/amd64
                 Suffix: cni
               cns:
                 name: cns
-                os_versions: ltsc2019 ltsc2022 ltsc2025
                 platforms: linux/amd64 linux/arm64 windows/amd64
                 Suffix: cns
               ipv6_hp_bpf:
@@ -299,7 +261,6 @@ stages:
                 Suffix: ipv6-hp-bpf
               npm:
                 name: npm
-                os_versions: ltsc2022
                 platforms: linux/amd64 linux/arm64 windows/amd64
                 Suffix: npm
           variables:
@@ -317,7 +278,6 @@ stages:
             - template: containers/manifest-template.steps.yaml@ACNTools
               parameters:
                 name: $(name)
-                os_versions: $(os_versions)
                 platforms: $(platforms)
 
     # Cilium Podsubnet E2E tests

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,6 @@ GOOS 	 ?= $(shell go env GOOS)
 GOARCH   ?= $(shell go env GOARCH)
 GOOSES   ?= "linux windows" # To override at the cli do: GOOSES="\"darwin bsd\""
 GOARCHES ?= "amd64 arm64" # To override at the cli do: GOARCHES="\"ppc64 mips\""
-ltsc2019  = "10.0.17763.4010"
-ltsc2022  = "10.0.20348.643"
-ltsc2025  = "10.0.26244.5000"
 
 # Windows specific extensions
 # set these based on the GOOS, not the OS
@@ -266,15 +263,15 @@ CNS_IMAGE			= azure-cns
 NPM_IMAGE			= azure-npm
 
 ## Image platform tags.
-ACNCLI_PLATFORM_TAG				?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(ACN_VERSION)
-AZURE_IPAM_PLATFORM_TAG			?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(AZURE_IPAM_VERSION)
-AZURE_IPAM_WINDOWS_PLATFORM_TAG	?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(AZURE_IPAM_VERSION)-$(OS_SKU_WIN)
-IPV6_HP_BPF_IMAGE_PLATFORM_TAG	?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(IPV6_HP_BPF_VERSION)
-CNI_PLATFORM_TAG				?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(CNI_VERSION)
-CNI_WINDOWS_PLATFORM_TAG		?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(CNI_VERSION)-$(OS_SKU_WIN)
-CNS_PLATFORM_TAG				?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(CNS_VERSION)
-CNS_WINDOWS_PLATFORM_TAG		?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(CNS_VERSION)-$(OS_SKU_WIN)
-NPM_PLATFORM_TAG				?= $(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(NPM_VERSION)
+ACNCLI_PLATFORM_TAG				?= $(subst /,-,$(PLATFORM))-$(ACN_VERSION)
+AZURE_IPAM_PLATFORM_TAG			?= $(subst /,-,$(PLATFORM))-$(AZURE_IPAM_VERSION)
+AZURE_IPAM_WINDOWS_PLATFORM_TAG	?= $(subst /,-,$(PLATFORM))-$(AZURE_IPAM_VERSION)-$(OS_SKU_WIN)
+IPV6_HP_BPF_IMAGE_PLATFORM_TAG	?= $(subst /,-,$(PLATFORM))-$(IPV6_HP_BPF_VERSION)
+CNI_PLATFORM_TAG				?= $(subst /,-,$(PLATFORM))-$(CNI_VERSION)
+CNI_WINDOWS_PLATFORM_TAG		?= $(subst /,-,$(PLATFORM))-$(CNI_VERSION)-$(OS_SKU_WIN)
+CNS_PLATFORM_TAG				?= $(subst /,-,$(PLATFORM))-$(CNS_VERSION)
+CNS_WINDOWS_PLATFORM_TAG		?= $(subst /,-,$(PLATFORM))-$(CNS_VERSION)-$(OS_SKU_WIN)
+NPM_PLATFORM_TAG				?= $(subst /,-,$(PLATFORM))-$(NPM_VERSION)
 
 
 qemu-user-static: ## Set up the host to run qemu multiplatform container builds.
@@ -287,7 +284,6 @@ container-buildah: # util target to build container images using buildah. do not
 	buildah bud \
 		--build-arg ARCH=$(ARCH) \
 		--build-arg OS=$(OS) \
-		--build-arg OS_VERSION=$(OS_VERSION) \
 		--build-arg PLATFORM=$(PLATFORM) \
 		--build-arg VERSION=$(TAG) \
 		$(EXTRA_BUILD_ARGS) \
@@ -305,7 +301,6 @@ container-docker: # util target to build container images using docker buildx. d
 		$(BUILDX_ACTION) \
 		--build-arg ARCH=$(ARCH) \
 		--build-arg OS=$(OS) \
-		--build-arg OS_VERSION=$(OS_VERSION) \
 		--build-arg PLATFORM=$(PLATFORM) \
 		--build-arg VERSION=$(TAG) \
 		$(EXTRA_BUILD_ARGS) \
@@ -319,7 +314,6 @@ container: # util target to build container images. do not invoke directly.
 	$(MAKE) container-$(CONTAINER_BUILDER) \
 		ARCH=$(ARCH) \
 		OS=$(OS) \
-		OS_VERSION=$(OS_VERSION) \
 		PLATFORM=$(PLATFORM) \
 		TAG=$(TAG) \
 		TARGET=$(TARGET)
@@ -376,8 +370,7 @@ azure-ipam-image: ## build azure-ipam container image.
 		TAG=$(AZURE_IPAM_PLATFORM_TAG) \
 		TARGET=$(OS) \
 		OS=$(OS) \
-		ARCH=$(ARCH) \
-		OS_VERSION=$(OS_VERSION)
+		ARCH=$(ARCH)
 
 azure-ipam-image-push: ## push azure-ipam container image.
 	$(MAKE) container-push \
@@ -401,13 +394,12 @@ ipv6-hp-bpf-image: ## build ipv6-hp-bpf container image.
 	$(MAKE) container \
 		DOCKERFILE=bpf-prog/ipv6-hp-bpf/$(OS).Dockerfile \
 		IMAGE=$(IPV6_HP_BPF_IMAGE) \
-		EXTRA_BUILD_ARGS='--build-arg OS=$(OS) --build-arg ARCH=$(ARCH) --build-arg OS_VERSION=$(OS_VERSION) --build-arg DEBUG=$(DEBUG)'\
+		EXTRA_BUILD_ARGS='--build-arg OS=$(OS) --build-arg ARCH=$(ARCH) --build-arg DEBUG=$(DEBUG)'\
 		PLATFORM=$(PLATFORM) \
 		TAG=$(IPV6_HP_BPF_IMAGE_PLATFORM_TAG) \
 		TARGET=$(OS) \
 		OS=$(OS) \
-		ARCH=$(ARCH) \
-		OS_VERSION=$(OS_VERSION)
+		ARCH=$(ARCH)
 
 ipv6-hp-bpf-image-push: ## push ipv6-hp-bpf container image.
 	$(MAKE) container-push \
@@ -436,7 +428,6 @@ cni-image: ## build cni container image.
 		TARGET=$(OS) \
 		OS=$(OS) \
 		ARCH=$(ARCH) \
-		OS_VERSION=$(OS_VERSION) \
 		EXTRA_BUILD_ARGS='--build-arg CNI_AI_PATH=$(CNI_AI_PATH) --build-arg CNI_AI_ID=$(CNI_AI_ID)'
 
 cni-image-push: ## push cni container image.
@@ -467,8 +458,7 @@ cns-image: ## build cns container image.
 		TAG=$(CNS_PLATFORM_TAG) \
 		TARGET=$(OS) \
 		OS=$(OS) \
-		ARCH=$(ARCH) \
-		OS_VERSION=$(OS_VERSION)
+		ARCH=$(ARCH)
 
 cns-image-push: ## push cns container image.
 	$(MAKE) container-push \
@@ -497,8 +487,7 @@ npm-image: ## build the npm container image.
 		TAG=$(NPM_PLATFORM_TAG) \
 		TARGET=$(OS) \
 		OS=$(OS) \
-		ARCH=$(ARCH) \
-		OS_VERSION=$(OS_VERSION)
+		ARCH=$(ARCH)
 
 npm-image-push: ## push npm container image.
 	$(MAKE) container-push \
@@ -518,16 +507,14 @@ manifest-create:
 	$(CONTAINER_BUILDER) manifest create $(IMAGE_REGISTRY)/$(IMAGE):$(TAG)
 
 manifest-add:
-	$(CONTAINER_BUILDER) manifest add --os=$(OS) --os-version=$($(OS_VERSION)) $(IMAGE_REGISTRY)/$(IMAGE):$(TAG) docker://$(IMAGE_REGISTRY)/$(IMAGE):$(subst /,-,$(PLATFORM))$(if $(OS_VERSION),-$(OS_VERSION),)-$(TAG)
+	$(CONTAINER_BUILDER) manifest add --os=$(OS) $(IMAGE_REGISTRY)/$(IMAGE):$(TAG) docker://$(IMAGE_REGISTRY)/$(IMAGE):$(subst /,-,$(PLATFORM))-$(TAG)
 
 manifest-build: # util target to compose multiarch container manifests from platform specific images.
 	$(MAKE) manifest-create
 	$(foreach PLATFORM,$(PLATFORMS),\
 		$(if $(filter $(PLATFORM),windows/amd64),\
-			$(foreach OS_VERSION,$(OS_VERSIONS),\
-				$(MAKE) manifest-add CONTAINER_BUILDER=$(CONTAINER_BUILDER) OS=windows OS_VERSION=$(OS_VERSION) PLATFORM=$(PLATFORM);\
-			),\
-			$(MAKE) manifest-add PLATFORM=$(PLATFORM);\
+			$(MAKE) manifest-add CONTAINER_BUILDER=$(CONTAINER_BUILDER) OS=windows OS_VERSION=$(OS_VERSION) PLATFORM=$(PLATFORM);,\
+		$(MAKE) manifest-add PLATFORM=$(PLATFORM);\
 		)\
 	)\
 
@@ -559,8 +546,7 @@ azure-ipam-manifest-build: ## build azure-ipam multiplat container manifest.
 	$(MAKE) manifest-build \
 		PLATFORMS="$(PLATFORMS)" \
 		IMAGE=$(AZURE_IPAM_IMAGE) \
-		TAG=$(AZURE_IPAM_VERSION) \
-		OS_VERSIONS="$(OS_VERSIONS)"
+		TAG=$(AZURE_IPAM_VERSION)
 
 azure-ipam-manifest-push: ## push azure-ipam multiplat container manifest
 	$(MAKE) manifest-push \
@@ -576,8 +562,7 @@ ipv6-hp-bpf-manifest-build: ## build ipv6-hp-bpf multiplat container manifest.
 	$(MAKE) manifest-build \
 		PLATFORMS="$(PLATFORMS)" \
 		IMAGE=$(IPV6_HP_BPF_IMAGE) \
-		TAG=$(IPV6_HP_BPF_VERSION) \
-		OS_VERSIONS="$(OS_VERSIONS)"
+		TAG=$(IPV6_HP_BPF_VERSION)
 
 ipv6-hp-bpf-manifest-push: ## push ipv6-hp-bpf multiplat container manifest
 	$(MAKE) manifest-push \
@@ -593,8 +578,7 @@ cni-manifest-build: ## build cni multiplat container manifest.
 	$(MAKE) manifest-build \
 		PLATFORMS="$(PLATFORMS)" \
 		IMAGE=$(CNI_IMAGE) \
-		TAG=$(CNI_VERSION) \
-		OS_VERSIONS="$(OS_VERSIONS)"
+		TAG=$(CNI_VERSION)
 
 cni-manifest-push: ## push cni multiplat container manifest
 	$(MAKE) manifest-push \
@@ -610,8 +594,7 @@ cns-manifest-build: ## build azure-cns multiplat container manifest.
 	$(MAKE) manifest-build \
 		PLATFORMS="$(PLATFORMS)" \
 		IMAGE=$(CNS_IMAGE) \
-		TAG=$(CNS_VERSION) \
-		OS_VERSIONS="$(OS_VERSIONS)"
+		TAG=$(CNS_VERSION)
 
 cns-manifest-push: ## push cns multiplat container manifest
 	$(MAKE) manifest-push \
@@ -627,8 +610,7 @@ npm-manifest-build: ## build azure-npm multiplat container manifest.
 	$(MAKE) manifest-build \
 		PLATFORMS="$(PLATFORMS)" \
 		IMAGE=$(NPM_IMAGE) \
-		TAG=$(NPM_VERSION) \
-		OS_VERSIONS="$(OS_VERSIONS)"
+		TAG=$(NPM_VERSION)
 
 npm-manifest-push: ## push multiplat container manifest
 	$(MAKE) manifest-push \

--- a/azure-ipam/Dockerfile
+++ b/azure-ipam/Dockerfile
@@ -37,15 +37,7 @@ FROM scratch AS linux
 COPY --from=dropgz /go/bin/dropgz dropgz
 ENTRYPOINT [ "/dropgz" ]
 
-# skopeo inspect --override-os windows docker://mcr.microsoft.com/windows/nanoserver:ltsc2019 --format "{{.Name}}@{{.Digest}}"
-FROM mcr.microsoft.com/windows/nanoserver@sha256:7f6649348a11655e3576463fd6d55c29248f97405f8e643cab2409009339f520 AS ltsc2019
-
-# skopeo inspect --override-os windows docker://mcr.microsoft.com/windows/nanoserver:ltsc2022 --format "{{.Name}}@{{.Digest}}"
-FROM mcr.microsoft.com/windows/nanoserver@sha256:244113e50a678a25a63930780f9ccafd22e1a37aa9e3d93295e4cebf0f170a11 AS ltsc2022
-
-# skopeo inspect --override-os windows docker://mcr.microsoft.com/windows/nanoserver:ltsc2025 --format "{{.Name}}@{{.Digest}}" ## 2025 isn't tagged yet
-FROM mcr.microsoft.com/windows/nanoserver/insider@sha256:67e0ab7f3a79cd73be4a18bae24659c03b294aed0dbeaa624feb3810931f0bd2 AS ltsc2025
-
-FROM ${OS_VERSION} AS windows
+# skopeo inspect docker://mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0 --format "{{.Name}}@{{.Digest}}"
+FROM mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image@sha256:b4c9637e032f667c52d1eccfa31ad8c63f1b035e8639f3f48a510536bf34032b as windows
 COPY --from=dropgz /go/bin/dropgz dropgz.exe
 ENTRYPOINT [ "/dropgz.exe" ]

--- a/cni/Dockerfile
+++ b/cni/Dockerfile
@@ -51,15 +51,7 @@ FROM scratch AS linux
 COPY --from=dropgz /go/bin/dropgz dropgz
 ENTRYPOINT [ "/dropgz" ]
 
-# skopeo inspect --override-os windows docker://mcr.microsoft.com/windows/nanoserver:ltsc2019 --format "{{.Name}}@{{.Digest}}"
-FROM mcr.microsoft.com/windows/nanoserver@sha256:7f6649348a11655e3576463fd6d55c29248f97405f8e643cab2409009339f520 AS ltsc2019
-
-# skopeo inspect --override-os windows docker://mcr.microsoft.com/windows/nanoserver:ltsc2022 --format "{{.Name}}@{{.Digest}}"
-FROM mcr.microsoft.com/windows/nanoserver@sha256:244113e50a678a25a63930780f9ccafd22e1a37aa9e3d93295e4cebf0f170a11 AS ltsc2022
-
-# skopeo inspect --override-os windows docker://mcr.microsoft.com/windows/nanoserver:ltsc2025 --format "{{.Name}}@{{.Digest}}" ## 2025 isn't tagged yet
-FROM mcr.microsoft.com/windows/nanoserver/insider@sha256:67e0ab7f3a79cd73be4a18bae24659c03b294aed0dbeaa624feb3810931f0bd2 AS ltsc2025
-
-FROM ${OS_VERSION} as windows
+# skopeo inspect docker://mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0 --format "{{.Name}}@{{.Digest}}"
+FROM mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image@sha256:b4c9637e032f667c52d1eccfa31ad8c63f1b035e8639f3f48a510536bf34032b as windows
 COPY --from=dropgz /go/bin/dropgz dropgz.exe
 ENTRYPOINT [ "/dropgz.exe" ]

--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -30,16 +30,8 @@ COPY --from=builder /go/bin/azure-cns /usr/local/bin/azure-cns
 ENTRYPOINT [ "/usr/local/bin/azure-cns" ]
 EXPOSE 10090
 
-# skopeo inspect --override-os windows docker://mcr.microsoft.com/windows/nanoserver:ltsc2019 --format "{{.Name}}@{{.Digest}}"
-FROM mcr.microsoft.com/windows/nanoserver@sha256:7f6649348a11655e3576463fd6d55c29248f97405f8e643cab2409009339f520 AS ltsc2019
-
-# skopeo inspect --override-os windows docker://mcr.microsoft.com/windows/nanoserver:ltsc2022 --format "{{.Name}}@{{.Digest}}"
-FROM mcr.microsoft.com/windows/nanoserver@sha256:244113e50a678a25a63930780f9ccafd22e1a37aa9e3d93295e4cebf0f170a11 AS ltsc2022
-
-# skopeo inspect --override-os windows docker://mcr.microsoft.com/windows/nanoserver:ltsc2025 --format "{{.Name}}@{{.Digest}}" ## 2025 isn't tagged yet
-FROM mcr.microsoft.com/windows/nanoserver/insider@sha256:67e0ab7f3a79cd73be4a18bae24659c03b294aed0dbeaa624feb3810931f0bd2 AS ltsc2025
-
-FROM ${OS_VERSION} AS windows
+# skopeo inspect docker://mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0 --format "{{.Name}}@{{.Digest}}"
+FROM mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image@sha256:b4c9637e032f667c52d1eccfa31ad8c63f1b035e8639f3f48a510536bf34032b as windows
 COPY --from=builder /azure-container-networking/cns/kubeconfigtemplate.yaml kubeconfigtemplate.yaml
 COPY --from=builder /azure-container-networking/npm/examples/windows/setkubeconfigpath.ps1 setkubeconfigpath.ps1
 COPY --from=builder /go/bin/azure-cns /azure-cns.exe

--- a/npm/windows.Dockerfile
+++ b/npm/windows.Dockerfile
@@ -8,9 +8,7 @@ COPY . .
 RUN GOOS=windows CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm.exe -ldflags "-X main.version="$VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" -gcflags="-dwarflocationlists=true" npm/cmd/*.go
 
 # intermediate for win-ltsc2022
-FROM mcr.microsoft.com/windows/servercore@sha256:45952938708fbde6ec0b5b94de68bcdec3f8c838be018536b1e9e5bd95e6b943 as ltsc2022
-
-FROM ${OS_VERSION} as windows
+FROM mcr.microsoft.com/windows/servercore@sha256:45952938708fbde6ec0b5b94de68bcdec3f8c838be018536b1e9e5bd95e6b943 as windows
 COPY --from=builder /usr/local/src/npm/examples/windows/kubeconfigtemplate.yaml kubeconfigtemplate.yaml
 COPY --from=builder /usr/local/src/npm/examples/windows/setkubeconfigpath.ps1 setkubeconfigpath.ps1
 COPY --from=builder /usr/local/src/npm/examples/windows/setkubeconfigpath-capz.ps1 setkubeconfigpath-capz.ps1


### PR DESCRIPTION
Windows HPC are special.

They explicitly [do not run in a `chroot`](https://github.com/kubernetes/enhancements/tree/master/keps/sig-windows/1981-windows-privileged-container-support#container-mounts:~:text=There%20will%20be%20no%20chroot%20equivalent) or similar execution sandbox, and their [filesystem is a merged view](https://github.com/kubernetes/enhancements/tree/master/keps/sig-windows/1981-windows-privileged-container-support#container-mounts) of the hostfs and their shipped containerfs. This means that we don't need to ship a filesystem: we recently moved from `servercore` to `nanoserver` and observed that the lack of `pwsh.exe` in `nanoserver` is manageable (in containerd 1.7+, automatically, and in 1.6, by tweaking the container `PATH`). We can go further and remove the rest of the OS since, as HPC, we don't need it and can escape to the hostfs for dependencies like powershell.

Further, HPC do not have the [same Windows OS version compatibility requirements](https://github.com/containerd/containerd/issues/7431) (the "os-version") as regular Windows containers - any Windows HPC may run on any Windows Server Host (given the executables are compatible with that Host). 
In some of the testing with WS25 we have seen that this may happen - it was observed that containerd on WS25 inconsistently fetched the WS25 CNI image specified in our multiplatform manifest but was able to run other WS images without any issue.
Containerd >= 1.6 [should have compatibility for Windows HPC without an `os-version` set](https://github.com/containerd/containerd/pull/8101), so we don't need to build separate Windows images for all of our target WS variants and can simply build one without that extra metadata.

