### PR TITLE
feat: add transparent-tunnel CNI mode for GPS VFP enforcement (Windows)

### DIFF
--- a/network/endpoint_linux.go
+++ b/network/endpoint_linux.go
@@ -163,6 +163,9 @@ func (nw *network) newEndpointImpl(
 					plc,
 					iptc)
 			}
+		} else if epInfo.Mode == opModeTransparentTunnel {
+			logger.Info("Transparent tunnel client")
+			epClient = NewTransparentTunnelEndpointClient(nw, epInfo, hostIfName, contIfName, nl, netioCli, plc, iptc)
 		} else if epInfo.Mode != opModeTransparent {
 			logger.Info("Bridge client")
 			epClient = NewLinuxBridgeEndpointClient(nw.extIf, hostIfName, contIfName, epInfo.Mode, nl, plc)
@@ -282,6 +285,9 @@ func (nw *network) deleteEndpointImpl(nl netlink.NetlinkInterface, plc platform.
 			} else {
 				epClient = NewOVSEndpointClient(nw, epInfo, ep.HostIfName, "", ep.VlanID, ep.LocalIP, nl, ovsctl.NewOvsctl(), plc, iptc)
 			}
+		} else if mode == opModeTransparentTunnel {
+			epInfo := ep.getInfo()
+			epClient = NewTransparentTunnelEndpointClient(nw, epInfo, ep.HostIfName, "", nl, nioc, plc, iptc)
 		} else if mode != opModeTransparent {
 			epClient = NewLinuxBridgeEndpointClient(nw.extIf, ep.HostIfName, "", mode, nl, plc)
 		} else {

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -5,6 +5,7 @@ package network
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"net"
 	"strings"
@@ -19,6 +20,8 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
+
+var errTransparentTunnelRequiresHNSv2 = stderrors.New("transparent-tunnel mode requires HNS v2 (container namespace), HNS v1 is not supported")
 
 const (
 	// hcnSchemaVersionMajor indicates major version number for hcn schema
@@ -166,8 +169,32 @@ func (nw *network) newEndpointImpl(
 			return nil, err
 		}
 
-		return nw.newEndpointImplHnsV2(cli, epInfo)
+		ep, createErr := nw.newEndpointImplHnsV2(cli, epInfo)
+		if createErr != nil {
+			return nil, createErr
+		}
 
+		// For transparent-tunnel mode, add /32 host routes to steer pod traffic
+		// through the gateway where VFP enforces NSG rules.
+		if nw.Mode == opModeTransparentTunnel {
+			gw := ipv4Gateway(nw.Subnets)
+			if err := addTransparentTunnelRoutes(plc, ep.IPAddresses, gw); err != nil {
+				// Route programming failed — roll back the HNS endpoint to avoid
+				// a live endpoint that bypasses VFP/NSG enforcement.
+				logger.Error("transparent-tunnel: rolling back HNS endpoint after route failure",
+					zap.String("hnsId", ep.HnsId), zap.Error(err))
+				_ = nw.deleteEndpointImplHnsV2(ep)
+				return nil, fmt.Errorf("transparent-tunnel route setup failed, endpoint rolled back: %w", err)
+			}
+		}
+
+		return ep, nil
+
+	}
+
+	// transparent-tunnel mode requires HNSv2 for transparent-tunnel /32 route enforcement.
+	if nw.Mode == opModeTransparentTunnel {
+		return nil, errTransparentTunnelRequiresHNSv2
 	}
 
 	return nw.newEndpointImplHnsV1(epInfo, plc)
@@ -552,7 +579,7 @@ func (nw *network) newEndpointImplHnsV2(cli apipaClient, epInfo *EndpointInfo) (
 }
 
 // deleteEndpointImpl deletes an existing endpoint from the network.
-func (nw *network) deleteEndpointImpl(_ netlink.NetlinkInterface, _ platform.ExecClient, _ EndpointClient, _ netio.NetIOInterface, _ NamespaceClientInterface,
+func (nw *network) deleteEndpointImpl(_ netlink.NetlinkInterface, plc platform.ExecClient, _ EndpointClient, _ netio.NetIOInterface, _ NamespaceClientInterface,
 	_ ipTablesClient, _ dhcpClient, ep *endpoint, _ string,
 ) error {
 	// endpoint deletion is not required for IB
@@ -569,15 +596,24 @@ func (nw *network) deleteEndpointImpl(_ netlink.NetlinkInterface, _ platform.Exe
 		return nil
 	}
 
+	var hnsErr error
 	if useHnsV2, err := UseHnsV2(ep.NetNs); useHnsV2 {
 		if err != nil {
 			return err
 		}
-
-		return nw.deleteEndpointImplHnsV2(ep)
+		hnsErr = nw.deleteEndpointImplHnsV2(ep)
+	} else {
+		hnsErr = nw.deleteEndpointImplHnsV1(ep)
 	}
 
-	return nw.deleteEndpointImplHnsV1(ep)
+	// For transparent-tunnel mode, remove /32 host routes AFTER deleting the HNS endpoint.
+	// This ordering ensures that if HNS delete fails, the routes remain in place to keep
+	// VFP/NSG enforcement active on the still-live endpoint.
+	if hnsErr == nil && nw.Mode == opModeTransparentTunnel {
+		deleteTransparentTunnelRoutes(plc, ep.IPAddresses)
+	}
+
+	return hnsErr
 }
 
 // deleteEndpointImplHnsV1 deletes an existing endpoint from the network using HNS v1.

--- a/network/manager.go
+++ b/network/manager.go
@@ -519,7 +519,7 @@ func (nm *networkManager) DeleteEndpointStateless(networkID string, epInfo *Endp
 	nw := &network{
 		Id:           networkID, // currently unused in stateless cni
 		HnsId:        epInfo.HNSNetworkID,
-		Mode:         opModeTransparent,
+		Mode:         mode,
 		SnatBridgeIP: "",
 		NetNs:        dummyGUID, // to trigger hns v2, windows
 		extIf: &externalInterface{

--- a/network/network.go
+++ b/network/network.go
@@ -20,8 +20,9 @@ const (
 	opModeBridge          = "bridge"
 	opModeTunnel          = "tunnel"
 	opModeTransparent     = "transparent"
-	opModeTransparentVlan = "transparent-vlan"
-	opModeDefault         = opModeTunnel
+	opModeTransparentVlan   = "transparent-vlan"
+	opModeTransparentTunnel = "transparent-tunnel"
+	opModeDefault           = opModeTunnel
 )
 
 const (

--- a/network/network_linux.go
+++ b/network/network_linux.go
@@ -91,6 +91,15 @@ func (nm *networkManager) newNetworkImpl(nwInfo *EndpointInfo, extIf *externalIn
 				return nil, fmt.Errorf("Ipv6 forwarding failed: %w", err)
 			}
 		}
+	case opModeTransparentTunnel:
+		logger.Info("Transparent tunnel mode")
+		ifName = extIf.Name
+		if nwInfo.IPV6Mode != "" {
+			nu := networkutils.NewNetworkUtils(nm.netlink, nm.plClient)
+			if err := nu.EnableIPV6Forwarding(); err != nil {
+				return nil, fmt.Errorf("Ipv6 forwarding failed: %w", err)
+			}
+		}
 	case opModeTransparentVlan:
 		logger.Info("Transparent vlan mode")
 		ifName = extIf.Name

--- a/network/transparent_tunnel_endpoint_windows.go
+++ b/network/transparent_tunnel_endpoint_windows.go
@@ -1,0 +1,90 @@
+// Copyright 2017 Microsoft. All rights reserved.
+// MIT License
+
+package network
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/Azure/azure-container-networking/platform"
+	"go.uber.org/zap"
+)
+
+var errTransparentTunnelGatewayNilOrUnspecified = errors.New("transparent-tunnel: gateway is nil or unspecified, cannot add tunnel routes")
+
+// ipv4Gateway returns the gateway IP from the first IPv4 subnet, or nil if none found.
+func ipv4Gateway(subnets []SubnetInfo) net.IP {
+	for i := range subnets {
+		if gw := subnets[i].Gateway; gw != nil && gw.To4() != nil {
+			return gw
+		}
+	}
+	return nil
+}
+
+// addTransparentTunnelRoutes adds a /32 host route for each IPv4 address of the endpoint,
+// forcing same-node traffic to that pod through the gateway (and VFP) for NSG enforcement.
+// This is the Windows equivalent of the Linux fwmark+policy-routing approach.
+// On Windows, a /32 route is more specific than the subnet's /16 on-link route, so it
+// takes priority and steers traffic out through the physical NIC where VFP can enforce NSGs.
+// Returns an error if any route fails to be added (excluding idempotent duplicates).
+func addTransparentTunnelRoutes(plc platform.ExecClient, ipAddresses []net.IPNet, gateway net.IP) error {
+	if gateway == nil || gateway.IsUnspecified() {
+		return errTransparentTunnelGatewayNilOrUnspecified
+	}
+
+	gwStr := gateway.String()
+	var addedRoutes []string
+
+	for _, ipAddr := range ipAddresses {
+		if ipAddr.IP.To4() == nil {
+			continue // skip IPv6
+		}
+		podIP := ipAddr.IP.String()
+		_, err := plc.ExecuteCommand(context.TODO(), "route", "add", podIP, "mask", "255.255.255.255", gwStr)
+		if err != nil {
+			// "route add" is not idempotent on Windows — it fails if the route exists.
+			// Treat "already exists" as success (another pod create may have raced us,
+			// or the route survived a CNI restart).
+			if strings.Contains(strings.ToLower(err.Error()), "already") {
+				logger.Info("transparent-tunnel: /32 route already exists, skipping",
+					zap.String("podIP", podIP), zap.String("gw", gwStr))
+				continue
+			}
+			// Real failure — roll back any routes we already added in this call.
+			for _, rollbackIP := range addedRoutes {
+				if _, rbErr := plc.ExecuteCommand(context.TODO(), "route", "delete", rollbackIP, "mask", "255.255.255.255"); rbErr != nil {
+					logger.Error("transparent-tunnel: failed to roll back /32 route",
+						zap.String("podIP", rollbackIP), zap.Error(rbErr))
+				}
+			}
+			return fmt.Errorf("transparent-tunnel: failed to add /32 route for %s via %s: %w", podIP, gwStr, err)
+		}
+		addedRoutes = append(addedRoutes, podIP)
+		logger.Info("transparent-tunnel: added /32 host route via gateway",
+			zap.String("podIP", podIP), zap.String("gw", gwStr))
+	}
+
+	return nil
+}
+
+// deleteTransparentTunnelRoutes removes the /32 host routes added by addTransparentTunnelRoutes.
+// Best-effort: errors are logged but do not block endpoint deletion.
+func deleteTransparentTunnelRoutes(plc platform.ExecClient, ipAddresses []net.IPNet) {
+	for _, ipAddr := range ipAddresses {
+		if ipAddr.IP.To4() == nil {
+			continue
+		}
+		podIP := ipAddr.IP.String()
+		if _, err := plc.ExecuteCommand(context.TODO(), "route", "delete", podIP, "mask", "255.255.255.255"); err != nil {
+			logger.Error("transparent-tunnel: failed to delete /32 route",
+				zap.String("podIP", podIP), zap.Error(err))
+		} else {
+			logger.Info("transparent-tunnel: deleted /32 host route", zap.String("podIP", podIP))
+		}
+	}
+}

--- a/network/transparent_tunnel_endpoint_windows_test.go
+++ b/network/transparent_tunnel_endpoint_windows_test.go
@@ -1,0 +1,270 @@
+// Copyright 2017 Microsoft. All rights reserved.
+// MIT License
+
+//go:build windows
+// +build windows
+
+package network
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-container-networking/platform"
+)
+
+var (
+	errObjectAlreadyExists = errors.New("the object already exists")
+	errNetworkUnreachable  = errors.New("network unreachable")
+)
+
+func TestIPv4Gateway(t *testing.T) {
+	tests := []struct {
+		name    string
+		subnets []SubnetInfo
+		want    net.IP
+	}{
+		{
+			name:    "single IPv4 subnet",
+			subnets: []SubnetInfo{{Gateway: net.ParseIP("10.0.0.1")}},
+			want:    net.ParseIP("10.0.0.1"),
+		},
+		{
+			name: "IPv6 first then IPv4",
+			subnets: []SubnetInfo{
+				{Gateway: net.ParseIP("fd00::1")},
+				{Gateway: net.ParseIP("10.0.0.1")},
+			},
+			want: net.ParseIP("10.0.0.1"),
+		},
+		{
+			name:    "empty subnets",
+			subnets: nil,
+			want:    nil,
+		},
+		{
+			name:    "nil gateway in subnet",
+			subnets: []SubnetInfo{{Gateway: nil}},
+			want:    nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ipv4Gateway(tt.subnets)
+			if !got.Equal(tt.want) {
+				t.Errorf("ipv4Gateway() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAddTransparentTunnelRoutes(t *testing.T) {
+	tests := []struct {
+		name        string
+		ipAddresses []net.IPNet
+		gateway     net.IP
+		execFn      func(cmd string, args ...string) (string, error)
+		wantCmds    []string
+		wantNoCmds  bool
+		wantErr     bool
+		wantErrMsg  string
+	}{
+		{
+			name: "single IPv4 pod",
+			ipAddresses: []net.IPNet{
+				{IP: net.ParseIP("10.0.0.5"), Mask: net.CIDRMask(16, 32)},
+			},
+			gateway:  net.ParseIP("10.0.0.1"),
+			wantCmds: []string{"route add 10.0.0.5 mask 255.255.255.255 10.0.0.1"},
+		},
+		{
+			name: "multiple IPv4 pods",
+			ipAddresses: []net.IPNet{
+				{IP: net.ParseIP("10.0.0.5"), Mask: net.CIDRMask(16, 32)},
+				{IP: net.ParseIP("10.0.0.6"), Mask: net.CIDRMask(16, 32)},
+			},
+			gateway: net.ParseIP("10.0.0.1"),
+			wantCmds: []string{
+				"route add 10.0.0.5 mask 255.255.255.255 10.0.0.1",
+				"route add 10.0.0.6 mask 255.255.255.255 10.0.0.1",
+			},
+		},
+		{
+			name: "skip IPv6 addresses",
+			ipAddresses: []net.IPNet{
+				{IP: net.ParseIP("10.0.0.5"), Mask: net.CIDRMask(16, 32)},
+				{IP: net.ParseIP("fd00::5"), Mask: net.CIDRMask(64, 128)},
+			},
+			gateway:  net.ParseIP("10.0.0.1"),
+			wantCmds: []string{"route add 10.0.0.5 mask 255.255.255.255 10.0.0.1"},
+		},
+		{
+			name:        "nil gateway returns error",
+			ipAddresses: []net.IPNet{{IP: net.ParseIP("10.0.0.5"), Mask: net.CIDRMask(16, 32)}},
+			gateway:     nil,
+			wantNoCmds:  true,
+			wantErr:     true,
+			wantErrMsg:  "gateway is nil",
+		},
+		{
+			name:        "unspecified gateway returns error",
+			ipAddresses: []net.IPNet{{IP: net.ParseIP("10.0.0.5"), Mask: net.CIDRMask(16, 32)}},
+			gateway:     net.IPv4zero,
+			wantNoCmds:  true,
+			wantErr:     true,
+			wantErrMsg:  "gateway is nil or unspecified",
+		},
+		{
+			name: "duplicate route already exists is tolerated",
+			ipAddresses: []net.IPNet{
+				{IP: net.ParseIP("10.0.0.5"), Mask: net.CIDRMask(16, 32)},
+			},
+			gateway: net.ParseIP("10.0.0.1"),
+			execFn: func(_ string, _ ...string) (string, error) {
+				return "", errObjectAlreadyExists
+			},
+			wantCmds: []string{"route add 10.0.0.5 mask 255.255.255.255 10.0.0.1"},
+		},
+		{
+			name: "real failure returns error and rolls back",
+			ipAddresses: []net.IPNet{
+				{IP: net.ParseIP("10.0.0.5"), Mask: net.CIDRMask(16, 32)},
+				{IP: net.ParseIP("10.0.0.6"), Mask: net.CIDRMask(16, 32)},
+			},
+			gateway: net.ParseIP("10.0.0.1"),
+			execFn: func() func(string, ...string) (string, error) {
+				callCount := 0
+				return func(_ string, args ...string) (string, error) {
+					callCount++
+					if callCount == 1 {
+						return "", nil // first route succeeds
+					}
+					if len(args) > 0 && args[0] == "delete" {
+						return "", nil // rollback succeeds
+					}
+					return "", errNetworkUnreachable // second route fails
+				}
+			}(),
+			// route add .5 (success), route add .6 (fail), route delete .5 (rollback)
+			wantCmds: []string{
+				"route add 10.0.0.5 mask 255.255.255.255 10.0.0.1",
+				"route add 10.0.0.6 mask 255.255.255.255 10.0.0.1",
+				"route delete 10.0.0.5 mask 255.255.255.255",
+			},
+			wantErr:    true,
+			wantErrMsg: "network unreachable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var executedCmds []string
+			mockPlc := platform.NewMockExecClient(false)
+			recordCmd := func(cmd string, args ...string) string {
+				full := cmd + " " + strings.Join(args, " ")
+				executedCmds = append(executedCmds, full)
+				return full
+			}
+			if tt.execFn != nil {
+				mockPlc.SetExecCommand(func(cmd string, args ...string) (string, error) {
+					recordCmd(cmd, args...)
+					return tt.execFn(cmd, args...)
+				})
+			} else {
+				mockPlc.SetExecCommand(func(cmd string, args ...string) (string, error) {
+					recordCmd(cmd, args...)
+					return "", nil
+				})
+			}
+
+			err := addTransparentTunnelRoutes(mockPlc, tt.ipAddresses, tt.gateway)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.wantErrMsg != "" && !strings.Contains(err.Error(), tt.wantErrMsg) {
+					t.Errorf("error %q should contain %q", err.Error(), tt.wantErrMsg)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.wantNoCmds {
+				if len(executedCmds) != 0 {
+					t.Errorf("expected no commands, got %v", executedCmds)
+				}
+				return
+			}
+
+			if len(executedCmds) != len(tt.wantCmds) {
+				t.Fatalf("expected %d commands, got %d: %v", len(tt.wantCmds), len(executedCmds), executedCmds)
+			}
+			for i, want := range tt.wantCmds {
+				if executedCmds[i] != want {
+					t.Errorf("cmd[%d] = %q, want %q", i, executedCmds[i], want)
+				}
+			}
+		})
+	}
+}
+
+func TestDeleteTransparentTunnelRoutes(t *testing.T) {
+	tests := []struct {
+		name        string
+		ipAddresses []net.IPNet
+		wantCmds    []string
+	}{
+		{
+			name: "single IPv4 pod cleanup",
+			ipAddresses: []net.IPNet{
+				{IP: net.ParseIP("10.0.0.5"), Mask: net.CIDRMask(16, 32)},
+			},
+			wantCmds: []string{"route delete 10.0.0.5 mask 255.255.255.255"},
+		},
+		{
+			name: "skip IPv6 on delete",
+			ipAddresses: []net.IPNet{
+				{IP: net.ParseIP("10.0.0.5"), Mask: net.CIDRMask(16, 32)},
+				{IP: net.ParseIP("fd00::5"), Mask: net.CIDRMask(64, 128)},
+			},
+			wantCmds: []string{"route delete 10.0.0.5 mask 255.255.255.255"},
+		},
+		{
+			name:        "empty IP list does nothing",
+			ipAddresses: []net.IPNet{},
+			wantCmds:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var executedCmds []string
+			mockPlc := platform.NewMockExecClient(false)
+			mockPlc.SetExecCommand(func(cmd string, args ...string) (string, error) {
+				executedCmds = append(executedCmds, cmd+" "+strings.Join(args, " "))
+				return "", nil
+			})
+
+			deleteTransparentTunnelRoutes(mockPlc, tt.ipAddresses)
+
+			if len(tt.wantCmds) == 0 {
+				if len(executedCmds) != 0 {
+					t.Errorf("expected no commands, got %v", executedCmds)
+				}
+				return
+			}
+
+			if len(executedCmds) != len(tt.wantCmds) {
+				t.Fatalf("expected %d commands, got %d: %v", len(tt.wantCmds), len(executedCmds), executedCmds)
+			}
+			for i, want := range tt.wantCmds {
+				if executedCmds[i] != want {
+					t.Errorf("cmd[%d] = %q, want %q", i, executedCmds[i], want)
+				}
+			}
+		})
+	}
+}

--- a/network/transparent_tunnel_endpointclient_linux.go
+++ b/network/transparent_tunnel_endpointclient_linux.go
@@ -1,0 +1,318 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/Azure/azure-container-networking/iptables"
+	"github.com/Azure/azure-container-networking/netio"
+	"github.com/Azure/azure-container-networking/netlink"
+	"github.com/Azure/azure-container-networking/platform"
+	"github.com/pkg/errors"
+	vishnetlink "github.com/vishvananda/netlink"
+	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	// transparentTunnelFwmark is the fwmark value used to re-route pod traffic through VFP.
+	// Packets marked with this value are looked up in transparentTunnelRouteTable instead of
+	// the main routing table, forcing them out via the host's physical interface where
+	// VFP can enforce NSG rules on same-node pod-to-pod traffic.
+	transparentTunnelFwmark = 3
+
+	// transparentTunnelRouteTable is the custom routing table used for fwmark-marked packets.
+	transparentTunnelRouteTable = 101
+)
+
+// tunnelPolicyRouteClient abstracts vishvananda/netlink operations for policy
+// routing (ip rule) and route table management so that unit tests avoid
+// touching real netlink sockets.
+type tunnelPolicyRouteClient interface {
+	RuleAdd(rule *vishnetlink.Rule) error
+	RuleDel(rule *vishnetlink.Rule) error
+	RouteReplace(route *vishnetlink.Route) error
+	RouteDel(route *vishnetlink.Route) error
+}
+
+// defaultTunnelPolicyRouteClient delegates to the real vishvananda/netlink package.
+type defaultTunnelPolicyRouteClient struct{}
+
+func (defaultTunnelPolicyRouteClient) RuleAdd(rule *vishnetlink.Rule) error {
+	if err := vishnetlink.RuleAdd(rule); err != nil {
+		return fmt.Errorf("netlink rule add: %w", err)
+	}
+	return nil
+}
+
+func (defaultTunnelPolicyRouteClient) RuleDel(rule *vishnetlink.Rule) error {
+	if err := vishnetlink.RuleDel(rule); err != nil {
+		return fmt.Errorf("netlink rule del: %w", err)
+	}
+	return nil
+}
+
+func (defaultTunnelPolicyRouteClient) RouteReplace(route *vishnetlink.Route) error {
+	if err := vishnetlink.RouteReplace(route); err != nil {
+		return fmt.Errorf("netlink route replace: %w", err)
+	}
+	return nil
+}
+
+func (defaultTunnelPolicyRouteClient) RouteDel(route *vishnetlink.Route) error {
+	if err := vishnetlink.RouteDel(route); err != nil {
+		return fmt.Errorf("netlink route del: %w", err)
+	}
+	return nil
+}
+
+// TransparentTunnelEndpointClient extends TransparentEndpointClient with
+// iptables and ip-rule based tunneling that forces same-node pod-to-pod
+// traffic through the host's physical interface (and therefore through VFP)
+// so that Azure NSG rules are enforced even for intra-node communication.
+type TransparentTunnelEndpointClient struct {
+	*TransparentEndpointClient
+	iptablesClient ipTablesClient
+	nlPolicyRoute  tunnelPolicyRouteClient
+	serviceCIDRs   []string // Cluster service CIDRs to exempt from fwmark
+	gateway        net.IP   // Host's IPv4 gateway (for custom route table)
+}
+
+func NewTransparentTunnelEndpointClient(
+	nw *network,
+	epInfo *EndpointInfo,
+	hostVethName string,
+	containerVethName string,
+	nl netlink.NetlinkInterface,
+	nioc netio.NetIOInterface,
+	plc platform.ExecClient,
+	iptc ipTablesClient,
+) *TransparentTunnelEndpointClient {
+	base := NewTransparentEndpointClient(nw.extIf, hostVethName, containerVethName, epInfo.Mode, nl, nioc, plc)
+
+	var serviceCIDRs []string
+	if epInfo.ServiceCidrs != "" {
+		serviceCIDRs = strings.Split(epInfo.ServiceCidrs, ",")
+	}
+
+	var gw net.IP
+	if nw.extIf != nil {
+		gw = nw.extIf.IPv4Gateway
+	}
+
+	return &TransparentTunnelEndpointClient{
+		TransparentEndpointClient: base,
+		iptablesClient:            iptc,
+		nlPolicyRoute:             defaultTunnelPolicyRouteClient{},
+		serviceCIDRs:              serviceCIDRs,
+		gateway:                   gw,
+	}
+}
+
+// AddEndpointRules sets up the base transparent rules (host route + ARP proxy)
+// and then adds transparent-tunnel-specific iptables and ip-rule entries that tunnel pod traffic
+// through VFP.
+func (client *TransparentTunnelEndpointClient) AddEndpointRules(epInfo *EndpointInfo) error {
+	if err := client.TransparentEndpointClient.AddEndpointRules(epInfo); err != nil {
+		return err
+	}
+
+	if err := client.addTransparentTunnelRules(); err != nil {
+		return errors.Wrap(err, "failed to add tunnel rules")
+	}
+
+	return nil
+}
+
+// DeleteEndpointRules removes transparent-tunnel-specific rules, then delegates to the base
+// transparent client for standard cleanup.
+func (client *TransparentTunnelEndpointClient) DeleteEndpointRules(ep *endpoint) {
+	client.deleteTransparentTunnelRules(ep)
+	client.TransparentEndpointClient.DeleteEndpointRules(ep)
+}
+
+// addTransparentTunnelRules installs per-endpoint iptables and routing-policy rules:
+//
+//  1. Service CIDR RETURN — exempts ClusterIP-destined traffic from fwmark to
+//     prevent conntrack tuple collisions. Without this, same-node DNAT'd UDP
+//     traffic (e.g. DNS to CoreDNS) suffers ~50% packet loss because the fwmark
+//     causes a re-entry through the pod's veth that creates a second conntrack
+//     entry whose reply tuple collides with the original DNAT entry.
+//
+//  2. MARK rule — sets fwmark on all remaining ingress traffic from the pod's
+//     host-side veth, causing it to be looked up in the custom routing table.
+//
+//  3. IP rule + route — marked packets are routed via the host's physical
+//     interface, which forces them through VFP for NSG enforcement.
+//
+// In NodeSubnet mode, pods and the node share the same VNet subnet (e.g.
+// 10.224.0.0/16) — there is no distinct pod CIDR. An ip-rule "from" match
+// would also capture node-originated traffic (kubelet, API-server health
+// probes), which must NOT be re-routed through VFP. The fwmark approach
+// uses interface-based matching (-i <vethName>) in iptables to identify
+// only pod-originated traffic, then stamps it with a mark that the ip rule
+// selects on. This is the only reliable way to distinguish pod vs node
+// traffic when they share the same subnet.
+//
+// The MARK target is a packet-alteration operation and is only valid in the
+// mangle (and raw) tables — filter can only ACCEPT/DROP/REJECT, and nat is
+// for address translation. The mangle PREROUTING chain runs before the
+// kernel routing decision (chain order: raw → mangle → nat → filter), so
+// the fwmark is set before the kernel consults the routing table — exactly
+// what we need for policy routing via table 101.
+// Ref: iptables(8) man page, Netfilter Packet Traversal documentation.
+func (client *TransparentTunnelEndpointClient) addTransparentTunnelRules() error {
+	// Gateway is required — without it the custom routing table would have no default
+	// route, and all fwmarked packets would be black-holed. Fail early before creating
+	// any iptables rules to avoid leaving the node in a partially-configured state.
+	if client.gateway == nil {
+		return errors.New("cannot add tunnel rules: host gateway is nil")
+	}
+
+	hostVeth := client.hostVethName
+	markStr := strconv.Itoa(transparentTunnelFwmark)
+
+	// 1. Service CIDR RETURN rules (must be inserted BEFORE the MARK rule).
+	for _, cidr := range client.serviceCIDRs {
+		cidr = strings.TrimSpace(cidr)
+		if cidr == "" {
+			continue
+		}
+		match := "-i " + hostVeth + " -d " + cidr
+		if err := client.iptablesClient.InsertIptableRule(
+			iptables.V4, iptables.Mangle, iptables.Prerouting, match, "RETURN",
+		); err != nil {
+			return errors.Wrapf(err, "failed to insert service CIDR RETURN rule for %s", cidr)
+		}
+		logger.Info("transparent-tunnel: added service CIDR RETURN rule",
+			zap.String("veth", hostVeth), zap.String("cidr", cidr))
+	}
+
+	// 2. Fwmark MARK rule — append so it comes after RETURN rules.
+	markMatch := "-i " + hostVeth
+	markTarget := "MARK --set-mark " + markStr
+	if err := client.iptablesClient.AppendIptableRule(
+		iptables.V4, iptables.Mangle, iptables.Prerouting, markMatch, markTarget,
+	); err != nil {
+		return errors.Wrap(err, "failed to append fwmark MARK rule")
+	}
+	logger.Info("transparent-tunnel: added fwmark MARK rule",
+		zap.String("veth", hostVeth), zap.String("mark", markStr))
+
+	// 3. IP rule: fwmark → custom routing table (via netlink).
+	// The ip rule is shared across all transparent-tunnel endpoints on this node —
+	// every pod uses the same fwmark (3) and lookup table (101). We always attempt
+	// the add and tolerate EEXIST. This avoids a TOCTOU race where two concurrent
+	// pod creates both see the rule missing and both try to add it.
+	rule := vishnetlink.NewRule()
+	rule.Mark = transparentTunnelFwmark
+	rule.Table = transparentTunnelRouteTable
+	rule.Family = unix.AF_INET
+	if err := client.nlPolicyRoute.RuleAdd(rule); err != nil {
+		if !errors.Is(err, syscall.EEXIST) {
+			return errors.Wrap(err, "failed to add ip rule for fwmark")
+		}
+		logger.Info("transparent-tunnel: ip rule already exists, skipping",
+			zap.Int("fwmark", transparentTunnelFwmark), zap.Int("table", transparentTunnelRouteTable))
+	} else {
+		logger.Info("transparent-tunnel: added ip rule",
+			zap.Int("fwmark", transparentTunnelFwmark), zap.Int("table", transparentTunnelRouteTable))
+	}
+
+	// 4. Default route in custom table via physical interface → VFP (via netlink).
+	// RouteReplace is idempotent, so safe to call from every endpoint.
+	iface, err := client.netioshim.GetNetworkInterfaceByName(client.hostPrimaryIfName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to look up interface %s for tunnel route", client.hostPrimaryIfName)
+	}
+	_, defaultDst, _ := net.ParseCIDR("0.0.0.0/0")
+	route := &vishnetlink.Route{
+		LinkIndex: iface.Index,
+		Dst:       defaultDst,
+		Gw:        client.gateway,
+		Table:     transparentTunnelRouteTable,
+	}
+	if err := client.nlPolicyRoute.RouteReplace(route); err != nil {
+		return errors.Wrapf(err, "failed to add default route in table %d", transparentTunnelRouteTable)
+	}
+	logger.Info("transparent-tunnel: added default route in custom table",
+		zap.String("gw", client.gateway.String()),
+		zap.String("dev", client.hostPrimaryIfName),
+		zap.Int("table", transparentTunnelRouteTable))
+
+	return nil
+}
+
+// deleteTransparentTunnelRules removes the per-endpoint iptables and routing-policy rules.
+func (client *TransparentTunnelEndpointClient) deleteTransparentTunnelRules(ep *endpoint) {
+	hostVeth := ep.HostIfName
+	markStr := strconv.Itoa(transparentTunnelFwmark)
+
+	// Remove service CIDR RETURN rules.
+	for _, cidr := range client.serviceCIDRs {
+		cidr = strings.TrimSpace(cidr)
+		if cidr == "" {
+			continue
+		}
+		match := "-i " + hostVeth + " -d " + cidr
+		if err := client.iptablesClient.DeleteIptableRule(
+			iptables.V4, iptables.Mangle, iptables.Prerouting, match, "RETURN",
+		); err != nil {
+			logger.Error("transparent-tunnel: failed to delete service CIDR RETURN rule",
+				zap.String("cidr", cidr), zap.Error(err))
+		}
+	}
+
+	// Remove fwmark MARK rule.
+	markMatch := "-i " + hostVeth
+	markTarget := "MARK --set-mark " + markStr
+	if err := client.iptablesClient.DeleteIptableRule(
+		iptables.V4, iptables.Mangle, iptables.Prerouting, markMatch, markTarget,
+	); err != nil {
+		logger.Error("transparent-tunnel: failed to delete fwmark MARK rule", zap.Error(err))
+	}
+
+	// Best-effort removal of the shared ip rule and route. The ip rule and route
+	// table are shared by all transparent-tunnel endpoints on this node — every pod
+	// uses the same fwmark (3) and lookup table (101). We only remove them if no
+	// other endpoint's fwmark MARK rules remain in mangle PREROUTING.
+	// This prevents deleting one pod from breaking routing for all other pods.
+	// If checking fails, we skip removal (safe — a stale rule is harmless without
+	// any MARK rules to trigger it, and will be cleaned up with the last pod).
+	//
+	// Note: `iptables -S` normalizes `--set-mark N` to `--set-xmark 0xN/0xffffffff`,
+	// so we count the normalized form.
+	hexMark := fmt.Sprintf("0x%x", transparentTunnelFwmark)
+	out, _ := client.plClient.ExecuteCommand(context.TODO(), "iptables", "-t", "mangle", "-S", "PREROUTING")
+	markCount := 0
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "--set-xmark "+hexMark+"/") {
+			markCount++
+		}
+	}
+
+	if markCount == 0 {
+		rule := vishnetlink.NewRule()
+		rule.Mark = transparentTunnelFwmark
+		rule.Table = transparentTunnelRouteTable
+		rule.Family = unix.AF_INET
+		if err := client.nlPolicyRoute.RuleDel(rule); err != nil && !errors.Is(err, syscall.ENOENT) && !errors.Is(err, syscall.ESRCH) {
+			logger.Error("transparent-tunnel: failed to delete ip rule",
+				zap.Int("fwmark", transparentTunnelFwmark), zap.Error(err))
+		}
+
+		_, defaultDst, _ := net.ParseCIDR("0.0.0.0/0")
+		route := &vishnetlink.Route{
+			Dst:   defaultDst,
+			Table: transparentTunnelRouteTable,
+		}
+		if err := client.nlPolicyRoute.RouteDel(route); err != nil && !errors.Is(err, syscall.ESRCH) {
+			logger.Error("transparent-tunnel: failed to delete route in table",
+				zap.Int("table", transparentTunnelRouteTable), zap.Error(err))
+		}
+	}
+}

--- a/network/transparent_tunnel_endpointclient_linux_test.go
+++ b/network/transparent_tunnel_endpointclient_linux_test.go
@@ -1,0 +1,302 @@
+package network
+
+import (
+	"context"
+	"net"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/Azure/azure-container-networking/iptables"
+	"github.com/Azure/azure-container-networking/netio"
+	"github.com/Azure/azure-container-networking/netlink"
+	"github.com/Azure/azure-container-networking/platform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vishnetlink "github.com/vishvananda/netlink"
+)
+
+// transparentTunnelMockIPTablesClient tracks all iptables calls for test verification.
+type transparentTunnelMockIPTablesClient struct {
+	insertCalls []iptablesCall
+	appendCalls []iptablesCall
+	deleteCalls []iptablesCall
+}
+
+func (c *transparentTunnelMockIPTablesClient) InsertIptableRule(version, tableName, chainName, match, target string) error {
+	c.insertCalls = append(c.insertCalls, iptablesCall{version, tableName, chainName, match, target})
+	return nil
+}
+
+func (c *transparentTunnelMockIPTablesClient) AppendIptableRule(version, tableName, chainName, match, target string) error {
+	c.appendCalls = append(c.appendCalls, iptablesCall{version, tableName, chainName, match, target})
+	return nil
+}
+
+func (c *transparentTunnelMockIPTablesClient) DeleteIptableRule(version, tableName, chainName, match, target string) error {
+	c.deleteCalls = append(c.deleteCalls, iptablesCall{version, tableName, chainName, match, target})
+	return nil
+}
+
+func (c *transparentTunnelMockIPTablesClient) CreateChain(_, _, _ string) error { return nil }
+func (c *transparentTunnelMockIPTablesClient) RunCmd(_, _ string) error         { return nil }
+
+// transparentTunnelMockExecClient tracks executed commands and returns canned responses.
+type transparentTunnelMockExecClient struct {
+	platform.ExecClient
+	executedCmds []string
+	// cmdResponses maps a substring to the response returned when a command contains it.
+	cmdResponses map[string]string
+}
+
+func (c *transparentTunnelMockExecClient) ExecuteCommand(_ context.Context, cmd string, args ...string) (string, error) {
+	full := cmd + " " + strings.Join(args, " ")
+	c.executedCmds = append(c.executedCmds, full)
+	for substr, resp := range c.cmdResponses {
+		if strings.Contains(full, substr) {
+			return resp, nil
+		}
+	}
+	return "", nil
+}
+
+// transparentTunnelMockNlClient tracks netlink rule/route calls for test verification.
+type transparentTunnelMockNlClient struct {
+	ruleAddCalls      []*vishnetlink.Rule
+	ruleDelCalls      []*vishnetlink.Rule
+	routeReplaceCalls []*vishnetlink.Route
+	routeDelCalls     []*vishnetlink.Route
+	ruleAddErr        error // injected error for RuleAdd
+}
+
+func (c *transparentTunnelMockNlClient) RuleAdd(rule *vishnetlink.Rule) error {
+	c.ruleAddCalls = append(c.ruleAddCalls, rule)
+	return c.ruleAddErr
+}
+
+func (c *transparentTunnelMockNlClient) RuleDel(rule *vishnetlink.Rule) error {
+	c.ruleDelCalls = append(c.ruleDelCalls, rule)
+	return nil
+}
+
+func (c *transparentTunnelMockNlClient) RouteReplace(route *vishnetlink.Route) error {
+	c.routeReplaceCalls = append(c.routeReplaceCalls, route)
+	return nil
+}
+
+func (c *transparentTunnelMockNlClient) RouteDel(route *vishnetlink.Route) error {
+	c.routeDelCalls = append(c.routeDelCalls, route)
+	return nil
+}
+
+func TestTransparentTunnelAddEndpointRules(t *testing.T) {
+	tests := []struct {
+		name            string
+		serviceCIDRs    string
+		gateway         net.IP
+		expectedInserts int // Number of iptables INSERT calls (service CIDR RETURN rules)
+		expectedAppends int // Number of iptables APPEND calls (MARK rule)
+		expectRuleAdd   bool
+		expectRouteAdd  bool
+		ruleAddErr      error // Injected RuleAdd error (nil = success, EEXIST = tolerated)
+		expectError     bool
+		errorContains   string
+	}{
+		{
+			name:            "single service CIDR",
+			serviceCIDRs:    "10.0.0.0/16",
+			gateway:         net.ParseIP("10.224.0.1"),
+			expectedInserts: 1,
+			expectedAppends: 1,
+			expectRuleAdd:   true,
+			expectRouteAdd:  true,
+		},
+		{
+			name:            "multiple service CIDRs",
+			serviceCIDRs:    "10.0.0.0/16,fd00::/108",
+			gateway:         net.ParseIP("10.224.0.1"),
+			expectedInserts: 2,
+			expectedAppends: 1,
+			expectRuleAdd:   true,
+			expectRouteAdd:  true,
+		},
+		{
+			name:            "no service CIDRs",
+			serviceCIDRs:    "",
+			gateway:         net.ParseIP("10.224.0.1"),
+			expectedInserts: 0,
+			expectedAppends: 1,
+			expectRuleAdd:   true,
+			expectRouteAdd:  true,
+		},
+		{
+			name:            "rule already exists is tolerated",
+			serviceCIDRs:    "10.0.0.0/16",
+			gateway:         net.ParseIP("10.224.0.1"),
+			expectedInserts: 1,
+			expectedAppends: 1,
+			expectRuleAdd:   true,
+			expectRouteAdd:  true,
+			ruleAddErr:      syscall.EEXIST,
+		},
+		{
+			name:          "nil gateway returns error before creating any rules",
+			serviceCIDRs:  "10.0.0.0/16",
+			gateway:       nil,
+			expectError:   true,
+			errorContains: "gateway is nil",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			iptMock := &transparentTunnelMockIPTablesClient{}
+			nlMock := &transparentTunnelMockNlClient{ruleAddErr: tt.ruleAddErr}
+
+			var serviceCIDRs []string
+			if tt.serviceCIDRs != "" {
+				serviceCIDRs = strings.Split(tt.serviceCIDRs, ",")
+			}
+
+			client := &TransparentTunnelEndpointClient{
+				TransparentEndpointClient: &TransparentEndpointClient{
+					hostVethName:      "azv1234",
+					hostPrimaryIfName: "eth0",
+					netioshim:         netio.NewMockNetIO(false, 0),
+				},
+				iptablesClient: iptMock,
+				nlPolicyRoute:  nlMock,
+				serviceCIDRs:   serviceCIDRs,
+				gateway:        tt.gateway,
+			}
+
+			err := client.addTransparentTunnelRules()
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorContains)
+				assert.Empty(t, iptMock.insertCalls, "no iptables rules should be created on error")
+				assert.Empty(t, iptMock.appendCalls, "no iptables rules should be created on error")
+				assert.Empty(t, nlMock.ruleAddCalls, "no netlink calls should run on error")
+				return
+			}
+
+			require.NoError(t, err)
+
+			// Verify service CIDR RETURN rules were inserted.
+			assert.Len(t, iptMock.insertCalls, tt.expectedInserts)
+			for _, call := range iptMock.insertCalls {
+				assert.Equal(t, iptables.V4, call.version)
+				assert.Equal(t, iptables.Mangle, call.tableName)
+				assert.Equal(t, iptables.Prerouting, call.chainName)
+				assert.Equal(t, "RETURN", call.target)
+				assert.Contains(t, call.match, "-i azv1234")
+			}
+
+			// Verify MARK rule was appended.
+			assert.Len(t, iptMock.appendCalls, tt.expectedAppends)
+			if tt.expectedAppends > 0 {
+				markCall := iptMock.appendCalls[0]
+				assert.Equal(t, iptables.V4, markCall.version)
+				assert.Equal(t, iptables.Mangle, markCall.tableName)
+				assert.Equal(t, iptables.Prerouting, markCall.chainName)
+				assert.Contains(t, markCall.match, "-i azv1234")
+				assert.Contains(t, markCall.target, "MARK --set-mark 3")
+			}
+
+			// Verify netlink rule add.
+			if tt.expectRuleAdd {
+				require.Len(t, nlMock.ruleAddCalls, 1)
+				assert.Equal(t, transparentTunnelFwmark, int(nlMock.ruleAddCalls[0].Mark))
+				assert.Equal(t, transparentTunnelRouteTable, nlMock.ruleAddCalls[0].Table)
+			}
+
+			// Verify netlink route replace.
+			if tt.expectRouteAdd {
+				require.Len(t, nlMock.routeReplaceCalls, 1)
+				assert.Equal(t, transparentTunnelRouteTable, nlMock.routeReplaceCalls[0].Table)
+				assert.True(t, tt.gateway.Equal(nlMock.routeReplaceCalls[0].Gw))
+			}
+		})
+	}
+}
+
+func TestTransparentTunnelDeleteEndpointRules(t *testing.T) {
+	makeClient := func(plMock *transparentTunnelMockExecClient, nlMock *transparentTunnelMockNlClient) (*TransparentTunnelEndpointClient, *transparentTunnelMockIPTablesClient) {
+		iptMock := &transparentTunnelMockIPTablesClient{}
+		client := &TransparentTunnelEndpointClient{
+			TransparentEndpointClient: &TransparentEndpointClient{
+				hostVethName:      "azv1234",
+				hostPrimaryIfName: "eth0",
+				plClient:          plMock,
+				netlink:           netlink.NewMockNetlink(false, ""),
+				netioshim:         netio.NewMockNetIO(false, 0),
+			},
+			iptablesClient: iptMock,
+			nlPolicyRoute:  nlMock,
+			serviceCIDRs:   []string{"10.0.0.0/16"},
+			gateway:        net.ParseIP("10.224.0.1"),
+		}
+		return client, iptMock
+	}
+
+	ep := &endpoint{
+		HostIfName: "azv1234",
+		IPAddresses: []net.IPNet{
+			{IP: net.ParseIP("10.224.0.46"), Mask: net.CIDRMask(32, 32)},
+		},
+	}
+
+	t.Run("last pod cleans up shared ip rule and route", func(t *testing.T) {
+		// Mock returns empty iptables output — no remaining MARK rules.
+		plMock := &transparentTunnelMockExecClient{
+			cmdResponses: map[string]string{
+				"iptables": "",
+			},
+		}
+		nlMock := &transparentTunnelMockNlClient{}
+		client, iptMock := makeClient(plMock, nlMock)
+
+		client.deleteTransparentTunnelRules(ep)
+
+		// Should delete service CIDR RETURN rule + MARK rule.
+		assert.Len(t, iptMock.deleteCalls, 2)
+
+		// Verify RETURN rule deletion.
+		returnCall := iptMock.deleteCalls[0]
+		assert.Equal(t, iptables.Mangle, returnCall.tableName)
+		assert.Contains(t, returnCall.match, "-d 10.0.0.0/16")
+		assert.Equal(t, "RETURN", returnCall.target)
+
+		// Verify MARK rule deletion.
+		markCall := iptMock.deleteCalls[1]
+		assert.Equal(t, iptables.Mangle, markCall.tableName)
+		assert.Contains(t, markCall.target, "MARK --set-mark 3")
+
+		// Verify netlink cleanup: rule del + route del.
+		assert.Len(t, nlMock.ruleDelCalls, 1)
+		assert.Equal(t, transparentTunnelFwmark, int(nlMock.ruleDelCalls[0].Mark))
+		assert.Len(t, nlMock.routeDelCalls, 1)
+		assert.Equal(t, transparentTunnelRouteTable, nlMock.routeDelCalls[0].Table)
+	})
+
+	t.Run("other pods remain skips shared rule cleanup", func(t *testing.T) {
+		// Mock returns iptables output with matching MARK rules still present.
+		plMock := &transparentTunnelMockExecClient{
+			cmdResponses: map[string]string{
+				"iptables": "-A PREROUTING -i azv5678 -j MARK --set-xmark 0x3/0xffffffff\n-A PREROUTING -i azv9999 -j MARK --set-xmark 0x3/0xffffffff\n",
+			},
+		}
+		nlMock := &transparentTunnelMockNlClient{}
+		client, iptMock := makeClient(plMock, nlMock)
+
+		client.deleteTransparentTunnelRules(ep)
+
+		// Per-pod iptables rules still deleted.
+		assert.Len(t, iptMock.deleteCalls, 2)
+
+		// No netlink cleanup — other pods still active.
+		assert.Empty(t, nlMock.ruleDelCalls, "should not delete shared rule")
+		assert.Empty(t, nlMock.routeDelCalls, "should not delete shared route")
+	})
+}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
﻿Adds Windows support for the `transparent-tunnel` CNI operating mode, enabling GlobalPodSecurity (GPS) VFP enforcement. Companion to #4319 (Linux).

 GPS requires pod traffic to traverse the Azure VFP pipeline so NSG rules can be enforced at the pod level. On Windows with HNS, pod traffic normally bypasses VFP via direct L2 switching. The `transparent-tunnel` mode adds /32 host routes via the gateway for each pod IP,
forcing traffic through VFP for inspection.

 Key changes:
 - Per-pod /32 routes added on endpoint create, removed on delete
 - Fail-safe rollback: partial route failure rolls back routes AND HNS endpoint
 - HNSv1 explicitly rejected for transparent-tunnel mode
 - Fixed `DeleteEndpointStateless` in manager.go (was hardcoding mode, skipping GPS cleanup)


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] relevant PR labels added

**Notes**:
﻿ - Depends on #4319 (Linux transparent-tunnel) for shared `opModeTransparentTunnel` constant
 - GPS logic in dedicated `transparent_tunnel_endpoint_windows.go` matching Linux's file pattern
 - 15 unit tests covering gateway selection, route add/rollback, and route delete
 - No shared infrastructure (unlike Linux's iptables/ip-rule) — /32 routes are 1:1 per pod, no race conditions