### PR TITLE
ci: disable swiftv2 E2E

### DIFF
--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -358,21 +358,6 @@ stages:
         vmSize: Standard_B2ms
         dependsOn: "containerize"
 
-    # Swiftv2 E2E tests with multitenancy cluster start up
-    - template: multitenancy/swiftv2-e2e-job-template.yaml
-      parameters:
-        name: "swiftv2_e2e"
-        displayName: Swiftv2 Multitenancy
-        os: linux
-        clusterType: swiftv2-multitenancy-cluster-up
-        clusterName: "mtacluster"
-        nodePoolName: "mtapool"
-        vmSize: $(SWIFTV2_MT_CLUSTER_SKU)
-        dependsOn: "containerize"
-        dummyClusterName: "swiftv2dummy"
-        dummyClusterType: "swiftv2-dummy-cluster-up"
-        dummyClusterDisplayName: Swiftv2 Multitenancy Dummy Cluster
-
     - stage: delete
       displayName: Delete Clusters
       condition: always()
@@ -390,7 +375,6 @@ stages:
         - aks_windows_22_e2e
         - dualstackoverlay_e2e
         - cilium_dualstackoverlay_e2e
-        - swiftv2_e2e
       variables:
         commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
       jobs:
@@ -403,7 +387,7 @@ stages:
               cilium_e2e:
                 name: cilium_e2e
                 clusterName: "ciliume2e"
-                region: $(REGION_AKS_CLUSTER_TEST)                
+                region: $(REGION_AKS_CLUSTER_TEST)
               cilium_nodesubnet_e2e:
                 name: cilium_nodesubnet_e2e
                 clusterName: "cilndsubnete2e"
@@ -456,26 +440,3 @@ stages:
                 region: $(region)
                 sub: $(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS)
                 svcConn: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
-
-        - job: delete_test
-          displayName: Delete Cluster
-          pool:
-            name: "$(BUILD_POOL_NAME_DEFAULT)"
-          strategy:
-            matrix:
-              swiftv2_e2e:
-                name: swiftv2_e2e
-                clusterName: "mtacluster"
-                region: $(REGION_SWIFTV2_CLUSTER_TEST)
-              swiftv2_dummy_e2e:
-                name: swiftv2_dummy_e2e
-                clusterName: "swiftv2dummy"
-                region: $(REGION_SWIFTV2_CLUSTER_TEST)
-          steps:
-            - template: templates/delete-cluster.yaml
-              parameters:
-                name: $(name)
-                clusterName: $(clusterName)-$(commitID)
-                region: $(region)
-                sub: $(SUB_AZURE_NETWORK_AGENT_TEST)
-                svcConn: $(ACN_TEST_SERVICE_CONNECTION)

--- a/.pipelines/run-pipeline.yaml
+++ b/.pipelines/run-pipeline.yaml
@@ -7,7 +7,7 @@ parameters:
 - name: triggerBuildReason
   type: string
   default: ''
-  
+
 - name: triggerBuildGitRef
   type: string
   default: ''
@@ -400,21 +400,6 @@ stages:
         vmSize: Standard_B2ms
         dependsOn: "containerize"
 
-    # Swiftv2 E2E tests with multitenancy cluster start up
-    - template: multitenancy/swiftv2-e2e.jobs.yaml@ACNTools
-      parameters:
-        name: "swiftv2_e2e"
-        displayName: Swiftv2 Multitenancy
-        os: linux
-        clusterType: swiftv2-multitenancy-cluster-up
-        clusterName: "mtacluster"
-        nodePoolName: "mtapool"
-        vmSize: $(SWIFTV2_MT_CLUSTER_SKU)
-        dependsOn: "containerize"
-        dummyClusterName: "swiftv2dummy"
-        dummyClusterType: "swiftv2-dummy-cluster-up"
-        dummyClusterDisplayName: Swiftv2 Multitenancy Dummy Cluster
-
     - stage: delete
       displayName: Delete Clusters
       condition: always()
@@ -430,7 +415,6 @@ stages:
         - aks_windows_22_e2e
         - dualstackoverlay_e2e
         - cilium_dualstackoverlay_e2e
-        - swiftv2_e2e
       variables:
         ACN_DIR: $(Build.SourcesDirectory)
         commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
@@ -483,14 +467,6 @@ stages:
                 name: cilium_dualstackoverlay_e2e
                 clusterName: "cildsovere2e"
                 Suffix: cilium_dualstackoverlay_e2e
-              swiftv2_e2e:
-                name: swiftv2_e2e
-                clusterName: "mtcluster"
-                Suffix: swiftv2_e2e
-              swiftv2_dummy_e2e:
-                name: swiftv2_dummy_e2e
-                clusterName: "swiftv2dummy"
-                Suffix: swiftv2_dummy_e2e
           variables:
             STORAGE_ID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.StorageID'] ]
             ob_outputDirectory: $(Build.ArtifactStagingDirectory)


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

Current iteration of swiftv2 E2E coverage is satisfied in other pipelines. Disable until next iteration.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
