### PR TITLE
feat: allow waagent to install iptables rule, in eBPF host routing mode

### DIFF
--- a/bpf-prog/azure-block-iptables/bpf/src/block_iptables.bpf.c
+++ b/bpf-prog/azure-block-iptables/bpf/src/block_iptables.bpf.c
@@ -13,7 +13,7 @@
 #define EPERM 1
 #define IPT_SO_SET_REPLACE 64
 #define TASK_COMM_LEN 16
-#define COMM_COUNT 5
+#define COMM_COUNT 6
 #define IPPROTO_IP 0
 #define IPPROTO_IP6 41
 #define AF_NETLINK 16
@@ -27,6 +27,7 @@
 #define AZURE_CNS "azure-cns"
 #define ISTIO_NODE_AGENT "install-cni"
 #define NFS_MOUNT_SCRIPTS "nfs" // nfvsv3mountscript, nfsv4mountscript
+#define WAAGENT "python" // this allows all python processes including waagent. Will narrow down in the future.
 
 char __license[] SEC("license") = "Dual MIT/GPL";
 volatile const u64 host_netns_inode = 4026531840; // Initialized by userspace
@@ -46,9 +47,9 @@ bool is_allowed_parent ()
     struct task_struct *task = (struct task_struct *)bpf_get_current_task();
     struct task_struct *parent_task = NULL;
 
-    // Allow cilium-agent, ip-masq-agent and azure-cns
+    // Allow cilium-agent, ip-masq-agent, waagent and azure-cns
     char parent_comm[TASK_COMM_LEN] = {};
-    const char target_prefixes[COMM_COUNT][TASK_COMM_LEN] = {CILIUM_AGENT, IP_MASQ, AZURE_CNS, ISTIO_NODE_AGENT, NFS_MOUNT_SCRIPTS};
+    const char target_prefixes[COMM_COUNT][TASK_COMM_LEN] = {CILIUM_AGENT, IP_MASQ, AZURE_CNS, ISTIO_NODE_AGENT, NFS_MOUNT_SCRIPTS, WAAGENT};
 
     // Safely get parent task_struct
     parent_task = BPF_CORE_READ(task, real_parent);
@@ -74,6 +75,9 @@ bool is_allowed_parent ()
             return 1;
         }
     }
+
+    parent_comm[TASK_COMM_LEN - 1] = '\0'; // Ensure null termination
+    bpf_printk("Blocked iptables rule - parent comm: %s, pid: %d\n", parent_comm, BPF_CORE_READ(parent_task, pid));
 
     return 0; // Block
 }

--- a/bpf-prog/azure-block-iptables/bpf/src/block_iptables.bpf.c
+++ b/bpf-prog/azure-block-iptables/bpf/src/block_iptables.bpf.c
@@ -47,7 +47,7 @@ bool is_allowed_parent ()
     struct task_struct *task = (struct task_struct *)bpf_get_current_task();
     struct task_struct *parent_task = NULL;
 
-    // Allow cilium-agent, ip-masq-agent, waagent and azure-cns
+    // Allow cilium-agent, ip-masq-agent, nfs, istio, waagent and azure-cns
     char parent_comm[TASK_COMM_LEN] = {};
     const char target_prefixes[COMM_COUNT][TASK_COMM_LEN] = {CILIUM_AGENT, IP_MASQ, AZURE_CNS, ISTIO_NODE_AGENT, NFS_MOUNT_SCRIPTS, WAAGENT};
 

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -10,13 +10,13 @@ AZIMG   = mcr.microsoft.com/azure-cli
 AZCLI   ?= docker run --rm -v $(AZCFG):/root/.azure -v $(KUBECFG):/root/.kube -v $(SSH):/root/.ssh -v $(PWD):/root/tmpsrc $(AZIMG) az
 
 # overrideable defaults
-AUTOUPGRADE          ?= none
+AUTOUPGRADE          ?= patch
 K8S_VER              ?= 1.33
 NODE_COUNT           ?= 2
 NODE_COUNT_WIN	     ?= $(NODE_COUNT)
 NODEUPGRADE          ?= NodeImage
 OS				     ?= linux # Used to signify if you want to bring up a windows nodePool on byocni clusters
-OS_SKU               ?= Ubuntu2404
+OS_SKU               ?= Ubuntu
 OS_SKU_WIN           ?= Windows2022
 REGION               ?= westus2
 VM_SIZE	             ?= Standard_B2s
@@ -27,7 +27,7 @@ PUBLIC_IP_ID         ?= /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/
 PUBLIC_IPv4          ?= $(PUBLIC_IP_ID)/$(IP_PREFIX)-$(CLUSTER)-v4
 PUBLIC_IPv6          ?= $(PUBLIC_IP_ID)/$(IP_PREFIX)-$(CLUSTER)-v6
 KUBE_PROXY_JSON_PATH ?= ./kube-proxy.json
-LTS					 ?= true
+LTS					 ?= false
 ACNS				 ?= false
 
 
@@ -195,7 +195,6 @@ overlay-cilium-up: rg-up ipv4 overlay-net-up ## Brings up an Overlay Cilium clus
 		--load-balancer-outbound-ips $(PUBLIC_IPv4) \
 		--network-plugin azure \
 		--network-dataplane cilium \
-		--workload-runtime KataVmIsolation \
 		--network-plugin-mode overlay \
 		--pod-cidr $(POD_CIDR) \
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
@@ -257,11 +256,9 @@ swift-cilium-up: rg-up ipv4 swift-net-up ## Bring up a SWIFT Cilium cluster
 		--load-balancer-outbound-ips $(PUBLIC_IPv4) \
 		--network-plugin azure \
 		--network-dataplane cilium \
-		--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/AdvancedNetworkingPerformancePreview \
+		--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/CiliumDataplanePreview \
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
 		--pod-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/podnet \
-		--enable-acns \
-		--acns-datapath-acceleration-mode BpfVeth \
 		--yes
 	@$(MAKE) set-kubeconf
 

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -10,13 +10,13 @@ AZIMG   = mcr.microsoft.com/azure-cli
 AZCLI   ?= docker run --rm -v $(AZCFG):/root/.azure -v $(KUBECFG):/root/.kube -v $(SSH):/root/.ssh -v $(PWD):/root/tmpsrc $(AZIMG) az
 
 # overrideable defaults
-AUTOUPGRADE          ?= patch
+AUTOUPGRADE          ?= none
 K8S_VER              ?= 1.33
 NODE_COUNT           ?= 2
 NODE_COUNT_WIN	     ?= $(NODE_COUNT)
 NODEUPGRADE          ?= NodeImage
 OS				     ?= linux # Used to signify if you want to bring up a windows nodePool on byocni clusters
-OS_SKU               ?= Ubuntu
+OS_SKU               ?= Ubuntu2404
 OS_SKU_WIN           ?= Windows2022
 REGION               ?= westus2
 VM_SIZE	             ?= Standard_B2s
@@ -27,7 +27,7 @@ PUBLIC_IP_ID         ?= /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/
 PUBLIC_IPv4          ?= $(PUBLIC_IP_ID)/$(IP_PREFIX)-$(CLUSTER)-v4
 PUBLIC_IPv6          ?= $(PUBLIC_IP_ID)/$(IP_PREFIX)-$(CLUSTER)-v6
 KUBE_PROXY_JSON_PATH ?= ./kube-proxy.json
-LTS					 ?= false
+LTS					 ?= true
 ACNS				 ?= false
 
 
@@ -195,6 +195,7 @@ overlay-cilium-up: rg-up ipv4 overlay-net-up ## Brings up an Overlay Cilium clus
 		--load-balancer-outbound-ips $(PUBLIC_IPv4) \
 		--network-plugin azure \
 		--network-dataplane cilium \
+		--workload-runtime KataVmIsolation \
 		--network-plugin-mode overlay \
 		--pod-cidr $(POD_CIDR) \
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
@@ -256,9 +257,11 @@ swift-cilium-up: rg-up ipv4 swift-net-up ## Bring up a SWIFT Cilium cluster
 		--load-balancer-outbound-ips $(PUBLIC_IPv4) \
 		--network-plugin azure \
 		--network-dataplane cilium \
-		--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/CiliumDataplanePreview \
+		--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/AdvancedNetworkingPerformancePreview \
 		--vnet-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/nodenet \
 		--pod-subnet-id /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/Microsoft.Network/virtualNetworks/$(VNET)/subnets/podnet \
+		--enable-acns \
+		--acns-datapath-acceleration-mode BpfVeth \
 		--yes
 	@$(MAKE) set-kubeconf
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
Allow python scripts to install iptables rules. This is overapproximating waagent, which we need to allow to install iptables rules. We will look into ways to narrow down this. This is needed because in eBPF host routing mode, our ipttables block logic prevents rule installation, and the waagent script keeps trying. This in turn causes IPTablesRuleBlocked events to be created on the node, which is noise from the perspective of a customer. We are allowing python because in BPF, we don't see the actual script that's run, only the python executable.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Validation**:
Manually validated on an AKS cluster


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
