### PR TITLE
[Forwardport] [NPM] fix: Update Iptables to Legacy (#3782)

### DIFF
--- a/npm/pkg/dataplane/policies/chain-management_linux_test.go
+++ b/npm/pkg/dataplane/policies/chain-management_linux_test.go
@@ -936,7 +936,7 @@ func TestDetectIptablesVersion(t *testing.T) {
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-L", "KUBE-IPTABLES-HINT", "-t", "mangle", "-n"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-L", "KUBE-IPTABLES-HINT", "-t", "mangle", "-n"},
 					ExitCode: 0,
 				},
 			},
@@ -954,11 +954,11 @@ func TestDetectIptablesVersion(t *testing.T) {
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-L", "KUBE-IPTABLES-HINT", "-t", "mangle", "-n"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-L", "KUBE-IPTABLES-HINT", "-t", "mangle", "-n"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-L", "KUBE-KUBELET-CANARY", "-t", "mangle", "-n"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-L", "KUBE-KUBELET-CANARY", "-t", "mangle", "-n"},
 					ExitCode: 1,
 				},
 			},
@@ -976,11 +976,11 @@ func TestDetectIptablesVersion(t *testing.T) {
 					ExitCode: 2,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-L", "KUBE-IPTABLES-HINT", "-t", "mangle", "-n"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-L", "KUBE-IPTABLES-HINT", "-t", "mangle", "-n"},
 					ExitCode: 2,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-L", "KUBE-KUBELET-CANARY", "-t", "mangle", "-n"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-L", "KUBE-KUBELET-CANARY", "-t", "mangle", "-n"},
 					ExitCode: 2,
 				},
 			},
@@ -1027,12 +1027,12 @@ func TestCleanupOtherChains(t *testing.T) {
 			name:         "cleanup legacy jump no chains",
 			startWithNft: true,
 			calls: []testutils.TestCmd{
-				{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}}, // deprecated rule existed
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}}, // deprecated rule existed
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
 					ExitCode: 1,
 				},
-				{Cmd: []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
 				{
 					Cmd:      []string{"grep", "Chain AZURE-NPM"},
 					ExitCode: 1,
@@ -1044,19 +1044,19 @@ func TestCleanupOtherChains(t *testing.T) {
 			name:         "cleanup legacy jump and chains",
 			startWithNft: true,
 			calls: []testutils.TestCmd{
-				{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}}, // deprecated rule existed
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}}, // deprecated rule existed
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
 					ExitCode: 1,
 				},
-				{Cmd: []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
 				{
 					Cmd:    []string{"grep", "Chain AZURE-NPM"},
 					Stdout: grepOutputTwoAzureChains,
 				},
-				{Cmd: []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"}},
-				{Cmd: []string{"iptables", "-w", "60", "-X", "AZURE-NPM"}},
-				{Cmd: []string{"iptables", "-w", "60", "-X", "AZURE-NPM-INGRESS"}},
+				{Cmd: []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"}},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-X", "AZURE-NPM"}},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-X", "AZURE-NPM-INGRESS"}},
 			},
 			expectedErr: false,
 		},
@@ -1065,30 +1065,30 @@ func TestCleanupOtherChains(t *testing.T) {
 			startWithNft: true,
 			calls: []testutils.TestCmd{
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
 					ExitCode: 1,
 				},
-				{Cmd: []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
 				{
 					Cmd:    []string{"grep", "Chain AZURE-NPM"},
 					Stdout: grepOutputTwoAzureChains,
 				},
 				{
-					Cmd:      []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"},
+					Cmd:      []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"},
+					Cmd:      []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"},
 					ExitCode: 1,
 				},
-				{Cmd: []string{"iptables", "-w", "60", "-F", "AZURE-NPM"}},
-				{Cmd: []string{"iptables", "-w", "60", "-F", "AZURE-NPM-INGRESS"}},
-				{Cmd: []string{"iptables", "-w", "60", "-X", "AZURE-NPM"}},
-				{Cmd: []string{"iptables", "-w", "60", "-X", "AZURE-NPM-INGRESS"}},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-F", "AZURE-NPM"}},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-F", "AZURE-NPM-INGRESS"}},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-X", "AZURE-NPM"}},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-X", "AZURE-NPM-INGRESS"}},
 			},
 			expectedErr: false,
 		},
@@ -1097,28 +1097,28 @@ func TestCleanupOtherChains(t *testing.T) {
 			startWithNft: true,
 			calls: []testutils.TestCmd{
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
 					ExitCode: 1,
 				},
-				{Cmd: []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
 				{
 					Cmd:    []string{"grep", "Chain AZURE-NPM"},
 					Stdout: grepOutputTwoAzureChains,
 				},
 				{
-					Cmd:      []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"},
+					Cmd:      []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"},
+					Cmd:      []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-F", "AZURE-NPM"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-F", "AZURE-NPM"},
 					ExitCode: 1,
 				},
 			},
@@ -1129,28 +1129,28 @@ func TestCleanupOtherChains(t *testing.T) {
 			startWithNft: true,
 			calls: []testutils.TestCmd{
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
 					ExitCode: 1,
 				},
-				{Cmd: []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
 				{
 					Cmd:    []string{"grep", "Chain AZURE-NPM"},
 					Stdout: "Chain AZURE-NPM-INGRESS (1 references)\n",
 				},
 				{
-					Cmd:      []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"},
+					Cmd:      []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"},
+					Cmd:      []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"},
 					ExitCode: 1,
 				},
-				{Cmd: []string{"iptables", "-w", "60", "-F", "AZURE-NPM-INGRESS"}},
-				{Cmd: []string{"iptables", "-w", "60", "-X", "AZURE-NPM-INGRESS"}},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-F", "AZURE-NPM-INGRESS"}},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-X", "AZURE-NPM-INGRESS"}},
 			},
 			expectedErr: false,
 		},
@@ -1159,37 +1159,37 @@ func TestCleanupOtherChains(t *testing.T) {
 			startWithNft: true,
 			calls: []testutils.TestCmd{
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"},
 					ExitCode: 1,
 				},
-				{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
-				{Cmd: []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
 				{
 					Cmd:    []string{"grep", "Chain AZURE-NPM"},
 					Stdout: grepOutputTwoAzureChains,
 				},
 				{
-					Cmd:      []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"},
+					Cmd:      []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"},
+					Cmd:      []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-F", "AZURE-NPM"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-F", "AZURE-NPM"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-F", "AZURE-NPM-INGRESS"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-F", "AZURE-NPM-INGRESS"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-X", "AZURE-NPM"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-X", "AZURE-NPM"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-X", "AZURE-NPM-INGRESS"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-X", "AZURE-NPM-INGRESS"},
 					ExitCode: 1,
 				},
 			},
@@ -1199,38 +1199,38 @@ func TestCleanupOtherChains(t *testing.T) {
 			name:         "cleanup legacy errors ok if deleted jump (deprecated)",
 			startWithNft: true,
 			calls: []testutils.TestCmd{
-				{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
 					ExitCode: 1,
 				},
-				{Cmd: []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
 				{
 					Cmd:    []string{"grep", "Chain AZURE-NPM"},
 					Stdout: grepOutputTwoAzureChains,
 				},
 				{
-					Cmd:      []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"},
+					Cmd:      []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"},
+					Cmd:      []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-F", "AZURE-NPM"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-F", "AZURE-NPM"},
 					ExitCode: 2,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-F", "AZURE-NPM-INGRESS"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-F", "AZURE-NPM-INGRESS"},
 					ExitCode: 2,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-X", "AZURE-NPM"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-X", "AZURE-NPM"},
 					ExitCode: 2,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-X", "AZURE-NPM-INGRESS"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-X", "AZURE-NPM-INGRESS"},
 					ExitCode: 2,
 				},
 			},
@@ -1240,13 +1240,13 @@ func TestCleanupOtherChains(t *testing.T) {
 			name:         "cleanup legacy other flush errors ok",
 			startWithNft: true,
 			calls: []testutils.TestCmd{
-				{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
 					ExitCode: 1,
 				},
 				{
-					Cmd: []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true,
+					Cmd: []string{"iptables-legacy", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true,
 					ExitCode: 1,
 				},
 				{
@@ -1254,21 +1254,21 @@ func TestCleanupOtherChains(t *testing.T) {
 					Stdout: grepOutputTwoAzureChains,
 				},
 				{
-					Cmd:      []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"},
+					Cmd:      []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"},
+					Cmd:      []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"},
 					ExitCode: 1,
 				},
-				{Cmd: []string{"iptables", "-w", "60", "-F", "AZURE-NPM"}},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-F", "AZURE-NPM"}},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-F", "AZURE-NPM-INGRESS"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-F", "AZURE-NPM-INGRESS"},
 					ExitCode: 1,
 				},
-				{Cmd: []string{"iptables", "-w", "60", "-X", "AZURE-NPM"}},
+				{Cmd: []string{"iptables-legacy", "-w", "60", "-X", "AZURE-NPM"}},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-X", "AZURE-NPM-INGRESS"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-X", "AZURE-NPM-INGRESS"},
 					ExitCode: 1,
 				},
 			},
@@ -1279,15 +1279,15 @@ func TestCleanupOtherChains(t *testing.T) {
 			startWithNft: true,
 			calls: []testutils.TestCmd{
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"},
 					ExitCode: 1,
 				},
 				{
-					Cmd:      []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
+					Cmd:      []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"},
 					ExitCode: 1,
 				},
 				{
-					Cmd: []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true, HasStartError: true,
+					Cmd: []string{"iptables-legacy", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true, HasStartError: true,
 					ExitCode: 1,
 				},
 				{Cmd: []string{"grep", "Chain AZURE-NPM"}},

--- a/npm/pkg/dataplane/policies/testutils_linux.go
+++ b/npm/pkg/dataplane/policies/testutils_linux.go
@@ -57,17 +57,17 @@ func GetBootupTestCalls() []testutils.TestCmd {
 			ExitCode: 0,
 		},
 		// legacy clean up
-		{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}, ExitCode: 2},                                        //nolint // AZURE-NPM chain didn't exist
-		{Cmd: []string{"iptables", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}, ExitCode: 2}, //nolint // AZURE-NPM chain didn't exist
-		{Cmd: []string{"iptables", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
+		{Cmd: []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}, ExitCode: 2},                                        //nolint // AZURE-NPM chain didn't exist
+		{Cmd: []string{"iptables-legacy", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM", "-m", "conntrack", "--ctstate", "NEW"}, ExitCode: 2}, //nolint // AZURE-NPM chain didn't exist
+		{Cmd: []string{"iptables-legacy", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},
 		{
 			// 1 AZURE-NPM chain
 			Cmd: []string{"grep", "Chain AZURE-NPM"},
 			Stdout: `Chain AZURE-NPM (0 references)
 `,
 		},
-		{Cmd: []string{"iptables-restore", "-w", "60", "-T", "filter", "--noflush"}},
-		{Cmd: []string{"iptables", "-w", "60", "-X", "AZURE-NPM"}},
+		{Cmd: []string{"iptables-legacy-restore", "-w", "60", "-T", "filter", "--noflush"}},
+		{Cmd: []string{"iptables-legacy", "-w", "60", "-X", "AZURE-NPM"}},
 		// nft bootup
 		{Cmd: []string{"iptables-nft", "-w", "60", "-D", "FORWARD", "-j", "AZURE-NPM"}, ExitCode: 2}, //nolint // AZURE-NPM chain didn't exist
 		{Cmd: []string{"iptables-nft", "-w", "60", "-t", "filter", "-n", "-L"}, PipedToCommand: true},

--- a/npm/util/const.go
+++ b/npm/util/const.go
@@ -37,9 +37,9 @@ const (
 	Ip6tablesLegacy            string = "ip6tables" //nolint (avoid warning to capitalize this p)
 	IptablesSaveNft            string = "iptables-nft-save"
 	IptablesRestoreNft         string = "iptables-nft-restore"
-	IptablesLegacy             string = "iptables"
-	IptablesSaveLegacy         string = "iptables-save"
-	IptablesRestoreLegacy      string = "iptables-restore"
+	IptablesLegacy             string = "iptables-legacy"
+	IptablesSaveLegacy         string = "iptables-legacy-save"
+	IptablesRestoreLegacy      string = "iptables-legacy-restore"
 	IptablesRestoreNoFlushFlag string = "--noflush"
 	IptablesRestoreTableFlag   string = "-T"
 	IptablesRestoreCommit      string = "COMMIT"


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
Forwardport the bug fix made in https://github.com/Azure/azure-container-networking/pull/3782 to master branch.

Updates iptables to `legacy` fix crashloopbackoffs in `CBL-Mariner/Linux` nodepools.

**Issue Fixed**:
NPM's Ubuntu base image was recently updated to `24.04` from `20.04` as the older version was EOL (see: https://github.com/Azure/azure-container-networking/pull/3743). There was a behavioral change between the 2 Ubuntu versions that required NPM to specify `legacy` for its Iptables. 

`Error: failed to create dataplane with error Operation [BootupDataplane] failed with error code [999], full cmd [], full error failed to reset policy dataplane: Operation [BootupPolicyManager] failed with error code [999], full cmd [], full error failed to bootup policy manager: failed to detect iptables version: unable to locate which iptables version kube proxy is using`

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [x] relevant PR labels added

**Notes**:
