### PR TITLE
cns: add bootstrap-phase Prometheus metrics

### DIFF
--- a/cns/kubecontroller/nodenetworkconfig/reconciler.go
+++ b/cns/kubecontroller/nodenetworkconfig/reconciler.go
@@ -3,9 +3,11 @@ package nodenetworkconfig
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/logger"
+	"github.com/Azure/azure-container-networking/cns/metric"
 	"github.com/Azure/azure-container-networking/cns/restserver"
 	cnstypes "github.com/Azure/azure-container-networking/cns/types"
 	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig"
@@ -70,18 +72,40 @@ func NewReconciler(cnscli cnsClient, initializer nodenetworkconfigSink, ipampool
 
 // Reconcile is called on CRD status changes
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	start := time.Now()
+	var (
+		result    reconcile.Result
+		reconErr  error
+	)
+	defer func() {
+		// Classify the terminal disposition: success on nil error,
+		// requeue when controller-runtime asked for one, error
+		// otherwise.
+		outcome := metric.NNCReconcileResultSuccess
+		switch {
+		case reconErr != nil:
+			outcome = metric.NNCReconcileResultError
+		case result.Requeue || result.RequeueAfter > 0:
+			outcome = metric.NNCReconcileResultRequeue
+		}
+		metric.ObserveNNCReconcile(time.Since(start), outcome)
+	}()
+
 	listenersToNotify := []nodenetworkconfigSink{}
 	nnc, err := r.nnccli.Get(ctx, req.NamespacedName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			hasNNC.Set(0)
 			logger.Printf("[cns-rc] CRD not found, ignoring %v", err)
-			return reconcile.Result{}, errors.Wrapf(client.IgnoreNotFound(err), "NodeNetworkConfig %v not found", req.NamespacedName)
+			reconErr = errors.Wrapf(client.IgnoreNotFound(err), "NodeNetworkConfig %v not found", req.NamespacedName)
+			return result, reconErr
 		}
 		logger.Errorf("[cns-rc] Error retrieving CRD from cache : %v", err)
-		return reconcile.Result{}, errors.Wrapf(err, "failed to get NodeNetworkConfig %v", req.NamespacedName)
+		reconErr = errors.Wrapf(err, "failed to get NodeNetworkConfig %v", req.NamespacedName)
+		return result, reconErr
 	}
 	hasNNC.Set(1)
+	metric.RecordFirstNNCReceived()
 	logger.Printf("[cns-rc] CRD Spec: %+v", nnc.Spec)
 
 	ipAssignments := 0
@@ -101,7 +125,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	if r.initializer != nil {
 		if err := r.initializer(nnc); err != nil {
 			logger.Errorf("[cns-rc] initializer failed during reconcile: %v", err)
-			return reconcile.Result{}, errors.Wrap(err, "initializer failed during reconcile")
+			reconErr = errors.Wrap(err, "initializer failed during reconcile")
+			return result, reconErr
 		}
 		r.initializer = nil
 	}
@@ -134,14 +159,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		if err != nil {
 			logger.Errorf("[cns-rc] failed to generate CreateNCRequest from NC: %v, assignmentMode %s", err,
 				nnc.Status.NetworkContainers[i].AssignmentMode)
-			return reconcile.Result{}, errors.Wrapf(err, "failed to generate CreateNCRequest from NC "+
+			reconErr = errors.Wrapf(err, "failed to generate CreateNCRequest from NC "+
 				"assignmentMode %s", nnc.Status.NetworkContainers[i].AssignmentMode)
+			return result, reconErr
 		}
 
 		responseCode := r.cnscli.CreateOrUpdateNetworkContainerInternal(req)
 		if err := restserver.ResponseCodeToError(responseCode); err != nil {
 			logger.Errorf("[cns-rc] Error creating or updating NC in reconcile: %v", err)
-			return reconcile.Result{}, errors.Wrap(err, "failed to create or update network container")
+			reconErr = errors.Wrap(err, "failed to create or update network container")
+			return result, reconErr
 		}
 		ipAssignments += len(req.SecondaryIPConfigs)
 	}
@@ -152,7 +179,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// push the NNC to the registered NNC listeners.
 	for _, l := range listenersToNotify {
 		if err := l(nnc); err != nil {
-			return reconcile.Result{}, errors.Wrap(err, "nnc listener return error during update")
+			reconErr = errors.Wrap(err, "nnc listener return error during update")
+			return result, reconErr
 		}
 	}
 
@@ -161,7 +189,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		close(r.started)
 		logger.Printf("[cns-rc] CNS NNC Reconciler Started")
 	})
-	return reconcile.Result{}, nil
+	return result, nil
 }
 
 // Started blocks until the Reconciler has reconciled at least once,

--- a/cns/metric/bootstrap.go
+++ b/cns/metric/bootstrap.go
@@ -1,0 +1,474 @@
+// Copyright 2024 Microsoft. All rights reserved.
+// MIT License
+
+// Package metric publishes CNS bootstrap and lifecycle metrics for
+// Prometheus scraping. The exported "Record*" setters are
+// idempotent: callers can invoke them at known startup boundaries
+// and only the first call records a value.
+//
+// The metrics in this file are intended for production dashboards
+// and fleet-wide startup SLO tracking; they expose enough phase
+// boundaries that consumers can compute per-node bootstrap time
+// directly from /metrics rather than reconstructing it from logs.
+package metric
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/Azure/azure-container-networking/internal/fs"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// BootStateFile is the persistent location where CNS records the
+// current kernel boot_id so that subsequent CNS starts can detect
+// whether the kernel has restarted (reboot) or only the CNS
+// process has restarted (restart). The file is small (~36 bytes)
+// and lives alongside the main CNS state.
+//
+// Variable rather than const so tests can override it.
+var BootStateFile = "/var/lib/azure-network/.cns_boot_id"
+
+// Boot state label values for cns_boot_state.
+const (
+	BootStateFresh   = "fresh"   // no prior CNS run on this node
+	BootStateReboot  = "reboot"  // kernel restarted since CNS last ran
+	BootStateRestart = "restart" // CNS process restart, kernel intact
+	BootStateUnknown = "unknown" // could not determine (e.g., Windows v1)
+)
+
+// Event labels for cns_time_to_event_seconds.
+const (
+	EventStateRestored          = "state_restored"
+	EventFirstNNCReceived       = "first_nnc_received"
+	EventInitialIPAMReconciled  = "initial_ipam_reconciled"
+	EventFirstNCProgrammed      = "first_nc_programmed"
+	EventHTTPListenerReady      = "http_listener_ready"
+	EventConflistWritten        = "conflist_written"
+	EventReadyToAssign          = "ready_to_assign"
+)
+
+// allEvents is iterated at registration time so every label
+// combination has a series with sample count 0, giving dashboards
+// the full set up-front.
+var allEvents = []string{
+	EventStateRestored,
+	EventFirstNNCReceived,
+	EventInitialIPAMReconciled,
+	EventFirstNCProgrammed,
+	EventHTTPListenerReady,
+	EventConflistWritten,
+	EventReadyToAssign,
+}
+
+var (
+	cnsBuildInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "cns_build_info",
+			Help: "Constant 1 with build identity labels for CNS.",
+		},
+		[]string{"version", "goversion", "os"},
+	)
+
+	cnsStartTime = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "cns_start_time_seconds",
+			Help: "Unix timestamp (sub-second precision) of when CNS main() was entered.",
+		},
+	)
+
+	cnsModeInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "cns_mode_info",
+			Help: "Constant 1 with the active CNS mode labels (channel mode, IPAM v2, SwiftV2, manage-endpoint-state, dual-stack).",
+		},
+		[]string{"channel_mode", "ipam_v2", "swift_v2", "manage_endpoint_state", "dual_stack"},
+	)
+
+	cnsBootState = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "cns_boot_state",
+			Help: "Boot-state classification: fresh = no prior CNS run on this node; reboot = kernel restarted since CNS last ran; restart = CNS process restart on a running kernel; unknown = could not classify. Exactly one label value is set to 1 per process.",
+		},
+		[]string{"state"},
+	)
+
+	cnsStateRestoredSeconds = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "cns_state_restored_seconds",
+		Help: "Unix timestamp at which CNS state was restored from disk (or determined absent).",
+	})
+
+	cnsFirstNNCReceivedSeconds = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "cns_first_nnc_received_seconds",
+		Help: "Unix timestamp of the first NodeNetworkConfig reconcile, regardless of init success.",
+	})
+
+	cnsInitialIPAMReconciledSeconds = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "cns_initial_ipam_reconciled_seconds",
+		Help: "Unix timestamp at which the initial IPAM reconcile from the first NNC completed successfully.",
+	})
+
+	cnsFirstNCProgrammedSeconds = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "cns_first_nc_programmed_seconds",
+		Help: "Unix timestamp at which CNS first observed an NC reach its desired version via NMAgent.",
+	})
+
+	cnsHTTPListenerReadySeconds = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "cns_http_listener_ready_seconds",
+		Help: "Unix timestamp at which the CNS HTTP REST listener bound successfully.",
+	})
+
+	cnsConflistWrittenSeconds = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "cns_conflist_written_seconds",
+		Help: "Unix timestamp at which the CNI conflist was written (after atomic rename).",
+	})
+
+	cnsReadyToAssignSeconds = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "cns_ready_to_assign_seconds",
+		Help: "Unix timestamp at which CNS first satisfied the mode-aware ready-to-assign predicate (HTTP listener up AND mode-specific IP availability).",
+	})
+
+	// Pair with cns_first_nnc_received_seconds: that gauge answers
+	// "did NNC ever arrive?", these gauges answer "is it still
+	// arriving?" and "is it still being processed successfully?"
+	// Suitable for staleness alerting (e.g. "NNC last reconciled >
+	// 10 minutes ago" -> page).
+	cnsNNCLastReceivedSeconds = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "cns_nnc_last_received_seconds",
+		Help: "Unix timestamp of the most recent NodeNetworkConfig reconcile (regardless of outcome). Pair with cns_first_nnc_received_seconds for end-to-end staleness alerting.",
+	})
+
+	cnsNNCLastSuccessfulReconcileSeconds = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "cns_nnc_last_successful_reconcile_seconds",
+		Help: "Unix timestamp of the most recent NodeNetworkConfig reconcile that returned without error.",
+	})
+
+	// Latency histogram and result counter for the NNC reconciler.
+	// Detects stuck or hot-looping reconciliation in production.
+	// Bounded label set: result enum has 3 values.
+	cnsNNCReconcileDurationSeconds = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "cns_nnc_reconcile_duration_seconds",
+		Help: "Wall-clock duration of NodeNetworkConfig reconciler invocations.",
+		// 1ms .. ~16s, same shape as the existing CNS HTTP-latency
+		// histogram so dashboards can correlate.
+		Buckets: prometheus.ExponentialBuckets(0.001, 2, 15), //nolint:gomnd // standard bucket geometry
+	})
+
+	cnsNNCReconcileTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "cns_nnc_reconcile_total",
+			Help: "Count of NodeNetworkConfig reconcile invocations by terminal result.",
+		},
+		[]string{"result"},
+	)
+
+	// Histogram of process-relative time to each bootstrap event.
+	// Records exactly one observation per event per process. The
+	// per-event gauges (cns_*_seconds) provide the per-node "when"
+	// view; this histogram provides the fleet-wide "how long" view
+	// so dashboards can compute histogram_quantile() across nodes
+	// without external recording rules.
+	cnsTimeToEventSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "cns_time_to_event_seconds",
+			Help: "Process-relative time (cns_start_time_seconds -> event timestamp) for each bootstrap event, one observation per event per process.",
+			Buckets: []float64{
+				0.5, 1, 2, 5, 10, 20, 30, 60, 120, 300,
+			},
+		},
+		[]string{"event"},
+	)
+)
+
+// NNC reconcile result label values for cns_nnc_reconcile_total.
+const (
+	NNCReconcileResultSuccess = "success"
+	NNCReconcileResultError   = "error"
+	NNCReconcileResultRequeue = "requeue"
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		cnsBuildInfo,
+		cnsStartTime,
+		cnsModeInfo,
+		cnsBootState,
+		cnsStateRestoredSeconds,
+		cnsFirstNNCReceivedSeconds,
+		cnsInitialIPAMReconciledSeconds,
+		cnsFirstNCProgrammedSeconds,
+		cnsHTTPListenerReadySeconds,
+		cnsConflistWrittenSeconds,
+		cnsReadyToAssignSeconds,
+		cnsNNCLastReceivedSeconds,
+		cnsNNCLastSuccessfulReconcileSeconds,
+		cnsNNCReconcileDurationSeconds,
+		cnsNNCReconcileTotal,
+		cnsTimeToEventSeconds,
+	)
+	// Pre-register every boot_state series with value 0 so dashboards
+	// can rely on the full label set being present. Same pattern as
+	// upstream kube_pod_status_phase. ClassifyAndRecordBootState sets
+	// the active value to 1 once classification completes.
+	for _, s := range []string{BootStateFresh, BootStateReboot, BootStateRestart, BootStateUnknown} {
+		cnsBootState.WithLabelValues(s).Set(0)
+	}
+	// Pre-create the per-event histogram series so the full label
+	// set is visible in /metrics from process start. Each Observe()
+	// adds to the appropriate series; pre-creating them at zero
+	// just makes the empty buckets visible.
+	for _, ev := range allEvents {
+		cnsTimeToEventSeconds.WithLabelValues(ev)
+	}
+	// Same for the NNC reconcile result counter.
+	for _, r := range []string{NNCReconcileResultSuccess, NNCReconcileResultError, NNCReconcileResultRequeue} {
+		cnsNNCReconcileTotal.WithLabelValues(r)
+	}
+}
+
+// nowSeconds returns the current Unix time as a float64 with
+// sub-second precision.
+func nowSeconds() float64 {
+	return float64(time.Now().UnixNano()) / 1e9
+}
+
+// idempotent setters
+
+var (
+	startTimeOnce            sync.Once
+	bootStateOnce            sync.Once
+	stateRestoredOnce        sync.Once
+	firstNNCReceivedOnce     sync.Once
+	initialIPAMReconciledOnce sync.Once
+	firstNCProgrammedOnce    sync.Once
+	httpListenerReadyOnce    sync.Once
+	conflistWrittenOnce      sync.Once
+	readyToAssignOnce        sync.Once
+)
+
+// SetBuildInfo records the build identity. Safe to call multiple
+// times; the gauge is idempotent in shape (same labels = same series).
+func SetBuildInfo(version string) {
+	cnsBuildInfo.WithLabelValues(version, runtime.Version(), runtime.GOOS).Set(1)
+}
+
+// SetMode records the active CNS mode. Bool labels are encoded as
+// "true"/"false" strings.
+func SetMode(channelMode string, ipamV2, swiftV2, manageEndpointState, dualStack bool) {
+	cnsModeInfo.WithLabelValues(
+		channelMode,
+		strconv.FormatBool(ipamV2),
+		strconv.FormatBool(swiftV2),
+		strconv.FormatBool(manageEndpointState),
+		strconv.FormatBool(dualStack),
+	).Set(1)
+}
+
+// RecordStartTime sets cns_start_time_seconds to now. Idempotent.
+// Should be called as early as possible in main().
+func RecordStartTime() {
+	startTimeOnce.Do(func() {
+		cnsStartTime.Set(nowSeconds())
+	})
+}
+
+// ClassifyAndRecordBootState reads the current kernel boot_id,
+// compares it to the value persisted at BootStateFile, and sets
+// cns_boot_state{state} accordingly. The current boot_id is then
+// atomically written back to BootStateFile so that subsequent
+// CNS starts can compare against it.
+//
+// On unsupported platforms (e.g., Windows v1), readBootID returns
+// "" and the state is recorded as "unknown".
+//
+// Returns the recorded state for callers that want to log or
+// otherwise act on the classification. Idempotent: only the first
+// call performs the classification and write.
+func ClassifyAndRecordBootState() string {
+	var classified string
+	bootStateOnce.Do(func() {
+		classified = classifyBootState()
+		cnsBootState.WithLabelValues(classified).Set(1)
+	})
+	return classified
+}
+
+// classifyBootState performs the boot-state classification logic
+// without the once-guard.
+func classifyBootState() string {
+	current := readBootIDFn()
+	if current == "" {
+		return BootStateUnknown
+	}
+
+	previous, err := os.ReadFile(BootStateFile)
+	switch {
+	case os.IsNotExist(err):
+		writeBootID(current)
+		return BootStateFresh
+	case err != nil:
+		// Treat unreadable boot file as unknown rather than misclassify.
+		return BootStateUnknown
+	}
+
+	state := BootStateRestart
+	if string(previous) != current {
+		state = BootStateReboot
+	}
+	writeBootID(current)
+	return state
+}
+
+// readBootIDFn is the function used to read the kernel's boot id.
+// Indirected through a variable so tests can override it. Defaults
+// to the per-OS readBootID implementation.
+var readBootIDFn = readBootID
+
+// writeBootID atomically writes the current boot_id to
+// BootStateFile. Errors are silent: failure to persist boot_id
+// only causes the next CNS start to misclassify, which is not
+// catastrophic.
+func writeBootID(bootID string) {
+	dir := filepath.Dir(BootStateFile)
+	// Ensure the directory exists; this matches the other CNS
+	// state files (azure-cns.json, azure-endpoints.json) which
+	// rely on the directory being created by the daemonset
+	// hostPath mount, but creating it here makes the function
+	// robust on test rigs and non-AKS deployments.
+	if err := os.MkdirAll(dir, 0o755); err != nil { //nolint:gomnd // standard 0755
+		return
+	}
+	w, err := fs.NewAtomicWriter(BootStateFile)
+	if err != nil {
+		return
+	}
+	defer w.Close() //nolint:errcheck // best-effort persistence
+	_, _ = w.Write([]byte(bootID))
+}
+
+// observeTimeToEvent records a sample on cns_time_to_event_seconds
+// for the named event. Computed against cns_start_time_seconds; if
+// start time hasn't been recorded yet (impossible in practice but
+// possible in tests), the observation is skipped to avoid emitting
+// a meaningless negative value.
+func observeTimeToEvent(event string, eventSeconds float64) {
+	startVal := readGaugeValueByPtr(cnsStartTime)
+	if startVal == 0 {
+		return
+	}
+	delta := eventSeconds - startVal
+	if delta < 0 {
+		delta = 0
+	}
+	cnsTimeToEventSeconds.WithLabelValues(event).Observe(delta)
+}
+
+// readGaugeValueByPtr extracts a gauge's current value. Internal
+// helper to avoid pulling in a test dependency.
+func readGaugeValueByPtr(g prometheus.Gauge) float64 {
+	var m dto.Metric
+	if err := g.Write(&m); err != nil {
+		return 0
+	}
+	if m.Gauge == nil || m.Gauge.Value == nil {
+		return 0
+	}
+	return *m.Gauge.Value
+}
+
+// RecordStateRestored marks the moment restoreState() returned.
+func RecordStateRestored() {
+	stateRestoredOnce.Do(func() {
+		now := nowSeconds()
+		cnsStateRestoredSeconds.Set(now)
+		observeTimeToEvent(EventStateRestored, now)
+	})
+}
+
+// RecordFirstNNCReceived marks the moment of the first NNC reconcile.
+func RecordFirstNNCReceived() {
+	firstNNCReceivedOnce.Do(func() {
+		now := nowSeconds()
+		cnsFirstNNCReceivedSeconds.Set(now)
+		observeTimeToEvent(EventFirstNNCReceived, now)
+	})
+}
+
+// RecordInitialIPAMReconciled marks the moment the initial IPAM
+// reconcile from the first NNC completes successfully.
+func RecordInitialIPAMReconciled() {
+	initialIPAMReconciledOnce.Do(func() {
+		now := nowSeconds()
+		cnsInitialIPAMReconciledSeconds.Set(now)
+		observeTimeToEvent(EventInitialIPAMReconciled, now)
+	})
+}
+
+// RecordFirstNCProgrammed marks the moment CNS first observed an
+// NC reach its desired version via NMAgent.
+func RecordFirstNCProgrammed() {
+	firstNCProgrammedOnce.Do(func() {
+		now := nowSeconds()
+		cnsFirstNCProgrammedSeconds.Set(now)
+		observeTimeToEvent(EventFirstNCProgrammed, now)
+	})
+}
+
+// RecordHTTPListenerReady marks the moment the HTTP REST listener
+// bound successfully. Also signals the ready-to-assign recorder.
+func RecordHTTPListenerReady() {
+	httpListenerReadyOnce.Do(func() {
+		now := nowSeconds()
+		cnsHTTPListenerReadySeconds.Set(now)
+		observeTimeToEvent(EventHTTPListenerReady, now)
+		markListenerReady()
+	})
+}
+
+// RecordConflistWritten marks the moment the CNI conflist was
+// atomically renamed into place. Must only be called after both
+// the writer's Generate() and Close() have succeeded.
+func RecordConflistWritten() {
+	conflistWrittenOnce.Do(func() {
+		now := nowSeconds()
+		cnsConflistWrittenSeconds.Set(now)
+		observeTimeToEvent(EventConflistWritten, now)
+	})
+}
+
+// RecordReadyToAssign marks the moment the mode-aware
+// ready-to-assign predicate was first satisfied. The predicate
+// itself is owned by the central recorder (see readyToAssign.go);
+// callers should normally use NotifyAvailableIPCount and
+// NotifyNodeSubnetReady to feed signals to the recorder rather
+// than calling this directly.
+func RecordReadyToAssign() {
+	readyToAssignOnce.Do(func() {
+		now := nowSeconds()
+		cnsReadyToAssignSeconds.Set(now)
+		observeTimeToEvent(EventReadyToAssign, now)
+	})
+}
+
+// ObserveNNCReconcile records one NNC reconcile invocation: its
+// duration, its terminal result, and (if non-error) the timestamp
+// of the most recent successful reconcile. The cns_nnc_last_received_seconds
+// gauge is updated on every call regardless of result so it
+// reflects "is the NNC stream alive?" while
+// cns_nnc_last_successful_reconcile_seconds reflects "is the
+// reconciler actually progressing?".
+func ObserveNNCReconcile(duration time.Duration, result string) {
+	cnsNNCReconcileDurationSeconds.Observe(duration.Seconds())
+	cnsNNCReconcileTotal.WithLabelValues(result).Inc()
+	now := nowSeconds()
+	cnsNNCLastReceivedSeconds.Set(now)
+	if result == NNCReconcileResultSuccess {
+		cnsNNCLastSuccessfulReconcileSeconds.Set(now)
+	}
+}

--- a/cns/metric/bootstrap_linux.go
+++ b/cns/metric/bootstrap_linux.go
@@ -1,0 +1,20 @@
+// Copyright 2024 Microsoft. All rights reserved.
+// MIT License
+
+package metric
+
+import (
+	"os"
+	"strings"
+)
+
+// readBootID returns the kernel boot identifier, a UUID stable
+// across the life of a single kernel boot. Empty string indicates
+// the value could not be read; callers treat that as "unknown".
+func readBootID() string {
+	b, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}

--- a/cns/metric/bootstrap_test.go
+++ b/cns/metric/bootstrap_test.go
@@ -1,0 +1,320 @@
+// Copyright 2024 Microsoft. All rights reserved.
+// MIT License
+
+package metric
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+func TestClassifyBootState(t *testing.T) {
+	tests := []struct {
+		name              string
+		writePrevBootID   string
+		setBootStateFile  bool
+		want              string
+		wantPersistedBoot string
+	}{
+		{
+			name:              "fresh: no previous boot file",
+			setBootStateFile:  false,
+			want:              BootStateFresh,
+			wantPersistedBoot: "test-boot-id",
+		},
+		{
+			name:              "restart: previous boot id matches current",
+			setBootStateFile:  true,
+			writePrevBootID:   "test-boot-id",
+			want:              BootStateRestart,
+			wantPersistedBoot: "test-boot-id",
+		},
+		{
+			name:              "reboot: previous boot id differs",
+			setBootStateFile:  true,
+			writePrevBootID:   "previous-boot-id",
+			want:              BootStateReboot,
+			wantPersistedBoot: "test-boot-id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			restoreBootFile := overrideBootStateFile(t, filepath.Join(dir, ".cns_boot_id"))
+			defer restoreBootFile()
+			restoreReadBootID := overrideReadBootID(t, func() string { return "test-boot-id" })
+			defer restoreReadBootID()
+
+			if tt.setBootStateFile {
+				require.NoError(t, os.WriteFile(BootStateFile, []byte(tt.writePrevBootID), 0o600))
+			}
+
+			got := classifyBootState()
+			assert.Equal(t, tt.want, got)
+
+			persisted, err := os.ReadFile(BootStateFile)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPersistedBoot, string(persisted))
+		})
+	}
+}
+
+func TestClassifyBootStateUnknownWhenReadFails(t *testing.T) {
+	restoreReadBootID := overrideReadBootID(t, func() string { return "" })
+	defer restoreReadBootID()
+
+	assert.Equal(t, BootStateUnknown, classifyBootState())
+}
+
+func TestReadyToAssignCRDPredicate(t *testing.T) {
+	tests := []struct {
+		name             string
+		dualStack        bool
+		listener         bool
+		availableV4      uint64
+		availableV6      uint64
+		wantFire         bool
+	}{
+		{name: "no listener, has v4", listener: false, availableV4: 1, wantFire: false},
+		{name: "listener, no IPs", listener: true, wantFire: false},
+		{name: "listener, v4 only, single-stack", listener: true, availableV4: 1, wantFire: true},
+		{name: "listener, v4 only, dual-stack", listener: true, dualStack: true, availableV4: 1, wantFire: false},
+		{name: "listener, both, dual-stack", listener: true, dualStack: true, availableV4: 1, availableV6: 1, wantFire: true},
+		{name: "listener, v6 only, single-stack", listener: true, availableV4: 0, availableV6: 1, wantFire: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetReadyToAssignForTest(t)
+			SetReadyToAssignMode(ReadyToAssignModeCRD, tt.dualStack)
+			NotifyAvailableIPCount(tt.availableV4, tt.availableV6)
+			if tt.listener {
+				RecordHTTPListenerReady()
+			}
+
+			got := readyAssignTimestamp()
+			if tt.wantFire {
+				assert.NotZero(t, got, "ready_to_assign should have fired")
+			} else {
+				assert.Zero(t, got, "ready_to_assign should not have fired")
+			}
+		})
+	}
+}
+
+func TestReadyToAssignNodeSubnetPredicate(t *testing.T) {
+	resetReadyToAssignForTest(t)
+	SetReadyToAssignMode(ReadyToAssignModeNodeSubnet, false)
+
+	// Listener alone is not enough.
+	RecordHTTPListenerReady()
+	assert.Zero(t, readyAssignTimestamp())
+
+	// NodeSubnet ready triggers it.
+	NotifyNodeSubnetReady()
+	assert.NotZero(t, readyAssignTimestamp())
+}
+
+func TestReadyToAssignFiresOnceOnly(t *testing.T) {
+	resetReadyToAssignForTest(t)
+	SetReadyToAssignMode(ReadyToAssignModeCRD, false)
+	RecordHTTPListenerReady()
+	NotifyAvailableIPCount(1, 0)
+	first := readyAssignTimestamp()
+	require.NotZero(t, first)
+
+	// Subsequent state changes must not change the recorded value.
+	NotifyAvailableIPCount(5, 5)
+	assert.Equal(t, first, readyAssignTimestamp())
+}
+
+func TestSetBuildInfoAndMode(t *testing.T) {
+	// These are smoke tests that ensure label values are accepted
+	// and the metric is registered.
+	SetBuildInfo("v1.2.3-test")
+	SetMode("CRD", true, false, true, false)
+}
+
+func TestAllBootstrapMetricsRegistered(t *testing.T) {
+	// Confirm every bootstrap-metric we ship is reachable through
+	// the controller-runtime metrics.Registry that healthserver
+	// scrapes via /metrics. A drift here would silently lose the
+	// signal in production even if the setter worked.
+
+	// GaugeVec metrics only become visible in the registry once at
+	// least one label combination has been instantiated. Trigger
+	// the setters that materialize them; the underlying metric
+	// objects are still the same registered instances.
+	SetBuildInfo("test")
+	SetMode("CRD", false, false, false, false)
+
+	want := []string{
+		"cns_build_info",
+		"cns_start_time_seconds",
+		"cns_mode_info",
+		"cns_boot_state",
+		"cns_state_restored_seconds",
+		"cns_first_nnc_received_seconds",
+		"cns_initial_ipam_reconciled_seconds",
+		"cns_first_nc_programmed_seconds",
+		"cns_http_listener_ready_seconds",
+		"cns_conflist_written_seconds",
+		"cns_ready_to_assign_seconds",
+		"cns_nnc_last_received_seconds",
+		"cns_nnc_last_successful_reconcile_seconds",
+		"cns_nnc_reconcile_duration_seconds",
+		"cns_nnc_reconcile_total",
+		"cns_time_to_event_seconds",
+	}
+
+	mfs, err := ctrlmetrics.Registry.Gather()
+	require.NoError(t, err)
+
+	got := map[string]bool{}
+	for _, mf := range mfs {
+		got[mf.GetName()] = true
+	}
+	for _, name := range want {
+		assert.True(t, got[name], "metric %s not registered", name)
+	}
+}
+
+func TestObserveNNCReconcileSuccessUpdatesBothStalenessGauges(t *testing.T) {
+	// Prime the success gauge to zero so we can detect that a
+	// success advances it.
+	cnsNNCLastReceivedSeconds.Set(0)
+	cnsNNCLastSuccessfulReconcileSeconds.Set(0)
+
+	ObserveNNCReconcile(150*time.Millisecond, NNCReconcileResultSuccess)
+
+	rcvd := readGaugeValue(cnsNNCLastReceivedSeconds)
+	succ := readGaugeValue(cnsNNCLastSuccessfulReconcileSeconds)
+	assert.NotZero(t, rcvd)
+	assert.NotZero(t, succ)
+	assert.InDelta(t, rcvd, succ, 0.01, "received and successful should be set to the same instant")
+}
+
+func TestObserveNNCReconcileErrorAdvancesOnlyReceived(t *testing.T) {
+	cnsNNCLastReceivedSeconds.Set(0)
+	cnsNNCLastSuccessfulReconcileSeconds.Set(0)
+
+	ObserveNNCReconcile(50*time.Millisecond, NNCReconcileResultError)
+
+	rcvd := readGaugeValue(cnsNNCLastReceivedSeconds)
+	succ := readGaugeValue(cnsNNCLastSuccessfulReconcileSeconds)
+	assert.NotZero(t, rcvd, "error reconcile must still update last_received")
+	assert.Zero(t, succ, "error reconcile must NOT update last_successful")
+}
+
+func TestObserveTimeToEventSkipsWhenStartTimeUnset(t *testing.T) {
+	// Reset start-time gauge to zero. observeTimeToEvent should
+	// no-op rather than emit a giant negative observation.
+	cnsStartTime.Set(0)
+	// Read counter before / after; should be unchanged.
+	before := readHistogramSampleCount(cnsTimeToEventSeconds.WithLabelValues(EventStateRestored))
+	observeTimeToEvent(EventStateRestored, 1700000005)
+	after := readHistogramSampleCount(cnsTimeToEventSeconds.WithLabelValues(EventStateRestored))
+	assert.Equal(t, before, after, "no observation should be recorded with start time unset")
+}
+
+func TestObserveTimeToEventClampsNegativeToZero(t *testing.T) {
+	cnsStartTime.Set(1700000010)
+	before := readHistogramSampleCount(cnsTimeToEventSeconds.WithLabelValues(EventConflistWritten))
+	// Event timestamp earlier than start time -- shouldn't happen
+	// in practice but guard against negative observation.
+	observeTimeToEvent(EventConflistWritten, 1700000000)
+	after := readHistogramSampleCount(cnsTimeToEventSeconds.WithLabelValues(EventConflistWritten))
+	assert.Equal(t, before+1, after, "observation should be recorded (clamped to 0)")
+}
+
+func TestRecordStartTimeIsIdempotent(t *testing.T) {
+	startTimeOnce = sync.Once{}
+	RecordStartTime()
+	first := startTimestamp()
+	require.NotZero(t, first)
+
+	RecordStartTime()
+	assert.Equal(t, first, startTimestamp(), "start time must not advance on second call")
+}
+
+// --- test helpers ---
+
+// overrideBootStateFile temporarily redirects BootStateFile to
+// the given path. The returned function restores the original.
+func overrideBootStateFile(t *testing.T, path string) func() {
+	t.Helper()
+	prev := BootStateFile
+	BootStateFile = path
+	bootStateOnce = sync.Once{}
+	return func() { BootStateFile = prev }
+}
+
+// overrideReadBootID temporarily replaces the readBootID function
+// for the duration of a test. The returned function restores it.
+func overrideReadBootID(t *testing.T, fn func() string) func() {
+	t.Helper()
+	prev := readBootIDFn
+	readBootIDFn = fn
+	return func() { readBootIDFn = prev }
+}
+
+// resetReadyToAssignForTest wipes the recorder state and the
+// once-guard so a test can drive the predicate from scratch.
+func resetReadyToAssignForTest(t *testing.T) {
+	t.Helper()
+	readyRecorder = readyToAssignRecorder{}
+	readyToAssignOnce = sync.Once{}
+	cnsReadyToAssignSeconds.Set(0)
+	httpListenerReadyOnce = sync.Once{}
+	cnsHTTPListenerReadySeconds.Set(0)
+}
+
+// readyAssignTimestamp reads the current value of the
+// cns_ready_to_assign_seconds gauge.
+func readyAssignTimestamp() float64 {
+	return readGaugeValue(cnsReadyToAssignSeconds)
+}
+
+// startTimestamp reads the current value of cns_start_time_seconds.
+func startTimestamp() float64 {
+	return readGaugeValue(cnsStartTime)
+}
+
+// readGaugeValue extracts the float64 value from a prometheus gauge.
+func readGaugeValue(g prometheus.Gauge) float64 {
+	var m dto.Metric
+	if err := g.Write(&m); err != nil {
+		return 0
+	}
+	if m.Gauge == nil || m.Gauge.Value == nil {
+		return 0
+	}
+	return *m.Gauge.Value
+}
+
+// readHistogramSampleCount returns the cumulative observation count
+// of a Histogram observer.
+func readHistogramSampleCount(o prometheus.Observer) uint64 {
+	h, ok := o.(prometheus.Histogram)
+	if !ok {
+		return 0
+	}
+	var m dto.Metric
+	if err := h.Write(&m); err != nil {
+		return 0
+	}
+	if m.Histogram == nil || m.Histogram.SampleCount == nil {
+		return 0
+	}
+	return *m.Histogram.SampleCount
+}

--- a/cns/metric/bootstrap_windows.go
+++ b/cns/metric/bootstrap_windows.go
@@ -1,0 +1,12 @@
+// Copyright 2024 Microsoft. All rights reserved.
+// MIT License
+
+package metric
+
+// readBootID is unimplemented on Windows in v1; CNS will record
+// boot state as "unknown" until a Windows-specific implementation
+// is added (e.g., via Win32_OperatingSystem.LastBootUpTime or
+// kernel session ID).
+func readBootID() string {
+	return ""
+}

--- a/cns/metric/heartbeat.go
+++ b/cns/metric/heartbeat.go
@@ -11,12 +11,20 @@ import (
 	"github.com/Azure/azure-container-networking/aitelemetry"
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/logger"
-	"github.com/Azure/azure-container-networking/cns/restserver"
 	"github.com/Azure/azure-container-networking/cns/types"
 )
 
+// HomeAzGetter is the consumer-side interface SendHeartBeat uses to
+// query the current Home AZ. Defined here (not in restserver) to
+// keep cns/metric free of a back-edge into cns/restserver, which
+// would create an import cycle now that restserver imports
+// cns/metric for the bootstrap-metric setters.
+type HomeAzGetter interface {
+	GetHomeAz(ctx context.Context) cns.GetHomeAzResponse
+}
+
 // SendHeartBeat emits node metrics periodically
-func SendHeartBeat(ctx context.Context, heartbeatInterval time.Duration, homeAzMonitor *restserver.HomeAzMonitor, channelMode string) {
+func SendHeartBeat(ctx context.Context, heartbeatInterval time.Duration, homeAzMonitor HomeAzGetter, channelMode string) {
 	ticker := time.NewTicker(heartbeatInterval)
 	defer ticker.Stop()
 	for {

--- a/cns/metric/ready_to_assign.go
+++ b/cns/metric/ready_to_assign.go
@@ -1,0 +1,141 @@
+// Copyright 2024 Microsoft. All rights reserved.
+// MIT License
+
+package metric
+
+import (
+	"sync"
+)
+
+// ReadyToAssignMode names the high-level CNS mode that determines
+// the ready-to-assign predicate. The predicate is "the next
+// normal-pod RequestIPConfigs would succeed" and is mode-specific.
+type ReadyToAssignMode int
+
+const (
+	// ReadyToAssignModeUnset means no mode has been configured yet;
+	// the recorder will not fire until SetReadyToAssignMode is called.
+	ReadyToAssignModeUnset ReadyToAssignMode = iota
+
+	// ReadyToAssignModeCRD covers Swift / Overlay (and SwiftV2 in
+	// v1, as a best-effort approximation). Predicate: HTTP listener
+	// up AND >=1 IP per required family in Available state.
+	ReadyToAssignModeCRD
+
+	// ReadyToAssignModeNodeSubnet covers AzureHost / NodeSubnet.
+	// Predicate: HTTP listener up AND InitializeNodeSubnet returned
+	// successfully (signaled via NotifyNodeSubnetReady).
+	ReadyToAssignModeNodeSubnet
+)
+
+// readyToAssign tracks the inputs to the mode-aware predicate.
+// All fields are protected by mu. The recorder fires
+// cns_ready_to_assign_seconds at most once when the predicate
+// transitions from false to true.
+type readyToAssignRecorder struct {
+	mu sync.Mutex
+
+	mode             ReadyToAssignMode
+	requireDualStack bool
+
+	listenerReady bool
+
+	availableV4Count uint64
+	availableV6Count uint64
+
+	nodeSubnetReady bool
+}
+
+var readyRecorder readyToAssignRecorder
+
+// SetReadyToAssignMode configures which predicate the recorder
+// will use to determine ready-to-assign. requireDualStack is only
+// meaningful for ReadyToAssignModeCRD (in which case the predicate
+// requires both an IPv4 AND an IPv6 Available IP).
+//
+// Should be called once during CNS initialization, after the
+// channel mode and dual-stack config are known. Subsequent calls
+// overwrite the mode (but the once-only firing is preserved).
+func SetReadyToAssignMode(mode ReadyToAssignMode, requireDualStack bool) {
+	readyRecorder.mu.Lock()
+	readyRecorder.mode = mode
+	readyRecorder.requireDualStack = requireDualStack
+	readyRecorder.mu.Unlock()
+	notifyReadyToAssignWatcher()
+}
+
+// NotifyAvailableIPCount feeds the recorder the current count of
+// IPs in Available state per family. CRD-mode predicate fires
+// when at least one IP is available per required family.
+//
+// Callers in CNS's IPAM hot path should invoke this whenever the
+// per-family Available count changes (or, more pragmatically,
+// after each batch of state transitions). Cheap calls are fine —
+// the recorder short-circuits once it has fired.
+func NotifyAvailableIPCount(availableV4, availableV6 uint64) {
+	readyRecorder.mu.Lock()
+	readyRecorder.availableV4Count = availableV4
+	readyRecorder.availableV6Count = availableV6
+	readyRecorder.mu.Unlock()
+	notifyReadyToAssignWatcher()
+}
+
+// NotifyNodeSubnetReady marks the NodeSubnet path's
+// InitializeNodeSubnet as complete.
+func NotifyNodeSubnetReady() {
+	readyRecorder.mu.Lock()
+	readyRecorder.nodeSubnetReady = true
+	readyRecorder.mu.Unlock()
+	notifyReadyToAssignWatcher()
+}
+
+// notifyReadyToAssignWatcher checks whether the predicate is now
+// satisfied and, if so, records cns_ready_to_assign_seconds. The
+// underlying RecordReadyToAssign is once-guarded, so duplicate
+// invocations are safe. Also folds in HTTP listener readiness
+// because RecordHTTPListenerReady calls into here.
+func notifyReadyToAssignWatcher() {
+	readyRecorder.mu.Lock()
+	// Listener readiness is sourced from the once-set gauge, but
+	// reading the gauge value back from prometheus is awkward; we
+	// instead track a local flag set by the same call site.
+	listenerReady := readyRecorder.listenerReady
+	mode := readyRecorder.mode
+	dualStack := readyRecorder.requireDualStack
+	v4 := readyRecorder.availableV4Count
+	v6 := readyRecorder.availableV6Count
+	nodeSubnetReady := readyRecorder.nodeSubnetReady
+	readyRecorder.mu.Unlock()
+
+	if !listenerReady {
+		return
+	}
+
+	switch mode {
+	case ReadyToAssignModeCRD:
+		if v4 == 0 {
+			return
+		}
+		if dualStack && v6 == 0 {
+			return
+		}
+		RecordReadyToAssign()
+	case ReadyToAssignModeNodeSubnet:
+		if !nodeSubnetReady {
+			return
+		}
+		RecordReadyToAssign()
+	default:
+		// Unset / unknown mode: do not fire.
+	}
+}
+
+// markListenerReady is the internal hook invoked by
+// RecordHTTPListenerReady. It updates the recorder's
+// listenerReady flag and re-evaluates the predicate.
+func markListenerReady() {
+	readyRecorder.mu.Lock()
+	readyRecorder.listenerReady = true
+	readyRecorder.mu.Unlock()
+	notifyReadyToAssignWatcher()
+}

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/logger"
+	"github.com/Azure/azure-container-networking/cns/metric"
 	"github.com/Azure/azure-container-networking/cns/nodesubnet"
 	"github.com/Azure/azure-container-networking/cns/types"
 	"github.com/Azure/azure-container-networking/common"
@@ -177,6 +178,9 @@ func (service *HTTPRestService) SyncHostNCVersion(ctx context.Context, channelMo
 	programmedNCCount, err := service.syncHostNCVersion(ctx, channelMode)
 	// even if we get an error, we want to write the CNI conflist if we have any NC programmed to any version
 	if programmedNCCount > 0 {
+		// Both calls are once-guarded, so calling them on every
+		// successful sync is cheap.
+		metric.RecordFirstNCProgrammed()
 		// This will only be done once per lifetime of the CNS process. This function is threadsafe and will panic
 		// if it fails, so it is safe to call in a non-preemptable goroutine.
 		go service.MustGenerateCNIConflistOnce()

--- a/cns/restserver/metrics.go
+++ b/cns/restserver/metrics.go
@@ -3,14 +3,17 @@ package restserver
 import (
 	"maps"
 	"net/http"
+	"net/netip"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/logger"
+	"github.com/Azure/azure-container-networking/cns/metric"
 	"github.com/Azure/azure-container-networking/cns/types"
 	"github.com/prometheus/client_golang/prometheus"
-	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 const (
@@ -114,7 +117,7 @@ var (
 )
 
 func init() {
-	metrics.Registry.MustRegister(
+	ctrlmetrics.Registry.MustRegister(
 		HTTPRequestLatency,
 		ipAssignmentLatency,
 		ipConfigStatusStateTransitionTime,
@@ -158,6 +161,10 @@ type ipState struct {
 	assignedIPs int64
 	// availableIPs are the IPs in state "Available".
 	availableIPs int64
+	// availableV4IPs are the IPs in state "Available" with IPv4 addresses.
+	availableV4IPs int64
+	// availableV6IPs are the IPs in state "Available" with IPv6 addresses.
+	availableV6IPs int64
 	// programmingIPs are the IPs in state "PendingProgramming".
 	programmingIPs int64
 	// releasingIPs are the IPs in state "PendingReleasr".
@@ -190,6 +197,12 @@ func (a *asyncMetricsRecorder) record() {
 		}
 		if ipConfig.GetState() == types.Available {
 			state.availableIPs++
+			switch ipFamily(ipConfig.IPAddress) {
+			case ipFamilyV4:
+				state.availableV4IPs++
+			case ipFamilyV6:
+				state.availableV6IPs++
+			}
 		}
 		if ipConfig.GetState() == types.PendingProgramming {
 			state.programmingIPs++
@@ -213,6 +226,36 @@ func (a *asyncMetricsRecorder) record() {
 	availableIPCount.WithLabelValues(labels...).Set(float64(state.availableIPs))
 	pendingProgrammingIPCount.WithLabelValues(labels...).Set(float64(state.programmingIPs))
 	pendingReleaseIPCount.WithLabelValues(labels...).Set(float64(state.releasingIPs))
+
+	// Feed per-family Available counts to the bootstrap recorder so
+	// it can fire cns_ready_to_assign_seconds when the mode-aware
+	// predicate is satisfied. NotifyAvailableIPCount short-circuits
+	// once the gauge has fired, so this is cheap on every call after
+	// startup.
+	metric.NotifyAvailableIPCount(uint64(state.availableV4IPs), uint64(state.availableV6IPs))
+}
+
+const (
+	ipFamilyUnknown = iota
+	ipFamilyV4
+	ipFamilyV6
+)
+
+// ipFamily classifies a CNS-stored IP string as v4 or v6. CNS stores
+// the address as a bare textual form (e.g. "10.0.0.5" or
+// "fd00::5"); a "/" prefix length suffix is tolerated.
+func ipFamily(s string) int {
+	if i := strings.IndexByte(s, '/'); i >= 0 {
+		s = s[:i]
+	}
+	addr, err := netip.ParseAddr(s)
+	if err != nil {
+		return ipFamilyUnknown
+	}
+	if addr.Is4() {
+		return ipFamilyV4
+	}
+	return ipFamilyV6
 }
 
 // publishIPStateMetrics logs and publishes the IP Config state metrics to Prometheus.

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Azure/azure-container-networking/cns/dockerclient"
 	"github.com/Azure/azure-container-networking/cns/imds"
 	"github.com/Azure/azure-container-networking/cns/logger"
+	"github.com/Azure/azure-container-networking/cns/metric"
 	"github.com/Azure/azure-container-networking/cns/networkcontainers"
 	"github.com/Azure/azure-container-networking/cns/nodesubnet"
 	"github.com/Azure/azure-container-networking/cns/routes"
@@ -393,6 +394,10 @@ func (service *HTTPRestService) MustGenerateCNIConflistOnce() {
 		if err := service.cniConflistGenerator.Close(); err != nil {
 			panic("unable to close the cni conflist output stream: " + err.Error())
 		}
+		// Atomic rename happens in Close(); record only after both
+		// Generate and Close have succeeded so the timestamp reflects
+		// the file being visible at its final path.
+		metric.RecordConflistWritten()
 	})
 }
 

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/dockerclient"
 	"github.com/Azure/azure-container-networking/cns/logger"
+	"github.com/Azure/azure-container-networking/cns/metric"
 	"github.com/Azure/azure-container-networking/cns/networkcontainers"
 	"github.com/Azure/azure-container-networking/cns/nodesubnet"
 	"github.com/Azure/azure-container-networking/cns/types"
@@ -98,6 +99,7 @@ func (service *HTTPRestService) saveState() error {
 
 // restoreState restores CNS state from persistent store.
 func (service *HTTPRestService) restoreState() {
+	defer metric.RecordStateRestored()
 	logger.Printf("[Azure CNS] restoreState")
 
 	// Skip if a store is not provided.

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -498,6 +498,15 @@ func main() {
 	// Initialize and parse command line arguments.
 	acn.ParseArgs(&args, printVersion)
 
+	// Capture process-wide bootstrap signals as early as possible. The
+	// boot-state classifier reads /proc/sys/kernel/random/boot_id and
+	// compares it to the value persisted at /var/lib/azure-network/.cns_boot_id;
+	// running it before any state I/O guarantees the classification
+	// reflects pre-restore reality.
+	metric.RecordStartTime()
+	metric.SetBuildInfo(version)
+	metric.ClassifyAndRecordBootState()
+
 	cniPath := acn.GetArg(acn.OptNetPluginPath).(string)
 	cniConfigFile := acn.GetArg(acn.OptNetPluginConfigFile).(string)
 	cnsURL := acn.GetArg(acn.OptCnsURL).(string)
@@ -696,6 +705,22 @@ func main() {
 	}
 	if isManaged, ok := acn.GetArg(acn.OptManaged).(bool); ok && isManaged {
 		config.ChannelMode = cns.Managed
+	}
+
+	// Publish the active CNS mode for dashboard pivoting now that the
+	// channel mode is finalized. Configure the ready-to-assign
+	// recorder with the predicate appropriate for the mode.
+	metric.SetMode(
+		config.ChannelMode,
+		cnsconfig.EnableIPAMv2,
+		cnsconfig.EnableSwiftV2,
+		cnsconfig.ManageEndpointState,
+		cnsconfig.EnableSwiftV1DualStack,
+	)
+	if config.ChannelMode == cns.AzureHost {
+		metric.SetReadyToAssignMode(metric.ReadyToAssignModeNodeSubnet, false)
+	} else {
+		metric.SetReadyToAssignMode(metric.ReadyToAssignModeCRD, cnsconfig.EnableSwiftV1DualStack)
 	}
 
 	homeAzMonitor := restserver.NewHomeAzMonitor(nmaClient, time.Duration(cnsconfig.AZRSettings.PopulateHomeAzCacheRetryIntervalSecs)*time.Second)
@@ -922,6 +947,7 @@ func main() {
 			logger.Errorf("[Azure CNS] Failed to initialize node subnet: %v", err)
 			return
 		}
+		metric.NotifyNodeSubnetReady()
 	}
 
 	// Initialize multi-tenant controller if the CNS is running in MultiTenantCRD mode.
@@ -1018,6 +1044,7 @@ func main() {
 			logger.Errorf("Failed to start CNS, err:%v.\n", err)
 			return
 		}
+		metric.RecordHTTPListenerReady()
 
 	}
 
@@ -1442,6 +1469,7 @@ func InitializeCRDState(ctx context.Context, z *zap.Logger, httpRestService cns.
 			return initErr
 		}
 		hasNNCInitialized.Set(1)
+		metric.RecordInitialIPAMReconciled()
 		return nil
 	}
 


### PR DESCRIPTION
CNS today exposes a useful baseline of Prometheus metrics
(HTTP latency, IPAM pool state, IP-state-transition latencies,
NMA sync wrapper, NNC initialization booleans), but
bootstrap-phase observability and NodeNetworkConfig (NNC) reconciler
health are essentially absent from the metrics surface. Tools that
want to observe how long CNS took to reach each startup boundary
(state restored, first NNC reconciled, NC programmed by NMAgent,
conflist written, ready-to-assign IPs) have to reconstruct it by
parsing CNS logs. Operators that want to alert on a stalled NNC
stream have only the `cns_nnc_initialized` boolean (set once on
first success) to work with.

This change addresses the gaps in startup instrumentation so that
we can directly measure the things that we are interested in instead 
of reconstructing or inferring from logs or other events.