### PR TITLE
[RNMDeprecation] feat: call createOrUpdateNodeInfoCRD when EnableHomeAz is true

### DIFF
--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -31,6 +31,7 @@ type CNSConfig struct {
 	EnableAPIServerHealthPing       bool
 	EnableAsyncPodDelete            bool
 	EnableCNIConflistGeneration     bool
+	EnableHomeAz                    bool
 	EnableIPAMv2                    bool
 	EnableK8sDevicePlugin           bool
 	EnableLoggerV2                  bool

--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -31,7 +31,7 @@ type CNSConfig struct {
 	EnableAPIServerHealthPing       bool
 	EnableAsyncPodDelete            bool
 	EnableCNIConflistGeneration     bool
-	EnableHomeAz                    bool
+	EnableHomeAZ                    bool
 	EnableIPAMv2                    bool
 	EnableK8sDevicePlugin           bool
 	EnableLoggerV2                  bool

--- a/cns/configuration/configuration_test.go
+++ b/cns/configuration/configuration_test.go
@@ -55,6 +55,7 @@ func TestReadConfigFromFile(t *testing.T) {
 			want: &CNSConfig{
 				ChannelMode:            "Direct",
 				InitializeFromCNI:      true,
+				EnableHomeAz:           true,
 				EnablePprof:            true,
 				EnableSubnetScarcity:   true,
 				EnableSwiftV1DualStack: true,

--- a/cns/configuration/configuration_test.go
+++ b/cns/configuration/configuration_test.go
@@ -55,7 +55,7 @@ func TestReadConfigFromFile(t *testing.T) {
 			want: &CNSConfig{
 				ChannelMode:            "Direct",
 				InitializeFromCNI:      true,
-				EnableHomeAz:           true,
+				EnableHomeAZ:           true,
 				EnablePprof:            true,
 				EnableSubnetScarcity:   true,
 				EnableSwiftV1DualStack: true,

--- a/cns/configuration/testdata/good.json
+++ b/cns/configuration/testdata/good.json
@@ -2,6 +2,7 @@
     "ChannelMode": "Direct",
     "InitializeFromCNI": true,
     "EnablePprof": true,
+    "EnableHomeAz": true,
     "EnableSubnetScarcity": true,
     "EnableSwiftV1DualStack": true,
     "ManagedSettings": {

--- a/cns/configuration/testdata/good.json
+++ b/cns/configuration/testdata/good.json
@@ -2,7 +2,7 @@
     "ChannelMode": "Direct",
     "InitializeFromCNI": true,
     "EnablePprof": true,
-    "EnableHomeAz": true,
+    "EnableHomeAZ": true,
     "EnableSubnetScarcity": true,
     "EnableSwiftV1DualStack": true,
     "ManagedSettings": {

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1425,22 +1425,12 @@ func InitializeCRDState(ctx context.Context, z *zap.Logger, httpRestService cns.
 	if _, ok := node.Labels[configuration.LabelNodeSwiftV2]; ok {
 		cnsconfig.EnableSwiftV2 = true
 		cnsconfig.WatchPods = true
+	}
+
+	// populate the NodeInfo CRD if any scenario requires it (SwiftV2, SwiftV1 DualStack, or HomeAz)
+	if cnsconfig.EnableSwiftV2 || cnsconfig.EnableSwiftV1DualStack || cnsconfig.EnableHomeAz {
 		if nodeInfoErr := createOrUpdateNodeInfoCRD(ctx, kubeConfig, node); nodeInfoErr != nil {
 			return errors.Wrap(nodeInfoErr, "error creating or updating nodeinfo crd")
-		}
-	}
-
-	// populate the NodeInfo CRD for Swift V1 dualstack scenario when enabled via config
-	if cnsconfig.EnableSwiftV1DualStack {
-		if nodeInfoErr := createOrUpdateNodeInfoCRD(ctx, kubeConfig, node); nodeInfoErr != nil {
-			return errors.Wrap(nodeInfoErr, "error creating or updating nodeinfo crd for swift v1 dualstack")
-		}
-	}
-
-	// populate the NodeInfo CRD when HomeAz is enabled
-	if cnsconfig.EnableHomeAz {
-		if nodeInfoErr := createOrUpdateNodeInfoCRD(ctx, kubeConfig, node); nodeInfoErr != nil {
-			return errors.Wrap(nodeInfoErr, "error creating or updating nodeinfo crd for home az")
 		}
 	}
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1428,7 +1428,7 @@ func InitializeCRDState(ctx context.Context, z *zap.Logger, httpRestService cns.
 	}
 
 	// populate the NodeInfo CRD if any scenario requires it (SwiftV2, SwiftV1 DualStack, or HomeAz)
-	if cnsconfig.EnableSwiftV2 || cnsconfig.EnableSwiftV1DualStack || cnsconfig.EnableHomeAz {
+	if cnsconfig.EnableSwiftV2 || cnsconfig.EnableSwiftV1DualStack || cnsconfig.EnableHomeAZ {
 		if nodeInfoErr := createOrUpdateNodeInfoCRD(ctx, kubeConfig, node); nodeInfoErr != nil {
 			return errors.Wrap(nodeInfoErr, "error creating or updating nodeinfo crd")
 		}

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1437,6 +1437,13 @@ func InitializeCRDState(ctx context.Context, z *zap.Logger, httpRestService cns.
 		}
 	}
 
+	// populate the NodeInfo CRD when HomeAz is enabled
+	if cnsconfig.EnableHomeAz {
+		if nodeInfoErr := createOrUpdateNodeInfoCRD(ctx, kubeConfig, node); nodeInfoErr != nil {
+			return errors.Wrap(nodeInfoErr, "error creating or updating nodeinfo crd for home az")
+		}
+	}
+
 	// perform state migration from CNI in case CNS is set to manage the endpoint state and has emty state
 	if cnsconfig.EnableStateMigration && !httpRestServiceImplementation.EndpointStateStore.Exists() {
 		if err = PopulateCNSEndpointState(httpRestServiceImplementation.EndpointStateStore); err != nil {


### PR DESCRIPTION
**Reason for Change**:
Add the `EnableHomeAz` feature flag to CNS configuration so that when enabled, CNS populates the NodeInfo CRD with HomeAZ information from NMAgent. This allows nodes that are not labeled for Swift V2 or Swift V1 DualStack to still have their HomeAZ information published via the NodeInfo CRD.

**Issue Fixed**:


**Requirements**:

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [X] adds unit tests
- [X] relevant PR labels added

**Notes**:
- Added `EnableHomeAz` bool field to `CNSConfig` struct
- When `EnableHomeAz` is true in CRD mode, `createOrUpdateNodeInfoCRD` is called during `InitializeCRDState` to populate the NodeInfo CRD with VMUniqueID and HomeAZ
- Updated `testdata/good.json` and `TestReadConfigFromFile` to cover the new config field
- Existing `TestBuildNodeInfoSpec_WithHomeAZ` already covers the `buildAndCreateNodeInfo` function that gets invoked through this path