### PR TITLE
Prefix on nicv6 support

### DIFF
--- a/azure-ipam/ipam.go
+++ b/azure-ipam/ipam.go
@@ -146,8 +146,7 @@ func (p *IPAMPlugin) CmdAdd(args *cniSkel.CmdArgs) error {
 	for _, podIPInfo := range resp.PodIPInfo {
 		// Skip if interface already seen
 		// This is to avoid duplicate interfaces in the result
-		// which can happen if multiple IPs are assigned to the same interface
-		// or if multiple interfaces are assigned to the same pod
+		// Deduplication is necessary because there is one podIPInfo entry for each IP family(IPv4 and IPv6), and both may point to the same interface or if multiple interfaces are assigned to the same pod
 		if podIPInfo.MacAddress == "" || seenInterfaces[podIPInfo.MacAddress] {
 			continue
 		}

--- a/azure-ipam/ipam.go
+++ b/azure-ipam/ipam.go
@@ -115,7 +115,7 @@ func (p *IPAMPlugin) CmdAdd(args *cniSkel.CmdArgs) error {
 	p.logger.Debug("Received CNS IP config response", zap.Any("response", resp))
 
 	// Get Pod IP and gateway IP from ip config response
-	podIPNet, err := ipconfig.ProcessIPConfigsResp(resp)
+	podIPNet, gatewayIP, err := ipconfig.ProcessIPConfigsResp(resp)
 	if err != nil {
 		p.logger.Error("Failed to interpret CNS IPConfigResponse", zap.Error(err), zap.Any("response", resp))
 		return cniTypes.NewError(ErrProcessIPConfigResponse, err.Error(), "failed to interpret CNS IPConfigResponse")
@@ -136,7 +136,32 @@ func (p *IPAMPlugin) CmdAdd(args *cniSkel.CmdArgs) error {
 				Mask: net.CIDRMask(ipNet.Bits(), 128), // nolint
 			}
 		}
+		ipConfig.Gateway = (*gatewayIP)[i]
 		cniResult.IPs[i] = ipConfig
+	}
+
+	cniResult.Interfaces = []*types100.Interface{}
+	seenInterfaces := map[string]bool{}
+
+	for _, podIPInfo := range resp.PodIPInfo {
+		// Skip if interface already seen
+		// This is to avoid duplicate interfaces in the result
+		// which can happen if multiple IPs are assigned to the same interface
+		// or if multiple interfaces are assigned to the same pod
+		if podIPInfo.MacAddress == "" || seenInterfaces[podIPInfo.MacAddress] {
+			continue
+		}
+
+		infMac, err := net.ParseMAC(podIPInfo.MacAddress)
+		if err != nil {
+			p.logger.Error("Failed to parse interface MAC address", zap.Error(err), zap.String("macAddress", podIPInfo.MacAddress))
+			return cniTypes.NewError(cniTypes.ErrUnsupportedField, err.Error(), "failed to parse interface MAC address")
+		}
+
+		cniResult.Interfaces = append(cniResult.Interfaces, &types100.Interface{
+			Mac: infMac.String(),
+		})
+		seenInterfaces[podIPInfo.MacAddress] = true
 	}
 
 	// Get versioned result

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -389,9 +389,10 @@ type NetworkInterfaceInfo struct {
 
 // IPConfiguration contains details about ip config to provision in the VM.
 type IPConfiguration struct {
-	IPSubnet         IPSubnet
-	DNSServers       []string
-	GatewayIPAddress string
+	IPSubnet           IPSubnet
+	DNSServers         []string
+	GatewayIPAddress   string
+	GatewayIPv6Address string
 }
 
 // SecondaryIPConfig contains IP info of SecondaryIP
@@ -746,3 +747,11 @@ type NodeRegisterRequest struct {
 	NumCores             int
 	NmAgentSupportedApis []string
 }
+
+// IPFamily - Enum for determining IPFamily when retrieving IPs from network containers
+type IPFamily string
+
+const (
+	IPv4 IPFamily = "ipv4"
+	IPv6 IPFamily = "ipv6"
+)

--- a/cns/kubecontroller/nodenetworkconfig/conversion_linux.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_linux.go
@@ -16,12 +16,15 @@ import (
 func createNCRequestFromStaticNCHelper(nc v1alpha.NetworkContainer, primaryIPPrefix netip.Prefix, subnet cns.IPSubnet) (*cns.CreateNetworkContainerRequest, error) {
 	secondaryIPConfigs := map[string]cns.SecondaryIPConfig{}
 
-	// iterate through all IP addresses in the subnet described by primaryPrefix and
-	// add them to the request as secondary IPConfigs.
-	for addr := primaryIPPrefix.Masked().Addr(); primaryIPPrefix.Contains(addr); addr = addr.Next() {
-		secondaryIPConfigs[addr.String()] = cns.SecondaryIPConfig{
-			IPAddress: addr.String(),
-			NCVersion: int(nc.Version),
+	// in the case of vnet prefix on swift v2 the primary IP is a /32 and should not be added to secondary IP configs
+	if !primaryIPPrefix.IsSingleIP() {
+		// iterate through all IP addresses in the subnet described by primaryPrefix and
+		// add them to the request as secondary IPConfigs.
+		for addr := primaryIPPrefix.Masked().Addr(); primaryIPPrefix.Contains(addr); addr = addr.Next() {
+			secondaryIPConfigs[addr.String()] = cns.SecondaryIPConfig{
+				IPAddress: addr.String(),
+				NCVersion: int(nc.Version),
+			}
 		}
 	}
 
@@ -52,9 +55,13 @@ func createNCRequestFromStaticNCHelper(nc v1alpha.NetworkContainer, primaryIPPre
 		NetworkContainerType: cns.Docker,
 		Version:              strconv.FormatInt(nc.Version, 10), //nolint:gomnd // it's decimal
 		IPConfiguration: cns.IPConfiguration{
-			IPSubnet:         subnet,
-			GatewayIPAddress: nc.DefaultGateway,
+			IPSubnet:           subnet,
+			GatewayIPAddress:   nc.DefaultGateway,
+			GatewayIPv6Address: nc.DefaultGatewayV6,
 		},
 		NCStatus: nc.Status,
+		NetworkInterfaceInfo: cns.NetworkInterfaceInfo{
+			MACAddress: nc.MacAddress,
+		},
 	}, nil
 }

--- a/cns/restserver/internalapi_linux.go
+++ b/cns/restserver/internalapi_linux.go
@@ -68,6 +68,12 @@ func (service *HTTPRestService) programSNATRules(req *cns.CreateNetworkContainer
 
 	// use any secondary ip + the nnc prefix length to get an iptables rule to allow dns and imds traffic from the pods
 	for _, v := range req.SecondaryIPConfigs {
+		// check if the ip address is IPv4
+		if net.ParseIP(v.IPAddress).To4() == nil {
+			// skip if the ip address is not IPv4
+			continue
+		}
+
 		// put the ip address in standard cidr form (where we zero out the parts that are not relevant)
 		_, podSubnet, _ := net.ParseCIDR(v.IPAddress + "/" + fmt.Sprintf("%d", req.IPConfiguration.IPSubnet.PrefixLength))
 

--- a/cns/restserver/ipam_test.go
+++ b/cns/restserver/ipam_test.go
@@ -176,36 +176,46 @@ func updatePnpIDMacAddressState(svc *HTTPRestService) {
 	}
 }
 
-// create an endpoint with only one IP
-func TestEndpointStateReadAndWriteSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestEndpointStateReadAndWrite(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	EndpointStateReadAndWrite(t, ncStates)
-}
-
-// create an endpoint with one IP from each NC
-func TestEndpointStateReadAndWriteMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		EndpointStateReadAndWrite(t, ncState)
 	}
-	EndpointStateReadAndWrite(t, ncStates)
 }
 
 // Tests the creation of an endpoint using the NCs and IPs as input and then tests the deletion of that endpoint
@@ -280,35 +290,46 @@ func EndpointStateReadAndWrite(t *testing.T, ncStates []ncState) {
 }
 
 // assign the available IP to the new pod
-func TestIPAMGetAvailableIPConfigSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMGetAvailableIPConfig(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	IPAMGetAvailableIPConfig(t, ncStates)
-}
-
-// assign one IP per NC to the pod
-func TestIPAMGetAvailableIPConfigMultipleNCs(t *testing.T) {
-	nsStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMGetAvailableIPConfig(t, ncState)
 	}
-	IPAMGetAvailableIPConfig(t, nsStates)
 }
 
 // Add one IP per NC to the pool and request those IPs
@@ -357,37 +378,51 @@ func IPAMGetAvailableIPConfig(t *testing.T, ncStates []ncState) {
 	}
 }
 
-func TestIPAMGetNextAvailableIPConfigSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMGetNextAvailableIPConfig(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+					testIP2v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+					testIP1v6,
+					testIP2v6,
+				},
 			},
 		},
 	}
