### PR TITLE
ci: Remove File Copy and Add Image Build Stage to Regular Build

### DIFF
--- a/.pipelines/run-pipeline.yaml
+++ b/.pipelines/run-pipeline.yaml
@@ -20,167 +20,166 @@ stages:
 
 - template: templates/run-unit-tests.stages.yaml
 
+- stage: build
+  displayName: "Build Project"
+  dependsOn:
+    - setup
+    - unittest
+  variables:
+    ACN_DIR: drop_setup_env_source
+    ACN_PACKAGE_PATH: github.com/Azure/azure-container-networking
+    CNI_AI_PATH: $(ACN_PACKAGE_PATH)/telemetry.aiMetadata
+    CNS_AI_PATH: $(ACN_PACKAGE_PATH)/cns/logger.aiMetadata
+    NPM_AI_PATH: $(ACN_PACKAGE_PATH)/npm.aiMetadata
+
+    STORAGE_ID: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.StorageID'] ]
+    TAG: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.Tag'] ]
+
+    IMAGE_REPO_PATH: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.imageRepositoryPath'] ]
+    AZURE_IPAM_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.azureIpamVersion'] ]
+    AZURE_IP_MASQ_MERGER_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.azureIpMasqMergerVersion'] ]
+    CNI_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.cniVersion'] ]
+    CNS_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.cnsVersion'] ]
+    IPV6_HP_BPF_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.ipv6HpBpfVersion'] ]
+    NPM_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.npmVersion'] ]
+  jobs:
+  - template: /.pipelines/build/images.jobs.yaml
+    parameters:
+      images:
+      - job: linux_amd64
+        displayName: "Linux/AMD64"
+        templateContext:
+          repositoryArtifact: drop_setup_env_source
+          buildScript: .pipelines/build/scripts/$(name).sh
+          obDockerfile: .pipelines/build/dockerfiles/$(name).Dockerfile
+        strategy:
+          maxParallel: 5
+          matrix:
+            azure_ipam:
+              name: azure-ipam
+              extraArgs: ''
+              archiveName: azure-ipam
+              archiveVersion: $(AZURE_IPAM_VERSION)
+              imageTag: $(Build.BuildNumber)
+              packageWithDropGZ: True
+            azure_ip_masq_merger:
+              name: azure-ip-masq-merger
+              extraArgs: ''
+              archiveName: azure-ip-masq-merger
+              archiveVersion: $(AZURE_IP_MASQ_MERGER_VERSION)
+              imageTag: $(Build.BuildNumber)
+            cni:
+              name: cni
+              extraArgs: '--build-arg CNI_AI_PATH=$(CNI_AI_PATH) --build-arg CNI_AI_ID=$(CNI_AI_ID)'
+              archiveName: azure-cni
+              archiveVersion: $(CNI_VERSION)
+              imageTag: $(Build.BuildNumber)
+              packageWithDropGZ: True
+            cns:
+              name: cns
+              extraArgs: '--build-arg CNS_AI_PATH=$(CNS_AI_PATH) --build-arg CNS_AI_ID=$(CNS_AI_ID)'
+              archiveName: azure-cns
+              archiveVersion: $(CNS_VERSION)
+              imageTag: $(Build.BuildNumber)
+            ipv6_hp_bpf:
+              name: ipv6-hp-bpf
+              extraArgs: "--build-arg DEBUG=$(System.Debug)"
+              archiveName: ipv6-hp-bpf
+              archiveVersion: $(IPV6_HP_BPF_VERSION)
+              imageTag: $(Build.BuildNumber)
+            # npm:
+            #   name: npm
+            #   extraArgs: '--build-arg NPM_AI_PATH=$(NPM_AI_PATH) --build-arg NPM_AI_ID=$(NPM_AI_ID)'
+            #   archiveName: azure-npm
+            #   archiveVersion: $(NPM_VERSION)
+            #   imageTag: $(Build.BuildNumber)
+
+      - job: windows_amd64
+        displayName: "Windows"
+        templateContext:
+          repositoryArtifact: drop_setup_env_source
+          buildScript: .pipelines/build/scripts/$(name).sh
+          obDockerfile: .pipelines/build/dockerfiles/$(name).Dockerfile
+        strategy:
+          maxParallel: 5
+          matrix:
+            azure_ipam:
+              name: azure-ipam
+              extraArgs: ''
+              archiveName: azure-ipam
+              archiveVersion: $(AZURE_IPAM_VERSION)
+              imageTag: $(Build.BuildNumber)
+              packageWithDropGZ: True
+            cni:
+              name: cni
+              extraArgs: '--build-arg CNI_AI_PATH=$(CNI_AI_PATH) --build-arg CNI_AI_ID=$(CNI_AI_ID)'
+              archiveName: azure-cni
+              archiveVersion: $(CNI_VERSION)
+              imageTag: $(Build.BuildNumber)
+              packageWithDropGZ: True
+            cns:
+              name: cns
+              extraArgs: '--build-arg CNS_AI_PATH=$(CNS_AI_PATH) --build-arg CNS_AI_ID=$(CNS_AI_ID)'
+              archiveName: azure-cns
+              archiveVersion: $(CNS_VERSION)
+              imageTag: $(Build.BuildNumber)
+            # npm:
+            #   name: npm
+            #   extraArgs: '--build-arg NPM_AI_PATH=$(NPM_AI_PATH) --build-arg NPM_AI_ID=$(NPM_AI_ID)'
+            #   archiveName: azure-npm
+            #   archiveVersion: $(NPM_VERSION)
+            #   imageTag: $(Build.BuildNumber)
+
+      - job: linux_arm64
+        displayName: "Linux/ARM64"
+        templateContext:
+          repositoryArtifact: drop_setup_env_source
+          buildScript: .pipelines/build/scripts/$(name).sh
+          obDockerfile: .pipelines/build/dockerfiles/$(name).Dockerfile
+        strategy:
+          maxParallel: 3
+          matrix:
+            azure_ipam:
+              name: azure-ipam
+              archiveName: azure-ipam
+              archiveVersion: $(AZURE_IPAM_VERSION)
+              extraArgs: ''
+              imageTag: $(Build.BuildNumber)
+              packageWithDropGZ: True
+            azure_ip_masq_merger:
+              name: azure-ip-masq-merger
+              extraArgs: ''
+              archiveName: azure-ip-masq-merger
+              archiveVersion: $(AZURE_IP_MASQ_MERGER_VERSION)
+              imageTag: $(Build.BuildNumber)
+            cni:
+              name: cni
+              extraArgs: '--build-arg CNI_AI_PATH=$(CNI_AI_PATH) --build-arg CNI_AI_ID=$(CNI_AI_ID)'
+              archiveName: azure-cni
+              archiveVersion: $(CNI_VERSION)
+              imageTag: $(Build.BuildNumber)
+              packageWithDropGZ: True
+            cns:
+              name: cns
+              extraArgs: '--build-arg CNS_AI_PATH=$(CNS_AI_PATH) --build-arg CNS_AI_ID=$(CNS_AI_ID)'
+              archiveName: azure-cns
+              archiveVersion: $(CNS_VERSION)
+              imageTag: $(Build.BuildNumber)
+            ipv6_hp_bpf:
+              name: ipv6-hp-bpf
+              extraArgs: "--build-arg DEBUG=$(System.Debug)"
+              archiveName: ipv6-hp-bpf
+              archiveVersion: $(IPV6_HP_BPF_VERSION)
+              imageTag: $(Build.BuildNumber)
+            # npm:
+            #   name: npm
+            #   extraArgs: '--build-arg NPM_AI_PATH=$(NPM_AI_PATH) --build-arg NPM_AI_ID=$(NPM_AI_ID)'
+            #   archiveName: azure-npm
+            #   archiveVersion: $(NPM_VERSION)
+            #   imageTag: $(Build.BuildNumber)
+
 
 - ${{ if not(contains(variables['Build.SourceBranch'], 'refs/pull')) }}:
-  - stage: build
-    displayName: "Build Project"
-    dependsOn:
-      - setup
-      - unittest
-    variables:
-      ACN_DIR: drop_setup_env_source
-      ACN_PACKAGE_PATH: github.com/Azure/azure-container-networking
-      CNI_AI_PATH: $(ACN_PACKAGE_PATH)/telemetry.aiMetadata
-      CNS_AI_PATH: $(ACN_PACKAGE_PATH)/cns/logger.aiMetadata
-      NPM_AI_PATH: $(ACN_PACKAGE_PATH)/npm.aiMetadata
-
-      STORAGE_ID: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.StorageID'] ]
-      TAG: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.Tag'] ]
-
-      IMAGE_REPO_PATH: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.imageRepositoryPath'] ]
-      AZURE_IPAM_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.azureIpamVersion'] ]
-      AZURE_IP_MASQ_MERGER_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.azureIpMasqMergerVersion'] ]
-      CNI_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.cniVersion'] ]
-      CNS_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.cnsVersion'] ]
-      IPV6_HP_BPF_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.ipv6HpBpfVersion'] ]
-      NPM_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.npmVersion'] ]
-    jobs:
-    - template: /.pipelines/build/images.jobs.yaml
-      parameters:
-        images:
-        - job: linux_amd64
-          displayName: "Linux/AMD64"
-          templateContext:
-            repositoryArtifact: drop_setup_env_source
-            buildScript: .pipelines/build/scripts/$(name).sh
-            obDockerfile: .pipelines/build/dockerfiles/$(name).Dockerfile
-          strategy:
-            maxParallel: 5
-            matrix:
-              azure_ipam:
-                name: azure-ipam
-                extraArgs: ''
-                archiveName: azure-ipam
-                archiveVersion: $(AZURE_IPAM_VERSION)
-                imageTag: $(Build.BuildNumber)
-                packageWithDropGZ: True
-              azure_ip_masq_merger:
-                name: azure-ip-masq-merger
-                extraArgs: ''
-                archiveName: azure-ip-masq-merger
-                archiveVersion: $(AZURE_IP_MASQ_MERGER_VERSION)
-                imageTag: $(Build.BuildNumber)
-              cni:
-                name: cni
-                extraArgs: '--build-arg CNI_AI_PATH=$(CNI_AI_PATH) --build-arg CNI_AI_ID=$(CNI_AI_ID)'
-                archiveName: azure-cni
-                archiveVersion: $(CNI_VERSION)
-                imageTag: $(Build.BuildNumber)
-                packageWithDropGZ: True
-              cns:
-                name: cns
-                extraArgs: '--build-arg CNS_AI_PATH=$(CNS_AI_PATH) --build-arg CNS_AI_ID=$(CNS_AI_ID)'
-                archiveName: azure-cns
-                archiveVersion: $(CNS_VERSION)
-                imageTag: $(Build.BuildNumber)
-              ipv6_hp_bpf:
-                name: ipv6-hp-bpf
-                extraArgs: "--build-arg DEBUG=$(System.Debug)"
-                archiveName: ipv6-hp-bpf
-                archiveVersion: $(IPV6_HP_BPF_VERSION)
-                imageTag: $(Build.BuildNumber)
-              # npm:
-              #   name: npm
-              #   extraArgs: '--build-arg NPM_AI_PATH=$(NPM_AI_PATH) --build-arg NPM_AI_ID=$(NPM_AI_ID)'
-              #   archiveName: azure-npm
-              #   archiveVersion: $(NPM_VERSION)
-              #   imageTag: $(Build.BuildNumber)
-
-        - job: windows_amd64
-          displayName: "Windows"
-          templateContext:
-            repositoryArtifact: drop_setup_env_source
-            buildScript: .pipelines/build/scripts/$(name).sh
-            obDockerfile: .pipelines/build/dockerfiles/$(name).Dockerfile
-          strategy:
-            maxParallel: 5
-            matrix:
-              azure_ipam:
-                name: azure-ipam
-                extraArgs: ''
-                archiveName: azure-ipam
-                archiveVersion: $(AZURE_IPAM_VERSION)
-                imageTag: $(Build.BuildNumber)
-                packageWithDropGZ: True
-              cni:
-                name: cni
-                extraArgs: '--build-arg CNI_AI_PATH=$(CNI_AI_PATH) --build-arg CNI_AI_ID=$(CNI_AI_ID)'
-                archiveName: azure-cni
-                archiveVersion: $(CNI_VERSION)
-                imageTag: $(Build.BuildNumber)
-                packageWithDropGZ: True
-              cns:
-                name: cns
-                extraArgs: '--build-arg CNS_AI_PATH=$(CNS_AI_PATH) --build-arg CNS_AI_ID=$(CNS_AI_ID)'
-                archiveName: azure-cns
-                archiveVersion: $(CNS_VERSION)
-                imageTag: $(Build.BuildNumber)
-              # npm:
-              #   name: npm
-              #   extraArgs: '--build-arg NPM_AI_PATH=$(NPM_AI_PATH) --build-arg NPM_AI_ID=$(NPM_AI_ID)'
-              #   archiveName: azure-npm
-              #   archiveVersion: $(NPM_VERSION)
-              #   imageTag: $(Build.BuildNumber)
-
-        - job: linux_arm64
-          displayName: "Linux/ARM64"
-          templateContext:
-            repositoryArtifact: drop_setup_env_source
-            buildScript: .pipelines/build/scripts/$(name).sh
-            obDockerfile: .pipelines/build/dockerfiles/$(name).Dockerfile
-          strategy:
-            maxParallel: 3
-            matrix:
-              azure_ipam:
-                name: azure-ipam
-                archiveName: azure-ipam
-                archiveVersion: $(AZURE_IPAM_VERSION)
-                extraArgs: ''
-                imageTag: $(Build.BuildNumber)
-                packageWithDropGZ: True
-              azure_ip_masq_merger:
-                name: azure-ip-masq-merger
-                extraArgs: ''
-                archiveName: azure-ip-masq-merger
-                archiveVersion: $(AZURE_IP_MASQ_MERGER_VERSION)
-                imageTag: $(Build.BuildNumber)
-              cni:
-                name: cni
-                extraArgs: '--build-arg CNI_AI_PATH=$(CNI_AI_PATH) --build-arg CNI_AI_ID=$(CNI_AI_ID)'
-                archiveName: azure-cni
-                archiveVersion: $(CNI_VERSION)
-                imageTag: $(Build.BuildNumber)
-                packageWithDropGZ: True
-              cns:
-                name: cns
-                extraArgs: '--build-arg CNS_AI_PATH=$(CNS_AI_PATH) --build-arg CNS_AI_ID=$(CNS_AI_ID)'
-                archiveName: azure-cns
-                archiveVersion: $(CNS_VERSION)
-                imageTag: $(Build.BuildNumber)
-              ipv6_hp_bpf:
-                name: ipv6-hp-bpf
-                extraArgs: "--build-arg DEBUG=$(System.Debug)"
-                archiveName: ipv6-hp-bpf
-                archiveVersion: $(IPV6_HP_BPF_VERSION)
-                imageTag: $(Build.BuildNumber)
-              # npm:
-              #   name: npm
-              #   extraArgs: '--build-arg NPM_AI_PATH=$(NPM_AI_PATH) --build-arg NPM_AI_ID=$(NPM_AI_ID)'
-              #   archiveName: azure-npm
-              #   archiveVersion: $(NPM_VERSION)
-              #   imageTag: $(Build.BuildNumber)
-
-
   - stage: manifests
     displayName: "Image Manifests"
     dependsOn:

--- a/.pipelines/templates/run-unit-tests.stages.yaml
+++ b/.pipelines/templates/run-unit-tests.stages.yaml
@@ -47,7 +47,6 @@ stages:
           } | { read xs; exit $xs; }
         } 4>&1
 
-        cp coverage-all.out "$COVERAGE_OUT"
         ls -la "$REPORT_DIR"
       retryCountOnTaskFailure: 3
       displayName: "Run Unit Tests - Linux"


### PR DESCRIPTION
- Removes the file copy of the coverage-all.out file from the run unit tests stage.
- Adds the image build steps to the regular pipeline execution.

**Reason for Change**:
There is an error on the file copy because the cover-all.out is not generated by the Official or Unofficial builds. Removing the copy should fix this.
The images aren't currently built during general pipeline execution. This will allow us to make sure that we are able to build images when changes are submitted.

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
