### PR TITLE
fix: enhance logging in CNS (isNCWaitingforUpdate)

### DIFF
--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -454,7 +454,7 @@ func (service *HTTPRestService) getAllNetworkContainerResponses(
 				waitingForUpdate, getNetworkContainerResponse.Response.ReturnCode, getNetworkContainerResponse.Response.Message = service.isNCWaitingForUpdate(service.state.ContainerStatus[ncid].CreateNetworkContainerRequest.Version, ncid, nmaNCs) //nolint:lll // bad code
 				// If the return code is not success, return the error to the caller
 				if getNetworkContainerResponse.Response.ReturnCode == types.NetworkContainerVfpProgramPending {
-					logger.Errorf("[Azure-CNS] isNCWaitingForUpdate failed for NCID: %s", ncid)
+					logger.Errorf("[Azure-CNS] isNCWaitingForUpdate failed for NCID: %s Message: %s", ncid, getNetworkContainerResponse.Response.Message)
 				}
 
 				vfpUpdateComplete := !waitingForUpdate


### PR DESCRIPTION
**Reason for Change**:
This pull request makes a minor improvement to the error logging in the `getAllNetworkContainerResponses` function. The log message now includes the error message returned by `isNCWaitingForUpdate`, making it easier to diagnose issues related to network container updates.

**Issue Fixed**:
- Enhances logging in CNS by logging the message

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

