### PR TITLE
[backport v1.7] fix: find interface by mac address for swiftv2 delegated interfaces (#4414)

### DIFF
--- a/azure-iptables-monitor/go.sum
+++ b/azure-iptables-monitor/go.sum
@@ -29,6 +29,8 @@ github.com/go-openapi/jsonreference v0.20.2/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-openapi/swag v0.22.4 h1:QLMzNJnMGPRNDCbySlcj1x01tzU8/9LTTL9hZZZogBU=
 github.com/go-openapi/swag v0.22.4/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
+github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6 h1:teYtXy9B7y5lHTp8V9KPxpYRAVA7dozigQcMiBust1s=
+github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6/go.mod h1:p4lGIVX+8Wa6ZPNDvqcxq36XpUDLh42FLetFU7odllI=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -209,7 +209,10 @@ func (plugin *NetPlugin) Stop() {
 	logger.Info("Plugin stopped")
 }
 
-// findInterfaceByMAC returns the name of the master interface
+// findInterfaceByMAC returns the name of the master interface matching the given MAC.
+// With accelerated networking, both the netvsc upper device (e.g. eth1) and the VF
+// (e.g. enP12217s2) share the same MAC. When the matched interface is a VF, this
+// function resolves and returns its master.
 func (plugin *NetPlugin) findInterfaceByMAC(macAddress string) string {
 	interfaces, err := plugin.netClient.GetNetworkInterfaces()
 	if err != nil {
@@ -218,14 +221,26 @@ func (plugin *NetPlugin) findInterfaceByMAC(macAddress string) string {
 	}
 	macs := make([]string, 0, len(interfaces))
 	for _, iface := range interfaces {
-		// find master interface by macAddress for Swiftv2
-		macs = append(macs, iface.HardwareAddr.String())
-		if iface.HardwareAddr.String() == macAddress {
-			return iface.Name
+		mac := iface.HardwareAddr.String()
+		macs = append(macs, mac)
+		if mac != macAddress {
+			continue
 		}
+		ifName, err := resolveMasterInterface(iface.Name)
+		if err != nil {
+			logger.Error("failed to resolve master interface",
+				zap.String("name", iface.Name),
+				zap.String("mac", macAddress),
+				zap.Error(err))
+			return ""
+		}
+		logger.Info("found master interface by MAC",
+			zap.String("resolved-master", ifName),
+			zap.String("interface", iface.Name),
+			zap.String("mac", macAddress))
+		return ifName
 	}
-	// Failed to find a suitable interface.
-	logger.Error("Failed to find interface by MAC", zap.String("macAddress", macAddress), zap.Strings("interfaces", macs))
+	logger.Error("failed to find interface by MAC", zap.String("macAddress", macAddress), zap.Strings("macs", macs))
 	return ""
 }
 

--- a/cni/network/network_linux.go
+++ b/cni/network/network_linux.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"fmt"
 	"net"
 	"strconv"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/Azure/azure-container-networking/network"
 	"github.com/Azure/azure-container-networking/network/policy"
 	cniTypesCurr "github.com/containernetworking/cni/pkg/types/100"
+	vishnetlink "github.com/vishvananda/netlink"
 	"go.uber.org/zap"
 )
 
@@ -18,6 +20,56 @@ const (
 )
 
 const snatConfigFileName = "/tmp/snatConfig"
+
+// netlinkClient abstracts vishvananda/netlink link-lookup calls for testing.
+type netlinkClient interface {
+	LinkByName(name string) (vishnetlink.Link, error)
+	LinkByIndex(index int) (vishnetlink.Link, error)
+}
+
+// defaultNetlinkClient delegates to the real vishvananda/netlink package functions.
+type defaultNetlinkClient struct{}
+
+func (defaultNetlinkClient) LinkByName(name string) (vishnetlink.Link, error) {
+	link, err := vishnetlink.LinkByName(name)
+	if err != nil {
+		return nil, fmt.Errorf("get link by name: %w", err)
+	}
+	return link, nil
+}
+
+func (defaultNetlinkClient) LinkByIndex(index int) (vishnetlink.Link, error) {
+	link, err := vishnetlink.LinkByIndex(index)
+	if err != nil {
+		return nil, fmt.Errorf("get link by index: %w", err)
+	}
+	return link, nil
+}
+
+// nlClient is the active netlink client used by resolveMasterInterface.
+// Override in tests to inject a mock.
+var nlClient netlinkClient = defaultNetlinkClient{}
+
+// resolveMasterInterface returns the name of the upper (master) interface for the
+// given interface name. On Linux with accelerated networking, the VF (e.g.
+// enP12217s2) is bonded to the netvsc upper device (e.g. eth1). A VF has a
+// non-zero MasterIndex; the upper device does not. If name is already the
+// upper device, it is returned unchanged.
+func resolveMasterInterface(name string) (string, error) {
+	link, err := nlClient.LinkByName(name)
+	if err != nil {
+		return "", fmt.Errorf("get link %q: %w", name, err)
+	}
+	masterIndex := link.Attrs().MasterIndex
+	if masterIndex == 0 {
+		return name, nil
+	}
+	master, err := nlClient.LinkByIndex(masterIndex)
+	if err != nil {
+		return "", fmt.Errorf("get master link by index %d failed with: %w", masterIndex, err)
+	}
+	return master.Attrs().Name, nil
+}
 
 func addDefaultRoute(gwIPString string, epInfo *network.EndpointInfo, result *network.InterfaceInfo) {
 	_, defaultIPNet, _ := net.ParseCIDR("0.0.0.0/0")

--- a/cni/network/network_linux_test.go
+++ b/cni/network/network_linux_test.go
@@ -4,6 +4,7 @@
 package network
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"regexp"
@@ -17,6 +18,7 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	vishnetlink "github.com/vishvananda/netlink"
 )
 
 func TestSetNetworkOptions(t *testing.T) {
@@ -251,6 +253,7 @@ func TestPluginLinuxAdd(t *testing.T) {
 		name   string
 		plugin *NetPlugin
 		args   *cniSkel.CmdArgs
+		setup  func(t *testing.T)
 		want   []endpointEntry
 		match  func(*network.EndpointInfo, *network.EndpointInfo) bool
 	}{
@@ -375,6 +378,7 @@ func TestPluginLinuxAdd(t *testing.T) {
 				Args:        fmt.Sprintf("K8S_POD_NAME=%v;K8S_POD_NAMESPACE=%v", "test-pod", "test-pod-ns"),
 				IfName:      eth0IfName,
 			},
+			setup: func(t *testing.T) { stubResolveMasterInterface(t, "secondary") },
 			match: func(ei1, ei2 *network.EndpointInfo) bool {
 				return ei1.NICType == ei2.NICType
 			},
@@ -498,6 +502,9 @@ func TestPluginLinuxAdd(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.setup != nil {
+				tt.setup(t)
+			}
 			err := tt.plugin.Add(tt.args)
 			require.NoError(t, err)
 			allEndpoints, _ := tt.plugin.nm.GetAllEndpoints("")
@@ -546,4 +553,244 @@ func TestPluginLinuxAdd(t *testing.T) {
 			require.Empty(t, allEndpoints)
 		})
 	}
+}
+
+// stubResolveMasterInterface installs a mock nlClient that treats the given interface as a
+// master (MasterIndex == 0), so resolveMasterInterface returns the name unchanged.
+// Used by cross-platform tests in network_test.go that exercise the delegated NIC path.
+func stubResolveMasterInterface(t *testing.T, ifName string) {
+	t.Helper()
+	original := nlClient
+	nlClient = &mockNetlinkClient{
+		links: map[string]vishnetlink.Link{
+			ifName: &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{Name: ifName, MasterIndex: 0}},
+		},
+	}
+	t.Cleanup(func() { nlClient = original })
+}
+
+// sentinel errors for mock netlink client.
+var (
+	errLinkNotFound      = errors.New("link not found")
+	errLinkNotFoundByIdx = errors.New("link not found by index")
+	errNotImplemented    = errors.New("not implemented")
+)
+
+// test interface name constants used across resolveMasterInterface and findInterfaceByMAC tests.
+const (
+	testMasterInterface = "eth1"       // upper/master interface (netvsc) name
+	testVFInterface     = "enP12217s2" // VF interface bonded to testMasterInterface
+	testVF2Interface    = "enP100s1"   // another VF interface used in error-path tests
+	testMACAddr         = "00:22:48:d5:56:86"
+)
+
+// mockNetlinkClient implements netlinkClient for unit testing resolveMasterInterface.
+type mockNetlinkClient struct {
+	links map[string]vishnetlink.Link // keyed by name
+	byIdx map[int]vishnetlink.Link    // keyed by index
+}
+
+func (m *mockNetlinkClient) LinkByName(name string) (vishnetlink.Link, error) {
+	l, ok := m.links[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", errLinkNotFound, name)
+	}
+	return l, nil
+}
+
+func (m *mockNetlinkClient) LinkByIndex(index int) (vishnetlink.Link, error) {
+	l, ok := m.byIdx[index]
+	if !ok {
+		return nil, fmt.Errorf("%w: %d", errLinkNotFoundByIdx, index)
+	}
+	return l, nil
+}
+
+func TestResolveMasterInterface(t *testing.T) {
+	tests := []struct {
+		name       string
+		ifName     string
+		client     *mockNetlinkClient
+		wantResult string
+		wantErr    bool
+	}{
+		{
+			name:   "interface is already master (MasterIndex == 0)",
+			ifName: testMasterInterface,
+			client: &mockNetlinkClient{
+				links: map[string]vishnetlink.Link{
+					testMasterInterface: &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
+						Name:        testMasterInterface,
+						Index:       2,
+						MasterIndex: 0,
+					}},
+				},
+			},
+			wantResult: testMasterInterface,
+		},
+		{
+			name:   "VF resolves to master upper device",
+			ifName: testVFInterface,
+			client: &mockNetlinkClient{
+				links: map[string]vishnetlink.Link{
+					testVFInterface: &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
+						Name:        testVFInterface,
+						Index:       5,
+						MasterIndex: 2,
+					}},
+				},
+				byIdx: map[int]vishnetlink.Link{
+					2: &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
+						Name:        testMasterInterface,
+						Index:       2,
+						MasterIndex: 0,
+					}},
+				},
+			},
+			wantResult: testMasterInterface,
+		},
+		{
+			name:   "LinkByName fails returns error",
+			ifName: "nonexistent",
+			client: &mockNetlinkClient{
+				links: map[string]vishnetlink.Link{},
+			},
+			wantErr: true,
+		},
+		{
+			name:   "LinkByIndex fails returns error",
+			ifName: testVF2Interface,
+			client: &mockNetlinkClient{
+				links: map[string]vishnetlink.Link{
+					testVF2Interface: &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
+						Name:        testVF2Interface,
+						Index:       10,
+						MasterIndex: 99, // master index that doesn't exist
+					}},
+				},
+				byIdx: map[int]vishnetlink.Link{}, // no index 99
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := nlClient
+			nlClient = tt.client
+			t.Cleanup(func() { nlClient = original })
+
+			result, err := resolveMasterInterface(tt.ifName)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantResult, result)
+		})
+	}
+}
+
+func TestFindInterfaceByMAC_WithMasterResolution(t *testing.T) {
+	mac, _ := net.ParseMAC(testMACAddr)
+
+	tests := []struct {
+		name       string
+		macAddr    string
+		interfaces []net.Interface
+		client     *mockNetlinkClient
+		wantResult string
+	}{
+		{
+			name:    "single master match returns master name",
+			macAddr: testMACAddr,
+			interfaces: []net.Interface{
+				{Name: testMasterInterface, HardwareAddr: mac},
+			},
+			client: &mockNetlinkClient{
+				links: map[string]vishnetlink.Link{
+					testMasterInterface: &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
+						Name:        testMasterInterface,
+						Index:       2,
+						MasterIndex: 0,
+					}},
+				},
+			},
+			wantResult: testMasterInterface,
+		},
+		{
+			name:    "VF matched resolves to master",
+			macAddr: testMACAddr,
+			interfaces: []net.Interface{
+				{Name: testVFInterface, HardwareAddr: mac},
+			},
+			client: &mockNetlinkClient{
+				links: map[string]vishnetlink.Link{
+					testVFInterface: &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
+						Name:        testVFInterface,
+						Index:       5,
+						MasterIndex: 2,
+					}},
+				},
+				byIdx: map[int]vishnetlink.Link{
+					2: &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{
+						Name:        testMasterInterface,
+						Index:       2,
+						MasterIndex: 0,
+					}},
+				},
+			},
+			wantResult: testMasterInterface,
+		},
+		{
+			name:    "resolve error returns empty",
+			macAddr: testMACAddr,
+			interfaces: []net.Interface{
+				{Name: testVF2Interface, HardwareAddr: mac},
+			},
+			client: &mockNetlinkClient{
+				links: map[string]vishnetlink.Link{}, // LinkByName will fail
+			},
+			wantResult: "",
+		},
+		{
+			name:    "no MAC match returns empty string",
+			macAddr: testMACAddr,
+			interfaces: []net.Interface{
+				{Name: "eth0", HardwareAddr: net.HardwareAddr{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}},
+			},
+			client: &mockNetlinkClient{
+				links: map[string]vishnetlink.Link{},
+			},
+			wantResult: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := nlClient
+			nlClient = tt.client
+			t.Cleanup(func() { nlClient = original })
+
+			plugin := &NetPlugin{
+				netClient: &mockInterfaceGetter{interfaces: tt.interfaces},
+			}
+			result := plugin.findInterfaceByMAC(tt.macAddr)
+			require.Equal(t, tt.wantResult, result)
+		})
+	}
+}
+
+// mockInterfaceGetter implements InterfaceGetter for testing.
+type mockInterfaceGetter struct {
+	interfaces []net.Interface
+	err        error
+}
+
+func (m *mockInterfaceGetter) GetNetworkInterfaces() ([]net.Interface, error) {
+	return m.interfaces, m.err
+}
+
+func (m *mockInterfaceGetter) GetNetworkInterfaceAddrs(_ *net.Interface) ([]net.Addr, error) {
+	return nil, errNotImplemented
 }

