### PR TITLE
feat: make logger encoders kube-aware

### DIFF
--- a/cns/logger/v2/cores/etw_windows.go
+++ b/cns/logger/v2/cores/etw_windows.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	ctrlzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 type ETWConfig struct {
@@ -44,5 +45,5 @@ func ETWCore(cfg *ETWConfig) (zapcore.Core, func(), error) {
 	encoderConfig := zap.NewProductionEncoderConfig()
 	encoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	jsonEncoder := zapcore.NewJSONEncoder(encoderConfig)
-	return zapetw.New(cfg.ProviderName, cfg.EventName, jsonEncoder, cfg.level) //nolint:wrapcheck // ignore
+	return zapetw.New(cfg.ProviderName, cfg.EventName, &ctrlzap.KubeAwareEncoder{Encoder: jsonEncoder}, cfg.level) //nolint:wrapcheck // ignore
 }

--- a/cns/logger/v2/cores/file.go
+++ b/cns/logger/v2/cores/file.go
@@ -7,6 +7,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"gopkg.in/natefinch/lumberjack.v2"
+	ctrlzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 type FileConfig struct {
@@ -50,5 +51,5 @@ func FileCore(cfg *FileConfig) (zapcore.Core, func(), error) {
 	encoderConfig := zap.NewProductionEncoderConfig()
 	encoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	jsonEncoder := zapcore.NewJSONEncoder(encoderConfig)
-	return zapcore.NewCore(jsonEncoder, zapcore.AddSync(filesink), cfg.level), func() { _ = filesink.Close() }, nil
+	return zapcore.NewCore(&ctrlzap.KubeAwareEncoder{Encoder: jsonEncoder}, zapcore.AddSync(filesink), cfg.level), func() { _ = filesink.Close() }, nil
 }

--- a/cns/logger/v2/cores/stdout.go
+++ b/cns/logger/v2/cores/stdout.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	ctrlzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 type StdoutConfig struct {
@@ -41,5 +42,5 @@ func (cfg *StdoutConfig) UnmarshalJSON(data []byte) error {
 func StdoutCore(l zapcore.Level) zapcore.Core {
 	encoderConfig := zap.NewProductionEncoderConfig()
 	encoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
-	return zapcore.NewCore(logfmt.NewEncoder(encoderConfig), os.Stdout, l)
+	return zapcore.NewCore(&ctrlzap.KubeAwareEncoder{Encoder: logfmt.NewEncoder(encoderConfig)}, os.Stdout, l)
 }


### PR DESCRIPTION
wraps the v2 logger encoders with controller-runtime's kube-aware encoder shim