### PR TITLE
Remove l2bridge checker on windows and l2tunnel mode

### DIFF
--- a/cni/azure-windows-swift-overlay-dualstack.conflist
+++ b/cni/azure-windows-swift-overlay-dualstack.conflist
@@ -5,7 +5,6 @@
     "plugins": [
         {
             "type": "azure-vnet",
-            "mode": "bridge",
             "bridge": "azure0",
             "capabilities": {
                 "portMappings": true,

--- a/cni/azure-windows-swift-overlay.conflist
+++ b/cni/azure-windows-swift-overlay.conflist
@@ -5,7 +5,6 @@
     "plugins": [
         {
             "type": "azure-vnet",
-            "mode": "bridge",
             "bridge": "azure0",
             "capabilities": {
                 "portMappings": true,

--- a/cni/azure-windows-swift.conflist
+++ b/cni/azure-windows-swift.conflist
@@ -5,7 +5,6 @@
     "plugins": [
         {
             "type": "azure-vnet",
-            "mode": "bridge",
             "bridge": "azure0",
             "executionMode": "v4swift",
             "capabilities": {

--- a/cns/hnsclient/hnsclient_windows.go
+++ b/cns/hnsclient/hnsclient_windows.go
@@ -30,7 +30,6 @@ const (
 
 	// HNS network types
 	hnsL2Bridge = "l2bridge"
-	hnsL2Tunnel = "l2tunnel"
 
 	// hcnSchemaVersionMajor indicates major version number for hcn schema
 	hcnSchemaVersionMajor = 2
@@ -145,7 +144,7 @@ func CreateDefaultExtNetwork(networkType string) error {
 		return nil
 	}
 
-	if networkType != hnsL2Bridge && networkType != hnsL2Tunnel {
+	if networkType != hnsL2Bridge {
 		return fmt.Errorf("Invalid hns network type %s", networkType)
 	}
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -244,7 +244,7 @@ var args = acn.ArgumentList{
 	{
 		Name:         acn.OptCreateDefaultExtNetworkType,
 		Shorthand:    acn.OptCreateDefaultExtNetworkTypeAlias,
-		Description:  "Create default external network for windows platform with the specified type (l2bridge or l2tunnel)",
+		Description:  "Create default external network for windows platform with the specified type (l2bridge)",
 		Type:         "string",
 		DefaultValue: "",
 	},

--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -223,7 +223,7 @@ func (nm *networkManager) configureHcnNetwork(nwInfo *EndpointInfo, extIf *exter
 	// Initialize HNS network.
 	hcnNetwork := &hcn.HostComputeNetwork{
 		Name: nwInfo.NetworkID,
-		Type: hcn.L2Bridge
+		Type: hcn.L2Bridge,
 		Ipams: []hcn.Ipam{
 			{
 				Type: hcnIpamTypeStatic,

--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -24,7 +24,6 @@ import (
 const (
 	// HNS network types.
 	hnsL2bridge            = "l2bridge"
-	hnsL2tunnel            = "l2tunnel"
 	CnetAddressSpace       = "cnetAddressSpace"
 	vEthernetAdapterPrefix = "vEthernet"
 	baseDecimal            = 10
@@ -113,6 +112,7 @@ func (nm *networkManager) newNetworkImplHnsV1(nwInfo *EndpointInfo, extIf *exter
 	// Initialize HNS network.
 	hnsNetwork := &hcsshim.HNSNetwork{
 		Name:               nwInfo.NetworkID,
+		Type:               hnsL2bridge,
 		NetworkAdapterName: networkAdapterName,
 		Policies:           policy.SerializePolicies(policy.NetworkPolicy, nwInfo.NetworkPolicies, nil, false, false),
 	}
@@ -130,16 +130,6 @@ func (nm *networkManager) newNetworkImplHnsV1(nwInfo *EndpointInfo, extIf *exter
 		hnsNetwork.Policies = append(hnsNetwork.Policies, serializedVlanPolicy)
 
 		vlanid = (int)(vlanPolicy.VLAN)
-	}
-
-	// Set network mode.
-	switch nwInfo.Mode {
-	case opModeBridge:
-		hnsNetwork.Type = hnsL2bridge
-	case opModeTunnel:
-		hnsNetwork.Type = hnsL2tunnel
-	default:
-		return nil, errNetworkModeInvalid
 	}
 
 	// Populate subnets.
@@ -233,6 +223,7 @@ func (nm *networkManager) configureHcnNetwork(nwInfo *EndpointInfo, extIf *exter
 	// Initialize HNS network.
 	hcnNetwork := &hcn.HostComputeNetwork{
 		Name: nwInfo.NetworkID,
+		Type: hcn.L2Bridge
 		Ipams: []hcn.Ipam{
 			{
 				Type: hcnIpamTypeStatic,
@@ -285,16 +276,6 @@ func (nm *networkManager) configureHcnNetwork(nwInfo *EndpointInfo, extIf *exter
 		}
 
 		vlanid = (int)(vlanID)
-	}
-
-	// Set network mode.
-	switch nwInfo.Mode {
-	case opModeBridge:
-		hcnNetwork.Type = hcn.L2Bridge
-	case opModeTunnel:
-		hcnNetwork.Type = hcn.L2Tunnel
-	default:
-		return nil, errNetworkModeInvalid
 	}
 
 	// AccelnetNIC flag: hcn.EnableIov(9216) - treat Delegated/FrontendNIC also the same as Accelnet

--- a/network/network_windows_test.go
+++ b/network/network_windows_test.go
@@ -522,6 +522,47 @@ func TestTransparentNetworkCreationForDelegated(t *testing.T) {
 	}
 }
 
+// Test Configure HNC network for infraNIC ensuring the hcn network type is always l2 bridge
+func TestConfigureHCNNetworkInfraNIC(t *testing.T) {
+	expectedHcnNetworkType := hcn.L2Bridge
+
+	nm := &networkManager{
+		ExternalInterfaces: map[string]*externalInterface{},
+	}
+
+	extIf := externalInterface{
+		Name: "eth0",
+	}
+
+	nwInfo := &EndpointInfo{
+		AdapterName:  "eth0",
+		NetworkID:    "d3e97a83-ba4c-45d5-ba88-dc56757ece28",
+		MasterIfName: "eth0",
+		NICType:      cns.InfraNIC,
+		IfIndex:      1,
+		EndpointID:  "753d3fb6-e9b3-49e2-a109-2acc5dda61f1",
+		ContainerID: "545055c2-1462-42c8-b222-e75d0b291632",
+		NetNsPath:   "fakeNameSpace",
+		IfName:      "eth0",
+		Data:        make(map[string]interface{}),
+		EndpointDNS: DNSInfo{
+			Suffix:  "10.0.0.0",
+			Servers: []string{"10.0.0.1, 10.0.0.2"},
+			Options: nil,
+		},
+		HNSNetworkID: "853d3fb6-e9b3-49e2-a109-2acc5dda61f1",
+	}
+
+	hostComputeNetwork, err := nm.configureHcnNetwork(nwInfo, &extIf)
+	if err != nil {
+		t.Fatalf("Failed to configure hcn network for infraNIC interface due to: %v", err)
+	}
+
+	if hostComputeNetwork.Type != expectedHcnNetworkType {
+		t.Fatalf("Host network mode is not configured as %v mode when interface NIC type is infraNIC", expectedHcnNetworkType)
+	}
+}
+
 // Test Configure HCN Network for Swiftv2 DelegatedNIC HostComputeNetwork fields
 func TestConfigureHCNNetworkSwiftv2DelegatedNIC(t *testing.T) {
 	expectedSwiftv2NetworkMode := hcn.Transparent

--- a/network/network_windows_test.go
+++ b/network/network_windows_test.go
@@ -60,7 +60,6 @@ func TestNewAndDeleteNetworkImplHnsV2(t *testing.T) {
 	}
 
 	err = nm.deleteNetworkImplHnsV2(network)
-
 	if err != nil {
 		fmt.Printf("+%v", err)
 		t.Fatal(err)
@@ -95,7 +94,6 @@ func TestSuccesfulNetworkCreationWhenAlreadyExists(t *testing.T) {
 	}
 
 	_, err = nm.newNetworkImplHnsV2(nwInfo, extInterface)
-
 	if err != nil {
 		fmt.Printf("+%v", err)
 		t.Fatal(err)
@@ -468,7 +466,6 @@ func TestNewAndDeleteNetworkImplHnsV2ForDelegated(t *testing.T) {
 	}
 
 	err = nm.deleteNetworkImpl(network, cns.NodeNetworkInterfaceFrontendNIC)
-
 	if err != nil {
 		fmt.Printf("+%v", err)
 		t.Fatal(err)
@@ -540,11 +537,11 @@ func TestConfigureHCNNetworkInfraNIC(t *testing.T) {
 		MasterIfName: "eth0",
 		NICType:      cns.InfraNIC,
 		IfIndex:      1,
-		EndpointID:  "753d3fb6-e9b3-49e2-a109-2acc5dda61f1",
-		ContainerID: "545055c2-1462-42c8-b222-e75d0b291632",
-		NetNsPath:   "fakeNameSpace",
-		IfName:      "eth0",
-		Data:        make(map[string]interface{}),
+		EndpointID:   "753d3fb6-e9b3-49e2-a109-2acc5dda61f1",
+		ContainerID:  "545055c2-1462-42c8-b222-e75d0b291632",
+		NetNsPath:    "fakeNameSpace",
+		IfName:       "eth0",
+		Data:         make(map[string]interface{}),
 		EndpointDNS: DNSInfo{
 			Suffix:  "10.0.0.0",
 			Servers: []string{"10.0.0.1, 10.0.0.2"},


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
This PR is to simplify windows l2bridge mode and remove l2tunnel mode from the system.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
