### PR TITLE
Revert "feat: use proto in CNS usage of client-go "

### DIFF
--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1245,8 +1245,6 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 		return errors.Wrap(err, "failed to get kubeconfig")
 	}
 	kubeConfig.UserAgent = fmt.Sprintf("azure-cns-%s", version)
-	kubeConfig.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
-	kubeConfig.ContentType = "application/vnd.kubernetes.protobuf"
 
 	clientset, err := kubernetes.NewForConfig(kubeConfig)
 	if err != nil {


### PR DESCRIPTION
Reverts Azure/azure-container-networking#3131
might be causing a problem for swift v2