### PR TITLE
Add HomeAZ to NodeInfoStatus

### DIFF
--- a/crd/multitenancy/api/v1alpha1/nodeinfo.go
+++ b/crd/multitenancy/api/v1alpha1/nodeinfo.go
@@ -47,6 +47,10 @@ type NodeInfoStatus struct {
 type DeviceInfo struct {
 	DeviceType DeviceType `json:"deviceType,omitempty"`
 	MacAddress string     `json:"macAddress"`
+
+	// +kubebuilder:validation:optional
+	// +kubebuilder:validation:Pattern=`^AZ\d{2}$`
+	HomeAZ string `json:"homeAZ,omitempty"`
 }
 
 func init() {

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_nodeinfo.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_nodeinfo.yaml
@@ -59,6 +59,9 @@ spec:
                       - acn.azure.com/vnet-nic
                       - acn.azure.com/infiniband-nic
                       type: string
+                    homeAZ:
+                      pattern: ^AZ\d{2}$
+                      type: string
                     macAddress:
                       type: string
                   required:


### PR DESCRIPTION
In service of adding HomeAZ awareness to apiserver-vnet-integration, this adds HomeAZ to the NodeInfoStatus portion of the NodeInfo CRD. Similar to other elements of NodeInfoStatus, HomeAZ is an optional property of a node that can be communicated. If present, it strictly follows the AZXX format, where XX are two 0-9 integers.
