### PR TITLE
Revert "ci: set aks preview to 14.0.0b3"

### DIFF
--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -45,10 +45,8 @@ azlogin: ## Login and set account to $SUB
 	@$(AZCLI) account set -s $(SUB)
 
 azcfg: ## Set the $AZCLI to use aks-preview
-## 	Remove the extension if it exists so we can install the set version
-	@$(AZCLI) extension remove --name aks-preview || true
-	@$(AZCLI) extension add --name aks-preview --version 14.0.0b3 --yes
-##	@$(AZCLI) extension update --name aks-preview
+	@$(AZCLI) extension add --name aks-preview --yes
+	@$(AZCLI) extension update --name aks-preview
 
 ip:
 	$(AZCLI) network public-ip create --name $(IP_PREFIX)-$(CLUSTER)-$(IPVERSION) \


### PR DESCRIPTION
Reverts Azure/azure-container-networking#3607 as https://github.com/Azure/azure-cli/issues/31345 has been resolved with https://github.com/Azure/azure-cli-extensions/pull/8703