### PR TITLE
feat: snat azure dns traffic to node ip in cns linux

### DIFF
--- a/cns/fakes/iptablesfake.go
+++ b/cns/fakes/iptablesfake.go
@@ -20,7 +20,11 @@ type IPTablesLegacyMock struct {
 	deleteCallCount int
 }
 
+<<<<<<< HEAD
 func (c *IPTablesLegacyMock) Delete(_, _ string, _ ...string) error {
+=======
+func (c *IPTablesLegacyMock) Delete(table, chain string, rulespec ...string) error {
+>>>>>>> 584547398 (add logic to delete jump to swift postrouting in legacy and fix uts)
 	c.deleteCallCount++
 	return nil
 }

--- a/cns/fakes/iptablesfake.go
+++ b/cns/fakes/iptablesfake.go
@@ -20,11 +20,7 @@ type IPTablesLegacyMock struct {
 	deleteCallCount int
 }
 
-<<<<<<< HEAD
 func (c *IPTablesLegacyMock) Delete(_, _ string, _ ...string) error {
-=======
-func (c *IPTablesLegacyMock) Delete(table, chain string, rulespec ...string) error {
->>>>>>> 584547398 (add logic to delete jump to swift postrouting in legacy and fix uts)
 	c.deleteCallCount++
 	return nil
 }

--- a/cns/restserver/internalapi_linux_test.go
+++ b/cns/restserver/internalapi_linux_test.go
@@ -78,8 +78,8 @@ func TestAddSNATRules(t *testing.T) {
 					chain: SWIFTPOSTROUTING,
 					expected: []string{
 						"-N SWIFT-POSTROUTING",
-						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p udp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 240.1.2.1",
-						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p tcp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 240.1.2.1",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p udp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 10.0.0.4",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p tcp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 10.0.0.4",
 						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureIMDS + " -p tcp --dport " + strconv.Itoa(iptables.HTTPPort) + " -j SNAT --to 10.0.0.4",
 					},
 				},
@@ -148,8 +148,8 @@ func TestAddSNATRules(t *testing.T) {
 					chain: SWIFTPOSTROUTING,
 					expected: []string{
 						"-N SWIFT-POSTROUTING",
-						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p udp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 240.1.2.1",
-						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p tcp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 240.1.2.1",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p udp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 10.0.0.4",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p tcp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 10.0.0.4",
 						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureIMDS + " -p tcp --dport " + strconv.Itoa(iptables.HTTPPort) + " -j SNAT --to 10.0.0.4",
 					},
 				},
@@ -209,7 +209,7 @@ func TestAddSNATRules(t *testing.T) {
 					chain: SWIFTPOSTROUTING,
 					rule: []string{
 						"-m", "addrtype", "!", "--dst-type", "local", "-s", "240.1.2.0/24", "-d", networkutils.AzureDNS,
-						"-p", "udp", "--dport", strconv.Itoa(iptables.DNSPort), "-j", "SNAT", "--to", "240.1.2.1",
+						"-p", "udp", "--dport", strconv.Itoa(iptables.DNSPort), "-j", "SNAT", "--to", "10.0.0.4",
 					},
 				},
 				{
@@ -217,7 +217,7 @@ func TestAddSNATRules(t *testing.T) {
 					chain: SWIFTPOSTROUTING,
 					rule: []string{
 						"-m", "addrtype", "!", "--dst-type", "local", "-s", "240.1.2.0/24", "-d", networkutils.AzureDNS,
-						"-p", "tcp", "--dport", strconv.Itoa(iptables.DNSPort), "-j", "SNAT", "--to", "240.1.2.1",
+						"-p", "tcp", "--dport", strconv.Itoa(iptables.DNSPort), "-j", "SNAT", "--to", "10.0.0.4",
 					},
 				},
 				{
@@ -243,8 +243,8 @@ func TestAddSNATRules(t *testing.T) {
 					chain: SWIFTPOSTROUTING,
 					expected: []string{
 						"-N SWIFT-POSTROUTING",
-						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p udp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 240.1.2.1",
-						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p tcp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 240.1.2.1",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p udp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 10.0.0.4",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p tcp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 10.0.0.4",
 						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureIMDS + " -p tcp --dport " + strconv.Itoa(iptables.HTTPPort) + " -j SNAT --to 10.0.0.4",
 					},
 				},


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Changes the ip CNS-added IPTables rules SNAT to from the primary ip to node ip for **linux** podsubnet scenarios (both azure and cilium cases). CNI-added iptables rules are not modified and windows behavior remains the same (will be modified in a future PR).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests
- [X] relevant PR labels added

**Notes**:
Tested:
- Podsubnet linux upgrade from 1.7.3 --> this version --> downgrade to 1.7.3 and dns snat is as expected
- Podsubnet linux cilium ugprade from 1.7.3 --> this version --> downgrade to 1.7.3 and dns snat is as expected
