### PR TITLE
ci: add k8s yaml deprecation check to nightly

### DIFF
--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -174,6 +174,10 @@ stages:
               name: cilium_overlay_nightly
               clusterName: ciliumnightly
         steps:
+          - template: ../../templates/k8s-yaml-test.yaml
+            parameters:
+              clusterName: $(clusterName)-$(commitID)
+
           - template: ../../templates/delete-cluster.yaml
             parameters:
               name: $(name)

--- a/.pipelines/templates/delete-cluster.yaml
+++ b/.pipelines/templates/delete-cluster.yaml
@@ -18,3 +18,4 @@ steps:
         echo "Cluster and resources down"
     name: delete
     displayName: Delete - ${{ parameters.name }}
+    condition: always()

--- a/.pipelines/templates/k8s-yaml-test.yaml
+++ b/.pipelines/templates/k8s-yaml-test.yaml
@@ -1,0 +1,34 @@
+parameters:
+  clusterName: ""
+
+steps:
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+      scriptLocation: "inlineScript"
+      scriptType: "bash"
+      addSpnToEnvironment: true
+      inlineScript: |
+        make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
+        deployments="cilium-operator"
+        daemonsets="cilium|azure-cns|ip-masq"
+
+        exit=0
+        for ds in $(kubectl get ds -n kube-system | grep -E $daemonsets | awk '{print $1}'); do
+          if ! kubectl rollout restart ds -n kube-system $ds --warnings-as-errors=true; then
+            exit=1
+          fi
+        done
+
+        for deploy in $(kubectl get deploy -n kube-system | grep -E $deployments | awk '{print $1}'); do
+          if ! kubectl rollout restart deploy -n kube-system $deploy --warnings-as-errors=true; then
+            exit=1
+          fi
+        done
+
+        if [ ${exit} == 1 ]; then
+          echo "Warnings within maintained daemonsets/deployment need to be resolved."
+          exit 1
+        fi
+    name: "k8syaml"
+    displayName: "Check k8s YAML"


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Regular k8s updates are causing warnings with our maintained daemonsets and deployments for using, soon to be, outdated config values and fields. Currently adding this to nightly pipeline as to not block PR(s), but still capture these warnings.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
