### PR TITLE
chore: enable CiliumEndpointSlice in testing

### DIFF
--- a/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
+++ b/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
@@ -120,6 +120,7 @@ stages:
                   echo "Deploy Azure-CNS"
                   sudo -E env "PATH=$PATH" make test-integration AZURE_IPAM_VERSION=$(make azure-ipam-version) CNS_VERSION=$(make cns-version) INSTALL_CNS=true INSTALL_OVERLAY=true CNS_IMAGE_REPO=$(CNS_IMAGE_REPO)
                   kubectl get po -owide -A
+                  kubectl get crd -A
       - ${{if eq(parameters.hubbleEnabled, true)}}:
         - job: deploy_cilium_components
           displayName: Deploy Cilium with Hubble
@@ -154,6 +155,7 @@ stages:
                   echo "Deploy Azure-CNS"
                   sudo -E env "PATH=$PATH" make test-integration AZURE_IPAM_VERSION=$(make azure-ipam-version) CNS_VERSION=$(make cns-version) INSTALL_CNS=true INSTALL_OVERLAY=true CNS_IMAGE_REPO=$(CNS_IMAGE_REPO)
                   kubectl get po -owide -A
+                  kubectl get crd -A
 
       - job: deploy_pods
         condition: and( and( not(canceled()), not(failed()) ), or( contains(variables.CONTROL_SCENARIO, 'scaleTest') , contains(variables.CONTROL_SCENARIO, 'all') ) )

--- a/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-step-template.yaml
@@ -65,6 +65,7 @@ steps:
       echo "Waiting < 2 minutes for cilium to be ready"
       # Ensure Cilium is ready Xm\Xs
       cilium status --wait --wait-duration 2m
+      kubectl get crd -A
     retryCountOnTaskFailure: 3
     name: "CiliumStatus"
     displayName: "Cilium Status"

--- a/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e.steps.yaml
+++ b/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e.steps.yaml
@@ -49,6 +49,7 @@ steps:
         envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY},${IPV6_HP_BPF_VERSION}' < test/integration/manifests/cilium/v${DIR}/cilium-agent/templates/daemonset-dualstack.yaml | kubectl apply -f -
         envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-operator/templates/deployment.yaml | kubectl apply -f -
         kubectl get po -owide -A
+        kubectl get crd -A
     name: "installCilium"
     displayName: "Install Cilium on AKS Dualstack Overlay"
 

--- a/.pipelines/singletenancy/cilium-nodesubnet/cilium-nodesubnet-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-nodesubnet/cilium-nodesubnet-e2e-step-template.yaml
@@ -69,6 +69,7 @@ steps:
         envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-agent/templates/daemonset.yaml | kubectl apply -f -
         envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-operator/templates/deployment.yaml | kubectl apply -f -
         kubectl get po -owide -A
+        kubectl get crd -A
     name: "installCilium"
     displayName: "Install Cilium"
 

--- a/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e-step-template.yaml
@@ -69,6 +69,7 @@ steps:
       echo "Waiting < 2 minutes for cilium to be ready"
       # Ensure Cilium is ready Xm\Xs
       cilium status --wait --wait-duration 2m
+      kubectl get crd -A
     retryCountOnTaskFailure: 3
     name: "CiliumStatus"
     displayName: "Cilium Status"

--- a/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e.steps.yaml
+++ b/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e.steps.yaml
@@ -64,6 +64,7 @@ steps:
       echo "Waiting < 2 minutes for cilium to be ready"
       # Ensure Cilium is ready Xm\Xs
       cilium status --wait --wait-duration 2m
+      kubectl get crd -A
     retryCountOnTaskFailure: 3
     name: "CiliumStatus"
     displayName: "Cilium Status"

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e-step-template.yaml
@@ -91,6 +91,7 @@ steps:
       echo "Waiting < 2 minutes for cilium to be ready"
       # Ensure Cilium is ready Xm\Xs
       cilium status --wait --wait-duration 2m
+      kubectl get crd -A
     retryCountOnTaskFailure: 3
     name: "CiliumStatus"
     displayName: "Cilium Status"

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e.steps.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e.steps.yaml
@@ -86,6 +86,7 @@ steps:
       echo "Waiting < 2 minutes for cilium to be ready"
       # Ensure Cilium is ready Xm\Xs
       cilium status --wait --wait-duration 2m
+      kubectl get crd -A
     retryCountOnTaskFailure: 3
     name: "CiliumStatus"
     displayName: "Cilium Status"

--- a/.pipelines/singletenancy/cilium/cilium-e2e.steps.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e.steps.yaml
@@ -64,6 +64,7 @@ steps:
       echo "Waiting < 2 minutes for cilium to be ready"
       # Ensure Cilium is ready Xm\Xs
       cilium status --wait --wait-duration 2m
+      kubectl get crd -A
     retryCountOnTaskFailure: 3
     name: "CiliumStatus"
     displayName: "Cilium Status"

--- a/.pipelines/templates/cilium-tests.yaml
+++ b/.pipelines/templates/cilium-tests.yaml
@@ -4,6 +4,7 @@ steps:
       echo "Waiting < 2 minutes for cilium to be ready"
       # Ensure Cilium is ready Xm\Xs
       cilium status --wait --wait-duration 2m
+      kubectl get crd -A
     retryCountOnTaskFailure: 3
     name: "CiliumStatus"
     displayName: "Cilium Status"

--- a/test/integration/manifests/cilium/cilium-nightly-config.yaml
+++ b/test/integration/manifests/cilium/cilium-nightly-config.yaml
@@ -9,6 +9,7 @@ data:
   bpf-map-dynamic-size-ratio: "0.0025"
   bpf-policy-map-max: "16384"
   bpf-root: /sys/fs/bpf
+  ces-slice-mode: fcfs
   cgroup-root: /run/cilium/cgroupv2
   cilium-endpoint-gc-interval: 5m0s
   cluster-id: "0"
@@ -19,6 +20,7 @@ data:
   enable-auto-protect-node-port-range: "true"
   enable-bgp-control-plane: "false"
   enable-bpf-clock-probe: "true"
+  enable-cilium-endpoint-slice: "true"
   enable-endpoint-health-checking: "false"
   enable-endpoint-routes: "true"
   enable-health-check-nodeport: "true"

--- a/test/integration/manifests/cilium/v1.13/cilium-operator/templates/deployment.yaml
+++ b/test/integration/manifests/cilium/v1.13/cilium-operator/templates/deployment.yaml
@@ -38,6 +38,8 @@ spec:
         - --debug=$(CILIUM_DEBUG)
         - --identity-gc-interval=0m20s
         - --identity-heartbeat-timeout=0m20s
+        - --enable-cilium-endpoint-slice=true
+        - --ces-slice-mode=cesSliceModeFCFS
         env:
         - name: K8S_NODE_NAME
           valueFrom:

--- a/test/integration/manifests/cilium/v1.14/cilium-operator/templates/deployment.yaml
+++ b/test/integration/manifests/cilium/v1.14/cilium-operator/templates/deployment.yaml
@@ -38,6 +38,8 @@ spec:
         - --debug=$(CILIUM_DEBUG)
         - --identity-gc-interval=0m20s
         - --identity-heartbeat-timeout=0m20s
+        - --enable-cilium-endpoint-slice=true
+        - --ces-slice-mode=cesSliceModeFCFS
         env:
         - name: K8S_NODE_NAME
           valueFrom:

--- a/test/integration/manifests/cilium/v1.16/cilium-operator/templates/deployment.yaml
+++ b/test/integration/manifests/cilium/v1.16/cilium-operator/templates/deployment.yaml
@@ -38,6 +38,8 @@ spec:
         - --debug=$(CILIUM_DEBUG)
         - --identity-gc-interval=0m20s
         - --identity-heartbeat-timeout=0m20s
+        - --enable-cilium-endpoint-slice=true
+        - --ces-slice-mode=cesSliceModeFCFS
         env:
         - name: K8S_NODE_NAME
           valueFrom:


### PR DESCRIPTION
**Reason for Change**:
Enable CiliumEndpointSlice (CES) in Cilium clusters for testing prior to release. Enable CES in Cilium Operator only for version 1.13-1.16, and on the entire cluster from v1.17 / Nightly Pipeline. Adding list CRDs to pipelines for debugging.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added