### PR TITLE
feat: query host to check if dhcp rehydration feature is enabled before issuing dhcp request

### DIFF
--- a/dhcp/dhcp_linux.go
+++ b/dhcp/dhcp_linux.go
@@ -475,7 +475,7 @@ func (c *DHCP) DHCPRehydrationFeatureOnHost(ctx context.Context) (bool, error) {
 		resp       *http.Response
 		httpClient = &http.Client{Timeout: DefaultTimeout}
 	)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, nmAgentSupportedApisURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, nmAgentSupportedApisURL, http.NoBody)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to create http request")
 	}
@@ -489,11 +489,11 @@ func (c *DHCP) DHCPRehydrationFeatureOnHost(ctx context.Context) (bool, error) {
 	if resp.StatusCode != http.StatusOK {
 		return false, errResponseNotOK
 	}
-	bytes, err := io.ReadAll(resp.Body)
+	readBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to read response body")
 	}
-	str := string(bytes)
+	str := string(readBytes)
 	if !strings.Contains(str, dhcpRehydrationAPIStr) {
 		return false, nil
 	}

--- a/dhcp/dhcp_windows.go
+++ b/dhcp/dhcp_windows.go
@@ -20,3 +20,7 @@ func New(logger *zap.Logger) *DHCP {
 func (c *DHCP) DiscoverRequest(_ context.Context, _ net.HardwareAddr, _ string) error {
 	return nil
 }
+
+func (c *DHCP) DHCPRehydrationFeatureOnHost(ctx context.Context) (bool, error) {
+	return false, nil
+}

--- a/dhcp/dhcp_windows.go
+++ b/dhcp/dhcp_windows.go
@@ -21,6 +21,6 @@ func (c *DHCP) DiscoverRequest(_ context.Context, _ net.HardwareAddr, _ string) 
 	return nil
 }
 
-func (c *DHCP) DHCPRehydrationFeatureOnHost(ctx context.Context) (bool, error) {
+func (c *DHCP) DHCPRehydrationFeatureOnHost(_ context.Context) (bool, error) {
 	return false, nil
 }

--- a/network/dhcp.go
+++ b/network/dhcp.go
@@ -7,10 +7,15 @@ import (
 
 type dhcpClient interface {
 	DiscoverRequest(context.Context, net.HardwareAddr, string) error
+	DHCPRehydrationFeatureOnHost(context.Context) (bool, error)
 }
 
 type mockDHCP struct{}
 
-func (netns *mockDHCP) DiscoverRequest(context.Context, net.HardwareAddr, string) error {
+func (d *mockDHCP) DiscoverRequest(context.Context, net.HardwareAddr, string) error {
 	return nil
+}
+
+func (d *mockDHCP) DHCPRehydrationFeatureOnHost(context.Context) (bool, error) {
+	return false, nil
 }

--- a/network/secondary_endpoint_client_linux.go
+++ b/network/secondary_endpoint_client_linux.go
@@ -156,8 +156,8 @@ func (client *SecondaryEndpointClient) ConfigureContainerInterfacesAndRoutes(epI
 		if err != nil {
 			return errors.Wrap(err, "failed to issue dhcp discover packet to create mapping in host")
 		}
-		logger.Info("Finished configuring container interfaces and routes for secondary endpoint client")
 	}
+	logger.Info("Finished configuring container interfaces and routes for secondary endpoint client")
 
 	return nil
 }

--- a/network/secondary_endpoint_client_linux.go
+++ b/network/secondary_endpoint_client_linux.go
@@ -143,12 +143,21 @@ func (client *SecondaryEndpointClient) ConfigureContainerInterfacesAndRoutes(epI
 	timeout := time.Duration(numSecs) * time.Second
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(timeout))
 	defer cancel()
-	logger.Info("Sending DHCP packet", zap.Any("macAddress", epInfo.MacAddress), zap.String("ifName", epInfo.IfName))
-	err := client.dhcpClient.DiscoverRequest(ctx, epInfo.MacAddress, epInfo.IfName)
+
+	// check if the permanent fix on the host has already rolled out
+	dhcpRehydrationFeatureEnabled, err := client.dhcpClient.DHCPRehydrationFeatureOnHost(ctx)
 	if err != nil {
 		return errors.Wrap(err, NetworkNotReadyErrorMsg+" - failed to issue dhcp discover packet to create mapping in host")
 	}
-	logger.Info("Finished configuring container interfaces and routes for secondary endpoint client")
+	// only send the dhcp packet if the host does not have the permanent fix
+	if !dhcpRehydrationFeatureEnabled {
+		logger.Info("Sending DHCP packet", zap.Any("macAddress", epInfo.MacAddress), zap.String("ifName", epInfo.IfName))
+		err := client.dhcpClient.DiscoverRequest(ctx, epInfo.MacAddress, epInfo.IfName)
+		if err != nil {
+			return errors.Wrap(err, "failed to issue dhcp discover packet to create mapping in host")
+		}
+		logger.Info("Finished configuring container interfaces and routes for secondary endpoint client")
+	}
 
 	return nil
 }


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
There is a temporary workaround in swiftv2 linux which requires the cni to send a dhcp request when adding secondary nics. A more permanent fix is available, but once that is merged in, cni will still attempt to send the dhcp request and will fail perpetually. This PR adds a check to see if the dhcp rehydration feature (the more permanent fix) is enabled on the host before sending the dhcp request. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
See above

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
Only affects swiftv2 linux setups with delegated nics