### PR TITLE
fix: don't restart HNS if the ARP regkey is not changed

### DIFF
--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -799,14 +799,11 @@ func main() {
 	}
 
 	// Setting the remote ARP MAC address to 12-34-56-78-9a-bc on windows for external traffic if HNS is enabled
-	arpCtx, arpCtxCancel := context.WithTimeout(rootCtx, 30*time.Second)
-	err = platform.SetSdnRemoteArpMacAddress(arpCtx)
+	err = platform.SetSdnRemoteArpMacAddress(rootCtx)
 	if err != nil {
 		logger.Errorf("Failed to set remote ARP MAC address: %v", err)
-		arpCtxCancel()
 		return
 	}
-	arpCtxCancel()
 
 	// We are only setting the PriorityVLANTag in 'cns.Direct' mode, because it neatly maps today, to 'isUsingMultitenancy'
 	// In the future, we would want to have a better CNS flag, to explicitly say, this CNS is using multitenancy


### PR DESCRIPTION
don't restart HNS when setting SDNRemoteArpMacAddress (or at all, it's fragile).
reverts behavior changed in https://github.com/Azure/azure-container-networking/pull/3343 (timeout and retry if HNS is not responding) and https://github.com/Azure/azure-container-networking/pull/2993 (restart HNS after the regkey is set unconditionally)