### PR TITLE
[backport] v1.6 ci: skip portforward in windows dualstack (#4076) 

### DIFF
--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
@@ -71,7 +71,7 @@ stages:
           dependsOn: ${{ parameters.name }}_${{ parameters.os }}
           dualstack: ${{ eq(parameters.os, 'linux') }} # RUN IN LINUX not WINDOWS Currently broken for scenario and blocking releases, HNS is investigating. Covered by go test in E2E step template
           dns: true
-          portforward: true
+          portforward: ${{ eq(parameters.os, 'linux') }} # RUN IN LINUX NOT WINDOWS Currently broken for scenario and blocking releases
           service: ${{ eq(parameters.os, 'linux') }}  # RUN IN LINUX NOT WINDOWS Currently broken for scenario and blocking releases, HNS is investigating.
           hostport: true
           hybridWin: ${{ eq(parameters.os, 'windows') }}

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e.stages.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e.stages.yaml
@@ -76,7 +76,7 @@ stages:
           dependsOn: ${{ parameters.name }}_${{ parameters.os }}
           dualstack: ${{ eq(parameters.os, 'linux') }} # RUN IN LINUX not WINDOWS Currently broken for scenario and blocking releases, HNS is investigating. Covered by go test in E2E step template
           dns: true
-          portforward: true
+          portforward: ${{ eq(parameters.os, 'linux') }} # RUN IN LINUX NOT WINDOWS Currently broken for scenario and blocking releases
           service: ${{ eq(parameters.os, 'linux') }}  # RUN IN LINUX NOT WINDOWS Currently broken for scenario and blocking releases, HNS is investigating.
           hostport: true
           hybridWin: ${{ eq(parameters.os, 'windows') }}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

Backports #4076, E2E is affecting multiple k8s versions.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
