### PR TITLE
fix: let NNCResonciler process update events with different generations when IPAMv2 is enabled

### DIFF
--- a/cns/kubecontroller/nodenetworkconfig/reconciler.go
+++ b/cns/kubecontroller/nodenetworkconfig/reconciler.go
@@ -160,35 +160,47 @@ func (r *Reconciler) Started(ctx context.Context) (bool, error) {
 // SetupWithManager Sets up the reconciler with a new manager, filtering using NodeNetworkConfigFilter on nodeName.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, node *v1.Node, cnsconfig *configuration.CNSConfig) error {
 	r.nnccli = nodenetworkconfig.NewClient(mgr.GetClient())
+
+	// specific event funcs
+	eventFuncs := predicate.Funcs{
+		// ignore delete events.
+		DeleteFunc: func(event.DeleteEvent) bool {
+			return false
+		},
+		UpdateFunc: func(ue event.UpdateEvent) bool {
+			if ue.ObjectOld == nil || ue.ObjectNew == nil {
+				return false
+			}
+			// check that the generation is the same - status changes don't update generation. But in IPAMv2
+			// it is safe to reconcile objects with a changed generation (typically means it was patched by
+			// CNS itself). This saves us from filtering out updates that were made while this controller's
+			// watch was down.
+			if cnsconfig != nil && cnsconfig.EnableIPAMv2 {
+				return true
+			}
+			return ue.ObjectOld.GetGeneration() == ue.ObjectNew.GetGeneration()
+		},
+	}
+
+	// these are applied to every event type
+	universalFuncs := predicate.NewPredicateFuncs(func(object client.Object) bool {
+		// match on node controller ref for all other events.
+		if !metav1.IsControlledBy(object, node) {
+			return false
+		}
+
+		// only process events on objects that are not being deleted.
+		if !object.GetDeletionTimestamp().IsZero() {
+			return false
+		}
+		return true
+	})
+
+	filters := predicate.And(eventFuncs, universalFuncs)
+
 	err := ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha.NodeNetworkConfig{}).
-		WithEventFilter(predicate.Funcs{
-			// ignore delete events.
-			DeleteFunc: func(event.DeleteEvent) bool {
-				return false
-			},
-		}).
-		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
-			// match on node controller ref for all other events.
-			return metav1.IsControlledBy(object, node)
-		})).
-		WithEventFilter(predicate.Funcs{
-			// check that the generation is the same iff IPAMv1 - status changes don't update generation.
-			UpdateFunc: func(ue event.UpdateEvent) bool {
-				if ue.ObjectOld == nil || ue.ObjectNew == nil {
-					return false
-				}
-				// IPAMv2 is idempotent and can process every update event.
-				if cnsconfig != nil && cnsconfig.EnableIPAMv2 {
-					return true
-				}
-				return ue.ObjectOld.GetGeneration() == ue.ObjectNew.GetGeneration()
-			},
-		}).
-		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
-			// only process events on objects that are not being deleted.
-			return object.GetDeletionTimestamp().IsZero()
-		})).
+		WithEventFilter(filters).
 		Complete(r)
 	if err != nil {
 		return errors.Wrap(err, "failed to set up reconciler with manager")

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -981,7 +981,7 @@ func main() {
 		// Start fs watcher here
 		z.Info("AsyncPodDelete is enabled")
 		logger.Printf("AsyncPodDelete is enabled")
-		cnsclient, err := cnsclient.New("", cnsReqTimeout) //nolint
+		cnsclient, err := cnsclient.New("", cnsReqTimeout) // nolint
 		if err != nil {
 			z.Error("failed to create cnsclient", zap.Error(err))
 		}
@@ -1412,7 +1412,7 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 	nodeIP := configuration.NodeIP()
 	nncReconciler := nncctrl.NewReconciler(httpRestServiceImplementation, poolMonitor, nodeIP)
 	// pass Node to the Reconciler for Controller xref
-	if err := nncReconciler.SetupWithManager(manager, node); err != nil { //nolint:govet // intentional shadow
+	if err := nncReconciler.SetupWithManager(manager, node, cnsconfig); err != nil { //nolint:govet // intentional shadow
 		return errors.Wrapf(err, "failed to setup nnc reconciler with manager")
 	}
 
@@ -1482,7 +1482,7 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 		// wait for the Reconciler to run once on a NNC that was made for this Node.
 		// the nncReadyCtx has a timeout of 15 minutes, after which we will consider
 		// this false and the NNC Reconciler stuck/failed, log and retry.
-		nncReadyCtx, cancel := context.WithTimeout(ctx, 15*time.Minute) //nolint // it will time out and not leak
+		nncReadyCtx, cancel := context.WithTimeout(ctx, 15*time.Minute) // nolint // it will time out and not leak
 		if started, err := nncReconciler.Started(nncReadyCtx); !started {
 			logger.Errorf("NNC reconciler has not started, does the NNC exist? err: %v", err)
 			nncReconcilerStartFailures.Inc()

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1412,7 +1412,10 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 	nodeIP := configuration.NodeIP()
 	nncReconciler := nncctrl.NewReconciler(httpRestServiceImplementation, poolMonitor, nodeIP)
 	// pass Node to the Reconciler for Controller xref
-	if err := nncReconciler.SetupWithManager(manager, node, cnsconfig); err != nil { //nolint:govet // intentional shadow
+	// IPAMv1 - reconcile only status changes (where generation doesn't change).
+	// IPAMv2 - reconcile all updates.
+	filterGenerationChange := !cnsconfig.EnableIPAMv2
+	if err := nncReconciler.SetupWithManager(manager, node, filterGenerationChange); err != nil { //nolint:govet // intentional shadow
 		return errors.Wrapf(err, "failed to setup nnc reconciler with manager")
 	}
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

IPAMv2 can handle update events even when the update is made from CNS itself, like patching
the spec for more IPs. This solves the problem of missed updates when a watch is re-established
and an NNC has been updated in both its spec and status. IPAMv2 is idempotent and will not
fall into a feedback loop where after CNS patches the NNC for more IPs its NNC reconciler still
sees IPs needed so it requests more IPs again, which triggers the reconciler again to request
more IPs, and so on ...

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #3278 

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [x] relevant PR labels added

**Notes**:

The first commit is the basic implementation. The 2nd commit does some more refactoring. I am fine to take just the first commit if you all don't like the refactoring attempt.