### PR TITLE
fix: ipv6-hp-bpf prog to clean up existing cilium tc filters

### DIFF
--- a/bpf-prog/ipv6-hp-bpf/pkg/egress/egress.go
+++ b/bpf-prog/ipv6-hp-bpf/pkg/egress/egress.go
@@ -32,6 +32,15 @@ func SetupEgressFilter(ifaceIndex int, objs *EgressObjects, logger *zap.Logger) 
 			}
 			break
 		}
+		// Delete the old filter for cilium if priority is 1. This is to avoid duplicate filters after restarting the daemonset in the
+		// singlestack -> dualstack migration scenario.
+		if filter, ok := filter.(*netlink.BpfFilter); ok && filter.Name == "cil_to_netdev-eth0" && filter.Priority == 1 {
+			if err := netlink.FilterDel(filter); err != nil {
+				logger.Error("Failed to delete filter", zap.Error(err))
+				return err
+			}
+			break
+		}
 	}
 
 	egressFilter := &netlink.BpfFilter{


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
Addresses issue with cilium dual stack upgrade where cilium filter priority change breaks node connectivity. 
ipv6-hp-bpf program will clean up the existing cilium filter on start up (if it is priority 1 -- so should only be in the case of dual stack upgrade) 


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
