### PR TITLE
fix: find interface by mac address fix for swiftv2 delegated interfac…

### DIFF
--- a/azure-iptables-monitor/go.sum
+++ b/azure-iptables-monitor/go.sum
@@ -29,6 +29,8 @@ github.com/go-openapi/jsonreference v0.20.2/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-openapi/swag v0.22.4 h1:QLMzNJnMGPRNDCbySlcj1x01tzU8/9LTTL9hZZZogBU=
 github.com/go-openapi/swag v0.22.4/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
+github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6 h1:teYtXy9B7y5lHTp8V9KPxpYRAVA7dozigQcMiBust1s=
+github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6/go.mod h1:p4lGIVX+8Wa6ZPNDvqcxq36XpUDLh42FLetFU7odllI=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -227,11 +227,11 @@ func (plugin *NetPlugin) findInterfaceByMAC(macAddress string) string {
 		}
 		master, err := resolveMasterInterface(iface.Name)
 		if err != nil {
-			logger.Error("failed to resolve master interface",
+			logger.Warn("failed to resolve master interface, falling back to interface name",
 				zap.String("name", iface.Name),
 				zap.String("mac", macAddress),
 				zap.Error(err))
-			return ""
+			return iface.Name
 		}
 		return master
 	}

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -233,6 +233,10 @@ func (plugin *NetPlugin) findInterfaceByMAC(macAddress string) string {
 				zap.Error(err))
 			return ""
 		}
