### PR TITLE
ci, hack/scripts: version-aware skip for [FeatureGate:*] e2e specs

### DIFF
--- a/.pipelines/cni/k8s-e2e/k8s-e2e-job-template.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e-job-template.yaml
@@ -27,6 +27,11 @@ jobs:
             # pulling k8s version from AKS.
             eval k8sVersion="v"$( az aks show -g ${{ parameters.clusterName }} -n ${{ parameters.clusterName }} --query "currentKubernetesVersion")
             echo $k8sVersion
+            # Persist the cluster's k8s version so the per-test step templates
+            # can gate alpha-default-off [FeatureGate:*] e2e specs (AKS does
+            # not expose kube-apiserver --feature-gates, so they cannot be
+            # enabled on a stock managed cluster).
+            echo "$k8sVersion" > ./k8s-version
             curl -L https://dl.k8s.io/$k8sVersion/kubernetes-test-linux-amd64.tar.gz -o ./kubernetes-test-linux-amd64.tar.gz
 
             # https://github.com/kubernetes/sig-release/blob/master/release-engineering/artifacts.md#content-of-kubernetes-test-system-archtargz-on-example-of-kubernetes-test-linux-amd64targz-directories-removed-from-list

--- a/.pipelines/cni/k8s-e2e/k8s-e2e-step-template.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e-step-template.yaml
@@ -20,6 +20,31 @@ steps:
         SKIP="LinuxOnly"
       fi
 
+      # Map of upstream Kubernetes feature gates that are alpha-default-off
+      # until the listed minor goes Beta-default-on. AKS does not expose
+      # kube-apiserver --feature-gates, so on clusters older than the
+      # default-on version we skip the corresponding [FeatureGate:*] specs.
+      # See ./k8s-version, written by the job's "Setup Environment" step.
+      declare -A FEATURE_GATE_DEFAULT_ON_FROM=(
+        [RelaxedServiceNameValidation]="1.36"
+      )
+      K8S_VER=$(cat ./k8s-version 2>/dev/null | sed 's/^v//')
+      K8S_MM=$(echo "$K8S_VER" | awk -F. '{ if ($1 != "") printf "%d.%d", $1, $2 }')
+      ver_lt() { [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -1)" = "$1" ]; }
+      GATE_SKIP=""
+      for gate in "${!FEATURE_GATE_DEFAULT_ON_FROM[@]}"; do
+        min="${FEATURE_GATE_DEFAULT_ON_FROM[$gate]}"
+        # If the version file is missing/unreadable, be conservative and skip.
+        if [ -z "$K8S_MM" ] || ver_lt "$K8S_MM" "$min"; then
+          if [ -n "${{ parameters.ginkgoSkip }}$SKIP$GATE_SKIP" ]; then
+            GATE_SKIP="${GATE_SKIP}|\\[FeatureGate:${gate}\\]"
+          else
+            GATE_SKIP="\\[FeatureGate:${gate}\\]"
+          fi
+        fi
+      done
+      echo "k8s version: ${K8S_VER:-unknown}; feature-gate skips: ${GATE_SKIP:-<none>}"
+
       # Taint Linux nodes so that windows tests do not run on them
       if ${{ lower(eq(parameters.os, 'windows')) }}
       then
@@ -43,7 +68,7 @@ steps:
       --num-nodes=2 \
       --provider=skeleton \
       --ginkgo.focus='${{ parameters.ginkgoFocus }}' \
-      --ginkgo.skip="${{ parameters.ginkgoSkip }}$SKIP" \
+      --ginkgo.skip="${{ parameters.ginkgoSkip }}$SKIP$GATE_SKIP" \
       --ginkgo.flakeAttempts=${{ parameters.attempts }} \
       --ginkgo.v \
       --node-os-distro=${{ parameters.os }} \

--- a/.pipelines/cni/k8s-e2e/k8s-e2e.jobs.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e.jobs.yaml
@@ -30,6 +30,11 @@ jobs:
             # pulling k8s version from AKS.
             eval k8sVersion="v"$( az aks show -g ${{ parameters.clusterName }} -n ${{ parameters.clusterName }} --query "currentKubernetesVersion")
             echo $k8sVersion
+            # Persist the cluster's k8s version so the per-test step templates
+            # can gate alpha-default-off [FeatureGate:*] e2e specs (AKS does
+            # not expose kube-apiserver --feature-gates, so they cannot be
+            # enabled on a stock managed cluster).
+            echo "$k8sVersion" > ./k8s-version
             curl -L https://dl.k8s.io/$k8sVersion/kubernetes-test-linux-amd64.tar.gz -o ./kubernetes-test-linux-amd64.tar.gz
 
             # https://github.com/kubernetes/sig-release/blob/master/release-engineering/artifacts.md#content-of-kubernetes-test-system-archtargz-on-example-of-kubernetes-test-linux-amd64targz-directories-removed-from-list

--- a/.pipelines/cni/k8s-e2e/k8s-e2e.steps.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e.steps.yaml
@@ -21,6 +21,31 @@ steps:
         SKIP="LinuxOnly"
       fi
 
+      # Map of upstream Kubernetes feature gates that are alpha-default-off
+      # until the listed minor goes Beta-default-on. AKS does not expose
+      # kube-apiserver --feature-gates, so on clusters older than the
+      # default-on version we skip the corresponding [FeatureGate:*] specs.
+      # See ./k8s-version, written by the job's "Setup Environment" step.
+      declare -A FEATURE_GATE_DEFAULT_ON_FROM=(
+        [RelaxedServiceNameValidation]="1.36"
+      )
+      K8S_VER=$(cat ./k8s-version 2>/dev/null | sed 's/^v//')
+      K8S_MM=$(echo "$K8S_VER" | awk -F. '{ if ($1 != "") printf "%d.%d", $1, $2 }')
+      ver_lt() { [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -1)" = "$1" ]; }
+      GATE_SKIP=""
+      for gate in "${!FEATURE_GATE_DEFAULT_ON_FROM[@]}"; do
+        min="${FEATURE_GATE_DEFAULT_ON_FROM[$gate]}"
+        # If the version file is missing/unreadable, be conservative and skip.
+        if [ -z "$K8S_MM" ] || ver_lt "$K8S_MM" "$min"; then
+          if [ -n "${{ parameters.ginkgoSkip }}$SKIP$GATE_SKIP" ]; then
+            GATE_SKIP="${GATE_SKIP}|\\[FeatureGate:${gate}\\]"
+          else
+            GATE_SKIP="\\[FeatureGate:${gate}\\]"
+          fi
+        fi
+      done
+      echo "k8s version: ${K8S_VER:-unknown}; feature-gate skips: ${GATE_SKIP:-<none>}"
+
       # Taint Linux nodes so that windows tests do not run on them
       if ${{ lower(eq(parameters.os, 'windows')) }}
       then
@@ -44,7 +69,7 @@ steps:
       --num-nodes=2 \
       --provider=skeleton \
       --ginkgo.focus='${{ parameters.ginkgoFocus }}' \
-      --ginkgo.skip="${{ parameters.ginkgoSkip }}$SKIP" \
+      --ginkgo.skip="${{ parameters.ginkgoSkip }}$SKIP$GATE_SKIP" \
       --ginkgo.flakeAttempts=${{ parameters.attempts }} \
       --ginkgo.v \
       --node-os-distro=${{ parameters.os }} \

--- a/.pipelines/templates/k8s-e2e-step-template.yaml
+++ b/.pipelines/templates/k8s-e2e-step-template.yaml
@@ -26,6 +26,11 @@ steps:
         # pulling k8s version from AKS.
         eval k8sVersion="v"$( az aks show -g ${{ parameters.clusterName }} -n ${{ parameters.clusterName }} --query "currentKubernetesVersion")
         echo $k8sVersion
+        # Persist the cluster's k8s version so the per-test step templates can
+        # gate alpha-default-off [FeatureGate:*] e2e specs (AKS does not expose
+        # kube-apiserver --feature-gates, so they cannot be enabled on a stock
+        # managed cluster and the corresponding specs must be skipped).
+        echo "$k8sVersion" > ./k8s-version
         curl -L https://dl.k8s.io/$k8sVersion/kubernetes-test-linux-amd64.tar.gz -o ./kubernetes-test-linux-amd64.tar.gz
 
         # https://github.com/kubernetes/sig-release/blob/master/release-engineering/artifacts.md#content-of-kubernetes-test-system-archtargz-on-example-of-kubernetes-test-linux-amd64targz-directories-removed-from-list

--- a/hack/scripts/k8se2e-tests.sh
+++ b/hack/scripts/k8se2e-tests.sh
@@ -1,6 +1,34 @@
 OS=$1
 TYPE=$2
 
+# Map of upstream Kubernetes feature gates that are alpha-default-off until the
+# minor version listed below (at which point they go Beta-default-on). AKS does
+# not expose kube-apiserver --feature-gates, so on clusters older than the
+# default-on version we skip the corresponding [FeatureGate:*] labeled e2e
+# specs (otherwise the spec contacts an apiserver that rejects it on validation
+# and fails). When AKS catches up to the default-on minor, the entry can be
+# dropped from this map and the spec will run for real.
+declare -A FEATURE_GATE_DEFAULT_ON_FROM=(
+  [RelaxedServiceNameValidation]="1.36"
+)
+
+K8S_VER=$(cat ./k8s-version 2>/dev/null | sed 's/^v//')
+K8S_MM=$(echo "$K8S_VER" | awk -F. '{ if ($1 != "") printf "%d.%d", $1, $2 }')
+
+ver_lt() {
+  [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -1)" = "$1" ]
+}
+
+GATE_SKIP=""
+for gate in "${!FEATURE_GATE_DEFAULT_ON_FROM[@]}"; do
+  min="${FEATURE_GATE_DEFAULT_ON_FROM[$gate]}"
+  # If we couldn't read the cluster version, be conservative and skip.
+  if [ -z "$K8S_MM" ] || ver_lt "$K8S_MM" "$min"; then
+    GATE_SKIP="${GATE_SKIP}|\\[FeatureGate:${gate}\\]"
+  fi
+done
+echo "Cluster k8s version: ${K8S_VER:-unknown}; feature-gate skips: ${GATE_SKIP:-<none>}"
+
 # Taint Linux nodes so that windows tests do not run on them and ensure no LinuxOnly tests run on windows nodes
 if [[ 'windows' == $OS ]]
 then
@@ -18,7 +46,7 @@ echo "./ginkgo --nodes=4 \
 --num-nodes=2 \
 --provider=skeleton \
 --ginkgo.focus='(.*).Networking.should|(.*).Networking.Granular|(.*)kubernetes.api' \
---ginkgo.skip='SCTP|Disruptive|Slow|hostNetwork|kube-proxy|IPv6' \
+--ginkgo.skip='SCTP|Disruptive|Slow|hostNetwork|kube-proxy|IPv6${SKIP}${GATE_SKIP}' \
 --ginkgo.flakeAttempts=3 \
 --ginkgo.v \
 --node-os-distro=$OS \
@@ -28,7 +56,7 @@ echo "./ginkgo --nodes=4 \
 --num-nodes=2 \
 --provider=skeleton \
 --ginkgo.focus='(.*).Networking.should|(.*).Networking.Granular|(.*)kubernetes.api' \
---ginkgo.skip="SCTP|Disruptive|Slow|hostNetwork|kube-proxy|IPv6$SKIP" \
+--ginkgo.skip="SCTP|Disruptive|Slow|hostNetwork|kube-proxy|IPv6$SKIP$GATE_SKIP" \
 --ginkgo.flakeAttempts=3 \
 --ginkgo.v \
 --node-os-distro=$OS \
@@ -40,7 +68,7 @@ echo "./ginkgo --nodes=4 \
 --num-nodes=2 \
 --provider=skeleton \
 --ginkgo.focus='(.*).Networking.should|(.*).Networking.Granular|(.*)kubernetes.api|\[sig-network\].DNS.should|\[sig-cli\].Kubectl.Port|Services.*\[Conformance\].*|\[sig-network\](.*)HostPort|\[sig-scheduling\](.*)hostPort' \
---ginkgo.skip='SCTP|Disruptive|Slow|hostNetwork|kube-proxy|IPv6|resolv|exists conflict$SKIP' \
+--ginkgo.skip='SCTP|Disruptive|Slow|hostNetwork|kube-proxy|IPv6|resolv|exists conflict${SKIP}${GATE_SKIP}' \
 --ginkgo.flakeAttempts=3 \
 --ginkgo.v \
 --node-os-distro=$OS \
@@ -50,7 +78,7 @@ echo "./ginkgo --nodes=4 \
 --num-nodes=2 \
 --provider=skeleton \
 --ginkgo.focus='(.*).Networking.should|(.*).Networking.Granular|(.*)kubernetes.api|\[sig-network\].DNS.should|\[sig-cli\].Kubectl.Port|Services.*\[Conformance\].*|\[sig-network\](.*)HostPort|\[sig-scheduling\](.*)hostPort' \
---ginkgo.skip="SCTP|Disruptive|Slow|hostNetwork|kube-proxy|IPv6|resolv|exists conflict$SKIP" \
+--ginkgo.skip="SCTP|Disruptive|Slow|hostNetwork|kube-proxy|IPv6|resolv|exists conflict$SKIP$GATE_SKIP" \
 --ginkgo.flakeAttempts=3 \
 --ginkgo.v \
 --node-os-distro=$OS \

--- a/hack/scripts/k8se2e.sh
+++ b/hack/scripts/k8se2e.sh
@@ -3,6 +3,11 @@ echo "Cluster -g $GROUP -n $CLUSTER"
 eval k8sVersion="v"$( az aks show -g $GROUP -n $CLUSTER --query "currentKubernetesVersion")
 echo $k8sVersion "e2e Test Suite"
 
+# Persist the cluster's k8s version for k8se2e-tests.sh so it can gate
+# alpha-default-off [FeatureGate:*] specs (AKS does not expose kube-apiserver
+# --feature-gates, so they cannot be enabled on a stock managed cluster).
+echo "$k8sVersion" > ./k8s-version
+
 curl -L https://dl.k8s.io/$k8sVersion/kubernetes-test-linux-amd64.tar.gz -o ./kubernetes-test-linux-amd64.tar.gz
 
 tar -xvzf kubernetes-test-linux-amd64.tar.gz --strip-components=3 kubernetes/test/bin/ginkgo kubernetes/test/bin/e2e.test


### PR DESCRIPTION
AKS does not expose kube-apiserver --feature-gates, so alpha-default-off features cannot be enabled on the managed control plane. Running upstream e2e specs that are guarded by such gates (for example, KEP-4439's 'should work with a service name that starts with a digit' in test/e2e/network/dns.go) hits the strict validator and fails with errors like:
```
  Service "1kubernetes" is invalid: metadata.name: ... a DNS-1035 label
  must consist of lower case alphanumeric characters or '-', start with
  an alphabetic character ...
```
even though the spec is tagged [FeatureGate:RelaxedServiceNameValidation] and is expected to be opt-in. On AKS clusters older than the minor where a feature graduates to beta-default-on (k8s 1.35 predates KEP-4439 going Beta in 1.36), these gated specs run, hit the strict validator, and fail.

The CI k8s e2e steps are driven by two paths: the Makefile/hack-scripts path (k8se2e.sh -> k8se2e-tests.sh) and the per-test-type templates in .pipelines/cni/k8s-e2e/ and .pipelines/templates/, which invoke ./ginkgo ./e2e.test directly with a hardcoded --ginkgo.skip per step. Neither path included [FeatureGate:*] labels in its skip regex.

Fix both paths the same way:

  - hack/scripts: plumb the cluster's currentKubernetesVersion from k8se2e.sh into k8se2e-tests.sh and append a [FeatureGate:*] skip regex built from a small per-gate min-default-on table.

  - pipelines: persist currentKubernetesVersion from the Setup Environment step in each outer template into ./k8s-version, and have both inner step templates read it, compare against the same per-gate min default-on minor, and append \[FeatureGate:Foo\] to the ginkgo skip when the cluster is older. The append is guarded so that empty base skips (Service Conformance for cni) do not produce a leading '|' (which would be parsed as an empty alternation that matches and skips every spec).

On 1.36+ the gate is on by default and the entry contributes no skip, so the spec runs for real. Conservative default: if the version file is missing, skip the gated specs.

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Notes**: https://msazure.visualstudio.com/One/_build/results?buildId=165279966&view=results
