### PR TITLE
fix: controller-runtime manager can't be restarted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ test/scale/generated/*
 
 # omit e2e bin
 test/e2e/bin/*
+
+**/service

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1583,20 +1583,18 @@ func InitializeCRDState(ctx context.Context, z *zap.Logger, httpRestService cns.
 	// Start the Manager which starts the reconcile loop.
 	// The Reconciler will send an initial NodeNetworkConfig update to the PoolMonitor, starting the
 	// Monitor's internal loop.
+	// Note: controller-runtime Managers are not restartable. The *first* thing that Start() does is
+	// set the started semaphore, and *any* restart attempt will fail.
+	// The Manager is permanently marked as started and subsequent calls will always fail with
+	// "manager already started". If the Manager returns AT ALL, we must exit the process and
+	// let the kubelet restart the pod (or rebuild world, but exiting is more reliable).
 	go func() {
 		logger.Printf("Starting controller-manager.")
-		for {
-			if err := manager.Start(ctx); err != nil {
-				logger.Errorf("Failed to start controller-manager: %v", err)
-				// retry to start the request controller
-				// inc the managerStartFailures metric for failure tracking
-				managerStartFailures.Inc()
-			} else {
-				logger.Printf("Stopped controller-manager.")
-				return
-			}
-			time.Sleep(time.Second) // TODO(rbtr): make this exponential backoff
+		if err := manager.Start(ctx); err != nil {
+			logger.Errorf("Failed to start controller-manager: %v", err)
+			os.Exit(1)
 		}
+		logger.Printf("Stopped controller-manager.")
 	}()
 	logger.Printf("Initialized controller-manager.")
 	for {

--- a/cns/service/metrics.go
+++ b/cns/service/metrics.go
@@ -6,16 +6,6 @@ import (
 )
 
 var (
-	// managerStartFailures is a monotic counter which tracks the number of times the controller-runtime
-	// manager failed to start. To drive alerting based on this metric, it is recommended to use the rate
-	// of increase over a period of time. A positive rate of change indicates that the CNS is actively
-	// failing and retrying.
-	managerStartFailures = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Name: "cns_ctrlmanager_start_failures_total",
-			Help: "Number of times the controller-runtime manager failed to start.",
-		},
-	)
 	// nncReconcilerStartFailures is a monotic counter which tracks the number of times the NNC reconciler
 	// has failed to start within the timeout period. To drive alerting based on this metric, it is
 	// recommended to use the rate of increase over a period of time. A positive rate of change indicates
@@ -45,7 +35,6 @@ var (
 
 func init() {
 	metrics.Registry.MustRegister(
-		managerStartFailures,
 		nncReconcilerStartFailures,
 		nncInitFailure,
 		hasNNCInitialized,


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
There is no scenario in which a controller-runtime manager can be restarted. If the context is cancelled, it may exit without error; if it errors during Start, it will return that error - either scenario is unrecoverable and the Manager must be rebuilt.

This [snippet of the Start method](https://github.com/kubernetes-sigs/controller-runtime/blob/main/pkg/manager/internal.go#L347) makes this very clear:

```go
// Start starts the manager and waits indefinitely.
// There is only two ways to have start return:
// An error has occurred during in one of the internal operations,
// such as leader election, cache start, webhooks, and so on.
// Or, the context is cancelled.
func (cm *controllerManager) Start(ctx context.Context) (err error) {
	cm.Lock()
	if cm.started {
		cm.Unlock()
		return errors.New("manager already started")
	}
	cm.started = true
...
...
...
}
```

It's clear that Start _cannot be called more than once_. That will never work. 

We could try to respring main, rebuild the manager, and Start the new one. But it's probably safer and definitely more reliable that we simply exit and let the Pod be restarted.

**Notes**:
I don't know if this never could have worked or if ctrlruntime has evolved...but it definitely doesn't work today and we need this fix to keep CNS from deadlocking during Manager init.