### PR TITLE
[NPM Lite] Added DefaultDeny in PNI + MTPNC CRD's

### DIFF
--- a/crd/multitenancy/api/v1alpha1/multitenantpodnetworkconfig.go
+++ b/crd/multitenancy/api/v1alpha1/multitenantpodnetworkconfig.go
@@ -85,7 +85,8 @@ type MultitenantPodNetworkConfigStatus struct {
 	// InterfaceInfos describes all of the network container goal state for this Pod
 	// +kubebuilder:validation:Optional
 	InterfaceInfos []InterfaceInfo `json:"interfaceInfos,omitempty"`
-	// DefaultDenyAcl bool indicates whether default deny policy will be present on the pods upon pod creation
+	// DefaultDenyACL bool indicates whether default deny policy will be present on the pods upon pod creation
+	// +kubebuilder:validation:Optional
 	DefaultDenyACL bool `json:"defaultDenyACL"`
 }
 

--- a/crd/multitenancy/api/v1alpha1/multitenantpodnetworkconfig.go
+++ b/crd/multitenancy/api/v1alpha1/multitenantpodnetworkconfig.go
@@ -85,6 +85,8 @@ type MultitenantPodNetworkConfigStatus struct {
 	// InterfaceInfos describes all of the network container goal state for this Pod
 	// +kubebuilder:validation:Optional
 	InterfaceInfos []InterfaceInfo `json:"interfaceInfos,omitempty"`
+	// DefaultDenyAcl bool indicates whether default deny policy will be present on the pods upon pod creation
+	DefaultDenyACL bool `json:"defaultDenyACL"`
 }
 
 func init() {

--- a/crd/multitenancy/api/v1alpha1/podnetworkinstance.go
+++ b/crd/multitenancy/api/v1alpha1/podnetworkinstance.go
@@ -56,6 +56,9 @@ type PodNetworkInstanceSpec struct {
 	// optional for now in case orchestrator uses the deprecated fields
 	// +kubebuilder:validation:Optional
 	PodNetworkConfigs []PodNetworkConfig `json:"podNetworkConfigs"`
+	// DefaultDenyAcl bool indicates whether default deny policy will be present on the pods upon pod creation
+	// +kubebuilder:default=false
+	DefaultDenyACL bool `json:"defaultDenyACL"`
 }
 
 // PodNetworkInstanceStatus defines the observed state of PodNetworkInstance

--- a/crd/multitenancy/api/v1alpha1/podnetworkinstance.go
+++ b/crd/multitenancy/api/v1alpha1/podnetworkinstance.go
@@ -57,6 +57,7 @@ type PodNetworkInstanceSpec struct {
 	// +kubebuilder:validation:Optional
 	PodNetworkConfigs []PodNetworkConfig `json:"podNetworkConfigs"`
 	// DefaultDenyAcl bool indicates whether default deny policy will be present on the pods upon pod creation
+	// +kubebuilder:default=false
 	DefaultDenyACL bool `json:"defaultDenyACL"`
 }
 

--- a/crd/multitenancy/api/v1alpha1/podnetworkinstance.go
+++ b/crd/multitenancy/api/v1alpha1/podnetworkinstance.go
@@ -57,7 +57,6 @@ type PodNetworkInstanceSpec struct {
 	// +kubebuilder:validation:Optional
 	PodNetworkConfigs []PodNetworkConfig `json:"podNetworkConfigs"`
 	// DefaultDenyAcl bool indicates whether default deny policy will be present on the pods upon pod creation
-	// +kubebuilder:default=false
 	DefaultDenyACL bool `json:"defaultDenyACL"`
 }
 

--- a/crd/multitenancy/api/v1alpha1/podnetworkinstance.go
+++ b/crd/multitenancy/api/v1alpha1/podnetworkinstance.go
@@ -56,8 +56,9 @@ type PodNetworkInstanceSpec struct {
 	// optional for now in case orchestrator uses the deprecated fields
 	// +kubebuilder:validation:Optional
 	PodNetworkConfigs []PodNetworkConfig `json:"podNetworkConfigs"`
-	// DefaultDenyAcl bool indicates whether default deny policy will be present on the pods upon pod creation
+	// DefaultDenyACL bool indicates whether default deny policy will be present on the pods upon pod creation
 	// +kubebuilder:default=false
+	// +kubebuilder:validation:Optional
 	DefaultDenyACL bool `json:"defaultDenyACL"`
 }
 

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_multitenantpodnetworkconfigs.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_multitenantpodnetworkconfigs.yaml
@@ -75,6 +75,9 @@ spec:
               gatewayIP:
                 description: Deprecated - use InterfaceInfos
                 type: string
+              DefaultDenyACL:
+                description: indicates whether default deny policy will be present on the pods upon pod creation
+                type: bool
               interfaceInfos:
                 description: InterfaceInfos describes all of the network container
                   goal state for this Pod

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_multitenantpodnetworkconfigs.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_multitenantpodnetworkconfigs.yaml
@@ -72,12 +72,13 @@ spec:
             description: MultitenantPodNetworkConfigStatus defines the observed state
               of PodNetworkConfig
             properties:
+              defaultDenyACL:
+                description: DefaultDenyAcl bool indicates whether default deny policy
+                  will be present on the pods upon pod creation
+                type: boolean
               gatewayIP:
                 description: Deprecated - use InterfaceInfos
                 type: string
-              defaultDenyACL:
-                description: indicates whether default deny policy will be present on the pods upon pod creation
-                type: boolean
               interfaceInfos:
                 description: InterfaceInfos describes all of the network container
                   goal state for this Pod
@@ -122,6 +123,8 @@ spec:
               primaryIP:
                 description: Deprecated - use InterfaceInfos
                 type: string
+            required:
+            - defaultDenyACL
             type: object
         type: object
     served: true

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_multitenantpodnetworkconfigs.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_multitenantpodnetworkconfigs.yaml
@@ -123,8 +123,6 @@ spec:
               primaryIP:
                 description: Deprecated - use InterfaceInfos
                 type: string
-            required:
-            - defaultDenyACL
             type: object
         type: object
     served: true

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_multitenantpodnetworkconfigs.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_multitenantpodnetworkconfigs.yaml
@@ -77,7 +77,7 @@ spec:
                 type: string
               DefaultDenyACL:
                 description: indicates whether default deny policy will be present on the pods upon pod creation
-                type: bool
+                type: boolean
               interfaceInfos:
                 description: InterfaceInfos describes all of the network container
                   goal state for this Pod

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_multitenantpodnetworkconfigs.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_multitenantpodnetworkconfigs.yaml
@@ -75,7 +75,7 @@ spec:
               gatewayIP:
                 description: Deprecated - use InterfaceInfos
                 type: string
-              DefaultDenyACL:
+              defaultDenyACL:
                 description: indicates whether default deny policy will be present on the pods upon pod creation
                 type: boolean
               interfaceInfos:

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_multitenantpodnetworkconfigs.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_multitenantpodnetworkconfigs.yaml
@@ -73,7 +73,7 @@ spec:
               of PodNetworkConfig
             properties:
               defaultDenyACL:
-                description: DefaultDenyAcl bool indicates whether default deny policy
+                description: DefaultDenyACL bool indicates whether default deny policy
                   will be present on the pods upon pod creation
                 type: boolean
               gatewayIP:

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_podnetworkinstances.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_podnetworkinstances.yaml
@@ -57,6 +57,10 @@ spec:
                 default: 0
                 description: Deprecated - use PodNetworks
                 type: integer
+              defaultDenyACL:
+                default: false
+                description: indicates whether default deny policy will be present on the pods upon pod creation
+                type: bool
               podNetworkConfigs:
                 description: |-
                   PodNetworkConfigs describes each PodNetwork to attach to a single Pod

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_podnetworkinstances.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_podnetworkinstances.yaml
@@ -55,7 +55,7 @@ spec:
             properties:
               defaultDenyACL:
                 default: false
-                description: DefaultDenyAcl bool indicates whether default deny policy
+                description: DefaultDenyACL bool indicates whether default deny policy
                   will be present on the pods upon pod creation
                 type: boolean
               podIPReservationSize:

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_podnetworkinstances.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_podnetworkinstances.yaml
@@ -53,14 +53,15 @@ spec:
           spec:
             description: PodNetworkInstanceSpec defines the desired state of PodNetworkInstance
             properties:
+              defaultDenyACL:
+                default: false
+                description: DefaultDenyAcl bool indicates whether default deny policy
+                  will be present on the pods upon pod creation
+                type: boolean
               podIPReservationSize:
                 default: 0
                 description: Deprecated - use PodNetworks
                 type: integer
-              defaultDenyACL:
-                default: false
-                description: indicates whether default deny policy will be present on the pods upon pod creation
-                type: boolean
               podNetworkConfigs:
                 description: |-
                   PodNetworkConfigs describes each PodNetwork to attach to a single Pod
@@ -84,6 +85,8 @@ spec:
               podnetwork:
                 description: Deprecated - use PodNetworks
                 type: string
+            required:
+            - defaultDenyACL
             type: object
           status:
             description: PodNetworkInstanceStatus defines the observed state of PodNetworkInstance

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_podnetworkinstances.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_podnetworkinstances.yaml
@@ -60,7 +60,7 @@ spec:
               defaultDenyACL:
                 default: false
                 description: indicates whether default deny policy will be present on the pods upon pod creation
-                type: bool
+                type: boolean
               podNetworkConfigs:
                 description: |-
                   PodNetworkConfigs describes each PodNetwork to attach to a single Pod

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_podnetworkinstances.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_podnetworkinstances.yaml
@@ -85,8 +85,6 @@ spec:
               podnetwork:
                 description: Deprecated - use PodNetworks
                 type: string
-            required:
-            - defaultDenyACL
             type: object
           status:
             description: PodNetworkInstanceStatus defines the observed state of PodNetworkInstance


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
As part of adding default deny so pods can't communicate with one another when network policies are not present, this pr is part 1 which updates the pni crd and mtpnc crd with adding a default deny acl bool field.

**Test**:
Confirmed when default deny is not added as a field or is added as a field and set to false, mtpnc displays Default Deny ACL : false as shown below
![image](https://github.com/user-attachments/assets/5a71388b-07b8-4760-8462-9437e844c604)


Confirmed when default deny is added as a field and set to true, mtpnc displays Default Deny ACL : true as shown below
![image](https://github.com/user-attachments/assets/dc8c3e57-f752-472f-84ec-caf61e95c2ec)

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
