### PR TITLE
feat: cns logger v2 [2/2]

### DIFF
--- a/aitelemetry/telemetrywrapper_linux.go
+++ b/aitelemetry/telemetrywrapper_linux.go
@@ -1,5 +1,0 @@
-package aitelemetry
-
-const (
-	metadataFile = "/tmp/azuremetadata.json"
-)

--- a/aitelemetry/telemetrywrapper_windows.go
+++ b/aitelemetry/telemetrywrapper_windows.go
@@ -1,8 +1,0 @@
-package aitelemetry
-
-import (
-	"os"
-	"path/filepath"
-)
-
-var metadataFile = filepath.FromSlash(os.Getenv("TEMP")) + "\\azuremetadata.json"

--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -30,6 +30,7 @@ type CNSConfig struct {
 	EnableCNIConflistGeneration bool
 	EnableIPAMv2                bool
 	EnableK8sDevicePlugin       bool
+	EnableLoggerV2              bool
 	EnablePprof                 bool
 	EnableStateMigration        bool
 	EnableSubnetScarcity        bool

--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/logger"
+	loggerv2 "github.com/Azure/azure-container-networking/cns/logger/v2"
 	"github.com/Azure/azure-container-networking/common"
 	"github.com/pkg/errors"
 )
@@ -37,6 +38,7 @@ type CNSConfig struct {
 	EnableSwiftV2               bool
 	InitializeFromCNI           bool
 	KeyVaultSettings            KeyVaultSettings
+	Logger                      loggerv2.Config
 	MSISettings                 MSISettings
 	ManageEndpointState         bool
 	ManagedSettings             ManagedSettings

--- a/cns/logger/log.go
+++ b/cns/logger/log.go
@@ -6,66 +6,95 @@ import (
 	"github.com/Azure/azure-container-networking/cns/types"
 )
 
+type loggershim interface {
+	Close()
+	InitAI(aitelemetry.AIConfig, bool, bool, bool)
+	InitAIWithIKey(aitelemetry.AIConfig, string, bool, bool, bool)
+	SetContextDetails(string, string)
+	SetAPIServer(string)
+	Printf(string, ...any)
+	Debugf(string, ...any)
+	Warnf(string, ...any)
+	LogEvent(aitelemetry.Event)
+	Errorf(string, ...any)
+	Request(string, any, error)
+	Response(string, any, types.ResponseCode, error)
+	ResponseEx(string, any, any, types.ResponseCode, error)
+	SendMetric(aitelemetry.Metric)
+}
+
 var (
-	Log             *CNSLogger
-	aiMetadata      string // this var is set at build time.
+	Log             loggershim
 	AppInsightsIKey = aiMetadata
+	aiMetadata      string // this var is set at build time.
 )
 
-// todo: the functions below should be removed. CNSLogger should be injected where needed and not used from package level scope.
-
+// Deprecated: The global logger is deprecated. Migrate to zap using the cns/logger/v2 package and pass the logger instead.
 func Close() {
 	Log.Close()
 }
 
+// Deprecated: The global logger is deprecated. Migrate to zap using the cns/logger/v2 package and pass the logger instead.
 func InitLogger(fileName string, logLevel, logTarget int, logDir string) {
 	Log, _ = New(fileName, logLevel, logTarget, logDir)
 }
 
+// Deprecated: The global logger is deprecated. Migrate to zap using the cns/logger/v2 package and pass the logger instead.
 func InitAI(aiConfig aitelemetry.AIConfig, disableTraceLogging, disableMetricLogging, disableEventLogging bool) {
 	Log.InitAI(aiConfig, disableTraceLogging, disableMetricLogging, disableEventLogging)
 }
 
+// Deprecated: The global logger is deprecated. Migrate to zap using the cns/logger/v2 package and pass the logger instead.
 func InitAIWithIKey(aiConfig aitelemetry.AIConfig, instrumentationKey string, disableTraceLogging, disableMetricLogging, disableEventLogging bool) {
 	Log.InitAIWithIKey(aiConfig, instrumentationKey, disableTraceLogging, disableMetricLogging, disableEventLogging)
 }
 
+// Deprecated: The global logger is deprecated. Migrate to zap using the cns/logger/v2 package and pass the logger instead.
 func SetContextDetails(orchestrator, nodeID string) {
 	Log.SetContextDetails(orchestrator, nodeID)
 }
 
+// Deprecated: The global logger is deprecated. Migrate to zap using the cns/logger/v2 package and pass the logger instead.
 func Printf(format string, args ...any) {
 	Log.Printf(format, args...)
 }
 
+// Deprecated: The global logger is deprecated. Migrate to zap using the cns/logger/v2 package and pass the logger instead.
 func Debugf(format string, args ...any) {
 	Log.Debugf(format, args...)
 }
 
+// Deprecated: The global logger is deprecated. Migrate to zap using the cns/logger/v2 package and pass the logger instead.
 func Warnf(format string, args ...any) {
 	Log.Warnf(format, args...)
 }
 
+// Deprecated: The global logger is deprecated. Migrate to zap using the cns/logger/v2 package and pass the logger instead.
 func LogEvent(event aitelemetry.Event) {
 	Log.LogEvent(event)
 }
 
+// Deprecated: The global logger is deprecated. Migrate to zap using the cns/logger/v2 package and pass the logger instead.
 func Errorf(format string, args ...any) {
 	Log.Errorf(format, args...)
 }
 
+// Deprecated: The global logger is deprecated. Migrate to zap using the cns/logger/v2 package and pass the logger instead.
 func Request(tag string, request any, err error) {
 	Log.Request(tag, request, err)
 }
 
+// Deprecated: The global logger is deprecated. Migrate to zap using the cns/logger/v2 package and pass the logger instead.
 func Response(tag string, response any, returnCode types.ResponseCode, err error) {
 	Log.Response(tag, response, returnCode, err)
 }
 
+// Deprecated: The global logger is deprecated. Migrate to zap using the cns/logger/v2 package and pass the logger instead.
 func ResponseEx(tag string, request, response any, returnCode types.ResponseCode, err error) {
 	Log.ResponseEx(tag, request, response, returnCode, err)
 }
 
+// Deprecated: The global logger is deprecated. Migrate to zap using the cns/logger/v2 package and pass the logger instead.
 func SendMetric(metric aitelemetry.Metric) {
 	Log.SendMetric(metric)
 }

--- a/cns/logger/v2/config.go
+++ b/cns/logger/v2/config.go
@@ -42,8 +42,8 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// Normalize checks the Config for missing or illegal values and sets them
-// to defaults if appropriate.
+// Normalize checks the Config for missing/default values and sets them
+// if appropriate.
 func (c *Config) Normalize() {
 	if c.File != nil {
 		if c.File.Filepath == "" {

--- a/cns/logger/v2/cores/ai.go
+++ b/cns/logger/v2/cores/ai.go
@@ -62,6 +62,6 @@ func ApplicationInsightsCore(cfg *AppInsightsConfig) (zapcore.Core, func(), erro
 	core := zapai.NewCore(cfg.level, sink)
 	core = core.WithFieldMappers(zapai.DefaultMappers)
 	// add normalized fields for the built-in AI Tags
-	// TODO(rbtr): move to the caller
+
 	return core.With(cfg.Fields), aiclose, nil
 }

--- a/cns/logger/v2/cores/etw_windows.go
+++ b/cns/logger/v2/cores/etw_windows.go
@@ -1,15 +1,41 @@
 package logger
 
 import (
+	"encoding/json"
+
 	"github.com/Azure/azure-container-networking/zapetw"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
 type ETWConfig struct {
-	EventName    string
-	Level        zapcore.Level
-	ProviderName string
+	EventName    string          `json:"eventname"`
+	Level        string          `json:"level"`
+	level        zapcore.Level   `json:"-"`
+	ProviderName string          `json:"providername"`
+	Fields       []zapcore.Field `json:"fields"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler for the Config.
+// It only differs from the default by parsing the
+// Level string into a zapcore.Level and setting the level field.
+func (cfg *ETWConfig) UnmarshalJSON(data []byte) error {
+	type Alias ETWConfig
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(cfg),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return errors.Wrap(err, "failed to unmarshal ETWConfig")
+	}
+	lvl, err := zapcore.ParseLevel(cfg.Level)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse ETWConfig Level")
+	}
+	cfg.level = lvl
+	return nil
 }
 
 // ETWCore builds a zapcore.Core that sends logs to ETW.
@@ -18,5 +44,5 @@ func ETWCore(cfg *ETWConfig) (zapcore.Core, func(), error) {
 	encoderConfig := zap.NewProductionEncoderConfig()
 	encoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	jsonEncoder := zapcore.NewJSONEncoder(encoderConfig)
-	return zapetw.New(cfg.ProviderName, cfg.EventName, jsonEncoder, cfg.Level) //nolint:wrapcheck // ignore
+	return zapetw.New(cfg.ProviderName, cfg.EventName, jsonEncoder, cfg.level) //nolint:wrapcheck // ignore
 }

--- a/cns/logger/v2/cores/file.go
+++ b/cns/logger/v2/cores/file.go
@@ -10,11 +10,12 @@ import (
 )
 
 type FileConfig struct {
-	Filepath   string        `json:"filepath"`
-	Level      string        `json:"level"`
-	level      zapcore.Level `json:"-"`
-	MaxBackups int           `json:"maxBackups"`
-	MaxSize    int           `json:"maxSize"`
+	Filepath   string          `json:"filepath"`
+	Level      string          `json:"level"`
+	level      zapcore.Level   `json:"-"`
+	MaxBackups int             `json:"maxBackups"`
+	MaxSize    int             `json:"maxSize"`
+	Fields     []zapcore.Field `json:"fields"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler for the Config.

--- a/cns/logger/v2/cores/stdout.go
+++ b/cns/logger/v2/cores/stdout.go
@@ -1,12 +1,41 @@
 package logger
 
 import (
+	"encoding/json"
 	"os"
 
 	logfmt "github.com/jsternberg/zap-logfmt"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
+
+type StdoutConfig struct {
+	Level  string          `json:"level"`
+	level  zapcore.Level   `json:"-"`
+	Fields []zapcore.Field `json:"fields"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler for the Config.
+// It only differs from the default by parsing the
+// Level string into a zapcore.Level and setting the level field.
+func (cfg *StdoutConfig) UnmarshalJSON(data []byte) error {
+	type Alias StdoutConfig
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(cfg),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return errors.Wrap(err, "failed to unmarshal StdoutConfig")
+	}
+	lvl, err := zapcore.ParseLevel(cfg.Level)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse StdoutConfig Level")
+	}
+	cfg.level = lvl
+	return nil
+}
 
 // StdoutCore builds a zapcore.Core that writes to stdout.
 func StdoutCore(l zapcore.Level) zapcore.Core {

--- a/cns/logger/v2/fields.go
+++ b/cns/logger/v2/fields.go
@@ -1,0 +1,23 @@
+package logger
+
+import (
+	"github.com/Azure/azure-container-networking/common"
+	"go.uber.org/zap"
+)
+
+// MetadataToFields transforms Az IMDS Metadata in to zap.Field for
+// attaching to a root zap core or logger instance.
+// This uses the nice-names from the zapai.DefaultMappers instead of
+// raw AppInsights key names.
+func MetadataToFields(meta common.Metadata) []zap.Field {
+	return []zap.Field{
+		zap.String("account", meta.SubscriptionID),
+		zap.String("anonymous_user_id", meta.VMName),
+		zap.String("location", meta.Location),
+		zap.String("resource_group", meta.ResourceGroupName),
+		zap.String("vm_size", meta.VMSize),
+		zap.String("os_version", meta.OSVersion),
+		zap.String("vm_id", meta.VMID),
+		zap.String("session_id", meta.VMID),
+	}
+}

--- a/cns/logger/v2/logger.go
+++ b/cns/logger/v2/logger.go
@@ -1,3 +1,5 @@
+// Package logger provides an opinionated logger for CNS which knows how to
+// log to Application Insights, file, stdout and ETW (based on platform).
 package logger
 
 import (

--- a/cns/logger/v2/logger.go
+++ b/cns/logger/v2/logger.go
@@ -16,6 +16,7 @@ func (c compoundCloser) Close() {
 	}
 }
 
+// New creates a v2 CNS logger built with Zap.
 func New(cfg *Config) (*zap.Logger, func(), error) {
 	cfg.Normalize()
 	core := cores.StdoutCore(cfg.level)

--- a/cns/logger/v2/logger_linux.go
+++ b/cns/logger/v2/logger_linux.go
@@ -4,7 +4,7 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-// platformCore returns a no-op core for Linux.
+// On Linux, platformCore returns a no-op core.
 func platformCore(*Config) (zapcore.Core, func(), error) {
 	return zapcore.NewNopCore(), func() {}, nil
 }

--- a/cns/logger/v2/logger_windows.go
+++ b/cns/logger/v2/logger_windows.go
@@ -5,7 +5,7 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-// platformCore returns a zapcore.Core that sends logs to ETW.
+// On Windows, platformCore returns a zapcore.Core that sends logs to ETW.
 func platformCore(cfg *Config) (zapcore.Core, func(), error) {
 	if cfg.ETW == nil {
 		return zapcore.NewNopCore(), func() {}, nil

--- a/cns/logger/v2/shim.go
+++ b/cns/logger/v2/shim.go
@@ -1,0 +1,64 @@
+package logger
+
+import (
+	"github.com/Azure/azure-container-networking/aitelemetry"
+	"github.com/Azure/azure-container-networking/cns/types"
+	"go.uber.org/zap"
+)
+
+// shim wraps the Zap logger to provide a compatible interface to the
+// legacy CNS logger. This is temporary and exists to make migration
+// feasible and optional.
+type shim struct {
+	z      *zap.Logger
+	closer func()
+}
+
+func (s *shim) Close() {
+	_ = s.z.Sync()
+	s.closer()
+}
+
+func (s *shim) Printf(format string, a ...any) {
+	s.z.Sugar().Infof(format, a...)
+}
+
+func (s *shim) Debugf(format string, a ...any) {
+	s.z.Sugar().Debugf(format, a...)
+}
+
+func (s *shim) Warnf(format string, a ...any) {
+	s.z.Sugar().Warnf(format, a...)
+}
+
+func (s *shim) Errorf(format string, a ...any) {
+	s.z.Sugar().Errorf(format, a...)
+}
+
+func (s *shim) Request(msg string, data any, err error) {
+	s.z.Sugar().Infow("Request", "message", msg, "data", data, "error", err)
+}
+
+func (s *shim) Response(msg string, data any, code types.ResponseCode, err error) {
+	s.z.Sugar().Infow("Response", "message", msg, "data", data, "code", code, "error", err)
+}
+
+func (s *shim) ResponseEx(msg string, request, response any, code types.ResponseCode, err error) {
+	s.z.Sugar().Infow("ResponseEx", "message", msg, "request", request, "response", response, "code", code, "error", err)
+}
+
+func (*shim) InitAI(aitelemetry.AIConfig, bool, bool, bool) {}
+
+func (*shim) InitAIWithIKey(aitelemetry.AIConfig, string, bool, bool, bool) {}
+
+func (s *shim) SetContextDetails(string, string) {}
+
+func (s *shim) SetAPIServer(string) {}
+
+func (s *shim) SendMetric(aitelemetry.Metric) {}
+
+func (s *shim) LogEvent(aitelemetry.Event) {}
+
+func AsV1(z *zap.Logger, closer func()) *shim { //nolint:revive // I want it to be annoying to use.
+	return &shim{z: z, closer: closer}
+}

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -67,6 +67,7 @@ import (
 	"github.com/Azure/azure-container-networking/store"
 	"github.com/Azure/azure-container-networking/telemetry"
 	"github.com/avast/retry-go/v4"
+	"github.com/go-logr/zapr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -84,7 +85,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	ctrlzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
@@ -629,7 +629,7 @@ func main() {
 	}
 
 	// build the zap logger
-	z, c, err := loggerv2.New(&loggerv2.Config{})
+	z, c, err := loggerv2.New(&cnsconfig.Logger)
 	defer c()
 	if err != nil {
 		fmt.Printf("failed to create logger: %v", err)
@@ -1515,7 +1515,7 @@ func InitializeCRDState(ctx context.Context, z *zap.Logger, httpRestService cns.
 		Scheme:  scheme,
 		Metrics: ctrlmetrics.Options{BindAddress: "0"},
 		Cache:   cacheOpts,
-		Logger:  ctrlzap.New(),
+		Logger:  zapr.NewLogger(z),
 	}
 
 	manager, err := ctrl.NewManager(kubeConfig, managerOpts)


### PR DESCRIPTION
Adds v2 logger package for CNS. [2/2]

The v2 logger is built with zap and offers structured logging, derived contexts, multiple output targets and formats including stdout, files, ETW, and AppInsights.
The logger constructor is opinionated and will initialize targets and formats fully based on what is supported per-platform. The logger is intended to be used directly.

This pt. 2 change adds a migration path to the v2 logger via CNS config. `EnableLoggerV2=true` replaces the global logger during CNS init with a shimmed v2 logger.