### PR TITLE
[backport v1.7] fix: clean pre-installed Go before msft-go extraction (#4405)

### DIFF
--- a/.pipelines/build/scripts/install-go.sh
+++ b/.pipelines/build/scripts/install-go.sh
@@ -49,8 +49,24 @@ fi
 
 ARCH="${ARCH:-amd64}"
 
+# Remove any pre-installed Go to prevent source file contamination.
+# tar extract overlays onto the existing directory without deleting files that
+# are absent from the archive. When the agent's pre-installed Go and msft-go
+# have different source files (e.g. crypto/internal/fips140, internal/runtime),
+# both sets survive the overlay, causing redeclaration and undefined-symbol
+# build errors.
+sudo rm -rf /usr/local/go
+
 # Extract /usr/local/go from the image without needing a Docker daemon.
 # crane export streams the full image filesystem; we extract just usr/local/go.
 crane export --platform "linux/${ARCH}" "$MSFT_GO_IMAGE" - | sudo tar -xf - -C / usr/local/go
+
+# Prevent the Go toolchain from auto-downloading upstream (non-FIPS) Go.
+# With GOTOOLCHAIN=local, the build uses exactly the msft-go we just installed.
+export GOTOOLCHAIN=local
+echo "##vso[task.setvariable variable=GOTOOLCHAIN]local"
+
+# Clear any build cache left by the agent's previous Go version.
+/usr/local/go/bin/go clean -cache 2>/dev/null || true
 
 echo "##vso[task.prependpath]/usr/local/go/bin"


### PR DESCRIPTION
Backport of #4405 to elease/v1.7.

Cherry-pick of `c6ba93c1d` (`fix: clean pre-installed Go before msft-go extraction (#4405)`) via `git cherry-pick -x` (original authorship preserved).

**Why this is needed on release/v1.7**
The OneBranch **Official Build** installs Go by tar-overlaying msft-go onto the agent's pre-installed Go in `/usr/local/go` via `.pipelines/build/scripts/install-go.sh`. On current agents this leaves source files from both Go versions behind, causing build failures:
- `xorBytes redeclared` (crypto/internal/fips140/subtle)
- `undefined: math.MaxUint64` (internal/runtime/strconv)

`release/v1.7`'s `install-go.sh` still lacks this cleanup, so the v1.7.18 release/tag build would fail at the Go step on today's agents. This change `rm -rf /usr/local/go` before extraction, sets `GOTOOLCHAIN=local`, and clears the build cache.

**Scope**
- Single CI-only file: `.pipelines/build/scripts/install-go.sh` (+16 lines). No product/runtime code changes; nothing ships in the release binaries.
- Does **not** affect the ACN PR pipeline (which builds via Dockerfiles and does not call `install-go.sh`).

**Validation**
- v1.8.6 (without #4405) fails the Official build at `math.MaxUint64`; v1.8.7 (which *is* commit `c6ba93c1d`) and later build cleanly.
- The combined test branch `release/v1.7 + #4414 + #4405` builds through Unit Tests -> Build -> Image Manifests on the Official pipeline.

Pairs with #4462 ([backport v1.7] #4414); the two are independent and can merge in any order.