### PR TITLE
Fix: Add default route on delegatedNIC interface

### DIFF
--- a/cns/middlewares/k8sSwiftV2.go
+++ b/cns/middlewares/k8sSwiftV2.go
@@ -237,6 +237,8 @@ func (k *K8sSWIFTv2Middleware) getIPConfig(ctx context.Context, podInfo cns.PodI
 					return nil, errors.Wrap(err, "failed to parse mtpnc subnetAddressSpace prefix")
 				}
 				podIPInfos = append(podIPInfos, podIPInfo)
+				// for windows scenario, it is required to add default route with gatewayIP from CNS
+				k.addDefaultRoute(&podIPInfo, interfaceInfo.GatewayIP)
 			}
 		}
 	}

--- a/cns/middlewares/k8sSwiftV2_linux.go
+++ b/cns/middlewares/k8sSwiftV2_linux.go
@@ -101,3 +101,5 @@ func addRoutes(cidrs []string, gatewayIP string) []cns.Route {
 func (k *K8sSWIFTv2Middleware) assignSubnetPrefixLengthFields(_ *cns.PodIpInfo, _ v1alpha1.InterfaceInfo, _ string) error {
 	return nil
 }
+
+func (k *K8sSWIFTv2Middleware) addDefaultRoute(_ *cns.PodIpInfo, _ string) {}

--- a/cns/middlewares/k8sSwiftV2_linux.go
+++ b/cns/middlewares/k8sSwiftV2_linux.go
@@ -102,4 +102,4 @@ func (k *K8sSWIFTv2Middleware) assignSubnetPrefixLengthFields(_ *cns.PodIpInfo, 
 	return nil
 }
 
-func (k *K8sSWIFTv2Middleware) addDefaultRoute(_ *cns.PodIpInfo, _ string) {}
+func (k *K8sSWIFTv2Middleware) addDefaultRoute(*cns.PodIpInfo, string) {}

--- a/cns/middlewares/k8sSwiftV2_windows.go
+++ b/cns/middlewares/k8sSwiftV2_windows.go
@@ -11,8 +11,9 @@ import (
 // default route is set for secondary interface NIC(i.e,delegatedNIC)
 func (k *K8sSWIFTv2Middleware) setRoutes(podIPInfo *cns.PodIpInfo) error {
 	if podIPInfo.NICType == cns.InfraNIC {
-		// as a workaround, set a default route with gw 0.0.0.0 to avoid HNS setting default route to infraNIC interface
-		// TODO: Remove this once HNS supports custom routes adding to the pod
+		// as a workaround, HNS will not set this dummy default route(0.0.0.0/0, nexthop:0.0.0.0) on infraVnet interface eth0
+		// the only usage for this dummy default is to bypass HNS setting default route on eth0
+		// TODO: Remove this once HNS fix is ready
 		route := cns.Route{
 			IPAddress:        "0.0.0.0/0",
 			GatewayIPAddress: "0.0.0.0",

--- a/cns/middlewares/k8sSwiftV2_windows.go
+++ b/cns/middlewares/k8sSwiftV2_windows.go
@@ -46,7 +46,6 @@ func (k *K8sSWIFTv2Middleware) assignSubnetPrefixLengthFields(podIPInfo *cns.Pod
 		},
 		GatewayIPAddress: interfaceInfo.GatewayIP,
 	}
-
 	return nil
 }
 

--- a/cns/middlewares/k8sSwiftV2_windows.go
+++ b/cns/middlewares/k8sSwiftV2_windows.go
@@ -46,12 +46,15 @@ func (k *K8sSWIFTv2Middleware) assignSubnetPrefixLengthFields(podIPInfo *cns.Pod
 		},
 		GatewayIPAddress: interfaceInfo.GatewayIP,
 	}
-	// assign the default route with gateway IP
-	route := cns.Route{
-		IPAddress:        "0.0.0.0/0",
-		GatewayIPAddress: interfaceInfo.GatewayIP,
-	}
-	podIPInfo.Routes = append(podIPInfo.Routes, route)
 
 	return nil
+}
+
+// add default route with gateway IP to podIPInfo
+func (k *K8sSWIFTv2Middleware) addDefaultRoute(podIPInfo *cns.PodIpInfo, gwIP string) {
+	route := cns.Route{
+		IPAddress:        "0.0.0.0/0",
+		GatewayIPAddress: gwIP,
+	}
+	podIPInfo.Routes = append(podIPInfo.Routes, route)
 }

--- a/cns/middlewares/k8sSwiftV2_windows.go
+++ b/cns/middlewares/k8sSwiftV2_windows.go
@@ -47,8 +47,8 @@ func (k *K8sSWIFTv2Middleware) assignSubnetPrefixLengthFields(podIPInfo *cns.Pod
 		GatewayIPAddress: interfaceInfo.GatewayIP,
 	}
 	// assign the default route with gateway IP
-	route := cns.Route {
-		IPAddress: "0.0.0.0/0",
+	route := cns.Route{
+		IPAddress:        "0.0.0.0/0",
 		GatewayIPAddress: interfaceInfo.GatewayIP,
 	}
 	podIPInfo.Routes = append(podIPInfo.Routes, route)

--- a/cns/middlewares/k8sSwiftV2_windows.go
+++ b/cns/middlewares/k8sSwiftV2_windows.go
@@ -2,7 +2,6 @@ package middlewares
 
 import (
 	"github.com/Azure/azure-container-networking/cns"
-	"github.com/Azure/azure-container-networking/cns/logger"
 	"github.com/Azure/azure-container-networking/cns/middlewares/utils"
 	"github.com/Azure/azure-container-networking/crd/multitenancy/api/v1alpha1"
 	"github.com/pkg/errors"

--- a/cns/middlewares/k8sSwiftV2_windows_test.go
+++ b/cns/middlewares/k8sSwiftV2_windows_test.go
@@ -1,6 +1,7 @@
 package middlewares
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/Azure/azure-container-networking/cns"
@@ -53,9 +54,17 @@ func TestAssignSubnetPrefixSuccess(t *testing.T) {
 		MacAddress: "12:34:56:78:9a:bc",
 	}
 
+	gatewayIP := "20.240.1.1"
 	intInfo := v1alpha1.InterfaceInfo{
-		GatewayIP:          "20.240.1.1",
+		GatewayIP:          gatewayIP,
 		SubnetAddressSpace: "20.240.1.0/16",
+	}
+
+	routes := []cns.Route{
+		{
+			IPAddress:        "0.0.0.0/0",
+			GatewayIPAddress: gatewayIP,
+		},
 	}
 
 	ipInfo := podIPInfo
@@ -65,4 +74,9 @@ func TestAssignSubnetPrefixSuccess(t *testing.T) {
 	assert.Equal(t, ipInfo.PodIPConfig.PrefixLength, uint8(16))
 	assert.Equal(t, ipInfo.HostPrimaryIPInfo.Gateway, intInfo.GatewayIP)
 	assert.Equal(t, ipInfo.HostPrimaryIPInfo.Subnet, intInfo.SubnetAddressSpace)
+
+	// compare two slices of routes
+	if !reflect.DeepEqual(ipInfo.Routes, routes) {
+		t.Errorf("got '%+v', expected '%+v'", ipInfo.Routes, routes)
+	}
 }

--- a/cns/middlewares/k8sSwiftV2_windows_test.go
+++ b/cns/middlewares/k8sSwiftV2_windows_test.go
@@ -91,7 +91,7 @@ func TestAddDefaultRoute(t *testing.T) {
 
 	expectedRoutes := []cns.Route{
 		{
-			IPAddress: "0.0.0.0/0",
+			IPAddress:        "0.0.0.0/0",
 			GatewayIPAddress: gatewayIP,
 		},
 	}

--- a/cns/middlewares/k8sSwiftV2_windows_test.go
+++ b/cns/middlewares/k8sSwiftV2_windows_test.go
@@ -54,9 +54,8 @@ func TestAssignSubnetPrefixSuccess(t *testing.T) {
 		MacAddress: "12:34:56:78:9a:bc",
 	}
 
-	gatewayIP := "20.240.1.1"
 	intInfo := v1alpha1.InterfaceInfo{
-		GatewayIP:          gatewayIP,
+		GatewayIP:          "20.240.1.1",
 		SubnetAddressSpace: "20.240.1.0/16",
 	}
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
This PR is to fix one issue in swiftv2 Windows scenario:
When a pod is created, the default route is added on infra vnet:
root@swiftv2-pod-3:/# ip route
default via 10.244.2.1 dev eth0 metric 1
It leads to ping a VM IP in the same VNET that cannot work.

There are two issues::
1.CNS does not provide the default route to CNI;
2.CNI should only add the default route to secondary interface customer vnet; on Swiftv2 scenario, skipDefaultRoutes is set to true for infraNIC interface and false for a secondary interface; so if !info.skipDefaultRoutes, then add default route.

Add dummy default route and pass to CNI as a workaround;

After this fix after a pod creation is done, the route table shows:
**root@swiftv2-pod-1:/# ip route
default via 10.241.0.1 dev eth1**
10.241.0.0/16 dev eth1 proto kernel scope link src 10.241.0.55
10.244.0.0/16 dev eth0 proto kernel scope link src 10.244.1.103

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
