### PR TITLE
revert: [NPM] Remove hostUsers Configuration

### DIFF
--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -108,7 +108,7 @@ stages:
             IS_STRESS_TEST: "false"
           v2-linux-stress:
             AZURE_CLUSTER: "conformance-v2-linux-stress"
-            PROFILE: "v2-background"
+            PROFILE: "v2-linux-stress"
             IS_STRESS_TEST: "true"
           v2-place-first:
             AZURE_CLUSTER: "conformance-v2-place-first"

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -166,6 +166,9 @@ stages:
               chmod +x kubectl
               echo Cluster $(AZURE_CLUSTER)
               echo Resource $(RESOURCE_GROUP)
+              echo Public IP $(PUBLIC_IP_NAME)
+              export PUBLIC_IP_ID=$(az network public-ip show -g $(RESOURCE_GROUP) -n $(PUBLIC_IP_NAME) --query id -o tsv)
+              echo Public IP ID $PUBLIC_IP_ID
 
               if [[ $(AZURE_CLUSTER) == *ws22 ]] # * is used for pattern matching
               then
@@ -183,7 +186,7 @@ stages:
                     --vm-set-type VirtualMachineScaleSets \
                     --node-vm-size Standard_D4s_v3 \
                     --node-count 1 \
-                    --load-balancer-outbound-ips $(PUBLIC_IP_ID)
+                    --load-balancer-outbound-ips $PUBLIC_IP_ID
 
                 if [ $? != 0 ]
                 then
@@ -231,7 +234,7 @@ stages:
                 --resource-group $(RESOURCE_GROUP) \
                 --name $(AZURE_CLUSTER) \
                 --network-plugin azure \
-                --load-balancer-outbound-ips $(PUBLIC_IP_ID)
+                --load-balancer-outbound-ips $PUBLIC_IP_ID
 
                 if [ $? != 0 ]
                 then

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -123,7 +123,7 @@ stages:
         RESOURCE_GROUP: $[ stagedependencies.setup.setup.outputs['EnvironmentalVariables.RESOURCE_GROUP'] ]
         TAG: $[ stagedependencies.setup.setup.outputs['EnvironmentalVariables.TAG'] ]
         FQDN: empty
-        PUBLIC_IP_NAME: $(RESOURCE_GROUP)-public-ip
+        PUBLIC_IP_NAME: $(RESOURCE_GROUP)-$(PROFILE)-public-ip
       steps:
         - checkout: self
 

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -150,7 +150,9 @@ stages:
                 --resource-group $(RESOURCE_GROUP) \
                 --allocation-method Static \
                 --ip-tags 'FirstPartyUsage=/DelegatedNetworkControllerTest' \
-                --location $(LOCATION) --sku Standard --tier Regional \
+                --location $(LOCATION) \
+                --sku Standard \
+                --tier Regional \
                 --version IPv4
 
         - task: AzureCLI@2
@@ -186,6 +188,7 @@ stages:
                     --vm-set-type VirtualMachineScaleSets \
                     --node-vm-size Standard_D4s_v3 \
                     --node-count 1 \
+                    --load-balancer-sku standard \ 
                     --load-balancer-outbound-ips $PUBLIC_IP_ID
 
                 if [ $? != 0 ]
@@ -234,6 +237,7 @@ stages:
                 --resource-group $(RESOURCE_GROUP) \
                 --name $(AZURE_CLUSTER) \
                 --network-plugin azure \
+                --load-balancer-sku standard \ 
                 --load-balancer-outbound-ips $PUBLIC_IP_ID
 
                 if [ $? != 0 ]

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -123,6 +123,7 @@ stages:
         RESOURCE_GROUP: $[ stagedependencies.setup.setup.outputs['EnvironmentalVariables.RESOURCE_GROUP'] ]
         TAG: $[ stagedependencies.setup.setup.outputs['EnvironmentalVariables.TAG'] ]
         FQDN: empty
+        PUBLIC_IP_NAME: $(RESOURCE_GROUP)-public-ip
       steps:
         - checkout: self
 
@@ -136,6 +137,21 @@ stages:
               az group create -n $(RESOURCE_GROUP) -l $(LOCATION) -o table
               echo created RG $(RESOURCE_GROUP) in $(LOCATION)
               az version
+
+        - task: AzureCLI@2
+          displayName: "Create public IP with a service tag"
+          inputs:
+            azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+            scriptType: "bash"
+            scriptLocation: "inlineScript"
+            inlineScript: |
+              az network public-ip create \
+                --name $(PUBLIC_IP_NAME) \
+                --resource-group $(RESOURCE_GROUP) \
+                --allocation-method Static \
+                --ip-tags 'FirstPartyUsage=/DelegatedNetworkControllerTest' \
+                --location $(LOCATION) --sku Standard --tier Regional \
+                --version IPv4
 
         - task: AzureCLI@2
           displayName: "Deploy NPM to Test Cluster"
@@ -166,7 +182,8 @@ stages:
                     --network-plugin azure \
                     --vm-set-type VirtualMachineScaleSets \
                     --node-vm-size Standard_D4s_v3 \
-                    --node-count 1
+                    --node-count 1 \
+                    --load-balancer-outbound-ips $(PUBLIC_IP_ID)
 
                 if [ $? != 0 ]
                 then
@@ -213,7 +230,8 @@ stages:
                 az aks create --no-ssh-key \
                 --resource-group $(RESOURCE_GROUP) \
                 --name $(AZURE_CLUSTER) \
-                --network-plugin azure
+                --network-plugin azure \
+                --load-balancer-outbound-ips $(PUBLIC_IP_ID)
 
                 if [ $? != 0 ]
                 then

--- a/.pipelines/npm/npm-conformance-tests.yaml
+++ b/.pipelines/npm/npm-conformance-tests.yaml
@@ -188,7 +188,6 @@ stages:
                     --vm-set-type VirtualMachineScaleSets \
                     --node-vm-size Standard_D4s_v3 \
                     --node-count 1 \
-                    --load-balancer-sku standard \ 
                     --load-balancer-outbound-ips $PUBLIC_IP_ID
 
                 if [ $? != 0 ]
@@ -237,7 +236,6 @@ stages:
                 --resource-group $(RESOURCE_GROUP) \
                 --name $(AZURE_CLUSTER) \
                 --network-plugin azure \
-                --load-balancer-sku standard \ 
                 --load-balancer-outbound-ips $PUBLIC_IP_ID
 
                 if [ $? != 0 ]

--- a/.pipelines/npm/npm-scale-test.yaml
+++ b/.pipelines/npm/npm-scale-test.yaml
@@ -146,7 +146,9 @@ jobs:
                 --resource-group $(RESOURCE_GROUP) \
                 --allocation-method Static \
                 --ip-tags 'FirstPartyUsage=/DelegatedNetworkControllerTest' \
-                --location $(LOCATION) --sku Standard --tier Regional \
+                --location $(LOCATION) \
+                --sku Standard \
+                --tier Regional \
                 --version IPv4
             export PUBLIC_IP_ID=$(az network public-ip show -g $(RESOURCE_GROUP) -n $PUBLIC_IP_NAME --query id -o tsv)
 
@@ -164,6 +166,7 @@ jobs:
                 --node-count 1 \
                 --tier standard \
                 --max-pods 100 \
+                --load-balancer-sku standard \ 
                 --load-balancer-outbound-ips $PUBLIC_IP_ID
 
             echo "Getting credentials to $CLUSTER_NAME"

--- a/.pipelines/npm/npm-scale-test.yaml
+++ b/.pipelines/npm/npm-scale-test.yaml
@@ -140,9 +140,9 @@ jobs:
             az group create --name $(RESOURCE_GROUP) -l $(LOCATION) -o table
 
             export PUBLIC_IP_NAME=$(RESOURCE_GROUP)-$(PROFILE)-public-ip
-            echo "Creating public IP with a service tag named $(PUBLIC_IP_NAME)"
+            echo "Creating public IP with a service tag named $PUBLIC_IP_NAME"
             az network public-ip create \
-                --name $(PUBLIC_IP_NAME) \
+                --name $PUBLIC_IP_NAME \
                 --resource-group $(RESOURCE_GROUP) \
                 --allocation-method Static \
                 --ip-tags 'FirstPartyUsage=/DelegatedNetworkControllerTest' \
@@ -164,7 +164,7 @@ jobs:
                 --node-count 1 \
                 --tier standard \
                 --max-pods 100 \
-                --load-balancer-outbound-ips $(PUBLIC_IP_ID)
+                --load-balancer-outbound-ips $PUBLIC_IP_ID
 
             echo "Getting credentials to $CLUSTER_NAME"
             az aks get-credentials -g $(RESOURCE_GROUP) -n $CLUSTER_NAME --overwrite-existing --file ./kubeconfig

