### PR TITLE
ci: combine go tests such that any test failure will report a failure for the entire task

### DIFF
--- a/.pipelines/templates/run-unit-tests.yaml
+++ b/.pipelines/templates/run-unit-tests.yaml
@@ -39,9 +39,8 @@ stages:
         steps:
           # Only run one go test per script
           - script: |
-              set CGO_ENABLED=1
               cd azure-container-networking/
-              go test -race -timeout 30m ./npm/... ./cni/... ./platform/...
+              go test -timeout 30m ./npm/... ./cni/... ./platform/...
             retryCountOnTaskFailure: 3
             name: "TestWindows"
             displayName: "Run Windows Tests"

--- a/.pipelines/templates/run-unit-tests.yaml
+++ b/.pipelines/templates/run-unit-tests.yaml
@@ -37,10 +37,11 @@ stages:
         pool:
           name: "$(BUILD_POOL_NAME_DEFAULT_WINDOWS_ALT)"
         steps:
-          # Test changes under review; only run one go test per script
+          # Only run one go test per script
           - script: |
+              set CGO_ENABLED=1
               cd azure-container-networking/
-              go test ./npm/... ./cni/... ./platform/...
+              go test -race -timeout 30m ./npm/... ./cni/... ./platform/...
             retryCountOnTaskFailure: 3
             name: "TestWindows"
             displayName: "Run Windows Tests"

--- a/.pipelines/templates/run-unit-tests.yaml
+++ b/.pipelines/templates/run-unit-tests.yaml
@@ -37,13 +37,10 @@ stages:
         pool:
           name: "$(BUILD_POOL_NAME_DEFAULT_WINDOWS_ALT)"
         steps:
+          # Test changes under review; only run one go test per script
           - script: |
-              cd npm/
-              go test ./...
-              cd ../cni/
-              go test ./...
-              cd ../platform/
-              go test ./...
+              cd azure-container-networking/
+              go test ./npm/... ./cni/... ./platform/...
             retryCountOnTaskFailure: 3
             name: "TestWindows"
             displayName: "Run Windows Tests"

--- a/.pipelines/templates/unit-tests.stages.yaml
+++ b/.pipelines/templates/unit-tests.stages.yaml
@@ -52,9 +52,8 @@ stages:
           - checkout: ACNReviewChanges
             clean: true
           - script: |
-              set CGO_ENABLED=1
               cd azure-container-networking/
-              go test -race -timeout 30m ./npm/... ./cni/... ./platform/...
+              go test -timeout 30m ./npm/... ./cni/... ./platform/...
             retryCountOnTaskFailure: 3
             name: "TestWindows"
             displayName: "Run Windows Tests"

--- a/.pipelines/templates/unit-tests.stages.yaml
+++ b/.pipelines/templates/unit-tests.stages.yaml
@@ -48,18 +48,12 @@ stages:
           type: windows
           name: "$(BUILD_POOL_NAME_DEFAULT_WINDOWS_ALT)"
         steps:
-          # Test changes under review
+          # Test changes under review; only run one go test per script
           - checkout: ACNReviewChanges
             clean: true
-
           - script: |
               cd azure-container-networking/
-              cd npm/
-              go test ./...
-              cd ../cni/
-              go test ./...
-              cd ../platform/
-              go test ./...
+              go test ./npm/... ./cni/... ./platform/...
             retryCountOnTaskFailure: 3
             name: "TestWindows"
             displayName: "Run Windows Tests"

--- a/.pipelines/templates/unit-tests.stages.yaml
+++ b/.pipelines/templates/unit-tests.stages.yaml
@@ -52,8 +52,9 @@ stages:
           - checkout: ACNReviewChanges
             clean: true
           - script: |
+              set CGO_ENABLED=1
               cd azure-container-networking/
-              go test ./npm/... ./cni/... ./platform/...
+              go test -race -timeout 30m ./npm/... ./cni/... ./platform/...
             retryCountOnTaskFailure: 3
             name: "TestWindows"
             displayName: "Run Windows Tests"


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
When the go tests are split up, only the status of the last command run determines the status of the entire step/task. Any previous steps, even if they exited with a failure, won't cause the task to visibly fail. By combining all tests together in one command, if this single command fails (due to any of the tests failing), the step/task will visibly fail on the pipeline.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
See above

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
**Will fail in the pipeline until npm windows tests are fixed (this is expected, as previously those tests were silently failing).**
When those npm changes are merged in, I will rebase this PR against master to resolve the errors.
Will be backported to `release/v1.5`
