### PR TITLE
Mereta/fix iptables legacy with ubuntu2404

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -150,7 +150,7 @@ require (
 	github.com/go-openapi/spec v0.20.11 // indirect
 	github.com/go-openapi/strfmt v0.21.9 // indirect
 	github.com/go-openapi/validate v0.22.3 // indirect
-	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
+	github.com/go-viper/mapstructure/v2 v2.3.0 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/gorilla/websocket v1.5.1 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/go-openapi/validate v0.22.3/go.mod h1:kVxh31KbfsxU8ZyoHaDbLBWU5CnMdqB
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
-github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
-github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/go-viper/mapstructure/v2 v2.3.0 h1:27XbWsHIqhbdR5TIC911OfYvgSaW93HM+dX7970Q7jk=
+github.com/go-viper/mapstructure/v2 v2.3.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v4.2.0+incompatible h1:yyYWMnhkhrKwwr8gAOcOCYxOOscHgDS9yZgBrnJfGa0=
 github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -19,7 +19,7 @@ OS_SKU_WIN           ?= Windows2022
 REGION               ?= westus2
 VM_SIZE	             ?= Standard_B2s
 VM_SIZE_WIN          ?= Standard_B2s
-IP_TAG               ?= FirstPartyUsage=/DelegatedNetworkControllerTest
+IP_TAG               ?= FirstPartyUsage=/NonProd
 IP_PREFIX            ?= serviceTaggedIp
 PUBLIC_IP_ID         ?= /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/publicIPAddresses
 PUBLIC_IPv4          ?= $(PUBLIC_IP_ID)/$(IP_PREFIX)-$(CLUSTER)-v4

--- a/npm/linux.Dockerfile
+++ b/npm/linux.Dockerfile
@@ -6,8 +6,8 @@ WORKDIR /usr/local/src
 COPY . .
 RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm -ldflags "-X main.version="$VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" -gcflags="-dwarflocationlists=true" npm/cmd/*.go
 
-FROM mcr.microsoft.com/mirror/docker/library/ubuntu:20.04 as linux
+FROM mcr.microsoft.com/mirror/docker/library/ubuntu:24.04 as linux
 COPY --from=builder /usr/local/bin/azure-npm /usr/bin/azure-npm
-RUN apt-get update && apt-get install -y iptables ipset ca-certificates && apt-get autoremove -y && apt-get clean
+RUN apt-get update && apt-get install -y libsystemd0=255.4-1ubuntu8.8 libudev1=255.4-1ubuntu8.8 iptables ipset ca-certificates && apt-get autoremove -y && apt-get clean
 RUN chmod +x /usr/bin/azure-npm
 ENTRYPOINT ["/usr/bin/azure-npm", "start"]

--- a/npm/linux.Dockerfile
+++ b/npm/linux.Dockerfile
@@ -8,6 +8,6 @@ RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm -ldflags "-X main.vers
 
 FROM mcr.microsoft.com/mirror/docker/library/ubuntu:24.04 as linux
 COPY --from=builder /usr/local/bin/azure-npm /usr/bin/azure-npm
-RUN apt-get update && apt-get install -y libsystemd0=255.4-1ubuntu8.8 libudev1=255.4-1ubuntu8.8 iptables ipset ca-certificates && apt-get autoremove -y && apt-get clean
+RUN apt-get update && apt-get install -y libsystemd0=255.4-1ubuntu8.8 libudev1=255.4-1ubuntu8.8 libpam-modules=1.5.3-5ubuntu5.4 libpam-modules-bin=1.5.3-5ubuntu5.4 libpam-runtime=1.5.3-5ubuntu5.4 libpam0g=1.5.3-5ubuntu5.4 iptables ipset ca-certificates && apt-get autoremove -y && apt-get clean
 RUN chmod +x /usr/bin/azure-npm
 ENTRYPOINT ["/usr/bin/azure-npm", "start"]

--- a/npm/pkg/dataplane/policies/chain-management_linux_test.go
+++ b/npm/pkg/dataplane/policies/chain-management_linux_test.go
@@ -936,7 +936,7 @@ func TestDetectIptablesVersion(t *testing.T) {
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-L", "KUBE-IPTABLES-HINT", "-t", "mangle", "-n"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-L", "KUBE-IPTABLES-HINT", "-t", "mangle", "-n"},
 					ExitCode: 0,
 				},
 			},
