### PR TITLE
Revert "Add HomeAZ to NodeInfoStatus"

### DIFF
--- a/crd/multitenancy/api/v1alpha1/nodeinfo.go
+++ b/crd/multitenancy/api/v1alpha1/nodeinfo.go
@@ -47,10 +47,6 @@ type NodeInfoStatus struct {
 type DeviceInfo struct {
 	DeviceType DeviceType `json:"deviceType,omitempty"`
 	MacAddress string     `json:"macAddress"`
-
-	// +kubebuilder:validation:optional
-	// +kubebuilder:validation:Pattern=`^AZ\d{2}$`
-	HomeAZ string `json:"homeAZ,omitempty"`
 }
 
 func init() {

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_nodeinfo.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_nodeinfo.yaml
@@ -59,9 +59,6 @@ spec:
                       - acn.azure.com/vnet-nic
                       - acn.azure.com/infiniband-nic
                       type: string
-                    homeAZ:
-                      pattern: ^AZ\d{2}$
-                      type: string
                     macAddress:
                       type: string
                   required:


### PR DESCRIPTION
Reverts Azure/azure-container-networking#3738

New Home AZ property should be in spec not status