### PR TITLE
fix: correct inverted errors.As in DeleteHNSEndpointbyID and improve logging in HNS delete functions

### DIFF
--- a/cns/hnsclient/hnsclient_windows.go
+++ b/cns/hnsclient/hnsclient_windows.go
@@ -651,17 +651,20 @@ func deleteNetworkByIDHnsV2(
 				"error with GetNetworkByID: %v", err)
 		}
 
-		logger.Printf("Delete called on network %s which doesn't exist, treating as success", networkID)
+		logger.Printf("Delete called on network %s which doesn't exist, treating as success", networkID) //nolint:staticcheck // TODO: migrate to zap
 
 		return nil
 	}
 
 	if err = network.Delete(); err != nil {
-		networkJSON, _ := json.Marshal(network)
-		return fmt.Errorf("Failed to delete network: %s. Error: %v", string(networkJSON), err)
+		networkJSON, marshalErr := json.Marshal(network)
+		if marshalErr != nil {
+			return fmt.Errorf("failed to delete network %s: %w", network.Id, err)
+		}
+		return fmt.Errorf("failed to delete network %s: %w", string(networkJSON), err)
 	}
 
-	logger.Printf("[Azure CNS] Successfully deleted network: %s", network.Id)
+	logger.Printf("[Azure CNS] Successfully deleted network: %s", network.Id) //nolint:staticcheck // TODO: migrate to zap
 
 	return nil
 }
@@ -682,17 +685,20 @@ func deleteEndpointByNameHnsV2(
 				"error with GetEndpointByName: %v", err)
 		}
 
-		logger.Printf("[Azure CNS] Delete called on endpoint %s which doesn't exist, treating as success", endpointName)
+		logger.Printf("[Azure CNS] Delete called on endpoint %s which doesn't exist, treating as success", endpointName) //nolint:staticcheck // TODO: migrate to zap
 
 		return nil
 	}
 
 	if err = endpoint.Delete(); err != nil {
-		endpointJSON, _ := json.Marshal(endpoint)
-		return fmt.Errorf("Failed to delete endpoint: %s. Error: %v", string(endpointJSON), err)
+		endpointJSON, marshalErr := json.Marshal(endpoint)
+		if marshalErr != nil {
+			return fmt.Errorf("failed to delete endpoint %s: %w", endpoint.Id, err)
+		}
+		return fmt.Errorf("failed to delete endpoint %s: %w", string(endpointJSON), err)
 	}
 
-	logger.Printf("[Azure CNS] Successfully deleted endpoint: %s", endpoint.Id)
+	logger.Printf("[Azure CNS] Successfully deleted endpoint: %s", endpoint.Id) //nolint:staticcheck // TODO: migrate to zap
 
 	return nil
 }
@@ -734,7 +740,7 @@ func DeleteHNSEndpointbyID(hnsEndpointID string) error {
 			return fmt.Errorf("Failed to get hcn endpoint with id: %s due to err: %w", hnsEndpointID, err)
 		}
 
-		logger.Printf("Delete called on endpoint %s which doesn't exist, treating as success", hnsEndpointID)
+		logger.Printf("Delete called on endpoint %s which doesn't exist, treating as success", hnsEndpointID) //nolint:staticcheck // TODO: migrate to zap
 		return nil
 	}
 
@@ -747,7 +753,7 @@ func DeleteHNSEndpointbyID(hnsEndpointID string) error {
 		return fmt.Errorf("Failed to delete endpoint: %s. Error: %w", hnsEndpointID, err)
 	}
 
-	logger.Printf("[Azure CNS] Successfully deleted endpoint: %s", hnsEndpointID)
+	logger.Printf("[Azure CNS] Successfully deleted endpoint: %s", hnsEndpointID) //nolint:staticcheck // TODO: migrate to zap
 
 	return nil
 }


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
- Fix inverted `errors.As` check in `DeleteHNSEndpointbyID` where it was returning error on `EndpointNotFoundError` instead of succeeding as suggested by comment
- Replace `Errorf` with `Printf` for success/not-found log
- Use JSON marshal instead of `%+v` for error messages to avoid dumping raw pointer fields

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
