### PR TITLE
fix: exclude delegated NIC IPs from NNC reconcile on CNS restart

### DIFF
--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -660,21 +660,16 @@ func (plugin *NetPlugin) Add(args *cniSkel.CmdArgs) error {
 // entries come before all other NIC types, preserving relative order among equals.
 func sortInfraNICFirst(epInfos []*network.EndpointInfo) {
 	slices.SortStableFunc(epInfos, func(a, b *network.EndpointInfo) int {
-		if isInfraOrLegacyNICType(a.NICType) && !isInfraOrLegacyNICType(b.NICType) {
+		if a.NICType.IsInfraOrLegacy() && !b.NICType.IsInfraOrLegacy() {
 			return -1
 		}
-		if !isInfraOrLegacyNICType(a.NICType) && isInfraOrLegacyNICType(b.NICType) {
+		if !a.NICType.IsInfraOrLegacy() && b.NICType.IsInfraOrLegacy() {
 			return 1
 		}
 		return 0
 	})
 }
 
-// isInfraOrLegacyNICType returns true if the NIC type is InfraNIC or empty (legacy).
-// Empty NICType is treated as infra for backward compatibility with older CNS responses.
-func isInfraOrLegacyNICType(nicType cns.NICType) bool {
-	return nicType.IsInfraOrLegacy()
-}
 
 func (plugin *NetPlugin) findMasterInterface(opt *createEpInfoOpt) string {
 	switch opt.ifInfo.NICType {
@@ -1193,7 +1188,7 @@ func (plugin *NetPlugin) Delete(args *cniSkel.CmdArgs) error {
 			zap.String("endpointID", epInfo.EndpointID))
 		telemetryClient.SendEvent("Deleting endpoint: " + epInfo.EndpointID)
 
-		if !nwCfg.MultiTenancy && isInfraOrLegacyNICType(epInfo.NICType) {
+		if !nwCfg.MultiTenancy && epInfo.NICType.IsInfraOrLegacy() {
 			// Call into IPAM plugin to release the endpoint's addresses.
 			for i := range epInfo.IPAddresses {
 				logger.Info("Release ip", zap.String("ip", epInfo.IPAddresses[i].IP.String()))

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -673,7 +673,7 @@ func sortInfraNICFirst(epInfos []*network.EndpointInfo) {
 // isInfraOrLegacyNICType returns true if the NIC type is InfraNIC or empty (legacy).
 // Empty NICType is treated as infra for backward compatibility with older CNS responses.
 func isInfraOrLegacyNICType(nicType cns.NICType) bool {
-	return nicType == cns.InfraNIC || nicType == ""
+	return nicType.IsInfraOrLegacy()
 }
 
 func (plugin *NetPlugin) findMasterInterface(opt *createEpInfoOpt) string {

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -98,6 +98,12 @@ const (
 	ApipaNIC NICType = "ApipaNIC"
 )
 
+// IsInfraOrLegacy returns true if the NIC type represents an InfraNIC
+// or is empty (legacy endpoints that predate the NICType field).
+func (n NICType) IsInfraOrLegacy() bool {
+	return n == InfraNIC || n == ""
+}
+
 // ChannelMode :- CNS channel modes
 const (
 	Direct         = "Direct"

--- a/cns/stateprovider/cns/podinfoprovider.go
+++ b/cns/stateprovider/cns/podinfoprovider.go
@@ -41,6 +41,11 @@ func endpointStateToPodInfoByIP(state map[string]*restserver.EndpointInfo) (map[
 	podInfoByIP := map[string]cns.PodInfo{}
 	for containerID, endpointInfo := range state { // for each endpoint
 		for _, ipinfo := range endpointInfo.IfnameToIPMap { // for each IP info object of the endpoint's interfaces
+			// Only InfraNIC IPs participate in NNC reconcile; delegated NIC IPs
+			// (FrontendNIC/BackendNIC) are owned by per-pod MTPNC.
+			if !ipinfo.NICType.IsInfraOrLegacy() {
+				continue
+			}
 			for _, ipv4conf := range ipinfo.IPv4 { // for each IPv4 config of the endpoint's interfaces
 				if _, ok := podInfoByIP[ipv4conf.IP.String()]; ok {
 					return nil, errors.Wrap(cns.ErrDuplicateIP, ipv4conf.IP.String())

--- a/cns/stateprovider/cns/podinfoprovider_test.go
+++ b/cns/stateprovider/cns/podinfoprovider_test.go
@@ -11,10 +11,60 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testDefaultNamespace = "default"
+
+func TestEndpointStateToPodInfoByIP_ExcludesDelegatedNIC(t *testing.T) {
+	containerID := "cd97a4018a2584fd0853fee15649a36688e92984142d9178af916a840155a725"
+	state := map[string]*restserver.EndpointInfo{
+		containerID: {
+			PodName:      "vfpod1",
+			PodNamespace: testDefaultNamespace,
+			IfnameToIPMap: map[string]*restserver.IPInfo{
+				"eth0": {
+					IPv4:    []net.IPNet{{IP: net.IPv4(10, 226, 0, 52), Mask: net.IPv4Mask(255, 255, 255, 0)}},
+					NICType: cns.InfraNIC,
+				},
+				"Ethernet 4": {
+					IPv4:    []net.IPNet{{IP: net.IPv4(172, 25, 0, 7), Mask: net.IPv4Mask(255, 255, 255, 0)}},
+					NICType: cns.DelegatedVMNIC,
+				},
+			},
+		},
+	}
+
+	podInfoByIP, err := endpointStateToPodInfoByIP(state)
+	require.NoError(t, err)
+
+	// Only the InfraNIC IP should be present; the FrontendNIC IP must be excluded.
+	assert.Len(t, podInfoByIP, 1)
+	assert.Contains(t, podInfoByIP, "10.226.0.52")
+	assert.NotContains(t, podInfoByIP, "172.25.0.7")
+}
+
+func TestEndpointStateToPodInfoByIP_LegacyEmptyNICType(t *testing.T) {
+	// Legacy endpoints with empty NICType should still be included.
+	state := map[string]*restserver.EndpointInfo{
+		"abc123": {
+			PodName:      "legacy-pod",
+			PodNamespace: testDefaultNamespace,
+			IfnameToIPMap: map[string]*restserver.IPInfo{
+				"eth0": {
+					IPv4:    []net.IPNet{{IP: net.IPv4(10, 0, 0, 1), Mask: net.IPv4Mask(255, 255, 255, 0)}},
+					NICType: "", // legacy empty
+				},
+			},
+		},
+	}
+
+	podInfoByIP, err := endpointStateToPodInfoByIP(state)
+	require.NoError(t, err)
+	assert.Contains(t, podInfoByIP, "10.0.0.1")
+}
+
 func TestNewCNSPodInfoProvider(t *testing.T) {
 	goodStore := store.NewMockStore("")
 	goodEndpointState := make(map[string]*restserver.EndpointInfo)
-	endpointInfo := &restserver.EndpointInfo{PodName: "goldpinger-deploy-bbbf9fd7c-z8v4l", PodNamespace: "default", IfnameToIPMap: make(map[string]*restserver.IPInfo)}
+	endpointInfo := &restserver.EndpointInfo{PodName: "goldpinger-deploy-bbbf9fd7c-z8v4l", PodNamespace: testDefaultNamespace, IfnameToIPMap: make(map[string]*restserver.IPInfo)}
 	endpointInfo.IfnameToIPMap["eth0"] = &restserver.IPInfo{IPv4: []net.IPNet{{IP: net.IPv4(10, 241, 0, 65), Mask: net.IPv4Mask(255, 255, 255, 0)}}}
 
 	goodEndpointState["0a4917617e15d24dc495e407d8eb5c88e4406e58fa209e4eb75a2c2fb7045eea"] = endpointInfo
@@ -32,7 +82,7 @@ func TestNewCNSPodInfoProvider(t *testing.T) {
 			name:  "good",
 			store: goodStore,
 			want: map[string]cns.PodInfo{"10.241.0.65": cns.NewPodInfo("0a4917617e15d24dc495e407d8eb5c88e4406e58fa209e4eb75a2c2fb7045eea",
-				"0a4917617e15d24dc495e407d8eb5c88e4406e58fa209e4eb75a2c2fb7045eea", "goldpinger-deploy-bbbf9fd7c-z8v4l", "default")},
+				"0a4917617e15d24dc495e407d8eb5c88e4406e58fa209e4eb75a2c2fb7045eea", "goldpinger-deploy-bbbf9fd7c-z8v4l", testDefaultNamespace)},
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
On SwiftV2 Windows nodes, PR #4375 started persisting IPv4 addresses for delegated NICs (FrontendNIC/BackendNIC) in the endpoint state. When CNS restarts, endpointStateToPodInfoByIP emits both the InfraNIC and FrontendNIC IPs under the same pod key, causing errMultipleIPPerFamily in newPodKeyToPodIPsMap and a permanent reconcile failure loop.

Fix: filter non-InfraNIC interfaces in endpointStateToPodInfoByIP so only InfraNIC IPs enter NNC reconcile. Add NICType.IsInfraOrLegacy() method for reuse across packages, and refactor the existing isInfraOrLegacyNICType helper in cni/network to use it.

Empty NICType is treated as InfraNIC for backward compatibility with legacy endpoint state that predates the NICType field.

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
