### PR TITLE
[NPM] [Vulnerability] Resolve stdlib CVEs by Updating go Version from 1.25.6 -> 1.25.7

### DIFF
--- a/npm/linux.Dockerfile
+++ b/npm/linux.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.25.6 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.25.7 AS builder
 ARG VERSION
 ARG NPM_AI_PATH
 ARG NPM_AI_ID


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
Resolve Linux stdlib CVEs by updating go version from `1.25.6` to `1.25.7`. Copacetic in the signed release will patch remaining Ubuntu CVEs.


`GoLang 1.25.6 Trivy Scan:`
```

acnpublic.azurecr.io/azure-npm:v1.6.38CVEFixOld (ubuntu 24.04)
==============================================================
Total: 8 (UNKNOWN: 0, LOW: 0, MEDIUM: 7, HIGH: 1, CRITICAL: 0)

┌────────────┬────────────────┬──────────┬────────┬─────────────────────────┬─────────────────────────┬──────────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability  │ Severity │ Status │    Installed Version    │      Fixed Version      │                            Title                             │
├────────────┼────────────────┼──────────┼────────┼─────────────────────────┼─────────────────────────┼──────────────────────────────────────────────────────────────┤
│ gpgv       │ CVE-2025-68973 │ HIGH     │ fixed  │ 2.4.4-2ubuntu17.3       │ 2.4.4-2ubuntu17.4       │ GnuPG: GnuPG: Information disclosure and potential arbitrary │
│            │                │          │        │                         │                         │ code execution via out-of-bounds write...                    │
│            │                │          │        │                         │                         │ https://avd.aquasec.com/nvd/cve-2025-68973                   │
├────────────┼────────────────┼──────────┤        ├─────────────────────────┼─────────────────────────┼──────────────────────────────────────────────────────────────┤
│ libc-bin   │ CVE-2025-15281 │ MEDIUM   │        │ 2.39-0ubuntu8.6         │ 2.39-0ubuntu8.7         │ glibc: wordexp with WRDE_REUSE and WRDE_APPEND may return    │
│            │                │          │        │                         │                         │ uninitialized memory                                         │
│            │                │          │        │                         │                         │ https://avd.aquasec.com/nvd/cve-2025-15281                   │
│            ├────────────────┤          │        │                         │                         ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2026-0861  │          │        │                         │                         │ glibc: Integer overflow in memalign leads to heap corruption │
│            │                │          │        │                         │                         │ https://avd.aquasec.com/nvd/cve-2026-0861                    │
│            ├────────────────┤          │        │                         │                         ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2026-0915  │          │        │                         │                         │ glibc: glibc: Information disclosure via zero-valued network │
│            │                │          │        │                         │                         │ query                                                        │
│            │                │          │        │                         │                         │ https://avd.aquasec.com/nvd/cve-2026-0915                    │
├────────────┼────────────────┤          │        │                         │                         ├──────────────────────────────────────────────────────────────┤
│ libc6      │ CVE-2025-15281 │          │        │                         │                         │ glibc: wordexp with WRDE_REUSE and WRDE_APPEND may return    │
│            │                │          │        │                         │                         │ uninitialized memory                                         │
│            │                │          │        │                         │                         │ https://avd.aquasec.com/nvd/cve-2025-15281                   │
│            ├────────────────┤          │        │                         │                         ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2026-0861  │          │        │                         │                         │ glibc: Integer overflow in memalign leads to heap corruption │
│            │                │          │        │                         │                         │ https://avd.aquasec.com/nvd/cve-2026-0861                    │
│            ├────────────────┤          │        │                         │                         ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2026-0915  │          │        │                         │                         │ glibc: glibc: Information disclosure via zero-valued network │
│            │                │          │        │                         │                         │ query                                                        │
│            │                │          │        │                         │                         │ https://avd.aquasec.com/nvd/cve-2026-0915                    │
├────────────┼────────────────┤          │        ├─────────────────────────┼─────────────────────────┼──────────────────────────────────────────────────────────────┤
│ libtasn1-6 │ CVE-2025-13151 │          │        │ 4.19.0-3ubuntu0.24.04.1 │ 4.19.0-3ubuntu0.24.04.2 │ libtasn1: libtasn1: Denial of Service via stack-based buffer │
│            │                │          │        │                         │                         │ overflow in asn1_expend_octet_string                         │
│            │                │          │        │                         │                         │ https://avd.aquasec.com/nvd/cve-2025-13151                   │
└────────────┴────────────────┴──────────┴────────┴─────────────────────────┴─────────────────────────┴──────────────────────────────────────────────────────────────┘

usr/bin/azure-npm (gobinary)
============================
Total: 1 (UNKNOWN: 1, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────┬──────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │        Fixed Version         │                          Title                           │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────┼──────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-68121 │ UNKNOWN  │ fixed  │ v1.25.6           │ 1.24.13, 1.25.7, 1.26.0-rc.3 │ [crypto/tls: Config.Clone copies automatically generated │
│         │                │          │        │                   │                              │ session ticket keys, session resumption does not...      │
│         │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-68121               │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────┴──────────────────────────────────────────────────────────┘

```

`GoLang 1.25.7 Trivy Scan:`
```

acnpublic.azurecr.io/azure-npm:v1.6.38CVEFixNew (ubuntu 24.04)
==============================================================
Total: 8 (UNKNOWN: 0, LOW: 0, MEDIUM: 7, HIGH: 1, CRITICAL: 0)

┌────────────┬────────────────┬──────────┬────────┬─────────────────────────┬─────────────────────────┬──────────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability  │ Severity │ Status │    Installed Version    │      Fixed Version      │                            Title                             │
├────────────┼────────────────┼──────────┼────────┼─────────────────────────┼─────────────────────────┼──────────────────────────────────────────────────────────────┤
│ gpgv       │ CVE-2025-68973 │ HIGH     │ fixed  │ 2.4.4-2ubuntu17.3       │ 2.4.4-2ubuntu17.4       │ GnuPG: GnuPG: Information disclosure and potential arbitrary │
│            │                │          │        │                         │                         │ code execution via out-of-bounds write...                    │
│            │                │          │        │                         │                         │ https://avd.aquasec.com/nvd/cve-2025-68973                   │
├────────────┼────────────────┼──────────┤        ├─────────────────────────┼─────────────────────────┼──────────────────────────────────────────────────────────────┤
│ libc-bin   │ CVE-2025-15281 │ MEDIUM   │        │ 2.39-0ubuntu8.6         │ 2.39-0ubuntu8.7         │ glibc: wordexp with WRDE_REUSE and WRDE_APPEND may return    │
│            │                │          │        │                         │                         │ uninitialized memory                                         │
│            │                │          │        │                         │                         │ https://avd.aquasec.com/nvd/cve-2025-15281                   │
│            ├────────────────┤          │        │                         │                         ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2026-0861  │          │        │                         │                         │ glibc: Integer overflow in memalign leads to heap corruption │
│            │                │          │        │                         │                         │ https://avd.aquasec.com/nvd/cve-2026-0861                    │
│            ├────────────────┤          │        │                         │                         ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2026-0915  │          │        │                         │                         │ glibc: glibc: Information disclosure via zero-valued network │
│            │                │          │        │                         │                         │ query                                                        │
│            │                │          │        │                         │                         │ https://avd.aquasec.com/nvd/cve-2026-0915                    │
├────────────┼────────────────┤          │        │                         │                         ├──────────────────────────────────────────────────────────────┤
│ libc6      │ CVE-2025-15281 │          │        │                         │                         │ glibc: wordexp with WRDE_REUSE and WRDE_APPEND may return    │
│            │                │          │        │                         │                         │ uninitialized memory                                         │
│            │                │          │        │                         │                         │ https://avd.aquasec.com/nvd/cve-2025-15281                   │
│            ├────────────────┤          │        │                         │                         ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2026-0861  │          │        │                         │                         │ glibc: Integer overflow in memalign leads to heap corruption │
│            │                │          │        │                         │                         │ https://avd.aquasec.com/nvd/cve-2026-0861                    │
│            ├────────────────┤          │        │                         │                         ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2026-0915  │          │        │                         │                         │ glibc: glibc: Information disclosure via zero-valued network │
│            │                │          │        │                         │                         │ query                                                        │
│            │                │          │        │                         │                         │ https://avd.aquasec.com/nvd/cve-2026-0915                    │
├────────────┼────────────────┤          │        ├─────────────────────────┼─────────────────────────┼──────────────────────────────────────────────────────────────┤
│ libtasn1-6 │ CVE-2025-13151 │          │        │ 4.19.0-3ubuntu0.24.04.1 │ 4.19.0-3ubuntu0.24.04.2 │ libtasn1: libtasn1: Denial of Service via stack-based buffer │
│            │                │          │        │                         │                         │ overflow in asn1_expend_octet_string                         │
│            │                │          │        │                         │                         │ https://avd.aquasec.com/nvd/cve-2025-13151                   │
└────────────┴────────────────┴──────────┴────────┴─────────────────────────┴─────────────────────────┴──────────────────────────────────────────────────────────────┘

```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
