### PR TITLE
ci: fix log template pipeline variable expansion

### DIFF
--- a/.pipelines/templates/log-template.yaml
+++ b/.pipelines/templates/log-template.yaml
@@ -112,12 +112,12 @@ steps:
         if [ -z ${array[0]} ]; then
           echo "There are no kube-system pods in a non-ready state."
         else
-          mkdir -p $acnLogs/${{ parameters.os }}non-ready
-          echo "Directory created: $acnLogs/${{ parameters.os }}non-ready"
+          mkdir -p $(acnLogs)/${{ parameters.os }}non-ready
+          echo "Directory created: $(acnLogs)/${{ parameters.os }}non-ready"
           echo "Capturing failed pods"
           for pod in $podList; do
-            kubectl describe pod -n kube-system $pod > $acnLogs/${{ parameters.os }}non-ready/$pod.txt
-            echo "$acnLogs/${{ parameters.os }}non-ready/$pod.txt"
+            kubectl describe pod -n kube-system $pod > $(acnLogs)/${{ parameters.os }}non-ready/$pod.txt
+            echo "$(acnLogs)/${{ parameters.os }}non-ready/$pod.txt"
           done
         fi
       displayName: Failure Logs


### PR DESCRIPTION
```
$(acnLogs) is a pipeline variable
$acnLogs is a bash variable 
echo "##vso[task.setvariable variable=acnLogs]$acnLogs" sets the pipeline var 
$acnLogs the bash variable was not set in the task, so it resolved to empty (bad) 
$(acnLogs) is replaced with the pipeline variable val prior to the script running
```
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
See above

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
See build dalec-cni-cns-v1.7.13-1-20260505.3 in acn pr > Failed stage > Failure Logs job > Failure Logs step

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
