### PR TITLE
Move HomeAZ to NodeInfo Spec

### DIFF
--- a/crd/multitenancy/api/v1alpha1/nodeinfo.go
+++ b/crd/multitenancy/api/v1alpha1/nodeinfo.go
@@ -32,13 +32,19 @@ type NodeInfoList struct {
 	Items           []NodeInfo `json:"items"`
 }
 
-// NodeInfoSpec defines the desired state of NodeInfo
+// NodeInfoSpec defines the desired state of NodeInfo. This is information
+// provided by CNS.
 type NodeInfoSpec struct {
 	// +kubebuilder:validation:Optional
 	VMUniqueID string `json:"vmUniqueID,omitempty"`
+
+	// +kubebuilder:validation:optional
+	// +kubebuilder:validation:Pattern=`^AZ\d{2}$`
+	HomeAZ string `json:"homeAZ,omitempty"`
 }
 
-// NodeInfoStatus defines the observed state of NodeInfo
+// NodeInfoStatus defines the observed state of NodeInfo. This is information
+// provided by DNC.
 type NodeInfoStatus struct {
 	// +kubebuilder:validation:Optional
 	DeviceInfos []DeviceInfo `json:"deviceInfos,omitempty"`
@@ -47,10 +53,6 @@ type NodeInfoStatus struct {
 type DeviceInfo struct {
 	DeviceType DeviceType `json:"deviceType,omitempty"`
 	MacAddress string     `json:"macAddress"`
-
-	// +kubebuilder:validation:optional
-	// +kubebuilder:validation:Pattern=`^AZ\d{2}$`
-	HomeAZ string `json:"homeAZ,omitempty"`
 }
 
 func init() {

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_nodeinfo.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_nodeinfo.yaml
@@ -43,13 +43,20 @@ spec:
           metadata:
             type: object
           spec:
-            description: NodeInfoSpec defines the desired state of NodeInfo
+            description: |-
+              NodeInfoSpec defines the desired state of NodeInfo. This is information
+              provided by CNS.
             properties:
+              homeAZ:
+                pattern: ^AZ\d{2}$
+                type: string
               vmUniqueID:
                 type: string
             type: object
           status:
-            description: NodeInfoStatus defines the observed state of NodeInfo
+            description: |-
+              NodeInfoStatus defines the observed state of NodeInfo. This is information
+              provided by DNC.
             properties:
               deviceInfos:
                 items:
@@ -58,9 +65,6 @@ spec:
                       enum:
                       - acn.azure.com/vnet-nic
                       - acn.azure.com/infiniband-nic
-                      type: string
-                    homeAZ:
-                      pattern: ^AZ\d{2}$
                       type: string
                     macAddress:
                       type: string


### PR DESCRIPTION
It was discovered that HomeAZ was incorrectly placed in the Status portion of NodeInfo, rather than the Spec, where it should be placed. This is because information in Spec is provided by CNS, while information in the Status is provided by DNC. As CNS is the entity that is initially aware of the HomeAZ of some node, the correct place for this to be communicated is in the Spec. Comments have also been updated to reflect the ownership of these fields, so as to not cause the same confusion to future contributors.