### PR TITLE
chore: add swiftv2 windows conflist

### DIFF
--- a/cni/azure-windows-swiftv2-stateless.conflist
+++ b/cni/azure-windows-swiftv2-stateless.conflist
@@ -1,23 +1,27 @@
 {
     "cniVersion": "1.0.0",
     "name": "azure",
-    "type": "azure-vnet",
-    "mode": "bridge",
-    "bridge": "azure0",
-    "capabilities": {
-        "portMappings": true,
-        "dns": true
-    },
-    "ipam": {
-        "type": "azure-cns"
-    },
-    "dns": {
-        "Nameservers": [
-            "168.63.129.16"
-        ],
-        "Search": [
-            "svc.cluster.local"
-        ]
-    },
-    "disableAsyncDelete": true
+    "plugins": [
+        {
+            "type": "azure-vnet",
+            "mode": "bridge",
+            "bridge": "azure0",
+            "capabilities": {
+                "portMappings": true,
+                "dns": true
+            },
+            "ipam": {
+                "type": "azure-cns"
+            },
+            "dns": {
+                "Nameservers": [
+                    "168.63.129.16"
+                ],
+                "Search": [
+                    "svc.cluster.local"
+                ]
+            },
+            "disableAsyncDelete": true
+        }
+    ]
 }


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Add a simple default Windows SwiftV2 conflist for usage with Stateless CNI. SwiftV2 uses delegated NICs and has no need for AdditionalArgs like endpoint policies for OutBoundNAT, ROUTE, or ACL. This conflist would be bundled with Stateless CNI for Windows SwiftV2 in the official nuget package for partners to consume.
