### PR TITLE
[CNS] add config snapshot event metrics at an interval

### DIFF
--- a/cns/configuration/cns_config.json
+++ b/cns/configuration/cns_config.json
@@ -5,6 +5,7 @@
         "HeartBeatIntervalInMins": 30,
         "RefreshIntervalInSecs": 15,
         "SnapshotIntervalInMins": 60,
+        "ConfigSnapshotIntervalInMins": 60,
         "TelemetryBatchIntervalInSecs": 15,
         "TelemetryBatchSizeBytes": 16384
     },

--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -79,6 +79,8 @@ type TelemetrySettings struct {
 	DebugMode bool
 	// Interval for sending snapshot events.
 	SnapshotIntervalInMins int
+	// Interval for sending config snapshot events.
+	ConfigSnapshotIntervalInMins int
 	// AppInsightsInstrumentationKey allows the user to override the default appinsights ikey
 	AppInsightsInstrumentationKey string
 }
@@ -175,6 +177,10 @@ func setTelemetrySettingDefaults(telemetrySettings *TelemetrySettings) {
 
 	if telemetrySettings.SnapshotIntervalInMins == 0 {
 		telemetrySettings.SnapshotIntervalInMins = 60
+	}
+
+	if telemetrySettings.ConfigSnapshotIntervalInMins == 0 {
+		telemetrySettings.ConfigSnapshotIntervalInMins = 60
 	}
 }
 

--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -178,10 +178,6 @@ func setTelemetrySettingDefaults(telemetrySettings *TelemetrySettings) {
 	if telemetrySettings.SnapshotIntervalInMins == 0 {
 		telemetrySettings.SnapshotIntervalInMins = 60
 	}
-
-	if telemetrySettings.ConfigSnapshotIntervalInMins == 0 {
-		telemetrySettings.ConfigSnapshotIntervalInMins = 60
-	}
 }
 
 // set managed setting defaults

--- a/cns/configuration/configuration_test.go
+++ b/cns/configuration/configuration_test.go
@@ -123,7 +123,6 @@ func TestSetTelemetrySettingDefaults(t *testing.T) {
 				TelemetryBatchSizeBytes:      32768,
 				HeartBeatIntervalInMins:      30,
 				SnapshotIntervalInMins:       60,
-				ConfigSnapshotIntervalInMins: 60,
 			},
 		},
 		{
@@ -134,7 +133,6 @@ func TestSetTelemetrySettingDefaults(t *testing.T) {
 				TelemetryBatchSizeBytes:      5,
 				HeartBeatIntervalInMins:      6,
 				SnapshotIntervalInMins:       7,
-				ConfigSnapshotIntervalInMins: 8,
 			},
 			want: TelemetrySettings{
 				RefreshIntervalInSecs:        3,
@@ -142,7 +140,6 @@ func TestSetTelemetrySettingDefaults(t *testing.T) {
 				TelemetryBatchSizeBytes:      5,
 				HeartBeatIntervalInMins:      6,
 				SnapshotIntervalInMins:       7,
-				ConfigSnapshotIntervalInMins: 8,
 			},
 		},
 	}
@@ -210,7 +207,6 @@ func TestSetCNSConfigDefaults(t *testing.T) {
 					HeartBeatIntervalInMins:      30,
 					RefreshIntervalInSecs:        15,
 					SnapshotIntervalInMins:       60,
-					ConfigSnapshotIntervalInMins: 60,
 				},
 				KeyVaultSettings: KeyVaultSettings{
 					RefreshIntervalInHrs: 12,
@@ -243,7 +239,6 @@ func TestSetCNSConfigDefaults(t *testing.T) {
 					HeartBeatIntervalInMins:      3,
 					RefreshIntervalInSecs:        1,
 					SnapshotIntervalInMins:       6,
-					ConfigSnapshotIntervalInMins: 7,
 				},
 				KeyVaultSettings: KeyVaultSettings{
 					RefreshIntervalInHrs: 3,
@@ -271,7 +266,6 @@ func TestSetCNSConfigDefaults(t *testing.T) {
 					HeartBeatIntervalInMins:      3,
 					RefreshIntervalInSecs:        1,
 					SnapshotIntervalInMins:       6,
-					ConfigSnapshotIntervalInMins: 7,
 				},
 				KeyVaultSettings: KeyVaultSettings{
 					RefreshIntervalInHrs: 3,

--- a/cns/configuration/configuration_test.go
+++ b/cns/configuration/configuration_test.go
@@ -80,6 +80,7 @@ func TestReadConfigFromFile(t *testing.T) {
 					HeartBeatIntervalInMins:      30,
 					RefreshIntervalInSecs:        15,
 					SnapshotIntervalInMins:       60,
+					ConfigSnapshotIntervalInMins: 60,
 					TelemetryBatchIntervalInSecs: 15,
 					TelemetryBatchSizeBytes:      16384,
 				},
@@ -122,6 +123,7 @@ func TestSetTelemetrySettingDefaults(t *testing.T) {
 				TelemetryBatchSizeBytes:      32768,
 				HeartBeatIntervalInMins:      30,
 				SnapshotIntervalInMins:       60,
+				ConfigSnapshotIntervalInMins: 60,
 			},
 		},
 		{
@@ -132,6 +134,7 @@ func TestSetTelemetrySettingDefaults(t *testing.T) {
 				TelemetryBatchSizeBytes:      5,
 				HeartBeatIntervalInMins:      6,
 				SnapshotIntervalInMins:       7,
+				ConfigSnapshotIntervalInMins: 8,
 			},
 			want: TelemetrySettings{
 				RefreshIntervalInSecs:        3,
@@ -139,6 +142,7 @@ func TestSetTelemetrySettingDefaults(t *testing.T) {
 				TelemetryBatchSizeBytes:      5,
 				HeartBeatIntervalInMins:      6,
 				SnapshotIntervalInMins:       7,
+				ConfigSnapshotIntervalInMins: 8,
 			},
 		},
 	}
@@ -206,6 +210,7 @@ func TestSetCNSConfigDefaults(t *testing.T) {
 					HeartBeatIntervalInMins:      30,
 					RefreshIntervalInSecs:        15,
 					SnapshotIntervalInMins:       60,
+					ConfigSnapshotIntervalInMins: 60,
 				},
 				KeyVaultSettings: KeyVaultSettings{
 					RefreshIntervalInHrs: 12,
@@ -238,6 +243,7 @@ func TestSetCNSConfigDefaults(t *testing.T) {
 					HeartBeatIntervalInMins:      3,
 					RefreshIntervalInSecs:        1,
 					SnapshotIntervalInMins:       6,
+					ConfigSnapshotIntervalInMins: 7,
 				},
 				KeyVaultSettings: KeyVaultSettings{
 					RefreshIntervalInHrs: 3,
@@ -265,6 +271,7 @@ func TestSetCNSConfigDefaults(t *testing.T) {
 					HeartBeatIntervalInMins:      3,
 					RefreshIntervalInSecs:        1,
 					SnapshotIntervalInMins:       6,
+					ConfigSnapshotIntervalInMins: 7,
 				},
 				KeyVaultSettings: KeyVaultSettings{
 					RefreshIntervalInHrs: 3,

--- a/cns/configuration/testdata/good.json
+++ b/cns/configuration/testdata/good.json
@@ -26,6 +26,7 @@
         "HeartBeatIntervalInMins": 30,
         "RefreshIntervalInSecs": 15,
         "SnapshotIntervalInMins": 60,
+        "ConfigSnapshotIntervalInMins": 60,
         "TelemetryBatchIntervalInSecs": 15,
         "TelemetryBatchSizeBytes": 16384
     },

--- a/cns/logger/constants.go
+++ b/cns/logger/constants.go
@@ -7,12 +7,14 @@ const (
 	ConfigSnapshotMetricsStr = "ConfigSnapshot"
 
 	// Dimensions
-	OrchestratorTypeStr = "OrchestratorType"
-	NodeIDStr           = "NodeID"
-	HomeAZStr           = "HomeAZ"
-	IsAZRSupportedStr   = "IsAZRSupported"
-	HomeAZErrorCodeStr  = "HomeAZErrorCode"
-	HomeAZErrorMsgStr   = "HomeAZErrorMsg"
+	OrchestratorTypeStr             = "OrchestratorType"
+	NodeIDStr                       = "NodeID"
+	HomeAZStr                       = "HomeAZ"
+	IsAZRSupportedStr               = "IsAZRSupported"
+	HomeAZErrorCodeStr              = "HomeAZErrorCode"
+	HomeAZErrorMsgStr               = "HomeAZErrorMsg"
+	CNSConfigPropertyStr            = "CNSConfiguration"
+	CNSConfigMD5CheckSumPropertyStr = "CNSConfigurationMD5Checksum"
 
 	// CNS NC Snspshot properties
 	CnsNCSnapshotEventStr         = "CNSNCSnapshot"

--- a/cns/logger/constants.go
+++ b/cns/logger/constants.go
@@ -3,7 +3,8 @@ package logger
 
 const (
 	// Metrics
-	HeartBeatMetricStr = "HeartBeat"
+	HeartBeatMetricStr       = "HeartBeat"
+	ConfigSnapshotMetricsStr = "ConfigSnapshot"
 
 	// Dimensions
 	OrchestratorTypeStr = "OrchestratorType"
@@ -13,7 +14,7 @@ const (
 	HomeAZErrorCodeStr  = "HomeAZErrorCode"
 	HomeAZErrorMsgStr   = "HomeAZErrorMsg"
 
-	// CNS Snspshot properties
+	// CNS NC Snspshot properties
 	CnsNCSnapshotEventStr         = "CNSNCSnapshot"
 	IpConfigurationStr            = "IPConfiguration"
 	LocalIPConfigurationStr       = "LocalIPConfiguration"

--- a/cns/metric/configsnapshot.go
+++ b/cns/metric/configsnapshot.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-container-networking/aitelemetry"
 	"github.com/Azure/azure-container-networking/cns/configuration"
 	"github.com/Azure/azure-container-networking/cns/logger"
+	"github.com/pkg/errors"
 )
 
 // SendCNSConfigSnapshot emits CNS config periodically
@@ -21,7 +22,7 @@ func SendCNSConfigSnapshot(ctx context.Context, config *configuration.CNSConfig)
 
 	event, err := createCNSConfigSnapshotEvent(config)
 	if err != nil {
-		logger.Errorf("[Azure CNS] SendCNSConfigSnapshot failed to create event at an interval: %v", err)
+		logger.Errorf("[Azure CNS] SendCNSConfigSnapshot: %v", err)
 		return
 	}
 
@@ -38,7 +39,7 @@ func SendCNSConfigSnapshot(ctx context.Context, config *configuration.CNSConfig)
 func createCNSConfigSnapshotEvent(config *configuration.CNSConfig) (aitelemetry.Event, error) {
 	bb, err := json.Marshal(config) //nolint:musttag // no tag needed for config
 	if err != nil {
-		return aitelemetry.Event{}, err
+		return aitelemetry.Event{}, errors.Wrap(err, "failed to marshal config")
 	}
 
 	cs := md5.Sum(bb) //nolint:gosec // used for checksum

--- a/cns/metric/configsnapshot.go
+++ b/cns/metric/configsnapshot.go
@@ -26,6 +26,9 @@ func SendCNSConfigSnapshot(ctx context.Context, config *configuration.CNSConfig)
 		return
 	}
 
+	// Log the first event immediately
+	logger.LogEvent(event)
+
 	for {
 		select {
 		case <-ctx.Done():

--- a/cns/metric/configsnapshot.go
+++ b/cns/metric/configsnapshot.go
@@ -1,0 +1,57 @@
+// Copyright 2018 Microsoft. All rights reserved.
+// MIT License
+
+package metric
+
+import (
+	"context"
+	"crypto/md5" //nolint:gosec // used for checksum
+	"encoding/json"
+	"time"
+
+	"github.com/Azure/azure-container-networking/aitelemetry"
+	"github.com/Azure/azure-container-networking/cns/configuration"
+	"github.com/Azure/azure-container-networking/cns/logger"
+)
+
+// SendCNSConfigSnapshot emits CNS config periodically
+func SendCNSConfigSnapshot(ctx context.Context, config *configuration.CNSConfig) {
+	ticker := time.NewTicker(time.Minute * time.Duration(config.TelemetrySettings.ConfigSnapshotIntervalInMins))
+	defer ticker.Stop()
+
+	event, err := createCNSConfigSnapshotEvent(config)
+	if err != nil {
+		logger.Errorf("[Azure CNS] SendCNSConfigSnapshot failed to create event at an interval: %v", err)
+		return
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			logger.LogEvent(event)
+		}
+	}
+}
+
+func createCNSConfigSnapshotEvent(config *configuration.CNSConfig) (aitelemetry.Event, error) {
+	bb, err := json.Marshal(config) //nolint:musttag // no tag needed for config
+	if err != nil {
+		return aitelemetry.Event{}, err
+	}
+
+	cs := md5.Sum(bb) //nolint:gosec // used for checksum
+	csStr := string(cs[:])
+
+	event := aitelemetry.Event{
+		EventName:  logger.ConfigSnapshotMetricsStr,
+		ResourceID: csStr, // not guaranteed unique, instead use VM ID and Subscription to correlate
+		Properties: map[string]string{
+			logger.CNSConfigPropertyStr:            string(bb),
+			logger.CNSConfigMD5CheckSumPropertyStr: csStr,
+		},
+	}
+
+	return event, nil
+}

--- a/cns/metric/configsnapshot.go
+++ b/cns/metric/configsnapshot.go
@@ -1,6 +1,3 @@
-// Copyright 2018 Microsoft. All rights reserved.
-// MIT License
-
 package metric
 
 import (

--- a/cns/metric/configsnapshot_test.go
+++ b/cns/metric/configsnapshot_test.go
@@ -1,7 +1,7 @@
 package metric
 
 import (
-	"crypto/md5"
+	"crypto/md5" //nolint:gosec // used for checksum
 	"encoding/json"
 	"testing"
 
@@ -21,10 +21,10 @@ func TestCreateCNSConfigSnapshotEvent(t *testing.T) {
 	event, err := createCNSConfigSnapshotEvent(config)
 	require.NoError(t, err)
 
-	bb, err := json.Marshal(config)
+	bb, err := json.Marshal(config) //nolint:musttag // no tag needed for config
 	require.NoError(t, err)
 
-	cs := md5.Sum(bb)
+	cs := md5.Sum(bb) //nolint:gosec // used for checksum
 	csStr := string(cs[:])
 
 	expected := aitelemetry.Event{

--- a/cns/metric/configsnapshot_test.go
+++ b/cns/metric/configsnapshot_test.go
@@ -1,7 +1,6 @@
 package metric
 
 import (
-	//nolint:gosec // used for checksum
 	"encoding/json"
 	"testing"
 
@@ -25,7 +24,7 @@ func TestCreateCNSConfigSnapshotEvent(t *testing.T) {
 	assert.Contains(t, event.Properties[logger.CNSConfigPropertyStr], "\"TLSPort\":\"10091\"")
 
 	eventConfig := &configuration.CNSConfig{}
-	err = json.Unmarshal([]byte(event.Properties[logger.CNSConfigPropertyStr]), eventConfig)
+	err = json.Unmarshal([]byte(event.Properties[logger.CNSConfigPropertyStr]), eventConfig) //nolint:musttag // no tag needed for config
 	require.NoError(t, err)
 	assert.EqualValues(t, config, eventConfig)
 }

--- a/cns/metric/configsnapshot_test.go
+++ b/cns/metric/configsnapshot_test.go
@@ -1,0 +1,40 @@
+package metric
+
+import (
+	"crypto/md5"
+	"encoding/json"
+	"testing"
+
+	"github.com/Azure/azure-container-networking/aitelemetry"
+	"github.com/Azure/azure-container-networking/cns/configuration"
+	"github.com/Azure/azure-container-networking/cns/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateCNSConfigSnapshotEvent(t *testing.T) {
+	logger.InitLogger("testlogs", 0, 0, "./")
+
+	config, err := configuration.ReadConfig("../configuration/testdata/good.json")
+	require.NoError(t, err)
+
+	event, err := createCNSConfigSnapshotEvent(config)
+	require.NoError(t, err)
+
+	bb, err := json.Marshal(config)
+	require.NoError(t, err)
+
+	cs := md5.Sum(bb)
+	csStr := string(cs[:])
+
+	expected := aitelemetry.Event{
+		EventName:  logger.ConfigSnapshotMetricsStr,
+		ResourceID: csStr,
+		Properties: map[string]string{
+			logger.CNSConfigPropertyStr:            string(bb),
+			logger.CNSConfigMD5CheckSumPropertyStr: csStr,
+		},
+	}
+
+	assert.Equal(t, expected, event)
+}

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -578,6 +578,8 @@ func main() {
 		} else {
 			logger.InitAI(aiConfig, ts.DisableTrace, ts.DisableMetric, ts.DisableEvent)
 		}
+
+		go metric.SendCNSConfigSnapshot(rootCtx, cnsconfig)
 	}
 	logger.Printf("[Azure CNS] Using config: %+v", cnsconfig)
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -579,7 +579,9 @@ func main() {
 			logger.InitAI(aiConfig, ts.DisableTrace, ts.DisableMetric, ts.DisableEvent)
 		}
 
-		go metric.SendCNSConfigSnapshot(rootCtx, cnsconfig)
+		if cnsconfig.TelemetrySettings.ConfigSnapshotIntervalInMins > 0 {
+			go metric.SendCNSConfigSnapshot(rootCtx, cnsconfig)
+		}
 	}
 	logger.Printf("[Azure CNS] Using config: %+v", cnsconfig)
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
Inspired by @ramiro-gamarra's PR to emit config snapshots at an interval, we should do the same for CNS for a consistent view for both components.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [x] relevant PR labels added

**Notes**:
