### PR TITLE
feat: [AKS ASVI Dual Stack] populate NodeInfo CRD for MultiTenantCRD channel mode

### DIFF
--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1417,6 +1417,12 @@ func InitializeCRDState(ctx context.Context, z *zap.Logger, httpRestService cns.
 		}
 	}
 
+	if cnsconfig.ChannelMode == cns.MultiTenantCRD {
+		if nodeInfoErr := createOrUpdateNodeInfoCRD(ctx, kubeConfig, node); nodeInfoErr != nil {
+			return errors.Wrap(nodeInfoErr, "error creating or updating nodeinfo crd for multi-tenant node")
+		}
+	}
+
 	// perform state migration from CNI in case CNS is set to manage the endpoint state and has emty state
 	if cnsconfig.EnableStateMigration && !httpRestServiceImplementation.EndpointStateStore.Exists() {
 		if err = PopulateCNSEndpointState(httpRestServiceImplementation.EndpointStateStore); err != nil {

--- a/cns/service/main_test.go
+++ b/cns/service/main_test.go
@@ -231,3 +231,59 @@ func TestBuildNodeInfoSpec_WithHomeAZ(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildAndCreateNodeInfo_MultiTenantCRD verifies that buildAndCreateNodeInfo
+// correctly creates a NodeInfo CRD in the MultiTenantCRD channel mode scenario.
+func TestBuildAndCreateNodeInfo_MultiTenantCRD(t *testing.T) {
+	tests := []struct {
+		name        string
+		vmUniqueID  string
+		homeAz      uint
+		expectedAZ  string
+		expectError bool
+	}{
+		{
+			name:        "multi-tenant CRD with valid HomeAZ",
+			vmUniqueID:  "mt-vm-unique-id",
+			homeAz:      3,
+			expectedAZ:  "AZ03",
+			expectError: false,
+		},
+		{
+			name:        "multi-tenant CRD with no HomeAZ",
+			vmUniqueID:  "mt-vm-no-az",
+			homeAz:      0,
+			expectedAZ:  "",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			imdsCli := &mockIMDSClient{
+				vmUniqueID: tt.vmUniqueID,
+			}
+			nmaCli := &mockNMAgentClient{
+				homeAzResponse: nmagent.AzResponse{HomeAz: tt.homeAz},
+			}
+			nodeInfoCli := &mockNodeInfoClient{}
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "mt-test-node",
+					UID:  "mt-test-uid",
+				},
+			}
+
+			err := buildAndCreateNodeInfo(context.Background(), imdsCli, nmaCli, nodeInfoCli, node)
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, nodeInfoCli.createdNodeInfo)
+			assert.Equal(t, tt.vmUniqueID, nodeInfoCli.createdNodeInfo.Spec.VMUniqueID)
+			assert.Equal(t, tt.expectedAZ, nodeInfoCli.createdNodeInfo.Spec.HomeAZ)
+			assert.Equal(t, "mt-test-node", nodeInfoCli.createdNodeInfo.Name)
+		})
+	}
+}


### PR DESCRIPTION
**Reason for Change**:
Enable HomeAZ population for multi-tenant CRD scenarios by calling `createOrUpdateNodeInfoCRD` when `cnsconfig.ChannelMode == cns.MultiTenantCRD` in `InitializeCRDState`. This ensures the NodeInfo CRD is created/updated with VMUniqueID and HomeAZ information for nodes running in MultiTenantCRD mode, consistent with the existing behavior for SwiftV2 and SwiftV1 DualStack scenarios.

**Issue Fixed**:


**Requirements**:

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [X] adds unit tests
- [ ] relevant PR labels added

**Notes**:
- Added a conditional block in `InitializeCRDState` to call `createOrUpdateNodeInfoCRD` when channel mode is `MultiTenantCRD`
- Added `TestBuildAndCreateNodeInfo_MultiTenantCRD` unit test to validate NodeInfo CRD creation for the multi-tenant scenario