### PR TITLE
ci: add retry to validate pods and ignore "completed" pods

### DIFF
--- a/.pipelines/templates/cilium-tests.yaml
+++ b/.pipelines/templates/cilium-tests.yaml
@@ -54,6 +54,7 @@ steps:
       make test-validate-state
     name: "validatePods"
     displayName: "Validate Pods"
+    retryCountOnTaskFailure: 3
 
   - script: |
       echo "Run wireserver and metadata connectivity Tests"

--- a/test/internal/kubernetes/utils_get.go
+++ b/test/internal/kubernetes/utils_get.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"log"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -46,6 +47,14 @@ func GetPodsIpsByNode(ctx context.Context, clientset *kubernetes.Clientset, name
 	}
 	ips := make([]string, 0, len(pods.Items)*2) //nolint
 	for index := range pods.Items {
+		// skip succeeded/failed pods since even though we released those ips internally,
+		// the api server still reports their existence
+		phase := pods.Items[index].Status.Phase
+		if phase == corev1.PodSucceeded || phase == corev1.PodFailed {
+			log.Printf("skipping pod %s/%s on node %s in terminal phase %s (IPs: %v) when collecting pod IPs",
+				pods.Items[index].Namespace, pods.Items[index].Name, nodeName, phase, pods.Items[index].Status.PodIPs)
+			continue
+		}
 		for _, podIP := range pods.Items[index].Status.PodIPs {
 			ips = append(ips, podIP.IP)
 		}


### PR DESCRIPTION
a completed pod already had its ip released, but the api server still seems to keep track of it so when we compare the actual ips to expected ips, actual ips has this completed pod's ip after a short period of time the completed pod disappears and the state becomes consistent again.


<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Fix flake in pipeline caused by new pod coming up and going into "completed" state (related to azuresecuritylinuxagent, not a component we control)

Example:
```
azuresecuritylinuxagent   azuresecuritylinuxagent-stale-pod-cleanup-29625080-rzbt2   0/1     Completed   0               84s   192.168.0.4     aks-nodepool1-15814823-vmss000001   <none>           <none>
```
will show up in the actual ips as `192.168.0.4` even though it would have already been cleaned up internally.

Example run:  
20260429.13 E2E-Cil EBPF on AKS Overlay Azure Linux stage > validate pods

```
2026/04/29 23:21:41 skipping pod azuresecuritylinuxagent/azuresecuritylinuxagent-stale-pod-cleanup-29625080-rzbt2 on node aks-nodepool1-15814823-vmss000001 in terminal phase Succeeded (IPs: [{192.168.0.4}]) when collecting pod IPs
```


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
