### PR TITLE
test: combined init for v1.19 cilium daemonsets

### DIFF
--- a/test/integration/manifests/cilium/v1.19/cilium-agent/templates/daemonset-dualstack.yaml
+++ b/test/integration/manifests/cilium/v1.19/cilium-agent/templates/daemonset-dualstack.yaml
@@ -253,6 +253,14 @@ spec:
           name: cilium-run
         - mountPath: /run/xtables.lock
           name: xtables-lock
+        - mountPath: /host/etc/systemd
+          name: host-etc-systemd
+        - mountPath: /host/lib/systemd
+          name: host-lib-systemd
+          readOnly: true
+        - mountPath: /host/usr/lib
+          name: host-usr-lib
+          readOnly: true
         resources:
           requests:
             cpu: 100m

--- a/test/integration/manifests/cilium/v1.19/cilium-agent/templates/daemonset-dualstack.yaml
+++ b/test/integration/manifests/cilium/v1.19/cilium-agent/templates/daemonset-dualstack.yaml
@@ -173,117 +173,54 @@ spec:
       dnsPolicy: ClusterFirst
       hostNetwork: true
       initContainers:
-      - name: install-cni-binaries
+      # Merged init container: shares a single image pull and container start
+      # across the steps that previously ran in install-cni-binaries,
+      # mount-cgroup, apply-sysctl-overwrites, mount-bpf-fs, clean-cilium-state
+      # and block-wireserver. Runs privileged because mount-bpf-fs needs
+      # Bidirectional mount propagation.
+      - name: cilium-init-all
         image: $CILIUM_IMAGE_REGISTRY/cilium/cilium-distroless-init:$CILIUM_VERSION_TAG
         imagePullPolicy: IfNotPresent
-        args:
-          - "/install-plugin.sh"
         command:
-          - sh
-        securityContext:
-          seLinuxOptions:
-            level: 's0'
-            # Running with spc_t since we have removed the privileged mode.
-            # Users can change it to a different type as long as they have the
-            # type available on the system.
-            type: 'spc_t'
-          capabilities:
-            drop:
-              - ALL
-        volumeMounts:
-          - name: cni-path
-            mountPath: /host/opt/cni/bin
-      - command:
-        - sh
+        - /bin/sh
         - -ec
         - |
-          cp /usr/bin/cilium-mount /hostbin/cilium-mount;
-          nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT;
+          # 1. Install Cilium CNI plugin binaries on the host (was install-cni-binaries).
+          sh /install-plugin.sh
+
+          # 2. Mount host cgroup2 via nsenter (was mount-cgroup).
+          cp /usr/bin/cilium-mount /hostbin/cilium-mount
+          nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" "$CGROUP_ROOT"
           rm /hostbin/cilium-mount
+
+          # 3. Apply sysctl overwrites on the host (was apply-sysctl-overwrites).
+          cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix
+          nsenter --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-sysctlfix"
+          rm /hostbin/cilium-sysctlfix
+
+          # 4. Mount bpf fs if not already mounted (was mount-bpf-fs).
+          mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf
+
+          # 5. Clean cilium state if requested (was clean-cilium-state).
+          sh /init-container.sh
+
+          # 6. Install wireserver-blocking iptables rule in the mangle forward
+          # chain (was block-wireserver). Idempotent and -e safe.
+          installRuleIdempotent() {
+            rule=$1
+            if ! iptables -t mangle -C $rule 2> /dev/null; then
+              echo "installing iptables rule: $rule"
+              iptables -t mangle -I $rule || exit 1
+            else
+              echo "iptables rule already installed: $rule"
+            fi
+          }
+          installRuleIdempotent "FORWARD -d 168.63.129.16 -p tcp --dport 80 -j DROP"
         env:
         - name: CGROUP_ROOT
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium-distroless-init:$CILIUM_VERSION_TAG
-        imagePullPolicy: IfNotPresent
-        name: mount-cgroup
-        resources: {}
-        securityContext:
-          appArmorProfile:
-            type: Unconfined
-          capabilities:
-            add:
-            - SYS_ADMIN
-            - SYS_CHROOT
-            - SYS_PTRACE
-            drop:
-            - ALL
-          seLinuxOptions:
-            level: s0
-            type: spc_t
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /hostproc
-          name: hostproc
-        - mountPath: /hostbin
-          name: cni-path
-      - command:
-        - sh
-        - -ec
-        - |
-          cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;
-          nsenter --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-sysctlfix";
-          rm /hostbin/cilium-sysctlfix
-        env:
-        - name: BIN_PATH
-          value: /opt/cni/bin
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium-distroless-init:$CILIUM_VERSION_TAG
-        imagePullPolicy: IfNotPresent
-        name: apply-sysctl-overwrites
-        resources: {}
-        securityContext:
-          appArmorProfile:
-            type: Unconfined
-          capabilities:
-            add:
-            - SYS_ADMIN
-            - SYS_CHROOT
-            - SYS_PTRACE
-            drop:
-            - ALL
-          seLinuxOptions:
-            level: s0
-            type: spc_t
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /hostproc
-          name: hostproc
-        - mountPath: /hostbin
-          name: cni-path
-      - args:
-        - mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf
-        command:
-        - sh
-        - -c
-        - --
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium-distroless-init:$CILIUM_VERSION_TAG
-        imagePullPolicy: IfNotPresent
-        name: mount-bpf-fs
-        resources: {}
-        securityContext:
-          privileged: true
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /sys/fs/bpf
-          mountPropagation: Bidirectional
-          name: bpf-maps
-      - command:
-        - /init-container.sh
-        env:
         - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
