### PR TITLE
[backport] #3791 ci: only check for code coverage at merge, not release

### DIFF
--- a/.pipelines/templates/run-unit-tests.yaml
+++ b/.pipelines/templates/run-unit-tests.yaml
@@ -60,50 +60,52 @@ stages:
               targetPath: 'windows-coverage.out'
               artifactName: 'windows-coverage'
 
-  - stage: code_coverage
-    displayName: Code Coverage Check
-    dependsOn:
-      - test
-    jobs:
-      - job: coverage
-        displayName: Check Coverage
-        pool:
-          name: "$(BUILD_POOL_NAME_DEFAULT)"
-        steps:
-          - task: DownloadPipelineArtifact@2
-            inputs:
-              artifact: 'linux-coverage'
-              path: './'
-          - bash: |
-              make tools
-              sudo ln -s $(pwd)/build/tools/bin/gocov /usr/local/bin/gocov
-              sudo ln -s $(pwd)/build/tools/bin/gocov-xml /usr/local/bin/gocov-xml
+  - ${{ if contains(variables['Build.SourceBranch'], 'master/pr') }}:
+    - stage: code_coverage
+      displayName: Code Coverage Check
+      dependsOn:
+        - test
+      jobs:
+        - job: coverage
+          displayName: Check Coverage
+          pool:
+            name: "$(BUILD_POOL_NAME_DEFAULT)"
+          steps:
+            - task: DownloadPipelineArtifact@2
+              inputs:
+                artifact: 'linux-coverage'
+                path: './'
+            - bash: |
+                make tools
+                sudo ln -s $(pwd)/build/tools/bin/gocov /usr/local/bin/gocov
+                sudo ln -s $(pwd)/build/tools/bin/gocov-xml /usr/local/bin/gocov-xml
 
-              GOOS=linux gocov convert linux-coverage.out > linux-coverage.json
-              GOOS=linux gocov-xml < linux-coverage.json > linux-coverage.xml
+                GOOS=linux gocov convert linux-coverage.out > linux-coverage.json
+                GOOS=linux gocov-xml < linux-coverage.json > linux-coverage.xml
 
-              # TODO: Add windows coverage back in once PublishCodeCoverageResults v2 works with BuildQualityChecks
+                # TODO: Add windows coverage back in once PublishCodeCoverageResults v2 works with BuildQualityChecks
 
-              mkdir coverage
+                mkdir coverage
 
-              mv linux-coverage.xml coverage/
-            name: "Coverage"
-            displayName: "Generate Coverage Report"
-            condition: always()
-          - task: PublishCodeCoverageResults@1
-            displayName: "Publish Code Coverage Report"
-            condition: always()
-            inputs:
-              codeCoverageTool: 'Cobertura'
-              summaryFileLocation: coverage/linux-coverage.xml
-          - task: BuildQualityChecks@8
-            displayName: "Check Code Coverage Regression"
-            condition: always()
-            inputs:
-              checkCoverage: true
-              coverageFailOption: "build"
-              coverageType: "lines"
-              fallbackOnPRTargetBranch: false
-              baseBranchRef: "master"
-              allowCoverageVariance: true
-              coverageVariance: 0.25
+                mv linux-coverage.xml coverage/
+              name: "Coverage"
+              displayName: "Generate Coverage Report"
+              condition: always()
+
+            - task: PublishCodeCoverageResults@1
+              displayName: "Publish Code Coverage Report"
+              condition: always()
+              inputs:
+                codeCoverageTool: 'Cobertura'
+                summaryFileLocation: coverage/linux-coverage.xml
+            - task: BuildQualityChecks@8
+              displayName: "Check Code Coverage Regression"
+              condition: always()
+              inputs:
+                checkCoverage: true
+                coverageFailOption: "build"
+                coverageType: "lines"
+                fallbackOnPRTargetBranch: false
+                baseBranchRef: "master"
+                allowCoverageVariance: true
+                coverageVariance: 0.25


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
See #3791 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
