### PR TITLE
ci: Update Create Release Tag Workflow to use deployment to create tag

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -91,35 +91,15 @@ jobs:
           echo "full_tag=$FULL_TAG" >> "$GITHUB_OUTPUT"
           echo "Validated request for $FULL_TAG on $TARGET_SHA"
 
-  approve_tag:
-    name: Approve Tag
-    runs-on: ubuntu-latest
-    needs: validate
-    # Operational requirement:
-    # - This workflow expects a GitHub Environment named `tag-approval`.
-    # - Configure that environment with required reviewers / approval rules
-    #   to gate release tag creation in this repository.
-    # - In forks or newly created repositories, create and maintain the
-    #   `tag-approval` environment before using this workflow, or update this
-    #   workflow to reference the repository's documented approval environment.
-    environment: tag-approval
-    concurrency:
-      group: release-tag-${{ inputs.tag_prefix }}-${{ inputs.tag_name }}
-      cancel-in-progress: false
-    steps:
-      - name: Echo tag
-        env:
-          FULL_TAG: ${{ needs.validate.outputs.full_tag }}
-        run: echo $FULL_TAG
-
   create_tag:
     name: Create and Push Tag
     runs-on: ubuntu-latest
+    environment: tag-approval
     permissions:
       contents: write
+      deployments: write
     needs:
       - validate
-      - approve_tag
     steps:
       - name: Checkout target commit
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -137,6 +117,31 @@ jobs:
             echo "Tag already exists on origin: $FULL_TAG"
             exit 1
           fi
+
+      - name: Record successful tag-approval deployment for target SHA
+        env:
+          TARGET_SHA: ${{ needs.validate.outputs.target_sha }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          DEPLOYMENT_ID=$(gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${GITHUB_REPOSITORY}/deployments" \
+            -f ref="$TARGET_SHA" \
+            -f environment="tag-approval" \
+            -f required_contexts[] \
+            -F auto_merge=false \
+            --jq '.id')
+
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" \
+            -f state="success" \
+            -f environment="tag-approval" \
+            -f auto_inactive=false >/dev/null
 
       - name: Create and push annotated tag
         env:

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -23,7 +23,7 @@ on:
         description: Tag version in Go release format, e.g. v1.2.3
         required: true
         type: string
-      target_ref:
+      target_sha:
         description: Full 40-character commit SHA to tag
         required: true
         type: string
@@ -41,7 +41,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       target_sha: ${{ steps.validate.outputs.target_sha }}
-      target_ref: ${{ steps.validate.outputs.target_ref }}
       full_tag: ${{ steps.validate.outputs.full_tag }}
     steps:
       - name: Checkout
@@ -55,7 +54,7 @@ jobs:
         env:
           TAG_PREFIX: ${{ inputs.tag_prefix }}
           TAG_NAME: ${{ inputs.tag_name }}
-          TARGET_REF: ${{ inputs.target_ref }}
+          TARGET_SHA_INPUT: ${{ inputs.target_sha }}
         run: |
           set -euo pipefail
 
@@ -71,8 +70,8 @@ jobs:
             exit 1
           fi
 
-          if ! echo "$TARGET_REF" | grep -Eq '^[0-9a-fA-F]{40}$'; then
-            echo "target_ref must be a full 40-character commit SHA: $TARGET_REF"
+          if ! echo "$TARGET_SHA_INPUT" | grep -Eq '^[0-9a-fA-F]{40}$'; then
+            echo "target_sha must be a full 40-character commit SHA: $TARGET_SHA_INPUT"
             exit 1
           fi
 
@@ -83,23 +82,17 @@ jobs:
 
           git fetch --quiet origin --tags
 
-          if ! TARGET_SHA=$(git rev-parse "$TARGET_REF^{commit}" 2>/dev/null); then
-            echo "Unable to resolve target_ref to a commit: $TARGET_REF"
-            exit 1
-          fi
-
-          if git show-ref --verify --quiet "refs/tags/$TARGET_REF"; then
-            echo "target_ref must be a commit SHA, not a tag: $TARGET_REF"
+          if ! TARGET_SHA=$(git rev-parse "$TARGET_SHA_INPUT^{commit}" 2>/dev/null); then
+            echo "Unable to resolve target_sha to a commit: $TARGET_SHA_INPUT"
             exit 1
           fi
 
           echo "target_sha=$TARGET_SHA" >> "$GITHUB_OUTPUT"
-          echo "target_ref=$TARGET_REF" >> "$GITHUB_OUTPUT"
           echo "full_tag=$FULL_TAG" >> "$GITHUB_OUTPUT"
-          echo "Validated request for $FULL_TAG on $TARGET_REF ($TARGET_SHA)"
+          echo "Validated request for $FULL_TAG on $TARGET_SHA"
 
-  create_tag:
-    name: Create Tag (Approval Required)
+  approve_tag:
+    name: Approve Tag
     runs-on: ubuntu-latest
     needs: validate
     # Operational requirement:
@@ -110,11 +103,23 @@ jobs:
     #   `tag-approval` environment before using this workflow, or update this
     #   workflow to reference the repository's documented approval environment.
     environment: tag-approval
-    permissions:
-      contents: write
     concurrency:
       group: release-tag-${{ inputs.tag_prefix }}-${{ inputs.tag_name }}
       cancel-in-progress: false
+    steps:
+      - name: Echo tag
+        env:
+          FULL_TAG: ${{ needs.validate.outputs.full_tag }}
+        run: echo $FULL_TAG
+
+  create_tag:
+    name: Create and Push Tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    needs:
+      - validate
+      - approve_tag
     steps:
       - name: Checkout target commit
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -137,7 +142,6 @@ jobs:
         env:
           FULL_TAG: ${{ needs.validate.outputs.full_tag }}
           TARGET_SHA: ${{ needs.validate.outputs.target_sha }}
-          TARGET_REF: ${{ needs.validate.outputs.target_ref }}
           REASON: ${{ inputs.reason }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -148,10 +152,9 @@ jobs:
 
           RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           TAG_MESSAGE=$(cat <<EOF
-          Release $FULL_TAG
+          $FULL_TAG
 
           Target SHA: $TARGET_SHA
-          Target Ref: $TARGET_REF
           Requested By: $GITHUB_ACTOR
           Reason: $REASON
           Workflow Run: $RUN_URL
@@ -165,7 +168,6 @@ jobs:
         env:
           FULL_TAG: ${{ needs.validate.outputs.full_tag }}
           TARGET_SHA: ${{ needs.validate.outputs.target_sha }}
-          TARGET_REF: ${{ needs.validate.outputs.target_ref }}
           REASON: ${{ inputs.reason }}
         run: |
           {
@@ -173,7 +175,6 @@ jobs:
             echo ""
             echo "- Tag: $FULL_TAG"
             echo "- Target SHA: $TARGET_SHA"
-            echo "- Target Ref: $TARGET_REF"
             echo "- Requested By: $GITHUB_ACTOR"
             echo "- Reason: $REASON"
             echo "- Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -94,12 +94,18 @@ jobs:
   create_tag:
     name: Create and Push Tag
     runs-on: ubuntu-latest
+    # Requires a repository environment named tag-approval.
+    # Configure that environment with the intended approval and ruleset settings,
+    # or this job may block awaiting approval or fail where the environment does not exist.
     environment: tag-approval
     permissions:
       contents: write
       deployments: write
     needs:
       - validate
+    concurrency:
+      group: create-release-tag-${{ needs.validate.outputs.full_tag }}
+      cancel-in-progress: false
     steps:
       - name: Checkout target commit
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -121,7 +127,7 @@ jobs:
       - name: Record successful tag-approval deployment for target SHA
         env:
           TARGET_SHA: ${{ needs.validate.outputs.target_sha }}
-          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
**Reason for Change**:
Simplifies the release tag workflow and aligns it with tag ruleset enforcement by gating tag creation through the tag-approval environment in the actual tag-push job and recording the required deployment status before pushing the tag.

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
Tag Creation Run : https://github.com/Azure/azure-container-networking/actions/runs/25463081177
