### PR TITLE
[release/v1.6] fix(ci): stop ImagePullPolicy: Always on load-test noop deployments

### DIFF
--- a/test/integration/manifests/noop-deployment-linux.yaml
+++ b/test/integration/manifests/noop-deployment-linux.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: no-op
           image: mcr.microsoft.com/oss/kubernetes/pause:3.6
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
       nodeSelector:

--- a/test/integration/manifests/noop-deployment-windows.yaml
+++ b/test/integration/manifests/noop-deployment-windows.yaml
@@ -17,6 +17,7 @@ spec:
       containers:
       - name: noop
         image: mcr.microsoft.com/oss/kubernetes/pause:3.6
+        imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 80
       nodeSelector:


### PR DESCRIPTION
Backport of #4511 to release/v1.6.

## Problem

The load-test noop Deployments pull `mcr.microsoft.com/oss/kubernetes/pause:3.6`. With `imagePullPolicy: Always`, kubelet issues a manifest HEAD to MCR on **every pod start**, even though the cached digest never changes for an immutable tag. When the load test fans a deployment out across many nodes behind a single VMSS outbound NAT, the aggregate QPS trips MCR's per-edge AFD throttle:

```
load-test 36m Warning Failed pod/load-test-598b58dc-wx5dh
  Failed to pull image "mcr.microsoft.com/oss/kubernetes/pause:3.6":
  pull QPS exceeded
```

## Fix

Set `imagePullPolicy: IfNotPresent` on both noop manifests. After the first pull per node, kubelet reuses the local copy (shared with the CRI sandbox pause) with zero registry traffic on subsequent pod starts.

The Windows manifest previously had no explicit policy; since the tag isn't `:latest` the effective default was already `IfNotPresent`. Made explicit for parity.

Cherry-picked from 1405e0b on master (#4511).