@@ -296,37 +233,30 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium-distroless-init:$CILIUM_VERSION_TAG
-        imagePullPolicy: IfNotPresent
-        name: clean-cilium-state
-        resources:
-          requests:
-            cpu: 100m
-            memory: 100Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         securityContext:
-          appArmorProfile:
-            type: Unconfined
-          capabilities:
-            add:
-            - NET_ADMIN
-            - SYS_MODULE
-            - SYS_ADMIN
-            - SYS_RESOURCE
-            drop:
-            - ALL
-          seLinuxOptions:
-            level: s0
-            type: spc_t
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+          privileged: true
         volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /hostbin
+          name: cni-path
+        - mountPath: /hostproc
+          name: hostproc
         - mountPath: /sys/fs/bpf
+          mountPropagation: Bidirectional
           name: bpf-maps
         - mountPath: /run/cilium/cgroupv2
           mountPropagation: HostToContainer
           name: cilium-cgroup
         - mountPath: /var/run/cilium
           name: cilium-run
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
       - name: start-ipv6-hp-bpf
         image: acnpublic.azurecr.io/ipv6-hp-bpf:$IPV6_HP_BPF_VERSION
         imagePullPolicy: IfNotPresent
@@ -336,28 +266,6 @@ spec:
         volumeMounts:
         - mountPath: /var/log
           name: ipv6-hp-bpf
-      - name: block-wireserver
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium-distroless-init:$CILIUM_VERSION_TAG
-        imagePullPolicy: IfNotPresent
-        command:
-        - sh
-        - -cx
-        - |
-          iptables -t mangle -C FORWARD -d 168.63.129.16 -p tcp --dport 80 -j DROP
-          status=$?
-          set -e
-          if [ $status -eq 0 ]; then
-            echo "Skip adding iptables as it already exists"
-          else
-            iptables -t mangle -I FORWARD -d 168.63.129.16 -p tcp --dport 80 -j DROP
-          fi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-            - NET_RAW
-            drop:
-            - ALL
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical

--- a/test/integration/manifests/cilium/v1.19/cilium-agent/templates/daemonset.yaml
+++ b/test/integration/manifests/cilium/v1.19/cilium-agent/templates/daemonset.yaml
@@ -173,117 +173,54 @@ spec:
       dnsPolicy: ClusterFirst
       hostNetwork: true
       initContainers:
-      - name: install-cni-binaries
+      # Merged init container: shares a single image pull and container start
+      # across the steps that previously ran in install-cni-binaries,
+      # mount-cgroup, apply-sysctl-overwrites, mount-bpf-fs, clean-cilium-state
+      # and block-wireserver. Runs privileged because mount-bpf-fs needs
+      # Bidirectional mount propagation.
+      - name: cilium-init-all
         image: $CILIUM_IMAGE_REGISTRY/cilium/cilium-distroless-init:$CILIUM_VERSION_TAG
         imagePullPolicy: IfNotPresent
-        args:
-          - "/install-plugin.sh"
         command:
-          - sh
-        securityContext:
-          seLinuxOptions:
-            level: 's0'
-            # Running with spc_t since we have removed the privileged mode.
-            # Users can change it to a different type as long as they have the
-            # type available on the system.
-            type: 'spc_t'
-          capabilities:
-            drop:
-              - ALL
-        volumeMounts:
-          - name: cni-path
-            mountPath: /host/opt/cni/bin
-      - command:
-        - sh
+        - /bin/sh
         - -ec
         - |
-          cp /usr/bin/cilium-mount /hostbin/cilium-mount;
-          nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT;
+          # 1. Install Cilium CNI plugin binaries on the host (was install-cni-binaries).
+          sh /install-plugin.sh
+
+          # 2. Mount host cgroup2 via nsenter (was mount-cgroup).
+          cp /usr/bin/cilium-mount /hostbin/cilium-mount
+          nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" "$CGROUP_ROOT"
           rm /hostbin/cilium-mount
+
+          # 3. Apply sysctl overwrites on the host (was apply-sysctl-overwrites).
+          cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix
+          nsenter --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-sysctlfix"
+          rm /hostbin/cilium-sysctlfix
+
+          # 4. Mount bpf fs if not already mounted (was mount-bpf-fs).
+          mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf
+
+          # 5. Clean cilium state if requested (was clean-cilium-state).
+          sh /init-container.sh
+
+          # 6. Install wireserver-blocking iptables rule in the mangle forward
+          # chain (was block-wireserver). Idempotent and -e safe.
+          installRuleIdempotent() {
+            rule=$1
+            if ! iptables -t mangle -C $rule 2> /dev/null; then
+              echo "installing iptables rule: $rule"
+              iptables -t mangle -I $rule || exit 1
+            else
+              echo "iptables rule already installed: $rule"
+            fi
+          }
+          installRuleIdempotent "FORWARD -d 168.63.129.16 -p tcp --dport 80 -j DROP"
         env:
         - name: CGROUP_ROOT
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium-distroless-init:$CILIUM_VERSION_TAG
-        imagePullPolicy: IfNotPresent
-        name: mount-cgroup
-        resources: {}
-        securityContext:
-          appArmorProfile:
-            type: Unconfined
-          capabilities:
-            add:
-            - SYS_ADMIN
-            - SYS_CHROOT
-            - SYS_PTRACE
-            drop:
-            - ALL
-          seLinuxOptions:
-            level: s0
-            type: spc_t
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /hostproc
-          name: hostproc
-        - mountPath: /hostbin
-          name: cni-path
-      - command:
-        - sh
-        - -ec
-        - |
-          cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;
-          nsenter --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-sysctlfix";
-          rm /hostbin/cilium-sysctlfix
-        env:
-        - name: BIN_PATH
-          value: /opt/cni/bin
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium-distroless-init:$CILIUM_VERSION_TAG
-        imagePullPolicy: IfNotPresent
-        name: apply-sysctl-overwrites
-        resources: {}
-        securityContext:
-          appArmorProfile:
-            type: Unconfined
-          capabilities:
-            add:
-            - SYS_ADMIN
-            - SYS_CHROOT
-            - SYS_PTRACE
-            drop:
-            - ALL
-          seLinuxOptions:
-            level: s0
-            type: spc_t
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /hostproc
-          name: hostproc
-        - mountPath: /hostbin
-          name: cni-path
-      - args:
-        - mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf
-        command:
-        - sh
-        - -c
-        - --
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium-distroless-init:$CILIUM_VERSION_TAG
-        imagePullPolicy: IfNotPresent
-        name: mount-bpf-fs
-        resources: {}
-        securityContext:
-          privileged: true
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /sys/fs/bpf
-          mountPropagation: Bidirectional
-          name: bpf-maps
-      - command:
-        - /init-container.sh
-        env:
         - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
@@ -296,67 +233,30 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium-distroless-init:$CILIUM_VERSION_TAG
-        imagePullPolicy: IfNotPresent
-        name: clean-cilium-state
-        resources:
-          requests:
-            cpu: 100m
-            memory: 100Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         securityContext:
-          appArmorProfile:
-            type: Unconfined
-          capabilities:
-            add:
-            - NET_ADMIN
-            - SYS_MODULE
-            - SYS_ADMIN
-            - SYS_RESOURCE
-            drop:
-            - ALL
-          seLinuxOptions:
-            level: s0
-            type: spc_t
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+          privileged: true
         volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /hostbin
+          name: cni-path
+        - mountPath: /hostproc
+          name: hostproc
         - mountPath: /sys/fs/bpf
+          mountPropagation: Bidirectional
           name: bpf-maps
         - mountPath: /run/cilium/cgroupv2
           mountPropagation: HostToContainer
           name: cilium-cgroup
         - mountPath: /var/run/cilium
           name: cilium-run
-        - mountPath: /host/etc/systemd
-          name: host-etc-systemd
-        - mountPath: /host/lib/systemd
-          name: host-lib-systemd
-          readOnly: true
-        - mountPath: /host/usr/lib
-          name: host-usr-lib
-          readOnly: true
-      - name: block-wireserver
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium-distroless-init:$CILIUM_VERSION_TAG
-        imagePullPolicy: IfNotPresent
-        command:
-        - sh
-        - -cx
-        - |
-          iptables -t mangle -C FORWARD -d 168.63.129.16 -p tcp --dport 80 -j DROP
-          status=$?
-          set -e
-          if [ $status -eq 0 ]; then
-            echo "Skip adding iptables as it already exists"
-          else
-            iptables -t mangle -I FORWARD -d 168.63.129.16 -p tcp --dport 80 -j DROP
-          fi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-            - NET_RAW
-            drop:
-            - ALL
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical

--- a/test/integration/manifests/cilium/v1.19/cilium-agent/templates/daemonset.yaml
+++ b/test/integration/manifests/cilium/v1.19/cilium-agent/templates/daemonset.yaml
@@ -253,6 +253,14 @@ spec:
           name: cilium-run
         - mountPath: /run/xtables.lock
           name: xtables-lock
+        - mountPath: /host/etc/systemd
+          name: host-etc-systemd
+        - mountPath: /host/lib/systemd
+          name: host-lib-systemd
+          readOnly: true
+        - mountPath: /host/usr/lib
+          name: host-usr-lib
+          readOnly: true
         resources:
           requests:
             cpu: 100m

--- a/test/integration/manifests/cilium/v1.19/ebpf/dualstack/cilium.yaml
+++ b/test/integration/manifests/cilium/v1.19/ebpf/dualstack/cilium.yaml
@@ -284,6 +284,14 @@ spec:
           name: cilium-cgroup
         - mountPath: /var/run/cilium
           name: cilium-run
+        - mountPath: /host/etc/systemd
+          name: host-etc-systemd
+        - mountPath: /host/lib/systemd
+          name: host-lib-systemd
+          readOnly: true
+        - mountPath: /host/usr/lib
+          name: host-usr-lib
+          readOnly: true
         resources:
           requests:
             cpu: 100m

--- a/test/integration/manifests/cilium/v1.19/ebpf/dualstack/cilium.yaml
+++ b/test/integration/manifests/cilium/v1.19/ebpf/dualstack/cilium.yaml
@@ -219,115 +219,41 @@ spec:
               name: bpf-maps
             - mountPath: /proc
               name: hostproc   
-      - command:
-        - /install-plugin.sh
+      # Merged init container: shares a single image pull and container start
+      # across the steps that previously ran in install-cni-binaries,
+      # mount-cgroup, apply-sysctl-overwrites, mount-bpf-fs and
+      # clean-cilium-state. Runs privileged because mount-bpf-fs needs
+      # Bidirectional mount propagation.
+      - name: cilium-init-all
         image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
         imagePullPolicy: IfNotPresent
-        name: install-cni-binaries
-        resources: {}
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-          seLinuxOptions:
-            level: s0
-            type: spc_t
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /host/opt/cni/bin
-          name: cni-path
-      - command:
-        - sh
+        command:
+        - /bin/bash
         - -ec
         - |
-          cp /usr/bin/cilium-mount /hostbin/cilium-mount;
-          nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT;
+          # 1. Install Cilium CNI plugin binaries on the host (was install-cni-binaries).
+          sh /install-plugin.sh
+
+          # 2. Mount host cgroup2 via nsenter (was mount-cgroup).
+          cp /usr/bin/cilium-mount /hostbin/cilium-mount
+          nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" "$CGROUP_ROOT"
           rm /hostbin/cilium-mount
+
+          # 3. Apply sysctl overwrites on the host (was apply-sysctl-overwrites).
+          cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix
+          nsenter --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-sysctlfix"
+          rm /hostbin/cilium-sysctlfix
+
+          # 4. Mount bpf fs if not already mounted (was mount-bpf-fs).
+          mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf
+
+          # 5. Clean cilium state if requested (was clean-cilium-state).
+          sh /init-container.sh
         env:
         - name: CGROUP_ROOT
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
-        imagePullPolicy: IfNotPresent
-        name: mount-cgroup
-        resources: {}
-        securityContext:
-          appArmorProfile:
-            type: Unconfined
-          capabilities:
-            add:
-            - SYS_ADMIN
-            - SYS_CHROOT
-            - SYS_PTRACE
-            drop:
-            - ALL
-          seLinuxOptions:
-            level: s0
-            type: spc_t
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /hostproc
-          name: hostproc
-        - mountPath: /hostbin
-          name: cni-path
-      - command:
-        - sh
-        - -ec
-        - |
-          cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;
-          nsenter --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-sysctlfix";
-          rm /hostbin/cilium-sysctlfix
-        env:
-        - name: BIN_PATH
-          value: /opt/cni/bin
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
-        imagePullPolicy: IfNotPresent
-        name: apply-sysctl-overwrites
-        resources: {}
-        securityContext:
-          appArmorProfile:
-            type: Unconfined
-          capabilities:
-            add:
-            - SYS_ADMIN
-            - SYS_CHROOT
-            - SYS_PTRACE
-            drop:
-            - ALL
-          seLinuxOptions:
-            level: s0
-            type: spc_t
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /hostproc
-          name: hostproc
-        - mountPath: /hostbin
-          name: cni-path
-      - args:
-        - mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf
-        command:
-        - /bin/bash
-        - -c
-        - --
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
-        imagePullPolicy: IfNotPresent
-        name: mount-bpf-fs
-        resources: {}
-        securityContext:
-          privileged: true
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /sys/fs/bpf
-          mountPropagation: Bidirectional
-          name: bpf-maps
-      - command:
-        - /init-container.sh
-        env:
         - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
@@ -340,38 +266,28 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: $CILIUM_IMAGE_REGISTRY/cilium/cilium:$CILIUM_VERSION_TAG
-        imagePullPolicy: IfNotPresent
-        name: clean-cilium-state
+        terminationMessagePolicy: FallbackToLogsOnError
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /hostbin
+          name: cni-path
+        - mountPath: /hostproc
+          name: hostproc
+        - mountPath: /sys/fs/bpf
+          mountPropagation: Bidirectional
+          name: bpf-maps
+        - mountPath: /run/cilium/cgroupv2
+          mountPropagation: HostToContainer
+          name: cilium-cgroup
+        - mountPath: /var/run/cilium
+          name: cilium-run
         resources:
           requests:
             cpu: 100m
             memory: 100Mi
-        securityContext:
-          appArmorProfile:
-            type: Unconfined
-          capabilities:
-            add:
-            - NET_ADMIN
-            - SYS_MODULE
-            - SYS_ADMIN
-            - SYS_RESOURCE
-            drop:
-            - ALL
-          seLinuxOptions:
-            level: s0
-            type: spc_t
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /host/etc/systemd
-          name: host-etc-systemd
-        - mountPath: /host/lib/systemd
-          name: host-lib-systemd
-          readOnly: true
-        - mountPath: /host/usr/lib
-          name: host-usr-lib
-          readOnly: true
       - command:
         - /ipv6-hp-bpf
         image: $IPV6_IMAGE_REGISTRY/ipv6-hp-bpf:$IPV6_HP_BPF_VERSION

--- a/test/integration/manifests/cilium/v1.19/ebpf/overlay/cilium.yaml
+++ b/test/integration/manifests/cilium/v1.19/ebpf/overlay/cilium.yaml
@@ -326,6 +326,14 @@ spec:
               name: cilium-cgroup
             - mountPath: /var/run/cilium
               name: cilium-run
+            - mountPath: /host/etc/systemd
+              name: host-etc-systemd
+            - mountPath: /host/lib/systemd
+              name: host-lib-systemd
+              readOnly: true
+            - mountPath: /host/usr/lib
+              name: host-usr-lib
+              readOnly: true
           resources:
             requests:
               cpu: 100m

--- a/test/integration/manifests/cilium/v1.19/ebpf/overlay/cilium.yaml
+++ b/test/integration/manifests/cilium/v1.19/ebpf/overlay/cilium.yaml
@@ -261,119 +261,41 @@ spec:
           volumeMounts:
             - mountPath: /etc/config
               name: iptables-config
-        - command:
-            - sh
-          args:
-            - "/install-plugin.sh"
+        # Merged init container: shares a single image pull and container start
+        # across the steps that previously ran in install-cni-binaries,
+        # mount-cgroup, apply-sysctl-overwrites, mount-bpf-fs and
+        # clean-cilium-state. Runs privileged because mount-bpf-fs needs
+        # Bidirectional mount propagation.
+        - name: cilium-init-all
           image: $CILIUM_IMAGE_REGISTRY/cilium/cilium-distroless-init:$CILIUM_VERSION_TAG
           imagePullPolicy: IfNotPresent
