### PR TITLE
[backport v1.6] [NPM Lite] Bypassing IPSets for IP CIDR Block Based Network Policies …

### DIFF
--- a/npm/pkg/dataplane/policies/policy.go
+++ b/npm/pkg/dataplane/policies/policy.go
@@ -114,6 +114,10 @@ type ACLPolicy struct {
 	SrcList []SetInfo
 	// DstList destination IPSets condition setinfos
 	DstList []SetInfo
+	// SrcDirectIPs holds direct IPs for source matching (used for /32 CIDRs on Windows with npm lite enabled)
+	SrcDirectIPs []string
+	// DstDirectIPs holds direct IPs for destination matching (used for /32 CIDRs on Windows with npm lite enabled)
+	DstDirectIPs []string
 	// Target defines a target in iptables for linux. i,e, Mark, Accept, Drop
 	// in windows, this is either ALLOW or DENY
 	Target Verdict
@@ -282,7 +286,9 @@ func translatedIPSetsToString(items []*ipsets.TranslatedIPSet) string {
 // Included is false when match set have "!".
 // MatchType captures match direction flags.
 // For example match set in linux:
-//             ! azure-npm-123 src
+//
+//	! azure-npm-123 src
+//
 // "!" this indicates a negative match (Included is false) of an azure-npm-123
 // MatchType is "src"
 type SetInfo struct {


### PR DESCRIPTION
…(#4107)

* added logic to bypass ipsets for /32 cidrs with npm lite

* removed logic to only look at /32 pod cidrs and allow all pod cidr

* updated code specific to direct ip logic

* fixed if else logic

* added error for named port

* get rid of unneeded comments

* got rid of function in utils that was not neede

* added unit test for translate policy

* resolved pr comments

* resolved copilot comments

* fixed golinter

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
