### PR TITLE
fix(cni/windows-swiftv2): drop OutBoundNAT on SwiftV2 FrontendNIC endpoints

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -567,13 +567,24 @@ func (plugin *NetPlugin) Add(args *cniSkel.CmdArgs) error {
 		natInfo := getNATInfo(nwCfg, options[network.SNATIPKey], enableSnatForDNS)
 		networkID, _ := plugin.getNetworkID(args.Netns, &ifInfo, nwCfg)
 
+		// SwiftV2 FrontendNIC (delegated VM NIC / Accelnet) endpoints land on a
+		// Transparent HNS network, which does not support OutBoundNAT policies and
+		// rejects them with HCN_E_ENDPOINT_ATTACHMENT_NOT_SUPPORTED (0x803B0007),
+		// failing pod sandbox attach. Drop OutBoundNAT from both the natInfo
+		// (Swift DNS/IMDS SNAT) and the conflist-derived policies for this NIC.
+		ifPolicies := policies
+		if ifInfo.NICType == cns.NodeNetworkInterfaceFrontendNIC {
+			natInfo = nil
+			ifPolicies = filterOutOutBoundNATPolicies(policies)
+		}
+
 		createEpInfoOpt := createEpInfoOpt{
 			nwCfg:            nwCfg,
 			cnsNetworkConfig: ifInfo.NCResponse,
 			ipamAddResult:    ipamAddResult,
 			azIpamResult:     azIpamResult,
 			args:             args,
-			policies:         policies,
+			policies:         ifPolicies,
 			k8sPodName:       k8sPodName,
 			k8sNamespace:     k8sNamespace,
 			enableInfraVnet:  enableInfraVnet,
@@ -1460,4 +1471,52 @@ func (plugin *NetPlugin) validateArgs(args *cniSkel.CmdArgs, nwCfg *cni.NetworkC
 	}
 
 	return nil
+}
+
+// filterOutOutBoundNATPolicies returns a copy of the input policy slice with
+// all entries that resolve to an HNS OutBoundNAT policy removed. Used for
+// SwiftV2 FrontendNIC endpoints, which land on a Transparent HNS network that
+// does not support OutBoundNAT and rejects it with
+// HCN_E_ENDPOINT_ATTACHMENT_NOT_SUPPORTED (0x803B0007) on attach.
+//
+// Conflist-derived policies arrive with outer Type=="EndpointPolicy" and the
+// real policy kind encoded inside Data as {"Type":"<kind>", ...}; bare
+// in-code policies set Type directly. We strip both shapes, and we also strip
+// LoopbackDSR because the Windows backend serializes it as an OutboundNAT on
+// the endpoint, which Transparent networks likewise reject.
+//
+// Returns nil when the input is nil/empty or when every entry was filtered
+// out, preserving the nil-policy semantics expected by downstream code.
+func filterOutOutBoundNATPolicies(in []policy.Policy) []policy.Policy {
+	if len(in) == 0 {
+		return nil
+	}
+	var out []policy.Policy
+	for _, p := range in {
+		if isOutBoundNATLikePolicy(p) {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// isOutBoundNATLikePolicy reports whether p will be applied to an HNS
+// endpoint as an OutBoundNAT policy. It matches both the bare-Type shape and
+// the conflist-wrapped shape (outer Type=="EndpointPolicy", inner Data.Type
+// in {OutBoundNAT, LoopbackDSR}).
+func isOutBoundNATLikePolicy(p policy.Policy) bool {
+	if p.Type == policy.OutBoundNatPolicy {
+		return true
+	}
+	if len(p.Data) == 0 {
+		return false
+	}
+	var inner struct {
+		Type policy.CNIPolicyType `json:"Type"`
+	}
+	if err := json.Unmarshal(p.Data, &inner); err != nil {
+		return false
+	}
+	return inner.Type == policy.OutBoundNatPolicy || inner.Type == policy.LoopbackDSRPolicy
 }

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -787,7 +787,8 @@ func (plugin *NetPlugin) createEpInfo(opt *createEpInfoOpt) (*network.EndpointIn
 			nwCfg:       opt.nwCfg,
 			ipconfigs:   opt.ifInfo.IPConfigs,
 		}
-		endpointPolicies, err := getEndpointPolicies(policyArgs)
+		var endpointPolicies []policy.Policy
+		endpointPolicies, err = getEndpointPolicies(policyArgs)
 		if err != nil {
 			logger.Error("Failed to get endpoint policies", zap.Error(err))
 			return nil, err

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -567,11 +567,7 @@ func (plugin *NetPlugin) Add(args *cniSkel.CmdArgs) error {
 		natInfo := getNATInfo(nwCfg, options[network.SNATIPKey], enableSnatForDNS)
 		networkID, _ := plugin.getNetworkID(args.Netns, &ifInfo, nwCfg)
 
-		// SwiftV2 FrontendNIC (delegated VM NIC / Accelnet) endpoints land on a
-		// Transparent HNS network, which does not support OutBoundNAT policies and
-		// rejects them with HCN_E_ENDPOINT_ATTACHMENT_NOT_SUPPORTED (0x803B0007),
-		// failing pod sandbox attach. Drop OutBoundNAT from both the natInfo
-		// (Swift DNS/IMDS SNAT) and the conflist-derived policies for this NIC.
+		// FrontendNIC lands on a Transparent HNS network, which rejects OutBoundNAT (0x803B0007).
 		ifPolicies := policies
 		if ifInfo.NICType == cns.NodeNetworkInterfaceFrontendNIC {
 			natInfo = nil
@@ -784,14 +780,7 @@ func (plugin *NetPlugin) createEpInfo(opt *createEpInfoOpt) (*network.EndpointIn
 	setNetworkOptions(opt.ifInfo.NCResponse, &endpointInfo)
 
 	// update endpoint policies
-	//
-	// SwiftV2 FrontendNIC (delegated VM NIC / Accelnet) endpoints land on a
-	// Transparent HNS network, which rejects OutBoundNAT-derived policies with
-	// HCN_E_ENDPOINT_ATTACHMENT_NOT_SUPPORTED (0x803B0007) on attach. The
-	// LoopbackDSR policy synthesized here (when windowsSettings.enableLoopbackDSR
-	// is set) is serialized by the Windows HCN backend as an OutBoundNAT with
-	// Destinations=[<podIP>], so it must be skipped for FrontendNIC endpoints.
-	// IPv6 NAT is likewise only relevant to InfraNIC.
+	// Skip for FrontendNIC: LoopbackDSR is serialized as OutBoundNAT, which the Transparent HNS network rejects (0x803B0007).
 	if opt.ifInfo.NICType != cns.NodeNetworkInterfaceFrontendNIC {
 		policyArgs := PolicyArgs{
 			subnetInfos: endpointInfo.Subnets, // getEndpointPolicies requires nwInfo.Subnets only (checked)
@@ -1483,20 +1472,8 @@ func (plugin *NetPlugin) validateArgs(args *cniSkel.CmdArgs, nwCfg *cni.NetworkC
 	return nil
 }
 
-// filterOutOutBoundNATPolicies returns a copy of the input policy slice with
-// all entries that resolve to an HNS OutBoundNAT policy removed. Used for
-// SwiftV2 FrontendNIC endpoints, which land on a Transparent HNS network that
-// does not support OutBoundNAT and rejects it with
-// HCN_E_ENDPOINT_ATTACHMENT_NOT_SUPPORTED (0x803B0007) on attach.
-//
-// Conflist-derived policies arrive with outer Type=="EndpointPolicy" and the
-// real policy kind encoded inside Data as {"Type":"<kind>", ...}; bare
-// in-code policies set Type directly. We strip both shapes, and we also strip
-// LoopbackDSR because the Windows backend serializes it as an OutboundNAT on
-// the endpoint, which Transparent networks likewise reject.
-//
-// Returns nil when the input is nil/empty or when every entry was filtered
-// out, preserving the nil-policy semantics expected by downstream code.
+// filterOutOutBoundNATPolicies returns in with OutBoundNAT-like entries removed, or nil if none remain.
+// Used for FrontendNIC endpoints, which land on a Transparent HNS network that rejects OutBoundNAT.
 func filterOutOutBoundNATPolicies(in []policy.Policy) []policy.Policy {
 	if len(in) == 0 {
 		return nil
@@ -1511,10 +1488,8 @@ func filterOutOutBoundNATPolicies(in []policy.Policy) []policy.Policy {
 	return out
 }
 
-// isOutBoundNATLikePolicy reports whether p will be applied to an HNS
-// endpoint as an OutBoundNAT policy. It matches both the bare-Type shape and
-// the conflist-wrapped shape (outer Type=="EndpointPolicy", inner Data.Type
-// in {OutBoundNAT, LoopbackDSR}).
+// isOutBoundNATLikePolicy reports whether p serializes to an HNS OutBoundNAT policy.
+// Matches bare Type and the conflist-wrapped shape (Data.Type in {OutBoundNAT, LoopbackDSR}).
 func isOutBoundNATLikePolicy(p policy.Policy) bool {
 	if p.Type == policy.OutBoundNatPolicy {
 		return true

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -784,19 +784,29 @@ func (plugin *NetPlugin) createEpInfo(opt *createEpInfoOpt) (*network.EndpointIn
 	setNetworkOptions(opt.ifInfo.NCResponse, &endpointInfo)
 
 	// update endpoint policies
-	policyArgs := PolicyArgs{
-		subnetInfos: endpointInfo.Subnets, // getEndpointPolicies requires nwInfo.Subnets only (checked)
-		nwCfg:       opt.nwCfg,
-		ipconfigs:   opt.ifInfo.IPConfigs,
+	//
+	// SwiftV2 FrontendNIC (delegated VM NIC / Accelnet) endpoints land on a
+	// Transparent HNS network, which rejects OutBoundNAT-derived policies with
+	// HCN_E_ENDPOINT_ATTACHMENT_NOT_SUPPORTED (0x803B0007) on attach. The
+	// LoopbackDSR policy synthesized here (when windowsSettings.enableLoopbackDSR
+	// is set) is serialized by the Windows HCN backend as an OutBoundNAT with
+	// Destinations=[<podIP>], so it must be skipped for FrontendNIC endpoints.
+	// IPv6 NAT is likewise only relevant to InfraNIC.
+	if opt.ifInfo.NICType != cns.NodeNetworkInterfaceFrontendNIC {
+		policyArgs := PolicyArgs{
+			subnetInfos: endpointInfo.Subnets, // getEndpointPolicies requires nwInfo.Subnets only (checked)
+			nwCfg:       opt.nwCfg,
+			ipconfigs:   opt.ifInfo.IPConfigs,
+		}
+		endpointPolicies, err := getEndpointPolicies(policyArgs)
+		if err != nil {
+			logger.Error("Failed to get endpoint policies", zap.Error(err))
+			return nil, err
+		}
+		// create endpoint policies by appending to network policies
+		// the value passed into NetworkPolicies should be unaffected since we reassign here
+		opt.policies = append(opt.policies, endpointPolicies...)
 	}
-	endpointPolicies, err := getEndpointPolicies(policyArgs)
-	if err != nil {
-		logger.Error("Failed to get endpoint policies", zap.Error(err))
-		return nil, err
-	}
-	// create endpoint policies by appending to network policies
-	// the value passed into NetworkPolicies should be unaffected since we reassign here
-	opt.policies = append(opt.policies, endpointPolicies...)
 
 	// appends endpoint policies specific to this interface
 	opt.policies = append(opt.policies, opt.ifInfo.EndpointPolicies...)

--- a/cni/network/network_test.go
+++ b/cni/network/network_test.go
@@ -1849,3 +1849,61 @@ func TestValidateArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestFilterOutOutBoundNATPolicies(t *testing.T) {
+	in := []policy.Policy{
+		{Type: policy.OutBoundNatPolicy, Data: []byte(`{}`)},
+		{Type: policy.ACLPolicy, Data: []byte(`{}`)},
+		{Type: policy.OutBoundNatPolicy, Data: []byte(`{}`)},
+		{Type: policy.RoutePolicy, Data: []byte(`{}`)},
+	}
+	out := filterOutOutBoundNATPolicies(in)
+	require.Len(t, out, 2)
+	for _, p := range out {
+		require.NotEqual(t, policy.OutBoundNatPolicy, p.Type)
+	}
+	// input not mutated
+	require.Len(t, in, 4)
+	require.Equal(t, policy.OutBoundNatPolicy, in[0].Type)
+
+	// nil input yields nil (preserve nil semantics for downstream consumers)
+	require.Nil(t, filterOutOutBoundNATPolicies(nil))
+
+	// empty input yields nil
+	require.Nil(t, filterOutOutBoundNATPolicies([]policy.Policy{}))
+
+	// all OutBoundNAT input yields nil
+	require.Nil(t, filterOutOutBoundNATPolicies([]policy.Policy{
+		{Type: policy.OutBoundNatPolicy},
+		{Type: policy.OutBoundNatPolicy},
+	}))
+
+	// Conflist-wrapped form: outer Type=="EndpointPolicy", real type encoded
+	// inside Data. This is the shape produced by cni.GetPoliciesFromNwCfg
+	// against an AKS conflist. The filter must strip OutBoundNAT and
+	// LoopbackDSR (the Windows backend serializes LoopbackDSR as an
+	// OutboundNatPolicy on the endpoint, which the SwiftV2 Transparent network
+	// also rejects).
+	wrapped := []policy.Policy{
+		{Type: policy.EndpointPolicy, Data: []byte(`{"Type":"OutBoundNAT","ExceptionList":["10.16.1.0/24"]}`)},
+		{Type: policy.EndpointPolicy, Data: []byte(`{"Type":"ACL","Action":"Allow","Direction":"In","Priority":65500}`)},
+		{Type: policy.EndpointPolicy, Data: []byte(`{"Type":"LoopbackDSR","IPAddress":"172.26.0.4"}`)},
+		{Type: policy.EndpointPolicy, Data: []byte(`{"Type":"ACL","Action":"Allow","Direction":"Out","Priority":65500}`)},
+	}
+	out = filterOutOutBoundNATPolicies(wrapped)
+	require.Len(t, out, 2, "OutBoundNAT and LoopbackDSR should both be removed from the conflist-wrapped form")
+	for _, p := range out {
+		require.False(t, isOutBoundNATLikePolicy(p), "filtered slice must not contain OutBoundNAT-like entries")
+	}
+
+	// Mixed bare + wrapped inputs.
+	mixed := []policy.Policy{
+		{Type: policy.OutBoundNatPolicy},
+		{Type: policy.EndpointPolicy, Data: []byte(`{"Type":"OutBoundNAT"}`)},
+		{Type: policy.EndpointPolicy, Data: []byte(`{"Type":"LoopbackDSR","IPAddress":"1.2.3.4"}`)},
+		{Type: policy.EndpointPolicy, Data: []byte(`{"Type":"ACL","Action":"Allow"}`)},
+	}
+	out = filterOutOutBoundNATPolicies(mixed)
+	require.Len(t, out, 1)
+	require.Equal(t, policy.EndpointPolicy, out[0].Type)
+}

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -327,15 +327,11 @@ func (nw *network) configureHcnEndpoint(epInfo *EndpointInfo) (*hcn.HostComputeE
 		return nil, err
 	}
 
-	// add hcnEndpoint policy for accelnet for frontendNIC
-	if epInfo.NICType == cns.NodeNetworkInterfaceFrontendNIC {
-		endpointPolicy, err := policy.AddAccelnetPolicySetting()
-		if err != nil {
-			logger.Error("Failed to set iov endpoint policy", zap.Error(err))
-			return nil, errors.Wrapf(err, "Failed to set iov endpoint policy for endpointId :%s", epInfo.EndpointID)
-		}
-		hcnEndpoint.Policies = append(hcnEndpoint.Policies, endpointPolicy)
-	}
+	// SwiftV2: skip the AccelNet/IOV endpoint policy on FrontendNIC.
+	// HCS attach-namespace fails with HCN_E_PORT_NOT_FOUND (0x803B0007) when an IOV
+	// policy is attached but no SR-IOV VF can be bound (e.g. non-AccelNet hosts, or
+	// hosts where the VF is already in use). Leaving the policy off lets the silo
+	// attach succeed; AccelNet acceleration, if needed, must be enabled out-of-band.
 
 	for _, route := range epInfo.Routes {
 		hcnRoute := hcn.Route{

--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -281,12 +281,14 @@ func (nm *networkManager) configureHcnNetwork(nwInfo *EndpointInfo, extIf *exter
 	// Enable non-persistent flag so networks are removed after host reboot
 	hcnNetwork.Flags = hcn.EnableNonPersistent
 
-	// AccelnetNIC flag: hcn.EnableIov(9216) - treat Delegated/FrontendNIC also the same as Accelnet
-	// For L1VH with accelnet, hcn.DisableHostPort and hcn.EnableIov must be configured
+	// SwiftV2 FrontendNIC: use a Transparent network with HostPort disabled, but do
+	// NOT set hcn.EnableIov here. EnableIov forces HCS to bind an SR-IOV VF at silo
+	// attach time; on hosts without a free AccelNet VF that fails with
+	// HCN_E_PORT_NOT_FOUND (0x803B0007). AccelNet acceleration, if required, must be
+	// enabled separately rather than implied by the FrontendNIC NIC type.
 	if nwInfo.NICType == cns.NodeNetworkInterfaceFrontendNIC {
 		hcnNetwork.Type = hcn.Transparent
-		// hcnNetwork.flags = hcn.DisableHostPort | hcn.EnableIov (1024 + 8192 = 9216)
-		hcnNetwork.Flags |= hcn.DisableHostPort | hcn.EnableIov
+		hcnNetwork.Flags |= hcn.DisableHostPort
 	}
 	// Populate subnets.
 	for _, subnet := range nwInfo.Subnets {

--- a/network/network_windows_test.go
+++ b/network/network_windows_test.go
@@ -563,7 +563,8 @@ func TestConfigureHCNNetworkInfraNIC(t *testing.T) {
 // Test Configure HCN Network for Swiftv2 DelegatedNIC HostComputeNetwork fields
 func TestConfigureHCNNetworkSwiftv2DelegatedNIC(t *testing.T) {
 	expectedSwiftv2NetworkMode := hcn.Transparent
-	expectedSwifv2NetworkFlags := hcn.EnableNonPersistent | hcn.DisableHostPort | hcn.EnableIov
+	// FrontendNIC no longer sets hcn.EnableIov: see configureHcnNetwork comment.
+	expectedSwifv2NetworkFlags := hcn.EnableNonPersistent | hcn.DisableHostPort
 
 	nm := &networkManager{
 		ExternalInterfaces: map[string]*externalInterface{},


### PR DESCRIPTION
**Reason for Change**:

AKS-managed Windows SwiftV2 pods fail pod sandbox attach with
`HCN_E_ENDPOINT_ATTACHMENT_NOT_SUPPORTED (0x803B0007)` and get stuck in
`ContainerCreating`. Root cause: the FrontendNIC iteration of
`NetPlugin.Add` was attaching OutBoundNAT-shaped policies to a
FrontendNIC (delegated VM NIC / Accelnet) endpoint, which lands on a
Transparent HNS network. Transparent HNS networks reject OutBoundNAT
policies on attach, so any OutBoundNAT-like entry — whether it came
from the conflist's `AdditionalArgs` or was synthesized at runtime from
`windowsSettings.enableLoopbackDSR` (HCN serializes LoopbackDSR as
`OutBoundNAT{Destinations:[podIP]}`) — fails the attach for the whole
pod.

This PR scopes OutBoundNAT-shaped policies to InfraNIC only, where they
are required and where the HNS network type (L2Bridge) accepts them.
InfraNIC behavior, ACI baremetal, Swift v1 multitenancy / Service
Fabric, and Linux are all unchanged — they never carried these
policies on a FrontendNIC iteration to begin with (Linux's
`getEndpointPolicies` is a no-op stub; ACI exits `Add` early; Swiftv1
never produces a FrontendNIC NICType).

**Changes**:

- `cni/network/network.go::NetPlugin.Add`: for the per-NIC iteration
  where `ifInfo.NICType == cns.NodeNetworkInterfaceFrontendNIC`, set
  `natInfo = nil` and replace the conflist-derived `policies` slice
  with `filterOutOutBoundNATPolicies(policies)` before constructing
  `createEpInfoOpt`. InfraNIC iterations are untouched.
- `cni/network/network.go::createEpInfo`: gate the
  `getEndpointPolicies(...)` call (which synthesizes the
  `LoopbackDSR`/IPv6 NAT policy on Windows) behind
  `opt.ifInfo.NICType != cns.NodeNetworkInterfaceFrontendNIC`, so that
  the synthesized OutBoundNAT-shaped policy is never produced for
  FrontendNIC endpoints in the first place.
- Add two helpers in `cni/network/network.go`:
  `filterOutOutBoundNATPolicies` returns a copy of a `policy.Policy`
  slice with OutBoundNAT-like entries removed (returns `nil` when the
  result would be empty); `isOutBoundNATLikePolicy` matches both the
  bare-`Type` and the conflist-wrapped `Data.Type` shapes, including
  `LoopbackDSR`.

**Issue Fixed**:

<!-- Add the GitHub/internal tracking issue here, e.g. Fixes #NNNN -->

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [x] includes documentation (rationale captured in commit messages
  and in-tree comments on the changed call sites; no user-facing docs
  needed — the fix preserves existing public behavior)
- [x] adds unit tests (`TestFilterOutOutBoundNATPolicies` in
  `cni/network/network_test.go` covers bare OutBoundNAT, nil/empty
  input, all-OutBoundNAT input, conflist-wrapped `EndpointPolicy`
  including `LoopbackDSR`, mixed bare+wrapped input, and verifies the
  input slice is not mutated)
- [x] relevant PR labels added <!-- area/cni, area/windows, area/swiftv2 -->

**Notes**:

- Scope: Windows-only failure surface. Linux is unaffected by
  construction — `getEndpointPolicies` on Linux returns `nil, nil` and
  there is no `OutBoundNAT` policy type on Linux.
- Failure trigger requires the combination AKS + Windows + SwiftV2:
  AgentBaker / CSE injects `"windowsSettings": { "enableLoopbackDSR":
  true }` into the on-node conflist (no in-tree conflist sets it), CNS
  returns a `NodeNetworkInterfaceFrontendNIC` entry in `PodIPInfo`,
  and HNS selects `hcn.Transparent` for that NIC at
  `network/network_windows.go`.
- Statefulness: the fix sits in the shared ADD codepath, which runs
  identically for the stateful and stateless CNI binaries. AKS 1.35
  (stateless-only) is fixed by the same change.
- Verified end-to-end on AKS test cluster `dannepu-mt-test`
  (Windows2022 nodepool with `aks-nic-enable-multi-tenancy=true`,
  NetworkingMultiTenancyPreview): the previously failing pod
  `swift2-win-toolbox` now reaches `Running 1/1` with both InfraNIC
  and FrontendNIC IPs assigned (FrontendNIC IP from the customer
  `winpodsubnet`).
- Diff is small and surgical (`cni/network/network.go +57/-13`,
  `cni/network/network_test.go +58/-0`); commits are split into the
  conflist-side filter, the runtime-synthesis gate, and a comment
  cleanup commit so each change can be reviewed independently.