### PR TITLE
docs: update cilium setup guide with --network-policy requirement and…

### DIFF
--- a/docs/feature/swift-v2/setup-guide-cil.md
+++ b/docs/feature/swift-v2/setup-guide-cil.md
@@ -25,7 +25,17 @@ At no point should connectivity to services like core dns fail.
 
 ### Existing Cluster Only: Upgrade to managed cilium (should remove NPM automatically)
 Run the aks command like
-`az aks update --name <cluster name> --resource-group <rg> --network-dataplane cilium`
+`az aks update --name <cluster name> --resource-group <rg> --network-dataplane cilium --network-policy cilium`
+
+> [!NOTE]
+> Both `--network-dataplane cilium` and `--network-policy cilium` are required. The API will reject the request if only `--network-dataplane cilium` is specified.
+
+> [!TIP]
+> If your cluster has a single system node pool, the upgrade may fail with a `PodDrainFailure` due to Pod Disruption Budgets (e.g., `konnectivity-agent`). To work around this, delete the blocking PDBs before running the update — AKS addon manager will recreate them after the upgrade:
+> ```
+> kubectl delete pdb konnectivity-agent -n kube-system --ignore-not-found
+> kubectl delete pdb coredns -n kube-system --ignore-not-found
+> ```
 
 ### All: Checkpoint
 From this point on, I am assuming you have the following


### PR DESCRIPTION
… PDB workaround

The az aks update command requires both --network-dataplane cilium and --network-policy cilium flags. Without --network-policy, the API returns a BadRequest error.

Also documents a workaround for single-node pool clusters where PDBs (konnectivity-agent, coredns) block node drain during the upgrade.

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
