### PR TITLE
fix: migrate runtime base images from distroless/minimal to distroless/base

### DIFF
--- a/.pipelines/build/dockerfiles/azure-iptables-monitor.Dockerfile
+++ b/.pipelines/build/dockerfiles/azure-iptables-monitor.Dockerfile
@@ -5,8 +5,8 @@ ARG ARCH
 # mcr.microsoft.com/azurelinux/base/core:3.0
 FROM mcr.microsoft.com/azurelinux/base/core@sha256:35149ae8dd179684f969944f54a337c665a64e702486154eb44253fb39c2505b AS mariner-core
 
-# mcr.microsoft.com/azurelinux/distroless/minimal:3.0
-FROM mcr.microsoft.com/azurelinux/distroless/minimal@sha256:5a66f9f16ac675db2a8229dac72d83811b73b502d6ad192d8b374c7f3be498af AS mariner-distroless
+# mcr.microsoft.com/azurelinux/distroless/base:3.0
+FROM mcr.microsoft.com/azurelinux/distroless/base@sha256:32820d2cf20e896aa9111742dd683dd0ccff370f742e256889bb3bb50320c0d4 AS mariner-distroless
 
 FROM mariner-core AS iptools
 RUN tdnf install -y iptables iproute

--- a/.pipelines/build/dockerfiles/cns.Dockerfile
+++ b/.pipelines/build/dockerfiles/cns.Dockerfile
@@ -14,8 +14,8 @@ EXPOSE 10090
 FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/base/core@sha256:35149ae8dd179684f969944f54a337c665a64e702486154eb44253fb39c2505b AS build-helper
 RUN tdnf install -y iptables
 
-# mcr.microsoft.com/azurelinux/distroless/minimal:3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/minimal@sha256:5a66f9f16ac675db2a8229dac72d83811b73b502d6ad192d8b374c7f3be498af AS linux
+# mcr.microsoft.com/azurelinux/distroless/base:3.0
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/base@sha256:32820d2cf20e896aa9111742dd683dd0ccff370f742e256889bb3bb50320c0d4 AS linux
 ARG ARTIFACT_DIR .
 
 COPY --from=build-helper /usr/sbin/*tables* /usr/sbin/

--- a/.pipelines/build/dockerfiles/ipv6-hp-bpf.Dockerfile
+++ b/.pipelines/build/dockerfiles/ipv6-hp-bpf.Dockerfile
@@ -1,7 +1,7 @@
 ARG ARCH
 
 
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/minimal:3.0 AS linux
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/base:3.0 AS linux
 ARG ARTIFACT_DIR
 COPY ${ARTIFACT_DIR}/lib/* /lib
 COPY ${ARTIFACT_DIR}/bin/ipv6-hp-bpf /ipv6-hp-bpf

--- a/azure-iptables-monitor/Dockerfile
+++ b/azure-iptables-monitor/Dockerfile
@@ -5,8 +5,8 @@ ARG ARCH
 # mcr.microsoft.com/azurelinux/base/core:3.0
 FROM mcr.microsoft.com/azurelinux/base/core@sha256:35149ae8dd179684f969944f54a337c665a64e702486154eb44253fb39c2505b AS mariner-core
 
-# mcr.microsoft.com/azurelinux/distroless/minimal:3.0
-FROM mcr.microsoft.com/azurelinux/distroless/minimal@sha256:5a66f9f16ac675db2a8229dac72d83811b73b502d6ad192d8b374c7f3be498af AS mariner-distroless
+# mcr.microsoft.com/azurelinux/distroless/base:3.0
+FROM mcr.microsoft.com/azurelinux/distroless/base@sha256:32820d2cf20e896aa9111742dd683dd0ccff370f742e256889bb3bb50320c0d4 AS mariner-distroless
 
 # mcr.microsoft.com/oss/go/microsoft/golang:1.24-azurelinux3.0
 FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:bc7423b52b62e8f0281b5f7f564eb1862dc315bc57e1373c6a81e87ef3ac39ab AS go

--- a/bpf-prog/ipv6-hp-bpf/linux.Dockerfile
+++ b/bpf-prog/ipv6-hp-bpf/linux.Dockerfile
@@ -39,7 +39,7 @@ RUN if [ "$DEBUG" = "true" ]; then echo "\n#define DEBUG" >> /bpf-prog/ipv6-hp-b
 RUN GOOS=$OS CGO_ENABLED=0 go generate ./...
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/ipv6-hp-bpf -trimpath -ldflags "-s -w -X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" .
 
-FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 AS linux
+FROM mcr.microsoft.com/azurelinux/distroless/base:3.0 AS linux
 COPY --from=go /go/bin/ipv6-hp-bpf /ipv6-hp-bpf
 COPY --from=go /usr/sbin/nft /usr/sbin/nft
 COPY --from=go /sbin/ip /sbin/ip

--- a/build/images.mk
+++ b/build/images.mk
@@ -1,7 +1,7 @@
 # Source images
 export GO_IMG					?= mcr.microsoft.com/oss/go/microsoft/golang:1.24-azurelinux3.0
 export MARINER_CORE_IMG			?= mcr.microsoft.com/azurelinux/base/core:3.0
-export MARINER_DISTROLESS_IMG	?= mcr.microsoft.com/azurelinux/distroless/minimal:3.0
+export MARINER_DISTROLESS_IMG	?= mcr.microsoft.com/azurelinux/distroless/base:3.0
 export WIN_HPC_IMG				?= mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0
 
 

--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -10,8 +10,8 @@ FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:b
 # mcr.microsoft.com/azurelinux/base/core:3.0
 FROM mcr.microsoft.com/azurelinux/base/core@sha256:35149ae8dd179684f969944f54a337c665a64e702486154eb44253fb39c2505b AS mariner-core
 
-# mcr.microsoft.com/azurelinux/distroless/minimal:3.0
-FROM mcr.microsoft.com/azurelinux/distroless/minimal@sha256:5a66f9f16ac675db2a8229dac72d83811b73b502d6ad192d8b374c7f3be498af AS mariner-distroless
+# mcr.microsoft.com/azurelinux/distroless/base:3.0
+FROM mcr.microsoft.com/azurelinux/distroless/base@sha256:32820d2cf20e896aa9111742dd683dd0ccff370f742e256889bb3bb50320c0d4 AS mariner-distroless
 
 FROM --platform=linux/${ARCH} go AS builder
 ARG OS


### PR DESCRIPTION
## Summary

Migrates runtime base images from `distroless/minimal:3.0` to `distroless/base:3.0` to prepare for Go 1.26 FIPS compliance.

## Motivation

Go 1.26 enforces system crypto for FIPS compliance. Runtime images **must include crypto libraries** — `distroless/minimal` lacks these and causes pod startup failures. This lays the groundwork before the actual Go 1.26 version bump.

## Changes

### Source of truth
- `build/images.mk`: `MARINER_DISTROLESS_IMG` from `distroless/minimal:3.0` → `distroless/base:3.0`

### Manual (non-template) files
- `bpf-prog/ipv6-hp-bpf/linux.Dockerfile`: `cbl-mariner/distroless/minimal:2.0` → `azurelinux/distroless/base:3.0`
- `.pipelines/build/dockerfiles/ipv6-hp-bpf.Dockerfile`: `distroless/minimal:3.0` → `distroless/base:3.0`

### Auto-regenerated via `make dockerfiles`
- `cns/Dockerfile`, `cni/Dockerfile`, `azure-ipam/Dockerfile`, `azure-ip-masq-merger/Dockerfile`, `azure-iptables-monitor/Dockerfile`, `cilium-log-collector/Dockerfile`
- Pipeline copies in `.pipelines/build/dockerfiles/`

## Testing
- [ ] Pipeline builds pass
- [ ] No runtime regressions (pod startup, crypto operations)
- [ ] ARM and AMD builds succeed

Resolves #4364
