### PR TITLE
chore: use AppArmorProfile for cilium 1.16

### DIFF
--- a/test/integration/manifests/cilium/daemonset.yaml
+++ b/test/integration/manifests/cilium/daemonset.yaml
@@ -16,10 +16,6 @@ spec:
   template:
     metadata:
       annotations:
-        container.apparmor.security.beta.kubernetes.io/apply-sysctl-overwrites: unconfined
-        container.apparmor.security.beta.kubernetes.io/cilium-agent: unconfined
-        container.apparmor.security.beta.kubernetes.io/clean-cilium-state: unconfined
-        container.apparmor.security.beta.kubernetes.io/mount-cgroup: unconfined
         prometheus.io/port: "9962"
         prometheus.io/scrape: "true"
       creationTimestamp: null
@@ -102,6 +98,8 @@ spec:
           timeoutSeconds: 5
         resources: {}
         securityContext:
+          appArmorProfile: 
+            type: Unconfined
           capabilities:
             add:
             - CHOWN
@@ -197,6 +195,8 @@ spec:
         name: mount-cgroup
         resources: {}
         securityContext:
+          appArmorProfile: 
+            type: Unconfined
           capabilities:
             add:
             - SYS_ADMIN
@@ -229,6 +229,8 @@ spec:
         name: apply-sysctl-overwrites
         resources: {}
         securityContext:
+          appArmorProfile: 
+            type: Unconfined
           capabilities:
             add:
             - SYS_ADMIN
@@ -287,6 +289,8 @@ spec:
             cpu: 100m
             memory: 100Mi
         securityContext:
+          appArmorProfile: 
+            type: Unconfined
           capabilities:
             add:
             - NET_ADMIN

--- a/test/integration/manifests/cilium/v1.16/cilium-agent/templates/daemonset-dualstack.yaml
+++ b/test/integration/manifests/cilium/v1.16/cilium-agent/templates/daemonset-dualstack.yaml
@@ -17,10 +17,6 @@ spec:
   template:
     metadata:
       annotations:
-        container.apparmor.security.beta.kubernetes.io/apply-sysctl-overwrites: unconfined
-        container.apparmor.security.beta.kubernetes.io/cilium-agent: unconfined
-        container.apparmor.security.beta.kubernetes.io/clean-cilium-state: unconfined
-        container.apparmor.security.beta.kubernetes.io/mount-cgroup: unconfined
         prometheus.io/port: "9962"
         prometheus.io/scrape: "true"
       creationTimestamp: null
@@ -43,6 +39,9 @@ spec:
                 operator: In
                 values:
                 - linux
+      securityContext:
+        appArmorProfile:
+          type: Unconfined
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map
@@ -97,6 +96,8 @@ spec:
           timeoutSeconds: 5
         resources: {}
         securityContext:
+          appArmorProfile: 
+            type: Unconfined
           capabilities:
             add:
             - CHOWN
@@ -192,6 +193,8 @@ spec:
         name: mount-cgroup
         resources: {}
         securityContext:
+          appArmorProfile: 
+            type: Unconfined
           capabilities:
             add:
             - SYS_ADMIN
@@ -224,6 +227,8 @@ spec:
         name: apply-sysctl-overwrites
         resources: {}
         securityContext:
+          appArmorProfile: 
+            type: Unconfined
           capabilities:
             add:
             - SYS_ADMIN

--- a/test/integration/manifests/cilium/v1.16/cilium-agent/templates/daemonset-dualstack.yaml
+++ b/test/integration/manifests/cilium/v1.16/cilium-agent/templates/daemonset-dualstack.yaml
@@ -39,9 +39,6 @@ spec:
                 operator: In
                 values:
                 - linux
-      securityContext:
-        appArmorProfile:
-          type: Unconfined
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map
@@ -287,6 +284,8 @@ spec:
             cpu: 100m
             memory: 100Mi
         securityContext:
+          appArmorProfile: 
+            type: Unconfined
           capabilities:
             add:
             - NET_ADMIN

--- a/test/integration/manifests/cilium/v1.16/cilium-agent/templates/daemonset.yaml
+++ b/test/integration/manifests/cilium/v1.16/cilium-agent/templates/daemonset.yaml
@@ -17,10 +17,6 @@ spec:
   template:
     metadata:
       annotations:
-        container.apparmor.security.beta.kubernetes.io/apply-sysctl-overwrites: unconfined
-        container.apparmor.security.beta.kubernetes.io/cilium-agent: unconfined
-        container.apparmor.security.beta.kubernetes.io/clean-cilium-state: unconfined
-        container.apparmor.security.beta.kubernetes.io/mount-cgroup: unconfined
         prometheus.io/port: "9962"
         prometheus.io/scrape: "true"
       creationTimestamp: null
@@ -43,6 +39,9 @@ spec:
                 operator: In
                 values:
                 - linux
+      securityContext:
+        appArmorProfile: 
+          type: Unconfined
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map
@@ -97,6 +96,8 @@ spec:
           timeoutSeconds: 5
         resources: {}
         securityContext:
+          appArmorProfile: 
+            type: Unconfined
           capabilities:
             add:
             - CHOWN
@@ -192,6 +193,8 @@ spec:
         name: mount-cgroup
         resources: {}
         securityContext:
+          appArmorProfile: 
+            type: Unconfined
           capabilities:
             add:
             - SYS_ADMIN
@@ -224,6 +227,8 @@ spec:
         name: apply-sysctl-overwrites
         resources: {}
         securityContext:
+          appArmorProfile: 
+            type: Unconfined
           capabilities:
             add:
             - SYS_ADMIN

--- a/test/integration/manifests/cilium/v1.16/cilium-agent/templates/daemonset.yaml
+++ b/test/integration/manifests/cilium/v1.16/cilium-agent/templates/daemonset.yaml
@@ -39,9 +39,6 @@ spec:
                 operator: In
                 values:
                 - linux
-      securityContext:
-        appArmorProfile: 
-          type: Unconfined
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map
@@ -287,6 +284,8 @@ spec:
             cpu: 100m
             memory: 100Mi
         securityContext:
+          appArmorProfile: 
+            type: Unconfined
           capabilities:
             add:
             - NET_ADMIN


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
AppArmor annotations are deprecated in kubernetes 1.30+, moving cilium 1.16 chart away from annotations and using security context for AppArmorProfile instead.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
