### PR TITLE
fix: recreate missing HNS network during endpoint add

### DIFF
--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -463,7 +463,7 @@ func (nw *network) newEndpointImplHnsV2(cli apipaClient, epInfo *EndpointInfo) (
 	logger.Info("Creating hcn endpoint", zap.Any("hcnEndpoint", hcnEndpoint), zap.String("computenetwork", hcnEndpoint.HostComputeNetwork))
 	hnsResponse, err := Hnsv2.CreateEndpoint(hcnEndpoint)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create endpoint: %s due to error: %v", hcnEndpoint.Name, err)
+		return nil, fmt.Errorf("Failed to create endpoint: %s due to error: %w", hcnEndpoint.Name, err)
 	}
 
 	logger.Info("Successfully created hcn endpoint with response", zap.Any("hnsResponse", hnsResponse))

--- a/network/network.go
+++ b/network/network.go
@@ -337,7 +337,7 @@ func (nm *networkManager) EndpointCreate(cnsclient apipaClient, epInfos []*Endpo
 				return err
 			}
 		}
-		ep, err := nm.createEndpoint(cnsclient, epInfo.NetworkID, epInfo)
+		ep, err := nm.createEndpointWithNetworkRetry(cnsclient, epInfo)
 		if err != nil {
 			return err
 		}
@@ -351,4 +351,30 @@ func (nm *networkManager) EndpointCreate(cnsclient apipaClient, epInfos []*Endpo
 
 	// save endpoints
 	return nm.SaveState(eps)
+}
+
+func (nm *networkManager) createEndpointWithNetworkRetry(cnsclient apipaClient, epInfo *EndpointInfo) (*endpoint, error) {
+	ep, err := nm.createEndpoint(cnsclient, epInfo.NetworkID, epInfo)
+	if err == nil || !shouldRecreateNetworkOnEndpointCreateFailure(err) {
+		return ep, err
+	}
+
+	logger.Info("HNS network not found while creating endpoint, recreating network and retrying",
+		zap.String("networkID", epInfo.NetworkID), zap.Error(err))
+
+	if err = nm.recreateNetworkForEndpointCreate(epInfo); err != nil {
+		return nil, errors.Wrapf(err, "failed to recreate network %s after endpoint create failed", epInfo.NetworkID)
+	}
+
+	return nm.createEndpoint(cnsclient, epInfo.NetworkID, epInfo)
+}
+
+func (nm *networkManager) recreateNetworkForEndpointCreate(epInfo *EndpointInfo) error {
+	nm.Lock()
+	for _, extIf := range nm.ExternalInterfaces {
+		delete(extIf.Networks, epInfo.NetworkID)
+	}
+	nm.Unlock()
+
+	return nm.CreateNetwork(epInfo)
 }

--- a/network/network_linux.go
+++ b/network/network_linux.go
@@ -733,6 +733,10 @@ func getNetworkInfoImpl(nwInfo *EndpointInfo, nw *network) {
 	}
 }
 
+func shouldRecreateNetworkOnEndpointCreateFailure(error) bool {
+	return false
+}
+
 // AddStaticRoute adds a static route to the interface.
 func AddStaticRoute(nl netlink.NetlinkInterface, netioshim netio.NetIOInterface, ip, interfaceName string) error {
 	logger.Info("Adding static route", zap.String("ip", ip))

--- a/network/network_windows.go
+++ b/network/network_windows.go
@@ -480,3 +480,7 @@ func (nm *networkManager) deleteNetworkImplHnsV2(nw *network) error {
 
 func getNetworkInfoImpl(_ *EndpointInfo, _ *network) {
 }
+
+func shouldRecreateNetworkOnEndpointCreateFailure(err error) bool {
+	return errors.As(err, &hcn.NetworkNotFoundError{})
+}

--- a/network/network_windows_test.go
+++ b/network/network_windows_test.go
@@ -26,6 +26,22 @@ var (
 	succededCaseReturn = "true"
 )
 
+type createEndpointNetworkNotFoundOnceWrapper struct {
+	*hnswrapper.Hnsv2wrapperFake
+	createEndpointNetworkIDs []string
+	failedOnce               bool
+}
+
+func (w *createEndpointNetworkNotFoundOnceWrapper) CreateEndpoint(endpoint *hcn.HostComputeEndpoint) (*hcn.HostComputeEndpoint, error) {
+	w.createEndpointNetworkIDs = append(w.createEndpointNetworkIDs, endpoint.HostComputeNetwork)
+	if !w.failedOnce {
+		w.failedOnce = true
+		return nil, hcn.NetworkNotFoundError{NetworkID: endpoint.HostComputeNetwork}
+	}
+
+	return w.Hnsv2wrapperFake.CreateEndpoint(endpoint)
+}
+
 func TestNewAndDeleteNetworkImplHnsV2(t *testing.T) {
 	nm := &networkManager{
 		ExternalInterfaces: map[string]*externalInterface{},
@@ -97,6 +113,82 @@ func TestSuccesfulNetworkCreationWhenAlreadyExists(t *testing.T) {
 	if err != nil {
 		fmt.Printf("+%v", err)
 		t.Fatal(err)
+	}
+}
+
+func TestCreateEndpointRecreatesNetworkWhenCachedHNSNetworkIsMissing(t *testing.T) {
+	hnsFake := &createEndpointNetworkNotFoundOnceWrapper{
+		Hnsv2wrapperFake: hnswrapper.NewHnsv2wrapperFake(),
+	}
+	Hnsv2 = hnsFake
+
+	extInterface := &externalInterface{
+		Name:     "eth0",
+		Subnets:  []string{"10.10.0.0/16"},
+		Networks: map[string]*network{},
+	}
+	const (
+		networkID     = "azure"
+		staleHNSID    = "stale-hns-network-id"
+		containerID   = "69e37cacdd5903823834a5ab5c4032f64dd623671fb6e0d8276ebd70a47503c9"
+		netNsPath     = "d9eb40f1-b35d-409b-a55e-a76be3bc0322"
+		networkPrefix = "192.168.0.0/16"
+	)
+	extInterface.Networks[networkID] = &network{
+		Id:        networkID,
+		HnsId:     staleHNSID,
+		Mode:      "bridge",
+		Endpoints: make(map[string]*endpoint),
+		extIf:     extInterface,
+	}
+
+	nm := &networkManager{
+		ExternalInterfaces: map[string]*externalInterface{
+			extInterface.Name: extInterface,
+		},
+	}
+
+	_, subnetPrefix, _ := net.ParseCIDR(networkPrefix)
+	_, ipAddress, _ := net.ParseCIDR("192.168.3.89/16")
+	epInfo := &EndpointInfo{
+		NetworkID:        networkID,
+		MasterIfName:     extInterface.Name,
+		HostSubnetPrefix: extInterface.Subnets[0],
+		Mode:             "bridge",
+		EndpointID:       "69e37cac-eth0",
+		ContainerID:      containerID,
+		NetNs:            netNsPath,
+		NetNsPath:        netNsPath,
+		IfName:           "eth0",
+		Data:             map[string]interface{}{},
+		NICType:          cns.InfraNIC,
+		HNSNetworkID:     staleHNSID,
+		MacAddress:       net.HardwareAddr{0x00, 0x00, 0x5e, 0x00, 0x53, 0x01},
+		IPAddresses:      []net.IPNet{*ipAddress},
+		Subnets: []SubnetInfo{
+			{
+				Prefix:  *subnetPrefix,
+				Gateway: net.ParseIP("192.168.3.1"),
+			},
+		},
+	}
+
+	ep, err := nm.createEndpointWithNetworkRetry(nil, epInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(hnsFake.createEndpointNetworkIDs) != 2 {
+		t.Fatalf("expected endpoint create to be retried once, got %d attempts", len(hnsFake.createEndpointNetworkIDs))
+	}
+	if hnsFake.createEndpointNetworkIDs[0] != staleHNSID {
+		t.Fatalf("expected first endpoint create to use stale HNS ID %q, got %q", staleHNSID, hnsFake.createEndpointNetworkIDs[0])
+	}
+	if hnsFake.createEndpointNetworkIDs[1] == staleHNSID {
+		t.Fatalf("expected retry to use recreated HNS network ID, got stale ID %q", hnsFake.createEndpointNetworkIDs[1])
+	}
+	if ep.HNSNetworkID != hnsFake.createEndpointNetworkIDs[1] {
+		t.Fatalf("expected endpoint HNS network ID %q, got %q", hnsFake.createEndpointNetworkIDs[1], ep.HNSNetworkID)
 	}
 }
 


### PR DESCRIPTION
**Reason for Change**:

Windows HNS removes non-persistent networks after a VM reboot. If azure-vnet still has the old HNS network ID in its restored state, endpoint ADD can fail indefinitely with `hcnOpenNetwork` / `NetworkNotFoundError` while trying to create the endpoint on the stale HNS network ID.

This change retries endpoint creation once when Windows endpoint ADD fails with `hcn.NetworkNotFoundError`:

1. remove the stale in-memory network entry,
2. recreate the HNS network from the current endpoint/network config,
3. retry endpoint creation against the recreated HNS network ID.

This complements #4460, which handles not-found during DEL. This PR handles the ADD-side recovery path observed after Windows node reboot.

**Issue Fixed**:

Observed in AKS Windows reboot testing for CNS/CNI v1.8.9: CNS/IPAM successfully assigned pod IPs, but azure-vnet repeatedly failed endpoint ADD because the cached `HostComputeNetwork` ID no longer existed in HNS.

**Requirements**:

- [x] uses conventional commit messages
- [ ] includes documentation
- [x] adds unit tests
- [ ] relevant PR labels added

**Testing**:

- `go test .\network -run '^(TestCreateEndpointRecreatesNetworkWhenCachedHNSNetworkIsMissing|TestNewAndDeleteNetworkImplHnsV2|TestSuccesfulNetworkCreationWhenAlreadyExists)$' -count=1 -v`
- `GOOS=linux GOARCH=amd64 go test -c .\network`

Note: `go test .\network -count=1` on this Windows workstation has pre-existing failures in older Ginkgo tests that call real HNS and fail with `Access is denied (0x5)` / HNS timeout. The new focused regression test passes.