### PR TITLE
fix: replace AKS LTS versioning with commonly reached k8s patch version

### DIFF
--- a/.pipelines/cni/k8s-e2e/k8s-e2e-job-template.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e-job-template.yaml
@@ -27,6 +27,12 @@ jobs:
             # pulling k8s version from AKS.
             eval k8sVersion="v"$( az aks show -g ${{ parameters.clusterName }} -n ${{ parameters.clusterName }} --query "currentKubernetesVersion")
             echo $k8sVersion
+            patchVersion=`echo "${k8sVersion##*.}"`
+            if [ $patchVersion -ge 100 ]; then
+              # For LTS versions we use a commonly reached patch version from kubernetes upstream
+              k8sVersion="${k8sVersion%.*}.12"
+              echo "LTS version detected, adjusting k8sVersion to ${k8sVersion}"
+            fi
             curl -L https://dl.k8s.io/$k8sVersion/kubernetes-test-linux-amd64.tar.gz -o ./kubernetes-test-linux-amd64.tar.gz
 
             # https://github.com/kubernetes/sig-release/blob/master/release-engineering/artifacts.md#content-of-kubernetes-test-system-archtargz-on-example-of-kubernetes-test-linux-amd64targz-directories-removed-from-list

--- a/.pipelines/cni/k8s-e2e/k8s-e2e.jobs.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e.jobs.yaml
@@ -30,6 +30,12 @@ jobs:
             # pulling k8s version from AKS.
             eval k8sVersion="v"$( az aks show -g ${{ parameters.clusterName }} -n ${{ parameters.clusterName }} --query "currentKubernetesVersion")
             echo $k8sVersion
+            patchVersion=`echo "${k8sVersion##*.}"`
+            if [ $patchVersion -ge 100 ]; then
+              # For LTS versions we use a commonly reached patch version from kubernetes upstream
+              k8sVersion="${k8sVersion%.*}.12"
+              echo "LTS version detected, adjusting k8sVersion to ${k8sVersion}"
+            fi
             curl -L https://dl.k8s.io/$k8sVersion/kubernetes-test-linux-amd64.tar.gz -o ./kubernetes-test-linux-amd64.tar.gz
 
             # https://github.com/kubernetes/sig-release/blob/master/release-engineering/artifacts.md#content-of-kubernetes-test-system-archtargz-on-example-of-kubernetes-test-linux-amd64targz-directories-removed-from-list


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
AKS LTS versioning now sets its kubernetes patch version to `A.BC.1DE` instead of the expected `A.BC.DE`

This broke the automation for upstream k8s-e2e test suite downloads as we leveraged the cluster versioning for the test we were going to run.  

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
Needs to be forwardported