### PR TITLE
fix: only mark IPs Available for matching NCID

### DIFF
--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -673,6 +673,8 @@ func (service *HTTPRestService) MarkIpsAsAvailableUntransacted(ncID string, newH
 			for uuid, secondaryIPConfigs := range ncInfo.CreateNetworkContainerRequest.SecondaryIPConfigs {
 				if ipConfigStatus, exist := service.PodIPConfigState[uuid]; !exist {
 					logger.Errorf("IP %s with uuid as %s exist in service state Secondary IP list but can't find in PodIPConfigState", ipConfigStatus.IPAddress, uuid)
+				} else if ipConfigStatus.NCID != ncID {
+					logger.Errorf("IP %s with uuid as %s NCID %s mismatch with current processing NCID %s, skip updating its status", ipConfigStatus.IPAddress, uuid, ipConfigStatus.NCID, ncID)
 				} else if ipConfigStatus.GetState() == types.PendingProgramming && secondaryIPConfigs.NCVersion <= newHostNCVersion {
 					_, err := service.updateIPConfigState(uuid, types.Available, nil)
 					if err != nil {

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -673,9 +673,7 @@ func (service *HTTPRestService) MarkIpsAsAvailableUntransacted(ncID string, newH
 			for uuid, secondaryIPConfigs := range ncInfo.CreateNetworkContainerRequest.SecondaryIPConfigs {
 				if ipConfigStatus, exist := service.PodIPConfigState[uuid]; !exist {
 					logger.Errorf("IP %s with uuid as %s exist in service state Secondary IP list but can't find in PodIPConfigState", ipConfigStatus.IPAddress, uuid)
-				} else if ipConfigStatus.NCID != ncID {
-					logger.Errorf("IP %s with uuid as %s NCID %s mismatch with current processing NCID %s, skip updating its status", ipConfigStatus.IPAddress, uuid, ipConfigStatus.NCID, ncID)
-				} else if ipConfigStatus.GetState() == types.PendingProgramming && secondaryIPConfigs.NCVersion <= newHostNCVersion {
+				} else if ipConfigStatus.NCID == ncID && ipConfigStatus.GetState() == types.PendingProgramming && secondaryIPConfigs.NCVersion <= newHostNCVersion {
 					_, err := service.updateIPConfigState(uuid, types.Available, nil)
 					if err != nil {
 						logger.Errorf("Error updating IPConfig [%+v] state to Available, err: %+v", ipConfigStatus, err)

--- a/cns/restserver/ipam_test.go
+++ b/cns/restserver/ipam_test.go
@@ -1427,6 +1427,30 @@ func TestIPAMMarkIPAsPendingWithPendingProgrammingIPs(t *testing.T) {
 	}
 }
 
+func TestMarkIpsAsAvailableUntransactedSkipsMismatchedNCID(t *testing.T) {
+	svc := getTestService(cns.KubernetesCRD)
+	secondaryIPConfigs := map[string]cns.SecondaryIPConfig{
+		testIP1: {
+			IPAddress: testIP1,
+			NCVersion: 0,
+		},
+	}
+
+	createAndValidateNCRequest(t, secondaryIPConfigs, testNCID, "0")
+	createAndValidateNCRequest(t, secondaryIPConfigs, testNCIDv6, "0")
+
+	ncInfo := svc.state.ContainerStatus[testNCIDv6]
+	ncInfo.HostVersion = "0"
+	svc.state.ContainerStatus[testNCIDv6] = ncInfo
+
+	svc.MarkIpsAsAvailableUntransacted(testNCIDv6, 1)
+
+	ipState := svc.PodIPConfigState[testIP1]
+	assert.Equal(t, types.PendingProgramming, ipState.GetState())
+	assert.Equal(t, testNCID, ipState.NCID)
+	assert.Equal(t, 0, svc.state.ContainerStatus[testNCIDv6].CreateNetworkContainerRequest.SecondaryIPConfigs[testIP1].NCVersion)
+}
+
 func constructSecondaryIPConfigs(ipAddress, uuid string, ncVersion int, secondaryIPConfigs map[string]cns.SecondaryIPConfig) {
 	secIPConfig := cns.SecondaryIPConfig{
 		IPAddress: ipAddress,


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
In block allocation modes, IPs are stored in CNS state not by an allocation UUID, but by their IP string as a key. This means that if a Node gets multiple NCs with overlapping blocks, when we program the new NC it is possible that the IPs in CNS state are for the wrong NC and we should not mark those as Available. This adds a last-minute sanity check to confirm that the IP is from the expected NC.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
