### PR TITLE
backport: ci: increase goldpinger replicas from 4 to 8 and add topology constraints

### DIFF
--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -383,6 +383,8 @@ dualstack-overlay-byocni-up: rg-up overlay-net-up ## Brings up an dualstack Over
 		--ip-families ipv4,ipv6 \
 		--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/AzureOverlayDualStackPreview \
 		--no-ssh-key \
+		--tier premium \
+		--k8s-support-plan AKSLongTermSupport \
 		--yes
 	@$(MAKE) set-kubeconf
 
@@ -417,6 +419,8 @@ dualstack-byocni-nokubeproxy-up: rg-up overlay-net-up ## Brings up a Dualstack o
 		--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/AzureOverlayDualStackPreview \
 		--no-ssh-key \
 		--kube-proxy-config ./kube-proxy.json \
+		--tier premium \
+		--k8s-support-plan AKSLongTermSupport \
 		--yes
 	@$(MAKE) set-kubeconf
 

--- a/test/integration/manifests/datapath/linux-deployment-ipv6.yaml
+++ b/test/integration/manifests/datapath/linux-deployment-ipv6.yaml
@@ -86,3 +86,10 @@ spec:
               periodSeconds: 5
         nodeSelector:
           kubernetes.io/os: linux
+        topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: "goldpinger"

--- a/test/integration/manifests/datapath/linux-deployment-ipv6.yaml
+++ b/test/integration/manifests/datapath/linux-deployment-ipv6.yaml
@@ -4,7 +4,7 @@ metadata:
   name: goldpinger-deploy
   namespace: linux-datapath-test
 spec:
-  replicas: 4
+  replicas: 8
   selector:
     matchLabels:
       app: goldpinger

--- a/test/integration/manifests/datapath/linux-deployment.yaml
+++ b/test/integration/manifests/datapath/linux-deployment.yaml
@@ -84,3 +84,10 @@ spec:
               periodSeconds: 5
         nodeSelector:
           kubernetes.io/os: linux
+        topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: "goldpinger"

--- a/test/integration/manifests/datapath/linux-deployment.yaml
+++ b/test/integration/manifests/datapath/linux-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: goldpinger-deploy
   namespace: linux-datapath-test
 spec:
-  replicas: 4
+  replicas: 8
   selector:
     matchLabels:
       app: goldpinger

--- a/test/integration/manifests/datapath/windows-deployment.yaml
+++ b/test/integration/manifests/datapath/windows-deployment.yaml
@@ -20,3 +20,10 @@ spec:
           args: ["sleep", "5000"]
       nodeSelector:
         kubernetes.io/os: windows
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: "datapod"

--- a/test/integration/manifests/datapath/windows-deployment.yaml
+++ b/test/integration/manifests/datapath/windows-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: windows-pod
   namespace: datapath-win
 spec:
-  replicas: 4
+  replicas: 8
   selector:
     matchLabels:
       app: datapod


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Backport https://github.com/Azure/azure-container-networking/pull/3376
Cherry picking the two commits in that PR to 1.5 branch
Also enables LTS support for k8 version 1.28 during cluster creation

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
