### PR TITLE
ci: modify ipv6 hp bpf headers for building in acn official build pipeline

### DIFF
--- a/.pipelines/build/images.jobs.yaml
+++ b/.pipelines/build/images.jobs.yaml
@@ -28,7 +28,7 @@ jobs:
       ob_outputDirectory: $(Build.ArtifactStagingDirectory)
       ${{ if eq(job_data.job, 'linux_amd64') }}:
         DEBIAN_FRONTEND: noninteractive
-        LinuxContainerImage: 'onebranch.azurecr.io/linux/ubuntu-2404:latest'
+        LinuxContainerImage: 'mcr.microsoft.com/onebranch/azurelinux/build:3.0'
         #mcr.microsoft.com/mirror/docker/library/ubuntu:24.04'
         #LinuxContainerImage: 'mcr.microsoft.com/onebranch/azurelinux/build:3.0'
         OS: linux

--- a/bpf-prog/ipv6-hp-bpf/include/helper.h
+++ b/bpf-prog/ipv6-hp-bpf/include/helper.h
@@ -1,4 +1,6 @@
-#include <netinet/in.h>
+#include <linux/in6.h>
+#include <linux/if_ether.h>
+#include <linux/ipv6.h>
 #include <stdbool.h>
 
 #define L4_HDR_OFF (ETH_HLEN + sizeof(struct ipv6hdr))

--- a/bpf-prog/ipv6-hp-bpf/pkg/egress/bpf/egress.c
+++ b/bpf-prog/ipv6-hp-bpf/pkg/egress/bpf/egress.c
@@ -4,11 +4,9 @@
 #include <linux/pkt_cls.h>
 #include <linux/if_ether.h>
 #include <linux/ipv6.h>
-#include <netinet/in.h>
-#include <netinet/tcp.h>
-#include <linux/if_ether.h>
-#include <string.h>
-#include <stdint.h>
+#include <linux/in.h>
+#include <linux/in6.h>
+#include <linux/tcp.h>
 #include <stdbool.h>
 #include "../../../include/helper.h"
 

--- a/bpf-prog/ipv6-hp-bpf/pkg/ingress/bpf/ingress.c
+++ b/bpf-prog/ipv6-hp-bpf/pkg/ingress/bpf/ingress.c
@@ -3,11 +3,9 @@
 #include <linux/pkt_cls.h>
 #include <linux/if_ether.h>
 #include <linux/ipv6.h>
-#include <netinet/in.h>
-#include <netinet/tcp.h>
-#include <linux/if_ether.h>
-#include <string.h>
-#include <stdint.h>
+#include <linux/in.h>
+#include <linux/in6.h>
+#include <linux/tcp.h>
 #include <stdbool.h>
 #include "../../../include/helper.h"
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

Run passes acn unofficial build pipeline: 20260503.2
Compare against all other recent runs on that pipeline which fail during image build. Cherry-picked Mugesh's image update which resolved most the image failures. Then updated headers to linux to resolve the ipv6 build issue shown in 20260501.7

See commit description for [77086ab](https://github.com/Azure/azure-container-networking/pull/4390/commits/77086abe8fb0ef5ec223e874812bfae9576ddef6) for explanation.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
ACN Official Build Pipeline (for releasing images) appears to currently be broken for all runs.