-	IPAMGetNextAvailableIPConfig(t, ncStates)
-}
-
-func TestIPAMGetNextAvailableIPConfigMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-				testIP2v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMGetNextAvailableIPConfig(t, ncState)
 	}
-	IPAMGetNextAvailableIPConfig(t, ncStates)
 }
 
 // First IP is already assigned to a pod, want second IP
@@ -440,34 +475,46 @@ func IPAMGetNextAvailableIPConfig(t *testing.T, ncStates []ncState) {
 	}
 }
 
-func TestIPAMGetAlreadyAssignedIPConfigForSamePodSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMGetAlreadyAssignedIPConfigForSamePod(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	IPAMGetAlreadyAssignedIPConfigForSamePod(t, ncStates)
-}
-
-func TestIPAMGetAlreadyAssignedIPConfigForSamePodMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMGetAlreadyAssignedIPConfigForSamePod(t, ncState)
 	}
-	IPAMGetAlreadyAssignedIPConfigForSamePod(t, ncStates)
 }
 
 func IPAMGetAlreadyAssignedIPConfigForSamePod(t *testing.T, ncStates []ncState) {
@@ -515,37 +562,51 @@ func IPAMGetAlreadyAssignedIPConfigForSamePod(t *testing.T, ncStates []ncState) 
 	}
 }
 
-func TestIPAMAttemptToRequestIPNotFoundInPoolSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMAttemptToRequestIPNotFoundInPool(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+					testIP2v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+					testIP1v6,
+					testIP2v6,
+				},
 			},
 		},
 	}
-	IPAMAttemptToRequestIPNotFoundInPool(t, ncStates)
-}
-
-func TestIPAMAttemptToRequestIPNotFoundInPoolMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-				testIP2v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMAttemptToRequestIPNotFoundInPool(t, ncState)
 	}
-	IPAMAttemptToRequestIPNotFoundInPool(t, ncStates)
 }
 
 func IPAMAttemptToRequestIPNotFoundInPool(t *testing.T, ncStates []ncState) {
@@ -578,34 +639,46 @@ func IPAMAttemptToRequestIPNotFoundInPool(t *testing.T, ncStates []ncState) {
 	}
 }
 
-func TestIPAMGetDesiredIPConfigWithSpecfiedIPSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMGetDesiredIPConfigWithSpecfiedIP(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	IPAMGetDesiredIPConfigWithSpecfiedIP(t, ncStates)
-}
-
-func TestIPAMGetDesiredIPConfigWithSpecfiedIPMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMGetDesiredIPConfigWithSpecfiedIP(t, ncState)
 	}
-	IPAMGetDesiredIPConfigWithSpecfiedIP(t, ncStates)
 }
 
 func IPAMGetDesiredIPConfigWithSpecfiedIP(t *testing.T, ncStates []ncState) {
@@ -657,34 +730,46 @@ func IPAMGetDesiredIPConfigWithSpecfiedIP(t *testing.T, ncStates []ncState) {
 	}
 }
 
-func TestIPAMFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIPSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIP(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	IPAMFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIP(t, ncStates)
-}
-
-func TestIPAMFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIPMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIP(t, ncState)
 	}
-	IPAMFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIP(t, ncStates)
 }
 
 func IPAMFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIP(t *testing.T, ncStates []ncState) {
@@ -718,37 +803,51 @@ func IPAMFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIP(t *testing.T, ncS
 	}
 }
 
-func TestIPAMFailToGetIPWhenAllIPsAreAssignedSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMFailToGetIPWhenAllIPsAreAssigned(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+					testIP2v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+					testIP1v6,
+					testIP2v6,
+				},
 			},
 		},
 	}
-	IPAMFailToGetIPWhenAllIPsAreAssigned(t, ncStates)
-}
-
-func TestIPAMFailToGetIPWhenAllIPsAreAssignedMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-				testIP2v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMFailToGetIPWhenAllIPsAreAssigned(t, ncState)
 	}
-	IPAMFailToGetIPWhenAllIPsAreAssigned(t, ncStates)
 }
 
 func IPAMFailToGetIPWhenAllIPsAreAssigned(t *testing.T, ncStates []ncState) {
@@ -778,34 +877,46 @@ func IPAMFailToGetIPWhenAllIPsAreAssigned(t *testing.T, ncStates []ncState) {
 	}
 }
 
-func TestIPAMRequestThenReleaseThenRequestAgainSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMRequestThenReleaseThenRequestAgain(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	IPAMRequestThenReleaseThenRequestAgain(t, ncStates)
-}
-
-func TestIPAMRequestThenReleaseThenRequestAgainMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMRequestThenReleaseThenRequestAgain(t, ncState)
 	}
-	IPAMRequestThenReleaseThenRequestAgain(t, ncStates)
 }
 
 // 10.0.0.1 = PodInfo1
@@ -887,34 +998,46 @@ func IPAMRequestThenReleaseThenRequestAgain(t *testing.T, ncStates []ncState) {
 	}
 }
 
-func TestIPAMReleaseIPIdempotencySingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMReleaseIPIdempotency(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	IPAMReleaseIPIdempotency(t, ncStates)
-}
-
-func TestIPAMReleaseIPIdempotencyMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMReleaseIPIdempotency(t, ncState)
 	}
-	IPAMReleaseIPIdempotency(t, ncStates)
 }
 
 func IPAMReleaseIPIdempotency(t *testing.T, ncStates []ncState) {
@@ -943,34 +1066,46 @@ func IPAMReleaseIPIdempotency(t *testing.T, ncStates []ncState) {
 	}
 }
 
-func TestIPAMAllocateIPIdempotencySingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMAllocateIPIdempotency(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	IPAMAllocateIPIdempotency(t, ncStates)
-}
-
-func TestIPAMAllocateIPIdempotencyMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMAllocateIPIdempotency(t, ncState)
 	}
-	IPAMAllocateIPIdempotency(t, ncStates)
 }
 
 func IPAMAllocateIPIdempotency(t *testing.T, ncStates []ncState) {
@@ -992,40 +1127,56 @@ func IPAMAllocateIPIdempotency(t *testing.T, ncStates []ncState) {
 	}
 }
 
-func TestAvailableIPConfigsSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestAvailableIPConfigs(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
-				testIP3,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+					testIP3,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+					testIP3,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+					testIP2v6,
+					testIP3v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+					testIP3,
+					testIP1v6,
+					testIP2v6,
+					testIP3v6,
+				},
 			},
 		},
 	}
-	AvailableIPConfigs(t, ncStates)
-}
-
-func TestAvailableIPConfigsMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
-				testIP3,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-				testIP2v6,
-				testIP3v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		AvailableIPConfigs(t, ncState)
 	}
-	AvailableIPConfigs(t, ncStates)
 }
 
 func AvailableIPConfigs(t *testing.T, ncStates []ncState) {
@@ -1111,34 +1262,46 @@ func validateIpState(t *testing.T, actualIps []cns.IPConfigurationStatus, expect
 	}
 }
 
-func TestIPAMMarkIPCountAsPendingSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMMarkIPCountAsPending(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	IPAMMarkIPCountAsPending(t, ncStates)
-}
-
-func TestIPAMMarkIPCountAsPendingMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMMarkIPCountAsPending(t, ncState)
 	}
-	IPAMMarkIPCountAsPending(t, ncStates)
 }
 
 func IPAMMarkIPCountAsPending(t *testing.T, ncStates []ncState) {
@@ -1270,37 +1433,51 @@ func constructSecondaryIPConfigs(ipAddress, uuid string, ncVersion int, secondar
 	secondaryIPConfigs[uuid] = secIPConfig
 }
 
-func TestIPAMMarkExistingIPConfigAsPendingSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMMarkExistingIPConfigAsPending(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+					testIP2v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+					testIP1v6,
+					testIP2v6,
+				},
 			},
 		},
 	}
