### PR TITLE
ci: standardize E2E job timeout to 2 hours on PR pipeline

### DIFF
--- a/.pipelines/singletenancy/aks/aks-e2e.jobs.yaml
+++ b/.pipelines/singletenancy/aks/aks-e2e.jobs.yaml
@@ -48,6 +48,7 @@ stages:
     jobs:
       - job: ${{ parameters.name }}
         displayName: Singletenancy AKS - (${{ parameters.name }})
+        timeoutInMinutes: 120
         pool:
           isCustom: true
           type: linux

--- a/.pipelines/singletenancy/aks/e2e-job-template.yaml
+++ b/.pipelines/singletenancy/aks/e2e-job-template.yaml
@@ -50,6 +50,7 @@ stages:
     jobs:
       - job: ${{ parameters.name }}
         displayName: Singletenancy AKS - (${{ parameters.name }})
+        timeoutInMinutes: 120
         pool:
           name: $(BUILD_POOL_NAME_DEFAULT)
           demands:

--- a/.pipelines/singletenancy/azure-cni-overlay-stateless/azure-cni-overlay-stateless-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay-stateless/azure-cni-overlay-stateless-e2e-job-template.yaml
@@ -50,6 +50,7 @@ stages:
     jobs:
       - job: ${{ parameters.name }}_windows
         displayName: Azure Stateless CNI Overlay Test Suite | Windows - (${{ parameters.name }})
+        timeoutInMinutes: 120
         pool:
           name: $(BUILD_POOL_NAME_DEFAULT)
           demands:

--- a/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-job-template.yaml
@@ -45,6 +45,7 @@ stages:
     jobs:
       - job: ${{ parameters.name }}
         displayName: Cilium Dualstack Overlay Test Suite - (${{ parameters.name }})
+        timeoutInMinutes: 120
         pool:
           name: $(BUILD_POOL_NAME_DEFAULT)
           demands:

--- a/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e.jobs.yaml
+++ b/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e.jobs.yaml
@@ -43,6 +43,7 @@ stages:
     jobs:
       - job: ${{ parameters.name }}
         displayName: Cilium Dualstack Overlay Test Suite - (${{ parameters.name }})
+        timeoutInMinutes: 120
         pool:
           isCustom: true
           type: linux

--- a/.pipelines/singletenancy/cilium-nodesubnet/cilium-nodesubnet-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/cilium-nodesubnet/cilium-nodesubnet-e2e-job-template.yaml
@@ -50,6 +50,7 @@ stages:
     jobs:
       - job: ${{ parameters.name }}
         displayName: Nodesubnet with Cilium - (${{ parameters.name }})
+        timeoutInMinutes: 120
         pool:
           name: $(BUILD_POOL_NAME_DEFAULT)
           demands:


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Seeing runs fail due to extended testing times and component detection taking 10 minutes of the default 60. Increasing it to 2 hours can potentially increase run times on failed states, but will allow for enough time for flaky tests to succeed and still have a successful run.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
