### PR TITLE
fix: use explicit format strings in logger calls

### DIFF
--- a/cni/network/invoker_azure.go
+++ b/cni/network/invoker_azure.go
@@ -78,7 +78,7 @@ func (invoker *AzureIPAMInvoker) Add(addConfig IPAMAddConfig) (IPAMAddResult, er
 		if err != nil {
 			if len(addResult.interfaceInfo) > 0 && len(addResult.interfaceInfo[invoker.getInterfaceInfoKey(cns.InfraNIC)].IPConfigs) > 0 {
 				if er := invoker.Delete(&addResult.interfaceInfo[invoker.getInterfaceInfoKey(cns.InfraNIC)].IPConfigs[0].Address, addConfig.nwCfg, nil, addConfig.options); er != nil {
-					err = invoker.plugin.Errorf("Failed to clean up IP's during Delete with error %v, after Add failed with error %w", er, err)
+					err = invoker.plugin.Errorf("Failed to clean up IP's during Delete with error %v, after Add failed with error %v", er, err)
 				}
 			} else {
 				err = fmt.Errorf("No IP's to delete on error: %v", err)

--- a/cns/common/service.go
+++ b/cns/common/service.go
@@ -73,7 +73,7 @@ func NewService(name, version, channelMode string, store store.KeyValueStore) (*
 func (service *Service) Initialize(config *ServiceConfig) error {
 	if config == nil {
 		err := "[Azure CNS Errror] Initialize called with nil ServiceConfig."
-		logger.Errorf(err)
+		logger.Errorf("%s", err)
 		return errors.New(err)
 	}
 

--- a/cns/networkcontainers/networkcontainers.go
+++ b/cns/networkcontainers/networkcontainers.go
@@ -52,7 +52,7 @@ func InterfaceExists(iFaceName string) (bool, error) {
 	_, err := net.InterfaceByName(iFaceName)
 	if err != nil {
 		errMsg := fmt.Sprintf("[Azure CNS] Unable to get interface by name %s. Error: %v", iFaceName, err)
-		logger.Printf(errMsg)
+		logger.Printf("%s", errMsg)
 		return false, errors.New(errMsg)
 	}
 
@@ -126,7 +126,7 @@ func getNetworkConfig(configFilePath string) ([]byte, error) {
 
 	if flatNetConfigMap == nil {
 		msg := "[Azure CNS] " + pluginsStr + " section of the network configuration cannot be empty."
-		logger.Printf(msg)
+		logger.Printf("%s", msg)
 		return nil, errors.New(msg)
 	}
 

--- a/cns/networkcontainers/networkcontainers_linux.go
+++ b/cns/networkcontainers/networkcontainers_linux.go
@@ -39,7 +39,7 @@ func updateInterface(createNetworkContainerRequest cns.CreateNetworkContainerReq
 	if _, err := os.Stat(netpluginConfig.path); err != nil {
 		if os.IsNotExist(err) {
 			msg := "[Azure CNS] Unable to find " + netpluginConfig.path + ", cannot continue."
-			logger.Printf(msg)
+			logger.Printf("%s", msg)
 			return errors.New(msg)
 		}
 	}

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -149,7 +149,7 @@ func (service *HTTPRestService) createNetwork(w http.ResponseWriter, r *http.Req
 					}
 				} else {
 					returnMessage = fmt.Sprintf("[Azure CNS] Received a request to create an already existing network %v", req.NetworkName)
-					logger.Printf(returnMessage)
+					logger.Printf("%s", returnMessage)
 				}
 
 			default:

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -78,7 +78,7 @@ func (service *HTTPRestService) SyncNodeStatus(dncEP, infraVnet, nodeID string, 
 	if err != nil {
 		returnCode = types.UnexpectedError
 		errStr = fmt.Sprintf("[Azure-CNS] Failed to sync node with error: %+v", err)
-		logger.Errorf(errStr)
+		logger.Errorf("%s", errStr)
 		return
 	}
 
@@ -573,7 +573,7 @@ func (service *HTTPRestService) MustEnsureNoStaleNCs(validNCIDs []string) {
 			// stale NCs with assigned IPs are an unexpected CNS state which we need to alert on.
 			if assignedIPs, hasAssignedIPs := ncIDToAssignedIPs[ncID]; hasAssignedIPs {
 				msg := fmt.Sprintf("Unexpected state: found stale NC ID %s in CNS state with %d assigned IPs: %+v", ncID, len(assignedIPs), assignedIPs)
-				logger.Errorf(msg)
+				logger.Errorf("%s", msg)
 				panic(msg)
 			}
 
@@ -655,13 +655,13 @@ func (service *HTTPRestService) CreateOrUpdateNetworkContainerInternal(req *cns.
 		logNCSnapshot(*req)
 		service.publishIPStateMetrics()
 	} else {
-		logger.Errorf(returnMessage)
+		logger.Errorf("%s", returnMessage)
 	}
 
 	if service.Options[common.OptProgramSNATIPTables] == true {
 		returnCode, returnMessage = service.programSNATRules(req)
 		if returnCode != 0 {
-			logger.Errorf(returnMessage)
+			logger.Errorf("%s", returnMessage)
 		}
 	}
 

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -895,7 +895,7 @@ func (service *HTTPRestService) GetExistingIPConfig(podInfo cns.PodInfo) ([]cns.
 				ipConfigExists = true
 			} else {
 				errMsg := fmt.Sprintf("Failed to get existing ipconfig for pod %+v. Pod to IPID exists, but IPID to IPConfig doesn't exist, CNS State potentially corrupt", podInfo)
-				logger.Errorf(errMsg)
+				logger.Errorf("%s", errMsg)
 				return podIPInfo, false, errors.New(errMsg)
 			}
 		}
@@ -977,12 +977,12 @@ func (service *HTTPRestService) AssignDesiredIPConfigs(podInfo cns.PodInfo, desi
 	// assigns all IPs that were found as available to the pod
 	for i := range ipConfigsToAssign {
 		if err := service.assignIPConfig(ipConfigsToAssign[i], podInfo); err != nil {
-			logger.Errorf(err.Error())
+			logger.Errorf("%s", err.Error())
 			failedToAssignIP = true
 			break
 		}
 		if err := service.populateIPConfigInfoUntransacted(ipConfigsToAssign[i], &podIPInfo[numIPConfigsAssigned]); err != nil {
-			logger.Errorf(err.Error())
+			logger.Errorf("%s", err.Error())
 			failedToAssignIP = true
 			break
 		}
@@ -1075,13 +1075,13 @@ func (service *HTTPRestService) AssignAvailableIPConfigs(podInfo cns.PodInfo) ([
 	// assigns all IPs in the map to the pod
 	for _, ip := range ipsToAssign { //nolint:gocritic // ignore copy
 		if err := service.assignIPConfig(ip, podInfo); err != nil {
-			logger.Errorf(err.Error())
+			logger.Errorf("%s", err.Error())
 			failedToAssignIP = true
 			break
 		}
 
 		if err := service.populateIPConfigInfoUntransacted(ip, &podIPInfo[numIPConfigsAssigned]); err != nil {
-			logger.Errorf(err.Error())
+			logger.Errorf("%s", err.Error())
 			failedToAssignIP = true
 			break
 		}

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -239,13 +239,13 @@ func (service *HTTPRestService) saveNetworkContainerGoalState(req cns.CreateNetw
 			}
 		default:
 			errMsg := fmt.Sprintf("Unsupported orchestrator type: %s", service.state.OrchestratorType)
-			logger.Errorf(errMsg)
+			logger.Errorf("%s", errMsg)
 			return types.UnsupportedOrchestratorType, errMsg
 		}
 
 	default:
 		errMsg := fmt.Sprintf("Unsupported network container type %s", req.NetworkContainerType)
-		logger.Errorf(errMsg)
+		logger.Errorf("%s", errMsg)
 		return types.UnsupportedNetworkContainerType, errMsg
 	}
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -454,7 +454,7 @@ func sendRegisterNodeRequest(ctx context.Context, httpClient httpDoer, httpRestS
 
 	if response.StatusCode != http.StatusOK {
 		err = fmt.Errorf("[Azure CNS] Failed to register node, DNC replied with http status code %s", strconv.Itoa(response.StatusCode))
-		logger.Errorf(err.Error())
+		logger.Errorf("%s", err.Error())
 		return errors.Wrap(err, "failed to sendRegisterNodeRequest")
 	}
 


### PR DESCRIPTION
## Summary

Fix `go vet` failures exposed by Go 1.26's stricter printf format checking.

### Changes
- **9 files, 18 substitutions**: All instances of `logger.Errorf(variable)` / `logger.Printf(variable)` changed to `logger.Errorf("%s", variable)`
- **1 fix**: `delegatePlugin.Errorf` using unsupported `%w` directive → changed to `%v`

### Why
Go 1.26 vet reports `non-constant format string` when a variable (not a string literal) is passed as the first argument to a printf-like function. This is a correctness/security concern — if the variable contains `%` characters, they'd be interpreted as format directives.

### Backward compatible
These fixes work on **any Go version** — they don't require Go 1.26. Using `"%s"` as an explicit format string is universally valid.

### Affected packages
- `cns/common`
- `cns/networkcontainers`
- `cns/restserver`
- `cns/service`
- `cni/network`

### Testing
`go vet` passes cleanly on all affected packages (remaining warnings in `restserver/util_test.go` are pre-existing lock-copy issues).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>