### PR TITLE
fix[store]: goroutine leak and orphaned file lock on Lock timeout

### DIFF
--- a/store/json.go
+++ b/store/json.go
@@ -189,7 +189,8 @@ func (kvs *jsonFileStore) Lock(timeout time.Duration) error {
 	kvs.Mutex.Lock()
 	defer kvs.Mutex.Unlock()
 
-	afterTime := time.After(timeout)
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 	status := make(chan error, 1) // buffered so lockUtil doesn't block after timeout
 
 	if kvs.logger != nil {
@@ -202,13 +203,19 @@ func (kvs *jsonFileStore) Lock(timeout time.Duration) error {
 
 	var err error
 	select {
-	case <-afterTime:
+	case <-timer.C:
 		// lockUtil may still be waiting on the file lock. When it eventually
 		// acquires it, release it so subsequent Lock calls are not permanently
 		// blocked.
 		go func() {
 			if lockErr := <-status; lockErr == nil {
-				kvs.processLock.Unlock() //nolint:errcheck // best-effort cleanup
+				if err := kvs.processLock.Unlock(); err != nil {
+					if kvs.logger != nil {
+						kvs.logger.Error("Failed to release process lock during timeout cleanup", zap.Error(err))
+					} else {
+						log.Printf("Failed to release process lock during timeout cleanup: %v", err)
+					}
+				}
 			}
 		}()
 		return ErrTimeoutLockingStore

--- a/store/json.go
+++ b/store/json.go
@@ -190,7 +190,7 @@ func (kvs *jsonFileStore) Lock(timeout time.Duration) error {
 	defer kvs.Mutex.Unlock()
 
 	afterTime := time.After(timeout)
-	status := make(chan error)
+	status := make(chan error, 1) // buffered so lockUtil doesn't block after timeout
 
 	if kvs.logger != nil {
 		kvs.logger.Info("Acquiring process lock")
@@ -203,6 +203,14 @@ func (kvs *jsonFileStore) Lock(timeout time.Duration) error {
 	var err error
 	select {
 	case <-afterTime:
+		// lockUtil may still be waiting on the file lock. When it eventually
+		// acquires it, release it so subsequent Lock calls are not permanently
+		// blocked.
+		go func() {
+			if lockErr := <-status; lockErr == nil {
+				kvs.processLock.Unlock() //nolint:errcheck // best-effort cleanup
+			}
+		}()
 		return ErrTimeoutLockingStore
 	case err = <-status:
 	}

--- a/store/json_test.go
+++ b/store/json_test.go
@@ -225,6 +225,62 @@ func TestLock(t *testing.T) {
 	}
 }
 
+// slowFileLock simulates a file lock that blocks until unblocked via a channel,
+// and tracks whether Unlock was called.
+type slowFileLock struct {
+	blockCh    chan struct{} // close to unblock Lock
+	unlockCh   chan struct{} // closed when Unlock is called
+	lockCalled chan struct{} // closed when Lock begins waiting
+}
+
+func newSlowFileLock() *slowFileLock {
+	return &slowFileLock{
+		blockCh:    make(chan struct{}),
+		unlockCh:   make(chan struct{}),
+		lockCalled: make(chan struct{}),
+	}
+}
+
+func (l *slowFileLock) Lock() error {
+	close(l.lockCalled) // signal that Lock has been entered
+	<-l.blockCh         // block until test unblocks us
+	return nil
+}
+
+func (l *slowFileLock) Unlock() error {
+	close(l.unlockCh)
+	return nil
+}
+
+// TestLockTimeoutReleasesOrphanedLock verifies that when Lock times out, the
+// file lock is released after the background goroutine eventually acquires it.
+// Before the fix, the orphaned lock was never released, causing a goroutine
+// leak and permanently blocking subsequent Lock calls.
+func TestLockTimeoutReleasesOrphanedLock(t *testing.T) {
+	fl := newSlowFileLock()
+	kvs, err := NewJsonFileStore(testFileName, fl, nil)
+	require.NoError(t, err)
+	defer os.Remove(testFileName)
+
+	// Lock with a very short timeout so it times out while slowFileLock blocks.
+	err = kvs.Lock(1 * time.Millisecond)
+	require.ErrorIs(t, err, ErrTimeoutLockingStore)
+
+	// Wait for the background goroutine to enter Lock().
+	<-fl.lockCalled
+
+	// Unblock the background goroutine — it now "acquires" the file lock.
+	close(fl.blockCh)
+
+	// The cleanup goroutine should call Unlock. Wait up to 1 second.
+	select {
+	case <-fl.unlockCh:
+		// Success: the orphaned lock was released.
+	case <-time.After(1 * time.Second):
+		t.Fatal("orphaned file lock was never released after timeout — goroutine leak")
+	}
+}
+
 // test case for testing newjsonfilestore idempotent
 func TestFileName(t *testing.T) {
 	_, err := NewJsonFileStore("", processlock.NewMockFileLock(false), nil)

--- a/store/json_test.go
+++ b/store/json_test.go
@@ -267,7 +267,12 @@ func TestLockTimeoutReleasesOrphanedLock(t *testing.T) {
 	require.ErrorIs(t, err, ErrTimeoutLockingStore)
 
 	// Wait for the background goroutine to enter Lock().
-	<-fl.lockCalled
+	select {
+	case <-fl.lockCalled:
+		// Success: the background goroutine reached Lock().
+	case <-time.After(1 * time.Second):
+		t.Fatal("background goroutine never reached file lock acquisition")
+	}
 
 	// Unblock the background goroutine — it now "acquires" the file lock.
 	close(fl.blockCh)


### PR DESCRIPTION
When Lock() timed out, the background lockUtil goroutine
was never cleaned up. Two issues resulted:

1. lockUtil sends on an unbuffered channel with no reader
after the timeout path returns, so the goroutine blocks forever (leak).
3. If lockUtil eventually acquires the file lock, nobody calls Unlock(),
so the lock is held for the lifetime of the process. All subsequent
Lock() calls from any process will also time out, permanently
breaking CNI/CNS operations on the node.

Fix:
- Make the status channel buffered (capacity 1) so lockUtil can complete its send even after the caller has returned.
- In the timeout path, spawn a cleanup goroutine that waits for lockUtil to finish and releases the file lock if it was acquired.

Add TestLockTimeoutReleasesOrphanedLock to reproduce the bug using a blocking mock file lock.

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
