### PR TITLE
feat(CNS/CNI): Add connection string support for application insights inside CNI and CNS packages

### DIFF
--- a/aitelemetry/connection_string_parser.go
+++ b/aitelemetry/connection_string_parser.go
@@ -39,6 +39,7 @@ func parseConnectionString(connectionString string) (*connectionVars, error) {
 			connectionVars.instrumentationKey = value
 		case "ingestionendpoint":
 			if value != "" {
+				// Ensure trailing slash so the ingestion URL path joins cleanly
 				if !strings.HasSuffix(value, "/") {
 					value += "/"
 				}

--- a/aitelemetry/connection_string_parser.go
+++ b/aitelemetry/connection_string_parser.go
@@ -39,6 +39,9 @@ func parseConnectionString(connectionString string) (*connectionVars, error) {
 			connectionVars.instrumentationKey = value
 		case "ingestionendpoint":
 			if value != "" {
+				if !strings.HasSuffix(value, "/") {
+					value += "/"
+				}
 				connectionVars.ingestionURL = value + "v2.1/track"
 			}
 		}

--- a/aitelemetry/connection_string_parser_test.go
+++ b/aitelemetry/connection_string_parser_test.go
@@ -48,6 +48,15 @@ func TestParseConnectionString(t *testing.T) {
 			want:             nil,
 			wantErr:          true,
 		},
+		{
+			name:             "Valid connection string without trailing slash on ingestion endpoint",
+			connectionString: "InstrumentationKey=0000-0000-0000-0000-0000;IngestionEndpoint=https://ingestion.endpoint.com",
+			want: &connectionVars{
+				instrumentationKey: "0000-0000-0000-0000-0000",
+				ingestionURL:       "https://ingestion.endpoint.com/v2.1/track",
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/cni/telemetry/service/telemetrymain.go
+++ b/cni/telemetry/service/telemetrymain.go
@@ -167,10 +167,8 @@ func main() {
 		GetEnvRetryWaitTimeInSecs:    config.GetEnvRetryWaitTimeInSecs,
 	}
 
-	// If sovereign cloud is enabled, use connection string for the telemetry handle
-	if config.EnableAIInSovereignCloud {
+	if config.AIConnectionString != "" {
 		telemetry.SetAIConnectionString(config.AIConnectionString)
-		telemetry.SetEnableAIInSovereignCloud(true)
 	}
 
 	if err := tb.CreateAITelemetryHandle(aiConfig, config.DisableAll, config.DisableTrace, config.DisableMetric); err != nil { // nolint

--- a/cni/telemetry/service/telemetrymain.go
+++ b/cni/telemetry/service/telemetrymain.go
@@ -167,6 +167,13 @@ func main() {
 		GetEnvRetryWaitTimeInSecs:    config.GetEnvRetryWaitTimeInSecs,
 	}
 
+	// Use the connection string path only when sovereign cloud is enabled AND a
+	// connection string is provided; otherwise fall back to the legacy iKey path.
+	if config.EnableAIInSovereignCloud && config.AIConnectionString != "" {
+		telemetry.SetAIConnectionString(config.AIConnectionString)
+		telemetry.SetEnableAIInSovereignCloud(true)
+	}
+
 	if err := tb.CreateAITelemetryHandle(aiConfig, config.DisableAll, config.DisableTrace, config.DisableMetric); err != nil { // nolint
 		logger.Error("AI Handle creation error:", zap.Error(err))
 	}

--- a/cni/telemetry/service/telemetrymain.go
+++ b/cni/telemetry/service/telemetrymain.go
@@ -167,9 +167,8 @@ func main() {
 		GetEnvRetryWaitTimeInSecs:    config.GetEnvRetryWaitTimeInSecs,
 	}
 
-	// Use the connection string path only when sovereign cloud is enabled AND a
-	// connection string is provided; otherwise fall back to the legacy iKey path.
-	if config.EnableAIInSovereignCloud && config.AIConnectionString != "" {
+	// If sovereign cloud is enabled, use connection string for the telemetry handle
+	if config.EnableAIInSovereignCloud {
 		telemetry.SetAIConnectionString(config.AIConnectionString)
 		telemetry.SetEnableAIInSovereignCloud(true)
 	}

--- a/cns/cni-telemetry-sidecar/sidecar.go
+++ b/cns/cni-telemetry-sidecar/sidecar.go
@@ -105,6 +105,14 @@ func (s *TelemetrySidecar) startTelemetryService(ctx context.Context, config tel
 		}
 	}
 
+	// Set connection string only if sovereign cloud is enabled
+	if cnsConfig.TelemetrySettings.EnableAIInSovereignCloud {
+		if connStr := cnsConfig.TelemetrySettings.AppInsightsConnectionString; connStr != "" {
+			telemetry.SetAIConnectionString(connStr)
+		}
+		telemetry.SetEnableAIInSovereignCloud(true)
+	}
+
 	// Clean up any orphan socket
 	err := telemetry.NewTelemetryBuffer(s.logger).Cleanup(telemetry.FdName)
 	if err != nil {
@@ -142,7 +150,7 @@ func (s *TelemetrySidecar) startTelemetryService(ctx context.Context, config tel
 		time.Sleep(200 * time.Millisecond)
 	}
 
-	if telemetry.GetAIMetadata() != "" {
+	if telemetry.GetAIMetadata() != "" || telemetry.GetAIConnectionString() != "" {
 		aiConfig := aitelemetry.AIConfig{
 			AppName:                      pluginName,
 			AppVersion:                   s.version,
@@ -159,8 +167,7 @@ func (s *TelemetrySidecar) startTelemetryService(ctx context.Context, config tel
 		}
 	}
 
-	s.logger.Info("Telemetry service started",
-		zap.Bool("appInsightsEnabled", telemetry.GetAIMetadata() != ""))
+	s.logger.Info("Telemetry service started", zap.Bool("appInsightsEnabled", telemetry.GetAIMetadata() != "" || telemetry.GetAIConnectionString() != ""))
 
 	go s.telemetryBuffer.PushData(ctx)
 	return nil

--- a/cns/cni-telemetry-sidecar/sidecar.go
+++ b/cns/cni-telemetry-sidecar/sidecar.go
@@ -105,12 +105,9 @@ func (s *TelemetrySidecar) startTelemetryService(ctx context.Context, config tel
 		}
 	}
 
-	// Set connection string only if sovereign cloud is enabled
-	if cnsConfig.TelemetrySettings.EnableAIInSovereignCloud {
-		if connStr := cnsConfig.TelemetrySettings.AppInsightsConnectionString; connStr != "" {
-			telemetry.SetAIConnectionString(connStr)
-		}
-		telemetry.SetEnableAIInSovereignCloud(true)
+	// Set AI connection string from config if provided
+	if connStr := cnsConfig.TelemetrySettings.AppInsightsConnectionString; connStr != "" {
+		telemetry.SetAIConnectionString(connStr)
 	}
 
 	// Clean up any orphan socket

--- a/cns/configuration/cns_config.json
+++ b/cns/configuration/cns_config.json
@@ -7,7 +7,9 @@
         "SnapshotIntervalInMins": 60,
         "ConfigSnapshotIntervalInMins": 60,
         "TelemetryBatchIntervalInSecs": 15,
-        "TelemetryBatchSizeBytes": 16384
+        "TelemetryBatchSizeBytes": 16384,
+        "AppInsightsConnectionString": "",
+        "EnableAIInSovereignCloud": false
     },
     "ManagedSettings": {
         "InfrastructureNetworkID": "",

--- a/cns/configuration/cns_config.json
+++ b/cns/configuration/cns_config.json
@@ -8,8 +8,7 @@
         "ConfigSnapshotIntervalInMins": 60,
         "TelemetryBatchIntervalInSecs": 15,
         "TelemetryBatchSizeBytes": 16384,
-        "AppInsightsConnectionString": "",
-        "EnableAIInSovereignCloud": false
+        "AppInsightsConnectionString": ""
     },
     "ManagedSettings": {
         "InfrastructureNetworkID": "",

--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -93,6 +93,10 @@ type TelemetrySettings struct {
 	ConfigSnapshotIntervalInMins int
 	// AppInsightsInstrumentationKey allows the user to override the default appinsights ikey
 	AppInsightsInstrumentationKey string
+	// Connection string for the AI resource
+	AppInsightsConnectionString string
+	// Enable AI telemetry in sovereign clouds
+	EnableAIInSovereignCloud bool
 }
 
 type ManagedSettings struct {

--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -91,12 +91,11 @@ type TelemetrySettings struct {
 	SnapshotIntervalInMins int
 	// Interval for sending config snapshot events.
 	ConfigSnapshotIntervalInMins int
-	// AppInsightsInstrumentationKey allows the user to override the default appinsights ikey
+	// AppInsightsInstrumentationKey allows the user to override the default appinsights ikey.
+	// Used only when AppInsightsConnectionString is empty.
 	AppInsightsInstrumentationKey string
-	// Connection string for the AI resource
+	// AppInsightsConnectionString is the connection string for the app insights resource.
 	AppInsightsConnectionString string
-	// Enable AI telemetry in sovereign clouds
-	EnableAIInSovereignCloud bool
 }
 
 type ManagedSettings struct {

--- a/cns/configuration/configuration_test.go
+++ b/cns/configuration/configuration_test.go
@@ -84,6 +84,8 @@ func TestReadConfigFromFile(t *testing.T) {
 					ConfigSnapshotIntervalInMins: 60,
 					TelemetryBatchIntervalInSecs: 15,
 					TelemetryBatchSizeBytes:      16384,
+					AppInsightsConnectionString:  "",
+					EnableAIInSovereignCloud:     false,
 				},
 				AZRSettings: AZRSettings{
 					PopulateHomeAzCacheRetryIntervalSecs: 60,

--- a/cns/configuration/configuration_test.go
+++ b/cns/configuration/configuration_test.go
@@ -85,7 +85,6 @@ func TestReadConfigFromFile(t *testing.T) {
 					TelemetryBatchIntervalInSecs: 15,
 					TelemetryBatchSizeBytes:      16384,
 					AppInsightsConnectionString:  "",
-					EnableAIInSovereignCloud:     false,
 				},
 				AZRSettings: AZRSettings{
 					PopulateHomeAzCacheRetryIntervalSecs: 60,

--- a/cns/configuration/testdata/good.json
+++ b/cns/configuration/testdata/good.json
@@ -29,7 +29,9 @@
         "SnapshotIntervalInMins": 60,
         "ConfigSnapshotIntervalInMins": 60,
         "TelemetryBatchIntervalInSecs": 15,
-        "TelemetryBatchSizeBytes": 16384
+        "TelemetryBatchSizeBytes": 16384,
+        "AppInsightsConnectionString": "",
+        "EnableAIInSovereignCloud": false
     },
     "UseHTTPS": true,
     "UseMTLS": true,

--- a/cns/configuration/testdata/good.json
+++ b/cns/configuration/testdata/good.json
@@ -30,8 +30,7 @@
         "ConfigSnapshotIntervalInMins": 60,
         "TelemetryBatchIntervalInSecs": 15,
         "TelemetryBatchSizeBytes": 16384,
-        "AppInsightsConnectionString": "",
-        "EnableAIInSovereignCloud": false
+        "AppInsightsConnectionString": ""
     },
     "UseHTTPS": true,
     "UseMTLS": true,

--- a/cns/logger/cnslogger.go
+++ b/cns/logger/cnslogger.go
@@ -71,6 +71,19 @@ func (c *logger) InitAIWithIKey(aiConfig ai.AIConfig, instrumentationKey string,
 	c.disableEventLogging = disableEventLogging
 }
 
+func (c *logger) InitAIWithConnectionString(aiConfig ai.AIConfig, connectionString string, disableTraceLogging, disableMetricLogging, disableEventLogging bool) {
+	th, err := ai.NewWithConnectionString(connectionString, aiConfig)
+	if err != nil {
+		c.logger.Errorf("Error initializing AI Telemetry with connection string:%v", err)
+		return
+	}
+	c.th = th
+	c.logger.Printf("AI Telemetry Handle created with connection string")
+	c.disableMetricLogging = disableMetricLogging
+	c.disableTraceLogging = disableTraceLogging
+	c.disableEventLogging = disableEventLogging
+}
+
 func (c *logger) Close() {
 	c.logger.Close()
 	if c.th != nil {

--- a/cns/logger/log.go
+++ b/cns/logger/log.go
@@ -10,6 +10,7 @@ type loggershim interface {
 	Close()
 	InitAI(aitelemetry.AIConfig, bool, bool, bool)
 	InitAIWithIKey(aitelemetry.AIConfig, string, bool, bool, bool)
+	InitAIWithConnectionString(aitelemetry.AIConfig, string, bool, bool, bool)
 	SetContextDetails(string, string)
 	SetAPIServer(string)
 	Printf(string, ...any)
@@ -26,7 +27,7 @@ type loggershim interface {
 var (
 	Log             loggershim
 	AppInsightsIKey = aiMetadata
-	aiMetadata      string // this var is set at build time.
+	aiMetadata      string // set at build time via ldflags
 )
 
 // Deprecated: The global logger is deprecated. Migrate to zap using the cns/logger/v2 package and pass the logger instead.
@@ -47,6 +48,11 @@ func InitAI(aiConfig aitelemetry.AIConfig, disableTraceLogging, disableMetricLog
 // Deprecated: The global logger is deprecated. Migrate to zap using the cns/logger/v2 package and pass the logger instead.
 func InitAIWithIKey(aiConfig aitelemetry.AIConfig, instrumentationKey string, disableTraceLogging, disableMetricLogging, disableEventLogging bool) {
 	Log.InitAIWithIKey(aiConfig, instrumentationKey, disableTraceLogging, disableMetricLogging, disableEventLogging)
+}
+
+// Deprecated: The global logger is deprecated. Migrate to zap using the cns/logger/v2 package and pass the logger instead.
+func InitAIWithConnectionString(aiConfig aitelemetry.AIConfig, connectionString string, disableTraceLogging, disableMetricLogging, disableEventLogging bool) {
+	Log.InitAIWithConnectionString(aiConfig, connectionString, disableTraceLogging, disableMetricLogging, disableEventLogging)
 }
 
 // Deprecated: The global logger is deprecated. Migrate to zap using the cns/logger/v2 package and pass the logger instead.

--- a/cns/logger/log.go
+++ b/cns/logger/log.go
@@ -27,7 +27,7 @@ type loggershim interface {
 var (
 	Log             loggershim
 	AppInsightsIKey = aiMetadata
-	aiMetadata      string // set at build time via ldflags
+	aiMetadata      string // this var is set at build time.
 )
 
 // Deprecated: The global logger is deprecated. Migrate to zap using the cns/logger/v2 package and pass the logger instead.

--- a/cns/logger/v2/shim.go
+++ b/cns/logger/v2/shim.go
@@ -51,6 +51,8 @@ func (*shim) InitAI(aitelemetry.AIConfig, bool, bool, bool) {}
 
 func (*shim) InitAIWithIKey(aitelemetry.AIConfig, string, bool, bool, bool) {}
 
+func (*shim) InitAIWithConnectionString(aitelemetry.AIConfig, string, bool, bool, bool) {}
+
 func (s *shim) SetContextDetails(string, string) {}
 
 func (s *shim) SetAPIServer(string) {}

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -585,8 +585,9 @@ func main() {
 			//nolint:staticcheck // SA1019 ignore deprecated global logger
 			logger.InitAIWithConnectionString(aiConfig, ts.AppInsightsConnectionString, ts.DisableTrace, ts.DisableMetric, ts.DisableEvent)
 		case aiInstrumentationKey:
+			//nolint:staticcheck // SA1019 ignore deprecated global logger
 			logger.InitAIWithIKey(aiConfig, ts.AppInsightsInstrumentationKey, ts.DisableTrace, ts.DisableMetric, ts.DisableEvent)
-		default:
+		case aiDefault:
 			logger.InitAI(aiConfig, ts.DisableTrace, ts.DisableMetric, ts.DisableEvent)
 		}
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -580,13 +580,13 @@ func main() {
 			DebugMode:                    ts.DebugMode,
 		}
 
-		// Use connection string only if sovereign cloud is enabled
-		if ts.EnableAIInSovereignCloud && cnsconfig.TelemetrySettings.AppInsightsConnectionString != "" {
+		switch selectAIMode(ts) {
+		case aiConnectionString:
 			//nolint:staticcheck // SA1019 ignore deprecated global logger
-			logger.InitAIWithConnectionString(aiConfig, cnsconfig.TelemetrySettings.AppInsightsConnectionString, ts.DisableTrace, ts.DisableMetric, ts.DisableEvent)
-		} else if aiKey := cnsconfig.TelemetrySettings.AppInsightsInstrumentationKey; aiKey != "" {
-			logger.InitAIWithIKey(aiConfig, aiKey, ts.DisableTrace, ts.DisableMetric, ts.DisableEvent)
-		} else {
+			logger.InitAIWithConnectionString(aiConfig, ts.AppInsightsConnectionString, ts.DisableTrace, ts.DisableMetric, ts.DisableEvent)
+		case aiInstrumentationKey:
+			logger.InitAIWithIKey(aiConfig, ts.AppInsightsInstrumentationKey, ts.DisableTrace, ts.DisableMetric, ts.DisableEvent)
+		default:
 			logger.InitAI(aiConfig, ts.DisableTrace, ts.DisableMetric, ts.DisableEvent)
 		}
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -580,7 +580,11 @@ func main() {
 			DebugMode:                    ts.DebugMode,
 		}
 
-		if aiKey := cnsconfig.TelemetrySettings.AppInsightsInstrumentationKey; aiKey != "" {
+		// Use connection string only if sovereign cloud is enabled
+		if ts.EnableAIInSovereignCloud && cnsconfig.TelemetrySettings.AppInsightsConnectionString != "" {
+			//nolint:staticcheck // SA1019 ignore deprecated global logger
+			logger.InitAIWithConnectionString(aiConfig, cnsconfig.TelemetrySettings.AppInsightsConnectionString, ts.DisableTrace, ts.DisableMetric, ts.DisableEvent)
+		} else if aiKey := cnsconfig.TelemetrySettings.AppInsightsInstrumentationKey; aiKey != "" {
 			logger.InitAIWithIKey(aiConfig, aiKey, ts.DisableTrace, ts.DisableMetric, ts.DisableEvent)
 		} else {
 			logger.InitAI(aiConfig, ts.DisableTrace, ts.DisableMetric, ts.DisableEvent)

--- a/cns/service/telemetry.go
+++ b/cns/service/telemetry.go
@@ -1,0 +1,32 @@
+// Copyright 2024 Microsoft. All rights reserved.
+// MIT License
+
+package main
+
+import "github.com/Azure/azure-container-networking/cns/configuration"
+
+// aiMode is the AppInsights telemetry init path selected from the config.
+type aiMode int
+
+const (
+	// aiDefault uses the build-time-injected instrumentation key.
+	aiDefault aiMode = iota
+	// aiInstrumentationKey uses the instrumentation key from config.
+	aiInstrumentationKey
+	// aiConnectionString uses the connection string from config.
+	aiConnectionString
+)
+
+// selectAIMode picks the AppInsights init path. Connection string takes
+// precedence over instrumentation key. If neither is set, the build-time
+// default is used.
+func selectAIMode(ts configuration.TelemetrySettings) aiMode {
+	switch {
+	case ts.AppInsightsConnectionString != "":
+		return aiConnectionString
+	case ts.AppInsightsInstrumentationKey != "":
+		return aiInstrumentationKey
+	default:
+		return aiDefault
+	}
+}

--- a/cns/service/telemetry_test.go
+++ b/cns/service/telemetry_test.go
@@ -1,0 +1,54 @@
+// Copyright 2024 Microsoft. All rights reserved.
+// MIT License
+
+package main
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-container-networking/cns/configuration"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectAIMode(t *testing.T) {
+	tests := []struct {
+		name string
+		ts   configuration.TelemetrySettings
+		want aiMode
+	}{
+		{
+			name: "connection string only",
+			ts: configuration.TelemetrySettings{
+				AppInsightsConnectionString: "InstrumentationKey=abc;IngestionEndpoint=https://x/",
+			},
+			want: aiConnectionString,
+		},
+		{
+			name: "instrumentation key only",
+			ts: configuration.TelemetrySettings{
+				AppInsightsInstrumentationKey: "abc",
+			},
+			want: aiInstrumentationKey,
+		},
+		{
+			name: "both are set but connection string is selected",
+			ts: configuration.TelemetrySettings{
+				AppInsightsConnectionString:   "InstrumentationKey=abc;IngestionEndpoint=https://x/",
+				AppInsightsInstrumentationKey: "abc",
+			},
+			want: aiConnectionString,
+		},
+		{
+			name: "neither are set, use build-time default",
+			ts:   configuration.TelemetrySettings{},
+			want: aiDefault,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, selectAIMode(tt.ts))
+		})
+	}
+}

--- a/cns/service/telemetry_test.go
+++ b/cns/service/telemetry_test.go
@@ -46,7 +46,6 @@ func TestSelectAIMode(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.want, selectAIMode(tt.ts))
 		})

--- a/telemetry/aiwrapper.go
+++ b/telemetry/aiwrapper.go
@@ -3,17 +3,20 @@ package telemetry
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/Azure/azure-container-networking/aitelemetry"
 	"github.com/Azure/azure-container-networking/log"
 )
 
 var (
-	aiMetadata           string
-	th                   aitelemetry.TelemetryHandle
-	gDisableTrace        bool
-	gDisableMetric       bool
-	ErrTelemetryDisabled = errors.New("telemetry is disabled")
+	aiMetadata               string
+	connectionString         string
+	enableAIInSovereignCloud bool
+	th                       aitelemetry.TelemetryHandle
+	gDisableTrace            bool
+	gDisableMetric           bool
+	ErrTelemetryDisabled     = errors.New("telemetry is disabled")
 )
 
 const (
@@ -33,9 +36,17 @@ func (tb *TelemetryBuffer) CreateAITelemetryHandle(aiConfig aitelemetry.AIConfig
 		return ErrTelemetryDisabled
 	}
 
-	th, err = aitelemetry.NewAITelemetry("", aiMetadata, aiConfig)
-	if err != nil {
-		return err
+	// Use connection string only if sovereign cloud is enabled
+	if enableAIInSovereignCloud {
+		th, err = aitelemetry.NewWithConnectionString(connectionString, aiConfig)
+		if err != nil {
+			return fmt.Errorf("failed to create telemetry handle with connection string: %w", err)
+		}
+	} else {
+		th, err = aitelemetry.NewAITelemetry("", aiMetadata, aiConfig)
+		if err != nil {
+			return fmt.Errorf("failed to create telemetry handle: %w", err)
+		}
 	}
 
 	gDisableMetric = disableMetric
@@ -95,4 +106,24 @@ func GetAIMetadata() string {
 // SetAIMetadata sets the aiMetadata value (for runtime configuration)
 func SetAIMetadata(metadata string) {
 	aiMetadata = metadata
+}
+
+// GetAIConnectionString returns the current AI connection string value
+func GetAIConnectionString() string {
+	return connectionString
+}
+
+// SetAIConnectionString sets the AI connection string value (for runtime configuration)
+func SetAIConnectionString(connStr string) {
+	connectionString = connStr
+}
+
+// GetEnableAIInSovereignCloud returns the current AI sovereign cloud flag value
+func GetEnableAIInSovereignCloud() bool {
+	return enableAIInSovereignCloud
+}
+
+// SetEnableAIInSovereignCloud sets the AI sovereign cloud flag (for runtime configuration)
+func SetEnableAIInSovereignCloud(isSovereign bool) {
+	enableAIInSovereignCloud = isSovereign
 }

--- a/telemetry/aiwrapper.go
+++ b/telemetry/aiwrapper.go
@@ -10,13 +10,12 @@ import (
 )
 
 var (
-	aiMetadata               string
-	connectionString         string
-	enableAIInSovereignCloud bool
-	th                       aitelemetry.TelemetryHandle
-	gDisableTrace            bool
-	gDisableMetric           bool
-	ErrTelemetryDisabled     = errors.New("telemetry is disabled")
+	aiMetadata           string
+	connectionString     string
+	th                   aitelemetry.TelemetryHandle
+	gDisableTrace        bool
+	gDisableMetric       bool
+	ErrTelemetryDisabled = errors.New("telemetry is disabled")
 )
 
 const (
@@ -36,8 +35,8 @@ func (tb *TelemetryBuffer) CreateAITelemetryHandle(aiConfig aitelemetry.AIConfig
 		return ErrTelemetryDisabled
 	}
 
-	// Use connection string only if sovereign cloud is enabled
-	if enableAIInSovereignCloud {
+	// Use the connection string if configured. Fall back to the instrumentation key otherwise.
+	if connectionString != "" {
 		th, err = aitelemetry.NewWithConnectionString(connectionString, aiConfig)
 		if err != nil {
 			return fmt.Errorf("failed to create telemetry handle with connection string: %w", err)
@@ -116,14 +115,4 @@ func GetAIConnectionString() string {
 // SetAIConnectionString sets the AI connection string value (for runtime configuration)
 func SetAIConnectionString(connStr string) {
 	connectionString = connStr
-}
-
-// GetEnableAIInSovereignCloud returns the current AI sovereign cloud flag value
-func GetEnableAIInSovereignCloud() bool {
-	return enableAIInSovereignCloud
-}
-
-// SetEnableAIInSovereignCloud sets the AI sovereign cloud flag (for runtime configuration)
-func SetEnableAIInSovereignCloud(isSovereign bool) {
-	enableAIInSovereignCloud = isSovereign
 }

--- a/telemetry/aiwrapper_test.go
+++ b/telemetry/aiwrapper_test.go
@@ -12,7 +12,6 @@ func TestCreateAITelemetryHandle(t *testing.T) {
 		name             string
 		aiConfig         aitelemetry.AIConfig
 		connectionString string
-		enableSovereign  bool
 		disableAll       bool
 		disableMetric    bool
 		disableTrace     bool
@@ -27,11 +26,10 @@ func TestCreateAITelemetryHandle(t *testing.T) {
 			wantErr:       true,
 		},
 		{
-			name:             "sovereign cloud enabled with empty connection string returns error",
+			name:             "telemetry handle created with connection string",
 			aiConfig:         aitelemetry.AIConfig{},
-			connectionString: "",
-			enableSovereign:  true,
-			wantErr:          true,
+			connectionString: "InstrumentationKey=abc;IngestionEndpoint=https://x/",
+			wantErr:          false,
 		},
 	}
 
@@ -39,10 +37,8 @@ func TestCreateAITelemetryHandle(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			SetAIConnectionString(tt.connectionString)
-			SetEnableAIInSovereignCloud(tt.enableSovereign)
 			t.Cleanup(func() {
 				SetAIConnectionString("")
-				SetEnableAIInSovereignCloud(false)
 			})
 
 			tb := NewTelemetryBuffer(nil)

--- a/telemetry/aiwrapper_test.go
+++ b/telemetry/aiwrapper_test.go
@@ -9,12 +9,14 @@ import (
 
 func TestCreateAITelemetryHandle(t *testing.T) {
 	tests := []struct {
-		name          string
-		aiConfig      aitelemetry.AIConfig
-		disableAll    bool
-		disableMetric bool
-		disableTrace  bool
-		wantErr       bool
+		name             string
+		aiConfig         aitelemetry.AIConfig
+		connectionString string
+		enableSovereign  bool
+		disableAll       bool
+		disableMetric    bool
+		disableTrace     bool
+		wantErr          bool
 	}{
 		{
 			name:          "disabled telemetry with empty aiconfig",
@@ -24,11 +26,25 @@ func TestCreateAITelemetryHandle(t *testing.T) {
 			disableTrace:  true,
 			wantErr:       true,
 		},
+		{
+			name:             "sovereign cloud enabled with empty connection string returns error",
+			aiConfig:         aitelemetry.AIConfig{},
+			connectionString: "",
+			enableSovereign:  true,
+			wantErr:          true,
+		},
 	}
 
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			SetAIConnectionString(tt.connectionString)
+			SetEnableAIInSovereignCloud(tt.enableSovereign)
+			t.Cleanup(func() {
+				SetAIConnectionString("")
+				SetEnableAIInSovereignCloud(false)
+			})
+
 			tb := NewTelemetryBuffer(nil)
 			err := tb.CreateAITelemetryHandle(tt.aiConfig, tt.disableAll, tt.disableMetric, tt.disableTrace)
 			if tt.wantErr {

--- a/telemetry/azure-vnet-telemetry.config
+++ b/telemetry/azure-vnet-telemetry.config
@@ -4,5 +4,7 @@
     "BatchIntervalInSecs":15,
     "RefreshTimeoutInSecs": 15,
     "DisableAll": false,
-    "DebugMode":false
+    "DebugMode":false,
+    "AIConnectionString": "",
+    "EnableAIInSovereignCloud": false
 }

--- a/telemetry/azure-vnet-telemetry.config
+++ b/telemetry/azure-vnet-telemetry.config
@@ -5,6 +5,5 @@
     "RefreshTimeoutInSecs": 15,
     "DisableAll": false,
     "DebugMode":false,
-    "AIConnectionString": "",
-    "EnableAIInSovereignCloud": false
+    "AIConnectionString": ""
 }

--- a/telemetry/telemetrybuffer.go
+++ b/telemetry/telemetrybuffer.go
@@ -34,6 +34,8 @@ type TelemetryConfig struct {
 	BatchSizeInBytes              int
 	GetEnvRetryCount              int
 	GetEnvRetryWaitTimeInSecs     int
+	AIConnectionString            string `json:"AIConnectionString"`
+	EnableAIInSovereignCloud      bool   `json:"EnableAIInSovereignCloud"`
 }
 
 // FdName - file descriptor name

--- a/telemetry/telemetrybuffer.go
+++ b/telemetry/telemetrybuffer.go
@@ -35,7 +35,6 @@ type TelemetryConfig struct {
 	GetEnvRetryCount              int
 	GetEnvRetryWaitTimeInSecs     int
 	AIConnectionString            string `json:"AIConnectionString"`
-	EnableAIInSovereignCloud      bool   `json:"EnableAIInSovereignCloud"`
 }
 
 // FdName - file descriptor name

--- a/telemetry/telemetrybuffer_test.go
+++ b/telemetry/telemetrybuffer_test.go
@@ -158,6 +158,8 @@ func TestReadConfigFile(t *testing.T) {
 				RefreshTimeoutInSecs:          15,
 				BatchIntervalInSecs:           15,
 				BatchSizeInBytes:              16384,
+				AIConnectionString:            "",
+				EnableAIInSovereignCloud:      false,
 			},
 			wantErr: false,
 		},

--- a/telemetry/telemetrybuffer_test.go
+++ b/telemetry/telemetrybuffer_test.go
@@ -162,19 +162,16 @@ func TestReadConfigFile(t *testing.T) {
 				BatchIntervalInSecs:           15,
 				BatchSizeInBytes:              16384,
 				AIConnectionString:            "",
-				EnableAIInSovereignCloud:      false,
 			},
 			wantErr: false,
 		},
 		{
-			name: "parse non-empty connection string and sovereign flag",
+			name: "parse non-empty connection string",
 			content: `{
-				"AIConnectionString": "InstrumentationKey=abc;IngestionEndpoint=https://x/",
-				"EnableAIInSovereignCloud": true
+				"AIConnectionString": "InstrumentationKey=abc;IngestionEndpoint=https://x/"
 			}`,
 			want: TelemetryConfig{
-				AIConnectionString:       "InstrumentationKey=abc;IngestionEndpoint=https://x/",
-				EnableAIInSovereignCloud: true,
+				AIConnectionString: "InstrumentationKey=abc;IngestionEndpoint=https://x/",
 			},
 			wantErr: false,
 		},

--- a/telemetry/telemetrybuffer_test.go
+++ b/telemetry/telemetrybuffer_test.go
@@ -1,6 +1,8 @@
 package telemetry
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -147,6 +149,7 @@ func TestReadConfigFile(t *testing.T) {
 	tests := []struct {
 		name     string
 		fileName string
+		content  string
 		want     TelemetryConfig
 		wantErr  bool
 	}{
@@ -164,6 +167,18 @@ func TestReadConfigFile(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "parse non-empty connection string and sovereign flag",
+			content: `{
+				"AIConnectionString": "InstrumentationKey=abc;IngestionEndpoint=https://x/",
+				"EnableAIInSovereignCloud": true
+			}`,
+			want: TelemetryConfig{
+				AIConnectionString:       "InstrumentationKey=abc;IngestionEndpoint=https://x/",
+				EnableAIInSovereignCloud: true,
+			},
+			wantErr: false,
+		},
+		{
 			name:     "read non-existing file",
 			fileName: "non-existing-file",
 			want:     TelemetryConfig{},
@@ -174,7 +189,12 @@ func TestReadConfigFile(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ReadConfigFile(tt.fileName)
+			fileName := tt.fileName
+			if tt.content != "" {
+				fileName = filepath.Join(t.TempDir(), "telemetry.config")
+				require.NoError(t, os.WriteFile(fileName, []byte(tt.content), 0o600))
+			}
+			got, err := ReadConfigFile(fileName)
 			if tt.wantErr {
 				require.Error(t, err)
 				return


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Added connection string support for application insights as instrumentation keys are not valid in sovereign clouds due to the fixed ingestion endpoints. The ingestion URL cannot be modified when passing the instrumentation key so the telemetry will fail. This is reprimanded when using connection strings

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] relevant PR labels added

**Notes**:
