### PR TITLE
ci: split dualstack and overlay e2e tests by operating system

### DIFF
--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -283,14 +283,27 @@ stages:
     # Azure Overlay E2E tests
     - template: singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
       parameters:
-        name: "azure_overlay_e2e"
-        displayName: Azure Overlay
+        name: "linux_azure_overlay_e2e"
+        displayName: Azure Overlay Linux
         os: linux
-        clusterType: overlay-byocni-up
-        clusterName: "azovere2e"
+        clusterType: linux-overlay-byocni-up
+        clusterName: "linuxazovere2e"
         vmSize: Standard_B2ms
         k8sVersion: ""
         dependsOn: "containerize"
+        scaleup: 100
+    
+    - template: singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
+      parameters:
+        name: "win_azure_overlay_e2e"
+        displayName: Azure Overlay Windows
+        os: windows
+        clusterType: windows-overlay-byocni-up
+        clusterName: "winazovere2e"
+        vmSize: Standard_B2ms
+        k8sVersion: ""
+        dependsOn: "containerize"
+        scaleup: 50
 
     # Azure Overlay E2E Stateless CNI tests
     - template: singletenancy/azure-cni-overlay-stateless/azure-cni-overlay-stateless-e2e-job-template.yaml
@@ -382,7 +395,8 @@ stages:
       condition: always()
       dependsOn:
         - setup
-        - azure_overlay_e2e
+        - linux_azure_overlay_e2e
+        - win_azure_overlay_e2e
         - azure_overlay_stateless_e2e
         - aks_swift_e2e
         - cilium_e2e
@@ -420,9 +434,13 @@ stages:
                 name: cilium_h_overlay_e2e
                 clusterName: "cilwhleovere2e"
                 region: $(REGION_AKS_CLUSTER_TEST)
-              azure_overlay_e2e:
-                name: azure_overlay_e2e
-                clusterName: "azovere2e"
+              linux_azure_overlay_e2e:
+                name: linux_azure_overlay_e2e
+                clusterName: "linuxazovere2e"
+                region: $(REGION_AKS_CLUSTER_TEST)
+              windows_azure_overlay_e2e:
+                name: win_azure_overlay_e2e
+                clusterName: "winazovere2e"
                 region: $(REGION_AKS_CLUSTER_TEST)
               azure_overlay_stateless_e2e:
                 name: azure_overlay_stateless_e2e

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -357,13 +357,25 @@ stages:
     # CNI dual stack overlay E2E tests
     - template: singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
       parameters:
-        name: "dualstackoverlay_e2e"
-        displayName: AKS DualStack Overlay
+        name: "linux_dualstackoverlay_e2e"
+        displayName: AKS DualStack Overlay Linux
         os: linux
-        clusterType: dualstack-overlay-byocni-up
-        clusterName: "dsovere2e"
+        clusterType: linux-dualstack-overlay-byocni-up
+        clusterName: "linuxdsovere2e"
         vmSize: Standard_B2ms
         dependsOn: "containerize"
+        scaleup: 100
+
+    - template: singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
+      parameters:
+        name: "win_dualstackoverlay_e2e"
+        displayName: AKS DualStack Overlay Windows
+        os: windows
+        clusterType: windows-dualstack-overlay-byocni-up
+        clusterName: "windsovere2e"
+        vmSize: Standard_B2ms
+        dependsOn: "containerize"
+        scaleup: 50
 
     - stage: delete
       displayName: Delete Clusters
@@ -380,7 +392,8 @@ stages:
         - aks_ubuntu_22_linux_e2e
         - aks_swift_vnetscale_e2e
         - aks_windows_22_e2e
-        - dualstackoverlay_e2e
+        - linux_dualstackoverlay_e2e
+        - win_dualstackoverlay_e2e
         - cilium_dualstackoverlay_e2e
       variables:
         commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
@@ -431,9 +444,13 @@ stages:
                 name: aks_windows_22_e2e
                 clusterName: "win22e2e"
                 region: $(REGION_AKS_CLUSTER_TEST)
