### PR TITLE
fix: Re-enable codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -58,7 +58,7 @@
 	"remoteUser": "vscode",
 	"features": {
 		"ghcr.io/devcontainers/features/go:1": {
-			"version": "1.23.2"
+			"version": "1.24.1"
 		},
 		"docker-in-docker": "latest",
 		"kubectl-helm-minikube": "latest",


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Our codespace utils have dependencies on bullseye. Going to pin to bullseye until we update to GO 1.25, which we then should update to [trixie](https://www.debian.org/releases/stable/index.en.html)

This has been broken since #3912.

Bullseye
- 5.10 Kernel
- Debian distro
- Has LTS support until Aug 2026

Trixie
- 6.12 Kernel
- Debian distro
- Has LTS support until June 2030

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
Go 1.25.1 has been released for some time now. https://go.dev/doc/go1.25