### PR TITLE
fix: do not return a StripPrefix handler when building checker

### DIFF
--- a/cns/healthserver/healthz.go
+++ b/cns/healthserver/healthz.go
@@ -55,7 +55,7 @@ func NewHealthzHandlerWithChecks(cnsConfig *configuration.CNSConfig) (http.Handl
 
 	// strip prefix so that it runs through all checks registered on the handler.
 	// otherwise it will look for a check named "healthz" and return a 404 if not there.
-	return http.StripPrefix("/healthz", &healthz.Handler{
+	return &healthz.Handler{
 		Checks: checks,
-	}), nil
+	}, nil
 }

--- a/cns/healthserver/healthz_test.go
+++ b/cns/healthserver/healthz_test.go
@@ -198,7 +198,7 @@ func TestNewHealthzHandlerWithChecks(t *testing.T) {
 
 			responseRecorder := httptest.NewRecorder()
 			healthHandler, err := NewHealthzHandlerWithChecks(tt.cnsConfig)
-      healthHandler = http.StripPrefix("/healthz", healthHandler)
+			healthHandler = http.StripPrefix("/healthz", healthHandler)
 			require.NoError(t, err)
 
 			healthHandler.ServeHTTP(responseRecorder, httptest.NewRequest("GET", "/healthz", http.NoBody))

--- a/cns/healthserver/healthz_test.go
+++ b/cns/healthserver/healthz_test.go
@@ -198,6 +198,7 @@ func TestNewHealthzHandlerWithChecks(t *testing.T) {
 
 			responseRecorder := httptest.NewRecorder()
 			healthHandler, err := NewHealthzHandlerWithChecks(tt.cnsConfig)
+      healthHandler = http.StripPrefix("/healthz", healthHandler)
 			require.NoError(t, err)
 
 			healthHandler.ServeHTTP(responseRecorder, httptest.NewRequest("GET", "/healthz", http.NoBody))


### PR DESCRIPTION


<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

already doing the strip prefix https://github.com/tyler-lloyd/azure-container-networking/blob/40b6c443d62321ee61c134bf6573ed2de9813d50/cns/healthserver/server.go#L15

so doing it inside check builder is redunant and causes the /healthz endpoint to return a 404


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