+		logger.Info("found master interface by MAC",
+			zap.String("resolved-master", ifName),
+			zap.String("interface", iface.Name),
+			zap.String("mac", macAddress))
 		return ifName
 	}
 	logger.Error("failed to find interface by MAC", zap.String("macAddress", macAddress), zap.Strings("macs", macs))

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -225,7 +225,18 @@ func (plugin *NetPlugin) findInterfaceByMAC(macAddress string) string {
 		if iface.HardwareAddr.String() != macAddress {
 			continue
 		}
-		if !isInterfaceMaster(iface.Name) {
+		isMaster, err := isInterfaceMaster(iface.Name)
+		if err != nil {
+			logger.Warn("failed to determine interface master relationship",
+				zap.String("name", iface.Name),
+				zap.String("mac", macAddress),
+				zap.Error(err))
+			if fallback == "" {
+				fallback = iface.Name
+			}
+			continue
+		}
+		if !isMaster {
 			logger.Info("skipping non-master interface with matching MAC",
 				zap.String("name", iface.Name), zap.String("mac", macAddress))
 			if fallback == "" {

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -208,9 +208,10 @@ func (plugin *NetPlugin) Stop() {
 	logger.Info("Plugin stopped")
 }
 
-// findInterfaceByMAC returns the name of the upper (master) interface matching the given MAC.
+// findInterfaceByMAC returns the name of the master interface matching the given MAC.
 // With accelerated networking, both the netvsc upper device (e.g. eth1) and the VF
-// (e.g. enP12217s2) share the same MAC. This function prefers the upper device.
+// (e.g. enP12217s2) share the same MAC. When the matched interface is a VF, this
+// function resolves and returns its master.
 func (plugin *NetPlugin) findInterfaceByMAC(macAddress string) string {
 	interfaces, err := plugin.netClient.GetNetworkInterfaces()
 	if err != nil {
@@ -218,40 +219,23 @@ func (plugin *NetPlugin) findInterfaceByMAC(macAddress string) string {
 		return ""
 	}
 	macs := make([]string, 0, len(interfaces))
-	var fallback string
 	for _, iface := range interfaces {
-		// find master interface by macAddress for Swiftv2
-		macs = append(macs, iface.HardwareAddr.String())
-		if iface.HardwareAddr.String() != macAddress {
+		mac := iface.HardwareAddr.String()
+		macs = append(macs, mac)
+		if mac != macAddress {
 			continue
 		}
-		isMaster, err := isInterfaceMaster(iface.Name)
+		master, err := resolveMasterInterface(iface.Name)
 		if err != nil {
-			logger.Warn("failed to determine interface master relationship",
+			logger.Error("failed to resolve master interface",
 				zap.String("name", iface.Name),
 				zap.String("mac", macAddress),
 				zap.Error(err))
-			if fallback == "" {
-				fallback = iface.Name
-			}
-			continue
+			return ""
 		}
-		if !isMaster {
-			logger.Info("skipping non-master interface with matching MAC",
-				zap.String("name", iface.Name), zap.String("mac", macAddress))
-			if fallback == "" {
-				fallback = iface.Name
-			}
-			continue
-		}
-		return iface.Name
+		return master
 	}
-	if fallback != "" {
-		logger.Info("no master interface found, using non-master",
-			zap.String("name", fallback), zap.String("mac", macAddress))
-		return fallback
-	}
-	logger.Error("failed to find interface by MAC", zap.String("macAddress", macAddress), zap.Strings("interfaces", macs))
+	logger.Error("failed to find interface by MAC", zap.String("macAddress", macAddress), zap.Strings("macs", macs))
 	return ""
 }
 

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -225,15 +225,15 @@ func (plugin *NetPlugin) findInterfaceByMAC(macAddress string) string {
 		if mac != macAddress {
 			continue
 		}
-		master, err := resolveMasterInterface(iface.Name)
+		ifName, err := resolveMasterInterface(iface.Name)
 		if err != nil {
-			logger.Warn("failed to resolve master interface, falling back to interface name",
+			logger.Error("failed to resolve master interface",
 				zap.String("name", iface.Name),
 				zap.String("mac", macAddress),
 				zap.Error(err))
-			return iface.Name
+			return ""
 		}
-		return master
+		return ifName
 	}
 	logger.Error("failed to find interface by MAC", zap.String("macAddress", macAddress), zap.Strings("macs", macs))
 	return ""

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -208,7 +208,9 @@ func (plugin *NetPlugin) Stop() {
 	logger.Info("Plugin stopped")
 }
 
-// findInterfaceByMAC returns the name of the master interface
+// findInterfaceByMAC returns the name of the upper (master) interface matching the given MAC.
+// With accelerated networking, both the netvsc upper device (e.g. eth1) and the VF
+// (e.g. enP12217s2) share the same MAC. This function prefers the upper device.
 func (plugin *NetPlugin) findInterfaceByMAC(macAddress string) string {
 	interfaces, err := plugin.netClient.GetNetworkInterfaces()
 	if err != nil {
@@ -216,15 +218,29 @@ func (plugin *NetPlugin) findInterfaceByMAC(macAddress string) string {
 		return ""
 	}
 	macs := make([]string, 0, len(interfaces))
+	var fallback string
 	for _, iface := range interfaces {
 		// find master interface by macAddress for Swiftv2
 		macs = append(macs, iface.HardwareAddr.String())
-		if iface.HardwareAddr.String() == macAddress {
-			return iface.Name
+		if iface.HardwareAddr.String() != macAddress {
+			continue
 		}
+		if !isInterfaceMaster(iface.Name) {
+			logger.Info("skipping non-master interface with matching MAC",
+				zap.String("name", iface.Name), zap.String("mac", macAddress))
+			if fallback == "" {
+				fallback = iface.Name
+			}
+			continue
+		}
+		return iface.Name
 	}
-	// Failed to find a suitable interface.
-	logger.Error("Failed to find interface by MAC", zap.String("macAddress", macAddress), zap.Strings("interfaces", macs))
+	if fallback != "" {
+		logger.Info("no master interface found, using non-master",
+			zap.String("name", fallback), zap.String("mac", macAddress))
+		return fallback
+	}
+	logger.Error("failed to find interface by MAC", zap.String("macAddress", macAddress), zap.Strings("interfaces", macs))
 	return ""
 }
 

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"fmt"
 	"net"
 	"strconv"
 
@@ -28,7 +29,7 @@ const snatConfigFileName = "/tmp/snatConfig"
 func resolveMasterInterface(name string) (string, error) {
 	link, err := vishnetlink.LinkByName(name)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("get link %q: %w", name, err)
 	}
 	masterIndex := link.Attrs().MasterIndex
 	if masterIndex == 0 {
@@ -36,7 +37,7 @@ func resolveMasterInterface(name string) (string, error) {
 	}
 	master, err := vishnetlink.LinkByIndex(masterIndex)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("get master link by index %d: %w", masterIndex, err)
 	}
 	return master.Attrs().Name, nil
 }

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -37,7 +37,7 @@ func resolveMasterInterface(name string) (string, error) {
 	}
 	master, err := vishnetlink.LinkByIndex(masterIndex)
 	if err != nil {
-		return "", fmt.Errorf("get master link by index %d: %w", masterIndex, err)
+		return "", fmt.Errorf("get master link by index %d failed with: %w", masterIndex, err)
 	}
 	return master.Attrs().Name, nil
 }

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -21,13 +21,34 @@ const (
 
 const snatConfigFileName = "/tmp/snatConfig"
 
+// netlinkClient abstracts vishvananda/netlink link-lookup calls for testing.
+type netlinkClient interface {
+	LinkByName(name string) (vishnetlink.Link, error)
+	LinkByIndex(index int) (vishnetlink.Link, error)
+}
+
+// defaultNetlinkClient delegates to the real vishvananda/netlink package functions.
+type defaultNetlinkClient struct{}
+
+func (defaultNetlinkClient) LinkByName(name string) (vishnetlink.Link, error) {
+	return vishnetlink.LinkByName(name)
+}
+
+func (defaultNetlinkClient) LinkByIndex(index int) (vishnetlink.Link, error) {
+	return vishnetlink.LinkByIndex(index)
+}
+
+// nlClient is the active netlink client used by resolveMasterInterface.
+// Override in tests to inject a mock.
+var nlClient netlinkClient = defaultNetlinkClient{}
+
 // resolveMasterInterface returns the name of the upper (master) interface for the
 // given interface name. On Linux with accelerated networking, the VF (e.g.
 // enP12217s2) is bonded to the netvsc upper device (e.g. eth1). A VF has a
 // non-zero MasterIndex; the upper device does not. If name is already the
 // upper device, it is returned unchanged.
 func resolveMasterInterface(name string) (string, error) {
-	link, err := vishnetlink.LinkByName(name)
+	link, err := nlClient.LinkByName(name)
 	if err != nil {
 		return "", fmt.Errorf("get link %q: %w", name, err)
 	}
@@ -35,7 +56,7 @@ func resolveMasterInterface(name string) (string, error) {
 	if masterIndex == 0 {
 		return name, nil
 	}
-	master, err := vishnetlink.LinkByIndex(masterIndex)
+	master, err := nlClient.LinkByIndex(masterIndex)
 	if err != nil {
 		return "", fmt.Errorf("get master link by index %d failed with: %w", masterIndex, err)
 	}

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -20,17 +20,25 @@ const (
 
 const snatConfigFileName = "/tmp/snatConfig"
 
-// isInterfaceMaster reports whether the named interface is an upper (master) device.
-// On Linux with accelerated networking, the VF (e.g. enP12217s2) is bonded to the
-// netvsc upper device (e.g. eth1). A VF has a non-zero MasterIndex while
-// the upper device does not.
-func isInterfaceMaster(name string) (bool, error) {
+// resolveMasterInterface returns the name of the upper (master) interface for the
+// given interface name. On Linux with accelerated networking, the VF (e.g.
+// enP12217s2) is bonded to the netvsc upper device (e.g. eth1). A VF has a
+// non-zero MasterIndex; the upper device does not. If name is already the
+// upper device, it is returned unchanged.
+func resolveMasterInterface(name string) (string, error) {
 	link, err := vishnetlink.LinkByName(name)
 	if err != nil {
-		return false, err
+		return "", err
 	}
-
-	return link.Attrs().MasterIndex == 0, nil
+	masterIndex := link.Attrs().MasterIndex
+	if masterIndex == 0 {
+		return name, nil
+	}
+	master, err := vishnetlink.LinkByIndex(masterIndex)
+	if err != nil {
+		return "", err
+	}
+	return master.Attrs().Name, nil
 }
 
 func addDefaultRoute(gwIPString string, epInfo *network.EndpointInfo, result *network.InterfaceInfo) {

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -2,7 +2,6 @@ package network
 
 import (
 	"net"
-	"os"
 	"strconv"
 
 	"github.com/Azure/azure-container-networking/cni"
@@ -10,6 +9,7 @@ import (
 	"github.com/Azure/azure-container-networking/network"
 	"github.com/Azure/azure-container-networking/network/policy"
 	cniTypesCurr "github.com/containernetworking/cni/pkg/types/100"
+	vishnetlink "github.com/vishvananda/netlink"
 	"go.uber.org/zap"
 )
 
@@ -22,11 +22,15 @@ const snatConfigFileName = "/tmp/snatConfig"
 
 // isInterfaceMaster reports whether the named interface is an upper (master) device.
 // On Linux with accelerated networking, the VF (e.g. enP12217s2) is bonded to the
-// netvsc upper device (e.g. eth1). Only the VF has a /sys/class/net/<name>/master
-// symlink; the upper device does not.
-func isInterfaceMaster(name string) bool {
-	_, err := os.Stat("/sys/class/net/" + name + "/master")
-	return err != nil
+// netvsc upper device (e.g. eth1). A VF has a non-zero MasterIndex while
+// the upper device does not.
+func isInterfaceMaster(name string) (bool, error) {
+	link, err := vishnetlink.LinkByName(name)
+	if err != nil {
+		return false, err
+	}
+
+	return link.Attrs().MasterIndex == 0, nil
 }
 
 func addDefaultRoute(gwIPString string, epInfo *network.EndpointInfo, result *network.InterfaceInfo) {

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"net"
+	"os"
 	"strconv"
 
 	"github.com/Azure/azure-container-networking/cni"
@@ -18,6 +19,15 @@ const (
 )
 
 const snatConfigFileName = "/tmp/snatConfig"
+
+// isInterfaceMaster reports whether the named interface is an upper (master) device.
+// On Linux with accelerated networking, the VF (e.g. enP12217s2) is bonded to the
+// netvsc upper device (e.g. eth1). Only the VF has a /sys/class/net/<name>/master
+// symlink; the upper device does not.
+func isInterfaceMaster(name string) bool {
+	_, err := os.Stat("/sys/class/net/" + name + "/master")
+	return err != nil
+}
 
 func addDefaultRoute(gwIPString string, epInfo *network.EndpointInfo, result *network.InterfaceInfo) {
 	_, defaultIPNet, _ := net.ParseCIDR("0.0.0.0/0")

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"fmt"
 	"net"
 	"strconv"
 
@@ -27,7 +28,7 @@ const snatConfigFileName = "/tmp/snatConfig"
 func isInterfaceMaster(name string) (bool, error) {
 	link, err := vishnetlink.LinkByName(name)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("link by name %q: %w", name, err)
 	}
 
 	return link.Attrs().MasterIndex == 0, nil

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -31,11 +31,19 @@ type netlinkClient interface {
 type defaultNetlinkClient struct{}
 
 func (defaultNetlinkClient) LinkByName(name string) (vishnetlink.Link, error) {
-	return vishnetlink.LinkByName(name)
+	link, err := vishnetlink.LinkByName(name)
+	if err != nil {
+		return nil, fmt.Errorf("get link by name: %w", err)
+	}
+	return link, nil
 }
 
 func (defaultNetlinkClient) LinkByIndex(index int) (vishnetlink.Link, error) {
-	return vishnetlink.LinkByIndex(index)
+	link, err := vishnetlink.LinkByIndex(index)
+	if err != nil {
+		return nil, fmt.Errorf("get link by index: %w", err)
+	}
+	return link, nil
 }
 
 // nlClient is the active netlink client used by resolveMasterInterface.

--- a/cni/network/network_linux_test.go
+++ b/cni/network/network_linux_test.go
@@ -709,7 +709,7 @@ func TestFindInterfaceByMAC_WithMasterResolution(t *testing.T) {
 			wantResult: "eth1",
 		},
 		{
-			name:    "resolve error falls back to matched interface name",
+			name:    "resolve error returns empty",
 			macAddr: "00:22:48:d5:56:86",
 			interfaces: []net.Interface{
 				{Name: "enP100s1", HardwareAddr: mac},
@@ -717,7 +717,7 @@ func TestFindInterfaceByMAC_WithMasterResolution(t *testing.T) {
 			client: &mockNetlinkClient{
 				links: map[string]vishnetlink.Link{}, // LinkByName will fail
 			},
-			wantResult: "enP100s1",
+			wantResult: "",
 		},
 		{
 			name:    "no MAC match returns empty string",

--- a/cni/network/network_linux_test.go
+++ b/cni/network/network_linux_test.go
@@ -578,9 +578,10 @@ var (
 
 // test interface name constants used across resolveMasterInterface and findInterfaceByMAC tests.
 const (
-	testVFInterface  = "enP12217s2"
-	testVF2Interface = "enP100s1"
-	testMACAddr      = "00:22:48:d5:56:86"
+	testMasterInterface = "eth1"       // upper/master interface (netvsc) name
+	testVFInterface     = "enP12217s2" // VF interface bonded to testMasterInterface
+	testVF2Interface    = "enP100s1"   // another VF interface used in error-path tests
+	testMACAddr         = "00:22:48:d5:56:86"
 )
 
 // mockNetlinkClient implements netlinkClient for unit testing resolveMasterInterface.
@@ -615,17 +616,17 @@ func TestResolveMasterInterface(t *testing.T) {
 	}{
 		{
 			name:   "interface is already master (MasterIndex == 0)",
-			ifName: snatInterface,
+			ifName: testMasterInterface,
 			client: &mockNetlinkClient{
 				links: map[string]vishnetlink.Link{
-					snatInterface: &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
-						Name:        snatInterface,
+					testMasterInterface: &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
+						Name:        testMasterInterface,
 						Index:       2,
 						MasterIndex: 0,
 					}},
 				},
 			},
-			wantResult: snatInterface,
+			wantResult: testMasterInterface,
 		},
 		{
 			name:   "VF resolves to master upper device",
@@ -640,13 +641,13 @@ func TestResolveMasterInterface(t *testing.T) {
 				},
 				byIdx: map[int]vishnetlink.Link{
 					2: &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
-						Name:        snatInterface,
+						Name:        testMasterInterface,
 						Index:       2,
 						MasterIndex: 0,
 					}},
 				},
 			},
-			wantResult: snatInterface,
+			wantResult: testMasterInterface,
 		},
 		{
 			name:   "LinkByName fails returns error",
@@ -704,18 +705,18 @@ func TestFindInterfaceByMAC_WithMasterResolution(t *testing.T) {
 			name:    "single master match returns master name",
 			macAddr: testMACAddr,
 			interfaces: []net.Interface{
-				{Name: snatInterface, HardwareAddr: mac},
+				{Name: testMasterInterface, HardwareAddr: mac},
 			},
 			client: &mockNetlinkClient{
 				links: map[string]vishnetlink.Link{
-					snatInterface: &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
-						Name:        snatInterface,
+					testMasterInterface: &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
+						Name:        testMasterInterface,
 						Index:       2,
 						MasterIndex: 0,
 					}},
 				},
 			},
-			wantResult: snatInterface,
+			wantResult: testMasterInterface,
 		},
 		{
 			name:    "VF matched resolves to master",
@@ -733,13 +734,13 @@ func TestFindInterfaceByMAC_WithMasterResolution(t *testing.T) {
 				},
 				byIdx: map[int]vishnetlink.Link{
 					2: &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
-						Name:        snatInterface,
+						Name:        testMasterInterface,
 						Index:       2,
 						MasterIndex: 0,
 					}},
 				},
 			},
-			wantResult: snatInterface,
+			wantResult: testMasterInterface,
 		},
 		{
 			name:    "resolve error returns empty",

--- a/cni/network/network_linux_test.go
+++ b/cni/network/network_linux_test.go
@@ -569,6 +569,20 @@ func stubResolveMasterInterface(t *testing.T, ifName string) {
 	t.Cleanup(func() { nlClient = original })
 }
 
+// sentinel errors for mock netlink client.
+var (
+	errLinkNotFound      = errors.New("link not found")
+	errLinkNotFoundByIdx = errors.New("link not found by index")
+	errNotImplemented    = errors.New("not implemented")
+)
+
+// test interface name constants used across resolveMasterInterface and findInterfaceByMAC tests.
+const (
+	testVFInterface  = "enP12217s2"
+	testVF2Interface = "enP100s1"
+	testMACAddr      = "00:22:48:d5:56:86"
+)
+
 // mockNetlinkClient implements netlinkClient for unit testing resolveMasterInterface.
 type mockNetlinkClient struct {
 	links map[string]vishnetlink.Link // keyed by name
@@ -578,7 +592,7 @@ type mockNetlinkClient struct {
 func (m *mockNetlinkClient) LinkByName(name string) (vishnetlink.Link, error) {
 	l, ok := m.links[name]
 	if !ok {
-		return nil, fmt.Errorf("link not found: %s", name)
+		return nil, fmt.Errorf("%w: %s", errLinkNotFound, name)
 	}
 	return l, nil
 }
@@ -586,7 +600,7 @@ func (m *mockNetlinkClient) LinkByName(name string) (vishnetlink.Link, error) {
 func (m *mockNetlinkClient) LinkByIndex(index int) (vishnetlink.Link, error) {
 	l, ok := m.byIdx[index]
 	if !ok {
-		return nil, fmt.Errorf("link not found by index: %d", index)
+		return nil, fmt.Errorf("%w: %d", errLinkNotFoundByIdx, index)
 	}
 	return l, nil
 }
@@ -601,38 +615,38 @@ func TestResolveMasterInterface(t *testing.T) {
 	}{
 		{
 			name:   "interface is already master (MasterIndex == 0)",
-			ifName: "eth1",
+			ifName: snatInterface,
 			client: &mockNetlinkClient{
 				links: map[string]vishnetlink.Link{
-					"eth1": &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
-						Name:        "eth1",
+					snatInterface: &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
+						Name:        snatInterface,
 						Index:       2,
 						MasterIndex: 0,
 					}},
 				},
 			},
-			wantResult: "eth1",
+			wantResult: snatInterface,
 		},
 		{
 			name:   "VF resolves to master upper device",
-			ifName: "enP12217s2",
+			ifName: testVFInterface,
 			client: &mockNetlinkClient{
 				links: map[string]vishnetlink.Link{
-					"enP12217s2": &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
-						Name:        "enP12217s2",
+					testVFInterface: &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
+						Name:        testVFInterface,
 						Index:       5,
 						MasterIndex: 2,
 					}},
 				},
 				byIdx: map[int]vishnetlink.Link{
 					2: &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
-						Name:        "eth1",
+						Name:        snatInterface,
 						Index:       2,
 						MasterIndex: 0,
 					}},
 				},
 			},
-			wantResult: "eth1",
+			wantResult: snatInterface,
 		},
 		{
 			name:   "LinkByName fails returns error",
@@ -644,11 +658,11 @@ func TestResolveMasterInterface(t *testing.T) {
 		},
 		{
 			name:   "LinkByIndex fails returns error",
-			ifName: "enP100s1",
+			ifName: testVF2Interface,
 			client: &mockNetlinkClient{
 				links: map[string]vishnetlink.Link{
-					"enP100s1": &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
-						Name:        "enP100s1",
+					testVF2Interface: &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
+						Name:        testVF2Interface,
 						Index:       10,
 						MasterIndex: 99, // master index that doesn't exist
 					}},
@@ -677,7 +691,7 @@ func TestResolveMasterInterface(t *testing.T) {
 }
 
 func TestFindInterfaceByMAC_WithMasterResolution(t *testing.T) {
-	mac, _ := net.ParseMAC("00:22:48:d5:56:86")
+	mac, _ := net.ParseMAC(testMACAddr)
 
 	tests := []struct {
 		name       string
@@ -688,50 +702,50 @@ func TestFindInterfaceByMAC_WithMasterResolution(t *testing.T) {
 	}{
 		{
 			name:    "single master match returns master name",
-			macAddr: "00:22:48:d5:56:86",
+			macAddr: testMACAddr,
 			interfaces: []net.Interface{
-				{Name: "eth1", HardwareAddr: mac},
+				{Name: snatInterface, HardwareAddr: mac},
 			},
 			client: &mockNetlinkClient{
 				links: map[string]vishnetlink.Link{
-					"eth1": &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
-						Name:        "eth1",
+					snatInterface: &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
+						Name:        snatInterface,
 						Index:       2,
 						MasterIndex: 0,
 					}},
 				},
 			},
-			wantResult: "eth1",
+			wantResult: snatInterface,
 		},
 		{
 			name:    "VF matched resolves to master",
-			macAddr: "00:22:48:d5:56:86",
+			macAddr: testMACAddr,
 			interfaces: []net.Interface{
-				{Name: "enP12217s2", HardwareAddr: mac},
+				{Name: testVFInterface, HardwareAddr: mac},
 			},
 			client: &mockNetlinkClient{
 				links: map[string]vishnetlink.Link{
-					"enP12217s2": &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
-						Name:        "enP12217s2",
+					testVFInterface: &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
+						Name:        testVFInterface,
 						Index:       5,
 						MasterIndex: 2,
 					}},
 				},
 				byIdx: map[int]vishnetlink.Link{
 					2: &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
-						Name:        "eth1",
+						Name:        snatInterface,
 						Index:       2,
 						MasterIndex: 0,
 					}},
 				},
 			},
-			wantResult: "eth1",
+			wantResult: snatInterface,
 		},
 		{
 			name:    "resolve error returns empty",
-			macAddr: "00:22:48:d5:56:86",
+			macAddr: testMACAddr,
 			interfaces: []net.Interface{
-				{Name: "enP100s1", HardwareAddr: mac},
+				{Name: testVF2Interface, HardwareAddr: mac},
 			},
 			client: &mockNetlinkClient{
 				links: map[string]vishnetlink.Link{}, // LinkByName will fail
@@ -740,7 +754,7 @@ func TestFindInterfaceByMAC_WithMasterResolution(t *testing.T) {
 		},
 		{
 			name:    "no MAC match returns empty string",
-			macAddr: "00:22:48:d5:56:86",
+			macAddr: testMACAddr,
 			interfaces: []net.Interface{
 				{Name: "eth0", HardwareAddr: net.HardwareAddr{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}},
 			},
@@ -777,5 +791,5 @@ func (m *mockInterfaceGetter) GetNetworkInterfaces() ([]net.Interface, error) {
 }
 
 func (m *mockInterfaceGetter) GetNetworkInterfaceAddrs(_ *net.Interface) ([]net.Addr, error) {
-	return nil, errors.New("not implemented")
+	return nil, errNotImplemented
 }

--- a/cni/network/network_linux_test.go
+++ b/cni/network/network_linux_test.go
@@ -253,6 +253,7 @@ func TestPluginLinuxAdd(t *testing.T) {
 		name   string
 		plugin *NetPlugin
 		args   *cniSkel.CmdArgs
+		setup  func(t *testing.T)
 		want   []endpointEntry
 		match  func(*network.EndpointInfo, *network.EndpointInfo) bool
 	}{
@@ -377,6 +378,7 @@ func TestPluginLinuxAdd(t *testing.T) {
 				Args:        fmt.Sprintf("K8S_POD_NAME=%v;K8S_POD_NAMESPACE=%v", "test-pod", "test-pod-ns"),
 				IfName:      eth0IfName,
 			},
+			setup: func(t *testing.T) { stubResolveMasterInterface(t, "secondary") },
 			match: func(ei1, ei2 *network.EndpointInfo) bool {
 				return ei1.NICType == ei2.NICType
 			},
@@ -500,6 +502,9 @@ func TestPluginLinuxAdd(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.setup != nil {
+				tt.setup(t)
+			}
 			err := tt.plugin.Add(tt.args)
 			require.NoError(t, err)
 			allEndpoints, _ := tt.plugin.nm.GetAllEndpoints("")
@@ -548,6 +553,20 @@ func TestPluginLinuxAdd(t *testing.T) {
 			require.Empty(t, allEndpoints)
 		})
 	}
+}
+
+// stubResolveMasterInterface installs a mock nlClient that treats the given interface as a
+// master (MasterIndex == 0), so resolveMasterInterface returns the name unchanged.
+// Used by cross-platform tests in network_test.go that exercise the delegated NIC path.
+func stubResolveMasterInterface(t *testing.T, ifName string) {
+	t.Helper()
+	original := nlClient
+	nlClient = &mockNetlinkClient{
+		links: map[string]vishnetlink.Link{
+			ifName: &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{Name: ifName, MasterIndex: 0}},
+		},
+	}
+	t.Cleanup(func() { nlClient = original })
 }
 
 // mockNetlinkClient implements netlinkClient for unit testing resolveMasterInterface.

--- a/cni/network/network_linux_test.go
+++ b/cni/network/network_linux_test.go
@@ -4,6 +4,7 @@
 package network
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"regexp"
@@ -17,6 +18,7 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	vishnetlink "github.com/vishvananda/netlink"
 )
 
 func TestSetNetworkOptions(t *testing.T) {
@@ -546,4 +548,215 @@ func TestPluginLinuxAdd(t *testing.T) {
 			require.Empty(t, allEndpoints)
 		})
 	}
+}
+
+// mockNetlinkClient implements netlinkClient for unit testing resolveMasterInterface.
+type mockNetlinkClient struct {
+	links map[string]vishnetlink.Link // keyed by name
+	byIdx map[int]vishnetlink.Link    // keyed by index
+}
+
+func (m *mockNetlinkClient) LinkByName(name string) (vishnetlink.Link, error) {
+	l, ok := m.links[name]
+	if !ok {
+		return nil, fmt.Errorf("link not found: %s", name)
+	}
+	return l, nil
+}
+
+func (m *mockNetlinkClient) LinkByIndex(index int) (vishnetlink.Link, error) {
+	l, ok := m.byIdx[index]
+	if !ok {
+		return nil, fmt.Errorf("link not found by index: %d", index)
+	}
+	return l, nil
+}
+
+func TestResolveMasterInterface(t *testing.T) {
+	tests := []struct {
+		name       string
+		ifName     string
+		client     *mockNetlinkClient
+		wantResult string
+		wantErr    bool
+	}{
+		{
+			name:   "interface is already master (MasterIndex == 0)",
+			ifName: "eth1",
+			client: &mockNetlinkClient{
+				links: map[string]vishnetlink.Link{
+					"eth1": &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
+						Name:        "eth1",
+						Index:       2,
+						MasterIndex: 0,
+					}},
+				},
+			},
+			wantResult: "eth1",
+		},
+		{
+			name:   "VF resolves to master upper device",
+			ifName: "enP12217s2",
+			client: &mockNetlinkClient{
+				links: map[string]vishnetlink.Link{
+					"enP12217s2": &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
+						Name:        "enP12217s2",
+						Index:       5,
+						MasterIndex: 2,
+					}},
+				},
+				byIdx: map[int]vishnetlink.Link{
+					2: &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
+						Name:        "eth1",
+						Index:       2,
+						MasterIndex: 0,
+					}},
+				},
+			},
+			wantResult: "eth1",
+		},
+		{
+			name:   "LinkByName fails returns error",
+			ifName: "nonexistent",
+			client: &mockNetlinkClient{
+				links: map[string]vishnetlink.Link{},
+			},
+			wantErr: true,
+		},
+		{
+			name:   "LinkByIndex fails returns error",
+			ifName: "enP100s1",
+			client: &mockNetlinkClient{
+				links: map[string]vishnetlink.Link{
+					"enP100s1": &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
+						Name:        "enP100s1",
+						Index:       10,
+						MasterIndex: 99, // master index that doesn't exist
+					}},
+				},
+				byIdx: map[int]vishnetlink.Link{}, // no index 99
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := nlClient
+			nlClient = tt.client
+			t.Cleanup(func() { nlClient = original })
+
+			result, err := resolveMasterInterface(tt.ifName)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantResult, result)
+		})
+	}
+}
+
+func TestFindInterfaceByMAC_WithMasterResolution(t *testing.T) {
+	mac, _ := net.ParseMAC("00:22:48:d5:56:86")
+
+	tests := []struct {
+		name       string
+		macAddr    string
+		interfaces []net.Interface
+		client     *mockNetlinkClient
+		wantResult string
+	}{
+		{
+			name:    "single master match returns master name",
+			macAddr: "00:22:48:d5:56:86",
+			interfaces: []net.Interface{
+				{Name: "eth1", HardwareAddr: mac},
+			},
+			client: &mockNetlinkClient{
+				links: map[string]vishnetlink.Link{
+					"eth1": &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
+						Name:        "eth1",
+						Index:       2,
+						MasterIndex: 0,
+					}},
+				},
+			},
+			wantResult: "eth1",
+		},
+		{
+			name:    "VF matched resolves to master",
+			macAddr: "00:22:48:d5:56:86",
+			interfaces: []net.Interface{
+				{Name: "enP12217s2", HardwareAddr: mac},
+			},
+			client: &mockNetlinkClient{
+				links: map[string]vishnetlink.Link{
+					"enP12217s2": &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
+						Name:        "enP12217s2",
+						Index:       5,
+						MasterIndex: 2,
+					}},
+				},
+				byIdx: map[int]vishnetlink.Link{
+					2: &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
+						Name:        "eth1",
+						Index:       2,
+						MasterIndex: 0,
+					}},
+				},
+			},
+			wantResult: "eth1",
+		},
+		{
+			name:    "resolve error falls back to matched interface name",
+			macAddr: "00:22:48:d5:56:86",
+			interfaces: []net.Interface{
+				{Name: "enP100s1", HardwareAddr: mac},
+			},
+			client: &mockNetlinkClient{
+				links: map[string]vishnetlink.Link{}, // LinkByName will fail
+			},
+			wantResult: "enP100s1",
+		},
+		{
+			name:    "no MAC match returns empty string",
+			macAddr: "00:22:48:d5:56:86",
+			interfaces: []net.Interface{
+				{Name: "eth0", HardwareAddr: net.HardwareAddr{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}},
+			},
+			client: &mockNetlinkClient{
+				links: map[string]vishnetlink.Link{},
+			},
+			wantResult: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := nlClient
+			nlClient = tt.client
+			t.Cleanup(func() { nlClient = original })
+
+			plugin := &NetPlugin{
+				netClient: &mockInterfaceGetter{interfaces: tt.interfaces},
+			}
+			result := plugin.findInterfaceByMAC(tt.macAddr)
+			require.Equal(t, tt.wantResult, result)
+		})
+	}
+}
+
+// mockInterfaceGetter implements InterfaceGetter for testing.
+type mockInterfaceGetter struct {
+	interfaces []net.Interface
+	err        error
+}
+
+func (m *mockInterfaceGetter) GetNetworkInterfaces() ([]net.Interface, error) {
+	return m.interfaces, m.err
+}
+
+func (m *mockInterfaceGetter) GetNetworkInterfaceAddrs(_ *net.Interface) ([]net.Addr, error) {
+	return nil, errors.New("not implemented")
 }

