### PR TITLE
fix: add vnetscale staticblock changes to aks makefile

### DIFF
--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -274,9 +274,6 @@ swiftv2-dummy-cluster-up: rg-up swift-net-up ## Bring up a SWIFT AzCNI cluster
 		--yes
 	@$(MAKE) set-kubeconf
 
-# The below Vnet Scale clusters are currently only in private preview and available with Kubernetes 1.28
-# These AKS clusters can only be created in a limited subscription listed here:
-# https://dev.azure.com/msazure/CloudNativeCompute/_git/aks-rp?path=/resourceprovider/server/microsoft.com/containerservice/flags/network_flags.go&version=GBmaster&line=134&lineEnd=135&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents
 vnetscale-swift-byocni-up: rg-up vnetscale-swift-net-up ## Bring up a Vnet Scale SWIFT BYO CNI cluster
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
 		--auto-upgrade-channel $(AUTOUPGRADE) \
@@ -288,6 +285,8 @@ vnetscale-swift-byocni-up: rg-up vnetscale-swift-net-up ## Bring up a Vnet Scale
 		--network-plugin none \
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
 		--pod-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/podnet \
+		--pod-ip-allocation-mode StaticBlock \
+		--max-pods 63 \
 		--no-ssh-key \
 		--os-sku $(OS_SKU) \
 		--yes
@@ -304,9 +303,11 @@ vnetscale-swift-byocni-nokubeproxy-up: rg-up vnetscale-swift-net-up ## Bring up 
 		--network-plugin none \
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
 		--pod-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/podnet \
+		--pod-ip-allocation-mode StaticBlock \
+		--max-pods 63 \
 		--no-ssh-key \
 		--os-sku $(OS_SKU) \
-		--kube-proxy-config $(KUBE_PROXY_JSON_PATH) \
+		--kube-proxy-config ./kube-proxy.json \
 		--yes
 	@$(MAKE) set-kubeconf
 
@@ -323,6 +324,8 @@ vnetscale-swift-cilium-up: rg-up vnetscale-swift-net-up ## Bring up a Vnet Scale
 		--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/CiliumDataplanePreview \
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
 		--pod-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/podnet \
+		--pod-ip-allocation-mode StaticBlock \
+		--max-pods 63 \
 		--no-ssh-key \
 		--yes
 	@$(MAKE) set-kubeconf
@@ -338,6 +341,8 @@ vnetscale-swift-up: rg-up vnetscale-swift-net-up ## Bring up a Vnet Scale SWIFT 
 		--network-plugin azure \
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
 		--pod-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/podnet \
+		--pod-ip-allocation-mode StaticBlock \
+		--max-pods 63 \
 		--no-ssh-key \
 		--yes
 	@$(MAKE) set-kubeconf


### PR DESCRIPTION
The `vnetscale-*` targets in the AKS Makefile did not have the flag which indicates `StaticBlock` allocation mode and therefore build normal dynamic podsubnet clusters instead.

Incidentally this means that the VnetScale E2E was not using a VnetScale cluster and this will fix that.