### PR TITLE
fix: Reprogram NCs missing from CNS for Succeeded CRs after restart

### DIFF
--- a/.pipelines/build/dockerfiles/azure-iptables-monitor.Dockerfile
+++ b/.pipelines/build/dockerfiles/azure-iptables-monitor.Dockerfile
@@ -3,10 +3,10 @@
 ARG ARCH
 
 # mcr.microsoft.com/azurelinux/base/core:3.0
-FROM mcr.microsoft.com/azurelinux/base/core@sha256:a452d39c91576f5a2c983c7d3b62521fabd08e16b4a7237e24bf2be3b06e1651 AS mariner-core
+FROM mcr.microsoft.com/azurelinux/base/core@sha256:35149ae8dd179684f969944f54a337c665a64e702486154eb44253fb39c2505b AS mariner-core
 
 # mcr.microsoft.com/azurelinux/distroless/minimal:3.0
-FROM mcr.microsoft.com/azurelinux/distroless/minimal@sha256:22810fd97d6ad5ec7d5bdd5b00233a3050be01d9e26b47b16cb6f1a7f178834b AS mariner-distroless
+FROM mcr.microsoft.com/azurelinux/distroless/minimal@sha256:5a66f9f16ac675db2a8229dac72d83811b73b502d6ad192d8b374c7f3be498af AS mariner-distroless
 
 FROM mariner-core AS iptools
 RUN tdnf install -y iptables iproute

--- a/.pipelines/build/dockerfiles/cns.Dockerfile
+++ b/.pipelines/build/dockerfiles/cns.Dockerfile
@@ -11,11 +11,11 @@ ENTRYPOINT ["azure-cns.exe"]
 EXPOSE 10090
 
 # mcr.microsoft.com/azurelinux/base/core:3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/base/core@sha256:a452d39c91576f5a2c983c7d3b62521fabd08e16b4a7237e24bf2be3b06e1651 AS build-helper
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/base/core@sha256:35149ae8dd179684f969944f54a337c665a64e702486154eb44253fb39c2505b AS build-helper
 RUN tdnf install -y iptables
 
 # mcr.microsoft.com/azurelinux/distroless/minimal:3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/minimal@sha256:22810fd97d6ad5ec7d5bdd5b00233a3050be01d9e26b47b16cb6f1a7f178834b AS linux
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/minimal@sha256:5a66f9f16ac675db2a8229dac72d83811b73b502d6ad192d8b374c7f3be498af AS linux
 ARG ARTIFACT_DIR .
 
 COPY --from=build-helper /usr/sbin/*tables* /usr/sbin/

--- a/azure-ipam/Dockerfile
+++ b/azure-ipam/Dockerfile
@@ -9,7 +9,7 @@ ARG OS
 FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:bc7423b52b62e8f0281b5f7f564eb1862dc315bc57e1373c6a81e87ef3ac39ab AS go
 
 # mcr.microsoft.com/azurelinux/base/core:3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/base/core@sha256:a452d39c91576f5a2c983c7d3b62521fabd08e16b4a7237e24bf2be3b06e1651 AS mariner-core
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/base/core@sha256:35149ae8dd179684f969944f54a337c665a64e702486154eb44253fb39c2505b AS mariner-core
 
 FROM go AS azure-ipam
 ARG OS

--- a/azure-iptables-monitor/Dockerfile
+++ b/azure-iptables-monitor/Dockerfile
@@ -3,10 +3,10 @@
 ARG ARCH
 
 # mcr.microsoft.com/azurelinux/base/core:3.0
-FROM mcr.microsoft.com/azurelinux/base/core@sha256:a452d39c91576f5a2c983c7d3b62521fabd08e16b4a7237e24bf2be3b06e1651 AS mariner-core
+FROM mcr.microsoft.com/azurelinux/base/core@sha256:35149ae8dd179684f969944f54a337c665a64e702486154eb44253fb39c2505b AS mariner-core
 
 # mcr.microsoft.com/azurelinux/distroless/minimal:3.0
-FROM mcr.microsoft.com/azurelinux/distroless/minimal@sha256:22810fd97d6ad5ec7d5bdd5b00233a3050be01d9e26b47b16cb6f1a7f178834b AS mariner-distroless
+FROM mcr.microsoft.com/azurelinux/distroless/minimal@sha256:5a66f9f16ac675db2a8229dac72d83811b73b502d6ad192d8b374c7f3be498af AS mariner-distroless
 
 # mcr.microsoft.com/oss/go/microsoft/golang:1.24-azurelinux3.0
 FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:bc7423b52b62e8f0281b5f7f564eb1862dc315bc57e1373c6a81e87ef3ac39ab AS go

--- a/azure-iptables-monitor/go.sum
+++ b/azure-iptables-monitor/go.sum
@@ -29,8 +29,6 @@ github.com/go-openapi/jsonreference v0.20.2/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-openapi/swag v0.22.4 h1:QLMzNJnMGPRNDCbySlcj1x01tzU8/9LTTL9hZZZogBU=
 github.com/go-openapi/swag v0.22.4/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
-github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6 h1:teYtXy9B7y5lHTp8V9KPxpYRAVA7dozigQcMiBust1s=
-github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6/go.mod h1:p4lGIVX+8Wa6ZPNDvqcxq36XpUDLh42FLetFU7odllI=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=

--- a/azure-iptables-monitor/go.sum
+++ b/azure-iptables-monitor/go.sum
@@ -29,6 +29,8 @@ github.com/go-openapi/jsonreference v0.20.2/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-openapi/swag v0.22.4 h1:QLMzNJnMGPRNDCbySlcj1x01tzU8/9LTTL9hZZZogBU=
 github.com/go-openapi/swag v0.22.4/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
+github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6 h1:teYtXy9B7y5lHTp8V9KPxpYRAVA7dozigQcMiBust1s=
+github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6/go.mod h1:p4lGIVX+8Wa6ZPNDvqcxq36XpUDLh42FLetFU7odllI=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=

--- a/cni/Dockerfile
+++ b/cni/Dockerfile
@@ -9,7 +9,7 @@ ARG OS
 FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:bc7423b52b62e8f0281b5f7f564eb1862dc315bc57e1373c6a81e87ef3ac39ab AS go
 
 # mcr.microsoft.com/azurelinux/base/core:3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/base/core@sha256:a452d39c91576f5a2c983c7d3b62521fabd08e16b4a7237e24bf2be3b06e1651 AS mariner-core
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/base/core@sha256:35149ae8dd179684f969944f54a337c665a64e702486154eb44253fb39c2505b AS mariner-core
 
 FROM go AS azure-vnet
 ARG OS

--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -8,10 +8,10 @@ ARG OS
 FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:bc7423b52b62e8f0281b5f7f564eb1862dc315bc57e1373c6a81e87ef3ac39ab AS go
 
 # mcr.microsoft.com/azurelinux/base/core:3.0
-FROM mcr.microsoft.com/azurelinux/base/core@sha256:a452d39c91576f5a2c983c7d3b62521fabd08e16b4a7237e24bf2be3b06e1651 AS mariner-core
+FROM mcr.microsoft.com/azurelinux/base/core@sha256:35149ae8dd179684f969944f54a337c665a64e702486154eb44253fb39c2505b AS mariner-core
 
 # mcr.microsoft.com/azurelinux/distroless/minimal:3.0
-FROM mcr.microsoft.com/azurelinux/distroless/minimal@sha256:22810fd97d6ad5ec7d5bdd5b00233a3050be01d9e26b47b16cb6f1a7f178834b AS mariner-distroless
+FROM mcr.microsoft.com/azurelinux/distroless/minimal@sha256:5a66f9f16ac675db2a8229dac72d83811b73b502d6ad192d8b374c7f3be498af AS mariner-distroless
 
 FROM --platform=linux/${ARCH} go AS builder
 ARG OS

--- a/cns/multitenantcontroller/multitenantoperator/multitenantcrdreconciler.go
+++ b/cns/multitenantcontroller/multitenantoperator/multitenantcrdreconciler.go
@@ -91,7 +91,7 @@ func (r *multiTenantCrdReconciler) Reconcile(ctx context.Context, request reconc
 	// For "Succeeded" CRs, we must verify the NC still exists in CNS — it may have been lost
 	// due to CNS restart or state file corruption. If missing, we fall through to reprogram it.
 	if nc.Status.State != NCStateInitialized && nc.Status.State != NCStateSucceeded {
-		logger.Printf("MultiTenantNetworkContainer %s in state %s, skip reconciling", request.NamespacedName.String(), nc.Status.State)
+		logger.Printf("MultiTenantNetworkContainer %s in state %s, skip reconciling", request.NamespacedName.String(), nc.Status.State) //nolint:staticcheck // TODO: migrate to cns/logger/v2
 		return ctrl.Result{}, nil
 	}
 
@@ -125,7 +125,7 @@ func (r *multiTenantCrdReconciler) Reconcile(ctx context.Context, request reconc
 	}
 
 	if nc.Status.State == NCStateSucceeded {
-		logger.Warnf("NC %s (UUID: %s) missing from CNS despite CR state Succeeded, reprogramming", request.NamespacedName.String(), nc.Spec.UUID)
+		logger.Warnf("NC %s (UUID: %s) missing from CNS despite CR state Succeeded, reprogramming", request.NamespacedName.String(), nc.Spec.UUID) //nolint:staticcheck // TODO: migrate to cns/logger/v2
 	}
 
 	// Check that the MultiTenantInfo is set

--- a/cns/multitenantcontroller/multitenantoperator/multitenantcrdreconciler.go
+++ b/cns/multitenantcontroller/multitenantoperator/multitenantcrdreconciler.go
@@ -87,9 +87,11 @@ func (r *multiTenantCrdReconciler) Reconcile(ctx context.Context, request reconc
 		return ctrl.Result{}, nil
 	}
 
-	// Do nothing if the network container hasn't been initialized yet from control plane.
-	if nc.Status.State != NCStateInitialized {
-		logger.Printf("MultiTenantNetworkContainer %s hasn't initialized yet, skip reconciling", request.NamespacedName.String())
+	// Skip reconciliation for CRs that are not yet initialized and not previously succeeded.
+	// For "Succeeded" CRs, we must verify the NC still exists in CNS — it may have been lost
+	// due to CNS restart or state file corruption. If missing, we fall through to reprogram it.
+	if nc.Status.State != NCStateInitialized && nc.Status.State != NCStateSucceeded {
+		logger.Printf("MultiTenantNetworkContainer %s in state %s, skip reconciling", request.NamespacedName.String(), nc.Status.State)
 		return ctrl.Result{}, nil
 	}
 
@@ -120,6 +122,10 @@ func (r *multiTenantCrdReconciler) Reconcile(ctx context.Context, request reconc
 	if !errors.As(err, &cnsRESTErr) || cnsRESTErr.ResponseCode != types.UnknownContainerID {
 		logger.Errorf("Failed to fetch NC %s (UUID: %s) from CNS: %v", request.NamespacedName.String(), nc.Spec.UUID, err)
 		return ctrl.Result{}, err
+	}
+
+	if nc.Status.State == NCStateSucceeded {
+		logger.Printf("[WARNING] NC %s (UUID: %s) missing from CNS despite CR state Succeeded, reprogramming", request.NamespacedName.String(), nc.Spec.UUID)
 	}
 
 	// Check that the MultiTenantInfo is set

--- a/cns/multitenantcontroller/multitenantoperator/multitenantcrdreconciler.go
+++ b/cns/multitenantcontroller/multitenantoperator/multitenantcrdreconciler.go
@@ -125,7 +125,7 @@ func (r *multiTenantCrdReconciler) Reconcile(ctx context.Context, request reconc
 	}
 
 	if nc.Status.State == NCStateSucceeded {
-		logger.Printf("[WARNING] NC %s (UUID: %s) missing from CNS despite CR state Succeeded, reprogramming", request.NamespacedName.String(), nc.Spec.UUID)
+		logger.Warnf("NC %s (UUID: %s) missing from CNS despite CR state Succeeded, reprogramming", request.NamespacedName.String(), nc.Spec.UUID)
 	}
 
 	// Check that the MultiTenantInfo is set

--- a/cns/multitenantcontroller/multitenantoperator/multitenantcrdreconciler_test.go
+++ b/cns/multitenantcontroller/multitenantoperator/multitenantcrdreconciler_test.go
@@ -116,7 +116,7 @@ var _ = Describe("multiTenantCrdReconciler", func() {
 
 		It("Should reprogram NC when CR is in Succeeded state but NC is missing from CNS", func() {
 			uuid := uuidValue
-			var nc ncapi.MultiTenantNetworkContainer = ncapi.MultiTenantNetworkContainer{
+			nc := ncapi.MultiTenantNetworkContainer{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      namespacedName.Name,
 					Namespace: namespacedName.Namespace,
@@ -179,7 +179,7 @@ var _ = Describe("multiTenantCrdReconciler", func() {
 
 		It("Should skip reconciliation when CR is in Succeeded state and NC exists in CNS", func() {
 			uuid := uuidValue
-			var nc ncapi.MultiTenantNetworkContainer = ncapi.MultiTenantNetworkContainer{
+			nc := ncapi.MultiTenantNetworkContainer{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      namespacedName.Name,
 					Namespace: namespacedName.Namespace,
@@ -214,7 +214,7 @@ var _ = Describe("multiTenantCrdReconciler", func() {
 
 		It("Should return error when CR is in Succeeded state and CNS returns transient error", func() {
 			uuid := uuidValue
-			var nc ncapi.MultiTenantNetworkContainer = ncapi.MultiTenantNetworkContainer{
+			nc := ncapi.MultiTenantNetworkContainer{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      namespacedName.Name,
 					Namespace: namespacedName.Namespace,

--- a/cns/multitenantcontroller/multitenantoperator/multitenantcrdreconciler_test.go
+++ b/cns/multitenantcontroller/multitenantoperator/multitenantcrdreconciler_test.go
@@ -114,6 +114,139 @@ var _ = Describe("multiTenantCrdReconciler", func() {
 			Expect(err).To(BeNil())
 		})
 
+		It("Should reprogram NC when CR is in Succeeded state but NC is missing from CNS", func() {
+			uuid := uuidValue
+			var nc ncapi.MultiTenantNetworkContainer = ncapi.MultiTenantNetworkContainer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      namespacedName.Name,
+					Namespace: namespacedName.Namespace,
+				},
+				Spec: ncapi.MultiTenantNetworkContainerSpec{
+					UUID: uuid,
+				},
+				Status: ncapi.MultiTenantNetworkContainerStatus{
+					State: NCStateSucceeded,
+					MultiTenantInfo: ncapi.MultiTenantInfo{
+						EncapType: "Vlan",
+						ID:        1,
+					},
+					IPSubnet: "10.0.0.0/8",
+					IP:       "10.1.0.0",
+				},
+			}
+
+			orchestratorContext, err := json.Marshal(podInfo)
+			Expect(err).To(BeNil())
+
+			kubeClient.EXPECT().Get(gomock.Any(), namespacedName, gomock.Any()).SetArg(2, nc)
+			// NC is missing from CNS — returns UnknownContainerID
+			cnsRestService.EXPECT().GetNetworkContainerInternal(cns.GetNetworkContainerRequest{
+				NetworkContainerid:  uuid,
+				OrchestratorContext: orchestratorContext,
+			}).Return(cns.GetNetworkContainerResponse{}, cnstypes.UnknownContainerID)
+
+			// Should reprogram the NC
+			cnsRestService.EXPECT().CreateOrUpdateNetworkContainerInternal(&cns.CreateNetworkContainerRequest{
+				NetworkContainerid:   nc.Spec.UUID,
+				OrchestratorContext:  orchestratorContext,
+				NetworkContainerType: cns.Kubernetes,
+				Version:              "0",
+				IPConfiguration: cns.IPConfiguration{
+					IPSubnet: cns.IPSubnet{
+						IPAddress:    nc.Status.IP,
+						PrefixLength: 8,
+					},
+					GatewayIPAddress: nc.Status.Gateway,
+				},
+				PrimaryInterfaceIdentifier: nc.Status.PrimaryInterfaceIdentifier,
+				MultiTenancyInfo: cns.MultiTenancyInfo{
+					EncapType: nc.Status.MultiTenantInfo.EncapType,
+					ID:        int(nc.Status.MultiTenantInfo.ID),
+				},
+			}).Return(cnstypes.Success)
+
+			kubeClient.EXPECT().Status().DoAndReturn(func() client.SubResourceWriter {
+				nc.Status.State = NCStateSucceeded
+				statusWriter.EXPECT().Update(gomock.Any(), gomock.Any()).SetArg(1, nc)
+				return statusWriter
+			})
+
+			_, err = reconciler.Reconcile(context.TODO(), reconcile.Request{
+				NamespacedName: namespacedName,
+			})
+			Expect(err).To(BeNil())
+		})
+
+		It("Should skip reconciliation when CR is in Succeeded state and NC exists in CNS", func() {
+			uuid := uuidValue
+			var nc ncapi.MultiTenantNetworkContainer = ncapi.MultiTenantNetworkContainer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      namespacedName.Name,
+					Namespace: namespacedName.Namespace,
+				},
+				Spec: ncapi.MultiTenantNetworkContainerSpec{
+					UUID: uuid,
+				},
+				Status: ncapi.MultiTenantNetworkContainerStatus{
+					State: NCStateSucceeded,
+					MultiTenantInfo: ncapi.MultiTenantInfo{
+						EncapType: "Vlan",
+						ID:        1,
+					},
+				},
+			}
+
+			orchestratorContext, err := json.Marshal(podInfo)
+			Expect(err).To(BeNil())
+
+			kubeClient.EXPECT().Get(gomock.Any(), namespacedName, gomock.Any()).SetArg(2, nc)
+			// NC exists in CNS — should skip without reprogramming
+			cnsRestService.EXPECT().GetNetworkContainerInternal(cns.GetNetworkContainerRequest{
+				NetworkContainerid:  uuid,
+				OrchestratorContext: orchestratorContext,
+			}).Return(cns.GetNetworkContainerResponse{}, cnstypes.Success)
+
+			_, err = reconciler.Reconcile(context.TODO(), reconcile.Request{
+				NamespacedName: namespacedName,
+			})
+			Expect(err).To(BeNil())
+		})
+
+		It("Should return error when CR is in Succeeded state and CNS returns transient error", func() {
+			uuid := uuidValue
+			var nc ncapi.MultiTenantNetworkContainer = ncapi.MultiTenantNetworkContainer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      namespacedName.Name,
+					Namespace: namespacedName.Namespace,
+				},
+				Spec: ncapi.MultiTenantNetworkContainerSpec{
+					UUID: uuid,
+				},
+				Status: ncapi.MultiTenantNetworkContainerStatus{
+					State: NCStateSucceeded,
+					MultiTenantInfo: ncapi.MultiTenantInfo{
+						EncapType: "Vlan",
+						ID:        1,
+					},
+				},
+			}
+
+			orchestratorContext, err := json.Marshal(podInfo)
+			Expect(err).To(BeNil())
+
+			kubeClient.EXPECT().Get(gomock.Any(), namespacedName, gomock.Any()).SetArg(2, nc)
+			// CNS returns an internal error — should NOT reprogram, should surface error
+			cnsRestService.EXPECT().GetNetworkContainerInternal(cns.GetNetworkContainerRequest{
+				NetworkContainerid:  uuid,
+				OrchestratorContext: orchestratorContext,
+			}).Return(cns.GetNetworkContainerResponse{}, cnstypes.UnexpectedError)
+
+			_, err = reconciler.Reconcile(context.TODO(), reconcile.Request{
+				NamespacedName: namespacedName,
+			})
+			Expect(err).NotTo(BeNil())
+		})
+
 		It("Should succeed when the NC is in Initialized state and it has not yet been persisted in CNS", func() {
 			uuid := uuidValue
 			var nc ncapi.MultiTenantNetworkContainer = ncapi.MultiTenantNetworkContainer{


### PR DESCRIPTION
When CNS restarts or loses persisted state, NetworkContainers may be lost from the in-memory ContainerIDByOrchestratorContext map while the corresponding MultiTenantNetworkContainer CRs remain in Succeeded state.

  Previously, the reconciler skipped all CRs not in Initialized state, meaning Succeeded CRs with missing NCs were never reprogrammed. This caused permanent CNI ADD failures (Code 18: UnknownContainerID) with no self-healing path.

  Now, the reconciler allows Succeeded CRs through to the NC existence check. If the NC exists in CNS, reconciliation is skipped as before (no behavior change for the happy path). If the NC is missing, it is reprogrammed from the CR's
  status fields.

  Transient CNS errors are not masked — only UnknownContainerID triggers reprogramming, matching the existing behavior for Initialized CRs.

  Reason for Change: Fix permanent CNI ADD failures after CNS restart when NCs are lost from memory but CRs remain in Succeeded state.

  Issue Fixed:

  Requirements:

   - [X]  uses conventional commit messages
   - [ ]  includes documentation
   - [X]  adds unit tests
   - [ ]  relevant PR labels added

  Notes:

   - No behavior change for the happy path (Succeeded CRs with NCs present in CNS are still skipped)
   - Only UnknownContainerID triggers reprogramming; transient errors are surfaced as before
   - Three new test cases cover: missing NC reprogramming, existing NC skip, and transient error handling
