### PR TITLE
ci: clean up agent disk space before binary build (release/v1.7)

### DIFF
--- a/.pipelines/containers/container-template.yaml
+++ b/.pipelines/containers/container-template.yaml
@@ -13,28 +13,7 @@ steps:
     inlineScript: |
       az acr login -n $(ACR)
 
-- script: |
-    set -e
-    echo "Disk space before cleanup..."
-    df -h /
-    echo "Removing unnecessary files to free up disk space..."
-    sudo rm -rf \
-      /opt/hostedtoolcache \
-      /opt/google/chrome \
-      /opt/microsoft/msedge \
-      /opt/microsoft/powershell \
-      /opt/pipx \
-      /usr/lib/mono \
-      /usr/local/julia* \
-      /usr/local/lib/android \
-      /usr/local/lib/node_modules \
-      /usr/local/share/chromium \
-      /usr/local/share/powershell \
-      /usr/share/dotnet \
-      /usr/share/swift
-    echo "Disk space after cleanup..."
-    df -h /
-  displayName: "Clean up disk space"
+- template: ../templates/disk-cleanup.steps.yaml
 
 - script: |
     set -e

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -75,6 +75,7 @@ stages:
           pool:
             name: "$(BUILD_POOL_NAME_DEFAULT)"
           steps:
+            - template: templates/disk-cleanup.steps.yaml
             - script: |
                 make bpf-lib
                 make all-binaries-platforms

--- a/.pipelines/templates/disk-cleanup.steps.yaml
+++ b/.pipelines/templates/disk-cleanup.steps.yaml
@@ -8,7 +8,6 @@ steps:
       df -h /
       echo "Removing unnecessary files to free up disk space..."
       sudo rm -rf \
-        /opt/hostedtoolcache \
         /opt/google/chrome \
         /opt/microsoft/msedge \
         /opt/microsoft/powershell \

--- a/.pipelines/templates/disk-cleanup.steps.yaml
+++ b/.pipelines/templates/disk-cleanup.steps.yaml
@@ -1,0 +1,29 @@
+steps:
+  - script: |
+      set -e
+      echo "=== Tool locations BEFORE cleanup ==="
+      which go || true
+      go version || true
+      echo "=== Disk space BEFORE cleanup ==="
+      df -h /
+      echo "Removing unnecessary files to free up disk space..."
+      sudo rm -rf \
+        /opt/hostedtoolcache \
+        /opt/google/chrome \
+        /opt/microsoft/msedge \
+        /opt/microsoft/powershell \
+        /opt/pipx \
+        /usr/lib/mono \
+        /usr/local/julia* \
+        /usr/local/lib/android \
+        /usr/local/lib/node_modules \
+        /usr/local/share/chromium \
+        /usr/local/share/powershell \
+        /usr/share/dotnet \
+        /usr/share/swift
+      echo "=== Tool locations AFTER cleanup ==="
+      which go || true
+      go version || true
+      echo "=== Disk space AFTER cleanup ==="
+      df -h /
+    displayName: "Clean up disk space"


### PR DESCRIPTION
**Reason for Change**:
The `binaries` stage `build` job has been running out of disk space on the default build pool while running `make all-binaries-platforms`. This adds a reusable cleanup step that frees ~30+ GB by removing pre-installed tooling we do not use on the agent (hostedtoolcache, dotnet, android SDK, chromium, powershell, swift, etc.) and prints `df -h` before/after so future disk pressure is visible in the log.

The cleanup script mirrors the one introduced for container builds in #4109 and is now factored into a shared template at `.pipelines/templates/disk-cleanup.steps.yaml` so it can be reused from any agent-side stage.



**Update**: The shared `disk-cleanup.steps.yaml` template no longer deletes `/opt/hostedtoolcache` so the agent's pre-installed Go toolchain remains available to downstream steps. All other cleanups are unchanged.

**Issue Fixed**:

**Requirements**:
- [x] uses conventional commit messages
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
This is part of a coordinated change landing in master and release/v1.5, v1.6, v1.7.