### PR TITLE
feat: remove jump to swift-postrouting in iptables legacy as rules already exist in iptables nftables

### DIFF
--- a/cns/fakes/iptablesfake.go
+++ b/cns/fakes/iptablesfake.go
@@ -16,6 +16,19 @@ var (
 	errIndexBounds   = errors.New("index out of bounds")
 )
 
+type IPTablesLegacyMock struct {
+	deleteCallCount int
+}
+
+func (c *IPTablesLegacyMock) Delete(table, chain string, rulespec ...string) error {
+	c.deleteCallCount++
+	return nil
+}
+
+func (c *IPTablesLegacyMock) DeleteCallCount() int {
+	return c.deleteCallCount
+}
+
 type IPTablesMock struct {
 	state               map[string]map[string][]string
 	clearChainCallCount int

--- a/cns/fakes/iptablesfake.go
+++ b/cns/fakes/iptablesfake.go
@@ -20,7 +20,7 @@ type IPTablesLegacyMock struct {
 	deleteCallCount int
 }
 
-func (c *IPTablesLegacyMock) Delete(table, chain string, rulespec ...string) error {
+func (c *IPTablesLegacyMock) Delete(_, _ string, _ ...string) error {
 	c.deleteCallCount++
 	return nil
 }

--- a/cns/restserver/internalapi_linux.go
+++ b/cns/restserver/internalapi_linux.go
@@ -45,13 +45,14 @@ func (service *HTTPRestService) programSNATRules(req *cns.CreateNetworkContainer
 	ncPrimaryIP, _, _ := net.ParseCIDR(req.IPConfiguration.IPSubnet.IPAddress + "/" + fmt.Sprintf("%d", req.IPConfiguration.IPSubnet.PrefixLength))
 
 	iptl, err := service.iptables.GetIPTablesLegacy()
-	if err != nil {
-		return types.UnexpectedError, fmt.Sprintf("[Azure CNS] Error. Failed to create iptables legacy interface : %v", err)
-	}
-	err = iptl.Delete(iptables.Nat, iptables.Postrouting, "-j", SWIFTPOSTROUTING)
-	// ignore if command fails
 	if err == nil {
-		logger.Printf("[Azure CNS] Deleted legacy jump to SWIFT-POSTROUTING Chain")
+		err = iptl.Delete(iptables.Nat, iptables.Postrouting, "-j", SWIFTPOSTROUTING)
+		// ignore if command fails
+		if err == nil {
+			logger.Printf("[Azure CNS] Deleted legacy jump to SWIFT-POSTROUTING Chain")
+		}
+	} else {
+		logger.Printf("[Azure CNS] Could not create iptables legacy interface, continuing : %v", err)
 	}
 
 	ipt, err := service.iptables.GetIPTables()

--- a/cns/restserver/internalapi_linux.go
+++ b/cns/restserver/internalapi_linux.go
@@ -31,7 +31,7 @@ type iptablesLegacy struct{}
 
 func (c *iptablesLegacy) Delete(table, chain string, rulespec ...string) error {
 	cmd := append([]string{"-t", table, "-D", chain}, rulespec...)
-	return exec.Command("iptables-legacy", cmd...).Run()
+	return errors.Wrap(exec.Command("iptables-legacy", cmd...).Run(), "iptables legacy failed delete")
 }
 
 // nolint

--- a/cns/restserver/internalapi_linux.go
+++ b/cns/restserver/internalapi_linux.go
@@ -152,7 +152,7 @@ func (service *HTTPRestService) programSNATRules(req *cns.CreateNetworkContainer
 		// if rule count doesn't match or not all rules exist, reconcile
 		// add one because there is always a singular starting rule in the chain, in addition to the ones we add
 		if len(currentRules) != len(rules)+1 || !allRulesExist {
-			logger.Printf("[Azure CNS] Reconciling SWIFT-POSTROUTING chain rules")
+			logger.Printf("[Azure CNS] Reconciling SWIFT-POSTROUTING chain rules to SNAT Azure DNS and IMDS to Host IP")
 
 			err = ipt.ClearChain(iptables.Nat, SWIFTPOSTROUTING)
 			if err != nil {
@@ -165,6 +165,7 @@ func (service *HTTPRestService) programSNATRules(req *cns.CreateNetworkContainer
 					return types.FailedToRunIPTableCmd, "[Azure CNS] failed to append rule to SWIFT-POSTROUTING chain : " + err.Error()
 				}
 			}
+			logger.Printf("[Azure CNS] Finished reconciling SWIFT-POSTROUTING chain")
 		}
 
 		// we only need to run this code once as the iptable rule applies to all secondary ip configs in the same subnet

--- a/cns/restserver/internalapi_linux_test.go
+++ b/cns/restserver/internalapi_linux_test.go
@@ -78,8 +78,8 @@ func TestAddSNATRules(t *testing.T) {
 					chain: SWIFTPOSTROUTING,
 					expected: []string{
 						"-N SWIFT-POSTROUTING",
-						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p udp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 10.0.0.4",
-						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p tcp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 10.0.0.4",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p udp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 240.1.2.1",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p tcp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 240.1.2.1",
 						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureIMDS + " -p tcp --dport " + strconv.Itoa(iptables.HTTPPort) + " -j SNAT --to 10.0.0.4",
 					},
 				},
@@ -148,8 +148,8 @@ func TestAddSNATRules(t *testing.T) {
 					chain: SWIFTPOSTROUTING,
 					expected: []string{
 						"-N SWIFT-POSTROUTING",
-						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p udp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 10.0.0.4",
-						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p tcp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 10.0.0.4",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p udp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 240.1.2.1",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p tcp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 240.1.2.1",
 						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureIMDS + " -p tcp --dport " + strconv.Itoa(iptables.HTTPPort) + " -j SNAT --to 10.0.0.4",
 					},
 				},
@@ -209,7 +209,7 @@ func TestAddSNATRules(t *testing.T) {
 					chain: SWIFTPOSTROUTING,
 					rule: []string{
 						"-m", "addrtype", "!", "--dst-type", "local", "-s", "240.1.2.0/24", "-d", networkutils.AzureDNS,
-						"-p", "udp", "--dport", strconv.Itoa(iptables.DNSPort), "-j", "SNAT", "--to", "10.0.0.4",
+						"-p", "udp", "--dport", strconv.Itoa(iptables.DNSPort), "-j", "SNAT", "--to", "240.1.2.1",
 					},
 				},
 				{
@@ -217,7 +217,7 @@ func TestAddSNATRules(t *testing.T) {
 					chain: SWIFTPOSTROUTING,
 					rule: []string{
 						"-m", "addrtype", "!", "--dst-type", "local", "-s", "240.1.2.0/24", "-d", networkutils.AzureDNS,
-						"-p", "tcp", "--dport", strconv.Itoa(iptables.DNSPort), "-j", "SNAT", "--to", "10.0.0.4",
+						"-p", "tcp", "--dport", strconv.Itoa(iptables.DNSPort), "-j", "SNAT", "--to", "240.1.2.1",
 					},
 				},
 				{
@@ -243,8 +243,8 @@ func TestAddSNATRules(t *testing.T) {
 					chain: SWIFTPOSTROUTING,
 					expected: []string{
 						"-N SWIFT-POSTROUTING",
-						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p udp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 10.0.0.4",
-						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p tcp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 10.0.0.4",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p udp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 240.1.2.1",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p tcp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 240.1.2.1",
 						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureIMDS + " -p tcp --dport " + strconv.Itoa(iptables.HTTPPort) + " -j SNAT --to 10.0.0.4",
 					},
 				},

--- a/cns/restserver/internalapi_linux_test.go
+++ b/cns/restserver/internalapi_linux_test.go
@@ -15,7 +15,8 @@ import (
 )
 
 type FakeIPTablesProvider struct {
-	iptables *fakes.IPTablesMock
+	iptables       *fakes.IPTablesMock
+	iptablesLegacy *fakes.IPTablesLegacyMock
 }
 
 func (c *FakeIPTablesProvider) GetIPTables() (iptablesClient, error) {
@@ -24,6 +25,13 @@ func (c *FakeIPTablesProvider) GetIPTables() (iptablesClient, error) {
 		c.iptables = fakes.NewIPTablesMock()
 	}
 	return c.iptables, nil
+}
+
+func (c *FakeIPTablesProvider) GetIPTablesLegacy() iptablesLegacyClient {
+	if c.iptablesLegacy == nil {
+		c.iptablesLegacy = &fakes.IPTablesLegacyMock{}
+	}
+	return c.iptablesLegacy
 }
 
 func TestAddSNATRules(t *testing.T) {
@@ -70,8 +78,8 @@ func TestAddSNATRules(t *testing.T) {
 					chain: SWIFTPOSTROUTING,
 					expected: []string{
 						"-N SWIFT-POSTROUTING",
-						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p udp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 240.1.2.1",
-						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p tcp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 240.1.2.1",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p udp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 10.0.0.4",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p tcp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 10.0.0.4",
 						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureIMDS + " -p tcp --dport " + strconv.Itoa(iptables.HTTPPort) + " -j SNAT --to 10.0.0.4",
 					},
 				},
@@ -140,8 +148,8 @@ func TestAddSNATRules(t *testing.T) {
 					chain: SWIFTPOSTROUTING,
 					expected: []string{
 						"-N SWIFT-POSTROUTING",
-						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p udp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 240.1.2.1",
-						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p tcp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 240.1.2.1",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p udp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 10.0.0.4",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p tcp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 10.0.0.4",
 						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureIMDS + " -p tcp --dport " + strconv.Itoa(iptables.HTTPPort) + " -j SNAT --to 10.0.0.4",
 					},
 				},
@@ -201,7 +209,7 @@ func TestAddSNATRules(t *testing.T) {
 					chain: SWIFTPOSTROUTING,
 					rule: []string{
 						"-m", "addrtype", "!", "--dst-type", "local", "-s", "240.1.2.0/24", "-d", networkutils.AzureDNS,
-						"-p", "udp", "--dport", strconv.Itoa(iptables.DNSPort), "-j", "SNAT", "--to", "240.1.2.1",
+						"-p", "udp", "--dport", strconv.Itoa(iptables.DNSPort), "-j", "SNAT", "--to", "10.0.0.4",
 					},
 				},
 				{
@@ -209,7 +217,7 @@ func TestAddSNATRules(t *testing.T) {
 					chain: SWIFTPOSTROUTING,
 					rule: []string{
 						"-m", "addrtype", "!", "--dst-type", "local", "-s", "240.1.2.0/24", "-d", networkutils.AzureDNS,
-						"-p", "tcp", "--dport", strconv.Itoa(iptables.DNSPort), "-j", "SNAT", "--to", "240.1.2.1",
+						"-p", "tcp", "--dport", strconv.Itoa(iptables.DNSPort), "-j", "SNAT", "--to", "10.0.0.4",
 					},
 				},
 				{
@@ -235,8 +243,8 @@ func TestAddSNATRules(t *testing.T) {
 					chain: SWIFTPOSTROUTING,
 					expected: []string{
 						"-N SWIFT-POSTROUTING",
-						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p udp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 240.1.2.1",
-						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p tcp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 240.1.2.1",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p udp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 10.0.0.4",
+						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureDNS + " -p tcp --dport " + strconv.Itoa(iptables.DNSPort) + " -j SNAT --to 10.0.0.4",
 						"-A SWIFT-POSTROUTING -m addrtype ! --dst-type local -s 240.1.2.0/24 -d " + networkutils.AzureIMDS + " -p tcp --dport " + strconv.Itoa(iptables.HTTPPort) + " -j SNAT --to 10.0.0.4",
 					},
 				},
@@ -307,8 +315,10 @@ func TestAddSNATRules(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			service := getTestService(cns.KubernetesCRD)
 			ipt := fakes.NewIPTablesMock()
+			iptl := &fakes.IPTablesLegacyMock{}
 			service.iptables = &FakeIPTablesProvider{
-				iptables: ipt,
+				iptables:       ipt,
+				iptablesLegacy: iptl,
 			}
 
 			// setup pre-existing rules
@@ -359,6 +369,12 @@ func TestAddSNATRules(t *testing.T) {
 			actualClearChainCalls := ipt.ClearChainCallCount()
 			if actualClearChainCalls != tt.expectedClearChainCalls {
 				t.Fatalf("ClearChain call count mismatch: got %d, expected %d", actualClearChainCalls, tt.expectedClearChainCalls)
+			}
+
+			// verify we delete legacy swift postrouting jump
+			actualLegacyDeleteCalls := iptl.DeleteCallCount()
+			if actualLegacyDeleteCalls != 1 {
+				t.Fatalf("Delete call count mismatch: got %d, expected 1", actualLegacyDeleteCalls)
 			}
 		})
 	}

--- a/cns/restserver/internalapi_linux_test.go
+++ b/cns/restserver/internalapi_linux_test.go
@@ -27,11 +27,11 @@ func (c *FakeIPTablesProvider) GetIPTables() (iptablesClient, error) {
 	return c.iptables, nil
 }
 
-func (c *FakeIPTablesProvider) GetIPTablesLegacy() iptablesLegacyClient {
+func (c *FakeIPTablesProvider) GetIPTablesLegacy() (iptablesLegacyClient, error) {
 	if c.iptablesLegacy == nil {
 		c.iptablesLegacy = &fakes.IPTablesLegacyMock{}
 	}
-	return c.iptablesLegacy
+	return c.iptablesLegacy, nil
 }
 
 func TestAddSNATRules(t *testing.T) {

--- a/cns/restserver/internalapi_windows.go
+++ b/cns/restserver/internalapi_windows.go
@@ -24,6 +24,10 @@ func (*IPtablesProvider) GetIPTables() (iptablesClient, error) {
 	return nil, errUnsupportedAPI
 }
 
+func (*IPtablesProvider) GetIPTablesLegacy() (iptablesLegacyClient, error) {
+	return nil, errUnsupportedAPI
+}
+
 // nolint
 func (service *HTTPRestService) programSNATRules(req *cns.CreateNetworkContainerRequest) (types.ResponseCode, string) {
 	return types.Success, ""

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -64,9 +64,13 @@ type iptablesClient interface {
 	ClearChain(table string, chain string) error
 	Delete(table, chain string, rulespec ...string) error
 }
+type iptablesLegacyClient interface {
+	Delete(table, chain string, rulespec ...string) error
+}
 
 type iptablesGetter interface {
 	GetIPTables() (iptablesClient, error)
+	GetIPTablesLegacy() iptablesLegacyClient
 }
 
 // HTTPRestService represents http listener for CNS - Container Networking Service.

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -70,7 +70,7 @@ type iptablesLegacyClient interface {
 
 type iptablesGetter interface {
 	GetIPTables() (iptablesClient, error)
-	GetIPTablesLegacy() iptablesLegacyClient
+	GetIPTablesLegacy() (iptablesLegacyClient, error)
 }
 
 // HTTPRestService represents http listener for CNS - Container Networking Service.


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Contains same changes as #3930 but without the behavioral change of snat to node ip

Deletes iptables legacy jump to swift postrouting rule **before** adding nftables rules because:
If we delete before:
If iptables maps to iptables nftables, we should already have nftables rules programmed on the node because cns 1.7.1 has fully rolled out, so deleting first should not cause any connectivity blip.
If iptables somehow maps to iptables legacy, we have a blip and then write the rule immediately after
 
If we delete afterwards:
If iptables maps to iptables nftables, we write the rules and delete the legacy jump after as expected
If iptables somehow maps to iptables legacy, we would add the rules and then delete the jump we just added, breaking the node until the cns restarts

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests
- [X] relevant PR labels added

**Notes**:
Tested upgrade from 1.7.0 --> 1.7.1 --> 1.7.2 (this PR) for cns