-              dualstackoverlay_e2e:
-                name: dualstackoverlay_e2e
-                clusterName: "dsovere2e"
+              linux_dualstackoverlay_e2e:
+                name: linux_dualstackoverlay_e2e
+                clusterName: "linuxdsovere2e"
+                region: $(REGION_DUALSTACKOVERLAY_CLUSTER_TEST)
+              windows_dualstackoverlay_e2e:
+                name: windows_dualstackoverlay_e2e
+                clusterName: "windsovere2e"
                 region: $(REGION_DUALSTACKOVERLAY_CLUSTER_TEST)
               cilium_dualstackoverlay_e2e:
                 name: cilium_dualstackoverlay_e2e

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -286,7 +286,7 @@ stages:
         name: "linux_azure_overlay_e2e"
         displayName: Azure Overlay Linux
         os: linux
-        clusterType: linux-overlay-byocni-up
+        clusterType: overlay-byocni-up
         clusterName: "linuxazovere2e"
         vmSize: Standard_B2ms
         k8sVersion: ""
@@ -298,7 +298,7 @@ stages:
         name: "win_azure_overlay_e2e"
         displayName: Azure Overlay Windows
         os: windows
-        clusterType: windows-overlay-byocni-up
+        clusterType: overlay-byocni-up
         clusterName: "winazovere2e"
         vmSize: Standard_B2ms
         k8sVersion: ""
@@ -373,7 +373,7 @@ stages:
         name: "linux_dualstackoverlay_e2e"
         displayName: AKS DualStack Overlay Linux
         os: linux
-        clusterType: linux-dualstack-overlay-byocni-up
+        clusterType: dualstack-overlay-byocni-up
         clusterName: "linuxdsovere2e"
         vmSize: Standard_B2ms
         dependsOn: "containerize"
@@ -384,7 +384,7 @@ stages:
         name: "win_dualstackoverlay_e2e"
         displayName: AKS DualStack Overlay Windows
         os: windows
-        clusterType: windows-dualstack-overlay-byocni-up
+        clusterType: dualstack-overlay-byocni-up
         clusterName: "windsovere2e"
         vmSize: Standard_B2ms
         dependsOn: "containerize"

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
@@ -7,6 +7,7 @@ parameters:
   k8sVersion: ""
   dependsOn: ""
   scaleup: ""
+  os: ""
 
 stages:
   - stage: ${{ parameters.clusterName }}
@@ -29,6 +30,7 @@ stages:
           vmSizeWin: ${{ parameters.vmSize }}
           k8sVersion: ${{ parameters.k8sVersion }}
           dependsOn: ${{ parameters.dependsOn }}
+          os: ${{ parameters.os }}
           region: $(REGION_AKS_CLUSTER_TEST)
 
   - stage: ${{ parameters.name }}

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
@@ -6,6 +6,7 @@ parameters:
   vmSize: ""
   k8sVersion: ""
   dependsOn: ""
+  scaleup: ""
 
 stages:
   - stage: ${{ parameters.clusterName }}
@@ -25,6 +26,7 @@ stages:
           clusterType: ${{ parameters.clusterType }}
           clusterName: ${{ parameters.clusterName }}-$(commitID)
           vmSize: ${{ parameters.vmSize }}
+          vmSizeWin: ${{ parameters.vmSize }}
           k8sVersion: ${{ parameters.k8sVersion }}
           dependsOn: ${{ parameters.dependsOn }}
           region: $(REGION_AKS_CLUSTER_TEST)
@@ -43,8 +45,8 @@ stages:
     pool:
       name: $(BUILD_POOL_NAME_DEFAULT)
     jobs:
-      - job: ${{ parameters.name }}_linux
-        displayName: Azure CNI Overlay Test Suite | Linux - (${{ parameters.name }})
+      - job: ${{ parameters.name }}_${{ parameters.os }}
+        displayName: Azure CNI Overlay Test Suite | ${{ parameters.os }} - (${{ parameters.name }})
         timeoutInMinutes: 120
         pool:
           name: $(BUILD_POOL_NAME_DEFAULT)
@@ -56,78 +58,31 @@ stages:
             parameters:
               name: ${{ parameters.name }}
               clusterName: ${{ parameters.clusterName }}-$(commitID)
-              os: linux
-              scaleup: 100
-      - template: ../../templates/add-windows-nodepool-job.yaml
-        parameters:
-          depend: ${{ parameters.name }}_linux
-          clusterName: ${{ parameters.clusterName }}-$(commitID)
-          vmSize: ${{ parameters.vmSize }}
-      - job: ${{ parameters.name }}_windows
-        displayName: Azure CNI Overlay Test Suite | Windows - (${{ parameters.name }})
-        timeoutInMinutes: 120
-        dependsOn: windows_nodepool
-        pool:
-          name: $(BUILD_POOL_NAME_DEFAULT)
-          demands:
-          - agent.os -equals Linux
-          - Role -equals $(CUSTOM_E2E_ROLE)
-        steps:
-          - template: azure-cni-overlay-e2e-step-template.yaml
-            parameters:
-              name: ${{ parameters.name }}
-              clusterName: ${{ parameters.clusterName }}-$(commitID)
-              os: windows
-              scaleup: 50
+              os: ${{ parameters.os }}
+              scaleup: ${{ parameters.scaleup }} # 50 in windows or 100 in linux
 
       - template: ../../cni/k8s-e2e/k8s-e2e-job-template.yaml
         parameters:
           sub: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
           clusterName: ${{ parameters.clusterName }}-$(commitID)
           os: ${{ parameters.os }}
-          dependsOn: ${{ parameters.name }}_windows
+          dependsOn: ${{ parameters.name }}_${{ parameters.os }}
           datapath: true
           dns: true
           portforward: true
           hostport: true
           service: true
+          hybridWin: ${{ eq(parameters.os, 'windows') }}
 
-      - template: ../../cni/k8s-e2e/k8s-e2e-job-template.yaml
-        parameters:
-          sub: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
-          clusterName: ${{ parameters.clusterName }}-$(commitID)
-          os: windows
-          dependsOn: cni_${{ parameters.os }}
-          datapath: true
-          dns: true
-          portforward: true
-          hostport: true
-          service: true
-          hybridWin: true
-
-      - job: failedE2ELogs_linux
-        displayName: "Linux Failure Logs"
+      - job: failedE2ELogs_${{ parameters.os }}
+        displayName: "${{ parameters.os }} Failure Logs"
         dependsOn:
-          - ${{ parameters.name }}_linux
-          - cni_linux
-        condition: in(dependencies.${{ parameters.name }}_linux.result, 'Failed')
+          - ${{ parameters.name }}_${{ parameters.os }}
+          - CNI_${{ parameters.os }}
+        condition: in(dependencies.${{ parameters.name }}_${{ parameters.os }}.result, 'Failed')
         steps:
           - template: ../../templates/log-template.yaml
             parameters:
               clusterName: ${{ parameters.clusterName }}-$(commitID)
-              os: linux
+              os: ${{ parameters.os }}
               cni: cniv2
-
-      - job: failedE2ELogs_windows
-        displayName: "Windows Failure Logs"
-        dependsOn:
-          - ${{ parameters.name }}_windows
-          - cni_windows
-        condition: in(dependencies.${{ parameters.name }}_windows.result, 'Failed')
-        steps:
-          - template: ../../templates/log-template.yaml
-            parameters:
-              clusterName: ${{ parameters.clusterName }}-$(commitID)
-              os: windows
-              cni: cniv2
-

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
@@ -30,6 +30,7 @@ stages:
           vmSizeWin: ${{ parameters.vmSize }}
           k8sVersion: ${{ parameters.k8sVersion }}
           dependsOn: ${{ parameters.dependsOn }}
+          os: ${{ parameters.os }}
           region: $(REGION_DUALSTACKOVERLAY_CLUSTER_TEST) # Dualstack has a specific region requirement
 
   - stage: ${{ parameters.name }}

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
@@ -6,6 +6,8 @@ parameters:
   vmSize: ""
   k8sVersion: ""
   dependsOn: ""
+  os: ""
+  scaleup: ""
 
 stages:
   - stage: ${{ parameters.clusterName }}
@@ -25,12 +27,12 @@ stages:
           clusterType: ${{ parameters.clusterType }}
           clusterName: ${{ parameters.clusterName }}-$(commitID)
           vmSize: ${{ parameters.vmSize }}
+          vmSizeWin: ${{ parameters.vmSize }}
           k8sVersion: ${{ parameters.k8sVersion }}
           dependsOn: ${{ parameters.dependsOn }}
           region: $(REGION_DUALSTACKOVERLAY_CLUSTER_TEST) # Dualstack has a specific region requirement
 
   - stage: ${{ parameters.name }}
-    condition: and( succeeded(), not(eq(dependencies.dualstackoverlaye2e.result,'SucceededWithIssues')) ) # Cant use parameters in dependencies
     displayName: E2E - ${{ parameters.displayName }}
     dependsOn:
     - setup
@@ -44,8 +46,8 @@ stages:
     pool:
       name: $(BUILD_POOL_NAME_DEFAULT)
     jobs:
-      - job: ${{ parameters.name }}_linux
-        displayName: DualStack Overlay Test Suite | Linux - (${{ parameters.name }})
+      - job: ${{ parameters.name }}_${{ parameters.os }}
+        displayName: DualStack Overlay Test Suite | ${{ parameters.os }} - (${{ parameters.name }})
         timeoutInMinutes: 120
         pool:
           name: $(BUILD_POOL_NAME_DEFAULT)
@@ -57,77 +59,31 @@ stages:
             parameters:
               name: ${{ parameters.name }}
               clusterName: ${{ parameters.clusterName }}-$(commitID)
-              os: linux
-              scaleup: 100
-      - template: ../../templates/add-windows-nodepool-job.yaml
-        parameters:
-          depend: ${{ parameters.name }}_linux
-          clusterName: ${{ parameters.clusterName }}-$(commitID)
-          vmSize: "Standard_D2_v3"
-      - job: ${{ parameters.name }}_windows
-        displayName: DualStack Overlay Test Suite | Windows - (${{ parameters.name }})
-        timeoutInMinutes: 120
-        dependsOn: windows_nodepool
-        pool:
-          name: $(BUILD_POOL_NAME_DEFAULT)
-          demands:
-          - agent.os -equals Linux
-          - Role -equals $(CUSTOM_E2E_ROLE)
-        steps:
-          - template: dualstackoverlay-e2e-step-template.yaml
-            parameters:
-              name: ${{ parameters.name }}
-              clusterName: ${{ parameters.clusterName }}-$(commitID)
-              os: windows
-              scaleup: 50
+              os: ${{ parameters.os }}
+              scaleup: ${{ parameters.scaleup }} # 50 in windows or 100 in linux
 
       - template: ../../cni/k8s-e2e/k8s-e2e-job-template.yaml
         parameters:
           sub: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
           clusterName: ${{ parameters.clusterName }}-$(commitID)
-          os: linux
-          dependsOn: ${{ parameters.name }}_windows
-          dualstack: true
+          os: ${{ parameters.os }}
+          dependsOn: ${{ parameters.name }}_${{ parameters.os }}
+          dualstack: ${{ eq(parameters.os, 'linux') }} # RUN IN LINUX not WINDOWS Currently broken for scenario and blocking releases, HNS is investigating. Covered by go test in E2E step template
           dns: true
           portforward: true
+          service: ${{ eq(parameters.os, 'linux') }}  # RUN IN LINUX NOT WINDOWS Currently broken for scenario and blocking releases, HNS is investigating.
           hostport: true
-          service: true
+          hybridWin: ${{ eq(parameters.os, 'windows') }}
 
-      - template: ../../cni/k8s-e2e/k8s-e2e-job-template.yaml
-        parameters:
-          sub: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
-          clusterName: ${{ parameters.clusterName }}-$(commitID)
-          os: windows
-          dependsOn: cni_linux
-          # dualstack: true # Currently broken for scenario and blocking releases, HNS is investigating. Covered by go test in E2E step template
-          dns: true
-          portforward: true
-          # service: true  # Currently broken for scenario and blocking releases, HNS is investigating.
-          hostport: true
-          hybridWin: true
-
-      - job: failedE2ELogs_linux
-        displayName: "Linux Failure Logs"
+      - job: failedE2ELogs_${{ parameters.os }}
+        displayName: "${{ parameters.os }} Failure Logs"
         dependsOn:
-          - ${{ parameters.name }}_linux
-          - cni_linux
-        condition: in(dependencies.${{ parameters.name }}_linux.result, 'Failed')
+          - ${{ parameters.name }}_${{ parameters.os }}
+          - CNI_${{ parameters.os }}
+        condition: in(dependencies.${{ parameters.name }}_${{ parameters.os }}.result, 'Failed')
         steps:
           - template: ../../templates/log-template.yaml
             parameters:
               clusterName: ${{ parameters.clusterName }}-$(commitID)
