### PR TITLE
ci: remove windows2019 from release test pipeline

### DIFF
--- a/.pipelines/cni/pipeline.yaml
+++ b/.pipelines/cni/pipeline.yaml
@@ -531,7 +531,6 @@ stages:
       - rdma_linux_overlay
       - windows_podsubnet_HNS
       - windows_overlay_HNS
-      - windows19_overlay_HNS
       - setup
       - ${{if eq(parameters.upgradeScenario, true)}}:
         - cilium_overlay_upgrade
@@ -606,9 +605,6 @@ stages:
             win-cniv2-overlay:
               name: windows_overlay
               clusterName: w22-over
-            windows19_overlay:
-              name: windows19_overlay
-              clusterName: w19-amd-ov
         steps:
           - task: AzureCLI@2
             inputs:

--- a/.pipelines/cni/pipeline.yaml
+++ b/.pipelines/cni/pipeline.yaml
@@ -213,22 +213,6 @@ stages:
       scaleup: ${SCALEUP_WIN}
       iterations: ${ITERATIONS_WIN}
 
-  - template: singletenancy/cniv2-template.yaml
-    parameters:
-      name: windows19_overlay
-      clusterType: overlay-byocni-up
-      clusterName: w19-amd-ov
-      nodeCount: ${NODE_COUNT_WINCLUSTER_SYSTEMPOOL}
-      nodeCountWin: ${NODE_COUNT_WIN}
-      vmSize: ${VM_SIZE_WINCLUSTER_SYSTEMPOOL}
-      vmSizeWin: ${VM_SIZE_WIN}
-      arch: amd64
-      os: windows
-      os_version: 'ltsc2019'
-      osSkuWin: 'Windows2019'
-      scaleup: ${SCALEUP_WIN}
-      iterations: ${ITERATIONS_WIN}
-
 ## Linux E2E
   - template: singletenancy/cniv1-template.yaml
     parameters:


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
```
ERROR: (Windows2019NotSupportedWithOrchestratorVersion) Cannot create Windows2019 node pools with the current Kubernetes version "1.33.1" because Windows2019 was deprecated after Kubernetes version "1.33.0". Please create Windows2022 node pools instead.
Code: Windows2019NotSupportedWithOrchestratorVersion
Message: Cannot create Windows2019 node pools with the current Kubernetes version "1.33.1" because Windows2019 was deprecated after Kubernetes version "1.33.0". Please create Windows2022 node pools instead.
```
not supported with latest pipeline k8s, removing cluster create/test from pipeline

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
