### PR TITLE
chore: CNS - Only log CreateOrUpdateNetworkContainer on failure

### DIFF
--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -567,9 +567,10 @@ func (service *HTTPRestService) createOrUpdateNetworkContainer(w http.ResponseWr
 	// If the NC was created successfully, log NC snapshot.
 	if returnCode == types.Success {
 		logNCSnapshot(req)
+	} else {
+		// Only emit response trace/log for non-success responses to avoid noisy success logs.
+		logger.Response(service.Name, reserveResp, resp.ReturnCode, err)
 	}
-
-	logger.Response(service.Name, reserveResp, resp.ReturnCode, err)
 }
 
 func (service *HTTPRestService) getNetworkContainerByID(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
**Reason for Change**:
CNS logs every time a Network Container is created or updated. DNC will constantly call into CNS to refresh its association, resulting in a very high level of the following lines being logged:

`[azure-cns] Sent *cns.CreateNetworkContainerResponse &{Response:{ReturnCode:Success Message:}}.`

This line offers little value as it doesn't have context about which NC was updated.

This change will result in this response line only being logged on error.



**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
