### PR TITLE
fix(azure-iptables-monitor): build with Go 1.25 to remediate CVE-2026-39825

### DIFF
--- a/.pipelines/build/scripts/azure-iptables-monitor.sh
+++ b/.pipelines/build/scripts/azure-iptables-monitor.sh
@@ -5,6 +5,9 @@ set -eux
 FILE_EXT=''
 
 export CGO_ENABLED=0
+# MS Go 1.25 makes systemcrypto (cgo/OpenSSL) the default backend; with CGO_ENABLED=0
+# and crypto stdlib deps the build fails, so disable it to keep the pure-Go static build.
+export MS_GO_NOSYSTEMCRYPTO=1
 export C_INCLUDE_PATH=/usr/include/bpf
 
 mkdir -p "$OUT_DIR"/bin

--- a/Makefile
+++ b/Makefile
@@ -207,8 +207,8 @@ endif
 
 # Build the azure-block-iptables binary.
 azure-block-iptables-binary: bpf-lib
-	cd $(AZURE_BLOCK_IPTABLES_DIR) && CGO_ENABLED=0 go generate ./...
-	cd $(AZURE_BLOCK_IPTABLES_DIR)/cmd/azure-block-iptables && CGO_ENABLED=0 go build -v -o $(AZURE_BLOCK_IPTABLES_BUILD_DIR)/azure-block-iptables$(EXE_EXT) -ldflags "-X main.version=$(AZURE_BLOCK_IPTABLES_VERSION)" -gcflags="-dwarflocationlists=true"
+	cd $(AZURE_BLOCK_IPTABLES_DIR) && MS_GO_NOSYSTEMCRYPTO=1 CGO_ENABLED=0 go generate ./...
+	cd $(AZURE_BLOCK_IPTABLES_DIR)/cmd/azure-block-iptables && MS_GO_NOSYSTEMCRYPTO=1 CGO_ENABLED=0 go build -v -o $(AZURE_BLOCK_IPTABLES_BUILD_DIR)/azure-block-iptables$(EXE_EXT) -ldflags "-X main.version=$(AZURE_BLOCK_IPTABLES_VERSION)" -gcflags="-dwarflocationlists=true"
 
 # Build the Azure CNI network binary.
 azure-vnet-binary:
@@ -254,7 +254,7 @@ azure-ip-masq-merger-binary:
 
 # Build the azure-iptables-monitor binary.
 azure-iptables-monitor-binary:
-	cd $(AZURE_IPTABLES_MONITOR_DIR) && CGO_ENABLED=0 go build -v -o $(AZURE_IPTABLES_MONITOR_BUILD_DIR)/azure-iptables-monitor$(EXE_EXT) -ldflags "-X main.version=$(AZURE_IPTABLES_MONITOR_VERSION)" -gcflags="-dwarflocationlists=true"
+	cd $(AZURE_IPTABLES_MONITOR_DIR) && MS_GO_NOSYSTEMCRYPTO=1 CGO_ENABLED=0 go build -v -o $(AZURE_IPTABLES_MONITOR_BUILD_DIR)/azure-iptables-monitor$(EXE_EXT) -ldflags "-X main.version=$(AZURE_IPTABLES_MONITOR_VERSION)" -gcflags="-dwarflocationlists=true"
 
 ##@ Containers
 

--- a/azure-iptables-monitor/Dockerfile
+++ b/azure-iptables-monitor/Dockerfile
@@ -8,8 +8,9 @@ FROM mcr.microsoft.com/azurelinux/base/core@sha256:35149ae8dd179684f969944f54a33
 # mcr.microsoft.com/azurelinux/distroless/base:3.0
 FROM mcr.microsoft.com/azurelinux/distroless/base@sha256:32820d2cf20e896aa9111742dd683dd0ccff370f742e256889bb3bb50320c0d4 AS mariner-distroless
 
-# mcr.microsoft.com/oss/go/microsoft/golang:1.24-azurelinux3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:bc7423b52b62e8f0281b5f7f564eb1862dc315bc57e1373c6a81e87ef3ac39ab AS go
+# Pinned to Go 1.25 to remediate CVE-2026-39825 (Go stdlib); the shared GO_IMG is still 1.24.
+# mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:a5480db3386072bf9edde57ddc8b8a4d1470bfac893b2cd56cb18060cb051974 AS go
 
 
 FROM go AS azure-iptables-monitor
@@ -17,7 +18,7 @@ ARG OS
 ARG VERSION
 WORKDIR /azure-iptables-monitor
 COPY ./azure-iptables-monitor .
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/iptables-monitor -trimpath -ldflags "-s -w -X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" .
+RUN GOOS=$OS MS_GO_NOSYSTEMCRYPTO=1 CGO_ENABLED=0 go build -a -o /go/bin/iptables-monitor -trimpath -ldflags "-s -w -X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" .
 
 FROM go AS azure-block-iptables
 ARG OS
@@ -45,8 +46,8 @@ RUN if [ "$ARCH" = "amd64" ]; then \
             fi; \
         done; \
     fi
-RUN GOOS=$OS CGO_ENABLED=0 go generate ./bpf-prog/azure-block-iptables/...
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-block-iptables -trimpath -ldflags "-s -w -X main.version="$AZURE_BLOCK_IPTABLES_VERSION"" -gcflags="-dwarflocationlists=true" ./bpf-prog/azure-block-iptables/cmd/azure-block-iptables
+RUN GOOS=$OS MS_GO_NOSYSTEMCRYPTO=1 CGO_ENABLED=0 go generate ./bpf-prog/azure-block-iptables/...
+RUN GOOS=$OS MS_GO_NOSYSTEMCRYPTO=1 CGO_ENABLED=0 go build -a -o /go/bin/azure-block-iptables -trimpath -ldflags "-s -w -X main.version="$AZURE_BLOCK_IPTABLES_VERSION"" -gcflags="-dwarflocationlists=true" ./bpf-prog/azure-block-iptables/cmd/azure-block-iptables
 
 FROM mariner-core AS iptools
 RUN tdnf install -y iptables iproute

--- a/azure-iptables-monitor/Dockerfile.tmpl
+++ b/azure-iptables-monitor/Dockerfile.tmpl
@@ -8,8 +8,9 @@ FROM {{.MARINER_CORE_PIN}} AS mariner-core
 # {{.MARINER_DISTROLESS_IMG}}
 FROM {{.MARINER_DISTROLESS_PIN}} AS mariner-distroless
 
-# {{.GO_IMG}}
-FROM --platform=linux/${ARCH} {{.GO_PIN}} AS go
+# Pinned to Go 1.25 to remediate CVE-2026-39825 (Go stdlib); the shared GO_IMG is still 1.24.
+# mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang@sha256:a5480db3386072bf9edde57ddc8b8a4d1470bfac893b2cd56cb18060cb051974 AS go
 
 
 FROM go AS azure-iptables-monitor
@@ -17,7 +18,7 @@ ARG OS
 ARG VERSION
 WORKDIR /azure-iptables-monitor
 COPY ./azure-iptables-monitor .
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/iptables-monitor -trimpath -ldflags "-s -w -X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" .
+RUN GOOS=$OS MS_GO_NOSYSTEMCRYPTO=1 CGO_ENABLED=0 go build -a -o /go/bin/iptables-monitor -trimpath -ldflags "-s -w -X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" .
 
 FROM go AS azure-block-iptables
 ARG OS
@@ -45,8 +46,8 @@ RUN if [ "$ARCH" = "amd64" ]; then \
             fi; \
         done; \
     fi
-RUN GOOS=$OS CGO_ENABLED=0 go generate ./bpf-prog/azure-block-iptables/...
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-block-iptables -trimpath -ldflags "-s -w -X main.version="$AZURE_BLOCK_IPTABLES_VERSION"" -gcflags="-dwarflocationlists=true" ./bpf-prog/azure-block-iptables/cmd/azure-block-iptables
+RUN GOOS=$OS MS_GO_NOSYSTEMCRYPTO=1 CGO_ENABLED=0 go generate ./bpf-prog/azure-block-iptables/...
+RUN GOOS=$OS MS_GO_NOSYSTEMCRYPTO=1 CGO_ENABLED=0 go build -a -o /go/bin/azure-block-iptables -trimpath -ldflags "-s -w -X main.version="$AZURE_BLOCK_IPTABLES_VERSION"" -gcflags="-dwarflocationlists=true" ./bpf-prog/azure-block-iptables/cmd/azure-block-iptables
 
 FROM mariner-core AS iptools
 RUN tdnf install -y iptables iproute


### PR DESCRIPTION
## Summary

The published `azure-iptables-monitor` image (`mcr.microsoft.com/containernetworking/azure-iptables-monitor`) ships the `iptables-monitor` and `azure-block-iptables` binaries built with **Go stdlib 1.24.13**, which is affected by **CVE-2026-39825** (gobinary, published 2026-05-07). The fix is available in Go **1.25.10+** / **1.26.3+**.

This PR bumps **only** this component's Go builder to the **1.25** line, leaving the shared `GO_IMG` (1.24) and all other components unchanged.

## Why this scope works

`.pipelines/build/scripts/install-go.sh` resolves the host Go toolchain **per-component** by reading the `FROM ... golang ... AS go` line from `${name}/Dockerfile`. So pinning `azure-iptables-monitor/Dockerfile` to Go 1.25 fixes **both** build paths:
- **Pipeline (production image):** `install-go.sh` (name=`azure-iptables-monitor`) installs Go 1.25, then `.pipelines/build/scripts/azure-iptables-monitor.sh` compiles the binaries.
- **Local/dev:** the component `Dockerfile` `FROM go` stages compile with Go 1.25 directly.

Precedent: `npm` is already pinned to Go 1.25 independently of the shared image.

## Version pinned

`mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0` → digest `sha256:a5480db3...` = **Go 1.25.12** (≥ 1.25.10 ✓).

## FIPS / crypto handling

Per the MS Go FIPS docs, **since Go 1.25 `systemcrypto` (cgo/OpenSSL) is the default backend**. With `CGO_ENABLED=0` and crypto stdlib dependencies (both binaries import `crypto/*`), the build now **fails** unless systemcrypto is disabled — the cgo-less OpenSSL backend does not exist until Go 1.26 (`ms_nocgo_opensslcrypto`) / 1.27 (default).

We set **`MS_GO_NOSYSTEMCRYPTO=1`** on every `CGO_ENABLED=0` `go build`/`go generate` for this image's binaries (mirroring the existing `npm` Dockerfiles). This preserves the exact pure-Go, static-binary crypto posture the component already had on Go 1.24 — no FIPS regression, just patched stdlib.

## Files changed (azure-iptables-monitor only)

| File | Change |
|---|---|
| `azure-iptables-monitor/Dockerfile.tmpl` | Pin Go builder to 1.25; add `MS_GO_NOSYSTEMCRYPTO=1` to CGO=0 build/generate |
| `azure-iptables-monitor/Dockerfile` (generated) | Regenerated to match template |
| `.pipelines/build/scripts/azure-iptables-monitor.sh` | `export MS_GO_NOSYSTEMCRYPTO=1` (production build path) |
| `Makefile` | `MS_GO_NOSYSTEMCRYPTO=1` on `azure-iptables-monitor-binary` and `azure-block-iptables-binary` |

## Validation

- `install-go.sh` correctly parses the new pinned image from the Dockerfile.
- Rendered template == committed `Dockerfile` (baseimages `make dockerfiles` diff check passes).
- Smoke build of `iptables-monitor` with `MS_GO_NOSYSTEMCRYPTO=1 CGO_ENABLED=0` succeeds.

## Notes

- The shared `GO_IMG` remains 1.24; the go-version-check digest-refresh automation targets the shared image only and won't touch this pin. When the repo moves to 1.25/1.26 repo-wide, this component should be re-templated back onto the shared `{{.GO_PIN}}`.