### PR TITLE
ci: re-render Dockerfiles (release/v1.6)

### DIFF
--- a/cni/Dockerfile
+++ b/cni/Dockerfile
@@ -9,7 +9,7 @@ ARG OS
 FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:b05a9bbf50a8ccfdd0ebe9f673ef29dca7c1d5e209434b35a560a4e8ae5f72b2 AS go
 
 # mcr.microsoft.com/cbl-mariner/base/core:2.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/cbl-mariner/base/core@sha256:61b8c8e5c769784be2137cba8612c3a0f0c1752a66276b3b1b5306014a1e20e0 AS mariner-core
+FROM --platform=linux/${ARCH} mcr.microsoft.com/cbl-mariner/base/core@sha256:c833841d2dcfd3081d2ee807050d19368854f70d9b6faef027463e2c6f45ee41 AS mariner-core
 
 FROM go AS azure-vnet
 ARG OS

--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -11,7 +11,7 @@ FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:b
 FROM mcr.microsoft.com/cbl-mariner/base/core@sha256:c833841d2dcfd3081d2ee807050d19368854f70d9b6faef027463e2c6f45ee41 AS mariner-core
 
 # mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
-FROM mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:16d7c214232ee1db683e767a7a30a47f9976801c929b0f2f300521c595eb33ff AS mariner-distroless
+FROM mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:4fb6c12ad8ef326f648872121030fa132b820b4a85345754f17fefcdf5a4b5ff AS mariner-distroless
 
 FROM --platform=linux/${ARCH} go AS builder
 ARG OS


### PR DESCRIPTION
>> **PoC for [Azure/azure-container-networking#4440](https://github.com/Azure/azure-container-networking/pull/4440)** — the `ci-mx` custom agent definition. This PR demonstrates the agent operating in `op_mode=fix` against `release/v1.6`. It may be closed without merging once the agent PR is reviewed.

Automated fix from `ci-mx` for CI failures on `release/v1.6` at `87debdab64bc18510321060c1484a2b67d74691c`.

- Originating failing run: https://github.com/Azure/azure-container-networking/actions/runs/26857694514 (on a different branch; ci-mx probed release/v1.6 directly)
- Verified by re-running `make dockerfiles` locally per the ci-mx contract; render is idempotent.

Scope: `make dockerfiles` re-render only. Never edits workflow YAML, the matrix, Makefiles, Dockerfile templates, or the Go toolchain version. Never auto-merged.

### Blockers surfaced (out of ci-mx scope, human action required)

ci-mx detected 6 govulncheck failures classified as `stop:out-of-scope (stdlib)` on `release/v1.6` (3 additional source-run modules suppressed via `does-not-apply` because they don't exist on this release branch). The 6 blocked modules require a Go toolchain bump and are NOT included in this fix PR:
- `Run govulncheck (.)`, `azure-ipam`, `bpf-prog/ipv6-hp-bpf`, `dropgz`, `tools/azure-npm-to-cilium-validator`, `zapai`.
