### PR TITLE
feat: Enhancing ETW logging for CNI

### DIFF
--- a/cni/log/logger.go
+++ b/cni/log/logger.go
@@ -38,7 +38,7 @@ func initZapLog(logFile string) *zap.Logger {
 		// If we fail to join the platform cores, fallback to the original core.
 		core = textFileCore
 	}
-	return zap.New(core, zap.AddCaller()).With(zap.Int("pid", os.Getpid()))
+	return zap.New(&metadataCore{Core: core}, zap.AddCaller()).With(zap.Int("pid", os.Getpid()))
 }
 
 var (

--- a/cni/log/metadata_core.go
+++ b/cni/log/metadata_core.go
@@ -1,0 +1,50 @@
+package log
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// globalMetadata holds metadata fields shared across all loggers built from initZapLog.
+// It is set once from main() via SetMetadata after host metadata becomes available.
+var globalMetadata atomic.Pointer[[]zapcore.Field]
+
+// SetMetadata sets metadata fields that will be appended to every log entry
+// written through CNILogger, IPamLogger, and TelemetryLogger (and any loggers
+// derived from them). Safe to call once from main() after metadata is available.
+func SetMetadata(fields ...zap.Field) {
+	globalMetadata.Store(&fields)
+}
+
+// metadataCore is a zapcore.Core wrapper that appends shared metadata fields
+// to every log entry at write time. All cores derived via With() share the
+// same globalMetadata pointer, so setting metadata once propagates everywhere.
+type metadataCore struct {
+	zapcore.Core
+}
+
+func (c *metadataCore) With(fields []zapcore.Field) zapcore.Core {
+	return &metadataCore{Core: c.Core.With(fields)}
+}
+
+// Check registers this wrapper (not the inner core) as the writer so that
+// Write is called on metadataCore, allowing metadata fields to be appended.
+func (c *metadataCore) Check(entry zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if c.Enabled(entry.Level) {
+		return ce.AddCore(entry, c)
+	}
+	return ce
+}
+
+func (c *metadataCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
+	if extra := globalMetadata.Load(); extra != nil {
+		fields = append(fields, *extra...)
+	}
+	if err := c.Core.Write(entry, fields); err != nil {
+		return fmt.Errorf("writing log entry: %w", err)
+	}
+	return nil
+}

--- a/cni/network/plugin/main.go
+++ b/cni/network/plugin/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/Azure/azure-container-networking/cni"
@@ -50,6 +51,25 @@ func printVersion() {
 }
 
 func rootExecute() error {
+	// Enrich all CNI loggers with host metadata so ETW events carry VM identity for diagnostics.
+	metadataFile := filepath.Join(os.TempDir(), "azuremetadata.json")
+	if metadata, err := common.GetHostMetadata(metadataFile); err == nil {
+		host, _ := os.Hostname()
+		zaplog.SetMetadata(
+			zap.String("hostname", host),
+			zap.String("version", version),
+			zap.String("kubernetes_apiserver", os.Getenv("KUBERNETES_SERVICE_HOST")),
+			zap.String("account", metadata.SubscriptionID),
+			zap.String("anonymous_user_id", metadata.VMName),
+			zap.String("location", metadata.Location),
+			zap.String("resource_group", metadata.ResourceGroupName),
+			zap.String("vm_size", metadata.VMSize),
+			zap.String("os_version", metadata.OSVersion),
+			zap.String("vm_id", metadata.VMID),
+			zap.String("session_id", metadata.VMID),
+		)
+	}
+
 	var config common.PluginConfig
 
 	config.Version = version

--- a/cni/network/stateless/main.go
+++ b/cni/network/stateless/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/Azure/azure-container-networking/cni"
@@ -50,6 +51,25 @@ func printVersion() {
 }
 
 func rootExecute() error {
+	// Enrich all CNI loggers with host metadata so ETW events carry VM identity for diagnostics.
+	metadataFile := filepath.Join(os.TempDir(), "azuremetadata.json")
+	if metadata, err := common.GetHostMetadata(metadataFile); err == nil {
+		host, _ := os.Hostname()
+		zapLog.SetMetadata(
+			zap.String("hostname", host),
+			zap.String("version", version),
+			zap.String("kubernetes_apiserver", os.Getenv("KUBERNETES_SERVICE_HOST")),
+			zap.String("account", metadata.SubscriptionID),
+			zap.String("anonymous_user_id", metadata.VMName),
+			zap.String("location", metadata.Location),
+			zap.String("resource_group", metadata.ResourceGroupName),
+			zap.String("vm_size", metadata.VMSize),
+			zap.String("os_version", metadata.OSVersion),
+			zap.String("vm_id", metadata.VMID),
+			zap.String("session_id", metadata.VMID),
+		)
+	}
+
 	var config common.PluginConfig
 
 	log.SetName(name)


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

## Enhancing ETW logging for CNI

### Summary

Adds Azure VM identity metadata to all CNI log entries (file + ETW) so that diagnostics events can be correlated to a specific node without external joins.

### Problem

CNI ETW events contained no host-identifying information (VM name, subscription, resource group, etc.), making it difficult to attribute log entries to specific nodes during incident triage.

### Solution

Introduces a `metadataCore` wrapper around zap's `zapcore.Core` that lazily appends shared metadata fields to every log entry at write time. This ensures **all** CNI loggers — including those in downstream packages (`cni/network`, `cni/ipam`) that derive their loggers at package init — automatically include the metadata once it's set from `main()`.

**How it works:**
1. `initZapLog` wraps the platform core with `metadataCore`, which holds a reference to a shared `atomic.Pointer` of metadata fields.
2. At startup, `rootExecute()` reads host metadata (from cached file or Azure IMDS) and calls `zaplog.SetMetadata(...)`.
3. All subsequent log writes append the metadata fields — no per-package wiring required.

### Fields added

| Field | Source |
|-------|--------|
| `hostname` | `os.Hostname()` |
| `version` | Build-injected CNI version |
| `kubernetes_apiserver` | `KUBERNETES_SERVICE_HOST` env var |
| `account` | Azure Subscription ID |
| `anonymous_user_id` | VM Name |
| `location` | Azure region |
| `resource_group` | Resource group name |
| `vm_size` | VM SKU |
| `os_version` | OS version |
| `vm_id` / `session_id` | Azure VM ID |

### Changes

- **`cni/log/metadata_core.go`** (new): `metadataCore` type, `SetMetadata` function, and shared `globalMetadata` atomic pointer.
- **`cni/log/logger.go`**: Wrap core with `&metadataCore{Core: core}` in `initZapLog`.
- **`cni/network/plugin/main.go`**: Call `zaplog.SetMetadata(...)` with host metadata at startup.
- **`cni/network/stateless/main.go`**: Same as above for the stateless CNI binary.

### Notes

- If metadata is unavailable (file missing + IMDS unreachable), the enrichment is skipped gracefully — no impact on CNI operation.
- The metadata file (`azuremetadata.json`) is pre-populated by the CNS DaemonSet, which runs as `system-node-critical` and starts before user pods trigger CNI.

**Issue Fixed**:
No issue associated to this task.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Tests**:
Tested on a service fabric cluster with ETW (Geneva Logs) enabled.
<img width="1694" height="904" alt="image" src="https://github.com/user-attachments/assets/5df66ee4-44bd-40c5-8065-d85207fe0dc2" />