-              os: linux
-              cni: cniv2
-
-      - job: failedE2ELogs_windows
-        displayName: "Windows Failure Logs"
-        dependsOn:
-          - ${{ parameters.name }}_windows
-          - cni_windows
-        condition: in(dependencies.${{ parameters.name }}_windows.result, 'Failed')
-        steps:
-          - template: ../../templates/log-template.yaml
-            parameters:
-              clusterName: ${{ parameters.clusterName }}-$(commitID)
-              os: windows
+              os: ${{ parameters.os }}
               cni: cniv2

--- a/Makefile
+++ b/Makefile
@@ -772,7 +772,7 @@ test-load: ## run all load tests
 	AZURE_IPAM_VERSION=$(AZURE_IPAM_VERSION) \
 		CNI_VERSION=$(CNI_VERSION)
 		CNS_VERSION=$(CNS_VERSION) \
-		go test -timeout 30m -race -tags=load ./test/integration/load... -v
+		go test -timeout 40m -race -tags=load ./test/integration/load... -v
 
 test-validate-state:
 	cd test/integration/load && go test -mod=readonly -count=1 -timeout 30m -tags load --skip 'TestE2E*' -run ^TestValidateState

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -389,7 +389,7 @@ dualstack-overlay-up: rg-up overlay-net-up ## Brings up an dualstack Overlay clu
 		--yes
 	@$(MAKE) set-kubeconf
 
-dualstack-overlay-byocni-up: rg-up overlay-net-up ## Brings up an dualstack Overlay BYO CNI cluster
+linux-dualstack-overlay-byocni-up: rg-up overlay-net-up ## Brings up an dualstack Overlay BYO CNI cluster
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
 		--auto-upgrade-channel $(AUTOUPGRADE) \
 		--node-os-upgrade-channel $(NODEUPGRADE) \
@@ -403,6 +403,17 @@ dualstack-overlay-byocni-up: rg-up overlay-net-up ## Brings up an dualstack Over
 		--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/AzureOverlayDualStackPreview \
 		--no-ssh-key \
 		--yes
+	@$(MAKE) set-kubeconf
+
+windows-dualstack-overlay-byocni-up: linux-dualstack-overlay-byocni-up
+	WINDOWS_NODEPOOL=$$(az aks nodepool list --resource-group $(GROUP) --cluster-name $(CLUSTER) --query "[?osType=='Windows']" --output tsv); \
+	if [ -z "$$WINDOWS_NODEPOOL" ]; then \
+		echo "No Windows node pool found in the AKS cluster."; \
+		AZCLI="az" GROUP="$(GROUP)" CLUSTER="$(CLUSTER)" sh ../scripts/wait-cluster-update.sh; \
+		$(MAKE) windows-nodepool-up; \
+	else \
+		echo "AKS cluster already has a Windows node pool."; \
+	fi
 	@$(MAKE) set-kubeconf
 
 cilium-dualstack-up: rg-up overlay-net-up ## Brings up a Cilium Dualstack Overlay cluster with Linux node only

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -132,14 +132,8 @@ linux-overlay-byocni-up: rg-up overlay-net-up ## Brings up a Linux Overlay BYO C
 	@$(MAKE) set-kubeconf
 
 windows-overlay-byocni-up: linux-overlay-byocni-up rg-up overlay-net-up ## Brings up a Windows Overlay BYO CNI cluster
-	WINDOWS_NODEPOOL=$$(az aks nodepool list --resource-group $(GROUP) --cluster-name $(CLUSTER) --query "[?osType=='Windows']" --output tsv); \
-	if [ -z "$$WINDOWS_NODEPOOL" ]; then \
-		echo "No Windows node pool found in the AKS cluster."; \
-		AZCLI="az" GROUP="$(GROUP)" CLUSTER="$(CLUSTER)" sh ../scripts/wait-cluster-update.sh; \
-		$(MAKE) windows-nodepool-up; \
-	else \
-		echo "AKS cluster already has a Windows node pool."; \
-	fi
+	AZCLI="az" GROUP="$(GROUP)" CLUSTER="$(CLUSTER)" sh ../scripts/wait-cluster-update.sh
+	$(MAKE) windows-nodepool-up
 	@$(MAKE) set-kubeconf
 
 overlay-byocni-nokubeproxy-up: rg-up overlay-net-up ## Brings up an Overlay BYO CNI cluster without kube-proxy
@@ -414,14 +408,8 @@ linux-dualstack-overlay-byocni-up: rg-up overlay-net-up ## Brings up an dualstac
 	@$(MAKE) set-kubeconf
 
 windows-dualstack-overlay-byocni-up: linux-dualstack-overlay-byocni-up
-	WINDOWS_NODEPOOL=$$(az aks nodepool list --resource-group $(GROUP) --cluster-name $(CLUSTER) --query "[?osType=='Windows']" --output tsv); \
-	if [ -z "$$WINDOWS_NODEPOOL" ]; then \
-		echo "No Windows node pool found in the AKS cluster."; \
-		AZCLI="az" GROUP="$(GROUP)" CLUSTER="$(CLUSTER)" sh ../scripts/wait-cluster-update.sh; \
-		$(MAKE) windows-nodepool-up; \
-	else \
-		echo "AKS cluster already has a Windows node pool."; \
-	fi
+	AZCLI="az" GROUP="$(GROUP)" CLUSTER="$(CLUSTER)" sh ../scripts/wait-cluster-update.sh
+	$(MAKE) windows-nodepool-up
 	@$(MAKE) set-kubeconf
 
 cilium-dualstack-up: rg-up overlay-net-up ## Brings up a Cilium Dualstack Overlay cluster with Linux node only

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -114,7 +114,7 @@ nodesubnet-byocni-nokubeproxy-up: rg-up overlay-net-up ## Brings up an NodeSubne
 		--yes
 	@$(MAKE) set-kubeconf
 
-overlay-byocni-up: rg-up overlay-net-up ## Brings up an Overlay BYO CNI cluster
+linux-overlay-byocni-up: rg-up overlay-net-up ## Brings up a Linux Overlay BYO CNI cluster
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
 		--auto-upgrade-channel $(AUTOUPGRADE) \
 		--node-os-upgrade-channel $(NODEUPGRADE) \
@@ -129,9 +129,17 @@ overlay-byocni-up: rg-up overlay-net-up ## Brings up an Overlay BYO CNI cluster
 		--no-ssh-key \
 		--os-sku $(OS_SKU) \
 		--yes
-ifeq ($(OS),windows)
-	@$(MAKE) windows-nodepool-up
-endif
+	@$(MAKE) set-kubeconf
+
+windows-overlay-byocni-up: linux-overlay-byocni-up rg-up overlay-net-up ## Brings up a Windows Overlay BYO CNI cluster
+	WINDOWS_NODEPOOL=$$(az aks nodepool list --resource-group $(GROUP) --cluster-name $(CLUSTER) --query "[?osType=='Windows']" --output tsv); \
+	if [ -z "$$WINDOWS_NODEPOOL" ]; then \
+		echo "No Windows node pool found in the AKS cluster."; \
+		AZCLI="az" GROUP="$(GROUP)" CLUSTER="$(CLUSTER)" sh ../scripts/wait-cluster-update.sh; \
+		$(MAKE) windows-nodepool-up; \
+	else \
+		echo "AKS cluster already has a Windows node pool."; \
+	fi
 	@$(MAKE) set-kubeconf
 
 overlay-byocni-nokubeproxy-up: rg-up overlay-net-up ## Brings up an Overlay BYO CNI cluster without kube-proxy

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -114,6 +114,9 @@ nodesubnet-byocni-nokubeproxy-up: rg-up overlay-net-up ## Brings up an NodeSubne
 		--yes
 	@$(MAKE) set-kubeconf
 
+# alias for linux-overlay-byocni-up
+overlay-byocni-up: linux-overlay-byocni-up
+
 linux-overlay-byocni-up: rg-up overlay-net-up ## Brings up a Linux Overlay BYO CNI cluster
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
 		--auto-upgrade-channel $(AUTOUPGRADE) \
@@ -390,6 +393,9 @@ dualstack-overlay-up: rg-up overlay-net-up ## Brings up an dualstack Overlay clu
 		--no-ssh-key \
 		--yes
 	@$(MAKE) set-kubeconf
+
+# alias for linux-dualstack-overlay-byocni-up
+dualstack-overlay-byocni-up: linux-dualstack-overlay-byocni-up
 
 linux-dualstack-overlay-byocni-up: rg-up overlay-net-up ## Brings up an dualstack Overlay BYO CNI cluster
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -114,10 +114,7 @@ nodesubnet-byocni-nokubeproxy-up: rg-up overlay-net-up ## Brings up an NodeSubne
 		--yes
 	@$(MAKE) set-kubeconf
 
-# alias for linux-overlay-byocni-up
-overlay-byocni-up: linux-overlay-byocni-up
-
-linux-overlay-byocni-up: rg-up overlay-net-up ## Brings up a Linux Overlay BYO CNI cluster
+overlay-byocni-up: rg-up overlay-net-up ## Brings up a Linux Overlay BYO CNI cluster
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
 		--auto-upgrade-channel $(AUTOUPGRADE) \
 		--node-os-upgrade-channel $(NODEUPGRADE) \
@@ -133,11 +130,10 @@ linux-overlay-byocni-up: rg-up overlay-net-up ## Brings up a Linux Overlay BYO C
 		--os-sku $(OS_SKU) \
 		--yes
 	@$(MAKE) set-kubeconf
-
-windows-overlay-byocni-up: linux-overlay-byocni-up rg-up overlay-net-up ## Brings up a Windows Overlay BYO CNI cluster
+ifeq ($(OS),windows)
 	AZCLI="az" GROUP="$(GROUP)" CLUSTER="$(CLUSTER)" sh ../scripts/wait-cluster-update.sh
 	$(MAKE) windows-nodepool-up
-	@$(MAKE) set-kubeconf
+endif
 
 overlay-byocni-nokubeproxy-up: rg-up overlay-net-up ## Brings up an Overlay BYO CNI cluster without kube-proxy
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
@@ -394,10 +390,7 @@ dualstack-overlay-up: rg-up overlay-net-up ## Brings up an dualstack Overlay clu
 		--yes
 	@$(MAKE) set-kubeconf
 
-# alias for linux-dualstack-overlay-byocni-up
-dualstack-overlay-byocni-up: linux-dualstack-overlay-byocni-up
-
-linux-dualstack-overlay-byocni-up: rg-up overlay-net-up ## Brings up an dualstack Overlay BYO CNI cluster
+dualstack-overlay-byocni-up: rg-up overlay-net-up ## Brings up an dualstack Overlay BYO CNI cluster
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
 		--auto-upgrade-channel $(AUTOUPGRADE) \
 		--node-os-upgrade-channel $(NODEUPGRADE) \
@@ -412,11 +405,10 @@ linux-dualstack-overlay-byocni-up: rg-up overlay-net-up ## Brings up an dualstac
 		--no-ssh-key \
 		--yes
 	@$(MAKE) set-kubeconf
-
-windows-dualstack-overlay-byocni-up: linux-dualstack-overlay-byocni-up
+ifeq ($(OS),windows)
 	AZCLI="az" GROUP="$(GROUP)" CLUSTER="$(CLUSTER)" sh ../scripts/wait-cluster-update.sh
 	$(MAKE) windows-nodepool-up
-	@$(MAKE) set-kubeconf
+endif
 
 cilium-dualstack-up: rg-up overlay-net-up ## Brings up a Cilium Dualstack Overlay cluster with Linux node only
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \

--- a/hack/scripts/wait-cluster-update.sh
+++ b/hack/scripts/wait-cluster-update.sh
@@ -1,0 +1,16 @@
+# wait for cluster to update
+while true; do
+    cluster_state=$($AZCLI aks show \
+    --name "$CLUSTER" \
+    --resource-group "$GROUP" \
+    --query provisioningState)
+    
+    if echo "$cluster_state" | grep -q "Updating"; then
+        echo "Cluster is updating. Sleeping for 30 seconds..."
+        sleep 30
+    else
+        break
+    fi
+done
+# cluster state is always set and visible outside the loop
+echo "Cluster state is: $cluster_state"


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Splits dualstack and overlay E2E testing stages into stages dedicated to each operating system.
Dualstack E2E --> Dualstack Windows E2E and Dualstack Linux E2E
Overlay E2E --> Overlay Windows E2E and Overlay Linux E2E
Increases load test timeout from 30m to 40m due to timeouts (even though it seemed like the test was progressing)

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Dualstack and Overlay E2E stages take the longest to run in the pipeline and are the most likely to fail. These stages will fail faster if run in parallel.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
Green run: https://msazure.visualstudio.com/One/_build/results?buildId=115530896&view=results