### PR TITLE
WIP: Adding default route for swiftv2 vnet nics

### DIFF
--- a/cns/middlewares/k8sSwiftV2.go
+++ b/cns/middlewares/k8sSwiftV2.go
@@ -137,8 +137,12 @@ func (k *K8sSWIFTv2Middleware) getIPConfig(ctx context.Context, podInfo cns.PodI
 					},
 					MacAddress:        interfaceInfo.MacAddress,
 					NICType:           nicType,
-					SkipDefaultRoutes: false,
+					SkipDefaultRoutes: true,
 					// InterfaceName is empty for DelegatedVMNIC and AccelnetFrontendNIC
+				}
+				if interfaceInfo.DefaultRoute {
+					podIPInfo.SkipDefaultRoutes = false // Default route is added in setRoutes() for Linux swiftv2
+					k.addDefaultRoute(&podIPInfo, interfaceInfo.GatewayIP)
 				}
 				// for windows scenario, it is required to add additional fields with the exact subnetAddressSpace
 				// received from MTPNC, this function assigns them for windows while linux is a no-op
@@ -148,7 +152,7 @@ func (k *K8sSWIFTv2Middleware) getIPConfig(ctx context.Context, podInfo cns.PodI
 				}
 				podIPInfos = append(podIPInfos, podIPInfo)
 				// for windows scenario, it is required to add default route with gatewayIP from CNS
-				k.addDefaultRoute(&podIPInfo, interfaceInfo.GatewayIP)
+
 			}
 		}
 	}

--- a/cns/middlewares/k8sSwiftV2_linux.go
+++ b/cns/middlewares/k8sSwiftV2_linux.go
@@ -160,8 +160,8 @@ func (k *K8sSWIFTv2Middleware) IPConfigsRequestHandlerWrapper(defaultHandler, fa
 		// Set routes for the pod
 		for i := range ipConfigsResp.PodIPInfo {
 			ipInfo := &ipConfigsResp.PodIPInfo[i]
-			// Backend nics doesn't need routes to be set
-			if ipInfo.NICType != cns.BackendNIC {
+			// Backend nics doesn't need routes to be set, Fronted nics which doesn't require default routes will have skipDefaultRoutes set to true
+			if ipInfo.NICType != cns.BackendNIC && !ipInfo.SkipDefaultRoutes {
 				err = k.setRoutes(ipInfo)
 				if err != nil {
 					return &cns.IPConfigsResponse{

--- a/crd/multitenancy/api/v1alpha1/multitenantpodnetworkconfig.go
+++ b/crd/multitenancy/api/v1alpha1/multitenantpodnetworkconfig.go
@@ -66,6 +66,8 @@ type InterfaceInfo struct {
 	// AccelnetEnabled determines if the CNI will provision the NIC with accelerated networking enabled
 	// +kubebuilder:validation:Optional
 	AccelnetEnabled bool `json:"accelnetEnabled,omitempty"`
+	// DefaultRoute indicates whether this PodNetwork should be used as the default route for the Pod
+	DefaultRoute bool `json:"defaultRoute,omitempty"`
 }
 
 // MultitenantPodNetworkConfigStatus defines the observed state of PodNetworkConfig

--- a/crd/multitenancy/api/v1alpha1/podnetworkinstance.go
+++ b/crd/multitenancy/api/v1alpha1/podnetworkinstance.go
@@ -42,6 +42,8 @@ type PodNetworkConfig struct {
 	// PodIPReservationSize is the number of IP address to statically reserve
 	// +kubebuilder:default=0
 	PodIPReservationSize int `json:"podIPReservationSize,omitempty"`
+	// DefaultRoute indicates whether this PodNetwork should be used as the default route for the Pod
+	DefaultRoute bool `json:"defaultRoute,omitempty"`
 }
 
 // PodNetworkInstanceSpec defines the desired state of PodNetworkInstance


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
