### PR TITLE
feat: Add comprehensive unit tests for stateless CNI endpoint management

### DIFF
--- a/cni/network/stateless_cni_test.go
+++ b/cni/network/stateless_cni_test.go
@@ -1,0 +1,389 @@
+package network
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/Azure/azure-container-networking/cni"
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/restserver"
+	"github.com/Azure/azure-container-networking/common"
+	acnnetwork "github.com/Azure/azure-container-networking/network"
+	"github.com/Azure/azure-container-networking/nns"
+	cniSkel "github.com/containernetworking/cni/pkg/skel"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testNamespace = "test-ns"
+)
+
+// GetStatelessTestResources creates a test NetPlugin configured for stateless CNI mode.
+// It uses MockCNSEndpointClient so tests can set up endpoint state in CNS format
+// and verify the conversion to CNI EndpointInfo format.
+//
+// For simpler tests that don't need CNS format testing, you can instead:
+// 1. Call mockNM.SetStatelessCNIMode() without MockCNSClient
+// 2. Use mockNM.SetEndpointState(containerID, []*EndpointInfo{...}) directly
+func GetStatelessTestResources(t *testing.T) (*NetPlugin, *acnnetwork.MockNetworkManager) {
+	pluginName := "testplugin"
+	isIPv6 := false
+	config := &common.PluginConfig{}
+	grpcClient := &nns.MockGrpcClient{}
+	plugin, err := NewPlugin(pluginName, config, grpcClient, &Multitenancy{})
+	require.NoError(t, err, "NewPlugin should not fail")
+
+	// Create mock network manager with stateless mode enabled
+	mockNetworkManager := acnnetwork.NewMockNetworkmanager(acnnetwork.NewMockEndpointClient(nil))
+	err = mockNetworkManager.SetStatelessCNIMode()
+	require.NoError(t, err, "SetStatelessCNIMode should not fail")
+
+	// Initialize MockCNSClient for tests that need CNS format testing or call tracking
+	mockNetworkManager.MockCNSClient = acnnetwork.NewMockCNSEndpointClient()
+
+	plugin.nm = mockNetworkManager
+	plugin.ipamInvoker = NewMockIpamInvoker(isIPv6, false, false, false, false)
+
+	return plugin, mockNetworkManager
+}
+
+// createStatelessTestConfig creates a network config for stateless CNI tests
+func createStatelessTestConfig() cni.NetworkConfig {
+	return cni.NetworkConfig{
+		Name:              "test-stateless-nwcfg",
+		CNIVersion:        "0.3.0",
+		Type:              "azure-vnet",
+		Mode:              OpModeTransparent,
+		Master:            "eth0",
+		IPsToRouteViaHost: []string{"169.254.20.10"},
+		IPAM: cni.IPAM{
+			Type: "azure-cns",
+		},
+	}
+}
+
+// createTestCmdArgs creates CmdArgs for stateless CNI tests, reducing duplication across test cases
+func createTestCmdArgs(nwCfg cni.NetworkConfig, containerID, podName, podNamespace string) *cniSkel.CmdArgs {
+	return &cniSkel.CmdArgs{
+		StdinData:   nwCfg.Serialize(),
+		ContainerID: containerID,
+		Netns:       containerID,
+		Args:        fmt.Sprintf("K8S_POD_NAME=%v;K8S_POD_NAMESPACE=%v", podName, podNamespace),
+		IfName:      "eth0",
+	}
+}
+
+// TestStatelessCNI_Delete_CNSGetEndpointError tests DELETE when CNS returns errors
+func TestStatelessCNI_Delete_CNSGetEndpointError(t *testing.T) {
+	nwCfgStateless := createStatelessTestConfig()
+
+	tests := []struct {
+		name            string
+		setupError      func(*acnnetwork.MockCNSEndpointClient)
+		wantErr         bool
+		wantErrContains string
+	}{
+		{
+			name: "CNS returns EndpointStateNotFound - should succeed",
+			setupError: func(mockCNS *acnnetwork.MockCNSEndpointClient) {
+				mockCNS.GetEndpointErr = acnnetwork.ErrEndpointStateNotFound
+			},
+			wantErr: false, // EndpointStateNotFound is handled gracefully
+		},
+		{
+			name: "CNS returns ConnectionFailure - should succeed (async IP release)",
+			setupError: func(mockCNS *acnnetwork.MockCNSEndpointClient) {
+				mockCNS.GetEndpointErr = acnnetwork.ErrConnectionFailure
+			},
+			wantErr: false, // Connection failure handled with async release
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create fresh plugin and mocks for each test to avoid cross-test contamination
+			plugin, mockNM := GetStatelessTestResources(t)
+
+			// Set up error condition
+			tt.setupError(mockNM.MockCNSClient)
+
+			cmdArgs := createTestCmdArgs(nwCfgStateless, "error-test-container", "error-pod", testNamespace)
+			err := plugin.Delete(cmdArgs)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.wantErrContains != "" {
+					require.Contains(t, err.Error(), tt.wantErrContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestStatelessCNI_Delete_HappyPath tests DELETE when CNS returns valid endpoint state
+func TestStatelessCNI_Delete_HappyPath(t *testing.T) {
+	nwCfgStateless := createStatelessTestConfig()
+	containerID := "happy-path-container"
+	podName := "test-pod"
+	podNamespace := testNamespace
+
+	tests := []struct {
+		name          string
+		setupState    func(*acnnetwork.MockCNSEndpointClient, *MockIpamInvoker)
+		validateAfter func(*testing.T, *MockIpamInvoker)
+		wantErr       bool
+		description   string
+	}{
+		{
+			name: "Delete InfraNIC endpoint - IP released",
+			setupState: func(mockCNS *acnnetwork.MockCNSEndpointClient, mockIpam *MockIpamInvoker) {
+				// Set up InfraNIC endpoint in CNS
+				mockCNS.SetEndpointStateWithIPInfo(containerID, podName, podNamespace, map[string]*restserver.IPInfo{
+					"eth0": acnnetwork.CreateMockIPInfo(cns.InfraNIC, "10.240.0.5/24", "", "", "veth-host", ""),
+				})
+				// Pre-populate ipam invoker with the IP so Delete validates it
+				mockIpam.ipMap["10.240.0.5/24"] = true
+			},
+			validateAfter: func(t *testing.T, mockIpam *MockIpamInvoker) {
+				// Verify IP was released from IPAM
+				_, exists := mockIpam.ipMap["10.240.0.5/24"]
+				require.False(t, exists, "InfraNIC IP should be released from IPAM")
+			},
+			wantErr:     false,
+			description: "InfraNIC endpoint should be deleted and IP released via ipamInvoker.Delete",
+		},
+		{
+			name: "Delete FrontendNIC endpoint - IP NOT released (delegated)",
+			setupState: func(mockCNS *acnnetwork.MockCNSEndpointClient, _ *MockIpamInvoker) {
+				// Set up FrontendNIC (delegated) endpoint in CNS
+				mockCNS.SetEndpointStateWithIPInfo(containerID, podName, podNamespace, map[string]*restserver.IPInfo{
+					"eth1": acnnetwork.CreateMockIPInfo(cns.NodeNetworkInterfaceFrontendNIC, "20.20.20.20/32", "", "", "", "aa:bb:cc:dd:ee:ff"),
+				})
+				// Do NOT add to ipam invoker - delegated IPs should not be released
+			},
+			validateAfter: func(t *testing.T, mockIpam *MockIpamInvoker) {
+				// Verify ipMap is unchanged (delegated NICs don't release IPs via IPAM)
+				require.Empty(t, mockIpam.ipMap, "FrontendNIC should not trigger IPAM release")
+			},
+			wantErr:     false,
+			description: "FrontendNIC (delegated) endpoint should be deleted but IP NOT released",
+		},
+		{
+			name: "Delete BackendNIC endpoint - IP NOT released",
+			setupState: func(mockCNS *acnnetwork.MockCNSEndpointClient, _ *MockIpamInvoker) {
+				// Set up BackendNIC endpoint in CNS
+				mockCNS.SetEndpointStateWithIPInfo(containerID, podName, podNamespace, map[string]*restserver.IPInfo{
+					"ib1": acnnetwork.CreateMockIPInfo(cns.BackendNIC, "", "", "", "", ""),
+				})
+				// BackendNIC has no IP to release
+			},
+			validateAfter: func(t *testing.T, mockIpam *MockIpamInvoker) {
+				// Verify ipMap is unchanged (BackendNIC has no IPs)
+				require.Empty(t, mockIpam.ipMap, "BackendNIC should not trigger IPAM release")
+			},
+			wantErr:     false,
+			description: "BackendNIC endpoint should be deleted (no IP release needed)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create fresh plugin and mocks for each test
+			plugin, mockNM := GetStatelessTestResources(t)
+			mockIpam := NewMockIpamInvoker(false, false, false, false, false)
+			plugin.ipamInvoker = mockIpam
+
+			// Set up endpoint state
+			tt.setupState(mockNM.MockCNSClient, mockIpam)
+
+			cmdArgs := createTestCmdArgs(nwCfgStateless, containerID, podName, podNamespace)
+			err := plugin.Delete(cmdArgs)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// Validate side effects
+			if tt.validateAfter != nil {
+				tt.validateAfter(t, mockIpam)
+			}
+		})
+	}
+}
+
+// TestStatelessCNI_Delete_MultiNIC tests DELETE with multiple NICs (SwiftV2 scenario)
+func TestStatelessCNI_Delete_MultiNIC(t *testing.T) {
+	nwCfgStateless := createStatelessTestConfig()
+	containerID := "multi-nic-container"
+	podName := "multi-nic-pod"
+	podNamespace := testNamespace
+
+	tests := []struct {
+		name          string
+		setupState    func(*acnnetwork.MockCNSEndpointClient, *MockIpamInvoker)
+		validateAfter func(*testing.T, *MockIpamInvoker, *acnnetwork.MockCNSEndpointClient)
+		wantErr       bool
+		description   string
+	}{
+		{
+			name: "Delete InfraNIC + FrontendNIC - only InfraNIC IP released",
+			setupState: func(mockCNS *acnnetwork.MockCNSEndpointClient, mockIpam *MockIpamInvoker) {
+				// Set up both InfraNIC and FrontendNIC (SwiftV2 scenario)
+				mockCNS.SetEndpointStateWithIPInfo(containerID, podName, podNamespace, map[string]*restserver.IPInfo{
+					"eth0": acnnetwork.CreateMockIPInfo(cns.InfraNIC, "10.240.0.5/24", "", "", "veth-infra", ""),
+					"eth1": acnnetwork.CreateMockIPInfo(cns.NodeNetworkInterfaceFrontendNIC, "20.20.20.20/32", "", "", "", "aa:bb:cc:dd:ee:ff"),
+				})
+				// Only InfraNIC IP should be released
+				mockIpam.ipMap["10.240.0.5/24"] = true
+			},
+			validateAfter: func(t *testing.T, mockIpam *MockIpamInvoker, mockCNS *acnnetwork.MockCNSEndpointClient) {
+				// Verify InfraNIC IP was released from IPAM
+				_, exists := mockIpam.ipMap["10.240.0.5/24"]
+				require.False(t, exists, "InfraNIC IP should be released from IPAM")
+				// Verify FrontendNIC IP was NOT released (delegated IPs are not released via IPAM)
+				// Note: FrontendNIC IPs are not added to ipMap, so nothing to check there
+				// Verify CNS GetEndpointState was called to retrieve endpoint state
+				require.Contains(t, mockCNS.GetEndpointStateCalls, containerID, "GetEndpointState should be called for containerID")
+			},
+			wantErr:     false,
+			description: "Both endpoints deleted, only InfraNIC IP released via ipamInvoker.Delete",
+		},
+		{
+			name: "Delete InfraNIC + BackendNIC",
+			setupState: func(mockCNS *acnnetwork.MockCNSEndpointClient, mockIpam *MockIpamInvoker) {
+				// Set up both InfraNIC and BackendNIC
+				mockCNS.SetEndpointStateWithIPInfo(containerID, podName, podNamespace, map[string]*restserver.IPInfo{
+					"eth0": acnnetwork.CreateMockIPInfo(cns.InfraNIC, "10.240.0.5/24", "", "", "veth-infra", ""),
+					"ib1":  acnnetwork.CreateMockIPInfo(cns.BackendNIC, "", "", "", "", ""),
+				})
+				// Only InfraNIC IP should be released
+				mockIpam.ipMap["10.240.0.5/24"] = true
+			},
+			validateAfter: func(t *testing.T, mockIpam *MockIpamInvoker, mockCNS *acnnetwork.MockCNSEndpointClient) {
+				// Verify InfraNIC IP was released from IPAM
+				_, exists := mockIpam.ipMap["10.240.0.5/24"]
+				require.False(t, exists, "InfraNIC IP should be released from IPAM")
+				// Verify BackendNIC was processed (no IP to release, but endpoint should be deleted)
+				// Verify CNS GetEndpointState was called
+				require.Contains(t, mockCNS.GetEndpointStateCalls, containerID, "GetEndpointState should be called for containerID")
+			},
+			wantErr:     false,
+			description: "Both endpoints deleted, only InfraNIC IP released",
+		},
+		{
+			name: "Delete two FrontendNICs - no IP released",
+			setupState: func(mockCNS *acnnetwork.MockCNSEndpointClient, _ *MockIpamInvoker) {
+				// Set up two FrontendNICs (standalone SwiftV2)
+				mockCNS.SetEndpointStateWithIPInfo(containerID, podName, podNamespace, map[string]*restserver.IPInfo{
+					"eth1": acnnetwork.CreateMockIPInfo(cns.NodeNetworkInterfaceFrontendNIC, "20.20.20.20/32", "", "", "", "aa:bb:cc:dd:ee:f1"),
+					"eth2": acnnetwork.CreateMockIPInfo(cns.NodeNetworkInterfaceFrontendNIC, "20.20.20.21/32", "", "", "", "aa:bb:cc:dd:ee:f2"),
+				})
+				// Delegated IPs not released - ipMap stays empty
+			},
+			validateAfter: func(t *testing.T, mockIpam *MockIpamInvoker, mockCNS *acnnetwork.MockCNSEndpointClient) {
+				// Verify ipMap is unchanged (delegated NICs don't release IPs via IPAM)
+				require.Empty(t, mockIpam.ipMap, "FrontendNICs should not trigger IPAM release")
+				// Verify CNS GetEndpointState was called to retrieve endpoint state
+				require.Contains(t, mockCNS.GetEndpointStateCalls, containerID, "GetEndpointState should be called for containerID")
+			},
+			wantErr:     false,
+			description: "Both FrontendNIC endpoints deleted, no IPs released (delegated)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create fresh plugin and mocks for each test
+			plugin, mockNM := GetStatelessTestResources(t)
+			mockIpam := NewMockIpamInvoker(false, false, false, false, false)
+			plugin.ipamInvoker = mockIpam
+
+			// Set up endpoint state
+			tt.setupState(mockNM.MockCNSClient, mockIpam)
+
+			cmdArgs := createTestCmdArgs(nwCfgStateless, containerID, podName, podNamespace)
+			err := plugin.Delete(cmdArgs)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// Validate side effects (IPAM state and CNS state)
+			if tt.validateAfter != nil {
+				tt.validateAfter(t, mockIpam, mockNM.MockCNSClient)
+			}
+		})
+	}
+}
+
+// TestStatelessCNI_Delete_DualStack tests DELETE with IPv4+IPv6 addresses
+// This verifies that the Delete path handles endpoints with multiple IPs
+func TestStatelessCNI_Delete_DualStack(t *testing.T) {
+	nwCfgStateless := createStatelessTestConfig()
+	containerID := "dualstack-container"
+	podName := "dualstack-pod"
+	podNamespace := testNamespace
+
+	// Create fresh plugin and mocks
+	plugin, mockNM := GetStatelessTestResources(t)
+	mockIpam := NewMockIpamInvoker(false, false, false, false, false)
+	plugin.ipamInvoker = mockIpam
+
+	// Use CreateMockIPInfo helper which handles IP/mask formats correctly
+	ipInfo := acnnetwork.CreateMockIPInfo(cns.InfraNIC, "10.240.0.5/24", "", "", "veth-host", "")
+	// Add IPv6 address
+	_, ipv6Net, _ := net.ParseCIDR("fc00::5/128")
+	ipv6Net.IP = net.ParseIP("fc00::5")
+	ipInfo.IPv6 = []net.IPNet{*ipv6Net}
+
+	mockNM.MockCNSClient.SetEndpointStateWithIPInfo(containerID, podName, podNamespace, map[string]*restserver.IPInfo{
+		"eth0": ipInfo,
+	})
+
+	// Pre-populate ipam invoker with both IPs so Delete validates them
+	mockIpam.ipMap["10.240.0.5/24"] = true
+	mockIpam.ipMap["fc00::5/128"] = true
+
+	cmdArgs := createTestCmdArgs(nwCfgStateless, containerID, podName, podNamespace)
+
+	// Verify Delete succeeds with dual-stack endpoint
+	err := plugin.Delete(cmdArgs)
+	require.NoError(t, err)
+
+	// Verify both IPv4 and IPv6 addresses were released
+	_, v4Exists := mockIpam.ipMap["10.240.0.5/24"]
+	require.False(t, v4Exists, "IPv4 address should be released from IPAM")
+	_, v6Exists := mockIpam.ipMap["fc00::5/128"]
+	require.False(t, v6Exists, "IPv6 address should be released from IPAM")
+}
+
+// TestStatelessCNI_Delete_IpamDeleteFails tests DELETE when ipamInvoker.Delete fails
+func TestStatelessCNI_Delete_IpamDeleteFails(t *testing.T) {
+	nwCfgStateless := createStatelessTestConfig()
+	containerID := "ipam-fail-container"
+	podName := "ipam-fail-pod"
+	podNamespace := testNamespace
+
+	// Create fresh plugin and mocks
+	plugin, mockNM := GetStatelessTestResources(t)
+	mockIpam := NewMockIpamInvoker(false, true, false, false, false) // v4Fail=true to trigger delete failure
+	plugin.ipamInvoker = mockIpam
+
+	// Set up InfraNIC endpoint in CNS
+	mockNM.MockCNSClient.SetEndpointStateWithIPInfo(containerID, podName, podNamespace, map[string]*restserver.IPInfo{
+		"eth0": acnnetwork.CreateMockIPInfo(cns.InfraNIC, "10.240.0.5/24", "", "", "veth-host", ""),
+	})
+	// DO NOT add to ipMap to trigger delete failure
+
+	cmdArgs := createTestCmdArgs(nwCfgStateless, containerID, podName, podNamespace)
+	err := plugin.Delete(cmdArgs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to release address")
+}

--- a/network/cns_client_interface.go
+++ b/network/cns_client_interface.go
@@ -1,0 +1,27 @@
+// Copyright 2017 Microsoft. All rights reserved.
+// MIT License
+
+package network
+
+import (
+	"context"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/restserver"
+)
+
+// CNSClient defines the interface for CNS client operations used by networkManager
+// in stateless CNI mode. This interface allows for dependency injection and unit testing.
+//
+// The concrete implementation is *cnsclient.Client which makes HTTP calls to CNS.
+// For testing, use MockCNSEndpointClient which implements this interface.
+type CNSClient interface {
+	// GetEndpoint retrieves endpoint state from CNS
+	GetEndpoint(ctx context.Context, endpointID string) (*restserver.GetEndpointResponse, error)
+
+	// UpdateEndpoint updates endpoint state in CNS with HNS/veth information
+	UpdateEndpoint(ctx context.Context, endpointID string, ifnameToIPInfoMap map[string]*restserver.IPInfo) (*cns.Response, error)
+
+	// DeleteEndpointState removes endpoint state from CNS
+	DeleteEndpointState(ctx context.Context, endpointID string) (*cns.Response, error)
+}

--- a/network/manager.go
+++ b/network/manager.go
@@ -77,7 +77,7 @@ type EndpointClient interface {
 // NetworkManager manages the set of container networking resources.
 type networkManager struct {
 	statelessCniMode   bool
-	CnsClient          *cnsclient.Client
+	CnsClient          CNSClient // Interface for CNS client operations (injectable for testing)
 	Version            string
 	TimeStamp          time.Time
 	ExternalInterfaces map[string]*externalInterface
@@ -455,7 +455,6 @@ func validateUpdateEndpointState(endpointID string, ifNameToIPInfoMap map[string
 }
 
 // GetEndpointState will make a call to CNS GetEndpointState API in the stateless CNI mode to fetch the endpointInfo
-// TODO unit tests need to be added, WorkItem: 26606939
 // In stateless cni, container id is the endpoint id, so you can pass in either
 func (nm *networkManager) GetEndpointState(networkID, containerID, netns string) ([]*EndpointInfo, error) {
 	endpointResponse, err := nm.CnsClient.GetEndpoint(context.TODO(), containerID)

--- a/network/manager_mock.go
+++ b/network/manager_mock.go
@@ -11,6 +11,9 @@ type MockNetworkManager struct {
 	TestEndpointInfoMap map[string]*EndpointInfo
 	TestEndpointClient  *MockEndpointClient
 	SaveStateMap        map[string]*endpoint
+	// Stateless CNI mode support
+	StatelessCNIMode bool
+	MockCNSClient    *MockCNSEndpointClient
 }
 
 // NewMockNetworkmanager returns a new mock
@@ -72,14 +75,29 @@ func (nm *MockNetworkManager) DeleteEndpoint(_, endpointID string, _ *EndpointIn
 	return nil
 }
 
-// SetStatelessCNIMode enable the statelessCNI falg and inititlizes a CNSClient
+// SetStatelessCNIMode enables the statelessCNI flag.
+// Note: MockCNSClient is optional. If you need CNS-format testing or call tracking,
+// set nm.MockCNSClient = NewMockCNSEndpointClient() after calling this.
+// For simpler test scenarios, use SetEndpointState() to directly populate TestEndpointInfoMap.
 func (nm *MockNetworkManager) SetStatelessCNIMode() error {
+	nm.StatelessCNIMode = true
+	// MockCNSClient is now optional - tests can use TestEndpointInfoMap directly
+	// via SetEndpointState() for simpler scenarios
 	return nil
+}
+
+// SetEndpointState is a helper to directly set endpoint state for testing.
+// This is the simpler alternative to using MockCNSEndpointClient.
+// Use this when you don't need CNS format conversion testing or call tracking.
+func (nm *MockNetworkManager) SetEndpointState(_ string, epInfos []*EndpointInfo) {
+	for _, ep := range epInfos {
+		nm.TestEndpointInfoMap[ep.EndpointID] = ep
+	}
 }
 
 // IsStatelessCNIMode checks if the Stateless CNI mode has been enabled or not
 func (nm *MockNetworkManager) IsStatelessCNIMode() bool {
-	return false
+	return nm.StatelessCNIMode
 }
 
 // GetEndpointID returns the ContainerID value
@@ -208,8 +226,14 @@ func (nm *MockNetworkManager) GetEndpointInfosFromContainerID(containerID string
 	return ret
 }
 
-func (nm *MockNetworkManager) GetEndpointState(_, _, _ string) ([]*EndpointInfo, error) {
-	return []*EndpointInfo{}, nil
+func (nm *MockNetworkManager) GetEndpointState(_, containerID, netns string) ([]*EndpointInfo, error) {
+	// GetEndpointState is only called in stateless CNI mode.
+	// The third argument represents netns and is not used for filtering.
+	if nm.MockCNSClient != nil {
+		return nm.MockCNSClient.GetEndpointState(containerID, netns)
+	}
+	// When no CNS client is configured, return all mock endpoint infos for the container ID.
+	return nm.GetEndpointInfosFromContainerID(containerID), nil
 }
 
 // GetEndpointIDByNicType returns a unique endpoint ID based on the CNI mode and NIC type.

--- a/network/mock_cns_endpoint_client.go
+++ b/network/mock_cns_endpoint_client.go
@@ -1,0 +1,256 @@
+// Copyright 2017 Microsoft. All rights reserved.
+// MIT License
+
+package network
+
+import (
+	"context"
+	"errors"
+	"net"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/restserver"
+	"github.com/Azure/azure-container-networking/cns/types"
+)
+
+// Compile-time check that MockCNSEndpointClient implements CNSClient interface
+var _ CNSClient = (*MockCNSEndpointClient)(nil)
+
+// MockCNSEndpointClient is a mock implementation of the CNSClient interface for testing.
+// It can be injected into networkManager.CnsClient to unit test GetEndpointState, DeleteState, etc.
+//
+// USAGE IN TESTS:
+//
+// For testing real networkManager methods (GetEndpointState, DeleteState, UpdateEndpointState):
+//
+//	mockCNS := NewMockCNSEndpointClient()
+//	mockCNS.SetEndpointStateWithIPInfo("container123", "pod", "ns", map[string]*restserver.IPInfo{
+//	    "eth0": CreateMockIPInfo(cns.InfraNIC, "10.0.0.5/24", "", "", "veth-host", ""),
+//	})
+//	nm := &networkManager{
+//	    statelessCniMode: true,
+//	    CnsClient:        mockCNS,  // Inject mock
+//	}
+//	epInfos, err := nm.GetEndpointState("", "container123", "netns")
+//
+// FEATURES:
+//   - Method call tracking (GetEndpointCalls, DeleteEndpointStateCalls, etc.)
+//   - Error injection (GetEndpointErr, DeleteEndpointStateErr)
+//   - State storage in CNS format (restserver.IPInfo with NICType, IPv4, etc.)
+//   - Uses real cnsEndpointInfotoCNIEpInfos for format conversion testing
+type MockCNSEndpointClient struct {
+	// EndpointState stores the mock endpoint state, keyed by containerID
+	EndpointState map[string]*restserver.EndpointInfo
+
+	// Error injection fields
+	GetEndpointErr         error
+	GetEndpointReturnCode  types.ResponseCode
+	UpdateEndpointErr      error
+	DeleteEndpointStateErr error
+
+	// Track method calls for verification
+	GetEndpointCalls         []string
+	GetEndpointStateCalls    []string
+	UpdateEndpointCalls      []UpdateEndpointCall
+	DeleteEndpointStateCalls []string
+}
+
+// UpdateEndpointCall stores the arguments passed to UpdateEndpoint
+type UpdateEndpointCall struct {
+	EndpointID string
+	IPInfo     map[string]*restserver.IPInfo
+}
+
+// NewMockCNSEndpointClient creates a new MockCNSEndpointClient with empty state
+func NewMockCNSEndpointClient() *MockCNSEndpointClient {
+	return &MockCNSEndpointClient{
+		EndpointState:            make(map[string]*restserver.EndpointInfo),
+		GetEndpointCalls:         []string{},
+		GetEndpointStateCalls:    []string{},
+		UpdateEndpointCalls:      []UpdateEndpointCall{},
+		DeleteEndpointStateCalls: []string{},
+	}
+}
+
+// GetEndpoint retrieves the endpoint state from the mock store
+func (m *MockCNSEndpointClient) GetEndpoint(_ context.Context, containerID string) (*restserver.GetEndpointResponse, error) {
+	m.GetEndpointCalls = append(m.GetEndpointCalls, containerID)
+
+	// Return error if configured
+	if m.GetEndpointErr != nil {
+		returnCode := m.GetEndpointReturnCode
+		// If ReturnCode wasn't explicitly set (defaults to 0/Success), infer from error type
+		// to match production behavior where errors always have appropriate return codes.
+		if returnCode == types.Success {
+			returnCode = m.inferReturnCodeFromError(m.GetEndpointErr)
+		}
+		return &restserver.GetEndpointResponse{
+			Response: restserver.Response{
+				ReturnCode: returnCode,
+				Message:    m.GetEndpointErr.Error(),
+			},
+		}, m.GetEndpointErr
+	}
+
+	// Check if endpoint exists in mock state
+	endpointInfo, exists := m.EndpointState[containerID]
+	if !exists {
+		return &restserver.GetEndpointResponse{
+			Response: restserver.Response{
+				ReturnCode: types.NotFound,
+				Message:    "endpoint not found",
+			},
+		}, ErrEndpointStateNotFound
+	}
+
+	return &restserver.GetEndpointResponse{
+		Response: restserver.Response{
+			ReturnCode: types.Success,
+			Message:    "success",
+		},
+		EndpointInfo: *endpointInfo,
+	}, nil
+}
+
+// UpdateEndpoint updates the endpoint state in the mock store
+func (m *MockCNSEndpointClient) UpdateEndpoint(_ context.Context, endpointID string, ipInfo map[string]*restserver.IPInfo) (*cns.Response, error) {
+	m.UpdateEndpointCalls = append(m.UpdateEndpointCalls, UpdateEndpointCall{
+		EndpointID: endpointID,
+		IPInfo:     ipInfo,
+	})
+
+	// Return error if configured
+	if m.UpdateEndpointErr != nil {
+		return nil, m.UpdateEndpointErr
+	}
+
+	// Create or update endpoint state
+	if _, exists := m.EndpointState[endpointID]; !exists {
+		m.EndpointState[endpointID] = &restserver.EndpointInfo{
+			IfnameToIPMap: make(map[string]*restserver.IPInfo),
+		}
+	}
+
+	// Merge IPInfo into existing state
+	for ifName, info := range ipInfo {
+		m.EndpointState[endpointID].IfnameToIPMap[ifName] = info
+	}
+
+	return &cns.Response{
+		ReturnCode: types.Success,
+		Message:    "success",
+	}, nil
+}
+
+// DeleteEndpointState deletes the endpoint state from the mock store
+func (m *MockCNSEndpointClient) DeleteEndpointState(_ context.Context, endpointID string) (*cns.Response, error) {
+	m.DeleteEndpointStateCalls = append(m.DeleteEndpointStateCalls, endpointID)
+
+	// Return error if configured
+	if m.DeleteEndpointStateErr != nil {
+		return nil, m.DeleteEndpointStateErr
+	}
+
+	// Delete endpoint state
+	delete(m.EndpointState, endpointID)
+
+	return &cns.Response{
+		ReturnCode: types.Success,
+		Message:    "success",
+	}, nil
+}
+
+// inferReturnCodeFromError maps common errors to their appropriate ReturnCode values
+// to match production behavior where errors always have specific return codes.
+func (m *MockCNSEndpointClient) inferReturnCodeFromError(err error) types.ResponseCode {
+	if err == nil {
+		return types.Success
+	}
+	switch {
+	case errors.Is(err, ErrEndpointStateNotFound):
+		return types.NotFound
+	case errors.Is(err, ErrConnectionFailure):
+		return types.ConnectionError
+	default:
+		// For unknown errors, use a generic failure code
+		return types.UnexpectedError
+	}
+}
+
+// SetNotFoundError configures the mock to return a NotFound error with the appropriate ReturnCode.
+// This helper ensures tests match production behavior where GetEndpoint returns types.NotFound
+// when an endpoint doesn't exist.
+func (m *MockCNSEndpointClient) SetNotFoundError() {
+	m.GetEndpointErr = ErrEndpointStateNotFound
+	m.GetEndpointReturnCode = types.NotFound
+}
+
+// SetConnectionError configures the mock to return a ConnectionError with the appropriate ReturnCode.
+// This helper ensures tests match production behavior where GetEndpoint returns types.ConnectionError
+// when CNS connectivity fails.
+func (m *MockCNSEndpointClient) SetConnectionError() {
+	m.GetEndpointErr = ErrConnectionFailure
+	m.GetEndpointReturnCode = types.ConnectionError
+}
+
+// SetEndpointState is a helper to set up mock endpoint state for testing
+func (m *MockCNSEndpointClient) SetEndpointState(containerID string, endpointInfo *restserver.EndpointInfo) {
+	m.EndpointState[containerID] = endpointInfo
+}
+
+// SetEndpointStateWithIPInfo is a helper to set up mock endpoint state with specific IP info
+func (m *MockCNSEndpointClient) SetEndpointStateWithIPInfo(containerID, podName, podNamespace string, ifnameToIPMap map[string]*restserver.IPInfo) {
+	m.EndpointState[containerID] = &restserver.EndpointInfo{
+		PodName:       podName,
+		PodNamespace:  podNamespace,
+		IfnameToIPMap: ifnameToIPMap,
+	}
+}
+
+// CreateMockIPInfo is a helper to create IPInfo for testing
+func CreateMockIPInfo(nicType cns.NICType, ipv4, hnsEndpointID, hnsNetworkID, hostVethName, macAddress string) *restserver.IPInfo {
+	ipInfo := &restserver.IPInfo{
+		NICType:       nicType,
+		HnsEndpointID: hnsEndpointID,
+		HnsNetworkID:  hnsNetworkID,
+		HostVethName:  hostVethName,
+		MacAddress:    macAddress,
+	}
+
+	if ipv4 != "" {
+		ip, ipNet, _ := net.ParseCIDR(ipv4)
+		if ipNet != nil {
+			// Use the original IP with the network mask (not the network address)
+			ipNet.IP = ip
+			ipInfo.IPv4 = []net.IPNet{*ipNet}
+		}
+	}
+
+	return ipInfo
+}
+
+// GetEndpointState returns the endpoint state in EndpointInfo format for MockNetworkManager.
+// This uses the production cnsEndpointInfotoCNIEpInfos function to ensure consistent behavior
+// with production code, including legacy/unmigrated case handling where IfnameToIPMap key is "".
+// Matches the production networkManager.GetEndpointState behavior - returns ErrEndpointStateNotFound when not found.
+func (m *MockCNSEndpointClient) GetEndpointState(containerID, netns string) ([]*EndpointInfo, error) {
+	// Track method calls for verification
+	m.GetEndpointStateCalls = append(m.GetEndpointStateCalls, containerID)
+
+	// Return error if configured
+	if m.GetEndpointErr != nil {
+		return nil, m.GetEndpointErr
+	}
+
+	// Check if endpoint state exists for this containerID
+	// Production behavior: returns ErrEndpointStateNotFound when endpoint is not in state
+	epInfo, exists := m.EndpointState[containerID]
+	if !exists || epInfo == nil {
+		return []*EndpointInfo{}, ErrEndpointStateNotFound
+	}
+
+	// Use the production conversion function to ensure consistent behavior with production code.
+	// This handles legacy cases (empty ifName mapped to InfraInterfaceName with NICType=InfraNIC)
+	// and populates all fields that production does (IfIndex, NetworkContainerID, etc.)
+	return cnsEndpointInfotoCNIEpInfos(*epInfo, containerID, netns), nil
+}

--- a/network/stateless_cni_linux_test.go
+++ b/network/stateless_cni_linux_test.go
@@ -1,0 +1,389 @@
+//go:build linux
+// +build linux
+
+package network
+
+import (
+	"net"
+	"testing"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/restserver"
+	"github.com/Azure/azure-container-networking/netio"
+	"github.com/Azure/azure-container-networking/netlink"
+	"github.com/Azure/azure-container-networking/platform"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStatelessCNI_Delete_Linux_TransparentMode tests DELETE flow on Linux in transparent mode
+func TestStatelessCNI_Delete_Linux_TransparentMode(t *testing.T) {
+	// Create mock netlink - this will be used by DeleteEndpointStateless
+	mockNetlink := netlink.NewMockNetlink(false, "")
+
+	// Track if DeleteLink was called (for veth deletion)
+	var deletedLinks []string
+	mockNetlink.DeleteLinkFn = func(name string) error {
+		deletedLinks = append(deletedLinks, name)
+		return nil
+	}
+
+	// Create network manager with mock netlink
+	nm := &networkManager{
+		ExternalInterfaces: map[string]*externalInterface{},
+		netlink:            mockNetlink,
+		plClient:           platform.NewMockExecClient(false),
+		netio:              &netio.MockNetIO{},
+	}
+
+	// Set up endpoint info for transparent mode on Linux
+	containerID := "test-stateless-container-linux"
+	epInfo := &EndpointInfo{
+		EndpointID:   containerID,
+		ContainerID:  containerID,
+		Data:         make(map[string]interface{}),
+		IfName:       "eth0",
+		NICType:      cns.InfraNIC,
+		HostIfName:   "veth-host-1", // Linux uses HostVethName
+		HNSNetworkID: "",            // No HNS on Linux
+		MacAddress:   net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
+		IPAddresses: []net.IPNet{
+			{IP: net.ParseIP("10.0.0.10"), Mask: net.CIDRMask(24, 32)},
+		},
+	}
+
+	// Execute DeleteEndpointStateless
+	err := nm.DeleteEndpointStateless("azure-test-network", epInfo, opModeTransparent)
+	require.NoError(t, err)
+
+	// TransparentEndpointClient.DeleteEndpoints() intentionally does not delete the veth -
+	// the CRI removes the network namespace which automatically cleans up the veth pair.
+	// Verify no links were deleted by the endpoint client.
+	require.Empty(t, deletedLinks, "TransparentEndpointClient should not delete links directly (CRI handles cleanup)")
+}
+
+// Tests for stateless CNI DELETE operations on Linux using MockNetlink and MockNamespaceClient.
+
+// TestStatelessCNI_Delete_Linux_FrontendNIC tests DELETE for SwiftV2 FrontendNIC on Linux
+func TestStatelessCNI_Delete_Linux_FrontendNIC(t *testing.T) {
+	mockNetlink := netlink.NewMockNetlink(false, "")
+
+	nm := &networkManager{
+		ExternalInterfaces: map[string]*externalInterface{},
+		netlink:            mockNetlink,
+		plClient:           platform.NewMockExecClient(false),
+		netio:              &netio.MockNetIO{},
+		nsClient:           NewMockNamespaceClient(),
+	}
+
+	// Set up endpoint info for SwiftV2 FrontendNIC
+	containerID := "swiftv2-frontend-container"
+	epInfo := &EndpointInfo{
+		EndpointID:   containerID + "-eth1",
+		ContainerID:  containerID,
+		Data:         make(map[string]interface{}),
+		IfName:       "eth1",
+		NICType:      cns.NodeNetworkInterfaceFrontendNIC,
+		HostIfName:   "veth-frontend",
+		NetNsPath:    "/var/run/netns/test-ns", // MockNamespaceClient will handle this
+		HNSNetworkID: "",
+		MacAddress:   net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+		IPAddresses: []net.IPNet{
+			{IP: net.ParseIP("10.1.0.10"), Mask: net.CIDRMask(24, 32)},
+		},
+	}
+
+	// Execute DeleteEndpointStateless
+	// SecondaryEndpointClient is created internally and handles the FrontendNIC
+	err := nm.DeleteEndpointStateless("azure-frontend-network", epInfo, opModeTransparent)
+	require.NoError(t, err)
+}
+
+// TestStatelessCNI_Delete_Linux_BackendNIC tests that BackendNIC is skipped on Linux
+func TestStatelessCNI_Delete_Linux_BackendNIC(t *testing.T) {
+	mockNetlink := netlink.NewMockNetlink(false, "")
+
+	nm := &networkManager{
+		ExternalInterfaces: map[string]*externalInterface{},
+		netlink:            mockNetlink,
+		plClient:           platform.NewMockExecClient(false),
+		netio:              &netio.MockNetIO{},
+	}
+
+	containerID := "backend-nic-container-linux"
+	epInfo := &EndpointInfo{
+		EndpointID:  containerID + "-eth2",
+		ContainerID: containerID,
+		Data:        make(map[string]interface{}),
+		IfName:      "eth2",
+		NICType:     cns.BackendNIC,
+		HostIfName:  "veth-backend",
+		MacAddress:  net.HardwareAddr{0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00},
+	}
+
+	// Delete endpoint - BackendNIC should be skipped (same as Windows)
+	err := nm.DeleteEndpointStateless("azure-backend-network", epInfo, opModeTransparent)
+	require.NoError(t, err)
+
+	// BackendNIC endpoint deletion is intentionally skipped in deleteEndpointImpl
+	// (see endpoint_linux.go - "endpoint deletion is not required for IB")
+}
+
+// TestStatelessCNI_Delete_Linux_NetlinkErrorIgnored verifies that netlink errors during
+// FrontendNIC deletion are intentionally swallowed (deleteEndpointImpl ignores DeleteEndpoints errors).
+// This ensures cleanup continues even when network namespace operations fail.
+func TestStatelessCNI_Delete_Linux_NetlinkErrorIgnored(t *testing.T) {
+	// Create mock netlink that returns errors - this will fail SetLinkNetNs
+	mockNetlink := netlink.NewMockNetlink(true, "simulated netlink failure")
+
+	nm := &networkManager{
+		ExternalInterfaces: map[string]*externalInterface{},
+		netlink:            mockNetlink,
+		plClient:           platform.NewMockExecClient(false),
+		netio:              &netio.MockNetIO{},
+		nsClient:           NewMockNamespaceClient(), // Required for SecondaryEndpointClient
+	}
+
+	containerID := "error-test-container"
+	epInfo := &EndpointInfo{
+		EndpointID:  containerID + "-eth1",
+		ContainerID: containerID,
+		Data:        make(map[string]interface{}),
+		IfName:      "eth1",
+		NICType:     cns.NodeNetworkInterfaceFrontendNIC, // FrontendNIC uses SecondaryEndpointClient which calls netlink
+		HostIfName:  "veth-error",
+		NetNsPath:   "/var/run/netns/test-ns", // Required for namespace operations
+		MacAddress:  net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
+	}
+
+	// Execute - even though netlink.SetLinkNetNs fails, deleteEndpointImpl intentionally
+	// ignores errors from epClient.DeleteEndpoints (see //nolint:errcheck comment in endpoint_linux.go)
+	// This is by design: cleanup should continue even if namespace operations fail
+	err := nm.DeleteEndpointStateless("azure-error-network", epInfo, opModeTransparent)
+	require.NoError(t, err)
+}
+
+// =============================================================================
+// Tests for REAL networkManager using CNSClient interface
+// =============================================================================
+
+// TestNetworkManager_GetEndpointState tests the real networkManager.GetEndpointState
+// using the CNSClient interface with MockCNSEndpointClient injected.
+func TestNetworkManager_GetEndpointState(t *testing.T) {
+	tests := []struct {
+		name             string
+		containerID      string
+		setupMock        func(*MockCNSEndpointClient)
+		expectedCount    int
+		expectedErr      error
+		expectedNICTypes []cns.NICType
+	}{
+		{
+			name:        "Success - InfraNIC endpoint",
+			containerID: "infra-container",
+			setupMock: func(mockCNS *MockCNSEndpointClient) {
+				mockCNS.SetEndpointStateWithIPInfo("infra-container", "test-pod", "test-ns", map[string]*restserver.IPInfo{
+					"eth0": CreateMockIPInfo(cns.InfraNIC, "10.0.0.5/24", "", "", "veth-host", ""),
+				})
+			},
+			expectedCount:    1,
+			expectedErr:      nil,
+			expectedNICTypes: []cns.NICType{cns.InfraNIC},
+		},
+		{
+			name:        "Success - MultiNIC (InfraNIC + FrontendNIC)",
+			containerID: "multi-nic-container",
+			setupMock: func(mockCNS *MockCNSEndpointClient) {
+				mockCNS.SetEndpointStateWithIPInfo("multi-nic-container", "test-pod", "test-ns", map[string]*restserver.IPInfo{
+					"eth0": CreateMockIPInfo(cns.InfraNIC, "10.0.0.5/24", "", "", "veth-infra", ""),
+					"eth1": CreateMockIPInfo(cns.NodeNetworkInterfaceFrontendNIC, "20.20.20.20/32", "", "", "", "aa:bb:cc:dd:ee:ff"),
+				})
+			},
+			expectedCount:    2,
+			expectedErr:      nil,
+			expectedNICTypes: []cns.NICType{cns.InfraNIC, cns.NodeNetworkInterfaceFrontendNIC},
+		},
+		{
+			name:        "Endpoint not found",
+			containerID: "nonexistent-container",
+			setupMock: func(_ *MockCNSEndpointClient) {
+				// Don't set up any state - endpoint will not be found
+			},
+			expectedCount: 0,
+			expectedErr:   ErrEndpointStateNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock CNS client
+			mockCNS := NewMockCNSEndpointClient()
+			tt.setupMock(mockCNS)
+
+			// Create REAL networkManager with mock CNS client injected
+			nm := &networkManager{
+				statelessCniMode: true,
+				CnsClient:        mockCNS, // Inject mock via CNSClient interface
+			}
+
+			// Call GetEndpointState on the REAL networkManager
+			epInfos, err := nm.GetEndpointState("", tt.containerID, "test-netns")
+
+			// Verify error
+			if tt.expectedErr != nil {
+				require.ErrorIs(t, err, tt.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// Verify endpoint count
+			require.Len(t, epInfos, tt.expectedCount)
+
+			// Verify NIC types if we have endpoints
+			if tt.expectedCount > 0 {
+				foundNICTypes := make(map[cns.NICType]bool)
+				for _, ep := range epInfos {
+					foundNICTypes[ep.NICType] = true
+				}
+				for _, expectedType := range tt.expectedNICTypes {
+					require.True(t, foundNICTypes[expectedType], "Expected NIC type %v not found", expectedType)
+				}
+			}
+
+			// Verify GetEndpoint was called on the mock
+			require.Contains(t, mockCNS.GetEndpointCalls, tt.containerID)
+		})
+	}
+}
+
+// TestNetworkManager_DeleteState tests the real networkManager.DeleteState
+// using the CNSClient interface with MockCNSEndpointClient injected.
+func TestNetworkManager_DeleteState(t *testing.T) {
+	tests := []struct {
+		name          string
+		epInfos       []*EndpointInfo
+		setupMock     func(*MockCNSEndpointClient)
+		validateAfter func(*testing.T, *MockCNSEndpointClient)
+		expectErr     bool
+	}{
+		{
+			name: "With InfraNIC - state already deleted by IPAM (no CNS call)",
+			epInfos: []*EndpointInfo{
+				{EndpointID: "infra-ep", NICType: cns.InfraNIC},
+				{EndpointID: "frontend-ep", NICType: cns.NodeNetworkInterfaceFrontendNIC},
+			},
+			setupMock: func(_ *MockCNSEndpointClient) {
+				// State doesn't matter - when InfraNIC is present, DeleteState returns early
+			},
+			validateAfter: func(t *testing.T, mockCNS *MockCNSEndpointClient) {
+				// When InfraNIC is present, DeleteState returns early without calling CNS
+				// because IPAM invoker already deleted the state
+				require.Empty(t, mockCNS.DeleteEndpointStateCalls, "DeleteEndpointState should not be called when InfraNIC present")
+			},
+			expectErr: false,
+		},
+		{
+			name: "FrontendNIC only - calls DeleteEndpointState",
+			epInfos: []*EndpointInfo{
+				{EndpointID: "frontend-ep", NICType: cns.NodeNetworkInterfaceFrontendNIC},
+			},
+			setupMock: func(mockCNS *MockCNSEndpointClient) {
+				mockCNS.EndpointState["frontend-ep"] = &restserver.EndpointInfo{}
+			},
+			validateAfter: func(t *testing.T, mockCNS *MockCNSEndpointClient) {
+				// Without InfraNIC, DeleteState should call DeleteEndpointState on CNS
+				require.Contains(t, mockCNS.DeleteEndpointStateCalls, "frontend-ep",
+					"DeleteEndpointState should be called for standalone FrontendNIC")
+			},
+			expectErr: false,
+		},
+		{
+			name: "AccelnetFrontendNIC - calls DeleteEndpointState",
+			epInfos: []*EndpointInfo{
+				{EndpointID: "accelnet-ep", NICType: cns.NodeNetworkInterfaceAccelnetFrontendNIC},
+			},
+			setupMock: func(mockCNS *MockCNSEndpointClient) {
+				mockCNS.EndpointState["accelnet-ep"] = &restserver.EndpointInfo{}
+			},
+			validateAfter: func(t *testing.T, mockCNS *MockCNSEndpointClient) {
+				require.Contains(t, mockCNS.DeleteEndpointStateCalls, "accelnet-ep",
+					"DeleteEndpointState should be called for AccelnetFrontendNIC")
+			},
+			expectErr: false,
+		},
+		{
+			name: "BackendNIC only - no CNS call (not FrontendNIC type)",
+			epInfos: []*EndpointInfo{
+				{EndpointID: "backend-ep", NICType: cns.BackendNIC},
+			},
+			setupMock: func(_ *MockCNSEndpointClient) {},
+			validateAfter: func(t *testing.T, mockCNS *MockCNSEndpointClient) {
+				// BackendNIC doesn't trigger DeleteEndpointState (only FrontendNIC types do)
+				require.Empty(t, mockCNS.DeleteEndpointStateCalls)
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCNS := NewMockCNSEndpointClient()
+			tt.setupMock(mockCNS)
+
+			// Create REAL networkManager with mock CNS client injected
+			nm := &networkManager{
+				statelessCniMode: true,
+				CnsClient:        mockCNS, // Inject mock via CNSClient interface
+			}
+
+			// Call DeleteState on the REAL networkManager
+			err := nm.DeleteState(tt.epInfos)
+
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			tt.validateAfter(t, mockCNS)
+		})
+	}
+}
+
+// TestNetworkManager_UpdateEndpointState tests the real networkManager.UpdateEndpointState
+// (called via SaveState) using the CNSClient interface.
+func TestNetworkManager_UpdateEndpointState(t *testing.T) {
+	mockCNS := NewMockCNSEndpointClient()
+
+	nm := &networkManager{
+		statelessCniMode: true,
+		CnsClient:        mockCNS,
+	}
+
+	// Create test endpoints
+	eps := []*endpoint{
+		{
+			ContainerID:        "test-container",
+			IfName:             "eth0",
+			NICType:            cns.InfraNIC,
+			HnsId:              "hns-endpoint-123",
+			HNSNetworkID:       "hns-network-456",
+			HostIfName:         "veth-host",
+			MacAddress:         net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
+			NetworkContainerID: "nc-789",
+		},
+	}
+
+	// Call SaveState which internally calls UpdateEndpointState
+	err := nm.SaveState(eps)
+	require.NoError(t, err)
+
+	// Verify UpdateEndpoint was called with correct data
+	require.Len(t, mockCNS.UpdateEndpointCalls, 1)
+	require.Equal(t, "test-container", mockCNS.UpdateEndpointCalls[0].EndpointID)
+	require.Contains(t, mockCNS.UpdateEndpointCalls[0].IPInfo, "eth0")
+
+	ipInfo := mockCNS.UpdateEndpointCalls[0].IPInfo["eth0"]
+	require.Equal(t, cns.InfraNIC, ipInfo.NICType)
+	require.Equal(t, "hns-endpoint-123", ipInfo.HnsEndpointID)
+	require.Equal(t, "veth-host", ipInfo.HostVethName)
+}

--- a/network/stateless_cni_windows_test.go
+++ b/network/stateless_cni_windows_test.go
@@ -1,0 +1,280 @@
+// Copyright 2017 Microsoft. All rights reserved.
+// MIT License
+
+//go:build windows
+// +build windows
+
+package network
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/network/hnswrapper"
+	"github.com/Microsoft/hcsshim/hcn"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStatelessCNI_Delete_Windows_WithHNSEndpointID tests DELETE flow on Windows
+// where HNS endpoint ID is retrieved from CNS endpoint state
+func TestStatelessCNI_Delete_Windows_WithHNSEndpointID(t *testing.T) {
+	// Save and restore original Hnsv2 to avoid test pollution
+	originalHnsv2 := Hnsv2
+	defer func() { Hnsv2 = originalHnsv2 }()
+
+	// Set up mock HNS wrapper
+	hnsFake := hnswrapper.NewHnsv2wrapperFake()
+	Hnsv2 = hnswrapper.Hnsv2wrapperwithtimeout{
+		Hnsv2:          hnsFake,
+		HnsCallTimeout: 5 * time.Second,
+	}
+
+	// Create HNS network
+	hnsNetworkID := "test-hns-network-stateless"
+	hnsNetwork := &hcn.HostComputeNetwork{
+		Id:   hnsNetworkID,
+		Name: "azure-stateless",
+	}
+	_, err := Hnsv2.CreateNetwork(hnsNetwork)
+	require.NoError(t, err)
+
+	// Create HNS endpoint
+	hnsEndpointID := "test-hns-endpoint-stateless"
+	hnsEndpoint := &hcn.HostComputeEndpoint{
+		Id:                 hnsEndpointID,
+		Name:               hnsEndpointID,
+		HostComputeNetwork: hnsNetworkID,
+		MacAddress:         "00:11:22:33:44:55",
+	}
+	_, err = Hnsv2.CreateEndpoint(hnsEndpoint)
+	require.NoError(t, err)
+
+	// Verify endpoint was created
+	endpoints := hnsFake.Cache.GetEndpoints()
+	require.Len(t, endpoints, 1, "HNS endpoint should be created")
+
+	// Create network manager in stateless mode
+	containerID := "test-stateless-container-windows"
+	nm := &networkManager{
+		ExternalInterfaces: map[string]*externalInterface{},
+	}
+
+	// Create endpoint info with HNS IDs (in production, this comes from CNS endpoint state)
+	epInfo := &EndpointInfo{
+		EndpointID:    containerID,
+		ContainerID:   containerID,
+		Data:          make(map[string]interface{}),
+		IfName:        "eth0",
+		NICType:       cns.InfraNIC,
+		HNSEndpointID: hnsEndpointID,
+		HNSNetworkID:  hnsNetworkID,
+		MacAddress:    net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
+	}
+
+	// Execute DeleteEndpointStateless - should delete the HNS endpoint
+	err = nm.DeleteEndpointStateless(hnsNetworkID, epInfo, "")
+	require.NoError(t, err)
+
+	// Verify HNS endpoint was deleted
+	endpoints = hnsFake.Cache.GetEndpoints()
+	require.Empty(t, endpoints, "HNS endpoint should be deleted")
+}
+
+// TestStatelessCNI_Delete_Windows_SwiftV2_MultipleNICs tests DELETE for SwiftV2 Windows with multiple NICs.
+// In SwiftV2 Windows: each NIC has its own SEPARATE endpoint entry in CNS keyed by EndpointID.
+// - InfraNIC: keyed by containerID
+// - FrontendNIC: keyed by containerID-ifName (e.g., "containerID-eth1")
+// Uses HNS IDs (no veth names on Windows).
+func TestStatelessCNI_Delete_Windows_SwiftV2_MultipleNICs(t *testing.T) {
+	// Save and restore original Hnsv2 to avoid test pollution
+	originalHnsv2 := Hnsv2
+	defer func() { Hnsv2 = originalHnsv2 }()
+
+	hnsFake := hnswrapper.NewHnsv2wrapperFake()
+	Hnsv2 = hnswrapper.Hnsv2wrapperwithtimeout{
+		Hnsv2:          hnsFake,
+		HnsCallTimeout: 5 * time.Second,
+	}
+
+	// Create network for InfraNIC
+	infraNetworkID := "azure-infra-net"
+	_, err := Hnsv2.CreateNetwork(&hcn.HostComputeNetwork{
+		Id:   infraNetworkID,
+		Name: "azure-infra",
+	})
+	require.NoError(t, err)
+
+	// Create network for FrontendNIC (SwiftV2)
+	frontendNetworkID := "azure-frontend-net"
+	_, err = Hnsv2.CreateNetwork(&hcn.HostComputeNetwork{
+		Id:   frontendNetworkID,
+		Name: "azure-frontend",
+		Type: hcn.Transparent,
+	})
+	require.NoError(t, err)
+
+	// Create InfraNIC endpoint
+	infraEndpointID := "infra-endpoint-123"
+	_, err = Hnsv2.CreateEndpoint(&hcn.HostComputeEndpoint{
+		Id:                 infraEndpointID,
+		Name:               infraEndpointID,
+		HostComputeNetwork: infraNetworkID,
+	})
+	require.NoError(t, err)
+
+	// Create FrontendNIC endpoint (SwiftV2)
+	frontendEndpointID := "frontend-endpoint-456"
+	_, err = Hnsv2.CreateEndpoint(&hcn.HostComputeEndpoint{
+		Id:                 frontendEndpointID,
+		Name:               frontendEndpointID,
+		HostComputeNetwork: frontendNetworkID,
+		MacAddress:         "aa:bb:cc:dd:ee:ff",
+	})
+	require.NoError(t, err)
+
+	// Verify both endpoints created
+	require.Len(t, hnsFake.Cache.GetEndpoints(), 2)
+
+	containerID := "multi-nic-container-windows"
+	frontendEntryID := containerID + "-eth1"
+
+	nm := &networkManager{
+		ExternalInterfaces: map[string]*externalInterface{},
+	}
+
+	// Delete FrontendNIC endpoint first (in production, epInfo comes from CNS endpoint state)
+	frontendEpInfo := &EndpointInfo{
+		EndpointID:    frontendEntryID, // containerID-eth1
+		ContainerID:   containerID,
+		Data:          make(map[string]interface{}),
+		IfName:        "eth1",
+		NICType:       cns.NodeNetworkInterfaceFrontendNIC,
+		HNSEndpointID: frontendEndpointID,
+		HNSNetworkID:  frontendNetworkID,
+		MacAddress:    net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+	}
+	err = nm.DeleteEndpointStateless(frontendNetworkID, frontendEpInfo, "")
+	require.NoError(t, err)
+
+	// Verify frontend endpoint deleted, infra endpoint still exists
+	endpoints := hnsFake.Cache.GetEndpoints()
+	require.Len(t, endpoints, 1, "Should have 1 endpoint remaining (InfraNIC)")
+
+	// Delete InfraNIC endpoint
+	infraEpInfo := &EndpointInfo{
+		EndpointID:    containerID, // InfraNIC uses containerID as EndpointID
+		ContainerID:   containerID,
+		Data:          make(map[string]interface{}),
+		IfName:        "eth0",
+		NICType:       cns.InfraNIC,
+		HNSEndpointID: infraEndpointID,
+		HNSNetworkID:  infraNetworkID,
+		MacAddress:    net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
+	}
+	err = nm.DeleteEndpointStateless(infraNetworkID, infraEpInfo, "")
+	require.NoError(t, err)
+
+	// Verify all endpoints deleted
+	endpoints = hnsFake.Cache.GetEndpoints()
+	require.Empty(t, endpoints, "All HNS endpoints should be deleted")
+}
+
+// TestStatelessCNI_Delete_Windows_HNSNotFound tests DELETE when HNS endpoint doesn't exist
+func TestStatelessCNI_Delete_Windows_HNSNotFound(t *testing.T) {
+	// Save and restore original Hnsv2 to avoid test pollution
+	originalHnsv2 := Hnsv2
+	defer func() { Hnsv2 = originalHnsv2 }()
+
+	hnsFake := hnswrapper.NewHnsv2wrapperFake()
+	Hnsv2 = hnswrapper.Hnsv2wrapperwithtimeout{
+		Hnsv2:          hnsFake,
+		HnsCallTimeout: 5 * time.Second,
+	}
+
+	// Create network but NOT the endpoint
+	hnsNetworkID := "test-network-no-endpoint"
+	_, err := Hnsv2.CreateNetwork(&hcn.HostComputeNetwork{
+		Id:   hnsNetworkID,
+		Name: "azure-no-ep",
+	})
+	require.NoError(t, err)
+
+	nm := &networkManager{
+		ExternalInterfaces: map[string]*externalInterface{},
+	}
+
+	// CNS has endpoint state but HNS endpoint doesn't exist
+	epInfo := &EndpointInfo{
+		EndpointID:    "container-no-hns",
+		ContainerID:   "container-no-hns",
+		Data:          make(map[string]interface{}),
+		IfName:        "eth0",
+		NICType:       cns.InfraNIC,
+		HNSEndpointID: "non-existent-hns-endpoint",
+		HNSNetworkID:  hnsNetworkID,
+	}
+
+	// Should not error - DELETE should be idempotent
+	err = nm.DeleteEndpointStateless(hnsNetworkID, epInfo, "")
+	require.NoError(t, err)
+}
+
+// TestStatelessCNI_Delete_Windows_BackendNIC tests DELETE for backend NIC type
+func TestStatelessCNI_Delete_Windows_BackendNIC(t *testing.T) {
+	// Save and restore original Hnsv2 to avoid test pollution
+	originalHnsv2 := Hnsv2
+	defer func() { Hnsv2 = originalHnsv2 }()
+
+	hnsFake := hnswrapper.NewHnsv2wrapperFake()
+	Hnsv2 = hnswrapper.Hnsv2wrapperwithtimeout{
+		Hnsv2:          hnsFake,
+		HnsCallTimeout: 5 * time.Second,
+	}
+
+	// Create backend network
+	backendNetworkID := "backend-network-123"
+	_, err := Hnsv2.CreateNetwork(&hcn.HostComputeNetwork{
+		Id:   backendNetworkID,
+		Name: "azure-backend",
+		Type: hcn.Transparent,
+	})
+	require.NoError(t, err)
+
+	// Create backend endpoint
+	backendEndpointID := "backend-endpoint-789"
+	_, err = Hnsv2.CreateEndpoint(&hcn.HostComputeEndpoint{
+		Id:                 backendEndpointID,
+		Name:               backendEndpointID,
+		HostComputeNetwork: backendNetworkID,
+		MacAddress:         "bb:cc:dd:ee:ff:00",
+	})
+	require.NoError(t, err)
+
+	nm := &networkManager{
+		ExternalInterfaces: map[string]*externalInterface{},
+	}
+
+	// Set up endpoint info for backend NIC
+	containerID := "backend-nic-container"
+	epInfo := &EndpointInfo{
+		EndpointID:    containerID + "-eth1",
+		ContainerID:   containerID,
+		Data:          make(map[string]interface{}),
+		IfName:        "eth1",
+		NICType:       cns.BackendNIC,
+		HNSEndpointID: backendEndpointID,
+		HNSNetworkID:  backendNetworkID,
+		MacAddress:    net.HardwareAddr{0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00},
+	}
+
+	// Delete endpoint - BackendNIC deletion is intentionally skipped (see endpoint_windows.go)
+	// "endpoint deletion is not required for IB"
+	err = nm.DeleteEndpointStateless(backendNetworkID, epInfo, "")
+	require.NoError(t, err)
+
+	// Verify endpoint is NOT deleted - BackendNIC endpoints are skipped
+	endpoints := hnsFake.Cache.GetEndpoints()
+	require.Len(t, endpoints, 1, "BackendNIC endpoint should NOT be deleted")
+}


### PR DESCRIPTION
**Reason for Change**:
Add unit test coverage for stateless CNI operations across CNI plugin (common, Linux, Windows), improving test coverage for the endpoint state management flow used in SwiftV2 and overlay scenarios.

## New: CNSClient Interface for Testability

Added `CNSClient` interface to enable proper unit testing of real `networkManager` methods without requiring HTTP connections:

**File**: `network/cns_client_interface.go` (NEW)
- Defines interface with `GetEndpoint`, `UpdateEndpoint`, `DeleteEndpointState` methods
- `MockCNSEndpointClient` implements this interface
- `networkManager.CnsClient` changed from concrete `*cnsclient.Client` to `CNSClient` interface

## CNI Common Tests

**File**: `cni/network/stateless_cni_test.go`

| Test Function | Description |
|---------------|-------------|
| `TestStatelessCNI_Delete_CNSGetEndpointError` | Error handling when CNS endpoint lookup fails |
| `TestStatelessCNI_Delete_HappyPath` | InfraNIC, FrontendNIC, BackendNIC deletion scenarios |
| `TestStatelessCNI_Delete_MultiNIC` | Multi-NIC combinations (SwiftV2) with CNS state validation |
| `TestStatelessCNI_Delete_DualStack` | IPv4+IPv6 IP release |
| `TestStatelessCNI_Delete_IpamDeleteFails` | IPAM error handling during delete |

## CNI Linux Tests

**File**: `network/stateless_cni_linux_test.go`

| Test Function | Description |
|---------------|-------------|
| `TestStatelessCNI_Delete_Linux_TransparentMode` | Delete endpoint in transparent mode (CRI handles veth cleanup) |
| `TestStatelessCNI_Delete_Linux_FrontendNIC` | Delete FrontendNIC using SecondaryEndpointClient |
| `TestStatelessCNI_Delete_Linux_BackendNIC` | BackendNIC deletion intentionally skipped |
| `TestStatelessCNI_Delete_Linux_NetlinkErrorIgnored` | Netlink errors swallowed during cleanup |
| `TestNetworkManager_GetEndpointState` | **REAL** networkManager.GetEndpointState with mock CNS injected |
| `TestNetworkManager_DeleteState` | **REAL** networkManager.DeleteState conditional logic |
| `TestNetworkManager_UpdateEndpointState` | **REAL** networkManager.SaveState → UpdateEndpoint flow |

## CNI Windows Tests

**File**: `network/stateless_cni_windows_test.go`

| Test Function | Description |
|---------------|-------------|
| `TestStatelessCNI_Delete_Windows_WithHNSEndpointID` | Delete endpoint using HNS endpoint ID |
| `TestStatelessCNI_Delete_Windows_SwiftV2_MultipleNICs` | SwiftV2 multi-NIC deletion on Windows |
| `TestStatelessCNI_Delete_Windows_HNSNotFound` | DELETE idempotent when HNS endpoint missing |
| `TestStatelessCNI_Delete_Windows_BackendNIC` | BackendNIC deletion intentionally skipped |



## Verification

```bash
# Run CNI common tests
go test -v -run 'TestStatelessCNI' ./cni/network/

# Run CNI Linux tests (includes real networkManager tests)
go test -v -run 'TestStatelessCNI|TestNetworkManager' ./network/
