### PR TITLE
feat: add fields in pod network crd for prefix block mode for swiftv2

### DIFF
--- a/crd/multitenancy/api/v1alpha1/podnetwork.go
+++ b/crd/multitenancy/api/v1alpha1/podnetwork.go
@@ -45,6 +45,14 @@ const (
 	DeviceTypeInfiniBandNIC DeviceType = "acn.azure.com/infiniband-nic"
 )
 
+// +kubebuilder:validation:Enum=Single;PrefixBlock
+type SubnetAllocationMode string
+
+const (
+	Single      SubnetAllocationMode = "Single"
+	PrefixBlock SubnetAllocationMode = "PrefixBlock"
+)
+
 // PodNetworkSpec defines the desired state of PodNetwork
 type PodNetworkSpec struct {
 	// NetworkID is the identifier for the network, e.g. vnet guid or IB network ID
@@ -62,6 +70,10 @@ type PodNetworkSpec struct {
 	// Deprecated - Use NetworkID
 	// +kubebuilder:validation:Optional
 	VnetGUID string `json:"vnetGUID,omitempty"`
+	// subnet allocation mode
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=Single
+	SubnetAllocationMode SubnetAllocationMode `json:"subnetAllocationMode,omitempty"`
 }
 
 // Status indicates the status of PN
@@ -80,6 +92,9 @@ type PodNetworkStatus struct {
 	// +kubebuilder:validation:Optional
 	Status          Status   `json:"status,omitempty"`
 	AddressPrefixes []string `json:"addressPrefixes,omitempty"`
+	// BlockModeAllocationSize indicates the size of IP block allocated (default 16)
+	// +kubebuilder:default=16
+	BlockModeAllocationSize int `json:"blockModeAllocationSize,omitempty"`
 }
 
 func init() {

--- a/crd/multitenancy/api/v1alpha1/podnetwork.go
+++ b/crd/multitenancy/api/v1alpha1/podnetwork.go
@@ -92,9 +92,9 @@ type PodNetworkStatus struct {
 	// +kubebuilder:validation:Optional
 	Status          Status   `json:"status,omitempty"`
 	AddressPrefixes []string `json:"addressPrefixes,omitempty"`
-	// BlockModeAllocationSize indicates the size of IP block allocated (default 16)
+	// PrefixBlockAllocationSize indicates the size of IP block allocated to the subnet
 	// +kubebuilder:default=16
-	BlockModeAllocationSize int `json:"blockModeAllocationSize,omitempty"`
+	PrefixBlockAllocationSize int `json:"prefixBlockAllocationSize,omitempty"`
 }
 
 func init() {

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_podnetworks.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_podnetworks.yaml
@@ -37,7 +37,7 @@ spec:
       name: SubnetGUID
       priority: 1
       type: string
-    - jsonPath: .spec.subnetGUID
+    - jsonPath: .spec.deviceType
       name: DeviceType
       priority: 1
       type: string
@@ -77,6 +77,13 @@ spec:
                 description: NetworkID is the identifier for the network, e.g. vnet
                   guid or IB network ID
                 type: string
+              subnetAllocationMode:
+                default: Single
+                description: subnet allocation mode
+                enum:
+                - Single
+                - PrefixBlock
+                type: string
               subnetGUID:
                 description: customer subnet guid
                 type: string
@@ -94,6 +101,10 @@ spec:
                 items:
                   type: string
                 type: array
+              prefixBlockAllocationSize:
+                default: 16
+                description: PrefixBlockAllocationSize indicates the size of IP block allocated to the subnet
+                type: integer
               status:
                 description: Status indicates the status of PN
                 enum:


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
Adding new fields that would be required in podnetwork CRD for enabling prefix block IP allocation to pods in swiftv2 flow. Design doc - https://microsoft.sharepoint.com/:w:/t/ContainerNetworking/EbbITCQaW91FrROW1XQ74ewBT8Sp1GfdJ9z5DcuksFH1_g?e=RaqQPT



**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [X ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
