### PR TITLE
log: [NPM] init telemetry before dataplane

### DIFF
--- a/npm/cmd/start.go
+++ b/npm/cmd/start.go
@@ -131,7 +131,11 @@ func start(config npmconfig.Config, flags npmconfig.Flags) error {
 			}),
 		)
 	}
-	k8sServerVersion := k8sServerVersion(clientset)
+
+	err = metrics.CreateTelemetryHandle(config.NPMVersion(), version, npm.GetAIMetadata())
+	if err != nil {
+		klog.Infof("CreateTelemetryHandle failed with error %v. AITelemetry is not initialized.", err)
+	}
 
 	var dp dataplane.GenericDataplane
 	stopChannel := wait.NeverStop
@@ -197,11 +201,9 @@ func start(config npmconfig.Config, flags npmconfig.Flags) error {
 		}
 		dp.RunPeriodicTasks()
 	}
+
+	k8sServerVersion := k8sServerVersion(clientset)
 	npMgr := npm.NewNetworkPolicyManager(config, factory, podFactory, dp, exec.New(), version, k8sServerVersion)
-	err = metrics.CreateTelemetryHandle(config.NPMVersion(), version, npm.GetAIMetadata())
-	if err != nil {
-		klog.Infof("CreateTelemetryHandle failed with error %v. AITelemetry is not initialized.", err)
-	}
 
 	go restserver.NPMRestServerListenAndServe(config, npMgr)
 


### PR DESCRIPTION
**Reason for Change**:
Missing telemetry in case of a few potential errors during NPM bootup.

**Issue Fixed**:
Fixes #3145 

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:

`metrics.SendErrorLog()` doesn't work as intended in these three places since telemetry is not initialized until later:

https://github.com/Azure/azure-container-networking/blob/bbe5cb9d1216cea6a57364f90714a352193ea2f3/npm/cmd/start.go#L239-L240

https://github.com/Azure/azure-container-networking/blob/bbe5cb9d1216cea6a57364f90714a352193ea2f3/npm/cmd/start.go#L184-L186

https://github.com/Azure/azure-container-networking/blob/bbe5cb9d1216cea6a57364f90714a352193ea2f3/npm/cmd/start.go#L193-L195