### PR TITLE
test: sort npm set policy values before validation

### DIFF
--- a/npm/pkg/dataplane/ipsets/ipsetmanager_windows_test.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_windows_test.go
@@ -2,6 +2,8 @@ package ipsets
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/Azure/azure-container-networking/common"
@@ -379,7 +381,14 @@ func verifyHNSCache(t *testing.T, expected map[string]hcn.SetPolicySetting, hns 
 	for setName, setObj := range expected {
 		cacheObj := hns.Cache.SetPolicy(setObj.Id)
 		require.NotNil(t, cacheObj)
-		require.Equal(t, setObj, *cacheObj, fmt.Sprintf("%s mismatch in cache", setName))
+
+		// make values always sorted for testing consistency
+		members := strings.Split(cacheObj.Values, ",")
+		sort.Strings(members)
+		copyOfCachedObj := *cacheObj
+		copyOfCachedObj.Values = strings.Join(members, ",")
+
+		require.Equal(t, setObj, copyOfCachedObj, fmt.Sprintf("%s mismatch in cache", setName))
 	}
 }
 

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_windows_test.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_windows_test.go
@@ -387,7 +387,12 @@ func verifyHNSCache(t *testing.T, expected map[string]hcn.SetPolicySetting, hns 
 		copyOfCachedObj := *cacheObj
 		copyOfCachedObj.Values = strings.Join(members, ",")
 
-		require.Equal(t, setObj, copyOfCachedObj, setName+" mismatch in cache")
+		expectedMembers := strings.Split(setObj.Values, ",")
+		sort.Strings(expectedMembers)
+		copyOfExpectedObj := setObj
+		copyOfExpectedObj.Values = strings.Join(expectedMembers, ",")
+
+		require.Equal(t, copyOfExpectedObj, copyOfCachedObj, setName+" mismatch in cache")
 	}
 }
 

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_windows_test.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_windows_test.go
@@ -1,7 +1,6 @@
 package ipsets
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 	"testing"
@@ -388,7 +387,7 @@ func verifyHNSCache(t *testing.T, expected map[string]hcn.SetPolicySetting, hns 
 		copyOfCachedObj := *cacheObj
 		copyOfCachedObj.Values = strings.Join(members, ",")
 
-		require.Equal(t, setObj, copyOfCachedObj, fmt.Sprintf("%s mismatch in cache", setName))
+		require.Equal(t, setObj, copyOfCachedObj, setName+" mismatch in cache")
 	}
 }
 

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_windows_test.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_windows_test.go
@@ -376,21 +376,23 @@ func TestFailureOnDeletion(t *testing.T) {
 	verifyDeletedHNSCache(t, toDeleteSetNames, hns)
 }
 
+// sorts the Values field of the hcn set policy setting and returns a copy with sorted values
+func getSortedHnsPolicySetting(setting *hcn.SetPolicySetting) hcn.SetPolicySetting {
+	members := strings.Split(setting.Values, ",")
+	sort.Strings(members)
+	copyOfSetting := *setting
+	copyOfSetting.Values = strings.Join(members, ",")
+	return copyOfSetting
+}
+
 func verifyHNSCache(t *testing.T, expected map[string]hcn.SetPolicySetting, hns *hnswrapper.Hnsv2wrapperFake) {
 	for setName, setObj := range expected {
 		cacheObj := hns.Cache.SetPolicy(setObj.Id)
 		require.NotNil(t, cacheObj)
 
 		// make values always sorted for testing consistency
-		members := strings.Split(cacheObj.Values, ",")
-		sort.Strings(members)
-		copyOfCachedObj := *cacheObj
-		copyOfCachedObj.Values = strings.Join(members, ",")
-
-		expectedMembers := strings.Split(setObj.Values, ",")
-		sort.Strings(expectedMembers)
-		copyOfExpectedObj := setObj
-		copyOfExpectedObj.Values = strings.Join(expectedMembers, ",")
+		copyOfCachedObj := getSortedHnsPolicySetting(cacheObj)
+		copyOfExpectedObj := getSortedHnsPolicySetting(&setObj)
 
 		require.Equal(t, copyOfExpectedObj, copyOfCachedObj, setName+" mismatch in cache")
 	}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Previously `TestFailureOnCreation` in `npm/pkg/dataplane/ipsets/ipsetmanager_windows_test.go` could flake: https://msazure.visualstudio.com/One/_build/results?buildId=112594849&view=logs&j=1e95c5bf-f785-5c1d-a4c1-33b038e882fb&t=4058cacc-5989-52ae-5341-5beff346fc28 since the contents of a set have no defined order. This PR changes the test validation behavior to copy the cache object, sort the values, and then replace the copy's values with the sorted values before comparing the copy (sorted) to the expected.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
This PR is made so this PR won't flake https://github.com/Azure/azure-container-networking/pull/3156