### PR TITLE
fix: restrict host routes to InfraNIC in stateless CNI SwiftV2

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -736,6 +736,15 @@ func (plugin *NetPlugin) createEpInfo(opt *createEpInfoOpt) (*network.EndpointIn
 		endpointID = plugin.nm.GetEndpointIDByNicType(opt.args.ContainerID, ifName, opt.ifInfo.NICType)
 	}
 
+	// Only copy options (RoutesKey, IPTablesKey, SNATIPKey) for InfraNIC or legacy (empty NICType).
+	// These options are infra-only host-namespace constructs set by setHostOptions and are not
+	// applicable to delegated/secondary NICs on either Linux or Windows.
+	// For non-infra NICs, options remains nil so handleCommonOptions becomes a no-op.
+	var options map[string]interface{}
+	if opt.ifInfo.NICType == cns.InfraNIC || opt.ifInfo.NICType == "" {
+		options = opt.ipamAddConfig.shallowCopyIpamAddConfigOptions()
+	}
+
 	endpointInfo := network.EndpointInfo{
 		NetworkID:                     opt.networkID,
 		Mode:                          opt.ipamAddConfig.nwCfg.Mode,
@@ -744,7 +753,7 @@ func (plugin *NetPlugin) createEpInfo(opt *createEpInfoOpt) (*network.EndpointIn
 		BridgeName:                    opt.ipamAddConfig.nwCfg.Bridge,
 		NetworkPolicies:               networkPolicies, // nw and ep policies separated to avoid possible conflicts
 		NetNs:                         opt.ipamAddConfig.args.Netns,
-		Options:                       opt.ipamAddConfig.shallowCopyIpamAddConfigOptions(),
+		Options:                       options,
 		DisableHairpinOnHostInterface: opt.ipamAddConfig.nwCfg.DisableHairpinOnHostInterface,
 		IsIPv6Enabled:                 opt.ipv6Enabled, // present infra only
 

--- a/cni/network/network_linux_test.go
+++ b/cni/network/network_linux_test.go
@@ -472,9 +472,7 @@ func TestPluginLinuxAdd(t *testing.T) {
 							},
 							Suffix: "myDomain",
 						},
-						Options: map[string]interface{}{
-							"testflag": "copy",
-						},
+						Options: nil,
 						// matches with cns ip configuration
 						IPAddresses: []net.IPNet{
 							{

--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -107,7 +107,7 @@ type EndpointInfo struct {
 	Subnets                       []SubnetInfo
 	BridgeName                    string
 	NetNs                         string // used in windows
-	Options                       map[string]interface{}
+	Options                       map[string]interface{} // populated only for InfraNIC; nil for non-infra NICs
 	DisableHairpinOnHostInterface bool
 	IsIPv6Enabled                 bool
 	HostSubnetPrefix              string // can be used later to add an external interface

--- a/network/network_linux.go
+++ b/network/network_linux.go
@@ -134,18 +134,14 @@ func (nm *networkManager) newNetworkImpl(nwInfo *EndpointInfo, extIf *externalIn
 
 func (nm *networkManager) handleCommonOptions(ifName string, nwInfo *EndpointInfo) error {
 	var err error
-	// Only apply RoutesKey routes for InfraNIC - host gateway routes (set by setHostOptions)
-	// are not reachable from secondary NICs like DelegatedVMNIC which are on different subnets.
-	// Empty NICType is treated as InfraNIC for legacy compatibility.
-	if routes, exists := nwInfo.Options[RoutesKey]; exists && (nwInfo.NICType == cns.InfraNIC || nwInfo.NICType == "") {
+	if routes, exists := nwInfo.Options[RoutesKey]; exists {
 		err = addRoutes(nm.netlink, nm.netio, ifName, routes.([]RouteInfo))
 		if err != nil {
 			return err
 		}
 	}
 
-	// IPTables rules (SNAT for DNS/IMDS) are also only relevant for InfraNIC traffic
-	if iptcmds, exists := nwInfo.Options[IPTablesKey]; exists && (nwInfo.NICType == cns.InfraNIC || nwInfo.NICType == "") {
+	if iptcmds, exists := nwInfo.Options[IPTablesKey]; exists {
 		err = nm.addToIptables(iptcmds.([]iptables.IPTableEntry))
 		if err != nil {
 			return err

--- a/network/network_linux.go
+++ b/network/network_linux.go
@@ -134,14 +134,18 @@ func (nm *networkManager) newNetworkImpl(nwInfo *EndpointInfo, extIf *externalIn
 
 func (nm *networkManager) handleCommonOptions(ifName string, nwInfo *EndpointInfo) error {
 	var err error
-	if routes, exists := nwInfo.Options[RoutesKey]; exists {
+	// Only apply RoutesKey routes for InfraNIC - host gateway routes (set by setHostOptions)
+	// are not reachable from secondary NICs like DelegatedVMNIC which are on different subnets.
+	// Empty NICType is treated as InfraNIC for legacy compatibility.
+	if routes, exists := nwInfo.Options[RoutesKey]; exists && (nwInfo.NICType == cns.InfraNIC || nwInfo.NICType == "") {
 		err = addRoutes(nm.netlink, nm.netio, ifName, routes.([]RouteInfo))
 		if err != nil {
 			return err
 		}
 	}
 
-	if iptcmds, exists := nwInfo.Options[IPTablesKey]; exists {
+	// IPTables rules (SNAT for DNS/IMDS) are also only relevant for InfraNIC traffic
+	if iptcmds, exists := nwInfo.Options[IPTablesKey]; exists && (nwInfo.NICType == cns.InfraNIC || nwInfo.NICType == "") {
 		err = nm.addToIptables(iptcmds.([]iptables.IPTableEntry))
 		if err != nil {
 			return err

--- a/network/network_linux_test.go
+++ b/network/network_linux_test.go
@@ -140,29 +140,3 @@ func TestHandleCommonOptions_SkipsIPTablesForDelegatedNIC(t *testing.T) {
 	}
 }
 
-func TestEndpointCreate_DoesNotSort(t *testing.T) {
-	// Verify EndpointCreate processes epInfos in the order given (sorting is now
-	// the caller's responsibility in cni/network).
-	epInfos := []*EndpointInfo{
-		{
-			NICType:    cns.DelegatedVMNIC,
-			EndpointID: "delegated-ep",
-			NetworkID:  DefaultNetworkID,
-		},
-		{
-			NICType:    cns.InfraNIC,
-			EndpointID: "infra-ep",
-			NetworkID:  DefaultNetworkID,
-		},
-	}
-
-	nm := &networkManager{
-		ExternalInterfaces: map[string]*externalInterface{},
-	}
-
-	_ = nm.EndpointCreate(nil, epInfos)
-
-	// Order should be unchanged — EndpointCreate no longer sorts
-	assert.Equal(t, cns.DelegatedVMNIC, epInfos[0].NICType)
-	assert.Equal(t, cns.InfraNIC, epInfos[1].NICType)
-}

--- a/network/network_linux_test.go
+++ b/network/network_linux_test.go
@@ -4,7 +4,6 @@ import (
 	"net"
 	"testing"
 
-	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/iptables"
 	"github.com/Azure/azure-container-networking/netio"
 	"github.com/Azure/azure-container-networking/netlink"
@@ -23,120 +22,84 @@ func (c *mockIPTablesClientWithRunCmd) RunCmd(version, params string) error {
 	return nil
 }
 
-func TestHandleCommonOptions_SkipsRoutesForDelegatedNIC(t *testing.T) {
-	tests := []struct {
-		name            string
-		nicType         cns.NICType
-		expectRouteCall bool
-	}{
-		{
-			name:            "InfraNIC applies routes",
-			nicType:         cns.InfraNIC,
-			expectRouteCall: true,
-		},
-		{
-			name:            "empty NICType applies routes (legacy)",
-			nicType:         "",
-			expectRouteCall: true,
-		},
-		{
-			name:            "DelegatedVMNIC skips routes",
-			nicType:         cns.DelegatedVMNIC,
-			expectRouteCall: false,
-		},
-		{
-			name:            "NodeNetworkInterfaceFrontendNIC skips routes",
-			nicType:         cns.NodeNetworkInterfaceFrontendNIC,
-			expectRouteCall: false,
-		},
+func TestHandleCommonOptions_AppliesRoutes(t *testing.T) {
+	routeCalled := false
+	nl := netlink.NewMockNetlink(false, "")
+	nl.SetAddRouteValidationFn(func(_ *netlink.Route) error {
+		routeCalled = true
+		return nil
+	})
+
+	nm := &networkManager{
+		netlink:        nl,
+		netio:          netio.NewMockNetIO(false, 0),
+		iptablesClient: &mockIPTablesClient{},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			routeCalled := false
-			nl := netlink.NewMockNetlink(false, "")
-			nl.SetAddRouteValidationFn(func(_ *netlink.Route) error {
-				routeCalled = true
-				return nil
-			})
-
-			nm := &networkManager{
-				netlink:        nl,
-				netio:          netio.NewMockNetIO(false, 0),
-				iptablesClient: &mockIPTablesClient{},
-			}
-
-			nwInfo := &EndpointInfo{
-				NICType: tt.nicType,
-				Options: map[string]interface{}{
-					RoutesKey: []RouteInfo{
-						{
-							Dst: net.IPNet{IP: net.ParseIP("10.1.0.0"), Mask: net.CIDRMask(16, 32)},
-							Gw:  net.ParseIP("10.0.0.1"),
-						},
-					},
+	nwInfo := &EndpointInfo{
+		Options: map[string]interface{}{
+			RoutesKey: []RouteInfo{
+				{
+					Dst: net.IPNet{IP: net.ParseIP("10.1.0.0"), Mask: net.CIDRMask(16, 32)},
+					Gw:  net.ParseIP("10.0.0.1"),
 				},
-			}
-
-			err := nm.handleCommonOptions("eth0", nwInfo)
-			require.NoError(t, err)
-			assert.Equal(t, tt.expectRouteCall, routeCalled,
-				"route add called=%v, want=%v for NICType=%q", routeCalled, tt.expectRouteCall, tt.nicType)
-		})
+			},
+		},
 	}
+
+	err := nm.handleCommonOptions("eth0", nwInfo)
+	require.NoError(t, err)
+	assert.True(t, routeCalled, "expected route to be added when RoutesKey is present in options")
 }
 
-func TestHandleCommonOptions_SkipsIPTablesForDelegatedNIC(t *testing.T) {
-	tests := []struct {
-		name              string
-		nicType           cns.NICType
-		expectIPTableCall bool
-	}{
-		{
-			name:              "InfraNIC applies iptables",
-			nicType:           cns.InfraNIC,
-			expectIPTableCall: true,
-		},
-		{
-			name:              "empty NICType applies iptables (legacy)",
-			nicType:           "",
-			expectIPTableCall: true,
-		},
-		{
-			name:              "DelegatedVMNIC skips iptables",
-			nicType:           cns.DelegatedVMNIC,
-			expectIPTableCall: false,
+func TestHandleCommonOptions_AppliesIPTables(t *testing.T) {
+	iptc := &mockIPTablesClientWithRunCmd{}
+
+	nm := &networkManager{
+		netlink:        netlink.NewMockNetlink(false, ""),
+		netio:          netio.NewMockNetIO(false, 0),
+		iptablesClient: iptc,
+	}
+
+	nwInfo := &EndpointInfo{
+		Options: map[string]interface{}{
+			IPTablesKey: []iptables.IPTableEntry{
+				{Version: iptables.V4, Params: "-A FORWARD -j ACCEPT"},
+			},
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			iptc := &mockIPTablesClientWithRunCmd{}
-
-			nm := &networkManager{
-				netlink:        netlink.NewMockNetlink(false, ""),
-				netio:          netio.NewMockNetIO(false, 0),
-				iptablesClient: iptc,
-			}
-
-			nwInfo := &EndpointInfo{
-				NICType: tt.nicType,
-				Options: map[string]interface{}{
-					IPTablesKey: []iptables.IPTableEntry{
-						{Version: iptables.V4, Params: "-A FORWARD -j ACCEPT"},
-					},
-				},
-			}
-
-			err := nm.handleCommonOptions("eth0", nwInfo)
-			require.NoError(t, err)
-
-			if tt.expectIPTableCall {
-				assert.NotEmpty(t, iptc.runCmdCalls, "expected iptables RunCmd to be called for NICType=%q", tt.nicType)
-			} else {
-				assert.Empty(t, iptc.runCmdCalls, "expected no iptables RunCmd call for NICType=%q", tt.nicType)
-			}
-		})
-	}
+	err := nm.handleCommonOptions("eth0", nwInfo)
+	require.NoError(t, err)
+	assert.NotEmpty(t, iptc.runCmdCalls, "expected iptables RunCmd to be called when IPTablesKey is present")
 }
 
+func TestHandleCommonOptions_NoOptionsNoError(t *testing.T) {
+	nm := &networkManager{
+		netlink:        netlink.NewMockNetlink(false, ""),
+		netio:          netio.NewMockNetIO(false, 0),
+		iptablesClient: &mockIPTablesClient{},
+	}
+
+	nwInfo := &EndpointInfo{
+		Options: map[string]interface{}{},
+	}
+
+	err := nm.handleCommonOptions("eth0", nwInfo)
+	require.NoError(t, err)
+}
+
+func TestHandleCommonOptions_NilOptionsNoError(t *testing.T) {
+	nm := &networkManager{
+		netlink:        netlink.NewMockNetlink(false, ""),
+		netio:          netio.NewMockNetIO(false, 0),
+		iptablesClient: &mockIPTablesClient{},
+	}
+
+	nwInfo := &EndpointInfo{
+		Options: nil,
+	}
+
+	err := nm.handleCommonOptions("eth0", nwInfo)
+	require.NoError(t, err)
+}

--- a/network/network_linux_test.go
+++ b/network/network_linux_test.go
@@ -1,0 +1,168 @@
+package network
+
+import (
+	"net"
+	"testing"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/iptables"
+	"github.com/Azure/azure-container-networking/netio"
+	"github.com/Azure/azure-container-networking/netlink"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockIPTablesClientWithRunCmd extends mock to track RunCmd calls.
+type mockIPTablesClientWithRunCmd struct {
+	mockIPTablesClient
+	runCmdCalls []string
+}
+
+func (c *mockIPTablesClientWithRunCmd) RunCmd(version, params string) error {
+	c.runCmdCalls = append(c.runCmdCalls, version+" "+params)
+	return nil
+}
+
+func TestHandleCommonOptions_SkipsRoutesForDelegatedNIC(t *testing.T) {
+	tests := []struct {
+		name            string
+		nicType         cns.NICType
+		expectRouteCall bool
+	}{
+		{
+			name:            "InfraNIC applies routes",
+			nicType:         cns.InfraNIC,
+			expectRouteCall: true,
+		},
+		{
+			name:            "empty NICType applies routes (legacy)",
+			nicType:         "",
+			expectRouteCall: true,
+		},
+		{
+			name:            "DelegatedVMNIC skips routes",
+			nicType:         cns.DelegatedVMNIC,
+			expectRouteCall: false,
+		},
+		{
+			name:            "NodeNetworkInterfaceFrontendNIC skips routes",
+			nicType:         cns.NodeNetworkInterfaceFrontendNIC,
+			expectRouteCall: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			routeCalled := false
+			nl := netlink.NewMockNetlink(false, "")
+			nl.SetAddRouteValidationFn(func(_ *netlink.Route) error {
+				routeCalled = true
+				return nil
+			})
+
+			nm := &networkManager{
+				netlink:        nl,
+				netio:          netio.NewMockNetIO(false, 0),
+				iptablesClient: &mockIPTablesClient{},
+			}
+
+			nwInfo := &EndpointInfo{
+				NICType: tt.nicType,
+				Options: map[string]interface{}{
+					RoutesKey: []RouteInfo{
+						{
+							Dst: net.IPNet{IP: net.ParseIP("10.1.0.0"), Mask: net.CIDRMask(16, 32)},
+							Gw:  net.ParseIP("10.0.0.1"),
+						},
+					},
+				},
+			}
+
+			err := nm.handleCommonOptions("eth0", nwInfo)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectRouteCall, routeCalled,
+				"route add called=%v, want=%v for NICType=%q", routeCalled, tt.expectRouteCall, tt.nicType)
+		})
+	}
+}
+
+func TestHandleCommonOptions_SkipsIPTablesForDelegatedNIC(t *testing.T) {
+	tests := []struct {
+		name              string
+		nicType           cns.NICType
+		expectIPTableCall bool
+	}{
+		{
+			name:              "InfraNIC applies iptables",
+			nicType:           cns.InfraNIC,
+			expectIPTableCall: true,
+		},
+		{
+			name:              "empty NICType applies iptables (legacy)",
+			nicType:           "",
+			expectIPTableCall: true,
+		},
+		{
+			name:              "DelegatedVMNIC skips iptables",
+			nicType:           cns.DelegatedVMNIC,
+			expectIPTableCall: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			iptc := &mockIPTablesClientWithRunCmd{}
+
+			nm := &networkManager{
+				netlink:        netlink.NewMockNetlink(false, ""),
+				netio:          netio.NewMockNetIO(false, 0),
+				iptablesClient: iptc,
+			}
+
+			nwInfo := &EndpointInfo{
+				NICType: tt.nicType,
+				Options: map[string]interface{}{
+					IPTablesKey: []iptables.IPTableEntry{
+						{Version: iptables.V4, Params: "-A FORWARD -j ACCEPT"},
+					},
+				},
+			}
+
+			err := nm.handleCommonOptions("eth0", nwInfo)
+			require.NoError(t, err)
+
+			if tt.expectIPTableCall {
+				assert.NotEmpty(t, iptc.runCmdCalls, "expected iptables RunCmd to be called for NICType=%q", tt.nicType)
+			} else {
+				assert.Empty(t, iptc.runCmdCalls, "expected no iptables RunCmd call for NICType=%q", tt.nicType)
+			}
+		})
+	}
+}
+
+func TestEndpointCreate_DoesNotSort(t *testing.T) {
+	// Verify EndpointCreate processes epInfos in the order given (sorting is now
+	// the caller's responsibility in cni/network).
+	epInfos := []*EndpointInfo{
+		{
+			NICType:    cns.DelegatedVMNIC,
+			EndpointID: "delegated-ep",
+			NetworkID:  DefaultNetworkID,
+		},
+		{
+			NICType:    cns.InfraNIC,
+			EndpointID: "infra-ep",
+			NetworkID:  DefaultNetworkID,
+		},
+	}
+
+	nm := &networkManager{
+		ExternalInterfaces: map[string]*externalInterface{},
+	}
+
+	_ = nm.EndpointCreate(nil, epInfos)
+
+	// Order should be unchanged — EndpointCreate no longer sorts
+	assert.Equal(t, cns.DelegatedVMNIC, epInfos[0].NICType)
+	assert.Equal(t, cns.InfraNIC, epInfos[1].NICType)
+}


### PR DESCRIPTION
## Summary

Fixes a transient `ENETUNREACH` error in SwiftV2 stateless CNI Linux during pod creation.

## Problem

In SwiftV2 stateless CNI with multiple NICs (InfraNIC + DelegatedVMNIC), the `Options[RoutesKey]` containing host gateway routes was being applied to **all** networks including the DelegatedVMNIC.

This caused kernel `ENETUNREACH` errors when trying to add routes like:
```
10.1.0.0/16 via 10.0.0.1 dev eth1
```

Where:
- `eth1` (DelegatedVMNIC) is in the **pod VNet** (10.1.0.0/16)
- Gateway `10.0.0.1` is in the **host VNet** (10.0.0.0/16)
- `eth1` has **no route to reach 10.0.0.1** → kernel returns `ENETUNREACH`

The route should only be applied to `eth0` (InfraNIC) which is connected to the host VNet.

## Root Cause

1. `setHostOptions()` populates `options[RoutesKey]` with a route to the host gateway for InfraNIC
2. All `EndpointInfo` structs get the **same options** via `shallowCopyIpamAddConfigOptions()`
3. `handleCommonOptions()` blindly applies these routes to every interface during network creation

## Fix

Moved the NICType check from handleCommonOptions (network/network_linux.go) to createEpInfo (cni/network/network.go). Non-infra NICs (DelegatedVMNIC, FrontendNIC) no longer receiveRoutesKey/IPTablesKey/SNATIPKey options from shallowCopyIpamAddConfigOptions() — these are infra-only host-namespace constructs. handleCommonOptions is reverted to its original unconditional behavior sincebad data is now prevented at the source.

## Why Transient

The error is transient because Go map iteration over interfaceInfo is non-deterministic. When InfraNIC processes first, its CreateNetwork installs the route on eth0; the subsequent DelegatedVMNIC attemptgets "file exists" and skips. When DelegatedVMNIC processes first, it hits ENETUNREACH. On retry, iteration order may differ.

## Testing

- [x] Code compiles successfully
- [ ] Manual testing on SwiftV2 cluster

## Requirements

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added
