### PR TITLE
fix: save cni state only during endpoint creation or deletion

### DIFF
--- a/cni/network/invoker_azure.go
+++ b/cni/network/invoker_azure.go
@@ -56,6 +56,8 @@ func (invoker *AzureIPAMInvoker) Add(addConfig IPAMAddConfig) (IPAMAddResult, er
 
 	if err != nil && strings.Contains(err.Error(), ipam.ErrNoAvailableAddressPools.Error()) {
 		invoker.deleteIpamState()
+		log.Printf("Retry pool allocation after deleting IPAM state")
+		addResult.ipv4Result, err = invoker.plugin.DelegateAdd(addConfig.nwCfg.IPAM.Type, addConfig.nwCfg)
 	}
 	if err != nil {
 		err = invoker.plugin.Errorf("Failed to allocate pool: %v", err)

--- a/network/manager.go
+++ b/network/manager.go
@@ -250,11 +250,6 @@ func (nm *networkManager) AddExternalInterface(ifName string, subnet string) err
 		return err
 	}
 
-	err = nm.save()
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -264,11 +259,6 @@ func (nm *networkManager) CreateNetwork(nwInfo *NetworkInfo) error {
 	defer nm.Unlock()
 
 	_, err := nm.newNetwork(nwInfo)
-	if err != nil {
-		return err
-	}
-
-	err = nm.save()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
This PR removes saving to the azure cni statefile from the AddExternalInterface and CreateNetwork methods since we only want to commit to the statefile once we create the endpoint. Saving the state will save all in-memory state including all networks, external interfaces, and endpoints, so it's unecessary to call save state after each update-- we only need to call it once at the end (which is when the endpoint is created).

We also backport https://github.com/Azure/azure-container-networking/pull/2309/files here

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Previously, if we wrote the external interface to the state, and then crashed before we wrote the corresponding network, the subsequent DEL call would not clean up the ips (since azure cni does not see the network in the azure cni state file, leading to leaked ips), and we would not be able to auto recover by deleting the azure ipam statefile either since the program detects that the azure cni statefile exists (Autorecovery is here https://github.com/Azure/azure-container-networking/blob/release/v1.4/cni/network/invoker_azure.go#L58).

Now, if there is a panic or crash between adding the external interface and adding the network, no state file is written, and so the azure cni will auto recover by deleting the ipam state file (as it determines the azure cni statefile is not present) and continue as normal.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
Tested by forcing a panic between adding the external interface and creating the network-- no azure cni statefile is created, and when the forced panic is removed, we can successfully create an endpoint with no leaked ips.

Also tested forcing a panic during endpoint create-- the logs mention that we clean up the ip (issue ipam delete) and when we remove the forced panic, there are no leaked ips (# ips in azure ipam statefile match the azure cni statefile).

Confirmed that we will never have a scenario where the azure cni creates an external interface only (without a network)-- it's either the interface, network, **and** endpoint are saved to the statefile or none of them are.