### PR TITLE
bug: Fixing ETW metadata bug in CNI

### DIFF
--- a/cni/network/plugin/main.go
+++ b/cni/network/plugin/main.go
@@ -51,6 +51,8 @@ func printVersion() {
 }
 
 func rootExecute() error {
+	var config common.PluginConfig
+
 	// Enrich all CNI loggers with host metadata so ETW events carry VM identity for diagnostics.
 	metadataFile := filepath.Join(os.TempDir(), "azuremetadata.json")
 	if metadata, err := common.GetHostMetadata(metadataFile); err == nil {
@@ -70,8 +72,6 @@ func rootExecute() error {
 			zap.String("os_type", metadata.OsType),
 		)
 	}
-
-	var config common.PluginConfig
 
 	config.Version = version
 

--- a/cni/network/stateless/main.go
+++ b/cni/network/stateless/main.go
@@ -51,6 +51,15 @@ func printVersion() {
 }
 
 func rootExecute() error {
+	var config common.PluginConfig
+
+	log.SetName(name)
+	log.SetLevel(log.LevelInfo)
+	if err := log.SetTargetLogDirectory(log.TargetLogfile, ""); err != nil {
+		fmt.Printf("Failed to setup cni logging: %v\n", err)
+	}
+	defer log.Close()
+
 	// Enrich all CNI loggers with host metadata so ETW events carry VM identity for diagnostics.
 	metadataFile := filepath.Join(os.TempDir(), "azuremetadata.json")
 	if metadata, err := common.GetHostMetadata(metadataFile); err == nil {
@@ -70,15 +79,6 @@ func rootExecute() error {
 			zap.String("os_type", metadata.OsType),
 		)
 	}
-
-	var config common.PluginConfig
-
-	log.SetName(name)
-	log.SetLevel(log.LevelInfo)
-	if err := log.SetTargetLogDirectory(log.TargetLogfile, ""); err != nil {
-		fmt.Printf("Failed to setup cni logging: %v\n", err)
-	}
-	defer log.Close()
 
 	config.Version = version
 	config.Stateless = stateless

--- a/common/utils.go
+++ b/common/utils.go
@@ -178,8 +178,6 @@ func GetHostMetadata(fileName string) (Metadata, error) {
 		}
 	}
 
-	log.Printf("[Telemetry] Request metadata from wireserver")
-
 	req, err := http.NewRequest("GET", metadataURL, nil)
 	if err != nil {
 		return Metadata{}, err


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:

Commit `09cd3b2c2` ("feat: Enhancing ETW logging for CNI #4426", CNI bundle 1.8.9) added a metadata-enrichment block at the top of `rootExecute()` that calls `common.GetHostMetadata()` before the legacy logger is redirected from stderr to a file. On a metadata-cache miss (cold boot / node reimage), the legacy logger writes `[Telemetry] Request metadata from wireserver` to stderr.

CNS invokes the CNI binary via `cmd.CombinedOutput()` to fetch endpoint state, merging stderr into stdout. The stray log line pollutes the JSON response, causing `json.Unmarshal` to fail with `invalid character '/' after top-level value`, which crashes CNS → CrashLoopBackOff.

This PR moves the legacy logger initialization above the `GetHostMetadata()` call in both CNI entry points so stderr is redirected to a log file before anything can write to it.

**Issue Fixed**:
No issue associated to this PR.

**Requirements**:

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:

- **`cni/network/stateless/main.go`** — Reordered: logger redirect now precedes `GetHostMetadata()`
- **`cni/network/plugin/main.go`** — Added legacy `log` import and logger redirect before `GetHostMetadata()` (previously had no legacy logger setup at all)
- Both binaries compile cleanly; on cache miss the `[Telemetry]` line now goes to `azure-vnet.log` instead of stderr

**Tests**:
**ETW logs working correctly**
<img width="1739" height="1024" alt="image" src="https://github.com/user-attachments/assets/98f31c44-4a5c-4449-979f-d187a588c362" />

**Failure reproduction**
Overlay BYOCNI cluster created
<img width="929" height="67" alt="image" src="https://github.com/user-attachments/assets/44cb9cc0-1d03-478e-89c8-748102a7720b" />

Removing `azuremetadata.json` file
<img width="1798" height="460" alt="image" src="https://github.com/user-attachments/assets/ab5fe2e3-4538-4e94-bfac-325c801fe07b" />

Test were performed twice:
a. With `EnableStateMigration:true` and `ManageEndpointState:true` as per IcM
b. With `EnableStateMigration:false` and `ManageEndpointState:false` as per default values

Deploying CNS/CNI v1.8.9 (bad version) in AKS BYOCNI cluster
a. Configmap `EnableStateMigration:true` and `ManageEndpointState:true`
<img width="939" height="780" alt="image" src="https://github.com/user-attachments/assets/db92dc3f-f774-496c-af7f-7fd3eab6484e" />

a. Error reproduction `EnableStateMigration:true` and `ManageEndpointState:true`
<img width="958" height="578" alt="image" src="https://github.com/user-attachments/assets/d0cb542b-e0d1-43fd-9125-40d73f944e81" />

b. Configmap  `EnableStateMigration:false` and `ManageEndpointState:false`
<img width="939" height="791" alt="image" src="https://github.com/user-attachments/assets/beb3f1eb-b879-400e-b0aa-57a66bc8b5d6" />

b. Error reproduction `EnableStateMigration:false` and `ManageEndpointState:false`
<img width="962" height="465" alt="image" src="https://github.com/user-attachments/assets/d9b3c5c5-eab1-430f-be72-0d2d52218f0e" />

Test CNI image build/push (acnpublic.azurecr.io/azure-cni:v1.8.9-11-g96e8addde): https://msazure.visualstudio.com/One/Quota%20and%20Capacity%20Management/_build/results?buildId=171170956&view=logs&j=70019b04-dce6-53f1-c9a2-8bfe2dbe6823&t=ec0b9213-fa84-5643-8208-b10307f124c9&l=29

Test CNS image build/push (acnpublic.azurecr.io/azure-cns:v1.8.9-11-g96e8addde): https://msazure.visualstudio.com/One/Quota%20and%20Capacity%20Management/_build/results?buildId=171170956&view=logs&j=58f5182c-d509-5a71-bd8e-7b4908aff171&t=69962e21-bd97-56a3-0e68-084f3e045884&l=29

Error not present anymore
a. `EnableStateMigration:true` and `ManageEndpointState:true`
<img width="956" height="315" alt="image" src="https://github.com/user-attachments/assets/e605d3e3-1c9c-4cd9-b2e4-2e129b387f16" />

b. `EnableStateMigration:false` and `ManageEndpointState:false`
<img width="960" height="473" alt="image" src="https://github.com/user-attachments/assets/fb2ee20f-4844-4006-8ee2-36b4c5d4272e" />