### PR TITLE
ci: Allow manual overwrite of k8s version in CI/CD

### DIFF
--- a/.pipelines/cni/load-test-templates/create-cluster-template.yaml
+++ b/.pipelines/cni/load-test-templates/create-cluster-template.yaml
@@ -19,7 +19,7 @@ steps:
       inlineScript: |
         set -ex
         if ! [ -z ${K8S_VERSION} ]; then
-          echo "Default k8s version, $(make -C ./hack/aks vars | grep K8S | cut -d'=' -f 2), is being overwritten by ${K8S_VERSION}"
+          echo "Default k8s version, $(make -C ./hack/aks vars | grep K8S | cut -d'=' -f 2), is manually set to ${K8S_VERSION}"
           export K8S_VER=${K8S_VERSION}
         fi
 

--- a/.pipelines/cni/load-test-templates/create-cluster-template.yaml
+++ b/.pipelines/cni/load-test-templates/create-cluster-template.yaml
@@ -18,6 +18,11 @@ steps:
       addSpnToEnvironment: true
       inlineScript: |
         set -ex
+        if ! [ -z ${K8S_VERSION} ]; then
+          echo "Default k8s version, $(make -C ./hack/aks vars | grep K8S | cut -d'=' -f 2), is being overwritten by ${K8S_VERSION}"
+          export K8S_VER=${K8S_VERSION}
+        fi
+
         make -C ./hack/aks azcfg AZCLI=az REGION=${{ parameters.region }}
         make -C ./hack/aks ${{ parameters.clusterType }} \
         AZCLI=az REGION=${{ parameters.region }} SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) \

--- a/.pipelines/templates/create-cluster.jobs.yaml
+++ b/.pipelines/templates/create-cluster.jobs.yaml
@@ -44,7 +44,7 @@ jobs:
             fi
 
             if ! [ -z ${K8S_VERSION} ]; then
-              echo "Default k8s version, $(make -C ./hack/aks vars | grep K8S | cut -d'=' -f 2), is being overwritten by ${K8S_VERSION}"
+              echo "Default k8s version, $(make -C ./hack/aks vars | grep K8S | cut -d'=' -f 2), is manually set to ${K8S_VERSION}"
               export K8S_VER=${K8S_VERSION}
             fi
 

--- a/.pipelines/templates/create-cluster.jobs.yaml
+++ b/.pipelines/templates/create-cluster.jobs.yaml
@@ -42,6 +42,12 @@ jobs:
               az extension add --name aks-preview
               az extension update --name aks-preview
             fi
+
+            if ! [ -z ${K8S_VERSION} ]; then
+              echo "Default k8s version, $(make -C ./hack/aks vars | grep K8S | cut -d'=' -f 2), is being overwritten by ${K8S_VERSION}"
+              export K8S_VER=${K8S_VERSION}
+            fi
+
             mkdir -p ~/.kube/
             make -C ./hack/aks azcfg AZCLI=az REGION=${{ parameters.region }}
 

--- a/.pipelines/templates/create-cluster.yaml
+++ b/.pipelines/templates/create-cluster.yaml
@@ -33,7 +33,7 @@ jobs:
             fi
 
             if ! [ -z ${K8S_VERSION} ]; then
-              echo "Default k8s version, $(make -C ./hack/aks vars | grep K8S | cut -d'=' -f 2), is being overwritten by ${K8S_VERSION}"
+              echo "Default k8s version, $(make -C ./hack/aks vars | grep K8S | cut -d'=' -f 2), is manually set to ${K8S_VERSION}"
               export K8S_VER=${K8S_VERSION}
             fi
 

--- a/.pipelines/templates/create-cluster.yaml
+++ b/.pipelines/templates/create-cluster.yaml
@@ -31,6 +31,12 @@ jobs:
               az extension add --name aks-preview
               az extension update --name aks-preview
             fi
+
+            if ! [ -z ${K8S_VERSION} ]; then
+              echo "Default k8s version, $(make -C ./hack/aks vars | grep K8S | cut -d'=' -f 2), is being overwritten by ${K8S_VERSION}"
+              export K8S_VER=${K8S_VERSION}
+            fi
+
             mkdir -p ~/.kube/
             make -C ./hack/aks azcfg AZCLI=az REGION=${{ parameters.region }}
 

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -65,6 +65,7 @@ vars: ## Show the input vars configured for the cluster commands
 	@echo VM_SIZE=$(VM_SIZE)
 	@echo NODE_COUNT=$(NODE_COUNT)
 	@echo VMSS_NAME=$(VMSS_NAME)
+	@echo K8S_VER=$(K8S_VER)
 
 
 ##@ SWIFT Infra


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Enables testing of various Kubernetes versions against master. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
Does not impact functionality of PR or Releases.

Using variable `${K8S_VERSION}`
ACN PR - https://msazure.visualstudio.com/One/_build/results?buildId=120416666&view=logs&j=b7272be1-c4e1-5606-108c-57e47d6749ec&t=24d1cf9e-6a2a-5c4b-89db-514da0326b17&l=77
CNI Release Test - https://msazure.visualstudio.com/One/_build/results?buildId=120417599&view=logs&j=5880768e-a1e2-5440-d89b-0c014d2bdd3f&t=36f18d29-ef7e-52ae-b9f6-f2d795e40dd6&l=74