### PR TITLE
ci: add patch-kubeclusterconfig before Windows node restart in Official pipeline

### DIFF
--- a/.pipelines/singletenancy/azure-cni-overlay-stateless/azure-cni-overlay-stateless-e2e.steps.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay-stateless/azure-cni-overlay-stateless-e2e.steps.yaml
@@ -49,6 +49,12 @@ steps:
     displayName: "Windows v4Overlay ControlPlane Scale Tests"
     retryCountOnTaskFailure: 2
 
+  - script: |
+      # set cni name to azure so windows cleanup script runs on reboot
+      cd hack/scripts
+      bash patch-kubeclusterconfig.sh || true
+    displayName: "Patch kubeclusterconfig for Windows cleanup"
+
   - task: AzureCLI@2
     inputs:
       azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e.steps.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e.steps.yaml
@@ -115,6 +115,12 @@ steps:
       displayName: "Windows v4Overlay Datapath Tests"
       retryCountOnTaskFailure: 3
 
+    - script: |
+        # set cni name to azure so windows cleanup script runs on reboot
+        cd hack/scripts
+        bash patch-kubeclusterconfig.sh || true
+      displayName: "Patch kubeclusterconfig for Windows cleanup"
+
     - task: AzureCLI@2
       inputs:
         azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)


### PR DESCRIPTION
## Problem

On BYOCNI overlay clusters (created by E2E pipelines), `kubeclusterconfig.json` has `Cni.Name='none'`. The node's `cleanupnetwork.ps1` (called by `windowsnodereset.ps1` on every reboot) only removes stale `azure-vnet.json` and HNS networks when `Cni.Name='azure'`.

Without patching `kubeclusterconfig.json` before restarting nodes, stale CNI state persists after reboot, causing:
```
hcnOpenNetwork failed in Win32: The network was not found
```

## Root Cause

The **PR pipeline** (`windows-overlay-e2e-step-template.yaml`) already calls `patch-kubeclusterconfig.sh` before node restarts (added in #4345). The **Official pipeline** (`azure-cni-overlay-e2e.steps.yaml`) and the **stateless Official pipeline** were missing this step.

## Fix

Add the same `patch-kubeclusterconfig.sh` call before the Windows node restart step in:
- `.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e.steps.yaml`
- `.pipelines/singletenancy/azure-cni-overlay-stateless/azure-cni-overlay-stateless-e2e.steps.yaml`

## Verification

Confirmed on live clusters:
- Managed AKS clusters with `networkPlugin=azure` have `Cni.Name='azure'` → cleanup works natively
- BYOCNI overlay clusters have `Cni.Name='none'` → cleanup is skipped without patching
- `cleanupnetwork.ps1` gates all HNS network removal and `azure-vnet.json` deletion behind `$global:NetworkPlugin -eq "azure"`

Related: #4345