### PR TITLE
ci: add code coverage publishing and check to pipeline

### DIFF
--- a/.pipelines/templates/run-unit-tests.yaml
+++ b/.pipelines/templates/run-unit-tests.yaml
@@ -13,7 +13,12 @@ stages:
         steps:
           - script: |
               make tools
-              # run test, echo exit status code to fd 3, pipe output from test to tee, which splits output to stdout and go-junit-report (which converts test output to report.xml), stdout from tee is redirected to fd 4. Take output written to fd 3 (which is the exit code of test), redirect to stdout, pipe to read from stdout then exit with that status code. Read all output from fd 4 (output from tee) and write to top stdout
+              sudo ln -s $(pwd)/build/tools/bin/gocov /usr/local/bin/gocov
+              sudo ln -s $(pwd)/build/tools/bin/gocov-xml /usr/local/bin/gocov-xml
+
+              # run test, echo exit status code to fd 3, pipe output from test to tee, which splits output to stdout and go-junit-report (which converts test output to report.xml),
+              # stdout from tee is redirected to fd 4. Take output written to fd 3 (which is the exit code of test), redirect to stdout, pipe to read from stdout then exit with that status code.
+              # Read all output from fd 4 (output from tee) and write to top stdout
               { { { {
                     sudo -E env "PATH=$PATH" make test-all;
                     echo $? >&3;
@@ -21,9 +26,17 @@ stages:
                   } 3>&1;
                 } | { read xs; exit $xs; }
               } 4>&1
+
+              gocov convert coverage-all.out > total_ut_coverage.json
+              gocov-xml < total_ut_coverage.json > total_ut_coverage.xml
             retryCountOnTaskFailure: 3
             name: "Test"
             displayName: "Run Tests"
+          - task: PublishCodeCoverageResults@2
+            displayName: "Publish Code Coverage Report"
+            condition: always()
+            inputs:
+              summaryFileLocation: total_ut_coverage.xml
 
   - stage: test_windows
     displayName: Test ACN Windows

--- a/.pipelines/templates/run-unit-tests.yaml
+++ b/.pipelines/templates/run-unit-tests.yaml
@@ -14,8 +14,6 @@ stages:
           - script: |
               set -e
               make tools
-              sudo ln -s $(pwd)/build/tools/bin/gocov /usr/local/bin/gocov
-              sudo ln -s $(pwd)/build/tools/bin/gocov-xml /usr/local/bin/gocov-xml
 
               # run test, echo exit status code to fd 3, pipe output from test to tee, which splits output to stdout and go-junit-report (which converts test output to report.xml),
               # stdout from tee is redirected to fd 4. Take output written to fd 3 (which is the exit code of test), redirect to stdout, pipe to read from stdout then exit with that status code.
@@ -31,6 +29,8 @@ stages:
             name: "Test"
             displayName: "Run Tests"
           - bash: |
+              sudo ln -s $(pwd)/build/tools/bin/gocov /usr/local/bin/gocov
+              sudo ln -s $(pwd)/build/tools/bin/gocov-xml /usr/local/bin/gocov-xml
               gocov convert coverage-all.out > total_ut_coverage.json
               gocov-xml < total_ut_coverage.json > total_ut_coverage.xml
             name: "Coverage"

--- a/.pipelines/templates/run-unit-tests.yaml
+++ b/.pipelines/templates/run-unit-tests.yaml
@@ -25,13 +25,73 @@ stages:
                   } 3>&1;
                 } | { read xs; exit $xs; }
               } 4>&1
+
+              mv coverage-all.out linux-coverage.out
             retryCountOnTaskFailure: 3
             name: "Test"
             displayName: "Run Tests"
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: 'linux-coverage.out'
+              artifactName: 'linux-coverage'
+
+  - stage: test_windows
+    displayName: Test ACN Windows
+    dependsOn:
+      - setup
+    jobs:
+      - job: test
+        displayName: Run Tests
+        variables:
+          STORAGE_ID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.StorageID'] ]
+        pool:
+          name: "$(BUILD_POOL_NAME_DEFAULT_WINDOWS_ALT)"
+        steps:
+          # Only run one go test per script
+          - script: |
+              cd azure-container-networking/
+              go test -timeout 30m -covermode atomic -coverprofile=windows-coverage.out ./npm/... ./cni/... ./platform/...
+              go tool cover -func=windows-coverage.out
+            retryCountOnTaskFailure: 3
+            name: "TestWindows"
+            displayName: "Run Windows Tests"
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: 'windows-coverage.out'
+              artifactName: 'windows-coverage'
+
+  - stage: code_coverage
+    displayName: Code Coverage Check
+    dependsOn:
+      - test
+      - test_windows
+    jobs:
+      - job: coverage
+        displayName: Check Coverage
+        pool:
+          name: "$(BUILD_POOL_NAME_DEFAULT)"
+        steps:
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifact: 'linux-coverage'
+              path: './'
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifact: 'windows-coverage'
+              path: './'
           - bash: |
+              make tools
               sudo ln -s $(pwd)/build/tools/bin/gocov /usr/local/bin/gocov
               sudo ln -s $(pwd)/build/tools/bin/gocov-xml /usr/local/bin/gocov-xml
-              gocov convert coverage-all.out > total_ut_coverage.json
+
+              sed -i "1d" linux-coverage.out
+              sed -i "1d" windows-coverage.out
+
+              echo "mode: atomic" > total_ut_coverage.out
+              cat linux-coverage.out >> total_ut_coverage.out
+              cat windows-coverage.out >> total_ut_coverage.out
+              
+              gocov convert total_ut_coverage.out > total_ut_coverage.json
               gocov-xml < total_ut_coverage.json > total_ut_coverage.xml
             name: "Coverage"
             displayName: "Generate Coverage Report"
@@ -52,23 +112,3 @@ stages:
               baseBranchRef: "master"
               allowCoverageVariance: true
               coverageVariance: 0.25
-
-  - stage: test_windows
-    displayName: Test ACN Windows
-    dependsOn:
-      - setup
-    jobs:
-      - job: test
-        displayName: Run Tests
-        variables:
-          STORAGE_ID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.StorageID'] ]
-        pool:
-          name: "$(BUILD_POOL_NAME_DEFAULT_WINDOWS_ALT)"
-        steps:
-          # Only run one go test per script
-          - script: |
-              cd azure-container-networking/
-              go test -timeout 30m ./npm/... ./cni/... ./platform/...
-            retryCountOnTaskFailure: 3
-            name: "TestWindows"
-            displayName: "Run Windows Tests"

--- a/.pipelines/templates/run-unit-tests.yaml
+++ b/.pipelines/templates/run-unit-tests.yaml
@@ -84,15 +84,16 @@ stages:
               sudo ln -s $(pwd)/build/tools/bin/gocov /usr/local/bin/gocov
               sudo ln -s $(pwd)/build/tools/bin/gocov-xml /usr/local/bin/gocov-xml
 
-              sed -i "1d" linux-coverage.out
-              sed -i "1d" windows-coverage.out
+              GOOS=linux gocov convert linux-coverage.out > linux-coverage.json
+              GOOS=linux gocov-xml < linux-coverage.json > linux-coverage.xml
 
-              echo "mode: atomic" > total_ut_coverage.out
-              cat linux-coverage.out >> total_ut_coverage.out
-              cat windows-coverage.out >> total_ut_coverage.out
-              
-              gocov convert total_ut_coverage.out > total_ut_coverage.json
-              gocov-xml < total_ut_coverage.json > total_ut_coverage.xml
+              GOOS=windows gocov convert windows-coverage.out > windows-coverage.json
+              GOOS=windows gocov-xml < windows-coverage.json > windows-coverage.xml
+
+              mkdir coverage
+
+              mv linux-coverage.xml coverage/
+              mv windows-coverage.xml coverage/
             name: "Coverage"
             displayName: "Generate Coverage Report"
             condition: always()
@@ -100,7 +101,7 @@ stages:
             displayName: "Publish Code Coverage Report"
             condition: always()
             inputs:
-              summaryFileLocation: total_ut_coverage.xml
+              summaryFileLocation: coverage/*
           - task: BuildQualityChecks@8
             displayName: "Check Code Coverage Regression"
             condition: always()

--- a/.pipelines/templates/run-unit-tests.yaml
+++ b/.pipelines/templates/run-unit-tests.yaml
@@ -12,6 +12,7 @@ stages:
           name: "$(BUILD_POOL_NAME_DEFAULT)"
         steps:
           - script: |
+              set -e
               make tools
               sudo ln -s $(pwd)/build/tools/bin/gocov /usr/local/bin/gocov
               sudo ln -s $(pwd)/build/tools/bin/gocov-xml /usr/local/bin/gocov-xml
@@ -26,12 +27,15 @@ stages:
                   } 3>&1;
                 } | { read xs; exit $xs; }
               } 4>&1
-
-              gocov convert coverage-all.out > total_ut_coverage.json
-              gocov-xml < total_ut_coverage.json > total_ut_coverage.xml
             retryCountOnTaskFailure: 3
             name: "Test"
             displayName: "Run Tests"
+          - bash: |
+              gocov convert coverage-all.out > total_ut_coverage.json
+              gocov-xml < total_ut_coverage.json > total_ut_coverage.xml
+            name: "Coverage"
+            displayName: "Generate Coverage Report"
+            condition: always()
           - task: PublishCodeCoverageResults@2
             displayName: "Publish Code Coverage Report"
             condition: always()

--- a/.pipelines/templates/run-unit-tests.yaml
+++ b/.pipelines/templates/run-unit-tests.yaml
@@ -37,6 +37,17 @@ stages:
             condition: always()
             inputs:
               summaryFileLocation: total_ut_coverage.xml
+          - task: BuildQualityChecks@8
+            displayName: "Check Code Coverage Regression"
+            condition: always()
+            inputs:
+              checkCoverage: true
+              coverageFailOption: "build"
+              coverageType: "lines"
+              fallbackOnPRTargetBranch: false
+              baseBranchRef: "master"
+              allowCoverageVariance: true
+              coverageVariance: 0.25
 
   - stage: test_windows
     displayName: Test ACN Windows

--- a/Makefile
+++ b/Makefile
@@ -758,9 +758,8 @@ RESTART_CASE ?= false
 CNI_TYPE ?= cilium
 
 test-all: ## run all unit tests.
-	@$(eval COVER_FILTER=`go list $(COVER_PKG)/... | tr '\n' ','`)
-	@echo Test coverpkg: $(COVER_FILTER)
-	go test -mod=readonly -buildvcs=false -tags "unit" --skip 'TestE2E*' -coverpkg=$(COVER_FILTER) -race -covermode atomic -coverprofile=coverage.out $(COVER_PKG)/...
+	-go test -mod=readonly -buildvcs=false -tags "unit" --skip 'TestE2E*' -race -covermode atomic -coverprofile=coverage-all.out $(COVER_PKG)/...
+	go tool cover -func=coverage-all.out
 
 test-integration: ## run all integration tests.
 	AZURE_IPAM_VERSION=$(AZURE_IPAM_VERSION) \

--- a/Makefile
+++ b/Makefile
@@ -758,7 +758,7 @@ RESTART_CASE ?= false
 CNI_TYPE ?= cilium
 
 test-all: ## run all unit tests.
-	-go test -mod=readonly -buildvcs=false -tags "unit" --skip 'TestE2E*' -race -covermode atomic -coverprofile=coverage-all.out $(COVER_PKG)/...
+	go test -mod=readonly -buildvcs=false -tags "unit" --skip 'TestE2E*' -race -covermode atomic -coverprofile=coverage-all.out $(COVER_PKG)/...
 	go tool cover -func=coverage-all.out
 
 test-integration: ## run all integration tests.


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
The current pr pipeline does not check if a PR drastically decreases the code coverage of the repository, nor does it publish code coverage results to the code coverage tab in ADO. This PR enables publishing code coverage and should mark the build as a failure if the code coverage decreases by a significant amount (> 0.25% I believe) compared to the master branch. Merges code coverage between windows and linux oses.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
See above

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
