### PR TITLE
ci: add azure ipam and azure ip masq merger uts to pipeline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,10 +7,12 @@
 # review a PR in an area.
 #
 # Rules are evaluated in this order, and the last match is used for auto-assignment.
-*           @azure/azure-sdn-members
-/.github/   @azure/acn-admins
-/cns/       @azure/acn-cns-reviewers
-/cni/       @azure/acn-cni-reviewers
-/dropgz/    @rbtr @camrynl @paulyufan2 @ashvindeodhar @thatmattlong
-/npm/       @azure/acn-npm-reviewers
-/zapai/     @rbtr @ZetaoZhuang
+*                       @azure/azure-sdn-members
+/.github/               @azure/acn-admins
+/cns/                   @azure/acn-cns-reviewers
+/cni/                   @azure/acn-cni-reviewers
+/dropgz/                @rbtr @camrynl @paulyufan2 @ashvindeodhar @thatmattlong
+/npm/                   @azure/acn-npm-reviewers
+/zapai/                 @rbtr @ZetaoZhuang
+/bpf-prog/              @camrynl
+/azure-ip-masq-merger/  @QxBytes @santhoshmprabhu

--- a/.pipelines/templates/run-unit-tests.yaml
+++ b/.pipelines/templates/run-unit-tests.yaml
@@ -25,8 +25,10 @@ stages:
                   } 3>&1;
                 } | { read xs; exit $xs; }
               } 4>&1
-
-              mv coverage-all.out linux-coverage.out
+              
+              # combine coverage from multiple modules
+              (echo "mode: atomic"; tail -q -n +2 coverage-*.out) > coverage.cover
+              mv coverage.cover linux-coverage.out
             retryCountOnTaskFailure: 3
             name: "Test"
             displayName: "Run Tests"
@@ -75,6 +77,9 @@ stages:
               artifact: 'linux-coverage'
               path: './'
           - bash: |
+              # use go work to include multiple modules or gocov will omit results from those modules
+              make workspace
+
               make tools
               sudo ln -s $(pwd)/build/tools/bin/gocov /usr/local/bin/gocov
               sudo ln -s $(pwd)/build/tools/bin/gocov-xml /usr/local/bin/gocov-xml

--- a/Makefile
+++ b/Makefile
@@ -827,6 +827,7 @@ test-all: test-azure-ipam test-azure-ip-masq-merger test-main ## run all unit te
 
 test-main: 
 	go test -mod=readonly -buildvcs=false -tags "unit" --skip 'TestE2E*' -race -covermode atomic -coverprofile=coverage-main.out $(COVER_PKG)/...
+	go tool cover -func=coverage-main.out
 
 test-integration: ## run all integration tests.
 	AZURE_IPAM_VERSION=$(AZURE_IPAM_VERSION) \
@@ -857,10 +858,10 @@ test-extended-cyclonus: ## run the cyclonus test for npm.
 	cd ..
 
 test-azure-ipam: ## run the unit test for azure-ipam
-	cd $(AZURE_IPAM_DIR) && go test -race -covermode atomic -coverprofile=../coverage-azure-ipam.out
+	cd $(AZURE_IPAM_DIR) && go test -race -covermode atomic -coverprofile=../coverage-azure-ipam.out && go tool cover -func=../coverage-azure-ipam.out
 
 test-azure-ip-masq-merger: ## run the unit test for azure-ip-masq-merger
-	cd $(AZURE_IP_MASQ_MERGER_DIR) && go test -race -covermode atomic -coverprofile=../coverage-azure-ip-masq-merger.out
+	cd $(AZURE_IP_MASQ_MERGER_DIR) && go test -race -covermode atomic -coverprofile=../coverage-azure-ip-masq-merger.out && go tool cover -func=../coverage-azure-ip-masq-merger.out
 
 kind:
 	kind create cluster --config ./test/kind/kind.yaml

--- a/Makefile
+++ b/Makefile
@@ -810,6 +810,7 @@ workspace: ## Set up the Go workspace.
 	go work init
 	go work use .
 	go work use ./azure-ipam
+	go work use ./azure-ip-masq-merger
 	go work use ./build/tools
 	go work use ./dropgz
 	go work use ./zapai
@@ -822,9 +823,10 @@ RESTART_CASE ?= false
 # CNI type is a key to direct the types of state validation done on a cluster.
 CNI_TYPE ?= cilium
 
-test-all: ## run all unit tests.
-	go test -mod=readonly -buildvcs=false -tags "unit" --skip 'TestE2E*' -race -covermode atomic -coverprofile=coverage-all.out $(COVER_PKG)/...
-	go tool cover -func=coverage-all.out
+test-all: test-azure-ipam test-azure-ip-masq-merger test-main ## run all unit tests.
+
+test-main: 
+	go test -mod=readonly -buildvcs=false -tags "unit" --skip 'TestE2E*' -race -covermode atomic -coverprofile=coverage-main.out $(COVER_PKG)/...
 
 test-integration: ## run all integration tests.
 	AZURE_IPAM_VERSION=$(AZURE_IPAM_VERSION) \
@@ -855,10 +857,10 @@ test-extended-cyclonus: ## run the cyclonus test for npm.
 	cd ..
 
 test-azure-ipam: ## run the unit test for azure-ipam
-	cd $(AZURE_IPAM_DIR) && go test
+	cd $(AZURE_IPAM_DIR) && go test -race -covermode atomic -coverprofile=../coverage-azure-ipam.out
 
 test-azure-ip-masq-merger: ## run the unit test for azure-ip-masq-merger
-	cd $(AZURE_IP_MASQ_MERGER_DIR) && go test
+	cd $(AZURE_IP_MASQ_MERGER_DIR) && go test -race -covermode atomic -coverprofile=../coverage-azure-ip-masq-merger.out
 
 kind:
 	kind create cluster --config ./test/kind/kind.yaml


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->
Updates codeowners and adds uts for these go modules to the pr pipeline, combining code coverage as necessary. Previously, azure ipam and azure ip masq merger uts weren't included in make test-all because they were in different modules from the root module. Running make workspace before running the coverage allows us to include these numbers in the overall code coverage.

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
See above.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests
- [X] relevant PR labels added

**Notes**:
