### PR TITLE
feat: Remove symbols from all binaries

### DIFF
--- a/.pipelines/build/scripts/azure-ip-masq-merger.sh
+++ b/.pipelines/build/scripts/azure-ip-masq-merger.sh
@@ -4,7 +4,7 @@ set -eux
 [[ $OS =~ windows ]] && { echo "azure-ip-masq-merger is not supported on Windows"; exit 1; }
 FILE_EXT=''
 
-export CGO_ENABLED=0 
+export CGO_ENABLED=0
 
 mkdir -p "$OUT_DIR"/bin
 mkdir -p "$OUT_DIR"/files
@@ -12,7 +12,7 @@ mkdir -p "$OUT_DIR"/files
 pushd "$REPO_ROOT"/azure-ip-masq-merger
   GOOS="$OS" go build -v -a -trimpath \
     -o "$OUT_DIR"/bin/azure-ip-masq-merger"$FILE_EXT" \
-    -ldflags "-X github.com/Azure/azure-container-networking/azure-ip-masq-merger/internal/buildinfo.Version=$AZURE_IP_MASQ_MERGER_VERSION -X main.version=$AZURE_IP_MASQ_MERGER_VERSION" \
+    -ldflags "-s -w" "-X github.com/Azure/azure-container-networking/azure-ip-masq-merger/internal/buildinfo.Version=$AZURE_IP_MASQ_MERGER_VERSION -X main.version=$AZURE_IP_MASQ_MERGER_VERSION" \
     -gcflags="-dwarflocationlists=true" \
     .
 popd

--- a/.pipelines/build/scripts/azure-ip-masq-merger.sh
+++ b/.pipelines/build/scripts/azure-ip-masq-merger.sh
@@ -12,7 +12,7 @@ mkdir -p "$OUT_DIR"/files
 pushd "$REPO_ROOT"/azure-ip-masq-merger
   GOOS="$OS" go build -v -a -trimpath \
     -o "$OUT_DIR"/bin/azure-ip-masq-merger"$FILE_EXT" \
-    -ldflags "-s -w" "-X github.com/Azure/azure-container-networking/azure-ip-masq-merger/internal/buildinfo.Version=$AZURE_IP_MASQ_MERGER_VERSION -X main.version=$AZURE_IP_MASQ_MERGER_VERSION" \
+    -ldflags "-s -w -X github.com/Azure/azure-container-networking/azure-ip-masq-merger/internal/buildinfo.Version=$AZURE_IP_MASQ_MERGER_VERSION -X main.version=$AZURE_IP_MASQ_MERGER_VERSION" \
     -gcflags="-dwarflocationlists=true" \
     .
 popd

--- a/.pipelines/build/scripts/azure-ipam.sh
+++ b/.pipelines/build/scripts/azure-ipam.sh
@@ -3,7 +3,7 @@ set -eux
 
 [[ $OS =~ windows ]] && FILE_EXT='.exe' || FILE_EXT=''
 
-export CGO_ENABLED=0 
+export CGO_ENABLED=0
 
 mkdir -p "$OUT_DIR"/bin
 mkdir -p "$OUT_DIR"/files
@@ -11,7 +11,7 @@ mkdir -p "$OUT_DIR"/files
 pushd "$REPO_ROOT"/azure-ipam
   GOOS="$OS" go build -v -a -trimpath \
     -o "$OUT_DIR"/bin/azure-ipam"$FILE_EXT" \
-    -ldflags "-X github.com/Azure/azure-container-networking/azure-ipam/internal/buildinfo.Version="$AZURE_IPAM_VERSION" -X main.version="$AZURE_IPAM_VERSION"" \
+    -ldflags "-s -w" "-X github.com/Azure/azure-container-networking/azure-ipam/internal/buildinfo.Version="$AZURE_IPAM_VERSION" -X main.version="$AZURE_IPAM_VERSION"" \
     -gcflags="-dwarflocationlists=true" \
     .
 

--- a/.pipelines/build/scripts/azure-ipam.sh
+++ b/.pipelines/build/scripts/azure-ipam.sh
@@ -11,7 +11,7 @@ mkdir -p "$OUT_DIR"/files
 pushd "$REPO_ROOT"/azure-ipam
   GOOS="$OS" go build -v -a -trimpath \
     -o "$OUT_DIR"/bin/azure-ipam"$FILE_EXT" \
-    -ldflags "-s -w" "-X github.com/Azure/azure-container-networking/azure-ipam/internal/buildinfo.Version="$AZURE_IPAM_VERSION" -X main.version="$AZURE_IPAM_VERSION"" \
+    -ldflags "-s -w -X github.com/Azure/azure-container-networking/azure-ipam/internal/buildinfo.Version="$AZURE_IPAM_VERSION" -X main.version="$AZURE_IPAM_VERSION"" \
     -gcflags="-dwarflocationlists=true" \
     .
 

--- a/.pipelines/build/scripts/cni.sh
+++ b/.pipelines/build/scripts/cni.sh
@@ -13,7 +13,7 @@ CNI_NET_DIR="$REPO_ROOT"/cni/network/plugin
 pushd "$CNI_NET_DIR"
   GOOS="$OS" go build -v -a -trimpath \
     -o "$OUT_DIR"/bin/azure-vnet"$FILE_EXT" \
-    -ldflags "-s -w" "-X main.version="$CNI_VERSION"" \
+    -ldflags "-s -w -X main.version="$CNI_VERSION"" \
     -gcflags="-dwarflocationlists=true" \
     ./main.go
 popd
@@ -22,7 +22,7 @@ STATELESS_CNI_BUILD_DIR="$REPO_ROOT"/cni/network/stateless
 pushd "$STATELESS_CNI_BUILD_DIR"
   GOOS="$OS" go build -v -a -trimpath \
     -o "$OUT_DIR"/bin/azure-vnet-stateless"$FILE_EXT" \
-    -ldflags "-s -w" "-X main.version="$CNI_VERSION"" \
+    -ldflags "-s -w -X main.version="$CNI_VERSION"" \
     -gcflags="-dwarflocationlists=true" \
     ./main.go
 popd
@@ -31,7 +31,7 @@ CNI_IPAM_DIR="$REPO_ROOT"/cni/ipam/plugin
 pushd "$CNI_IPAM_DIR"
   GOOS="$OS" go build -v -a -trimpath \
     -o "$OUT_DIR"/bin/azure-vnet-ipam"$FILE_EXT" \
-    -ldflags "-s -w" "-X main.version="$CNI_VERSION"" \
+    -ldflags "-s -w -X main.version="$CNI_VERSION"" \
     -gcflags="-dwarflocationlists=true" \
     ./main.go
 popd
@@ -40,7 +40,7 @@ CNI_IPAMV6_DIR="$REPO_ROOT"/cni/ipam/pluginv6
 pushd "$CNI_IPAMV6_DIR"
   GOOS="$OS" go build -v -a -trimpath \
     -o "$OUT_DIR"/bin/azure-vnet-ipamv6"$FILE_EXT" \
-    -ldflags "-s -w" "-X main.version="$CNI_VERSION"" \
+    -ldflags "-s -w -X main.version="$CNI_VERSION"" \
     -gcflags="-dwarflocationlists=true" \
     ./main.go
 popd
@@ -49,7 +49,7 @@ CNI_TELEMETRY_DIR="$REPO_ROOT"/cni/telemetry/service
 pushd "$CNI_TELEMETRY_DIR"
   GOOS="$OS" go build -v -a -trimpath \
     -o "$OUT_DIR"/bin/azure-vnet-telemetry"$FILE_EXT" \
-    -ldflags "-s -w" "-X main.version="$CNI_VERSION" -X "$CNI_AI_PATH"="$CNI_AI_ID"" \
+    -ldflags "-s -w -X main.version="$CNI_VERSION" -X "$CNI_AI_PATH"="$CNI_AI_ID"" \
     -gcflags="-dwarflocationlists=true" \
    ./telemetrymain.go
 popd

--- a/.pipelines/build/scripts/cni.sh
+++ b/.pipelines/build/scripts/cni.sh
@@ -6,14 +6,14 @@ set -eux
 mkdir -p "$OUT_DIR"/files
 mkdir -p "$OUT_DIR"/bin
 
-export CGO_ENABLED=0 
+export CGO_ENABLED=0
 
 
 CNI_NET_DIR="$REPO_ROOT"/cni/network/plugin
 pushd "$CNI_NET_DIR"
   GOOS="$OS" go build -v -a -trimpath \
     -o "$OUT_DIR"/bin/azure-vnet"$FILE_EXT" \
-    -ldflags "-X main.version="$CNI_VERSION"" \
+    -ldflags "-s -w" "-X main.version="$CNI_VERSION"" \
     -gcflags="-dwarflocationlists=true" \
     ./main.go
 popd
@@ -22,7 +22,7 @@ STATELESS_CNI_BUILD_DIR="$REPO_ROOT"/cni/network/stateless
 pushd "$STATELESS_CNI_BUILD_DIR"
   GOOS="$OS" go build -v -a -trimpath \
     -o "$OUT_DIR"/bin/azure-vnet-stateless"$FILE_EXT" \
-    -ldflags "-X main.version="$CNI_VERSION"" \
+    -ldflags "-s -w" "-X main.version="$CNI_VERSION"" \
     -gcflags="-dwarflocationlists=true" \
     ./main.go
 popd
@@ -31,7 +31,7 @@ CNI_IPAM_DIR="$REPO_ROOT"/cni/ipam/plugin
 pushd "$CNI_IPAM_DIR"
   GOOS="$OS" go build -v -a -trimpath \
     -o "$OUT_DIR"/bin/azure-vnet-ipam"$FILE_EXT" \
-    -ldflags "-X main.version="$CNI_VERSION"" \
+    -ldflags "-s -w" "-X main.version="$CNI_VERSION"" \
     -gcflags="-dwarflocationlists=true" \
     ./main.go
 popd
@@ -40,7 +40,7 @@ CNI_IPAMV6_DIR="$REPO_ROOT"/cni/ipam/pluginv6
 pushd "$CNI_IPAMV6_DIR"
   GOOS="$OS" go build -v -a -trimpath \
     -o "$OUT_DIR"/bin/azure-vnet-ipamv6"$FILE_EXT" \
-    -ldflags "-X main.version="$CNI_VERSION"" \
+    -ldflags "-s -w" "-X main.version="$CNI_VERSION"" \
     -gcflags="-dwarflocationlists=true" \
     ./main.go
 popd
@@ -49,7 +49,7 @@ CNI_TELEMETRY_DIR="$REPO_ROOT"/cni/telemetry/service
 pushd "$CNI_TELEMETRY_DIR"
   GOOS="$OS" go build -v -a -trimpath \
     -o "$OUT_DIR"/bin/azure-vnet-telemetry"$FILE_EXT" \
-    -ldflags "-X main.version="$CNI_VERSION" -X "$CNI_AI_PATH"="$CNI_AI_ID"" \
+    -ldflags "-s -w" "-X main.version="$CNI_VERSION" -X "$CNI_AI_PATH"="$CNI_AI_ID"" \
     -gcflags="-dwarflocationlists=true" \
    ./telemetrymain.go
 popd

--- a/.pipelines/build/scripts/cns.sh
+++ b/.pipelines/build/scripts/cns.sh
@@ -3,7 +3,7 @@ set -eux
 
 [[ $OS =~ windows ]] && FILE_EXT='.exe' || FILE_EXT=''
 
-export CGO_ENABLED=0 
+export CGO_ENABLED=0
 
 mkdir -p "$OUT_DIR"/files
 mkdir -p "$OUT_DIR"/bin
@@ -12,7 +12,7 @@ mkdir -p "$OUT_DIR"/scripts
 pushd "$REPO_ROOT"/cns
   GOOS="$OS" go build -v -a \
     -o "$OUT_DIR"/bin/azure-cns"$FILE_EXT" \
-    -ldflags "-X main.version="$CNS_VERSION" -X "$CNS_AI_PATH"="$CNS_AI_ID"" \
+    -ldflags "-s -w" "-X main.version="$CNS_VERSION" -X "$CNS_AI_PATH"="$CNS_AI_ID"" \
     -gcflags="-dwarflocationlists=true" \
     service/*.go
   cp kubeconfigtemplate.yaml "$OUT_DIR"/files/kubeconfigtemplate.yaml

--- a/.pipelines/build/scripts/cns.sh
+++ b/.pipelines/build/scripts/cns.sh
@@ -12,7 +12,7 @@ mkdir -p "$OUT_DIR"/scripts
 pushd "$REPO_ROOT"/cns
   GOOS="$OS" go build -v -a \
     -o "$OUT_DIR"/bin/azure-cns"$FILE_EXT" \
-    -ldflags "-s -w" "-X main.version="$CNS_VERSION" -X "$CNS_AI_PATH"="$CNS_AI_ID"" \
+    -ldflags "-s -w -X main.version="$CNS_VERSION" -X "$CNS_AI_PATH"="$CNS_AI_ID"" \
     -gcflags="-dwarflocationlists=true" \
     service/*.go
   cp kubeconfigtemplate.yaml "$OUT_DIR"/files/kubeconfigtemplate.yaml

--- a/.pipelines/build/scripts/dropgz.sh
+++ b/.pipelines/build/scripts/dropgz.sh
@@ -58,7 +58,7 @@ pushd "$DROPGZ_BUILD_DIR"/pkg/mod/"$DROPGZ_MOD_DOWNLOAD_PATH"
   mv "$PAYLOAD_DIR"/* pkg/embed/fs/
   GOOS="$OS" go build -v -trimpath -a \
     -o "$OUT_DIR"/bin/dropgz"$FILE_EXT" \
-    -ldflags "-s -w" "-X github.com/Azure/azure-container-networking/dropgz/internal/buildinfo.Version="$DROPGZ_VERSION"" \
+    -ldflags "-s -w -X github.com/Azure/azure-container-networking/dropgz/internal/buildinfo.Version="$DROPGZ_VERSION"" \
     -gcflags="-dwarflocationlists=true" \
     main.go
 popd

--- a/.pipelines/build/scripts/dropgz.sh
+++ b/.pipelines/build/scripts/dropgz.sh
@@ -20,7 +20,7 @@ function files::remove_exe_extensions() {
 
 [[ $OS =~ windows ]] && FILE_EXT='.exe' || FILE_EXT=''
 
-export CGO_ENABLED=0 
+export CGO_ENABLED=0
 
 mkdir -p "$GEN_DIR"
 mkdir -p "$OUT_DIR"/bin
@@ -40,11 +40,11 @@ pushd "$PAYLOAD_DIR"
   [[ -d "$OUT_DIR"/bin ]] && cp "$OUT_DIR"/bin/* . || true
 
   [[ $OS =~ windows ]] && files::remove_exe_extensions .
-  
+
   sha256sum * > sum.txt
   gzip --verbose --best --recursive .
 
-  for file in $(find . -name '*.gz'); do 
+  for file in $(find . -name '*.gz'); do
     mv "$file" "${file%%.gz}"
   done
 popd
@@ -58,7 +58,7 @@ pushd "$DROPGZ_BUILD_DIR"/pkg/mod/"$DROPGZ_MOD_DOWNLOAD_PATH"
   mv "$PAYLOAD_DIR"/* pkg/embed/fs/
   GOOS="$OS" go build -v -trimpath -a \
     -o "$OUT_DIR"/bin/dropgz"$FILE_EXT" \
-    -ldflags "-X github.com/Azure/azure-container-networking/dropgz/internal/buildinfo.Version="$DROPGZ_VERSION"" \
+    -ldflags "-s -w" "-X github.com/Azure/azure-container-networking/dropgz/internal/buildinfo.Version="$DROPGZ_VERSION"" \
     -gcflags="-dwarflocationlists=true" \
     main.go
 popd

--- a/.pipelines/build/scripts/ipv6-hp-bpf.sh
+++ b/.pipelines/build/scripts/ipv6-hp-bpf.sh
@@ -159,6 +159,6 @@ pushd "$REPO_ROOT"/bpf-prog/ipv6-hp-bpf
   go generate ./...
   GOOS="$OS" go build -v -a -trimpath \
     -o "$OUT_DIR"/bin/ipv6-hp-bpf"$FILE_EXT" \
-    -ldflags "-s -w" "-X main.version="$IPV6_HP_BPF_VERSION"" \
+    -ldflags "-s -w -X main.version="$IPV6_HP_BPF_VERSION"" \
     -gcflags="-dwarflocationlists=true" .
 popd

--- a/.pipelines/build/scripts/ipv6-hp-bpf.sh
+++ b/.pipelines/build/scripts/ipv6-hp-bpf.sh
@@ -37,7 +37,7 @@ function findcp::shared_library() {
 
 [[ $OS =~ windows ]] && FILE_EXT='.exe' || FILE_EXT=''
 
-export CGO_ENABLED=0 
+export CGO_ENABLED=0
 export C_INCLUDE_PATH=/usr/include/bpf
 
 mkdir -p "$OUT_DIR"/bin
@@ -52,7 +52,7 @@ if [[ -f /etc/debian_version ]];then
 
     ARCH=x86_64-linux-gnu
     cp /usr/lib/"$ARCH"/ld-linux-x86-64.so.2 "$OUT_DIR"/lib/
-  
+
   elif [[ $ARCH =~ arm64 ]]; then
     apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu
 
@@ -60,7 +60,7 @@ if [[ -f /etc/debian_version ]];then
     cp /usr/lib/"$ARCH"/ld-linux-aarch64.so.1 "$OUT_DIR"/lib/
   fi
 
-  for dir in /usr/include/"$ARCH"/*; do 
+  for dir in /usr/include/"$ARCH"/*; do
     ln -sfn "$dir" /usr/include/$(basename "$dir")
   done
 
@@ -101,14 +101,14 @@ else
     ARCH=aarch64-linux-gnu
     #tdnf install -y glibc-devel.i386
     if [[ -f '/usr/lib/ld-linux-aarch64.so.1' ]]; then
-      cp /usr/lib/ld-linux-aarch64.so.1 "$OUT_DIR"/lib/ 
+      cp /usr/lib/ld-linux-aarch64.so.1 "$OUT_DIR"/lib/
     fi
   fi
-  for dir in /usr/include/"$ARCH"/*; do 
+  for dir in /usr/include/"$ARCH"/*; do
     if [[ -d $dir ]]; then
-      ln -sfn "$dir" /usr/include/$(basename "$dir") 
+      ln -sfn "$dir" /usr/include/$(basename "$dir")
     elif [[ -f "$dir" ]]; then
-      ln -Tsfn "$dir" /usr/include/$(basename "$dir") 
+      ln -Tsfn "$dir" /usr/include/$(basename "$dir")
     fi
   done
 
@@ -152,13 +152,13 @@ cp /sbin/ip "$OUT_DIR"/bin/ip"$FILE_EXT"
 pushd "$REPO_ROOT"/bpf-prog/ipv6-hp-bpf
   cp ./cmd/ipv6-hp-bpf/*.go .
 
-  if [[ "$DEBUG" =~ ^[T|t]rue$ ]]; then 
+  if [[ "$DEBUG" =~ ^[T|t]rue$ ]]; then
     echo -e "\n#define DEBUG" >> ./include/helper.h
   fi
 
   go generate ./...
   GOOS="$OS" go build -v -a -trimpath \
     -o "$OUT_DIR"/bin/ipv6-hp-bpf"$FILE_EXT" \
-    -ldflags "-X main.version="$IPV6_HP_BPF_VERSION"" \
+    -ldflags "-s -w" "-X main.version="$IPV6_HP_BPF_VERSION"" \
     -gcflags="-dwarflocationlists=true" .
 popd

--- a/.pipelines/build/scripts/npm.sh
+++ b/.pipelines/build/scripts/npm.sh
@@ -12,7 +12,7 @@ mkdir -p "$OUT_DIR"/scripts
 pushd "$REPO_ROOT"/npm
   GOOS="$OS" go build -a -v -trimpath \
     -o "$OUT_DIR"/bin/azure-npm"$FILE_EXT" \
-    -ldflags "-s -w" "-X main.version="$NPM_VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" \
+    -ldflags "-s -w -X main.version="$NPM_VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" \
     -gcflags="-dwarflocationlists=true" \
     ./cmd/*.go
 

--- a/.pipelines/build/scripts/npm.sh
+++ b/.pipelines/build/scripts/npm.sh
@@ -3,7 +3,7 @@ set -eux
 
 [[ $OS =~ windows ]] && FILE_EXT='.exe' || FILE_EXT=''
 
-export CGO_ENABLED=0 
+export CGO_ENABLED=0
 
 mkdir -p "$OUT_DIR"/files
 mkdir -p "$OUT_DIR"/bin
@@ -12,7 +12,7 @@ mkdir -p "$OUT_DIR"/scripts
 pushd "$REPO_ROOT"/npm
   GOOS="$OS" go build -a -v -trimpath \
     -o "$OUT_DIR"/bin/azure-npm"$FILE_EXT" \
-    -ldflags "-X main.version="$NPM_VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" \
+    -ldflags "-s -w" "-X main.version="$NPM_VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" \
     -gcflags="-dwarflocationlists=true" \
     ./cmd/*.go
 

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,11 @@ RMDIR := powershell.exe -NoProfile -Command Remove-Item -Recurse -Force
 endif
 
 # Build defaults.
-GOOS 	 ?= $(shell go env GOOS)
-GOARCH   ?= $(shell go env GOARCH)
-GOOSES   ?= "linux windows" # To override at the cli do: GOOSES="\"darwin bsd\""
-GOARCHES ?= "amd64 arm64" # To override at the cli do: GOARCHES="\"ppc64 mips\""
+GOOS 	 		?= $(shell go env GOOS)
+GOARCH   		?= $(shell go env GOARCH)
+GOOSES   		?= "linux windows" # To override at the cli do: GOOSES="\"darwin bsd\""
+GOARCHES 		?= "amd64 arm64" # To override at the cli do: GOARCHES="\"ppc64 mips\""
+LD_BUILD_FLAGS 	?= ""
 
 # Windows specific extensions
 # set these based on the GOOS, not the OS
@@ -176,12 +177,12 @@ zapai-version: ## prints the zapai version
 
 # Build the delegated IPAM plugin binary.
 azure-ipam-binary:
-	cd $(AZURE_IPAM_DIR) && CGO_ENABLED=0 go build -v -o $(AZURE_IPAM_BUILD_DIR)/azure-ipam$(EXE_EXT) -ldflags "-X github.com/Azure/azure-container-networking/azure-ipam/internal/buildinfo.Version=$(AZURE_IPAM_VERSION)" -gcflags="-dwarflocationlists=true"
+	cd $(AZURE_IPAM_DIR) && CGO_ENABLED=0 go build -v -o $(AZURE_IPAM_BUILD_DIR)/azure-ipam$(EXE_EXT) -ldflags "-X github.com/Azure/azure-container-networking/azure-ipam/internal/buildinfo.Version=$(AZURE_IPAM_VERSION) $(LD_BUILD_FLAGS)" -gcflags="-dwarflocationlists=true"
 
 # Build the ipv6-hp-bpf binary.
 ipv6-hp-bpf-binary:
 	cd $(IPV6_HP_BPF_DIR) && CGO_ENABLED=0 go generate ./...
-	cd $(IPV6_HP_BPF_DIR)/cmd/ipv6-hp-bpf && CGO_ENABLED=0 go build -v -o $(IPV6_HP_BPF_BUILD_DIR)/ipv6-hp-bpf$(EXE_EXT) -ldflags "-X main.version=$(IPV6_HP_BPF_VERSION)" -gcflags="-dwarflocationlists=true"
+	cd $(IPV6_HP_BPF_DIR)/cmd/ipv6-hp-bpf && CGO_ENABLED=0 go build -v -o $(IPV6_HP_BPF_BUILD_DIR)/ipv6-hp-bpf$(EXE_EXT) -ldflags "-X main.version=$(IPV6_HP_BPF_VERSION) $(LD_BUILD_FLAGS)" -gcflags="-dwarflocationlists=true"
 
 # Libraries for ipv6-hp-bpf
 ipv6-hp-bpf-lib:
@@ -195,40 +196,40 @@ endif
 
 # Build the Azure CNI network binary.
 azure-vnet-binary:
-	cd $(CNI_NET_DIR) && CGO_ENABLED=0 go build -v -o $(CNI_BUILD_DIR)/azure-vnet$(EXE_EXT) -ldflags "-X main.version=$(CNI_VERSION)" -gcflags="-dwarflocationlists=true"
+	cd $(CNI_NET_DIR) && CGO_ENABLED=0 go build -v -o $(CNI_BUILD_DIR)/azure-vnet$(EXE_EXT) -ldflags "-X main.version=$(CNI_VERSION) $(LD_BUILD_FLAGS)" -gcflags="-dwarflocationlists=true"
 
 # Build the Azure CNI stateless network binary
 azure-vnet-stateless-binary:
-	cd $(STATELESS_CNI_NET_DIR) && CGO_ENABLED=0 go build -v -o $(STATELESS_CNI_BUILD_DIR)/azure-vnet$(EXE_EXT) -ldflags "-X main.version=$(CNI_VERSION)" -gcflags="-dwarflocationlists=true"
+	cd $(STATELESS_CNI_NET_DIR) && CGO_ENABLED=0 go build -v -o $(STATELESS_CNI_BUILD_DIR)/azure-vnet$(EXE_EXT) -ldflags "-X main.version=$(CNI_VERSION) $(LD_BUILD_FLAGS)" -gcflags="-dwarflocationlists=true"
 
 # Build the Azure CNI IPAM binary.
 azure-vnet-ipam-binary:
-	cd $(CNI_IPAM_DIR) && CGO_ENABLED=0 go build -v -o $(CNI_BUILD_DIR)/azure-vnet-ipam$(EXE_EXT) -ldflags "-X main.version=$(CNI_VERSION)" -gcflags="-dwarflocationlists=true"
+	cd $(CNI_IPAM_DIR) && CGO_ENABLED=0 go build -v -o $(CNI_BUILD_DIR)/azure-vnet-ipam$(EXE_EXT) -ldflags "-X main.version=$(CNI_VERSION) $(LD_BUILD_FLAGS)" -gcflags="-dwarflocationlists=true"
 
 # Build the Azure CNI IPAMV6 binary.
 azure-vnet-ipamv6-binary:
-	cd $(CNI_IPAMV6_DIR) && CGO_ENABLED=0 go build -v -o $(CNI_BUILD_DIR)/azure-vnet-ipamv6$(EXE_EXT) -ldflags "-X main.version=$(CNI_VERSION)" -gcflags="-dwarflocationlists=true"
+	cd $(CNI_IPAMV6_DIR) && CGO_ENABLED=0 go build -v -o $(CNI_BUILD_DIR)/azure-vnet-ipamv6$(EXE_EXT) -ldflags "-X main.version=$(CNI_VERSION) $(LD_BUILD_FLAGS)" -gcflags="-dwarflocationlists=true"
 
 # Build the Azure CNI telemetry binary.
 azure-vnet-telemetry-binary:
-	cd $(CNI_TELEMETRY_DIR) && CGO_ENABLED=0 go build -v -o $(CNI_BUILD_DIR)/azure-vnet-telemetry$(EXE_EXT) -ldflags "-X main.version=$(CNI_VERSION) -X $(CNI_AI_PATH)=$(CNI_AI_ID)" -gcflags="-dwarflocationlists=true"
+	cd $(CNI_TELEMETRY_DIR) && CGO_ENABLED=0 go build -v -o $(CNI_BUILD_DIR)/azure-vnet-telemetry$(EXE_EXT) -ldflags "-X main.version=$(CNI_VERSION) -X $(CNI_AI_PATH)=$(CNI_AI_ID) $(LD_BUILD_FLAGS)" -gcflags="-dwarflocationlists=true"
 
 # Build the Azure CLI network binary.
 acncli-binary:
-	cd $(ACNCLI_DIR) && CGO_ENABLED=0 go build -v -o $(ACNCLI_BUILD_DIR)/acn$(EXE_EXT) -ldflags "-X main.version=$(ACN_VERSION)" -gcflags="-dwarflocationlists=true"
+	cd $(ACNCLI_DIR) && CGO_ENABLED=0 go build -v -o $(ACNCLI_BUILD_DIR)/acn$(EXE_EXT) -ldflags "-X main.version=$(ACN_VERSION) $(LD_BUILD_FLAGS)" -gcflags="-dwarflocationlists=true"
 
 # Build the Azure CNS binary.
 azure-cns-binary:
-	cd $(CNS_DIR) && CGO_ENABLED=0 go build -v -o $(CNS_BUILD_DIR)/azure-cns$(EXE_EXT) -ldflags "-X main.version=$(CNS_VERSION) -X $(CNS_AI_PATH)=$(CNS_AI_ID) -X $(CNI_AI_PATH)=$(CNI_AI_ID)" -gcflags="-dwarflocationlists=true"
+	cd $(CNS_DIR) && CGO_ENABLED=0 go build -v -o $(CNS_BUILD_DIR)/azure-cns$(EXE_EXT) -ldflags "-X main.version=$(CNS_VERSION) -X $(CNS_AI_PATH)=$(CNS_AI_ID) -X $(CNI_AI_PATH)=$(CNI_AI_ID) $(LD_BUILD_FLAGS)" -gcflags="-dwarflocationlists=true"
 
 # Build the Azure NPM binary.
 azure-npm-binary:
-	cd $(CNI_TELEMETRY_DIR) && CGO_ENABLED=0 go build -v -o $(NPM_BUILD_DIR)/azure-vnet-telemetry$(EXE_EXT) -ldflags "-X main.version=$(NPM_VERSION)" -gcflags="-dwarflocationlists=true"
-	cd $(NPM_DIR) && CGO_ENABLED=0 go build -v -o $(NPM_BUILD_DIR)/azure-npm$(EXE_EXT) -ldflags "-X main.version=$(NPM_VERSION) -X $(NPM_AI_PATH)=$(NPM_AI_ID)" -gcflags="-dwarflocationlists=true"
+	cd $(CNI_TELEMETRY_DIR) && CGO_ENABLED=0 go build -v -o $(NPM_BUILD_DIR)/azure-vnet-telemetry$(EXE_EXT) -ldflags "-X main.version=$(NPM_VERSION) $(LD_BUILD_FLAGS)" -gcflags="-dwarflocationlists=true"
+	cd $(NPM_DIR) && CGO_ENABLED=0 go build -v -o $(NPM_BUILD_DIR)/azure-npm$(EXE_EXT) -ldflags "-X main.version=$(NPM_VERSION) -X $(NPM_AI_PATH)=$(NPM_AI_ID) $(LD_BUILD_FLAGS)" -gcflags="-dwarflocationlists=true"
 
 # Build the azure-ip-masq-merger binary.
 azure-ip-masq-merger-binary:
-	cd $(AZURE_IP_MASQ_MERGER_DIR) && CGO_ENABLED=0 go build -v -o $(AZURE_IP_MASQ_MERGER_BUILD_DIR)/azure-ip-masq-merger$(EXE_EXT) -ldflags "-X main.version=$(AZURE_IP_MASQ_MERGER_VERSION)" -gcflags="-dwarflocationlists=true"
+	cd $(AZURE_IP_MASQ_MERGER_DIR) && CGO_ENABLED=0 go build -v -o $(AZURE_IP_MASQ_MERGER_BUILD_DIR)/azure-ip-masq-merger$(EXE_EXT) -ldflags "-X main.version=$(AZURE_IP_MASQ_MERGER_VERSION) $(LD_BUILD_FLAGS)" -gcflags="-dwarflocationlists=true"
 
 ##@ Containers
 
@@ -825,7 +826,7 @@ CNI_TYPE ?= cilium
 
 test-all: test-azure-ipam test-azure-ip-masq-merger test-main ## run all unit tests.
 
-test-main: 
+test-main:
 	go test -mod=readonly -buildvcs=false -tags "unit" --skip 'TestE2E*' -race -covermode atomic -coverprofile=coverage-main.out $(COVER_PKG)/...
 	go tool cover -func=coverage-main.out
 

--- a/azure-ip-masq-merger/Dockerfile
+++ b/azure-ip-masq-merger/Dockerfile
@@ -9,7 +9,7 @@ ARG OS
 ARG VERSION
 WORKDIR /azure-ip-masq-merger
 COPY ./azure-ip-masq-merger .
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/ip-masq-merger -trimpath -ldflags "-s -w" "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" .
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/ip-masq-merger -trimpath -ldflags "-s -w -X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" .
 
 FROM scratch AS linux
 COPY --from=azure-ip-masq-merger /go/bin/ip-masq-merger azure-ip-masq-merger

--- a/azure-ip-masq-merger/Dockerfile
+++ b/azure-ip-masq-merger/Dockerfile
@@ -9,7 +9,7 @@ ARG OS
 ARG VERSION
 WORKDIR /azure-ip-masq-merger
 COPY ./azure-ip-masq-merger .
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/ip-masq-merger -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" .
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/ip-masq-merger -trimpath -ldflags "-s -w" "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" .
 
 FROM scratch AS linux
 COPY --from=azure-ip-masq-merger /go/bin/ip-masq-merger azure-ip-masq-merger

--- a/azure-ipam/Dockerfile
+++ b/azure-ipam/Dockerfile
@@ -14,7 +14,7 @@ ARG OS
 ARG VERSION
 WORKDIR /azure-ipam
 COPY ./azure-ipam .
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-ipam -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" .
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-ipam -trimpath -ldflags "-s -w" "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" .
 
 FROM mariner-core AS compressor
 ARG OS
@@ -31,7 +31,7 @@ ARG VERSION
 RUN go mod download github.com/azure/azure-container-networking/dropgz@$DROPGZ_VERSION
 WORKDIR /go/pkg/mod/github.com/azure/azure-container-networking/dropgz\@$DROPGZ_VERSION
 COPY --from=compressor /payload/* pkg/embed/fs/
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/dropgz -trimpath -ldflags "-X github.com/Azure/azure-container-networking/dropgz/internal/buildinfo.Version="$VERSION"" -gcflags="-dwarflocationlists=true" main.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/dropgz -trimpath -ldflags "-s -w" "-X github.com/Azure/azure-container-networking/dropgz/internal/buildinfo.Version="$VERSION"" -gcflags="-dwarflocationlists=true" main.go
 
 FROM scratch AS linux
 COPY --from=dropgz /go/bin/dropgz dropgz

--- a/azure-ipam/Dockerfile
+++ b/azure-ipam/Dockerfile
@@ -14,7 +14,7 @@ ARG OS
 ARG VERSION
 WORKDIR /azure-ipam
 COPY ./azure-ipam .
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-ipam -trimpath -ldflags "-s -w" "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" .
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-ipam -trimpath -ldflags "-s -w -X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" .
 
 FROM mariner-core AS compressor
 ARG OS
@@ -31,7 +31,7 @@ ARG VERSION
 RUN go mod download github.com/azure/azure-container-networking/dropgz@$DROPGZ_VERSION
 WORKDIR /go/pkg/mod/github.com/azure/azure-container-networking/dropgz\@$DROPGZ_VERSION
 COPY --from=compressor /payload/* pkg/embed/fs/
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/dropgz -trimpath -ldflags "-s -w" "-X github.com/Azure/azure-container-networking/dropgz/internal/buildinfo.Version="$VERSION"" -gcflags="-dwarflocationlists=true" main.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/dropgz -trimpath -ldflags "-s -w -X github.com/Azure/azure-container-networking/dropgz/internal/buildinfo.Version="$VERSION"" -gcflags="-dwarflocationlists=true" main.go
 
 FROM scratch AS linux
 COPY --from=dropgz /go/bin/dropgz dropgz

--- a/bpf-prog/ipv6-hp-bpf/linux.Dockerfile
+++ b/bpf-prog/ipv6-hp-bpf/linux.Dockerfile
@@ -37,7 +37,7 @@ RUN if [ "$ARCH" = "arm64" ]; then \
 ENV C_INCLUDE_PATH=/usr/include/bpf
 RUN if [ "$DEBUG" = "true" ]; then echo "\n#define DEBUG" >> /bpf-prog/ipv6-hp-bpf/include/helper.h; fi
 RUN GOOS=$OS CGO_ENABLED=0 go generate ./...
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/ipv6-hp-bpf -trimpath -ldflags "-s -w" "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" .
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/ipv6-hp-bpf -trimpath -ldflags "-s -w -X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" .
 
 FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 AS linux
 COPY --from=builder /go/bin/ipv6-hp-bpf /ipv6-hp-bpf

--- a/bpf-prog/ipv6-hp-bpf/linux.Dockerfile
+++ b/bpf-prog/ipv6-hp-bpf/linux.Dockerfile
@@ -37,7 +37,7 @@ RUN if [ "$ARCH" = "arm64" ]; then \
 ENV C_INCLUDE_PATH=/usr/include/bpf
 RUN if [ "$DEBUG" = "true" ]; then echo "\n#define DEBUG" >> /bpf-prog/ipv6-hp-bpf/include/helper.h; fi
 RUN GOOS=$OS CGO_ENABLED=0 go generate ./...
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/ipv6-hp-bpf -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" .
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/ipv6-hp-bpf -trimpath -ldflags "-s -w" "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" .
 
 FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 AS linux
 COPY --from=builder /go/bin/ipv6-hp-bpf /ipv6-hp-bpf

--- a/cni/Dockerfile
+++ b/cni/Dockerfile
@@ -18,10 +18,10 @@ ARG CNI_AI_PATH
 ARG CNI_AI_ID
 WORKDIR /azure-container-networking
 COPY . .
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet -trimpath -ldflags "-s -w" "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/plugin/main.go
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-telemetry -trimpath -ldflags "-s -w" "-X main.version="$VERSION" -X "$CNI_AI_PATH"="$CNI_AI_ID"" -gcflags="-dwarflocationlists=true" cni/telemetry/service/telemetrymain.go
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-ipam -trimpath -ldflags "-s -w" "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/ipam/plugin/main.go
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-stateless -trimpath -ldflags "-s -w" "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/stateless/main.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet -trimpath -ldflags "-s -w -X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/plugin/main.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-telemetry -trimpath -ldflags "-s -w -X main.version="$VERSION" -X "$CNI_AI_PATH"="$CNI_AI_ID"" -gcflags="-dwarflocationlists=true" cni/telemetry/service/telemetrymain.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-ipam -trimpath -ldflags "-s -w -X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/ipam/plugin/main.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-stateless -trimpath -ldflags "-s -w -X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/stateless/main.go
 
 FROM mariner-core AS compressor
 ARG OS
@@ -44,7 +44,7 @@ ARG VERSION
 RUN go mod download github.com/azure/azure-container-networking/dropgz@$DROPGZ_VERSION
 WORKDIR /go/pkg/mod/github.com/azure/azure-container-networking/dropgz\@$DROPGZ_VERSION
 COPY --from=compressor /payload/* pkg/embed/fs/
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/dropgz -trimpath -ldflags "-s -w" "-X github.com/Azure/azure-container-networking/dropgz/internal/buildinfo.Version="$VERSION"" -gcflags="-dwarflocationlists=true" main.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/dropgz -trimpath -ldflags "-s -w -X github.com/Azure/azure-container-networking/dropgz/internal/buildinfo.Version="$VERSION"" -gcflags="-dwarflocationlists=true" main.go
 
 FROM scratch AS bins
 COPY --from=azure-vnet /go/bin/* /

--- a/cni/Dockerfile
+++ b/cni/Dockerfile
@@ -18,10 +18,10 @@ ARG CNI_AI_PATH
 ARG CNI_AI_ID
 WORKDIR /azure-container-networking
 COPY . .
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/plugin/main.go
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-telemetry -trimpath -ldflags "-X main.version="$VERSION" -X "$CNI_AI_PATH"="$CNI_AI_ID"" -gcflags="-dwarflocationlists=true" cni/telemetry/service/telemetrymain.go
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-ipam -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/ipam/plugin/main.go
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-stateless -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/stateless/main.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet -trimpath -ldflags "-s -w" "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/plugin/main.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-telemetry -trimpath -ldflags "-s -w" "-X main.version="$VERSION" -X "$CNI_AI_PATH"="$CNI_AI_ID"" -gcflags="-dwarflocationlists=true" cni/telemetry/service/telemetrymain.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-ipam -trimpath -ldflags "-s -w" "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/ipam/plugin/main.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-stateless -trimpath -ldflags "-s -w" "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/stateless/main.go
 
 FROM mariner-core AS compressor
 ARG OS
@@ -44,7 +44,7 @@ ARG VERSION
 RUN go mod download github.com/azure/azure-container-networking/dropgz@$DROPGZ_VERSION
 WORKDIR /go/pkg/mod/github.com/azure/azure-container-networking/dropgz\@$DROPGZ_VERSION
 COPY --from=compressor /payload/* pkg/embed/fs/
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/dropgz -trimpath -ldflags "-X github.com/Azure/azure-container-networking/dropgz/internal/buildinfo.Version="$VERSION"" -gcflags="-dwarflocationlists=true" main.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/dropgz -trimpath -ldflags "-s -w" "-X github.com/Azure/azure-container-networking/dropgz/internal/buildinfo.Version="$VERSION"" -gcflags="-dwarflocationlists=true" main.go
 
 FROM scratch AS bins
 COPY --from=azure-vnet /go/bin/* /

--- a/cni/Dockerfile.tmpl
+++ b/cni/Dockerfile.tmpl
@@ -18,10 +18,10 @@ ARG CNI_AI_PATH
 ARG CNI_AI_ID
 WORKDIR /azure-container-networking
 COPY . .
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet -trimpath -ldflags "-s -w" "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/plugin/main.go
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-telemetry -trimpath -ldflags "-s -w" "-X main.version="$VERSION" -X "$CNI_AI_PATH"="$CNI_AI_ID"" -gcflags="-dwarflocationlists=true" cni/telemetry/service/telemetrymain.go
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-ipam -trimpath -ldflags "-s -w" "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/ipam/plugin/main.go
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-stateless -trimpath -ldflags "-s -w" "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/stateless/main.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet -trimpath -ldflags "-s -w -X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/plugin/main.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-telemetry -trimpath -ldflags "-s -w -X main.version="$VERSION" -X "$CNI_AI_PATH"="$CNI_AI_ID"" -gcflags="-dwarflocationlists=true" cni/telemetry/service/telemetrymain.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-ipam -trimpath -ldflags "-s -w -X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/ipam/plugin/main.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-stateless -trimpath -ldflags "-s -w -X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/stateless/main.go
 
 FROM mariner-core AS compressor
 ARG OS
@@ -44,7 +44,7 @@ ARG VERSION
 RUN go mod download github.com/azure/azure-container-networking/dropgz@$DROPGZ_VERSION
 WORKDIR /go/pkg/mod/github.com/azure/azure-container-networking/dropgz\@$DROPGZ_VERSION
 COPY --from=compressor /payload/* pkg/embed/fs/
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/dropgz -trimpath -ldflags "-s -w" "-X github.com/Azure/azure-container-networking/dropgz/internal/buildinfo.Version="$VERSION"" -gcflags="-dwarflocationlists=true" main.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/dropgz -trimpath -ldflags "-s -w -X github.com/Azure/azure-container-networking/dropgz/internal/buildinfo.Version="$VERSION"" -gcflags="-dwarflocationlists=true" main.go
 
 FROM scratch AS bins
 COPY --from=azure-vnet /go/bin/* /

--- a/cni/Dockerfile.tmpl
+++ b/cni/Dockerfile.tmpl
@@ -18,10 +18,10 @@ ARG CNI_AI_PATH
 ARG CNI_AI_ID
 WORKDIR /azure-container-networking
 COPY . .
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/plugin/main.go
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-telemetry -trimpath -ldflags "-X main.version="$VERSION" -X "$CNI_AI_PATH"="$CNI_AI_ID"" -gcflags="-dwarflocationlists=true" cni/telemetry/service/telemetrymain.go
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-ipam -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/ipam/plugin/main.go
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-stateless -trimpath -ldflags "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/stateless/main.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet -trimpath -ldflags "-s -w" "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/plugin/main.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-telemetry -trimpath -ldflags "-s -w" "-X main.version="$VERSION" -X "$CNI_AI_PATH"="$CNI_AI_ID"" -gcflags="-dwarflocationlists=true" cni/telemetry/service/telemetrymain.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-ipam -trimpath -ldflags "-s -w" "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/ipam/plugin/main.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-stateless -trimpath -ldflags "-s -w" "-X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/stateless/main.go
 
 FROM mariner-core AS compressor
 ARG OS
@@ -44,7 +44,7 @@ ARG VERSION
 RUN go mod download github.com/azure/azure-container-networking/dropgz@$DROPGZ_VERSION
 WORKDIR /go/pkg/mod/github.com/azure/azure-container-networking/dropgz\@$DROPGZ_VERSION
 COPY --from=compressor /payload/* pkg/embed/fs/
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/dropgz -trimpath -ldflags "-X github.com/Azure/azure-container-networking/dropgz/internal/buildinfo.Version="$VERSION"" -gcflags="-dwarflocationlists=true" main.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/dropgz -trimpath -ldflags "-s -w" "-X github.com/Azure/azure-container-networking/dropgz/internal/buildinfo.Version="$VERSION"" -gcflags="-dwarflocationlists=true" main.go
 
 FROM scratch AS bins
 COPY --from=azure-vnet /go/bin/* /

--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -20,7 +20,7 @@ ARG CNS_AI_PATH
 ARG VERSION
 WORKDIR /azure-container-networking
 COPY . .
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-cns -ldflags "-s -w" "-X main.version="$VERSION" -X "$CNS_AI_PATH"="$CNS_AI_ID"" -gcflags="-dwarflocationlists=true" cns/service/*.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-cns -ldflags "-s -w -X main.version="$VERSION" -X "$CNS_AI_PATH"="$CNS_AI_ID"" -gcflags="-dwarflocationlists=true" cns/service/*.go
 
 FROM mariner-core AS iptables
 RUN tdnf install -y iptables

--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -20,7 +20,7 @@ ARG CNS_AI_PATH
 ARG VERSION
 WORKDIR /azure-container-networking
 COPY . .
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-cns -ldflags "-X main.version="$VERSION" -X "$CNS_AI_PATH"="$CNS_AI_ID"" -gcflags="-dwarflocationlists=true" cns/service/*.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-cns -ldflags "-s -w" "-X main.version="$VERSION" -X "$CNS_AI_PATH"="$CNS_AI_ID"" -gcflags="-dwarflocationlists=true" cns/service/*.go
 
 FROM mariner-core AS iptables
 RUN tdnf install -y iptables

--- a/cns/Dockerfile.tmpl
+++ b/cns/Dockerfile.tmpl
@@ -20,7 +20,7 @@ ARG CNS_AI_PATH
 ARG VERSION
 WORKDIR /azure-container-networking
 COPY . .
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-cns -ldflags "-s -w" "-X main.version="$VERSION" -X "$CNS_AI_PATH"="$CNS_AI_ID"" -gcflags="-dwarflocationlists=true" cns/service/*.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-cns -ldflags "-s -w -X main.version="$VERSION" -X "$CNS_AI_PATH"="$CNS_AI_ID"" -gcflags="-dwarflocationlists=true" cns/service/*.go
 
 FROM mariner-core AS iptables
 RUN tdnf install -y iptables

--- a/cns/Dockerfile.tmpl
+++ b/cns/Dockerfile.tmpl
@@ -20,7 +20,7 @@ ARG CNS_AI_PATH
 ARG VERSION
 WORKDIR /azure-container-networking
 COPY . .
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-cns -ldflags "-X main.version="$VERSION" -X "$CNS_AI_PATH"="$CNS_AI_ID"" -gcflags="-dwarflocationlists=true" cns/service/*.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-cns -ldflags "-s -w" "-X main.version="$VERSION" -X "$CNS_AI_PATH"="$CNS_AI_ID"" -gcflags="-dwarflocationlists=true" cns/service/*.go
 
 FROM mariner-core AS iptables
 RUN tdnf install -y iptables

--- a/npm/linux.Dockerfile
+++ b/npm/linux.Dockerfile
@@ -4,7 +4,7 @@ ARG NPM_AI_PATH
 ARG NPM_AI_ID
 WORKDIR /usr/local/src
 COPY . .
-RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm -ldflags "-s -w" "-X main.version="$VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" -gcflags="-dwarflocationlists=true" npm/cmd/*.go
+RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm -ldflags "-s -w -X main.version="$VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" -gcflags="-dwarflocationlists=true" npm/cmd/*.go
 
 FROM mcr.microsoft.com/mirror/docker/library/ubuntu:24.04 as linux
 COPY --from=builder /usr/local/bin/azure-npm /usr/bin/azure-npm

--- a/npm/linux.Dockerfile
+++ b/npm/linux.Dockerfile
@@ -4,7 +4,7 @@ ARG NPM_AI_PATH
 ARG NPM_AI_ID
 WORKDIR /usr/local/src
 COPY . .
-RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm -ldflags "-X main.version="$VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" -gcflags="-dwarflocationlists=true" npm/cmd/*.go
+RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm -ldflags "-s -w" "-X main.version="$VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" -gcflags="-dwarflocationlists=true" npm/cmd/*.go
 
 FROM mcr.microsoft.com/mirror/docker/library/ubuntu:24.04 as linux
 COPY --from=builder /usr/local/bin/azure-npm /usr/bin/azure-npm

--- a/npm/windows.Dockerfile
+++ b/npm/windows.Dockerfile
@@ -5,7 +5,7 @@ ARG NPM_AI_PATH
 ARG NPM_AI_ID
 WORKDIR /usr/local/src
 COPY . .
-RUN GOOS=windows CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm.exe -ldflags "-X main.version="$VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" -gcflags="-dwarflocationlists=true" npm/cmd/*.go
+RUN GOOS=windows CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm.exe -ldflags "-s -w" "-X main.version="$VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" -gcflags="-dwarflocationlists=true" npm/cmd/*.go
 
 # intermediate for win-ltsc2022
 FROM mcr.microsoft.com/windows/servercore@sha256:45952938708fbde6ec0b5b94de68bcdec3f8c838be018536b1e9e5bd95e6b943 as windows

--- a/npm/windows.Dockerfile
+++ b/npm/windows.Dockerfile
@@ -5,7 +5,7 @@ ARG NPM_AI_PATH
 ARG NPM_AI_ID
 WORKDIR /usr/local/src
 COPY . .
-RUN GOOS=windows CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm.exe -ldflags "-s -w" "-X main.version="$VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" -gcflags="-dwarflocationlists=true" npm/cmd/*.go
+RUN GOOS=windows CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm.exe -ldflags "-s -w -X main.version="$VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" -gcflags="-dwarflocationlists=true" npm/cmd/*.go
 
 # intermediate for win-ltsc2022
 FROM mcr.microsoft.com/windows/servercore@sha256:45952938708fbde6ec0b5b94de68bcdec3f8c838be018536b1e9e5bd95e6b943 as windows


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
In a distroless environment we lose the need for debug symbols to be present on binaries. Debug symbol removal from binaries generally saves 20%-35% of HDD space.

For comparison linux/amd64 bins
CNS 91MB v 63MB
CNI 82MB v 56MB
IPAM 49MB v 34MB
NPM 66MB v 45MB
ipv6-hp-bpf 8MB v 5.3MB
azure-ip-masq-merger 20MB v 13MB

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
Want to move to leveraging our make commands for binary generation. This is a placeholder until that effort can be picked up.
