### PR TITLE
fix: [NPM] Update Ubuntu Base Image to 24.04

### DIFF
--- a/npm/linux.Dockerfile
+++ b/npm/linux.Dockerfile
@@ -6,8 +6,8 @@ WORKDIR /usr/local/src
 COPY . .
 RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm -ldflags "-X main.version="$VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" -gcflags="-dwarflocationlists=true" npm/cmd/*.go
 
-FROM mcr.microsoft.com/mirror/docker/library/ubuntu:20.04 as linux
+FROM mcr.microsoft.com/mirror/docker/library/ubuntu:24.04 as linux
 COPY --from=builder /usr/local/bin/azure-npm /usr/bin/azure-npm
-RUN apt-get update && apt-get install -y iptables ipset ca-certificates && apt-get autoremove -y && apt-get clean
+RUN apt-get update && apt-get install -y libsystemd0=255.4-1ubuntu8.8 libudev1=255.4-1ubuntu8.8 iptables ipset ca-certificates && apt-get autoremove -y && apt-get clean
 RUN chmod +x /usr/bin/azure-npm
 ENTRYPOINT ["/usr/bin/azure-npm", "start"]


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
Bumps the NPM Ubuntu base image version from `20.04` to `24.04` as `20.04` is EOL and no longer supported (https://ubuntu.com/blog/ubuntu-20-04-lts-end-of-life-standard-support-is-coming-to-an-end-heres-how-to-prepare).

Manually updates the Ubuntu packages `libsystemd0` and `libudev1` to `255.4-1ubuntu8.8` or else `CVE-2025-4598` is present in the image (Will revert later when base image updates packages to resolve the vulnerability):

```
acnpublic.azurecr.io/azure-npm:v1.6.26Test (ubuntu 24.04)
=========================================================
Total: 2 (UNKNOWN: 0, LOW: 0, MEDIUM: 2, HIGH: 0, CRITICAL: 0)

┌─────────────┬───────────────┬──────────┬────────┬───────────────────┬──────────────────┬──────────────────────────────────────────────────────┐
│   Library   │ Vulnerability │ Severity │ Status │ Installed Version │  Fixed Version   │                        Title                         │
├─────────────┼───────────────┼──────────┼────────┼───────────────────┼──────────────────┼──────────────────────────────────────────────────────┤
│ libsystemd0 │ CVE-2025-4598 │ MEDIUM   │ fixed  │ 255.4-1ubuntu8.6  │ 255.4-1ubuntu8.8 │ systemd-coredump: race condition that allows a local │
│             │               │          │        │                   │                  │ attacker to crash a SUID...                          │
│             │               │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2025-4598            │
├─────────────┤               │          │        │                   │                  │                                                      │
│ libudev1    │               │          │        │                   │                  │                                                      │
│             │               │          │        │                   │                  │                                                      │
│             │               │          │        │                   │                  │                                                      │
└─────────────┴───────────────┴──────────┴────────┴───────────────────┴──────────────────┴──────────────────────────────────────────────────────┘
```

Trivy scan of NPM linux with changes to dockerfile (with manual package updates):

```
acnpublic.azurecr.io/azure-npm:v1.6.26Test2 (ubuntu 24.04)
==========================================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

**Tests Ran**:
- [Conformance](https://msazure.visualstudio.com/One/_build/results?buildId=127569481&view=results)
- [Scale](https://msazure.visualstudio.com/One/_build/results?buildId=127560669&view=results)
- [Cyclonus](https://github.com/Azure/azure-container-networking/actions/runs/15714472025)
- [Cyclonus-Extended](https://github.com/Azure/azure-container-networking/actions/runs/15714473162)


**Issue Fixed**:
```

mcr.microsoft.com/containernetworking/azure-npm:v1.5.48 (ubuntu 20.04)
======================================================================
Total: 2 (UNKNOWN: 0, LOW: 0, MEDIUM: 2, HIGH: 0, CRITICAL: 0)

┌──────────┬───────────────┬──────────┬────────┬───────────────────┬──────────────────┬───────────────────────────────────────────────────────────┐
│ Library  │ Vulnerability │ Severity │ Status │ Installed Version │  Fixed Version   │                           Title                           │
├──────────┼───────────────┼──────────┼────────┼───────────────────┼──────────────────┼───────────────────────────────────────────────────────────┤
│ libc-bin │ CVE-2025-4802 │ MEDIUM   │ fixed  │ 2.31-0ubuntu9.17  │ 2.31-0ubuntu9.18 │ glibc: static setuid binary dlopen may incorrectly search │
│          │               │          │        │                   │                  │ LD_LIBRARY_PATH                                           │
│          │               │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2025-4802                 │
├──────────┤               │          │        │                   │                  │                                                           │
│ libc6    │               │          │        │                   │                  │                                                           │
│          │               │          │        │                   │                  │                                                           │
│          │               │          │        │                   │                  │                                                           │
└──────────┴───────────────┴──────────┴────────┴───────────────────┴──────────────────┴───────────────────────────────────────────────────────────┘

usr/bin/azure-npm (gobinary)
============================
Total: 3 (UNKNOWN: 0, LOW: 0, MEDIUM: 2, HIGH: 1, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬──────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                            Title                             │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼──────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-22874 │ HIGH     │ fixed  │ v1.23.9           │ 1.23.10, 1.24.4 │ crypto/x509: Usage of ExtKeyUsageAny disables policy         │
│         │                │          │        │                   │                 │ validation in crypto/x509                                    │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-22874                   │
│         ├────────────────┼──────────┤        │                   │                 ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-0913  │ MEDIUM   │        │                   │                 │ Inconsistent handling of O_CREATE|O_EXCL on Unix and Windows │
│         │                │          │        │                   │                 │ in os in syscall...                                          │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-0913                    │
│         ├────────────────┤          │        │                   │                 ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-4673  │          │        │                   │                 │ Proxy-Authorization and Proxy-Authenticate headers persisted │
│         │                │          │        │                   │                 │ on cross- ...                                                │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-4673                    │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴──────────────────────────────────────────────────────────────┘

```

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [x] relevant PR labels added

**Notes**:
Releasing from `release/v1.6` branch instead of `release/v1.5` due to Ubuntu base image update as well as v1.5 will be not be supported soon (due to k8s dependencies not matching with our offerings as it is tied to 1.27-1.29).