### PR TITLE
fix: Fixing ETW metadata

### DIFF
--- a/cni/network/plugin/main.go
+++ b/cni/network/plugin/main.go
@@ -67,6 +67,7 @@ func rootExecute() error {
 			zap.String("os_version", metadata.OSVersion),
 			zap.String("vm_id", metadata.VMID),
 			zap.String("session_id", metadata.VMID),
+			zap.String("os_type", metadata.OsType),
 		)
 	}
 

--- a/cni/network/stateless/main.go
+++ b/cni/network/stateless/main.go
@@ -67,6 +67,7 @@ func rootExecute() error {
 			zap.String("os_version", metadata.OSVersion),
 			zap.String("vm_id", metadata.VMID),
 			zap.String("session_id", metadata.VMID),
+			zap.String("os_type", metadata.OsType),
 		)
 	}
 

--- a/cns/logger/v2/fields.go
+++ b/cns/logger/v2/fields.go
@@ -19,5 +19,6 @@ func MetadataToFields(meta common.Metadata) []zap.Field {
 		zap.String("os_version", meta.OSVersion),
 		zap.String("vm_id", meta.VMID),
 		zap.String("session_id", meta.VMID),
+		zap.String("os_type", meta.OsType),
 	}
 }

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -655,7 +655,7 @@ func main() {
 	if cnsconfig.Logger.AppInsights != nil {
 		cnsconfig.Logger.AppInsights.Fields = append(cnsconfig.Logger.AppInsights.Fields, aifields...)
 	}
-	cnsconfig.Logger.AppendETWFields(aifields)
+	cnsconfig.Logger.AppendETWFields(allFields)
 
 	// build the zap logger
 	z, c, err := loggerv2.New(&cnsconfig.Logger)

--- a/zapai/example/main.go
+++ b/zapai/example/main.go
@@ -2,15 +2,16 @@ package main
 
 import (
 	"fmt"
+	"net/http"
+	"os"
+	"runtime"
+	"time"
+
 	"github.com/Azure/azure-container-networking/zapai"
 	logfmt "github.com/jsternberg/zap-logfmt"
 	"github.com/microsoft/ApplicationInsights-Go/appinsights"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	"net/http"
-	"os"
-	"runtime"
-	"time"
 )
 
 const version = "1.2.3"
@@ -93,6 +94,7 @@ func main() {
 		zap.String("VMSize", "VMSize"),
 		zap.String("OSVersion", "OSVersion"),
 		zap.String("VMID", "VMID"),
+		zap.String("OSType", "OsType"),
 	)
 
 	subn := Sub{


### PR DESCRIPTION
**Reason for Change**:
Fixes ETW (Event Tracing for Windows) metadata enrichment by including the OS type field in telemetry events and correcting the field selection when appending ETW metadata in CNS and CNI. This ensures comprehensive system information is available for diagnostics and monitoring across all container networking components.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
No issue associated to this PR.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Tests**:
CNS Logs ingested by Geneva Logs and Kusto Cluster
<img width="2953" height="454" alt="image" src="https://github.com/user-attachments/assets/f432812e-b4d3-4aa7-86a9-acf81978c957" />

CNI Logs ingested by Geneva Logs and Kusto Cluster
<img width="2934" height="428" alt="image" src="https://github.com/user-attachments/assets/2b712ec8-e819-43eb-a6dc-1980c9d16a60" />


**Notes**:
- Added `os_type` metadata field to CNI plugin, stateless, and CNS logger components
- Fixed bug in `cns/service/main.go` where `aifields` was passed to `AppendETWFields()` instead of `allFields`, ensuring all metadata is sent to ETW
- Corrected import ordering in `zapai/example/main.go` for consistency
