### PR TITLE
Add --region parameter to persistent-cluster-metrics calls

### DIFF
--- a/.pipelines/swiftv2-long-running/template/datapath-tests-stage.yaml
+++ b/.pipelines/swiftv2-long-running/template/datapath-tests-stage.yaml
@@ -1,6 +1,8 @@
 parameters:
   - name: workloadType
     type: string
+  - name: location
+    type: string
   - name: subscriptionId
     type: string
   - name: rgName
@@ -19,13 +21,13 @@ parameters:
     default: []
 
 stages:
-  - stage: DataPathTests_${{ replace(parameters.workloadType, '-', '_') }}
-    displayName: "Stage: Swiftv2 Data Path Tests - ${{ parameters.workloadType }}"
+  - stage: DataPathTests_${{ replace(parameters.workloadType, '-', '_') }}_${{ replace(parameters.location, '-', '_') }}
+    displayName: "Stage: Swiftv2 Data Path Tests - ${{ parameters.workloadType }} (${{ parameters.location }})"
     ${{ if ne(length(parameters.dependsOn), 0) }}:
       dependsOn: ${{ parameters.dependsOn }}
     ${{ else }}:
       dependsOn: AKSClusterAndNetworking
-    condition: or(eq(${{ parameters.runSetupStages }}, false), succeeded())
+    condition: and(eq(variables.isAllowedRun, true), or(eq(${{ parameters.runSetupStages }}, false), succeeded()))
     variables:
       storageAccount1: ${{ parameters.storageAccount1 }}
       storageAccount2: ${{ parameters.storageAccount2 }}
@@ -68,7 +70,7 @@ stages:
             displayName: "Publish kubeconfig files"
             inputs:
               targetPath: $(Pipeline.Workspace)/kubeconfigs
-              artifactName: kubeconfigs-${{ parameters.workloadType }}
+              artifactName: kubeconfigs-${{ parameters.workloadType }}-${{ parameters.location }}
               publishLocation: pipeline
 
       - job: BuildMetricsBinary
@@ -89,7 +91,7 @@ stages:
             displayName: "Publish metrics binary and config"
             inputs:
               targetPath: '$(System.DefaultWorkingDirectory)/src/dnc'
-              artifact: 'persistent-cluster-metrics-${{ parameters.workloadType }}'
+              artifact: 'persistent-cluster-metrics-${{ parameters.workloadType }}-${{ parameters.location }}'
               publishLocation: 'pipeline'
 
       - job: CreatePods
@@ -101,6 +103,7 @@ stages:
           - template: metrics-setup-steps.yaml
             parameters:
               workloadType: ${{ parameters.workloadType }}
+              location: ${{ parameters.location }}
 
           - task: AzureCLI@2
             name: RunCreatePods
@@ -123,11 +126,11 @@ stages:
                 if go test -v -timeout=1h -tags=create_test; then
                   echo "CreatePods test PASSED"
                   cd $metrics_dir
-                  output/linux_amd64/metrics/persistent-cluster-metrics --metric-name "PersistentClusterTestsSucceeded" --ado-run-id $ado_run_id --resource-group "$RG" --cluster-type "${{ parameters.workloadType }}" --test-scenario "Pod creation"
+                  output/linux_amd64/metrics/persistent-cluster-metrics --metric-name "PersistentClusterTestsSucceeded" --ado-run-id $ado_run_id --resource-group "$RG" --cluster-type "${{ parameters.workloadType }}" --test-scenario "Pod creation" --region "${{ parameters.location }}"
                 else
                   echo "CreatePods test FAILED"
                   cd $metrics_dir
-                  output/linux_amd64/metrics/persistent-cluster-metrics --metric-name "PersistentClusterTestsFailed" --ado-run-id $ado_run_id --resource-group "$RG" --cluster-type "${{ parameters.workloadType }}" --test-scenario "Pod creation"
+                  output/linux_amd64/metrics/persistent-cluster-metrics --metric-name "PersistentClusterTestsFailed" --ado-run-id $ado_run_id --resource-group "$RG" --cluster-type "${{ parameters.workloadType }}" --test-scenario "Pod creation" --region "${{ parameters.location }}"
                   exit 1
                 fi
               workingDirectory: $(System.DefaultWorkingDirectory)
@@ -142,6 +145,7 @@ stages:
           - template: metrics-setup-steps.yaml
             parameters:
               workloadType: ${{ parameters.workloadType }}
+              location: ${{ parameters.location }}
 
           - task: AzureCLI@2
             displayName: "Run Connectivity Tests"
@@ -163,11 +167,11 @@ stages:
                 if go test -v -timeout=30m -tags=connectivity_test; then
                   echo "ConnectivityTests test PASSED"
                   cd $metrics_dir
-                  output/linux_amd64/metrics/persistent-cluster-metrics --metric-name "PersistentClusterTestsSucceeded" --ado-run-id $ado_run_id --resource-group "$RG" --cluster-type "${{ parameters.workloadType }}" --test-scenario "Connectivity tests"
+                  output/linux_amd64/metrics/persistent-cluster-metrics --metric-name "PersistentClusterTestsSucceeded" --ado-run-id $ado_run_id --resource-group "$RG" --cluster-type "${{ parameters.workloadType }}" --test-scenario "Connectivity tests" --region "${{ parameters.location }}"
                 else
                   echo "ConnectivityTests test FAILED"
                   cd $metrics_dir
-                  output/linux_amd64/metrics/persistent-cluster-metrics --metric-name "PersistentClusterTestsFailed" --ado-run-id $ado_run_id --resource-group "$RG" --cluster-type "${{ parameters.workloadType }}" --test-scenario "Connectivity tests"
+                  output/linux_amd64/metrics/persistent-cluster-metrics --metric-name "PersistentClusterTestsFailed" --ado-run-id $ado_run_id --resource-group "$RG" --cluster-type "${{ parameters.workloadType }}" --test-scenario "Connectivity tests" --region "${{ parameters.location }}"
                   exit 1
                 fi
               workingDirectory: $(System.DefaultWorkingDirectory)
@@ -182,6 +186,7 @@ stages:
           - template: metrics-setup-steps.yaml
             parameters:
               workloadType: ${{ parameters.workloadType }}
+              location: ${{ parameters.location }}
 
           - task: AzureCLI@2
             name: DiscoverStorageAccounts
@@ -239,11 +244,11 @@ stages:
                 if go test -v -timeout=30m -tags=private_endpoint_test; then
                   echo "PrivateEndpointTests test PASSED"
                   cd $metrics_dir
-                  output/linux_amd64/metrics/persistent-cluster-metrics --metric-name "PersistentClusterTestsSucceeded" --ado-run-id $ado_run_id --resource-group "$RG" --cluster-type "${{ parameters.workloadType }}" --test-scenario "Private endpoint tests"
+                  output/linux_amd64/metrics/persistent-cluster-metrics --metric-name "PersistentClusterTestsSucceeded" --ado-run-id $ado_run_id --resource-group "$RG" --cluster-type "${{ parameters.workloadType }}" --test-scenario "Private endpoint tests" --region "${{ parameters.location }}"
                 else
                   echo "PrivateEndpointTests test FAILED"
                   cd $metrics_dir
-                  output/linux_amd64/metrics/persistent-cluster-metrics --metric-name "PersistentClusterTestsFailed" --ado-run-id $ado_run_id --resource-group "$RG" --cluster-type "${{ parameters.workloadType }}" --test-scenario "Private endpoint tests"
+                  output/linux_amd64/metrics/persistent-cluster-metrics --metric-name "PersistentClusterTestsFailed" --ado-run-id $ado_run_id --resource-group "$RG" --cluster-type "${{ parameters.workloadType }}" --test-scenario "Private endpoint tests" --region "${{ parameters.location }}"
                   exit 1
                 fi
               workingDirectory: $(System.DefaultWorkingDirectory)
@@ -272,6 +277,7 @@ stages:
           - template: metrics-setup-steps.yaml
             parameters:
               workloadType: ${{ parameters.workloadType }}
+              location: ${{ parameters.location }}
 
           - task: AzureCLI@2
             displayName: "Run Scale Test (Create and Delete)"
@@ -295,11 +301,11 @@ stages:
                 if go test -v -timeout 1h -tags=scale_test; then
                   echo "ScaleTest test PASSED"
                   cd $metrics_dir
-                  output/linux_amd64/metrics/persistent-cluster-metrics --metric-name "PersistentClusterTestsSucceeded" --ado-run-id $ado_run_id --resource-group "$RG" --cluster-type "${{ parameters.workloadType }}" --test-scenario "Scale tests"
+                  output/linux_amd64/metrics/persistent-cluster-metrics --metric-name "PersistentClusterTestsSucceeded" --ado-run-id $ado_run_id --resource-group "$RG" --cluster-type "${{ parameters.workloadType }}" --test-scenario "Scale tests" --region "${{ parameters.location }}"
                 else
                   echo "ScaleTest test FAILED"
                   cd $metrics_dir
-                  output/linux_amd64/metrics/persistent-cluster-metrics --metric-name "PersistentClusterTestsFailed" --ado-run-id $ado_run_id --resource-group "$RG" --cluster-type "${{ parameters.workloadType }}" --test-scenario "Scale tests"
+                  output/linux_amd64/metrics/persistent-cluster-metrics --metric-name "PersistentClusterTestsFailed" --ado-run-id $ado_run_id --resource-group "$RG" --cluster-type "${{ parameters.workloadType }}" --test-scenario "Scale tests" --region "${{ parameters.location }}"
                   exit 1
                 fi
               workingDirectory: $(System.DefaultWorkingDirectory)
@@ -319,6 +325,7 @@ stages:
           - template: metrics-setup-steps.yaml
             parameters:
               workloadType: ${{ parameters.workloadType }}
+              location: ${{ parameters.location }}
 
           - task: AzureCLI@2
             displayName: "Delete Test Resources"
@@ -340,11 +347,11 @@ stages:
                 if go test -v -timeout=1h -tags=delete_test; then
                   echo "DeleteTestResources test PASSED"
                   cd $metrics_dir
-                  output/linux_amd64/metrics/persistent-cluster-metrics --metric-name "PersistentClusterTestsSucceeded" --ado-run-id $ado_run_id --resource-group "$RG" --cluster-type "${{ parameters.workloadType }}" --test-scenario "Delete test resources"
+                  output/linux_amd64/metrics/persistent-cluster-metrics --metric-name "PersistentClusterTestsSucceeded" --ado-run-id $ado_run_id --resource-group "$RG" --cluster-type "${{ parameters.workloadType }}" --test-scenario "Delete test resources" --region "${{ parameters.location }}"
                 else
                   echo "DeleteTestResources test FAILED"
                   cd $metrics_dir
-                  output/linux_amd64/metrics/persistent-cluster-metrics --metric-name "PersistentClusterTestsFailed" --ado-run-id $ado_run_id --resource-group "$RG" --cluster-type "${{ parameters.workloadType }}" --test-scenario "Delete test resources"
+                  output/linux_amd64/metrics/persistent-cluster-metrics --metric-name "PersistentClusterTestsFailed" --ado-run-id $ado_run_id --resource-group "$RG" --cluster-type "${{ parameters.workloadType }}" --test-scenario "Delete test resources" --region "${{ parameters.location }}"
                   exit 1
                 fi
               workingDirectory: $(System.DefaultWorkingDirectory)

--- a/.pipelines/swiftv2-long-running/template/long-running-pipeline-template.yaml
+++ b/.pipelines/swiftv2-long-running/template/long-running-pipeline-template.yaml
@@ -175,6 +175,7 @@ stages:
     - template: datapath-tests-stage.yaml
       parameters:
         workloadType: ${{ workload }}
+        location: ${{ parameters.location }}
         subscriptionId: ${{ parameters.subscriptionId }}
         rgName: $(rgName)
         storageAccount1: $[ stageDependencies.AKSClusterAndNetworking.NetworkingAndStorage.outputs['CreateStorageAccounts.StorageAccount1'] ]

--- a/.pipelines/swiftv2-long-running/template/metrics-setup-steps.yaml
+++ b/.pipelines/swiftv2-long-running/template/metrics-setup-steps.yaml
@@ -4,6 +4,8 @@
 parameters:
   - name: workloadType
     type: string
+  - name: location
+    type: string
 
 steps:
   - checkout: self
@@ -15,13 +17,13 @@ steps:
   - task: DownloadPipelineArtifact@2
     displayName: "Download kubeconfig files"
     inputs:
-      artifactName: kubeconfigs-${{ parameters.workloadType }}
+      artifactName: kubeconfigs-${{ parameters.workloadType }}-${{ parameters.location }}
       targetPath: $(Pipeline.Workspace)/kubeconfigs
 
   - task: DownloadPipelineArtifact@2
     displayName: "Download metrics binary"
     inputs:
-      artifact: 'persistent-cluster-metrics-${{ parameters.workloadType }}'
+      artifact: 'persistent-cluster-metrics-${{ parameters.workloadType }}-${{ parameters.location }}'
       path: '$(System.DefaultWorkingDirectory)/Networking-Aquarius/src/dnc'
 
   - task: Bash@3


### PR DESCRIPTION
The region column in the Grafana dashboard was not populated because the --region flag was never passed to persistent-cluster-metrics.

Changes:
- Added location parameter to datapath-tests-stage.yaml and metrics-setup-steps.yaml templates
- Added location to stage names, artifact names, and display names
- Added --region with the location parameter to all 10 metric calls across all test phases (create, connectivity, private endpoint, scale, delete)
- Updated long-running-pipeline-template.yaml to pass location to the datapath tests template
- Added isAllowedRun condition check to the datapath tests stage

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
