### PR TITLE
Remove gomnd from Golang CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,6 @@ linters:
   - gocritic
   - gocyclo
   - gofmt
-  - gomnd
   - goprintffuncname
   - gosimple
   - lll


### PR DESCRIPTION
Most developers agree that magic numbers are problematic. However, the gomnd linter lacks finesse to understand when magic numbers aren't magic at all. Examining the context of where the number is used is often enough to deem it non-magical.

Consider some common magic numbers flagged by gomnd: 0644, 8080. Without any additional context, it's fairly likely these are a file mode and a port number, respectively. It's even more obvious when presented with the context:

```go
f, err := os.OpenFile("notes.txt", os.O_RDWR|os.O_CREATE, 0644)
```

The linter would flag this, even though it's completely obvious what 0644 is. The remediations for the linter's flag creates categorically worse code. The most common learned behavior for developers facing this linter is to simply constantize everything it flags:

```go
flags := 0644
f, err := os.OpenFile("notes.txt", os.O_RDWR|os.O_CREATE, flags)
```

This makes the code *harder* to read, since you now have to trace the reference back (it's probably defined in some const block another file away).

Option number two for remediating this is to drop a comment providing literally zero information to the reader that they don't already have or could get from the documentation of the function where it's used.

```go
//nolint:gomnd // 0644 is a file mode
f, err := os.OpenFile("notes.txt", os.O_RDWR|os.O_CREATE, 0644)
```

This is not to say that magic numbers are not a problem--they definitely are. However, this tool has very low signal-to-noise ratio and causes people to take action that makes the codebase worse just to silence it. Reviewers understand when a magic number is confusing and can just flag it by hand more reliably.