### PR TITLE
ci: restart cilium ds after node restart

### DIFF
--- a/.pipelines/cni/load-test-templates/restart-node-template.yaml
+++ b/.pipelines/cni/load-test-templates/restart-node-template.yaml
@@ -34,8 +34,17 @@ steps:
           done
         fi
 
+        # Restart cilium if it is installed, bpf maps and endpoint states can be stale after a node restart (versions < v1.17)
+        if [ ${{ parameters.cni }} = 'cilium' ]; then
+          echo "Restart Cilium and ensure it is ready and available. "
+          kubectl rollout restart ds -n kube-system cilium
+          kubectl rollout status ds -n kube-system cilium
+          kubectl get pods -n kube-system -l k8s-app=cilium -owide
+        fi
+
         echo "Ensure Load-Test deployment pods are marked as ready"
         kubectl rollout status deploy -n load-test
+
     name: "RestartNodes"
     displayName: "Restart Nodes"
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Update release testing ci. Restart cilium daemonset after node restarts to clean up old states/endpoints before entering state file check. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
