### PR TITLE
feat: stateless cni compatibility with nodesubnet

### DIFF
--- a/cni/azure-linux.conflist
+++ b/cni/azure-linux.conflist
@@ -7,7 +7,7 @@
          "mode":"transparent",
          "ipsToRouteViaHost":["169.254.20.10"],
          "ipam":{
-            "type":"azure-vnet-ipam"
+            "type":"azure-vnet-ipam",
             "mode":"nodesubnet"
          }
       },

--- a/cni/azure-linux.conflist
+++ b/cni/azure-linux.conflist
@@ -8,6 +8,7 @@
          "ipsToRouteViaHost":["169.254.20.10"],
          "ipam":{
             "type":"azure-vnet-ipam"
+            "mode":"nodesubnet"
          }
       },
       {

--- a/cni/azure-windows.conflist
+++ b/cni/azure-windows.conflist
@@ -11,6 +11,7 @@
             },
             "ipam": {
                 "type": "azure-vnet-ipam"
+                "mode": "nodesubnet"
             },
             "dns": {
                 "Nameservers": [

--- a/cni/azure-windows.conflist
+++ b/cni/azure-windows.conflist
@@ -10,7 +10,7 @@
                 "dns": true
             },
             "ipam": {
-                "type": "azure-vnet-ipam"
+                "type": "azure-vnet-ipam",
                 "mode": "nodesubnet"
             },
             "dns": {

--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -387,6 +387,7 @@ func configureDefaultAddResult(info *IPResultInfo, addConfig *IPAMAddConfig, add
 	}
 
 	if ipamMode == util.Nodesubnet {
+		logger.Info("IPAM mode is nodesubnet, using host IP configuration info")
 		info.ncGatewayIPAddress = info.hostGateway
 		info.ncPrimaryIP = info.hostPrimaryIP
 		_, ncIPNet, err := net.ParseCIDR(info.hostSubnet)

--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -407,7 +407,7 @@ func configureDefaultAddResult(info *IPResultInfo, addConfig *IPAMAddConfig, add
 
 	podGateway := net.ParseIP(info.ncGatewayIPAddress)
 	// TODO: Remove v4overlay and dualstackoverlay options, after 'overlay' rolls out in AKS-RP
-	isPodSubnetMode := (ipamMode != util.V4Overlay) && (ipamMode != util.DualStackOverlay) && (ipamMode != util.Overlay) && (ipamMode != util.Nodesubnet)
+	isPodSubnetMode := ipamMode != util.V4Overlay && ipamMode != util.DualStackOverlay && ipamMode != util.Overlay && ipamMode != util.Nodesubnet
 
 	if podGateway == nil {
 		if isPodSubnetMode {

--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -396,7 +396,7 @@ func configureDefaultAddResult(info *IPResultInfo, addConfig *IPAMAddConfig, add
 		}
 
 		maskLen, _ := ncIPNet.Mask.Size()
-		info.ncSubnetPrefix = uint8(maskLen)
+		info.ncSubnetPrefix = uint8(maskLen) //nolint:gosec // length of mask, at most 128
 	}
 
 	ip, ncIPNet, err := net.ParseCIDR(info.podIPAddress + "/" + fmt.Sprint(info.ncSubnetPrefix))

--- a/cni/network/invoker_cns_test.go
+++ b/cni/network/invoker_cns_test.go
@@ -2324,11 +2324,11 @@ func Test_configureDefaultAddResult(t *testing.T) {
 		t.Fatalf("configureDefaultAddResult due to error: %v", err)
 	}
 
-	require.Equal(t, 1, len(addResult.interfaceInfo))
-	require.Equal(t, 1, len(addResult.interfaceInfo["00-15-5D-3D-AD-5D"].IPConfigs))
+	require.Len(t, addResult.interfaceInfo, 1)
+	require.Len(t, addResult.interfaceInfo["00-15-5D-3D-AD-5D"].IPConfigs, 1)
 	require.Equal(t, "10.240.2.10/16", addResult.interfaceInfo["00-15-5D-3D-AD-5D"].IPConfigs[0].Address.String())
 	require.Equal(t, "10.240.0.1", addResult.interfaceInfo["00-15-5D-3D-AD-5D"].IPConfigs[0].Gateway.String())
-	require.Equal(t, 1, len(addResult.interfaceInfo["00-15-5D-3D-AD-5D"].Routes))
+	require.Len(t, addResult.interfaceInfo["00-15-5D-3D-AD-5D"].Routes, 1)
 	require.Equal(t, "0.0.0.0/0", addResult.interfaceInfo["00-15-5D-3D-AD-5D"].Routes[0].Dst.String())
 	require.Equal(t, "10.240.0.1", addResult.interfaceInfo["00-15-5D-3D-AD-5D"].Routes[0].Gw.String())
 	require.Equal(t, cns.InfraNIC, addResult.interfaceInfo["00-15-5D-3D-AD-5D"].NICType)

--- a/cni/network/invoker_cns_test.go
+++ b/cni/network/invoker_cns_test.go
@@ -485,6 +485,7 @@ func TestCNSIPAMInvoker_Add_Overlay(t *testing.T) {
 			}
 			if tt.fields.ipamMode != "" {
 				invoker.ipamMode = tt.fields.ipamMode
+				tt.args.nwCfg.IPAM.Mode = string(tt.fields.ipamMode)
 			}
 			ipamAddResult, err := invoker.Add(IPAMAddConfig{nwCfg: tt.args.nwCfg, args: tt.args.args, options: tt.args.options})
 			if tt.wantErr {

--- a/cni/util/const.go
+++ b/cni/util/const.go
@@ -16,6 +16,7 @@ const (
 	V4Overlay        IpamMode = "v4overlay"
 	DualStackOverlay IpamMode = "dualStackOverlay"
 	Overlay          IpamMode = "overlay" // Nothing changes between 'v4overlay' and 'dualStackOverlay' mode, so consolidating to one
+	Nodesubnet       IpamMode = "nodesubnet"
 )
 
 // Overlay consolidation plan

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -9,12 +9,12 @@ AZCLI   ?= docker run --rm -v $(AZCFG):/root/.azure -v $(KUBECFG):/root/.kube -v
 
 # overrideable defaults
 AUTOUPGRADE          ?= patch
-K8S_VER              ?= 1.30
+K8S_VER              ?= 1.31
 NODE_COUNT           ?= 2
 NODE_COUNT_WIN	     ?= $(NODE_COUNT)
 NODEUPGRADE          ?= NodeImage
 OS				     ?= linux # Used to signify if you want to bring up a windows nodePool on byocni clusters
-OS_SKU               ?= Ubuntu
+OS_SKU               ?= AzureLinux
 OS_SKU_WIN           ?= Windows2022
 REGION               ?= westus2
 VM_SIZE	             ?= Standard_B2s
@@ -136,15 +136,13 @@ endif
 
 overlay-byocni-nokubeproxy-up: rg-up overlay-net-up ## Brings up an Overlay BYO CNI cluster without kube-proxy
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
-		--auto-upgrade-channel $(AUTOUPGRADE) \
-		--node-os-upgrade-channel $(NODEUPGRADE) \
 		--kubernetes-version $(K8S_VER) \
 		--node-count $(NODE_COUNT) \
 		--node-vm-size $(VM_SIZE) \
-		--load-balancer-sku basic \
 		--network-plugin none \
 		--network-plugin-mode overlay \
 		--pod-cidr 192.168.0.0/16 \
+		--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/UseCustomizedOSImage,OSImageSubscriptionID=109a5e88-712a-48ae-9078-9ca8b3c81345,OSImageResourceGroup=AKS-Ubuntu,OSImageGallery=AKSUbuntu,OSImageName=2404gen2containerd,OSImageVersion=202501.05.0 \
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
 		--no-ssh-key \
 		--kube-proxy-config $(KUBE_PROXY_JSON_PATH) \
@@ -163,6 +161,8 @@ overlay-cilium-up: rg-up overlay-net-up ## Brings up an Overlay Cilium cluster
 		--network-dataplane cilium \
 		--network-plugin-mode overlay \
 		--pod-cidr 192.168.0.0/16 \
+		--os-sku $(OS_SKU) \
+		--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/AzureLinuxV3Preview \
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
 		--no-ssh-key \
 		--yes

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -9,12 +9,12 @@ AZCLI   ?= docker run --rm -v $(AZCFG):/root/.azure -v $(KUBECFG):/root/.kube -v
 
 # overrideable defaults
 AUTOUPGRADE          ?= patch
-K8S_VER              ?= 1.31
+K8S_VER              ?= 1.30
 NODE_COUNT           ?= 2
 NODE_COUNT_WIN	     ?= $(NODE_COUNT)
 NODEUPGRADE          ?= NodeImage
 OS				     ?= linux # Used to signify if you want to bring up a windows nodePool on byocni clusters
-OS_SKU               ?= AzureLinux
+OS_SKU               ?= Ubuntu
 OS_SKU_WIN           ?= Windows2022
 REGION               ?= westus2
 VM_SIZE	             ?= Standard_B2s
@@ -136,13 +136,15 @@ endif
 
 overlay-byocni-nokubeproxy-up: rg-up overlay-net-up ## Brings up an Overlay BYO CNI cluster without kube-proxy
 	$(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
+		--auto-upgrade-channel $(AUTOUPGRADE) \
+		--node-os-upgrade-channel $(NODEUPGRADE) \
 		--kubernetes-version $(K8S_VER) \
 		--node-count $(NODE_COUNT) \
 		--node-vm-size $(VM_SIZE) \
+		--load-balancer-sku basic \
 		--network-plugin none \
 		--network-plugin-mode overlay \
 		--pod-cidr 192.168.0.0/16 \
-		--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/UseCustomizedOSImage,OSImageSubscriptionID=109a5e88-712a-48ae-9078-9ca8b3c81345,OSImageResourceGroup=AKS-Ubuntu,OSImageGallery=AKSUbuntu,OSImageName=2404gen2containerd,OSImageVersion=202501.05.0 \
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
 		--no-ssh-key \
 		--kube-proxy-config $(KUBE_PROXY_JSON_PATH) \
@@ -161,8 +163,6 @@ overlay-cilium-up: rg-up overlay-net-up ## Brings up an Overlay Cilium cluster
 		--network-dataplane cilium \
 		--network-plugin-mode overlay \
 		--pod-cidr 192.168.0.0/16 \
-		--os-sku $(OS_SKU) \
-		--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/AzureLinuxV3Preview \
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
 		--no-ssh-key \
 		--yes

--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -218,7 +218,7 @@ func (nw *network) deleteEndpoint(nl netlink.NetlinkInterface, plc platform.Exec
 	// Call the platform implementation.
 	// Pass nil for epClient and will be initialized in deleteEndpointImpl
 	err = nw.deleteEndpointImpl(nl, plc, nil, nioc, nsc, iptc, dhcpc, ep)
-	if err == ErrMissingHNSID {
+	if errors.Is(err, ErrMissingHNSID) {
 		logger.Info("HNS ID is missing, skipping endpoint deletion")
 	} else if err != nil {
 		return err

--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -218,7 +218,9 @@ func (nw *network) deleteEndpoint(nl netlink.NetlinkInterface, plc platform.Exec
 	// Call the platform implementation.
 	// Pass nil for epClient and will be initialized in deleteEndpointImpl
 	err = nw.deleteEndpointImpl(nl, plc, nil, nioc, nsc, iptc, dhcpc, ep)
-	if err != nil {
+	if err == ErrMissingHNSID {
+		logger.Info("HNS ID is missing, skipping endpoint deletion")
+	} else if err != nil {
 		return err
 	}
 

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -531,7 +531,7 @@ func (nw *network) deleteEndpointImpl(_ netlink.NetlinkInterface, _ platform.Exe
 
 	if ep.HnsId == "" {
 		logger.Error("No HNS id found. Skip endpoint deletion", zap.Any("nicType", ep.NICType), zap.String("containerId", ep.ContainerID))
-		return fmt.Errorf("No HNS id found. Skip endpoint deletion for nicType %v, containerID %s", ep.NICType, ep.ContainerID) //nolint
+		return nil
 	}
 
 	if useHnsV2, err := UseHnsV2(ep.NetNs); useHnsV2 {

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -531,7 +531,7 @@ func (nw *network) deleteEndpointImpl(_ netlink.NetlinkInterface, _ platform.Exe
 
 	if ep.HnsId == "" {
 		logger.Error("No HNS id found. Skip endpoint deletion", zap.Any("nicType", ep.NICType), zap.String("containerId", ep.ContainerID))
-		return nil
+		return ErrMissingHNSID
 	}
 
 	if useHnsV2, err := UseHnsV2(ep.NetNs); useHnsV2 {

--- a/network/endpoint_windows_test.go
+++ b/network/endpoint_windows_test.go
@@ -136,7 +136,7 @@ func TestDeleteEndpointImplHnsV2WithEmptyHNSID(t *testing.T) {
 	mockCli := NewMockEndpointClient(nil)
 	err := nw.deleteEndpointImpl(netlink.NewMockNetlink(false, ""), platform.NewMockExecClient(false), mockCli,
 		netio.NewMockNetIO(false, 0), NewMockNamespaceClient(), iptables.NewClient(), &mockDHCP{}, &ep)
-	if err != ErrMissingHNSID {
+	if !errors.Is(err, ErrMissingHNSID) {
 		t.Fatalf("unexpected error when deleting endpoint with empty HNS ID: %v", err)
 	}
 }

--- a/network/endpoint_windows_test.go
+++ b/network/endpoint_windows_test.go
@@ -81,7 +81,6 @@ func TestNewAndDeleteEndpointImplHnsV2(t *testing.T) {
 	}
 
 	err = nw.deleteEndpointImplHnsV2(ep)
-
 	if err != nil {
 		fmt.Printf("+%v", err)
 		t.Fatal(err)
@@ -137,8 +136,8 @@ func TestDeleteEndpointImplHnsV2WithEmptyHNSID(t *testing.T) {
 	mockCli := NewMockEndpointClient(nil)
 	err := nw.deleteEndpointImpl(netlink.NewMockNetlink(false, ""), platform.NewMockExecClient(false), mockCli,
 		netio.NewMockNetIO(false, 0), NewMockNamespaceClient(), iptables.NewClient(), &mockDHCP{}, &ep)
-	if err != nil {
-		t.Fatal("endpoint deletion gets executed")
+	if err != ErrMissingHNSID {
+		t.Fatalf("unexpected error when deleting endpoint with empty HNS ID: %v", err)
 	}
 }
 

--- a/network/errors.go
+++ b/network/errors.go
@@ -8,4 +8,5 @@ var (
 	ErrEndpointStateNotFound   = errors.New("endpoint state could not be found in the statefile")
 	ErrConnectionFailure       = errors.New("couldn't connect to CNS")
 	ErrGetEndpointStateFailure = errors.New("failure to obtain the endpoint state")
+	ErrMissingHNSID            = errors.New("HNS ID missing")
 )

--- a/network/manager.go
+++ b/network/manager.go
@@ -542,7 +542,7 @@ func (nm *networkManager) DeleteEndpointState(networkID string, epInfo *Endpoint
 	logger.Info("Deleting endpoint with", zap.String("Endpoint Info: ", epInfo.PrettyString()), zap.String("HNISID : ", ep.HnsId))
 
 	err := nw.deleteEndpointImpl(netlink.NewNetlink(), platform.NewExecClient(logger), nil, nil, nil, nil, nil, ep)
-	if err == ErrMissingHNSID {
+	if errors.Is(err, ErrMissingHNSID) {
 		logger.Info("HNS ID is missing, skipping endpoint deletion")
 	} else if err != nil {
 		return err

--- a/network/manager.go
+++ b/network/manager.go
@@ -542,7 +542,9 @@ func (nm *networkManager) DeleteEndpointState(networkID string, epInfo *Endpoint
 	logger.Info("Deleting endpoint with", zap.String("Endpoint Info: ", epInfo.PrettyString()), zap.String("HNISID : ", ep.HnsId))
 
 	err := nw.deleteEndpointImpl(netlink.NewNetlink(), platform.NewExecClient(logger), nil, nil, nil, nil, nil, ep)
-	if err != nil {
+	if err == ErrMissingHNSID {
+		logger.Info("HNS ID is missing, skipping endpoint deletion")
+	} else if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
Stateless CNI is currently not compatible with nodesubnet, even with the changes that were recently incorporated into CNS for Cilium+Nodesubnet support. Specifically, IP configs returned from CNS in Nodesubnet mode do not populate NC-specific fields - ncGatewayIPAddress, ncSubnetPrefix, ncPrimarIP etc. The CNI today expects these values, since CNS is invoked only for Podsubnet/Overlay cases. With this PR, we have the following changes:
1. Have a configuration option to configure the CNI for nodesubnet
2. In nodesubnet mode, the CNI uses hostGateway and subnet to configure the pods
3. The conflist for Azure CNI Nodesubnet on both windows and linux additionally specifies the mode as "nodesubnet". Today, the mode is specified only for overlay. Nodesubnet uses azure-vnet-ipam as the IPAM type, and podsubnet uses azure-cns as IPAM type with mode unspecified. With this change, cniv1 clusters can continue using azure-vnet-ipam (mode is ignored), whenever we deploy stateless CNI with nodesubnet, we'll use azure-cns as the type, and nodesubnet as the mode. Making this change here allows us to leave AgentBaker CSE scripts untouched.
4. Doesn't block pod deletion if HNS network is not found. Rather, we log the event and proceed with pod deletion. Effectively, this allows deleting pods that never got an IP. This is an enhancement to help debug issues more easily.

The PR touches code that appears to have TODO items to clean up the Overlay configuration parameter. I'm planning to do that separately once I validate that the new parameter is fully rolled out.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [x] relevant PR labels added

**Notes**:
