### PR TITLE
test(cns): bump distroless/minimal image SHA (release/v1.6)

### DIFF
--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -11,7 +11,7 @@ FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:b
 FROM mcr.microsoft.com/cbl-mariner/base/core@sha256:61b8c8e5c769784be2137cba8612c3a0f0c1752a66276b3b1b5306014a1e20e0 AS mariner-core
 
 # mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
-FROM mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:16d7c214232ee1db683e767a7a30a47f9976801c929b0f2f300521c595eb33ff AS mariner-distroless
+FROM mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:4fb6c12ad8ef326f648872121030fa132b820b4a85345754f17fefcdf5a4b5ff AS mariner-distroless
 
 FROM --platform=linux/${ARCH} go AS builder
 ARG OS


### PR DESCRIPTION
**Reason for Change**:
Testing fix for `cns-image` build failures on release/v1.6. The `tdnf install -y iptables` step in the `mariner-core` stage has been failing with:

```
Error(1261) : SSL peer certificate or SSH remote key was not OK
Error: Failed to synchronize cache for repo 'CBL-Mariner Official Base 2.0 x86_64'
...
error building at STEP "RUN tdnf install -y iptables"
```

This PR pins `cbl-mariner/distroless/minimal` to `sha256:4fb6c12ad8ef326f648872121030fa132b820b4a85345754f17fefcdf5a4b5ff` to validate whether the newer distroless image resolves the issue.

**Issue Fixed**:

**Requirements**:
- [x] uses conventional commit messages
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
- release/v1.5 has no distroless/minimal stage in `cns/linux.Dockerfile`, so this change applies only to release/v1.6.
- Marked `test:` because we are validating before deciding whether to roll forward.