### PR TITLE
ci: add azure iptables monitor pipeline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,12 +7,13 @@
 # review a PR in an area.
 #
 # Rules are evaluated in this order, and the last match is used for auto-assignment.
-*                       @azure/azure-sdn-members
-/.github/               @azure/acn-admins
-/cns/                   @azure/acn-cns-reviewers
-/cni/                   @azure/acn-cni-reviewers
-/dropgz/                @rbtr @camrynl @paulyufan2 @ashvindeodhar @thatmattlong
-/npm/                   @azure/acn-npm-reviewers
-/zapai/                 @rbtr @ZetaoZhuang
-/bpf-prog/              @camrynl
-/azure-ip-masq-merger/  @QxBytes @santhoshmprabhu
+*                           @azure/azure-sdn-members
+/.github/                   @azure/acn-admins
+/cns/                       @azure/acn-cns-reviewers
+/cni/                       @azure/acn-cni-reviewers
+/dropgz/                    @rbtr @camrynl @paulyufan2 @ashvindeodhar @thatmattlong
+/npm/                       @azure/acn-npm-reviewers
+/zapai/                     @rbtr @ZetaoZhuang
+/bpf-prog/                  @camrynl
+/azure-ip-masq-merger/      @QxBytes @santhoshmprabhu
+/azure-iptables-monitor/    @QxBytes @santhoshmprabhu

--- a/.pipelines/build/dockerfiles/azure-iptables-monitor.Dockerfile
+++ b/.pipelines/build/dockerfiles/azure-iptables-monitor.Dockerfile
@@ -1,0 +1,18 @@
+ARG ARCH
+
+# mcr.microsoft.com/azurelinux/base/core:3.0
+FROM mcr.microsoft.com/azurelinux/base/core@sha256:9948138108a3d69f1dae62104599ac03132225c3b7a5ac57b85a214629c8567d AS mariner-core
+
+# mcr.microsoft.com/azurelinux/distroless/minimal:3.0
+FROM mcr.microsoft.com/azurelinux/distroless/minimal@sha256:0801b80a0927309572b9adc99bd1813bc680473175f6e8175cd4124d95dbd50c AS mariner-distroless
+
+FROM mariner-core AS iptables
+RUN tdnf install -y iptables
+
+FROM mariner-distroless AS linux
+ARG ARTIFACT_DIR
+COPY --from=iptables /usr/sbin/*tables* /usr/sbin/
+COPY --from=iptables /usr/lib /usr/lib
+COPY ${ARTIFACT_DIR}/bin/azure-iptables-monitor /azure-iptables-monitor
+
+ENTRYPOINT ["/azure-iptables-monitor"]

--- a/.pipelines/build/ob-prepare.steps.yaml
+++ b/.pipelines/build/ob-prepare.steps.yaml
@@ -62,6 +62,10 @@ steps:
     echo "##vso[task.setvariable variable=azureIpMasqMergerVersion;isOutput=true]$AZUREIPMASQMERGERVERSION"
     echo "azureIpMasqMergerVersion: $AZUREIPMASQMERGERVERSION"
 
+    AZUREIPTABLESMONITORVERSION=$(make azure-iptables-monitor-version)
+    echo "##vso[task.setvariable variable=azureIptablesMonitorVersion;isOutput=true]$AZUREIPTABLESMONITORVERSION"
+    echo "azureIptablesMonitorVersion: $AZUREIPTABLESMONITORVERSION"
+
     CNIVERSION=$(make cni-version)
     echo "##vso[task.setvariable variable=cniVersion;isOutput=true]$CNIVERSION"
     echo "cniVersion: $CNIVERSION"

--- a/.pipelines/build/scripts/azure-iptables-monitor.sh
+++ b/.pipelines/build/scripts/azure-iptables-monitor.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -eux
+
+[[ $OS =~ windows ]] && { echo "azure-iptables-monitor is not supported on Windows"; exit 1; }
+FILE_EXT=''
+
+export CGO_ENABLED=0 
+
+mkdir -p "$OUT_DIR"/bin
+mkdir -p "$OUT_DIR"/files
+
+pushd "$REPO_ROOT"/azure-iptables-monitor
+  GOOS="$OS" go build -v -a -trimpath \
+    -o "$OUT_DIR"/bin/azure-iptables-monitor"$FILE_EXT" \
+    -ldflags "-X github.com/Azure/azure-container-networking/azure-iptables-monitor/internal/buildinfo.Version=$AZURE_IPTABLES_MONITOR_VERSION -X main.version=$AZURE_IPTABLES_MONITOR_VERSION" \
+    -gcflags="-dwarflocationlists=true" \
+    .
+popd

--- a/.pipelines/build/scripts/azure-iptables-monitor.sh
+++ b/.pipelines/build/scripts/azure-iptables-monitor.sh
@@ -4,7 +4,7 @@ set -eux
 [[ $OS =~ windows ]] && { echo "azure-iptables-monitor is not supported on Windows"; exit 1; }
 FILE_EXT=''
 
-export CGO_ENABLED=0 
+export CGO_ENABLED=0
 
 mkdir -p "$OUT_DIR"/bin
 mkdir -p "$OUT_DIR"/files
@@ -12,7 +12,7 @@ mkdir -p "$OUT_DIR"/files
 pushd "$REPO_ROOT"/azure-iptables-monitor
   GOOS="$OS" go build -v -a -trimpath \
     -o "$OUT_DIR"/bin/azure-iptables-monitor"$FILE_EXT" \
-    -ldflags "-X github.com/Azure/azure-container-networking/azure-iptables-monitor/internal/buildinfo.Version=$AZURE_IPTABLES_MONITOR_VERSION -X main.version=$AZURE_IPTABLES_MONITOR_VERSION" \
+    -ldflags "-s -w -X github.com/Azure/azure-container-networking/azure-iptables-monitor/internal/buildinfo.Version=$AZURE_IPTABLES_MONITOR_VERSION -X main.version=$AZURE_IPTABLES_MONITOR_VERSION" \
     -gcflags="-dwarflocationlists=true" \
     .
 popd

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -125,6 +125,10 @@ stages:
                 arch: amd64
                 name: azure-ip-masq-merger
                 os: linux
+              azure_iptables_monitor_linux_amd64:
+                arch: amd64
+                name: azure-iptables-monitor
+                os: linux
               cni_linux_amd64:
                 arch: amd64
                 name: cni
@@ -173,6 +177,10 @@ stages:
               azure_ip_masq_merger_linux_arm64:
                 arch: arm64
                 name: azure-ip-masq-merger
+                os: linux
+              azure_iptables_monitor_linux_arm64:
+                arch: arm64
+                name: azure-iptables-monitor
                 os: linux
               cni_linux_arm64:
                 arch: arm64
@@ -227,6 +235,9 @@ stages:
                 platforms: linux/amd64 linux/arm64 windows/amd64
               azure_ip_masq_merger:
                 name: azure-ip-masq-merger
+                platforms: linux/amd64 linux/arm64
+              azure_iptables_monitor:
+                name: azure-iptables-monitor
                 platforms: linux/amd64 linux/arm64
           steps:
             - template: containers/manifest-template.yaml

--- a/.pipelines/run-pipeline.yaml
+++ b/.pipelines/run-pipeline.yaml
@@ -38,6 +38,7 @@ stages:
     IMAGE_REPO_PATH: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.imageRepositoryPath'] ]
     AZURE_IPAM_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.azureIpamVersion'] ]
     AZURE_IP_MASQ_MERGER_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.azureIpMasqMergerVersion'] ]
+    AZURE_IPTABLES_MONITOR_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.azureIptablesMonitorVersion'] ]
     CNI_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.cniVersion'] ]
     CNS_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.cnsVersion'] ]
     IPV6_HP_BPF_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.ipv6HpBpfVersion'] ]
@@ -67,6 +68,12 @@ stages:
               extraArgs: ''
               archiveName: azure-ip-masq-merger
               archiveVersion: $(AZURE_IP_MASQ_MERGER_VERSION)
+              imageTag: $(Build.BuildNumber)
+            azure_iptables_monitor:
+              name: azure-iptables-monitor
+              extraArgs: ''
+              archiveName: azure-iptables-monitor
+              archiveVersion: $(AZURE_IPTABLES_MONITOR_VERSION)
               imageTag: $(Build.BuildNumber)
             cni:
               name: cni
@@ -152,6 +159,12 @@ stages:
               archiveName: azure-ip-masq-merger
               archiveVersion: $(AZURE_IP_MASQ_MERGER_VERSION)
               imageTag: $(Build.BuildNumber)
+            azure_iptables_monitor:
+              name: azure-iptables-monitor
+              extraArgs: ''
+              archiveName: azure-iptables-monitor
+              archiveVersion: $(AZURE_IPTABLES_MONITOR_VERSION)
+              imageTag: $(Build.BuildNumber)
             cni:
               name: cni
               extraArgs: '--build-arg CNI_AI_PATH=$(CNI_AI_PATH) --build-arg CNI_AI_ID=$(CNI_AI_ID)'
@@ -190,6 +203,7 @@ stages:
 
       AZURE_IPAM_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.azureIpamVersion'] ]
       AZURE_IP_MASQ_MERGER_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.azureIpMasqMergerVersion'] ]
+      AZURE_IPTABLES_MONITOR_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.azureIptablesMonitorVersion'] ]
       CNI_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.cniVersion'] ]
       CNS_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.cnsVersion'] ]
       IPV6_HP_BPF_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.ipv6HpBpfVersion'] ]
@@ -201,6 +215,9 @@ stages:
 
       IP_MASQ_MERGER_LINUX_AMD64_REF: $(IMAGE_REPO_PATH)/linux-amd64/azure-ip-masq-merger:$(Build.BuildNumber)
       IP_MASQ_MERGER_LINUX_ARM64_REF: $(IMAGE_REPO_PATH)/linux-arm64/azure-ip-masq-merger:$(Build.BuildNumber)
+
+      IPTABLES_MONITOR_LINUX_AMD64_REF: $(IMAGE_REPO_PATH)/linux-amd64/azure-iptables-monitor:$(Build.BuildNumber)
+      IPTABLES_MONITOR_LINUX_ARM64_REF: $(IMAGE_REPO_PATH)/linux-arm64/azure-iptables-monitor:$(Build.BuildNumber)
 
       CNI_LINUX_AMD64_REF: $(IMAGE_REPO_PATH)/linux-amd64/cni:$(Build.BuildNumber)
       CNI_LINUX_ARM64_REF: $(IMAGE_REPO_PATH)/linux-arm64/cni:$(Build.BuildNumber)
@@ -241,6 +258,15 @@ stages:
               imageReference: $(IP_MASQ_MERGER_LINUX_AMD64_REF)
             - platform: linux/arm64
               imageReference: $(IP_MASQ_MERGER_LINUX_ARM64_REF)
+        - job: azure_iptables_monitor
+          templateContext:
+            name: azure-iptables-monitor
+            image_tag: $(AZURE_IPTABLES_MONITOR_VERSION)
+            platforms:
+            - platform: linux/amd64
+              imageReference: $(IPTABLES_MONITOR_LINUX_AMD64_REF)
+            - platform: linux/arm64
+              imageReference: $(IPTABLES_MONITOR_LINUX_ARM64_REF)
         - job: cni
           templateContext:
             name: cni

--- a/azure-iptables-monitor/Dockerfile
+++ b/azure-iptables-monitor/Dockerfile
@@ -15,7 +15,7 @@ ARG OS
 ARG VERSION
 WORKDIR /azure-iptables-monitor
 COPY ./azure-iptables-monitor .
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/iptables-monitor -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" .
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/iptables-monitor -trimpath -ldflags "-s -w -X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" .
 
 FROM mariner-core AS iptables
 RUN tdnf install -y iptables


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Adds image publishing for azure iptables monitor to ACN Official Build pipeline and ACN PR pipeline
Merge after #3779

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
ACN PR: https://msazure.visualstudio.com/One/_build/results?buildId=129848847&view=results
ACN Build Pipeline: https://dev.azure.com/msazure/One/_build/results?buildId=129816140&view=results
ACN Unofficial Build: https://msazure.visualstudio.com/One/_build/results?buildId=129854515&view=results
which feeds into ACN Buddy Image Release: https://dev.azure.com/msazure/One/_build/results?buildId=129977665&view=results

After rebase:
ACN PR: https://msazure.visualstudio.com/One/_build/results?buildId=132175501&view=results
ACN Unofficial Build: https://msazure.visualstudio.com/One/_build/results?buildId=132175800&view=results