### PR TITLE
feat: adding selectablefields to multitenancy crds

### DIFF
--- a/crd/multitenancy/api/v1alpha1/multitenantpodnetworkconfig.go
+++ b/crd/multitenancy/api/v1alpha1/multitenantpodnetworkconfig.go
@@ -17,6 +17,11 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels=managed=
 // +kubebuilder:metadata:labels=owner=
+// +kubebuilder:selectablefield:JSONPath=`.spec.podNetworkInstance`
+// +kubebuilder:selectablefield:JSONPath=`.spec.podNetwork`
+// +kubebuilder:selectablefield:JSONPath=`.spec.podName`
+// +kubebuilder:selectablefield:JSONPath=`.status.status`
+// +kubebuilder:selectablefield:JSONPath=`.status.nodeName`
 // +kubebuilder:printcolumn:name="PodNetworkInstance",type=string,JSONPath=`.spec.podNetworkInstance`
 // +kubebuilder:printcolumn:name="PodName",type=string,JSONPath=`.spec.podName`
 // +kubebuilder:printcolumn:name="PodUID",type=string,JSONPath=`.spec.podUID`

--- a/crd/multitenancy/api/v1alpha1/nodeinfo.go
+++ b/crd/multitenancy/api/v1alpha1/nodeinfo.go
@@ -14,6 +14,7 @@ import (
 // NodeInfo is the Schema for the NodeInfo API
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=ni,scope=Cluster,path=nodeinfo
+// +kubebuilder:selectablefield:JSONPath=`.spec.vmUniqueID`
 // +kubebuilder:printcolumn:name="VMUniqueID",type=string,priority=0,JSONPath=`.spec.vmUniqueID`
 type NodeInfo struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/crd/multitenancy/api/v1alpha1/podnetwork.go
+++ b/crd/multitenancy/api/v1alpha1/podnetwork.go
@@ -14,6 +14,11 @@ import (
 // PodNetwork is the Schema for the PodNetworks API
 // +kubebuilder:resource:shortName=pn,scope=Cluster
 // +kubebuilder:subresource:status
+// +kubebuilder:selectablefield:JSONPath=`.spec.networkID`
+// +kubebuilder:selectablefield:JSONPath=`.spec.subnetResourceID`
+// +kubebuilder:selectablefield:JSONPath=`.spec.subnetGUID`
+// +kubebuilder:selectablefield:JSONPath=`.spec.deviceType`
+// +kubebuilder:selectablefield:JSONPath=`.status.status`
 // +kubebuilder:printcolumn:name="Status",type=string,priority=1,JSONPath=`.status.status`
 // +kubebuilder:printcolumn:name="Address Prefixes",type=string,priority=1,JSONPath=`.status.addressPrefixes`
 // +kubebuilder:printcolumn:name="Network",type=string,priority=1,JSONPath=`.spec.networkID`

--- a/crd/multitenancy/api/v1alpha1/podnetworkinstance.go
+++ b/crd/multitenancy/api/v1alpha1/podnetworkinstance.go
@@ -14,6 +14,8 @@ import (
 // PodNetworkInstance is the Schema for the PodNetworkInstances API
 // +kubebuilder:resource:shortName=pni,scope=Namespaced
 // +kubebuilder:subresource:status
+// +kubebuilder:selectablefield:JSONPath=`.spec.podnetwork`
+// +kubebuilder:selectablefield:JSONPath=`.status.status`
 // +kubebuilder:metadata:labels=managed=
 // +kubebuilder:metadata:labels=owner=
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.status`

--- a/crd/multitenancy/client.go
+++ b/crd/multitenancy/client.go
@@ -61,12 +61,12 @@ func ensureSelectableFieldsVersionSafe(res *v1.CustomResourceDefinition, k8sVers
 		return res
 	}
 
-	copy := res.DeepCopy()
-	for idx := range copy.Spec.Versions {
-		copy.Spec.Versions[idx].SelectableFields = nil
+	cleanedCrd := res.DeepCopy()
+	for idx := range cleanedCrd.Spec.Versions {
+		cleanedCrd.Spec.Versions[idx].SelectableFields = nil
 	}
 
-	return copy
+	return cleanedCrd
 }
 
 func detectServerVersion(c *rest.Config) (*utilversion.Version, error) {

--- a/crd/multitenancy/client.go
+++ b/crd/multitenancy/client.go
@@ -12,6 +12,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilversion "k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -27,7 +29,8 @@ func init() {
 
 // Installer provides methods to manage the lifecycle of the custom resource definition.
 type Installer struct {
-	cli typedv1.CustomResourceDefinitionInterface
+	cli        typedv1.CustomResourceDefinitionInterface
+	k8sVersion *utilversion.Version
 }
 
 func NewInstaller(c *rest.Config) (*Installer, error) {
@@ -35,17 +38,71 @@ func NewInstaller(c *rest.Config) (*Installer, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to init crd client")
 	}
+
+	k8sVersion, err := detectServerVersion(c)
+	if err != nil {
+		// Keep running; fallback behavior strips selectable fields on unknown versions.
+		k8sVersion = nil
+	}
+
 	return &Installer{
-		cli: cli,
+		cli:        cli,
+		k8sVersion: k8sVersion,
 	}, nil
 }
 
+func (i *Installer) makeCRDVersionSafe(res *v1.CustomResourceDefinition) *v1.CustomResourceDefinition {
+	res = ensureSelectableFieldsVersionSafe(res, i.k8sVersion)
+	return res
+}
+
+func ensureSelectableFieldsVersionSafe(res *v1.CustomResourceDefinition, k8sVersion *utilversion.Version) *v1.CustomResourceDefinition {
+	if k8sVersion != nil && k8sVersion.AtLeast(utilversion.MustParseGeneric("1.31.0")) {
+		return res
+	}
+
+	copy := res.DeepCopy()
+	for idx := range copy.Spec.Versions {
+		copy.Spec.Versions[idx].SelectableFields = nil
+	}
+
+	return copy
+}
+
+func detectServerVersion(c *rest.Config) (*utilversion.Version, error) {
+	disco, err := discovery.NewDiscoveryClientForConfig(c)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to init discovery client")
+	}
+
+	serverVersion, err := disco.ServerVersion()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get server version")
+	}
+
+	parsedK8sVersion, err := utilversion.ParseGeneric(serverVersion.GitVersion)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse server version")
+	}
+
+	return parsedK8sVersion, nil
+}
+
 func (i *Installer) create(ctx context.Context, res *v1.CustomResourceDefinition) (*v1.CustomResourceDefinition, error) {
-	res, err := i.cli.Create(ctx, res, metav1.CreateOptions{})
+	res, err := i.cli.Create(ctx, i.makeCRDVersionSafe(res), metav1.CreateOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create crd")
 	}
 	return res, nil
+}
+
+func (i *Installer) update(ctx context.Context, res *v1.CustomResourceDefinition) (*v1.CustomResourceDefinition, error) {
+	updated, err := i.cli.Update(ctx, i.makeCRDVersionSafe(res), metav1.UpdateOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to update existing crd")
+	}
+
+	return updated, nil
 }
 
 // Installs the embedded MultitenantPodNetworkConfig CRD definition in the cluster.
@@ -76,9 +133,9 @@ func (i *Installer) InstallOrUpdateMTPNC(ctx context.Context) (*v1.CustomResourc
 	if !reflect.DeepEqual(mtpnc.Spec.Versions, current.Spec.Versions) {
 		mtpnc.SetResourceVersion(current.GetResourceVersion())
 		previous := *current
-		current, err = i.cli.Update(ctx, mtpnc, metav1.UpdateOptions{})
+		current, err = i.update(ctx, mtpnc)
 		if err != nil {
-			return &previous, errors.Wrap(err, "failed to update existing mtpnc crd")
+			return &previous, err
 		}
 	}
 	return current, nil
@@ -112,9 +169,9 @@ func (i *Installer) InstallOrUpdateNodeInfo(ctx context.Context) (*v1.CustomReso
 	if !reflect.DeepEqual(nodeinfo.Spec.Versions, current.Spec.Versions) {
 		nodeinfo.SetResourceVersion(current.GetResourceVersion())
 		previous := *current
-		current, err = i.cli.Update(ctx, nodeinfo, metav1.UpdateOptions{})
+		current, err = i.update(ctx, nodeinfo)
 		if err != nil {
-			return &previous, errors.Wrap(err, "failed to update existing nodeinfo crd")
+			return &previous, err
 		}
 	}
 	return current, nil
@@ -148,9 +205,9 @@ func (i *Installer) InstallOrUpdatePodNetwork(ctx context.Context) (*v1.CustomRe
 	if !reflect.DeepEqual(podNetwork.Spec.Versions, current.Spec.Versions) {
 		podNetwork.SetResourceVersion(current.GetResourceVersion())
 		previous := *current
-		current, err = i.cli.Update(ctx, podNetwork, metav1.UpdateOptions{})
+		current, err = i.update(ctx, podNetwork)
 		if err != nil {
-			return &previous, errors.Wrap(err, "failed to update existing podnetwork crd")
+			return &previous, err
 		}
 	}
 	return current, nil
@@ -184,9 +241,9 @@ func (i *Installer) InstallOrUpdatePodNetworkInstance(ctx context.Context) (*v1.
 	if !reflect.DeepEqual(podnetworkinstance.Spec.Versions, current.Spec.Versions) {
 		podnetworkinstance.SetResourceVersion(current.GetResourceVersion())
 		previous := *current
-		current, err = i.cli.Update(ctx, podnetworkinstance, metav1.UpdateOptions{})
+		current, err = i.update(ctx, podnetworkinstance)
 		if err != nil {
-			return &previous, errors.Wrap(err, "failed to update existing podnetworkinstance crd")
+			return &previous, err
 		}
 	}
 	return current, nil

--- a/crd/multitenancy/client_versionchecks_test.go
+++ b/crd/multitenancy/client_versionchecks_test.go
@@ -1,0 +1,95 @@
+package multitenancy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilversion "k8s.io/apimachinery/pkg/util/version"
+)
+
+// crdWithSelectableFields returns a CRD with selectableFields populated on each version.
+func crdWithSelectableFields() *v1.CustomResourceDefinition {
+	return &v1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "test.example.com"},
+		Spec: v1.CustomResourceDefinitionSpec{
+			Versions: []v1.CustomResourceDefinitionVersion{
+				{
+					Name: "v1alpha1",
+					SelectableFields: []v1.SelectableField{
+						{JSONPath: ".spec.podName"},
+						{JSONPath: ".status.status"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestEnsureSelectableFieldsVersionSafe_NilVersion(t *testing.T) {
+	crd := crdWithSelectableFields()
+	result := ensureSelectableFieldsVersionSafe(crd, nil)
+
+	require.NotNil(t, result)
+	for _, ver := range result.Spec.Versions {
+		assert.Nil(t, ver.SelectableFields, "expected selectableFields to be stripped for nil k8s version")
+	}
+}
+
+func TestEnsureSelectableFieldsVersionSafe_OldVersion(t *testing.T) {
+	for _, v := range []string{"1.29.0", "1.30.5"} {
+		k8sVersion := utilversion.MustParseGeneric(v)
+		crd := crdWithSelectableFields()
+		result := ensureSelectableFieldsVersionSafe(crd, k8sVersion)
+
+		require.NotNil(t, result)
+		for _, ver := range result.Spec.Versions {
+			assert.Nil(t, ver.SelectableFields, "expected selectableFields to be stripped for k8s %s", v)
+		}
+	}
+}
+
+func TestEnsureSelectableFieldsVersionSafe_SupportedVersion(t *testing.T) {
+	for _, v := range []string{"1.31.0", "1.32.0", "1.33.1"} {
+		k8sVersion := utilversion.MustParseGeneric(v)
+		crd := crdWithSelectableFields()
+		result := ensureSelectableFieldsVersionSafe(crd, k8sVersion)
+
+		require.NotNil(t, result)
+		for _, ver := range result.Spec.Versions {
+			assert.NotNil(t, ver.SelectableFields, "expected selectableFields to be preserved for k8s %s", v)
+			assert.NotEmpty(t, ver.SelectableFields)
+		}
+	}
+}
+
+func TestEnsureSelectableFieldsVersionSafe_DoesNotMutateOriginal(t *testing.T) {
+	original := crdWithSelectableFields()
+	originalFields := original.Spec.Versions[0].SelectableFields
+
+	_ = ensureSelectableFieldsVersionSafe(original, nil)
+
+	assert.Equal(t, originalFields, original.Spec.Versions[0].SelectableFields, "original CRD must not be mutated")
+}
+
+func TestMakeCRDVersionSafe_NilVersion(t *testing.T) {
+	installer := &Installer{k8sVersion: nil}
+	crd := crdWithSelectableFields()
+	result := installer.makeCRDVersionSafe(crd)
+
+	for _, ver := range result.Spec.Versions {
+		assert.Nil(t, ver.SelectableFields, "expected selectableFields stripped when k8sVersion is nil")
+	}
+}
+
+func TestMakeCRDVersionSafe_SupportedVersion(t *testing.T) {
+	installer := &Installer{k8sVersion: utilversion.MustParseGeneric("1.31.0")}
+	crd := crdWithSelectableFields()
+	result := installer.makeCRDVersionSafe(crd)
+
+	for _, ver := range result.Spec.Versions {
+		assert.NotNil(t, ver.SelectableFields, "expected selectableFields preserved for k8s 1.31+")
+	}
+}

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_multitenantpodnetworkconfigs.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_multitenantpodnetworkconfigs.yaml
@@ -33,6 +33,12 @@ spec:
       name: Status
       type: string
     name: v1alpha1
+    selectableFields:
+    - jsonPath: .spec.podNetworkInstance
+    - jsonPath: .spec.podNetwork
+    - jsonPath: .spec.podName
+    - jsonPath: .status.status
+    - jsonPath: .status.nodeName
     schema:
       openAPIV3Schema:
         description: MultitenantPodNetworkConfig is the Schema for the multitenantpodnetworkconfigs

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_nodeinfo.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_nodeinfo.yaml
@@ -21,6 +21,8 @@ spec:
       name: VMUniqueID
       type: string
     name: v1alpha1
+    selectableFields:
+    - jsonPath: .spec.vmUniqueID
     schema:
       openAPIV3Schema:
         description: NodeInfo is the Schema for the NodeInfo API

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_podnetworkinstances.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_podnetworkinstances.yaml
@@ -24,6 +24,9 @@ spec:
       name: Status
       type: string
     name: v1alpha1
+    selectableFields:
+    - jsonPath: .spec.podnetwork
+    - jsonPath: .status.status
     schema:
       openAPIV3Schema:
         description: PodNetworkInstance is the Schema for the PodNetworkInstances

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_podnetworks.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_podnetworks.yaml
@@ -42,6 +42,12 @@ spec:
       priority: 1
       type: string
     name: v1alpha1
+    selectableFields:
+    - jsonPath: .spec.networkID
+    - jsonPath: .spec.subnetResourceID
+    - jsonPath: .spec.subnetGUID
+    - jsonPath: .spec.deviceType
+    - jsonPath: .status.status
     schema:
       openAPIV3Schema:
         description: PodNetwork is the Schema for the PodNetworks API


### PR DESCRIPTION
**Reason for Change**:
This PR adds selectablefields to the swiftv2/multitenancy CRDs to allow more efficient query and filter by controllers and common debugging scenarios. 

Field selectors is supported and enabled by default on K8 1.32+ [Custom Resources | Kubernetes](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#custom-resource-field-selectors) - so we can use structured fields for indexed search instead of labels for new features. 

Fields we are enabling as searchable at this point:  
- PN: networkid, subnetresourceid, subnetGUID, devicetype, status

- MTPNC: podNetworkInstance, podnetwork, podname, nodename, status
- NodeInfo: vmuniqueid
- PNI: podnetwork

There are some limitations: limited operators and we cannot match nested objects / operators, like podnetworkconfigurations in PNI, and we cannot add unbounded # of searchable fields so we're keeping these <= 5 fields. 

For safety also adding version check and transform on CRD install to fallback on k8 versions where the schema is not supported. 


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [x] relevant PR labels added

**Notes**:
