### PR TITLE
feat: add cns iptables reconciliation

### DIFF
--- a/cns/fakes/iptablesfake.go
+++ b/cns/fakes/iptablesfake.go
@@ -2,6 +2,7 @@ package fakes
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/Azure/azure-container-networking/iptables"
@@ -11,6 +12,7 @@ var (
 	errChainExists   = errors.New("chain already exists")
 	errChainNotFound = errors.New("chain not found")
 	errRuleExists    = errors.New("rule already exists")
+	errRuleNotFound  = errors.New("rule not found")
 )
 
 type IPTablesMock struct {
@@ -83,21 +85,101 @@ func (c *IPTablesMock) Exists(table, chain string, rulespec ...string) (bool, er
 func (c *IPTablesMock) Append(table, chain string, rulespec ...string) error {
 	c.ensureTableExists(table)
 
+	chainRules := c.state[table][chain]
+	return c.Insert(table, chain, len(chainRules)+1, rulespec...)
+}
+
+func (c *IPTablesMock) Insert(table, chain string, pos int, rulespec ...string) error {
+	c.ensureTableExists(table)
+
 	chainExists, _ := c.ChainExists(table, chain)
 	if !chainExists {
 		return errChainNotFound
 	}
 
-	ruleExists, _ := c.Exists(table, chain, rulespec...)
-	if ruleExists {
-		return errRuleExists
+	targetRule := strings.Join(rulespec, " ")
+	chainRules := c.state[table][chain]
+
+	// convert 1-based position to 0-based index
+	index := pos - 1
+	if index < 0 {
+		index = 0
 	}
 
-	targetRule := strings.Join(rulespec, " ")
-	c.state[table][chain] = append(c.state[table][chain], targetRule)
+	if index >= len(chainRules) {
+		c.state[table][chain] = append(chainRules, targetRule)
+	} else {
+		c.state[table][chain] = append(chainRules[:index], append([]string{targetRule}, chainRules[index:]...)...)
+	}
+
 	return nil
 }
 
-func (c *IPTablesMock) Insert(table, chain string, _ int, rulespec ...string) error {
-	return c.Append(table, chain, rulespec...)
+func (c *IPTablesMock) List(table, chain string) ([]string, error) {
+	c.ensureTableExists(table)
+
+	chainExists, _ := c.ChainExists(table, chain)
+	if !chainExists {
+		return nil, errChainNotFound
+	}
+
+	var result []string
+
+	// for built-in chains, start with policy -P, otherwise start with definition -N
+	builtins := []string{iptables.Input, iptables.Output, iptables.Prerouting, iptables.Postrouting, iptables.Forward}
+	isBuiltIn := false
+	for _, builtin := range builtins {
+		if chain == builtin {
+			isBuiltIn = true
+			break
+		}
+	}
+
+	if isBuiltIn {
+		result = append(result, fmt.Sprintf("-P %s ACCEPT", chain))
+	} else {
+		result = append(result, fmt.Sprintf("-N %s", chain))
+	}
+
+	// iptables with -S always outputs the rules in -A format
+	chainRules := c.state[table][chain]
+	for _, rule := range chainRules {
+		result = append(result, fmt.Sprintf("-A %s %s", chain, rule))
+	}
+
+	return result, nil
+}
+
+func (c *IPTablesMock) ClearChain(table, chain string) error {
+	c.ensureTableExists(table)
+
+	chainExists, _ := c.ChainExists(table, chain)
+	if !chainExists {
+		return errChainNotFound
+	}
+
+	c.state[table][chain] = []string{}
+	return nil
+}
+
+func (c *IPTablesMock) Delete(table, chain string, rulespec ...string) error {
+	c.ensureTableExists(table)
+
+	chainExists, _ := c.ChainExists(table, chain)
+	if !chainExists {
+		return errChainNotFound
+	}
+
+	targetRule := strings.Join(rulespec, " ")
+	chainRules := c.state[table][chain]
+
+	// delete first match
+	for i, rule := range chainRules {
+		if rule == targetRule {
+			c.state[table][chain] = append(chainRules[:i], chainRules[i+1:]...)
+			return nil
+		}
+	}
+
+	return errRuleNotFound
 }

--- a/cns/restserver/internalapi_linux.go
+++ b/cns/restserver/internalapi_linux.go
@@ -72,6 +72,7 @@ func (service *HTTPRestService) programSNATRules(req *cns.CreateNetworkContainer
 	if swiftRuleIndex != -1 {
 		// jump SWIFT rule exists, insert SWIFT-POSTROUTING rule at the same position so it ends up running first
 		// first, remove any existing SWIFT-POSTROUTING rules to avoid duplicates
+		// note: inserting at len(rules) and deleting a jump to SWIFT-POSTROUTING is mutually exclusive
 		swiftPostroutingExists, err := ipt.Exists(iptables.Nat, iptables.Postrouting, "-j", SWIFT)
 		if err != nil {
 			return types.UnexpectedError, fmt.Sprintf("[Azure CNS] Error. Failed to check for existence of SWIFT-POSTROUTING rule: %v", err)

--- a/cns/restserver/internalapi_linux.go
+++ b/cns/restserver/internalapi_linux.go
@@ -39,30 +39,59 @@ func (service *HTTPRestService) programSNATRules(req *cns.CreateNetworkContainer
 
 	chainExist, err := ipt.ChainExists(iptables.Nat, SWIFT)
 	if err != nil {
-		return types.UnexpectedError, fmt.Sprintf("[Azure CNS] Error. Failed to check for existence of SWIFT chain: %v", err)
+		return types.UnexpectedError, fmt.Sprintf("[Azure CNS] Error. Failed to check for existence of SWIFT-POSTROUTING chain: %v", err)
 	}
 	if !chainExist { // create and append chain if it doesn't exist
 		logger.Printf("[Azure CNS] Creating SWIFT Chain ...")
 		err = ipt.NewChain(iptables.Nat, SWIFT)
 		if err != nil {
-			return types.FailedToRunIPTableCmd, "[Azure CNS] failed to create SWIFT chain : " + err.Error()
-		}
-		logger.Printf("[Azure CNS] Append SWIFT Chain to POSTROUTING ...")
-		err = ipt.Append(iptables.Nat, iptables.Postrouting, "-j", SWIFT)
-		if err != nil {
-			return types.FailedToRunIPTableCmd, "[Azure CNS] failed to append SWIFT chain : " + err.Error()
+			return types.FailedToRunIPTableCmd, "[Azure CNS] failed to create SWIFT-POSTROUTING chain : " + err.Error()
 		}
 	}
 
-	postroutingToSwiftJumpexist, err := ipt.Exists(iptables.Nat, iptables.Postrouting, "-j", SWIFT)
+	// reconcile jump to SWIFT-POSTROUTING chain
+	rules, err := ipt.List(iptables.Nat, iptables.Postrouting)
 	if err != nil {
-		return types.UnexpectedError, fmt.Sprintf("[Azure CNS] Error. Failed to check for existence of POSTROUTING to SWIFT chain jump: %v", err)
+		return types.UnexpectedError, fmt.Sprintf("[Azure CNS] Error. Failed to check rules in postrouting chain of nat table: %v", err)
 	}
-	if !postroutingToSwiftJumpexist {
-		logger.Printf("[Azure CNS] Append SWIFT Chain to POSTROUTING ...")
-		err = ipt.Append(iptables.Nat, iptables.Postrouting, "-j", SWIFT)
+	swiftRuleIndex := len(rules) // append if neither jump rule from POSTROUTING is found
+	// one time migration from old SWIFT chain
+	// previously, CNI may have a jump to the SWIFT chain-- our jump to SWIFT-POSTROUTING needs to happen first
+	for index, rule := range rules {
+		if rule == "-A POSTROUTING -j SWIFT" {
+			// jump to SWIFT comes before jump to SWIFT-POSTROUTING, so potential reordering required
+			swiftRuleIndex = index
+			break
+		}
+		if rule == "-A POSTROUTING -j SWIFT-POSTROUTING" {
+			// jump to SWIFT-POSTROUTING comes before jump to SWIFT, which requires no further action
+			swiftRuleIndex = -1
+			break
+		}
+	}
+	if swiftRuleIndex != -1 {
+		// jump SWIFT rule exists, insert SWIFT-POSTROUTING rule at the same position so it ends up running first
+		// first, remove any existing SWIFT-POSTROUTING rules to avoid duplicates
+		swiftPostroutingExists, err := ipt.Exists(iptables.Nat, iptables.Postrouting, "-j", SWIFT)
 		if err != nil {
-			return types.FailedToRunIPTableCmd, "[Azure CNS] failed to append SWIFT chain : " + err.Error()
+			return types.UnexpectedError, fmt.Sprintf("[Azure CNS] Error. Failed to check for existence of SWIFT-POSTROUTING rule: %v", err)
+		}
+		if swiftPostroutingExists {
+			err = ipt.Delete(iptables.Nat, iptables.Postrouting, "-j", SWIFT)
+			if err != nil {
+				return types.FailedToRunIPTableCmd, "[Azure CNS] failed to delete existing SWIFT-POSTROUTING rule : " + err.Error()
+			}
+		}
+
+		// slice index is 0-based, iptables insert is 1-based, but list also gives us the -P POSTROUTING ACCEPT
+		// as the first rule so swiftRuleIndex gives us the correct 1-indexed iptables position.
+		// Example:
+		// -P POSTROUTING ACCEPT is at swiftRuleIndex 0
+		// -A POSTROUTING -j SWIFT is at swiftRuleIndex 1, and iptables index 1
+		logger.Printf("[Azure CNS] Inserting SWIFT-POSTROUTING Chain at iptables position %d", swiftRuleIndex)
+		err = ipt.Insert(iptables.Nat, iptables.Postrouting, swiftRuleIndex, "-j", SWIFT)
+		if err != nil {
+			return types.FailedToRunIPTableCmd, "[Azure CNS] failed to insert SWIFT-POSTROUTING chain : " + err.Error()
 		}
 	}
 
@@ -71,39 +100,47 @@ func (service *HTTPRestService) programSNATRules(req *cns.CreateNetworkContainer
 		// put the ip address in standard cidr form (where we zero out the parts that are not relevant)
 		_, podSubnet, _ := net.ParseCIDR(v.IPAddress + "/" + fmt.Sprintf("%d", req.IPConfiguration.IPSubnet.PrefixLength))
 
-		snatUDPRuleExists, err := ipt.Exists(iptables.Nat, SWIFT, "-m", "addrtype", "!", "--dst-type", "local", "-s", podSubnet.String(), "-d", networkutils.AzureDNS, "-p", iptables.UDP, "--dport", strconv.Itoa(iptables.DNSPort), "-j", iptables.Snat, "--to", ncPrimaryIP.String())
-		if err != nil {
-			return types.UnexpectedError, fmt.Sprintf("[Azure CNS] Error. Failed to check for existence of pod SNAT UDP rule : %v", err)
+		// define all rules we want in the chain
+		rules := [][]string{
+			{"-m", "addrtype", "!", "--dst-type", "local", "-s", podSubnet.String(), "-d", networkutils.AzureDNS, "-p", iptables.UDP, "--dport", strconv.Itoa(iptables.DNSPort), "-j", iptables.Snat, "--to", ncPrimaryIP.String()},
+			{"-m", "addrtype", "!", "--dst-type", "local", "-s", podSubnet.String(), "-d", networkutils.AzureDNS, "-p", iptables.TCP, "--dport", strconv.Itoa(iptables.DNSPort), "-j", iptables.Snat, "--to", ncPrimaryIP.String()},
+			{"-m", "addrtype", "!", "--dst-type", "local", "-s", podSubnet.String(), "-d", networkutils.AzureIMDS, "-p", iptables.TCP, "--dport", strconv.Itoa(iptables.HTTPPort), "-j", iptables.Snat, "--to", req.HostPrimaryIP},
 		}
-		if !snatUDPRuleExists {
-			logger.Printf("[Azure CNS] Inserting pod SNAT UDP rule ...")
-			err = ipt.Insert(iptables.Nat, SWIFT, 1, "-m", "addrtype", "!", "--dst-type", "local", "-s", podSubnet.String(), "-d", networkutils.AzureDNS, "-p", iptables.UDP, "--dport", strconv.Itoa(iptables.DNSPort), "-j", iptables.Snat, "--to", ncPrimaryIP.String())
+
+		// check if all rules exist
+		allRulesExist := true
+		for _, rule := range rules {
+			exists, err := ipt.Exists(iptables.Nat, SWIFT, rule...)
 			if err != nil {
-				return types.FailedToRunIPTableCmd, "[Azure CNS] failed to insert pod SNAT UDP rule : " + err.Error()
+				return types.UnexpectedError, fmt.Sprintf("[Azure CNS] Error. Failed to check for existence of rule: %v", err)
+			}
+			if !exists {
+				allRulesExist = false
+				break
 			}
 		}
 
-		snatPodTCPRuleExists, err := ipt.Exists(iptables.Nat, SWIFT, "-m", "addrtype", "!", "--dst-type", "local", "-s", podSubnet.String(), "-d", networkutils.AzureDNS, "-p", iptables.TCP, "--dport", strconv.Itoa(iptables.DNSPort), "-j", iptables.Snat, "--to", ncPrimaryIP.String())
+		// get current rule count in SWIFT-POSTROUTING chain
+		currentRules, err := ipt.List(iptables.Nat, SWIFT)
 		if err != nil {
-			return types.UnexpectedError, fmt.Sprintf("[Azure CNS] Error. Failed to check for existence of pod SNAT TCP rule : %v", err)
-		}
-		if !snatPodTCPRuleExists {
-			logger.Printf("[Azure CNS] Inserting pod SNAT TCP rule ...")
-			err = ipt.Insert(iptables.Nat, SWIFT, 1, "-m", "addrtype", "!", "--dst-type", "local", "-s", podSubnet.String(), "-d", networkutils.AzureDNS, "-p", iptables.TCP, "--dport", strconv.Itoa(iptables.DNSPort), "-j", iptables.Snat, "--to", ncPrimaryIP.String())
-			if err != nil {
-				return types.FailedToRunIPTableCmd, "[Azure CNS] failed to insert pod SNAT TCP rule : " + err.Error()
-			}
+			return types.UnexpectedError, fmt.Sprintf("[Azure CNS] Error. Failed to list rules in SWIFT-POSTROUTING chain: %v", err)
 		}
 
-		snatIMDSRuleexist, err := ipt.Exists(iptables.Nat, SWIFT, "-m", "addrtype", "!", "--dst-type", "local", "-s", podSubnet.String(), "-d", networkutils.AzureIMDS, "-p", iptables.TCP, "--dport", strconv.Itoa(iptables.HTTPPort), "-j", iptables.Snat, "--to", req.HostPrimaryIP)
-		if err != nil {
-			return types.UnexpectedError, fmt.Sprintf("[Azure CNS] Error. Failed to check for existence of pod SNAT IMDS rule : %v", err)
-		}
-		if !snatIMDSRuleexist {
-			logger.Printf("[Azure CNS] Inserting pod SNAT IMDS rule ...")
-			err = ipt.Insert(iptables.Nat, SWIFT, 1, "-m", "addrtype", "!", "--dst-type", "local", "-s", podSubnet.String(), "-d", networkutils.AzureIMDS, "-p", iptables.TCP, "--dport", strconv.Itoa(iptables.HTTPPort), "-j", iptables.Snat, "--to", req.HostPrimaryIP)
+		// if rule count doesn't match or not all rules exist, reconcile
+		// add one because there is always a singular starting rule in the chain, in addition to the ones we add
+		if len(currentRules) != len(rules)+1 || !allRulesExist {
+			logger.Printf("[Azure CNS] Reconciling SWIFT-POSTROUTING chain rules")
+
+			err = ipt.ClearChain(iptables.Nat, SWIFT)
 			if err != nil {
-				return types.FailedToRunIPTableCmd, "[Azure CNS] failed to insert pod SNAT IMDS rule : " + err.Error()
+				return types.FailedToRunIPTableCmd, "[Azure CNS] failed to flush SWIFT-POSTROUTING chain : " + err.Error()
+			}
+
+			for _, rule := range rules {
+				err = ipt.Append(iptables.Nat, SWIFT, rule...)
+				if err != nil {
+					return types.FailedToRunIPTableCmd, "[Azure CNS] failed to append rule to SWIFT-POSTROUTING chain : " + err.Error()
+				}
 			}
 		}
 

--- a/cns/restserver/internalapi_linux_test.go
+++ b/cns/restserver/internalapi_linux_test.go
@@ -27,16 +27,23 @@ func (c *FakeIPTablesProvider) GetIPTables() (iptablesClient, error) {
 }
 
 func TestAddSNATRules(t *testing.T) {
-	type expectedScenario struct {
+	type chainExpectation struct {
+		table    string
+		chain    string
+		expected []string
+	}
+
+	type preExistingRule struct {
 		table string
 		chain string
 		rule  []string
 	}
 
 	tests := []struct {
-		name     string
-		input    *cns.CreateNetworkContainerRequest
-		expected []expectedScenario
+		name             string
+		input            *cns.CreateNetworkContainerRequest
+		preExistingRules []preExistingRule
+		expectedChains   []chainExpectation
 	}{
 		{
 			// in pod subnet, the primary nic ip is in the same address space as the pod subnet
@@ -56,29 +63,178 @@ func TestAddSNATRules(t *testing.T) {
 				},
 				HostPrimaryIP: "10.0.0.4",
 			},
-			expected: []expectedScenario{
+			expectedChains: []chainExpectation{
 				{
 					table: iptables.Nat,
 					chain: SWIFT,
-					rule: []string{
-						"-m", "addrtype", "!", "--dst-type", "local", "-s", "240.1.2.0/24", "-d",
-						networkutils.AzureDNS, "-p", iptables.UDP, "--dport", strconv.Itoa(iptables.DNSPort), "-j", iptables.Snat, "--to", "240.1.2.1",
+					expected: []string{
+						"-N SWIFT-POSTROUTING",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p udp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 240.1.2.1",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p tcp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 240.1.2.1",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureIMDS + " -p tcp --dport " + strconv.Itoa(iptables.HTTPPort) + " -j SNAT --to 10.0.0.4",
 					},
 				},
 				{
 					table: iptables.Nat,
+					chain: iptables.Postrouting,
+					expected: []string{
+						"-P POSTROUTING ACCEPT",
+						"-A POSTROUTING -j SWIFT-POSTROUTING",
+					},
+				},
+			},
+		},
+		{
+			// test with pre-existing SWIFT rule that should be migrated
+			name: "migration from old SWIFT",
+			input: &cns.CreateNetworkContainerRequest{
+				NetworkContainerid: ncID,
+				IPConfiguration: cns.IPConfiguration{
+					IPSubnet: cns.IPSubnet{
+						IPAddress:    "240.1.2.1",
+						PrefixLength: 24,
+					},
+				},
+				SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+					"abc": {
+						IPAddress: "240.1.2.7",
+					},
+				},
+				HostPrimaryIP: "10.0.0.4",
+			},
+			preExistingRules: []preExistingRule{
+				{
+					table: iptables.Nat,
+					chain: iptables.Postrouting,
+					rule:  []string{"-j", "SWIFT"},
+				},
+				{
+					// stale rule at lower priority should be cleaned up
+					table: iptables.Nat,
+					chain: iptables.Postrouting,
+					rule:  []string{"-j", "SWIFT-POSTROUTING"},
+				},
+				{
+					// should be cleaned up
+					table: iptables.Nat,
 					chain: SWIFT,
-					rule: []string{
-						"-m", "addrtype", "!", "--dst-type", "local", "-s", "240.1.2.0/24", "-d",
-						networkutils.AzureDNS, "-p", iptables.TCP, "--dport", strconv.Itoa(iptables.DNSPort), "-j", iptables.Snat, "--to", "240.1.2.1",
+					rule:  []string{"-m", "addrtype", "!", "--dst-type", "local", "-s", "240.1.2.0/24", "-d", networkutils.AzureDNS, "-p", "udp", "--dport", strconv.Itoa(iptables.DNSPort), "-j", "SNAT", "--to", "99.1.2.1"},
+				},
+				{
+					table: iptables.Nat,
+					chain: "SWIFT",
+					rule:  []string{"-m", "addrtype", "!", "--dst-type", "local", "-s", "240.1.2.0/24", "-d", networkutils.AzureDNS, "-p", "udp", "--dport", strconv.Itoa(iptables.DNSPort), "-j", "SNAT", "--to", "192.1.2.1"},
+				},
+			},
+			expectedChains: []chainExpectation{
+				{
+					table: iptables.Nat,
+					chain: SWIFT,
+					expected: []string{
+						"-N SWIFT-POSTROUTING",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p udp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 240.1.2.1",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p tcp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 240.1.2.1",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureIMDS + " -p tcp --dport " + strconv.Itoa(iptables.HTTPPort) + " -j SNAT --to 10.0.0.4",
 					},
 				},
 				{
 					table: iptables.Nat,
+					chain: iptables.Postrouting,
+					expected: []string{
+						"-P POSTROUTING ACCEPT",
+						"-A POSTROUTING -j SWIFT-POSTROUTING",
+						"-A POSTROUTING -j SWIFT",
+					},
+				},
+				{
+					// stale old rule can remain
+					table: iptables.Nat,
+					chain: "SWIFT",
+					expected: []string{
+						"-N SWIFT",
+						"-A SWIFT -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p udp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 192.1.2.1",
+					},
+				},
+			},
+		},
+		{
+			// test after migration has already completed
+			name: "after migration from old SWIFT",
+			input: &cns.CreateNetworkContainerRequest{
+				NetworkContainerid: ncID,
+				IPConfiguration: cns.IPConfiguration{
+					IPSubnet: cns.IPSubnet{
+						IPAddress:    "240.1.2.1",
+						PrefixLength: 24,
+					},
+				},
+				SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+					"abc": {
+						IPAddress: "240.1.2.7",
+					},
+				},
+				HostPrimaryIP: "10.0.0.4",
+			},
+			preExistingRules: []preExistingRule{
+				{
+					// rule at higher priority means nothing happens
+					table: iptables.Nat,
+					chain: iptables.Postrouting,
+					rule:  []string{"-j", "SWIFT-POSTROUTING"},
+				},
+				{
+					table: iptables.Nat,
+					chain: iptables.Postrouting,
+					rule:  []string{"-j", "SWIFT"},
+				},
+				{
+					table: iptables.Nat,
 					chain: SWIFT,
-					rule: []string{
-						"-m", "addrtype", "!", "--dst-type", "local", "-s", "240.1.2.0/24", "-d",
-						networkutils.AzureIMDS, "-p", iptables.TCP, "--dport", strconv.Itoa(iptables.HTTPPort), "-j", iptables.Snat, "--to", "10.0.0.4",
+					rule:  []string{"-m", "addrtype", "!", "--dst-type", "local", "-s", "240.1.2.0/24", "-d", networkutils.AzureDNS, "-p", "udp", "--dport", strconv.Itoa(iptables.DNSPort), "-j", "SNAT", "--to", "240.1.2.1"},
+				},
+				{
+					table: iptables.Nat,
+					chain: SWIFT,
+					rule:  []string{"-m", "addrtype", "!", "--dst-type", "local", "-s", "240.1.2.0/24", "-d", networkutils.AzureDNS, "-p", "tcp", "--dport", strconv.Itoa(iptables.DNSPort), "-j", "SNAT", "--to", "240.1.2.1"},
+				},
+				{
+					table: iptables.Nat,
+					chain: SWIFT,
+					rule:  []string{"-m", "addrtype", "!", "--dst-type", "local", "-s", "240.1.2.0/24", "-d", networkutils.AzureIMDS, "-p", "tcp", "--dport", strconv.Itoa(iptables.HTTPPort), "-j", "SNAT", "--to", "10.0.0.4"},
+				},
+				{
+					table: iptables.Nat,
+					chain: "SWIFT",
+					rule:  []string{"-m", "addrtype", "!", "--dst-type", "local", "-s", "240.1.2.0/24", "-d", networkutils.AzureDNS, "-p", "udp", "--dport", strconv.Itoa(iptables.DNSPort), "-j", "SNAT", "--to", "192.1.2.1"},
+				},
+			},
+			expectedChains: []chainExpectation{
+				{
+					table: iptables.Nat,
+					chain: SWIFT,
+					expected: []string{
+						"-N SWIFT-POSTROUTING",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p udp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 240.1.2.1",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p tcp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 240.1.2.1",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureIMDS + " -p tcp --dport " + strconv.Itoa(iptables.HTTPPort) + " -j SNAT --to 10.0.0.4",
+					},
+				},
+				{
+					table: iptables.Nat,
+					chain: iptables.Postrouting,
+					expected: []string{
+						"-P POSTROUTING ACCEPT",
+						"-A POSTROUTING -j SWIFT-POSTROUTING",
+						"-A POSTROUTING -j SWIFT",
+					},
+				},
+				{
+					// stale old rule can remain
+					table: iptables.Nat,
+					chain: "SWIFT",
+					expected: []string{
+						"-N SWIFT",
+						"-A SWIFT -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p udp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 192.1.2.1",
 					},
 				},
 			},
@@ -101,29 +257,23 @@ func TestAddSNATRules(t *testing.T) {
 				},
 				HostPrimaryIP: "10.0.0.4",
 			},
-			expected: []expectedScenario{
+			expectedChains: []chainExpectation{
 				{
 					table: iptables.Nat,
 					chain: SWIFT,
-					rule: []string{
-						"-m", "addrtype", "!", "--dst-type", "local", "-s", "240.1.2.0/28", "-d",
-						networkutils.AzureDNS, "-p", iptables.UDP, "--dport", strconv.Itoa(iptables.DNSPort), "-j", iptables.Snat, "--to", "10.0.0.4",
+					expected: []string{
+						"-N SWIFT-POSTROUTING",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/28 -d " + networkutils.AzureDNS + " -p udp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 10.0.0.4",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/28 -d " + networkutils.AzureDNS + " -p tcp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 10.0.0.4",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/28 -d " + networkutils.AzureIMDS + " -p tcp --dport " + strconv.Itoa(iptables.HTTPPort) + " -j SNAT --to 10.0.0.4",
 					},
 				},
 				{
 					table: iptables.Nat,
-					chain: SWIFT,
-					rule: []string{
-						"-m", "addrtype", "!", "--dst-type", "local", "-s", "240.1.2.0/28", "-d",
-						networkutils.AzureDNS, "-p", iptables.TCP, "--dport", strconv.Itoa(iptables.DNSPort), "-j", iptables.Snat, "--to", "10.0.0.4",
-					},
-				},
-				{
-					table: iptables.Nat,
-					chain: SWIFT,
-					rule: []string{
-						"-m", "addrtype", "!", "--dst-type", "local", "-s", "240.1.2.0/28", "-d",
-						networkutils.AzureIMDS, "-p", iptables.TCP, "--dport", strconv.Itoa(iptables.HTTPPort), "-j", iptables.Snat, "--to", "10.0.0.4",
+					chain: iptables.Postrouting,
+					expected: []string{
+						"-P POSTROUTING ACCEPT",
+						"-A POSTROUTING -j SWIFT-POSTROUTING",
 					},
 				},
 			},
@@ -131,18 +281,58 @@ func TestAddSNATRules(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		service := getTestService(cns.KubernetesCRD)
-		service.iptables = &FakeIPTablesProvider{}
-		resp, msg := service.programSNATRules(tt.input)
-		if resp != types.Success {
-			t.Fatal("failed to program snat rules", msg, " case: ", tt.name)
-		}
-		finalState, _ := service.iptables.GetIPTables()
-		for _, ex := range tt.expected {
-			exists, err := finalState.Exists(ex.table, ex.chain, ex.rule...)
-			if err != nil || !exists {
-				t.Fatal("rule not found", ex.rule, " case: ", tt.name)
+		t.Run(tt.name, func(t *testing.T) {
+			service := getTestService(cns.KubernetesCRD)
+			service.iptables = &FakeIPTablesProvider{}
+
+			ipt, err := service.iptables.GetIPTables()
+			if err != nil {
+				t.Fatal("failed to get iptables client:", err)
 			}
-		}
+
+			// setup pre-existing rules
+			if len(tt.preExistingRules) > 0 {
+				for _, preRule := range tt.preExistingRules {
+					chainExists, _ := ipt.ChainExists(preRule.table, preRule.chain)
+
+					if !chainExists {
+						err = ipt.NewChain(preRule.table, preRule.chain)
+						if err != nil {
+							t.Fatal("failed to setup pre-existing rule chain:", err)
+						}
+					}
+
+					err = ipt.Append(preRule.table, preRule.chain, preRule.rule...)
+					if err != nil {
+						t.Fatal("failed to setup pre-existing rule:", err)
+					}
+				}
+			}
+
+			resp, msg := service.programSNATRules(tt.input)
+			if resp != types.Success {
+				t.Fatal("failed to program snat rules", msg)
+			}
+
+			// verify chain contents using List
+			for _, chainExp := range tt.expectedChains {
+				actualRules, err := ipt.List(chainExp.table, chainExp.chain)
+				if err != nil {
+					t.Fatal("failed to list rules for chain", chainExp.chain, ":", err)
+				}
+
+				if len(actualRules) != len(chainExp.expected) {
+					t.Fatalf("chain %s rule count mismatch: got %d, expected %d\nActual: %v\nExpected: %v",
+						chainExp.chain, len(actualRules), len(chainExp.expected), actualRules, chainExp.expected)
+				}
+
+				for i, expectedRule := range chainExp.expected {
+					if actualRules[i] != expectedRule {
+						t.Fatalf("chain %s rule %d mismatch:\nActual:   %s\nExpected: %s",
+							chainExp.chain, i, actualRules[i], expectedRule)
+					}
+				}
+			}
+		})
 	}
 }

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -60,6 +60,9 @@ type iptablesClient interface {
 	Append(table string, chain string, rulespec ...string) error
 	Exists(table string, chain string, rulespec ...string) (bool, error)
 	Insert(table string, chain string, pos int, rulespec ...string) error
+	List(table string, chain string) ([]string, error)
+	ClearChain(table string, chain string) error
+	Delete(table, chain string, rulespec ...string) error
 }
 
 type iptablesGetter interface {


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
CNS currently programs snat iptables rules only on NNC update/create. This PR makes it so that it also does so during cns bootup. Additionally, CNS will now attempt to "reconcile" the iptables on the node to what it expects. This allows us to "rollback" future updates to CNS iptables rules to match the expected state each time CNS reboots or restarts.

It is currently possible for CNI to add iptables rules to the node using chain "SWIFT". We want to jump to the cns-controlled chain "SWIFT-POSTROUTING" before we jump to the chain "SWIFT". The first piece of logic is to migrate to that:

Case 1: CNI already added a jump to SWIFT chain in nat POSTROUTING chain and it is at a higher priority than any SWIFT-POSTROUTING jump we may have added: We find the position of the SWIFT jump rule, and insert our SWIFT-POSTROUTING jump at that position, pushing the SWIFT jump rule to a lower priority
```
POSTROUTING
jump to KUBE POSTROUTING
...
jump to SWIFT
jump to SWIFT-POSTROUTING
```
or
```
POSTROUTING
jump to KUBE POSTROUTING
...
jump to SWIFT
```

Case 2: The SWIFT-POSTROUTING jump rule exists before the SWIFT jump rule, or exists without any SWIFT jump rule: We do not modify the nat POSTROUTING chain
```
POSTROUTING
jump to KUBE POSTROUTING
...
jump to SWIFT-POSTROUTING
jump to SWIFT
```
or
```
POSTROUTING
jump to KUBE POSTROUTING
...
jump to SWIFT-POSTROUTING
```

Case 3: The nat POSTROUTING chain does not contain a SWIFT jump rule nor a SWIFT-POSTROUTING rule: We append the SWIFT-POSTROUTING jump rule to the nat POSTROUTING chain
```
POSTROUTING
jump to KUBE POSTROUTING
...
```

Now, packets will go to the nat SWIFT-POSTROUTING chain first. We then take a look at the SWIFT-POSTROUTING chain. 
Case 1: The nat SWIFT-POSTROUTING chain does not contain every single rule we expect exactly, or the # of rules in the SWIFT-POSTROUTING chain does not match how many rules we expect: Flush the chain and reinstall the iptables rules we expect.

Case 2: The nat SWIFT-POSTROUTING chain contains every single rule we expect exactly, and the # of rules matches how many rules we expect: We do not modify or flush the SWIFT-POSTROUTING chain

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [X] includes documentation
- [X] adds unit tests
- [X] relevant PR labels added

**Notes**:
- Check iptables insert of bounds just in case
- When we list iptables rules, the first rule is always `-N ...` for custom chains or `-P ...` for built in chains (not shown in `iptables -nvL -t nat`). Feel free to check-- the library calls `iptables -t <table> -S <chain>` under the hood.
- When we list iptables rules, the rules use -A syntax when listed no matter how they were added (via insert, append, etc.)
- IPTables is 1-indexed, so insert at position 1 will be the first rule in the chain-- so when using `iptables -nvL -t nat` the first rule that shows up in a chain is at index 1.