### PR TITLE
CNS Change for Subnet Overlay Expansion Job

### DIFF
--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -746,8 +746,8 @@ func validateCIDRSuperset(newCIDR, oldCIDR string) bool {
 		return false
 	}
 
-	// Condition 2: Check if the base IP of oldCIDR is contained in newCIDR
-	if !newPrefix.Contains(oldPrefix.Addr()) {
+	// Condition 2: Check for Overlap - this will also ensure containment
+	if !newPrefix.Overlaps(oldPrefix) {
 		return false
 	}
 

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -133,6 +133,7 @@ func TestReconcileNCStatePrimaryIPChangeShouldNotFail(t *testing.T) {
 		{"10.0.1.0/24", "10.0.2.0/22"},
 		{"10.0.1.0/20", "10.0.1.0/18"},
 		{"10.0.1.0/19", "10.0.0.0/15"},
+		{"10.0.1.0/18", "10.0.1.0/18"},
 	}
 
 	// Run test cases


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Without this CNS change, expanding an overlay subnet causes the CNS daemonset to crash, resulting in a PrimaryCANotSame error for all clusters. 
To enable overlay subnet expansion:

- only for overlay clusters, we bypass the PrimaryCANotSame error. 
- The subnet address in the NNC is updated.
- The CNS state file gets updated to reflect the new pod cidr from NNC

Simply restarting CNS does not regenerate the state file with updated information. Instead, this pr will update the state file to have the new subnet address (same as the one from updated nnc) which will prevent the error only for overlay clusters when there is a mismatch of pod cidrs to start with.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
