### PR TITLE
fix: CNI DEL should ignore not-found errors during HNS network deletion

### DIFF
--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -386,7 +386,7 @@ func (nw *network) deleteHostNCApipaEndpoint(networkContainerID string) error {
 	if err != nil {
 		// If error is anything other than EndpointNotFoundError, return error.
 		// else log the error but don't return error because endpoint is already deleted.
-		if _, endpointNotFound := err.(hcn.EndpointNotFoundError); !endpointNotFound {
+		if !errors.As(err, &hcn.EndpointNotFoundError{}) {
 			return fmt.Errorf("deleteEndpointByNameHnsV2 failed due to error with GetEndpointByName: %w", err)
 		}
 
@@ -620,7 +620,7 @@ func (nw *network) deleteEndpointImplHnsV2(ep *endpoint) error {
 	if err != nil {
 		// If error is anything other than EndpointNotFoundError, return error.
 		// else log the error but don't return error because endpoint is already deleted.
-		if _, endpointNotFound := err.(hcn.EndpointNotFoundError); !endpointNotFound {
+		if !errors.As(err, &hcn.EndpointNotFoundError{}) {
 			return fmt.Errorf("Failed to get hcn endpoint with id: %s due to err: %w", ep.HnsId, err)
 		}
 

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -390,7 +390,7 @@ func (nw *network) deleteHostNCApipaEndpoint(networkContainerID string) error {
 			return fmt.Errorf("deleteEndpointByNameHnsV2 failed due to error with GetEndpointByName: %w", err)
 		}
 
-		logger.Error("Delete called on the Endpoint which doesn't exist. Error:", zap.String("endpointName", endpointName), zap.Error(err))
+		logger.Info("Delete called on the Endpoint which doesn't exist.", zap.String("endpointName", endpointName), zap.Error(err))
 		return nil
 	}
 
@@ -624,7 +624,7 @@ func (nw *network) deleteEndpointImplHnsV2(ep *endpoint) error {
 			return fmt.Errorf("Failed to get hcn endpoint with id: %s due to err: %w", ep.HnsId, err)
 		}
 
-		logger.Error("Delete called on the Endpoint which doesn't exist. Error:", zap.String("HnsId", ep.HnsId), zap.Error(err))
+		logger.Info("Delete called on the Endpoint which doesn't exist.", zap.String("HnsId", ep.HnsId), zap.Error(err))
 		return nil
 	}
 

--- a/network/errors.go
+++ b/network/errors.go
@@ -8,4 +8,6 @@ var (
 	ErrEndpointStateNotFound   = errors.New("endpoint state could not be found in the statefile")
 	ErrConnectionFailure       = errors.New("couldn't connect to CNS")
 	ErrGetEndpointStateFailure = errors.New("failure to obtain the endpoint state")
+	errGetHNSNetworkByID       = errors.New("failed to get hcn network by id")
+	errDeleteHNSNetwork        = errors.New("failed to delete hcn network")
 )

--- a/network/errors.go
+++ b/network/errors.go
@@ -8,6 +8,4 @@ var (
 	ErrEndpointStateNotFound   = errors.New("endpoint state could not be found in the statefile")
 	ErrConnectionFailure       = errors.New("couldn't connect to CNS")
 	ErrGetEndpointStateFailure = errors.New("failure to obtain the endpoint state")
-	errGetHNSNetworkByID       = errors.New("failed to get hcn network by id")
-	errDeleteHNSNetwork        = errors.New("failed to delete hcn network")
 )

--- a/network/hnswrapper/hnsv2wrapperfake.go
+++ b/network/hnswrapper/hnsv2wrapperfake.go
@@ -206,7 +206,7 @@ func (f Hnsv2wrapperFake) GetNetworkByID(networkID string) (*hcn.HostComputeNetw
 			return network.GetHCNObj(), nil
 		}
 	}
-	return &hcn.HostComputeNetwork{}, nil
+	return nil, hcn.NetworkNotFoundError{NetworkID: networkID}
 }
 
 func (f Hnsv2wrapperFake) GetEndpointByID(endpointID string) (*hcn.HostComputeEndpoint, error) {

--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -466,7 +466,13 @@ func (nm *networkManager) deleteNetworkImplHnsV2(nw *network) error {
 	logger.Info("Deleting hcn network with id", zap.String("id", nw.HnsId))
 
 	if hcnNetwork, err = Hnsv2.GetNetworkByID(nw.HnsId); err != nil {
-		return fmt.Errorf("Failed to get hcn network with id: %s due to err: %v", nw.HnsId, err)
+		if _, networkNotFound := err.(hcn.NetworkNotFoundError); !networkNotFound {
+			return fmt.Errorf("Failed to get hcn network with id: %s due to err: %v", nw.HnsId, err)
+		}
+
+		logger.Info("Delete called on the Network which doesn't exist.",
+			zap.String("HnsId", nw.HnsId), zap.Error(err))
+		return nil
 	}
 
 	if err = Hnsv2.DeleteNetwork(hcnNetwork); err != nil {

--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -466,8 +466,8 @@ func (nm *networkManager) deleteNetworkImplHnsV2(nw *network) error {
 	logger.Info("Deleting hcn network with id", zap.String("id", nw.HnsId))
 
 	if hcnNetwork, err = Hnsv2.GetNetworkByID(nw.HnsId); err != nil {
-		if _, networkNotFound := err.(hcn.NetworkNotFoundError); !networkNotFound {
-			return fmt.Errorf("Failed to get hcn network with id: %s due to err: %v", nw.HnsId, err)
+		if !errors.As(err, &hcn.NetworkNotFoundError{}) {
+			return fmt.Errorf("Failed to get hcn network with id: %s due to err: %w", nw.HnsId, err)
 		}
 
 		logger.Info("Delete called on the Network which doesn't exist.",
@@ -476,7 +476,7 @@ func (nm *networkManager) deleteNetworkImplHnsV2(nw *network) error {
 	}
 
 	if err = Hnsv2.DeleteNetwork(hcnNetwork); err != nil {
-		return fmt.Errorf("Failed to delete hcn network: %s due to error: %v", nw.HnsId, err)
+		return fmt.Errorf("Failed to delete hcn network: %s due to error: %w", nw.HnsId, err)
 	}
 
 	logger.Info("Successfully deleted hcn network with id", zap.String("id", nw.HnsId))

--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -467,7 +467,7 @@ func (nm *networkManager) deleteNetworkImplHnsV2(nw *network) error {
 
 	if hcnNetwork, err = Hnsv2.GetNetworkByID(nw.HnsId); err != nil {
 		if !errors.As(err, &hcn.NetworkNotFoundError{}) {
-			return fmt.Errorf("Failed to get hcn network with id: %s due to err: %w", nw.HnsId, err)
+			return fmt.Errorf("%w: id %s: %w", errGetHNSNetworkByID, nw.HnsId, err)
 		}
 
 		logger.Info("Delete called on the Network which doesn't exist.",
@@ -476,7 +476,7 @@ func (nm *networkManager) deleteNetworkImplHnsV2(nw *network) error {
 	}
 
 	if err = Hnsv2.DeleteNetwork(hcnNetwork); err != nil {
-		return fmt.Errorf("Failed to delete hcn network: %s due to error: %w", nw.HnsId, err)
+		return fmt.Errorf("%w: id %s: %w", errDeleteHNSNetwork, nw.HnsId, err)
 	}
 
 	logger.Info("Successfully deleted hcn network with id", zap.String("id", nw.HnsId))

--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -45,11 +45,6 @@ const (
 	defaultIPv6NextHop = "fe80::1234:5678:9abc"
 )
 
-var (
-	errGetHNSNetworkByID = errors.New("failed to get hcn network by id")
-	errDeleteHNSNetwork  = errors.New("failed to delete hcn network")
-)
-
 // Windows implementation of route.
 type route interface{}
 
@@ -472,7 +467,7 @@ func (nm *networkManager) deleteNetworkImplHnsV2(nw *network) error {
 
 	if hcnNetwork, err = Hnsv2.GetNetworkByID(nw.HnsId); err != nil {
 		if !errors.As(err, &hcn.NetworkNotFoundError{}) {
-			return fmt.Errorf("%w: id %s: %w", errGetHNSNetworkByID, nw.HnsId, err)
+			return fmt.Errorf("failed to get hcn network by id %s: %w", nw.HnsId, err)
 		}
 
 		logger.Info("Delete called on the Network which doesn't exist.",
@@ -481,7 +476,7 @@ func (nm *networkManager) deleteNetworkImplHnsV2(nw *network) error {
 	}
 
 	if err = Hnsv2.DeleteNetwork(hcnNetwork); err != nil {
-		return fmt.Errorf("%w: id %s: %w", errDeleteHNSNetwork, nw.HnsId, err)
+		return fmt.Errorf("failed to delete hcn network id %s: %w", nw.HnsId, err)
 	}
 
 	logger.Info("Successfully deleted hcn network with id", zap.String("id", nw.HnsId))

--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -45,6 +45,11 @@ const (
 	defaultIPv6NextHop = "fe80::1234:5678:9abc"
 )
 
+var (
+	errGetHNSNetworkByID = errors.New("failed to get hcn network by id")
+	errDeleteHNSNetwork  = errors.New("failed to delete hcn network")
+)
+
 // Windows implementation of route.
 type route interface{}
 

--- a/network/network_windows_test.go
+++ b/network/network_windows_test.go
@@ -66,6 +66,23 @@ func TestNewAndDeleteNetworkImplHnsV2(t *testing.T) {
 	}
 }
 
+func TestDeleteNetworkImplHnsV2NotFound(t *testing.T) {
+	nm := &networkManager{
+		ExternalInterfaces: map[string]*externalInterface{},
+	}
+
+	Hnsv2 = hnswrapper.NewHnsv2wrapperFake()
+
+	nw := &network{
+		HnsId: "nonexistent-network-id",
+	}
+
+	err := nm.deleteNetworkImplHnsV2(nw)
+	if err != nil {
+		t.Fatalf("delete should succeed when HNS network is not found, but got: %v", err)
+	}
+}
+
 func TestSuccesfulNetworkCreationWhenAlreadyExists(t *testing.T) {
 	nm := &networkManager{
 		ExternalInterfaces: map[string]*externalInterface{},


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->

CNI Delete can fail when the HNS network is not found after a VM reboot, since non-persistent HNS networks are already cleaned up. This mirrors the existing HNSv2 endpoint deletion pattern: if `GetNetworkByID` returns `NetworkNotFoundError`, log it and return nil instead of failing.

Also downgrades "not found" log level from error to info for both network and endpoint deletion, since this is an expected condition.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] relevant PR labels added

**Notes**:
