### PR TITLE
fix: restore DisableAsyncDelete check in CNS IPAM invoker Delete

### DIFF
--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -381,7 +381,7 @@ func (invoker *CNSIPAMInvoker) Delete(address *net.IPNet, nwCfg *cni.NetworkConf
 
 			if err = invoker.cnsClient.ReleaseIPAddress(context.TODO(), ipConfig); err != nil {
 				if errors.As(err, &connectionErr) {
-					if nwCfg.DisableAsyncDelete {
+					if nwCfg != nil && nwCfg.DisableAsyncDelete {
 						logger.Error("Failed to release IP address and async delete is disabled",
 							zap.String("podInterfaceID", ipConfigs.PodInterfaceID), zap.String("containerID", args.ContainerID), zap.Error(log.NewErrorWithoutStackTrace(err)))
 						return errors.Wrap(err, "failed to release IP address using ReleaseIPAddress and async delete is disabled")
@@ -402,7 +402,7 @@ func (invoker *CNSIPAMInvoker) Delete(address *net.IPNet, nwCfg *cni.NetworkConf
 			}
 		} else {
 			if errors.As(err, &connectionErr) {
-				if nwCfg.DisableAsyncDelete {
+				if nwCfg != nil && nwCfg.DisableAsyncDelete {
 					logger.Error("Failed to release IP address and async delete is disabled",
 						zap.String("podInterfaceID", ipConfigs.PodInterfaceID), zap.String("containerID", args.ContainerID), zap.Error(log.NewErrorWithoutStackTrace(err)))
 					return errors.Wrap(err, "failed to release IP address using ReleaseIPs and async delete is disabled")

--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -381,6 +381,11 @@ func (invoker *CNSIPAMInvoker) Delete(address *net.IPNet, nwCfg *cni.NetworkConf
 
 			if err = invoker.cnsClient.ReleaseIPAddress(context.TODO(), ipConfig); err != nil {
 				if errors.As(err, &connectionErr) {
+					if nwCfg.DisableAsyncDelete {
+						logger.Error("Failed to release IP address and async delete is disabled",
+							zap.String("podInterfaceID", ipConfigs.PodInterfaceID), zap.String("containerID", args.ContainerID), zap.Error(log.NewErrorWithoutStackTrace(err)))
+						return errors.Wrap(err, "failed to release IP address using ReleaseIPAddress and async delete is disabled")
+					}
 					addErr := fsnotify.AddFile(ipConfigs.PodInterfaceID, args.ContainerID, watcherPath)
 					if addErr != nil {
 						logger.Error("Failed to add file to watcher (unsupported api path)",
@@ -397,6 +402,11 @@ func (invoker *CNSIPAMInvoker) Delete(address *net.IPNet, nwCfg *cni.NetworkConf
 			}
 		} else {
 			if errors.As(err, &connectionErr) {
+				if nwCfg.DisableAsyncDelete {
+					logger.Error("Failed to release IP address and async delete is disabled",
+						zap.String("podInterfaceID", ipConfigs.PodInterfaceID), zap.String("containerID", args.ContainerID), zap.Error(log.NewErrorWithoutStackTrace(err)))
+					return errors.Wrap(err, "failed to release IP address using ReleaseIPs and async delete is disabled")
+				}
 				addErr := fsnotify.AddFile(ipConfigs.PodInterfaceID, args.ContainerID, watcherPath)
 				if addErr != nil {
 					logger.Error("Failed to add file to watcher", zap.String("podInterfaceID", ipConfigs.PodInterfaceID), zap.String("containerID", args.ContainerID),

--- a/cni/network/invoker_cns_test.go
+++ b/cni/network/invoker_cns_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-container-networking/cni"
 	"github.com/Azure/azure-container-networking/cni/util"
 	"github.com/Azure/azure-container-networking/cns"
+	cnscli "github.com/Azure/azure-container-networking/cns/client"
 	"github.com/Azure/azure-container-networking/iptables"
 	"github.com/Azure/azure-container-networking/network"
 	"github.com/Azure/azure-container-networking/network/policy"
@@ -1508,6 +1509,129 @@ func TestCNSIPAMInvoker_Delete_NotSupportedAPI(t *testing.T) {
 			err := invoker.Delete(tt.args.address, tt.args.nwCfg, tt.args.args, tt.args.options)
 			if tt.wantErr {
 				require.Error(err)
+			} else {
+				require.NoError(err)
+			}
+		})
+	}
+}
+
+func TestCNSIPAMInvoker_Delete_DisableAsyncDelete(t *testing.T) {
+	require := require.New(t) //nolint further usage of require without passing t
+
+	connErr := cnscli.NewConnectionFailureErr(errors.New("connection refused"))
+
+	tests := []struct {
+		name             string
+		disableAsync     bool
+		releaseIPsErr    error
+		wantErr          bool
+		wantErrContains  string
+	}{
+		{
+			name:            "connection failure with async delete disabled returns error",
+			disableAsync:    true,
+			releaseIPsErr:   connErr,
+			wantErr:         true,
+			wantErrContains: "async delete is disabled",
+		},
+		{
+			name:            "connection failure with async delete enabled attempts async write",
+			disableAsync:    false,
+			releaseIPsErr:   connErr,
+			wantErr:         true,
+			wantErrContains: "failed to add file to watcher",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			invoker := &CNSIPAMInvoker{
+				podName:      testPodInfo.PodName,
+				podNamespace: testPodInfo.PodNamespace,
+				cnsClient: &MockCNSClient{
+					require: require,
+					releaseIPs: releaseIPsHandler{
+						ipconfigArgument: getTestIPConfigsRequest(),
+						err:              tt.releaseIPsErr,
+					},
+				},
+			}
+			nwCfg := &cni.NetworkConfig{
+				DisableAsyncDelete: tt.disableAsync,
+			}
+			args := &cniSkel.CmdArgs{
+				ContainerID: "testcontainerid",
+				Netns:       "testnetns",
+				IfName:      "testifname",
+			}
+			err := invoker.Delete(nil, nwCfg, args, nil)
+			if tt.wantErr {
+				require.Error(err)
+				require.Contains(err.Error(), tt.wantErrContains)
+			} else {
+				require.NoError(err)
+			}
+		})
+	}
+}
+
+func TestCNSIPAMInvoker_Delete_DisableAsyncDelete_UnsupportedAPI(t *testing.T) {
+	require := require.New(t) //nolint further usage of require without passing t
+
+	connErr := cnscli.NewConnectionFailureErr(errors.New("connection refused"))
+	unsupportedAPIs := make(map[cnsAPIName]struct{})
+	unsupportedAPIs["ReleaseIPs"] = struct{}{}
+
+	tests := []struct {
+		name             string
+		disableAsync     bool
+		releaseIPErr     error
+		wantErr          bool
+		wantErrContains  string
+	}{
+		{
+			name:            "unsupported API path with connection failure and async delete disabled returns error",
+			disableAsync:    true,
+			releaseIPErr:    connErr,
+			wantErr:         true,
+			wantErrContains: "async delete is disabled",
+		},
+		{
+			name:            "unsupported API path with connection failure and async delete enabled attempts async write",
+			disableAsync:    false,
+			releaseIPErr:    connErr,
+			wantErr:         true,
+			wantErrContains: "failed to add file to watcher",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			invoker := &CNSIPAMInvoker{
+				podName:      testPodInfo.PodName,
+				podNamespace: testPodInfo.PodNamespace,
+				cnsClient: &MockCNSClient{
+					unsupportedAPIs: unsupportedAPIs,
+					require:         require,
+					releaseIP: releaseIPHandler{
+						ipconfigArgument: getTestIPConfigRequest(),
+						err:              tt.releaseIPErr,
+					},
+				},
+			}
+			nwCfg := &cni.NetworkConfig{
+				DisableAsyncDelete: tt.disableAsync,
+			}
+			args := &cniSkel.CmdArgs{
+				ContainerID: "testcontainerid",
+				Netns:       "testnetns",
+				IfName:      "testifname",
+			}
+			err := invoker.Delete(nil, nwCfg, args, nil)
+			if tt.wantErr {
+				require.Error(err)
+				require.Contains(err.Error(), tt.wantErrContains)
 			} else {
 				require.NoError(err)
 			}

--- a/cni/network/invoker_cns_test.go
+++ b/cni/network/invoker_cns_test.go
@@ -1519,14 +1519,14 @@ func TestCNSIPAMInvoker_Delete_NotSupportedAPI(t *testing.T) {
 func TestCNSIPAMInvoker_Delete_DisableAsyncDelete(t *testing.T) {
 	require := require.New(t) //nolint further usage of require without passing t
 
-	connErr := cnscli.NewConnectionFailureErr(errors.New("connection refused"))
+	connErr := cnscli.NewConnectionFailureErr(errConnectionRefused)
 
 	tests := []struct {
-		name           string
-		disableAsync   bool
-		releaseIPsErr  error
-		wantErr        bool
-		wantConnErr    bool
+		name          string
+		disableAsync  bool
+		releaseIPsErr error
+		wantErr       bool
+		wantConnErr   bool
 	}{
 		{
 			name:          "connection failure with async delete disabled returns connection error",
@@ -1544,8 +1544,7 @@ func TestCNSIPAMInvoker_Delete_DisableAsyncDelete(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(_ *testing.T) {
 			invoker := &CNSIPAMInvoker{
 				podName:      testPodInfo.PodName,
 				podNamespace: testPodInfo.PodNamespace,
@@ -1571,7 +1570,7 @@ func TestCNSIPAMInvoker_Delete_DisableAsyncDelete(t *testing.T) {
 			if tt.wantConnErr {
 				require.ErrorAs(err, &target)
 			} else {
-				require.False(errors.As(err, &target))
+				require.NotErrorAs(err, &target)
 			}
 		})
 	}
@@ -1580,7 +1579,7 @@ func TestCNSIPAMInvoker_Delete_DisableAsyncDelete(t *testing.T) {
 func TestCNSIPAMInvoker_Delete_DisableAsyncDelete_UnsupportedAPI(t *testing.T) {
 	require := require.New(t) //nolint further usage of require without passing t
 
-	connErr := cnscli.NewConnectionFailureErr(errors.New("connection refused"))
+	connErr := cnscli.NewConnectionFailureErr(errConnectionRefused)
 	unsupportedAPIs := make(map[cnsAPIName]struct{})
 	unsupportedAPIs["ReleaseIPs"] = struct{}{}
 
@@ -1607,8 +1606,7 @@ func TestCNSIPAMInvoker_Delete_DisableAsyncDelete_UnsupportedAPI(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(_ *testing.T) {
 			invoker := &CNSIPAMInvoker{
 				podName:      testPodInfo.PodName,
 				podNamespace: testPodInfo.PodNamespace,
@@ -1635,7 +1633,7 @@ func TestCNSIPAMInvoker_Delete_DisableAsyncDelete_UnsupportedAPI(t *testing.T) {
 			if tt.wantConnErr {
 				require.ErrorAs(err, &target)
 			} else {
-				require.False(errors.As(err, &target))
+				require.NotErrorAs(err, &target)
 			}
 		})
 	}

--- a/cni/network/invoker_cns_test.go
+++ b/cni/network/invoker_cns_test.go
@@ -1522,25 +1522,25 @@ func TestCNSIPAMInvoker_Delete_DisableAsyncDelete(t *testing.T) {
 	connErr := cnscli.NewConnectionFailureErr(errors.New("connection refused"))
 
 	tests := []struct {
-		name             string
-		disableAsync     bool
-		releaseIPsErr    error
-		wantErr          bool
-		wantErrContains  string
+		name           string
+		disableAsync   bool
+		releaseIPsErr  error
+		wantErr        bool
+		wantConnErr    bool
 	}{
 		{
-			name:            "connection failure with async delete disabled returns error",
-			disableAsync:    true,
-			releaseIPsErr:   connErr,
-			wantErr:         true,
-			wantErrContains: "async delete is disabled",
+			name:          "connection failure with async delete disabled returns connection error",
+			disableAsync:  true,
+			releaseIPsErr: connErr,
+			wantErr:       true,
+			wantConnErr:   true,
 		},
 		{
-			name:            "connection failure with async delete enabled attempts async write",
-			disableAsync:    false,
-			releaseIPsErr:   connErr,
-			wantErr:         true,
-			wantErrContains: "failed to add file to watcher",
+			name:          "connection failure with async delete enabled attempts async write",
+			disableAsync:  false,
+			releaseIPsErr: connErr,
+			wantErr:       true,
+			wantConnErr:   false,
 		},
 	}
 	for _, tt := range tests {
@@ -1566,11 +1566,12 @@ func TestCNSIPAMInvoker_Delete_DisableAsyncDelete(t *testing.T) {
 				IfName:      "testifname",
 			}
 			err := invoker.Delete(nil, nwCfg, args, nil)
-			if tt.wantErr {
-				require.Error(err)
-				require.Contains(err.Error(), tt.wantErrContains)
+			require.Error(err)
+			var target *cnscli.ConnectionFailureErr
+			if tt.wantConnErr {
+				require.ErrorAs(err, &target)
 			} else {
-				require.NoError(err)
+				require.False(errors.As(err, &target))
 			}
 		})
 	}
@@ -1584,25 +1585,25 @@ func TestCNSIPAMInvoker_Delete_DisableAsyncDelete_UnsupportedAPI(t *testing.T) {
 	unsupportedAPIs["ReleaseIPs"] = struct{}{}
 
 	tests := []struct {
-		name             string
-		disableAsync     bool
-		releaseIPErr     error
-		wantErr          bool
-		wantErrContains  string
+		name         string
+		disableAsync bool
+		releaseIPErr error
+		wantErr      bool
+		wantConnErr  bool
 	}{
 		{
-			name:            "unsupported API path with connection failure and async delete disabled returns error",
-			disableAsync:    true,
-			releaseIPErr:    connErr,
-			wantErr:         true,
-			wantErrContains: "async delete is disabled",
+			name:         "unsupported API path with connection failure and async delete disabled returns connection error",
+			disableAsync: true,
+			releaseIPErr: connErr,
+			wantErr:      true,
+			wantConnErr:  true,
 		},
 		{
-			name:            "unsupported API path with connection failure and async delete enabled attempts async write",
-			disableAsync:    false,
-			releaseIPErr:    connErr,
-			wantErr:         true,
-			wantErrContains: "failed to add file to watcher",
+			name:         "unsupported API path with connection failure and async delete enabled attempts async write",
+			disableAsync: false,
+			releaseIPErr: connErr,
+			wantErr:      true,
+			wantConnErr:  false,
 		},
 	}
 	for _, tt := range tests {
@@ -1629,11 +1630,12 @@ func TestCNSIPAMInvoker_Delete_DisableAsyncDelete_UnsupportedAPI(t *testing.T) {
 				IfName:      "testifname",
 			}
 			err := invoker.Delete(nil, nwCfg, args, nil)
-			if tt.wantErr {
-				require.Error(err)
-				require.Contains(err.Error(), tt.wantErrContains)
+			require.Error(err)
+			var target *cnscli.ConnectionFailureErr
+			if tt.wantConnErr {
+				require.ErrorAs(err, &target)
 			} else {
-				require.NoError(err)
+				require.False(errors.As(err, &target))
 			}
 		})
 	}

--- a/cni/network/multitenancy_test.go
+++ b/cni/network/multitenancy_test.go
@@ -79,6 +79,7 @@ var (
 	errNoRequestIPFound           = errors.New("No Request IP Found")
 	errNoReleaseIPFound           = errors.New("No Release IP Found")
 	errNoOrchestratorContextFound = errors.New("No CNI OrchestratorContext Found")
+	errConnectionRefused          = errors.New("connection refused") //nolint:goerr113 // test sentinel
 )
 
 type MockCNSClient struct {

--- a/cns/client/client.go
+++ b/cns/client/client.go
@@ -66,6 +66,10 @@ func (e *ConnectionFailureErr) Error() string {
 	return e.cause.Error()
 }
 
+func NewConnectionFailureErr(cause error) *ConnectionFailureErr {
+	return &ConnectionFailureErr{cause: cause}
+}
+
 // New returns a new CNS client configured with the passed URL and timeout.
 func New(baseURL string, requestTimeout time.Duration) (*Client, error) {
 	if baseURL == "" {


### PR DESCRIPTION
## Summary

The `disableAsyncDelete` conflist flag was previously checked in the stateless CNI Delete path to prevent writing to the fsnotify watcher directory when CNS is unreachable. This guard was accidentally removed during a refactor (ed48bcf36 — "Feat: necessary fixes for Stateless CNI Linux #4212"), leaving standalone/ACI scenarios (which have no CNS daemon to process async deletes) writing orphan files to `/var/run/azure-vnet/deleteIDs`.

## Changes

Re-adds the `nwCfg.DisableAsyncDelete` check in both connection-error branches of `CNSIPAMInvoker.Delete` (`cni/network/invoker_cns.go`):
- When `disableAsyncDelete: true` in the conflist, the CNI now returns the connection error directly instead of deferring to the watcher.
- When `disableAsyncDelete` is false (default), behavior is unchanged — async delete files are still written for CNS to pick up later.

## Motivation

In ACI/standalone scenarios (e.g., `azure-windows-swiftv2-stateless.conflist`), there is no CNS daemon running to process async deletes. Without this guard, orphan files accumulate in the deleteIDs directory with no consumer.

## Testing

- `go build ./cni/...` passes
- `TestCNSIPAMInvoker_Delete*` tests pass