### PR TITLE
fix: add code generation to run-unit-tests.stages

### DIFF
--- a/.pipelines/templates/run-unit-tests.stages.yaml
+++ b/.pipelines/templates/run-unit-tests.stages.yaml
@@ -35,6 +35,8 @@ stages:
         mkdir -p "$REPORT_DIR"
         touch "$REPORT_XML"
         make tools
+        make bpf-lib
+        go generate ./...
 
         # run test, echo exit status code to fd 3, pipe output from test to tee, which splits output to stdout and go-junit-report (which converts test output to report.xml),
         # stdout from tee is redirected to fd 4. Take output written to fd 3 (which is the exit code of test), redirect to stdout, pipe to read from stdout then exit with that status code.


### PR DESCRIPTION
**Reason for Change**:
We introduced bpf code as part of the iptables block binary, that relies on code generation. We updated run-unit-tests.yaml, which is used by the UT runs on the PR pipeline, to have the extra code generation steps.  But the signed binary release uses run-unit-tests.stages.yaml, which wasn't updated. This PR adds the code generation to that file as well.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
