### PR TITLE
ci: bump fluent bit base image

### DIFF
--- a/.pipelines/build/dockerfiles/cilium-log-collector.Dockerfile
+++ b/.pipelines/build/dockerfiles/cilium-log-collector.Dockerfile
@@ -2,6 +2,6 @@
 # SOURCE: .pipelines/build/dockerfiles/cilium-log-collector.Dockerfile.tmpl
 ARG ARCH
 
-FROM mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.3-7 as linux
+FROM mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.3-8 as linux
 ARG ARTIFACT_DIR
 COPY ${ARTIFACT_DIR}/bin/out_azure_app_insights.so /out_azure_app_insights.so

--- a/.pipelines/build/dockerfiles/cilium-log-collector.Dockerfile
+++ b/.pipelines/build/dockerfiles/cilium-log-collector.Dockerfile
@@ -2,6 +2,6 @@
 # SOURCE: .pipelines/build/dockerfiles/cilium-log-collector.Dockerfile.tmpl
 ARG ARCH
 
-FROM mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.2 as linux
+FROM mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.3-7 as linux
 ARG ARTIFACT_DIR
 COPY ${ARTIFACT_DIR}/bin/out_azure_app_insights.so /out_azure_app_insights.so

--- a/.pipelines/build/dockerfiles/cilium-log-collector.Dockerfile.tmpl
+++ b/.pipelines/build/dockerfiles/cilium-log-collector.Dockerfile.tmpl
@@ -2,6 +2,6 @@
 # SOURCE: {{.SRC_PIPE}}
 ARG ARCH
 
-FROM mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.3-7 as linux
+FROM mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.3-8 as linux
 ARG ARTIFACT_DIR
 COPY ${ARTIFACT_DIR}/bin/out_azure_app_insights.so /out_azure_app_insights.so

--- a/.pipelines/build/dockerfiles/cilium-log-collector.Dockerfile.tmpl
+++ b/.pipelines/build/dockerfiles/cilium-log-collector.Dockerfile.tmpl
@@ -2,6 +2,6 @@
 # SOURCE: {{.SRC_PIPE}}
 ARG ARCH
 
-FROM mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.2 as linux
+FROM mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.3-7 as linux
 ARG ARTIFACT_DIR
 COPY ${ARTIFACT_DIR}/bin/out_azure_app_insights.so /out_azure_app_insights.so

--- a/cilium-log-collector/Dockerfile
+++ b/cilium-log-collector/Dockerfile
@@ -12,5 +12,5 @@ WORKDIR /cilium-log-collector
 COPY ./cilium-log-collector .
 RUN go build -buildmode=c-shared -a -o out_azure_app_insights.so -trimpath -ldflags "-X main.version=$VERSION" -gcflags="-dwarflocationlists=true" .
 
-FROM mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.2 as linux
+FROM mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.3-7 as linux
 COPY --from=fluent-bit-plugin /cilium-log-collector/out_azure_app_insights.so /out_azure_app_insights.so

--- a/cilium-log-collector/Dockerfile
+++ b/cilium-log-collector/Dockerfile
@@ -12,5 +12,5 @@ WORKDIR /cilium-log-collector
 COPY ./cilium-log-collector .
 RUN go build -buildmode=c-shared -a -o out_azure_app_insights.so -trimpath -ldflags "-X main.version=$VERSION" -gcflags="-dwarflocationlists=true" .
 
-FROM mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.3-7 as linux
+FROM mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.3-8 as linux
 COPY --from=fluent-bit-plugin /cilium-log-collector/out_azure_app_insights.so /out_azure_app_insights.so

--- a/cilium-log-collector/Dockerfile.tmpl
+++ b/cilium-log-collector/Dockerfile.tmpl
@@ -12,5 +12,5 @@ WORKDIR /cilium-log-collector
 COPY ./cilium-log-collector .
 RUN go build -buildmode=c-shared -a -o out_azure_app_insights.so -trimpath -ldflags "-X main.version=$VERSION" -gcflags="-dwarflocationlists=true" .
 
-FROM mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.2 as linux
+FROM mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.3-7 as linux
 COPY --from=fluent-bit-plugin /cilium-log-collector/out_azure_app_insights.so /out_azure_app_insights.so

--- a/cilium-log-collector/Dockerfile.tmpl
+++ b/cilium-log-collector/Dockerfile.tmpl
@@ -12,5 +12,5 @@ WORKDIR /cilium-log-collector
 COPY ./cilium-log-collector .
 RUN go build -buildmode=c-shared -a -o out_azure_app_insights.so -trimpath -ldflags "-X main.version=$VERSION" -gcflags="-dwarflocationlists=true" .
 
-FROM mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.3-7 as linux
+FROM mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.3-8 as linux
 COPY --from=fluent-bit-plugin /cilium-log-collector/out_azure_app_insights.so /out_azure_app_insights.so


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Bump cilium log collector to latest published oss version

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
Confirmed that logs can still make it to app insights with this change. See 20260526.9, then get the cluster name, and query cilium logs for that AzureResourceGroup.
