### PR TITLE
ci: add fqdn with cilium local redirect policy test

### DIFF
--- a/test/integration/lrp/lrp_fqdn_test.go
+++ b/test/integration/lrp/lrp_fqdn_test.go
@@ -1,0 +1,96 @@
+//go:build lrp
+
+package lrp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-container-networking/test/internal/kubernetes"
+	ciliumClientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	fqdnCNPPath    = ciliumManifestsDir + "fqdn-cnp.yaml"
+	enableFQDNFlag = "enable-l7-proxy"
+)
+
+// TestLRPFQDN tests if the local redirect policy in a cilium cluster is functioning with a
+// FQDN Cilium Network Policy. As such, enable-l7-proxy should be enabled in the config
+// The test assumes the current kubeconfig points to a cluster with cilium, cns,
+// and kube-dns already installed. The lrp feature flag should also be enabled in the cilium config
+// Resources created are automatically cleaned up
+// From the lrp folder, run: go test ./ -v -tags "lrp" -run ^TestLRPFQDN$
+func TestLRPFQDN(t *testing.T) {
+	ctx := context.Background()
+
+	selectedPod, cleanupFn := setupLRP(t, ctx)
+	defer cleanupFn()
+	require.NotNil(t, selectedPod)
+
+	cs := kubernetes.MustGetClientset()
+	config := kubernetes.MustGetRestConfig()
+	ciliumCS, err := ciliumClientset.NewForConfig(config)
+	require.NoError(t, err)
+
+	// ensure enable l7 proxy flag is enabled
+	ciliumCM, err := kubernetes.GetConfigmap(ctx, cs, kubeSystemNamespace, ciliumConfigmapName)
+	require.NoError(t, err)
+	require.Equal(t, "true", ciliumCM.Data[enableFQDNFlag], "enable-l7-proxy not set to true in cilium-config")
+
+	_, cleanupCNP := kubernetes.MustSetupCNP(ctx, ciliumCS, fqdnCNPPath)
+	defer cleanupCNP()
+
+	tests := []struct {
+		name                   string
+		command                []string
+		expectedMsgContains    string
+		expectedErrMsgContains string
+		countIncreases         bool
+	}{
+		{
+			name:                "nslookup google succeeds",
+			command:             []string{"nslookup", "www.google.com", "10.0.0.10"},
+			expectedMsgContains: "Server:",
+			countIncreases:      true,
+		},
+		{
+			name:                   "wget google succeeds",
+			command:                []string{"wget", "-O", "index.html", "www.google.com", "--timeout=5"},
+			expectedErrMsgContains: "saved",
+			countIncreases:         true,
+		},
+		{
+			name:                "nslookup bing succeeds",
+			command:             []string{"nslookup", "www.bing.com", "10.0.0.10"},
+			expectedMsgContains: "Server:",
+			countIncreases:      true,
+		},
+		{
+			name:                   "wget bing fails but dns succeeds",
+			command:                []string{"wget", "-O", "index.html", "www.bing.com", "--timeout=5"},
+			expectedErrMsgContains: "timed out",
+			countIncreases:         true,
+		},
+		{
+			name:                "nslookup example fails",
+			command:             []string{"nslookup", "www.example.com", "10.0.0.10"},
+			expectedMsgContains: "REFUSED",
+			countIncreases:      false,
+		},
+		{
+			// won't be able to nslookup, let alone query the website
+			name:                   "wget example fails",
+			command:                []string{"wget", "-O", "index.html", "www.example.com", "--timeout=5"},
+			expectedErrMsgContains: "bad address",
+			countIncreases:         false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			testLRPCase(t, ctx, *selectedPod, tt.command, tt.expectedMsgContains, tt.expectedErrMsgContains, tt.countIncreases)
+		})
+	}
+}

--- a/test/integration/lrp/lrp_fqdn_test.go
+++ b/test/integration/lrp/lrp_fqdn_test.go
@@ -71,14 +71,14 @@ func TestLRPFQDN(t *testing.T) {
 			shouldError:            false,
 		},
 		{
-			name:           "nslookup bing succeeds",
-			command:        []string{"nslookup", "www.bing.com", "10.0.0.10"},
+			name:           "nslookup cloudflare succeeds",
+			command:        []string{"nslookup", "www.cloudflare.com", "10.0.0.10"},
 			countIncreases: true,
 			shouldError:    false,
 		},
 		{
-			name:                   "wget bing fails but dns succeeds",
-			command:                []string{"wget", "-O", "index.html", "www.bing.com", "--timeout=5"},
+			name:                   "wget cloudflare fails but dns succeeds",
+			command:                []string{"wget", "-O", "index.html", "www.cloudflare.com", "--timeout=5"},
 			expectedErrMsgContains: "timed out",
 			countIncreases:         true,
 			shouldError:            true,

--- a/test/integration/lrp/lrp_fqdn_test.go
+++ b/test/integration/lrp/lrp_fqdn_test.go
@@ -20,6 +20,7 @@ var (
 // FQDN Cilium Network Policy. As such, enable-l7-proxy should be enabled in the config
 // The test assumes the current kubeconfig points to a cluster with cilium, cns,
 // and kube-dns already installed. The lrp feature flag should also be enabled in the cilium config
+// Does not check if cluster is in a stable state
 // Resources created are automatically cleaned up
 // From the lrp folder, run: go test ./ -v -tags "lrp" -run ^TestLRPFQDN$
 func TestLRPFQDN(t *testing.T) {

--- a/test/integration/lrp/lrp_fqdn_test.go
+++ b/test/integration/lrp/lrp_fqdn_test.go
@@ -52,11 +52,16 @@ func TestLRPFQDN(t *testing.T) {
 		countIncreases         bool
 	}{
 		{
-			name:                "nslookup google succeeds",
-			command:             []string{"nslookup", "www.google.com", "10.0.0.10"},
-			expectedMsgContains: "answer:",
-			countIncreases:      true,
-			shouldError:         false,
+			name:           "nslookup google succeeds",
+			command:        []string{"nslookup", "www.google.com", "10.0.0.10"},
+			countIncreases: true,
+			shouldError:    false,
+		},
+		{
+			name:           "nslookup google succeeds without explicit dns server",
+			command:        []string{"nslookup", "www.google.com"},
+			countIncreases: true,
+			shouldError:    false,
 		},
 		{
 			name:                   "wget google succeeds",
@@ -66,11 +71,10 @@ func TestLRPFQDN(t *testing.T) {
 			shouldError:            false,
 		},
 		{
-			name:                "nslookup bing succeeds",
-			command:             []string{"nslookup", "www.bing.com", "10.0.0.10"},
-			expectedMsgContains: "answer:",
-			countIncreases:      true,
-			shouldError:         false,
+			name:           "nslookup bing succeeds",
+			command:        []string{"nslookup", "www.bing.com", "10.0.0.10"},
+			countIncreases: true,
+			shouldError:    false,
 		},
 		{
 			name:                   "wget bing fails but dns succeeds",

--- a/test/integration/lrp/lrp_fqdn_test.go
+++ b/test/integration/lrp/lrp_fqdn_test.go
@@ -48,37 +48,43 @@ func TestLRPFQDN(t *testing.T) {
 		command                []string
 		expectedMsgContains    string
 		expectedErrMsgContains string
+		shouldError            bool
 		countIncreases         bool
 	}{
 		{
 			name:                "nslookup google succeeds",
 			command:             []string{"nslookup", "www.google.com", "10.0.0.10"},
-			expectedMsgContains: "Server:",
+			expectedMsgContains: "answer:",
 			countIncreases:      true,
+			shouldError:         false,
 		},
 		{
 			name:                   "wget google succeeds",
 			command:                []string{"wget", "-O", "index.html", "www.google.com", "--timeout=5"},
 			expectedErrMsgContains: "saved",
 			countIncreases:         true,
+			shouldError:            false,
 		},
 		{
 			name:                "nslookup bing succeeds",
 			command:             []string{"nslookup", "www.bing.com", "10.0.0.10"},
-			expectedMsgContains: "Server:",
+			expectedMsgContains: "answer:",
 			countIncreases:      true,
+			shouldError:         false,
 		},
 		{
 			name:                   "wget bing fails but dns succeeds",
 			command:                []string{"wget", "-O", "index.html", "www.bing.com", "--timeout=5"},
 			expectedErrMsgContains: "timed out",
 			countIncreases:         true,
+			shouldError:            true,
 		},
 		{
 			name:                "nslookup example fails",
 			command:             []string{"nslookup", "www.example.com", "10.0.0.10"},
 			expectedMsgContains: "REFUSED",
 			countIncreases:      false,
+			shouldError:         true,
 		},
 		{
 			// won't be able to nslookup, let alone query the website
@@ -86,12 +92,13 @@ func TestLRPFQDN(t *testing.T) {
 			command:                []string{"wget", "-O", "index.html", "www.example.com", "--timeout=5"},
 			expectedErrMsgContains: "bad address",
 			countIncreases:         false,
+			shouldError:            true,
 		},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			testLRPCase(t, ctx, *selectedPod, tt.command, tt.expectedMsgContains, tt.expectedErrMsgContains, tt.countIncreases)
+			testLRPCase(t, ctx, *selectedPod, tt.command, tt.expectedMsgContains, tt.expectedErrMsgContains, tt.shouldError, tt.countIncreases)
 		})
 	}
 }

--- a/test/integration/lrp/lrp_test.go
+++ b/test/integration/lrp/lrp_test.go
@@ -170,7 +170,7 @@ func testLRPCase(t *testing.T, ctx context.Context, clientPod v1.Pod, clientCmd 
 	require.NoError(t, err)
 
 	t.Log("calling command from client")
-	// nslookup to 10.0.0.10 (coredns)
+
 	val, errMsg, err := kubernetes.ExecCmdOnPodOnce(ctx, cs, clientPod.Namespace, clientPod.Name, clientContainer, clientCmd, config)
 
 	require.Contains(t, string(val), expectResponse)
@@ -195,7 +195,7 @@ func testLRPCase(t *testing.T, ctx context.Context, clientPod v1.Pod, clientCmd 
 // The test assumes the current kubeconfig points to a cluster with cilium (1.16+), cns,
 // and kube-dns already installed. The lrp feature flag should be enabled in the cilium config
 // Resources created are automatically cleaned up
-// From the lrp folder, run: go test ./lrp_test.go -v -tags "lrp" -run ^TestLRP$
+// From the lrp folder, run: go test ./ -v -tags "lrp" -run ^TestLRP$
 func TestLRP(t *testing.T) {
 	ctx := context.Background()
 

--- a/test/integration/lrp/lrp_test.go
+++ b/test/integration/lrp/lrp_test.go
@@ -174,14 +174,14 @@ func testLRPCase(t *testing.T, ctx context.Context, clientPod corev1.Pod, client
 	t.Log("calling command from client")
 
 	val, errMsg, err := kubernetes.ExecCmdOnPod(ctx, cs, clientPod.Namespace, clientPod.Name, clientContainer, clientCmd, config, false)
-
-	require.Contains(t, string(val), expectResponse)
-	require.Contains(t, string(errMsg), expectErrMsg)
 	if shouldError {
 		require.Error(t, err)
 	} else {
 		require.NoError(t, err)
 	}
+
+	require.Contains(t, string(val), expectResponse)
+	require.Contains(t, string(errMsg), expectErrMsg)
 
 	// in case there is time to propagate
 	time.Sleep(500 * time.Millisecond)
@@ -212,7 +212,7 @@ func TestLRP(t *testing.T) {
 
 	testLRPCase(t, ctx, *selectedPod, []string{
 		"nslookup", "google.com", "10.0.0.10",
-	}, "Server:", "", false, true)
+	}, "", "", false, true)
 }
 
 // TakeOne takes one item from the slice randomly; if empty, it returns the empty value for the type

--- a/test/integration/lrp/lrp_test.go
+++ b/test/integration/lrp/lrp_test.go
@@ -175,9 +175,9 @@ func testLRPCase(t *testing.T, ctx context.Context, clientPod corev1.Pod, client
 
 	val, errMsg, err := kubernetes.ExecCmdOnPod(ctx, cs, clientPod.Namespace, clientPod.Name, clientContainer, clientCmd, config, false)
 	if shouldError {
-		require.Error(t, err)
+		require.Error(t, err, "stdout: %s, stderr: %s", string(val), string(errMsg))
 	} else {
-		require.NoError(t, err)
+		require.NoError(t, err, "stdout: %s, stderr: %s", string(val), string(errMsg))
 	}
 
 	require.Contains(t, string(val), expectResponse)

--- a/test/integration/manifests/cilium/lrp/fqdn-cnp.yaml
+++ b/test/integration/manifests/cilium/lrp/fqdn-cnp.yaml
@@ -1,0 +1,24 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "to-fqdn"
+  namespace: "default"
+spec:
+  endpointSelector:
+    matchLabels:
+      lrp-test: "true"
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": kube-system
+            "k8s:k8s-app": node-local-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+          rules:
+            dns:
+              - matchPattern: "*.google.com"
+              - matchPattern: "*.bing.com"
+    - toFQDNs:
+        - matchPattern: "*.google.com"

--- a/test/integration/manifests/cilium/lrp/fqdn-cnp.yaml
+++ b/test/integration/manifests/cilium/lrp/fqdn-cnp.yaml
@@ -19,6 +19,6 @@ spec:
           rules:
             dns:
               - matchPattern: "*.google.com"
-              - matchPattern: "*.bing.com"
+              - matchPattern: "*.cloudflare.com"
     - toFQDNs:
         - matchPattern: "*.google.com"

--- a/test/internal/datapath/datapath_win.go
+++ b/test/internal/datapath/datapath_win.go
@@ -19,7 +19,7 @@ var ipv6PrefixPolicy = []string{"powershell", "-c", "curl.exe", "-6", "-v", "www
 
 func podTest(ctx context.Context, clientset *kubernetes.Clientset, srcPod *apiv1.Pod, cmd []string, rc *restclient.Config, passFunc func(string) error) error {
 	logrus.Infof("podTest() - %v %v", srcPod.Name, cmd)
-	output, err := acnk8s.ExecCmdOnPod(ctx, clientset, srcPod.Namespace, srcPod.Name, "", cmd, rc)
+	output, _, err := acnk8s.ExecCmdOnPod(ctx, clientset, srcPod.Namespace, srcPod.Name, "", cmd, rc, true)
 	if err != nil {
 		return errors.Wrapf(err, "failed to execute command on pod: %v", srcPod.Name)
 	}

--- a/test/internal/kubernetes/utils.go
+++ b/test/internal/kubernetes/utils.go
@@ -500,7 +500,9 @@ func ExecCmdOnPod(ctx context.Context, clientset *kubernetes.Clientset, namespac
 	return result, errors.Wrapf(err, "could not execute the cmd %s on %s", cmd, podName)
 }
 
-func ExecCmdOnPodOnce(ctx context.Context, clientset *kubernetes.Clientset, namespace, podName, containerName string, cmd []string, config *rest.Config) ([]byte, []byte, error) {
+// ExecCmdOnPodOnce runs a command on the specified pod and returns its standard output, standard error output, and error in that order
+// The command does not retry when the command fails (ex: due to timeout), unlike ExecCmdOnPod
+func ExecCmdOnPodOnce(ctx context.Context, clientset *kubernetes.Clientset, namespace, podName, containerName string, cmd []string, config *rest.Config) ([]byte, []byte, error) { // nolint
 	req := clientset.CoreV1().RESTClient().Post().
 		Resource("pods").
 		Name(podName).

--- a/test/internal/kubernetes/utils.go
+++ b/test/internal/kubernetes/utils.go
@@ -233,37 +233,37 @@ func MustSetupDeployment(ctx context.Context, clientset *kubernetes.Clientset, d
 
 func MustSetupServiceAccount(ctx context.Context, clientset *kubernetes.Clientset, serviceAccountPath string) (corev1.ServiceAccount, func()) { // nolint
 	sa := mustParseServiceAccount(serviceAccountPath)
-	sas := clientset.CoreV1().ServiceAccounts(sa.Namespace)
-	mustCreateServiceAccount(ctx, sas, sa)
+	saClient := clientset.CoreV1().ServiceAccounts(sa.Namespace)
+	mustCreateServiceAccount(ctx, saClient, sa)
 	return sa, func() {
-		MustDeleteServiceAccount(ctx, sas, sa)
+		MustDeleteServiceAccount(ctx, saClient, sa)
 	}
 }
 
 func MustSetupService(ctx context.Context, clientset *kubernetes.Clientset, servicePath string) (corev1.Service, func()) { // nolint
 	svc := mustParseService(servicePath)
-	svcs := clientset.CoreV1().Services(svc.Namespace)
-	mustCreateService(ctx, svcs, svc)
+	svcClient := clientset.CoreV1().Services(svc.Namespace)
+	mustCreateService(ctx, svcClient, svc)
 	return svc, func() {
-		MustDeleteService(ctx, svcs, svc)
+		MustDeleteService(ctx, svcClient, svc)
 	}
 }
 
 func MustSetupLRP(ctx context.Context, clientset *cilium.Clientset, lrpPath string) (ciliumv2.CiliumLocalRedirectPolicy, func()) { // nolint
 	lrp := mustParseLRP(lrpPath)
-	lrps := clientset.CiliumV2().CiliumLocalRedirectPolicies(lrp.Namespace)
-	mustCreateCiliumLocalRedirectPolicy(ctx, lrps, lrp)
+	lrpClient := clientset.CiliumV2().CiliumLocalRedirectPolicies(lrp.Namespace)
+	mustCreateCiliumLocalRedirectPolicy(ctx, lrpClient, lrp)
 	return lrp, func() {
-		MustDeleteCiliumLocalRedirectPolicy(ctx, lrps, lrp)
+		MustDeleteCiliumLocalRedirectPolicy(ctx, lrpClient, lrp)
 	}
 }
 
 func MustSetupCNP(ctx context.Context, clientset *cilium.Clientset, cnpPath string) (ciliumv2.CiliumNetworkPolicy, func()) { // nolint
 	cnp := mustParseCNP(cnpPath)
-	cnps := clientset.CiliumV2().CiliumNetworkPolicies(cnp.Namespace)
-	mustCreateCiliumNetworkPolicy(ctx, cnps, cnp)
+	cnpClient := clientset.CiliumV2().CiliumNetworkPolicies(cnp.Namespace)
+	mustCreateCiliumNetworkPolicy(ctx, cnpClient, cnp)
 	return cnp, func() {
-		MustDeleteCiliumNetworkPolicy(ctx, cnps, cnp)
+		MustDeleteCiliumNetworkPolicy(ctx, cnpClient, cnp)
 	}
 }
 
@@ -488,59 +488,60 @@ func writeToFile(dir, fileName, str string) error {
 	return errors.Wrap(err, "failed to write string")
 }
 
-func ExecCmdOnPod(ctx context.Context, clientset *kubernetes.Clientset, namespace, podName, containerName string, cmd []string, config *rest.Config) ([]byte, error) {
+// ExecCmdOnPod runs the specified command on a particular pod and retries the command on failure if doRetry is set to true
+// The function returns the standard output, standard error, and error (if any) in that order
+func ExecCmdOnPod(ctx context.Context, clientset *kubernetes.Clientset, namespace, podName, containerName string, cmd []string, config *rest.Config, doRetry bool) ([]byte, []byte, error) { // nolint
 	var result []byte
+	var errResult []byte
 	execCmdOnPod := func() error {
-		output, _, err := ExecCmdOnPodOnce(ctx, clientset, namespace, podName, containerName, cmd, config)
-		result = output
-		return err
+		req := clientset.CoreV1().RESTClient().Post().
+			Resource("pods").
+			Name(podName).
+			Namespace(namespace).
+			SubResource("exec").
+			VersionedParams(&corev1.PodExecOptions{
+				Command:   cmd,
+				Container: containerName,
+				Stdin:     false,
+				Stdout:    true,
+				Stderr:    true,
+				TTY:       false,
+			}, scheme.ParameterCodec)
+
+		exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
+		if err != nil {
+			return errors.Wrapf(err, "error in creating executor for req %s", req.URL())
+		}
+
+		var stdout, stderr bytes.Buffer
+		err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+			Stdin:  nil,
+			Stdout: &stdout,
+			Stderr: &stderr,
+			Tty:    false,
+		})
+
+		result = stdout.Bytes()
+		errResult = stderr.Bytes()
+
+		if err != nil {
+			log.Printf("Error: %v had error %v from command - %v", podName, err, cmd)
+			return errors.Wrapf(err, "error in executing command %s", cmd)
+		}
+		if len(stdout.Bytes()) == 0 {
+			log.Printf("Warning: %v had 0 bytes returned from command - %v", podName, cmd)
+		}
+		return nil
 	}
-	retrier := retry.Retrier{Attempts: ShortRetryAttempts, Delay: RetryDelay}
-	err := retrier.Do(ctx, execCmdOnPod)
-	return result, errors.Wrapf(err, "could not execute the cmd %s on %s", cmd, podName)
-}
 
-// ExecCmdOnPodOnce runs a command on the specified pod and returns its standard output, standard error output, and error in that order
-// The command does not retry when the command fails (ex: due to timeout), unlike ExecCmdOnPod
-func ExecCmdOnPodOnce(ctx context.Context, clientset *kubernetes.Clientset, namespace, podName, containerName string, cmd []string, config *rest.Config) ([]byte, []byte, error) { // nolint
-	req := clientset.CoreV1().RESTClient().Post().
-		Resource("pods").
-		Name(podName).
-		Namespace(namespace).
-		SubResource("exec").
-		VersionedParams(&corev1.PodExecOptions{
-			Command:   cmd,
-			Container: containerName,
-			Stdin:     false,
-			Stdout:    true,
-			Stderr:    true,
-			TTY:       false,
-		}, scheme.ParameterCodec)
-
-	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
-	if err != nil {
-		return nil, nil, errors.Wrapf(err, "error in creating executor for req %s", req.URL())
+	var err error
+	if doRetry {
+		retrier := retry.Retrier{Attempts: ShortRetryAttempts, Delay: RetryDelay}
+		err = retrier.Do(ctx, execCmdOnPod)
+	} else {
+		err = execCmdOnPod()
 	}
-
-	var stdout, stderr bytes.Buffer
-	err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
-		Stdin:  nil,
-		Stdout: &stdout,
-		Stderr: &stderr,
-		Tty:    false,
-	})
-
-	result := stdout.Bytes()
-	errResult := stderr.Bytes()
-
-	if err != nil {
-		log.Printf("Error: %v had error %v from command - %v", podName, err, cmd)
-		return result, errResult, errors.Wrapf(err, "error in executing command %s", cmd)
-	}
-	if len(stdout.Bytes()) == 0 {
-		log.Printf("Warning: %v had 0 bytes returned from command - %v", podName, cmd)
-	}
-	return result, errResult, nil
+	return result, errResult, errors.Wrapf(err, "could not execute the cmd %s on %s", cmd, podName)
 }
 
 func NamespaceExists(ctx context.Context, clientset *kubernetes.Clientset, namespace string) (bool, error) {
@@ -655,7 +656,7 @@ func RestartKubeProxyService(ctx context.Context, clientset *kubernetes.Clientse
 		}
 		privilegedPod := pod.Items[0]
 		// exec into the pod and restart kubeproxy
-		_, err = ExecCmdOnPod(ctx, clientset, privilegedNamespace, privilegedPod.Name, "", restartKubeProxyCmd, config)
+		_, _, err = ExecCmdOnPod(ctx, clientset, privilegedNamespace, privilegedPod.Name, "", restartKubeProxyCmd, config, true)
 		if err != nil {
 			return errors.Wrapf(err, "failed to exec into privileged pod %s on node %s", privilegedPod.Name, node.Name)
 		}

--- a/test/internal/kubernetes/utils_create.go
+++ b/test/internal/kubernetes/utils_create.go
@@ -166,38 +166,26 @@ func mustCreateConfigMap(ctx context.Context, cmi typedcorev1.ConfigMapInterface
 }
 
 func mustCreateService(ctx context.Context, svci typedcorev1.ServiceInterface, svc corev1.Service) {
-	if err := svci.Delete(ctx, svc.Name, metav1.DeleteOptions{}); err != nil {
-		if !apierrors.IsNotFound(err) {
-			log.Fatal(errors.Wrap(err, "failed to delete service"))
-		}
-	}
+	MustDeleteService(ctx, svci, svc)
 	log.Printf("Creating Service %v", svc.Name)
 	if _, err := svci.Create(ctx, &svc, metav1.CreateOptions{}); err != nil {
-		log.Fatal(errors.Wrap(err, "failed to create service"))
+		panic(errors.Wrap(err, "failed to create service"))
 	}
 }
 
 func mustCreateCiliumLocalRedirectPolicy(ctx context.Context, lrpClient typedciliumv2.CiliumLocalRedirectPolicyInterface, clrp ciliumv2.CiliumLocalRedirectPolicy) {
-	if err := lrpClient.Delete(ctx, clrp.Name, metav1.DeleteOptions{}); err != nil {
-		if !apierrors.IsNotFound(err) {
-			log.Fatal(errors.Wrap(err, "failed to delete cilium local redirect policy"))
-		}
-	}
+	MustDeleteCiliumLocalRedirectPolicy(ctx, lrpClient, clrp)
 	log.Printf("Creating CiliumLocalRedirectPolicy %v", clrp.Name)
 	if _, err := lrpClient.Create(ctx, &clrp, metav1.CreateOptions{}); err != nil {
-		log.Fatal(errors.Wrap(err, "failed to create cilium local redirect policy"))
+		panic(errors.Wrap(err, "failed to create cilium local redirect policy"))
 	}
 }
 
 func mustCreateCiliumNetworkPolicy(ctx context.Context, cnpClient typedciliumv2.CiliumNetworkPolicyInterface, cnp ciliumv2.CiliumNetworkPolicy) {
-	if err := cnpClient.Delete(ctx, cnp.Name, metav1.DeleteOptions{}); err != nil {
-		if !apierrors.IsNotFound(err) {
-			log.Fatal(errors.Wrap(err, "failed to delete cilium network policy"))
-		}
-	}
+	MustDeleteCiliumNetworkPolicy(ctx, cnpClient, cnp)
 	log.Printf("Creating CiliumNetworkPolicy %v", cnp.Name)
 	if _, err := cnpClient.Create(ctx, &cnp, metav1.CreateOptions{}); err != nil {
-		log.Fatal(errors.Wrap(err, "failed to create cilium network policy"))
+		panic(errors.Wrap(err, "failed to create cilium network policy"))
 	}
 }
 

--- a/test/internal/kubernetes/utils_create.go
+++ b/test/internal/kubernetes/utils_create.go
@@ -189,6 +189,18 @@ func mustCreateCiliumLocalRedirectPolicy(ctx context.Context, lrpClient typedcil
 	}
 }
 
+func mustCreateCiliumNetworkPolicy(ctx context.Context, cnpClient typedciliumv2.CiliumNetworkPolicyInterface, cnp ciliumv2.CiliumNetworkPolicy) {
+	if err := cnpClient.Delete(ctx, cnp.Name, metav1.DeleteOptions{}); err != nil {
+		if !apierrors.IsNotFound(err) {
+			log.Fatal(errors.Wrap(err, "failed to delete cilium network policy"))
+		}
+	}
+	log.Printf("Creating CiliumNetworkPolicy %v", cnp.Name)
+	if _, err := cnpClient.Create(ctx, &cnp, metav1.CreateOptions{}); err != nil {
+		log.Fatal(errors.Wrap(err, "failed to create cilium network policy"))
+	}
+}
+
 func MustScaleDeployment(ctx context.Context,
 	deploymentsClient typedappsv1.DeploymentInterface,
 	deployment appsv1.Deployment,

--- a/test/internal/kubernetes/utils_delete.go
+++ b/test/internal/kubernetes/utils_delete.go
@@ -81,3 +81,11 @@ func MustDeleteCiliumLocalRedirectPolicy(ctx context.Context, lrpClient typedcil
 		}
 	}
 }
+
+func MustDeleteCiliumNetworkPolicy(ctx context.Context, cnpClient typedciliumv2.CiliumNetworkPolicyInterface, cnp ciliumv2.CiliumNetworkPolicy) {
+	if err := cnpClient.Delete(ctx, cnp.Name, metav1.DeleteOptions{}); err != nil {
+		if !apierrors.IsNotFound(err) {
+			panic(errors.Wrap(err, "failed to delete cilium network policy"))
+		}
+	}
+}

--- a/test/internal/kubernetes/utils_parse.go
+++ b/test/internal/kubernetes/utils_parse.go
@@ -66,3 +66,9 @@ func mustParseLRP(path string) ciliumv2.CiliumLocalRedirectPolicy {
 	mustParseResource(path, &lrp)
 	return lrp
 }
+
+func mustParseCNP(path string) ciliumv2.CiliumNetworkPolicy {
+	var cnp ciliumv2.CiliumNetworkPolicy
+	mustParseResource(path, &cnp)
+	return cnp
+}

--- a/test/validate/linux_validate.go
+++ b/test/validate/linux_validate.go
@@ -326,7 +326,7 @@ func (v *Validator) validateRestartNetwork(ctx context.Context) error {
 		}
 		privilegedPod := pod.Items[0]
 		// exec into the pod to get the state file
-		_, err = acnk8s.ExecCmdOnPod(ctx, v.clientset, privilegedNamespace, privilegedPod.Name, "", restartNetworkCmd, v.config)
+		_, _, err = acnk8s.ExecCmdOnPod(ctx, v.clientset, privilegedNamespace, privilegedPod.Name, "", restartNetworkCmd, v.config, true)
 		if err != nil {
 			return errors.Wrapf(err, "failed to exec into privileged pod %s on node %s", privilegedPod.Name, node.Name)
 		}

--- a/test/validate/validate.go
+++ b/test/validate/validate.go
@@ -142,7 +142,7 @@ func (v *Validator) validateIPs(ctx context.Context, stateFileIps stateFileIpsFu
 		podName := pod.Items[0].Name
 		// exec into the pod to get the state file
 		log.Printf("Executing command %s on pod %s, container %s", cmd, podName, containerName)
-		result, err := acnk8s.ExecCmdOnPod(ctx, v.clientset, namespace, podName, containerName, cmd, v.config)
+		result, _, err := acnk8s.ExecCmdOnPod(ctx, v.clientset, namespace, podName, containerName, cmd, v.config, true)
 		if err != nil {
 			return errors.Wrapf(err, "failed to exec into privileged pod - %s", podName)
 		}

--- a/test/validate/windows_validate.go
+++ b/test/validate/windows_validate.go
@@ -269,7 +269,7 @@ func validateHNSNetworkState(ctx context.Context, nodes *corev1.NodeList, client
 		}
 		podName := pod.Items[0].Name
 		// exec into the pod to get the state file
-		result, err := acnk8s.ExecCmdOnPod(ctx, clientset, privilegedNamespace, podName, "", hnsNetworkCmd, restConfig)
+		result, _, err := acnk8s.ExecCmdOnPod(ctx, clientset, privilegedNamespace, podName, "", hnsNetworkCmd, restConfig, true)
 		if err != nil {
 			return errors.Wrap(err, "failed to exec into privileged pod")
 		}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Adds a test to validate functionality of a cilium local redirect policy when a cilium network policy is applied-- for example, confirms whether certain dns requests are redirected and increment a metric when they are allowed in the network policy (and confirms that they don't increment the counter when not allowed). Updates necessary utility methods and creates a function that issues an exec on pod command but does _not_ retry on failure.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
N/A

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests
- [X] relevant PR labels added

**Notes**:
Example run: https://msazure.visualstudio.com/One/_build/results?buildId=119685764&view=logs&j=a725b465-af6c-5b16-2e20-4e0bf1d0563e&t=d9595ca1-827d-5105-2385-c679bcc42718
Nightly: https://msazure.visualstudio.com/One/_build/results?buildId=119489437&view=results
ACN PR run (no regression): https://msazure.visualstudio.com/One/_build/results?buildId=119699714&view=results 