### PR TITLE
backport: ci: clean up disk space before build and skip windows port forward (#4109)

### DIFF
--- a/.pipelines/containers/container-template.yaml
+++ b/.pipelines/containers/container-template.yaml
@@ -15,11 +15,38 @@ steps:
 
 - script: |
     set -e
+    echo "Disk space before cleanup..."
+    df -h /
+    echo "Removing unnecessary files to free up disk space..."
+    sudo rm -rf \
+      /opt/hostedtoolcache \
+      /opt/google/chrome \
+      /opt/microsoft/msedge \
+      /opt/microsoft/powershell \
+      /opt/pipx \
+      /usr/lib/mono \
+      /usr/local/julia* \
+      /usr/local/lib/android \
+      /usr/local/lib/node_modules \
+      /usr/local/share/chromium \
+      /usr/local/share/powershell \
+      /usr/share/dotnet \
+      /usr/share/swift
+    echo "Disk space after cleanup..."
+    df -h /
+  displayName: "Clean up disk space"
+
+- script: |
+    set -e
+    echo "=== Disk space BEFORE make image ==="
+    df -h
     if [ ${{ parameters.os }} = 'windows' ]; then export BUILDX_ACTION='--push'; fi
     make ${{ parameters.name }}-image OS=${{ parameters.os }} ARCH=${{ parameters.arch }}
+    echo "=== Disk space AFTER make image ==="
+    df -h
   name: image_build
   displayName: Image Build
-  retryCountOnTaskFailure: 3
+  retryCountOnTaskFailure: 2
 
 - task: AzureCLI@2
   displayName: "Logout"

--- a/.pipelines/singletenancy/aks-swift/e2e-job-template.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e-job-template.yaml
@@ -71,7 +71,7 @@ stages:
           dependsOn: ${{ parameters.name }}
           datapath: true
           dns: true
-          portforward: true
+          portforward: ${{ eq(parameters.os, 'linux') }} # Unblock Pipeline, broken for all windows scenarios
           hostport: true
           service: true
 

--- a/.pipelines/singletenancy/aks-swift/e2e.stages.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e.stages.yaml
@@ -76,7 +76,7 @@ stages:
           dependsOn: ${{ parameters.name }}
           datapath: true
           dns: true
-          portforward: true
+          portforward: ${{ eq(parameters.os, 'linux') }} # Unblock Pipeline, broken for all windows scenarios
           hostport: true
           service: true
 

--- a/.pipelines/singletenancy/aks/e2e-job-template.yaml
+++ b/.pipelines/singletenancy/aks/e2e-job-template.yaml
@@ -74,7 +74,7 @@ stages:
           os: ${{ parameters.os }}
           datapath: true
           dns: true
-          portforward: true
+          portforward: ${{ eq(parameters.os, 'linux') }} # Unblock Pipeline, broken for all windows scenarios
           hybridWin: true
           service: true
           hostport: true

--- a/.pipelines/singletenancy/aks/e2e.stages.yaml
+++ b/.pipelines/singletenancy/aks/e2e.stages.yaml
@@ -80,7 +80,7 @@ stages:
           os: ${{ parameters.os }}
           datapath: true
           dns: true
-          portforward: true
+          portforward: ${{ eq(parameters.os, 'linux') }} # Unblock Pipeline, broken for all windows scenarios
           hybridWin: true
           service: true
           hostport: true

--- a/.pipelines/singletenancy/azure-cni-overlay-stateless/azure-cni-overlay-stateless-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay-stateless/azure-cni-overlay-stateless-e2e-job-template.yaml
@@ -72,7 +72,7 @@ stages:
           dependsOn: ${{ parameters.name }}_windows
           datapath: true
           dns: true
-          portforward: true
+          portforward: false # Unblock Pipeline, as stateless is tested in windows, broken for all windows scenarios
           hostport: true
           service: true
           hybridWin: true

--- a/.pipelines/singletenancy/azure-cni-overlay-stateless/azure-cni-overlay-stateless-e2e.stages.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay-stateless/azure-cni-overlay-stateless-e2e.stages.yaml
@@ -78,7 +78,7 @@ stages:
           dependsOn: ${{ parameters.name }}_windows
           datapath: true
           dns: true
-          portforward: true
+          portforward: false # Unblock Pipeline, as stateless is tested in windows, broken for all windows scenarios
           hostport: true
           service: true
           hybridWin: true

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
@@ -71,7 +71,7 @@ stages:
           dependsOn: ${{ parameters.name }}_${{ parameters.os }}
           datapath: true
           dns: true
-          portforward: true
+          portforward: ${{ eq(parameters.os, 'linux') }} # Unblock Pipeline, broken for all windows scenarios
           hostport: true
           service: true
           hybridWin: ${{ eq(parameters.os, 'windows') }}

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e.stages.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e.stages.yaml
@@ -77,7 +77,7 @@ stages:
           dependsOn: ${{ parameters.name }}_${{ parameters.os }}
           datapath: true
           dns: true
-          portforward: true
+          portforward: ${{ eq(parameters.os, 'linux') }} # Unblock Pipeline, broken for all windows scenarios
           hostport: true
           service: true
           hybridWin: ${{ eq(parameters.os, 'windows') }}


### PR DESCRIPTION

* clean up disk space before build

* skip portforward e2e in windows

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Backport to potentially unblock release v1.6
Backport #4109

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
