### PR TITLE
change apipa endpoint gateway back to .1

### DIFF
--- a/cns/hnsclient/hnsclient_windows.go
+++ b/cns/hnsclient/hnsclient_windows.go
@@ -525,6 +525,7 @@ func configureHostNCApipaEndpoint(
 		endpoint.Policies = append(endpoint.Policies, endpointPolicy)
 	}
 
+	// keep Apipa Endpoint gw as 169.254.128.1 to make sure NC to host connectivity work for both Linux and Windows containers
 	hcnRoute := hcn.Route{
 		NextHop:           hnsLoopbackAdapterIPAddress,
 		DestinationPrefix: "0.0.0.0/0",

--- a/cns/hnsclient/hnsclient_windows.go
+++ b/cns/hnsclient/hnsclient_windows.go
@@ -316,7 +316,7 @@ func createHostNCApipaNetwork(
 				hostNCLoopbackAdapterName,
 				ipconfig,
 				false, /* Flag to setWeakHostOnInterface */
-				""     /* Empty primary Interface Identifier as setWeakHostOnInterface is not needed*/); err != nil {
+				"" /* Empty primary Interface Identifier as setWeakHostOnInterface is not needed*/); err != nil {
 				return nil, fmt.Errorf("Failed to create loopback adapter. Error: %v", err)
 			}
 

--- a/cns/hnsclient/hnsclient_windows.go
+++ b/cns/hnsclient/hnsclient_windows.go
@@ -316,7 +316,7 @@ func createHostNCApipaNetwork(
 				hostNCLoopbackAdapterName,
 				ipconfig,
 				false, /* Flag to setWeakHostOnInterface */
-				"" /* Empty primary Interface Identifier as setWeakHostOnInterface is not needed*/); err != nil {
+				""     /* Empty primary Interface Identifier as setWeakHostOnInterface is not needed*/); err != nil {
 				return nil, fmt.Errorf("Failed to create loopback adapter. Error: %v", err)
 			}
 
@@ -507,7 +507,6 @@ func configureHostNCApipaEndpoint(
 	}
 
 	networkContainerApipaIP := localIPConfiguration.IPSubnet.IPAddress
-	hostApipaIP := localIPConfiguration.GatewayIPAddress
 	protocolList := []string{protocolICMPv4, protocolTCP, protocolUDP}
 
 	endpointPolicies, err := configureAclSettingHostNCApipaEndpoint(
@@ -527,7 +526,7 @@ func configureHostNCApipaEndpoint(
 	}
 
 	hcnRoute := hcn.Route{
-		NextHop:           hostApipaIP,
+		NextHop:           hnsLoopbackAdapterIPAddress,
 		DestinationPrefix: "0.0.0.0/0",
 	}
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
revert the apipa endpoint gw change  to .1  to resolve the nc to host connection issue in Linux contianer. This does not impact the initial change for changing the apipa network gw and loop adapter defualt gw from .1 to .2 on host.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
This fix already been verified by updating the legacy runner cns with this fix for both windows and linux containers. 