--- a/cni/network/network_test.go
+++ b/cni/network/network_test.go
@@ -1586,13 +1586,16 @@ func TestFindMasterInterface(t *testing.T) {
 	plugin, _ := cni.NewPlugin("name", "0.3.0")
 	endpointIndex := 1
 	macAddress := "12:34:56:78:90:ab"
+	parsedMAC, err := net.ParseMAC(macAddress)
+	require.NoError(t, err)
 
 	tests := []struct {
 		name        string
 		endpointOpt createEpInfoOpt
 		plugin      *NetPlugin
 		nwCfg       *cni.NetworkConfig
-		want        string // expected master interface name
+		setup       func(t *testing.T) // optional per-test setup; called before the test runs
+		want        string             // expected master interface name
 		wantErr     bool
 	}{
 		{
@@ -1730,7 +1733,7 @@ func TestFindMasterInterface(t *testing.T) {
 					interfaces: []net.Interface{
 						{
 							Name:         "eth1",
-							HardwareAddr: net.HardwareAddr(macAddress),
+							HardwareAddr: parsedMAC,
 						},
 					},
 				},
@@ -1738,9 +1741,10 @@ func TestFindMasterInterface(t *testing.T) {
 			endpointOpt: createEpInfoOpt{
 				ifInfo: &acnnetwork.InterfaceInfo{
 					NICType:    cns.NodeNetworkInterfaceFrontendNIC,
-					MacAddress: net.HardwareAddr(macAddress),
+					MacAddress: parsedMAC,
 				},
 			},
+			setup:   func(t *testing.T) { stubResolveMasterInterface(t, "eth1") },
 			want:    "eth1",
 			wantErr: false,
 		},
@@ -1750,7 +1754,7 @@ func TestFindMasterInterface(t *testing.T) {
 				endpointIndex: endpointIndex,
 				ifInfo: &acnnetwork.InterfaceInfo{
 					NICType:    cns.BackendNIC,
-					MacAddress: net.HardwareAddr(macAddress),
+					MacAddress: parsedMAC,
 				},
 			},
 			want:    ibInterfacePrefix + strconv.Itoa(endpointIndex),
@@ -1762,7 +1766,7 @@ func TestFindMasterInterface(t *testing.T) {
 				endpointIndex: endpointIndex,
 				ifInfo: &acnnetwork.InterfaceInfo{
 					NICType:    "invalidType",
-					MacAddress: net.HardwareAddr(macAddress),
+					MacAddress: parsedMAC,
 				},
 			},
 			want:    "", // default interface name is ""
@@ -1773,6 +1777,9 @@ func TestFindMasterInterface(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.setup != nil {
+				tt.setup(t)
+			}
 			masterInterface := tt.plugin.findMasterInterface(&tt.endpointOpt)
 			t.Logf("masterInterface is %s\n", masterInterface)
 			require.Equal(t, tt.want, masterInterface)

--- a/cni/network/network_windows.go
+++ b/cni/network/network_windows.go
@@ -31,6 +31,13 @@ var (
 	dualStackCount = 2
 )
 
+// resolveMasterInterface returns the master interface name for the given interface.
+// Windows does not have the Linux netvsc + VF bonding model, so the name is
+// returned unchanged.
+func resolveMasterInterface(name string) (string, error) {
+	return name, nil
+}
+
 func addDefaultRoute(_ string, _ *network.EndpointInfo, _ *network.InterfaceInfo) {
 }
 

--- a/cni/network/network_windows_test.go
+++ b/cni/network/network_windows_test.go
@@ -22,6 +22,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// stubResolveMasterInterface is a no-op on Windows because resolveMasterInterface
+// already returns (name, nil). Used by cross-platform tests in network_test.go.
+func stubResolveMasterInterface(_ *testing.T, _ string) {}
+
 func init() {
 	network.Hnsv2 = hnswrapper.NewHnsv2wrapperFake()
 	network.Hnsv1 = hnswrapper.NewHnsv1wrapperFake()


### PR DESCRIPTION
## Backport of #4414 to `release/v1.7`

Backports the SwiftV2 delegated-interface master-interface resolution fix from
**#4414** so it can ship in a v1.7.x release. The fix is **not** in any current
v1.7.x tag (newest is v1.7.17, cut before #4414 merged to `master`).

### What
- Cherry-picked merge commit `801e2f2b0c7b21a7b6fe99344efadde7b413a352` (squash commit
  of #4414) onto `release/v1.7` with `git cherry-pick -x` (provenance preserved).
- Touches `cni/network/{network,network_linux,network_windows}.go` and their tests,
  plus a carried-over `azure-iptables-monitor/go.sum` line.

### Cherry-pick fidelity
- Applied cleanly; the only auto-merged file was `cni/network/network.go`, and its fix
  hunks are **byte-identical** to the original commit (verified).

### Verification (local)
- `GOOS=linux go build ./cni/network/...` — pass
- `GOOS=windows go build ./cni/network/...` — pass
- `GOOS=linux go test -c ./cni/network` (compile-check of the new Linux unit tests) — pass
- `go test ./cni/network/...` (Windows host) — pass

### Notes
- This is a clean backport with no functional changes relative to #4414.
- Tagging (e.g. v1.7.18) is handled separately by a maintainer via the
  `Create Release Tag` workflow — not part of this PR.
