### PR TITLE
[CNS] Overlay Expansion Subnet Update Job Bug Fix

### DIFF
--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -632,7 +632,9 @@ func (service *HTTPRestService) CreateOrUpdateNetworkContainerInternal(req *cns.
 		existingReq := existingNCInfo.CreateNetworkContainerRequest
 		if !reflect.DeepEqual(existingReq.IPConfiguration.IPSubnet, req.IPConfiguration.IPSubnet) {
 			// check for potential overlay subnet expansion - checking if new subnet is a superset of old subnet
-			isCIDRSuperset := validateCIDRSuperset(req.IPConfiguration.IPSubnet.IPAddress, existingReq.IPConfiguration.IPSubnet.IPAddress)
+			isCIDRSuperset := validateCIDRSuperset(
+				fmt.Sprintf("%s/%d", req.IPConfiguration.IPSubnet.IPAddress, req.IPConfiguration.IPSubnet.PrefixLength),
+				fmt.Sprintf("%s/%d", existingReq.IPConfiguration.IPSubnet.IPAddress, existingReq.IPConfiguration.IPSubnet.PrefixLength))
 			if !isCIDRSuperset {
 				logger.Errorf("[Azure CNS] Error. PrimaryCA is not same, NCId %s, old CA %s/%d, new CA %s/%d", //nolint:staticcheck // Suppress SA1019: logger.Errorf is deprecated
 					req.NetworkContainerid,

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -67,16 +67,16 @@ func TestReconcileNCStatePrimaryIPChangeShouldFail(t *testing.T) {
 	svc.state.ContainerStatus = make(map[string]containerstatus)
 
 	testCases := []struct {
-		existingIPAddress string
-		requestIPAddress  string
+		reqIPAddress         string
+		reqPrefixLength      uint8
+		existingIPAddress    string
+		existingPrefixLength uint8
 	}{
-		{"", "10.240.0.0/16"},
-		{"10.240.0.0", "2001:db8::/64"},
-		{"2001:db8::/64", "10.240.0.0/16"},
-		{"10.0.1.0/22", "10.0.2.0/24"},
-		{"10.0.1.0/21", "10.0.1.0/23"},
-		{"10.0.1.0", "10.0.0.0/15"},
-		{"10.0.1.0/15", "10.0.0.0"},
+		{"10.240.1.0", 16, "10.240.0.0", 16},
+		{"10.240.0.0", 64, "2001:db8::", 64},
+		{"2001:db8::", 64, "10.240.0.0", 16},
+		{"10.0.1.0", 24, "10.0.2.0", 22},
+		{"10.0.1.0", 23, "10.0.1.0", 21},
 	}
 
 	// Run test cases
@@ -92,7 +92,7 @@ func TestReconcileNCStatePrimaryIPChangeShouldFail(t *testing.T) {
 				IPConfiguration: cns.IPConfiguration{
 					IPSubnet: cns.IPSubnet{
 						IPAddress:    tc.existingIPAddress,
-						PrefixLength: 24,
+						PrefixLength: tc.existingPrefixLength,
 					},
 				},
 			},
@@ -103,8 +103,8 @@ func TestReconcileNCStatePrimaryIPChangeShouldFail(t *testing.T) {
 				NetworkContainerid: ncID,
 				IPConfiguration: cns.IPConfiguration{
 					IPSubnet: cns.IPSubnet{
-						IPAddress:    tc.requestIPAddress,
-						PrefixLength: 24,
+						IPAddress:    tc.reqIPAddress,
+						PrefixLength: tc.reqPrefixLength,
 					},
 				},
 			},
@@ -127,13 +127,17 @@ func TestReconcileNCStatePrimaryIPChangeShouldNotFail(t *testing.T) {
 	svc.state.ContainerStatus = make(map[string]containerstatus)
 
 	testCases := []struct {
-		existingIPAddress string
-		requestIPAddress  string
+		reqIPAddress         string
+		reqPrefixLength      uint8
+		existingIPAddress    string
+		existingPrefixLength uint8
 	}{
-		{"10.0.1.0/24", "10.0.2.0/22"},
-		{"10.0.1.0/20", "10.0.1.0/18"},
-		{"10.0.1.0/19", "10.0.0.0/15"},
-		{"10.0.1.0/18", "10.0.1.0/18"},
+		{"10.240.0.0", 20, "10.240.0.0", 24},
+
+		{"10.0.1.0", 22, "10.0.2.0", 24},
+		{"10.0.1.0", 18, "10.0.1.0", 20},
+		{"10.0.1.0", 15, "10.0.0.0", 19},
+		{"10.0.1.0", 18, "10.0.1.0", 18},
 	}
 
 	// Run test cases
@@ -149,7 +153,7 @@ func TestReconcileNCStatePrimaryIPChangeShouldNotFail(t *testing.T) {
 				IPConfiguration: cns.IPConfiguration{
 					IPSubnet: cns.IPSubnet{
 						IPAddress:    tc.existingIPAddress,
-						PrefixLength: 24,
+						PrefixLength: tc.existingPrefixLength,
 					},
 				},
 			},
@@ -160,8 +164,8 @@ func TestReconcileNCStatePrimaryIPChangeShouldNotFail(t *testing.T) {
 				NetworkContainerid: ncID,
 				IPConfiguration: cns.IPConfiguration{
 					IPSubnet: cns.IPSubnet{
-						IPAddress:    tc.requestIPAddress,
-						PrefixLength: 24,
+						IPAddress:    tc.reqIPAddress,
+						PrefixLength: tc.reqPrefixLength,
 					},
 				},
 				NetworkContainerType: cns.Kubernetes,


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
Previously, we called validateCIDRSuperset with only the IP address, which didn’t include the prefix length and resulted in incomplete CIDR notation, causing inaccurate superset validation for overlay subnet expansion.
For example, the function previously received just the IP address 10.240.0.0 instead of the full CIDR 10.240.0.0/24, which caused validateCIDRSuperset to read the logic inaccurately and led to incorrect subnet containment checks.
This happened because the IP and prefix length were stored separately in 2 different variables, and the code didn’t combine them before validation.
We considered explicitly building the CIDR string before validation. We chose to construct the full CIDR (IP/PrefixLength) for both the new and existing requests prior to calling validateCIDRSuperset, as this ensures correct subnet containment logic for subnet overlay expansion with minimal code change.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
