### PR TITLE
feat: Creating NNC with HomeAz info in AKS-Swift Workflows when CNS starts up behind a configuration flag

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,37 +3,37 @@ issues:
   max-issues-per-linter: 0
   new-from-rev: origin/master
 linters:
-  presets: 
-  - bugs
-  - error
-  - format
-  - performance
-  - unused
+  presets:
+    - bugs
+    - error
+    - format
+    - performance
+    - unused
   disable:
-  - maligned
-  - scopelint
+    - maligned
+    - scopelint
+    - gomnd
   enable:
-  - exportloopref
-  - goconst
-  - gocritic
-  - gocyclo
-  - gofmt
-  - gomnd
-  - goprintffuncname
-  - gosimple
-  - lll
-  - misspell
-  - nakedret
-  - promlinter
-  - revive
+    - exportloopref
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goprintffuncname
+    - gosimple
+    - lll
+    - misspell
+    - nakedret
+    - promlinter
+    - revive
 linters-settings:
   gocritic:
     enabled-tags:
-    - "diagnostic"
-    - "style"
-    - "performance"
+      - "diagnostic"
+      - "style"
+      - "performance"
     disabled-checks:
-    - "hugeParam"
+      - "hugeParam"
   govet:
     check-shadowing: true
   lll:

--- a/.pipelines/mdnc/azure-cns-cni-1.4.39.1.yaml
+++ b/.pipelines/mdnc/azure-cns-cni-1.4.39.1.yaml
@@ -12,7 +12,7 @@ metadata:
 rules:
 - apiGroups: ["acn.azure.com"]
   resources: ["nodenetworkconfigs"]
-  verbs: ["get", "list", "watch", "patch", "update"]
+  verbs: ["create", "delete", "get", "list", "watch", "patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/.pipelines/mdnc/azure-cns-cni-1.5.28.yaml
+++ b/.pipelines/mdnc/azure-cns-cni-1.5.28.yaml
@@ -12,7 +12,7 @@ metadata:
 rules:
 - apiGroups: ["acn.azure.com"]
   resources: ["nodenetworkconfigs"]
-  verbs: ["get", "list", "watch", "patch", "update"]
+  verbs: ["create", "delete", "get", "list", "watch", "patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/.pipelines/mdnc/azure-cns-cni-1.5.4.yaml
+++ b/.pipelines/mdnc/azure-cns-cni-1.5.4.yaml
@@ -12,7 +12,7 @@ metadata:
 rules:
 - apiGroups: ["acn.azure.com"]
   resources: ["nodenetworkconfigs"]
-  verbs: ["get", "list", "watch", "patch", "update"]
+  verbs: ["create", "delete", "get", "list", "watch", "patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/.pipelines/mdnc/azure-cns-cni.yaml
+++ b/.pipelines/mdnc/azure-cns-cni.yaml
@@ -12,7 +12,7 @@ metadata:
 rules:
 - apiGroups: ["acn.azure.com"]
   resources: ["nodenetworkconfigs"]
-  verbs: ["get", "list", "watch", "patch", "update"]
+  verbs: ["create", "delete", "get", "list", "watch", "patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/cns/azure-cns.yaml
+++ b/cns/azure-cns.yaml
@@ -12,7 +12,7 @@ metadata:
 rules:
 - apiGroups: ["acn.azure.com"]
   resources: ["nodenetworkconfigs"]
-  verbs: ["get", "list", "watch", "patch", "update"]
+  verbs: ["create", "delete", "get", "list", "watch", "patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -35,6 +35,7 @@ type CNSConfig struct {
 	EnableSubnetScarcity        bool
 	EnableSwiftV2               bool
 	InitializeFromCNI           bool
+	EnableHomeAz                bool
 	KeyVaultSettings            KeyVaultSettings
 	MSISettings                 MSISettings
 	ManageEndpointState         bool

--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -35,7 +35,7 @@ type CNSConfig struct {
 	EnableSubnetScarcity        bool
 	EnableSwiftV2               bool
 	InitializeFromCNI           bool
-	EnableHomeAz                bool
+	EnableHomeAZ                bool
 	KeyVaultSettings            KeyVaultSettings
 	MSISettings                 MSISettings
 	ManageEndpointState         bool

--- a/cns/restserver/homeazmonitor.go
+++ b/cns/restserver/homeazmonitor.go
@@ -135,7 +135,7 @@ func (h *HomeAzMonitor) Populate(ctx context.Context) {
 				return
 
 			default:
-				returnMessage := fmt.Sprintf("[HomeAzMonitor] failed with StatusCode: %d", apiError.StatusCode())
+				returnMessage := fmt.Sprintf("[HomeAzMonitor] failed with StatusCode: %d and error %v", apiError.StatusCode(), err)
 				returnCode := types.UnexpectedError
 				h.update(returnCode, returnMessage, cns.HomeAzResponse{IsSupported: true})
 				return

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -633,3 +633,11 @@ func (service *HTTPRestService) CreateOrUpdateNetworkContainerInternal(req *cns.
 func (service *HTTPRestService) SetVFForAccelnetNICs() error {
 	return service.setVFForAccelnetNICs()
 }
+
+// GetHomeAz - Get the Home Az for the Node where CNS is running.
+func (service *HTTPRestService) GetHomeAz() (homeAzResponse cns.GetHomeAzResponse) {
+	service.RLock()
+	homeAzResponse = service.homeAzMonitor.GetHomeAz(context.TODO())
+	service.RUnlock()
+	return
+}

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -635,9 +635,13 @@ func (service *HTTPRestService) SetVFForAccelnetNICs() error {
 }
 
 // GetHomeAz - Get the Home Az for the Node where CNS is running.
-func (service *HTTPRestService) GetHomeAz(ctx context.Context) (homeAzResponse cns.GetHomeAzResponse) {
+func (service *HTTPRestService) GetHomeAz(ctx context.Context) (cns.GetHomeAzResponse, error) {
 	service.RLock()
-	homeAzResponse = service.homeAzMonitor.GetHomeAz(ctx)
-	service.RUnlock()
-	return
+	defer service.RUnlock()
+	homeAzResponse := service.homeAzMonitor.GetHomeAz(ctx)
+	if homeAzResponse.Response.ReturnCode == types.NotFound {
+		return homeAzResponse, errors.New(homeAzResponse.Response.Message)
+	}
+
+	return homeAzResponse, nil
 }

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -635,9 +635,9 @@ func (service *HTTPRestService) SetVFForAccelnetNICs() error {
 }
 
 // GetHomeAz - Get the Home Az for the Node where CNS is running.
-func (service *HTTPRestService) GetHomeAz() (homeAzResponse cns.GetHomeAzResponse) {
+func (service *HTTPRestService) GetHomeAz(ctx context.Context) (homeAzResponse cns.GetHomeAzResponse) {
 	service.RLock()
-	homeAzResponse = service.homeAzMonitor.GetHomeAz(context.TODO())
+	homeAzResponse = service.homeAzMonitor.GetHomeAz(ctx)
 	service.RUnlock()
 	return
 }

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1308,7 +1308,8 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 		// Create Node Network Config CRD and update the Home Az field with the cache value from the HomeAz Monitor
 		nnc = createBaseNNC(node)
 	}
-	if err := directcli.Create(ctx, &nnc); err != nil {
+
+	if err = directcli.Create(ctx, &nnc); err != nil {
 		return errors.Wrap(err, "failed to create base NNC")
 	}
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1306,7 +1306,8 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 	// Create the base NNC CRD if HomeAz is enabled
 	if cnsconfig.EnableHomeAz {
 		homeAzResponse := httpRestServiceImplementation.GetHomeAz(ctx)
-		logger.Printf("[Azure CNS] HomeAz: %s", strconv.FormatUint(uint64(homeAzResponse.HomeAzResponse.HomeAz), 10))
+		az := int64(homeAzResponse.HomeAzResponse.HomeAz)
+		logger.Printf("[Azure CNS] HomeAz: %s", strconv.FormatInt(az, 10))
 		// Create Node Network Config CRD and update the Home Az field with the cache value from the HomeAz Monitor
 		var nnc *v1alpha.NodeNetworkConfig
 		if nnc, err = directnnccli.Get(ctx, types.NamespacedName{Namespace: "kube-system", Name: nodeName}); err != nil {
@@ -1316,13 +1317,13 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 		newNNC := createBaseNNC(node)
 		if nnc == nil {
 			logger.Printf("[Azure CNS] Creating new base NNC")
-			newNNC.Spec.AvailabilityZone = strconv.FormatUint(uint64(homeAzResponse.HomeAzResponse.HomeAz), 10)
+			newNNC.Spec.AvailabilityZone = az
 			if err = directcli.Create(ctx, newNNC); err != nil {
 				return errors.Wrap(err, "failed to create base NNC")
 			}
 		} else {
-			logger.Printf("[Azure CNS] Patching existing NNC with new Spec with HomeAz")
-			newNNC.Spec.AvailabilityZone = strconv.FormatUint(uint64(homeAzResponse.HomeAzResponse.HomeAz), 10)
+			logger.Printf("[Azure CNS] Patching existing NNC with new Spec with HomeAz %d", az)
+			newNNC.Spec.AvailabilityZone = az
 			newNNC.Spec.RequestedIPCount = nnc.Spec.RequestedIPCount
 			newNNC.Spec.IPsNotInUse = nnc.Spec.IPsNotInUse
 			newNNC.Status = nnc.Status

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1306,7 +1306,7 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 	nnc := v1alpha.NodeNetworkConfig{}
 	if cnsconfig.EnableHomeAz {
 		// Create Node Network Config CRD and update the Home Az field with the cache value from the HomeAz Monitor
-		nnc = createBaseNNC(ctx, node)
+		nnc = createBaseNNC(node)
 	}
 	directcli.Create(ctx, &nnc)
 
@@ -1520,7 +1520,7 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 	return nil
 }
 
-func createBaseNNC(ctx context.Context, node *corev1.Node) v1alpha.NodeNetworkConfig {
+func createBaseNNC(node *corev1.Node) v1alpha.NodeNetworkConfig {
 	return v1alpha.NodeNetworkConfig{ObjectMeta: metav1.ObjectMeta{
 		Annotations: make(map[string]string),
 		Labels: map[string]string{

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1308,7 +1308,9 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 		// Create Node Network Config CRD and update the Home Az field with the cache value from the HomeAz Monitor
 		nnc = createBaseNNC(node)
 	}
-	directcli.Create(ctx, &nnc)
+	if err := directcli.Create(ctx, &nnc); err != nil {
+		return errors.Wrap(err, "failed to create base NNC")
+	}
 
 	logger.Printf("Reconciling initial CNS state")
 	// apiserver nnc might not be registered or api server might be down and crashloop backof puts us outside of 5-10 minutes we have for

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1303,6 +1303,8 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 	// TODO(rbtr): nodename and namespace should be in the cns config
 	directscopedcli := nncctrl.NewScopedClient(directnnccli, types.NamespacedName{Namespace: "kube-system", Name: nodeName})
 
+	// TODO: Create the NNC CRD here and update it with HomeAzinfo
+
 	logger.Printf("Reconciling initial CNS state")
 	// apiserver nnc might not be registered or api server might be down and crashloop backof puts us outside of 5-10 minutes we have for
 	// aks addons to come up so retry a bit more aggresively here.

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1277,7 +1277,7 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 
 	if cnsconfig.EnableHomeAz {
 		// Create Node Network Config CRD and update the Home Az field with the cache value from the HomeAz Monitor
-
+		createOrUpdateNNC(ctx)
 	}
 
 	// perform state migration from CNI in case CNS is set to manage the endpoint state and has emty state
@@ -1518,6 +1518,17 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 	}()
 	logger.Printf("Initialized SyncHostNCVersion loop.")
 	return nil
+}
+
+func createBaseNNC(ctx context.Context, node *corev1.Node) v1alpha.NodeNetworkConfig {
+	return v1alpha.NodeNetworkConfig{ObjectMeta: metav1.ObjectMeta{
+		Annotations: make(map[string]string),
+		Labels: map[string]string{
+			"managed": "true",
+			"owner":   node.Name,
+		},
+		Name: node.Name,
+	}}
 }
 
 // getPodInfoByIPProvider returns a PodInfoByIPProvider that reads endpoint state from the configured source

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1306,8 +1306,8 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 	// Create the base NNC CRD if HomeAz is enabled
 	if cnsconfig.EnableHomeAz {
 		homeAzResponse := httpRestServiceImplementation.GetHomeAz(ctx)
-		az := int64(homeAzResponse.HomeAzResponse.HomeAz)
-		logger.Printf("[Azure CNS] HomeAz: %s", strconv.FormatInt(az, 10))
+		az := homeAzResponse.HomeAzResponse.HomeAz
+		logger.Printf("[Azure CNS] HomeAz: %d", az)
 		// Create Node Network Config CRD and update the Home Az field with the cache value from the HomeAz Monitor
 		var nnc *v1alpha.NodeNetworkConfig
 		if nnc, err = directnnccli.Get(ctx, types.NamespacedName{Namespace: "kube-system", Name: nodeName}); err != nil {

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -668,9 +668,9 @@ func main() {
 	}
 
 	homeAzMonitor := restserver.NewHomeAzMonitor(nmaClient, time.Duration(cnsconfig.AZRSettings.PopulateHomeAzCacheRetryIntervalSecs)*time.Second)
-	// homeAz monitor is only required when there is a direct channel between DNC and CNS.
-	// This will prevent the monitor from unnecessarily calling NMA APIs for other scenarios such as AKS-swift, swiftv2
-	if cnsconfig.ChannelMode == cns.Direct {
+	// homeAz monitor is required when there is a direct channel between DNC and CNS OR when homeAz feature is enabled in CNS for AKS-Swift
+	// This will prevent the monitor from unnecessarily calling NMA APIs for other scenarios such as AKS-swift, swiftv2 when disabled.
+	if cnsconfig.ChannelMode == cns.Direct || cnsconfig.EnableHomeAz {
 		homeAzMonitor.Start()
 		defer homeAzMonitor.Stop()
 	}
@@ -1273,6 +1273,11 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 		if nodeInfoErr := createOrUpdateNodeInfoCRD(ctx, kubeConfig, node); nodeInfoErr != nil {
 			return errors.Wrap(nodeInfoErr, "error creating or updating nodeinfo crd")
 		}
+	}
+
+	if cnsconfig.EnableHomeAz {
+		// Create Node Network Config CRD and update the Home Az field with the cache value from the HomeAz Monitor
+
 	}
 
 	// perform state migration from CNI in case CNS is set to manage the endpoint state and has emty state

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1307,7 +1307,7 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 	if cnsconfig.EnableHomeAz {
 		// Create Node Network Config CRD and update the Home Az field with the cache value from the HomeAz Monitor
 		nnc = createBaseNNC(node)
-		homeAzResponse := httpRestServiceImplementation.GetHomeAz()
+		homeAzResponse := httpRestServiceImplementation.GetHomeAz(ctx)
 		nnc.Spec.AvailabilityZone = strconv.FormatUint(uint64(homeAzResponse.HomeAzResponse.HomeAz), 10)
 	}
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1307,6 +1307,8 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 	if cnsconfig.EnableHomeAz {
 		// Create Node Network Config CRD and update the Home Az field with the cache value from the HomeAz Monitor
 		nnc = createBaseNNC(node)
+		homeAzResponse := httpRestServiceImplementation.GetHomeAz()
+		nnc.Spec.AvailabilityZone = strconv.FormatUint(uint64(homeAzResponse.HomeAzResponse.HomeAz), 10)
 	}
 
 	if err = directcli.Create(ctx, &nnc); err != nil {

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -670,7 +670,7 @@ func main() {
 	homeAzMonitor := restserver.NewHomeAzMonitor(nmaClient, time.Duration(cnsconfig.AZRSettings.PopulateHomeAzCacheRetryIntervalSecs)*time.Second)
 	// homeAz monitor is required when there is a direct channel between DNC and CNS OR when homeAz feature is enabled in CNS for AKS-Swift
 	// This will prevent the monitor from unnecessarily calling NMA APIs for other scenarios such as AKS-swift, swiftv2 when disabled.
-	if cnsconfig.ChannelMode == cns.Direct || cnsconfig.EnableHomeAz {
+	if cnsconfig.ChannelMode == cns.Direct || cnsconfig.EnableHomeAZ {
 		homeAzMonitor.Start()
 		defer homeAzMonitor.Stop()
 	}
@@ -1304,7 +1304,7 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 	directscopedcli := nncctrl.NewScopedClient(directnnccli, types.NamespacedName{Namespace: "kube-system", Name: nodeName})
 
 	// Create the base NNC CRD if HomeAz is enabled
-	if cnsconfig.EnableHomeAz {
+	if cnsconfig.EnableHomeAZ {
 		homeAzResponse := httpRestServiceImplementation.GetHomeAz(ctx)
 		az := homeAzResponse.HomeAzResponse.HomeAz
 		logger.Printf("[Azure CNS] HomeAz: %d", az)

--- a/crd/nodenetworkconfig/api/v1alpha/nodenetworkconfig.go
+++ b/crd/nodenetworkconfig/api/v1alpha/nodenetworkconfig.go
@@ -50,7 +50,7 @@ type NodeNetworkConfigSpec struct {
 	// AvailabilityZone contains the Azure availability zone for the virtual machine where network containers are placed.
 	// NMA returns an int value for the availability zone.
 	// +kubebuilder:validation:Optional
-	AvailabilityZone int64 `json:"availabilityZone,omitempty"`
+	AvailabilityZone uint `json:"availabilityZone,omitempty"`
 }
 
 // Status indicates the NNC reconcile status

--- a/crd/nodenetworkconfig/api/v1alpha/nodenetworkconfig.go
+++ b/crd/nodenetworkconfig/api/v1alpha/nodenetworkconfig.go
@@ -48,8 +48,9 @@ type NodeNetworkConfigSpec struct {
 	RequestedIPCount int64    `json:"requestedIPCount"`
 	IPsNotInUse      []string `json:"ipsNotInUse,omitempty"`
 	// AvailabilityZone contains the Azure availability zone for the virtual machine where network containers are placed.
+	// NMA returns an int value for the availability zone.
 	// +kubebuilder:validation:Optional
-	AvailabilityZone string `json:"availabilityZone,omitempty"`
+	AvailabilityZone int64 `json:"availabilityZone,omitempty"`
 }
 
 // Status indicates the NNC reconcile status

--- a/test/integration/manifests/cilium/cns-write-ovly.yaml
+++ b/test/integration/manifests/cilium/cns-write-ovly.yaml
@@ -12,7 +12,7 @@ metadata:
 rules:
 - apiGroups: ["acn.azure.com"]
   resources: ["nodenetworkconfigs"]
-  verbs: ["get", "list", "watch", "patch", "update"]
+  verbs: ["create", "delete", "get", "list", "watch", "patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
**Reason for Change**:
feat: Creating NNC with HomeAz info in AKS-Swift Workflows when CNS starts up behind a configuration flag


**Issue Fixed**:
N/A


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [X] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
