### PR TITLE
chore: move OIDC client-id and tenant-id to repository variables

### DIFF
--- a/.github/workflows/scheduled-release.yaml
+++ b/.github/workflows/scheduled-release.yaml
@@ -266,8 +266,8 @@ jobs:
         continue-on-error: true
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
-          client-id: 75013c7b-3bea-441b-952c-e13d7c9247bc
-          tenant-id: 72f988bf-86f1-41af-91ab-2d7cd011db47
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
           allow-no-subscriptions: true
 
       - name: Post release announcement to CNI Teams channel
@@ -387,8 +387,8 @@ jobs:
         continue-on-error: true
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
-          client-id: 75013c7b-3bea-441b-952c-e13d7c9247bc
-          tenant-id: 72f988bf-86f1-41af-91ab-2d7cd011db47
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
           allow-no-subscriptions: true
 
       - name: Install govulncheck
@@ -570,8 +570,8 @@ jobs:
         continue-on-error: true
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
-          client-id: 75013c7b-3bea-441b-952c-e13d7c9247bc
-          tenant-id: 72f988bf-86f1-41af-91ab-2d7cd011db47
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
           allow-no-subscriptions: true
 
       - name: Build release-cli
@@ -726,8 +726,8 @@ jobs:
       - name: Azure Login (OIDC)
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
-          client-id: 75013c7b-3bea-441b-952c-e13d7c9247bc
-          tenant-id: 72f988bf-86f1-41af-91ab-2d7cd011db47
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
           allow-no-subscriptions: true
 
       - name: Wait for tag to be created
@@ -841,8 +841,8 @@ jobs:
         continue-on-error: true
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
-          client-id: 75013c7b-3bea-441b-952c-e13d7c9247bc
-          tenant-id: 72f988bf-86f1-41af-91ab-2d7cd011db47
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
           allow-no-subscriptions: true
 
       - name: Post release thread in Release Channel


### PR DESCRIPTION
Replaces hardcoded Azure OIDC identifiers with `vars.AZURE_CLIENT_ID` and `vars.AZURE_TENANT_ID` to keep them out of source code.

These are not secrets (they're public identifiers per [Microsoft docs](https://learn.microsoft.com/en-us/azure/developer/github/connect-from-azure)), but moving to variables follows best practices and avoids accidental changes via PR.