### PR TITLE
fix: do not copy empty values into secondary IP configs

### DIFF
--- a/test/integration/cilium-nodesubnet/ipconfigupdate.go
+++ b/test/integration/cilium-nodesubnet/ipconfigupdate.go
@@ -104,11 +104,17 @@ func main() {
 			for i := 1; i <= secondaryConfigCount+1; i++ {
 				ipConfig := make(map[string]interface{})
 				for k, v := range primaryIPConfig {
-					// only the primary config needs loadBalancerBackendAddressPools. Azure doesn't allow
-					// secondary IP configs to be associated load balancer backend pools. Also skip nil values.
-					if k == "loadBalancerBackendAddressPools" || v == nil {
+					// Skip nil values.
+					if v == nil {
 						continue
 					}
+
+					// only the primary config needs loadBalancerBackendAddressPools. Azure doesn't allow
+					// secondary IP configs to be associated load balancer backend pools.
+					if i > 1 && k == "loadBalancerBackendAddressPools" {
+						continue
+					}
+
 					ipConfig[k] = v
 				}
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
For Cilium Nodesubnet tests, we need to create secondary ip configs on nodes, which is being done by copying the primary config, and editing some fields. During this process, we were leaving nil fields untouched. With a new AZ CLI update, this causes an error because some fields expect values to be set. In this PR, we skip over any values that are nil.

Validation:
Manually created a byocni cluster and verified that the script runs correctly.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
