### PR TITLE
feat: [AKS ASVI Dual Stack and RNM deprecation] populate NodeInfo CRD for MultiTenantCRD channel mode

### DIFF
--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -929,6 +929,12 @@ func main() {
 			logger.Errorf("Failed to start multiTenantController, err:%v.\n", err)
 			return
 		}
+
+		// Populate the NodeInfo CRD with HomeAZ for multi-tenant nodes
+		if err = createOrUpdateNodeInfoCRDForMultiTenant(rootCtx); err != nil {
+			logger.Errorf("Failed to create or update NodeInfo CRD for multi-tenant: %v", err)
+			return
+		}
 	}
 
 	if cnsconfig.EnableSwiftV2 && cnsconfig.EnableK8sDevicePlugin {
@@ -1417,12 +1423,6 @@ func InitializeCRDState(ctx context.Context, z *zap.Logger, httpRestService cns.
 		}
 	}
 
-	if cnsconfig.ChannelMode == cns.MultiTenantCRD {
-		if nodeInfoErr := createOrUpdateNodeInfoCRD(ctx, kubeConfig, node); nodeInfoErr != nil {
-			return errors.Wrap(nodeInfoErr, "error creating or updating nodeinfo crd for multi-tenant node")
-		}
-	}
-
 	// perform state migration from CNI in case CNS is set to manage the endpoint state and has emty state
 	if cnsconfig.EnableStateMigration && !httpRestServiceImplementation.EndpointStateStore.Exists() {
 		if err = PopulateCNSEndpointState(httpRestServiceImplementation.EndpointStateStore); err != nil {
@@ -1691,6 +1691,33 @@ func createOrUpdateNodeInfoCRD(ctx context.Context, restConfig *rest.Config, nod
 	}
 
 	return buildAndCreateNodeInfo(ctx, imdsCli, nmaCli, nodeInfoCli, node)
+}
+
+// createOrUpdateNodeInfoCRDForMultiTenant is a self-contained helper for the MultiTenantCRD path
+// that fetches kubeconfig and node info internally.
+func createOrUpdateNodeInfoCRDForMultiTenant(ctx context.Context) error {
+	kubeConfig, err := ctrl.GetConfig()
+	if err != nil {
+		return errors.Wrap(err, "failed to get kubeconfig")
+	}
+	kubeConfig.UserAgent = fmt.Sprintf("azure-cns-%s", version)
+
+	clientset, err := kubernetes.NewForConfig(kubeConfig)
+	if err != nil {
+		return errors.Wrap(err, "failed to build clientset")
+	}
+
+	nodeName, err := configuration.NodeName()
+	if err != nil {
+		return errors.Wrap(err, "failed to get NodeName")
+	}
+
+	node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "failed to get node %s", nodeName)
+	}
+
+	return createOrUpdateNodeInfoCRD(ctx, kubeConfig, node)
 }
 
 // VMUniqueIDGetter is an interface for getting VM unique ID from IMDS

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -932,7 +932,7 @@ func main() {
 
 		// Populate the NodeInfo CRD with HomeAZ for multi-tenant nodes
 		if err = createOrUpdateNodeInfoCRDForMultiTenant(rootCtx); err != nil {
-			logger.Errorf("Failed to create or update NodeInfo CRD for multi-tenant: %v", err)
+			z.Error("Failed to create or update NodeInfo CRD for multi-tenant", zap.Error(err))
 			return
 		}
 	}
@@ -1700,7 +1700,7 @@ func createOrUpdateNodeInfoCRDForMultiTenant(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to get kubeconfig")
 	}
-	kubeConfig.UserAgent = fmt.Sprintf("azure-cns-%s", version)
+	kubeConfig.UserAgent = "azure-cns-" + version
 
 	clientset, err := kubernetes.NewForConfig(kubeConfig)
 	if err != nil {

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1417,6 +1417,12 @@ func InitializeCRDState(ctx context.Context, z *zap.Logger, httpRestService cns.
 		}
 	}
 
+	if cnsconfig.ChannelMode == cns.MultiTenantCRD {
+		if nodeInfoErr := createOrUpdateNodeInfoCRD(ctx, kubeConfig, node); nodeInfoErr != nil {
+			return errors.Wrap(nodeInfoErr, "error creating or updating nodeinfo crd for multi-tenant node")
+		}
+	}
+
 	// perform state migration from CNI in case CNS is set to manage the endpoint state and has emty state
 	if cnsconfig.EnableStateMigration && !httpRestServiceImplementation.EndpointStateStore.Exists() {
 		if err = PopulateCNSEndpointState(httpRestServiceImplementation.EndpointStateStore); err != nil {

--- a/cns/service/main_test.go
+++ b/cns/service/main_test.go
@@ -231,3 +231,59 @@ func TestBuildNodeInfoSpec_WithHomeAZ(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildAndCreateNodeInfo_MultiTenantCRD verifies that buildAndCreateNodeInfo
+// correctly creates a NodeInfo CRD in the MultiTenantCRD channel mode scenario.
+func TestBuildAndCreateNodeInfo_MultiTenantCRD(t *testing.T) {
+	tests := []struct {
+		name        string
+		vmUniqueID  string
+		homeAz      uint
+		expectedAZ  string
+		expectError bool
+	}{
+		{
+			name:        "multi-tenant CRD with valid HomeAZ",
+			vmUniqueID:  "mt-vm-unique-id",
+			homeAz:      3,
+			expectedAZ:  "AZ03",
+			expectError: false,
+		},
+		{
+			name:        "multi-tenant CRD with no HomeAZ",
+			vmUniqueID:  "mt-vm-no-az",
+			homeAz:      0,
+			expectedAZ:  "",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			imdsCli := &mockIMDSClient{
+				vmUniqueID: tt.vmUniqueID,
+			}
+			nmaCli := &mockNMAgentClient{
+				homeAzResponse: nmagent.AzResponse{HomeAz: tt.homeAz},
+			}
+			nodeInfoCli := &mockNodeInfoClient{}
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "mt-test-node",
+					UID:  "mt-test-uid",
+				},
+			}
+
+			err := buildAndCreateNodeInfo(context.Background(), imdsCli, nmaCli, nodeInfoCli, node)
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, nodeInfoCli.createdNodeInfo)
+			assert.Equal(t, tt.vmUniqueID, nodeInfoCli.createdNodeInfo.Spec.VMUniqueID)
+			assert.Equal(t, tt.expectedAZ, nodeInfoCli.createdNodeInfo.Spec.HomeAZ)
+			assert.Equal(t, "mt-test-node", nodeInfoCli.createdNodeInfo.Name)
+		})
+	}
+}

--- a/cns/service/main_test.go
+++ b/cns/service/main_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Azure/azure-container-networking/nmagent"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -279,7 +280,7 @@ func TestBuildAndCreateNodeInfo_MultiTenantCRD(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, nodeInfoCli.createdNodeInfo)
 			assert.Equal(t, tt.vmUniqueID, nodeInfoCli.createdNodeInfo.Spec.VMUniqueID)
 			assert.Equal(t, tt.expectedAZ, nodeInfoCli.createdNodeInfo.Spec.HomeAZ)


### PR DESCRIPTION
**Reason for Change**:
Enable HomeAZ population for multi-tenant CRD scenarios by calling `createOrUpdateNodeInfoCRD` when `cnsconfig.ChannelMode == cns.MultiTenantCRD` in `InitializeCRDState`. This ensures the NodeInfo CRD is created/updated with VMUniqueID and HomeAZ information for nodes running in MultiTenantCRD mode, consistent with the existing behavior for SwiftV2 and SwiftV1 DualStack scenarios.

**Issue Fixed**:


**Requirements**:

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [X] adds unit tests
- [ ] relevant PR labels added

**Notes**:
- Added a conditional block in `InitializeCRDState` to call `createOrUpdateNodeInfoCRD` when channel mode is `MultiTenantCRD`
- Added `TestBuildAndCreateNodeInfo_MultiTenantCRD` unit test to validate NodeInfo CRD creation for the multi-tenant scenario