### PR TITLE
ci: add vnet scale cilium pipeline stage

### DIFF
--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -227,13 +227,26 @@ stages:
     - template: singletenancy/cilium/cilium-e2e-job-template.yaml
       parameters:
         name: "cilium_e2e"
-        displayName: Cilium
+        displayName: Cilium Podsubnet
         clusterType: swift-byocni-nokubeproxy-up
         clusterName: "ciliume2e"
         vmSize: Standard_B2ms
         k8sVersion: ""
         dependsOn: "containerize"
 
+    # Cilium Podsubnet Vnet Scale E2E tests
+    - template: singletenancy/cilium/cilium-e2e-job-template.yaml
+      parameters:
+        name: "cilium_vnetscale_e2e"
+        displayName: Cilium Podsubnet Vnet Scale Ubuntu
+        os: linux
+        clusterType: vnetscale-swift-byocni-nokubeproxy-up
+        clusterName: "ciliumvscalee2e"
+        vmSize: Standard_B2ms
+        k8sVersion: ""
+        dependsOn: "containerize"
+  
+    
     # Cilium Nodesubnet E2E tests
     - template: singletenancy/cilium-nodesubnet/cilium-nodesubnet-e2e-job-template.yaml
       parameters:
@@ -400,6 +413,7 @@ stages:
         - azure_overlay_stateless_e2e
         - aks_swift_e2e
         - cilium_e2e
+        - cilium_vnetscale_e2e
         - cilium_nodesubnet_e2e
         - cilium_overlay_e2e
         - cilium_h_overlay_e2e
@@ -421,6 +435,10 @@ stages:
               cilium_e2e:
                 name: cilium_e2e
                 clusterName: "ciliume2e"
+                region: $(REGION_AKS_CLUSTER_TEST)
+              cilium_vnetscale_e2e:
+                name: cilium_vnetscale_e2e
+                clusterName: "ciliumvscalee2e"
                 region: $(REGION_AKS_CLUSTER_TEST)
               cilium_nodesubnet_e2e:
                 name: cilium_nodesubnet_e2e

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -184,7 +184,7 @@ overlay-up: rg-up overlay-net-up ## Brings up an Overlay AzCNI cluster
 		--yes
 	@$(MAKE) set-kubeconf
 
-swift-byocni-up: rg-up swift-net-up ## Bring up a SWIFT BYO CNI cluster
+swift-byocni-up: rg-up swift-net-up ## Bring up a SWIFT (Podsubnet) BYO CNI cluster
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
 		--auto-upgrade-channel $(AUTOUPGRADE) \
 		--node-os-upgrade-channel $(NODEUPGRADE) \
@@ -203,7 +203,7 @@ ifeq ($(OS),windows)
 endif
 	@$(MAKE) set-kubeconf
 
-swift-byocni-nokubeproxy-up: rg-up swift-net-up ## Bring up a SWIFT BYO CNI cluster without kube-proxy
+swift-byocni-nokubeproxy-up: rg-up swift-net-up ## Bring up a SWIFT (Podsubnet) BYO CNI cluster without kube-proxy
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
 		--auto-upgrade-channel $(AUTOUPGRADE) \
 		--node-os-upgrade-channel $(NODEUPGRADE) \
@@ -290,10 +290,11 @@ vnetscale-swift-byocni-up: rg-up vnetscale-swift-net-up ## Bring up a Vnet Scale
 		--pod-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/podnet \
 		--no-ssh-key \
 		--os-sku $(OS_SKU) \
+		--pod-ip-allocation-mode StaticBlock \
 		--yes
 	@$(MAKE) set-kubeconf
 
-vnetscale-swift-byocni-nokubeproxy-up: rg-up vnetscale-swift-net-up ## Bring up a Vnet Scale SWIFT BYO CNI cluster without kube-proxy
+vnetscale-swift-byocni-nokubeproxy-up: rg-up vnetscale-swift-net-up ## Bring up a Vnet Scale SWIFT (Podsubnet) BYO CNI cluster without kube-proxy
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
 		--auto-upgrade-channel $(AUTOUPGRADE) \
 		--node-os-upgrade-channel $(NODEUPGRADE) \
@@ -307,6 +308,7 @@ vnetscale-swift-byocni-nokubeproxy-up: rg-up vnetscale-swift-net-up ## Bring up 
 		--no-ssh-key \
 		--os-sku $(OS_SKU) \
 		--kube-proxy-config $(KUBE_PROXY_JSON_PATH) \
+		--pod-ip-allocation-mode StaticBlock \
 		--yes
 	@$(MAKE) set-kubeconf
 
@@ -324,6 +326,7 @@ vnetscale-swift-cilium-up: rg-up vnetscale-swift-net-up ## Bring up a Vnet Scale
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
 		--pod-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/podnet \
 		--no-ssh-key \
+		--pod-ip-allocation-mode StaticBlock \
 		--yes
 	@$(MAKE) set-kubeconf
 
@@ -339,6 +342,7 @@ vnetscale-swift-up: rg-up vnetscale-swift-net-up ## Bring up a Vnet Scale SWIFT 
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
 		--pod-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/podnet \
 		--no-ssh-key \
+		--pod-ip-allocation-mode StaticBlock \
 		--yes
 	@$(MAKE) set-kubeconf
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Adds cilium podsubnet vnet scale to the pipeline for e2e testing of cns and related components. Also updates the makefile to explicitly include pod allocation mode static block for targets that are intended to use vnet scale mode. Currently there seem to be makefile targets that are meant to create vnet scale clusters but upon creation and examination of their nncs, the mode only mentions 
```
kubernetes.azure.com/podnetwork-subnet=podnet
kubernetes.azure.com/podnetwork-type=vnet
```
We expect 
```
kubernetes.azure.com/podnetwork-subnet=podnet
kubernetes.azure.com/podnetwork-type=vnetblock
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
Will fail until relevant backend changes go in for creating vnet scale clusters with network plugin none
Done: https://msazure.visualstudio.com/One/_build/results?buildId=120192520&view=results