### PR TITLE
add ipv6 subnet to HCN network

### DIFF
--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -289,13 +289,17 @@ func (nm *networkManager) configureHcnNetwork(nwInfo *EndpointInfo, extIf *exter
 
 	// Populate subnets.
 	for _, subnet := range nwInfo.Subnets {
+		subnetDefaultRoute := defaultRouteCIDR
+		if subnet.Family == platform.AfINET6 {
+			subnetDefaultRoute = defaultIPv6Route
+		}
 		hnsSubnet := hcn.Subnet{
 			IpAddressPrefix: subnet.Prefix.String(),
 			// Set the Gateway route
 			Routes: []hcn.Route{
 				{
 					NextHop:           subnet.Gateway.String(),
-					DestinationPrefix: defaultRouteCIDR,
+					DestinationPrefix: subnetDefaultRoute,
 				},
 			},
 		}

--- a/network/network_windows_test.go
+++ b/network/network_windows_test.go
@@ -596,3 +596,91 @@ func TestConfigureHCNNetworkSwiftv2DelegatedNIC(t *testing.T) {
 		t.Fatalf("host network flags is not configured as %v when interface NIC type is delegatedVMNIC", expectedSwifv2NetworkFlags)
 	}
 }
+
+func TestConfigureHCNNetworkSubnetDefaultRouteSelection(t *testing.T) {
+	nm := &networkManager{
+		ExternalInterfaces: map[string]*externalInterface{},
+	}
+
+	extIf := externalInterface{Name: "eth0"}
+
+	testCases := []struct {
+		name                  string
+		subnets               []SubnetInfo
+		expectedRoutePrefixes []string
+	}{
+		{
+			name: "ipv4 subnet uses ipv4 default route",
+			subnets: []SubnetInfo{
+				{
+					Family:  platform.AfINET,
+					Gateway: net.ParseIP("10.0.0.1"),
+					Prefix:  net.IPNet{IP: net.ParseIP("10.0.0.0"), Mask: net.CIDRMask(24, 32)},
+				},
+			},
+			expectedRoutePrefixes: []string{"0.0.0.0/0"},
+		},
+		{
+			name: "ipv6 subnet uses ipv6 default route",
+			subnets: []SubnetInfo{
+				{
+					Family:  platform.AfINET6,
+					Gateway: net.ParseIP("fd00::1"),
+					Prefix:  net.IPNet{IP: net.ParseIP("fd00::"), Mask: net.CIDRMask(64, 128)},
+				},
+			},
+			expectedRoutePrefixes: []string{"::/0"},
+		},
+		{
+			name: "dual stack subnets map default route by family",
+			subnets: []SubnetInfo{
+				{
+					Family:  platform.AfINET,
+					Gateway: net.ParseIP("10.1.0.1"),
+					Prefix:  net.IPNet{IP: net.ParseIP("10.1.0.0"), Mask: net.CIDRMask(24, 32)},
+				},
+				{
+					Family:  platform.AfINET6,
+					Gateway: net.ParseIP("fd01::1"),
+					Prefix:  net.IPNet{IP: net.ParseIP("fd01::"), Mask: net.CIDRMask(64, 128)},
+				},
+			},
+			expectedRoutePrefixes: []string{"0.0.0.0/0", "::/0"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			nwInfo := &EndpointInfo{
+				AdapterName: "eth0",
+				NetworkID:   "test-network-id",
+				Subnets:     tc.subnets,
+				Options:     map[string]interface{}{},
+			}
+
+			hostComputeNetwork, err := nm.configureHcnNetwork(nwInfo, &extIf)
+			if err != nil {
+				t.Fatalf("configureHcnNetwork returned error: %v", err)
+			}
+
+			if len(hostComputeNetwork.Ipams) == 0 {
+				t.Fatal("expected at least one IPAM entry")
+			}
+
+			subnets := hostComputeNetwork.Ipams[0].Subnets
+			if len(subnets) != len(tc.expectedRoutePrefixes) {
+				t.Fatalf("unexpected subnet count: got %d, want %d", len(subnets), len(tc.expectedRoutePrefixes))
+			}
+
+			for i, expectedPrefix := range tc.expectedRoutePrefixes {
+				if len(subnets[i].Routes) == 0 {
+					t.Fatalf("expected route for subnet index %d", i)
+				}
+
+				if got := subnets[i].Routes[0].DestinationPrefix; got != expectedPrefix {
+					t.Fatalf("unexpected route destination prefix for subnet index %d: got %s, want %s", i, got, expectedPrefix)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
To support IPV6 in WCOW, we need to add local ipv6 subnet to hcn network on Windows
**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] relevant PR labels added

**Notes**:

HNS network:

<img width="846" height="402" alt="image" src="https://github.com/user-attachments/assets/7b72aa85-be55-4e11-965b-a845a7d93964" />

HNS endpoint
<img width="823" height="416" alt="image" src="https://github.com/user-attachments/assets/60765ee8-9284-424c-a5c1-f91998413530" />



