### PR TITLE
Prefix on nicv6 support

### DIFF
--- a/azure-ipam/ipam.go
+++ b/azure-ipam/ipam.go
@@ -146,8 +146,7 @@ func (p *IPAMPlugin) CmdAdd(args *cniSkel.CmdArgs) error {
 	for _, podIPInfo := range resp.PodIPInfo {
 		// Skip if interface already seen
 		// This is to avoid duplicate interfaces in the result
-		// which can happen if multiple IPs are assigned to the same interface
-		// or if multiple interfaces are assigned to the same pod
+		// Deduplication is necessary because there is one podIPInfo entry for each IP family(IPv4 and IPv6), and both may point to the same interface or if multiple interfaces are assigned to the same pod
 		if podIPInfo.MacAddress == "" || seenInterfaces[podIPInfo.MacAddress] {
 			continue
 		}

--- a/azure-ipam/ipam.go
+++ b/azure-ipam/ipam.go
@@ -115,7 +115,7 @@ func (p *IPAMPlugin) CmdAdd(args *cniSkel.CmdArgs) error {
 	p.logger.Debug("Received CNS IP config response", zap.Any("response", resp))
 
 	// Get Pod IP and gateway IP from ip config response
-	podIPNet, err := ipconfig.ProcessIPConfigsResp(resp)
+	podIPNet, gatewayIP, err := ipconfig.ProcessIPConfigsResp(resp)
 	if err != nil {
 		p.logger.Error("Failed to interpret CNS IPConfigResponse", zap.Error(err), zap.Any("response", resp))
 		return cniTypes.NewError(ErrProcessIPConfigResponse, err.Error(), "failed to interpret CNS IPConfigResponse")
@@ -136,7 +136,32 @@ func (p *IPAMPlugin) CmdAdd(args *cniSkel.CmdArgs) error {
 				Mask: net.CIDRMask(ipNet.Bits(), 128), // nolint
 			}
 		}
+		ipConfig.Gateway = (*gatewayIP)[i]
 		cniResult.IPs[i] = ipConfig
+	}
+
+	cniResult.Interfaces = []*types100.Interface{}
+	seenInterfaces := map[string]bool{}
+
+	for _, podIPInfo := range resp.PodIPInfo {
+		// Skip if interface already seen
+		// This is to avoid duplicate interfaces in the result
+		// which can happen if multiple IPs are assigned to the same interface
+		// or if multiple interfaces are assigned to the same pod
+		if podIPInfo.MacAddress == "" || seenInterfaces[podIPInfo.MacAddress] {
+			continue
+		}
+
+		infMac, err := net.ParseMAC(podIPInfo.MacAddress)
+		if err != nil {
+			p.logger.Error("Failed to parse interface MAC address", zap.Error(err), zap.String("macAddress", podIPInfo.MacAddress))
+			return cniTypes.NewError(cniTypes.ErrUnsupportedField, err.Error(), "failed to parse interface MAC address")
+		}
+
+		cniResult.Interfaces = append(cniResult.Interfaces, &types100.Interface{
+			Mac: infMac.String(),
+		})
+		seenInterfaces[podIPInfo.MacAddress] = true
 	}
 
 	// Get versioned result

--- a/azure-ipam/ipam.go
+++ b/azure-ipam/ipam.go
@@ -146,7 +146,7 @@ func (p *IPAMPlugin) CmdAdd(args *cniSkel.CmdArgs) error {
 	for _, podIPInfo := range resp.PodIPInfo {
 		// Skip if interface already seen
 		// This is to avoid duplicate interfaces in the result
-		// Deduplication is necessary because there is one podIPInfo entry for each IP family(IPv4 and IPv6), and both may point to the same interface or if multiple interfaces are assigned to the same pod
+		// Deduplication is necessary because there is one podIPInfo entry for each IP family(IPv4 and IPv6), and both may point to the same interface
 		if podIPInfo.MacAddress == "" || seenInterfaces[podIPInfo.MacAddress] {
 			continue
 		}

--- a/azure-ipam/ipam_test.go
+++ b/azure-ipam/ipam_test.go
@@ -347,21 +347,9 @@ func TestCmdAdd(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "CNI add with nil gateway IP",
-			args: buildArgs("nilGateway", happyPodArgs, happyNetConfByteArr),
-			want: &types100.Result{
-				CNIVersion: "1.0.0",
-				IPs: []*types100.IPConfig{
-					{
-						Address: net.IPNet{
-							IP:   net.IPv4(10, 0, 1, 10),
-							Mask: net.CIDRMask(24, 32),
-						},
-					},
-				},
-				DNS: cniTypes.DNS{},
-			},
-			wantErr: false,
+			name:    "CNI add with nil gateway IP",
+			args:    buildArgs("nilGateway", happyPodArgs, happyNetConfByteArr),
+			wantErr: true,
 		},
 		{
 			name:    "Fail request CNS ipconfig during CmdAdd",

--- a/azure-ipam/ipam_test.go
+++ b/azure-ipam/ipam_test.go
@@ -266,46 +266,6 @@ func (c *MockCNSClient) RequestIPs(ctx context.Context, ipconfig cns.IPConfigsRe
 						Subnet:    "fd11:1234::/120",
 					},
 				},
-				{
-					PodIPConfig: cns.IPSubnet{
-						IPAddress:    "192.168.1.10",
-						PrefixLength: 24,
-					},
-					MacAddress: "aa:bb:cc:dd:ee:ff",
-					NetworkContainerPrimaryIPConfig: cns.IPConfiguration{
-						IPSubnet: cns.IPSubnet{
-							IPAddress:    "192.168.1.0",
-							PrefixLength: 24,
-						},
-						DNSServers:       nil,
-						GatewayIPAddress: "192.168.1.1",
-					},
-					HostPrimaryIPInfo: cns.HostIPInfo{
-						Gateway:   "192.168.1.1",
-						PrimaryIP: "192.168.1.1",
-						Subnet:    "192.168.1.0/24",
-					},
-				},
-				{
-					PodIPConfig: cns.IPSubnet{
-						IPAddress:    "172.16.1.10",
-						PrefixLength: 24,
-					},
-					MacAddress: "",
-					NetworkContainerPrimaryIPConfig: cns.IPConfiguration{
-						IPSubnet: cns.IPSubnet{
-							IPAddress:    "172.16.1.0",
-							PrefixLength: 24,
-						},
-						DNSServers:       nil,
-						GatewayIPAddress: "172.16.1.1",
-					},
-					HostPrimaryIPInfo: cns.HostIPInfo{
-						Gateway:   "172.16.1.1",
-						PrimaryIP: "172.16.1.1",
-						Subnet:    "172.16.1.0/24",
-					},
-				},
 			},
 			Response: cns.Response{
 				ReturnCode: 0,
@@ -443,53 +403,6 @@ func TestCmdAdd(t *testing.T) {
 							Mask: net.CIDRMask(120, 128),
 						},
 						Gateway: net.ParseIP("fe80::1234:5678:9abc"),
-					},
-				},
-				DNS: cniTypes.DNS{},
-			},
-			wantErr: false,
-		},
-		{
-			name: "Test MAC address deduplication and multi-interface",
-			args: buildArgs("happyArgsMultiInterface", happyPodArgs, happyNetConfByteArr),
-			want: &types100.Result{
-				CNIVersion: "1.0.0",
-				Interfaces: []*types100.Interface{
-					{
-						Mac: "00:11:22:33:44:55", // First unique MAC (dual-stack)
-					},
-					{
-						Mac: "aa:bb:cc:dd:ee:ff", // Second unique MAC
-					},
-				},
-				IPs: []*types100.IPConfig{
-					{
-						Address: net.IPNet{
-							IP:   net.IPv4(10, 0, 1, 10),
-							Mask: net.CIDRMask(24, 32),
-						},
-						Gateway: net.IPv4(10, 0, 0, 1),
-					},
-					{
-						Address: net.IPNet{
-							IP:   net.ParseIP("fd11:1234::1"),
-							Mask: net.CIDRMask(120, 128),
-						},
-						Gateway: net.ParseIP("fe80::1234:5678:9abc"),
-					},
-					{
-						Address: net.IPNet{
-							IP:   net.IPv4(192, 168, 1, 10),
-							Mask: net.CIDRMask(24, 32),
-						},
-						Gateway: net.IPv4(192, 168, 1, 1),
-					},
-					{
-						Address: net.IPNet{
-							IP:   net.IPv4(172, 16, 1, 10),
-							Mask: net.CIDRMask(24, 32),
-						},
-						Gateway: net.IPv4(172, 16, 1, 1),
 					},
 				},
 				DNS: cniTypes.DNS{},

--- a/azure-ipam/ipam_test.go
+++ b/azure-ipam/ipam_test.go
@@ -159,8 +159,7 @@ func (c *MockCNSClient) RequestIPs(ctx context.Context, ipconfig cns.IPConfigsRe
 							IPAddress:    "fd11:1234::",
 							PrefixLength: 120,
 						},
-						DNSServers:         nil,
-						GatewayIPv6Address: "fe80::1", // This value will be ignored - code uses defaultV6Gateway constant instead
+						DNSServers: nil,
 					},
 					HostPrimaryIPInfo: cns.HostIPInfo{
 						Gateway:   "fe80::1234:5678:9abc",
@@ -207,8 +206,7 @@ func (c *MockCNSClient) RequestIPs(ctx context.Context, ipconfig cns.IPConfigsRe
 							IPAddress:    "fd11:1234::",
 							PrefixLength: 112,
 						},
-						DNSServers:         nil,
-						GatewayIPv6Address: "fe80::1234:5678:9abc",
+						DNSServers: nil,
 					},
 					HostPrimaryIPInfo: cns.HostIPInfo{
 						Gateway:   "fe80::1234:5678:9abc",
@@ -257,8 +255,7 @@ func (c *MockCNSClient) RequestIPs(ctx context.Context, ipconfig cns.IPConfigsRe
 							IPAddress:    "fd11:1234::",
 							PrefixLength: 120,
 						},
-						DNSServers:         nil,
-						GatewayIPv6Address: "fe80::1234:5678:9abc",
+						DNSServers: nil,
 					},
 					HostPrimaryIPInfo: cns.HostIPInfo{
 						Gateway:   "fe80::1234:5678:9abc",

--- a/azure-ipam/ipam_test.go
+++ b/azure-ipam/ipam_test.go
@@ -160,7 +160,7 @@ func (c *MockCNSClient) RequestIPs(ctx context.Context, ipconfig cns.IPConfigsRe
 							PrefixLength: 120,
 						},
 						DNSServers:         nil,
-						GatewayIPv6Address: "fe80::1234:5678:9abc",
+						GatewayIPv6Address: "fe80::1", // This value will be ignored - code uses defaultV6Gateway constant instead
 					},
 					HostPrimaryIPInfo: cns.HostIPInfo{
 						Gateway:   "fe80::1234:5678:9abc",

--- a/azure-ipam/ipconfig/ipconfig.go
+++ b/azure-ipam/ipconfig/ipconfig.go
@@ -84,9 +84,9 @@ func ProcessIPConfigsResp(resp *cns.IPConfigsResponse) (*[]netip.Prefix, *[]net.
 		podIPNets[i] = podIPNet
 
 		if podIPNet.Addr().Is4() {
-			gatewayIP = net.ParseIP(resp.PodIPInfo[i].NetworkContainerPrimaryIPConfig.GatewayIPAddress)
+			gatewayIP, err : = net.ParseIP(resp.PodIPInfo[i].NetworkContainerPrimaryIPConfig.GatewayIPAddress)
 		} else if podIPNet.Addr().Is6() {
-			gatewayIP = net.ParseIP(resp.PodIPInfo[i].NetworkContainerPrimaryIPConfig.GatewayIPv6Address)
+			gatewayIP, err : = net.ParseIP(resp.PodIPInfo[i].NetworkContainerPrimaryIPConfig.GatewayIPv6Address)
 		}
 
 		if gatewayIP != nil {
@@ -94,6 +94,19 @@ func ProcessIPConfigsResp(resp *cns.IPConfigsResponse) (*[]netip.Prefix, *[]net.
 		} else {
 			logger.Printf("gatewayIP is nil or gateway ip parse failed for pod ip %s", resp.PodIPInfo[i].PodIPConfig.IPAddress)
 		}
+
+		var gatewayStr string
+        if podIPNet.Addr().Is4() {
+            gatewayStr = podInfo.NetworkContainerPrimaryIPConfig.GatewayIPAddress
+        } else if podIPNet.Addr().Is6() {
+            gatewayStr = podInfo.NetworkContainerPrimaryIPConfig.GatewayIPv6Address
+        }
+
+        gatewayIP := net.ParseIP(gatewayStr)
+        if gatewayIP == nil {
+            return nil, nil, errors.Errorf("failed to parse gateway IP %q for pod ip %s", gatewayStr, podInfo.PodIPConfig.IPAddress)
+        }
+        gatewaysIPs[i] = gatewayIP
 	}
 
 	return &podIPNets, &gatewaysIPs, nil

--- a/azure-ipam/ipconfig/ipconfig.go
+++ b/azure-ipam/ipconfig/ipconfig.go
@@ -7,6 +7,7 @@ import (
 	"net/netip"
 
 	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/logger"
 	cniSkel "github.com/containernetworking/cni/pkg/skel"
 	cniTypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/pkg/errors"
@@ -90,6 +91,8 @@ func ProcessIPConfigsResp(resp *cns.IPConfigsResponse) (*[]netip.Prefix, *[]net.
 
 		if gatewayIP != nil {
 			gatewaysIPs[i] = gatewayIP
+		} else {
+			logger.Printf("gatewayIP is nil or gateway ip parse failed for pod ip %s", resp.PodIPInfo[i].PodIPConfig.IPAddress)
 		}
 	}
 

--- a/azure-ipam/ipconfig/ipconfig.go
+++ b/azure-ipam/ipconfig/ipconfig.go
@@ -7,7 +7,6 @@ import (
 	"net/netip"
 
 	"github.com/Azure/azure-container-networking/cns"
-	"github.com/Azure/azure-container-networking/cns/logger"
 	cniSkel "github.com/containernetworking/cni/pkg/skel"
 	cniTypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/pkg/errors"
@@ -83,30 +82,18 @@ func ProcessIPConfigsResp(resp *cns.IPConfigsResponse) (*[]netip.Prefix, *[]net.
 		}
 		podIPNets[i] = podIPNet
 
-		if podIPNet.Addr().Is4() {
-			gatewayIP, err : = net.ParseIP(resp.PodIPInfo[i].NetworkContainerPrimaryIPConfig.GatewayIPAddress)
-		} else if podIPNet.Addr().Is6() {
-			gatewayIP, err : = net.ParseIP(resp.PodIPInfo[i].NetworkContainerPrimaryIPConfig.GatewayIPv6Address)
-		}
-
-		if gatewayIP != nil {
-			gatewaysIPs[i] = gatewayIP
-		} else {
-			logger.Printf("gatewayIP is nil or gateway ip parse failed for pod ip %s", resp.PodIPInfo[i].PodIPConfig.IPAddress)
-		}
-
 		var gatewayStr string
-        if podIPNet.Addr().Is4() {
-            gatewayStr = podInfo.NetworkContainerPrimaryIPConfig.GatewayIPAddress
-        } else if podIPNet.Addr().Is6() {
-            gatewayStr = podInfo.NetworkContainerPrimaryIPConfig.GatewayIPv6Address
-        }
+		if podIPNet.Addr().Is4() {
+			gatewayStr = podInfo.NetworkContainerPrimaryIPConfig.GatewayIPAddress
+		} else if podIPNet.Addr().Is6() {
+			gatewayStr = podInfo.NetworkContainerPrimaryIPConfig.GatewayIPv6Address
+		}
 
-        gatewayIP := net.ParseIP(gatewayStr)
-        if gatewayIP == nil {
-            return nil, nil, errors.Errorf("failed to parse gateway IP %q for pod ip %s", gatewayStr, podInfo.PodIPConfig.IPAddress)
-        }
-        gatewaysIPs[i] = gatewayIP
+		gatewayIP := net.ParseIP(gatewayStr)
+		if gatewayIP == nil {
+			return nil, nil, errors.Errorf("failed to parse gateway IP %q for pod ip %s", gatewayStr, podInfo.PodIPConfig.IPAddress)
+		}
+		gatewaysIPs[i] = gatewayIP
 	}
 
 	return &podIPNets, &gatewaysIPs, nil

--- a/azure-ipam/ipconfig/ipconfig.go
+++ b/azure-ipam/ipconfig/ipconfig.go
@@ -84,14 +84,16 @@ func ProcessIPConfigsResp(resp *cns.IPConfigsResponse) (*[]netip.Prefix, *[]net.
 
 		var gatewayStr string
 		if podIPNet.Addr().Is4() {
-			gatewayStr = podInfo.NetworkContainerPrimaryIPConfig.GatewayIPAddress
+			gatewayStr = resp.PodIPInfo[i].NetworkContainerPrimaryIPConfig.GatewayIPAddress
 		} else if podIPNet.Addr().Is6() {
-			gatewayStr = podInfo.NetworkContainerPrimaryIPConfig.GatewayIPv6Address
+			gatewayStr = resp.PodIPInfo[i].NetworkContainerPrimaryIPConfig.GatewayIPv6Address
 		}
 
-		gatewayIP := net.ParseIP(gatewayStr)
-		if gatewayIP == nil {
-			return nil, nil, errors.Errorf("failed to parse gateway IP %q for pod ip %s", gatewayStr, podInfo.PodIPConfig.IPAddress)
+		if gatewayStr != "" {
+			gatewayIP = net.ParseIP(gatewayStr)
+			if gatewayIP == nil {
+				return nil, nil, errors.Errorf("failed to parse gateway IP %q for pod ip %s", gatewayStr, resp.PodIPInfo[i].PodIPConfig.IPAddress)
+			}
 		}
 		gatewaysIPs[i] = gatewayIP
 	}

--- a/azure-ipam/ipconfig/ipconfig.go
+++ b/azure-ipam/ipconfig/ipconfig.go
@@ -89,11 +89,9 @@ func ProcessIPConfigsResp(resp *cns.IPConfigsResponse) (*[]netip.Prefix, *[]net.
 			gatewayStr = resp.PodIPInfo[i].NetworkContainerPrimaryIPConfig.GatewayIPv6Address
 		}
 
-		if gatewayStr != "" {
-			gatewayIP = net.ParseIP(gatewayStr)
-			if gatewayIP == nil {
-				return nil, nil, errors.Errorf("failed to parse gateway IP %q for pod ip %s", gatewayStr, resp.PodIPInfo[i].PodIPConfig.IPAddress)
-			}
+		gatewayIP = net.ParseIP(gatewayStr)
+		if gatewayIP == nil {
+			return nil, nil, errors.Errorf("failed to parse gateway IP %q for pod ip %s", gatewayStr, resp.PodIPInfo[i].PodIPConfig.IPAddress)
 		}
 		gatewaysIPs[i] = gatewayIP
 	}

--- a/azure-ipam/ipconfig/ipconfig.go
+++ b/azure-ipam/ipconfig/ipconfig.go
@@ -12,6 +12,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	defaultV6Gateway   = "fe80::1234:5678:9abc"
+)
+
 func CreateOrchestratorContext(args *cniSkel.CmdArgs) ([]byte, error) {
 	podConf, err := parsePodConf(args.Args)
 	if err != nil {
@@ -86,7 +90,7 @@ func ProcessIPConfigsResp(resp *cns.IPConfigsResponse) (*[]netip.Prefix, *[]net.
 		if podIPNet.Addr().Is4() {
 			gatewayStr = resp.PodIPInfo[i].NetworkContainerPrimaryIPConfig.GatewayIPAddress
 		} else if podIPNet.Addr().Is6() {
-			gatewayStr = resp.PodIPInfo[i].NetworkContainerPrimaryIPConfig.GatewayIPv6Address
+			gatewayStr = defaultV6Gateway
 		}
 
 		gatewayIP = net.ParseIP(gatewayStr)

--- a/azure-ipam/ipconfig/ipconfig.go
+++ b/azure-ipam/ipconfig/ipconfig.go
@@ -98,8 +98,6 @@ func ProcessIPConfigsResp(resp *cns.IPConfigsResponse) (*[]netip.Prefix, *[]net.
 			if gatewayIP == nil {
 				return nil, nil, errors.Errorf("failed to parse gateway IP %q for pod ip %s", gatewayStr, resp.PodIPInfo[i].PodIPConfig.IPAddress)
 			}
-		} else {
-			gatewayIP = nil
 		}
 		gatewaysIPs[i] = gatewayIP
 	}

--- a/azure-ipam/ipconfig/ipconfig.go
+++ b/azure-ipam/ipconfig/ipconfig.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	defaultV6Gateway   = "fe80::1234:5678:9abc"
+	defaultV6Gateway = "fe80::1234:5678:9abc"
 )
 
 func CreateOrchestratorContext(args *cniSkel.CmdArgs) ([]byte, error) {
@@ -93,9 +93,13 @@ func ProcessIPConfigsResp(resp *cns.IPConfigsResponse) (*[]netip.Prefix, *[]net.
 			gatewayStr = defaultV6Gateway
 		}
 
-		gatewayIP = net.ParseIP(gatewayStr)
-		if gatewayIP == nil {
-			return nil, nil, errors.Errorf("failed to parse gateway IP %q for pod ip %s", gatewayStr, resp.PodIPInfo[i].PodIPConfig.IPAddress)
+		if gatewayStr != "" {
+			gatewayIP = net.ParseIP(gatewayStr)
+			if gatewayIP == nil {
+				return nil, nil, errors.Errorf("failed to parse gateway IP %q for pod ip %s", gatewayStr, resp.PodIPInfo[i].PodIPConfig.IPAddress)
+			}
+		} else {
+			gatewayIP = nil
 		}
 		gatewaysIPs[i] = gatewayIP
 	}

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -398,9 +398,10 @@ type NetworkInterfaceInfo struct {
 
 // IPConfiguration contains details about ip config to provision in the VM.
 type IPConfiguration struct {
-	IPSubnet         IPSubnet
-	DNSServers       []string
-	GatewayIPAddress string
+	IPSubnet           IPSubnet
+	DNSServers         []string
+	GatewayIPAddress   string
+	GatewayIPv6Address string
 }
 
 // SecondaryIPConfig contains IP info of SecondaryIP
@@ -755,3 +756,11 @@ type NodeRegisterRequest struct {
 	NumCores             int
 	NmAgentSupportedApis []string
 }
+
+// IPFamily - Enum for determining IPFamily when retrieving IPs from network containers
+type IPFamily string
+
+const (
+	IPv4 IPFamily = "ipv4"
+	IPv6 IPFamily = "ipv6"
+)

--- a/cns/kubecontroller/nodenetworkconfig/conversion.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/configuration"
 	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	"github.com/pkg/errors"
 )
@@ -73,7 +74,7 @@ func CreateNCRequestFromDynamicNC(nc v1alpha.NetworkContainer) (*cns.CreateNetwo
 // CreateNCRequestFromStaticNC generates a CreateNetworkContainerRequest from a static NetworkContainer.
 //
 //nolint:gocritic //ignore hugeparam
-func CreateNCRequestFromStaticNC(nc v1alpha.NetworkContainer) (*cns.CreateNetworkContainerRequest, error) {
+func CreateNCRequestFromStaticNC(nc v1alpha.NetworkContainer, config *configuration.CNSConfig) (*cns.CreateNetworkContainerRequest, error) {
 	if nc.Type == v1alpha.Overlay {
 		nc.Version = 0 // fix for NMA always giving us version 0 for Overlay NCs
 	}
@@ -97,7 +98,7 @@ func CreateNCRequestFromStaticNC(nc v1alpha.NetworkContainer) (*cns.CreateNetwor
 		subnet.IPAddress = primaryPrefix.Addr().String()
 	}
 
-	req, err := createNCRequestFromStaticNCHelper(nc, primaryPrefix, subnet)
+	req, err := createNCRequestFromStaticNCHelper(nc, primaryPrefix, subnet, config)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error while creating NC request from static NC")
 	}

--- a/cns/kubecontroller/nodenetworkconfig/conversion.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-container-networking/cns"
-	"github.com/Azure/azure-container-networking/cns/configuration"
 	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	"github.com/pkg/errors"
 )
@@ -74,7 +73,7 @@ func CreateNCRequestFromDynamicNC(nc v1alpha.NetworkContainer) (*cns.CreateNetwo
 // CreateNCRequestFromStaticNC generates a CreateNetworkContainerRequest from a static NetworkContainer.
 //
 //nolint:gocritic //ignore hugeparam
-func CreateNCRequestFromStaticNC(nc v1alpha.NetworkContainer, config *configuration.CNSConfig) (*cns.CreateNetworkContainerRequest, error) {
+func CreateNCRequestFromStaticNC(nc v1alpha.NetworkContainer, isSwiftV2 bool) (*cns.CreateNetworkContainerRequest, error) {
 	if nc.Type == v1alpha.Overlay {
 		nc.Version = 0 // fix for NMA always giving us version 0 for Overlay NCs
 	}
@@ -98,7 +97,7 @@ func CreateNCRequestFromStaticNC(nc v1alpha.NetworkContainer, config *configurat
 		subnet.IPAddress = primaryPrefix.Addr().String()
 	}
 
-	req, err := createNCRequestFromStaticNCHelper(nc, primaryPrefix, subnet, config)
+	req, err := createNCRequestFromStaticNCHelper(nc, primaryPrefix, subnet, isSwiftV2)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error while creating NC request from static NC")
 	}

--- a/cns/kubecontroller/nodenetworkconfig/conversion_linux.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_linux.go
@@ -16,12 +16,15 @@ import (
 func createNCRequestFromStaticNCHelper(nc v1alpha.NetworkContainer, primaryIPPrefix netip.Prefix, subnet cns.IPSubnet) (*cns.CreateNetworkContainerRequest, error) {
 	secondaryIPConfigs := map[string]cns.SecondaryIPConfig{}
 
-	// iterate through all IP addresses in the subnet described by primaryPrefix and
-	// add them to the request as secondary IPConfigs.
-	for addr := primaryIPPrefix.Masked().Addr(); primaryIPPrefix.Contains(addr); addr = addr.Next() {
-		secondaryIPConfigs[addr.String()] = cns.SecondaryIPConfig{
-			IPAddress: addr.String(),
-			NCVersion: int(nc.Version),
+	// in the case of vnet prefix on swift v2 the primary IP is a /32 and should not be added to secondary IP configs
+	if !primaryIPPrefix.IsSingleIP() {
+		// iterate through all IP addresses in the subnet described by primaryPrefix and
+		// add them to the request as secondary IPConfigs.
+		for addr := primaryIPPrefix.Masked().Addr(); primaryIPPrefix.Contains(addr); addr = addr.Next() {
+			secondaryIPConfigs[addr.String()] = cns.SecondaryIPConfig{
+				IPAddress: addr.String(),
+				NCVersion: int(nc.Version),
+			}
 		}
 	}
 
@@ -52,9 +55,13 @@ func createNCRequestFromStaticNCHelper(nc v1alpha.NetworkContainer, primaryIPPre
 		NetworkContainerType: cns.Docker,
 		Version:              strconv.FormatInt(nc.Version, 10), //nolint:gomnd // it's decimal
 		IPConfiguration: cns.IPConfiguration{
-			IPSubnet:         subnet,
-			GatewayIPAddress: nc.DefaultGateway,
+			IPSubnet:           subnet,
+			GatewayIPAddress:   nc.DefaultGateway,
+			GatewayIPv6Address: nc.DefaultGatewayV6,
 		},
 		NCStatus: nc.Status,
+		NetworkInterfaceInfo: cns.NetworkInterfaceInfo{
+			MACAddress: nc.MacAddress,
+		},
 	}, nil
 }

--- a/cns/kubecontroller/nodenetworkconfig/conversion_linux.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_linux.go
@@ -16,15 +16,12 @@ import (
 func createNCRequestFromStaticNCHelper(nc v1alpha.NetworkContainer, primaryIPPrefix netip.Prefix, subnet cns.IPSubnet) (*cns.CreateNetworkContainerRequest, error) {
 	secondaryIPConfigs := map[string]cns.SecondaryIPConfig{}
 
-	// in the case of vnet prefix on swift v2 the primary IP is a /32 and should not be added to secondary IP configs
-	if !primaryIPPrefix.IsSingleIP() {
-		// iterate through all IP addresses in the subnet described by primaryPrefix and
-		// add them to the request as secondary IPConfigs.
-		for addr := primaryIPPrefix.Masked().Addr(); primaryIPPrefix.Contains(addr); addr = addr.Next() {
-			secondaryIPConfigs[addr.String()] = cns.SecondaryIPConfig{
-				IPAddress: addr.String(),
-				NCVersion: int(nc.Version),
-			}
+	// iterate through all IP addresses in the subnet described by primaryPrefix and
+	// add them to the request as secondary IPConfigs.
+	for addr := primaryIPPrefix.Masked().Addr(); primaryIPPrefix.Contains(addr); addr = addr.Next() {
+		secondaryIPConfigs[addr.String()] = cns.SecondaryIPConfig{
+			IPAddress: addr.String(),
+			NCVersion: int(nc.Version),
 		}
 	}
 

--- a/cns/kubecontroller/nodenetworkconfig/conversion_linux.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_linux.go
@@ -16,6 +16,8 @@ import (
 func createNCRequestFromStaticNCHelper(nc v1alpha.NetworkContainer, primaryIPPrefix netip.Prefix, subnet cns.IPSubnet) (*cns.CreateNetworkContainerRequest, error) {
 	secondaryIPConfigs := map[string]cns.SecondaryIPConfig{}
 
+	// Todo: Segregate the NIC’s primary IP from the list of secondary IPs to ensure the primary IP is not assigned to pods
+	// WorkItem: https://msazure.visualstudio.com/One/_workitems/edit/33460135
 	// iterate through all IP addresses in the subnet described by primaryPrefix and
 	// add them to the request as secondary IPConfigs.
 	for addr := primaryIPPrefix.Masked().Addr(); primaryIPPrefix.Contains(addr); addr = addr.Next() {

--- a/cns/kubecontroller/nodenetworkconfig/conversion_linux.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_linux.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/Azure/azure-container-networking/cns"
-	"github.com/Azure/azure-container-networking/cns/configuration"
 	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	"github.com/pkg/errors"
 )
@@ -14,13 +13,13 @@ import (
 // by adding all IPs in the the block to the secondary IP configs list. It does not skip any IPs.
 //
 //nolint:gocritic //ignore hugeparam
-func createNCRequestFromStaticNCHelper(nc v1alpha.NetworkContainer, primaryIPPrefix netip.Prefix, subnet cns.IPSubnet, config *configuration.CNSConfig) (*cns.CreateNetworkContainerRequest, error) {
+func createNCRequestFromStaticNCHelper(nc v1alpha.NetworkContainer, primaryIPPrefix netip.Prefix, subnet cns.IPSubnet, isSwiftV2 bool) (*cns.CreateNetworkContainerRequest, error) {
 	secondaryIPConfigs := map[string]cns.SecondaryIPConfig{}
 
 	// iterate through all IP addresses in the subnet described by primaryPrefix and
 	// add them to the request as secondary IPConfigs.
 	// Process primary prefix IPs in all scenarios except when nc.Type is v1alpha.VNETBlock AND SwiftV2 is enabled
-	if !(config.EnableSwiftV2 && nc.Type == v1alpha.VNETBlock) {
+	if !(isSwiftV2 && nc.Type == v1alpha.VNETBlock) {
 		for addr := primaryIPPrefix.Masked().Addr(); primaryIPPrefix.Contains(addr); addr = addr.Next() {
 			secondaryIPConfigs[addr.String()] = cns.SecondaryIPConfig{
 				IPAddress: addr.String(),

--- a/cns/kubecontroller/nodenetworkconfig/conversion_test.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-container-networking/cns"
-	"github.com/Azure/azure-container-networking/cns/configuration"
 	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -341,8 +340,7 @@ func TestCreateNCRequestFromStaticNC(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			config := &configuration.CNSConfig{}
-			got, err := CreateNCRequestFromStaticNC(tt.input, config)
+			got, err := CreateNCRequestFromStaticNC(tt.input, false)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -355,11 +353,11 @@ func TestCreateNCRequestFromStaticNC(t *testing.T) {
 
 func TestCreateNCRequestFromStaticNCWithConfig(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   v1alpha.NetworkContainer
-		config  *configuration.CNSConfig
-		want    *cns.CreateNetworkContainerRequest
-		wantErr bool
+		name      string
+		input     v1alpha.NetworkContainer
+		isSwiftV2 bool
+		want      *cns.CreateNetworkContainerRequest
+		wantErr   bool
 	}{
 		{
 			name: "SwiftV2 enabled with VNETBlock - should NOT process all IPs in prefix",
@@ -373,9 +371,7 @@ func TestCreateNCRequestFromStaticNCWithConfig(t *testing.T) {
 				Version:            1,
 				Status:             "Available",
 			},
-			config: &configuration.CNSConfig{
-				EnableSwiftV2: true,
-			},
+			isSwiftV2: true,
 			want: &cns.CreateNetworkContainerRequest{
 				NetworkContainerid:   ncID,
 				NetworkContainerType: cns.Docker,
@@ -413,7 +409,7 @@ func TestCreateNCRequestFromStaticNCWithConfig(t *testing.T) {
 					},
 				},
 			},
-			config: &configuration.CNSConfig{},
+			isSwiftV2: false,
 			want: &cns.CreateNetworkContainerRequest{
 				NetworkContainerid:   ncID,
 				NetworkContainerType: cns.Docker,
@@ -453,7 +449,7 @@ func TestCreateNCRequestFromStaticNCWithConfig(t *testing.T) {
 					},
 				},
 			},
-			config: &configuration.CNSConfig{},
+			isSwiftV2: false,
 			want: &cns.CreateNetworkContainerRequest{
 				NetworkContainerid:   ncID,
 				NetworkContainerType: cns.Docker,
@@ -477,7 +473,7 @@ func TestCreateNCRequestFromStaticNCWithConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := CreateNCRequestFromStaticNC(tt.input, tt.config)
+			got, err := CreateNCRequestFromStaticNC(tt.input, tt.isSwiftV2)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/cns/kubecontroller/nodenetworkconfig/conversion_test.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/configuration"
 	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -339,12 +341,148 @@ func TestCreateNCRequestFromStaticNC(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := CreateNCRequestFromStaticNC(tt.input)
+			config := &configuration.CNSConfig{}
+			got, err := CreateNCRequestFromStaticNC(tt.input, config)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
 			}
 			assert.NoError(t, err)
+			assert.EqualValues(t, tt.want, got)
+		})
+	}
+}
+
+func TestCreateNCRequestFromStaticNCWithConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   v1alpha.NetworkContainer
+		config  *configuration.CNSConfig
+		want    *cns.CreateNetworkContainerRequest
+		wantErr bool
+	}{
+		{
+			name: "SwiftV2 enabled with VNETBlock - should NOT process all IPs in prefix",
+			input: v1alpha.NetworkContainer{
+				ID:                 ncID,
+				PrimaryIP:          "10.0.0.0/32",
+				NodeIP:             "10.0.0.1",
+				Type:               v1alpha.VNETBlock,
+				SubnetAddressSpace: "10.0.0.0/24",
+				DefaultGateway:     "10.0.0.1",
+				Version:            1,
+				Status:             "Available",
+			},
+			config: &configuration.CNSConfig{
+				EnableSwiftV2: true,
+			},
+			want: &cns.CreateNetworkContainerRequest{
+				NetworkContainerid:   ncID,
+				NetworkContainerType: cns.Docker,
+				Version:              "1",
+				HostPrimaryIP:        "10.0.0.1",
+				IPConfiguration: cns.IPConfiguration{
+					IPSubnet: cns.IPSubnet{
+						IPAddress:    "10.0.0.1",
+						PrefixLength: 24,
+					},
+					GatewayIPAddress: "10.0.0.1",
+				},
+				SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+					// No IPs from primary prefix
+				},
+				NCStatus: "Available",
+			},
+			wantErr: false,
+		},
+		{
+			name: "SwiftV2 disabled with VNETBlock - should process all IP in prefix",
+			input: v1alpha.NetworkContainer{
+				ID:                 ncID,
+				PrimaryIP:          "10.0.0.0/32",
+				NodeIP:             "10.0.0.1",
+				Type:               v1alpha.VNETBlock,
+				SubnetAddressSpace: "10.0.0.0/24",
+				DefaultGateway:     "10.0.0.1",
+				Version:            1,
+				Status:             "Available",
+				IPAssignments: []v1alpha.IPAssignment{
+					{
+						Name: "test-ip",
+						IP:   "10.0.0.10/32",
+					},
+				},
+			},
+			config: &configuration.CNSConfig{},
+			want: &cns.CreateNetworkContainerRequest{
+				NetworkContainerid:   ncID,
+				NetworkContainerType: cns.Docker,
+				Version:              "1",
+				HostPrimaryIP:        "10.0.0.1",
+				IPConfiguration: cns.IPConfiguration{
+					IPSubnet: cns.IPSubnet{
+						IPAddress:    "10.0.0.1",
+						PrefixLength: 24,
+					},
+					GatewayIPAddress: "10.0.0.1",
+				},
+				SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+					"10.0.0.0": {IPAddress: "10.0.0.0", NCVersion: 1},
+					// IP assignments
+					"10.0.0.10": {IPAddress: "10.0.0.10", NCVersion: 1},
+				},
+				NCStatus: "Available",
+			},
+			wantErr: false,
+		},
+		{
+			name: "SwiftV2 disabled with non-VNETBlock type - should process IP in prefix",
+			input: v1alpha.NetworkContainer{
+				ID:                 ncID,
+				PrimaryIP:          "10.0.0.0/32",
+				NodeIP:             "10.0.0.1",
+				Type:               v1alpha.Overlay,
+				SubnetAddressSpace: "10.0.0.0/24",
+				DefaultGateway:     "10.0.0.1",
+				Version:            1,
+				Status:             "Available",
+				IPAssignments: []v1alpha.IPAssignment{
+					{
+						Name: "test-ip",
+						IP:   "10.0.0.10/32",
+					},
+				},
+			},
+			config: &configuration.CNSConfig{},
+			want: &cns.CreateNetworkContainerRequest{
+				NetworkContainerid:   ncID,
+				NetworkContainerType: cns.Docker,
+				Version:              "0",
+				HostPrimaryIP:        "10.0.0.1",
+				IPConfiguration: cns.IPConfiguration{
+					IPSubnet: cns.IPSubnet{
+						IPAddress:    "10.0.0.0",
+						PrefixLength: 24,
+					},
+					GatewayIPAddress: "10.0.0.1",
+				},
+				SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+					"10.0.0.0": {IPAddress: "10.0.0.0", NCVersion: 0},
+				},
+				NCStatus: "Available",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CreateNCRequestFromStaticNC(tt.input, tt.config)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
 			assert.EqualValues(t, tt.want, got)
 		})
 	}

--- a/cns/kubecontroller/nodenetworkconfig/conversion_windows.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_windows.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/Azure/azure-container-networking/cns"
-	"github.com/Azure/azure-container-networking/cns/configuration"
 	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	"github.com/pkg/errors"
 )
@@ -15,7 +14,7 @@ import (
 // secondary IPs. If the gateway is not empty, it will not reserve the 2nd IP and add it as a secondary IP.
 //
 //nolint:gocritic //ignore hugeparam
-func createNCRequestFromStaticNCHelper(nc v1alpha.NetworkContainer, primaryIPPrefix netip.Prefix, subnet cns.IPSubnet, config *configuration.CNSConfig) (*cns.CreateNetworkContainerRequest, error) {
+func createNCRequestFromStaticNCHelper(nc v1alpha.NetworkContainer, primaryIPPrefix netip.Prefix, subnet cns.IPSubnet, isSwiftV2 bool) (*cns.CreateNetworkContainerRequest, error) {
 	secondaryIPConfigs := map[string]cns.SecondaryIPConfig{}
 	// the masked address is the 0th IP in the subnet and startingAddr is the 2nd IP (*.1)
 	startingAddr := primaryIPPrefix.Masked().Addr().Next()
@@ -29,7 +28,7 @@ func createNCRequestFromStaticNCHelper(nc v1alpha.NetworkContainer, primaryIPPre
 	// iterate through all IP addresses in the subnet described by primaryPrefix and
 	// add them to the request as secondary IPConfigs.
 	// Process primary prefix IPs in all scenarios except when nc.Type is v1alpha.VNETBlock AND SwiftV2 is enabled
-	if !(config.EnableSwiftV2 && nc.Type == v1alpha.VNETBlock) {
+	if !(isSwiftV2 && nc.Type == v1alpha.VNETBlock) {
 		for addr := startingAddr; primaryIPPrefix.Contains(addr); addr = addr.Next() {
 			secondaryIPConfigs[addr.String()] = cns.SecondaryIPConfig{
 				IPAddress: addr.String(),

--- a/cns/kubecontroller/nodenetworkconfig/conversion_windows.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion_windows.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/configuration"
 	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	"github.com/pkg/errors"
 )
@@ -14,7 +15,7 @@ import (
 // secondary IPs. If the gateway is not empty, it will not reserve the 2nd IP and add it as a secondary IP.
 //
 //nolint:gocritic //ignore hugeparam
-func createNCRequestFromStaticNCHelper(nc v1alpha.NetworkContainer, primaryIPPrefix netip.Prefix, subnet cns.IPSubnet) (*cns.CreateNetworkContainerRequest, error) {
+func createNCRequestFromStaticNCHelper(nc v1alpha.NetworkContainer, primaryIPPrefix netip.Prefix, subnet cns.IPSubnet, config *configuration.CNSConfig) (*cns.CreateNetworkContainerRequest, error) {
 	secondaryIPConfigs := map[string]cns.SecondaryIPConfig{}
 	// the masked address is the 0th IP in the subnet and startingAddr is the 2nd IP (*.1)
 	startingAddr := primaryIPPrefix.Masked().Addr().Next()
@@ -27,12 +28,15 @@ func createNCRequestFromStaticNCHelper(nc v1alpha.NetworkContainer, primaryIPPre
 
 	// iterate through all IP addresses in the subnet described by primaryPrefix and
 	// add them to the request as secondary IPConfigs.
-	for addr := startingAddr; primaryIPPrefix.Contains(addr); addr = addr.Next() {
-		secondaryIPConfigs[addr.String()] = cns.SecondaryIPConfig{
-			IPAddress: addr.String(),
-			NCVersion: int(nc.Version),
+	// Process primary prefix IPs in all scenarios except when nc.Type is v1alpha.VNETBlock AND SwiftV2 is enabled
+	if !(config.EnableSwiftV2 && nc.Type == v1alpha.VNETBlock) {
+		for addr := startingAddr; primaryIPPrefix.Contains(addr); addr = addr.Next() {
+			secondaryIPConfigs[addr.String()] = cns.SecondaryIPConfig{
+				IPAddress: addr.String(),
+				NCVersion: int(nc.Version),
+			}
+			lastAddr = addr
 		}
-		lastAddr = addr
 	}
 
 	if nc.Type == v1alpha.VNETBlock {

--- a/cns/kubecontroller/nodenetworkconfig/reconciler.go
+++ b/cns/kubecontroller/nodenetworkconfig/reconciler.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/Azure/azure-container-networking/cns"
-	"github.com/Azure/azure-container-networking/cns/configuration"
 	"github.com/Azure/azure-container-networking/cns/logger"
 	"github.com/Azure/azure-container-networking/cns/restserver"
 	cnstypes "github.com/Azure/azure-container-networking/cns/types"
@@ -44,20 +43,20 @@ type Reconciler struct {
 	once               sync.Once
 	started            chan interface{}
 	nodeIP             string
-	config             *configuration.CNSConfig
+	isSwiftV2          bool
 }
 
 // NewReconciler creates a NodeNetworkConfig Reconciler which will get updates from the Kubernetes
 // apiserver for NNC events.
 // Provided nncListeners are passed the NNC after the Reconcile preprocesses it. Note: order matters! The
 // passed Listeners are notified in the order provided.
-func NewReconciler(cnscli cnsClient, ipampoolmonitorcli nodeNetworkConfigListener, nodeIP string, config *configuration.CNSConfig) *Reconciler {
+func NewReconciler(cnscli cnsClient, ipampoolmonitorcli nodeNetworkConfigListener, nodeIP string, isSwiftV2 bool) *Reconciler {
 	return &Reconciler{
 		cnscli:             cnscli,
 		ipampoolmonitorcli: ipampoolmonitorcli,
 		started:            make(chan interface{}),
 		nodeIP:             nodeIP,
-		config:             config,
+		isSwiftV2:          isSwiftV2,
 	}
 }
 
@@ -107,7 +106,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		switch nnc.Status.NetworkContainers[i].AssignmentMode { //nolint:exhaustive // skipping dynamic case
 		// For Overlay and Vnet Scale Scenarios
 		case v1alpha.Static:
-			req, err = CreateNCRequestFromStaticNC(nnc.Status.NetworkContainers[i], r.config)
+			req, err = CreateNCRequestFromStaticNC(nnc.Status.NetworkContainers[i], r.isSwiftV2)
 		// For Pod Subnet scenario
 		default: // For backward compatibility, default will be treated as Dynamic too.
 			req, err = CreateNCRequestFromDynamicNC(nnc.Status.NetworkContainers[i])

--- a/cns/kubecontroller/nodenetworkconfig/reconciler.go
+++ b/cns/kubecontroller/nodenetworkconfig/reconciler.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/configuration"
 	"github.com/Azure/azure-container-networking/cns/logger"
 	"github.com/Azure/azure-container-networking/cns/restserver"
 	cnstypes "github.com/Azure/azure-container-networking/cns/types"
@@ -43,18 +44,20 @@ type Reconciler struct {
 	once               sync.Once
 	started            chan interface{}
 	nodeIP             string
+	config             *configuration.CNSConfig
 }
 
 // NewReconciler creates a NodeNetworkConfig Reconciler which will get updates from the Kubernetes
 // apiserver for NNC events.
 // Provided nncListeners are passed the NNC after the Reconcile preprocesses it. Note: order matters! The
 // passed Listeners are notified in the order provided.
-func NewReconciler(cnscli cnsClient, ipampoolmonitorcli nodeNetworkConfigListener, nodeIP string) *Reconciler {
+func NewReconciler(cnscli cnsClient, ipampoolmonitorcli nodeNetworkConfigListener, nodeIP string, config *configuration.CNSConfig) *Reconciler {
 	return &Reconciler{
 		cnscli:             cnscli,
 		ipampoolmonitorcli: ipampoolmonitorcli,
 		started:            make(chan interface{}),
 		nodeIP:             nodeIP,
+		config:             config,
 	}
 }
 
@@ -104,7 +107,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		switch nnc.Status.NetworkContainers[i].AssignmentMode { //nolint:exhaustive // skipping dynamic case
 		// For Overlay and Vnet Scale Scenarios
 		case v1alpha.Static:
-			req, err = CreateNCRequestFromStaticNC(nnc.Status.NetworkContainers[i])
+			req, err = CreateNCRequestFromStaticNC(nnc.Status.NetworkContainers[i], r.config)
 		// For Pod Subnet scenario
 		default: // For backward compatibility, default will be treated as Dynamic too.
 			req, err = CreateNCRequestFromDynamicNC(nnc.Status.NetworkContainers[i])

--- a/cns/kubecontroller/nodenetworkconfig/reconciler_test.go
+++ b/cns/kubecontroller/nodenetworkconfig/reconciler_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-container-networking/cns"
-	"github.com/Azure/azure-container-networking/cns/configuration"
 	"github.com/Azure/azure-container-networking/cns/logger"
 	cnstypes "github.com/Azure/azure-container-networking/cns/types"
 	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
@@ -193,8 +192,7 @@ func TestReconcile(t *testing.T) {
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
-			config := &configuration.CNSConfig{} // Use default config for tests
-			r := NewReconciler(&tt.cnsClient, &tt.cnsClient, tt.nodeIP, config)
+			r := NewReconciler(&tt.cnsClient, &tt.cnsClient, tt.nodeIP, false)
 			r.nnccli = &tt.ncGetter
 			got, err := r.Reconcile(context.Background(), tt.in)
 			if tt.wantErr {
@@ -251,8 +249,7 @@ func TestReconcileStaleNCs(t *testing.T) {
 		return &nncLog[len(nncLog)-1], nil
 	}
 
-	config := &configuration.CNSConfig{} // Use default config for tests
-	r := NewReconciler(&cnsClient, &cnsClient, nodeIP, config)
+	r := NewReconciler(&cnsClient, &cnsClient, nodeIP, false)
 	r.nnccli = &mockNCGetter{get: nncIterator}
 
 	_, err := r.Reconcile(context.Background(), reconcile.Request{})

--- a/cns/kubecontroller/nodenetworkconfig/reconciler_test.go
+++ b/cns/kubecontroller/nodenetworkconfig/reconciler_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/configuration"
 	"github.com/Azure/azure-container-networking/cns/logger"
 	cnstypes "github.com/Azure/azure-container-networking/cns/types"
 	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
@@ -192,7 +193,8 @@ func TestReconcile(t *testing.T) {
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
-			r := NewReconciler(&tt.cnsClient, &tt.cnsClient, tt.nodeIP)
+			config := &configuration.CNSConfig{} // Use default config for tests
+			r := NewReconciler(&tt.cnsClient, &tt.cnsClient, tt.nodeIP, config)
 			r.nnccli = &tt.ncGetter
 			got, err := r.Reconcile(context.Background(), tt.in)
 			if tt.wantErr {
@@ -249,7 +251,8 @@ func TestReconcileStaleNCs(t *testing.T) {
 		return &nncLog[len(nncLog)-1], nil
 	}
 
-	r := NewReconciler(&cnsClient, &cnsClient, nodeIP)
+	config := &configuration.CNSConfig{} // Use default config for tests
+	r := NewReconciler(&cnsClient, &cnsClient, nodeIP, config)
 	r.nnccli = &mockNCGetter{get: nncIterator}
 
 	_, err := r.Reconcile(context.Background(), reconcile.Request{})

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -197,13 +197,6 @@ func (service *HTTPRestService) syncHostNCVersion(ctx context.Context, channelMo
 	outdatedNCs := map[string]struct{}{}
 	programmedNCs := map[string]struct{}{}
 	for idx := range service.state.ContainerStatus {
-
-		// For prefix-on-NIC SwiftV2 NIC scenario, the NC details is published to different path in NMAgent and call to NMA here creates error. So Skipping nma check, synchost version logic.
-		ncStatus := service.state.ContainerStatus[idx]
-		if mac := ncStatus.CreateNetworkContainerRequest.NetworkInterfaceInfo.MACAddress; mac != "" {
-			logger.Printf("NC %s has MAC address for prefix on nic swiftv2 prefix on NIC scenario, skipping syncHostNCVersion", ncStatus.ID)
-			continue
-		}
 		// Will open a separate PR to convert all the NC version related variable to int. Change from string to int is a pain.
 		localNCVersion, err := strconv.Atoi(service.state.ContainerStatus[idx].HostVersion)
 		if err != nil {

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -649,6 +649,7 @@ func (service *HTTPRestService) CreateOrUpdateNetworkContainerInternal(req *cns.
 	} else {
 		logger.Errorf(returnMessage)
 	}
+
 	if service.Options[common.OptProgramSNATIPTables] == true {
 		returnCode, returnMessage = service.programSNATRules(req)
 		if returnCode != 0 {

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -197,6 +197,13 @@ func (service *HTTPRestService) syncHostNCVersion(ctx context.Context, channelMo
 	outdatedNCs := map[string]struct{}{}
 	programmedNCs := map[string]struct{}{}
 	for idx := range service.state.ContainerStatus {
+
+		// For prefix-on-NIC SwiftV2 NIC scenario, the NC details is published to different path in NMAgent and call to NMA here creates error. So Skipping nma check, synchost version logic.
+		ncStatus := service.state.ContainerStatus[idx]
+		if mac := ncStatus.CreateNetworkContainerRequest.NetworkInterfaceInfo.MACAddress; mac != "" {
+			logger.Printf("NC %s has MAC address for prefix on nic swiftv2 scenario, skipping syncHostNCVersion", ncStatus.ID)
+			continue
+		}
 		// Will open a separate PR to convert all the NC version related variable to int. Change from string to int is a pain.
 		localNCVersion, err := strconv.Atoi(service.state.ContainerStatus[idx].HostVersion)
 		if err != nil {

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -222,8 +222,7 @@ func (service *HTTPRestService) syncHostNCVersion(ctx context.Context, channelMo
 	if len(outdatedNCs) == 0 {
 		return len(programmedNCs), nil
 	}
-	// Todo: Query NMA for the supported API to validate the build version. If supported, query IMDS for the Swiftv2 NC version list and perform synchostversion update.
-	// WorkItem: https://msazure.visualstudio.com/One/_workitems/edit/33460135
+
 	ncVersionListResp, err := service.nma.GetNCVersionList(ctx)
 	if err != nil {
 		return len(programmedNCs), errors.Wrap(err, "failed to get nc version list from nmagent")

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -201,7 +201,7 @@ func (service *HTTPRestService) syncHostNCVersion(ctx context.Context, channelMo
 		// For prefix-on-NIC SwiftV2 NIC scenario, the NC details is published to different path in NMAgent and call to NMA here creates error. So Skipping nma check, synchost version logic.
 		ncStatus := service.state.ContainerStatus[idx]
 		if mac := ncStatus.CreateNetworkContainerRequest.NetworkInterfaceInfo.MACAddress; mac != "" {
-			logger.Printf("NC %s has MAC address for prefix on nic swiftv2 scenario, skipping syncHostNCVersion", ncStatus.ID)
+			logger.Printf("NC %s has MAC address for prefix on nic swiftv2 prefix on NIC scenario, skipping syncHostNCVersion", ncStatus.ID)
 			continue
 		}
 		// Will open a separate PR to convert all the NC version related variable to int. Change from string to int is a pain.
@@ -656,7 +656,6 @@ func (service *HTTPRestService) CreateOrUpdateNetworkContainerInternal(req *cns.
 	} else {
 		logger.Errorf(returnMessage)
 	}
-
 	if service.Options[common.OptProgramSNATIPTables] == true {
 		returnCode, returnMessage = service.programSNATRules(req)
 		if returnCode != 0 {

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -222,6 +222,8 @@ func (service *HTTPRestService) syncHostNCVersion(ctx context.Context, channelMo
 	if len(outdatedNCs) == 0 {
 		return len(programmedNCs), nil
 	}
+	// Todo: Query NMA for the supported API to validate the build version. If supported, query IMDS for the Swiftv2 NC version list and perform synchostversion update.
+	// WorkItem: https://msazure.visualstudio.com/One/_workitems/edit/33460135
 	ncVersionListResp, err := service.nma.GetNCVersionList(ctx)
 	if err != nil {
 		return len(programmedNCs), errors.Wrap(err, "failed to get nc version list from nmagent")

--- a/cns/restserver/internalapi_linux.go
+++ b/cns/restserver/internalapi_linux.go
@@ -121,6 +121,12 @@ func (service *HTTPRestService) programSNATRules(req *cns.CreateNetworkContainer
 
 	// use any secondary ip + the nnc prefix length to get an iptables rule to allow dns and imds traffic from the pods
 	for _, v := range req.SecondaryIPConfigs {
+		// check if the ip address is IPv4
+		if net.ParseIP(v.IPAddress).To4() == nil {
+			// skip if the ip address is not IPv4
+			continue
+		}
+
 		// put the ip address in standard cidr form (where we zero out the parts that are not relevant)
 		_, podSubnet, _ := net.ParseCIDR(v.IPAddress + "/" + fmt.Sprintf("%d", req.IPConfiguration.IPSubnet.PrefixLength))
 

--- a/cns/restserver/internalapi_linux.go
+++ b/cns/restserver/internalapi_linux.go
@@ -121,7 +121,7 @@ func (service *HTTPRestService) programSNATRules(req *cns.CreateNetworkContainer
 
 	// use any secondary ip + the nnc prefix length to get an iptables rule to allow dns and imds traffic from the pods
 	for _, v := range req.SecondaryIPConfigs {
-		// check if the ip address is IPv4
+		// check if the ip address is IPv4. A check is required because DNS and IMDS do not have IPv6 addresses. Since support currently exists only for IPv4, other ip families are skipped.
 		if net.ParseIP(v.IPAddress).To4() == nil {
 			// skip if the ip address is not IPv4
 			continue

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -44,7 +45,6 @@ const (
 	initPoolSize        = 10
 	ncID                = "6a07155a-32d7-49af-872f-1e70ee366dc0"
 	imdsNCID            = "6a07155a-32d7-49af-872f-1e70ee36imds"
-	macAddress          = "00:11:22:33:44:55"
 )
 
 var dnsservers = []string{"8.8.8.8", "8.8.4.4"}
@@ -334,6 +334,212 @@ func TestPendingIPsGotUpdatedWhenSyncHostNCVersion(t *testing.T) {
 		if podIPConfigState.GetState() != types.Available {
 			t.Errorf("Unexpected State %s, expeted State is %s, IP address is %s", podIPConfigState.GetState(), types.Available, podIPConfigState.IPAddress)
 		}
+	}
+}
+
+func TestSyncHostNCVersionErrorMissingNC(t *testing.T) {
+	req := createNCReqeustForSyncHostNCVersion(t)
+
+	svc.Lock()
+	ncStatus := svc.state.ContainerStatus[req.NetworkContainerid]
+	ncStatus.CreateNetworkContainerRequest.Version = "2"
+	ncStatus.HostVersion = "0"
+	svc.state.ContainerStatus[req.NetworkContainerid] = ncStatus
+	svc.Unlock()
+
+	// Setup IMDS mock with different interface IDs (not matching the outdated NC)
+	cleanupIMDS := setupIMDSMockAPIsWithCustomIDs(svc, []string{"different-nc-id-1", "different-nc-id-2"})
+	defer cleanupIMDS()
+
+	// NMAgent returns empty
+	mnma := &fakes.NMAgentClientFake{
+		GetNCVersionListF: func(_ context.Context) (nma.NCVersionList, error) {
+			return nma.NCVersionList{
+				Containers: []nma.NCVersion{},
+			}, nil
+		},
+	}
+	cleanup := setMockNMAgent(svc, mnma)
+	defer cleanup()
+
+	_, err := svc.syncHostNCVersion(context.Background(), cns.KubernetesCRD)
+	if err == nil {
+		t.Errorf("Expected error when NC is missing from both NMAgent and IMDS, but got nil")
+	}
+
+	// Check that the error message contains the expected text
+	expectedErrorText := "unable to update some NCs"
+	if !strings.Contains(err.Error(), expectedErrorText) {
+		t.Errorf("Expected error to contain '%s', but got: %v", expectedErrorText, err)
+	}
+
+	// Verify that the NC HostVersion was not updated, should still be 0
+	containerStatus := svc.state.ContainerStatus[req.NetworkContainerid]
+	if containerStatus.HostVersion != "0" {
+		t.Errorf("Expected HostVersion to remain 0, but got %s", containerStatus.HostVersion)
+	}
+}
+
+func TestSyncHostNCVersionLocalVersionHigher(t *testing.T) {
+	// Test scenario where local NC version is higher than consolidated NC version from IMDS
+	// This should trigger the "NC version from consolidated sources is decreasing" error
+	req := createNCReqeustForSyncHostNCVersion(t)
+
+	svc.Lock()
+	ncStatus := svc.state.ContainerStatus[req.NetworkContainerid]
+	ncStatus.CreateNetworkContainerRequest.Version = "1" // DNC version is 1
+	ncStatus.HostVersion = "3"                           // But local host version is 3
+	svc.state.ContainerStatus[req.NetworkContainerid] = ncStatus
+	svc.Unlock()
+
+	// Create IMDS mock that returns lower version(1) than local host version(3)
+	// Setup IMDS mock with version support
+	cleanupIMDS := setupIMDSMockAPIsWithCustomIDs(svc, []string{imdsNCID, "nc2"})
+	defer cleanupIMDS()
+
+	mnma := &fakes.NMAgentClientFake{
+		GetNCVersionListF: func(_ context.Context) (nma.NCVersionList, error) {
+			return nma.NCVersionList{
+				Containers: []nma.NCVersion{},
+			}, nil
+		},
+	}
+	cleanup := setMockNMAgent(svc, mnma)
+	defer cleanup()
+
+	_, err := svc.syncHostNCVersion(context.Background(), cns.KubernetesCRD)
+	if err != nil {
+		t.Errorf("Expected sync to succeed, but got error: %v", err)
+	}
+
+	// Verify that the NC HostVersion was NOT updated (should remain "3")
+	containerStatus := svc.state.ContainerStatus[req.NetworkContainerid]
+	if containerStatus.HostVersion != "3" {
+		t.Errorf("Expected HostVersion to remain 3 (unchanged due to decreasing version), got %s", containerStatus.HostVersion)
+	}
+
+	t.Logf("Successfully handled decreasing version scenario: local=%s, consolidated=%s",
+		containerStatus.HostVersion, "2")
+}
+
+func TestSyncHostNCVersionLocalHigherThanDNC(t *testing.T) {
+	// Test scenario where localNCVersion > dncNCVersion
+	// This should trigger an error log: "NC version from NMAgent is larger than DNC"
+	req := createNCReqeustForSyncHostNCVersion(t)
+
+	// Set up the NC state where HostVersion (localNCVersion) > DNC NC Version
+	svc.Lock()
+	ncStatus := svc.state.ContainerStatus[req.NetworkContainerid]
+	ncStatus.CreateNetworkContainerRequest.Version = "1"
+	ncStatus.HostVersion = "3"
+	svc.state.ContainerStatus[req.NetworkContainerid] = ncStatus
+	svc.Unlock()
+
+	cleanupIMDS := setupIMDSMockAPIsWithCustomIDs(svc, []string{imdsNCID, "nc2"})
+	defer cleanupIMDS()
+
+	mnma := &fakes.NMAgentClientFake{
+		GetNCVersionListF: func(_ context.Context) (nma.NCVersionList, error) {
+			return nma.NCVersionList{
+				Containers: []nma.NCVersion{}, // Empty
+			}, nil
+		},
+	}
+	cleanup := setMockNMAgent(svc, mnma)
+	defer cleanup()
+
+	// This should detect that localNCVersion (3) > dncNCVersion (1) and log error
+	// but since there are no outdated NCs, it should return successfully
+	_, err := svc.syncHostNCVersion(context.Background(), cns.KubernetesCRD)
+	if err != nil {
+		t.Errorf("Expected no error when localNCVersion > dncNCVersion (no outdated NCs), but got: %v", err)
+	}
+
+	containerStatus := svc.state.ContainerStatus[req.NetworkContainerid]
+	if containerStatus.HostVersion != "3" {
+		t.Errorf("Expected HostVersion to remain 3 (unchanged), got %s", containerStatus.HostVersion)
+	}
+
+	// Verify that the DNC version remains unchanged, should still be 1
+	if containerStatus.CreateNetworkContainerRequest.Version != "1" {
+		t.Errorf("Expected DNC version to remain 1 (unchanged), got %s", containerStatus.CreateNetworkContainerRequest.Version)
+	}
+
+	t.Logf("Successfully handled localNCVersion > dncNCVersion scenario: local=%s, dnc=%s",
+		containerStatus.HostVersion, containerStatus.CreateNetworkContainerRequest.Version)
+}
+
+func TestSyncHostNCVersionIMDSAPIVersionNotSupported(t *testing.T) {
+	orchestratorTypes := []string{cns.Kubernetes, cns.KubernetesCRD}
+	for _, orchestratorType := range orchestratorTypes {
+		t.Run(orchestratorType, func(t *testing.T) {
+			req := createNCReqeustForSyncHostNCVersion(t)
+
+			// Make the NMA NC up-to-date so it doesn't interfere with the test
+			svc.Lock()
+			nmaNCStatus := svc.state.ContainerStatus[req.NetworkContainerid]
+			nmaNCStatus.HostVersion = "0" // Same as Version "0", so not outdated
+			svc.state.ContainerStatus[req.NetworkContainerid] = nmaNCStatus
+			svc.Unlock()
+
+			// NMAgent mock - not important for this test, just needs to not interfere
+			mnma := &fakes.NMAgentClientFake{
+				GetNCVersionListF: func(_ context.Context) (nma.NCVersionList, error) {
+					return nma.NCVersionList{Containers: []nma.NCVersion{}}, nil
+				},
+			}
+			cleanup := setMockNMAgent(svc, mnma)
+			defer cleanup()
+
+			// Add IMDS NC that is outdated - this is the focus of the test
+			svc.state.ContainerStatus[imdsNCID] = containerstatus{
+				ID:          imdsNCID,
+				VMVersion:   "0",
+				HostVersion: "-1", // Outdated
+				CreateNetworkContainerRequest: cns.CreateNetworkContainerRequest{
+					NetworkContainerid: imdsNCID,
+					Version:            "1", // Higher than HostVersion
+				},
+			}
+
+			// Setup IMDS mock that returns API versions WITHOUT the expected version "2025-07-24"
+			mockIMDS := &struct {
+				networkInterfaces func(_ context.Context) ([]imds.NetworkInterface, error)
+				imdsVersions      func(_ context.Context) (*imds.APIVersionsResponse, error)
+			}{
+				networkInterfaces: func(_ context.Context) ([]imds.NetworkInterface, error) {
+					return []imds.NetworkInterface{
+						{InterfaceCompartmentID: imdsNCID},
+					}, nil
+				},
+				imdsVersions: func(_ context.Context) (*imds.APIVersionsResponse, error) {
+					return &imds.APIVersionsResponse{
+						APIVersions: []string{"2017-03-01", "2021-01-01"}, // Missing "2025-07-24"
+					}, nil
+				},
+			}
+			originalIMDS := svc.imdsClient
+			svc.imdsClient = &mockIMDSAdapter{mockIMDS}
+			defer func() { svc.imdsClient = originalIMDS }()
+
+			// Test should fail because of outdated IMDS NC that can't be updated
+			_, err := svc.syncHostNCVersion(context.Background(), orchestratorType)
+			if err == nil {
+				t.Errorf("Expected error when there are outdated IMDS NCs but API version is not supported, but got nil")
+			}
+
+			// Verify the error is about being unable to update NCs
+			expectedErrorText := "unable to update some NCs"
+			if !strings.Contains(err.Error(), expectedErrorText) {
+				t.Errorf("Expected error to contain '%s', but got: %v", expectedErrorText, err)
+			}
+
+			// Only verify IMDS NC state - this is the focus of the test
+			imdsContainerStatus := svc.state.ContainerStatus[imdsNCID]
+			if imdsContainerStatus.HostVersion != "-1" {
+				t.Errorf("Expected IMDS NC HostVersion to remain -1, got %s", imdsContainerStatus.HostVersion)
+			}
+		})
 	}
 }
 

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -44,6 +44,7 @@ const (
 	initPoolSize        = 10
 	ncID                = "6a07155a-32d7-49af-872f-1e70ee366dc0"
 	imdsNCID            = "6a07155a-32d7-49af-872f-1e70ee36imds"
+	macAddress          = "00:11:22:33:44:55"
 )
 
 var dnsservers = []string{"8.8.8.8", "8.8.4.4"}
@@ -339,38 +340,26 @@ func TestPendingIPsGotUpdatedWhenSyncHostNCVersion(t *testing.T) {
 func TestSyncHostNCVersion_SkipsNCVersionForPrefixOnNICSwiftV2(t *testing.T) {
 	orchestratorTypes := []string{cns.Kubernetes, cns.KubernetesCRD}
 	for _, orchestratorType := range orchestratorTypes {
-		orchestratorType := orchestratorType
 		t.Run(orchestratorType, func(t *testing.T) {
-			restartService()
-			setEnv(t)
-			setOrchestratorTypeInternal(orchestratorType)
-
-			ncID := "swiftv2-ncid"
-			svc.state.ContainerStatus = map[string]containerstatus{
-				ncID: {
-					ID:          ncID,
-					HostVersion: "2",
-					CreateNetworkContainerRequest: cns.CreateNetworkContainerRequest{
-						NetworkContainerid: ncID,
-						Version:            "1",
-						NetworkInterfaceInfo: cns.NetworkInterfaceInfo{
-							MACAddress: "00:11:22:33:44:55",
-						},
-					},
-				},
-			}
-
-			// Should not error, and should not attempt version check
+			req := createNCReqeustForSyncHostNCVersion(t, macAddress)
+			containerStatus := svc.state.ContainerStatus[req.NetworkContainerid]
+			//// HostVersion -1 and NC Version 0  and should remain unchanged, should not error
 			svc.SyncHostNCVersion(context.Background(), orchestratorType)
+
 			// HostVersion and Version should remain unchanged
-			containerStatus := svc.state.ContainerStatus[ncID]
-			assert.Equal(t, "2", containerStatus.HostVersion)
-			assert.Equal(t, "1", containerStatus.CreateNetworkContainerRequest.Version)
+			assert.Equal(t, "-1", containerStatus.HostVersion)
+			assert.Equal(t, "0", containerStatus.CreateNetworkContainerRequest.Version)
 		})
 	}
 }
 
-func createNCReqeustForSyncHostNCVersion(t *testing.T) cns.CreateNetworkContainerRequest {
+func createNCReqeustForSyncHostNCVersion(t *testing.T, macAddresses ...string) cns.CreateNetworkContainerRequest {
+	var macAddress string
+	if len(macAddresses) > 0 {
+		macAddress = macAddresses[0]
+	} else {
+		macAddress = ""
+	}
 	restartService()
 	setEnv(t)
 	setOrchestratorTypeInternal(cns.KubernetesCRD)
@@ -384,7 +373,7 @@ func createNCReqeustForSyncHostNCVersion(t *testing.T) cns.CreateNetworkContaine
 	secIPConfig := newSecondaryIPConfig(ipAddress, ncVersion)
 	ipID := uuid.New()
 	secondaryIPConfigs[ipID.String()] = secIPConfig
-	req := createNCReqInternal(t, secondaryIPConfigs, ncID, strconv.Itoa(ncVersion))
+	req := createNCReqInternal(t, secondaryIPConfigs, ncID, strconv.Itoa(ncVersion), macAddress)
 	return req
 }
 
@@ -916,7 +905,14 @@ func validateNetworkRequest(t *testing.T, req cns.CreateNetworkContainerRequest)
 	}
 }
 
-func generateNetworkContainerRequest(secondaryIps map[string]cns.SecondaryIPConfig, ncID, ncVersion string) *cns.CreateNetworkContainerRequest {
+func generateNetworkContainerRequest(secondaryIps map[string]cns.SecondaryIPConfig, ncID, ncVersion string, macAddress ...string) *cns.CreateNetworkContainerRequest {
+	var mac string
+	if len(macAddress) > 0 {
+		mac = macAddress[0]
+	} else {
+		mac = ""
+	}
+
 	var ipConfig cns.IPConfiguration
 	ipConfig.DNSServers = dnsservers
 	ipConfig.GatewayIPAddress = gatewayIP
@@ -930,6 +926,9 @@ func generateNetworkContainerRequest(secondaryIps map[string]cns.SecondaryIPConf
 		NetworkContainerid:   ncID,
 		IPConfiguration:      ipConfig,
 		Version:              ncVersion,
+		NetworkInterfaceInfo: cns.NetworkInterfaceInfo{
+			MACAddress: mac,
+		},
 	}
 
 	ncVersionInInt, _ := strconv.Atoi(ncVersion)
@@ -1056,8 +1055,14 @@ func validateIPAMStateAfterReconcile(t *testing.T, ncReqs []*cns.CreateNetworkCo
 	}
 }
 
-func createNCReqInternal(t *testing.T, secondaryIPConfigs map[string]cns.SecondaryIPConfig, ncID, ncVersion string) cns.CreateNetworkContainerRequest {
-	req := generateNetworkContainerRequest(secondaryIPConfigs, ncID, ncVersion)
+func createNCReqInternal(t *testing.T, secondaryIPConfigs map[string]cns.SecondaryIPConfig, ncID, ncVersion string, macAddresses ...string) cns.CreateNetworkContainerRequest {
+	var macAddress string
+	if len(macAddresses) > 0 {
+		macAddress = macAddresses[0]
+	} else {
+		macAddress = ""
+	}
+	req := generateNetworkContainerRequest(secondaryIPConfigs, ncID, ncVersion, macAddress)
 	returnCode := svc.CreateOrUpdateNetworkContainerInternal(req)
 	if returnCode != 0 {
 		t.Fatalf("Failed to createNetworkContainerRequest, req: %+v, err: %d", req, returnCode)

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -998,7 +998,7 @@ func (service *HTTPRestService) AssignAvailableIPConfigs(podInfo cns.PodInfo) ([
 	}
 
 	// Get the number of distinct IP families (IPv4/IPv6) across all NC's
-	numOfIPFamilies := service.GetIpFamilyCount()
+	numOfIPFamilies := service.GetIPFamilyCount()
 
 	// Get the actual IP families map for validation
 	ncIPFamilies := service.getIPFamiliesMap()
@@ -1088,7 +1088,11 @@ func (service *HTTPRestService) AssignAvailableIPConfigs(podInfo cns.PodInfo) ([
 		return podIPInfo, fmt.Errorf("not enough IPs available, waiting on Azure CNS to allocate more")
 	}
 
-	logger.Printf("[AssignAvailableIPConfigs] Successfully assigned IPs for pod %+v", podInfo)
+	//lint:ignore SA1019 suppress deprecated logger.Printf usage. Todo: legacy logger usage is consistent in cns repo. Migrates when all logger usage is migrated
+	logger.Printf(
+		"[AssignAvailableIPConfigs] Successfully assigned IPs for pod %+v",
+		podInfo,
+	)
 	return podIPInfo, nil
 }
 
@@ -1389,10 +1393,10 @@ func (service *HTTPRestService) getIPFamiliesMap() map[cns.IPFamily]struct{} {
 	return ncIPFamilies
 }
 
-// GetIpFamilyCount returns the number of distinct IP families (IPv4/IPv6) across all NC's.
+// GetIPFamilyCount returns the number of distinct IP families (IPv4/IPv6) across all NC's.
 // This is used to determine how many IPs to assign per pod:
 // - In single-stack: 1 IP per pod
 // - In dual-stack: 2 IPs per pod (one IPv4, one IPv6)
-func (service *HTTPRestService) GetIpFamilyCount() int {
+func (service *HTTPRestService) GetIPFamilyCount() int {
 	return len(service.getIPFamiliesMap())
 }

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/netip"
 	"strconv"
 	"strings"
 
@@ -1009,14 +1010,14 @@ func (service *HTTPRestService) AssignAvailableIPConfigs(podInfo cns.PodInfo) ([
 				break
 			}
 
-			ip := net.ParseIP(secIPConfig.IPAddress)
-			if ip == nil {
+			addr, err := netip.ParseAddr(secIPConfig.IPAddress)
+			if err != nil {
 				continue
 			}
 
-			if ip.To4() != nil {
+			if addr.Is4() {
 				ncIPFamilies[cns.IPv4] = struct{}{}
-			} else {
+			} else if addr.Is6() {
 				ncIPFamilies[cns.IPv6] = struct{}{}
 			}
 		}

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -1088,7 +1088,7 @@ func (service *HTTPRestService) AssignAvailableIPConfigs(podInfo cns.PodInfo) ([
 		return podIPInfo, fmt.Errorf("not enough IPs available, waiting on Azure CNS to allocate more")
 	}
 
-	//lint:ignore SA1019 suppress deprecated logger.Printf usage. Todo: legacy logger usage is consistent in cns repo. Migrates when all logger usage is migrated
+	//nolint:staticcheck // SA1019: suppress deprecated logger.Printf usage. Todo: legacy logger usage is consistent in cns repo. Migrates when all logger usage is migrated
 	logger.Printf(
 		"[AssignAvailableIPConfigs] Successfully assigned IPs for pod %+v",
 		podInfo,

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -997,17 +997,11 @@ func (service *HTTPRestService) AssignAvailableIPConfigs(podInfo cns.PodInfo) ([
 		return nil, ErrNoNCs
 	}
 
-	// Get the number of distinct IP families (IPv4/IPv6) across all NC's
-	numOfIPFamilies := service.GetIPFamilyCount()
+	// Get the number of distinct IP families (IPv4/IPv6) across all NC's and determine the number of IPs to assign based on IP families found
+	numberOfIPs := service.GetIPFamilyCount()
 
 	// Get the actual IP families map for validation
 	ncIPFamilies := service.getIPFamiliesMap()
-
-	// Determine the number of IPs to assign based on IP families found
-	numberOfIPs := numOfNCs
-	if numOfIPFamilies != 0 {
-		numberOfIPs = numOfIPFamilies
-	}
 
 	service.Lock()
 	defer service.Unlock()

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -1014,10 +1014,9 @@ func (service *HTTPRestService) AssignAvailableIPConfigs(podInfo cns.PodInfo) ([
 	for _, ipState := range service.PodIPConfigState {
 
 		// get the IPFamily of the current ipState
-		var ipStateFamily cns.IPFamily
-		if net.ParseIP(ipState.IPAddress).To4() != nil {
-			ipStateFamily = cns.IPv4
-		} else {
+		var ipStateFamily cns.IPFamily = cns.IPv4
+
+		if ipAddr, err := netip.ParseAddr(ipState.IPAddress); err == nil && ipAddr.Is6() {
 			ipStateFamily = cns.IPv6
 		}
 

--- a/cns/restserver/ipam_test.go
+++ b/cns/restserver/ipam_test.go
@@ -2310,6 +2310,91 @@ func setupMockNMAgent(t *testing.T, svc *HTTPRestService, mockNMAgent *fakes.NMA
 	})
 }
 
+func TestIPAMRequestIPConfigsTwoFamiliesSameNC(t *testing.T) {
+	svc := getTestService(cns.KubernetesCRD)
+
+	// Add single NC with both IPv4 and IPv6 IPs
+	mixedConfigs := map[string]cns.IPConfigurationStatus{
+		"ipv4-1": NewPodState("10.0.0.1", "ipv4-1", testNCID, types.Available, 0),
+		"ipv4-2": NewPodState("10.0.0.2", "ipv4-2", testNCID, types.Available, 0),
+		"ipv6-1": NewPodState("2001:db8::1", "ipv6-1", testNCID, types.Available, 0),
+		"ipv6-2": NewPodState("2001:db8::2", "ipv6-2", testNCID, types.Available, 0),
+	}
+
+	err := UpdatePodIPConfigState(t, svc, mixedConfigs, testNCID)
+	require.NoError(t, err)
+
+	req := cns.IPConfigsRequest{
+		PodInterfaceID:   testPod1Info.InterfaceID(),
+		InfraContainerID: testPod1Info.InfraContainerID(),
+	}
+	b, _ := testPod1Info.OrchestratorContext()
+	req.OrchestratorContext = b
+
+	podIPs, err := requestIPConfigsHelper(svc, req)
+	require.NoError(t, err)
+
+	// Should assign 2 IPs (one of each family) of same NC
+	assert.Len(t, podIPs, 2)
+
+	// Verify we got one of each family
+	hasIPv4 := false
+	hasIPv6 := false
+	for _, podIP := range podIPs {
+		ip := net.ParseIP(podIP.PodIPConfig.IPAddress)
+		if ip.To4() != nil {
+			hasIPv4 = true
+		} else {
+			hasIPv6 = true
+		}
+	}
+	assert.True(t, hasIPv4, "Should have IPv4 address")
+	assert.True(t, hasIPv6, "Should have IPv6 address")
+}
+
+func TestIPAMRequestIPConfigsProgrammingPendingFailure(t *testing.T) {
+	svc := getTestService(cns.KubernetesCRD)
+
+	// Add IPv4 NC with available IP
+	ipv4configs := map[string]cns.IPConfigurationStatus{
+		"ipv4-1": NewPodState("10.0.0.1", "ipv4-1", testNCID, types.Available, 0),
+	}
+
+	// Add IPv6 NC with IP initially available
+	ipv6configs := map[string]cns.IPConfigurationStatus{
+		"ipv6-1": NewPodState("2001:db8::1", "ipv6-1", testNCIDv6, types.Available, 0),
+	}
+
+	err := UpdatePodIPConfigState(t, svc, ipv4configs, testNCID)
+	require.NoError(t, err)
+	err = UpdatePodIPConfigState(t, svc, ipv6configs, testNCIDv6)
+	require.NoError(t, err)
+
+	// Manually set IPv6 IP to PendingProgramming state after NC creation
+	ipv6State := svc.PodIPConfigState["ipv6-1"]
+	ipv6State.SetState(types.PendingProgramming)
+	svc.PodIPConfigState["ipv6-1"] = ipv6State
+
+	req := cns.IPConfigsRequest{
+		PodInterfaceID:   testPod1Info.InterfaceID(),
+		InfraContainerID: testPod1Info.InfraContainerID(),
+	}
+	b, _ := testPod1Info.OrchestratorContext()
+	req.OrchestratorContext = b
+
+	_, err = requestIPConfigsHelper(svc, req)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not enough IPs available")
+
+	// Verify no IPs were assigned
+	assignedIPs := svc.GetAssignedIPConfigs()
+	assert.Empty(t, assignedIPs)
+
+	// Verify IPv4 IP is still available and ipv6 is not available as the programming failed
+	availableIPs := svc.GetAvailableIPConfigs()
+	assert.Len(t, availableIPs, 1)
+}
+
 func createAndSaveMockNCRequest(t *testing.T, svc *HTTPRestService, ncID string, orchestratorContext json.RawMessage, desiredIP, mockGatewayIP, mockMACAddress string) {
 	t.Helper()
 

--- a/cns/restserver/ipam_test.go
+++ b/cns/restserver/ipam_test.go
@@ -178,36 +178,46 @@ func updatePnpIDMacAddressState(svc *HTTPRestService) {
 	}
 }
 
-// create an endpoint with only one IP
-func TestEndpointStateReadAndWriteSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestEndpointStateReadAndWrite(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	endpointStateReadAndWrite(t, ncStates)
-}
-
-// create an endpoint with one IP from each NC
-func TestEndpointStateReadAndWriteMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		EndpointStateReadAndWrite(t, ncState)
 	}
-	endpointStateReadAndWrite(t, ncStates)
 }
 
 // Tests the creation of an endpoint using the NCs and IPs as input and then tests the deletion of that endpoint
@@ -282,35 +292,46 @@ func endpointStateReadAndWrite(t *testing.T, ncStates []ncState) {
 }
 
 // assign the available IP to the new pod
-func TestIPAMGetAvailableIPConfigSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMGetAvailableIPConfig(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	ipamGetAvailableIPConfig(t, ncStates)
-}
-
-// assign one IP per NC to the pod
-func TestIPAMGetAvailableIPConfigMultipleNCs(t *testing.T) {
-	nsStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMGetAvailableIPConfig(t, ncState)
 	}
-	ipamGetAvailableIPConfig(t, nsStates)
 }
 
 // Add one IP per NC to the pool and request those IPs
@@ -359,37 +380,51 @@ func ipamGetAvailableIPConfig(t *testing.T, ncStates []ncState) {
 	}
 }
 
-func TestIPAMGetNextAvailableIPConfigSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMGetNextAvailableIPConfig(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+					testIP2v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+					testIP1v6,
+					testIP2v6,
+				},
 			},
 		},
 	}
-	getNextAvailableIPConfig(t, ncStates)
-}
-
-func TestIPAMGetNextAvailableIPConfigMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-				testIP2v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMGetNextAvailableIPConfig(t, ncState)
 	}
-	getNextAvailableIPConfig(t, ncStates)
 }
 
 // First IP is already assigned to a pod, want second IP
@@ -442,34 +477,46 @@ func getNextAvailableIPConfig(t *testing.T, ncStates []ncState) {
 	}
 }
 
-func TestIPAMGetAlreadyAssignedIPConfigForSamePodSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMGetAlreadyAssignedIPConfigForSamePod(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	ipamGetAlreadyAssignedIPConfigForSamePod(t, ncStates)
-}
-
-func TestIPAMGetAlreadyAssignedIPConfigForSamePodMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMGetAlreadyAssignedIPConfigForSamePod(t, ncState)
 	}
-	ipamGetAlreadyAssignedIPConfigForSamePod(t, ncStates)
 }
 
 func ipamGetAlreadyAssignedIPConfigForSamePod(t *testing.T, ncStates []ncState) {
@@ -517,37 +564,51 @@ func ipamGetAlreadyAssignedIPConfigForSamePod(t *testing.T, ncStates []ncState) 
 	}
 }
 
-func TestIPAMAttemptToRequestIPNotFoundInPoolSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMAttemptToRequestIPNotFoundInPool(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+					testIP2v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+					testIP1v6,
+					testIP2v6,
+				},
 			},
 		},
 	}
-	ipamAttemptToRequestIPNotFoundInPool(t, ncStates)
-}
-
-func TestIPAMAttemptToRequestIPNotFoundInPoolMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-				testIP2v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMAttemptToRequestIPNotFoundInPool(t, ncState)
 	}
-	ipamAttemptToRequestIPNotFoundInPool(t, ncStates)
 }
 
 func ipamAttemptToRequestIPNotFoundInPool(t *testing.T, ncStates []ncState) {
@@ -580,34 +641,46 @@ func ipamAttemptToRequestIPNotFoundInPool(t *testing.T, ncStates []ncState) {
 	}
 }
 
-func TestIPAMGetDesiredIPConfigWithSpecfiedIPSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMGetDesiredIPConfigWithSpecfiedIP(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	ipamGetDesiredIPConfigWithSpecfiedIP(t, ncStates)
-}
-
-func TestIPAMGetDesiredIPConfigWithSpecfiedIPMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMGetDesiredIPConfigWithSpecfiedIP(t, ncState)
 	}
-	ipamGetDesiredIPConfigWithSpecfiedIP(t, ncStates)
 }
 
 func ipamGetDesiredIPConfigWithSpecfiedIP(t *testing.T, ncStates []ncState) {
@@ -659,34 +732,46 @@ func ipamGetDesiredIPConfigWithSpecfiedIP(t *testing.T, ncStates []ncState) {
 	}
 }
 
-func TestIPAMFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIPSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIP(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	ipamFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIP(t, ncStates)
-}
-
-func TestIPAMFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIPMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIP(t, ncState)
 	}
-	ipamFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIP(t, ncStates)
 }
 
 func ipamFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIP(t *testing.T, ncStates []ncState) {
@@ -720,37 +805,51 @@ func ipamFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIP(t *testing.T, ncS
 	}
 }
 
-func TestIPAMFailToGetIPWhenAllIPsAreAssignedSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMFailToGetIPWhenAllIPsAreAssigned(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+					testIP2v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+					testIP1v6,
+					testIP2v6,
+				},
 			},
 		},
 	}
-	ipamFailToGetIPWhenAllIPsAreAssigned(t, ncStates)
-}
-
-func TestIPAMFailToGetIPWhenAllIPsAreAssignedMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-				testIP2v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMFailToGetIPWhenAllIPsAreAssigned(t, ncState)
 	}
-	ipamFailToGetIPWhenAllIPsAreAssigned(t, ncStates)
 }
 
 func ipamFailToGetIPWhenAllIPsAreAssigned(t *testing.T, ncStates []ncState) {
@@ -780,34 +879,46 @@ func ipamFailToGetIPWhenAllIPsAreAssigned(t *testing.T, ncStates []ncState) {
 	}
 }
 
-func TestIPAMRequestThenReleaseThenRequestAgainSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMRequestThenReleaseThenRequestAgain(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	ipamRequestThenReleaseThenRequestAgain(t, ncStates)
-}
-
-func TestIPAMRequestThenReleaseThenRequestAgainMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMRequestThenReleaseThenRequestAgain(t, ncState)
 	}
-	ipamRequestThenReleaseThenRequestAgain(t, ncStates)
 }
 
 // 10.0.0.1 = PodInfo1
@@ -889,34 +1000,46 @@ func ipamRequestThenReleaseThenRequestAgain(t *testing.T, ncStates []ncState) {
 	}
 }
 
-func TestIPAMReleaseIPIdempotencySingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMReleaseIPIdempotency(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	ipamReleaseIPIdempotency(t, ncStates)
-}
-
-func TestIPAMReleaseIPIdempotencyMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMReleaseIPIdempotency(t, ncState)
 	}
-	ipamReleaseIPIdempotency(t, ncStates)
 }
 
 func ipamReleaseIPIdempotency(t *testing.T, ncStates []ncState) {
@@ -945,34 +1068,46 @@ func ipamReleaseIPIdempotency(t *testing.T, ncStates []ncState) {
 	}
 }
 
-func TestIPAMAllocateIPIdempotencySingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMAllocateIPIdempotency(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	ipamAllocateIPIdempotency(t, ncStates)
-}
-
-func TestIPAMAllocateIPIdempotencyMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMAllocateIPIdempotency(t, ncState)
 	}
-	ipamAllocateIPIdempotency(t, ncStates)
 }
 
 func ipamAllocateIPIdempotency(t *testing.T, ncStates []ncState) {
@@ -994,40 +1129,56 @@ func ipamAllocateIPIdempotency(t *testing.T, ncStates []ncState) {
 	}
 }
 
-func TestAvailableIPConfigsSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestAvailableIPConfigs(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
-				testIP3,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+					testIP3,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+					testIP3,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+					testIP2v6,
+					testIP3v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+					testIP3,
+					testIP1v6,
+					testIP2v6,
+					testIP3v6,
+				},
 			},
 		},
 	}
-	availableIPConfigs(t, ncStates)
-}
-
-func TestAvailableIPConfigsMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
-				testIP3,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-				testIP2v6,
-				testIP3v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		AvailableIPConfigs(t, ncState)
 	}
-	availableIPConfigs(t, ncStates)
 }
 
 func availableIPConfigs(t *testing.T, ncStates []ncState) {
@@ -1113,34 +1264,46 @@ func validateIpState(t *testing.T, actualIps []cns.IPConfigurationStatus, expect
 	}
 }
 
-func TestIPAMMarkIPCountAsPendingSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMMarkIPCountAsPending(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP1v6,
+				},
 			},
 		},
 	}
-	ipamMarkIPCountAsPending(t, ncStates)
-}
-
-func TestIPAMMarkIPCountAsPendingMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMMarkIPCountAsPending(t, ncState)
 	}
-	ipamMarkIPCountAsPending(t, ncStates)
 }
 
 func ipamMarkIPCountAsPending(t *testing.T, ncStates []ncState) {
@@ -1272,37 +1435,51 @@ func constructSecondaryIPConfigs(ipAddress, uuid string, ncVersion int, secondar
 	secondaryIPConfigs[uuid] = secIPConfig
 }
 
-func TestIPAMMarkExistingIPConfigAsPendingSingleNC(t *testing.T) {
-	ncStates := []ncState{
+func TestIPAMMarkExistingIPConfigAsPending(t *testing.T) {
+	testNcs := [][]ncState{
+		// single stack NC
 		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+				},
+			},
+		},
+		// two NCs (one V4 and one V6)
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+				},
+			},
+			{
+				ncID: testNCIDv6,
+				ips: []string{
+					testIP1v6,
+					testIP2v6,
+				},
+			},
+		},
+		// dualstack NC
+		{
+			{
+				ncID: testNCID,
+				ips: []string{
+					testIP1,
+					testIP2,
+					testIP1v6,
+					testIP2v6,
+				},
 			},
 		},
 	}
-	ipamMarkExistingIPConfigAsPending(t, ncStates)
-}
-
-func TestIPAMMarkExistingIPConfigAsPendingMultipleNCs(t *testing.T) {
-	ncStates := []ncState{
-		{
-			ncID: testNCID,
-			ips: []string{
-				testIP1,
-				testIP2,
-			},
-		},
-		{
-			ncID: testNCIDv6,
-			ips: []string{
-				testIP1v6,
-				testIP2v6,
-			},
-		},
+	for _, ncState := range testNcs {
+		IPAMMarkExistingIPConfigAsPending(t, ncState)
 	}
-	ipamMarkExistingIPConfigAsPending(t, ncStates)
 }
 
 func ipamMarkExistingIPConfigAsPending(t *testing.T, ncStates []ncState) {
@@ -1433,27 +1610,32 @@ func TestIPAMReleaseOneIPWhenExpectedToHaveTwo(t *testing.T) {
 
 func TestIPAMFailToRequestOneIPWhenExpectedToHaveTwo(t *testing.T) {
 	svc := getTestService(cns.KubernetesCRD)
-
 	// set state as already assigned
-	testState := newPodState(testIP1, ipIDs[0][0], testNCID, types.Available, 0)
+	testState1, _ := NewPodStateWithOrchestratorContext(testIP1, testIPID1, testNCID, types.Assigned, 24, 0, testPod1Info)
+	testState2 := NewPodState(testIP2, testIPID2, testNCID, types.Available, 0)
 	ipconfigs := map[string]cns.IPConfigurationStatus{
-		testState.ID: testState,
+		testState1.ID: testState1,
+		testState2.ID: testState2,
 	}
-	emptyIpconfigs := map[string]cns.IPConfigurationStatus{}
+	testState1v6, _ := NewPodStateWithOrchestratorContext(testIP1v6, testIPID1v6, testNCIDv6, types.Assigned, 120, 0, testPod1Info)
+	// setting v6 IPs to Assigned so there are none available
+	ipconfigsV6 := map[string]cns.IPConfigurationStatus{
+		testState1v6.ID: testState1v6,
+	}
 
 	err := updatePodIPConfigState(t, svc, ipconfigs, testNCID)
 	if err != nil {
 		t.Fatalf("Expected to not fail adding IPs to state: %+v", err)
 	}
 
-	err = updatePodIPConfigState(t, svc, emptyIpconfigs, testNCIDv6)
+	err = UpdatePodIPConfigState(t, svc, ipconfigsV6, testNCIDv6)
 	if err != nil {
 		t.Fatalf("Expected to not fail adding empty NC to state: %+v", err)
 	}
 
 	// request should expect 2 IPs but there is only 1 in the pool
 	req := cns.IPConfigsRequest{}
-	b, _ := testPod1Info.OrchestratorContext()
+	b, _ := testPod2Info.OrchestratorContext()
 	req.OrchestratorContext = b
 
 	_, err = requestIPAddressAndGetState(t, req)

--- a/cns/restserver/ipam_test.go
+++ b/cns/restserver/ipam_test.go
@@ -91,7 +91,7 @@ func newSecondaryIPConfig(ipAddress string, ncVersion int) cns.SecondaryIPConfig
 	}
 }
 
-func newPodState(ipaddress, id, ncid string, state types.IPState, ncVersion int) cns.IPConfigurationStatus { //nolint:unparam // ignore unused parameter
+func newPodState(ipaddress, id, ncid string, state types.IPState, ncVersion int) cns.IPConfigurationStatus {
 	ipconfig := newSecondaryIPConfig(ipaddress, ncVersion)
 	status := &cns.IPConfigurationStatus{
 		IPAddress: ipconfig.IPAddress,
@@ -131,8 +131,7 @@ func requestIPAddressAndGetState(t *testing.T, req cns.IPConfigsRequest) ([]cns.
 	return ipConfigStatus, nil
 }
 
-// nolint:unparam // ignore unused inputs
-func newPodStateWithOrchestratorContext(ipaddress, id, ncid string, state types.IPState, _ uint8, ncVersion int, podInfo cns.PodInfo) (cns.IPConfigurationStatus, error) {
+func newPodStateWithOrchestratorContext(ipaddress, id, ncid string, state types.IPState, prefixLength uint8, ncVersion int, podInfo cns.PodInfo) (cns.IPConfigurationStatus, error) {
 	ipconfig := newSecondaryIPConfig(ipaddress, ncVersion)
 	status := &cns.IPConfigurationStatus{
 		IPAddress: ipconfig.IPAddress,
@@ -145,7 +144,6 @@ func newPodStateWithOrchestratorContext(ipaddress, id, ncid string, state types.
 }
 
 // Test function to populate the IPConfigState
-// nolint: unparam // ignore unused return
 func updatePodIPConfigState(t *testing.T, svc *HTTPRestService, ipconfigs map[string]cns.IPConfigurationStatus, ncID string) error {
 	// Create the NC
 	secondaryIPConfigs := make(map[string]cns.SecondaryIPConfig)
@@ -216,7 +214,7 @@ func TestEndpointStateReadAndWrite(t *testing.T) {
 		},
 	}
 	for _, ncState := range testNcs {
-		EndpointStateReadAndWrite(t, ncState)
+		endpointStateReadAndWrite(t, ncState)
 	}
 }
 
@@ -330,7 +328,7 @@ func TestIPAMGetAvailableIPConfig(t *testing.T) {
 		},
 	}
 	for _, ncState := range testNcs {
-		IPAMGetAvailableIPConfig(t, ncState)
+		ipamGetAvailableIPConfig(t, ncState)
 	}
 }
 
@@ -423,7 +421,7 @@ func TestIPAMGetNextAvailableIPConfig(t *testing.T) {
 		},
 	}
 	for _, ncState := range testNcs {
-		IPAMGetNextAvailableIPConfig(t, ncState)
+		getNextAvailableIPConfig(t, ncState)
 	}
 }
 
@@ -515,7 +513,7 @@ func TestIPAMGetAlreadyAssignedIPConfigForSamePod(t *testing.T) {
 		},
 	}
 	for _, ncState := range testNcs {
-		IPAMGetAlreadyAssignedIPConfigForSamePod(t, ncState)
+		ipamGetAlreadyAssignedIPConfigForSamePod(t, ncState)
 	}
 }
 
@@ -607,7 +605,7 @@ func TestIPAMAttemptToRequestIPNotFoundInPool(t *testing.T) {
 		},
 	}
 	for _, ncState := range testNcs {
-		IPAMAttemptToRequestIPNotFoundInPool(t, ncState)
+		ipamAttemptToRequestIPNotFoundInPool(t, ncState)
 	}
 }
 
@@ -679,7 +677,7 @@ func TestIPAMGetDesiredIPConfigWithSpecfiedIP(t *testing.T) {
 		},
 	}
 	for _, ncState := range testNcs {
-		IPAMGetDesiredIPConfigWithSpecfiedIP(t, ncState)
+		ipamGetDesiredIPConfigWithSpecfiedIP(t, ncState)
 	}
 }
 
@@ -770,7 +768,7 @@ func TestIPAMFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIP(t *testing.T)
 		},
 	}
 	for _, ncState := range testNcs {
-		IPAMFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIP(t, ncState)
+		ipamFailToGetDesiredIPConfigWithAlreadyAssignedSpecfiedIP(t, ncState)
 	}
 }
 
@@ -848,7 +846,7 @@ func TestIPAMFailToGetIPWhenAllIPsAreAssigned(t *testing.T) {
 		},
 	}
 	for _, ncState := range testNcs {
-		IPAMFailToGetIPWhenAllIPsAreAssigned(t, ncState)
+		ipamFailToGetIPWhenAllIPsAreAssigned(t, ncState)
 	}
 }
 
@@ -917,7 +915,7 @@ func TestIPAMRequestThenReleaseThenRequestAgain(t *testing.T) {
 		},
 	}
 	for _, ncState := range testNcs {
-		IPAMRequestThenReleaseThenRequestAgain(t, ncState)
+		ipamRequestThenReleaseThenRequestAgain(t, ncState)
 	}
 }
 
@@ -1038,7 +1036,7 @@ func TestIPAMReleaseIPIdempotency(t *testing.T) {
 		},
 	}
 	for _, ncState := range testNcs {
-		IPAMReleaseIPIdempotency(t, ncState)
+		ipamReleaseIPIdempotency(t, ncState)
 	}
 }
 
@@ -1106,7 +1104,7 @@ func TestIPAMAllocateIPIdempotency(t *testing.T) {
 		},
 	}
 	for _, ncState := range testNcs {
-		IPAMAllocateIPIdempotency(t, ncState)
+		ipamAllocateIPIdempotency(t, ncState)
 	}
 }
 
@@ -1177,7 +1175,7 @@ func TestAvailableIPConfigs(t *testing.T) {
 		},
 	}
 	for _, ncState := range testNcs {
-		AvailableIPConfigs(t, ncState)
+		availableIPConfigs(t, ncState)
 	}
 }
 
@@ -1302,7 +1300,7 @@ func TestIPAMMarkIPCountAsPending(t *testing.T) {
 		},
 	}
 	for _, ncState := range testNcs {
-		IPAMMarkIPCountAsPending(t, ncState)
+		ipamMarkIPCountAsPending(t, ncState)
 	}
 }
 
@@ -1478,7 +1476,7 @@ func TestIPAMMarkExistingIPConfigAsPending(t *testing.T) {
 		},
 	}
 	for _, ncState := range testNcs {
-		IPAMMarkExistingIPConfigAsPending(t, ncState)
+		ipamMarkExistingIPConfigAsPending(t, ncState)
 	}
 }
 
@@ -1611,13 +1609,13 @@ func TestIPAMReleaseOneIPWhenExpectedToHaveTwo(t *testing.T) {
 func TestIPAMFailToRequestOneIPWhenExpectedToHaveTwo(t *testing.T) {
 	svc := getTestService(cns.KubernetesCRD)
 	// set state as already assigned
-	testState1, _ := NewPodStateWithOrchestratorContext(testIP1, testIPID1, testNCID, types.Assigned, 24, 0, testPod1Info)
-	testState2 := NewPodState(testIP2, testIPID2, testNCID, types.Available, 0)
+	testState1, _ := newPodStateWithOrchestratorContext(testIP1, testIPID1, testNCID, types.Assigned, 24, 0, testPod1Info)
+	testState2 := newPodState(testIP2, testIPID2, testNCID, types.Available, 0)
 	ipconfigs := map[string]cns.IPConfigurationStatus{
 		testState1.ID: testState1,
 		testState2.ID: testState2,
 	}
-	testState1v6, _ := NewPodStateWithOrchestratorContext(testIP1v6, testIPID1v6, testNCIDv6, types.Assigned, 120, 0, testPod1Info)
+	testState1v6, _ := newPodStateWithOrchestratorContext(testIP1v6, testIPID1v6, testNCIDv6, types.Assigned, 120, 0, testPod1Info)
 	// setting v6 IPs to Assigned so there are none available
 	ipconfigsV6 := map[string]cns.IPConfigurationStatus{
 		testState1v6.ID: testState1v6,
@@ -1628,7 +1626,7 @@ func TestIPAMFailToRequestOneIPWhenExpectedToHaveTwo(t *testing.T) {
 		t.Fatalf("Expected to not fail adding IPs to state: %+v", err)
 	}
 
-	err = UpdatePodIPConfigState(t, svc, ipconfigsV6, testNCIDv6)
+	err = updatePodIPConfigState(t, svc, ipconfigsV6, testNCIDv6)
 	if err != nil {
 		t.Fatalf("Expected to not fail adding empty NC to state: %+v", err)
 	}
@@ -2315,13 +2313,13 @@ func TestIPAMRequestIPConfigsTwoFamiliesSameNC(t *testing.T) {
 
 	// Add single NC with both IPv4 and IPv6 IPs
 	mixedConfigs := map[string]cns.IPConfigurationStatus{
-		"ipv4-1": NewPodState("10.0.0.1", "ipv4-1", testNCID, types.Available, 0),
-		"ipv4-2": NewPodState("10.0.0.2", "ipv4-2", testNCID, types.Available, 0),
-		"ipv6-1": NewPodState("2001:db8::1", "ipv6-1", testNCID, types.Available, 0),
-		"ipv6-2": NewPodState("2001:db8::2", "ipv6-2", testNCID, types.Available, 0),
+		"ipv4-1": newPodState("10.0.0.1", "ipv4-1", testNCID, types.Available, 0),
+		"ipv4-2": newPodState("10.0.0.2", "ipv4-2", testNCID, types.Available, 0),
+		"ipv6-1": newPodState("2001:db8::1", "ipv6-1", testNCID, types.Available, 0),
+		"ipv6-2": newPodState("2001:db8::2", "ipv6-2", testNCID, types.Available, 0),
 	}
 
-	err := UpdatePodIPConfigState(t, svc, mixedConfigs, testNCID)
+	err := updatePodIPConfigState(t, svc, mixedConfigs, testNCID)
 	require.NoError(t, err)
 
 	req := cns.IPConfigsRequest{
@@ -2357,17 +2355,17 @@ func TestIPAMRequestIPConfigsProgrammingPendingFailure(t *testing.T) {
 
 	// Add IPv4 NC with available IP
 	ipv4configs := map[string]cns.IPConfigurationStatus{
-		"ipv4-1": NewPodState("10.0.0.1", "ipv4-1", testNCID, types.Available, 0),
+		"ipv4-1": newPodState("10.0.0.1", "ipv4-1", testNCID, types.Available, 0),
 	}
 
 	// Add IPv6 NC with IP initially available
 	ipv6configs := map[string]cns.IPConfigurationStatus{
-		"ipv6-1": NewPodState("2001:db8::1", "ipv6-1", testNCIDv6, types.Available, 0),
+		"ipv6-1": newPodState("2001:db8::1", "ipv6-1", testNCIDv6, types.Available, 0),
 	}
 
-	err := UpdatePodIPConfigState(t, svc, ipv4configs, testNCID)
+	err := updatePodIPConfigState(t, svc, ipv4configs, testNCID)
 	require.NoError(t, err)
-	err = UpdatePodIPConfigState(t, svc, ipv6configs, testNCIDv6)
+	err = updatePodIPConfigState(t, svc, ipv6configs, testNCIDv6)
 	require.NoError(t, err)
 
 	// Manually set IPv6 IP to PendingProgramming state after NC creation

--- a/cns/restserver/ipam_test.go
+++ b/cns/restserver/ipam_test.go
@@ -91,7 +91,7 @@ func newSecondaryIPConfig(ipAddress string, ncVersion int) cns.SecondaryIPConfig
 	}
 }
 
-func newPodState(ipaddress, id, ncid string, state types.IPState, ncVersion int) cns.IPConfigurationStatus {
+func newPodState(ipaddress, id, ncid string, state types.IPState, ncVersion int) cns.IPConfigurationStatus { //nolint:unparam // ignore unused parameter
 	ipconfig := newSecondaryIPConfig(ipaddress, ncVersion)
 	status := &cns.IPConfigurationStatus{
 		IPAddress: ipconfig.IPAddress,
@@ -131,7 +131,8 @@ func requestIPAddressAndGetState(t *testing.T, req cns.IPConfigsRequest) ([]cns.
 	return ipConfigStatus, nil
 }
 
-func newPodStateWithOrchestratorContext(ipaddress, id, ncid string, state types.IPState, prefixLength uint8, ncVersion int, podInfo cns.PodInfo) (cns.IPConfigurationStatus, error) {
+// nolint:unparam // ignore unused inputs
+func newPodStateWithOrchestratorContext(ipaddress, id, ncid string, state types.IPState, _ uint8, ncVersion int, podInfo cns.PodInfo) (cns.IPConfigurationStatus, error) {
 	ipconfig := newSecondaryIPConfig(ipaddress, ncVersion)
 	status := &cns.IPConfigurationStatus{
 		IPAddress: ipconfig.IPAddress,
@@ -144,6 +145,7 @@ func newPodStateWithOrchestratorContext(ipaddress, id, ncid string, state types.
 }
 
 // Test function to populate the IPConfigState
+// nolint: unparam // ignore unused return
 func updatePodIPConfigState(t *testing.T, svc *HTTPRestService, ipconfigs map[string]cns.IPConfigurationStatus, ncID string) error {
 	// Create the NC
 	secondaryIPConfigs := make(map[string]cns.SecondaryIPConfig)
@@ -2381,7 +2383,7 @@ func TestIPAMRequestIPConfigsProgrammingPendingFailure(t *testing.T) {
 	req.OrchestratorContext = b
 
 	_, err = requestIPConfigsHelper(svc, req)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not enough IPs available")
 
 	// Verify no IPs were assigned

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -845,6 +845,7 @@ func (service *HTTPRestService) populateIPConfigInfoUntransacted(ipConfigStatus 
 	podIPInfo.HostPrimaryIPInfo.PrimaryIP = primaryHostInterface.PrimaryIP
 	podIPInfo.HostPrimaryIPInfo.Subnet = primaryHostInterface.Subnet
 	podIPInfo.HostPrimaryIPInfo.Gateway = primaryHostInterface.Gateway
+	podIPInfo.MacAddress = ncStatus.CreateNetworkContainerRequest.NetworkInterfaceInfo.MACAddress
 	podIPInfo.NICType = cns.InfraNIC
 
 	return nil

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1311,13 +1311,7 @@ type ipamStateReconciler interface {
 
 // TODO(rbtr) where should this live??
 // reconcileInitialCNSState initializes cns by passing pods and a CreateNetworkContainerRequest
-func reconcileInitialCNSState(
-	ctx context.Context,
-	cli nodeNetworkConfigGetter,
-	ipamReconciler ipamStateReconciler,
-	podInfoByIPProvider cns.PodInfoByIPProvider,
-	config *configuration.CNSConfig,
-) error {
+func reconcileInitialCNSState(ctx context.Context, cli nodeNetworkConfigGetter, ipamReconciler ipamStateReconciler, podInfoByIPProvider cns.PodInfoByIPProvider, isSwiftV2 bool) error {
 	// Get nnc using direct client
 	nnc, err := cli.Get(ctx)
 	if err != nil {
@@ -1356,7 +1350,7 @@ func reconcileInitialCNSState(
 		)
 		switch nnc.Status.NetworkContainers[i].AssignmentMode { //nolint:exhaustive // skipping dynamic case
 		case v1alpha.Static:
-			ncRequest, err = nncctrl.CreateNCRequestFromStaticNC(nnc.Status.NetworkContainers[i], config)
+			ncRequest, err = nncctrl.CreateNCRequestFromStaticNC(nnc.Status.NetworkContainers[i], isSwiftV2)
 		default: // For backward compatibility, default will be treated as Dynamic too.
 			ncRequest, err = nncctrl.CreateNCRequestFromDynamicNC(nnc.Status.NetworkContainers[i])
 		}
@@ -1464,7 +1458,7 @@ func InitializeCRDState(ctx context.Context, z *zap.Logger, httpRestService cns.
 	_ = retry.Do(func() error {
 		attempt++
 		logger.Printf("reconciling initial CNS state attempt: %d", attempt)
-		err = reconcileInitialCNSState(ctx, directscopedcli, httpRestServiceImplementation, podInfoByIPProvider, cnsconfig)
+		err = reconcileInitialCNSState(ctx, directscopedcli, httpRestServiceImplementation, podInfoByIPProvider, cnsconfig.EnableSwiftV2)
 		if err != nil {
 			logger.Errorf("failed to reconcile initial CNS state, attempt: %d err: %v", attempt, err)
 			nncInitFailure.Inc()
@@ -1561,7 +1555,7 @@ func InitializeCRDState(ctx context.Context, z *zap.Logger, httpRestService cns.
 
 	// get CNS Node IP to compare NC Node IP with this Node IP to ensure NCs were created for this node
 	nodeIP := configuration.NodeIP()
-	nncReconciler := nncctrl.NewReconciler(httpRestServiceImplementation, poolMonitor, nodeIP, cnsconfig)
+	nncReconciler := nncctrl.NewReconciler(httpRestServiceImplementation, poolMonitor, nodeIP, cnsconfig.EnableSwiftV2)
 	// pass Node to the Reconciler for Controller xref
 	// IPAMv1 - reconcile only status changes (where generation doesn't change).
 	// IPAMv2 - reconcile all updates.


### PR DESCRIPTION
**Reason for Change**:
Current Problem: 
VNET currently limits scaling to 64K IP addresses per VNET due to per-IP route mappings. To support larger AKS clusters, the platform is introducing per-prefix (CIDR) route mapping, allowing a single mapping to represent multiple IPs (e.g., /24 enables 256 IPs per mapping). This enables scaling up to 16 million IPs per VNET without impacting the underlying platform.

Change needed:
Prefix on NIC v4 is supported in Swiftv1, but Swiftv1 does not support IPv6. This change upgrades Prefix on NIC v4 functionality to Swiftv2 and introduces IPv6 support in Swiftv2.

Changes
This PR has changes specific to Prefix on NICv6
CNS
--Consuming PrimaryIPv6, GatewayIPv6, MacAddress (DelegatedNIC) from NNC CRD because of dualstack NC
--IP allocation: Assign IPs of each IPFamily as part of RequestIPs api request (Currently when a pod is created, IPAM RequestsIPs from CNS where CNS picks one IP from each NC and hands it over to IPAM. 

IPAM
--Change RequestIPs response parsing to read GatewayIPv6 and MacAddress
--Populates Interfaces with MacAddress which is used by CNI to plumb routes to send traffic

[Design doc for pocv6 with sample NNC](https://microsoft.sharepoint.com/:w:/t/Aznet/EZy1F1lEUZpNiPwk6JsUtvcBHapTeO4yNEI6EMUxjElXnA?e=hNT4PN)
**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests
- [ ] relevant PR labels added

**Notes**:
