### PR TITLE
feat: cherry-pick automated release orchestrator workflow to release/v1.7

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -31,6 +31,7 @@ jobs:
           - dropgz
           - pkgerrlint
           - tools/azure-npm-to-cilium-validator
+          - tools/release
           - zapai
         include:
           - module: .
@@ -90,6 +91,7 @@ jobs:
             "dropgz"
             "pkgerrlint"
             "tools/azure-npm-to-cilium-validator"
+            "tools/release"
             "zapai"
           )
 

--- a/.github/workflows/scheduled-release.yaml
+++ b/.github/workflows/scheduled-release.yaml
@@ -1,0 +1,1064 @@
+# Automated Monthly Release Orchestrator for ACN
+# Handles: dependabot PR collection, vuln checks, tag creation, pipeline validation,
+# release channel posting, and R2D draft preparation.
+#
+# Trigger: First Friday of every month at 14:00 UTC + manual dispatch
+#
+# ─── Teams Notification Dependency ───────────────────────────────────────────
+# Teams messages are sent via the acn-notifier-bot Azure Function App,
+# authenticated using OIDC (federated credentials on acn-release-bot SP).
+# The bot creates/updates Adaptive Cards in Teams channels.
+# If notifications stop working, check:
+#   1. Federated credential on acn-release-bot (75013c7b) for this repo
+#   2. acn-notifier-bot Function App status in Azure portal
+#   3. Token audience: api://3976eca5-3f9d-4528-987f-c20c1f9f27f7
+# Contact: ACN Release Engineering team
+# ─────────────────────────────────────────────────────────────────────────────
+name: Scheduled Release
+
+on:
+  schedule:
+    # First Friday of every month at 14:00 UTC
+    - cron: "0 14 * * 5"
+  workflow_dispatch:
+    inputs:
+      release_branch:
+        description: "Release branch to target"
+        required: true
+        default: "release/v1.7"
+        type: choice
+        options:
+          - release/v1.7
+          - master
+      skip_dependabot_wait:
+        description: "Skip waiting for dependabot PRs to merge"
+        required: false
+        default: false
+        type: boolean
+      skip_vuln_check:
+        description: "Skip govulncheck gate"
+        required: false
+        default: false
+        type: boolean
+      dry_run:
+        description: "Dry run — post to Teams but skip actual tag creation and pipeline triggers"
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: scheduled-release-${{ inputs.release_branch || 'release/v1.7' }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  RELEASE_BRANCH: ${{ inputs.release_branch || 'release/v1.7' }}
+  MAX_PIPELINE_RETRIES: 5
+  NOTIFIER_URL: https://acn-notifier-bot.azurewebsites.net
+  NOTIFIER_AUDIENCE: api://3976eca5-3f9d-4528-987f-c20c1f9f27f7
+  TEAMS_TEAM_ID: 1eb27b57-8ace-4f0e-a9a9-e6db4e9829b7
+  TEAMS_CNI_CHANNEL_ID: "19:2b104ee19fdb450b807903eb7c79588a@thread.skype"
+  TEAMS_RELEASE_CHANNEL_ID: "19:ad6cb6596adf4850910e9be3e8a7f9ab@thread.skype"
+
+jobs:
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Gate: Check if this is a monthly release cycle (for cron trigger only)
+  # ─────────────────────────────────────────────────────────────────────────────
+  check_cadence:
+    name: Check Monthly Cadence
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - name: Determine if this is a release week
+        id: check
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Check if today is the first Friday of the month (day <= 7)
+          DAY_OF_MONTH=$(date +%d)
+          if (( DAY_OF_MONTH <= 7 )); then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "First Friday of the month (day $DAY_OF_MONTH) — release week"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "Not the first Friday (day $DAY_OF_MONTH). Skipping."
+          fi
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # STEP 1: Collect and wait for Dependabot PRs
+  # ─────────────────────────────────────────────────────────────────────────────
+  wait_dependabot:
+    name: "Step 1: Wait for Dependabot PRs"
+    runs-on: ubuntu-latest
+    needs: check_cadence
+    if: needs.check_cadence.outputs.should_run == 'true'
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: read
+      issues: write
+    outputs:
+      merged_count: ${{ steps.wait.outputs.merged_count || steps.skip.outputs.merged_count }}
+      skipped_prs: ${{ steps.wait.outputs.skipped_prs }}
+      tracking_issue: ${{ steps.create_issue.outputs.issue_number }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ env.RELEASE_BRANCH }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Build release-cli
+        run: |
+          cd tools/release && go build -o /tmp/release-cli ./cmd/release-cli/
+
+      - name: Collect pending PRs and upcoming tags
+        id: collect
+        if: ${{ inputs.skip_dependabot_wait != true }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          RESULT=$(/tmp/release-cli collect-prs --branch "$RELEASE_BRANCH")
+          echo "open_prs_json=$(echo "$RESULT" | jq -c '.prs')" >> "$GITHUB_OUTPUT"
+          echo "open_count=$(echo "$RESULT" | jq -r '.open_count')" >> "$GITHUB_OUTPUT"
+          echo "dependabot_count=$(echo "$RESULT" | jq -r '.dependabot_count')" >> "$GITHUB_OUTPUT"
+          echo "go_upgrade_count=$(echo "$RESULT" | jq -r '.go_upgrade_count')" >> "$GITHUB_OUTPUT"
+
+      - name: Determine version and binary tags
+        id: version_info
+        if: ${{ inputs.skip_dependabot_wait != true }}
+        run: |
+          set -euo pipefail
+          VERSION=$(/tmp/release-cli next-version --branch "$RELEASE_BRANCH")
+          echo "new_tag=$(echo "$VERSION" | jq -r '.new_tag')" >> "$GITHUB_OUTPUT"
+          echo "latest_tag=$(echo "$VERSION" | jq -r '.latest_tag')" >> "$GITHUB_OUTPUT"
+
+          BINARIES=$(/tmp/release-cli detect-binaries --branch "$RELEASE_BRANCH")
+          BINARY_TAGS=$(echo "$BINARIES" | jq -r '.[].new_tag' | sed 's/^/• `/' | sed 's/$/`/')
+          echo "binary_tags<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$BINARY_TAGS" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Find or create release tracking issue
+        id: create_issue
+        if: ${{ inputs.skip_dependabot_wait != true }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_TAG: ${{ steps.version_info.outputs.new_tag }}
+          OPEN_COUNT: ${{ steps.collect.outputs.open_count }}
+          DEPENDABOT_COUNT: ${{ steps.collect.outputs.dependabot_count }}
+          GO_UPGRADE_COUNT: ${{ steps.collect.outputs.go_upgrade_count }}
+          OPEN_PRS_JSON: ${{ steps.collect.outputs.open_prs_json }}
+          BINARY_TAGS: ${{ steps.version_info.outputs.binary_tags }}
+          RUN_ID: ${{ github.run_id }}
+          SERVER_URL: ${{ github.server_url }}
+        run: |
+          set -euo pipefail
+          REPO="${GITHUB_REPOSITORY}"
+
+          # Check if a tracking issue already exists for this tag (from a previous timed-out run)
+          EXISTING_ISSUE=$(gh issue list --repo "$REPO" \
+            --label "release-tracking" --state open \
+            --search "Release Tracking: ${NEW_TAG}" \
+            --json number,title --jq '.[0].number // empty' 2>/dev/null || echo "")
+
+          if [[ -n "$EXISTING_ISSUE" ]]; then
+            echo "Found existing tracking issue #${EXISTING_ISSUE} — resuming"
+            echo "issue_number=$EXISTING_ISSUE" >> "$GITHUB_OUTPUT"
+            echo "issue_url=https://github.com/${REPO}/issues/${EXISTING_ISSUE}" >> "$GITHUB_OUTPUT"
+            echo "resumed=true" >> "$GITHUB_OUTPUT"
+
+            # Post a resume comment with updated PR state
+            PR_LIST=""
+            if [[ "$OPEN_COUNT" -gt 0 ]]; then
+              PR_LIST=$(echo "$OPEN_PRS_JSON" | jq -r '.[] | "- [ ] #\(.number) — \(.title)"')
+            fi
+
+            gh issue comment "$EXISTING_ISSUE" --repo "$REPO" \
+              --body "🔄 **Workflow re-triggered** (run [$RUN_ID]($SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$RUN_ID))
+
+          Still pending (${OPEN_COUNT}):
+          ${PR_LIST:-_None — all clear!_}
+
+          Previous skip comments on this issue still apply." || true
+            exit 0
+          fi
+
+          # Build PR list for the issue body
+          PR_LIST=""
+          if [[ "$OPEN_COUNT" -gt 0 ]]; then
+            PR_LIST=$(echo "$OPEN_PRS_JSON" | jq -r '.[] | "- [ ] #\(.number) — \(.title)"')
+          fi
+
+          BODY="## 🚀 Release Cycle: ${NEW_TAG}
+
+          **Branch:** \`${RELEASE_BRANCH}\`
+          **Run:** ${SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}
+
+          ### Tags to be created:
+          • \`${NEW_TAG}\` (CNI/CNS/NPM)
+          ${BINARY_TAGS}
+          ### ⏳ Pending PRs — Dependabot (${DEPENDABOT_COUNT}) + Go Upgrade (${GO_UPGRADE_COUNT}):
+
+          ${PR_LIST:-_None — all clear!_}
+
+          ---
+          ### Skip Instructions
+
+          To skip a specific PR, comment on this issue:
+          \`\`\`
+          skip #<PR_NUMBER>
+          \`\`\`
+
+          To skip ALL remaining dependency PRs (dependabot + Go upgrade):
+          \`\`\`
+          skip all
+          \`\`\`
+
+          ### Pause for a non-dependabot PR
+
+          To hold the release until a specific PR merges (any PR, not just dependabot):
+          \`\`\`
+          pause #<PR_NUMBER>
+          \`\`\`
+
+          To remove the hold:
+          \`\`\`
+          unpause #<PR_NUMBER>
+          \`\`\`
+
+          ### Pause the release entirely
+
+          To freeze the release (e.g. waiting for an unrelated fix, discussion, etc.):
+          \`\`\`
+          pause
+          \`\`\`
+
+          To unfreeze and let it continue:
+          \`\`\`
+          resume
+          \`\`\`
+
+          ---
+          _This issue is managed by the Scheduled Release workflow. It will close automatically when the release completes._"
+
+          # Create the issue
+          ISSUE_URL=$(gh issue create --repo "$REPO" \
+            --title "🔄 Release Tracking: ${NEW_TAG}" \
+            --body "$BODY" \
+            --label "release-tracking" 2>&1)
+
+          ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oP '\d+$')
+          echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "issue_url=$ISSUE_URL" >> "$GITHUB_OUTPUT"
+          echo "resumed=false" >> "$GITHUB_OUTPUT"
+          echo "Created tracking issue: $ISSUE_URL"
+
+      - name: Azure Login (OIDC)
+        continue-on-error: true
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
+        with:
+          client-id: 75013c7b-3bea-441b-952c-e13d7c9247bc
+          tenant-id: 72f988bf-86f1-41af-91ab-2d7cd011db47
+          allow-no-subscriptions: true
+
+      - name: Post release announcement to CNI Teams channel
+        if: ${{ inputs.skip_dependabot_wait != true }}
+        env:
+          NEW_TAG: ${{ steps.version_info.outputs.new_tag }}
+          OPEN_COUNT: ${{ steps.collect.outputs.open_count }}
+          DEPENDABOT_COUNT: ${{ steps.collect.outputs.dependabot_count }}
+          GO_UPGRADE_COUNT: ${{ steps.collect.outputs.go_upgrade_count }}
+          OPEN_PRS_JSON: ${{ steps.collect.outputs.open_prs_json }}
+          BINARY_TAGS: ${{ steps.version_info.outputs.binary_tags }}
+          ISSUE_NUMBER: ${{ steps.create_issue.outputs.issue_number }}
+          RESUMED: ${{ steps.create_issue.outputs.resumed }}
+        run: |
+          set -euo pipefail
+          REPO="${GITHUB_REPOSITORY}"
+
+          PR_LIST_HTML=""
+          if [[ "$OPEN_COUNT" -gt 0 ]]; then
+            PR_LIST_HTML=$(echo "$OPEN_PRS_JSON" | jq -r '.[] | "• #\(.number) — \(.title)<br>"' | tr -d '\n')
+          else
+            PR_LIST_HTML="<i>None — all clear!</i>"
+          fi
+
+          BINARY_TAGS_HTML=$(echo "$BINARY_TAGS" | sed 's/$/<br>/g')
+          ISSUE_URL="https://github.com/${REPO}/issues/${ISSUE_NUMBER}"
+
+          if [[ "$RESUMED" == "true" ]]; then
+            MSG="🔄 <b>Release workflow re-triggered for ${NEW_TAG}</b><br><br><b>Still pending (${OPEN_COUNT}):</b><br>${PR_LIST_HTML}<br><br>Previous skip commands still apply. Tracking issue: ${ISSUE_URL}"
+          else
+            MSG="🚀 <b>Release cycle starting: ${NEW_TAG}</b><br><br><b>Tags to be created:</b><br>• <code>${NEW_TAG}</code> (CNI/CNS/NPM)<br>${BINARY_TAGS_HTML}<br><b>Pending PRs — Dependabot (${DEPENDABOT_COUNT}) + Go Upgrade (${GO_UPGRADE_COUNT}):</b><br>${PR_LIST_HTML}<br><br>⚠️ These PRs must merge before the release proceeds.<br>To skip a PR, comment <code>skip #NUMBER</code> on tracking issue ${ISSUE_URL}<br>To skip all: comment <code>skip all</code>"
+          fi
+
+          /tmp/release-cli notify \
+            --channel-id "$TEAMS_CNI_CHANNEL_ID" \
+            --title "Release ${NEW_TAG}" \
+            --status running \
+            --summary "$MSG" \
+            --stage release-start
+
+      - name: Wait for PRs to merge or be skipped
+        id: wait
+        if: ${{ inputs.skip_dependabot_wait != true }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ steps.create_issue.outputs.issue_number }}
+        run: |
+          set -euo pipefail
+          RESULT=$(/tmp/release-cli wait-prs \
+            --branch "$RELEASE_BRANCH" \
+            --issue-number "$ISSUE_NUMBER" \
+            --poll-interval 5m)
+          echo "merged_count=$(echo "$RESULT" | jq -r '.merged_count')" >> "$GITHUB_OUTPUT"
+          echo "skipped_prs=$(echo "$RESULT" | jq -r '.skipped_prs')" >> "$GITHUB_OUTPUT"
+
+      - name: Post update to CNI channel
+        if: ${{ inputs.skip_dependabot_wait != true && steps.wait.outcome == 'success' }}
+        env:
+          MERGED: ${{ steps.wait.outputs.merged_count }}
+          SKIPPED: ${{ steps.wait.outputs.skipped_prs }}
+          NEW_TAG: ${{ steps.version_info.outputs.new_tag }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${SKIPPED:-}" ]]; then
+            MSG="✅ Dependabot gate passed for ${NEW_TAG}. Merged: ${MERGED} | Skipped: ${SKIPPED}. Proceeding to vulnerability check..."
+          else
+            MSG="✅ All dependabot PRs merged for ${NEW_TAG}. Total merged: ${MERGED}. Proceeding to vulnerability check..."
+          fi
+          /tmp/release-cli notify \
+            --channel-id "$TEAMS_CNI_CHANNEL_ID" \
+            --title "Dependabot Gate: ${NEW_TAG}" \
+            --status succeeded \
+            --summary "$MSG" \
+            --stage dependabot-gate
+
+      - name: Skip dependabot wait (manual override)
+        id: skip
+        if: ${{ inputs.skip_dependabot_wait == true }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "merged_count=0" >> "$GITHUB_OUTPUT"
+          echo "Skipped dependabot wait per user request"
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # STEP 2: Vulnerability Gate Check
+  # ─────────────────────────────────────────────────────────────────────────────
+  vuln_check:
+    name: "Step 2: Vulnerability Gate"
+    runs-on: ubuntu-latest
+    needs: wait_dependabot
+    if: ${{ inputs.skip_vuln_check != true }}
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      vuln_count: ${{ steps.scan.outputs.vuln_count }}
+      clean: ${{ steps.scan.outputs.clean }}
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ env.RELEASE_BRANCH }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+
+      - name: Build release-cli
+        run: |
+          cd tools/release && go build -o /tmp/release-cli ./cmd/release-cli/
+
+      - name: Azure Login (OIDC)
+        continue-on-error: true
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
+        with:
+          client-id: 75013c7b-3bea-441b-952c-e13d7c9247bc
+          tenant-id: 72f988bf-86f1-41af-91ab-2d7cd011db47
+          allow-no-subscriptions: true
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+
+      - name: Run govulncheck on all modules
+        id: scan
+        run: |
+          set -euo pipefail
+          VULN_COUNT=0
+          VULN_REPORT=""
+          SCAN_ERRORS=0
+
+          for moddir in $(find . -name "go.mod" -not -path "*/vendor/*" -exec dirname {} \;); do
+            echo "Scanning $moddir..."
+            if OUTPUT=$(cd "$moddir" && govulncheck ./... 2>&1); then
+              echo "  ✅ $moddir: clean"
+            else
+              EXIT_CODE=$?
+              FOUND=$(echo "$OUTPUT" | grep -c "Vulnerability" || true)
+              if [[ "$FOUND" -gt 0 ]]; then
+                VULN_COUNT=$((VULN_COUNT + FOUND))
+                VULN_REPORT+="$moddir: $FOUND vulnerabilities found\n"
+              else
+                # govulncheck failed but no vulnerabilities reported — build/tooling error
+                SCAN_ERRORS=$((SCAN_ERRORS + 1))
+                VULN_REPORT+="$moddir: scan error (exit $EXIT_CODE, no vulns reported)\n"
+                echo "::error::govulncheck failed in $moddir (exit $EXIT_CODE) without reporting vulnerabilities — possible build error"
+              fi
+            fi
+          done
+
+          echo "vuln_count=$VULN_COUNT" >> "$GITHUB_OUTPUT"
+          echo "scan_errors=$SCAN_ERRORS" >> "$GITHUB_OUTPUT"
+          if [[ "$VULN_COUNT" -eq 0 && "$SCAN_ERRORS" -eq 0 ]]; then
+            echo "clean=true" >> "$GITHUB_OUTPUT"
+            echo "✅ No vulnerabilities found"
+          else
+            echo "clean=false" >> "$GITHUB_OUTPUT"
+            echo "::error::Found $VULN_COUNT vulnerabilities and $SCAN_ERRORS scan errors"
+            echo -e "$VULN_REPORT"
+            exit 1
+          fi
+
+      - name: Post vuln results to Teams
+        if: failure() && steps.scan.outputs.vuln_count != ''
+        env:
+          VULN_COUNT: ${{ steps.scan.outputs.vuln_count }}
+          SCAN_ERRORS: ${{ steps.scan.outputs.scan_errors }}
+        run: |
+          set -euo pipefail
+          MSG="🚫 <b>govulncheck FAILED</b> on $RELEASE_BRANCH. Vulnerabilities: ${VULN_COUNT}, Scan errors: ${SCAN_ERRORS}. Release blocked until resolved."
+          /tmp/release-cli notify \
+            --channel-id "$TEAMS_RELEASE_CHANNEL_ID" \
+            --title "Vuln Check: ${RELEASE_BRANCH}" \
+            --status failed \
+            --summary "$MSG" \
+            --stage vuln-check
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # STEP 2b: Detect Binary Changes (dropgz, azure-ipam, etc.)
+  # ─────────────────────────────────────────────────────────────────────────────
+  detect_binary_changes:
+    name: "Step 2b: Detect Binary Changes"
+    runs-on: ubuntu-latest
+    needs: [wait_dependabot, vuln_check]
+    if: always() && needs.wait_dependabot.result == 'success' && (needs.vuln_check.result == 'success' || needs.vuln_check.result == 'skipped')
+    outputs:
+      matrix: ${{ steps.detect.outputs.matrix }}
+      has_changes: ${{ steps.detect.outputs.has_changes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ env.RELEASE_BRANCH }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Build release-cli
+        run: |
+          cd tools/release && go build -o /tmp/release-cli ./cmd/release-cli/
+
+      - name: Detect changes per binary
+        id: detect
+        run: |
+          set -euo pipefail
+          RESULT=$(/tmp/release-cli detect-binaries --branch "$RELEASE_BRANCH")
+          MATRIX=$(echo "$RESULT" | jq -c '.')
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          if [[ "$MATRIX" == "[]" ]]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # STEP 2c: Tag Binaries That Have Changes
+  # NOTE: Binary tags (dropgz, azure-ipam, etc.) are pushed directly without the
+  # tag-approval environment gate. This is intentional — these are smaller utility
+  # binaries that don't go through managed DALEC, and the release workflow itself
+  # already provides the gating (vuln check + dependabot gate + manual dispatch).
+  # ─────────────────────────────────────────────────────────────────────────────
+  tag_binaries:
+    name: "Tag ${{ matrix.binary }}"
+    runs-on: ubuntu-latest
+    needs: detect_binary_changes
+    if: needs.detect_binary_changes.outputs.has_changes == 'true'
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.detect_binary_changes.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ env.RELEASE_BRANCH }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Create tag ${{ matrix.new_tag }}
+        id: create
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_TAG: ${{ matrix.new_tag }}
+          PREV_TAG: ${{ matrix.previous_tag }}
+          BINARY: ${{ matrix.binary }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          # Verify tag doesn't already exist (race guard)
+          if git ls-remote --exit-code --tags origin "refs/tags/$NEW_TAG" >/dev/null 2>&1; then
+            echo "::warning::Tag $NEW_TAG already exists — skipping"
+            echo "created=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          TARGET_SHA=$(git rev-parse HEAD)
+
+          # Show changelog summary
+          echo "Changes since $PREV_TAG:"
+          git log --oneline "${PREV_TAG}..HEAD" -- "${BINARY}/" | head -20
+
+          # Create and push tag
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "🏜️ DRY RUN: Would create and push tag $NEW_TAG at $TARGET_SHA"
+            echo "created=dry_run" >> "$GITHUB_OUTPUT"
+          else
+            TARGET_SHA=$(git rev-parse HEAD)
+            gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="refs/tags/$NEW_TAG" \
+              -f sha="$TARGET_SHA" --silent
+            echo "✅ Created and pushed tag: $NEW_TAG"
+            echo "created=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # STEP 2d: Post Binary Release Summary
+  # ─────────────────────────────────────────────────────────────────────────────
+  binary_release_summary:
+    name: "Binary Release Summary"
+    runs-on: ubuntu-latest
+    needs: [detect_binary_changes, tag_binaries]
+    if: always() && needs.detect_binary_changes.outputs.has_changes == 'true'
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout (for tag verification)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ env.RELEASE_BRANCH }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Azure Login (OIDC)
+        continue-on-error: true
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
+        with:
+          client-id: 75013c7b-3bea-441b-952c-e13d7c9247bc
+          tenant-id: 72f988bf-86f1-41af-91ab-2d7cd011db47
+          allow-no-subscriptions: true
+
+      - name: Build release-cli
+        run: |
+          cd tools/release && go build -o /tmp/release-cli ./cmd/release-cli/
+
+      - name: Verify created tags and post summary
+        env:
+          MATRIX: ${{ needs.detect_binary_changes.outputs.matrix }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          CREATED=""
+          FAILED=""
+
+          if [[ "$DRY_RUN" == "true" ]]; then
+            CREATED=$(echo "$MATRIX" | jq -r '.[].new_tag' | sed 's/^/• /')
+            MSG="🏜️ [DRY RUN] <b>Binary releases that WOULD be created:</b><br><br>${CREATED}<br><br>These tags were detected as needing a release but were not pushed (dry run mode)."
+            /tmp/release-cli notify \
+              --channel-id "$TEAMS_RELEASE_CHANNEL_ID" \
+              --title "Binary Release Summary: ${RELEASE_BRANCH}" \
+              --status queued \
+              --summary "$MSG" \
+              --stage binary-release
+          else
+            for TAG in $(echo "$MATRIX" | jq -r '.[].new_tag'); do
+              if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+                CREATED+="• $TAG\n"
+              else
+                FAILED+="• $TAG (not found)\n"
+              fi
+            done
+
+            if [[ -n "$CREATED" ]]; then
+              MSG="📦 <b>Binary releases created (monthly release cycle):</b><br><br>$(echo -e "$CREATED")<br>These tags were auto-created because changes were detected since the previous release."
+              /tmp/release-cli notify \
+                --channel-id "$TEAMS_RELEASE_CHANNEL_ID" \
+                --title "Binary Release Summary: ${RELEASE_BRANCH}" \
+                --status succeeded \
+                --summary "$MSG" \
+                --stage binary-release
+            fi
+
+            if [[ -n "$FAILED" ]]; then
+              echo "::warning::Some binary tags were not created:"
+              echo -e "$FAILED"
+            fi
+          fi
+
+      - name: Write binary summary to step summary
+        env:
+          MATRIX: ${{ needs.detect_binary_changes.outputs.matrix }}
+        run: |
+          {
+            echo "## 📦 Binary Releases"
+            echo ""
+            echo "| Binary | New Tag | Previous Tag |"
+            echo "|--------|---------|--------------|"
+            echo "$MATRIX" | jq -r '.[] | "| \(.binary) | \(.new_tag) | \(.previous_tag) |"'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # STEP 3: Determine Next Version & Trigger Tag Creation
+  # ─────────────────────────────────────────────────────────────────────────────
+  create_tag:
+    name: "Step 3: Determine Version & Create Tag"
+    runs-on: ubuntu-latest
+    needs: [wait_dependabot, vuln_check]
+    if: always() && needs.wait_dependabot.result == 'success' && (needs.vuln_check.result == 'success' || needs.vuln_check.result == 'skipped')
+    permissions:
+      contents: write
+    outputs:
+      new_tag: ${{ steps.version.outputs.new_tag }}
+      target_sha: ${{ steps.version.outputs.target_sha }}
+      previous_tag: ${{ steps.version.outputs.previous_tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ env.RELEASE_BRANCH }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Build release-cli
+        run: |
+          cd tools/release && go build -o /tmp/release-cli ./cmd/release-cli/
+
+      - name: Determine next patch version
+        id: version
+        run: |
+          set -euo pipefail
+          RESULT=$(/tmp/release-cli next-version --branch "$RELEASE_BRANCH")
+          echo "new_tag=$(echo "$RESULT" | jq -r '.new_tag')" >> "$GITHUB_OUTPUT"
+          echo "previous_tag=$(echo "$RESULT" | jq -r '.latest_tag')" >> "$GITHUB_OUTPUT"
+          echo "target_sha=$(echo "$RESULT" | jq -r '.target_sha')" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch create-release-tag workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_TAG: ${{ steps.version.outputs.new_tag }}
+          TARGET_SHA: ${{ steps.version.outputs.target_sha }}
+          VULN_COUNT: ${{ needs.vuln_check.outputs.vuln_count || '0' }}
+          MERGED_COUNT: ${{ needs.wait_dependabot.outputs.merged_count || '0' }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          REASON="Scheduled monthly release. Dependabot PRs merged: ${MERGED_COUNT}. CVEs patched: ${VULN_COUNT}."
+
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "🏜️ DRY RUN: Would dispatch create-release-tag for $NEW_TAG on $TARGET_SHA"
+            echo "Reason: $REASON"
+          else
+            echo "Dispatching create-release-tag for $NEW_TAG on $TARGET_SHA"
+
+            gh workflow run create-release-tag.yml \
+              --repo "${GITHUB_REPOSITORY}" \
+              -f tag_prefix=none \
+              -f tag_name="$NEW_TAG" \
+              -f target_sha="$TARGET_SHA" \
+              -f reason="$REASON"
+
+            echo "✅ Tag creation dispatched. Requires tag-approval environment approval."
+          fi
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # STEP 4: Pipeline Validation (ACN PR Pipeline + CNI Release Test)
+  # ─────────────────────────────────────────────────────────────────────────────
+  validate_pipelines:
+    name: "Step 4: Pipeline Validation"
+    runs-on: ubuntu-latest
+    needs: create_tag
+    if: inputs.dry_run != true
+    timeout-minutes: 360
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      pr_pipeline_run_url: ${{ steps.pr_pipeline.outputs.run_url }}
+      cni_release_run_url: ${{ steps.cni_release.outputs.run_url }}
+    steps:
+      - name: Checkout (needed for git ls-remote)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ env.RELEASE_BRANCH }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Build release-cli
+        run: |
+          cd tools/release && go build -o /tmp/release-cli ./cmd/release-cli/
+
+      - name: Azure Login (OIDC)
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
+        with:
+          client-id: 75013c7b-3bea-441b-952c-e13d7c9247bc
+          tenant-id: 72f988bf-86f1-41af-91ab-2d7cd011db47
+          allow-no-subscriptions: true
+
+      - name: Wait for tag to be created
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_TAG: ${{ needs.create_tag.outputs.new_tag }}
+        run: |
+          set -euo pipefail
+          echo "Waiting for tag $NEW_TAG to appear (requires human approval)..."
+
+          MAX_WAIT=7200  # 2 hours
+          POLL=60
+          elapsed=0
+          while true; do
+            if git ls-remote --exit-code --tags origin "refs/tags/$NEW_TAG" >/dev/null 2>&1; then
+              echo "✅ Tag $NEW_TAG found"
+              break
+            fi
+            if (( elapsed >= MAX_WAIT )); then
+              echo "::error::Tag $NEW_TAG not created within ${MAX_WAIT}s. Approval may be pending."
+              exit 1
+            fi
+            sleep $POLL
+            elapsed=$((elapsed + POLL))
+          done
+
+      - name: Get ADO Bearer token
+        id: ado_token
+        run: |
+          set -euo pipefail
+          # Azure DevOps resource ID
+          TOKEN=$(az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv)
+          echo "::add-mask::$TOKEN"
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for ACN PR Pipeline
+        id: pr_pipeline
+        env:
+          ADO_TOKEN: ${{ steps.ado_token.outputs.token }}
+          NEW_TAG: ${{ needs.create_tag.outputs.new_tag }}
+          PIPELINE_DEF_ID: ${{ vars.ACN_PR_PIPELINE_ID }}
+        run: |
+          set -euo pipefail
+          RESULT=$(/tmp/release-cli wait-pipeline \
+            --org "msazure" \
+            --project "One" \
+            --definition-id "$PIPELINE_DEF_ID" \
+            --token "$ADO_TOKEN" \
+            --tag "$NEW_TAG" \
+            --timeout 3h \
+            --name "ACN PR Pipeline")
+          echo "run_url=$(echo "$RESULT" | jq -r '.run_url')" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for ACN CNI Release Test
+        id: cni_release
+        env:
+          ADO_TOKEN: ${{ steps.ado_token.outputs.token }}
+          NEW_TAG: ${{ needs.create_tag.outputs.new_tag }}
+          PIPELINE_DEF_ID: ${{ vars.ACN_CNI_RELEASE_PIPELINE_ID }}
+        run: |
+          set -euo pipefail
+          RESULT=$(/tmp/release-cli wait-pipeline \
+            --org "msazure" \
+            --project "One" \
+            --definition-id "$PIPELINE_DEF_ID" \
+            --token "$ADO_TOKEN" \
+            --tag "$NEW_TAG" \
+            --timeout 3h \
+            --name "ACN CNI Release Test")
+          echo "run_url=$(echo "$RESULT" | jq -r '.run_url')" >> "$GITHUB_OUTPUT"
+
+      - name: Post pipeline validation to CNI Teams channel
+        env:
+          NEW_TAG: ${{ needs.create_tag.outputs.new_tag }}
+          PR_RUN: ${{ steps.pr_pipeline.outputs.run_url }}
+          CNI_RUN: ${{ steps.cni_release.outputs.run_url }}
+        run: |
+          set -euo pipefail
+          MSG="✅ <b>Pipeline validation complete for ${NEW_TAG}</b><br><br>• ACN PR Pipeline: ${PR_RUN}<br>• ACN CNI Release Test: ${CNI_RUN}<br>• CNI/CNS Signed Release: Managed DALEC (automatic — tag picked up)"
+          /tmp/release-cli notify \
+            --channel-id "$TEAMS_CNI_CHANNEL_ID" \
+            --title "Pipeline Validation: ${NEW_TAG}" \
+            --status succeeded \
+            --summary "$MSG" \
+            --stage pipeline-validation
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # STEP 5: Post in Release Channel + Draft R2D
+  # ─────────────────────────────────────────────────────────────────────────────
+  release_channel_post:
+    name: "Step 5: Release Channel + R2D Draft"
+    runs-on: ubuntu-latest
+    needs: [create_tag, validate_pipelines]
+    if: always() && needs.create_tag.result == 'success' && needs.validate_pipelines.result == 'success'
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ env.RELEASE_BRANCH }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Build release-cli
+        run: |
+          cd tools/release && go build -o /tmp/release-cli ./cmd/release-cli/
+
+      - name: Azure Login (OIDC)
+        continue-on-error: true
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
+        with:
+          client-id: 75013c7b-3bea-441b-952c-e13d7c9247bc
+          tenant-id: 72f988bf-86f1-41af-91ab-2d7cd011db47
+          allow-no-subscriptions: true
+
+      - name: Post release thread in Release Channel
+        id: release_thread
+        env:
+          NEW_TAG: ${{ needs.create_tag.outputs.new_tag }}
+          TARGET_SHA: ${{ needs.create_tag.outputs.target_sha }}
+          PREVIOUS_TAG: ${{ needs.create_tag.outputs.previous_tag }}
+          PR_RUN: ${{ needs.validate_pipelines.outputs.pr_pipeline_run_url }}
+          CNI_RUN: ${{ needs.validate_pipelines.outputs.cni_release_run_url }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          BRANCH="${RELEASE_BRANCH}"
+          PR_RUN="${PR_RUN:-_(dry run — skipped)_}"
+          CNI_RUN="${CNI_RUN:-_(dry run — skipped)_}"
+          DRY_PREFIX=""
+          if [[ "$DRY_RUN" == "true" ]]; then
+            DRY_PREFIX="🏜️ [DRY RUN] "
+          fi
+          REPO="${GITHUB_REPOSITORY}"
+          COMMIT_LINK="https://github.com/${REPO}/commit/${TARGET_SHA}"
+          CHANGELOG_LINK="https://github.com/${REPO}/compare/${PREVIOUS_TAG}...${NEW_TAG}"
+
+          RELEASE_MSG="${DRY_PREFIX}@Release I will start the release process for the acn repo (cni/cns/npm) ${NEW_TAG} based on this commit: ${COMMIT_LINK} from the ${BRANCH} branch. I intend for this release to make it to AKS.
+
+          ---
+          **SIGNED PATH (CNI/CNS) — Managed DALEC:**
+          - Changelog Link: ${CHANGELOG_LINK}
+          - CNI Release Test Pipeline Run Link: ${CNI_RUN}
+          - ACN PR Pipeline Run Link: ${PR_RUN}
+          - Managed DALEC Build: _(automatic — triggered by tag)_
+          - Managed DALEC Lead Approval: _(pending — 18hr timeout)_
+          - Managed DALEC MCR Publish: _(automatic after approval)_
+          - AgentBaker PR Link: _(pending BumpBump)_
+          - AKS PR/ENO Link: _(pending)_
+          - ENO Release Networking Sig Link: _(pending)_
+
+          ---
+          **SIGNED PATH (Other binaries) — Manual pipelines:**
+          - ACN Official Build Pipeline Run Link: _(pending — human to trigger)_
+          - ACN Official Image Release Pipeline Run Link: _(pending — human to trigger)_
+          - Safefly/R2D Link: _(human to fill after filing)_
+
+          ---
+          **UNSIGNED PATH CHECKLIST:**
+          - Changelog Link: ${CHANGELOG_LINK}
+          - CNI Release Test Pipeline Run Link: ${CNI_RUN}
+          - ACN PR Pipeline Run Link: ${PR_RUN}
+          - GitHub Release Pipeline Run Link: _(pending)_
+          - Safefly/R2D Link: _(human to fill after filing)_
+          - GitHub Release Link: _(pending)_
+          - NA Build Pipeline Run Link: _(pending)_
+          - OBP Signed Binaries Pipeline Run Link: _(pending)_"
+
+          echo "Release channel message:"
+          echo "$RELEASE_MSG"
+
+          RESPONSE=$(/tmp/release-cli notify \
+            --channel-id "$TEAMS_RELEASE_CHANNEL_ID" \
+            --title "Release ${NEW_TAG}" \
+            --status running \
+            --summary "$RELEASE_MSG" \
+            --stage release-thread)
+          MESSAGE_ID=$(echo "$RESPONSE" | jq -r '.messageId // empty' 2>/dev/null || true)
+          echo "message_id=$MESSAGE_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Generate R2D Draft (Unsigned)
+        id: r2d_unsigned
+        env:
+          NEW_TAG: ${{ needs.create_tag.outputs.new_tag }}
+          CNI_RUN: ${{ needs.validate_pipelines.outputs.cni_release_run_url }}
+        run: |
+          set -euo pipefail
+          TODAY=$(date +%Y-%m-%d)
+          END_DATE=$(date -d "+7 days" +%Y-%m-%d)
+
+          cat <<EOF > /tmp/r2d-unsigned-draft.md
+          # R2D DRAFT — UNSIGNED PATH
+          ## File at: https://aka.ms/R2D (Clone from Request #193479)
+
+          | Field | Value |
+          |-------|-------|
+          | Service Name | Azure Container Networking |
+          | Change Title | CNI/CNS Github Release ${NEW_TAG} |
+          | Change Description | Release ${NEW_TAG} binaries to our Github Release page to be consumed by ACI |
+          | Engineering Director | R2D-AzNet-SDN-ED-GRP |
+          | CVP | R2D-AzNet-CVP-GRP |
+          | Additional Users to Notify | tamanoha@microsoft.com |
+          | Deployment Type | regular |
+          | Deployment Tool | ev2 |
+          | Service Group Name | microsoft.azure.networking.containernetworking.githubrelease |
+          | Build Number | _(fill from Github Release Pipeline run)_ |
+          | ADO Build Link | _(fill from Github Release Pipeline run)_ |
+          | SFI Changes? | no |
+          | Anticipated Start Date | ${TODAY} |
+          | Anticipated End Date | ${END_DATE} |
+          | Targeted Regions | All regions |
+          | Covered by lease? | No |
+          | Nature of Deployment | General bug fixes, New feature |
+          | Deployment Following SDP | Standard SDP |
+          | Retakes? | no |
+          | Impact Type to Customer | None |
+          | Expected duration of impact | 0 |
+          | Blast Radius | Single Cluster |
+          | Pre-Prod Testing Types | End to End Testing (${CNI_RUN}) |
+          | Rollback/Roll-Forward | DRI determines rollback or rollforward in real time based on the issue |
+          | Rollback Tested | yes |
+          | Average Rollback Time | 01:00 (HH:MM) |
+          | Health signals integration | yes — Binaries are consumed by partners who have health checks |
+          | R2D Risk | Low |
+          | Team Assessed Risk | Low |
+          | Deployment Impact | Zero Impact |
+          | Auto Approval | Disabled |
+          EOF
+
+          echo "✅ Unsigned R2D draft generated at /tmp/r2d-unsigned-draft.md"
+          cat /tmp/r2d-unsigned-draft.md
+
+      - name: Generate R2D Draft (Signed)
+        id: r2d_signed
+        env:
+          NEW_TAG: ${{ needs.create_tag.outputs.new_tag }}
+          PR_RUN: ${{ needs.validate_pipelines.outputs.pr_pipeline_run_url }}
+          CNI_RUN: ${{ needs.validate_pipelines.outputs.cni_release_run_url }}
+        run: |
+          set -euo pipefail
+          TODAY=$(date +%Y-%m-%d)
+          END_DATE=$(date -d "+7 days" +%Y-%m-%d)
+
+          cat <<EOF > /tmp/r2d-signed-draft.md
+          # R2D DRAFT — SIGNED PATH
+          ## File at: https://aka.ms/R2D (Clone from Request #174991)
+
+          | Field | Value |
+          |-------|-------|
+          | Service Name | Azure Container Networking |
+          | Change Title | CNS and CNI release ${NEW_TAG} |
+          | Change Description | _(describe key changes in this release)_ |
+          | Engineering Director | AzNet_R2D_GroupA_SM, R2D-AzNet-SDN-ED-GRP |
+          | CVP | AzNet_R2D_CVP, R2D-AzNet-CVP-GRP |
+          | Additional Users to Notify | _(add leads if needed)_ |
+          | Deployment Type | regular |
+          | Deployment Tool | ev2 |
+          | Service Group Name | microsoft.azure.networking.containernetworking |
+          | Build Number | _(fill from ACN Official Build Pipeline run)_ |
+          | ADO Build Link | _(fill from ACN Official Build Pipeline run)_ |
+          | SFI Changes? | no |
+          | Anticipated Start Date | ${TODAY} |
+          | Anticipated End Date | ${END_DATE} |
+          | Targeted Regions | All regions |
+          | Covered by lease? | No |
+          | Nature of Deployment | New feature |
+          | Deployment Following SDP | Standard SDP |
+          | Retakes? | no |
+          | Impact Type to Customer | None |
+          | Expected duration of impact | 0 |
+          | Blast Radius | Single Cluster |
+          | Pre-Prod Testing Types | Unit Testing + Integration Testing (${PR_RUN}, ${CNI_RUN}) |
+          | Rollback/Roll-Forward | DRI determines rollback or rollforward in real time based on the issue |
+          | Rollback Tested | yes |
+          | Average Rollback Time | 00:01 (HH:MM) |
+          | Health signals integration | yes — AKS-Swift deployment follows AKS service health checks |
+          | R2D Risk | Low |
+          | Team Assessed Risk | Low |
+          | Deployment Impact | Zero Impact |
+          | Auto Approval | Disabled |
+          EOF
+
+          echo "✅ Signed R2D draft generated at /tmp/r2d-signed-draft.md"
+          cat /tmp/r2d-signed-draft.md
+
+      - name: Post R2D drafts summary to Release thread
+        env:
+          NEW_TAG: ${{ needs.create_tag.outputs.new_tag }}
+        run: |
+          /tmp/release-cli notify \
+            --channel-id "$TEAMS_RELEASE_CHANNEL_ID" \
+            --title "R2D Drafts: ${NEW_TAG}" \
+            --status running \
+            --summary "📋 R2D Drafts prepared for ${NEW_TAG}:<br><br><b>UNSIGNED</b> — Clone from SafeFly Request #193479<br>• Service Group: microsoft.azure.networking.containernetworking.githubrelease<br>• File at: https://aka.ms/R2D<br><br><b>SIGNED</b> — Clone from SafeFly Request #174991<br>• Service Group: microsoft.azure.networking.containernetworking<br>• File at: https://aka.ms/R2D<br><br>⚠️ <b>Human action required:</b> File both R2Ds, then post the Safefly/R2D links back in this thread." \
+            --stage r2d-draft
+
+      - name: Send email to leads
+        env:
+          NEW_TAG: ${{ needs.create_tag.outputs.new_tag }}
+        run: |
+          echo "📧 Email notification (manual step or integrate with Logic App/Power Automate):"
+          echo "  To: chandan.aggarwal@microsoft.com, neaggarw@microsoft.com, tamanoha@microsoft.com, caggard@microsoft.com"
+          echo "  Subject: ACN Release ${NEW_TAG}"
+          echo "  Body: I am currently making a CNI/CNS/NPM release for ${NEW_TAG}."
+          # NOTE: Email sending requires integration with a mail service (Graph API, Logic App, etc.)
+          # This step serves as documentation of the requirement
+
+      - name: Write workflow summary
+        env:
+          NEW_TAG: ${{ needs.create_tag.outputs.new_tag }}
+          PR_RUN: ${{ needs.validate_pipelines.outputs.pr_pipeline_run_url }}
+          CNI_RUN: ${{ needs.validate_pipelines.outputs.cni_release_run_url }}
+        run: |
+          {
+            echo "## 🚀 Scheduled Release: ${NEW_TAG}"
+            echo ""
+            echo "| Step | Status |"
+            echo "|------|--------|"
+            echo "| Dependabot PRs | ✅ Complete |"
+            echo "| Vuln Check | ✅ Complete |"
+            echo "| Tag Created | ✅ ${NEW_TAG} |"
+            echo "| ACN PR Pipeline | ✅ [Run](${PR_RUN}) |"
+            echo "| ACN CNI Release Test | ✅ [Run](${CNI_RUN}) |"
+            echo "| Release Channel Post | ✅ Posted |"
+            echo "| R2D Drafts | ✅ Generated (human to file) |"
+            echo ""
+            echo "### Next Steps (Human):"
+            echo "1. File R2D at https://aka.ms/R2D (clone from previous requests)"
+            echo "2. Post Safefly/R2D links back to Release channel thread"
+            echo "3. Trigger ACN Official Build Pipeline + Image Release Pipeline"
+            echo "4. Monitor BumpBump for AgentBaker PR"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/scheduled-release.yaml
+++ b/.github/workflows/scheduled-release.yaml
@@ -18,7 +18,7 @@ name: Scheduled Release
 
 on:
   schedule:
-    # First Friday of every month — staggered by 15 min per branch
+    # Every Friday at 14:00/14:15 UTC — check_cadence job gates to first Friday only
     - cron: "0 14 * * 5"   # release/v1.7
     - cron: "15 14 * * 5"  # master
   workflow_dispatch:

--- a/.github/workflows/scheduled-release.yaml
+++ b/.github/workflows/scheduled-release.yaml
@@ -2,7 +2,8 @@
 # Handles: dependabot PR collection, vuln checks, tag creation, pipeline validation,
 # release channel posting, and R2D draft preparation.
 #
-# Trigger: First Friday of every month at 14:00 UTC + manual dispatch
+# Trigger: Every Friday at 14:00/14:15 UTC (check_cadence gates to first Friday)
+# Branches: release/v1.7 (14:00) and master (14:15) + manual dispatch
 #
 # ─── Teams Notification Dependency ───────────────────────────────────────────
 # Teams messages are sent via the acn-notifier-bot Azure Function App,

--- a/.github/workflows/scheduled-release.yaml
+++ b/.github/workflows/scheduled-release.yaml
@@ -18,8 +18,9 @@ name: Scheduled Release
 
 on:
   schedule:
-    # First Friday of every month at 14:00 UTC
-    - cron: "0 14 * * 5"
+    # First Friday of every month — staggered by 15 min per branch
+    - cron: "0 14 * * 5"   # release/v1.7
+    - cron: "15 14 * * 5"  # master
   workflow_dispatch:
     inputs:
       release_branch:
@@ -47,7 +48,7 @@ on:
         type: boolean
 
 concurrency:
-  group: scheduled-release-${{ inputs.release_branch || 'release/v1.7' }}
+  group: scheduled-release-${{ inputs.release_branch || (github.event.schedule == '15 14 * * 5' && 'master') || 'release/v1.7' }}
   cancel-in-progress: false
 
 permissions:
@@ -55,7 +56,8 @@ permissions:
   pull-requests: read
 
 env:
-  RELEASE_BRANCH: ${{ inputs.release_branch || 'release/v1.7' }}
+  # Map cron schedules to branches: 14:00 → release/v1.7, 14:15 → master
+  RELEASE_BRANCH: ${{ inputs.release_branch || (github.event.schedule == '15 14 * * 5' && 'master') || 'release/v1.7' }}
   MAX_PIPELINE_RETRIES: 5
   NOTIFIER_URL: https://acn-notifier-bot.azurewebsites.net
   NOTIFIER_AUDIENCE: api://3976eca5-3f9d-4528-987f-c20c1f9f27f7

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ test/scale/generated/*
 
 # omit e2e bin
 test/e2e/bin/*
+
+**/service
+tools/release/release-cli

--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -1,0 +1,148 @@
+# ACN Release CLI
+
+A Go CLI tool (`release-cli`) used by the [Scheduled Release workflow](../../.github/workflows/scheduled-release.yaml) to automate monthly ACN releases.
+
+## Architecture
+
+```
+.github/workflows/scheduled-release.yaml     ← Orchestrator (cron + manual dispatch)
+         │
+         │  builds & invokes
+         ▼
+tools/release/cmd/release-cli/main.go        ← CLI entrypoint (7 commands)
+         │
+         ├── internal/github/github.go       ← PR collection + wait logic
+         ├── internal/version/version.go     ← Semver + binary change detection
+         ├── internal/pipeline/pipeline.go   ← ADO pipeline monitoring
+         └── internal/notify/notify.go       ← Teams notifications (OIDC)
+```
+
+## Workflow
+
+```
+┌───────────────────────────────────────────────────────────┐
+│  check_cadence                                            │
+│  Is this the first Friday of the month? (skip otherwise)  │
+└────────────────────────────┬──────────────────────────────┘
+                             ▼
+┌───────────────────────────────────────────────────────────┐
+│  Step 1: wait_dependabot                                  │
+│                                                           │
+│  CLI commands used:                                       │
+│    • collect-prs  → find open dependabot/Go upgrade PRs   │
+│    • next-version → calculate upcoming tag                │
+│    • detect-binaries → list binary tags to create         │
+│    • wait-prs    → poll until PRs merge or are skipped    │
+│    • notify      → post to Teams CNI channel              │
+│                                                           │
+│  Creates a tracking issue with skip/pause/resume commands │
+└────────────────────────────┬──────────────────────────────┘
+                             ▼
+            ┌────────────────┴────────────────┐
+            ▼                                 ▼
+┌────────────────────┐    ┌─────────────────────────────────┐
+│ Step 2: vuln_check │    │ Step 2b-d: binary tagging       │
+│                    │    │                                 │
+│ govulncheck on all │    │ detect-binaries → tag_binaries  │
+│ go.mod directories │    │ (dropgz, azure-ipam, etc.)      │
+│                    │    │ Auto-bump patch + push tags      │
+│ notify on failure  │    │ Post summary to Teams            │
+└─────────┬──────────┘    └─────────────────────────────────┘
+          ▼
+┌───────────────────────────────────────────────────────────┐
+│ Step 3: create_tag                                        │
+│                                                           │
+│ CLI: next-version → dispatches create-release-tag.yml     │
+│ (requires tag-approval environment gate)                  │
+└────────────────────────────┬──────────────────────────────┘
+                             ▼
+┌───────────────────────────────────────────────────────────┐
+│ Step 4: validate_pipelines                                │
+│                                                           │
+│ CLI: wait-pipeline (×2)                                   │
+│   • Waits for tag to appear (human approval gate)         │
+│   • Discovers ADO runs auto-triggered by tag push         │
+│   • Polls until pipelines complete (Bearer token, OIDC)   │
+│   • Posts results to Teams                                │
+└────────────────────────────┬──────────────────────────────┘
+                             ▼
+┌───────────────────────────────────────────────────────────┐
+│ Step 5: release_channel_post                              │
+│                                                           │
+│ CLI: notify                                               │
+│   • Posts release thread (signed/unsigned checklists)     │
+│   • Generates R2D drafts (signed + unsigned paths)        │
+│   • GitHub step summary with remaining human actions      │
+└───────────────────────────────────────────────────────────┘
+```
+
+## CLI Commands
+
+| Command | Description | Used by |
+|---------|-------------|---------|
+| `collect-prs` | Lists open dependabot + Go upgrade PRs on a branch | Step 1 |
+| `next-version` | Finds latest semver tag, bumps patch (e.g. v1.7.21 → v1.7.22) | Steps 1, 3 |
+| `detect-binaries` | Checks which binaries have changes since last tag | Steps 1, 2b |
+| `wait-prs` | Polls PRs until all merge or are skipped via tracking issue | Step 1 |
+| `wait-pipeline` | Discovers + waits for ADO pipeline runs triggered by a tag | Step 4 |
+| `notify` | Posts/updates Teams adaptive card via acn-notifier-bot | All steps |
+| `notify-reply` | Posts a reply under an existing release card | Step 5 |
+
+## File Descriptions
+
+### `cmd/release-cli/main.go`
+
+CLI entrypoint using [cobra](https://github.com/spf13/cobra). Defines all 7 commands, validates inputs, and delegates to internal packages. Outputs JSON to stdout for consumption by workflow steps.
+
+### `internal/github/github.go`
+
+Interacts with GitHub via the `gh` CLI (no SDK dependency). Key logic:
+- **CollectPRs**: Lists dependabot PRs (`--author app/dependabot`) and Go upgrade PRs (detected by title/branch/label patterns)
+- **WaitPRs**: Polling loop that checks PR states + parses tracking issue comments for `skip`, `pause`, `resume` commands
+- Supports: `skip #N`, `skip all`, `pause`, `resume`, `pause #N`, `unpause #N`
+
+### `internal/version/version.go`
+
+Git-based version detection. Key logic:
+- **NextVersion**: Finds latest `vX.Y.Z` tag merged into the branch, bumps patch
+- **DetectBinaryChanges**: For each binary (dropgz, azure-ipam, etc.), checks if files changed since its last tag
+- **resolveRef**: Handles CI checkout quirk where local branches don't exist (falls back to `origin/<ref>`)
+- Uses `git tag --merged <SHA>` with resolved refs for CI compatibility
+
+### `internal/pipeline/pipeline.go`
+
+ADO pipeline monitoring via REST API. Key logic:
+- **WaitForRun**: Two-phase polling — first discovers a run matching `refs/tags/<tag>`, then waits for completion
+- Uses Bearer token from OIDC (`az account get-access-token --resource 499b84ac-...`)
+- Polls builds list every 30s, checks status every 2min
+- Token field has `json:"-"` to prevent accidental logging
+
+### `internal/notify/notify.go`
+
+Teams notification client. Key logic:
+- Posts to `acn-notifier-bot` Azure Function (Adaptive Cards in Teams channels)
+- Authenticates via OIDC: acquires token for the Function App's audience
+- Env vars: `NOTIFIER_URL`, `NOTIFIER_AUDIENCE`, `TEAMS_TEAM_ID`
+
+## Authentication
+
+All authentication uses **OIDC federated credentials** — no PATs or long-lived secrets:
+
+| Service | Method | Identity |
+|---------|--------|----------|
+| GitHub API | `GITHUB_TOKEN` (automatic) | Workflow token |
+| Teams notifications | OIDC → acn-notifier-bot audience | `acn-release-bot` SP |
+| ADO pipeline API | OIDC → ADO resource ID | `acn-release-bot` SP |
+
+## Building
+
+```bash
+cd tools/release
+go build -o release-cli ./cmd/release-cli/
+```
+
+## Dependencies
+
+- `github.com/spf13/cobra` — CLI framework
+- No other external dependencies
+- Relies on `gh` CLI and `az` CLI being available at runtime (both pre-installed on GitHub Actions runners)

--- a/tools/release/cmd/release-cli/main.go
+++ b/tools/release/cmd/release-cli/main.go
@@ -1,0 +1,447 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	githubcli "github.com/Azure/azure-container-networking/tools/release/internal/github"
+	"github.com/Azure/azure-container-networking/tools/release/internal/notify"
+	"github.com/Azure/azure-container-networking/tools/release/internal/pipeline"
+	"github.com/Azure/azure-container-networking/tools/release/internal/version"
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	if err := newRootCommand().Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func newRootCommand() *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:   "release-cli",
+		Short: "Utilities for the scheduled release workflow",
+	}
+
+	rootCmd.AddCommand(
+		newNotifyCommand(),
+		newNotifyReplyCommand(),
+		newCollectPRsCommand(),
+		newNextVersionCommand(),
+		newDetectBinariesCommand(),
+		newWaitPipelineCommand(),
+		newWaitPRsCommand(),
+	)
+
+	return rootCmd
+}
+
+func newNotifyCommand() *cobra.Command {
+	var (
+		channelID string
+		title     string
+		status    string
+		summary   string
+		stage     string
+		teamID    string
+		runID     string
+		dryRun    bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "notify",
+		Short: "Create or update a Teams adaptive card",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			req := notify.NotificationRequest{
+				Source:    notify.SourceScheduledRelease,
+				RunID:     runID,
+				TeamID:    teamID,
+				ChannelID: channelID,
+				Title:     title,
+				Status:    normalizeNotifyStatus(status),
+				Summary:   summary,
+				Stage:     stage,
+			}
+			if err := validateNotificationRequest(req); err != nil {
+				return err
+			}
+
+			if dryRun {
+				return writeJSON(map[string]any{
+					"dry_run": true,
+					"request": req,
+				})
+			}
+
+			client := notify.NewClientFromEnv()
+			body, err := client.Notify(cmd.Context(), req)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "warning: notify failed: %v\n", err)
+				return writeJSONBody(body)
+			}
+
+			return writeJSONBody(body)
+		},
+	}
+
+	cmd.Flags().StringVar(&channelID, "channel-id", "", "Teams channel ID")
+	cmd.Flags().StringVar(&title, "title", "", "Card title")
+	cmd.Flags().StringVar(&status, "status", "", "Card status")
+	cmd.Flags().StringVar(&summary, "summary", "", "Card summary")
+	cmd.Flags().StringVar(&stage, "stage", "", "Release stage")
+	cmd.Flags().StringVar(&teamID, "team-id", notify.DefaultTeamID(), "Teams team ID")
+	cmd.Flags().StringVar(&runID, "run-id", notify.DefaultRunID(), "Release run ID")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print the request without sending it")
+	mustMarkFlagRequired(cmd, "channel-id", "title", "status", "summary")
+
+	return cmd
+}
+
+func newNotifyReplyCommand() *cobra.Command {
+	var (
+		text     string
+		tag      string
+		severity string
+		runID    string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "notify-reply",
+		Short: "Post a reply under an existing release card",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			req := notify.ReplyRequest{
+				Source:   notify.SourceScheduledRelease,
+				RunID:    runID,
+				Text:     text,
+				Tag:      tag,
+				Severity: severity,
+			}
+			if err := validateReplyRequest(req); err != nil {
+				return err
+			}
+
+			client := notify.NewClientFromEnv()
+			body, err := client.Reply(cmd.Context(), req)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "warning: notify-reply failed: %v\n", err)
+				return writeJSONBody(body)
+			}
+
+			return writeJSONBody(body)
+		},
+	}
+
+	cmd.Flags().StringVar(&text, "text", "", "Reply body")
+	cmd.Flags().StringVar(&tag, "tag", "", "Optional reply tag")
+	cmd.Flags().StringVar(&severity, "severity", "", "Optional reply severity")
+	cmd.Flags().StringVar(&runID, "run-id", notify.DefaultRunID(), "Release run ID")
+	mustMarkFlagRequired(cmd, "text")
+
+	return cmd
+}
+
+func newCollectPRsCommand() *cobra.Command {
+	var (
+		repo   string
+		branch string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "collect-prs",
+		Short: "Collect pending dependabot and Go upgrade PRs",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(repo) == "" {
+				return errors.New("repo is required")
+			}
+			if strings.TrimSpace(branch) == "" {
+				return errors.New("branch is required")
+			}
+
+			client := githubcli.NewClient()
+			result, err := client.CollectPRs(cmd.Context(), repo, branch)
+			if err != nil {
+				return err
+			}
+
+			return writeJSON(result)
+		},
+	}
+
+	cmd.Flags().StringVar(&repo, "repo", os.Getenv("GITHUB_REPOSITORY"), "GitHub repository in OWNER/REPO form")
+	cmd.Flags().StringVar(&branch, "branch", "", "Base branch")
+	mustMarkFlagRequired(cmd, "branch")
+
+	return cmd
+}
+
+func newNextVersionCommand() *cobra.Command {
+	var branch string
+
+	cmd := &cobra.Command{
+		Use:   "next-version",
+		Short: "Determine the next patch version for a branch",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			svc := version.NewService()
+			result, err := svc.NextVersion(cmd.Context(), branch)
+			if err != nil {
+				return err
+			}
+
+			return writeJSON(result)
+		},
+	}
+
+	cmd.Flags().StringVar(&branch, "branch", "", "Branch or ref to inspect")
+	mustMarkFlagRequired(cmd, "branch")
+
+	return cmd
+}
+
+func newDetectBinariesCommand() *cobra.Command {
+	var branch string
+
+	cmd := &cobra.Command{
+		Use:   "detect-binaries",
+		Short: "Detect binaries that need a release tag",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			svc := version.NewService()
+			result, err := svc.DetectBinaryChanges(cmd.Context(), branch)
+			if err != nil {
+				return err
+			}
+
+			return writeJSON(result)
+		},
+	}
+
+	cmd.Flags().StringVar(&branch, "branch", "", "Branch or ref to inspect")
+	mustMarkFlagRequired(cmd, "branch")
+
+	return cmd
+}
+
+func newWaitPipelineCommand() *cobra.Command {
+	var (
+		org          string
+		project      string
+		definitionID string
+		token        string
+		tag          string
+		timeout      time.Duration
+		name         string
+		dryRun       bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "wait-pipeline",
+		Short: "Find and wait for an ADO pipeline run triggered by a tag",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts := pipeline.WaitOptions{
+				Org:          org,
+				Project:      project,
+				DefinitionID: definitionID,
+				Token:        token,
+				Tag:          tag,
+				Timeout:      timeout,
+				Name:         name,
+			}
+			if err := validateWaitPipelineOptions(opts); err != nil {
+				return err
+			}
+
+			if dryRun {
+				return writeJSON(map[string]any{
+					"dry_run": true,
+					"request": opts,
+				})
+			}
+
+			client := pipeline.NewClient()
+			result, err := client.WaitForRun(cmd.Context(), opts, os.Stderr)
+			if err != nil {
+				return err
+			}
+
+			return writeJSON(result)
+		},
+	}
+
+	cmd.Flags().StringVar(&org, "org", "", "ADO organization")
+	cmd.Flags().StringVar(&project, "project", "", "ADO project")
+	cmd.Flags().StringVar(&definitionID, "definition-id", "", "ADO pipeline definition ID")
+	cmd.Flags().StringVar(&token, "token", "", "Bearer token (from OIDC)")
+	cmd.Flags().StringVar(&tag, "tag", "", "Git tag to look for")
+	cmd.Flags().DurationVar(&timeout, "timeout", 90*time.Minute, "Overall timeout")
+	cmd.Flags().StringVar(&name, "name", "", "Friendly pipeline name")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print the request without polling")
+	mustMarkFlagRequired(cmd, "org", "project", "definition-id", "token", "tag", "name")
+
+	return cmd
+}
+
+func newWaitPRsCommand() *cobra.Command {
+	var (
+		repo         string
+		branch       string
+		issueNumber  int
+		pollInterval time.Duration
+		maxWait      time.Duration
+	)
+
+	cmd := &cobra.Command{
+		Use:   "wait-prs",
+		Short: "Wait for PRs to merge or be skipped",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(repo) == "" {
+				return errors.New("repo is required")
+			}
+			if strings.TrimSpace(branch) == "" {
+				return errors.New("branch is required")
+			}
+			if issueNumber <= 0 {
+				return errors.New("issue-number must be greater than zero")
+			}
+			if pollInterval <= 0 {
+				return errors.New("poll-interval must be greater than zero")
+			}
+
+			client := githubcli.NewClient()
+			result, err := client.WaitPRs(cmd.Context(), githubcli.WaitOptions{
+				Repo:         repo,
+				Branch:       branch,
+				IssueNumber:  issueNumber,
+				PollInterval: pollInterval,
+				MaxWait:      maxWait,
+			}, os.Stderr)
+			if err != nil {
+				return err
+			}
+
+			return writeJSON(result)
+		},
+	}
+
+	cmd.Flags().StringVar(&repo, "repo", os.Getenv("GITHUB_REPOSITORY"), "GitHub repository in OWNER/REPO form")
+	cmd.Flags().StringVar(&branch, "branch", "", "Base branch")
+	cmd.Flags().IntVar(&issueNumber, "issue-number", 0, "Tracking issue number")
+	cmd.Flags().DurationVar(&pollInterval, "poll-interval", 5*time.Minute, "Polling interval")
+	cmd.Flags().DurationVar(&maxWait, "max-wait", 4*time.Hour, "Maximum wait time (0 = no limit)")
+	mustMarkFlagRequired(cmd, "branch", "issue-number")
+
+	return cmd
+}
+
+func validateNotificationRequest(req notify.NotificationRequest) error {
+	switch {
+	case strings.TrimSpace(req.RunID) == "":
+		return errors.New("run-id is required (or set GITHUB_RUN_ID)")
+	case strings.TrimSpace(req.TeamID) == "":
+		return errors.New("team-id is required (or set TEAMS_TEAM_ID)")
+	case strings.TrimSpace(req.ChannelID) == "":
+		return errors.New("channel-id is required")
+	case strings.TrimSpace(req.Title) == "":
+		return errors.New("title is required")
+	case strings.TrimSpace(req.Summary) == "":
+		return errors.New("summary is required")
+	}
+
+	if _, ok := allowedNotifyStatuses[req.Status]; !ok {
+		return fmt.Errorf("unsupported status %q", req.Status)
+	}
+
+	return nil
+}
+
+func validateReplyRequest(req notify.ReplyRequest) error {
+	switch {
+	case strings.TrimSpace(req.RunID) == "":
+		return errors.New("run-id is required (or set GITHUB_RUN_ID)")
+	case strings.TrimSpace(req.Text) == "":
+		return errors.New("text is required")
+	default:
+		return nil
+	}
+}
+
+func validateWaitPipelineOptions(opts pipeline.WaitOptions) error {
+	switch {
+	case strings.TrimSpace(opts.Org) == "":
+		return errors.New("org is required")
+	case strings.TrimSpace(opts.Project) == "":
+		return errors.New("project is required")
+	case strings.TrimSpace(opts.DefinitionID) == "":
+		return errors.New("definition-id is required")
+	case strings.TrimSpace(opts.Token) == "":
+		return errors.New("token is required")
+	case strings.TrimSpace(opts.Tag) == "":
+		return errors.New("tag is required")
+	case strings.TrimSpace(opts.Name) == "":
+		return errors.New("name is required")
+	case opts.Timeout <= 0:
+		return errors.New("timeout must be greater than zero")
+	default:
+		return nil
+	}
+}
+
+func normalizeNotifyStatus(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "in_progress":
+		return "running"
+	case "success":
+		return "succeeded"
+	case "failure":
+		return "failed"
+	case "cancelled":
+		return "canceled"
+	default:
+		return strings.ToLower(strings.TrimSpace(status))
+	}
+}
+
+func mustMarkFlagRequired(cmd *cobra.Command, names ...string) {
+	for _, name := range names {
+		if err := cmd.MarkFlagRequired(name); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func writeJSON(v any) error {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(v)
+}
+
+func writeJSONBody(body []byte) error {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return writeJSON(map[string]any{})
+	}
+
+	if json.Valid(trimmed) {
+		var out any
+		if err := json.Unmarshal(trimmed, &out); err != nil {
+			return err
+		}
+		return writeJSON(out)
+	}
+
+	return writeJSON(map[string]string{
+		"response": string(trimmed),
+	})
+}
+
+var allowedNotifyStatuses = map[string]struct{}{
+	"queued":    {},
+	"running":   {},
+	"succeeded": {},
+	"failed":    {},
+	"canceled":  {},
+}

--- a/tools/release/go.mod
+++ b/tools/release/go.mod
@@ -1,0 +1,10 @@
+module github.com/Azure/azure-container-networking/tools/release
+
+go 1.23.0
+
+require github.com/spf13/cobra v1.8.1
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/tools/release/go.sum
+++ b/tools/release/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
+github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tools/release/internal/github/github.go
+++ b/tools/release/internal/github/github.go
@@ -1,0 +1,465 @@
+package github
+
+import (
+	"context"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"regexp"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var (
+	goTitlePattern   = regexp.MustCompile(`(?i)go.*(upgrade|bump|version|1\.[0-9]+)`)
+	goBranchPattern  = regexp.MustCompile(`(?i)go.*(bump|upgrade|version|minor)`)
+	goLabelPattern   = regexp.MustCompile(`(?i)go-upgrade`)
+	skipPRPattern    = regexp.MustCompile(`(?i)\bskip\s+#(\d+)`)
+	pausePRPattern   = regexp.MustCompile(`(?i)\bpause\s+#(\d+)`)
+	unpausePRPattern = regexp.MustCompile(`(?i)\bunpause\s+#(\d+)`)
+	resumePRPattern  = regexp.MustCompile(`(?i)\bresume\s+#(\d+)`)
+)
+
+type execRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+type Client struct {
+	run execRunner
+}
+
+type PR struct {
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+	URL    string `json:"url"`
+}
+
+type CollectResult struct {
+	PRs             []PR `json:"prs"`
+	OpenCount       int  `json:"open_count"`
+	DependabotCount int  `json:"dependabot_count"`
+	GoUpgradeCount  int  `json:"go_upgrade_count"`
+}
+
+type WaitOptions struct {
+	Repo         string
+	Branch       string
+	IssueNumber  int
+	PollInterval time.Duration
+	MaxWait      time.Duration // 0 means no internal timeout (relies on job-level timeout)
+}
+
+type WaitResult struct {
+	MergedCount int    `json:"merged_count"`
+	SkippedPRs  string `json:"skipped_prs"`
+}
+
+type ghLabel struct {
+	Name string `json:"name"`
+}
+
+type ghPR struct {
+	Number      int       `json:"number"`
+	Title       string    `json:"title"`
+	URL         string    `json:"url"`
+	HeadRefName string    `json:"headRefName"`
+	Labels      []ghLabel `json:"labels"`
+	State       string    `json:"state"`
+}
+
+type ghIssueComment struct {
+	Body string `json:"body"`
+}
+
+type ghIssue struct {
+	Comments []ghIssueComment `json:"comments"`
+}
+
+type prState struct {
+	State string `json:"state"`
+	Title string `json:"title"`
+}
+
+func NewClient() *Client {
+	return &Client{run: runCommand}
+}
+
+func (c *Client) CollectPRs(ctx context.Context, repo, branch string) (CollectResult, error) {
+	dependabotPRs, err := c.listDependabotPRs(ctx, repo, branch)
+	if err != nil {
+		return CollectResult{}, err
+	}
+
+	goUpgradePRs, err := c.listGoUpgradePRs(ctx, repo, branch)
+	if err != nil {
+		return CollectResult{}, err
+	}
+
+	merged := uniquePRs(dependabotPRs, goUpgradePRs)
+	sort.Slice(merged, func(i, j int) bool {
+		return merged[i].Number < merged[j].Number
+	})
+
+	return CollectResult{
+		PRs:             merged,
+		OpenCount:       len(merged),
+		DependabotCount: len(dependabotPRs),
+		GoUpgradeCount:  len(goUpgradePRs),
+	}, nil
+}
+
+func (c *Client) WaitPRs(ctx context.Context, opts WaitOptions, progress io.Writer) (WaitResult, error) {
+	if progress == nil {
+		progress = io.Discard
+	}
+
+	// Apply internal timeout if configured
+	if opts.MaxWait > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, opts.MaxWait)
+		defer cancel()
+	}
+
+	skipped := map[int]struct{}{}
+	seen := map[int]PR{}
+
+	for {
+		comments, err := c.issueComments(ctx, opts.Repo, opts.IssueNumber)
+		if err != nil {
+			return WaitResult{}, err
+		}
+
+		commandState := parseIssueCommands(comments)
+		if commandState.barePauseCount > commandState.bareResumeCount {
+			fmt.Fprintf(progress, "release paused on issue #%d; waiting for resume\n", opts.IssueNumber)
+			if err := sleepContext(ctx, opts.PollInterval); err != nil {
+				return WaitResult{}, err
+			}
+			continue
+		}
+
+		activePauses, blockedTitles, err := c.activePauseHolds(ctx, opts.Repo, commandState)
+		if err != nil {
+			return WaitResult{}, err
+		}
+
+		current, err := c.CollectPRs(ctx, opts.Repo, opts.Branch)
+		if err != nil {
+			return WaitResult{}, err
+		}
+		for _, pr := range current.PRs {
+			seen[pr.Number] = pr
+		}
+
+		if commandState.skipAll {
+			for _, pr := range current.PRs {
+				skipped[pr.Number] = struct{}{}
+			}
+			if len(activePauses) == 0 {
+				break
+			}
+			fmt.Fprintf(progress, "skip all received, but pause holds remain: %v\n", activePauses)
+			if err := sleepContext(ctx, opts.PollInterval); err != nil {
+				return WaitResult{}, err
+			}
+			continue
+		}
+
+		waiting := make([]PR, 0, len(current.PRs))
+		for _, pr := range current.PRs {
+			if _, ok := commandState.skipPRs[pr.Number]; ok {
+				skipped[pr.Number] = struct{}{}
+				continue
+			}
+			waiting = append(waiting, pr)
+		}
+
+		if len(waiting) == 0 && len(activePauses) == 0 {
+			break
+		}
+
+		fmt.Fprintf(progress, "blocked on %d PR(s) and %d pause hold(s)\n", len(waiting), len(activePauses))
+		for _, pr := range waiting {
+			fmt.Fprintf(progress, "  waiting: #%d %s\n", pr.Number, pr.Title)
+		}
+		for _, prNumber := range activePauses {
+			fmt.Fprintf(progress, "  pause hold: #%d %s\n", prNumber, blockedTitles[prNumber])
+		}
+
+		if err := sleepContext(ctx, opts.PollInterval); err != nil {
+			return WaitResult{}, err
+		}
+	}
+
+	mergedCount := 0
+	for _, number := range sortedKeys(seen) {
+		if _, ok := skipped[number]; ok {
+			continue
+		}
+
+		state, err := c.prState(ctx, opts.Repo, number)
+		if err != nil {
+			return WaitResult{}, err
+		}
+		if state.State == "MERGED" {
+			mergedCount++
+		}
+	}
+
+	return WaitResult{
+		MergedCount: mergedCount,
+		SkippedPRs:  joinInts(sortedKeys(skipped)),
+	}, nil
+}
+
+func (c *Client) listDependabotPRs(ctx context.Context, repo, branch string) ([]PR, error) {
+	out, err := c.run(ctx, "gh", "pr", "list",
+		"--repo", repo,
+		"--base", branch,
+		"--author", "app/dependabot",
+		"--state", "open",
+		"--json", "number,title,url",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing dependabot PRs: %w", err)
+	}
+
+	var prs []PR
+	if err := json.Unmarshal(out, &prs); err != nil {
+		return nil, fmt.Errorf("decoding dependabot PRs: %w", err)
+	}
+
+	return prs, nil
+}
+
+func (c *Client) listGoUpgradePRs(ctx context.Context, repo, branch string) ([]PR, error) {
+	out, err := c.run(ctx, "gh", "pr", "list",
+		"--repo", repo,
+		"--base", branch,
+		"--state", "open",
+		"--json", "number,title,url,headRefName,labels",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing candidate Go upgrade PRs: %w", err)
+	}
+
+	var candidates []ghPR
+	if err := json.Unmarshal(out, &candidates); err != nil {
+		return nil, fmt.Errorf("decoding candidate Go upgrade PRs: %w", err)
+	}
+
+	matches := make([]PR, 0, len(candidates))
+	for _, pr := range candidates {
+		if !isGoUpgradePR(pr) {
+			continue
+		}
+		matches = append(matches, PR{
+			Number: pr.Number,
+			Title:  pr.Title,
+			URL:    pr.URL,
+		})
+	}
+
+	return matches, nil
+}
+
+func (c *Client) issueComments(ctx context.Context, repo string, issueNumber int) ([]string, error) {
+	out, err := c.run(ctx, "gh", "issue", "view",
+		strconv.Itoa(issueNumber),
+		"--repo", repo,
+		"--json", "comments",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("getting issue comments: %w", err)
+	}
+
+	var issue ghIssue
+	if err := json.Unmarshal(out, &issue); err != nil {
+		return nil, fmt.Errorf("decoding issue comments: %w", err)
+	}
+
+	comments := make([]string, 0, len(issue.Comments))
+	for _, comment := range issue.Comments {
+		comments = append(comments, comment.Body)
+	}
+
+	return comments, nil
+}
+
+func (c *Client) activePauseHolds(ctx context.Context, repo string, state issueCommandState) ([]int, map[int]string, error) {
+	active := make([]int, 0, len(state.pausePRs))
+	blockedTitles := make(map[int]string, len(state.pausePRs))
+	for number := range state.pausePRs {
+		if _, ok := state.resumePRs[number]; ok {
+			continue
+		}
+
+		prState, err := c.prState(ctx, repo, number)
+		if err != nil {
+			continue
+		}
+		if prState.State != "OPEN" {
+			continue
+		}
+
+		active = append(active, number)
+		blockedTitles[number] = prState.Title
+	}
+
+	sort.Ints(active)
+	return active, blockedTitles, nil
+}
+
+func (c *Client) prState(ctx context.Context, repo string, number int) (prState, error) {
+	out, err := c.run(ctx, "gh", "pr", "view",
+		strconv.Itoa(number),
+		"--repo", repo,
+		"--json", "state,title",
+	)
+	if err != nil {
+		return prState{}, fmt.Errorf("getting PR #%d state: %w", number, err)
+	}
+
+	var state prState
+	if err := json.Unmarshal(out, &state); err != nil {
+		return prState{}, fmt.Errorf("decoding PR #%d state: %w", number, err)
+	}
+
+	return state, nil
+}
+
+func isGoUpgradePR(pr ghPR) bool {
+	if goTitlePattern.MatchString(pr.Title) || goBranchPattern.MatchString(pr.HeadRefName) {
+		return true
+	}
+
+	return slices.ContainsFunc(pr.Labels, func(label ghLabel) bool {
+		return goLabelPattern.MatchString(label.Name)
+	})
+}
+
+func uniquePRs(groups ...[]PR) []PR {
+	seen := map[int]PR{}
+	for _, group := range groups {
+		for _, pr := range group {
+			if _, ok := seen[pr.Number]; ok {
+				continue
+			}
+			seen[pr.Number] = pr
+		}
+	}
+
+	merged := make([]PR, 0, len(seen))
+	for _, pr := range seen {
+		merged = append(merged, pr)
+	}
+
+	return merged
+}
+
+type issueCommandState struct {
+	barePauseCount  int
+	bareResumeCount int
+	skipAll         bool
+	skipPRs         map[int]struct{}
+	pausePRs        map[int]struct{}
+	resumePRs       map[int]struct{}
+}
+
+func parseIssueCommands(comments []string) issueCommandState {
+	state := issueCommandState{
+		skipPRs:   map[int]struct{}{},
+		pausePRs:  map[int]struct{}{},
+		resumePRs: map[int]struct{}{},
+	}
+
+	for _, comment := range comments {
+		for _, line := range strings.Split(comment, "\n") {
+			switch strings.ToLower(strings.TrimSpace(line)) {
+			case "pause":
+				state.barePauseCount++
+			case "resume":
+				state.bareResumeCount++
+			case "skip all":
+				state.skipAll = true
+			}
+		}
+
+		for _, number := range extractNumbers(skipPRPattern, comment) {
+			state.skipPRs[number] = struct{}{}
+		}
+		for _, number := range extractNumbers(pausePRPattern, comment) {
+			state.pausePRs[number] = struct{}{}
+		}
+		for _, number := range extractNumbers(unpausePRPattern, comment) {
+			state.resumePRs[number] = struct{}{}
+		}
+		for _, number := range extractNumbers(resumePRPattern, comment) {
+			state.resumePRs[number] = struct{}{}
+		}
+	}
+
+	return state
+}
+
+func extractNumbers(pattern *regexp.Regexp, text string) []int {
+	matches := pattern.FindAllStringSubmatch(text, -1)
+	numbers := make([]int, 0, len(matches))
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+		number, err := strconv.Atoi(match[1])
+		if err != nil {
+			continue
+		}
+		numbers = append(numbers, number)
+	}
+
+	return numbers
+}
+
+func sortedKeys[T any](m map[int]T) []int {
+	keys := make([]int, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Ints(keys)
+	return keys
+}
+
+func joinInts(numbers []int) string {
+	parts := make([]string, 0, len(numbers))
+	for _, number := range numbers {
+		parts = append(parts, strconv.Itoa(number))
+	}
+
+	return strings.Join(parts, ",")
+}
+
+func sleepContext(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func runCommand(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return out, fmt.Errorf("%s %s: %w: %s", name, strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+
+	return out, nil
+}

--- a/tools/release/internal/notify/notify.go
+++ b/tools/release/internal/notify/notify.go
@@ -1,0 +1,144 @@
+package notify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const SourceScheduledRelease = "scheduled-release"
+
+type NotificationRequest struct {
+	Source    string `json:"source"`
+	RunID     string `json:"runId"`
+	TeamID    string `json:"teamId"`
+	ChannelID string `json:"channelId"`
+	Title     string `json:"title"`
+	Status    string `json:"status"`
+	Summary   string `json:"summary"`
+	Stage     string `json:"stage,omitempty"`
+}
+
+type ReplyRequest struct {
+	Source   string `json:"source"`
+	RunID    string `json:"runId"`
+	Text     string `json:"text"`
+	Tag      string `json:"tag,omitempty"`
+	Severity string `json:"severity,omitempty"`
+}
+
+type httpDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type execRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+type Client struct {
+	baseURL  string
+	audience string
+	doer     httpDoer
+	run      execRunner
+}
+
+func NewClientFromEnv() *Client {
+	return &Client{
+		baseURL:  strings.TrimRight(os.Getenv("NOTIFIER_URL"), "/"),
+		audience: os.Getenv("NOTIFIER_AUDIENCE"),
+		doer:     http.DefaultClient,
+		run:      runCommand,
+	}
+}
+
+func DefaultTeamID() string {
+	return os.Getenv("TEAMS_TEAM_ID")
+}
+
+func DefaultRunID() string {
+	runID := strings.TrimSpace(os.Getenv("GITHUB_RUN_ID"))
+	if runID == "" {
+		return ""
+	}
+
+	return "scheduled-release-" + runID
+}
+
+func (c *Client) Notify(ctx context.Context, req NotificationRequest) ([]byte, error) {
+	return c.post(ctx, "/api/notifications", req)
+}
+
+func (c *Client) Reply(ctx context.Context, req ReplyRequest) ([]byte, error) {
+	return c.post(ctx, "/api/notifications/reply", req)
+}
+
+func (c *Client) post(ctx context.Context, path string, payload any) ([]byte, error) {
+	if strings.TrimSpace(c.baseURL) == "" {
+		return nil, fmt.Errorf("NOTIFIER_URL is not set")
+	}
+	if strings.TrimSpace(c.audience) == "" {
+		return nil, fmt.Errorf("NOTIFIER_AUDIENCE is not set")
+	}
+
+	token, err := c.accessToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.doer.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		return respBody, fmt.Errorf("notifier returned status %d", resp.StatusCode)
+	}
+
+	return respBody, nil
+}
+
+func (c *Client) accessToken(ctx context.Context) (string, error) {
+	out, err := c.run(ctx, "az", "account", "get-access-token", "--resource", c.audience, "--query", "accessToken", "-o", "tsv")
+	if err != nil {
+		return "", fmt.Errorf("acquiring notifier token: %w", err)
+	}
+
+	token := strings.TrimSpace(string(out))
+	if token == "" {
+		return "", fmt.Errorf("acquiring notifier token: empty token")
+	}
+
+	return token, nil
+}
+
+func runCommand(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return out, fmt.Errorf("%s %s: %w: %s", name, strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+
+	return out, nil
+}

--- a/tools/release/internal/pipeline/pipeline.go
+++ b/tools/release/internal/pipeline/pipeline.go
@@ -1,0 +1,224 @@
+package pipeline
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type httpDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type Client struct {
+	doer httpDoer
+}
+
+// WaitOptions configures how to find and wait for an auto-triggered pipeline run.
+type WaitOptions struct {
+	Org          string        `json:"org"`
+	Project      string        `json:"project"`
+	DefinitionID string        `json:"definition_id"`
+	Token        string        `json:"-"` // Bearer token (from OIDC)
+	Tag          string        `json:"tag"`
+	Timeout      time.Duration `json:"timeout"`
+	Name         string        `json:"name"`
+}
+
+type WaitResult struct {
+	RunURL string `json:"run_url"`
+	RunID  int    `json:"run_id"`
+	Result string `json:"result"`
+}
+
+type buildListResponse struct {
+	Value []buildEntry `json:"value"`
+}
+
+type buildEntry struct {
+	ID          int    `json:"id"`
+	Status      string `json:"status"`
+	Result      string `json:"result"`
+	SourceBranch string `json:"sourceBranch"`
+}
+
+func NewClient() *Client {
+	return &Client{doer: http.DefaultClient}
+}
+
+// WaitForRun discovers a pipeline run triggered by the given tag and waits for it to complete.
+// It polls the ADO builds API until it finds a run matching the tag, then polls until completion.
+func (c *Client) WaitForRun(ctx context.Context, opts WaitOptions, progress io.Writer) (WaitResult, error) {
+	if progress == nil {
+		progress = io.Discard
+	}
+
+	name := strings.TrimSpace(opts.Name)
+	if name == "" {
+		name = "ADO pipeline"
+	}
+
+	pollCtx, cancel := context.WithTimeout(ctx, opts.Timeout)
+	defer cancel()
+
+	// Phase 1: Find the run triggered by the tag
+	fmt.Fprintf(progress, "%s: waiting for run triggered by tag %s...\n", name, opts.Tag)
+	runID, err := c.findRunByTag(pollCtx, opts, progress)
+	if err != nil {
+		return WaitResult{}, fmt.Errorf("%s: %w", name, err)
+	}
+
+	runURL := buildRunURL(opts, runID)
+	fmt.Fprintf(progress, "%s: found run %d: %s\n", name, runID, runURL)
+
+	// Phase 2: Wait for the run to complete
+	result, err := c.waitForCompletion(pollCtx, opts, runID, progress)
+	if err != nil {
+		return WaitResult{}, fmt.Errorf("%s: %w", name, err)
+	}
+
+	return WaitResult{
+		RunURL: runURL,
+		RunID:  runID,
+		Result: result,
+	}, nil
+}
+
+// findRunByTag polls the builds list until a run matching refs/tags/<tag> appears.
+func (c *Client) findRunByTag(ctx context.Context, opts WaitOptions, progress io.Writer) (int, error) {
+	expectedBranch := "refs/tags/" + opts.Tag
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		builds, err := c.listBuilds(ctx, opts)
+		if err != nil {
+			fmt.Fprintf(progress, "%s: error listing builds: %v (retrying...)\n", opts.Name, err)
+		} else {
+			for _, b := range builds {
+				if strings.EqualFold(b.SourceBranch, expectedBranch) {
+					return b.ID, nil
+				}
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return 0, fmt.Errorf("timed out waiting for run triggered by %s", opts.Tag)
+		case <-ticker.C:
+			fmt.Fprintf(progress, "%s: no run found yet for %s, polling...\n", opts.Name, opts.Tag)
+		}
+	}
+}
+
+func (c *Client) listBuilds(ctx context.Context, opts WaitOptions) ([]buildEntry, error) {
+	url := fmt.Sprintf(
+		"https://dev.azure.com/%s/%s/_apis/build/builds?definitions=%s&$top=20&api-version=7.0",
+		opts.Org, opts.Project, opts.DefinitionID,
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+opts.Token)
+
+	body, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp buildListResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("decoding builds list: %w", err)
+	}
+
+	return resp.Value, nil
+}
+
+func (c *Client) waitForCompletion(ctx context.Context, opts WaitOptions, runID int, progress io.Writer) (string, error) {
+	ticker := time.NewTicker(2 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		state, err := c.buildStatus(ctx, opts, runID)
+		if err != nil {
+			return "", err
+		}
+
+		if strings.EqualFold(state.Status, "completed") {
+			if strings.EqualFold(state.Result, "succeeded") {
+				fmt.Fprintf(progress, "%s: succeeded\n", opts.Name)
+				return "succeeded", nil
+			}
+			return state.Result, fmt.Errorf("completed with result %q", state.Result)
+		}
+
+		fmt.Fprintf(progress, "%s: status=%s result=%s\n", opts.Name, state.Status, state.Result)
+
+		select {
+		case <-ctx.Done():
+			return "", fmt.Errorf("timed out after %s: %w", opts.Timeout, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+type buildStatusResponse struct {
+	Status string `json:"status"`
+	Result string `json:"result"`
+}
+
+func (c *Client) buildStatus(ctx context.Context, opts WaitOptions, runID int) (buildStatusResponse, error) {
+	url := fmt.Sprintf(
+		"https://dev.azure.com/%s/%s/_apis/build/builds/%d?api-version=7.0",
+		opts.Org, opts.Project, runID,
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return buildStatusResponse{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+opts.Token)
+
+	body, err := c.do(req)
+	if err != nil {
+		return buildStatusResponse{}, fmt.Errorf("checking status: %w", err)
+	}
+
+	var resp buildStatusResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return buildStatusResponse{}, fmt.Errorf("decoding status: %w", err)
+	}
+
+	return resp, nil
+}
+
+func (c *Client) do(req *http.Request) ([]byte, error) {
+	resp, err := c.doer.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	return body, nil
+}
+
+func buildRunURL(opts WaitOptions, runID int) string {
+	return fmt.Sprintf(
+		"https://dev.azure.com/%s/%s/_build/results?buildId=%d&view=results",
+		opts.Org, opts.Project, runID,
+	)
+}

--- a/tools/release/internal/version/version.go
+++ b/tools/release/internal/version/version.go
@@ -1,0 +1,246 @@
+package version
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	releaseBranchPattern = regexp.MustCompile(`^release/(v\d+\.\d+)$`)
+	rootTagPattern       = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
+)
+
+var binaries = []string{
+	"dropgz",
+	"azure-ipam",
+	"azure-iptables-monitor",
+	"azure-ip-masq-merger",
+	"cilium-log-collector",
+}
+
+type execRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+type Service struct {
+	run execRunner
+}
+
+type VersionInfo struct {
+	LatestTag string `json:"latest_tag"`
+	NewTag    string `json:"new_tag"`
+	TargetSHA string `json:"target_sha"`
+}
+
+type BinaryChange struct {
+	Binary      string `json:"binary"`
+	NewTag      string `json:"new_tag"`
+	PreviousTag string `json:"previous_tag"`
+}
+
+func NewService() *Service {
+	return &Service{run: runCommand}
+}
+
+func (s *Service) NextVersion(ctx context.Context, branch string) (VersionInfo, error) {
+	resolved, err := s.resolveRef(ctx, branch)
+	if err != nil {
+		return VersionInfo{}, err
+	}
+
+	latestTag, err := s.latestBranchTag(ctx, resolved, branch)
+	if err != nil {
+		return VersionInfo{}, err
+	}
+
+	newTag, err := bumpTag(latestTag)
+	if err != nil {
+		return VersionInfo{}, err
+	}
+
+	targetSHA, err := s.revParse(ctx, branch)
+	if err != nil {
+		return VersionInfo{}, err
+	}
+
+	return VersionInfo{
+		LatestTag: latestTag,
+		NewTag:    newTag,
+		TargetSHA: targetSHA,
+	}, nil
+}
+
+func (s *Service) DetectBinaryChanges(ctx context.Context, branch string) ([]BinaryChange, error) {
+	resolved, err := s.resolveRef(ctx, branch)
+	if err != nil {
+		return nil, err
+	}
+
+	changes := make([]BinaryChange, 0, len(binaries))
+	for _, binary := range binaries {
+		latestTag, err := s.latestBinaryTag(ctx, resolved, binary)
+		if err != nil {
+			return nil, err
+		}
+		if latestTag == "" {
+			continue
+		}
+
+		changed, err := s.hasBinaryChanges(ctx, latestTag, resolved, binary)
+		if err != nil {
+			return nil, err
+		}
+		if !changed {
+			continue
+		}
+
+		newTag, err := bumpBinaryTag(binary, latestTag)
+		if err != nil {
+			return nil, err
+		}
+
+		changes = append(changes, BinaryChange{
+			Binary:      binary,
+			NewTag:      newTag,
+			PreviousTag: latestTag,
+		})
+	}
+
+	return changes, nil
+}
+
+func (s *Service) latestBranchTag(ctx context.Context, resolvedRef, branch string) (string, error) {
+	if branch == "master" {
+		return s.firstMatchingTag(ctx, resolvedRef, "v*", rootTagPattern)
+	}
+
+	match := releaseBranchPattern.FindStringSubmatch(branch)
+	if len(match) != 2 {
+		return "", fmt.Errorf("unsupported release branch %q", branch)
+	}
+
+	prefix := regexp.MustCompile("^" + regexp.QuoteMeta(match[1]) + `\.\d+$`)
+	return s.firstMatchingTag(ctx, resolvedRef, match[1]+".*", prefix)
+}
+
+func (s *Service) latestBinaryTag(ctx context.Context, branch, binary string) (string, error) {
+	pattern := regexp.MustCompile("^" + regexp.QuoteMeta(binary) + `/v\d+\.\d+\.\d+$`)
+	out, err := s.run(ctx, "git", "tag", "--merged", branch, "-l", binary+"/v*", "--sort=-v:refname")
+	if err != nil {
+		return "", fmt.Errorf("listing tags for %s: %w", binary, err)
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		tag := strings.TrimSpace(line)
+		if tag == "" {
+			continue
+		}
+		if pattern.MatchString(tag) {
+			return tag, nil
+		}
+	}
+
+	return "", nil
+}
+
+func (s *Service) firstMatchingTag(ctx context.Context, branch, glob string, pattern *regexp.Regexp) (string, error) {
+	out, err := s.run(ctx, "git", "tag", "--merged", branch, "-l", glob, "--sort=-v:refname")
+	if err != nil {
+		return "", fmt.Errorf("listing tags for %s: %w", branch, err)
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		tag := strings.TrimSpace(line)
+		if tag == "" {
+			continue
+		}
+		if pattern.MatchString(tag) {
+			return tag, nil
+		}
+	}
+
+	return "", fmt.Errorf("no matching tag found for %s", branch)
+}
+
+func (s *Service) hasBinaryChanges(ctx context.Context, fromTag, branch, binary string) (bool, error) {
+	out, err := s.run(ctx, "git", "diff", "--name-only", fromTag+".."+branch, "--", binary+"/", "Makefile", "build/")
+	if err != nil {
+		return false, fmt.Errorf("checking changes for %s: %w", binary, err)
+	}
+
+	return strings.TrimSpace(string(out)) != "", nil
+}
+
+func (s *Service) revParse(ctx context.Context, ref string) (string, error) {
+	out, err := s.run(ctx, "git", "rev-parse", ref)
+	if err != nil {
+		// In CI checkout, local branch may not exist; try origin/<ref>
+		out, err = s.run(ctx, "git", "rev-parse", "origin/"+ref)
+		if err != nil {
+			return "", fmt.Errorf("resolving ref %s: %w", ref, err)
+		}
+	}
+
+	return strings.TrimSpace(string(out)), nil
+}
+
+// resolveRef resolves a branch name to a SHA that works with git commands like --merged.
+func (s *Service) resolveRef(ctx context.Context, ref string) (string, error) {
+	return s.revParse(ctx, ref)
+}
+
+func bumpTag(tag string) (string, error) {
+	parts, err := parseSemver(strings.TrimPrefix(tag, "v"))
+	if err != nil {
+		return "", fmt.Errorf("parsing tag %s: %w", tag, err)
+	}
+
+	return fmt.Sprintf("v%d.%d.%d", parts[0], parts[1], parts[2]+1), nil
+}
+
+func bumpBinaryTag(binary, tag string) (string, error) {
+	prefix := binary + "/v"
+	if !strings.HasPrefix(tag, prefix) {
+		return "", fmt.Errorf("tag %s does not match binary %s", tag, binary)
+	}
+
+	parts, err := parseSemver(strings.TrimPrefix(tag, prefix))
+	if err != nil {
+		return "", fmt.Errorf("parsing binary tag %s: %w", tag, err)
+	}
+
+	return fmt.Sprintf("%s/v%d.%d.%d", binary, parts[0], parts[1], parts[2]+1), nil
+}
+
+func parseSemver(version string) ([3]int, error) {
+	pieces := strings.Split(version, ".")
+	if len(pieces) != 3 {
+		return [3]int{}, fmt.Errorf("expected major.minor.patch, got %q", version)
+	}
+
+	var out [3]int
+	for i, piece := range pieces {
+		value, err := strconv.Atoi(piece)
+		if err != nil {
+			return [3]int{}, fmt.Errorf("parsing version part %q: %w", piece, err)
+		}
+		out[i] = value
+	}
+
+	return out, nil
+}
+
+func runCommand(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return out, fmt.Errorf("%s %s: %w: %s", name, strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+
+	return out, nil
+}


### PR DESCRIPTION
Cherry-pick of #4410 (ef7fc4ac1) from master to release/v1.7.

The scheduled release workflow checks out the release branch to operate on, so `tools/release/` must exist on the release branch. Without this, the workflow fails with `cd: tools/release: No such file or directory`.

**Files added:**
- `.github/workflows/scheduled-release.yaml` — orchestrator workflow
- `.github/workflows/govulncheck.yaml` — added `tools/release` to matrix
- `tools/release/` — Go CLI (11 files)
- `.gitignore` — ignore release-cli binary