-	IPAMMarkExistingIPConfigAsPending(t, ncStates)
-}
-
-func TestIPAMMarkExistingIPConfigAsPendingMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-				testIP2v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMMarkExistingIPConfigAsPending(t, ncState)
 	}
-	IPAMMarkExistingIPConfigAsPending(t, ncStates)
 }
 
 func IPAMMarkExistingIPConfigAsPending(t *testing.T, ncStates []ncState) {
@@ -1431,27 +1608,32 @@ func TestIPAMReleaseOneIPWhenExpectedToHaveTwo(t *testing.T) {
 
 func TestIPAMFailToRequestOneIPWhenExpectedToHaveTwo(t *testing.T) {
 	svc := getTestService(cns.KubernetesCRD)
-
 	// set state as already assigned
-	testState := NewPodState(testIP1, ipIDs[0][0], testNCID, types.Available, 0)
+	testState1, _ := NewPodStateWithOrchestratorContext(testIP1, testIPID1, testNCID, types.Assigned, 24, 0, testPod1Info)
+	testState2 := NewPodState(testIP2, testIPID2, testNCID, types.Available, 0)
 	ipconfigs := map[string]cns.IPConfigurationStatus{
-		testState.ID: testState,
+		testState1.ID: testState1,
+		testState2.ID: testState2,
 	}
-	emptyIpconfigs := map[string]cns.IPConfigurationStatus{}
+	testState1v6, _ := NewPodStateWithOrchestratorContext(testIP1v6, testIPID1v6, testNCIDv6, types.Assigned, 120, 0, testPod1Info)
+	// setting v6 IPs to Assigned so there are none available
+	ipconfigsV6 := map[string]cns.IPConfigurationStatus{
+		testState1v6.ID: testState1v6,
+	}
 
 	err := UpdatePodIPConfigState(t, svc, ipconfigs, testNCID)
 	if err != nil {
 		t.Fatalf("Expected to not fail adding IPs to state: %+v", err)
 	}
 
-	err = UpdatePodIPConfigState(t, svc, emptyIpconfigs, testNCIDv6)
+	err = UpdatePodIPConfigState(t, svc, ipconfigsV6, testNCIDv6)
 	if err != nil {
 		t.Fatalf("Expected to not fail adding empty NC to state: %+v", err)
 	}
 
 	// request should expect 2 IPs but there is only 1 in the pool
 	req := cns.IPConfigsRequest{}
-	b, _ := testPod1Info.OrchestratorContext()
+	b, _ := testPod2Info.OrchestratorContext()
 	req.OrchestratorContext = b
 
 	_, err = requestIPAddressAndGetState(t, req)

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -845,6 +845,7 @@ func (service *HTTPRestService) populateIPConfigInfoUntransacted(ipConfigStatus 
 	podIPInfo.HostPrimaryIPInfo.PrimaryIP = primaryHostInterface.PrimaryIP
 	podIPInfo.HostPrimaryIPInfo.Subnet = primaryHostInterface.Subnet
 	podIPInfo.HostPrimaryIPInfo.Gateway = primaryHostInterface.Gateway
+	podIPInfo.MacAddress = ncStatus.CreateNetworkContainerRequest.NetworkInterfaceInfo.MACAddress
 	podIPInfo.NICType = cns.InfraNIC
 
 	return nil


### PR DESCRIPTION
**Reason for Change**:
This PR has changes specific to Prefix on NICv6
CNS
--Consuming PrimaryIPv6, GatewayIPv6, MacAddress (DeletedNIC) from NNC CRD because of dualstack NC
--IP allocation: Assign IPs of each IPFamily as part of RequestIPs api request

IPAM
--Change RequestIPs response parsing to read GatewayIPv6 and MacAddress
--Populates Interfaces with MacAddress which is used by CNI to plumb routes to send traffic

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests
- [ ] relevant PR labels added

**Notes**:
