### PR TITLE
Add zap logger to cns apis

### DIFF
--- a/cns/common/service.go
+++ b/cns/common/service.go
@@ -10,6 +10,7 @@ import (
 	acn "github.com/Azure/azure-container-networking/common"
 	"github.com/Azure/azure-container-networking/server/tls"
 	"github.com/Azure/azure-container-networking/store"
+	"go.uber.org/zap"
 )
 
 // Service implements behavior common to all services.
@@ -20,6 +21,7 @@ type Service struct {
 	ErrChan     chan<- error
 	Store       store.KeyValueStore
 	ChannelMode string
+	Logger      *zap.Logger
 }
 
 // ServiceAPI defines base interface.
@@ -41,6 +43,7 @@ type ServiceConfig struct {
 	Server      server
 	ChannelMode string
 	TLSSettings tls.TlsSettings
+	Logger      *zap.Logger
 }
 
 // server struct to store primaryInterfaceIP from VM, port where customer provides by -p and temporary flag EnableLocalServer
@@ -80,6 +83,7 @@ func (service *Service) Initialize(config *ServiceConfig) error {
 	service.Store = config.Store
 	service.Version = config.Version
 	service.ChannelMode = config.ChannelMode
+	service.Logger = config.Logger
 
 	logger.Debugf("[Azure CNS] nitialized service: %+v with config: %+v.", service, config)
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -646,6 +646,7 @@ func main() {
 	}
 	host, _ := os.Hostname()
 	z = z.With(zap.String("hostname", host), zap.String("version", version), zap.String("kubernetes_apiserver", os.Getenv("KUBERNETES_SERVICE_HOST")))
+	config.Logger = z
 	// Set the v2 logger to the global logger if v2 logger enabled.
 	if cnsconfig.EnableLoggerV2 {
 		logger.Printf("hotswapping logger v2") //nolint:staticcheck // ignore new deprecation


### PR DESCRIPTION
I see we now have a zap logger v2 for cns

In #4002. I am getting:
`SA1019: logger.Printf is deprecated: The global logger is deprecated. Migrate to zap using the cns/logger/v2 package and pass the logger instead. (staticcheck)`

So this PR is to introduce the zap v2 logger into CNS APIs, by plumbing it through the CNS service config

Thoughts?

This would make
https://github.com/Azure/azure-container-networking/blob/f636b50e6086d42216bed8d5190cb8db0d47ef81/cns/restserver/api.go#L48

Into something like this:
```go
service.Logger.Info("[Azure CNS] setEnvironment")
```

I understand we already have a way to make `logger.Printf()` to point to a v2 zap logger underneath:
https://github.com/Azure/azure-container-networking/blob/f636b50e6086d42216bed8d5190cb8db0d47ef81/cns/service/main.go#L650-L653

But this is more about when adding _new_ APIs, and to avoid the linting errors