### PR TITLE
Add PNI status for using static reservation with PrefixBlock subnet

### DIFF
--- a/crd/multitenancy/api/v1alpha1/podnetworkinstance.go
+++ b/crd/multitenancy/api/v1alpha1/podnetworkinstance.go
@@ -70,14 +70,15 @@ type PodNetworkInstanceStatus struct {
 }
 
 // PNIStatus indicates the status of PNI
-// +kubebuilder:validation:Enum=Ready;CreateReservationSetError;PodNetworkNotReady;InsufficientIPAddressesOnSubnet
+// +kubebuilder:validation:Enum=Ready;CreateReservationSetError;PodNetworkNotReady;InsufficientIPAddressesOnSubnet;InvalidStaticReservationForPrefixBlock
 type PNIStatus string
 
 const (
-	PNIStatusReady                           PNIStatus = "Ready"
-	PNIStatusCreateReservationSetError       PNIStatus = "CreateReservationSetError"
-	PNIStatusPodNetworkNotReady              PNIStatus = "PodNetworkNotReady"
-	PNIStatusInsufficientIPAddressesOnSubnet PNIStatus = "InsufficientIPAddressesOnSubnet"
+	PNIStatusReady                                  PNIStatus = "Ready"
+	PNIStatusCreateReservationSetError              PNIStatus = "CreateReservationSetError"
+	PNIStatusPodNetworkNotReady                     PNIStatus = "PodNetworkNotReady"
+	PNIStatusInsufficientIPAddressesOnSubnet        PNIStatus = "InsufficientIPAddressesOnSubnet"
+	PNIStatusInvalidStaticReservationForPrefixBlock PNIStatus = "InvalidStaticReservationForPrefixBlock"
 )
 
 func init() {

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_podnetworkinstances.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_podnetworkinstances.yaml
@@ -97,6 +97,7 @@ spec:
                   - CreateReservationSetError
                   - PodNetworkNotReady
                   - InsufficientIPAddressesOnSubnet
+                  - InvalidStaticReservationForPrefixBlock
                   type: string
                 type: object
               status:
@@ -106,6 +107,7 @@ spec:
                 - CreateReservationSetError
                 - PodNetworkNotReady
                 - InsufficientIPAddressesOnSubnet
+                - InvalidStaticReservationForPrefixBlock
                 type: string
             type: object
         type: object


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
 Add a dedicated `PodNetworkInstance` status value for static reservation requests against `PrefixBlock` PodNetworks.

This lets downstream controllers report `InvalidStaticReservationForPrefixBlock` instead of overloading a generic reservation-set failure status when `podIPReservationSize` or `ipConstraint` is used with a `PrefixBlock` PodNetwork.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
N/A

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
