### PR TITLE
ci(cyclonus extended): [NPM] fix broken GH action

### DIFF
--- a/.github/workflows/cyclonus-netpol-extended-nightly-test.yaml
+++ b/.github/workflows/cyclonus-netpol-extended-nightly-test.yaml
@@ -42,6 +42,7 @@ jobs:
           version: "v0.22.0"
           kubectl_version: "v1.27.7"
           config: ./test/kind/kind.yaml
+          cluster_name: npm-kind
 
       - name: Check Kind
         run: |

--- a/.github/workflows/cyclonus-netpol-extended-nightly-test.yaml
+++ b/.github/workflows/cyclonus-netpol-extended-nightly-test.yaml
@@ -2,17 +2,9 @@ name: Cyclonus Network Policy Extended Test
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-      - release/*
-  pull_request:
-    paths:
-      - 'npm/**'
-      - '.github/**'
   schedule:
     # run once a day at midnight
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
 
 jobs:
   cyclonus-test:

--- a/.github/workflows/cyclonus-netpol-extended-nightly-test.yaml
+++ b/.github/workflows/cyclonus-netpol-extended-nightly-test.yaml
@@ -2,9 +2,17 @@ name: Cyclonus Network Policy Extended Test
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+      - release/*
+  pull_request:
+    paths:
+      - 'npm/**'
+      - '.github/**'
   schedule:
     # run once a day at midnight
-    - cron: "0 0 * * *"
+    - cron: '0 0 * * *'
 
 jobs:
   cyclonus-test:

--- a/.github/workflows/cyclonus-netpol-extended-nightly-test.yaml
+++ b/.github/workflows/cyclonus-netpol-extended-nightly-test.yaml
@@ -29,7 +29,7 @@ jobs:
           go-version: "^1.23"
 
       - name: Setup Kind
-        uses: engineerd/setup-kind@v0.6.2
+        uses: engineerd/setup-kind@0.24.0
         with:
           version: "v0.11.1"
           config: ./test/kind/kind.yaml

--- a/.github/workflows/cyclonus-netpol-extended-nightly-test.yaml
+++ b/.github/workflows/cyclonus-netpol-extended-nightly-test.yaml
@@ -37,11 +37,11 @@ jobs:
           go-version: "^1.23"
 
       - name: Setup Kind
-        uses: engineerd/setup-kind@0.24.0
+        uses: helm/kind-action@v1
         with:
-          version: "v0.11.1"
+          version: "v0.22.0"
+          kubectl_version: "v1.27.7"
           config: ./test/kind/kind.yaml
-          name: npm-kind
 
       - name: Check Kind
         run: |


### PR DESCRIPTION
**Reason for Change**:

[Cyclonus extended](https://github.com/Azure/azure-container-networking/actions/runs/13125530079) has been broken.

**Issue Fixed**:

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:

Fixed by changing the Kind setup step to the one in the other cyclonus github action.