### PR TITLE
refactor: Update apipa nic as separate entry in podIPInfo

### DIFF
--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -93,6 +93,9 @@ const (
 	NodeNetworkInterfaceFrontendNIC NICType = "FrontendNIC"
 	// NodeNetworkInterfaceBackendNIC is the new name for BackendNIC
 	NodeNetworkInterfaceBackendNIC NICType = "BackendNIC"
+
+	// ApipaNIC is used for internal communication between host and container
+	ApipaNIC NICType = "ApipaNIC"
 )
 
 // ChannelMode :- CNS channel modes
@@ -516,6 +519,10 @@ type PodIpInfo struct {
 	PnPID string
 	// Default Deny ACL's to configure on HNS endpoints for Swiftv2 window nodes
 	EndpointPolicies []policy.Policy
+	// This flag is in effect only if nic type is apipa. This allows connection originating from host to container via apipa nic and not other way.
+	AllowHostToNCCommunication bool
+	// This flag is in effect only if nic type is apipa. This allows connection originating from container to host via apipa nic and not other way.
+	AllowNCToHostCommunication bool
 }
 
 type HostIPInfo struct {

--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -342,7 +342,8 @@ func (nm *networkManager) addIPv6DefaultRoute() error {
 // newNetworkImplHnsV2 creates a new container network for HNSv2.
 func (nm *networkManager) newNetworkImplHnsV2(nwInfo *EndpointInfo, extIf *externalInterface) (*network, error) {
 	// network creation is not required for IB
-	if nwInfo.NICType == cns.BackendNIC {
+	// For apipa nic, we create network as part of endpoint creation
+	if nwInfo.NICType == cns.BackendNIC || nwInfo.NICType == cns.ApipaNIC {
 		return &network{Endpoints: make(map[string]*endpoint)}, nil
 	}
 


### PR DESCRIPTION
This PR updates both CNS and CNI code to construct apipa nic as separate entry in podIpInfo if either of allowhostonc or allownctohost set. This allows CNI to treat this as separate endpoint and align with current cni design/model of 1 nic per endpoint info. CNI then iterates through endpoint info and creates one nic at a time.

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
