### PR TITLE
test: [NPM] fix windows unit test for policymanager

### DIFF
--- a/npm/pkg/dataplane/policies/policymanager_test.go
+++ b/npm/pkg/dataplane/policies/policymanager_test.go
@@ -115,7 +115,9 @@ func TestBootup(t *testing.T) {
 	metrics.IncNumACLRules()
 
 	require.NoError(t, pMgr.Bootup(epIDs))
-	require.Equal(t, util.IptablesNft, util.Iptables)
+	if util.IsWindowsDP() {
+		require.Equal(t, util.IptablesNft, util.Iptables)
+	}
 
 	expectedNumACLs := 11
 	if util.IsWindowsDP() {

--- a/npm/pkg/dataplane/policies/policymanager_test.go
+++ b/npm/pkg/dataplane/policies/policymanager_test.go
@@ -115,7 +115,7 @@ func TestBootup(t *testing.T) {
 	metrics.IncNumACLRules()
 
 	require.NoError(t, pMgr.Bootup(epIDs))
-	if util.IsWindowsDP() {
+	if !util.IsWindowsDP() {
 		require.Equal(t, util.IptablesNft, util.Iptables)
 	}
 


### PR DESCRIPTION
Had this failure running Windows unit tests:
```
--- FAIL: TestBootup (0.00s)
    policymanager_test.go:118: 
        	Error Trace:	D:/a/_work/1/s/npm/pkg/dataplane/policies/policymanager_test.go:118
        	Error:      	Not equal: 
        	            	expected: "iptables-nft"
        	            	actual  : "iptables"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-iptables-nft
        	            	+iptables
        	Test:       	TestBootup
```