--- a/.pipelines/npm/npm-scale-test.yaml
+++ b/.pipelines/npm/npm-scale-test.yaml
@@ -148,7 +148,7 @@ jobs:
                 --ip-tags 'FirstPartyUsage=/DelegatedNetworkControllerTest' \
                 --location $(LOCATION) --sku Standard --tier Regional \
                 --version IPv4
-            export PUBLIC_IP_ID=$(az network public-ip show -g $(RESOURCE_GROUP) -n $(PUBLIC_IP_NAME) --query id -o tsv)
+            export PUBLIC_IP_ID=$(az network public-ip show -g $(RESOURCE_GROUP) -n $PUBLIC_IP_NAME --query id -o tsv)
 
             export CLUSTER_NAME=$(RESOURCE_GROUP)-$(PROFILE)
             echo "Creating cluster named $CLUSTER_NAME"

--- a/.pipelines/npm/npm-scale-test.yaml
+++ b/.pipelines/npm/npm-scale-test.yaml
@@ -139,6 +139,17 @@ jobs:
             echo "Creating resource group named $(RESOURCE_GROUP)"
             az group create --name $(RESOURCE_GROUP) -l $(LOCATION) -o table
 
+            export PUBLIC_IP_NAME=$(RESOURCE_GROUP)-$(PROFILE)-public-ip
+            echo "Creating public IP with a service tag named $(PUBLIC_IP_NAME)"
+            az network public-ip create \
+                --name $(PUBLIC_IP_NAME) \
+                --resource-group $(RESOURCE_GROUP) \
+                --allocation-method Static \
+                --ip-tags 'FirstPartyUsage=/DelegatedNetworkControllerTest' \
+                --location $(LOCATION) --sku Standard --tier Regional \
+                --version IPv4
+            export PUBLIC_IP_ID=$(az network public-ip show -g $(RESOURCE_GROUP) -n $(PUBLIC_IP_NAME) --query id -o tsv)
+
             export CLUSTER_NAME=$(RESOURCE_GROUP)-$(PROFILE)
             echo "Creating cluster named $CLUSTER_NAME"
             az aks create \
@@ -152,7 +163,8 @@ jobs:
                 --node-vm-size Standard_D4s_v3 \
                 --node-count 1 \
                 --tier standard \
-                --max-pods 100
+                --max-pods 100 \
+                --load-balancer-outbound-ips $(PUBLIC_IP_ID)
 
             echo "Getting credentials to $CLUSTER_NAME"
             az aks get-credentials -g $(RESOURCE_GROUP) -n $CLUSTER_NAME --overwrite-existing --file ./kubeconfig

--- a/.pipelines/npm/npm-scale-test.yaml
+++ b/.pipelines/npm/npm-scale-test.yaml
@@ -166,7 +166,6 @@ jobs:
                 --node-count 1 \
                 --tier standard \
                 --max-pods 100 \
-                --load-balancer-sku standard \ 
                 --load-balancer-outbound-ips $PUBLIC_IP_ID
 
             echo "Getting credentials to $CLUSTER_NAME"

--- a/npm/azure-npm.yaml
+++ b/npm/azure-npm.yaml
@@ -112,7 +112,6 @@ spec:
             - name: tmp
               mountPath: /tmp
       hostNetwork: true
-      hostUsers: false
       nodeSelector:
         kubernetes.io/os: linux
       volumes:

--- a/npm/examples/azure-npm-lite.yaml
+++ b/npm/examples/azure-npm-lite.yaml
@@ -112,7 +112,6 @@ spec:
             - name: tmp
               mountPath: /tmp
       hostNetwork: true
-      hostUsers: false
       nodeSelector:
         kubernetes.io/os: linux
       volumes:


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
Removes the `hostUsers: false` setting in the NPM daemonset. Reverts from changes https://github.com/Azure/azure-container-networking/pull/2589

Also adds a public-ip and service tag to NPM scale and conformance tests to comply with SFI rules (failing with `RequestDisallowedByPolicy` otherwise).

**Issue Fixed**:
From https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/#limitations 

When using a user namespace for the pod, it is disallowed to use other host namespaces. In particular, if you set `hostUsers: false` then you are not allowed to set any of:

```
hostNetwork: true
hostIPC: true
hostPID: true
```


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
