### PR TITLE
fix(cilium-log-collector): build fluent-bit without jemalloc for 64KB page support

### DIFF
--- a/cilium-log-collector/Dockerfile
+++ b/cilium-log-collector/Dockerfile
@@ -2,6 +2,7 @@
 # SOURCE: cilium-log-collector/Dockerfile.tmpl
 ARG ARCH
 ARG OS
+ARG FLUENT_BIT_VERSION=v4.2.3
 
 # mcr.microsoft.com/oss/go/microsoft/golang:1.24-azurelinux3.0
 FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:bc7423b52b62e8f0281b5f7f564eb1862dc315bc57e1373c6a81e87ef3ac39ab AS go
@@ -12,5 +13,36 @@ WORKDIR /cilium-log-collector
 COPY ./cilium-log-collector .
 RUN go build -buildmode=c-shared -a -o out_azure_app_insights.so -trimpath -ldflags "-X main.version=$VERSION" -gcflags="-dwarflocationlists=true" .
 
-FROM mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.3-8 as linux
+# Build fluent-bit from source without jemalloc to support ARM64 64KB page kernels.
+# The upstream MCR image statically links jemalloc which crashes on 64KB page systems
+# (CONFIG_ARM64_64K_PAGES) with "Unsupported system page size".
+FROM --platform=linux/${ARCH} debian:bookworm-slim AS fluent-bit-builder
+ARG FLUENT_BIT_VERSION
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cmake make gcc g++ \
+    libssl-dev libyaml-dev zlib1g-dev \
+    libcurl4-openssl-dev libsystemd-dev \
+    libsasl2-dev flex bison pkg-config \
+    git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+RUN git clone --depth 1 --branch ${FLUENT_BIT_VERSION} https://github.com/fluent/fluent-bit.git /src/fluent-bit
+WORKDIR /src/fluent-bit/build
+RUN cmake .. \
+    -DFLB_JEMALLOC=OFF \
+    -DFLB_RELEASE=On \
+    -DFLB_TRACE=Off \
+    -DFLB_SHARED_LIB=Off \
+    -DFLB_OUT_KAFKA=OFF \
+    -DFLB_OUT_PGSQL=OFF \
+    -DCMAKE_INSTALL_PREFIX=/fluent-bit \
+    -DCMAKE_BUILD_TYPE=Release \
+    && make -j$(nproc) && make install
+
+FROM --platform=linux/${ARCH} debian:bookworm-slim as linux
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libyaml-0-2 libssl3 zlib1g libcurl4 \
+    libsystemd0 libsasl2-2 libstdc++6 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=fluent-bit-builder /fluent-bit /fluent-bit
+RUN ln -s /fluent-bit/bin/fluent-bit /usr/bin/fluent-bit
 COPY --from=fluent-bit-plugin /cilium-log-collector/out_azure_app_insights.so /out_azure_app_insights.so

--- a/cilium-log-collector/Dockerfile.tmpl
+++ b/cilium-log-collector/Dockerfile.tmpl
@@ -2,6 +2,7 @@
 # SOURCE: {{.SRC}}
 ARG ARCH
 ARG OS
+ARG FLUENT_BIT_VERSION=v4.2.3
 
 # {{.GO_IMG}}
 FROM --platform=linux/${ARCH} {{.GO_PIN}} AS go
@@ -12,5 +13,36 @@ WORKDIR /cilium-log-collector
 COPY ./cilium-log-collector .
 RUN go build -buildmode=c-shared -a -o out_azure_app_insights.so -trimpath -ldflags "-X main.version=$VERSION" -gcflags="-dwarflocationlists=true" .
 
-FROM mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.3-8 as linux
+# Build fluent-bit from source without jemalloc to support ARM64 64KB page kernels.
+# The upstream MCR image statically links jemalloc which crashes on 64KB page systems
+# (CONFIG_ARM64_64K_PAGES) with "Unsupported system page size".
+FROM --platform=linux/${ARCH} debian:bookworm-slim AS fluent-bit-builder
+ARG FLUENT_BIT_VERSION
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cmake make gcc g++ \
+    libssl-dev libyaml-dev zlib1g-dev \
+    libcurl4-openssl-dev libsystemd-dev \
+    libsasl2-dev flex bison pkg-config \
+    git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+RUN git clone --depth 1 --branch ${FLUENT_BIT_VERSION} https://github.com/fluent/fluent-bit.git /src/fluent-bit
+WORKDIR /src/fluent-bit/build
+RUN cmake .. \
+    -DFLB_JEMALLOC=OFF \
+    -DFLB_RELEASE=On \
+    -DFLB_TRACE=Off \
+    -DFLB_SHARED_LIB=Off \
+    -DFLB_OUT_KAFKA=OFF \
+    -DFLB_OUT_PGSQL=OFF \
+    -DCMAKE_INSTALL_PREFIX=/fluent-bit \
+    -DCMAKE_BUILD_TYPE=Release \
+    && make -j$(nproc) && make install
+
+FROM --platform=linux/${ARCH} debian:bookworm-slim as linux
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libyaml-0-2 libssl3 zlib1g libcurl4 \
+    libsystemd0 libsasl2-2 libstdc++6 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=fluent-bit-builder /fluent-bit /fluent-bit
+RUN ln -s /fluent-bit/bin/fluent-bit /usr/bin/fluent-bit
 COPY --from=fluent-bit-plugin /cilium-log-collector/out_azure_app_insights.so /out_azure_app_insights.so


### PR DESCRIPTION
## Problem

The `cilium-log-collector` (cilium-fluent-bit sidecar) crashes on ARM64 nodes with 64KB page kernels (`CONFIG_ARM64_64K_PAGES`) — specifically the NVIDIA Grace Blackwell GB200 SKU (`StandardNDISRGB200V6ETHFamily`) which uses kernel `6.14.0-1007-azure-nvidia`.

The crash occurs because the upstream MCR fluent-bit image (`mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.3-8`) statically links jemalloc, which was compiled with a maximum page size of 4KB:

```
<jemalloc>: Unsupported system page size
[error] [/build/top/BUILD/fb/src/config_format/flb_config_format.c:110 errno=12] Cannot allocate memory
```

## Fix

Build fluent-bit from source with `-DFLB_JEMALLOC=OFF`, using the standard system allocator (glibc malloc) instead. This:
- ✅ Fixes the crash on 64KB page systems
- ✅ Has no functional regression on standard 4KB page systems (fluent-bit's log collection workload is I/O-bound, not allocator-bound)
- ✅ Keeps the same fluent-bit version (v4.2.3)

## Validation

Tested on AKS ARM64 cluster (`behzadm-cilium-arm64-v2`, eastus2) with:
- Node: `aks-u2404-38036024-vmss000000`
- Kernel: `6.14.0-1007-azure-nvidia` (64KB pages, `getconf PAGESIZE` = 65536)
- Image: `acnpublic.azurecr.io/cilium-log-collector:v0.0.1-no-jemalloc-64k`
- Result: fluent-bit starts successfully and collects cilium agent logs without errors

## Additional Note

The current image also ships `out_azure_app_insights.so` as x86-64 only — it will fail to load on ARM64 nodes regardless of page size. That's a pre-existing issue tracked separately.