### PR TITLE
feat: enable support for aks managed gateway api clusters and add support for cilium internalendpoint validation

### DIFF
--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -29,6 +29,7 @@ PUBLIC_IPv6          ?= $(PUBLIC_IP_ID)/$(IP_PREFIX)-$(CLUSTER)-v6
 KUBE_PROXY_JSON_PATH ?= ./kube-proxy.json
 LTS					 ?= false
 ACNS				 ?= false
+GATEWAYAPI			 ?= false
 
 
 # overrideable variables
@@ -52,6 +53,14 @@ else
 	ACNS_ARGS=
 endif
 
+# Only use with *cilium* recipes
+# Gateway API
+ifeq ($(GATEWAYAPI),true)
+	GATEWAYAPI_ARGS=--enable-gateway-api
+else
+	GATEWAYAPI_ARGS=
+endif
+
 # Common az aks create fields
 COMMON_AKS_FIELDS = $(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
 	--auto-upgrade-channel $(AUTOUPGRADE) \
@@ -61,7 +70,7 @@ COMMON_AKS_FIELDS = $(AZCLI) aks create -n $(CLUSTER) -g $(GROUP) -l $(REGION) \
 	--node-vm-size $(VM_SIZE) \
 	--no-ssh-key \
 	--os-sku $(OS_SKU) \
-	$(LTS_ARGS) $(ACNS_ARGS)
+	$(LTS_ARGS) $(ACNS_ARGS) $(GATEWAYAPI_ARGS)
 POD_CIDR = 192.168.0.0/16
 
 ##@ Help
@@ -122,6 +131,7 @@ vars: ## Show the input vars configured for the cluster commands
 	@echo K8S_VER=$(K8S_VER)
 	@echo LTS_ARGS=$(if $(LTS_ARGS),$(LTS_ARGS),$(LTS))
 	@echo ACNS_ARGS=$(if $(ACNS_ARGS),$(ACNS_ARGS),$(ACNS))
+	@echo GATEWAYAPI_ARGS=$(if $(GATEWAYAPI_ARGS),$(GATEWAYAPI_ARGS),$(GATEWAYAPI))
 	@echo COMMON_AKS_FIELDS=$(COMMON_AKS_FIELDS)
 
 

--- a/test/validate/linux_validate.go
+++ b/test/validate/linux_validate.go
@@ -146,7 +146,12 @@ type CiliumEndpointStatus struct {
 }
 
 type NetworkingStatus struct {
+	Labels     EndpointLabels       `json:"labels"`
 	Networking NetworkingAddressing `json:"networking"`
+}
+
+type EndpointLabels struct {
+	SecurityRelevant []string `json:"security-relevant"`
 }
 
 type NetworkingAddressing struct {

--- a/test/validate/utils.go
+++ b/test/validate/utils.go
@@ -63,7 +63,7 @@ func getCiliumInternalEndpointIPs(ctx context.Context, clientset *kubernetes.Cli
 		return nil
 	}
 
-	cmd := []string{bashCommand, "-c", "cilium endpoint list | grep 'reserved:ingress' | grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+' || true"}
+	cmd := []string{bashCommand, "-c", "cilium endpoint list | grep 'reserved:ingress' | grep -oE '([0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+|[0-9a-f:]+:[0-9a-f:]+)' || true"}
 	result, _, err := acnk8s.ExecCmdOnPod(ctx, clientset, "kube-system", pods.Items[0].Name, "cilium-agent", cmd, config, true)
 	if err != nil {
 		return nil

--- a/test/validate/utils.go
+++ b/test/validate/utils.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	ciliumBinary        = "cilium"
+	ciliumBinary         = "cilium"
 	reservedIngressLabel = "reserved:ingress"
 )
 

--- a/test/validate/utils.go
+++ b/test/validate/utils.go
@@ -64,7 +64,7 @@ func getCiliumInternalEndpointIPs(ctx context.Context, clientset *kubernetes.Cli
 	}
 
 	cmd := []string{bashCommand, "-c", "cilium endpoint list | grep 'reserved:ingress' | grep -oE '([0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+|[0-9a-f:]+:[0-9a-f:]+)' || true"}
-	result, _, err := acnk8s.ExecCmdOnPod(ctx, clientset, "kube-system", pods.Items[0].Name, "cilium-agent", cmd, config, true)
+	result, _, err := acnk8s.ExecCmdOnPod(ctx, clientset, "kube-system", pods.Items[0].Name, "cilium-agent", cmd, config, false)
 	if err != nil {
 		return nil
 	}

--- a/test/validate/utils.go
+++ b/test/validate/utils.go
@@ -13,6 +13,8 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+const bashCommand = "bash"
+
 func compareIPs(expected map[string]string, actual []string) error {
 	expectedLen := len(expected)
 
@@ -61,7 +63,7 @@ func getCiliumInternalEndpointIPs(ctx context.Context, clientset *kubernetes.Cli
 		return nil
 	}
 
-	cmd := []string{"bash", "-c", "cilium endpoint list | grep 'reserved:ingress' | grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+'"}
+	cmd := []string{bashCommand, "-c", "cilium endpoint list | grep 'reserved:ingress' | grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+'"}
 	result, _, err := acnk8s.ExecCmdOnPod(ctx, clientset, "kube-system", pods.Items[0].Name, "cilium-agent", cmd, config, true)
 	if err != nil {
 		return nil

--- a/test/validate/utils.go
+++ b/test/validate/utils.go
@@ -63,7 +63,7 @@ func getCiliumInternalEndpointIPs(ctx context.Context, clientset *kubernetes.Cli
 		return nil
 	}
 
-	cmd := []string{bashCommand, "-c", "cilium endpoint list | grep 'reserved:ingress' | grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+'"}
+	cmd := []string{bashCommand, "-c", "cilium endpoint list | grep 'reserved:ingress' | grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+' || true"}
 	result, _, err := acnk8s.ExecCmdOnPod(ctx, clientset, "kube-system", pods.Items[0].Name, "cilium-agent", cmd, config, true)
 	if err != nil {
 		return nil

--- a/test/validate/utils.go
+++ b/test/validate/utils.go
@@ -2,9 +2,9 @@ package validate
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 	"reflect"
-	"strings"
 
 	acnk8s "github.com/Azure/azure-container-networking/test/internal/kubernetes"
 	"github.com/pkg/errors"
@@ -12,8 +12,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
-
-const bashCommand = "bash"
 
 func compareIPs(expected map[string]string, actual []string) error {
 	expectedLen := len(expected)
@@ -53,17 +51,34 @@ func getPodIPsWithoutNodeIP(ctx context.Context, clientset *kubernetes.Clientset
 	return podsIpsWithoutNodeIP
 }
 
+// hasL7PolicyEnabled checks if L7 policy is enabled on the given node by looking
+// for a cilium pod and an acns-security-agent pod with a cilium-envoy container.
+func hasL7PolicyEnabled(ctx context.Context, clientset *kubernetes.Clientset, nodeName string) bool {
+
+	pods, err := acnk8s.GetPodsByNode(ctx, clientset, "kube-system", "k8s-app=acns-security-agent", nodeName)
+	if err != nil || len(pods.Items) == 0 {
+		return false
+	}
+	for _, c := range pods.Items[0].Spec.Containers {
+		if c.Name == "cilium-envoy" {
+			return true
+		}
+	}
+	return false
+}
+
 // getCiliumInternalEndpointIPs execs into the cilium agent pod on the given node
-// and runs `cilium endpoint list` to find IPs of reserved:ingress endpoints.
+// and runs `cilium endpoint list -o json` to find IPs of reserved:ingress endpoints.
 // These are not real Kubernetes pods but still have IPs allocated from CNS.
 // Returns nil when Cilium is not installed or the exec fails.
+// Uses the cilium binary directly (no shell) so it works on distroless containers.
 func getCiliumInternalEndpointIPs(ctx context.Context, clientset *kubernetes.Clientset, config *rest.Config, nodeName string) []string {
 	pods, err := acnk8s.GetPodsByNode(ctx, clientset, "kube-system", "k8s-app=cilium", nodeName)
 	if err != nil || len(pods.Items) == 0 {
 		return nil
 	}
 
-	cmd := []string{bashCommand, "-c", "cilium endpoint list | grep 'reserved:ingress' | grep -oE '([0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+|[0-9a-f:]+:[0-9a-f:]+)' || true"}
+	cmd := []string{"cilium", "endpoint", "list", "-o", "json"}
 	result, _, err := acnk8s.ExecCmdOnPod(ctx, clientset, "kube-system", pods.Items[0].Name, "cilium-agent", cmd, config, false)
 	if err != nil {
 		return nil
@@ -72,19 +87,41 @@ func getCiliumInternalEndpointIPs(ctx context.Context, clientset *kubernetes.Cli
 	return parseCiliumIngressIPs(result)
 }
 
-// parseCiliumIngressIPs parses the output of the grep pipeline that extracts
-// reserved:ingress endpoint IPs from `cilium endpoint list`.
+// parseCiliumIngressIPs parses the JSON output of `cilium endpoint list -o json`
+// and extracts IPs from endpoints with the reserved:ingress label.
 func parseCiliumIngressIPs(output []byte) []string {
+	var endpoints []CiliumEndpointStatus
+	if err := json.Unmarshal(output, &endpoints); err != nil {
+		log.Printf("Failed to parse cilium endpoint list JSON: %v", err)
+		return nil
+	}
+
 	var ips []string
-	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
-		if ip := strings.TrimSpace(line); ip != "" {
-			ips = append(ips, ip)
+	for _, ep := range endpoints {
+		isIngress := false
+		for _, label := range ep.Status.Labels.SecurityRelevant {
+			if label == "reserved:ingress" {
+				isIngress = true
+				break
+			}
+		}
+		if !isIngress {
+			continue
+		}
+		for _, addr := range ep.Status.Networking.Addresses {
+			if addr.IPv4 != "" {
+				ips = append(ips, addr.IPv4)
+			}
+			if addr.IPv6 != "" {
+				ips = append(ips, addr.IPv6)
+			}
 		}
 	}
+
 	if len(ips) > 0 {
 		log.Printf("Parsed Cilium internal endpoint IPs: %v", ips)
 	} else {
-		log.Printf("No Cilium internal endpoint IPs found in output")
+		log.Printf("No Cilium internal endpoint IPs found")
 	}
 	return ips
 }

--- a/test/validate/utils.go
+++ b/test/validate/utils.go
@@ -2,12 +2,15 @@ package validate
 
 import (
 	"context"
+	"log"
 	"reflect"
+	"strings"
 
 	acnk8s "github.com/Azure/azure-container-networking/test/internal/kubernetes"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 func compareIPs(expected map[string]string, actual []string) error {
@@ -46,6 +49,42 @@ func getPodIPsWithoutNodeIP(ctx context.Context, clientset *kubernetes.Clientset
 		}
 	}
 	return podsIpsWithoutNodeIP
+}
+
+// getCiliumInternalEndpointIPs execs into the cilium agent pod on the given node
+// and runs `cilium endpoint list` to find IPs of reserved:ingress endpoints.
+// These are not real Kubernetes pods but still have IPs allocated from CNS.
+// Returns nil when Cilium is not installed or the exec fails.
+func getCiliumInternalEndpointIPs(ctx context.Context, clientset *kubernetes.Clientset, config *rest.Config, nodeName string) []string {
+	pods, err := acnk8s.GetPodsByNode(ctx, clientset, "kube-system", "k8s-app=cilium", nodeName)
+	if err != nil || len(pods.Items) == 0 {
+		return nil
+	}
+
+	cmd := []string{"bash", "-c", "cilium endpoint list | grep 'reserved:ingress' | grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+'"}
+	result, _, err := acnk8s.ExecCmdOnPod(ctx, clientset, "kube-system", pods.Items[0].Name, "cilium-agent", cmd, config, true)
+	if err != nil {
+		return nil
+	}
+
+	return parseCiliumIngressIPs(result)
+}
+
+// parseCiliumIngressIPs parses the output of the grep pipeline that extracts
+// reserved:ingress endpoint IPs from `cilium endpoint list`.
+func parseCiliumIngressIPs(output []byte) []string {
+	var ips []string
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if ip := strings.TrimSpace(line); ip != "" {
+			ips = append(ips, ip)
+		}
+	}
+	if len(ips) > 0 {
+		log.Printf("Parsed Cilium internal endpoint IPs: %v", ips)
+	} else {
+		log.Printf("No Cilium internal endpoint IPs found in output")
+	}
+	return ips
 }
 
 func contain(obj, target interface{}) bool {

--- a/test/validate/utils.go
+++ b/test/validate/utils.go
@@ -13,6 +13,11 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+const (
+	ciliumBinary        = "cilium"
+	reservedIngressLabel = "reserved:ingress"
+)
+
 func compareIPs(expected map[string]string, actual []string) error {
 	expectedLen := len(expected)
 
@@ -54,13 +59,12 @@ func getPodIPsWithoutNodeIP(ctx context.Context, clientset *kubernetes.Clientset
 // hasL7PolicyEnabled checks if L7 policy is enabled on the given node by looking
 // for a cilium pod and an acns-security-agent pod with a cilium-envoy container.
 func hasL7PolicyEnabled(ctx context.Context, clientset *kubernetes.Clientset, nodeName string) bool {
-
 	pods, err := acnk8s.GetPodsByNode(ctx, clientset, "kube-system", "k8s-app=acns-security-agent", nodeName)
 	if err != nil || len(pods.Items) == 0 {
 		return false
 	}
-	for _, c := range pods.Items[0].Spec.Containers {
-		if c.Name == "cilium-envoy" {
+	for i := range pods.Items[0].Spec.Containers {
+		if pods.Items[0].Spec.Containers[i].Name == "cilium-envoy" {
 			return true
 		}
 	}
@@ -78,7 +82,7 @@ func getCiliumInternalEndpointIPs(ctx context.Context, clientset *kubernetes.Cli
 		return nil
 	}
 
-	cmd := []string{"cilium", "endpoint", "list", "-o", "json"}
+	cmd := []string{ciliumBinary, "endpoint", "list", "-o", "json"}
 	result, _, err := acnk8s.ExecCmdOnPod(ctx, clientset, "kube-system", pods.Items[0].Name, "cilium-agent", cmd, config, false)
 	if err != nil {
 		return nil
@@ -100,7 +104,7 @@ func parseCiliumIngressIPs(output []byte) []string {
 	for _, ep := range endpoints {
 		isIngress := false
 		for _, label := range ep.Status.Labels.SecurityRelevant {
-			if label == "reserved:ingress" {
+			if label == reservedIngressLabel {
 				isIngress = true
 				break
 			}

--- a/test/validate/utils_test.go
+++ b/test/validate/utils_test.go
@@ -1,10 +1,14 @@
 package validate
 
 import (
+	"encoding/json"
 	"testing"
 )
 
-const firstIngressIP = "10.224.0.55"
+func makeCiliumEndpointJSON(endpoints []CiliumEndpointStatus) []byte {
+	b, _ := json.Marshal(endpoints)
+	return b
+}
 
 func TestParseCiliumIngressIPs(t *testing.T) {
 	tests := []struct {
@@ -13,14 +17,24 @@ func TestParseCiliumIngressIPs(t *testing.T) {
 		expected []string
 	}{
 		{
-			name:     "single IP",
-			output:   []byte(firstIngressIP + "\n"),
-			expected: []string{firstIngressIP},
+			name: "single IP",
+			output: makeCiliumEndpointJSON([]CiliumEndpointStatus{
+				{Status: NetworkingStatus{
+					Labels:     EndpointLabels{SecurityRelevant: []string{"reserved:ingress"}},
+					Networking: NetworkingAddressing{Addresses: []Address{{IPv4: "10.224.0.55"}}},
+				}},
+			}),
+			expected: []string{"10.224.0.55"},
 		},
 		{
-			name:     "multiple IPs",
-			output:   []byte(firstIngressIP + "\n10.224.0.60\n"),
-			expected: []string{firstIngressIP, "10.224.0.60"},
+			name: "multiple IPs",
+			output: makeCiliumEndpointJSON([]CiliumEndpointStatus{
+				{Status: NetworkingStatus{
+					Labels:     EndpointLabels{SecurityRelevant: []string{"reserved:ingress"}},
+					Networking: NetworkingAddressing{Addresses: []Address{{IPv4: "10.224.0.55"}, {IPv4: "10.224.0.60"}}},
+				}},
+			}),
+			expected: []string{"10.224.0.55", "10.224.0.60"},
 		},
 		{
 			name:     "empty output",
@@ -28,19 +42,29 @@ func TestParseCiliumIngressIPs(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name:     "whitespace only",
-			output:   []byte("   \n  \n"),
+			name:     "empty JSON array",
+			output:   []byte("[]"),
 			expected: nil,
 		},
 		{
-			name:     "trailing newlines and spaces",
-			output:   []byte("  " + firstIngressIP + "  \n  10.224.0.60  \n\n"),
-			expected: []string{firstIngressIP, "10.224.0.60"},
+			name: "non-ingress endpoint ignored",
+			output: makeCiliumEndpointJSON([]CiliumEndpointStatus{
+				{Status: NetworkingStatus{
+					Labels:     EndpointLabels{SecurityRelevant: []string{"reserved:host"}},
+					Networking: NetworkingAddressing{Addresses: []Address{{IPv4: "10.224.0.55"}}},
+				}},
+			}),
+			expected: nil,
 		},
 		{
-			name:     "single IP no trailing newline",
-			output:   []byte("10.0.0.1"),
-			expected: []string{"10.0.0.1"},
+			name: "dualstack IPs",
+			output: makeCiliumEndpointJSON([]CiliumEndpointStatus{
+				{Status: NetworkingStatus{
+					Labels:     EndpointLabels{SecurityRelevant: []string{"reserved:ingress"}},
+					Networking: NetworkingAddressing{Addresses: []Address{{IPv4: "10.224.0.55", IPv6: "fd00::1"}}},
+				}},
+			}),
+			expected: []string{"10.224.0.55", "fd00::1"},
 		},
 	}
 

--- a/test/validate/utils_test.go
+++ b/test/validate/utils_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 )
 
+const firstIngressIP = "10.224.0.55"
+
 func TestParseCiliumIngressIPs(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -12,13 +14,13 @@ func TestParseCiliumIngressIPs(t *testing.T) {
 	}{
 		{
 			name:     "single IP",
-			output:   []byte("10.224.0.55\n"),
-			expected: []string{"10.224.0.55"},
+			output:   []byte(firstIngressIP + "\n"),
+			expected: []string{firstIngressIP},
 		},
 		{
 			name:     "multiple IPs",
-			output:   []byte("10.224.0.55\n10.224.0.60\n"),
-			expected: []string{"10.224.0.55", "10.224.0.60"},
+			output:   []byte(firstIngressIP + "\n10.224.0.60\n"),
+			expected: []string{firstIngressIP, "10.224.0.60"},
 		},
 		{
 			name:     "empty output",
@@ -32,8 +34,8 @@ func TestParseCiliumIngressIPs(t *testing.T) {
 		},
 		{
 			name:     "trailing newlines and spaces",
-			output:   []byte("  10.224.0.55  \n  10.224.0.60  \n\n"),
-			expected: []string{"10.224.0.55", "10.224.0.60"},
+			output:   []byte("  " + firstIngressIP + "  \n  10.224.0.60  \n\n"),
+			expected: []string{firstIngressIP, "10.224.0.60"},
 		},
 		{
 			name:     "single IP no trailing newline",

--- a/test/validate/utils_test.go
+++ b/test/validate/utils_test.go
@@ -1,0 +1,58 @@
+package validate
+
+import (
+	"testing"
+)
+
+func TestParseCiliumIngressIPs(t *testing.T) {
+	tests := []struct {
+		name     string
+		output   []byte
+		expected []string
+	}{
+		{
+			name:     "single IP",
+			output:   []byte("10.224.0.55\n"),
+			expected: []string{"10.224.0.55"},
+		},
+		{
+			name:     "multiple IPs",
+			output:   []byte("10.224.0.55\n10.224.0.60\n"),
+			expected: []string{"10.224.0.55", "10.224.0.60"},
+		},
+		{
+			name:     "empty output",
+			output:   []byte(""),
+			expected: nil,
+		},
+		{
+			name:     "whitespace only",
+			output:   []byte("   \n  \n"),
+			expected: nil,
+		},
+		{
+			name:     "trailing newlines and spaces",
+			output:   []byte("  10.224.0.55  \n  10.224.0.60  \n\n"),
+			expected: []string{"10.224.0.55", "10.224.0.60"},
+		},
+		{
+			name:     "single IP no trailing newline",
+			output:   []byte("10.0.0.1"),
+			expected: []string{"10.0.0.1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseCiliumIngressIPs(tt.output)
+			if len(got) != len(tt.expected) {
+				t.Fatalf("expected %d IPs, got %d: %v", len(tt.expected), len(got), got)
+			}
+			for i := range got {
+				if got[i] != tt.expected[i] {
+					t.Errorf("IP[%d]: expected %q, got %q", i, tt.expected[i], got[i])
+				}
+			}
+		})
+	}
+}

--- a/test/validate/utils_test.go
+++ b/test/validate/utils_test.go
@@ -5,8 +5,14 @@ import (
 	"testing"
 )
 
-func makeCiliumEndpointJSON(endpoints []CiliumEndpointStatus) []byte {
-	b, _ := json.Marshal(endpoints)
+const testIPv4 = "10.224.0.55"
+
+func makeCiliumEndpointJSON(t *testing.T, endpoints []CiliumEndpointStatus) []byte {
+	t.Helper()
+	b, err := json.Marshal(endpoints)
+	if err != nil {
+		t.Fatalf("failed to marshal endpoints: %v", err)
+	}
 	return b
 }
 
@@ -18,23 +24,23 @@ func TestParseCiliumIngressIPs(t *testing.T) {
 	}{
 		{
 			name: "single IP",
-			output: makeCiliumEndpointJSON([]CiliumEndpointStatus{
+			output: makeCiliumEndpointJSON(t, []CiliumEndpointStatus{
 				{Status: NetworkingStatus{
-					Labels:     EndpointLabels{SecurityRelevant: []string{"reserved:ingress"}},
-					Networking: NetworkingAddressing{Addresses: []Address{{IPv4: "10.224.0.55"}}},
+					Labels:     EndpointLabels{SecurityRelevant: []string{reservedIngressLabel}},
+					Networking: NetworkingAddressing{Addresses: []Address{{IPv4: testIPv4}}},
 				}},
 			}),
-			expected: []string{"10.224.0.55"},
+			expected: []string{testIPv4},
 		},
 		{
 			name: "multiple IPs",
-			output: makeCiliumEndpointJSON([]CiliumEndpointStatus{
+			output: makeCiliumEndpointJSON(t, []CiliumEndpointStatus{
 				{Status: NetworkingStatus{
-					Labels:     EndpointLabels{SecurityRelevant: []string{"reserved:ingress"}},
-					Networking: NetworkingAddressing{Addresses: []Address{{IPv4: "10.224.0.55"}, {IPv4: "10.224.0.60"}}},
+					Labels:     EndpointLabels{SecurityRelevant: []string{reservedIngressLabel}},
+					Networking: NetworkingAddressing{Addresses: []Address{{IPv4: testIPv4}, {IPv4: "10.224.0.60"}}},
 				}},
 			}),
-			expected: []string{"10.224.0.55", "10.224.0.60"},
+			expected: []string{testIPv4, "10.224.0.60"},
 		},
 		{
 			name:     "empty output",
@@ -48,23 +54,23 @@ func TestParseCiliumIngressIPs(t *testing.T) {
 		},
 		{
 			name: "non-ingress endpoint ignored",
-			output: makeCiliumEndpointJSON([]CiliumEndpointStatus{
+			output: makeCiliumEndpointJSON(t, []CiliumEndpointStatus{
 				{Status: NetworkingStatus{
 					Labels:     EndpointLabels{SecurityRelevant: []string{"reserved:host"}},
-					Networking: NetworkingAddressing{Addresses: []Address{{IPv4: "10.224.0.55"}}},
+					Networking: NetworkingAddressing{Addresses: []Address{{IPv4: testIPv4}}},
 				}},
 			}),
 			expected: nil,
 		},
 		{
 			name: "dualstack IPs",
-			output: makeCiliumEndpointJSON([]CiliumEndpointStatus{
+			output: makeCiliumEndpointJSON(t, []CiliumEndpointStatus{
 				{Status: NetworkingStatus{
-					Labels:     EndpointLabels{SecurityRelevant: []string{"reserved:ingress"}},
-					Networking: NetworkingAddressing{Addresses: []Address{{IPv4: "10.224.0.55", IPv6: "fd00::1"}}},
+					Labels:     EndpointLabels{SecurityRelevant: []string{reservedIngressLabel}},
+					Networking: NetworkingAddressing{Addresses: []Address{{IPv4: testIPv4, IPv6: "fd00::1"}}},
 				}},
 			}),
-			expected: []string{"10.224.0.55", "fd00::1"},
+			expected: []string{testIPv4, "fd00::1"},
 		},
 	}
 

--- a/test/validate/validate.go
+++ b/test/validate/validate.go
@@ -156,8 +156,11 @@ func (v *Validator) validateIPs(ctx context.Context, stateFileIps stateFileIpsFu
 		}
 		// get the pod ips
 		podIps := getPodIPsWithoutNodeIP(ctx, v.clientset, nodes.Items[index])
-		// include IPs from Cilium internal endpoints that are not real K8s pods
-		podIps = append(podIps, getCiliumInternalEndpointIPs(ctx, v.clientset, v.config, nodes.Items[index].Name)...)
+		// include IPs from Cilium internal endpoints (reserved:ingress) that are not real K8s pods.
+		// These only exist when L7 policy is enabled, indicated by the acns-security-agent pod with cilium-envoy container.
+		if hasL7PolicyEnabled(ctx, v.clientset, nodes.Items[index].Name) {
+			podIps = append(podIps, getCiliumInternalEndpointIPs(ctx, v.clientset, v.config, nodes.Items[index].Name)...)
+		}
 
 		if err := compareIPs(filePodIps, podIps); err != nil {
 			return errors.Wrapf(err, "State file validation failed for %s on node %s", checkType, nodes.Items[index].Name)

--- a/test/validate/validate.go
+++ b/test/validate/validate.go
@@ -156,6 +156,8 @@ func (v *Validator) validateIPs(ctx context.Context, stateFileIps stateFileIpsFu
 		}
 		// get the pod ips
 		podIps := getPodIPsWithoutNodeIP(ctx, v.clientset, nodes.Items[index])
+		// include IPs from Cilium internal endpoints that are not real K8s pods
+		podIps = append(podIps, getCiliumInternalEndpointIPs(ctx, v.clientset, v.config, nodes.Items[index].Name)...)
 
 		if err := compareIPs(filePodIps, podIps); err != nil {
 			return errors.Wrapf(err, "State file validation failed for %s on node %s", checkType, nodes.Items[index].Name)


### PR DESCRIPTION
This pull request introduces enhancements to both the AKS cluster Makefile and the Cilium IP validation logic. The Makefile now supports enabling the Gateway API via a new flag, and the Cilium validation has been improved to account for internal endpoints with the reserved:ingress label, ensuring a more accurate IP validation when L7 policies are enabled. Additionally, comprehensive unit tests have been added for the new parsing logic.

**Makefile improvements:**

- Added a `GATEWAYAPI` flag and logic to enable Gateway API support in AKS cluster creation commands, including propagating the new argument and displaying it in the `vars` target. [[1]](diffhunk://#diff-57046f2686ea559e17b63e0715ed093f51f3f557b4fcb783512962a45f24bc7aR32) [[2]](diffhunk://#diff-57046f2686ea559e17b63e0715ed093f51f3f557b4fcb783512962a45f24bc7aR56-R63) [[3]](diffhunk://#diff-57046f2686ea559e17b63e0715ed093f51f3f557b4fcb783512962a45f24bc7aL64-R73) [[4]](diffhunk://#diff-57046f2686ea559e17b63e0715ed093f51f3f557b4fcb783512962a45f24bc7aR134)

**Cilium endpoint IP validation enhancements:**

- Updated the validator to include IPs from Cilium internal endpoints (with the `reserved:ingress` label) when L7 policy is enabled, by detecting the presence of the `acns-security-agent` pod with a `cilium-envoy` container. [[1]](diffhunk://#diff-977f9453c70894afbf5031d436d65cc857390de12c94bc1d792702004e8b72e6R159-R163) [[2]](diffhunk://#diff-33afc72ded54e4cb0b5532faa2a98bc50579feb1d67625a7a84397b38bedf7ccR59-R132)
- Implemented the functions `hasL7PolicyEnabled`, `getCiliumInternalEndpointIPs`, and `parseCiliumIngressIPs` to fetch and parse Cilium internal endpoint IPs via direct pod exec and JSON parsing.
- Extended the data structures in `linux_validate.go` to support parsing of Cilium endpoint labels.

**Testing improvements:**

- Added a new unit test file `utils_test.go` with thorough test cases for the `parseCiliumIngressIPs` function, ensuring correct parsing across various scenarios.
**Reason for Change**:

The validation compares pod IPs from Kubernetes with IPs reported by cilium endpoint list. When Cilium Gateway API (L7 policy) is enabled, Cilium creates internal reserved:ingress endpoints that are allocated IPs from the pod CIDR but are not backed by any Kubernetes pod. Without this change, these extra IPs in the cilium state cause the validation to fail with a mismatch so the cilium state has IPs that don't correspond to any K8s pod. This PR accounts for reserved:ingress endpoint IPs by parsing the security-relevant labels from the cilium endpoint output and including those IPs in the known set, preventing false validation failures when Cilium Gateway API is enabled.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [x] relevant PR labels added

**Notes**:
