### PR TITLE
Expose GET NC list API in CNS client

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -40,6 +40,7 @@ const (
 	NumberOfCPUCores                         = NumberOfCPUCoresPath
 	NMAgentSupportedAPIs                     = NmAgentSupportedApisPath
 	EndpointAPI                              = EndpointPath
+	GetNCList                                = "/nclist"
 )
 
 // NetworkContainer Prefixes

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -19,6 +19,7 @@ import (
 const (
 	SetOrchestratorType                      = "/network/setorchestratortype"
 	GetHomeAz                                = "/homeaz"
+	GetNCList                                = "/nclist"
 	GetVMUniqueID                            = "/metadata/vmuniqueid"
 	CreateOrUpdateNetworkContainer           = "/network/createorupdatenetworkcontainer"
 	DeleteNetworkContainer                   = "/network/deletenetworkcontainer"
@@ -40,7 +41,6 @@ const (
 	NumberOfCPUCores                         = NumberOfCPUCoresPath
 	NMAgentSupportedAPIs                     = NmAgentSupportedApisPath
 	EndpointAPI                              = EndpointPath
-	GetNCList                                = "/nclist"
 )
 
 // NetworkContainer Prefixes

--- a/cns/api.go
+++ b/cns/api.go
@@ -353,6 +353,11 @@ type NmAgentSupportedApisResponse struct {
 	SupportedApis []string
 }
 
+type NCListResponse struct {
+	Response Response `json:"response"`
+	NCList   []string `json:"ncList"`
+}
+
 type HomeAzResponse struct {
 	IsSupported          bool `json:"isSupported"`
 	HomeAz               uint `json:"homeAz"`

--- a/cns/api.go
+++ b/cns/api.go
@@ -28,6 +28,7 @@ const (
 	CreateHostNCApipaEndpointPath = "/network/createhostncapipaendpoint"
 	DeleteHostNCApipaEndpointPath = "/network/deletehostncapipaendpoint"
 	NmAgentSupportedApisPath      = "/network/nmagentsupportedapis"
+	NMAgentGetNCListAPIPath       = "/nclist"
 	V1Prefix                      = "/v0.1"
 	V2Prefix                      = "/v0.2"
 	EndpointPath                  = "/network/endpoints/"

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -1317,6 +1317,7 @@ func (service *HTTPRestService) nmAgentNCListHandler(w http.ResponseWriter, r *h
 		if ncVersionerr != nil {
 			returnCode = types.NmAgentNCVersionListError
 			returnMessage = "[Azure-CNS] " + ncVersionerr.Error()
+			break
 		}
 
 		for _, container := range ncVersionList.Containers {

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -1306,10 +1306,10 @@ func (service *HTTPRestService) nmAgentNCListHandler(w http.ResponseWriter, r *h
 	logger.Request(service.Name, "nmAgentNCListHandler", nil)
 	var (
 		returnCode           types.ResponseCode
-		returnMessage        string
 		networkContainerList []string
 	)
 
+	returnMessage := "Successfully fetched NC list from NMAgent"
 	ctx := r.Context()
 	switch r.Method {
 	case http.MethodGet:

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -1300,3 +1300,39 @@ func (service *HTTPRestService) getVMUniqueID(w http.ResponseWriter, r *http.Req
 		})
 	}
 }
+
+// This function is used to query all NCs on a node from NMAgent
+func (service *HTTPRestService) nmAgentNCListHandler(w http.ResponseWriter, r *http.Request) {
+	logger.Request(service.Name, "nmAgentNCListHandler", nil)
+	var (
+		returnCode           types.ResponseCode
+		returnMessage        string
+		networkContainerList []string
+	)
+
+	ctx := r.Context()
+	switch r.Method {
+	case http.MethodGet:
+		ncVersionList, ncVersionerr := service.nma.GetNCVersionList(ctx)
+		if ncVersionerr != nil {
+			returnCode = types.NmAgentNCVersionListError
+			returnMessage = fmt.Sprintf("[Azure-CNS] %s", ncVersionerr.Error())
+		}
+
+		for _, container := range ncVersionList.Containers {
+			networkContainerList = append(networkContainerList, container.NetworkContainerID)
+		}
+
+	default:
+		returnMessage = "[Azure-CNS] NmAgentNCList API expects a GET method."
+	}
+
+	resp := cns.Response{ReturnCode: returnCode, Message: returnMessage}
+	NCListResponse := &cns.NCListResponse{
+		Response: resp,
+		NCList:   networkContainerList,
+	}
+
+	serviceErr := common.Encode(w, &NCListResponse)
+	logger.Response(service.Name, NCListResponse, resp.ReturnCode, serviceErr)
+}

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -1316,7 +1316,7 @@ func (service *HTTPRestService) nmAgentNCListHandler(w http.ResponseWriter, r *h
 		ncVersionList, ncVersionerr := service.nma.GetNCVersionList(ctx)
 		if ncVersionerr != nil {
 			returnCode = types.NmAgentNCVersionListError
-			returnMessage = fmt.Sprintf("[Azure-CNS] %s", ncVersionerr.Error())
+			returnMessage = "[Azure-CNS] " + ncVersionerr.Error()
 		}
 
 		for _, container := range ncVersionList.Containers {

--- a/cns/restserver/api_test.go
+++ b/cns/restserver/api_test.go
@@ -1306,7 +1306,10 @@ func TestNMAgentNCListHandler(t *testing.T) {
 	fmt.Println("Test: nmAgentNCListHandler")
 
 	setEnv(t)
-	setOrchestratorType(t, cns.Kubernetes)
+	errSetOrch := setOrchestratorType(t, cns.Kubernetes)
+	if errSetOrch != nil {
+		t.Fatalf("TestNMAgentNCListHandler failed with error:%+v", errSetOrch)
+	}
 
 	mnma := &fakes.NMAgentClientFake{}
 	cleanupNMA := setMockNMAgent(svc, mnma)

--- a/cns/restserver/api_test.go
+++ b/cns/restserver/api_test.go
@@ -1302,6 +1302,31 @@ func TestNmAgentSupportedApisHandler(t *testing.T) {
 	fmt.Printf("nmAgentSupportedApisHandler Responded with %+v\n", nmAgentSupportedApisResponse)
 }
 
+func TestNMAgentNCListHandler(t *testing.T) {
+	fmt.Println("Test: nmAgentNCListHandler")
+	var (
+		err error
+		req *http.Request
+	)
+
+	req, err = http.NewRequest(http.MethodGet, cns.NMAgentGetNCListAPIPath, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	var nmAgentNCListResponse cns.NCListResponse
+
+	err = decodeResponse(w, &nmAgentNCListResponse)
+	if err != nil || nmAgentNCListResponse.Response.ReturnCode != 0 {
+		t.Errorf("nmAgentNCListHandler failed with response %+v", nmAgentNCListResponse)
+	}
+
+	fmt.Printf("nmAgentNCListHandler responded with %+v\n", nmAgentNCListResponse)
+	require.Len(t, nmAgentNCListResponse.NCList, 0)
+}
+
 // Testing GetHomeAz API handler, return UnsupportedVerb if http method is not supported
 func TestGetHomeAz_UnsupportedHttpMethod(t *testing.T) {
 	req, err := http.NewRequestWithContext(context.TODO(), http.MethodPost, cns.GetHomeAz, http.NoBody)

--- a/cns/restserver/api_test.go
+++ b/cns/restserver/api_test.go
@@ -1309,7 +1309,7 @@ func TestNMAgentNCListHandler(t *testing.T) {
 		req *http.Request
 	)
 
-	req, err = http.NewRequest(http.MethodGet, cns.NMAgentGetNCListAPIPath, http.NoBody)
+	req, err = http.NewRequestWithContext(context.TODO(), http.MethodGet, cns.NMAgentGetNCListAPIPath, http.NoBody)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cns/restserver/api_test.go
+++ b/cns/restserver/api_test.go
@@ -1309,7 +1309,7 @@ func TestNMAgentNCListHandler(t *testing.T) {
 		req *http.Request
 	)
 
-	req, err = http.NewRequest(http.MethodGet, cns.NMAgentGetNCListAPIPath, nil)
+	req, err = http.NewRequest(http.MethodGet, cns.NMAgentGetNCListAPIPath, http.NoBody)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1324,7 +1324,7 @@ func TestNMAgentNCListHandler(t *testing.T) {
 	}
 
 	fmt.Printf("nmAgentNCListHandler responded with %+v\n", nmAgentNCListResponse)
-	require.Len(t, nmAgentNCListResponse.NCList, 0)
+	require.Empty(t, nmAgentNCListResponse.NCList)
 }
 
 // Testing GetHomeAz API handler, return UnsupportedVerb if http method is not supported

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -292,6 +292,7 @@ func (service *HTTPRestService) Init(config *common.ServiceConfig) error {
 	listener.AddHandler(cns.NetworkContainersURLPath, service.getOrRefreshNetworkContainers)
 	listener.AddHandler(cns.GetHomeAz, service.getHomeAz)
 	listener.AddHandler(cns.EndpointPath, service.EndpointHandlerAPI)
+	listener.AddHandler(cns.GetNCList, service.nmAgentNCListHandler)
 	// This API is only needed for Direct channel mode with Swift v2.
 	if config.ChannelMode == cns.Direct {
 		listener.AddHandler(cns.GetVMUniqueID, service.getVMUniqueID)
@@ -318,6 +319,7 @@ func (service *HTTPRestService) Init(config *common.ServiceConfig) error {
 	listener.AddHandler(cns.V2Prefix+cns.NmAgentSupportedApisPath, service.nmAgentSupportedApisHandler)
 	listener.AddHandler(cns.V2Prefix+cns.GetHomeAz, service.getHomeAz)
 	listener.AddHandler(cns.V2Prefix+cns.EndpointPath, service.EndpointHandlerAPI)
+	listener.AddHandler(cns.V2Prefix+cns.GetNCList, service.nmAgentNCListHandler)
 	// This API is only needed for Direct channel mode with Swift v2.
 	if config.ChannelMode == cns.Direct {
 		listener.AddHandler(cns.V2Prefix+cns.GetVMUniqueID, service.getVMUniqueID)

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -292,10 +292,10 @@ func (service *HTTPRestService) Init(config *common.ServiceConfig) error {
 	listener.AddHandler(cns.NetworkContainersURLPath, service.getOrRefreshNetworkContainers)
 	listener.AddHandler(cns.GetHomeAz, service.getHomeAz)
 	listener.AddHandler(cns.EndpointPath, service.EndpointHandlerAPI)
-	listener.AddHandler(cns.GetNCList, service.nmAgentNCListHandler)
-	// This API is only needed for Direct channel mode with Swift v2.
+	// This API is only needed for Direct channel mode.
 	if config.ChannelMode == cns.Direct {
 		listener.AddHandler(cns.GetVMUniqueID, service.getVMUniqueID)
+		listener.AddHandler(cns.GetNCList, service.nmAgentNCListHandler)
 	}
 
 	// handlers for v0.2
@@ -319,10 +319,10 @@ func (service *HTTPRestService) Init(config *common.ServiceConfig) error {
 	listener.AddHandler(cns.V2Prefix+cns.NmAgentSupportedApisPath, service.nmAgentSupportedApisHandler)
 	listener.AddHandler(cns.V2Prefix+cns.GetHomeAz, service.getHomeAz)
 	listener.AddHandler(cns.V2Prefix+cns.EndpointPath, service.EndpointHandlerAPI)
-	listener.AddHandler(cns.V2Prefix+cns.GetNCList, service.nmAgentNCListHandler)
-	// This API is only needed for Direct channel mode with Swift v2.
+	// This API is only needed for Direct channel mode.
 	if config.ChannelMode == cns.Direct {
 		listener.AddHandler(cns.V2Prefix+cns.GetVMUniqueID, service.getVMUniqueID)
+		listener.AddHandler(cns.V2Prefix+cns.GetNCList, service.nmAgentNCListHandler)
 	}
 
 	// Initialize HTTP client to be reused in CNS

--- a/cns/types/codes.go
+++ b/cns/types/codes.go
@@ -46,6 +46,7 @@ const (
 	FailedToAllocateBackendConfig          ResponseCode = 44
 	ConnectionError                        ResponseCode = 45
 	UnexpectedError                        ResponseCode = 99
+	NmAgentNCVersionListError              ResponseCode = 100
 )
 
 // nolint:gocyclo

--- a/nmagent/responses.go
+++ b/nmagent/responses.go
@@ -37,7 +37,7 @@ type NCVersion struct {
 	Version            string `json:"version"` // the current network container version
 }
 
-// NetworkContainerListResponse is a collection of network container IDs mapped
+// NCVersionList is a collection of network container IDs mapped
 // to their current versions.
 type NCVersionList struct {
 	Containers []NCVersion `json:"networkContainers"`


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
Expose GET NC list API in CNS client. DNC will call this endpoint to fetch the list of NCs programmed on the node.
In the backend, CNS calls NMAgent's _http://%s/machine/plugins/?comp=nmagent&type=NetworkManagement/interfaces/api-version/%s_ endpoint

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] relevant PR labels added

