### PR TITLE
Change manifold E2E region from westus2 to centraluseuap

### DIFF
--- a/.pipelines/multitenancy/swiftv2-manifold-e2e.stages.yaml
+++ b/.pipelines/multitenancy/swiftv2-manifold-e2e.stages.yaml
@@ -44,7 +44,7 @@ stages:
           - task: TriggerBuild@3
             inputs:
               buildDefinition: '391699'
-              templateParameters: 'regions: ["westus2"], useAcnPublic: true, cnscniversion: $(CNS_VERSION), cnscniversionwindows: $(CNS_VERSION), cnscniImagePrefix: $(IMAGE_REPO_PATH_REF), npmversion: $(NPM_VERSION)'
+              templateParameters: 'regions: ["centraluseuap"], useAcnPublic: true, cnscniversion: $(CNS_VERSION), cnscniversionwindows: $(CNS_VERSION), cnscniImagePrefix: $(IMAGE_REPO_PATH_REF), npmversion: $(NPM_VERSION)'
               useSameBranch: false
               queueBuildForUserThatTriggeredBuild: true
               branchToUse: 'refs/heads/master'


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Change the Swiftv2 manifold E2E test pipeline to trigger the Singularity runner pipeline in `centraluseuap` instead of `westus2` for ACN official build pipeline.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
This changes the `regions` parameter in the `TriggerBuild@3` task (pipeline definition `391699`) from `["westus2"]` to `["centraluseuap"]` in `.pipelines/multitenancy/swiftv2-manifold-e2e.stages.yaml`.