### PR TITLE
fix: zapetw core With fields

### DIFF
--- a/cni/log/logger_windows.go
+++ b/cni/log/logger_windows.go
@@ -26,7 +26,7 @@ func etwCore(loggingLevel zapcore.Level) (zapcore.Core, error) {
 	encoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	jsonEncoder := zapcore.NewJSONEncoder(encoderConfig)
 
-	etwcore, err := zapetw.NewETWCore(etwCNIEventName, jsonEncoder, loggingLevel)
+	etwcore, _, err := zapetw.New("ACN-Monitoring", etwCNIEventName, jsonEncoder, loggingLevel)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create ETW core")
 	}

--- a/cns/logger/cnslogger_windows.go
+++ b/cns/logger/cnslogger_windows.go
@@ -19,7 +19,7 @@ func getPlatformCores(loggingLevel zapcore.Level, encoder zapcore.Encoder) (zapc
 }
 
 func getETWCore(loggingLevel zapcore.Level, encoder zapcore.Encoder) (zapcore.Core, error) {
-	etwcore, err := zapetw.NewETWCore(etwCNSEventName, encoder, loggingLevel)
+	etwcore, _, err := zapetw.New("ACN-Monitoring", etwCNSEventName, encoder, loggingLevel)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create ETW core")
 	}


### PR DESCRIPTION
Fixes a bug in the zapetw core where the extra `fields` added by calling `With` were not referenced when producing the log output.

There was a private `fields` slice in the Core struct, but it is not referenced anywhere. When a new Core is created in `With`, the `fields` were copied over...but still not _used_.
Now, instead, these fields are added to the Encoder. In the `With` call, the Core is copied and the Encoder cloned, then new fields are added to the clone. This ensures that the new Fields in a derived logger/core do not propogate back _up_ to the root logger...and also that they are used in producing the log output.

Also includes some minor refactoring to fix naming and improve contracts.
