### PR TITLE
Configurable wire server ip address

### DIFF
--- a/cni/netconfig.go
+++ b/cni/netconfig.go
@@ -80,6 +80,7 @@ type NetworkConfig struct {
 	RuntimeConfig                 RuntimeConfig   `json:"runtimeConfig,omitempty"`
 	WindowsSettings               WindowsSettings `json:"windowsSettings,omitempty"`
 	AdditionalArgs                []KVPair        `json:"AdditionalArgs,omitempty"`
+	WireServerIP                  string          `json:"wireServerIP,omitempty"`
 }
 
 type WindowsSettings struct {

--- a/cni/netconfig.go
+++ b/cni/netconfig.go
@@ -80,7 +80,7 @@ type NetworkConfig struct {
 	RuntimeConfig                 RuntimeConfig   `json:"runtimeConfig,omitempty"`
 	WindowsSettings               WindowsSettings `json:"windowsSettings,omitempty"`
 	AdditionalArgs                []KVPair        `json:"AdditionalArgs,omitempty"`
-	WireServerIP                  string          `json:"wireServerIP,omitempty"`
+	WireServerAddress             string          `json:"wireServerAddress,omitempty"`
 }
 
 type WindowsSettings struct {

--- a/cni/netconfig.go
+++ b/cni/netconfig.go
@@ -80,7 +80,12 @@ type NetworkConfig struct {
 	RuntimeConfig                 RuntimeConfig   `json:"runtimeConfig,omitempty"`
 	WindowsSettings               WindowsSettings `json:"windowsSettings,omitempty"`
 	AdditionalArgs                []KVPair        `json:"AdditionalArgs,omitempty"`
-	WireServerAddress             string          `json:"wireServerAddress,omitempty"`
+	// Env selects the runtime environment for environment-specific behavior
+	// (e.g. which Wire Server endpoint to use). Recognized values:
+	//   ""      - production (default)
+	//   "test"  - test environment
+	// The JSON tag is "env" so conflist files can set: "env": "test"
+	Env string `json:"env,omitempty"`
 }
 
 type WindowsSettings struct {

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -62,13 +62,14 @@ const (
 )
 
 const (
-	// URL to query NMAgent version and determine whether we snat on host
-	nmAgentSupportedApisURL = "http://168.63.129.16/machine/plugins/?comp=nmagent&type=GetSupportedApis"
 	// Only SNAT support (no DNS support)
 	nmAgentSnatSupportAPI = "NetworkManagementSnatSupport"
 	// SNAT and DNS are both supported
 	nmAgentSnatAndDnsSupportAPI = "NetworkManagementDNSSupport"
 )
+
+// URL to query NMAgent version and determine whether we snat on host
+var nmAgentSupportedApisURL string
 
 // temporary consts related func determineSnat() which is to be deleted after
 // a baking period with newest NMAgent changes
@@ -344,6 +345,13 @@ func (plugin *NetPlugin) getNetworkInfo(netNs string, interfaceInfo *network.Int
 	return nwInfo
 }
 
+func initNmAgentSupportedApisURL(wireServerIP string) {
+	if wireServerIP == "" {
+		wireServerIP = "168.63.129.16"
+	}
+	nmAgentSupportedApisURL = fmt.Sprintf("http://%s/machine/plugins/?comp=nmagent&type=GetSupportedApis", wireServerIP)
+}
+
 // CNI implementation
 // https://github.com/containernetworking/cni/blob/master/SPEC.md
 
@@ -499,6 +507,8 @@ func (plugin *NetPlugin) Add(args *cniSkel.CmdArgs) error {
 		// multitenancy (swift v1) -> one interface info
 		telemetryClient.Settings().Context = "AzureCNIMultitenancy"
 		plugin.multitenancyClient.Init(cnsClient, AzureNetIOShim{})
+
+		initNmAgentSupportedApisURL(nwCfg.WireServerIP)
 
 		// Temporary if block to determining whether we disable SNAT on host (for multi-tenant scenario only)
 		if enableSnatForDNS, nwCfg.EnableSnatOnHost, err = plugin.multitenancyClient.DetermineSnatFeatureOnHost(

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -68,8 +68,8 @@ const (
 	nmAgentSnatAndDnsSupportAPI = "NetworkManagementDNSSupport"
 )
 
-// URL to query NMAgent version and determine whether we snat on host
-var nmAgentSupportedApisURL string
+// defaultWireServerIP is the Azure Wire Server IP address.
+const defaultWireServerIP = "168.63.129.16"
 
 // temporary consts related func determineSnat() which is to be deleted after
 // a baking period with newest NMAgent changes
@@ -345,11 +345,11 @@ func (plugin *NetPlugin) getNetworkInfo(netNs string, interfaceInfo *network.Int
 	return nwInfo
 }
 
-func initNmAgentSupportedApisURL(wireServerIP string) {
+func buildNmAgentSupportedApisURL(wireServerIP string) string {
 	if wireServerIP == "" {
-		wireServerIP = "168.63.129.16"
+		wireServerIP = defaultWireServerIP
 	}
-	nmAgentSupportedApisURL = fmt.Sprintf("http://%s/machine/plugins/?comp=nmagent&type=GetSupportedApis", wireServerIP)
+	return fmt.Sprintf("http://%s/machine/plugins/?comp=nmagent&type=GetSupportedApis", wireServerIP)
 }
 
 // CNI implementation
@@ -508,7 +508,7 @@ func (plugin *NetPlugin) Add(args *cniSkel.CmdArgs) error {
 		telemetryClient.Settings().Context = "AzureCNIMultitenancy"
 		plugin.multitenancyClient.Init(cnsClient, AzureNetIOShim{})
 
-		initNmAgentSupportedApisURL(nwCfg.WireServerIP)
+		nmAgentSupportedApisURL := buildNmAgentSupportedApisURL(nwCfg.WireServerIP)
 
 		// Temporary if block to determining whether we disable SNAT on host (for multi-tenant scenario only)
 		if enableSnatForDNS, nwCfg.EnableSnatOnHost, err = plugin.multitenancyClient.DetermineSnatFeatureOnHost(

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -68,8 +68,8 @@ const (
 	nmAgentSnatAndDnsSupportAPI = "NetworkManagementDNSSupport"
 )
 
-// defaultWireServerIP is the Azure Wire Server IP address.
-const defaultWireServerIP = "168.63.129.16"
+// defaultWireServerAddress is the Azure Wire Server IP address.
+const defaultWireServerAddress = "168.63.129.16"
 
 // temporary consts related func determineSnat() which is to be deleted after
 // a baking period with newest NMAgent changes
@@ -345,11 +345,11 @@ func (plugin *NetPlugin) getNetworkInfo(netNs string, interfaceInfo *network.Int
 	return nwInfo
 }
 
-func buildNmAgentSupportedApisURL(wireServerIP string) string {
-	if wireServerIP == "" {
-		wireServerIP = defaultWireServerIP
+func buildNmAgentSupportedApisURL(wireServerAddress string) string {
+	if wireServerAddress == "" {
+		wireServerAddress = defaultWireServerAddress
 	}
-	return fmt.Sprintf("http://%s/machine/plugins/?comp=nmagent&type=GetSupportedApis", wireServerIP)
+	return fmt.Sprintf("http://%s/machine/plugins/?comp=nmagent&type=GetSupportedApis", wireServerAddress)
 }
 
 // CNI implementation
@@ -508,7 +508,7 @@ func (plugin *NetPlugin) Add(args *cniSkel.CmdArgs) error {
 		telemetryClient.Settings().Context = "AzureCNIMultitenancy"
 		plugin.multitenancyClient.Init(cnsClient, AzureNetIOShim{})
 
-		nmAgentSupportedApisURL := buildNmAgentSupportedApisURL(nwCfg.WireServerIP)
+		nmAgentSupportedApisURL := buildNmAgentSupportedApisURL(nwCfg.WireServerAddress)
 
 		// Temporary if block to determining whether we disable SNAT on host (for multi-tenant scenario only)
 		if enableSnatForDNS, nwCfg.EnableSnatOnHost, err = plugin.multitenancyClient.DetermineSnatFeatureOnHost(

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -68,8 +68,28 @@ const (
 	nmAgentSnatAndDnsSupportAPI = "NetworkManagementDNSSupport"
 )
 
-// defaultWireServerAddress is the Azure Wire Server IP address.
-const defaultWireServerAddress = "168.63.129.16"
+// Wire Server addresses per environment.
+const (
+	// defaultWireServerAddress is the well-known Azure Wire Server IP used in production.
+	defaultWireServerAddress = "168.63.129.16"
+	// testWireServerAddress is the Wire Server endpoint used in test setups.
+	testWireServerAddress = "127.0.0.1:11281"
+)
+
+// Recognized values for cni.NetworkConfig.Env.
+const (
+	envTest = "test"
+)
+
+// wireServerAddressForEnv returns the Wire Server address to use for the given
+// environment value from the conflist ("env" field). Anything other than the
+// recognized test environment falls back to the production default.
+func wireServerAddressForEnv(env string) string {
+	if env == envTest {
+		return testWireServerAddress
+	}
+	return defaultWireServerAddress
+}
 
 // temporary consts related func determineSnat() which is to be deleted after
 // a baking period with newest NMAgent changes
@@ -346,9 +366,6 @@ func (plugin *NetPlugin) getNetworkInfo(netNs string, interfaceInfo *network.Int
 }
 
 func buildNmAgentSupportedApisURL(wireServerAddress string) string {
-	if wireServerAddress == "" {
-		wireServerAddress = defaultWireServerAddress
-	}
 	return fmt.Sprintf("http://%s/machine/plugins/?comp=nmagent&type=GetSupportedApis", wireServerAddress)
 }
 
@@ -508,7 +525,7 @@ func (plugin *NetPlugin) Add(args *cniSkel.CmdArgs) error {
 		telemetryClient.Settings().Context = "AzureCNIMultitenancy"
 		plugin.multitenancyClient.Init(cnsClient, AzureNetIOShim{})
 
-		nmAgentSupportedApisURL := buildNmAgentSupportedApisURL(nwCfg.WireServerAddress)
+		nmAgentSupportedApisURL := buildNmAgentSupportedApisURL(wireServerAddressForEnv(nwCfg.Env))
 
 		// Temporary if block to determining whether we disable SNAT on host (for multi-tenant scenario only)
 		if enableSnatForDNS, nwCfg.EnableSnatOnHost, err = plugin.multitenancyClient.DetermineSnatFeatureOnHost(

--- a/cni/network/network_test.go
+++ b/cni/network/network_test.go
@@ -1852,31 +1852,31 @@ func TestValidateArgs(t *testing.T) {
 
 func TestBuildNmAgentSupportedApisURL(t *testing.T) {
 	tests := []struct {
-		name         string
-		wireServerIP string
-		expectedURL  string
+		name               string
+		wireServerAddress  string
+		expectedURL        string
 	}{
 		{
-			name:         "empty string defaults to well-known wireserver IP",
-			wireServerIP: "",
-			expectedURL:  "http://168.63.129.16/machine/plugins/?comp=nmagent&type=GetSupportedApis",
+			name:              "empty string defaults to well-known wireserver IP",
+			wireServerAddress: "",
+			expectedURL:       "http://168.63.129.16/machine/plugins/?comp=nmagent&type=GetSupportedApis",
 		},
 		{
-			name:         "custom IPv4 address",
-			wireServerIP: "10.0.0.1",
-			expectedURL:  "http://10.0.0.1/machine/plugins/?comp=nmagent&type=GetSupportedApis",
+			name:              "custom IPv4 address",
+			wireServerAddress: "10.0.0.1",
+			expectedURL:       "http://10.0.0.1/machine/plugins/?comp=nmagent&type=GetSupportedApis",
 		},
 		{
-			name:         "custom IPv4 address with port",
-			wireServerIP: "10.0.0.1:8080",
-			expectedURL:  "http://10.0.0.1:8080/machine/plugins/?comp=nmagent&type=GetSupportedApis",
+			name:              "custom IPv4 address with port",
+			wireServerAddress: "10.0.0.1:8080",
+			expectedURL:       "http://10.0.0.1:8080/machine/plugins/?comp=nmagent&type=GetSupportedApis",
 		},
 	}
 
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			result := buildNmAgentSupportedApisURL(tt.wireServerIP)
+			result := buildNmAgentSupportedApisURL(tt.wireServerAddress)
 			assert.Equal(t, tt.expectedURL, result)
 		})
 	}

--- a/cni/network/network_test.go
+++ b/cni/network/network_test.go
@@ -1852,9 +1852,9 @@ func TestValidateArgs(t *testing.T) {
 
 func TestBuildNmAgentSupportedApisURL(t *testing.T) {
 	tests := []struct {
-		name               string
-		wireServerAddress  string
-		expectedURL        string
+		name              string
+		wireServerAddress string
+		expectedURL       string
 	}{
 		{
 			name:              "empty string defaults to well-known wireserver IP",
@@ -1874,7 +1874,6 @@ func TestBuildNmAgentSupportedApisURL(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			result := buildNmAgentSupportedApisURL(tt.wireServerAddress)
 			assert.Equal(t, tt.expectedURL, result)

--- a/cni/network/network_test.go
+++ b/cni/network/network_test.go
@@ -1849,3 +1849,35 @@ func TestValidateArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildNmAgentSupportedApisURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		wireServerIP string
+		expectedURL  string
+	}{
+		{
+			name:         "empty string defaults to well-known wireserver IP",
+			wireServerIP: "",
+			expectedURL:  "http://168.63.129.16/machine/plugins/?comp=nmagent&type=GetSupportedApis",
+		},
+		{
+			name:         "custom IPv4 address",
+			wireServerIP: "10.0.0.1",
+			expectedURL:  "http://10.0.0.1/machine/plugins/?comp=nmagent&type=GetSupportedApis",
+		},
+		{
+			name:         "custom IPv4 address with port",
+			wireServerIP: "10.0.0.1:8080",
+			expectedURL:  "http://10.0.0.1:8080/machine/plugins/?comp=nmagent&type=GetSupportedApis",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildNmAgentSupportedApisURL(tt.wireServerIP)
+			assert.Equal(t, tt.expectedURL, result)
+		})
+	}
+}

--- a/cni/network/network_test.go
+++ b/cni/network/network_test.go
@@ -1857,19 +1857,14 @@ func TestBuildNmAgentSupportedApisURL(t *testing.T) {
 		expectedURL       string
 	}{
 		{
-			name:              "empty string defaults to well-known wireserver IP",
-			wireServerAddress: "",
+			name:              "production wire server address",
+			wireServerAddress: defaultWireServerAddress,
 			expectedURL:       "http://168.63.129.16/machine/plugins/?comp=nmagent&type=GetSupportedApis",
 		},
 		{
-			name:              "custom IPv4 address",
-			wireServerAddress: "10.0.0.1",
-			expectedURL:       "http://10.0.0.1/machine/plugins/?comp=nmagent&type=GetSupportedApis",
-		},
-		{
-			name:              "custom IPv4 address with port",
-			wireServerAddress: "10.0.0.1:8080",
-			expectedURL:       "http://10.0.0.1:8080/machine/plugins/?comp=nmagent&type=GetSupportedApis",
+			name:              "test wire server address",
+			wireServerAddress: testWireServerAddress,
+			expectedURL:       "http://127.0.0.1:11281/machine/plugins/?comp=nmagent&type=GetSupportedApis",
 		},
 	}
 
@@ -1877,6 +1872,36 @@ func TestBuildNmAgentSupportedApisURL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := buildNmAgentSupportedApisURL(tt.wireServerAddress)
 			assert.Equal(t, tt.expectedURL, result)
+		})
+	}
+}
+
+func TestWireServerAddressForEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		env      string
+		expected string
+	}{
+		{
+			name:     "empty env defaults to production wire server",
+			env:      "",
+			expected: defaultWireServerAddress,
+		},
+		{
+			name:     "unknown env defaults to production wire server",
+			env:      "staging",
+			expected: defaultWireServerAddress,
+		},
+		{
+			name:     "test env returns test wire server",
+			env:      envTest,
+			expected: testWireServerAddress,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, wireServerAddressForEnv(tt.env))
 		})
 	}
 }


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
The NMAgent supported APIs URL used in the CNI multitenancy path was previously hardcoded to the well-known Azure Wire Server IP (168.63.129.16). This made it impossible to test CNI changes on OneBox environments where the Wire Server is not reachable at that address.

This PR makes the Wire Server IP configurable via the CNI conflist configuration ("env" field), allowing operators and developers to override it for testing in non-standard environments. When unset, the default 168.63.129.16 is used, preserving full backward compatibility.

Changes:
- `cni/netconfig.go`: Added `Env` field to `NetworkConfig` with JSON tag `"env"`.
- `cni/network/network.go`:
  - Added `defaultWireServerAddress` (`168.63.129.16`) and `testWireServerAddress` (`127.0.0.1:11281`) constants.
  - Added `envTest = "test"` constant for the recognized environment value.
  - Added `wireServerAddressForEnv(env string) string` to map the conflist `env` value to a Wire Server address (defaults to production for unknown/empty values).
  - Simplified `buildNmAgentSupportedApisURL()` to a pure URL formatter.
  - Wired the resolved address into the multitenancy path in `Add()`.
  - Added a structured `logger.Info` log emitting the resolved `env`, `wireServerAddress`, and full `url` for deployment-time debugging.
- `cni/network/network_test.go`:
  - Unit tests for `buildNmAgentSupportedApisURL` (production + test addresses).
  - Unit tests for `wireServerAddressForEnv` covering empty, unknown, and `"test"` env values.

Example conflist snippet to override:

```
{
  "env": "test"
}
```