### PR TITLE
fix: update network error msg to match kubelet expectations

### DIFF
--- a/cns/middlewares/k8sSwiftV2.go
+++ b/cns/middlewares/k8sSwiftV2.go
@@ -17,7 +17,9 @@ import (
 )
 
 var (
-	errMTPNCNotReady            = errors.New("mtpnc is not ready")
+	// In AKS, for kubelet to retry faster it is particularly looking for "network is not ready" error string.
+	// https://github.com/kubernetes/kubernetes/blob/efd2a0d1f514be96a2f012fc3cb40f7c872b4e67/pkg/kubelet/pod_workers.go#L1495C2-L1501C3
+	errMTPNCNotReady            = errors.New("network is not ready - mtpnc is not ready")
 	errInvalidSWIFTv2NICType    = errors.New("invalid NIC type for SWIFT v2 scenario")
 	errInvalidMTPNCPrefixLength = errors.New("invalid prefix length for MTPNC primaryIP, must be 32")
 )


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>


**Reason for Change**:
This is a perf fix. The particular error message is retries with faster backOffInterval than default error messages by the kubelet.


**Issue Fixed**:


**Requirements**:
- [x] uses [conventional commit messages]
- [x] includes documentation
- [x] adds unit tests
- [ ] relevant PR labels added

**Notes**:
