### PR TITLE
fix: only ping k8s for healthz in podsubnet

### DIFF
--- a/cni/Dockerfile
+++ b/cni/Dockerfile
@@ -6,10 +6,10 @@ ARG OS_VERSION
 ARG OS
 
 # mcr.microsoft.com/oss/go/microsoft/golang:1.23-cbl-mariner2.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:e656a885f0ff81be6ef145c7ae8b84ce9515da2bd182d8537f093dd5563d4e04 AS go
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:b06999cae63b9b6f43bcb16bd16bcbedae847684515317e15607a601ed108030 AS go
 
 # mcr.microsoft.com/cbl-mariner/base/core:2.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/cbl-mariner/base/core@sha256:2a5d3461de4c082b1ced83a491c0d83b80221311dbee1b6f0a98271cefe57b00 AS mariner-core
+FROM --platform=linux/${ARCH} mcr.microsoft.com/cbl-mariner/base/core@sha256:961bfedbbbdc0da51bc664f51d959da292eced1ad46c3bf674aba43b9be8c703 AS mariner-core
 
 FROM go AS azure-vnet
 ARG OS

--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -5,13 +5,13 @@ ARG OS_VERSION
 ARG OS
 
 # mcr.microsoft.com/oss/go/microsoft/golang:1.23-cbl-mariner2.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:e656a885f0ff81be6ef145c7ae8b84ce9515da2bd182d8537f093dd5563d4e04 AS go
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:b06999cae63b9b6f43bcb16bd16bcbedae847684515317e15607a601ed108030 AS go
 
 # mcr.microsoft.com/cbl-mariner/base/core:2.0
-FROM mcr.microsoft.com/cbl-mariner/base/core@sha256:2a5d3461de4c082b1ced83a491c0d83b80221311dbee1b6f0a98271cefe57b00 AS mariner-core
+FROM mcr.microsoft.com/cbl-mariner/base/core@sha256:961bfedbbbdc0da51bc664f51d959da292eced1ad46c3bf674aba43b9be8c703 AS mariner-core
 
 # mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
-FROM mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:6989c162e941656f8a6d00f1176a20a2f1ff261232fd01ec717d1ea0baff6cdb AS mariner-distroless
+FROM mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:7778a86d86947d5f64c1280a7ee0cf36c6c6d76b5749dd782fbcc14f113961bf AS mariner-distroless
 
 FROM --platform=linux/${ARCH} go AS builder
 ARG OS

--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -26,6 +26,7 @@ type CNSConfig struct {
 	CNIConflistFilepath         string
 	CNIConflistScenario         string
 	ChannelMode                 string
+	EnableAPIServerHealthPing   bool
 	EnableAsyncPodDelete        bool
 	EnableCNIConflistGeneration bool
 	EnableIPAMv2                bool

--- a/cns/healthserver/healthz_test.go
+++ b/cns/healthserver/healthz_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Azure/azure-container-networking/cns/configuration"
 	"github.com/stretchr/testify/require"
 )
 
@@ -162,30 +161,30 @@ const nncResult = `{
 func TestNewHealthzHandlerWithChecks(t *testing.T) {
 	tests := []struct {
 		name            string
-		cnsConfig       *configuration.CNSConfig
+		config          *Config
 		apiStatusCode   int
 		expectedHealthy bool
 	}{
 		{
 			name: "list NNC gives 200 should indicate healthy",
-			cnsConfig: &configuration.CNSConfig{
-				ChannelMode: "CRD",
+			config: &Config{
+				PingAPIServer: true,
 			},
 			apiStatusCode:   http.StatusOK,
 			expectedHealthy: true,
 		},
 		{
 			name: "unauthorized (401) from apiserver should be unhealthy",
-			cnsConfig: &configuration.CNSConfig{
-				ChannelMode: "CRD",
+			config: &Config{
+				PingAPIServer: true,
 			},
 			apiStatusCode:   http.StatusUnauthorized,
 			expectedHealthy: false,
 		},
 		{
 			name: "channel nodesubnet should not call apiserver so it doesn't matter if the status code is a 401",
-			cnsConfig: &configuration.CNSConfig{
-				ChannelMode: "AzureHost",
+			config: &Config{
+				PingAPIServer: false,
 			},
 			apiStatusCode:   http.StatusUnauthorized,
 			expectedHealthy: true,
@@ -197,7 +196,7 @@ func TestNewHealthzHandlerWithChecks(t *testing.T) {
 			configureLocalAPIServer(t, tt.apiStatusCode)
 
 			responseRecorder := httptest.NewRecorder()
-			healthHandler, err := NewHealthzHandlerWithChecks(tt.cnsConfig)
+			healthHandler, err := NewHealthzHandlerWithChecks(tt.config)
 			healthHandler = http.StripPrefix("/healthz", healthHandler)
 			require.NoError(t, err)
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -638,7 +638,7 @@ func main() {
 	}
 
 	// start the healthz/readyz/metrics server
-	readyCh := make(chan interface{})
+	readyCh := make(chan any)
 	readyChecker := healthz.CheckHandler{
 		Checker: healthz.Checker(func(*http.Request) error {
 			select {
@@ -650,7 +650,7 @@ func main() {
 		}),
 	}
 
-	healthzHandler, err := healthserver.NewHealthzHandlerWithChecks(cnsconfig)
+	healthzHandler, err := healthserver.NewHealthzHandlerWithChecks(&healthserver.Config{PingAPIServer: cnsconfig.EnableAPIServerHealthPing})
 	if err != nil {
 		logger.Errorf("unable to initialize a healthz handler: %v", err)
 		return


### PR DESCRIPTION
We only really need an ongoing connection to k8s if we are in dynamic podsubnet mode. Overlay and vnetblock are static and do not need it after initialization, so we shouldn't consider loss of apiserver connectivity a restartable failure in those scenarios.