### PR TITLE
Alew/snat azuredns to node

### DIFF
--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -243,11 +243,11 @@ func setHostOptions(ncSubnetPrefix *net.IPNet, options map[string]interface{}, i
 		},
 	}
 
+	// note: if changing any iptables rules here, make corresponding change in internalapi_linux.go on cns side
 	azureDNSUDPMatch := fmt.Sprintf(" -m addrtype ! --dst-type local -s %s -d %s -p %s --dport %d", ncSubnetPrefix.String(), networkutils.AzureDNS, iptables.UDP, iptables.DNSPort)
 	azureDNSTCPMatch := fmt.Sprintf(" -m addrtype ! --dst-type local -s %s -d %s -p %s --dport %d", ncSubnetPrefix.String(), networkutils.AzureDNS, iptables.TCP, iptables.DNSPort)
 	azureIMDSMatch := fmt.Sprintf(" -m addrtype ! --dst-type local -s %s -d %s -p %s --dport %d", ncSubnetPrefix.String(), networkutils.AzureIMDS, iptables.TCP, iptables.HTTPPort)
 
-	//snatPrimaryIPJump := fmt.Sprintf("%s --to %s", iptables.Snat, info.ncPrimaryIP)
 	// we need to snat IMDS traffic to node IP, this sets up snat '--to'
 	snatHostIPJump := fmt.Sprintf("%s --to %s", iptables.Snat, info.hostPrimaryIP)
 

--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -247,7 +247,7 @@ func setHostOptions(ncSubnetPrefix *net.IPNet, options map[string]interface{}, i
 	azureDNSTCPMatch := fmt.Sprintf(" -m addrtype ! --dst-type local -s %s -d %s -p %s --dport %d", ncSubnetPrefix.String(), networkutils.AzureDNS, iptables.TCP, iptables.DNSPort)
 	azureIMDSMatch := fmt.Sprintf(" -m addrtype ! --dst-type local -s %s -d %s -p %s --dport %d", ncSubnetPrefix.String(), networkutils.AzureIMDS, iptables.TCP, iptables.HTTPPort)
 
-	snatPrimaryIPJump := fmt.Sprintf("%s --to %s", iptables.Snat, info.ncPrimaryIP)
+	//snatPrimaryIPJump := fmt.Sprintf("%s --to %s", iptables.Snat, info.ncPrimaryIP)
 	// we need to snat IMDS traffic to node IP, this sets up snat '--to'
 	snatHostIPJump := fmt.Sprintf("%s --to %s", iptables.Snat, info.hostPrimaryIP)
 
@@ -261,12 +261,12 @@ func setHostOptions(ncSubnetPrefix *net.IPNet, options map[string]interface{}, i
 		iptableCmds = append(iptableCmds, iptablesClient.GetAppendIptableRuleCmd(iptables.V4, iptables.Nat, iptables.Postrouting, "", iptables.Swift))
 	}
 
-	if !iptablesClient.RuleExists(iptables.V4, iptables.Nat, iptables.Swift, azureDNSUDPMatch, snatPrimaryIPJump) {
-		iptableCmds = append(iptableCmds, iptablesClient.GetInsertIptableRuleCmd(iptables.V4, iptables.Nat, iptables.Swift, azureDNSUDPMatch, snatPrimaryIPJump))
+	if !iptablesClient.RuleExists(iptables.V4, iptables.Nat, iptables.Swift, azureDNSUDPMatch, snatHostIPJump) {
+		iptableCmds = append(iptableCmds, iptablesClient.GetInsertIptableRuleCmd(iptables.V4, iptables.Nat, iptables.Swift, azureDNSUDPMatch, snatHostIPJump))
 	}
 
-	if !iptablesClient.RuleExists(iptables.V4, iptables.Nat, iptables.Swift, azureDNSTCPMatch, snatPrimaryIPJump) {
-		iptableCmds = append(iptableCmds, iptablesClient.GetInsertIptableRuleCmd(iptables.V4, iptables.Nat, iptables.Swift, azureDNSTCPMatch, snatPrimaryIPJump))
+	if !iptablesClient.RuleExists(iptables.V4, iptables.Nat, iptables.Swift, azureDNSTCPMatch, snatHostIPJump) {
+		iptableCmds = append(iptableCmds, iptablesClient.GetInsertIptableRuleCmd(iptables.V4, iptables.Nat, iptables.Swift, azureDNSTCPMatch, snatHostIPJump))
 	}
 
 	if !iptablesClient.RuleExists(iptables.V4, iptables.Nat, iptables.Swift, azureIMDSMatch, snatHostIPJump) {

--- a/cni/network/invoker_cns_test.go
+++ b/cni/network/invoker_cns_test.go
@@ -1433,11 +1433,11 @@ func Test_setHostOptions(t *testing.T) {
 					},
 					{
 						Version: "4",
-						Params:  "-t nat -I SWIFT 1  -m addrtype ! --dst-type local -s 10.0.1.0/24 -d 168.63.129.16 -p udp --dport 53 -j SNAT --to 10.0.1.20",
+						Params:  "-t nat -I SWIFT 1  -m addrtype ! --dst-type local -s 10.0.1.0/24 -d 168.63.129.16 -p udp --dport 53 -j SNAT --to 10.0.0.3",
 					},
 					{
 						Version: "4",
-						Params:  "-t nat -I SWIFT 1  -m addrtype ! --dst-type local -s 10.0.1.0/24 -d 168.63.129.16 -p tcp --dport 53 -j SNAT --to 10.0.1.20",
+						Params:  "-t nat -I SWIFT 1  -m addrtype ! --dst-type local -s 10.0.1.0/24 -d 168.63.129.16 -p tcp --dport 53 -j SNAT --to 10.0.0.3",
 					},
 					{
 						Version: "4",

--- a/cni/network/network_test.go
+++ b/cni/network/network_test.go
@@ -1245,7 +1245,7 @@ func TestGetPodSubnetNatInfo(t *testing.T) {
 	natInfo := getNATInfo(nwCfg, ncPrimaryIP, false)
 	if runtime.GOOS == "windows" {
 		require.Equalf(t, natInfo, []policy.NATInfo{
-			{VirtualIP: ncPrimaryIP, Destinations: []string{networkutils.AzureDNS}},
+			{Destinations: []string{networkutils.AzureDNS}},
 			{Destinations: []string{networkutils.AzureIMDS}},
 		}, "invalid windows podsubnet natInfo")
 	} else {

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -385,12 +385,8 @@ func determineWinVer() {
 func getNATInfo(nwCfg *cni.NetworkConfig, ncPrimaryIPIface interface{}, enableSnatForDNS bool) (natInfo []policy.NATInfo) {
 	// TODO: Remove v4overlay and dualstackoverlay options, after 'overlay' rolls out in AKS-RP
 	if nwCfg.ExecutionMode == string(util.V4Swift) && nwCfg.IPAM.Mode != string(util.V4Overlay) && nwCfg.IPAM.Mode != string(util.DualStackOverlay) && nwCfg.IPAM.Mode != string(util.Overlay) {
-		ncPrimaryIP := ""
-		if ncPrimaryIPIface != nil {
-			ncPrimaryIP = ncPrimaryIPIface.(string)
-		}
-
-		natInfo = append(natInfo, []policy.NATInfo{{VirtualIP: ncPrimaryIP, Destinations: []string{networkutils.AzureDNS}}, {Destinations: []string{networkutils.AzureIMDS}}}...)
+		// if swift non-overlay mode...
+		natInfo = append(natInfo, []policy.NATInfo{{Destinations: []string{networkutils.AzureDNS}}, {Destinations: []string{networkutils.AzureIMDS}}}...)
 	} else if nwCfg.MultiTenancy && enableSnatForDNS {
 		natInfo = append(natInfo, policy.NATInfo{Destinations: []string{networkutils.AzureDNS}})
 	}

--- a/cns/restserver/internalapi_linux.go
+++ b/cns/restserver/internalapi_linux.go
@@ -28,10 +28,7 @@ func (service *HTTPRestService) programSNATRules(req *cns.CreateNetworkContainer
 	service.Lock()
 	defer service.Unlock()
 
-	// Parse primary ip and ipnet from nnc
-	// in podsubnet case, ncPrimaryIP is the pod subnet's primary ip
-	// in vnet scale case, ncPrimaryIP is the node's ip
-	// ncPrimaryIP, _, _ := net.ParseCIDR(req.IPConfiguration.IPSubnet.IPAddress + "/" + fmt.Sprintf("%d", req.IPConfiguration.IPSubnet.PrefixLength))
+	// note: if changing any iptables rules here, make corresponding change in invoker_cns.go on cni side
 	ipt, err := service.iptables.GetIPTables()
 	if err != nil {
 		return types.UnexpectedError, fmt.Sprintf("[Azure CNS] Error. Failed to create iptables interface : %v", err)

--- a/cns/restserver/internalapi_linux_test.go
+++ b/cns/restserver/internalapi_linux_test.go
@@ -62,7 +62,7 @@ func TestAddSNATRules(t *testing.T) {
 					chain: SWIFT,
 					rule: []string{
 						"-m", "addrtype", "!", "--dst-type", "local", "-s", "240.1.2.0/24", "-d",
-						networkutils.AzureDNS, "-p", iptables.UDP, "--dport", strconv.Itoa(iptables.DNSPort), "-j", iptables.Snat, "--to", "240.1.2.1",
+						networkutils.AzureDNS, "-p", iptables.UDP, "--dport", strconv.Itoa(iptables.DNSPort), "-j", iptables.Snat, "--to", "10.0.0.4",
 					},
 				},
 				{
@@ -70,7 +70,7 @@ func TestAddSNATRules(t *testing.T) {
 					chain: SWIFT,
 					rule: []string{
 						"-m", "addrtype", "!", "--dst-type", "local", "-s", "240.1.2.0/24", "-d",
-						networkutils.AzureDNS, "-p", iptables.TCP, "--dport", strconv.Itoa(iptables.DNSPort), "-j", iptables.Snat, "--to", "240.1.2.1",
+						networkutils.AzureDNS, "-p", iptables.TCP, "--dport", strconv.Itoa(iptables.DNSPort), "-j", iptables.Snat, "--to", "10.0.0.4",
 					},
 				},
 				{

--- a/cns/restserver/internalapi_linux_test.go
+++ b/cns/restserver/internalapi_linux_test.go
@@ -40,6 +40,7 @@ func TestAddSNATRules(t *testing.T) {
 	}{
 		{
 			// in pod subnet, the primary nic ip is in the same address space as the pod subnet
+			// however, we now snat azure dns traffic to the node ip for consistency across scenarios
 			name: "podsubnet",
 			input: &cns.CreateNetworkContainerRequest{
 				NetworkContainerid: ncID,


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Changes podsubnet windows and linux (including cilium case) to snat azure dns traffic to node ip. Currently vnet scale case snats to node ip but podsubnet cases do not.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests
- [X] relevant PR labels added

**Notes**:
