### PR TITLE
feat: Enahancing ETW logging for CNS

### DIFF
--- a/cns/logger/cnslogger.go
+++ b/cns/logger/cnslogger.go
@@ -94,8 +94,11 @@ func (c *logger) SetAPIServer(apiserver string) {
 
 func (c *logger) Printf(format string, args ...any) {
 	c.logger.Logf(format, args...)
+	if c.disableTraceLogging {
+		return
+	}
 	c.zapLogger.Info(fmt.Sprintf(format, args...))
-	if c.th == nil || c.disableTraceLogging {
+	if c.th == nil {
 		return
 	}
 	msg := fmt.Sprintf(format, args...)
@@ -104,8 +107,11 @@ func (c *logger) Printf(format string, args ...any) {
 
 func (c *logger) Debugf(format string, args ...any) {
 	c.logger.Debugf(format, args...)
+	if c.disableTraceLogging {
+		return
+	}
 	c.zapLogger.Debug(fmt.Sprintf(format, args...))
-	if c.th == nil || c.disableTraceLogging {
+	if c.th == nil {
 		return
 	}
 	msg := fmt.Sprintf(format, args...)
@@ -114,8 +120,11 @@ func (c *logger) Debugf(format string, args ...any) {
 
 func (c *logger) Warnf(format string, args ...any) {
 	c.logger.Warnf(format, args...)
+	if c.disableTraceLogging {
+		return
+	}
 	c.zapLogger.Warn(fmt.Sprintf(format, args...))
-	if c.th == nil || c.disableTraceLogging {
+	if c.th == nil {
 		return
 	}
 	msg := fmt.Sprintf(format, args...)
@@ -124,8 +133,11 @@ func (c *logger) Warnf(format string, args ...any) {
 
 func (c *logger) Errorf(format string, args ...any) {
 	c.logger.Errorf(format, args...)
+	if c.disableTraceLogging {
+		return
+	}
 	c.zapLogger.Error(fmt.Sprintf(format, args...))
-	if c.th == nil || c.disableTraceLogging {
+	if c.th == nil {
 		return
 	}
 	msg := fmt.Sprintf(format, args...)
@@ -200,7 +212,11 @@ func (c *logger) sendTraceInternal(msg string, lvl ai.Level) {
 }
 
 func (c *logger) LogEvent(event ai.Event) {
-	if c.th == nil || c.disableEventLogging {
+	if c.disableEventLogging {
+		return
+	}
+	c.zapLogger.Info(event.EventName, zap.String("resource_id", event.ResourceID), zap.Any("properties", event.Properties))
+	if c.th == nil {
 		return
 	}
 	c.m.RLock()

--- a/cns/logger/log.go
+++ b/cns/logger/log.go
@@ -4,6 +4,7 @@ package logger
 import (
 	"github.com/Azure/azure-container-networking/aitelemetry"
 	"github.com/Azure/azure-container-networking/cns/types"
+	"go.uber.org/zap"
 )
 
 type loggershim interface {
@@ -28,6 +29,13 @@ var (
 	AppInsightsIKey = aiMetadata
 	aiMetadata      string // this var is set at build time.
 )
+
+// Deprecated: The global logger is deprecated. Migrate to zap using the cns/logger/v2 package and pass the logger instead.
+func SetZapFields(fields ...zap.Field) {
+	if l, ok := Log.(*logger); ok {
+		l.zapLogger = l.zapLogger.With(fields...)
+	}
+}
 
 // Deprecated: The global logger is deprecated. Migrate to zap using the cns/logger/v2 package and pass the logger instead.
 func Close() {

--- a/cns/logger/v2/config_linux.go
+++ b/cns/logger/v2/config_linux.go
@@ -16,3 +16,5 @@ type Config struct {
 }
 
 func (c *Config) normalize() {}
+
+func (c *Config) AppendETWFields([]zapcore.Field) {}

--- a/cns/logger/v2/config_windows.go
+++ b/cns/logger/v2/config_windows.go
@@ -26,3 +26,9 @@ func (c *Config) normalize() {
 		}
 	}
 }
+
+func (c *Config) AppendETWFields(fields []zapcore.Field) {
+	if c.ETW != nil {
+		c.ETW.Fields = append(c.ETW.Fields, fields...)
+	}
+}

--- a/cns/logger/v2/cores/etw_windows.go
+++ b/cns/logger/v2/cores/etw_windows.go
@@ -45,5 +45,6 @@ func ETWCore(cfg *ETWConfig) (zapcore.Core, func(), error) {
 	encoderConfig := zap.NewProductionEncoderConfig()
 	encoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	jsonEncoder := zapcore.NewJSONEncoder(encoderConfig)
-	return zapetw.New(cfg.ProviderName, cfg.EventName, &ctrlzap.KubeAwareEncoder{Encoder: jsonEncoder}, cfg.level) //nolint:wrapcheck // ignore
+	core, closer, err := zapetw.New(cfg.ProviderName, cfg.EventName, &ctrlzap.KubeAwareEncoder{Encoder: jsonEncoder}, cfg.level)
+	return core.With(cfg.Fields), closer, err //nolint:wrapcheck // ignore
 }

--- a/cns/logger/v2/shim.go
+++ b/cns/logger/v2/shim.go
@@ -57,7 +57,9 @@ func (s *shim) SetAPIServer(string) {}
 
 func (s *shim) SendMetric(aitelemetry.Metric) {}
 
-func (s *shim) LogEvent(aitelemetry.Event) {}
+func (s *shim) LogEvent(event aitelemetry.Event) {
+	s.z.Sugar().Infow(event.EventName, "resource_id", event.ResourceID, "properties", event.Properties)
+}
 
 func AsV1(z *zap.Logger, closer func()) *shim { //nolint:revive // I want it to be annoying to use.
 	return &shim{z: z, closer: closer}

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -635,9 +635,22 @@ func main() {
 	// If this errors, we will not have metadata in the AI logs. Should we exit?
 	metadata, _ := acn.GetHostMetadata(aitelemetry.MetadataFile)
 	aifields := loggerv2.MetadataToFields(metadata)
+	host, _ := os.Hostname()
+	hostMetadataFields := []zap.Field{
+		zap.String("hostname", host),
+		zap.String("version", version),
+		zap.String("kubernetes_apiserver", os.Getenv("KUBERNETES_SERVICE_HOST")),
+	}
+
+	// Attach IMDS metadata and logger-level fields to the v1 logger's ETW output.
+	allFields := append([]zap.Field{}, aifields...)
+	allFields = append(allFields, hostMetadataFields...)
+	logger.SetZapFields(allFields...) //nolint:staticcheck // ignore new deprecation
+
 	if cnsconfig.Logger.AppInsights != nil {
 		cnsconfig.Logger.AppInsights.Fields = append(cnsconfig.Logger.AppInsights.Fields, aifields...)
 	}
+	cnsconfig.Logger.AppendETWFields(aifields)
 
 	// build the zap logger
 	z, c, err := loggerv2.New(&cnsconfig.Logger)
@@ -646,8 +659,7 @@ func main() {
 		fmt.Printf("failed to create logger: %v", err)
 		os.Exit(1)
 	}
-	host, _ := os.Hostname()
-	z = z.With(zap.String("hostname", host), zap.String("version", version), zap.String("kubernetes_apiserver", os.Getenv("KUBERNETES_SERVICE_HOST")))
+	z = z.With(hostMetadataFields...)
 	config.Logger = z.With(zap.String("module", "cns service"))
 	// Set the v2 logger to the global logger if v2 logger enabled.
 	if cnsconfig.EnableLoggerV2 {

--- a/zapetw/core_windows.go
+++ b/zapetw/core_windows.go
@@ -18,15 +18,12 @@ type Core struct {
 
 func New(providerName, eventName string, encoder zapcore.Encoder, levelEnabler zapcore.LevelEnabler) (zapcore.Core, func(), error) {
 	provider, err := etw.NewProviderWithOptions(providerName)
-	if err != nil {
-		return nil, func() { _ = provider.Close() }, errors.Wrap(err, "failed to create ETW provider")
-	}
 	return &Core{
 		provider:     provider,
 		eventName:    eventName,
 		encoder:      encoder,
 		LevelEnabler: levelEnabler,
-	}, func() { _ = provider.Close() }, nil
+	}, func() { _ = provider.Close() }, err //nolint:wrapcheck // ignore
 }
 
 func (core *Core) With(fields []zapcore.Field) zapcore.Core {


### PR DESCRIPTION
## Enhancing ETW Logging for CNS

### Summary

Enriches ETW (Event Tracing for Windows) log output with IMDS metadata and contextual fields (hostname, version, API server), and ensures `LogEvent` calls are captured by the zap/ETW pipeline in both the v1 and v2 logger paths.

### Changes

#### `cns/logger/cnslogger.go`
- Moves the `disableTraceLogging` / `disableEventLogging` guard **before** the zap log call in `Printf`, `Debugf`, `Warnf`, `Errorf`, and `LogEvent`. Previously, zap would still emit even when trace/event logging was disabled.
- Adds a zap `Info` call in `LogEvent` so events are captured in structured logs (with `resource_id` and `properties` fields) in addition to Application Insights.

#### `cns/logger/log.go`
- Adds a `SetZapFields` helper to append persistent zap fields to the global v1 logger's underlying zap instance. This allows host metadata to be attached once and included in all subsequent zap output.

#### `cns/logger/v2/config_windows.go` / `config_linux.go`
- Adds `AppendETWFields` method to the logger v2 `Config` struct. On Windows this appends fields to the ETW core config; on Linux it is a no-op.

#### `cns/logger/v2/cores/etw_windows.go`
- Applies `cfg.Fields` to the ETW core via `core.With(cfg.Fields)` so that IMDS metadata fields are baked into every ETW event.
- Handles the error from `zapetw.New` explicitly instead of relying on the `//nolint:wrapcheck` suppression.

#### `cns/logger/v2/shim.go`
- Implements `LogEvent` on the v2 shim so that AI telemetry events are emitted as structured zap logs (previously was a no-op).

#### `cns/service/main.go`
- Consolidates host metadata fields (`hostname`, `version`, `kubernetes_apiserver`) into a single slice and applies them to both the v1 global logger (via `SetZapFields`) and the v2 logger (via `z.With`).
- Appends IMDS-derived fields to the ETW config via `AppendETWFields` so ETW traces include subscription, resource group, and VM metadata.

**Reason for Change**:

Previously, ETW traces lacked the IMDS metadata and identifying fields (hostname, version, Kubernetes API server) that were available in Application Insights telemetry. This made correlating ETW events to specific nodes/versions difficult. These changes ensure parity between the two telemetry sinks and make `LogEvent` observable in ETW output.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Tests**:
Tested on Service Fabric test cluster with Geneva Logs enabled.
<img width="1833" height="867" alt="image" src="https://github.com/user-attachments/assets/092ef618-606f-477e-aa77-f07e71a5335d" />
