### PR TITLE
[Service Tags] ci: Update ACN to use Virtual Tags

### DIFF
--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -19,7 +19,7 @@ OS_SKU_WIN           ?= Windows2022
 REGION               ?= westus2
 VM_SIZE	             ?= Standard_B2s
 VM_SIZE_WIN          ?= Standard_B2s
-IP_TAG               ?= FirstPartyUsage=/DelegatedNetworkControllerTest
+IP_TAG               ?= FirstPartyUsage=/NonProd
 IP_PREFIX            ?= serviceTaggedIp
 PUBLIC_IP_ID         ?= /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/publicIPAddresses
 PUBLIC_IPv4          ?= $(PUBLIC_IP_ID)/$(IP_PREFIX)-$(CLUSTER)-v4


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Added virtual tags to all public ips. This change updates the previously added service tags ([in this PR](https://github.com/Azure/azure-container-networking/pull/3277)) to virtual tags since the public ips in these scenarios don't use NSGs, NSPs, or ACLs.

**Testing**:
Tested changes in a couple of pipelines:

[Cilium Nightly Pipeline](https://msazure.visualstudio.com/One/_build/results?buildId=127725784&view=results)
Seems like all runs of this pipeline are currently failing but cluster creation (the main concern here) is happening successfully

[CNI Release Test](https://msazure.visualstudio.com/One/_build/results?buildId=127803066&view=results)
A few scenarios are failing across all pipelines because of region capacity I believe. The remaining regions look okay for the most part.

[ACN PR](https://dev.azure.com/msazure/One/_build/results?buildId=127753942&view=results)

[CNI-LSG Integration](https://msazure.visualstudio.com/One/_build/results?buildId=127725810&view=results)
Was not expecting this test to pass -- just looking for successful cluster creation