@@ -954,11 +954,11 @@ func TestDetectIptablesVersion(t *testing.T) {
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-L", "KUBE-IPTABLES-HINT", "-t", "mangle", "-n"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-L", "KUBE-IPTABLES-HINT", "-t", "mangle", "-n"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-L", "KUBE-KUBELET-CANARY", "-t", "mangle", "-n"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-L", "KUBE-KUBELET-CANARY", "-t", "mangle", "-n"},
 					ExitCode: 1,
 				},
 			},
@@ -976,11 +976,11 @@ func TestDetectIptablesVersion(t *testing.T) {
 					ExitCode: 2,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-L", "KUBE-IPTABLES-HINT", "-t", "mangle", "-n"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-L", "KUBE-IPTABLES-HINT", "-t", "mangle", "-n"},
 					ExitCode: 2,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-L", "KUBE-KUBELET-CANARY", "-t", "mangle", "-n"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-L", "KUBE-KUBELET-CANARY", "-t", "mangle", "-n"},
 					ExitCode: 2,
 				},
 			},
@@ -1027,12 +1027,12 @@ func TestCleanupOtherChains(t *testing.T) {
 			name:         "cleanup legacy jump no chains",
 			startWithNft: true,
 			calls: []testutils.TestCmd{
-				{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}}, // deprecated rule existed
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}}, // deprecated rule existed
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
 					ExitCode: 1,
 				},
-				{Cmd: []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
 				{
 					Cmd:      []string{"grep", "Chain AZURE-NPM"},
 					ExitCode: 1,
@@ -1044,19 +1044,19 @@ func TestCleanupOtherChains(t *testing.T) {
 			name:         "cleanup legacy jump and chains",
 			startWithNft: true,
 			calls: []testutils.TestCmd{
-				{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}}, // deprecated rule existed
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}}, // deprecated rule existed
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
 					ExitCode: 1,
 				},
-				{Cmd: []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
 				{
 					Cmd:    []string{"grep", "Chain AZURE-NPM"},
 					Stdout: grepOutputTwoAzureChains,
 				},
-				{Cmd: []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"}},
-				{Cmd: []string{"iptables", "-w", "60", "-X", "AZURE-NPM"}},
-				{Cmd: []string{"iptables", "-w", "60", "-X", "AZURE-NPM-INGRESS"}},
+				{Cmd: []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"}},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-X", "AZURE-NPM"}},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-X", "AZURE-NPM-INGRESS"}},
 			},
 			expectedErr: false,
 		},
@@ -1065,30 +1065,30 @@ func TestCleanupOtherChains(t *testing.T) {
 			startWithNft: true,
 			calls: []testutils.TestCmd{
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
 					ExitCode: 1,
 				},
-				{Cmd: []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
 				{
 					Cmd:    []string{"grep", "Chain AZURE-NPM"},
 					Stdout: grepOutputTwoAzureChains,
 				},
 				{
-					Cmd:      []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"},
+					Cmd:      []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"},
+					Cmd:      []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"},
 					ExitCode: 1,
 				},
-				{Cmd: []string{"iptables", "-w", "60", "-F", "AZURE-NPM"}},
-				{Cmd: []string{"iptables", "-w", "60", "-F", "AZURE-NPM-INGRESS"}},
-				{Cmd: []string{"iptables", "-w", "60", "-X", "AZURE-NPM"}},
-				{Cmd: []string{"iptables", "-w", "60", "-X", "AZURE-NPM-INGRESS"}},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-F", "AZURE-NPM"}},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-F", "AZURE-NPM-INGRESS"}},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-X", "AZURE-NPM"}},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-X", "AZURE-NPM-INGRESS"}},
 			},
 			expectedErr: false,
 		},
@@ -1097,28 +1097,28 @@ func TestCleanupOtherChains(t *testing.T) {
 			startWithNft: true,
 			calls: []testutils.TestCmd{
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
 					ExitCode: 1,
 				},
-				{Cmd: []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
 				{
 					Cmd:    []string{"grep", "Chain AZURE-NPM"},
 					Stdout: grepOutputTwoAzureChains,
 				},
 				{
-					Cmd:      []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"},
+					Cmd:      []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"},
+					Cmd:      []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-F", "AZURE-NPM"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-F", "AZURE-NPM"},
 					ExitCode: 1,
 				},
 			},
@@ -1129,28 +1129,28 @@ func TestCleanupOtherChains(t *testing.T) {
 			startWithNft: true,
 			calls: []testutils.TestCmd{
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
 					ExitCode: 1,
 				},
-				{Cmd: []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
 				{
 					Cmd:    []string{"grep", "Chain AZURE-NPM"},
 					Stdout: "Chain AZURE-NPM-INGRESS (1 references)\n",
 				},
 				{
-					Cmd:      []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"},
+					Cmd:      []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"},
+					Cmd:      []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"},
 					ExitCode: 1,
 				},
-				{Cmd: []string{"iptables", "-w", "60", "-F", "AZURE-NPM-INGRESS"}},
-				{Cmd: []string{"iptables", "-w", "60", "-X", "AZURE-NPM-INGRESS"}},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-F", "AZURE-NPM-INGRESS"}},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-X", "AZURE-NPM-INGRESS"}},
 			},
 			expectedErr: false,
 		},
@@ -1159,37 +1159,37 @@ func TestCleanupOtherChains(t *testing.T) {
 			startWithNft: true,
 			calls: []testutils.TestCmd{
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"},
 					ExitCode: 1,
 				},
-				{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
-				{Cmd: []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
 				{
 					Cmd:    []string{"grep", "Chain AZURE-NPM"},
 					Stdout: grepOutputTwoAzureChains,
 				},
 				{
-					Cmd:      []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"},
+					Cmd:      []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"},
+					Cmd:      []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-F", "AZURE-NPM"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-F", "AZURE-NPM"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-F", "AZURE-NPM-INGRESS"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-F", "AZURE-NPM-INGRESS"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-X", "AZURE-NPM"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-X", "AZURE-NPM"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-X", "AZURE-NPM-INGRESS"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-X", "AZURE-NPM-INGRESS"},
 					ExitCode: 1,
 				},
 			},
@@ -1199,38 +1199,38 @@ func TestCleanupOtherChains(t *testing.T) {
 			name:         "cleanup legacy errors ok if deleted jump (deprecated)",
 			startWithNft: true,
 			calls: []testutils.TestCmd{
-				{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
 					ExitCode: 1,
 				},
-				{Cmd: []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
 				{
 					Cmd:    []string{"grep", "Chain AZURE-NPM"},
 					Stdout: grepOutputTwoAzureChains,
 				},
 				{
-					Cmd:      []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"},
+					Cmd:      []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"},
+					Cmd:      []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-F", "AZURE-NPM"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-F", "AZURE-NPM"},
 					ExitCode: 2,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-F", "AZURE-NPM-INGRESS"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-F", "AZURE-NPM-INGRESS"},
 					ExitCode: 2,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-X", "AZURE-NPM"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-X", "AZURE-NPM"},
 					ExitCode: 2,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-X", "AZURE-NPM-INGRESS"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-X", "AZURE-NPM-INGRESS"},
 					ExitCode: 2,
 				},
 			},
@@ -1240,13 +1240,13 @@ func TestCleanupOtherChains(t *testing.T) {
 			name:         "cleanup legacy other flush errors ok",
 			startWithNft: true,
 			calls: []testutils.TestCmd{
-				{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
 					ExitCode: 1,
 				},
 				{
-					Cmd: []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true,
+					Cmd: []string{"iptables-legacy", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true,
 					ExitCode: 1,
 				},
 				{
@@ -1254,21 +1254,21 @@ func TestCleanupOtherChains(t *testing.T) {
 					Stdout: grepOutputTwoAzureChains,
 				},
 				{
-					Cmd:      []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"},
+					Cmd:      []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"},
+					Cmd:      []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"},
 					ExitCode: 1,
 				},
-				{Cmd: []string{"iptables", "-w", "60", "-F", "AZURE-NPM"}},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-F", "AZURE-NPM"}},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-F", "AZURE-NPM-INGRESS"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-F", "AZURE-NPM-INGRESS"},
 					ExitCode: 1,
 				},
-				{Cmd: []string{"iptables", "-w", "60", "-X", "AZURE-NPM"}},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-X", "AZURE-NPM"}},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-X", "AZURE-NPM-INGRESS"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-X", "AZURE-NPM-INGRESS"},
 					ExitCode: 1,
 				},
 			},
@@ -1279,15 +1279,15 @@ func TestCleanupOtherChains(t *testing.T) {
 			startWithNft: true,
 			calls: []testutils.TestCmd{
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
 					ExitCode: 1,
 				},
 				{
-					Cmd: []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true, HasStartError: true,
+					Cmd: []string{"iptables-legacy", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true, HasStartError: true,
 					ExitCode: 1,
 				},
 				{Cmd: []string{"grep", "Chain AZURE-NPM"}},

--- a/npm/pkg/dataplane/policies/testutils_linux.go
+++ b/npm/pkg/dataplane/policies/testutils_linux.go
@@ -57,17 +57,17 @@ func GetBootupTestCalls() []testutils.TestCmd {
 			ExitCode: 0,
 		},
 		// legacy clean up
-		{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}, ExitCode: 2},                                        //nolint // AZURE-NPM chain didn't exist
-		{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}, ExitCode: 2}, //nolint // AZURE-NPM chain didn't exist
-		{Cmd: []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
+		{Cmd: []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}, ExitCode: 2},                                        //nolint // AZURE-NPM chain didn't exist
+		{Cmd: []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}, ExitCode: 2}, //nolint // AZURE-NPM chain didn't exist
+		{Cmd: []string{"iptables-legacy", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
 		{
 			// 1 AZURE-NPM chain
 			Cmd: []string{"grep", "Chain AZURE-NPM"},
 			Stdout: `Chain AZURE-NPM (0 references)
 `,
 		},
-		{Cmd: []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"}},
-		{Cmd: []string{"iptables", "-w", "60", "-X", "AZURE-NPM"}},
+		{Cmd: []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"}},
+		{Cmd: []string{"iptables-legacy", "-w", "60", "-X", "AZURE-NPM"}},
 		// nft bootup
 		{Cmd: []string{"iptables-nft", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}, ExitCode: 2}, //nolint // AZURE-NPM chain didn't exist
 		{Cmd: []string{"iptables-nft", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},

--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -36,10 +36,10 @@ const (
 	IptablesNft                string = "iptables-nft"
 	Ip6tablesLegacy            string = "ip6tables" //nolint (avoid warning to capitalize this p)
 	IptablesSaveNft            string = "iptables-nft-save"
-	IptablesRestoreNft         string = "iptables-legacy-nft-restore"
+	IptablesRestoreNft         string = "iptables-nft-restore"
 	IptablesLegacy             string = "iptables-legacy"
 	IptablesSaveLegacy         string = "iptables-legacy-save"
-	IptablesRestoreLegacy      string = "iptables-restore"
+	IptablesRestoreLegacy      string = "iptables-legacy-restore"
 	IptablesRestoreNoFlushFlag string = "--noflush"
 	IptablesRestoreTableFlag   string = "-T"
 	IptablesRestoreCommit      string = "COMMIT"

--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -36,9 +36,9 @@ const (
 	IptablesNft                string = "iptables-nft"
 	Ip6tablesLegacy            string = "ip6tables" //nolint (avoid warning to capitalize this p)
 	IptablesSaveNft            string = "iptables-nft-save"
-	IptablesRestoreNft         string = "iptables-nft-restore"
-	IptablesLegacy             string = "iptables"
-	IptablesSaveLegacy         string = "iptables-save"
+	IptablesRestoreNft         string = "iptables-legacy-nft-restore"
+	IptablesLegacy             string = "iptables-legacy"
+	IptablesSaveLegacy         string = "iptables-legacy-save"
 	IptablesRestoreLegacy      string = "iptables-restore"
 	IptablesRestoreNoFlushFlag string = "--noflush"
 	IptablesRestoreTableFlag   string = "-T"


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
Updates iptables to `legacy` fix crashloopbackoffs in `CBL-Mariner/Linux` nodepools.

**Issue Fixed**:
NPM's Ubuntu base image was recently updated to `24.04` from `20.04` as the older version was EOL (see: https://github.com/Azure/azure-container-networking/pull/3743). There was a behavioral change between the 2 Ubuntu versions that required NPM to specify `legacy` for its Iptables. 

`Error: failed to create dataplane with error Operation [BootupDataplane] failed with error code [999], full cmd [], full error failed to reset policy dataplane: Operation [BootupPolicyManager] failed with error code [999], full cmd [], full error failed to bootup policy manager: failed to detect iptables version: unable to locate which iptables version kube proxy is using`

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

Clone of  - https://github.com/Azure/azure-container-networking/pull/3782

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [x] relevant PR labels added

**Notes**:
