### PR TITLE
[POND] Remove the ipv6 check when setting ipset v6 address

### DIFF
--- a/cns/kubecontroller/nodenetworkconfig/conversion.go
+++ b/cns/kubecontroller/nodenetworkconfig/conversion.go
@@ -35,10 +35,6 @@ func parseIPv6Subnet(nc v1alpha.NetworkContainer) (cns.IPSubnet, error) {
 	if !subnetV6Prefix.Addr().Is6() {
 		return cns.IPSubnet{}, errors.Errorf("SubnetAddressSpaceV6 %s is not an IPv6 prefix", nc.SubnetAddressSpaceV6)
 	}
-	// remove the condition to allow that v6 prefix set but IPs not ready.
-	// if nc.PrimaryIPV6 == "" {
-	// 	return cns.IPSubnet{}, errors.New("PrimaryIPV6 must be set when SubnetAddressSpaceV6 is specified")
-	// }
 	return cns.IPSubnet{
 		IPAddress:    nc.PrimaryIPV6,
 		PrefixLength: uint8(subnetV6Prefix.Bits()), //#nosec G115 -- prefix bits are 0-128, fits uint8


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
We don't need the ipv6 address empty check since CNI doesn't need v6 address yet, it only needs gateway and ip subnet. Adding ip subnet v6 address is just for keeping consistent with v4 and future extension.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
