### PR TITLE
fix: let Windows CNS use the InClusterConfig

### DIFF
--- a/.pipelines/build/dockerfiles/cns.Dockerfile
+++ b/.pipelines/build/dockerfiles/cns.Dockerfile
@@ -6,8 +6,6 @@ ARG ARCH
 FROM --platform=windows/${ARCH} mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image@sha256:b4c9637e032f667c52d1eccfa31ad8c63f1b035e8639f3f48a510536bf34032b AS windows
 ARG ARTIFACT_DIR .
 
-COPY ${ARTIFACT_DIR}/files/kubeconfigtemplate.yaml kubeconfigtemplate.yaml
-COPY ${ARTIFACT_DIR}/scripts/setkubeconfigpath.ps1 setkubeconfigpath.ps1
 COPY ${ARTIFACT_DIR}/bin/azure-cns.exe /azure-cns.exe
 ENTRYPOINT ["azure-cns.exe"]
 EXPOSE 10090

--- a/.pipelines/build/dockerfiles/cns.Dockerfile.tmpl
+++ b/.pipelines/build/dockerfiles/cns.Dockerfile.tmpl
@@ -6,8 +6,6 @@ ARG ARCH
 FROM --platform=windows/${ARCH} {{.WIN_HPC_PIN}} AS windows
 ARG ARTIFACT_DIR .
 
-COPY ${ARTIFACT_DIR}/files/kubeconfigtemplate.yaml kubeconfigtemplate.yaml
-COPY ${ARTIFACT_DIR}/scripts/setkubeconfigpath.ps1 setkubeconfigpath.ps1
 COPY ${ARTIFACT_DIR}/bin/azure-cns.exe /azure-cns.exe
 ENTRYPOINT ["azure-cns.exe"]
 EXPOSE 10090

--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -32,8 +32,10 @@ COPY --from=builder /go/bin/azure-cns /usr/local/bin/azure-cns
 ENTRYPOINT [ "/usr/local/bin/azure-cns" ]
 EXPOSE 10090
 
-# skopeo inspect docker://mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0 --format "{{.Name}}@{{.Digest}}"
-FROM mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image@sha256:b4c9637e032f667c52d1eccfa31ad8c63f1b035e8639f3f48a510536bf34032b as windows
+# mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0
+FROM --platform=windows/${ARCH} mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image@sha256:b4c9637e032f667c52d1eccfa31ad8c63f1b035e8639f3f48a510536bf34032b as hpc
+
+FROM hpc as windows
 COPY --from=builder /go/bin/azure-cns /azure-cns.exe
 ENTRYPOINT ["azure-cns.exe"]
 EXPOSE 10090

--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -32,12 +32,8 @@ COPY --from=builder /go/bin/azure-cns /usr/local/bin/azure-cns
 ENTRYPOINT [ "/usr/local/bin/azure-cns" ]
 EXPOSE 10090
 
-# mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0
-FROM --platform=windows/${ARCH} mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image@sha256:b4c9637e032f667c52d1eccfa31ad8c63f1b035e8639f3f48a510536bf34032b as hpc
-
-FROM hpc as windows
-COPY --from=builder /azure-container-networking/cns/kubeconfigtemplate.yaml kubeconfigtemplate.yaml
-COPY --from=builder /azure-container-networking/npm/examples/windows/setkubeconfigpath.ps1 setkubeconfigpath.ps1
+# skopeo inspect docker://mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0 --format "{{.Name}}@{{.Digest}}"
+FROM mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image@sha256:b4c9637e032f667c52d1eccfa31ad8c63f1b035e8639f3f48a510536bf34032b as windows
 COPY --from=builder /go/bin/azure-cns /azure-cns.exe
 ENTRYPOINT ["azure-cns.exe"]
 EXPOSE 10090

--- a/cns/Dockerfile.tmpl
+++ b/cns/Dockerfile.tmpl
@@ -36,8 +36,6 @@ EXPOSE 10090
 FROM --platform=windows/${ARCH} {{.WIN_HPC_PIN}} as hpc
 
 FROM hpc as windows
-COPY --from=builder /azure-container-networking/cns/kubeconfigtemplate.yaml kubeconfigtemplate.yaml
-COPY --from=builder /azure-container-networking/npm/examples/windows/setkubeconfigpath.ps1 setkubeconfigpath.ps1
 COPY --from=builder /go/bin/azure-cns /azure-cns.exe
 ENTRYPOINT ["azure-cns.exe"]
 EXPOSE 10090

--- a/cns/azure-cns-windows.yaml
+++ b/cns/azure-cns-windows.yaml
@@ -35,10 +35,9 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
-          command: ["powershell.exe"]
+          command: "azure-cns.exe"
           args: 
-            [ 
-              'powershell.exe', '.\azure-cns.exe',
+            [
               '-c', "tcp://$(CNSIpAddress):$(CNSPort)",
               '-t', "$(CNSLogTarget)",
               '-o', "$(CNSLogDir)",

--- a/cns/azure-cns-windows.yaml
+++ b/cns/azure-cns-windows.yaml
@@ -38,14 +38,12 @@ spec:
           command: ["powershell.exe"]
           args: 
             [ 
-              '.\setkubeconfigpath.ps1', ";",
               'powershell.exe', '.\azure-cns.exe',
               '-c', "tcp://$(CNSIpAddress):$(CNSPort)",
               '-t', "$(CNSLogTarget)",
               '-o', "$(CNSLogDir)",
               '-storefilepath', "$(CNSStoreFilePath)",
               '-config-path', "%CONTAINER_SANDBOX_MOUNT_POINT%\\$(CNS_CONFIGURATION_PATH)",
-              '--kubeconfig', '.\kubeconfig',
             ]
           volumeMounts:
             - name: log

--- a/test/integration/manifests/cns/daemonset-windows.yaml
+++ b/test/integration/manifests/cns/daemonset-windows.yaml
@@ -49,10 +49,9 @@ spec:
           securityContext:
             privileged: true
           workingDir: $env:CONTAINER_SANDBOX_MOUNT_POINT
-          command: ["powershell.exe"]
+          command: ["azure-cns.exe"]
           args:
             [
-              '.\azure-cns.exe',
               "-c",
               "tcp://$(CNSIpAddress):$(CNSPort)",
               "-t",
@@ -107,7 +106,7 @@ spec:
           image: acnpublic.azurecr.io/cni-dropgz:latest
           imagePullPolicy: Always
           command:
-            - powershell.exe; $env:CONTAINER_SANDBOX_MOUNT_POINT/dropgz
+            - $env:CONTAINER_SANDBOX_MOUNT_POINT/dropgz
           args:
             - deploy
             - azure-vnet

--- a/test/integration/manifests/cns/daemonset-windows.yaml
+++ b/test/integration/manifests/cns/daemonset-windows.yaml
@@ -52,8 +52,6 @@ spec:
           command: ["powershell.exe"]
           args:
             [
-              '.\setkubeconfigpath.ps1',
-              ";",
               '.\azure-cns.exe',
               "-c",
               "tcp://$(CNSIpAddress):$(CNSPort)",
@@ -65,8 +63,6 @@ spec:
               "$(CNSStoreFilePath)",
               "-config-path",
               "%CONTAINER_SANDBOX_MOUNT_POINT%\\$(CNS_CONFIGURATION_PATH)",
-              "--kubeconfig",
-              '.\kubeconfig',
             ]
           volumeMounts:
             - name: log


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
As of [AKS 1.30](https://github.com/Azure/AKS/releases/tag/2024-06-09), service account tokens refresh every ~1 hour when OIDC is enabled. They were previously valid for a year.
[This `setkubeconfigpath.ps1` script](https://github.com/Azure/azure-container-networking/blob/47b243c42fd16119a96ab6d06eb602ac2ce40e7d/npm/examples/windows/setkubeconfigpath.ps1) was at some point necessary on Windows to create a valid kubeconfig for CNS (and NPM and others), but based on my testing we don't need it today. It copies the token from the token file to create a custom kubeconfig from a template at startup and then we pass CNS _that_ file via `--kubeconfig`. 

The script runs at startup and never re-runs, so the token that exists at Pod start is the token CNS will try to use forever. Yearly token lifespans were long enough that no CNS Pod was ever up long enough to hit token expiration.

This becomes an issue with hourly token lifespans. An hour after Pod start, the token becomes invalid and CNS can no longer auth to the API server. For PodSubnet clusters, this permanently prevents CNS from being able to scale the IPAM pool and provide more Pod IPs.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
https://github.com/Azure/AKS/issues/4679

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
