### PR TITLE
ci: remove beta kubernetes os selector

### DIFF
--- a/.pipelines/mdnc/azure-cns-cni-1.4.39.1.yaml
+++ b/.pipelines/mdnc/azure-cns-cni-1.4.39.1.yaml
@@ -82,7 +82,7 @@ spec:
                 operator: NotIn
                 values:
                 - virtual-kubelet
-              - key: beta.kubernetes.io/os
+              - key: kubernetes.io/os
                 operator: In
                 values:
                 - linux

--- a/.pipelines/mdnc/azure-cns-cni-1.5.28.yaml
+++ b/.pipelines/mdnc/azure-cns-cni-1.5.28.yaml
@@ -82,7 +82,7 @@ spec:
                 operator: NotIn
                 values:
                 - virtual-kubelet
-              - key: beta.kubernetes.io/os
+              - key: kubernetes.io/os
                 operator: In
                 values:
                 - linux

--- a/.pipelines/mdnc/azure-cns-cni-1.5.4.yaml
+++ b/.pipelines/mdnc/azure-cns-cni-1.5.4.yaml
@@ -82,7 +82,7 @@ spec:
                 operator: NotIn
                 values:
                 - virtual-kubelet
-              - key: beta.kubernetes.io/os
+              - key: kubernetes.io/os
                 operator: In
                 values:
                 - linux

--- a/.pipelines/mdnc/azure-cns-cni.yaml
+++ b/.pipelines/mdnc/azure-cns-cni.yaml
@@ -82,7 +82,7 @@ spec:
                 operator: NotIn
                 values:
                 - virtual-kubelet
-              - key: beta.kubernetes.io/os
+              - key: kubernetes.io/os
                 operator: In
                 values:
                 - linux

--- a/cns/azure-cns.yaml
+++ b/cns/azure-cns.yaml
@@ -82,7 +82,7 @@ spec:
                 operator: NotIn
                 values:
                 - virtual-kubelet
-              - key: beta.kubernetes.io/os
+              - key: kubernetes.io/os
                 operator: In
                 values:
                 - linux

--- a/hack/manifests/cni-installer.yaml
+++ b/hack/manifests/cni-installer.yaml
@@ -27,7 +27,7 @@ spec:
                     operator: NotIn
                     values:
                       - virtual-kubelet
-                  - key: beta.kubernetes.io/os
+                  - key: kubernetes.io/os
                     operator: In
                     values:
                       - linux

--- a/hack/toolbox/manifests/agents.yaml
+++ b/hack/toolbox/manifests/agents.yaml
@@ -16,7 +16,7 @@ spec:
         app: agent-pod-8085-tcp-host
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         kubernetes.io/role: agent
       hostNetwork: true
       containers:
@@ -47,7 +47,7 @@ spec:
         app: agent-pod-8085-tcp
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         kubernetes.io/role: agent
       containers:
         - name: agent-pod-8085-tcp
@@ -77,7 +77,7 @@ spec:
         app: agent-pod-8086-udp
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         kubernetes.io/role: agent
       containers:
         - name: agent-pod-8086-udp

--- a/hack/toolbox/manifests/daemonset.yaml
+++ b/hack/toolbox/manifests/daemonset.yaml
@@ -26,7 +26,7 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         kubernetes.io/role: agent
       containers:
         - name: azure-npm

--- a/hack/toolbox/manifests/master.yaml
+++ b/hack/toolbox/manifests/master.yaml
@@ -16,7 +16,7 @@ spec:
         app: master-pod-8085-tcp-host
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         kubernetes.io/role: master
       hostNetwork: true
       tolerations:
@@ -55,7 +55,7 @@ spec:
         app: master-pod-8085-tcp
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         kubernetes.io/role: master
       tolerations:
         - operator: "Exists"
@@ -92,7 +92,7 @@ spec:
         app: master-pod-8086-udp
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         kubernetes.io/role: master
       tolerations:
         - operator: "Exists"

--- a/test/integration/manifests/cilium/cns-write-ovly.yaml
+++ b/test/integration/manifests/cilium/cns-write-ovly.yaml
@@ -82,7 +82,7 @@ spec:
                 operator: NotIn
                 values:
                 - virtual-kubelet
-              - key: beta.kubernetes.io/os
+              - key: kubernetes.io/os
                 operator: In
                 values:
                 - linux

--- a/test/integration/manifests/cns/daemonset-linux.yaml
+++ b/test/integration/manifests/cns/daemonset-linux.yaml
@@ -27,7 +27,7 @@ spec:
                 operator: NotIn
                 values:
                 - virtual-kubelet
-              - key: beta.kubernetes.io/os
+              - key: kubernetes.io/os
                 operator: In
                 values:
                 - linux

--- a/test/scale/templates/kwok-node.yaml
+++ b/test/scale/templates/kwok-node.yaml
@@ -6,7 +6,6 @@ metadata:
     kwok.x-k8s.io/node: fake
   labels:
     beta.kubernetes.io/arch: amd64
-    beta.kubernetes.io/os: linux
     kubernetes.io/arch: amd64
     kubernetes.io/hostname: kwok-node-INSERT_NUMBER
     kubernetes.io/os: linux

--- a/tools/acncli/deployment/manager_swift.yaml
+++ b/tools/acncli/deployment/manager_swift.yaml
@@ -13,7 +13,7 @@ spec:
         acn: azure-cni-manager
     spec:
       nodeSelector:
-        "beta.kubernetes.io/os": linux
+        "kubernetes.io/os": linux
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Replaces the beta.kubernetes.io/os with kubernetes.io/os to fix the cilium nightly pipeline from failing

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
