### PR TITLE
fix: set EnableIPAMv2 to true for current release train

### DIFF
--- a/test/integration/manifests/cnsconfig/azurecnidualstackoverlaylinuxconfigmap.yaml
+++ b/test/integration/manifests/cnsconfig/azurecnidualstackoverlaylinuxconfigmap.yaml
@@ -29,5 +29,6 @@ data:
       "CNIConflistFilepath": "/etc/cni/net.d/15-azure-swift-overlay.conflist",
       "CNIConflistScenario": "overlay",
       "EnableAsyncPodDelete": false,
-      "AsyncPodDeletePath": "/var/run/azure-vnet/deleteIDs"
+      "AsyncPodDeletePath": "/var/run/azure-vnet/deleteIDs",
+      "EnableIPAMv2": true
     }

--- a/test/integration/manifests/cnsconfig/azurecnidualstackoverlaywindowsconfigmap.yaml
+++ b/test/integration/manifests/cnsconfig/azurecnidualstackoverlaywindowsconfigmap.yaml
@@ -31,5 +31,6 @@ data:
       "CNIConflistFilepath": "C:\\k\\azurecni\\netconf\\10-azure.conflist",
       "CNIConflistScenario": "dualStackOverlay",
       "EnableAsyncPodDelete": false,
-      "AsyncPodDeletePath": "/var/run/azure-vnet/deleteIDs"
+      "AsyncPodDeletePath": "/var/run/azure-vnet/deleteIDs",
+      "EnableIPAMv2": true
     }

--- a/test/integration/manifests/cnsconfig/azurecnioverlaylinuxconfigmap.yaml
+++ b/test/integration/manifests/cnsconfig/azurecnioverlaylinuxconfigmap.yaml
@@ -29,5 +29,6 @@ data:
       "CNIConflistFilepath": "/etc/cni/net.d/15-azure-swift-overlay.conflist",
       "CNIConflistScenario": "v4overlay",
       "EnableAsyncPodDelete": true,
-      "AsyncPodDeletePath": "/var/run/azure-vnet/deleteIDs"
+      "AsyncPodDeletePath": "/var/run/azure-vnet/deleteIDs",
+      "EnableIPAMv2": true
     }

--- a/test/integration/manifests/cnsconfig/azurecnioverlaywindowsconfigmap.yaml
+++ b/test/integration/manifests/cnsconfig/azurecnioverlaywindowsconfigmap.yaml
@@ -31,5 +31,6 @@ data:
       "CNIConflistFilepath": "C:\\k\\azurecni\\netconf\\10-azure.conflist",
       "CNIConflistScenario": "v4overlay",
       "EnableAsyncPodDelete": true,
-      "AsyncPodDeletePath": "/var/run/azure-vnet/deleteIDs"
+      "AsyncPodDeletePath": "/var/run/azure-vnet/deleteIDs",
+      "EnableIPAMv2": true
     }

--- a/test/integration/manifests/cnsconfig/azurestatelesscnioverlaywindowsconfigmap.yaml
+++ b/test/integration/manifests/cnsconfig/azurestatelesscnioverlaywindowsconfigmap.yaml
@@ -31,5 +31,6 @@ data:
       "CNIConflistFilepath": "C:\\k\\azurecni\\netconf\\10-azure.conflist",
       "CNIConflistScenario": "v4overlay",
       "EnableAsyncPodDelete": true,
-      "AsyncPodDeletePath": "/var/run/azure-vnet/deleteIDs"
+      "AsyncPodDeletePath": "/var/run/azure-vnet/deleteIDs",
+      "EnableIPAMv2": true
     }

--- a/test/integration/manifests/cnsconfig/ciliumconfigmap.yaml
+++ b/test/integration/manifests/cnsconfig/ciliumconfigmap.yaml
@@ -29,5 +29,6 @@ data:
       "CNIConflistFilepath": "/etc/cni/net.d/05-cilium.conflist",
       "CNIConflistScenario": "cilium",
       "EnableAsyncPodDelete": true,
-      "AsyncPodDeletePath": "/var/run/azure-vnet/deleteIDs"
+      "AsyncPodDeletePath": "/var/run/azure-vnet/deleteIDs",
+      "EnableIPAMv2": true
     }

--- a/test/integration/manifests/cnsconfig/ciliumnodesubnetconfigmap.yaml
+++ b/test/integration/manifests/cnsconfig/ciliumnodesubnetconfigmap.yaml
@@ -29,5 +29,6 @@ data:
       "CNIConflistFilepath": "/etc/cni/net.d/05-cilium.conflist",
       "CNIConflistScenario": "cilium",
       "EnableAsyncPodDelete": true,
-      "AsyncPodDeletePath": "/var/run/azure-vnet/deleteIDs"
+      "AsyncPodDeletePath": "/var/run/azure-vnet/deleteIDs",
+      "EnableIPAMv2": true
     }

--- a/test/integration/manifests/cnsconfig/overlayconfigmap.yaml
+++ b/test/integration/manifests/cnsconfig/overlayconfigmap.yaml
@@ -29,5 +29,6 @@ data:
       "CNIConflistFilepath": "/etc/cni/net.d/05-cilium.conflist",
       "CNIConflistScenario": "cilium",
       "EnableAsyncPodDelete": true,
-      "AsyncPodDeletePath": "/var/run/azure-vnet/deleteIDs"
+      "AsyncPodDeletePath": "/var/run/azure-vnet/deleteIDs",
+      "EnableIPAMv2": true
     }

--- a/test/integration/manifests/cnsconfig/swiftwindowsconfigmap.yaml
+++ b/test/integration/manifests/cnsconfig/swiftwindowsconfigmap.yaml
@@ -26,5 +26,6 @@ data:
       "ManageEndpointState": false,
       "ProgramSNATIPTables": false,
       "EnableAsyncPodDelete": true,
-      "AsyncPodDeletePath": "/var/run/azure-vnet/deleteIDs"
+      "AsyncPodDeletePath": "/var/run/azure-vnet/deleteIDs",
+      "EnableIPAMv2": true
     }


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Adds EnableIPAMv2 to all CNS configs as it is default enabled for 1.30+.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
