### PR TITLE
fix(ci): stop ImagePullPolicy: Always on load-test noop deployments

### DIFF
--- a/test/integration/manifests/noop-deployment-linux.yaml
+++ b/test/integration/manifests/noop-deployment-linux.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: no-op
           image: mcr.microsoft.com/oss/kubernetes/pause:3.6
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
       nodeSelector:

--- a/test/integration/manifests/noop-deployment-windows.yaml
+++ b/test/integration/manifests/noop-deployment-windows.yaml
@@ -17,6 +17,7 @@ spec:
       containers:
       - name: noop
         image: mcr.microsoft.com/oss/kubernetes/pause:3.6
+        imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 80
       nodeSelector:


### PR DESCRIPTION
## Problem

The load-test noop Deployments pull `mcr.microsoft.com/oss/kubernetes/pause:3.6`. With `imagePullPolicy: Always`, kubelet issues a manifest HEAD to MCR on **every pod start**, even though the cached digest never changes for an immutable tag. When the load test fans a deployment out across many nodes behind a single VMSS outbound NAT, the aggregate QPS trips MCR's per-edge AFD throttle:

```
load-test 36m Warning Failed pod/load-test-598b58dc-wx5dh
  Failed to pull image "mcr.microsoft.com/oss/kubernetes/pause:3.6":
  pull QPS exceeded
```

MCR sits behind Azure Front Door and throttles per POP as DDoS mitigation, keyed off the client IP the edge sees — for AKS that's the VMSS SNAT IP shared by many nodes.

## Fix

Set `imagePullPolicy: IfNotPresent` on both noop manifests. After the first pull per node, kubelet reuses the local copy (shared with the CRI sandbox pause, which is the same tag) with **zero registry traffic** on subsequent pod starts, restarts, and rescheduling.

## Notes

- `noop-deployment-windows.yaml` previously had no explicit policy. Since the tag isn't `:latest`, the effective default was already `IfNotPresent`; making it explicit prevents future edits from silently flipping it and keeps parity with the linux manifest.