### PR TITLE
Extrace controller-runtime's manager.GetClient() for other methods in CNS to use

### DIFF
--- a/cns/common/service.go
+++ b/cns/common/service.go
@@ -10,6 +10,7 @@ import (
 	acn "github.com/Azure/azure-container-networking/common"
 	"github.com/Azure/azure-container-networking/server/tls"
 	"github.com/Azure/azure-container-networking/store"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Service implements behavior common to all services.
@@ -19,6 +20,7 @@ type Service struct {
 	Options     map[string]interface{}
 	ErrChan     chan<- error
 	Store       store.KeyValueStore
+	Client      client.Client
 	ChannelMode string
 }
 
@@ -40,6 +42,7 @@ type ServiceConfig struct {
 	Store       store.KeyValueStore
 	Server      server
 	ChannelMode string
+	Client      client.Client
 	TLSSettings tls.TlsSettings
 }
 
@@ -79,6 +82,7 @@ func (service *Service) Initialize(config *ServiceConfig) error {
 	service.ErrChan = config.ErrChan
 	service.Store = config.Store
 	service.Version = config.Version
+	service.Client = config.Client
 	service.ChannelMode = config.ChannelMode
 
 	logger.Debugf("[Azure CNS] nitialized service: %+v with config: %+v.", service, config)


### PR DESCRIPTION
Basically, CNS will need to be able to create the MTPNC on the apiserver with a new feature coming up in #4002

In preparation for that, I'm extracting out the controller-runtime manager's kubernetes client, from `InitializeCRDState()`, for it to be used later on in CNS

### Other consideration taken and why I did not go with it:
One other way I could think of doing this was to have a separate function `makeManager()` called before `InitializeCRDState()`, that would do this:
```go
func makeManager() (ctrlmgr.Manager, error) {
    // build default clientset.
    kubeConfig, err := ctrl.GetConfig()
    if err != nil {
        logger.Errorf("[Azure CNS] Failed to get kubeconfig for request controller: %v", err)
        return nil, errors.Wrap(err, "failed to get kubeconfig")
    }
    kubeConfig.UserAgent = fmt.Sprintf("azure-cns-%s", version)

    managerOpts := ctrlmgr.Options{
        Scheme:  scheme,
        Metrics: ctrlmetrics.Options{BindAddress: "0"},
        Cache:   cacheOpts,
        Logger:  zapr.NewLogger(z),
    }

    manager, err := ctrl.NewManager(kubeConfig, managerOpts)
    if err != nil {
        return nil, errors.Wrap(err, "failed to create manager")
    }
    return manager, nil
}
```

So then, we'd give that manager, into `InitializeCRDState()` as a param, and pass it around too to other methods:

``` go
manager, err := makeManager()
..
config.Client = manager.GetClient()
...
InitializeCRDState(manager, ...)
```

Thing about this though, is **it's dangerous**! 😱

Because, the manager client, **is not ready to use** until `InitializeCRDState()` finishes:
``` go
// Start the Manager which starts the reconcile loop.
	// The Reconciler will send an initial NodeNetworkConfig update to the PoolMonitor, starting the
	// Monitor's internal loop.
	go func() {
		logger.Printf("Starting controller-manager.")
		for {
			if err := manager.Start(ctx); err != nil {
				logger.Errorf("Failed to start controller-manager: %v", err)
				// retry to start the request controller
				// inc the managerStartFailures metric for failure tracking
				managerStartFailures.Inc()
			} else {
				logger.Printf("Stopped controller-manager.")
				return
			}
			time.Sleep(time.Second) // TODO(rbtr): make this exponential backoff
		}
	}()
```
So I don't want people to call `makeManger()`, thinking "Oh this client is ready to go", when in reality, both `cnsConfig.ChannelMode` needs to be `CRD`, which in turns runs `InitializeCRDState()`, _and then_ it's finally ready

So I think it makes more sense to just pass it out of `InitializeCRDState()` (already initialized, ready to be used), and move the http service logic after that

Thoughts?