### PR TITLE
Updating CNS to work with a Dualstack NC

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -127,6 +127,7 @@ type CreateNetworkContainerRequest struct {
 	EndpointPolicies           []NetworkContainerRequestPolicies
 	NCStatus                   v1alpha.NCStatus
 	NetworkInterfaceInfo       NetworkInterfaceInfo //nolint // introducing new field for backendnic, to be used later by cni code
+	IPFamilies                 map[IPFamily]struct{}
 }
 
 func (req *CreateNetworkContainerRequest) Validate() error {
@@ -742,3 +743,11 @@ type NodeRegisterRequest struct {
 	NumCores             int
 	NmAgentSupportedApis []string
 }
+
+// IPFamily - Enum for determining IPFamily when retrieving IPs from network containers
+type IPFamily string
+
+const (
+	IPv4Family IPFamily = "ipv4"
+	IPv6Family IPFamily = "ipv6"
+)

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"net/netip"
 	"os"
 	"reflect"
 	"strconv"
@@ -914,11 +915,22 @@ func generateNetworkContainerRequest(secondaryIps map[string]cns.SecondaryIPConf
 	ipSubnet.PrefixLength = subnetPrfixLength
 	ipConfig.IPSubnet = ipSubnet
 
+	ipFamilies := map[cns.IPFamily]struct{}{}
+	for _, secIPConfig := range secondaryIps {
+		IP, _ := netip.ParseAddr(secIPConfig.IPAddress)
+		if IP.Is4() {
+			ipFamilies[cns.IPv4Family] = struct{}{}
+		} else {
+			ipFamilies[cns.IPv6Family] = struct{}{}
+		}
+	}
+
 	req := cns.CreateNetworkContainerRequest{
 		NetworkContainerType: dockerContainerType,
 		NetworkContainerid:   ncID,
 		IPConfiguration:      ipConfig,
 		Version:              ncVersion,
+		IPFamilies:           ipFamilies,
 	}
 
 	ncVersionInInt, _ := strconv.Atoi(ncVersion)

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -25,6 +25,7 @@ var (
 	ErrStoreEmpty             = errors.New("empty endpoint state store")
 	ErrParsePodIPFailed       = errors.New("failed to parse pod's ip")
 	ErrNoNCs                  = errors.New("no NCs found in the CNS internal state")
+	ErrNoIPFamilies           = errors.New("No IP Families found on NCs")
 	ErrOptManageEndpointState = errors.New("CNS is not set to manage the endpoint state")
 	ErrEndpointStateNotFound  = errors.New("endpoint state could not be found in the statefile")
 	ErrGetAllNCResponseEmpty  = errors.New("failed to get NC responses from statefile")
@@ -989,44 +990,69 @@ func (service *HTTPRestService) AssignDesiredIPConfigs(podInfo cns.PodInfo, desi
 // Assigns an available IP from each NC on the NNC. If there is one NC then we expect to only have one IP return
 // In the case of dualstack we would expect to have one IPv6 from one NC and one IPv4 from a second NC
 func (service *HTTPRestService) AssignAvailableIPConfigs(podInfo cns.PodInfo) ([]cns.PodIpInfo, error) {
-	// Gets the number of NCs which will determine the number of IPs given to a pod
-	numOfNCs := len(service.state.ContainerStatus)
-	// if there are no NCs on the NNC there will be no IPs in the pool so return error
-	if numOfNCs == 0 {
+	//  Map used to get the number of IPFamilies across all NCs
+	ipFamilies := map[cns.IPFamily]struct{}{}
+
+	// checks to make sure we have at least one NC
+	if len(service.state.ContainerStatus) == 0 {
 		return nil, ErrNoNCs
 	}
+
+	// Gets the IPFamilies from all NCs and stores them in a map. This will be ued to determine the amount of IPs to return
+	for ncID := range service.state.ContainerStatus {
+		for ipFamily := range service.state.ContainerStatus[ncID].CreateNetworkContainerRequest.IPFamilies {
+			ipFamilies[ipFamily] = struct{}{}
+		}
+	}
+
+	// Makes sure we have at least one IPFamily across all NCs
+	numOfIPFamilies := len(ipFamilies)
+	if numOfIPFamilies == 0 {
+		return nil, ErrNoIPFamilies
+	}
+
 	service.Lock()
 	defer service.Unlock()
 	// Creates a slice of PodIpInfo with the size as number of NCs to hold the result for assigned IP configs
-	podIPInfo := make([]cns.PodIpInfo, numOfNCs)
+	podIPInfo := make([]cns.PodIpInfo, numOfIPFamilies)
 	// This map is used to store whether or not we have found an available IP from an NC when looping through the pool
-	ipsToAssign := make(map[string]cns.IPConfigurationStatus)
+	ipsToAssign := make(map[cns.IPFamily]cns.IPConfigurationStatus)
 
 	// Searches for available IPs in the pool
 	for _, ipState := range service.PodIPConfigState {
-		// check if an IP from this NC is already set side for assignment.
-		if _, ncAlreadyMarkedForAssignment := ipsToAssign[ipState.NCID]; ncAlreadyMarkedForAssignment {
+		// get the IPFamily of the current ipState
+		var ipStateFamily cns.IPFamily
+		if net.ParseIP(ipState.IPAddress).To4() != nil {
+			ipStateFamily = cns.IPv4Family
+		} else {
+			ipStateFamily = cns.IPv6Family
+		}
+
+		// check if the IP with the same family type exists already
+		if _, IPFamilyAlreadyMarkedForAssignment := ipsToAssign[ipStateFamily]; IPFamilyAlreadyMarkedForAssignment {
 			continue
 		}
 		// Checks if the current IP is available
 		if ipState.GetState() != types.Available {
 			continue
 		}
-		ipsToAssign[ipState.NCID] = ipState
-		// Once one IP per container is found break out of the loop and stop searching
-		if len(ipsToAssign) == numOfNCs {
+		ipsToAssign[ipStateFamily] = ipState
+		// Once one IP per family is found break out of the loop and stop searching
+		if len(ipsToAssign) == numOfIPFamilies {
 			break
 		}
 	}
 
-	// Checks to make sure we found one IP for each NC
-	if len(ipsToAssign) != numOfNCs {
+	// Checks to make sure we found one IP for each IPFamily
+	if len(ipsToAssign) != numOfIPFamilies {
 		for ncID := range service.state.ContainerStatus {
-			if _, found := ipsToAssign[ncID]; found {
-				continue
+			for ipFamily := range service.state.ContainerStatus[ncID].CreateNetworkContainerRequest.IPFamilies {
+				if _, found := ipsToAssign[ipFamily]; found {
+					continue
+				}
+				return podIPInfo, errors.Errorf("not enough IPs available of type %s for %s, waiting on Azure CNS to allocate more with NC Status: %s",
+					ipFamily, ncID, string(service.state.ContainerStatus[ncID].CreateNetworkContainerRequest.NCStatus))
 			}
-			return podIPInfo, errors.Errorf("not enough IPs available for %s, waiting on Azure CNS to allocate more with NC Status: %s",
-				ncID, string(service.state.ContainerStatus[ncID].CreateNetworkContainerRequest.NCStatus))
 		}
 	}
 

--- a/cns/restserver/ipam_test.go
+++ b/cns/restserver/ipam_test.go
@@ -176,36 +176,46 @@ func updatePnpIDMacAddressState(svc *HTTPRestService) {
 	}
 }
 
-// create an endpoint with only one IP
-func TestEndpointStateReadAndWriteSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestEndpointStateReadAndWrite(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	EndpointStateReadAndWrite(t, ncStates)
-}
-
-// create an endpoint with one IP from each NC
-func TestEndpointStateReadAndWriteMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		EndpointStateReadAndWrite(t, ncState)
 	}
-	EndpointStateReadAndWrite(t, ncStates)
 }
 
 // Tests the creation of an endpoint using the NCs and IPs as input and then tests the deletion of that endpoint
@@ -280,35 +290,46 @@ func EndpointStateReadAndWrite(t *testing.T, ncStates []ncState) {
 }
 
 // assign the available IP to the new pod
-func TestIPAMGetAvailableIPConfigSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMGetAvailableIPConfig(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	IPAMGetAvailableIPConfig(t, ncStates)
-}
-
-// assign one IP per NC to the pod
-func TestIPAMGetAvailableIPConfigMultipleNCs(t *testing.T) {
-	nsStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMGetAvailableIPConfig(t, ncState)
 	}
-	IPAMGetAvailableIPConfig(t, nsStates)
 }
 
 // Add one IP per NC to the pool and request those IPs
@@ -357,37 +378,51 @@ func IPAMGetAvailableIPConfig(t *testing.T, ncStates []ncState) {
 	}
 }
 
-func TestIPAMGetNextAvailableIPConfigSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMGetNextAvailableIPConfig(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+					testIP2v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+					testIP1v6,
+					testIP2v6,
+				},
 			},
 		},
 	}
-	IPAMGetNextAvailableIPConfig(t, ncStates)
-}
-
-func TestIPAMGetNextAvailableIPConfigMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-				testIP2v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMGetNextAvailableIPConfig(t, ncState)
 	}
