### PR TITLE
fix: do not ingest duplicate IPs from a different NC

### DIFF
--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -43,6 +43,7 @@ const (
 	requestPercent      = 100
 	batchSize           = 10
 	initPoolSize        = 10
+	ncIDMismatchTestIP  = "10.0.0.6"
 	ncID                = "6a07155a-32d7-49af-872f-1e70ee366dc0"
 	imdsNCID            = "6a07155a-32d7-49af-872f-1e70ee36imds"
 )
@@ -66,7 +67,7 @@ func TestCreateOrUpdateNetworkContainerInternalDetectsNCIDMismatch(t *testing.T)
 	existingNCID := "existing-nc"
 	newNCID := "new-nc"
 	ipID := "ip-1"
-	ipAddress := "10.0.0.6"
+	ipAddress := ncIDMismatchTestIP
 
 	svc.PodIPConfigState[ipID] = newPodState(ipAddress, ipID, existingNCID, types.Available, 0)
 

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -320,7 +320,6 @@ func (service *HTTPRestService) addIPConfigStateUntransacted(ncID string, hostVe
 		if ipState, exists := service.PodIPConfigState[ipID]; exists {
 			if ipState.NCID != ncID {
 				errMsg := fmt.Sprintf("Duplicate IP %s with id %s belongs to NC %s, attempted to add to NC %s", ipState.IPAddress, ipID, ipState.NCID, ncID)
-				logger.Errorf(errMsg)
 				return types.InconsistentIPConfigState, errMsg
 			}
 		}

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -301,10 +301,13 @@ func (service *HTTPRestService) updateIPConfigsStateUntransacted(
 		return types.UnsupportedNCVersion, fmt.Sprintf("Invalid hostVersion is %s, err:%s", hostVersion, err)
 	}
 
-	service.addIPConfigStateUntransacted(req.NetworkContainerid, hostNCVersionInInt, req.SecondaryIPConfigs,
+	returnCode, errMsg := service.addIPConfigStateUntransacted(req.NetworkContainerid, hostNCVersionInInt, req.SecondaryIPConfigs,
 		existingSecondaryIPConfigs)
+	if returnCode != types.Success {
+		return returnCode, errMsg
+	}
 
-	return 0, ""
+	return types.Success, ""
 }
 
 // addIPConfigStateUntransacted adds the IPConfigs to the PodIpConfigState map with Available state
@@ -312,7 +315,7 @@ func (service *HTTPRestService) updateIPConfigsStateUntransacted(
 // acquire/release the service lock.
 func (service *HTTPRestService) addIPConfigStateUntransacted(ncID string, hostVersion int, ipconfigs,
 	existingSecondaryIPConfigs map[string]cns.SecondaryIPConfig,
-) {
+) (types.ResponseCode, string) {
 	// add ipconfigs to state
 	for ipID, ipconfig := range ipconfigs {
 		// New secondary IP configs has new NC version however, CNS don't want to override existing IPs'with new
@@ -323,6 +326,11 @@ func (service *HTTPRestService) addIPConfigStateUntransacted(ncID string, hostVe
 		}
 
 		if ipState, exists := service.PodIPConfigState[ipID]; exists {
+			if ipState.NCID != ncID {
+				errMsg := fmt.Sprintf("Duplicate IP %s with id %s belongs to NC %s, attempted to add to NC %s", ipState.IPAddress, ipID, ipState.NCID, ncID)
+				logger.Errorf(errMsg)
+				return types.InconsistentIPConfigState, errMsg
+			}
 			logger.Printf("[Azure-Cns] Set ipId %s, IP %s version to %d, programmed host nc version is %d, "+
 				"ipState: %s", ipID, ipconfig.IPAddress, ipconfig.NCVersion, hostVersion, ipState)
 			continue
@@ -353,6 +361,8 @@ func (service *HTTPRestService) addIPConfigStateUntransacted(ncID string, hostVe
 
 		// Todo Update batch API and maintain the count
 	}
+
+	return types.Success, ""
 }
 
 // Todo: call this when request is received

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -301,8 +301,7 @@ func (service *HTTPRestService) updateIPConfigsStateUntransacted(
 		return types.UnsupportedNCVersion, fmt.Sprintf("Invalid hostVersion is %s, err:%s", hostVersion, err)
 	}
 
-	returnCode, errMsg := service.addIPConfigStateUntransacted(req.NetworkContainerid, hostNCVersionInInt, req.SecondaryIPConfigs,
-		existingSecondaryIPConfigs)
+	returnCode, errMsg := service.addIPConfigStateUntransacted(req.NetworkContainerid, hostNCVersionInInt, req.SecondaryIPConfigs, existingSecondaryIPConfigs)
 	if returnCode != types.Success {
 		return returnCode, errMsg
 	}
@@ -316,9 +315,20 @@ func (service *HTTPRestService) updateIPConfigsStateUntransacted(
 func (service *HTTPRestService) addIPConfigStateUntransacted(ncID string, hostVersion int, ipconfigs,
 	existingSecondaryIPConfigs map[string]cns.SecondaryIPConfig,
 ) (types.ResponseCode, string) {
+	// validate incoming ipconfigs
+	for ipID := range ipconfigs {
+		if ipState, exists := service.PodIPConfigState[ipID]; exists {
+			if ipState.NCID != ncID {
+				errMsg := fmt.Sprintf("Duplicate IP %s with id %s belongs to NC %s, attempted to add to NC %s", ipState.IPAddress, ipID, ipState.NCID, ncID)
+				logger.Errorf(errMsg)
+				return types.InconsistentIPConfigState, errMsg
+			}
+		}
+	}
+
 	// add ipconfigs to state
 	for ipID, ipconfig := range ipconfigs {
-		// New secondary IP configs has new NC version however, CNS don't want to override existing IPs'with new
+		// New secondary IP configs has new NC version however, CNS don't want to override existing IPs with new
 		// NC version. Set it back to previous NC version if IP already exist.
 		if existingIPConfig, existsInPreviousIPConfig := existingSecondaryIPConfigs[ipID]; existsInPreviousIPConfig {
 			ipconfig.NCVersion = existingIPConfig.NCVersion
@@ -326,11 +336,6 @@ func (service *HTTPRestService) addIPConfigStateUntransacted(ncID string, hostVe
 		}
 
 		if ipState, exists := service.PodIPConfigState[ipID]; exists {
-			if ipState.NCID != ncID {
-				errMsg := fmt.Sprintf("Duplicate IP %s with id %s belongs to NC %s, attempted to add to NC %s", ipState.IPAddress, ipID, ipState.NCID, ncID)
-				logger.Errorf(errMsg)
-				return types.InconsistentIPConfigState, errMsg
-			}
 			logger.Printf("[Azure-Cns] Set ipId %s, IP %s version to %d, programmed host nc version is %d, "+
 				"ipState: %s", ipID, ipconfig.IPAddress, ipconfig.NCVersion, hostVersion, ipState)
 			continue
@@ -807,7 +812,7 @@ func (service *HTTPRestService) SendNCSnapShotPeriodically(ctx context.Context, 
 	}
 }
 
-func (service *HTTPRestService) validateIPConfigsRequest(ctx context.Context, ipConfigsRequest cns.IPConfigsRequest) (cns.PodInfo, types.ResponseCode, string) {
+func (service *HTTPRestService) validateIPConfigsRequest(_ context.Context, ipConfigsRequest cns.IPConfigsRequest) (cns.PodInfo, types.ResponseCode, string) {
 	if ipConfigsRequest.OrchestratorContext == nil {
 		return nil, types.EmptyOrchestratorContext, fmt.Sprintf("OrchestratorContext is not set in the req: %+v", ipConfigsRequest)
 	}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
In block/static IP scenarios, it is possible that a new NC comes with the same IPs as a previous (stale) NC. We should have removed those if we don't have the NC anymore, but in case there is an issue there, we must check as we ingest IPs if there are existing IPs from a different NC. This indicates that we have state corruption, and we should not proceed.