### PR TITLE
fix(log): time waiting for appinsights to close was unbounded

### DIFF
--- a/aitelemetry/telemetrywrapper.go
+++ b/aitelemetry/telemetrywrapper.go
@@ -27,6 +27,7 @@ const (
 	azurePublicCloudStr              = "AzurePublicCloud"
 	hostNameKey                      = "hostname"
 	defaultTimeout                   = 10
+	maxCloseTimeoutInSeconds         = 30
 	defaultBatchIntervalInSecs       = 15
 	defaultBatchSizeInBytes          = 32768
 	defaultGetEnvRetryCount          = 5
@@ -330,8 +331,32 @@ func (th *telemetryHandle) Close(timeout int) {
 		timeout = defaultTimeout
 	}
 
+	// max wait is the minimum of the timeout and maxCloseTimeoutInSeconds
+	maxWaitTimeInSeconds := timeout
+	if maxWaitTimeInSeconds < maxCloseTimeoutInSeconds {
+		maxWaitTimeInSeconds = maxCloseTimeoutInSeconds
+	}
+
 	// wait for items to be sent otherwise timeout
-	<-th.client.Channel().Close(time.Duration(timeout) * time.Second)
+	// similar to the example in the appinsights-go repo: https://github.com/microsoft/ApplicationInsights-Go#shutdown
+	select {
+	case <-th.client.Channel().Close(time.Duration(timeout) * time.Second):
+		// timeout specified for retries.
+
+		// If we got here, then all telemetry was submitted
+		// successfully, and we can proceed to exiting.
+	case <-time.After(time.Duration(maxWaitTimeInSeconds) * time.Second):
+		// Thirty second absolute timeout.  This covers any
+		// previous telemetry submission that may not have
+		// completed before Close was called.
+
+		// There are a number of reasons we could have
+		// reached here.  We gave it a go, but telemetry
+		// submission failed somewhere.  Perhaps old events
+		// were still retrying, or perhaps we're throttled.
+		// Either way, we don't want to wait around for it
+		// to complete, so let's just exit.
+	}
 
 	// Remove diganostic message listener
 	if th.diagListener != nil {

--- a/aitelemetry/telemetrywrapper.go
+++ b/aitelemetry/telemetrywrapper.go
@@ -339,14 +339,17 @@ func (th *telemetryHandle) Close(timeout int) {
 
 	// wait for items to be sent otherwise timeout
 	// similar to the example in the appinsights-go repo: https://github.com/microsoft/ApplicationInsights-Go#shutdown
+	timer := time.NewTimer(time.Duration(maxWaitTimeInSeconds) * time.Second)
+	defer timer.Stop()
 	select {
 	case <-th.client.Channel().Close(time.Duration(timeout) * time.Second):
 		// timeout specified for retries.
 
 		// If we got here, then all telemetry was submitted
 		// successfully, and we can proceed to exiting.
-	case <-time.After(time.Duration(maxWaitTimeInSeconds) * time.Second):
-		// Thirty second absolute timeout.  This covers any
+
+	case <-timer.C:
+		// absolute timeout.  This covers any
 		// previous telemetry submission that may not have
 		// completed before Close was called.
 


### PR DESCRIPTION
**Reason for Change**:

When CNS (and NPM after #3333) crash, they block on a call to close the app insights client so that queued logs are sent. This relies on a channel which might not close until much after the timeout which NPM/CNS specify. The ApplicationInsights-Go repo recommends having a timer of our own for the maximum time we want to wait for app insights to close.

This PR changes CNS and NPM so that they wait at most 30 seconds.

**Issue Fixed**:

Related to #3299.

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
