### PR TITLE
fix: delete cni statefile when unable to be parsed

### DIFF
--- a/network/manager.go
+++ b/network/manager.go
@@ -204,6 +204,12 @@ func (nm *networkManager) restore(isRehydrationRequired bool) error {
 		} else if errors.As(err, &syntaxErr) {
 			// if null chars detected or failed to parse, state is unrecoverable; delete it
 			logger.Error("Failed to parse corrupted state, deleting", zap.Error(err))
+			contents, readErr := nm.store.Dump()
+			if readErr != nil {
+				logger.Error("Could not read corrupted state", zap.Error(readErr))
+			} else {
+				logger.Info("Logging state", zap.String("stateFile", contents))
+			}
 			nm.store.Remove()
 			return errors.Wrap(err, "failed to parse corrupted state")
 		} else {

--- a/store/json.go
+++ b/store/json.go
@@ -246,6 +246,7 @@ func (kvs *jsonFileStore) Remove() {
 	kvs.Mutex.Unlock()
 }
 
+// Dump returns the contents of the store in string format, erroring if it could not be read
 func (kvs *jsonFileStore) Dump() (string, error) {
 	kvs.Mutex.Lock()
 	defer kvs.Mutex.Unlock()

--- a/store/json_test.go
+++ b/store/json_test.go
@@ -134,7 +134,7 @@ func TestKeyValuePairsAreWrittenAndReadCorrectly(t *testing.T) {
 	// Dump empty store.
 	_, err = kvs.Dump()
 	if err == nil {
-		t.Fatal("Expected store to be empty")
+		t.Fatal("Expected store to not exist")
 	}
 
 	// Write a key value pair.

--- a/store/json_test.go
+++ b/store/json_test.go
@@ -129,6 +129,14 @@ func TestKeyValuePairsAreWrittenAndReadCorrectly(t *testing.T) {
 		t.Fatalf("Failed to create KeyValueStore %v\n", err)
 	}
 
+	defer os.Remove(testFileName)
+
+	// Dump empty store.
+	_, err = kvs.Dump()
+	if err == nil {
+		t.Fatal("Expected store to be empty")
+	}
+
 	// Write a key value pair.
 	err = kvs.Write(testKey1, &writtenValue)
 	if err != nil {
@@ -153,8 +161,17 @@ func TestKeyValuePairsAreWrittenAndReadCorrectly(t *testing.T) {
 			testKey1, readValue, testKey1, writtenValue)
 	}
 
-	// Cleanup.
-	os.Remove(testFileName)
+	// Dump populated store.
+	val, err := kvs.Dump()
+	if err != nil {
+		t.Fatalf("Failed to dump store %v", err)
+	}
+	val = strings.ReplaceAll(val, " ", "")
+	val = strings.ReplaceAll(val, "\t", "")
+	val = strings.ReplaceAll(val, "\n", "")
+	if val != `{"key1":{"Field1":"test","Field2":42},"key2":{"Field1":"any","Field2":14}}` {
+		t.Errorf("Dumped data not expected: %v", val)
+	}
 }
 
 // test case for testing newjsonfilestore idempotent

--- a/store/mockstore.go
+++ b/store/mockstore.go
@@ -71,3 +71,7 @@ func (ms *mockStore) GetLockFileName() string {
 }
 
 func (ms *mockStore) Remove() {}
+
+func (ms *mockStore) Dump() (string, error) {
+	return fmt.Sprintf("%+v", ms.data), nil
+}

--- a/store/store.go
+++ b/store/store.go
@@ -18,6 +18,7 @@ type KeyValueStore interface {
 	Unlock() error
 	GetModificationTime() (time.Time, error)
 	Remove()
+	Dump() (string, error)
 }
 
 var (

--- a/testutils/store_mock.go
+++ b/testutils/store_mock.go
@@ -54,3 +54,7 @@ func (mockst *KeyValueStoreMock) GetModificationTime() (time.Time, error) {
 }
 
 func (mockst *KeyValueStoreMock) Remove() {}
+
+func (mockst *KeyValueStoreMock) Dump() (string, error) {
+	return "", nil
+}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Sometimes in certain scenarios (usually windows), if there is a crash of the OS, null bytes may be written to the state and log file. When the CNI tries to restore the state, it is unable to read the statefile and fails. All subsequent retries will fail as the state is irrecoverable. This PR changes this behavior to delete the entire cni statefile if there is a syntax error (ex: if there are a bunch of null bytes in the file), as manual intervention would be needed to recover anyway. The null statefile issue only seems to appear on the pipelines on windows nodes.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
See above

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [X] relevant PR labels added

**Notes**:
This issue appears sporadically