### PR TITLE
ci: clean up agent disk space before binary build (release/v1.6)

### DIFF
--- a/.pipelines/containers/container-template.yaml
+++ b/.pipelines/containers/container-template.yaml
@@ -13,28 +13,7 @@ steps:
     inlineScript: |
       az acr login -n $(ACR)
 
-- script: |
-    set -e
-    echo "Disk space before cleanup..."
-    df -h /
-    echo "Removing unnecessary files to free up disk space..."
-    sudo rm -rf \
-      /opt/hostedtoolcache \
-      /opt/google/chrome \
-      /opt/microsoft/msedge \
-      /opt/microsoft/powershell \
-      /opt/pipx \
-      /usr/lib/mono \
-      /usr/local/julia* \
-      /usr/local/lib/android \
-      /usr/local/lib/node_modules \
-      /usr/local/share/chromium \
-      /usr/local/share/powershell \
-      /usr/share/dotnet \
-      /usr/share/swift
-    echo "Disk space after cleanup..."
-    df -h /
-  displayName: "Clean up disk space"
+- template: ../templates/disk-cleanup.steps.yaml
 
 - script: |
     set -e

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -73,6 +73,7 @@ stages:
           pool:
             name: "$(BUILD_POOL_NAME_DEFAULT)"
           steps:
+            - template: templates/disk-cleanup.steps.yaml
             - script: |
                 make ipv6-hp-bpf-lib
                 make all-binaries-platforms

--- a/.pipelines/templates/disk-cleanup.steps.yaml
+++ b/.pipelines/templates/disk-cleanup.steps.yaml
@@ -8,7 +8,6 @@ steps:
       df -h /
       echo "Removing unnecessary files to free up disk space..."
       sudo rm -rf \
-        /opt/hostedtoolcache \
         /opt/google/chrome \
         /opt/microsoft/msedge \
         /opt/microsoft/powershell \

--- a/.pipelines/templates/disk-cleanup.steps.yaml
+++ b/.pipelines/templates/disk-cleanup.steps.yaml
@@ -1,0 +1,29 @@
+steps:
+  - script: |
+      set -e
+      echo "=== Tool locations BEFORE cleanup ==="
+      which go || true
+      go version || true
+      echo "=== Disk space BEFORE cleanup ==="
+      df -h /
+      echo "Removing unnecessary files to free up disk space..."
+      sudo rm -rf \
+        /opt/hostedtoolcache \
+        /opt/google/chrome \
+        /opt/microsoft/msedge \
+        /opt/microsoft/powershell \
+        /opt/pipx \
+        /usr/lib/mono \
+        /usr/local/julia* \
+        /usr/local/lib/android \
+        /usr/local/lib/node_modules \
+        /usr/local/share/chromium \
+        /usr/local/share/powershell \
+        /usr/share/dotnet \
+        /usr/share/swift
+      echo "=== Tool locations AFTER cleanup ==="
+      which go || true
+      go version || true
+      echo "=== Disk space AFTER cleanup ==="
+      df -h /
+    displayName: "Clean up disk space"

--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -8,7 +8,7 @@ ARG OS
 FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:b05a9bbf50a8ccfdd0ebe9f673ef29dca7c1d5e209434b35a560a4e8ae5f72b2 AS go
 
 # mcr.microsoft.com/cbl-mariner/base/core:2.0
-FROM mcr.microsoft.com/cbl-mariner/base/core@sha256:61b8c8e5c769784be2137cba8612c3a0f0c1752a66276b3b1b5306014a1e20e0 AS mariner-core
+FROM mcr.microsoft.com/cbl-mariner/base/core@sha256:c833841d2dcfd3081d2ee807050d19368854f70d9b6faef027463e2c6f45ee41 AS mariner-core
 
 # mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
 FROM mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:16d7c214232ee1db683e767a7a30a47f9976801c929b0f2f300521c595eb33ff AS mariner-distroless


### PR DESCRIPTION
**Reason for Change**:

This PR bundles two CI fixes for `release/v1.6`:

### 1. Agent disk-space cleanup before the binary build
The `binaries` stage `build` job has been running out of disk space on the default build pool while running `make all-binaries-platforms`. Adds a reusable cleanup step that frees ~30+ GB by removing pre-installed tooling we do not use on the agent (hostedtoolcache, dotnet, android SDK, chromium, powershell, swift, etc.) and prints `df -h` (plus `which go` / `go version`) before & after so future disk pressure is visible in the log.

The cleanup script is factored into a shared template at `.pipelines/templates/disk-cleanup.steps.yaml` so it can be reused. This PR also refactors the existing inline cleanup in `.pipelines/containers/container-template.yaml` (image build) to use the same shared template — behavior is unchanged, just deduplicated.

### 2. Bump `cbl-mariner/base/core` image SHA in `cns/Dockerfile`
The `cns-image` build has been failing in the `iptables` stage with:

```
Error(1261) : SSL peer certificate or SSH remote key was not OK
Error: Failed to synchronize cache for repo 'CBL-Mariner Official Base 2.0 x86_64'
...
iptables package not found or not installed
error building at STEP "RUN tdnf install -y iptables"
```

Updates `mcr.microsoft.com/cbl-mariner/base/core` from
`sha256:61b8c8e5...` → `sha256:c833841d2dcfd3081d2ee807050d19368854f70d9b6faef027463e2c6f45ee41`
(the current `2.0` manifest list digest). Verified locally that this resolves the tdnf SSL repo-sync failure during `make cns-image`. The `distroless/minimal` image was tested but is not part of the failure path (it only receives `COPY` operations) and is left unchanged.

### 3. Preserve `/opt/hostedtoolcache` during disk cleanup
Removing `/opt/hostedtoolcache` also wiped the agent's pre-installed Go toolchain, which downstream steps rely on. The shared `disk-cleanup.steps.yaml` template no longer deletes `/opt/hostedtoolcache`; all other cleanups are unchanged.

**Issue Fixed**:

**Requirements**:
- [x] uses conventional commit messages
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
The disk-cleanup template change is part of a coordinated change landing in master and release/v1.5, v1.6, v1.7 (#4432, #4433, #4435). The base/core SHA bump is v1.6-specific in this PR.
