### PR TITLE
fix: exclude SwiftV2 delegated-NIC IPs from CNS IPAM reconcile

### DIFF
--- a/cns/stateprovider/cns/podinfoprovider.go
+++ b/cns/stateprovider/cns/podinfoprovider.go
@@ -41,6 +41,14 @@ func endpointStateToPodInfoByIP(state map[string]*restserver.EndpointInfo) (map[
 	podInfoByIP := map[string]cns.PodInfo{}
 	for containerID, endpointInfo := range state { // for each endpoint
 		for _, ipinfo := range endpointInfo.IfnameToIPMap { // for each IP info object of the endpoint's interfaces
+			// Only InfraNIC IPs are allocated from the NodeNetworkConfig (NNC) IP pool and take part
+			// in CNS IPAM reconciliation. SwiftV2 delegated NIC IPs (e.g. FrontendNIC, BackendNIC) are
+			// owned by the per-pod MultitenantPodNetworkConfig, not the NNC, so reconciling them fails
+			// to map the IP to any NetworkContainer and aborts CNS initialization. An empty NICType
+			// denotes a legacy/InfraNIC entry and is retained for backward compatibility.
+			if ipinfo.NICType != cns.InfraNIC && ipinfo.NICType != "" {
+				continue
+			}
 			for _, ipv4conf := range ipinfo.IPv4 { // for each IPv4 config of the endpoint's interfaces
 				if _, ok := podInfoByIP[ipv4conf.IP.String()]; ok {
 					return nil, errors.Wrap(cns.ErrDuplicateIP, ipv4conf.IP.String())

--- a/cns/stateprovider/cns/podinfoprovider_test.go
+++ b/cns/stateprovider/cns/podinfoprovider_test.go
@@ -22,6 +22,21 @@ func TestNewCNSPodInfoProvider(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error writing to store: %v", err)
 	}
+
+	// swiftV2Store holds a SwiftV2 multitenant endpoint with both an InfraNIC (allocated from the
+	// NNC IP pool) and a delegated FrontendNIC (owned by the per-pod MTPNC, not the NNC). Only the
+	// InfraNIC IP must be returned for IPAM reconciliation; including the FrontendNIC IP would make
+	// reconcile fail to map it to a NetworkContainer and abort CNS initialization.
+	swiftV2Store := store.NewMockStore("")
+	swiftV2EndpointState := make(map[string]*restserver.EndpointInfo)
+	swiftV2EndpointInfo := &restserver.EndpointInfo{PodName: "vfpod1", PodNamespace: "default", IfnameToIPMap: make(map[string]*restserver.IPInfo)}
+	swiftV2EndpointInfo.IfnameToIPMap["eth0"] = &restserver.IPInfo{IPv4: []net.IPNet{{IP: net.IPv4(10, 226, 0, 52), Mask: net.IPv4Mask(255, 255, 0, 0)}}, NICType: cns.InfraNIC}
+	swiftV2EndpointInfo.IfnameToIPMap["Ethernet 4"] = &restserver.IPInfo{IPv4: []net.IPNet{{IP: net.IPv4(172, 25, 0, 7), Mask: net.IPv4Mask(255, 255, 0, 0)}}, NICType: cns.NodeNetworkInterfaceFrontendNIC}
+	swiftV2EndpointState["cd97a4018a"] = swiftV2EndpointInfo
+	if err := swiftV2Store.Write(restserver.EndpointStoreKey, swiftV2EndpointState); err != nil {
+		t.Fatalf("Error writing to store: %v", err)
+	}
+
 	tests := []struct {
 		name    string
 		store   store.KeyValueStore
@@ -33,6 +48,13 @@ func TestNewCNSPodInfoProvider(t *testing.T) {
 			store: goodStore,
 			want: map[string]cns.PodInfo{"10.241.0.65": cns.NewPodInfo("0a4917617e15d24dc495e407d8eb5c88e4406e58fa209e4eb75a2c2fb7045eea",
 				"0a4917617e15d24dc495e407d8eb5c88e4406e58fa209e4eb75a2c2fb7045eea", "goldpinger-deploy-bbbf9fd7c-z8v4l", "default")},
+			wantErr: false,
+		},
+		{
+			name:  "swiftv2 delegated nic excluded",
+			store: swiftV2Store,
+			want: map[string]cns.PodInfo{"10.226.0.52": cns.NewPodInfo("cd97a4018a",
+				"cd97a4018a", "vfpod1", "default")},
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
## Problem
On SwiftV2 Windows nodes, after a CNS restart the IPAM reconcile deadlocks and pods stay stuck in `ContainerCreating`.

`PR #4375` (`f4610451c`, "clean up stale APIPA endpoints during stale SwiftV2 HNS resource cleanup") began persisting the delegated-NIC IPv4 into the endpoint store via `updateIPInfoMap` (`cns/restserver/ipam.go`). This exposed a **latent defect** in the reconcile transform `endpointStateToPodInfoByIP` (`cns/stateprovider/cns/podinfoprovider.go`): delegated-NIC IPs (FrontendNIC/BackendNIC) are owned by the per-pod MultitenantPodNetworkConfig, **not** the NodeNetworkConfig (NNC) IP pool, so reconciling them fails to map the IP to any NetworkContainer and aborts CNS initialization.

Version-gated: works on `v1.7.16-0`, fails from `v1.8.7+` / `v1.8.8` (the first releases containing #4375).

## Fix
Guard the reconcile transform to only consider InfraNIC entries (empty `NICType` retained for backward compatibility). This restores pre-regression behavior **without reverting #4375's stale-HNS cleanup feature** — the persisted delegated IP is left in the endpoint store, but excluded from NNC reconciliation where it doesn't belong.

```go
if ipinfo.NICType != cns.InfraNIC && ipinfo.NICType != "" {
    continue
}
```

## Test
Adds regression subtest `swiftv2 delegated nic excluded`: a multitenant endpoint with both an InfraNIC and a delegated FrontendNIC; only the InfraNIC IP is returned for reconciliation. Verified the test **fails without** the guard (delegated IP leaks in) and **passes with** it. `go build`, `go vet`, `go test ./cns/stateprovider/cns/...` all pass.
