### PR TITLE
ci: ignore status of azuresecuritylinuxagent during testing

### DIFF
--- a/test/integration/datapath/datapath_linux_test.go
+++ b/test/integration/datapath/datapath_linux_test.go
@@ -131,7 +131,7 @@ func setupLinuxEnvironment(t *testing.T) {
 	})
 
 	t.Log("Waiting for pods to be running state")
-	err = kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector)
+	err = kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector, nil)
 	if err != nil {
 		t.Fatalf("Pods are not in running state due to %+v", err)
 	}
@@ -171,7 +171,7 @@ func TestDatapathLinux(t *testing.T) {
 	t.Run("Linux ping tests", func(t *testing.T) {
 		// Check goldpinger health
 		t.Run("all pods have IPs assigned", func(t *testing.T) {
-			err := kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector)
+			err := kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector, nil)
 			if err != nil {
 				t.Fatalf("Pods are not in running state due to %+v", err)
 			}

--- a/test/integration/datapath/datapath_windows_test.go
+++ b/test/integration/datapath/datapath_windows_test.go
@@ -104,7 +104,7 @@ func setupWindowsEnvironment(t *testing.T) {
 		kubernetes.MustCreateDeployment(ctx, deploymentsClient, deployment)
 
 		t.Log("Waiting for pods to be running state")
-		err = kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector)
+		err = kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -114,7 +114,7 @@ func setupWindowsEnvironment(t *testing.T) {
 		t.Log("Namespace already exists")
 
 		t.Log("Checking for pods to be running state")
-		err = kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector)
+		err = kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/test/integration/load/load_test.go
+++ b/test/integration/load/load_test.go
@@ -88,7 +88,7 @@ func TestLoad(t *testing.T) {
 	kubernetes.MustCreateDeployment(ctx, deploymentsClient, deployment)
 
 	t.Log("Checking pods are running")
-	err = kubernetes.WaitForPodsRunning(ctx, clientset, namespace, podLabelSelector)
+	err = kubernetes.WaitForPodsRunning(ctx, clientset, namespace, podLabelSelector, nil)
 	require.NoError(t, err)
 
 	t.Log("Repeating the scale up/down cycle")
@@ -101,7 +101,7 @@ func TestLoad(t *testing.T) {
 		kubernetes.MustScaleDeployment(ctx, deploymentsClient, deployment, clientset, namespace, podLabelSelector, testConfig.ScaleUpReplicas, testConfig.SkipWait)
 	}
 	t.Log("Checking pods are running and IP assigned")
-	err = kubernetes.WaitForPodsRunning(ctx, clientset, "", "", "azuresecuritylinuxagent")
+	err = kubernetes.WaitForPodsRunning(ctx, clientset, "", "", []string{"azuresecuritylinuxagent"})
 	require.NoError(t, err)
 
 	if testConfig.ValidateStateFile {

--- a/test/integration/swiftv2/swiftv2_test.go
+++ b/test/integration/swiftv2/swiftv2_test.go
@@ -65,7 +65,7 @@ func setupLinuxEnvironment(t *testing.T) {
 	}
 
 	t.Log("Waiting for pods to be running state")
-	err = kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector)
+	err = kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector, nil)
 	if err != nil {
 		t.Fatalf("Pods are not in running state due to %+v", err)
 	}

--- a/test/internal/kubernetes/utils.go
+++ b/test/internal/kubernetes/utils.go
@@ -269,7 +269,7 @@ func MustSetupCNP(ctx context.Context, clientset *cilium.Clientset, cnpPath stri
 
 func Int32ToPtr(i int32) *int32 { return &i }
 
-func WaitForPodsRunning(ctx context.Context, clientset *kubernetes.Clientset, namespace, labelselector string, excludeNamespaces ...string) error {
+func WaitForPodsRunning(ctx context.Context, clientset *kubernetes.Clientset, namespace, labelselector string, excludeNamespaces []string) error {
 	podsClient := clientset.CoreV1().Pods(namespace)
 
 	excludeSet := make(map[string]struct{}, len(excludeNamespaces))

--- a/test/validate/linux_validate.go
+++ b/test/validate/linux_validate.go
@@ -332,7 +332,7 @@ func (v *Validator) validateRestartNetwork(ctx context.Context) error {
 		if err != nil {
 			return errors.Wrapf(err, "failed to exec into privileged pod %s on node %s", privilegedPod.Name, node.Name)
 		}
-		err = acnk8s.WaitForPodsRunning(ctx, v.clientset, "", "", "azuresecuritylinuxagent")
+		err = acnk8s.WaitForPodsRunning(ctx, v.clientset, "", "", []string{"azuresecuritylinuxagent"})
 		if err != nil {
 			return errors.Wrapf(err, "failed to wait for pods running")
 		}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
During testing we check that all pods are up and running, but a new external component out of our control is crashing a % of the time, causing flakiness. We ignore this namespace as the pod is also a host networking pod unrelated to our components.

Also modifies an error path to return a real error. Previously it always returned a wrapped nil value, which resolves to just nil (so if we hit the error path it would hide the error).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
Ran 5-6 full runs of the pipeline with this change and have yet to see the issue reappear.