### PR TITLE
backport: ci: add delay after link creation for test add remove static arp (#2968)

### DIFF
--- a/netlink/netlink_test.go
+++ b/netlink/netlink_test.go
@@ -9,6 +9,7 @@ package netlink
 import (
 	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
@@ -285,6 +286,10 @@ func TestAddRemoveStaticArp(t *testing.T) {
 	mac, _ := net.ParseMAC("aa:b3:4d:5e:e2:4a")
 	nl := NewNetlink()
 
+	// wait for interface to fully come up
+	// if it isn't fully up it might wipe the arp entry we're about to add
+	time.Sleep(time.Millisecond * 100)
+
 	linkInfo := LinkInfo{
 		Name:       ifName,
 		IPAddr:     ip,
@@ -301,6 +306,9 @@ func TestAddRemoveStaticArp(t *testing.T) {
 		IPAddr:     ip,
 		MacAddress: mac,
 	}
+
+	// ensure arp address remains for a period of time
+	time.Sleep(time.Millisecond * 100)
 
 	err = nl.SetOrRemoveLinkAddress(linkInfo, REMOVE, NUD_INCOMPLETE)
 	if err != nil {


### PR DESCRIPTION
fix by adding delay after link creation

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Backports #2968

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
See above

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
