### PR TITLE
fix: clean pre-installed Go before msft-go extraction

### DIFF
--- a/.pipelines/build/scripts/install-go.sh
+++ b/.pipelines/build/scripts/install-go.sh
@@ -49,8 +49,24 @@ fi
 
 ARCH="${ARCH:-amd64}"
 
+# Remove any pre-installed Go to prevent source file contamination.
+# tar extract overlays onto the existing directory without deleting files that
+# are absent from the archive. When the agent's pre-installed Go and msft-go
+# have different source files (e.g. crypto/internal/fips140, internal/runtime),
+# both sets survive the overlay, causing redeclaration and undefined-symbol
+# build errors.
+sudo rm -rf /usr/local/go
+
 # Extract /usr/local/go from the image without needing a Docker daemon.
 # crane export streams the full image filesystem; we extract just usr/local/go.
 crane export --platform "linux/${ARCH}" "$MSFT_GO_IMAGE" - | sudo tar -xf - -C / usr/local/go
+
+# Prevent the Go toolchain from auto-downloading upstream (non-FIPS) Go.
+# With GOTOOLCHAIN=local, the build uses exactly the msft-go we just installed.
+export GOTOOLCHAIN=local
+echo "##vso[task.setvariable variable=GOTOOLCHAIN]local"
+
+# Clear any build cache left by the agent's previous Go version.
+/usr/local/go/bin/go clean -cache 2>/dev/null || true
 
 echo "##vso[task.prependpath]/usr/local/go/bin"


### PR DESCRIPTION
The tar overlay of msft-go onto the agent's pre-installed Go at /usr/local/go leaves behind source files from both versions. This causes build failures:
- xorBytes redeclared (crypto/internal/fips140/subtle)
- undefined math.MaxUint64 (internal/runtime/strconv)

Remove /usr/local/go before extracting msft-go to ensure a clean installation. Also set GOTOOLCHAIN=local to prevent auto-downloading upstream (non-FIPS) Go, and clear the build cache from any prior Go version on the agent.

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
