### PR TITLE
[NPM] [Vulnerability] Resolve Ubuntu CVEs in v1.6.39 Image

### DIFF
--- a/npm/linux.Dockerfile
+++ b/npm/linux.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.25.7 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.25.8 AS builder
 ARG VERSION
 ARG NPM_AI_PATH
 ARG NPM_AI_ID
@@ -9,16 +9,18 @@ RUN MS_GO_NOSYSTEMCRYPTO=1 CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm
 FROM mcr.microsoft.com/mirror/docker/library/ubuntu:24.04 AS linux
 COPY --from=builder /usr/local/bin/azure-npm /usr/bin/azure-npm
 # Manually patch Ubuntu CVEs:
-# gpgv:      CVE-2025-68973 (HIGH)
-# libc-bin:  CVE-2025-15281, CVE-2026-0861, CVE-2026-0915 (MEDIUM)
-# libc6:     CVE-2025-15281, CVE-2026-0861, CVE-2026-0915 (MEDIUM)
-# libtasn1-6: CVE-2025-13151 (MEDIUM)
+# gpgv:           CVE-2025-68973 (HIGH)
+# libc-bin:       CVE-2025-15281, CVE-2026-0861, CVE-2026-0915 (MEDIUM)
+# libc6:          CVE-2025-15281, CVE-2026-0861, CVE-2026-0915 (MEDIUM)
+# libtasn1-6:     CVE-2025-13151 (MEDIUM)
+# libgnutls30t64: CVE-2025-14831 (MEDIUM), CVE-2025-9820 (LOW)
 RUN apt-get update && apt-get install -y \
     iptables ipset ca-certificates \
     gpgv=2.4.4-2ubuntu17.4 \
     libc-bin=2.39-0ubuntu8.7 \
     libc6=2.39-0ubuntu8.7 \
     libtasn1-6=4.19.0-3ubuntu0.24.04.2 \
+    libgnutls30t64=3.8.3-1.1ubuntu3.5 \
     && apt-get autoremove -y && apt-get clean
 RUN chmod +x /usr/bin/azure-npm
 ENTRYPOINT ["/usr/bin/azure-npm", "start"]


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
Patches `libgnutls30t64` CVEs in Ubuntu and `stdlib` CVEs in GoBinary found in the `v1.6.39` NPM image.

```
mcr.microsoft.com/containernetworking/azure-npm:v1.6.39 (ubuntu 24.04)
======================================================================
Total: 2 (UNKNOWN: 0, LOW: 1, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

┌────────────────┬────────────────┬──────────┬────────┬────────────────────┬────────────────────┬──────────────────────────────────────────────────────────┐
│    Library     │ Vulnerability  │ Severity │ Status │ Installed Version  │   Fixed Version    │                          Title                           │
├────────────────┼────────────────┼──────────┼────────┼────────────────────┼────────────────────┼──────────────────────────────────────────────────────────┤
│ libgnutls30t64 │ CVE-2025-14831 │ MEDIUM   │ fixed  │ 3.8.3-1.1ubuntu3.4 │ 3.8.3-1.1ubuntu3.5 │ gnutls: GnuTLS: Denial of Service via excessive resource │
│                │                │          │        │                    │                    │ consumption during certificate verification...           │
│                │                │          │        │                    │                    │ https://avd.aquasec.com/nvd/cve-2025-14831               │
│                ├────────────────┼──────────┤        │                    │                    ├──────────────────────────────────────────────────────────┤
│                │ CVE-2025-9820  │ LOW      │        │                    │                    │ gnutls: Stack-based Buffer Overflow in                   │
│                │                │          │        │                    │                    │ gnutls_pkcs11_token_init() Function                      │
│                │                │          │        │                    │                    │ https://avd.aquasec.com/nvd/cve-2025-9820                │
└────────────────┴────────────────┴──────────┴────────┴────────────────────┴────────────────────┴──────────────────────────────────────────────────────────┘

usr/bin/azure-npm (gobinary)
============================
Total: 3 (UNKNOWN: 0, LOW: 1, MEDIUM: 2, HIGH: 0, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────┬─────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                            Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼─────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2026-25679 │ MEDIUM   │ fixed  │ v1.25.7           │ 1.25.8, 1.26.1 │ net/url: Incorrect parsing of IPv6 host literals in net/url │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2026-25679                  │
│         ├────────────────┤          │        │                   │                ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2026-27142 │          │        │                   │                │ html/template: URLs in meta content attribute actions are   │
│         │                │          │        │                   │                │ not escaped in html/template...                             │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2026-27142                  │
│         ├────────────────┼──────────┤        │                   │                ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2026-27139 │ LOW      │        │                   │                │ os: FileInfo can escape from a Root in golang os module     │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2026-27139                  │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────┴─────────────────────────────────────────────────────────────┘
```

`Testing:`

Scale: https://msazure.visualstudio.com/One/_build/results?buildId=156683869&view=results
Conformance: https://msazure.visualstudio.com/One/_build/results?buildId=156683858&view=results

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
