### PR TITLE
fix: modify cleanup path to always delete link

### DIFF
--- a/netlink/mocknetlink.go
+++ b/netlink/mocknetlink.go
@@ -22,6 +22,7 @@ type MockNetlink struct {
 	errorString   string
 	deleteRouteFn routeValidateFn
 	addRouteFn    routeValidateFn
+	DeleteLinkFn  func(name string) error
 }
 
 func NewMockNetlink(returnError bool, errorString string) *MockNetlink {
@@ -55,6 +56,9 @@ func (f *MockNetlink) SetLinkMTU(name string, mtu int) error {
 }
 
 func (f *MockNetlink) DeleteLink(name string) error {
+	if f.DeleteLinkFn != nil {
+		return f.DeleteLinkFn(name)
+	}
 	return f.error()
 }
 

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -632,7 +632,8 @@ func (client *TransparentVlanEndpointClient) DeleteEndpoints(ep *endpoint) error
 			return len(routes), nil
 		}
 
-		return client.DeleteEndpointsImpl(ep, getNumRoutesLeft)
+		client.DeleteEndpointsImpl(ep, getNumRoutesLeft)
+		return nil
 	})
 	if err != nil {
 		logger.Warn("could not delete transparent vlan endpoints", zap.String("errorMsg", err.Error()))
@@ -646,16 +647,16 @@ func (client *TransparentVlanEndpointClient) DeleteEndpoints(ep *endpoint) error
 }
 
 // getNumRoutesLeft is a function which gets the current number of routes in the namespace. Namespace: Vnet
-func (client *TransparentVlanEndpointClient) DeleteEndpointsImpl(ep *endpoint, _ func() (int, error)) error {
+func (client *TransparentVlanEndpointClient) DeleteEndpointsImpl(ep *endpoint, _ func() (int, error)) {
 	routeInfoList := client.GetVnetRoutes(ep.IPAddresses)
 	if err := deleteRoutes(client.netlink, client.netioshim, client.vnetVethName, routeInfoList); err != nil {
-		return errors.Wrap(err, "failed to remove routes")
+		logger.Error("Failed to remove routes", zap.Error(err))
 	}
 
 	logger.Info("Deleting host veth", zap.String("vnetVethName", client.vnetVethName))
 	// Delete Host Veth
 	if err := client.netlink.DeleteLink(client.vnetVethName); err != nil {
-		return errors.Wrapf(err, "deleteLink for %v failed", client.vnetVethName)
+		logger.Error("Failed to delete link", zap.Error(err), zap.String("vnetVethName", client.vnetVethName))
 	}
 
 	// TODO: revist if this require in future.
@@ -670,7 +671,6 @@ func (client *TransparentVlanEndpointClient) DeleteEndpointsImpl(ep *endpoint, _
 			}
 		}
 	*/
-	return nil
 }
 
 // Helper function that allows executing a function in a VM namespace

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -622,7 +622,7 @@ func (client *TransparentVlanEndpointClient) AddDefaultArp(interfaceName, destMa
 
 func (client *TransparentVlanEndpointClient) DeleteEndpoints(ep *endpoint) error {
 	// Vnet NS
-	err := ExecuteInNS(client.nsClient, client.vnetNSName, func() error {
+	_ = ExecuteInNS(client.nsClient, client.vnetNSName, func() error {
 		// Passing in functionality to get number of routes after deletion
 		getNumRoutesLeft := func() (int, error) {
 			routes, err := vishnetlink.RouteList(nil, vishnetlink.FAMILY_V4)
@@ -635,9 +635,6 @@ func (client *TransparentVlanEndpointClient) DeleteEndpoints(ep *endpoint) error
 		client.DeleteEndpointsImpl(ep, getNumRoutesLeft)
 		return nil
 	})
-	if err != nil {
-		logger.Warn("could not delete transparent vlan endpoints", zap.String("errorMsg", err.Error()))
-	}
 
 	// VM NS
 	if err := client.DeleteSnatEndpoint(); err != nil {


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Previously, `DeleteEndpointsImpl` would return an error if it failed to remove routes, skipping any further clean up logic. This could lead to the vnet veth device not being deleted (The vnet veth device is one end of the container's veth pair, the other resides in either the container if it was successfully moved, or still in the vnet ns if it was not moved). On subsequent adds, an error would pop up mentioning the pair already exists.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
The PR ensures both pieces of logic always run, even if there is an error (which is logged). Unit tests have been added to verify the correct code paths are hit and there don't seem to be other methods in the delete flow that have this problem for this scenario.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests
- [X] relevant PR labels added

**Notes**:
Tested on a multitenancy transparent vlan linux setup.