### PR TITLE
ci: Add exit code capture for PR pipeline

### DIFF
--- a/.pipelines/singletenancy/aks-swift/aks-swift-e2e.steps.yaml
+++ b/.pipelines/singletenancy/aks-swift/aks-swift-e2e.steps.yaml
@@ -68,6 +68,7 @@ steps:
       workingDirectory: $(ACN_DIR)
       addSpnToEnvironment: true
       inlineScript: |
+        set -e
         cd test/integration/load
 
         # Scale Cluster Up/Down to confirm functioning CNS

--- a/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
@@ -71,6 +71,7 @@ steps:
       scriptType: "bash"
       addSpnToEnvironment: true
       inlineScript: |
+        set -e
         cd test/integration/load
 
         # Scale Cluster Up/Down to confirm functioning CNS

--- a/.pipelines/singletenancy/aks/aks-e2e.steps.yaml
+++ b/.pipelines/singletenancy/aks/aks-e2e.steps.yaml
@@ -70,6 +70,7 @@ steps:
     displayName: "Restart Nodes"
 
   - script: |
+      set -e
       kubectl get pods -A -o wide
 
       echo "Deploying test pods"

--- a/.pipelines/singletenancy/aks/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks/e2e-step-template.yaml
@@ -64,6 +64,7 @@ steps:
         done
     displayName: "Restart Nodes"
   - script: |
+      set -e
       kubectl get pods -A -o wide
       echo "Deploying test pods"
       cd test/integration/load

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-step-template.yaml
@@ -64,6 +64,7 @@ steps:
         scriptType: "bash"
         addSpnToEnvironment: true
         inlineScript: |
+          set -e
           cd test/integration/load
 
           # Scale Cluster Up/Down to confirm functioning CNS
@@ -129,6 +130,7 @@ steps:
         scriptType: "bash"
         addSpnToEnvironment: true
         inlineScript: |
+          set -e
           cd test/integration/load
 
           # Scale Cluster Up/Down to confirm functioning CNS

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e.steps.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e.steps.yaml
@@ -68,6 +68,7 @@ steps:
         workingDirectory: $(ACN_DIR)
         addSpnToEnvironment: true
         inlineScript: |
+          set -e
           cd test/integration/load
 
           # Scale Cluster Up/Down to confirm functioning CNS
@@ -138,6 +139,7 @@ steps:
         workingDirectory: $(ACN_DIR)
         addSpnToEnvironment: true
         inlineScript: |
+          set -e
           cd test/integration/load
 
           # Scale Cluster Up/Down to confirm functioning CNS

--- a/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-step-template.yaml
@@ -92,6 +92,7 @@ steps:
       scriptType: "bash"
       addSpnToEnvironment: true
       inlineScript: |
+        set -e
         cd test/integration/load
 
         # Scale Cluster Up/Down to confirm functioning CNS
@@ -106,6 +107,7 @@ steps:
     retryCountOnTaskFailure: 3
 
   - script: |
+      set -e
       echo "Run Cilium Connectivity Tests"
       cilium status
       cilium connectivity test --connect-timeout 4s --request-timeout 30s --test '!pod-to-pod-encryption,!node-to-node-encryption,!no-unexpected-packet-drops' --force-deploy

--- a/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e.steps.yaml
+++ b/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e.steps.yaml
@@ -96,6 +96,7 @@ steps:
       workingDirectory: $(ACN_DIR)
       addSpnToEnvironment: true
       inlineScript: |
+        set -e
         cd test/integration/load
 
         # Scale Cluster Up/Down to confirm functioning CNS
@@ -110,6 +111,7 @@ steps:
     retryCountOnTaskFailure: 3
 
   - script: |
+      set -e
       echo "Run Cilium Connectivity Tests"
       cilium status
       cilium connectivity test --connect-timeout 4s --request-timeout 30s --test '!pod-to-pod-encryption,!node-to-node-encryption,!no-unexpected-packet-drops' --force-deploy

--- a/.pipelines/singletenancy/cilium-nodesubnet/cilium-nodesubnet-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-nodesubnet/cilium-nodesubnet-e2e-step-template.yaml
@@ -53,7 +53,7 @@ steps:
       inlineScript: |
         set -e
         make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
-        ls -lah      
+        ls -lah
         pwd
         kubectl cluster-info
         kubectl get po -owide -A
