### PR TITLE
backport: fix: pass ai metadata to telemetry during cni image build (#3095)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -430,7 +430,8 @@ cni-image: ## build cni container image.
 		TAG=$(CNI_PLATFORM_TAG) \
 		OS=$(OS) \
 		ARCH=$(ARCH) \
-		OS_VERSION=$(OS_VERSION)
+		OS_VERSION=$(OS_VERSION) \
+		EXTRA_BUILD_ARGS='--build-arg CNI_AI_PATH=$(CNI_AI_PATH) --build-arg CNI_AI_ID=$(CNI_AI_ID)'
 
 cni-image-push: ## push cni container image.
 	$(MAKE) container-push \

--- a/Makefile
+++ b/Makefile
@@ -425,13 +425,12 @@ cni-image: ## build cni container image.
 	$(MAKE) container \
 		DOCKERFILE=cni/$(OS).Dockerfile \
 		IMAGE=$(CNI_IMAGE) \
-		EXTRA_BUILD_ARGS='--build-arg OS=$(OS) --build-arg ARCH=$(ARCH) --build-arg OS_VERSION=$(OS_VERSION)' \
+		EXTRA_BUILD_ARGS='--build-arg OS=$(OS) --build-arg ARCH=$(ARCH) --build-arg OS_VERSION=$(OS_VERSION) --build-arg CNI_AI_PATH=$(CNI_AI_PATH) --build-arg CNI_AI_ID=$(CNI_AI_ID)' \
 		PLATFORM=$(PLATFORM) \
 		TAG=$(CNI_PLATFORM_TAG) \
 		OS=$(OS) \
 		ARCH=$(ARCH) \
-		OS_VERSION=$(OS_VERSION) \
-		EXTRA_BUILD_ARGS='--build-arg CNI_AI_PATH=$(CNI_AI_PATH) --build-arg CNI_AI_ID=$(CNI_AI_ID)'
+		OS_VERSION=$(OS_VERSION)
 
 cni-image-push: ## push cni container image.
 	$(MAKE) container-push \

--- a/cni/linux.Dockerfile
+++ b/cni/linux.Dockerfile
@@ -6,10 +6,12 @@ ARG OS
 FROM mcr.microsoft.com/oss/go/microsoft/golang:1.22 AS azure-vnet
 ARG OS
 ARG VERSION
+ARG CNI_AI_PATH
+ARG CNI_AI_ID
 WORKDIR /azure-container-networking
 COPY . .
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/plugin/main.go
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-telemetry -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/telemetry/service/telemetrymain.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-telemetry -trimpath -ldflags "-X main.version="$VERSION" -X "$CNI_AI_PATH"="$CNI_AI_ID"" -gcflags="-dwarflocationlists=true" cni/telemetry/service/telemetrymain.go
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-ipam -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/ipam/plugin/main.go
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azurecni-stateless -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/stateless/main.go
 

--- a/cni/telemetry/service/telemetrymain.go
+++ b/cni/telemetry/service/telemetrymain.go
@@ -167,8 +167,8 @@ func main() {
 		GetEnvRetryWaitTimeInSecs:    config.GetEnvRetryWaitTimeInSecs,
 	}
 
-	if tb.CreateAITelemetryHandle(aiConfig, config.DisableAll, config.DisableTrace, config.DisableMetric) != nil {
-		logger.Error("AI Handle creation error", zap.Error(err))
+	if err := tb.CreateAITelemetryHandle(aiConfig, config.DisableAll, config.DisableTrace, config.DisableMetric); err != nil { // nolint
+		logger.Error("AI Handle creation error:", zap.Error(err))
 	}
 	logger.Info("Report to host interval", zap.Duration("seconds", config.ReportToHostIntervalInSeconds))
 	tb.PushData(context.Background())

--- a/cni/windows.Dockerfile
+++ b/cni/windows.Dockerfile
@@ -6,10 +6,12 @@ ARG OS_VERSION
 FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.22 AS azure-vnet
 ARG OS
 ARG VERSION
+ARG CNI_AI_PATH
+ARG CNI_AI_ID
 WORKDIR /azure-container-networking
 COPY . .
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/plugin/main.go
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-telemetry -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/telemetry/service/telemetrymain.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-telemetry -trimpath -ldflags "-X main.version="$VERSION" -X "$CNI_AI_PATH"="$CNI_AI_ID"" -gcflags="-dwarflocationlists=true" cni/telemetry/service/telemetrymain.go
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-ipam -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/ipam/plugin/main.go
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-stateless -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/stateless/main.go
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -684,7 +684,7 @@ func main() {
 	}
 
 	if telemetryDaemonEnabled {
-		log.Printf("CNI Telemtry is enabled")
+		logger.Printf("CNI Telemetry is enabled")
 		go startTelemetryService(rootCtx)
 	}
 

--- a/telemetry/aiwrapper_test.go
+++ b/telemetry/aiwrapper_test.go
@@ -17,15 +17,7 @@ func TestCreateAITelemetryHandle(t *testing.T) {
 		wantErr       bool
 	}{
 		{
-			name:          "disable telemetry",
-			aiConfig:      aitelemetry.AIConfig{},
-			disableAll:    false,
-			disableMetric: true,
-			disableTrace:  true,
-			wantErr:       true,
-		},
-		{
-			name:          "empty aiconfig",
+			name:          "disabled telemetry with empty aiconfig",
 			aiConfig:      aitelemetry.AIConfig{},
 			disableAll:    true,
 			disableMetric: true,


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Backports #3095 
Updates Linux dockerfile since in v1.5 the dockerfile is split per OS

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:

