### PR TITLE
fix: hardcode CLI for 1.13 agent

### DIFF
--- a/.pipelines/templates/cilium-cli.yaml
+++ b/.pipelines/templates/cilium-cli.yaml
@@ -3,7 +3,7 @@ steps:
       echo "install cilium CLI"
       if [[ ${CILIUM_VERSION_TAG_V1_4#v} =~ ^1.1[1-3].[0-9]{1,2}|1.1[1-3].[0-9]{1,2}-[0-9]{1,6} ]]; then
         echo "Cilium Agent Version ${BASH_REMATCH[0]}"
-        CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable-v0.14.txt)
+        CILIUM_CLI_VERSION=v0.14.8
       elif [[ ${CILIUM_VERSION_TAG_V1_4#v} =~ ^1.1[1-4].[0-9]{1,2}|1.1[1-4].[0-9]{1,2}-[0-9]{1,6} ]]; then
         echo "Cilium Agent Version ${BASH_REMATCH[0]}"
         CILIUM_CLI_VERSION=v0.15.22


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Hardcodes CLI version for v1.13 agent to v0.14.8.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
Old txt file `stable-v0.14.txt` was removed from main with https://github.com/cilium/cilium-cli/pull/2869 . 
