### PR TITLE
ci: publish SBoM once

### DIFF
--- a/.pipelines/containers/manifest-template.yaml
+++ b/.pipelines/containers/manifest-template.yaml
@@ -45,13 +45,10 @@ steps:
       inlineScript: |
         docker logout
 
-  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-    displayName: "Add SBOM Generator tool"
-    inputs:
-      BuildDropPath: "$(Build.ArtifactStagingDirectory)"
-
+  # SBOM generation moved to the consolidated sbom_publish stage.
+  # Published here as an intermediate artifact named per image.
   - task: PublishBuildArtifacts@1
     inputs:
-      artifactName: "output"
+      artifactName: "unsigned-images-${{ parameters.name }}"
       pathtoPublish: "$(Build.ArtifactStagingDirectory)"
     condition: succeeded()

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -165,7 +165,7 @@ stages:
 
             - task: PublishBuildArtifacts@1
               inputs:
-                artifactName: "output"
+                artifactName: "unsigned-binaries"
                 pathtoPublish: "$(Build.ArtifactStagingDirectory)"
               condition: succeeded()
 
@@ -321,8 +321,6 @@ stages:
       displayName: Publish Multiarch Manifests
       dependsOn:
         - containerize
-      variables:
-        Packaging.EnableSBOMSigning: true
       jobs:
         - job: manifest
           displayName: Compile Manifests
@@ -374,6 +372,82 @@ stages:
               parameters:
                 name: npm
                 platforms: linux/amd64 linux/arm64 windows/amd64
+
+    # Aggregates intermediate per-image / per-binary artifacts and runs the
+    # Microsoft SBOM Generator over the assembled drop. This is the only
+    # place SBOM is generated and signed (Packaging.EnableSBOMSigning).
+    - stage: sbom_publish
+      displayName: Publish Signed SBOM Artifact
+      dependsOn:
+        - binaries
+        - publish
+        - publish_npm
+      # Run as long as no producer failed and at least one succeeded.
+      condition: |
+        and(
+          not(failed()),
+          or(
+            eq(dependencies.binaries.result, 'Succeeded'),
+            eq(dependencies.publish.result, 'Succeeded'),
+            eq(dependencies.publish_npm.result, 'Succeeded')
+          )
+        )
+      variables:
+        Packaging.EnableSBOMSigning: true
+      jobs:
+        - job: aggregate_sbom
+          displayName: Aggregate Drop and Generate SBOM
+          pool:
+            name: "$(BUILD_POOL_NAME_DEFAULT)"
+          steps:
+            # Missing intermediates (skipped producers) contribute zero files;
+            # the task does not fail.
+            - task: DownloadPipelineArtifact@2
+              displayName: Download all intermediate artifacts
+              inputs:
+                patterns: |
+                  unsigned-binaries/**
+                  unsigned-images-*/**
+                path: $(Pipeline.Workspace)/intermediate
+
+            - script: |
+                set -euo pipefail
+                STAGING="$(Pipeline.Workspace)/staging"
+                INTER="$(Pipeline.Workspace)/intermediate"
+                rm -rf "$STAGING"
+                mkdir -p "$STAGING"
+
+                if [ -d "$INTER/unsigned-binaries/bins" ]; then
+                  mkdir -p "$STAGING/bins"
+                  cp -r "$INTER/unsigned-binaries/bins/." "$STAGING/bins/"
+                fi
+
+                # Flatten per-image artifacts into a single staging/images/.
+                # Tarball filenames are unique per image, so no collisions.
+                shopt -s nullglob
+                image_dirs=("$INTER"/unsigned-images-*/images)
+                if [ ${#image_dirs[@]} -gt 0 ]; then
+                  mkdir -p "$STAGING/images"
+                  for d in "${image_dirs[@]}"; do
+                    cp "$d"/* "$STAGING/images/"
+                  done
+                fi
+
+                echo "Assembled drop:"
+                find "$STAGING" -maxdepth 3 -type f | sort
+              displayName: Assemble unified build drop
+
+            - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+              displayName: Generate signed SBOM
+              inputs:
+                BuildDropPath: $(Pipeline.Workspace)/staging
+
+            - task: PublishBuildArtifacts@1
+              displayName: Publish final output artifact
+              inputs:
+                artifactName: "output"
+                pathtoPublish: $(Pipeline.Workspace)/staging
+              condition: succeeded()
 
     # Cilium Podsubnet E2E tests
     - template: singletenancy/cilium/cilium-e2e-job-template.yaml


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
See below

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Previously we published the SBoM for each manifest, which kept overwriting the _manifest directory under output/ in published artifacts. Then, when the release pipeline consumed the artifacts, the _manifest directory would only contain the contents of the last publish leading to hash mismatches. This PR aims to only publish the _manifest directory w/ the SBoM (software bill of materials) once after all artifacts are available.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
Tested using the microsoft sbom validation tool to verify the _manifest folder validates the output/ folder in 20260520.3 and 20260519.8

The only surefire way to validate this that I know of is to run the real official release pipeline. The release pipeline only downloads the output artifact/folder so the _manifest should account for everything in that folder.