-	IPAMGetNextAvailableIPConfig(t, ncStates)
 }
 
 // First IP is already assigned to a pod, want second IP
@@ -440,34 +475,46 @@ func IPAMGetNextAvailableIPConfig(t *testing.T, ncStates []ncState) {
 	}
 }
 
-func TestIPAMGetAlreadyAssignedIPConfigForSamePodSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMGetAlreadyAssignedIPConfigForSamePod(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	IPAMGetAlreadyAssignedIPConfigForSamePod(t, ncStates)
-}
-
-func TestIPAMGetAlreadyAssignedIPConfigForSamePodMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMGetAlreadyAssignedIPConfigForSamePod(t, ncState)
 	}
-	IPAMGetAlreadyAssignedIPConfigForSamePod(t, ncStates)
 }
 
 func IPAMGetAlreadyAssignedIPConfigForSamePod(t *testing.T, ncStates []ncState) {
@@ -515,37 +562,51 @@ func IPAMGetAlreadyAssignedIPConfigForSamePod(t *testing.T, ncStates []ncState) 
 	}
 }
 
-func TestIPAMAttemptToRequestIPNotFoundInPoolSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMAttemptToRequestIPNotFoundInPool(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+					testIP2v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+					testIP1v6,
+					testIP2v6,
+				},
 			},
 		},
 	}
-	IPAMAttemptToRequestIPNotFoundInPool(t, ncStates)
-}
-
-func TestIPAMAttemptToRequestIPNotFoundInPoolMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-				testIP2v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMAttemptToRequestIPNotFoundInPool(t, ncState)
 	}
-	IPAMAttemptToRequestIPNotFoundInPool(t, ncStates)
 }
 
 func IPAMAttemptToRequestIPNotFoundInPool(t *testing.T, ncStates []ncState) {
@@ -578,34 +639,46 @@ func IPAMAttemptToRequestIPNotFoundInPool(t *testing.T, ncStates []ncState) {
 	}
 }
 
-func TestIPAMGetDesiredIPConfigWithSpecfiedIPSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMGetDesiredIPConfigWithSpecfiedIP(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	IPAMGetDesiredIPConfigWithSpecfiedIP(t, ncStates)
-}
-
-func TestIPAMGetDesiredIPConfigWithSpecfiedIPMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMGetDesiredIPConfigWithSpecfiedIP(t, ncState)
 	}
-	IPAMGetDesiredIPConfigWithSpecfiedIP(t, ncStates)
 }
 
 func IPAMGetDesiredIPConfigWithSpecfiedIP(t *testing.T, ncStates []ncState) {
@@ -657,34 +730,46 @@ func IPAMGetDesiredIPConfigWithSpecfiedIP(t *testing.T, ncStates []ncState) {
 	}
 }
 
-func TestIPAMFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIPSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIP(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	IPAMFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIP(t, ncStates)
-}
-
-func TestIPAMFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIPMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIP(t, ncState)
 	}
-	IPAMFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIP(t, ncStates)
 }
 
 func IPAMFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIP(t *testing.T, ncStates []ncState) {
@@ -718,37 +803,51 @@ func IPAMFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIP(t *testing.T, ncS
 	}
 }
 
-func TestIPAMFailToGetIPWhenAllIPsAreAssignedSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMFailToGetIPWhenAllIPsAreAssigned(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+					testIP2v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+					testIP1v6,
+					testIP2v6,
+				},
 			},
 		},
 	}
-	IPAMFailToGetIPWhenAllIPsAreAssigned(t, ncStates)
-}
-
-func TestIPAMFailToGetIPWhenAllIPsAreAssignedMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-				testIP2v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMFailToGetIPWhenAllIPsAreAssigned(t, ncState)
 	}
-	IPAMFailToGetIPWhenAllIPsAreAssigned(t, ncStates)
 }
 
 func IPAMFailToGetIPWhenAllIPsAreAssigned(t *testing.T, ncStates []ncState) {
@@ -778,34 +877,46 @@ func IPAMFailToGetIPWhenAllIPsAreAssigned(t *testing.T, ncStates []ncState) {
 	}
 }
 
-func TestIPAMRequestThenReleaseThenRequestAgainSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMRequestThenReleaseThenRequestAgain(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	IPAMRequestThenReleaseThenRequestAgain(t, ncStates)
-}
-
-func TestIPAMRequestThenReleaseThenRequestAgainMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMRequestThenReleaseThenRequestAgain(t, ncState)
 	}
-	IPAMRequestThenReleaseThenRequestAgain(t, ncStates)
 }
 
 // 10.0.0.1 = PodInfo1
@@ -887,34 +998,46 @@ func IPAMRequestThenReleaseThenRequestAgain(t *testing.T, ncStates []ncState) {
 	}
 }
 
-func TestIPAMReleaseIPIdempotencySingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMReleaseIPIdempotency(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	IPAMReleaseIPIdempotency(t, ncStates)
-}
-
-func TestIPAMReleaseIPIdempotencyMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMReleaseIPIdempotency(t, ncState)
 	}
-	IPAMReleaseIPIdempotency(t, ncStates)
 }
 
 func IPAMReleaseIPIdempotency(t *testing.T, ncStates []ncState) {
@@ -943,34 +1066,46 @@ func IPAMReleaseIPIdempotency(t *testing.T, ncStates []ncState) {
 	}
 }
 
-func TestIPAMAllocateIPIdempotencySingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMAllocateIPIdempotency(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	IPAMAllocateIPIdempotency(t, ncStates)
-}
-
-func TestIPAMAllocateIPIdempotencyMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMAllocateIPIdempotency(t, ncState)
 	}
-	IPAMAllocateIPIdempotency(t, ncStates)
 }
 
 func IPAMAllocateIPIdempotency(t *testing.T, ncStates []ncState) {
@@ -992,40 +1127,56 @@ func IPAMAllocateIPIdempotency(t *testing.T, ncStates []ncState) {
 	}
 }
 
-func TestAvailableIPConfigsSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestAvailableIPConfigs(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
-				testIP3,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+					testIP3,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+					testIP3,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+					testIP2v6,
+					testIP3v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+					testIP3,
+					testIP1v6,
+					testIP2v6,
+					testIP3v6,
+				},
 			},
 		},
 	}
-	AvailableIPConfigs(t, ncStates)
-}
-
-func TestAvailableIPConfigsMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
-				testIP3,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-				testIP2v6,
-				testIP3v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		AvailableIPConfigs(t, ncState)
 	}
-	AvailableIPConfigs(t, ncStates)
 }
 
 func AvailableIPConfigs(t *testing.T, ncStates []ncState) {
@@ -1111,34 +1262,46 @@ func validateIpState(t *testing.T, actualIps []cns.IPConfigurationStatus, expect
 	}
 }
 
-func TestIPAMMarkIPCountAsPendingSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMMarkIPCountAsPending(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	IPAMMarkIPCountAsPending(t, ncStates)
-}
-
-func TestIPAMMarkIPCountAsPendingMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMMarkIPCountAsPending(t, ncState)
 	}
-	IPAMMarkIPCountAsPending(t, ncStates)
 }
 
 func IPAMMarkIPCountAsPending(t *testing.T, ncStates []ncState) {
@@ -1270,37 +1433,51 @@ func constructSecondaryIPConfigs(ipAddress, uuid string, ncVersion int, secondar
 	secondaryIPConfigs[uuid] = secIPConfig
 }
 
-func TestIPAMMarkExistingIPConfigAsPendingSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMMarkExistingIPConfigAsPending(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+					testIP2v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+					testIP1v6,
+					testIP2v6,
+				},
 			},
 		},
 	}
-	IPAMMarkExistingIPConfigAsPending(t, ncStates)
-}
-
-func TestIPAMMarkExistingIPConfigAsPendingMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-				testIP2v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMMarkExistingIPConfigAsPending(t, ncState)
 	}
-	IPAMMarkExistingIPConfigAsPending(t, ncStates)
 }
 
 func IPAMMarkExistingIPConfigAsPending(t *testing.T, ncStates []ncState) {
@@ -1431,27 +1608,32 @@ func TestIPAMReleaseOneIPWhenExpectedToHaveTwo(t *testing.T) {
 
 func TestIPAMFailToRequestOneIPWhenExpectedToHaveTwo(t *testing.T) {
 	svc := getTestService(cns.KubernetesCRD)
-
 	// set state as already assigned
-	testState := NewPodState(testIP1, ipIDs[0][0], testNCID, types.Available, 0)
+	testState1, _ := NewPodStateWithOrchestratorContext(testIP1, testIPID1, testNCID, types.Assigned, 24, 0, testPod1Info)
+	testState2 := NewPodState(testIP2, testIPID2, testNCID, types.Available, 0)
 	ipconfigs := map[string]cns.IPConfigurationStatus{
-		testState.ID: testState,
+		testState1.ID: testState1,
+		testState2.ID: testState2,
 	}
-	emptyIpconfigs := map[string]cns.IPConfigurationStatus{}
+	testState1v6, _ := NewPodStateWithOrchestratorContext(testIP1v6, testIPID1v6, testNCIDv6, types.Assigned, 120, 0, testPod1Info)
+	// setting v6 IPs to Assigned so there are none available
+	ipconfigsV6 := map[string]cns.IPConfigurationStatus{
+		testState1v6.ID: testState1v6,
+	}
 
 	err := UpdatePodIPConfigState(t, svc, ipconfigs, testNCID)
 	if err != nil {
 		t.Fatalf("Expected to not fail adding IPs to state: %+v", err)
 	}
 
-	err = UpdatePodIPConfigState(t, svc, emptyIpconfigs, testNCIDv6)
+	err = UpdatePodIPConfigState(t, svc, ipconfigsV6, testNCIDv6)
 	if err != nil {
 		t.Fatalf("Expected to not fail adding empty NC to state: %+v", err)
 	}
 
 	// request should expect 2 IPs but there is only 1 in the pool
 	req := cns.IPConfigsRequest{}
-	b, _ := testPod1Info.OrchestratorContext()
+	b, _ := testPod2Info.OrchestratorContext()
 	req.OrchestratorContext = b
 
 	_, err = requestIPAddressAndGetState(t, req)

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -79,6 +79,7 @@ type HTTPRestService struct {
 	PnpIDByMacAddress          map[string]string
 	imdsClient                 imdsClient
 	nodesubnetIPFetcher        *nodesubnet.IPFetcher
+	IPFamilies                 []cns.IPFamily
 }
 
 type CNIConflistGenerator interface {


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
This PR allows for us to retrieve a dualstack NC from the NNC. A new enum has been added for IP family that will update when CNS reads an NC and populates the ipam pool. In ipam we will then retrieve the number of IPs needed according to the number of IP families found across all NCs. This work is to support dualstack NCs which will be used for Vnet Prefix dualstack and will still support the two NC solution used for dualstack overlay.

Also adds UT scenarios for ipam to include dualstack NC tests along with single stack NCs and two NCs of different IP families.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] relevant PR labels added

**Notes**:
