### PR TITLE
ci: force cns test manifests to always pull images

### DIFF
--- a/test/integration/manifests/cns/daemonset-linux.yaml
+++ b/test/integration/manifests/cns/daemonset-linux.yaml
@@ -42,7 +42,7 @@ spec:
       containers:
         - name: cns-container
           image: acnpublic.azurecr.io/azure-cns:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           args: [ "-c", "tcp://$(CNSIpAddress):$(CNSPort)", "-t", "$(CNSLogTarget)"]
           securityContext:
             capabilities:
@@ -88,7 +88,7 @@ spec:
                     fieldPath: spec.nodeName
         - name: debug
           image: mcr.microsoft.com/cbl-mariner/base/core:2.0
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           command: ["sleep", "3600"]
           securityContext:
             capabilities:

--- a/test/integration/manifests/cns/daemonset-windows.yaml
+++ b/test/integration/manifests/cns/daemonset-windows.yaml
@@ -45,7 +45,7 @@ spec:
       containers:
         - name: cns-container
           image: acnpublic.azurecr.io/azure-cns:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           securityContext:
             privileged: true
           workingDir: $env:CONTAINER_SANDBOX_MOUNT_POINT


### PR DESCRIPTION


<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
in the test pipeline, saw some unexpected behavior where cns pulled the wrong arch version from the multiarch manifest and could not recover. theorizing this was a transient error and would be fixed by repulling. however, currently, the daemonset will only pull once and never again-- this changes that behavior

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
See #20260407.12 -- cns is in crashloopbackoff with "exec format error"