### PR TITLE
feat: add AppGatewaySubnetID field to OverlayExtensionConfig CRD

### DIFF
--- a/crd/overlayextensionconfig/api/v1alpha1/overlayextensionconfig_types.go
+++ b/crd/overlayextensionconfig/api/v1alpha1/overlayextensionconfig_types.go
@@ -34,14 +34,12 @@ type OverlayExtensionConfigList struct {
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.extensionIPRange) || has(self.extensionIPRange)", message="ExtensionIPRange is required once set"
 type OverlayExtensionConfigSpec struct {
 	// ExtensionIPRange field defines a CIDR that should be able to reach routing domain ip addresses.
-	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	// +kubebuilder:validation:MaxLength=43
 	// 43 is max length of IPv6 CIDR string
 	ExtensionIPRange string `json:"extensionIPRange,omitempty"`
 
 	// AppGatewaySubnetID field defines a subnet delegated to Application Gateway that should be able to reach routing domain ip addresses.
-	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	AppGatewaySubnetID string `json:"appGatewaySubnetID,omitempty"`
 }

--- a/crd/overlayextensionconfig/api/v1alpha1/overlayextensionconfig_types.go
+++ b/crd/overlayextensionconfig/api/v1alpha1/overlayextensionconfig_types.go
@@ -39,6 +39,11 @@ type OverlayExtensionConfigSpec struct {
 	// +kubebuilder:validation:MaxLength=43
 	// 43 is max length of IPv6 CIDR string
 	ExtensionIPRange string `json:"extensionIPRange,omitempty"`
+
+	// AppGatewaySubnetID field defines a subnet delegated to Application Gateway that should be able to reach routing domain ip addresses.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
+	AppGatewaySubnetID string `json:"appGatewaySubnetID,omitempty"`
 }
 
 type OECState string

--- a/crd/overlayextensionconfig/manifests/acn.azure.com_overlayextensionconfigs.yaml
+++ b/crd/overlayextensionconfig/manifests/acn.azure.com_overlayextensionconfigs.yaml
@@ -47,6 +47,14 @@ spec:
           spec:
             description: OverlayExtensionConfigSpec defines the desired state of OverlayExtensionConfig.
             properties:
+              appGatewaySubnetID:
+                description: AppGatewaySubnetID field defines a subnet delegated to
+                  Application Gateway that should be able to reach routing domain
+                  ip addresses.
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               extensionIPRange:
                 description: |-
                   ExtensionIPRange field defines a CIDR that should be able to reach routing domain ip addresses.


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
OverlayExtensionConfig (OEC) was designed specifically to work with AGIC/AGC subnets. We want to extend Routing Domain connectivity to these subnets only. To avoid breaking changes (such as removing existing `extensionIPRange` field from OEC CRD), add a new `appGatewaySubnetID` field to OEC CRD.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
