### PR TITLE
fix: add iptables rules for dns in vnet scale cilium case

### DIFF
--- a/cns/client/client_test.go
+++ b/cns/client/client_test.go
@@ -151,7 +151,7 @@ func TestMain(m *testing.M) {
 	logger.InitLogger(logName, 0, 0, tmpLogDir+"/")
 	config := common.ServiceConfig{}
 
-	httpRestService, err := restserver.NewHTTPRestService(&config, &fakes.WireserverClientFake{}, &fakes.WireserverProxyFake{}, &fakes.NMAgentClientFake{}, nil, nil, nil)
+	httpRestService, err := restserver.NewHTTPRestService(&config, &fakes.WireserverClientFake{}, &fakes.WireserverProxyFake{}, &restserver.IPtablesProvider{}, &fakes.NMAgentClientFake{}, nil, nil, nil)
 	svc = httpRestService
 	httpRestService.Name = "cns-test-server"
 

--- a/cns/fakes/iptablesfake.go
+++ b/cns/fakes/iptablesfake.go
@@ -23,14 +23,6 @@ func NewIPTablesMock() *IPTablesMock {
 	}
 }
 
-type iptablesClient interface {
-	ChainExists(table string, chain string) (bool, error)
-	NewChain(table string, chain string) error
-	Exists(table string, chain string, rulespec ...string) (bool, error)
-	Append(table string, chain string, rulespec ...string) error
-	Insert(table string, chain string, pos int, rulespec ...string) error
-}
-
 func (c *IPTablesMock) ensureTableExists(table string) {
 	_, exists := c.state[table]
 	if !exists {
@@ -69,7 +61,7 @@ func (c *IPTablesMock) NewChain(table, chain string) error {
 	return nil
 }
 
-func (c *IPTablesMock) Exists(table string, chain string, rulespec ...string) (bool, error) {
+func (c *IPTablesMock) Exists(table, chain string, rulespec ...string) (bool, error) {
 	c.ensureTableExists(table)
 
 	chainExists, _ := c.ChainExists(table, chain)
@@ -77,7 +69,7 @@ func (c *IPTablesMock) Exists(table string, chain string, rulespec ...string) (b
 		return false, nil
 	}
 
-	targetRule := strings.Join(rulespec[:], " ")
+	targetRule := strings.Join(rulespec, " ")
 	chainRules := c.state[table][chain]
 
 	for _, chainRule := range chainRules {
@@ -88,7 +80,7 @@ func (c *IPTablesMock) Exists(table string, chain string, rulespec ...string) (b
 	return false, nil
 }
 
-func (c *IPTablesMock) Append(table string, chain string, rulespec ...string) error {
+func (c *IPTablesMock) Append(table, chain string, rulespec ...string) error {
 	c.ensureTableExists(table)
 
 	chainExists, _ := c.ChainExists(table, chain)
@@ -101,11 +93,11 @@ func (c *IPTablesMock) Append(table string, chain string, rulespec ...string) er
 		return errRuleExists
 	}
 
-	targetRule := strings.Join(rulespec[:], " ")
+	targetRule := strings.Join(rulespec, " ")
 	c.state[table][chain] = append(c.state[table][chain], targetRule)
 	return nil
 }
 
-func (c *IPTablesMock) Insert(table string, chain string, _ int, rulespec ...string) error {
+func (c *IPTablesMock) Insert(table, chain string, _ int, rulespec ...string) error {
 	return c.Append(table, chain, rulespec...)
 }

--- a/cns/fakes/iptablesfake.go
+++ b/cns/fakes/iptablesfake.go
@@ -1,0 +1,111 @@
+package fakes
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/Azure/azure-container-networking/iptables"
+)
+
+var (
+	errChainExists   = errors.New("chain already exists")
+	errChainNotFound = errors.New("chain not found")
+	errRuleExists    = errors.New("rule already exists")
+)
+
+type IPTablesMock struct {
+	state map[string]map[string][]string
+}
+
+func NewIPTablesMock() *IPTablesMock {
+	return &IPTablesMock{
+		state: make(map[string]map[string][]string),
+	}
+}
+
+type iptablesClient interface {
+	ChainExists(table string, chain string) (bool, error)
+	NewChain(table string, chain string) error
+	Exists(table string, chain string, rulespec ...string) (bool, error)
+	Append(table string, chain string, rulespec ...string) error
+	Insert(table string, chain string, pos int, rulespec ...string) error
+}
+
+func (c *IPTablesMock) ensureTableExists(table string) {
+	_, exists := c.state[table]
+	if !exists {
+		c.state[table] = make(map[string][]string)
+	}
+}
+
+func (c *IPTablesMock) ChainExists(table, chain string) (bool, error) {
+	c.ensureTableExists(table)
+
+	builtins := []string{iptables.Input, iptables.Output, iptables.Prerouting, iptables.Postrouting, iptables.Forward}
+
+	_, exists := c.state[table][chain]
+
+	// these chains always exist
+	for _, val := range builtins {
+		if chain == val && !exists {
+			c.state[table][chain] = []string{}
+			return true, nil
+		}
+	}
+
+	return exists, nil
+}
+
+func (c *IPTablesMock) NewChain(table, chain string) error {
+	c.ensureTableExists(table)
+
+	exists, _ := c.ChainExists(table, chain)
+
+	if exists {
+		return errChainExists
+	}
+
+	c.state[table][chain] = []string{}
+	return nil
+}
+
+func (c *IPTablesMock) Exists(table string, chain string, rulespec ...string) (bool, error) {
+	c.ensureTableExists(table)
+
+	chainExists, _ := c.ChainExists(table, chain)
+	if !chainExists {
+		return false, nil
+	}
+
+	targetRule := strings.Join(rulespec[:], " ")
+	chainRules := c.state[table][chain]
+
+	for _, chainRule := range chainRules {
+		if targetRule == chainRule {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (c *IPTablesMock) Append(table string, chain string, rulespec ...string) error {
+	c.ensureTableExists(table)
+
+	chainExists, _ := c.ChainExists(table, chain)
+	if !chainExists {
+		return errChainNotFound
+	}
+
+	ruleExists, _ := c.Exists(table, chain, rulespec...)
+	if ruleExists {
+		return errRuleExists
+	}
+
+	targetRule := strings.Join(rulespec[:], " ")
+	c.state[table][chain] = append(c.state[table][chain], targetRule)
+	return nil
+}
+
+func (c *IPTablesMock) Insert(table string, chain string, _ int, rulespec ...string) error {
+	return c.Append(table, chain, rulespec...)
+}

--- a/cns/restserver/api_test.go
+++ b/cns/restserver/api_test.go
@@ -1679,7 +1679,7 @@ func startService() error {
 	config.Store = fileStore
 
 	nmagentClient := &fakes.NMAgentClientFake{}
-	service, err = NewHTTPRestService(&config, &fakes.WireserverClientFake{}, &fakes.WireserverProxyFake{}, nmagentClient, nil, nil, nil)
+	service, err = NewHTTPRestService(&config, &fakes.WireserverClientFake{}, &fakes.WireserverProxyFake{}, &IPtablesProvider{}, nmagentClient, nil, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/cns/restserver/internalapi_linux.go
+++ b/cns/restserver/internalapi_linux.go
@@ -15,6 +15,14 @@ import (
 
 const SWIFT = "SWIFT-POSTROUTING"
 
+type IPtablesProvider struct {
+	iptc iptablesClient
+}
+
+func (c *IPtablesProvider) GetIPTables() (iptablesClient, error) {
+	return goiptables.New()
+}
+
 // nolint
 func (service *HTTPRestService) programSNATRules(req *cns.CreateNetworkContainerRequest) (types.ResponseCode, string) {
 	service.Lock()
@@ -24,7 +32,7 @@ func (service *HTTPRestService) programSNATRules(req *cns.CreateNetworkContainer
 	// in podsubnet case, ncPrimaryIP is the pod subnet's primary ip
 	// in vnet scale case, ncPrimaryIP is the node's ip
 	ncPrimaryIP, _, _ := net.ParseCIDR(req.IPConfiguration.IPSubnet.IPAddress + "/" + fmt.Sprintf("%d", req.IPConfiguration.IPSubnet.PrefixLength))
-	ipt, err := goiptables.New()
+	ipt, err := service.iptables.GetIPTables()
 	if err != nil {
 		return types.UnexpectedError, fmt.Sprintf("[Azure CNS] Error. Failed to create iptables interface : %v", err)
 	}

--- a/cns/restserver/internalapi_linux.go
+++ b/cns/restserver/internalapi_linux.go
@@ -11,16 +11,16 @@ import (
 	"github.com/Azure/azure-container-networking/iptables"
 	"github.com/Azure/azure-container-networking/network/networkutils"
 	goiptables "github.com/coreos/go-iptables/iptables"
+	"github.com/pkg/errors"
 )
 
 const SWIFT = "SWIFT-POSTROUTING"
 
-type IPtablesProvider struct {
-	iptc iptablesClient
-}
+type IPtablesProvider struct{}
 
 func (c *IPtablesProvider) GetIPTables() (iptablesClient, error) {
-	return goiptables.New()
+	client, err := goiptables.New()
+	return client, errors.Wrap(err, "failed to get iptables client")
 }
 
 // nolint

--- a/cns/restserver/internalapi_linux_test.go
+++ b/cns/restserver/internalapi_linux_test.go
@@ -1,0 +1,148 @@
+// Copyright 2020 Microsoft. All rights reserved.
+// MIT License
+
+package restserver
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/fakes"
+	"github.com/Azure/azure-container-networking/cns/types"
+	"github.com/Azure/azure-container-networking/iptables"
+	"github.com/Azure/azure-container-networking/network/networkutils"
+)
+
+type FakeIPTablesProvider struct {
+	iptables *fakes.IPTablesMock
+}
+
+func (c *FakeIPTablesProvider) GetIPTables() (iptablesClient, error) {
+	// persist iptables in testing
+	if c.iptables == nil {
+		c.iptables = fakes.NewIPTablesMock()
+	}
+	return c.iptables, nil
+}
+
+func TestAddSNATRules(t *testing.T) {
+	type expectedScenario struct {
+		table string
+		chain string
+		rule  []string
+	}
+
+	tests := []struct {
+		name     string
+		input    *cns.CreateNetworkContainerRequest
+		expected []expectedScenario
+	}{
+		{
+			// in pod subnet, the primary nic ip is in the same address space as the pod subnet
+			name: "podsubnet",
+			input: &cns.CreateNetworkContainerRequest{
+				NetworkContainerid: ncID,
+				IPConfiguration: cns.IPConfiguration{
+					IPSubnet: cns.IPSubnet{
+						IPAddress:    "240.1.2.1",
+						PrefixLength: 24,
+					},
+				},
+				SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+					"abc": {
+						IPAddress: "240.1.2.7",
+					},
+				},
+				HostPrimaryIP: "10.0.0.4",
+			},
+			expected: []expectedScenario{
+				{
+					table: iptables.Nat,
+					chain: SWIFT,
+					rule: []string{
+						"-m", "addrtype", "!", "--dst-type", "local", "-s", "240.1.2.0/24", "-d",
+						networkutils.AzureDNS, "-p", iptables.UDP, "--dport", strconv.Itoa(iptables.DNSPort), "-j", iptables.Snat, "--to", "240.1.2.1",
+					},
+				},
+				{
+					table: iptables.Nat,
+					chain: SWIFT,
+					rule: []string{
+						"-m", "addrtype", "!", "--dst-type", "local", "-s", "240.1.2.0/24", "-d",
+						networkutils.AzureDNS, "-p", iptables.TCP, "--dport", strconv.Itoa(iptables.DNSPort), "-j", iptables.Snat, "--to", "240.1.2.1",
+					},
+				},
+				{
+					table: iptables.Nat,
+					chain: SWIFT,
+					rule: []string{
+						"-m", "addrtype", "!", "--dst-type", "local", "-s", "240.1.2.0/24", "-d",
+						networkutils.AzureIMDS, "-p", iptables.TCP, "--dport", strconv.Itoa(iptables.HTTPPort), "-j", iptables.Snat, "--to", "10.0.0.4",
+					},
+				},
+			},
+		},
+		{
+			// in vnet scale, the primary nic ip becomes the node ip (diff address space from pod subnet)
+			name: "vnet scale",
+			input: &cns.CreateNetworkContainerRequest{
+				NetworkContainerid: ncID,
+				IPConfiguration: cns.IPConfiguration{
+					IPSubnet: cns.IPSubnet{
+						IPAddress:    "10.0.0.4",
+						PrefixLength: 28,
+					},
+				},
+				SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+					"abc": {
+						IPAddress: "240.1.2.15",
+					},
+				},
+				HostPrimaryIP: "10.0.0.4",
+			},
+			expected: []expectedScenario{
+				{
+					table: iptables.Nat,
+					chain: SWIFT,
+					rule: []string{
+						"-m", "addrtype", "!", "--dst-type", "local", "-s", "240.1.2.0/28", "-d",
+						networkutils.AzureDNS, "-p", iptables.UDP, "--dport", strconv.Itoa(iptables.DNSPort), "-j", iptables.Snat, "--to", "10.0.0.4",
+					},
+				},
+				{
+					table: iptables.Nat,
+					chain: SWIFT,
+					rule: []string{
+						"-m", "addrtype", "!", "--dst-type", "local", "-s", "240.1.2.0/28", "-d",
+						networkutils.AzureDNS, "-p", iptables.TCP, "--dport", strconv.Itoa(iptables.DNSPort), "-j", iptables.Snat, "--to", "10.0.0.4",
+					},
+				},
+				{
+					table: iptables.Nat,
+					chain: SWIFT,
+					rule: []string{
+						"-m", "addrtype", "!", "--dst-type", "local", "-s", "240.1.2.0/28", "-d",
+						networkutils.AzureIMDS, "-p", iptables.TCP, "--dport", strconv.Itoa(iptables.HTTPPort), "-j", iptables.Snat, "--to", "10.0.0.4",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		service := getTestService()
+		service.iptables = &FakeIPTablesProvider{}
+		resp, msg := service.programSNATRules(tt.input)
+		if resp != types.Success {
+			t.Fatal("failed to program snat rules", msg, " case: ", tt.name)
+		}
+		finalState, _ := service.iptables.GetIPTables()
+		for _, ex := range tt.expected {
+			exists, err := finalState.Exists(ex.table, ex.chain, ex.rule...)
+			if err != nil || !exists {
+				t.Fatal("rule not found", ex.rule, " case: ", tt.name)
+			}
+		}
+	}
+}

--- a/cns/restserver/internalapi_windows.go
+++ b/cns/restserver/internalapi_windows.go
@@ -1,9 +1,19 @@
 package restserver
 
 import (
+	"errors"
+
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/types"
 )
+
+var errUnsupportedAPI = errors.New("unsupported api")
+
+type IPtablesProvider struct{}
+
+func (_ *IPtablesProvider) GetIPTables() (iptablesClient, error) {
+	return nil, errUnsupportedAPI
+}
 
 // nolint
 func (service *HTTPRestService) programSNATRules(req *cns.CreateNetworkContainerRequest) (types.ResponseCode, string) {

--- a/cns/restserver/internalapi_windows.go
+++ b/cns/restserver/internalapi_windows.go
@@ -11,7 +11,7 @@ var errUnsupportedAPI = errors.New("unsupported api")
 
 type IPtablesProvider struct{}
 
-func (_ *IPtablesProvider) GetIPTables() (iptablesClient, error) {
+func (*IPtablesProvider) GetIPTables() (iptablesClient, error) {
 	return nil, errUnsupportedAPI
 }
 

--- a/cns/restserver/ipam_test.go
+++ b/cns/restserver/ipam_test.go
@@ -63,7 +63,7 @@ type ncState struct {
 
 func getTestService() *HTTPRestService {
 	var config common.ServiceConfig
-	httpsvc, _ := NewHTTPRestService(&config, &fakes.WireserverClientFake{}, &fakes.WireserverProxyFake{}, &fakes.NMAgentClientFake{}, store.NewMockStore(""), nil, nil)
+	httpsvc, _ := NewHTTPRestService(&config, &fakes.WireserverClientFake{}, &fakes.WireserverProxyFake{}, &IPtablesProvider{}, &fakes.NMAgentClientFake{}, store.NewMockStore(""), nil, nil)
 	svc = httpsvc
 	setOrchestratorTypeInternal(cns.KubernetesCRD)
 

--- a/cns/restserver/v2/server_test.go
+++ b/cns/restserver/v2/server_test.go
@@ -49,7 +49,7 @@ func startService(cnsPort, cnsURL string) error {
 	config := common.ServiceConfig{}
 
 	nmagentClient := &fakes.NMAgentClientFake{}
-	service, err := restserver.NewHTTPRestService(&config, &fakes.WireserverClientFake{}, &fakes.WireserverProxyFake{}, nmagentClient, nil, nil, nil)
+	service, err := restserver.NewHTTPRestService(&config, &fakes.WireserverClientFake{}, &fakes.WireserverProxyFake{}, &restserver.IPtablesProvider{}, nmagentClient, nil, nil, nil)
 	if err != nil {
 		return errors.Wrap(err, "Failed to initialize service")
 	}

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -747,7 +747,7 @@ func main() {
 		Logger:     logger.Log,
 	}
 
-	httpRemoteRestService, err := restserver.NewHTTPRestService(&config, wsclient, &wsProxy, nmaClient,
+	httpRemoteRestService, err := restserver.NewHTTPRestService(&config, wsclient, &wsProxy, &restserver.IPtablesProvider{}, nmaClient,
 		endpointStateStore, conflistGenerator, homeAzMonitor)
 	if err != nil {
 		logger.Errorf("Failed to create CNS object, err:%v.\n", err)


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
In the vnet scale scenario, we use the node's ip as the primary ip instead of an ip from the pod's subnet (what happens in pod subnet mode). In cilium, we add snat rules from the cns, and base our snat on the primary ip + subnet. However, the primary ip is now the node ip, meaning we only snat packets from the node's primary ip w/ the pod subnet cidr. It should be that we also snat packets from the pod subnet's network/cidr. This change modifies the cns to grab any secondary ip from the pod subnet, combine it with the pod subnet cidr, and create an iptable rule for the pod subnet. The cidr is for the whole subnet space (applies to all static ip blocks allocated).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
See above

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [X] relevant PR labels added

**Notes**:
Manually tested cilium w/ updated cns and iptable rule(s) are created with pod subnet cidr. DNS traffic succeeds afterwards.