### PR TITLE
fix: modify codeql query to use DataFlow instead of DataFlow2 library

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -43,7 +43,7 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
-          # queries: ./codeql/
+          queries: ./codeql/
       - name: Autobuild
         uses: github/codeql-action/autobuild@v3
       - name: Perform CodeQL Analysis

--- a/codeql/acn-addipamconfig.ql
+++ b/codeql/acn-addipamconfig.ql
@@ -13,7 +13,7 @@
 import go
 import lib.ACN
 
-private class Source extends DataFlow2::Node {
+private class Source extends DataFlow::Node {
   Source() {
     exists(DataFlow::CallNode c, Method m |
       //m.hasQualifiedName("github.com/Azure/azure-container-networking/cni/network", "NetPlugin",

--- a/codeql/acn-cni-args.ql
+++ b/codeql/acn-cni-args.ql
@@ -13,7 +13,7 @@
 import go
 import lib.ACN
 
-private class Source extends DataFlow2::Node {
+private class Source extends DataFlow::Node {
   Source() {
     exists(DataFlow::CallNode c, Method m |
       (

--- a/codeql/acn-cns-invoker.ql
+++ b/codeql/acn-cns-invoker.ql
@@ -14,7 +14,7 @@
 import go
 import lib.ACN
 
-private class Source extends DataFlow2::Node {
+private class Source extends DataFlow::Node {
   Source() {
     exists(DataFlow::CallNode c, Method m |
       (

--- a/codeql/acn-decode.ql
+++ b/codeql/acn-decode.ql
@@ -13,7 +13,7 @@
 import go
 import lib.ACN
 
-private class Source extends DataFlow2::Node {
+private class Source extends DataFlow::Node {
   Source() {
     exists(DataFlow::CallNode c |
       c.getTarget().hasQualifiedName("github.com/Azure/azure-container-networking/common", "Decode") and

--- a/codeql/lib/ACN.qll
+++ b/codeql/lib/ACN.qll
@@ -1,7 +1,7 @@
 import go
 
 module ACN {
-  class CommandSink extends DataFlow2::Node {
+  class CommandSink extends DataFlow::Node {
     CommandSink() {
       exists(DataFlow::CallNode c, Method m |
         (


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
A new version of the codeql bundle (2.20.0) caused existing queries to break.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Should address the compilation issue and re-enable custom codeql queries.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
