### PR TITLE
[backport v1.6] fix: bumping Go version to 1.24.13

### DIFF
--- a/.pipelines/build/binary.steps.yaml
+++ b/.pipelines/build/binary.steps.yaml
@@ -10,9 +10,12 @@ parameters:
 
 
 steps:
-- task: GoTool@0
+- task: ShellScript@2
+  displayName: "Install msft-go"
   inputs:
-    version: '$(GOVERSION)'
+    scriptPath: $(REPO_ROOT)/.pipelines/build/scripts/install-go.sh
+  env:
+      name: $(name)
 
 - bash: |
     # Ubuntu
@@ -20,24 +23,24 @@ steps:
       sudo apt-get update -y
       if [[ $GOARCH =~ amd64 ]]; then
         sudo apt-get install -y llvm clang linux-libc-dev linux-headers-generic libbpf-dev libc6-dev nftables iproute2 gcc-multilib tree
-        for dir in /usr/include/x86_64-linux-gnu/*; do 
-          sudo ln -sfn "$dir" /usr/include/$(basename "$dir") 
+        for dir in /usr/include/x86_64-linux-gnu/*; do
+          sudo ln -sfn "$dir" /usr/include/$(basename "$dir")
         done
-  
+
       elif [[ $GOARCH =~ arm64 ]]; then
         sudo apt-get install -y llvm clang linux-libc-dev linux-headers-generic libbpf-dev libc6-dev nftables iproute2 gcc-aarch64-linux-gnu tree
-        for dir in /usr/include/aarch64-linux-gnu/*; do 
+        for dir in /usr/include/aarch64-linux-gnu/*; do
           sudo ln -sfn "$dir" /usr/include/$(basename "$dir")
         done
       fi
     # Mariner
     else
       sudo tdnf install -y llvm clang libbpf-devel nftables tree
-      for dir in /usr/include/aarch64-linux-gnu/*; do 
+      for dir in /usr/include/aarch64-linux-gnu/*; do
         if [[ -d $dir ]]; then
-          sudo ln -sfn "$dir" /usr/include/$(basename "$dir") 
+          sudo ln -sfn "$dir" /usr/include/$(basename "$dir")
         elif [[ -f "$dir" ]]; then
-          sudo ln -Tsfn "$dir" /usr/include/$(basename "$dir") 
+          sudo ln -Tsfn "$dir" /usr/include/$(basename "$dir")
         fi
       done
     fi

--- a/.pipelines/build/images.jobs.yaml
+++ b/.pipelines/build/images.jobs.yaml
@@ -49,9 +49,17 @@ jobs:
         targetPath: $(REPO_ROOT)
         artifact: '${{ job_data.templateContext.repositoryArtifact }}'
 
-    - task: GoTool@0
+    - task: ShellScript@2
+      displayName: "Install crane"
       inputs:
-        version: '$(GOVERSION)'
+        scriptPath: $(REPO_ROOT)/.pipelines/build/scripts/install-crane.sh
+
+    - task: ShellScript@2
+      displayName: "Install msft-go"
+      inputs:
+        scriptPath: $(REPO_ROOT)/.pipelines/build/scripts/install-go.sh
+      env:
+        name: $(name)
 
     - task: ShellScript@2
       inputs:
@@ -76,7 +84,7 @@ jobs:
     - task: ShellScript@2
       displayName: "Package with DropGZ"
       condition: and(
-        succeeded(), 
+        succeeded(),
         eq(variables.packageWithDropGZ, 'True'))
       inputs:
         scriptPath: $(REPO_ROOT)/.pipelines/build/scripts/dropgz.sh
@@ -84,7 +92,7 @@ jobs:
     - ${{ if not(contains(job_data.job, 'linux')) }}:
       - task: onebranch.pipeline.signing@1
         condition: and(
-          succeeded(), 
+          succeeded(),
           eq(variables.packageWithDropGZ, 'True'))
         inputs:
           command: 'sign'
@@ -94,7 +102,7 @@ jobs:
 
     # OneBranch artifacts are stored on a Windows machine which obliterates
     # Linux file permissions.
-    # This task is added (along with ob_extract_root_artifact in jobs that 
+    # This task is added (along with ob_extract_root_artifact in jobs that
     # download the artifact) to protect those file permissions from changing
     # during image build time.
     #

--- a/.pipelines/build/scripts/install-crane.sh
+++ b/.pipelines/build/scripts/install-crane.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -eux
+
+# Install crane (google/go-containerregistry) for daemonless container image extraction.
+# crane can pull and export image filesystems without a Docker daemon.
+# Go is pre-installed in the build container, so we use go install.
+# Rely on go install for supply chain security and reproducibility
+if ! command -v crane &> /dev/null; then
+  go install github.com/google/go-containerregistry/cmd/crane@v0.21.3
+  sudo mv "$(go env GOPATH)/bin/crane" /usr/local/bin/crane
+fi
+
+crane version

--- a/.pipelines/build/scripts/install-go.sh
+++ b/.pipelines/build/scripts/install-go.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Install Go by extracting it from the msft-go container image.
+# The golang image reference is read directly from the source Dockerfile for the
+# current image (identified by $name), keeping the pipeline in sync with the build.
+#
+# Priority:
+#   1. MSFT_GO_IMAGE env var (explicit override)
+#   2. Parsed from the source Dockerfile for $name
+#   3. Hardcoded fallback digest below
+#
+# To update the fallback, run:
+#   skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
+DEFAULT_IMAGE="mcr.microsoft.com/oss/go/microsoft/golang@sha256:b05a9bbf50a8ccfdd0ebe9f673ef29dca7c1d5e209434b35a560a4e8ae5f72b2"
+
+# Resolves the golang image from the source Dockerfile for the given $name.
+# Echoes the image reference, or empty string if it cannot be determined.
+resolve_go_image() {
+  if [[ "${name:-}" == "npm" ]]; then
+    # npm uses OS-specific Dockerfiles with a tag-based reference.
+    # The image may be field 2 (no --platform) or field 3 (with --platform),
+    # so extract the mcr.* token directly.
+    # e.g. FROM mcr.../golang:1.25.5 AS builder
+    # e.g. FROM --platform=linux/amd64 mcr.../golang:1.25.5 AS builder
+    local buildfile="${REPO_ROOT}/npm/${OS:-linux}.Dockerfile"
+    grep -m1 '^FROM.*golang' "${buildfile}" 2>/dev/null | grep -o 'mcr[^ ]*' || true
+
+  else
+    # All other images use a digest-pinned reference and always have --platform,
+    # making the image consistently field 3: FROM --platform=X IMAGE AS alias
+    local buildfile
+    if [[ "${name:-}" == "ipv6-hp-bpf" ]]; then
+      buildfile="${REPO_ROOT}/bpf-prog/ipv6-hp-bpf/linux.Dockerfile"
+    elif [[ -n "${name:-}" ]]; then
+      buildfile="${REPO_ROOT}/${name}/Dockerfile"
+    fi
+
+    if [[ -n "${buildfile:-}" && -f "${buildfile}" ]]; then
+      grep -m1 '^FROM.*golang' "${buildfile}" | awk '{print $3}' || true
+    fi
+  fi
+}
+
+if [[ -z "${MSFT_GO_IMAGE:-}" ]]; then
+  MSFT_GO_IMAGE="$(resolve_go_image)"
+  MSFT_GO_IMAGE="${MSFT_GO_IMAGE:-$DEFAULT_IMAGE}"
+fi
+
+ARCH="${ARCH:-amd64}"
+
+# Extract /usr/local/go from the image without needing a Docker daemon.
+# crane export streams the full image filesystem; we extract just usr/local/go.
+crane export --platform "linux/${ARCH}" "$MSFT_GO_IMAGE" - | sudo tar -xf - -C / usr/local/go
+
+echo "##vso[task.prependpath]/usr/local/go/bin"

--- a/azure-ipam/Dockerfile
+++ b/azure-ipam/Dockerfile
@@ -3,8 +3,8 @@ ARG DROPGZ_VERSION=v0.0.12
 ARG OS_VERSION
 ARG OS
 
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.23.2-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:f8613198423d5cb702961f1547f9cb061f8da1c6ca9ce8da4824eb47db663cd7 AS go
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:b05a9bbf50a8ccfdd0ebe9f673ef29dca7c1d5e209434b35a560a4e8ae5f72b2 AS go
 
 # skopeo inspect docker://mcr.microsoft.com/cbl-mariner/base/core:2.0 --format "{{.Name}}@{{.Digest}}"
 FROM --platform=linux/${ARCH} mcr.microsoft.com/cbl-mariner/base/core@sha256:a490e0b0869dc570ae29782c2bc17643aaaad1be102aca83ce0b96e0d0d2d328 AS mariner-core

--- a/bpf-prog/ipv6-hp-bpf/linux.Dockerfile
+++ b/bpf-prog/ipv6-hp-bpf/linux.Dockerfile
@@ -1,6 +1,6 @@
 ARG ARCH
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.23.2 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:86c5b00bbed2a6e7157052d78bf4b45c0bf26545ed6e8fd7dbad51ac9415f534 AS builder
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:f3e556c9de4dd93be774dc0fa2ce3cfa76f7744d0bacada92d1624f04ce69461 AS builder
 ARG VERSION
 ARG DEBUG
 ARG OS

--- a/build/images.mk
+++ b/build/images.mk
@@ -1,5 +1,5 @@
 # Source images
-export GO_IMG					?= mcr.microsoft.com/oss/go/microsoft/golang:1.23-cbl-mariner2.0
+export GO_IMG					?= mcr.microsoft.com/oss/go/microsoft/golang:1.24-cbl-mariner2.0
 export MARINER_CORE_IMG			?= mcr.microsoft.com/cbl-mariner/base/core:2.0
 export MARINER_DISTROLESS_IMG	?= mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
 export WIN_HPC_IMG				?= mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0

--- a/cni/Dockerfile
+++ b/cni/Dockerfile
@@ -5,8 +5,8 @@ ARG DROPGZ_VERSION=v0.0.12
 ARG OS_VERSION
 ARG OS
 
-# mcr.microsoft.com/oss/go/microsoft/golang:1.23-cbl-mariner2.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:1d8a3fc8df13298bab0d6ea34f49ded3641fd60985c7968518717e965edaef99 AS go
+# mcr.microsoft.com/oss/go/microsoft/golang:1.24-cbl-mariner2.0
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:b05a9bbf50a8ccfdd0ebe9f673ef29dca7c1d5e209434b35a560a4e8ae5f72b2 AS go
 
 # mcr.microsoft.com/cbl-mariner/base/core:2.0
 FROM --platform=linux/${ARCH} mcr.microsoft.com/cbl-mariner/base/core@sha256:61b8c8e5c769784be2137cba8612c3a0f0c1752a66276b3b1b5306014a1e20e0 AS mariner-core

--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -4,8 +4,8 @@ ARG ARCH
 ARG OS_VERSION
 ARG OS
 
-# mcr.microsoft.com/oss/go/microsoft/golang:1.23-cbl-mariner2.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:1d8a3fc8df13298bab0d6ea34f49ded3641fd60985c7968518717e965edaef99 AS go
+# mcr.microsoft.com/oss/go/microsoft/golang:1.24-cbl-mariner2.0
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:b05a9bbf50a8ccfdd0ebe9f673ef29dca7c1d5e209434b35a560a4e8ae5f72b2 AS go
 
 # mcr.microsoft.com/cbl-mariner/base/core:2.0
 FROM mcr.microsoft.com/cbl-mariner/base/core@sha256:61b8c8e5c769784be2137cba8612c3a0f0c1752a66276b3b1b5306014a1e20e0 AS mariner-core


### PR DESCRIPTION
## Summary
Backport of #4289 to release/v1.6 — bumps Go from 1.23.x to 1.24 to fix critical CVEs.

## Changes
Updates Go image SHA in:
- `cni/Dockerfile`
- `cns/Dockerfile`  
- `azure-ipam/Dockerfile`

**New image:** `mcr.microsoft.com/oss/go/microsoft/golang:1.24-cbl-mariner2.0`
**SHA:** `sha256:b05a9bbf50a8ccfdd0ebe9f673ef29dca7c1d5e209434b35a560a4e8ae5f72b2`

## CVE Impact
| CVE | Severity | Package |
|-----|----------|---------|
| CVE-2025-68121 | CRITICAL | crypto/tls |
| CVE-2025-68132 | HIGH | net/http |
| CVE-2025-68133 | MEDIUM | os |
| CVE-2025-68134 | MEDIUM | strings |
| CVE-2025-68135 | LOW | encoding/json |

## Notes
- Manual SHA update (v1.6 uses cbl-mariner2.0, not azurelinux3.0)
- Dev tooling Dockerfiles (hack/toolbox, tools/acncli) not updated — internal only

## Related
- Original PR: https://github.com/Azure/azure-container-networking/pull/4289
- v1.7 backport: https://github.com/Azure/azure-container-networking/compare/release/v1.7...backport/go-cve-fix-to-release-v1.7