-          name: install-cni-binaries
-          resources: {}
-          securityContext:
-            capabilities:
-              drop:
-                - ALL
-            seLinuxOptions:
-              level: s0
-              type: spc_t
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: FallbackToLogsOnError
-          volumeMounts:
-            - mountPath: /host/opt/cni/bin
-              name: cni-path
-        - command:
-            - sh
+          command:
+            - /bin/sh
             - -ec
             - |
-              cp /usr/bin/cilium-mount /hostbin/cilium-mount;
-              nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT;
+              # 1. Install Cilium CNI plugin binaries on the host (was install-cni-binaries).
+              sh /install-plugin.sh
+
+              # 2. Mount host cgroup2 via nsenter (was mount-cgroup).
+              cp /usr/bin/cilium-mount /hostbin/cilium-mount
+              nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" "$CGROUP_ROOT"
               rm /hostbin/cilium-mount
+
+              # 3. Apply sysctl overwrites on the host (was apply-sysctl-overwrites).
+              cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix
+              nsenter --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-sysctlfix"
+              rm /hostbin/cilium-sysctlfix
+
+              # 4. Mount bpf fs if not already mounted (was mount-bpf-fs).
+              mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf
+
+              # 5. Clean cilium state if requested (was clean-cilium-state).
+              sh /init-container.sh
           env:
             - name: CGROUP_ROOT
               value: /run/cilium/cgroupv2
             - name: BIN_PATH
               value: /opt/cni/bin
-          image: $CILIUM_IMAGE_REGISTRY/cilium/cilium-distroless-init:$CILIUM_VERSION_TAG
-          imagePullPolicy: IfNotPresent
-          name: mount-cgroup
-          resources: {}
-          securityContext:
-            appArmorProfile:
-              type: Unconfined
-            capabilities:
-              add:
-                - SYS_ADMIN
-                - SYS_CHROOT
-                - SYS_PTRACE
-              drop:
-                - ALL
-            seLinuxOptions:
-              level: s0
-              type: spc_t
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: FallbackToLogsOnError
-          volumeMounts:
-            - mountPath: /hostproc
-              name: hostproc
-            - mountPath: /hostbin
-              name: cni-path
-        - command:
-            - sh
-            - -ec
-            - |
-              cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;
-              nsenter --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-sysctlfix";
-              rm /hostbin/cilium-sysctlfix
-          env:
-            - name: BIN_PATH
-              value: /opt/cni/bin
-          image: $CILIUM_IMAGE_REGISTRY/cilium/cilium-distroless-init:$CILIUM_VERSION_TAG
-          imagePullPolicy: IfNotPresent
-          name: apply-sysctl-overwrites
-          resources: {}
-          securityContext:
-            appArmorProfile:
-              type: Unconfined
-            capabilities:
-              add:
-                - SYS_ADMIN
-                - SYS_CHROOT
-                - SYS_PTRACE
-              drop:
-                - ALL
-            seLinuxOptions:
-              level: s0
-              type: spc_t
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: FallbackToLogsOnError
-          volumeMounts:
-            - mountPath: /hostproc
-              name: hostproc
-            - mountPath: /hostbin
-              name: cni-path
-        - args:
-            - mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf
-          command:
-            - sh
-            - -c
-            - --
-          image: $CILIUM_IMAGE_REGISTRY/cilium/cilium-distroless-init:$CILIUM_VERSION_TAG
-          imagePullPolicy: IfNotPresent
-          name: mount-bpf-fs
-          resources: {}
-          securityContext:
-            privileged: true
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: FallbackToLogsOnError
-          volumeMounts:
-            - mountPath: /sys/fs/bpf
-              mountPropagation: Bidirectional
-              name: bpf-maps
-        - command:
-            - sh
-          args:
-            - "/init-container.sh"
-          env:
             - name: CILIUM_ALL_STATE
               valueFrom:
                 configMapKeyRef:
@@ -386,37 +308,28 @@ spec:
                   key: clean-cilium-bpf-state
                   name: cilium-config
                   optional: true
-          image: $CILIUM_IMAGE_REGISTRY/cilium/cilium-distroless-init:$CILIUM_VERSION_TAG
-          imagePullPolicy: IfNotPresent
-          name: clean-cilium-state
-          resources:
-            requests:
-              cpu: 100m
-              memory: 100Mi
+          terminationMessagePolicy: FallbackToLogsOnError
           securityContext:
-            appArmorProfile:
-              type: Unconfined
-            capabilities:
-              add:
-                - NET_ADMIN
-                - SYS_MODULE
-                - SYS_ADMIN
-                - SYS_RESOURCE
-              drop:
-                - ALL
-            seLinuxOptions:
-              level: s0
-              type: spc_t
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
+            privileged: true
           volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-path
+            - mountPath: /hostbin
+              name: cni-path
+            - mountPath: /hostproc
+              name: hostproc
             - mountPath: /sys/fs/bpf
+              mountPropagation: Bidirectional
               name: bpf-maps
             - mountPath: /run/cilium/cgroupv2
               mountPropagation: HostToContainer
               name: cilium-cgroup
             - mountPath: /var/run/cilium
               name: cilium-run
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
       priorityClassName: system-node-critical
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/test/integration/manifests/cilium/v1.19/ebpf/podsubnet/cilium.yaml
+++ b/test/integration/manifests/cilium/v1.19/ebpf/podsubnet/cilium.yaml
@@ -311,6 +311,14 @@ spec:
               name: cilium-cgroup
             - mountPath: /var/run/cilium
               name: cilium-run
+            - mountPath: /host/etc/systemd
+              name: host-etc-systemd
+            - mountPath: /host/lib/systemd
+              name: host-lib-systemd
+              readOnly: true
+            - mountPath: /host/usr/lib
+              name: host-usr-lib
+              readOnly: true
           resources:
             requests:
               cpu: 100m

--- a/test/integration/manifests/cilium/v1.19/ebpf/podsubnet/cilium.yaml
+++ b/test/integration/manifests/cilium/v1.19/ebpf/podsubnet/cilium.yaml
@@ -246,119 +246,41 @@ spec:
           volumeMounts:
             - mountPath: /etc/config
               name: iptables-config
-        - command:
-            - sh
-          args:
-            - "/install-plugin.sh"
+        # Merged init container: shares a single image pull and container start
+        # across the steps that previously ran in install-cni-binaries,
+        # mount-cgroup, apply-sysctl-overwrites, mount-bpf-fs and
+        # clean-cilium-state. Runs privileged because mount-bpf-fs needs
+        # Bidirectional mount propagation.
+        - name: cilium-init-all
           image: $CILIUM_IMAGE_REGISTRY/cilium/cilium-distroless-init:$CILIUM_VERSION_TAG
           imagePullPolicy: IfNotPresent
-          name: install-cni-binaries
-          resources: {}
-          securityContext:
-            capabilities:
-              drop:
-                - ALL
-            seLinuxOptions:
-              level: s0
-              type: spc_t
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: FallbackToLogsOnError
-          volumeMounts:
-            - mountPath: /host/opt/cni/bin
-              name: cni-path
-        - command:
-            - sh
+          command:
+            - /bin/sh
             - -ec
             - |
-              cp /usr/bin/cilium-mount /hostbin/cilium-mount;
-              nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT;
+              # 1. Install Cilium CNI plugin binaries on the host (was install-cni-binaries).
+              sh /install-plugin.sh
+
+              # 2. Mount host cgroup2 via nsenter (was mount-cgroup).
+              cp /usr/bin/cilium-mount /hostbin/cilium-mount
+              nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" "$CGROUP_ROOT"
               rm /hostbin/cilium-mount
+
+              # 3. Apply sysctl overwrites on the host (was apply-sysctl-overwrites).
+              cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix
+              nsenter --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-sysctlfix"
+              rm /hostbin/cilium-sysctlfix
+
+              # 4. Mount bpf fs if not already mounted (was mount-bpf-fs).
+              mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf
+
+              # 5. Clean cilium state if requested (was clean-cilium-state).
+              sh /init-container.sh
           env:
             - name: CGROUP_ROOT
               value: /run/cilium/cgroupv2
             - name: BIN_PATH
               value: /opt/cni/bin
-          image: $CILIUM_IMAGE_REGISTRY/cilium/cilium-distroless-init:$CILIUM_VERSION_TAG
-          imagePullPolicy: IfNotPresent
-          name: mount-cgroup
-          resources: {}
-          securityContext:
-            appArmorProfile:
-              type: Unconfined
-            capabilities:
-              add:
-                - SYS_ADMIN
-                - SYS_CHROOT
-                - SYS_PTRACE
-              drop:
-                - ALL
-            seLinuxOptions:
-              level: s0
-              type: spc_t
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: FallbackToLogsOnError
-          volumeMounts:
-            - mountPath: /hostproc
-              name: hostproc
-            - mountPath: /hostbin
-              name: cni-path
-        - command:
-            - sh
-            - -ec
-            - |
-              cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;
-              nsenter --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-sysctlfix";
-              rm /hostbin/cilium-sysctlfix
-          env:
-            - name: BIN_PATH
-              value: /opt/cni/bin
-          image: $CILIUM_IMAGE_REGISTRY/cilium/cilium-distroless-init:$CILIUM_VERSION_TAG
-          imagePullPolicy: IfNotPresent
-          name: apply-sysctl-overwrites
-          resources: {}
-          securityContext:
-            appArmorProfile:
-              type: Unconfined
-            capabilities:
-              add:
-                - SYS_ADMIN
-                - SYS_CHROOT
-                - SYS_PTRACE
-              drop:
-                - ALL
-            seLinuxOptions:
-              level: s0
-              type: spc_t
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: FallbackToLogsOnError
-          volumeMounts:
-            - mountPath: /hostproc
-              name: hostproc
-            - mountPath: /hostbin
-              name: cni-path
-        - args:
-            - mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf
-          command:
-            - sh
-            - -c
-            - --
-          image: $CILIUM_IMAGE_REGISTRY/cilium/cilium-distroless-init:$CILIUM_VERSION_TAG
-          imagePullPolicy: IfNotPresent
-          name: mount-bpf-fs
-          resources: {}
-          securityContext:
-            privileged: true
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: FallbackToLogsOnError
-          volumeMounts:
-            - mountPath: /sys/fs/bpf
-              mountPropagation: Bidirectional
-              name: bpf-maps
-        - command:
-            - sh
-          args:
-            - "/init-container.sh"
-          env:
             - name: CILIUM_ALL_STATE
               valueFrom:
                 configMapKeyRef:
@@ -371,37 +293,28 @@ spec:
                   key: clean-cilium-bpf-state
                   name: cilium-config
                   optional: true
-          image: $CILIUM_IMAGE_REGISTRY/cilium/cilium-distroless-init:$CILIUM_VERSION_TAG
-          imagePullPolicy: IfNotPresent
-          name: clean-cilium-state
-          resources:
-            requests:
-              cpu: 100m
-              memory: 100Mi
+          terminationMessagePolicy: FallbackToLogsOnError
           securityContext:
-            appArmorProfile:
-              type: Unconfined
-            capabilities:
-              add:
-                - NET_ADMIN
-                - SYS_MODULE
-                - SYS_ADMIN
-                - SYS_RESOURCE
-              drop:
-                - ALL
-            seLinuxOptions:
-              level: s0
-              type: spc_t
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
+            privileged: true
           volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-path
+            - mountPath: /hostbin
+              name: cni-path
+            - mountPath: /hostproc
+              name: hostproc
             - mountPath: /sys/fs/bpf
+              mountPropagation: Bidirectional
               name: bpf-maps
             - mountPath: /run/cilium/cgroupv2
               mountPropagation: HostToContainer
               name: cilium-cgroup
             - mountPath: /var/run/cilium
               name: cilium-run
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
       priorityClassName: system-node-critical
       restartPolicy: Always
       schedulerName: default-scheduler


### PR DESCRIPTION
**Reason for Change**:

Consolidates the per-step Cilium init containers in the **v1.19** integration test manifests into a single privileged `cilium-init-all` init container, mirroring the aks-rp combined-init change (gated there on cilium `>=1.19`). Each step previously ran a separate image pull/start: `install-cni-binaries`, `mount-cgroup`, `apply-sysctl-overwrites`, `mount-bpf-fs`,  `clean-cilium-state`, and (non-EBPF only) `block-wireserver`. These now run sequentially inside one container, reducing image pulls and speeding pod start.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

 Files updated:
 - `cilium-agent/templates/daemonset.yaml`
 - `cilium-agent/templates/daemonset-dualstack.yaml` (keeps `start-ipv6-hp-bpf`)
 - `ebpf/overlay/cilium.yaml` (keeps `iptables-blocker-init`, `azure-iptables-monitor-init`; no wireserver block — EBPF)
 - `ebpf/podsubnet/cilium.yaml` (same as overlay)
 - `ebpf/dualstack/cilium.yaml` (keeps `iptables-blocker-init`, `start-ipv6-hp-bpf`)

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
 Test-only change to integration manifests. All 5 manifests validated as parseable YAML and via `envsubst` render.