### PR TITLE
ci: Unblocking ADO build pipeline

### DIFF
--- a/.pipelines/build/generate-manifest.steps.yaml
+++ b/.pipelines/build/generate-manifest.steps.yaml
@@ -12,7 +12,7 @@ steps:
         .args = [ (.platform | split("/")[0]), (.platform     | split("/")[1]) ] | 
         .args = [ ("--os "   + .args[0]     ), ("--arch "     + .args[1]     ) ] | 
         if .osVersion then .args += ["--os-version " + .osVersion] else . end    |
-        { image: .imageReference, annotate: .args }' | \
+        { image: .imageReference, annotate: (.args | join(" ")) }' | \
       jq -rcs)
     echo >&2 "##vso[task.setvariable variable=MANIFEST_JSON;isOutput=true]$MANIFEST_DATA"
     echo "$MANIFEST_DATA" | jq -r .

--- a/.pipelines/build/image.steps.yaml
+++ b/.pipelines/build/image.steps.yaml
@@ -33,6 +33,7 @@ parameters:
   default:
     - "--target $(os) "
     - "--platform $(os)/$(arch) "
+    - "--provenance false "
 
 - name: common_build_args
   type: object

--- a/.pipelines/build/images.jobs.yaml
+++ b/.pipelines/build/images.jobs.yaml
@@ -112,8 +112,8 @@ jobs:
     pool:
       os: linux
       type: docker
-#      ${{ if eq(job_data.job, 'linux_arm64') }}:
-#        hostArchitecture: arm64
+      ${{ if eq(job_data.job, 'linux_arm64') }}:
+        hostArchitecture: arm64
 #      ${{ else }}:
 #        LinuxHostVersion: 'AzLinux3.0AMD64'
     variables:
@@ -127,12 +127,12 @@ jobs:
         OS: linux
       ${{ elseif eq(job_data.job, 'windows_amd64') }}:
         LinuxContainerImage: 'mcr.microsoft.com/onebranch/azurelinux/build:3.0'
-        ob_enable_qemu: true
+        # ob_enable_qemu: true
         ARCH: amd64
         OS: windows
       ${{ elseif eq(job_data.job, 'linux_arm64') }}:
         LinuxContainerImage: 'mcr.microsoft.com/onebranch/azurelinux/build:3.0'
-        ob_enable_qemu: true
+        # ob_enable_qemu: true
         ARCH: arm64
         OS: linux
         GOARCH: arm64

--- a/.pipelines/build/images.jobs.yaml
+++ b/.pipelines/build/images.jobs.yaml
@@ -127,12 +127,10 @@ jobs:
         OS: linux
       ${{ elseif eq(job_data.job, 'windows_amd64') }}:
         LinuxContainerImage: 'mcr.microsoft.com/onebranch/azurelinux/build:3.0'
-        # ob_enable_qemu: true
         ARCH: amd64
         OS: windows
       ${{ elseif eq(job_data.job, 'linux_arm64') }}:
         LinuxContainerImage: 'mcr.microsoft.com/onebranch/azurelinux/build:3.0'
-        # ob_enable_qemu: true
         ARCH: arm64
         OS: linux
         GOARCH: arm64

--- a/.pipelines/build/ob-prepare.steps.yaml
+++ b/.pipelines/build/ob-prepare.steps.yaml
@@ -1,4 +1,41 @@
 steps:
+- template: utils/rename-dockerfile-references.steps.yaml
+  parameters:
+    topic: "Linux - ipv6-hp-bpf"
+    replace_references: true
+    source_path: bpf-prog/ipv6-hp-bpf
+    target_path: bpf-prog/ipv6-hp-bpf
+    source_dockerfile: linux.Dockerfile
+
+# - template: utils/rename-dockerfile-references.steps.yaml
+#   parameters:
+#     topic: "Windows - npm"
+#     replace_references: true
+#     working_directory: $(ACN_DIR)
+#     source_path: npm
+#     target_path: npm-windows
+#     source_dockerfile: windows.Dockerfile
+
+# - template: utils/rename-dockerfile-references.steps.yaml
+#   parameters:
+#     topic: "Linux - npm"
+#     replace_references: true
+#     working_directory: $(ACN_DIR)
+#     source_path: npm
+#     target_path: npm
+#     source_dockerfile: linux.Dockerfile
+
+- bash: |
+    rm -rf .hooks .github
+  displayName: "Remove Unnecessary Dirs from Source"
+  workingDirectory: $(Build.SourcesDirectory)/azure-container-networking
+
+- task: CopyFiles@2
+  displayName: "Add Repo to Container Artifacts"
+  inputs:
+    sourceFolder: $(Build.SourcesDirectory)/azure-container-networking
+    targetFolder: $(Build.ArtifactStagingDirectory)
+
 - script: |
     STORAGE_ID=$(echo "${BUILD_BUILDNUMBER//./-}")
     echo "##vso[task.setvariable variable=StorageID;isOutput=true]$STORAGE_ID"
@@ -55,18 +92,4 @@ steps:
   name: "EnvironmentalVariables"
   displayName: "Set environmental variables"
   condition: always()
-  # Use dev version of Makefile for development version
   workingDirectory: $(ACN_DIR)
-
-- bash: |
-    rm -rf .hooks .github .pipelines .git
-  displayName: "Remove Unnecessary Dirs from Source"
-  workingDirectory: $(ACN_DIR)
-
-
-- task: CopyFiles@2
-  displayName: "Add Pipeline Orchestration to Container Artifacts"
-  inputs:
-    sourceFolder: $(ACN_DEVOPS_DIR)/.pipelines
-    targetFolder: $(ACN_DIR)/.pipelines
-    CleanTargetFolder: false

--- a/.pipelines/run-pipeline.yaml
+++ b/.pipelines/run-pipeline.yaml
@@ -1,206 +1,24 @@
 stages:
 - stage: setup
   displayName: ACN
-  dependsOn:
-  - prebuild
   variables:
-    ACN_DEVOPS_DIR: $(Build.SourcesDirectory)/azure-container-networking
+    ACN_DIR: azure-container-networking
   jobs:
-  - job: copy
-    displayName: Copy Pipeline Files
-    pool:
-      type: linux
-    variables:
-      ob_outputDirectory: $(Build.ArtifactStagingDirectory)
-      ob_git_checkout: true
-    steps:
-    - checkout: acn-devops
-
-    - task: CopyFiles@2
-      displayName: "Add Pipeline Orchestration to Container Artifacts"
-      inputs:
-        sourceFolder: $(ACN_DEVOPS_DIR)/.pipelines
-        targetFolder: $(Build.ArtifactStagingDirectory)/.pipelines
-
   - job: env
     displayName: Setup
     pool:
       type: linux
-    dependsOn: copy
     variables:
-      ob_outputDirectory: $(Build.SourcesDirectory)/azure-container-networking
+      ob_outputDirectory: $(Build.ArtifactStagingDirectory)
       ob_artifactSuffix: _source
-      ob_git_checkout: true
 
-      ACN_DIR: $(Build.SourcesDirectory)/azure-container-networking
-      ACN_DEVOPS_DIR: $(Agent.BuildDirectory)/drop_setup_copy
+      ACR_DIR: $(Build.SourcesDirectory)/azure-container-networking
       BUILD_TYPE: $(IMAGE_ACR_TYPE)
     steps:
     - checkout: azure-container-networking
-    - download: current
-      artifact: drop_setup_copy
+    - template: build/ob-prepare.steps.yaml
 
-    - template: build/ob-prepare.steps.yaml@acn-devops
-
-- template: templates/run-unit-tests.stages.yaml@acn-devops
-
-- stage: build
-  displayName: "Build Project"
-  dependsOn:
-    - setup
-    - unittest
-  variables:
-    ACN_DIR: drop_setup_env_source
-    ACN_PACKAGE_PATH: github.com/Azure/azure-container-networking
-    CNI_AI_PATH: $(ACN_PACKAGE_PATH)/telemetry.aiMetadata
-    CNS_AI_PATH: $(ACN_PACKAGE_PATH)/cns/logger.aiMetadata
-    NPM_AI_PATH: $(ACN_PACKAGE_PATH)/npm.aiMetadata
-
-    STORAGE_ID: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.StorageID'] ]
-    TAG: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.Tag'] ]
-
-    IMAGE_REPO_PATH: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.imageRepositoryPath'] ]
-    AZURE_IPAM_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.azureIpamVersion'] ]
-    AZURE_IP_MASQ_MERGER_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.azureIpMasqMergerVersion'] ]
-    CNI_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.cniVersion'] ]
-    CNS_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.cnsVersion'] ]
-    IPV6_HP_BPF_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.ipv6HpBpfVersion'] ]
-    NPM_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.npmVersion'] ]
-  jobs:
-  - template: /.pipelines/build/images.jobs.yaml@acn-devops
-    parameters:
-      images:
-      - job: linux_amd64
-        displayName: "Linux/AMD64"
-        templateContext:
-          repositoryArtifact: drop_setup_env_source
-          buildScript: .pipelines/build/scripts/$(name).sh
-          obDockerfile: .pipelines/build/dockerfiles/$(name).Dockerfile
-        strategy:
-          maxParallel: 5
-          matrix:
-            azure_ipam:
-              name: azure-ipam
-              extraArgs: ''
-              archiveName: azure-ipam
-              archiveVersion: $(AZURE_IPAM_VERSION)
-              imageTag: $(Build.BuildNumber)
-              packageWithDropGZ: True
-            azure_ip_masq_merger:
-              name: azure-ip-masq-merger
-              extraArgs: ''
-              archiveName: azure-ip-masq-merger
-              archiveVersion: $(AZURE_IP_MASQ_MERGER_VERSION)
-              imageTag: $(Build.BuildNumber)
-            cni:
-              name: cni
-              extraArgs: '--build-arg CNI_AI_PATH=$(CNI_AI_PATH) --build-arg CNI_AI_ID=$(CNI_AI_ID)'
-              archiveName: azure-cni
-              archiveVersion: $(CNI_VERSION)
-              imageTag: $(Build.BuildNumber)
-              packageWithDropGZ: True
-            cns:
-              name: cns
-              extraArgs: '--build-arg CNS_AI_PATH=$(CNS_AI_PATH) --build-arg CNS_AI_ID=$(CNS_AI_ID)'
-              archiveName: azure-cns
-              archiveVersion: $(CNS_VERSION)
-              imageTag: $(Build.BuildNumber)
-            ipv6_hp_bpf:
-              name: ipv6-hp-bpf
-              extraArgs: "--build-arg DEBUG=$(System.Debug)"
-              archiveName: ipv6-hp-bpf
-              archiveVersion: $(IPV6_HP_BPF_VERSION)
-              imageTag: $(Build.BuildNumber)
-            npm:
-              name: npm
-              extraArgs: '--build-arg NPM_AI_PATH=$(NPM_AI_PATH) --build-arg NPM_AI_ID=$(NPM_AI_ID)'
-              archiveName: azure-npm
-              archiveVersion: $(NPM_VERSION)
-              imageTag: $(Build.BuildNumber)
-
-      - job: windows_amd64
-        displayName: "Windows"
-        templateContext:
-          repositoryArtifact: drop_setup_env_source
-          buildScript: .pipelines/build/scripts/$(name).sh
-          obDockerfile: .pipelines/build/dockerfiles/$(name).Dockerfile
-        strategy:
-          maxParallel: 5
-          matrix:
-            azure_ipam:
-              name: azure-ipam
-              extraArgs: ''
-              archiveName: azure-ipam
-              archiveVersion: $(AZURE_IPAM_VERSION)
-              imageTag: $(Build.BuildNumber)
-              packageWithDropGZ: True
-            cni:
-              name: cni
-              extraArgs: '--build-arg CNI_AI_PATH=$(CNI_AI_PATH) --build-arg CNI_AI_ID=$(CNI_AI_ID)'
-              archiveName: azure-cni
-              archiveVersion: $(CNI_VERSION)
-              imageTag: $(Build.BuildNumber)
-              packageWithDropGZ: True
-            cns:
-              name: cns
-              extraArgs: '--build-arg CNS_AI_PATH=$(CNS_AI_PATH) --build-arg CNS_AI_ID=$(CNS_AI_ID)'
-              archiveName: azure-cns
-              archiveVersion: $(CNS_VERSION)
-              imageTag: $(Build.BuildNumber)
-            npm:
-              name: npm
-              extraArgs: '--build-arg NPM_AI_PATH=$(NPM_AI_PATH) --build-arg NPM_AI_ID=$(NPM_AI_ID)'
-              archiveName: azure-npm
-              archiveVersion: $(NPM_VERSION)
-              imageTag: $(Build.BuildNumber)
-
-      - job: linux_arm64
-        displayName: "Linux/ARM64"
-        templateContext:
-          repositoryArtifact: drop_setup_env_source
-          buildScript: .pipelines/build/scripts/$(name).sh
-          obDockerfile: .pipelines/build/dockerfiles/$(name).Dockerfile
-        strategy:
-          maxParallel: 3
-          matrix:
-            azure_ipam:
-              name: azure-ipam
-              archiveName: azure-ipam
-              archiveVersion: $(AZURE_IPAM_VERSION)
-              extraArgs: ''
-              imageTag: $(Build.BuildNumber)
-              packageWithDropGZ: True
-            azure_ip_masq_merger:
-              name: azure-ip-masq-merger
-              extraArgs: ''
-              archiveName: azure-ip-masq-merger
-              archiveVersion: $(AZURE_IP_MASQ_MERGER_VERSION)
-              imageTag: $(Build.BuildNumber)
-            cni:
-              name: cni
-              extraArgs: '--build-arg CNI_AI_PATH=$(CNI_AI_PATH) --build-arg CNI_AI_ID=$(CNI_AI_ID)'
-              archiveName: azure-cni
-              archiveVersion: $(CNI_VERSION)
-              imageTag: $(Build.BuildNumber)
-              packageWithDropGZ: True
-            cns:
-              name: cns
-              extraArgs: '--build-arg CNS_AI_PATH=$(CNS_AI_PATH) --build-arg CNS_AI_ID=$(CNS_AI_ID)'
-              archiveName: azure-cns
-              archiveVersion: $(CNS_VERSION)
-              imageTag: $(Build.BuildNumber)
-            ipv6_hp_bpf:
-              name: ipv6-hp-bpf
-              extraArgs: "--build-arg DEBUG=$(System.Debug)"
-              archiveName: ipv6-hp-bpf
-              archiveVersion: $(IPV6_HP_BPF_VERSION)
-              imageTag: $(Build.BuildNumber)
-            npm:
-              name: npm
-              extraArgs: '--build-arg NPM_AI_PATH=$(NPM_AI_PATH) --build-arg NPM_AI_ID=$(NPM_AI_ID)'
-              archiveName: azure-npm
-              archiveVersion: $(NPM_VERSION)
-              imageTag: $(Build.BuildNumber)
+- template: templates/run-unit-tests.stages.yaml
 
 - stage: build
   displayName: "Build Project"
@@ -400,7 +218,7 @@ stages:
       NPM_WINDOWS_AMD64_REF: $(IMAGE_REPO_PATH)/windows-amd64/npm:$(Build.BuildNumber)
     jobs:
 
-    - template: build/manifests.jobs.yaml@acn-devops
+    - template: build/manifests.jobs.yaml
       parameters:
         generate:
         - job: azure_ipam
@@ -454,17 +272,17 @@ stages:
               imageReference: $(IPV6_LINUX_AMD64_REF)
             - platform: linux/arm64
               imageReference: $(IPV6_LINUX_ARM64_REF)
-        - job: npm
-          templateContext:
-            name: npm
-            image_tag: $(NPM_VERSION)
-            platforms:
-            - platform: linux/amd64
-              imageReference: $(NPM_LINUX_AMD64_REF)
-            - platform: linux/arm64
-              imageReference: $(NPM_LINUX_ARM64_REF)
-            - platform: windows/amd64
-              imageReference: $(NPM_WINDOWS_AMD64_REF)
+        # - job: npm
+        #   templateContext:
+        #     name: npm
+        #     image_tag: $(NPM_VERSION)
+        #     platforms:
+        #     - platform: linux/amd64
+        #       imageReference: $(NPM_LINUX_AMD64_REF)
+        #     - platform: linux/arm64
+        #       imageReference: $(NPM_LINUX_ARM64_REF)
+        #     - platform: windows/amd64
+        #       imageReference: $(NPM_WINDOWS_AMD64_REF)
 
 
   # Cilium Podsubnet E2E tests


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
The ADO build pipeline is currently blocked with a reference to a "acn-devops" repo which is not refenced in the main pipeline file (in the ADO repository).

This PR reverts this reference. It also implements a fix for a building all the images in the OneBranch ADO pipeline.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
No GitHub issue associated to this PR.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
