### PR TITLE
fix: cilium nightly pipeline set boringcrypto arg in build

### DIFF
--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -46,13 +46,13 @@ stages:
               #goImage=`cat ./images/$(directory)/Dockerfile | grep "ARG GOLANG_IMAGE" | awk '{print $2}'`
               alpineImage=`cat ./images/$(directory)/Dockerfile | grep "ARG ALPINE_IMAGE" | awk '{print $2}'`
 
-              #if ! [ -z $goImage ]; then
-              #  goTag=${goImage#*:}
-              #  goVersion=${goTag%@*}
-              #  goMCR=mcr.microsoft.com/oss/go/microsoft/golang:${goVersion}
-              #  echo "Golang MCR image: ${goMCR}"
-              #  GO_ARGS="--build-arg GOLANG_IMAGE=${goMCR} "
-              #fi
+              if ! [ -z $goImage ]; then
+                goTag=${goImage#*:}
+                goVersion=${goTag%@*}
+                goMCR=mcr.microsoft.com/oss/go/microsoft/golang:1.25.0
+                echo "Golang MCR image: ${goMCR}"
+                GO_ARGS="--build-arg GOLANG_IMAGE=${goMCR} "
+              fi
 
               if ! [ -z $alpineImage ]; then
                 alpineTag=${alpineImage#*:}

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -47,8 +47,8 @@ stages:
               fi
 
               # Override current images used within dockerfiles
-              goImage=`cat ./images/$(directory)/Dockerfile | grep "ARG GOLANG_IMAGE" | awk '{print $2}'`
-              alpineImage=`cat ./images/$(directory)/Dockerfile | grep "ARG ALPINE_IMAGE" | awk '{print $2}'`
+              goImage=`cat ./images/operator/Dockerfile | grep "ARG GOLANG_IMAGE" | awk '{print $2}'`
+              alpineImage=`cat ./images/operator/Dockerfile | grep "ARG ALPINE_IMAGE" | awk '{print $2}'`
 
               if ! [ -z $goImage ]; then
                 goTag=${goImage#*:}
@@ -72,9 +72,10 @@ stages:
               docker buildx rm cilium-builder || true
               docker buildx create --name cilium-builder --use --bootstrap
               
-              # Set GOEXPERIMENT in build environment and pass as build arg
-              DOCKER_FLAGS="$BUILD_ARGS --no-cache --build-arg GOEXPERIMENT=nosystemcrypto" \
+              # Set GOEXPERIMENT and CGO_ENABLED in build environment and pass as build args
+              DOCKER_FLAGS="$BUILD_ARGS --no-cache --build-arg GOEXPERIMENT=nosystemcrypto --build-arg CGO_ENABLED=1" \
               GOEXPERIMENT=nosystemcrypto \
+              CGO_ENABLED=1 \
               make $(type)
               
               # Clean up builder after build

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -49,7 +49,7 @@ stages:
               if ! [ -z $goImage ]; then
                 goTag=${goImage#*:}
                 goVersion=${goTag%@*}
-                goMCR=mcr.microsoft.com/oss/go/microsoft/golang:1.25.0
+                goMCR=mcr.microsoft.com/oss/go/microsoft/golang:1.25.0-1
                 echo "Golang MCR image: ${goMCR}"
                 GO_ARGS="--build-arg GOLANG_IMAGE=${goMCR} "
               fi

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -88,21 +88,28 @@ stages:
               #fi
 
               if [ "$(type)" = "docker-operator-generic-image" ]; then
-                echo "Applying systemcrypto patch for operator build"
-                
                 # Apply patch to Dockerfile  
                 DOCKERFILE_PATH="./images/$(directory)/Dockerfile"
                 echo "Patching Dockerfile: $DOCKERFILE_PATH"
                 
-                # Add ARG and ENV statements to enable systemcrypto
-                sed -i '/^FROM.*builder/a ARG GOEXPERIMENT=systemcrypto\nENV GOEXPERIMENT=${GOEXPERIMENT}\nENV CGO_ENABLED=1' "$DOCKERFILE_PATH"
+                # Check if we're using Microsoft Go image
+                if ! [ -z "$goMCR" ] && [[ "$goMCR" == *"microsoft"* ]]; then
+                  echo "Applying nosystemcrypto patch for Microsoft Go build"
+                  
+                  # Add ARG and ENV statements to disable systemcrypto for Microsoft Go
+                  sed -i '/^FROM.*builder/a ARG GOEXPERIMENT=nosystemcrypto\nENV GOEXPERIMENT=${GOEXPERIMENT}\nENV CGO_ENABLED=1' "$DOCKERFILE_PATH"
+                  
+                  # Clear Go module and build caches completely, then rebuild everything with nosystemcrypto
+                  sed -i '/ENV CGO_ENABLED=1/a RUN rm -rf /go/pkg /root/.cache && \\\n    mkdir -p /go/pkg /tmp/gocache && \\\n    cd /tmp && \\\n    GOCACHE=/tmp/gocache CGO_ENABLED=1 go env && \\\n    GOCACHE=/tmp/gocache CGO_ENABLED=1 GOEXPERIMENT=nosystemcrypto go install -a -x std' "$DOCKERFILE_PATH"
+                else
+                  echo "Using standard Go build - no GOEXPERIMENT patch needed"
+                  # Just add CGO_ENABLED for consistency
+                  sed -i '/^FROM.*builder/a ENV CGO_ENABLED=1' "$DOCKERFILE_PATH"
+                fi
                 
-                # Remove ALL cache mounts for /go/pkg and /root/.cache to avoid systemcrypto conflicts
+                # Remove ALL cache mounts for /go/pkg and /root/.cache to avoid conflicts
                 sed -i 's/--mount=type=cache,target=\/go\/pkg[[:space:]]*//g' "$DOCKERFILE_PATH"
                 sed -i 's/--mount=type=cache,target=\/root\/\.cache[[:space:]]*//g' "$DOCKERFILE_PATH"
-                
-                # Clear Go module and build caches completely, then rebuild everything with systemcrypto
-                sed -i '/ENV CGO_ENABLED=1/a RUN rm -rf /go/pkg /root/.cache && \\\n    mkdir -p /go/pkg /tmp/gocache && \\\n    cd /tmp && \\\n    GOCACHE=/tmp/gocache CGO_ENABLED=1 go env && \\\n    GOCACHE=/tmp/gocache CGO_ENABLED=1 GOEXPERIMENT=systemcrypto go install -a -x std' "$DOCKERFILE_PATH"
                 
                 echo "Modified Dockerfile contents (first 80 lines):"
                 head -80 "$DOCKERFILE_PATH"

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -68,28 +68,31 @@ stages:
               fi
               BUILD_ARGS=${GO_ARGS}${ALPINE_ARGS}
 
-              # Create patch for Dockerfile to add GOEXPERIMENT support
-              cat > dockerfile.patch << 'EOF'
-              ARG GOEXPERIMENT=nosystemcrypto
-              ENV GOEXPERIMENT=${GOEXPERIMENT}
-              ENV CGO_ENABLED=1
-              EOF
-              
-              # Apply patch to Dockerfile  
-              DOCKERFILE_PATH="./images/$(directory)/Dockerfile"
-              echo "Patching Dockerfile: $DOCKERFILE_PATH"
-              
-              # Add ARG after ALPINE_IMAGE at the top level
-              sed -i '/^ARG ALPINE_IMAGE/a ARG GOEXPERIMENT=nosystemcrypto' "$DOCKERFILE_PATH"
-              
-              # Add ARG and ENV statements after the first FROM instruction (inside the build stage)
-              sed -i '/^FROM.*builder/a ARG GOEXPERIMENT=nosystemcrypto\nENV GOEXPERIMENT=${GOEXPERIMENT}\nENV CGO_ENABLED=1' "$DOCKERFILE_PATH"
-              
-              # Remove the problematic cache mount for /go/pkg to avoid systemcrypto conflicts
-              sed -i 's/--mount=type=cache,target=\/go\/pkg[[:space:]]*//g' "$DOCKERFILE_PATH"
-              
-              echo "Modified Dockerfile contents (first 40 lines):"
-              head -40 "$DOCKERFILE_PATH"
+              if [ $(type) = "docker-operator-generic-image" ]; then
+                
+                # Create patch for Dockerfile to add GOEXPERIMENT support
+                cat > dockerfile.patch << 'EOF'
+                ARG GOEXPERIMENT=nosystemcrypto
+                ENV GOEXPERIMENT=${GOEXPERIMENT}
+                ENV CGO_ENABLED=1
+                EOF
+                
+                # Apply patch to Dockerfile  
+                DOCKERFILE_PATH="./images/$(directory)/Dockerfile"
+                echo "Patching Dockerfile: $DOCKERFILE_PATH"
+                
+                # Add ARG and ENV statements after the first FROM instruction (inside the build stage)
+                sed -i '/^FROM.*builder/a ARG GOEXPERIMENT=nosystemcrypto\nENV GOEXPERIMENT=${GOEXPERIMENT}\nENV CGO_ENABLED=1' "$DOCKERFILE_PATH"
+                
+                # Remove the problematic cache mount for /go/pkg to avoid systemcrypto conflicts
+                sed -i 's/--mount=type=cache,target=\/go\/pkg[[:space:]]*//g' "$DOCKERFILE_PATH"
+                
+                # Add step to clean Go installation and force rebuild of standard library
+                sed -i '/ENV CGO_ENABLED=1/a RUN go clean -cache && go clean -modcache' "$DOCKERFILE_PATH"
+                
+                echo "Modified Dockerfile contents (first 40 lines):"
+                head -40 "$DOCKERFILE_PATH"
+              fi
 
               # Create fresh builder with clean cache to avoid systemcrypto conflicts
               docker buildx rm cilium-builder || true

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -75,15 +75,18 @@ stages:
               ENV CGO_ENABLED=1
               EOF
               
-              # Apply patch to Dockerfile
+              # Apply patch to Dockerfile  
               DOCKERFILE_PATH="./images/$(directory)/Dockerfile"
               echo "Patching Dockerfile: $DOCKERFILE_PATH"
               
-              # Insert after the GOLANG_IMAGE ARG line
-              sed -i '/^ARG ALPINE_IMAGE/a ARG GOEXPERIMENT=nosystemcrypto\nENV GOEXPERIMENT=${GOEXPERIMENT}\nENV CGO_ENABLED=1' "$DOCKERFILE_PATH"
+              # Add ARG after ALPINE_IMAGE
+              sed -i '/^ARG ALPINE_IMAGE/a ARG GOEXPERIMENT=nosystemcrypto' "$DOCKERFILE_PATH"
               
-              echo "Modified Dockerfile contents (first 30 lines):"
-              head -30 "$DOCKERFILE_PATH"
+              # Add ENV statements after the first FROM instruction
+              sed -i '/^FROM.*builder/a ENV GOEXPERIMENT=${GOEXPERIMENT}\nENV CGO_ENABLED=1' "$DOCKERFILE_PATH"
+              
+              echo "Modified Dockerfile contents (first 40 lines):"
+              head -40 "$DOCKERFILE_PATH"
 
               # Create fresh builder with clean cache to avoid systemcrypto conflicts
               docker buildx rm cilium-builder || true

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -43,13 +43,13 @@ stages:
               fi
 
               # Override current images used within dockerfiles
-              #goImage=`cat ./images/$(directory)/Dockerfile | grep "ARG GOLANG_IMAGE" | awk '{print $2}'`
+              goImage=`cat ./images/$(directory)/Dockerfile | grep "ARG GOLANG_IMAGE" | awk '{print $2}'`
               alpineImage=`cat ./images/$(directory)/Dockerfile | grep "ARG ALPINE_IMAGE" | awk '{print $2}'`
 
               if ! [ -z $goImage ]; then
                 goTag=${goImage#*:}
                 goVersion=${goTag%@*}
-                goMCR=mcr.microsoft.com/oss/go/microsoft/golang:1.25.0-1
+                goMCR=mcr.microsoft.com/oss/go/microsoft/golang:${goVersion}
                 echo "Golang MCR image: ${goMCR}"
                 GO_ARGS="--build-arg GOLANG_IMAGE=${goMCR} "
               fi
@@ -62,9 +62,9 @@ stages:
                 echo "alpine MCR image: ${alpineACR}"
                 ALPINE_ARGS="--build-arg ALPINE_IMAGE=${alpineACR} "
               fi
-              BUILD_ARGS=${ALPINE_ARGS}
+              BUILD_ARGS=${GO_ARGS}${ALPINE_ARGS}
 
-              DOCKER_FLAGS="$BUILD_ARGS" \
+              DOCKER_FLAGS="$BUILD_ARGS --build-arg GOEXPERIMENT=nosystemcrypto" \
               make $(type)
             name: BuildCiliumImage
             displayName: "Build Cilium Image"

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -102,7 +102,7 @@ stages:
                 sed -i 's/--mount=type=cache,target=\/root\/\.cache[[:space:]]*//g' "$DOCKERFILE_PATH"
                 
                 # Clear Go module and build caches completely, then rebuild everything with systemcrypto
-                sed -i '/ENV CGO_ENABLED=1/a RUN rm -rf /go/pkg /root/.cache /go/src && \\\n    mkdir -p /go/pkg && \\\n    GOCACHE=/tmp/gocache CGO_ENABLED=1 go env && \\\n    GOCACHE=/tmp/gocache CGO_ENABLED=1 GOEXPERIMENT=systemcrypto go install -a -x std' "$DOCKERFILE_PATH"
+                sed -i '/ENV CGO_ENABLED=1/a RUN rm -rf /go/pkg /root/.cache && \\\n    mkdir -p /go/pkg /tmp/gocache && \\\n    cd /tmp && \\\n    GOCACHE=/tmp/gocache CGO_ENABLED=1 go env && \\\n    GOCACHE=/tmp/gocache CGO_ENABLED=1 GOEXPERIMENT=systemcrypto go install -a -x std' "$DOCKERFILE_PATH"
                 
                 echo "Modified Dockerfile contents (first 80 lines):"
                 head -80 "$DOCKERFILE_PATH"

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -43,16 +43,16 @@ stages:
               fi
 
               # Override current images used within dockerfiles
-              goImage=`cat ./images/$(directory)/Dockerfile | grep "ARG GOLANG_IMAGE" | awk '{print $2}'`
+              #goImage=`cat ./images/$(directory)/Dockerfile | grep "ARG GOLANG_IMAGE" | awk '{print $2}'`
               alpineImage=`cat ./images/$(directory)/Dockerfile | grep "ARG ALPINE_IMAGE" | awk '{print $2}'`
 
-              if ! [ -z $goImage ]; then
-                goTag=${goImage#*:}
-                goVersion=${goTag%@*}
-                goMCR=mcr.microsoft.com/oss/go/microsoft/golang:${goVersion}
-                echo "Golang MCR image: ${goMCR}"
-                GO_ARGS="--build-arg GOLANG_IMAGE=${goMCR} "
-              fi
+              #if ! [ -z $goImage ]; then
+              #  goTag=${goImage#*:}
+              #  goVersion=${goTag%@*}
+              #  goMCR=mcr.microsoft.com/oss/go/microsoft/golang:${goVersion}
+              #  echo "Golang MCR image: ${goMCR}"
+              #  GO_ARGS="--build-arg GOLANG_IMAGE=${goMCR} "
+              #fi
 
               if ! [ -z $alpineImage ]; then
                 alpineTag=${alpineImage#*:}
@@ -62,7 +62,7 @@ stages:
                 echo "alpine MCR image: ${alpineACR}"
                 ALPINE_ARGS="--build-arg ALPINE_IMAGE=${alpineACR} "
               fi
-              BUILD_ARGS=${GO_ARGS}${ALPINE_ARGS}
+              BUILD_ARGS=${ALPINE_ARGS}
 
               DOCKER_FLAGS="$BUILD_ARGS" \
               make $(type)

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -80,7 +80,7 @@ stages:
               echo "Patching Dockerfile: $DOCKERFILE_PATH"
               
               # Insert after the GOLANG_IMAGE ARG line
-              sed -i '/^ARG GOLANG_IMAGE/r dockerfile.patch' "$DOCKERFILE_PATH"
+              sed -i '/^ARG ALPINE_IMAGE/a ARG GOEXPERIMENT=nosystemcrypto\nENV GOEXPERIMENT=${GOEXPERIMENT}\nENV CGO_ENABLED=1' "$DOCKERFILE_PATH"
               
               echo "Modified Dockerfile contents (first 30 lines):"
               head -30 "$DOCKERFILE_PATH"

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -66,16 +66,9 @@ stages:
                 echo "alpine MCR image: ${alpineACR}"
                 ALPINE_ARGS="--build-arg ALPINE_IMAGE=${alpineACR} "
               fi
-              BUILD_ARGS=${GO_ARGS}${ALPINE_ARGS}
 
-              if [ $(type) = "docker-operator-generic-image" ]; then
-                
-                # Create patch for Dockerfile to add GOEXPERIMENT support
-                cat > dockerfile.patch << 'EOF'
-                ARG GOEXPERIMENT=nosystemcrypto
-                ENV GOEXPERIMENT=${GOEXPERIMENT}
-                ENV CGO_ENABLED=1
-                EOF
+              if [ "$(type)" = "docker-operator-generic-image" ]; then
+                echo "Applying GOEXPERIMENT patch for operator build"
                 
                 # Apply patch to Dockerfile  
                 DOCKERFILE_PATH="./images/$(directory)/Dockerfile"
@@ -98,10 +91,7 @@ stages:
               docker buildx rm cilium-builder || true
               docker buildx create --name cilium-builder --use --bootstrap
               
-              # Set GOEXPERIMENT and CGO_ENABLED in build environment and pass as build args
-              DOCKER_FLAGS="$BUILD_ARGS --no-cache --build-arg GOEXPERIMENT=nosystemcrypto --build-arg CGO_ENABLED=1" \
-              GOEXPERIMENT=nosystemcrypto \
-              CGO_ENABLED=1 \
+              BUILD_ARGS=${GO_ARGS}${ALPINE_ARGS}
               make $(type)
               
               # Clean up builder after build

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -67,26 +67,6 @@ stages:
                 ALPINE_ARGS="--build-arg ALPINE_IMAGE=${alpineACR} "
               fi
 
-              #if [ "$(type)" = "docker-operator-generic-image" ]; then
-              #  echo "Applying GOEXPERIMENT patch for operator build"
-                
-              #  # Apply patch to Dockerfile  
-              #  DOCKERFILE_PATH="./images/$(directory)/Dockerfile"
-              #  echo "Patching Dockerfile: $DOCKERFILE_PATH"
-                
-              #  # Add ARG and ENV statements after the first FROM instruction (inside the build stage)
-              #  sed -i '/^FROM.*builder/a ARG GOEXPERIMENT=nosystemcrypto\nENV GOEXPERIMENT=${GOEXPERIMENT}\nENV CGO_ENABLED=1' "$DOCKERFILE_PATH"
-                
-              #  # Remove the problematic cache mount for /go/pkg to avoid systemcrypto conflicts
-              #  sed -i 's/--mount=type=cache,target=\/go\/pkg[[:space:]]*//g' "$DOCKERFILE_PATH"
-                
-              #  # Clear Go cache directories and rebuild standard library with nosystemcrypto
-              #  sed -i '/ENV CGO_ENABLED=0/a RUN rm -rf /root/.cache/go-build /go/pkg && \\\n    mkdir -p /go/pkg && \\\n    GOEXPERIMENT=nosystemcrypto GOCACHE=/tmp/gocache go install -a std' "$DOCKERFILE_PATH"
-                
-              #  echo "Modified Dockerfile contents (first 50 lines):"
-              #  head -50 "$DOCKERFILE_PATH"
-              #fi
-
               if [ "$(type)" = "docker-operator-generic-image" ]; then
                 # Apply patch to Dockerfile  
                 DOCKERFILE_PATH="./images/$(directory)/Dockerfile"
@@ -97,10 +77,10 @@ stages:
                   echo "Applying nosystemcrypto patch for Microsoft Go build"
                   
                   # Add ARG and ENV statements to disable systemcrypto for Microsoft Go
-                  sed -i '/^FROM.*builder/a ARG GOEXPERIMENT=nosystemcrypto\nENV GOEXPERIMENT=${GOEXPERIMENT}\nENV CGO_ENABLED=1' "$DOCKERFILE_PATH"
+                  sed -i '/^FROM.*builder/a ARG GOEXPERIMENT=boringcrypto \nENV GOEXPERIMENT=${GOEXPERIMENT}\nENV CGO_ENABLED=1' "$DOCKERFILE_PATH"
                   
                   # Clear Go module and build caches completely, then rebuild everything with nosystemcrypto
-                  sed -i '/ENV CGO_ENABLED=1/a RUN rm -rf /go/pkg /root/.cache && \\\n    mkdir -p /go/pkg /tmp/gocache && \\\n    cd /tmp && \\\n    GOCACHE=/tmp/gocache CGO_ENABLED=1 go env && \\\n    GOCACHE=/tmp/gocache CGO_ENABLED=1 GOEXPERIMENT=nosystemcrypto go install -a -x std' "$DOCKERFILE_PATH"
+                  sed -i '/ENV CGO_ENABLED=1/a RUN rm -rf /go/pkg /root/.cache && \\\n    mkdir -p /go/pkg /tmp/gocache && \\\n    cd /tmp && \\\n    GOCACHE=/tmp/gocache CGO_ENABLED=1 go env && \\\n    GOCACHE=/tmp/gocache CGO_ENABLED=1 GOEXPERIMENT=boringcrypto go install -a -x std' "$DOCKERFILE_PATH"
                 else
                   echo "Using standard Go build - no GOEXPERIMENT patch needed"
                   # Just add CGO_ENABLED for consistency

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -47,8 +47,8 @@ stages:
               fi
 
               # Override current images used within dockerfiles
-              goImage=`cat ./images/operator/Dockerfile | grep "ARG GOLANG_IMAGE" | awk '{print $2}'`
-              alpineImage=`cat ./images/operator/Dockerfile | grep "ARG ALPINE_IMAGE" | awk '{print $2}'`
+              goImage=`cat ./images/$(directory)/Dockerfile | grep "ARG GOLANG_IMAGE" | awk '{print $2}'`
+              alpineImage=`cat ./images/$(directory)/Dockerfile | grep "ARG ALPINE_IMAGE" | awk '{print $2}'`
 
               if ! [ -z $goImage ]; then
                 goTag=${goImage#*:}
@@ -67,6 +67,23 @@ stages:
                 ALPINE_ARGS="--build-arg ALPINE_IMAGE=${alpineACR} "
               fi
               BUILD_ARGS=${GO_ARGS}${ALPINE_ARGS}
+
+              # Create patch for Dockerfile to add GOEXPERIMENT support
+              cat > dockerfile.patch << 'EOF'
+              ARG GOEXPERIMENT=nosystemcrypto
+              ENV GOEXPERIMENT=${GOEXPERIMENT}
+              ENV CGO_ENABLED=1
+              EOF
+              
+              # Apply patch to Dockerfile
+              DOCKERFILE_PATH="./images/$(directory)/Dockerfile"
+              echo "Patching Dockerfile: $DOCKERFILE_PATH"
+              
+              # Insert after the GOLANG_IMAGE ARG line
+              sed -i '/^ARG GOLANG_IMAGE/r dockerfile.patch' "$DOCKERFILE_PATH"
+              
+              echo "Modified Dockerfile contents (first 30 lines):"
+              head -30 "$DOCKERFILE_PATH"
 
               # Create fresh builder with clean cache to avoid systemcrypto conflicts
               docker buildx rm cilium-builder || true

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -70,10 +70,7 @@ stages:
                 echo "Patching Dockerfile: $DOCKERFILE_PATH"
                   
                 # Add ARG and ENV statements to disable systemcrypto for Microsoft Go
-                sed -i '/^FROM.*builder/a ARG GOEXPERIMENT=boringcrypto \nENV GOEXPERIMENT=${GOEXPERIMENT}\nENV CGO_ENABLED=1' "$DOCKERFILE_PATH"
-                  
-                # Clear Go module and build caches completely, then rebuild everything with boringcrypto
-                sed -i '/ENV CGO_ENABLED=1/a RUN rm -rf /go/pkg /root/.cache && \\\n    mkdir -p /go/pkg /tmp/gocache && \\\n    cd /tmp && \\\n    GOCACHE=/tmp/gocache CGO_ENABLED=1 go env && \\\n    GOCACHE=/tmp/gocache CGO_ENABLED=1 GOEXPERIMENT=boringcrypto go install -a -x std' "$DOCKERFILE_PATH"
+                sed -i '/^FROM.*builder/a ARG GOEXPERIMENT=boringcrypto \nENV GOEXPERIMENT=${GOEXPERIMENT}' "$DOCKERFILE_PATH"
               fi
 
               BUILD_ARGS=${GO_ARGS}${ALPINE_ARGS}

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -80,11 +80,11 @@ stages:
                 # Remove the problematic cache mount for /go/pkg to avoid systemcrypto conflicts
                 sed -i 's/--mount=type=cache,target=\/go\/pkg[[:space:]]*//g' "$DOCKERFILE_PATH"
                 
-                # Add step to clean Go installation and force rebuild of standard library
-                sed -i '/ENV CGO_ENABLED=1/a RUN go clean -cache && go clean -modcache' "$DOCKERFILE_PATH"
+                # Replace go clean with rebuilding standard library with nosystemcrypto
+                sed -i '/ENV CGO_ENABLED=1/a RUN GOEXPERIMENT=nosystemcrypto go install -a std' "$DOCKERFILE_PATH"
                 
-                echo "Modified Dockerfile contents (first 40 lines):"
-                head -40 "$DOCKERFILE_PATH"
+                echo "Modified Dockerfile contents (first 50 lines):"
+                head -50 "$DOCKERFILE_PATH"
               fi
 
               # Create fresh builder with clean cache to avoid systemcrypto conflicts

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -72,23 +72,14 @@ stages:
                 # Add ARG and ENV statements to disable systemcrypto for Microsoft Go
                 sed -i '/^FROM.*builder/a ARG GOEXPERIMENT=boringcrypto \nENV GOEXPERIMENT=${GOEXPERIMENT}\nENV CGO_ENABLED=1' "$DOCKERFILE_PATH"
                   
-                # Clear Go module and build caches completely, then rebuild everything with nosystemcrypto
+                # Clear Go module and build caches completely, then rebuild everything with boringcrypto
                 sed -i '/ENV CGO_ENABLED=1/a RUN rm -rf /go/pkg /root/.cache && \\\n    mkdir -p /go/pkg /tmp/gocache && \\\n    cd /tmp && \\\n    GOCACHE=/tmp/gocache CGO_ENABLED=1 go env && \\\n    GOCACHE=/tmp/gocache CGO_ENABLED=1 GOEXPERIMENT=boringcrypto go install -a -x std' "$DOCKERFILE_PATH"
-                
-                # Remove ALL cache mounts for /go/pkg and /root/.cache to avoid conflicts
-                sed -i 's/--mount=type=cache,target=\/go\/pkg[[:space:]]*//g' "$DOCKERFILE_PATH"
-                sed -i 's/--mount=type=cache,target=\/root\/\.cache[[:space:]]*//g' "$DOCKERFILE_PATH"
-                
-                echo "Modified Dockerfile contents (first 80 lines):"
-                head -80 "$DOCKERFILE_PATH"
               fi
 
               BUILD_ARGS=${GO_ARGS}${ALPINE_ARGS}
               DOCKER_FLAGS="$BUILD_ARGS" \
               make $(type)
               
-              # Clean up builder after build
-              docker buildx rm cilium-builder || true
             name: BuildCiliumImage
             displayName: "Build Cilium Image"
           - task: AzureCLI@2

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -79,11 +79,11 @@ stages:
               DOCKERFILE_PATH="./images/$(directory)/Dockerfile"
               echo "Patching Dockerfile: $DOCKERFILE_PATH"
               
-              # Add ARG after ALPINE_IMAGE
+              # Add ARG after ALPINE_IMAGE at the top level
               sed -i '/^ARG ALPINE_IMAGE/a ARG GOEXPERIMENT=nosystemcrypto' "$DOCKERFILE_PATH"
               
-              # Add ENV statements after the first FROM instruction
-              sed -i '/^FROM.*builder/a ENV GOEXPERIMENT=${GOEXPERIMENT}\nENV CGO_ENABLED=1' "$DOCKERFILE_PATH"
+              # Add ARG and ENV statements after the first FROM instruction (inside the build stage)
+              sed -i '/^FROM.*builder/a ARG GOEXPERIMENT=nosystemcrypto\nENV GOEXPERIMENT=${GOEXPERIMENT}\nENV CGO_ENABLED=1' "$DOCKERFILE_PATH"
               
               echo "Modified Dockerfile contents (first 40 lines):"
               head -40 "$DOCKERFILE_PATH"

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -68,10 +68,17 @@ stages:
               fi
               BUILD_ARGS=${GO_ARGS}${ALPINE_ARGS}
 
+              # Create fresh builder with clean cache to avoid systemcrypto conflicts
+              docker buildx rm cilium-builder || true
+              docker buildx create --name cilium-builder --use --bootstrap
+              
               # Set GOEXPERIMENT in build environment and pass as build arg
               DOCKER_FLAGS="$BUILD_ARGS --no-cache --build-arg GOEXPERIMENT=nosystemcrypto" \
               GOEXPERIMENT=nosystemcrypto \
               make $(type)
+              
+              # Clean up builder after build
+              docker buildx rm cilium-builder || true
             name: BuildCiliumImage
             displayName: "Build Cilium Image"
           - task: AzureCLI@2

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -67,24 +67,45 @@ stages:
                 ALPINE_ARGS="--build-arg ALPINE_IMAGE=${alpineACR} "
               fi
 
+              #if [ "$(type)" = "docker-operator-generic-image" ]; then
+              #  echo "Applying GOEXPERIMENT patch for operator build"
+                
+              #  # Apply patch to Dockerfile  
+              #  DOCKERFILE_PATH="./images/$(directory)/Dockerfile"
+              #  echo "Patching Dockerfile: $DOCKERFILE_PATH"
+                
+              #  # Add ARG and ENV statements after the first FROM instruction (inside the build stage)
+              #  sed -i '/^FROM.*builder/a ARG GOEXPERIMENT=nosystemcrypto\nENV GOEXPERIMENT=${GOEXPERIMENT}\nENV CGO_ENABLED=1' "$DOCKERFILE_PATH"
+                
+              #  # Remove the problematic cache mount for /go/pkg to avoid systemcrypto conflicts
+              #  sed -i 's/--mount=type=cache,target=\/go\/pkg[[:space:]]*//g' "$DOCKERFILE_PATH"
+                
+              #  # Clear Go cache directories and rebuild standard library with nosystemcrypto
+              #  sed -i '/ENV CGO_ENABLED=0/a RUN rm -rf /root/.cache/go-build /go/pkg && \\\n    mkdir -p /go/pkg && \\\n    GOEXPERIMENT=nosystemcrypto GOCACHE=/tmp/gocache go install -a std' "$DOCKERFILE_PATH"
+                
+              #  echo "Modified Dockerfile contents (first 50 lines):"
+              #  head -50 "$DOCKERFILE_PATH"
+              #fi
+
               if [ "$(type)" = "docker-operator-generic-image" ]; then
-                echo "Applying GOEXPERIMENT patch for operator build"
+                echo "Applying systemcrypto patch for operator build"
                 
                 # Apply patch to Dockerfile  
                 DOCKERFILE_PATH="./images/$(directory)/Dockerfile"
                 echo "Patching Dockerfile: $DOCKERFILE_PATH"
                 
-                # Add ARG and ENV statements after the first FROM instruction (inside the build stage)
-                sed -i '/^FROM.*builder/a ARG GOEXPERIMENT=nosystemcrypto\nENV GOEXPERIMENT=${GOEXPERIMENT}\nENV CGO_ENABLED=1' "$DOCKERFILE_PATH"
+                # Add ARG and ENV statements to enable systemcrypto
+                sed -i '/^FROM.*builder/a ARG GOEXPERIMENT=systemcrypto\nENV GOEXPERIMENT=${GOEXPERIMENT}\nENV CGO_ENABLED=1' "$DOCKERFILE_PATH"
                 
-                # Remove the problematic cache mount for /go/pkg to avoid systemcrypto conflicts
+                # Remove ALL cache mounts for /go/pkg and /root/.cache to avoid systemcrypto conflicts
                 sed -i 's/--mount=type=cache,target=\/go\/pkg[[:space:]]*//g' "$DOCKERFILE_PATH"
+                sed -i 's/--mount=type=cache,target=\/root\/\.cache[[:space:]]*//g' "$DOCKERFILE_PATH"
                 
-                # Clear Go cache directories and rebuild standard library with nosystemcrypto
-                sed -i '/ENV CGO_ENABLED=0/a RUN rm -rf /root/.cache/go-build /go/pkg && \\\n    mkdir -p /go/pkg && \\\n    GOEXPERIMENT=nosystemcrypto GOCACHE=/tmp/gocache go install -a std' "$DOCKERFILE_PATH"
+                # Clear Go module and build caches completely, then rebuild everything with systemcrypto
+                sed -i '/ENV CGO_ENABLED=1/a RUN rm -rf /go/pkg /root/.cache /go/src && \\\n    mkdir -p /go/pkg && \\\n    GOCACHE=/tmp/gocache CGO_ENABLED=1 go env && \\\n    GOCACHE=/tmp/gocache CGO_ENABLED=1 GOEXPERIMENT=systemcrypto go install -a -x std' "$DOCKERFILE_PATH"
                 
-                echo "Modified Dockerfile contents (first 50 lines):"
-                head -50 "$DOCKERFILE_PATH"
+                echo "Modified Dockerfile contents (first 80 lines):"
+                head -80 "$DOCKERFILE_PATH"
               fi
 
               # Create fresh builder with clean cache to avoid systemcrypto conflicts

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -80,8 +80,8 @@ stages:
                 # Remove the problematic cache mount for /go/pkg to avoid systemcrypto conflicts
                 sed -i 's/--mount=type=cache,target=\/go\/pkg[[:space:]]*//g' "$DOCKERFILE_PATH"
                 
-                # Replace go clean with rebuilding standard library with nosystemcrypto
-                sed -i '/ENV CGO_ENABLED=1/a RUN GOEXPERIMENT=nosystemcrypto go install -a std' "$DOCKERFILE_PATH"
+                # Clear Go cache directories and rebuild standard library with nosystemcrypto
+                sed -i '/ENV CGO_ENABLED=1/a RUN rm -rf /root/.cache/go-build /go/pkg && \\\n    mkdir -p /go/pkg && \\\n    GOEXPERIMENT=nosystemcrypto GOCACHE=/tmp/gocache go install -a std' "$DOCKERFILE_PATH"
                 
                 echo "Modified Dockerfile contents (first 50 lines):"
                 head -50 "$DOCKERFILE_PATH"

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -36,9 +36,6 @@ stages:
           - bash: |
               set -ex
               
-              # Clear Docker buildx cache to remove systemcrypto artifacts
-              docker buildx prune --all --force || true
-              
               cd .pipelines/
               git clone https://github.com/cilium/cilium.git
               cd cilium
@@ -71,21 +68,12 @@ stages:
                 # Apply patch to Dockerfile  
                 DOCKERFILE_PATH="./images/$(directory)/Dockerfile"
                 echo "Patching Dockerfile: $DOCKERFILE_PATH"
-                
-                # Check if we're using Microsoft Go image
-                if ! [ -z "$goMCR" ] && [[ "$goMCR" == *"microsoft"* ]]; then
-                  echo "Applying nosystemcrypto patch for Microsoft Go build"
                   
-                  # Add ARG and ENV statements to disable systemcrypto for Microsoft Go
-                  sed -i '/^FROM.*builder/a ARG GOEXPERIMENT=boringcrypto \nENV GOEXPERIMENT=${GOEXPERIMENT}\nENV CGO_ENABLED=1' "$DOCKERFILE_PATH"
+                # Add ARG and ENV statements to disable systemcrypto for Microsoft Go
+                sed -i '/^FROM.*builder/a ARG GOEXPERIMENT=boringcrypto \nENV GOEXPERIMENT=${GOEXPERIMENT}\nENV CGO_ENABLED=1' "$DOCKERFILE_PATH"
                   
-                  # Clear Go module and build caches completely, then rebuild everything with nosystemcrypto
-                  sed -i '/ENV CGO_ENABLED=1/a RUN rm -rf /go/pkg /root/.cache && \\\n    mkdir -p /go/pkg /tmp/gocache && \\\n    cd /tmp && \\\n    GOCACHE=/tmp/gocache CGO_ENABLED=1 go env && \\\n    GOCACHE=/tmp/gocache CGO_ENABLED=1 GOEXPERIMENT=boringcrypto go install -a -x std' "$DOCKERFILE_PATH"
-                else
-                  echo "Using standard Go build - no GOEXPERIMENT patch needed"
-                  # Just add CGO_ENABLED for consistency
-                  sed -i '/^FROM.*builder/a ENV CGO_ENABLED=1' "$DOCKERFILE_PATH"
-                fi
+                # Clear Go module and build caches completely, then rebuild everything with nosystemcrypto
+                sed -i '/ENV CGO_ENABLED=1/a RUN rm -rf /go/pkg /root/.cache && \\\n    mkdir -p /go/pkg /tmp/gocache && \\\n    cd /tmp && \\\n    GOCACHE=/tmp/gocache CGO_ENABLED=1 go env && \\\n    GOCACHE=/tmp/gocache CGO_ENABLED=1 GOEXPERIMENT=boringcrypto go install -a -x std' "$DOCKERFILE_PATH"
                 
                 # Remove ALL cache mounts for /go/pkg and /root/.cache to avoid conflicts
                 sed -i 's/--mount=type=cache,target=\/go\/pkg[[:space:]]*//g' "$DOCKERFILE_PATH"
@@ -95,10 +83,6 @@ stages:
                 head -80 "$DOCKERFILE_PATH"
               fi
 
-              # Create fresh builder with clean cache to avoid systemcrypto conflicts
-              docker buildx rm cilium-builder || true
-              docker buildx create --name cilium-builder --use --bootstrap
-              
               BUILD_ARGS=${GO_ARGS}${ALPINE_ARGS}
               DOCKER_FLAGS="$BUILD_ARGS" \
               make $(type)

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -85,6 +85,9 @@ stages:
               # Add ARG and ENV statements after the first FROM instruction (inside the build stage)
               sed -i '/^FROM.*builder/a ARG GOEXPERIMENT=nosystemcrypto\nENV GOEXPERIMENT=${GOEXPERIMENT}\nENV CGO_ENABLED=1' "$DOCKERFILE_PATH"
               
+              # Remove the problematic cache mount for /go/pkg to avoid systemcrypto conflicts
+              sed -i 's/--mount=type=cache,target=\/go\/pkg[[:space:]]*//g' "$DOCKERFILE_PATH"
+              
               echo "Modified Dockerfile contents (first 40 lines):"
               head -40 "$DOCKERFILE_PATH"
 

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -81,7 +81,7 @@ stages:
                 sed -i 's/--mount=type=cache,target=\/go\/pkg[[:space:]]*//g' "$DOCKERFILE_PATH"
                 
                 # Clear Go cache directories and rebuild standard library with nosystemcrypto
-                sed -i '/ENV CGO_ENABLED=1/a RUN rm -rf /root/.cache/go-build /go/pkg && \\\n    mkdir -p /go/pkg && \\\n    GOEXPERIMENT=nosystemcrypto GOCACHE=/tmp/gocache go install -a std' "$DOCKERFILE_PATH"
+                sed -i '/ENV CGO_ENABLED=0/a RUN rm -rf /root/.cache/go-build /go/pkg && \\\n    mkdir -p /go/pkg && \\\n    GOEXPERIMENT=nosystemcrypto GOCACHE=/tmp/gocache go install -a std' "$DOCKERFILE_PATH"
                 
                 echo "Modified Dockerfile contents (first 50 lines):"
                 head -50 "$DOCKERFILE_PATH"

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -92,6 +92,7 @@ stages:
               docker buildx create --name cilium-builder --use --bootstrap
               
               BUILD_ARGS=${GO_ARGS}${ALPINE_ARGS}
+              DOCKER_FLAGS="$BUILD_ARGS" \
               make $(type)
               
               # Clean up builder after build

--- a/.pipelines/cni/cilium/nightly-release-test.yml
+++ b/.pipelines/cni/cilium/nightly-release-test.yml
@@ -35,6 +35,10 @@ stages:
         steps:
           - bash: |
               set -ex
+              
+              # Clear Docker buildx cache to remove systemcrypto artifacts
+              docker buildx prune --all --force || true
+              
               cd .pipelines/
               git clone https://github.com/cilium/cilium.git
               cd cilium
@@ -64,7 +68,9 @@ stages:
               fi
               BUILD_ARGS=${GO_ARGS}${ALPINE_ARGS}
 
-              DOCKER_FLAGS="$BUILD_ARGS --build-arg GOEXPERIMENT=nosystemcrypto" \
+              # Set GOEXPERIMENT in build environment and pass as build arg
+              DOCKER_FLAGS="$BUILD_ARGS --no-cache --build-arg GOEXPERIMENT=nosystemcrypto" \
+              GOEXPERIMENT=nosystemcrypto \
               make $(type)
             name: BuildCiliumImage
             displayName: "Build Cilium Image"


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
unblock operator image build by setting GOEXPERIMENT arg to boringcrypto


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