--- a/cni/network/network_test.go
+++ b/cni/network/network_test.go
@@ -1586,6 +1586,8 @@ func TestFindMasterInterface(t *testing.T) {
 	plugin, _ := cni.NewPlugin("name", "0.3.0")
 	endpointIndex := 1
 	macAddress := "12:34:56:78:90:ab"
+	parsedMAC, err := net.ParseMAC(macAddress)
+	require.NoError(t, err)
 
 	tests := []struct {
 		name        string
@@ -1730,7 +1732,7 @@ func TestFindMasterInterface(t *testing.T) {
 					interfaces: []net.Interface{
 						{
 							Name:         "eth1",
-							HardwareAddr: net.HardwareAddr(macAddress),
+							HardwareAddr: parsedMAC,
 						},
 					},
 				},
@@ -1738,7 +1740,7 @@ func TestFindMasterInterface(t *testing.T) {
 			endpointOpt: createEpInfoOpt{
 				ifInfo: &acnnetwork.InterfaceInfo{
 					NICType:    cns.NodeNetworkInterfaceFrontendNIC,
-					MacAddress: net.HardwareAddr(macAddress),
+					MacAddress: parsedMAC,
 				},
 			},
 			want:    "eth1",
@@ -1750,7 +1752,7 @@ func TestFindMasterInterface(t *testing.T) {
 				endpointIndex: endpointIndex,
 				ifInfo: &acnnetwork.InterfaceInfo{
 					NICType:    cns.BackendNIC,
-					MacAddress: net.HardwareAddr(macAddress),
+					MacAddress: parsedMAC,
 				},
 			},
 			want:    ibInterfacePrefix + strconv.Itoa(endpointIndex),
@@ -1762,7 +1764,7 @@ func TestFindMasterInterface(t *testing.T) {
 				endpointIndex: endpointIndex,
 				ifInfo: &acnnetwork.InterfaceInfo{
 					NICType:    "invalidType",
-					MacAddress: net.HardwareAddr(macAddress),
+					MacAddress: parsedMAC,
 				},
 			},
 			want:    "", // default interface name is ""

--- a/cni/network/network_test.go
+++ b/cni/network/network_test.go
@@ -1594,7 +1594,8 @@ func TestFindMasterInterface(t *testing.T) {
 		endpointOpt createEpInfoOpt
 		plugin      *NetPlugin
 		nwCfg       *cni.NetworkConfig
-		want        string // expected master interface name
+		setup       func(t *testing.T) // optional per-test setup; called before the test runs
+		want        string             // expected master interface name
 		wantErr     bool
 	}{
 		{
@@ -1743,6 +1744,7 @@ func TestFindMasterInterface(t *testing.T) {
 					MacAddress: parsedMAC,
 				},
 			},
+			setup:   func(t *testing.T) { stubResolveMasterInterface(t, "eth1") },
 			want:    "eth1",
 			wantErr: false,
 		},
@@ -1775,6 +1777,9 @@ func TestFindMasterInterface(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.setup != nil {
+				tt.setup(t)
+			}
 			masterInterface := tt.plugin.findMasterInterface(&tt.endpointOpt)
 			t.Logf("masterInterface is %s\n", masterInterface)
 			require.Equal(t, tt.want, masterInterface)

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -31,10 +31,11 @@ var (
 	dualStackCount = 2
 )
 
-// isInterfaceMaster reports whether the named interface is an upper (master) device.
-// Windows does not have the Linux netvsc + VF bonding model, so all interfaces are treated as master.
-func isInterfaceMaster(_ string) (bool, error) {
-	return true, nil
+// resolveMasterInterface returns the master interface name for the given interface.
+// Windows does not have the Linux netvsc + VF bonding model, so the name is
+// returned unchanged.
+func resolveMasterInterface(name string) (string, error) {
+	return name, nil
 }
 
 func addDefaultRoute(_ string, _ *network.EndpointInfo, _ *network.InterfaceInfo) {

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -31,6 +31,12 @@ var (
 	dualStackCount = 2
 )
 
+// isInterfaceMaster reports whether the named interface is an upper (master) device.
+// Windows does not have the Linux netvsc + VF bonding model, so all interfaces are treated as master.
+func isInterfaceMaster(_ string) bool {
+	return true
+}
+
 func addDefaultRoute(_ string, _ *network.EndpointInfo, _ *network.InterfaceInfo) {
 }
 

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -33,8 +33,8 @@ var (
 
 // isInterfaceMaster reports whether the named interface is an upper (master) device.
 // Windows does not have the Linux netvsc + VF bonding model, so all interfaces are treated as master.
-func isInterfaceMaster(_ string) bool {
-	return true
+func isInterfaceMaster(_ string) (bool, error) {
+	return true, nil
 }
 
 func addDefaultRoute(_ string, _ *network.EndpointInfo, _ *network.InterfaceInfo) {

--- a/cni/network/network_windows_test.go
+++ b/cni/network/network_windows_test.go
@@ -22,6 +22,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// stubResolveMasterInterface is a no-op on Windows because resolveMasterInterface
+// already returns (name, nil). Used by cross-platform tests in network_test.go.
+func stubResolveMasterInterface(_ *testing.T, _ string) {}
+
 func init() {
 	network.Hnsv2 = hnswrapper.NewHnsv2wrapperFake()
 	network.Hnsv1 = hnswrapper.NewHnsv1wrapperFake()


### PR DESCRIPTION
Reason for Change:
SwiftV2 delegated interface lookup can select the wrong host interface when multiple Linux interfaces share the same MAC address. On accelerated networking nodes, the netvsc interface (for example `eth1`) and the VF interface (for example `enP12217s2`) can both present the delegated MAC. Azure CNI currently returns the first interface match by MAC, which can select the VF instead of the intended upper interface.

Issue Fixed:
This change makes Azure CNI prefer the Linux upper/master interface when resolving delegated SwiftV2 FrontendNICs by MAC.

This addresses the failure seen in ICM where delegated endpoint setup bound to `enP12217s2` and later failed during endpoint configuration with:

`SecondaryEndpointClient Error: route ip+net: no such network interface`

Relevant trace from the incident:
- CNS returned delegated FrontendNIC info with MAC `00:22:48:d5:56:86`
- CNI generated endpoint info with `MasterIfName=enP12217s2`
- endpoint setup then failed with:
  `failed to create endpoint: SecondaryEndpointClient Error: route ip+net: no such network interface`

Requirements:
- On Linux, when multiple interfaces share the same MAC, prefer the interface that is not a lower/VF interface
- Avoid selecting VF interfaces such as `enP...` when the corresponding upper interface such as `eth1` exists
- Keep Windows behavior unchanged, since Windows nodes do not expose the same netvsc/VF interface model

Notes:
- Linux detection uses the `/sys/class/net/<ifname>/master` relationship to distinguish the upper interface from the VF
- If no upper interface is found, the existing matching interface is still used as fallback
- This change is intended to prevent delegated SwiftV2 endpoint creation failures caused by binding to the wrong interface