@@ -81,5 +81,8 @@ steps:
     retryCountOnTaskFailure: 3
     name: "nodeSubnetE2ETests"
     displayName: "Run NodeSubnet E2E"
-  
+
   - template: ../../templates/cilium-tests.yaml
+    parameters:
+      clusterName: ${{ parameters.clusterName }}
+      scaleup: ${{ parameters.scaleup }}

--- a/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-step-template.yaml
@@ -96,6 +96,7 @@ steps:
       scriptType: "bash"
       addSpnToEnvironment: true
       inlineScript: |
+        set -e
         cd test/integration/load
 
         # Scale Cluster Up/Down to confirm functioning CNS
@@ -110,6 +111,7 @@ steps:
     retryCountOnTaskFailure: 3
 
   - script: |
+      set -e
       echo "Run Cilium Connectivity Tests"
       cilium status
       cilium connectivity test --connect-timeout 4s --request-timeout 30s --test '!pod-to-pod-encryption,!node-to-node-encryption' --force-deploy
@@ -135,19 +137,17 @@ steps:
         displayName: "Run Hubble Connectivity Tests"
 
   - script: |
+      set -e
       echo "validate pod IP assignment and check systemd-networkd restart"
       kubectl get pod -owide -A
-      # Deleting echo-external-node deployment until cilium version matches TODO. https://github.com/cilium/cilium-cli/issues/67 is addressing the change.
-      # Saves 17 minutes
 
-      kubectl delete deploy -n $(ciliumNamespace) echo-external-node
       if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]; then
         echo "Check cilium identities in $(ciliumNamespace) namepsace during nightly run"
         echo "expect the identities to be deleted when the namespace is deleted"
         kubectl get ciliumidentity | grep cilium-test
       fi
       make test-validate-state
-      echo "delete cilium connectivity test resources and re-validate state"
+      echo "delete cilium connectivity test resources and re-validate state" # TODO Delete this and the next 4 lines if connectivity no longer has bug
       kubectl delete ns $(ciliumNamespace)
       kubectl get pod -owide -A
       make test-validate-state

--- a/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e.steps.yaml
+++ b/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e.steps.yaml
@@ -93,6 +93,7 @@ steps:
       workingDirectory: $(ACN_DIR)
       addSpnToEnvironment: true
       inlineScript: |
+        set -e
         cd test/integration/load
 
         # Scale Cluster Up/Down to confirm functioning CNS
@@ -107,6 +108,7 @@ steps:
     retryCountOnTaskFailure: 3
 
   - script: |
+      set -e
       echo "Run Cilium Connectivity Tests"
       cilium status
       cilium connectivity test --connect-timeout 4s --request-timeout 30s --test '!pod-to-pod-encryption,!node-to-node-encryption' --force-deploy
@@ -134,19 +136,17 @@ steps:
         displayName: "Run Hubble Connectivity Tests"
 
   - script: |
+      set -e
       echo "validate pod IP assignment and check systemd-networkd restart"
       kubectl get pod -owide -A
-      # Deleting echo-external-node deployment until cilium version matches TODO. https://github.com/cilium/cilium-cli/issues/67 is addressing the change.
-      # Saves 17 minutes
 
-      kubectl delete deploy -n $(ciliumNamespace) echo-external-node
       if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]; then
         echo "Check cilium identities in $(ciliumNamespace) namepsace during nightly run"
         echo "expect the identities to be deleted when the namespace is deleted"
         kubectl get ciliumidentity | grep cilium-test
       fi
       make test-validate-state
-      echo "delete cilium connectivity test resources and re-validate state"
+      echo "delete cilium connectivity test resources and re-validate state" # TODO Delete this and the next 4 lines if connectivity no longer has bug
       kubectl delete ns $(ciliumNamespace)
       kubectl get pod -owide -A
       make test-validate-state

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
@@ -118,6 +118,7 @@ steps:
       scriptType: "bash"
       addSpnToEnvironment: true
       inlineScript: |
+        set -e
         cd test/integration/load
 
         # Scale Cluster Up/Down to confirm functioning CNS
@@ -132,6 +133,7 @@ steps:
     retryCountOnTaskFailure: 3
 
   - script: |
+      set -e
       echo "Run Cilium Connectivity Tests"
       cilium status
       if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]
@@ -162,11 +164,9 @@ steps:
         displayName: "Run Hubble Connectivity Tests"
 
   - script: |
+      set -e
       echo "validate pod IP assignment and check systemd-networkd restart"
       kubectl get pod -owide -A
-      # Deleting echo-external-node deployment until cilium version matches TODO. https://github.com/cilium/cilium-cli/issues/67 is addressing the change.
-      # Saves 17 minutes
-      kubectl delete deploy -n $(ciliumNamespace) echo-external-node
       if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]; then
         echo "Check cilium identities in $(ciliumNamespace) namepsace during nightly run"
         echo "expect the identities to be deleted when the namespace is deleted"
@@ -207,7 +207,8 @@ steps:
     name: "CiliumIdentities"
     displayName: "Verify Cilium Identities Deletion"
 
-  - script: |
+  - script: | # TODO REMOVE THIS STEP, make test-load covers this
+      set -e
       echo "validate pod IP assignment before CNS restart"
       kubectl get pod -owide -A
       make test-validate-state

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e.steps.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e.steps.yaml
@@ -115,6 +115,7 @@ steps:
       workingDirectory: $(ACN_DIR)
       addSpnToEnvironment: true
       inlineScript: |
+        set -e
         cd test/integration/load
 
         # Scale Cluster Up/Down to confirm functioning CNS
@@ -129,6 +130,7 @@ steps:
     retryCountOnTaskFailure: 3
 
   - script: |
+      set -e
       echo "Run Cilium Connectivity Tests"
       cilium status
       if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]
@@ -160,18 +162,16 @@ steps:
         displayName: "Run Hubble Connectivity Tests"
 
   - script: |
+      set -e
       echo "validate pod IP assignment and check systemd-networkd restart"
       kubectl get pod -owide -A
-      # Deleting echo-external-node deployment until cilium version matches TODO. https://github.com/cilium/cilium-cli/issues/67 is addressing the change.
-      # Saves 17 minutes
-      kubectl delete deploy -n $(ciliumNamespace) echo-external-node
       if [ "$CILIUM_VERSION_TAG" = "cilium-nightly-pipeline" ]; then
         echo "Check cilium identities in $(ciliumNamespace) namepsace during nightly run"
         echo "expect the identities to be deleted when the namespace is deleted"
         kubectl get ciliumidentity | grep cilium-test
       fi
       make test-validate-state
-      echo "delete cilium connectivity test resources and re-validate state"
+      echo "delete cilium connectivity test resources and re-validate state" # TODO Delete this and the next 4 lines if connectivity no longer has bug
       kubectl delete ns $(ciliumNamespace)
       kubectl get pod -owide -A
       make test-validate-state
@@ -206,7 +206,8 @@ steps:
     name: "CiliumIdentities"
     displayName: "Verify Cilium Identities Deletion"
 
-  - script: |
+  - script: | # TODO REMOVE THIS STEP, make test-load covers this
+      set -e
       echo "validate pod IP assignment before CNS restart"
       kubectl get pod -owide -A
       make test-validate-state

--- a/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e-step-template.yaml
@@ -65,3 +65,7 @@ steps:
     displayName: "Run Azilium E2E"
 
   - template: ../../templates/cilium-tests.yaml
+    parameters:
+      clusterName: ${{ parameters.clusterName }}
+      scaleup: ${{ parameters.scaleup }}
+

--- a/.pipelines/singletenancy/cilium/cilium-e2e.steps.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e.steps.yaml
@@ -93,6 +93,7 @@ steps:
       workingDirectory: $(ACN_DIR)
       addSpnToEnvironment: true
       inlineScript: |
+        set -e
         cd test/integration/load
 
         # Scale Cluster Up/Down to confirm functioning CNS
@@ -107,6 +108,7 @@ steps:
     retryCountOnTaskFailure: 3
 
   - script: |
+      set -e
       echo "Run Cilium Connectivity Tests"
       cilium status
       cilium connectivity test --connect-timeout 4s --request-timeout 30s --test '!pod-to-pod-encryption,!node-to-node-encryption' --force-deploy

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-step-template.yaml
@@ -77,6 +77,7 @@ steps:
         scriptType: "bash"
         addSpnToEnvironment: true
         inlineScript: |
+          set -e
           cd test/integration/load
 
           # Scale Cluster Up/Down to confirm functioning CNS
@@ -134,6 +135,7 @@ steps:
         scriptType: "bash"
         addSpnToEnvironment: true
         inlineScript: |
+          set -e
           cd test/integration/load
 
           # Scale Cluster Up/Down to confirm functioning CNS

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e.steps.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e.steps.yaml
@@ -82,6 +82,7 @@ steps:
         workingDirectory: $(ACN_DIR)
         addSpnToEnvironment: true
         inlineScript: |
+          set -e
           cd test/integration/load
 
           # Scale Cluster Up/Down to confirm functioning CNS
@@ -143,6 +144,7 @@ steps:
         workingDirectory: $(ACN_DIR)
         addSpnToEnvironment: true
         inlineScript: |
+          set -e
           cd test/integration/load
 
           # Scale Cluster Up/Down to confirm functioning CNS

--- a/.pipelines/templates/cilium-cli.steps.yaml
+++ b/.pipelines/templates/cilium-cli.steps.yaml
@@ -1,5 +1,6 @@
 steps:
   - script: |
+      set -e
       echo "install cilium CLI"
       if [[ ${CILIUM_VERSION_TAG#v} =~ ^1.1[1-3].[0-9]{1,2}|1.1[1-3].[0-9]{1,2}-[0-9]{1,6} ]]; then
         echo "Cilium Agent Version ${BASH_REMATCH[0]}"

--- a/.pipelines/templates/cilium-cli.yaml
+++ b/.pipelines/templates/cilium-cli.yaml
@@ -1,5 +1,6 @@
 steps:
   - script: |
+      set -e
       echo "install cilium CLI"
       if [[ ${CILIUM_VERSION_TAG#v} =~ ^1.1[1-3].[0-9]{1,2}|1.1[1-3].[0-9]{1,2}-[0-9]{1,6} ]]; then
         echo "Cilium Agent Version ${BASH_REMATCH[0]}"

--- a/.pipelines/templates/cilium-cli.yaml
+++ b/.pipelines/templates/cilium-cli.yaml
@@ -18,6 +18,9 @@ steps:
       sha256sum --check cilium-linux-${CLI_ARCH}.tar.gz.sha256sum
       sudo tar xzvfC cilium-linux-${CLI_ARCH}.tar.gz /usr/local/bin
       rm cilium-linux-${CLI_ARCH}.tar.gz{,.sha256sum}
+
+      # We can ignore failures from cilium status as cilium agent will not be in ready status until CNS is installed.
+      set +e
       cilium status
       cilium version
     name: "installCiliumCLI"

--- a/.pipelines/templates/cilium-tests.yaml
+++ b/.pipelines/templates/cilium-tests.yaml
@@ -31,6 +31,7 @@ steps:
       scriptType: "bash"
       addSpnToEnvironment: true
       inlineScript: |
+        set -e
         cd test/integration/load
 
         # Scale Cluster Up/Down to confirm functioning CNS
@@ -45,6 +46,7 @@ steps:
     retryCountOnTaskFailure: 3
 
   - script: |
+      set -e
       echo "Run Cilium Connectivity Tests"
       cilium status
       cilium connectivity test --connect-timeout 4s --request-timeout 30s --test '!pod-to-pod-encryption,!node-to-node-encryption' --force-deploy
@@ -55,13 +57,11 @@ steps:
     displayName: "Run Cilium Connectivity Tests"
 
   - script: |
+      set -e
       echo "validate pod IP assignment and check systemd-networkd restart"
       kubectl get pod -owide -A
-      # Deleting echo-external-node deployment until cilium version matches TODO. https://github.com/cilium/cilium-cli/issues/67 is addressing the change.
-      # Saves 17 minutes
-      kubectl delete deploy -n $(ciliumNamespace) echo-external-node
       make test-validate-state
-      echo "delete cilium connectivity test resources and re-validate state"
+      echo "delete cilium connectivity test resources and re-validate state" # TODO Delete this and the next 4 lines if connectivity no longer has bug
       kubectl delete ns $(ciliumNamespace)
       kubectl get pod -owide -A
       make test-validate-state


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Certain PR pipeline steps did not capture bash error codes correctly or overwrote them with successive calls. 
In fixing this I also captured a missed input for the `cilium-test.yaml` template that also required fixes.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
Instead of adding set -e everywhere we can also split out deleting namespaces, assigning variables, ect. 
Exit codes get overwritten when any command is ran after a test i.e `make test-validate-state | go test ...`