### PR TITLE
backport: ci: ignore status of azuresecuritylinuxagent and ignore completed pods in test

### DIFF
--- a/.pipelines/templates/cilium-tests.yaml
+++ b/.pipelines/templates/cilium-tests.yaml
@@ -55,6 +55,7 @@ steps:
       make test-validate-state
     name: "validatePods"
     displayName: "Validate Pods"
+    retryCountOnTaskFailure: 3
 
   - script: |
       echo "Run wireserver and metadata connectivity Tests"

--- a/test/integration/datapath/datapath_linux_test.go
+++ b/test/integration/datapath/datapath_linux_test.go
@@ -131,7 +131,7 @@ func setupLinuxEnvironment(t *testing.T) {
 	})
 
 	t.Log("Waiting for pods to be running state")
-	err = kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector)
+	err = kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector, nil)
 	if err != nil {
 		t.Fatalf("Pods are not in running state due to %+v", err)
 	}
@@ -171,7 +171,7 @@ func TestDatapathLinux(t *testing.T) {
 	t.Run("Linux ping tests", func(t *testing.T) {
 		// Check goldpinger health
 		t.Run("all pods have IPs assigned", func(t *testing.T) {
-			err := kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector)
+			err := kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector, nil)
 			if err != nil {
 				t.Fatalf("Pods are not in running state due to %+v", err)
 			}

--- a/test/integration/datapath/datapath_windows_test.go
+++ b/test/integration/datapath/datapath_windows_test.go
@@ -104,7 +104,7 @@ func setupWindowsEnvironment(t *testing.T) {
 		kubernetes.MustCreateDeployment(ctx, deploymentsClient, deployment)
 
 		t.Log("Waiting for pods to be running state")
-		err = kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector)
+		err = kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -114,7 +114,7 @@ func setupWindowsEnvironment(t *testing.T) {
 		t.Log("Namespace already exists")
 
 		t.Log("Checking for pods to be running state")
-		err = kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector)
+		err = kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/test/integration/load/load_test.go
+++ b/test/integration/load/load_test.go
@@ -88,7 +88,7 @@ func TestLoad(t *testing.T) {
 	kubernetes.MustCreateDeployment(ctx, deploymentsClient, deployment)
 
 	t.Log("Checking pods are running")
-	err = kubernetes.WaitForPodsRunning(ctx, clientset, namespace, podLabelSelector)
+	err = kubernetes.WaitForPodsRunning(ctx, clientset, namespace, podLabelSelector, nil)
 	require.NoError(t, err)
 
 	t.Log("Repeating the scale up/down cycle")
@@ -101,7 +101,7 @@ func TestLoad(t *testing.T) {
 		kubernetes.MustScaleDeployment(ctx, deploymentsClient, deployment, clientset, namespace, podLabelSelector, testConfig.ScaleUpReplicas, testConfig.SkipWait)
 	}
 	t.Log("Checking pods are running and IP assigned")
-	err = kubernetes.WaitForPodsRunning(ctx, clientset, "", "")
+	err = kubernetes.WaitForPodsRunning(ctx, clientset, "", "", []string{"azuresecuritylinuxagent"})
 	require.NoError(t, err)
 
 	if testConfig.ValidateStateFile {

--- a/test/integration/swiftv2/swiftv2_test.go
+++ b/test/integration/swiftv2/swiftv2_test.go
@@ -65,7 +65,7 @@ func setupLinuxEnvironment(t *testing.T) {
 	}
 
 	t.Log("Waiting for pods to be running state")
-	err = kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector)
+	err = kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector, nil)
 	if err != nil {
 		t.Fatalf("Pods are not in running state due to %+v", err)
 	}

--- a/test/internal/kubernetes/utils.go
+++ b/test/internal/kubernetes/utils.go
@@ -269,8 +269,13 @@ func MustSetupCNP(ctx context.Context, clientset *cilium.Clientset, cnpPath stri
 
 func Int32ToPtr(i int32) *int32 { return &i }
 
-func WaitForPodsRunning(ctx context.Context, clientset *kubernetes.Clientset, namespace, labelselector string) error {
+func WaitForPodsRunning(ctx context.Context, clientset *kubernetes.Clientset, namespace, labelselector string, excludeNamespaces []string) error {
 	podsClient := clientset.CoreV1().Pods(namespace)
+
+	excludeSet := make(map[string]struct{}, len(excludeNamespaces))
+	for _, ns := range excludeNamespaces {
+		excludeSet[ns] = struct{}{}
+	}
 
 	checkPodIPsFn := func() error {
 		podList, err := podsClient.List(ctx, metav1.ListOptions{LabelSelector: labelselector})
@@ -284,6 +289,9 @@ func WaitForPodsRunning(ctx context.Context, clientset *kubernetes.Clientset, na
 
 		for index := range podList.Items {
 			pod := podList.Items[index]
+			if _, excluded := excludeSet[pod.Namespace]; excluded {
+				continue
+			}
 			if pod.Status.Phase == corev1.PodPending {
 				return errors.New("some pods still pending")
 			}
@@ -291,8 +299,11 @@ func WaitForPodsRunning(ctx context.Context, clientset *kubernetes.Clientset, na
 
 		for index := range podList.Items {
 			pod := podList.Items[index]
+			if _, excluded := excludeSet[pod.Namespace]; excluded {
+				continue
+			}
 			if pod.Status.PodIP == "" {
-				return errors.Wrapf(err, "Pod %s/%s has not been allocated an IP yet with reason %s", pod.Namespace, pod.Name, pod.Status.Message)
+				return errors.Errorf("Pod %s/%s has not been allocated an IP yet with reason %s", pod.Namespace, pod.Name, pod.Status.Message)
 			}
 		}
 

--- a/test/internal/kubernetes/utils_get.go
+++ b/test/internal/kubernetes/utils_get.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"log"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -46,6 +47,14 @@ func GetPodsIpsByNode(ctx context.Context, clientset *kubernetes.Clientset, name
 	}
 	ips := make([]string, 0, len(pods.Items)*2) //nolint
 	for index := range pods.Items {
+		// skip succeeded/failed pods since even though we released those ips internally,
+		// the api server still reports their existence
+		phase := pods.Items[index].Status.Phase
+		if phase == corev1.PodSucceeded || phase == corev1.PodFailed {
+			log.Printf("skipping pod %s/%s on node %s in terminal phase %s (IPs: %v) when collecting pod IPs",
+				pods.Items[index].Namespace, pods.Items[index].Name, nodeName, phase, pods.Items[index].Status.PodIPs)
+			continue
+		}
 		for _, podIP := range pods.Items[index].Status.PodIPs {
 			ips = append(ips, podIP.IP)
 		}

--- a/test/validate/linux_validate.go
+++ b/test/validate/linux_validate.go
@@ -332,7 +332,7 @@ func (v *Validator) validateRestartNetwork(ctx context.Context) error {
 		if err != nil {
 			return errors.Wrapf(err, "failed to exec into privileged pod %s on node %s", privilegedPod.Name, node.Name)
 		}
-		err = acnk8s.WaitForPodsRunning(ctx, v.clientset, "", "")
+		err = acnk8s.WaitForPodsRunning(ctx, v.clientset, "", "", []string{"azuresecuritylinuxagent"})
 		if err != nil {
 			return errors.Wrapf(err, "failed to wait for pods running")
 		}


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Backports ci fixes on master to 1.7 release branch


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
20260615.3 is green