### PR TITLE
fix: use powershell copy for windows CNI install

### DIFF
--- a/.pipelines/build/dockerfiles/cni.Dockerfile
+++ b/.pipelines/build/dockerfiles/cni.Dockerfile
@@ -6,8 +6,9 @@ ARG ARCH
 FROM --platform=windows/${ARCH} mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0@sha256:b4c9637e032f667c52d1eccfa31ad8c63f1b035e8639f3f48a510536bf34032b AS windows
 ARG ARTIFACT_DIR .
 
-COPY ${ARTIFACT_DIR}/bin/dropgz.exe /dropgz.exe
-ENTRYPOINT [ "/dropgz.exe" ]
+COPY ${ARTIFACT_DIR}/bin/*.exe /
+COPY ${ARTIFACT_DIR}/files/ /
+ENTRYPOINT [ "powershell.exe" ]
 
 # mcr.microsoft.com/azurelinux/distroless/base:3.0
 FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:178f25fadf466549d31e234b3091bf815161159f2f2bc98720bbf39f7368aff4 AS linux

--- a/.pipelines/build/dockerfiles/cni.Dockerfile
+++ b/.pipelines/build/dockerfiles/cni.Dockerfile
@@ -6,8 +6,8 @@ ARG ARCH
 FROM --platform=windows/${ARCH} mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0@sha256:b4c9637e032f667c52d1eccfa31ad8c63f1b035e8639f3f48a510536bf34032b AS windows
 ARG ARTIFACT_DIR .
 
-COPY ${ARTIFACT_DIR}/bin/*.exe /
-COPY ${ARTIFACT_DIR}/files/ /
+COPY ${ARTIFACT_DIR}/bin/*.exe /Windows/System32/
+COPY ${ARTIFACT_DIR}/files/ /Windows/System32/
 ENTRYPOINT [ "powershell.exe" ]
 
 # mcr.microsoft.com/azurelinux/distroless/base:3.0

--- a/.pipelines/build/dockerfiles/cni.Dockerfile.tmpl
+++ b/.pipelines/build/dockerfiles/cni.Dockerfile.tmpl
@@ -6,8 +6,8 @@ ARG ARCH
 FROM --platform=windows/${ARCH} {{.WIN_HPC_PIN}} AS windows
 ARG ARTIFACT_DIR .
 
-COPY ${ARTIFACT_DIR}/bin/*.exe /
-COPY ${ARTIFACT_DIR}/files/ /
+COPY ${ARTIFACT_DIR}/bin/*.exe /Windows/System32/
+COPY ${ARTIFACT_DIR}/files/ /Windows/System32/
 ENTRYPOINT [ "powershell.exe" ]
 
 # {{.MARINER_DISTROLESS_IMG}}

--- a/.pipelines/build/dockerfiles/cni.Dockerfile.tmpl
+++ b/.pipelines/build/dockerfiles/cni.Dockerfile.tmpl
@@ -6,8 +6,9 @@ ARG ARCH
 FROM --platform=windows/${ARCH} {{.WIN_HPC_PIN}} AS windows
 ARG ARTIFACT_DIR .
 
-COPY ${ARTIFACT_DIR}/bin/dropgz.exe /dropgz.exe
-ENTRYPOINT [ "/dropgz.exe" ]
+COPY ${ARTIFACT_DIR}/bin/*.exe /
+COPY ${ARTIFACT_DIR}/files/ /
+ENTRYPOINT [ "powershell.exe" ]
 
 # {{.MARINER_DISTROLESS_IMG}}
 FROM --platform=linux/${ARCH} {{.MARINER_DISTROLESS_PIN}} AS linux

--- a/cni/Dockerfile
+++ b/cni/Dockerfile
@@ -28,7 +28,7 @@ RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-ipam -trimpath -ldf
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-stateless -trimpath -ldflags "-s -w -X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/stateless/main.go
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-cni-telemetry-sidecar -trimpath -ldflags "-s -w -X main.version="$VERSION" -X "$CNI_AI_PATH"="$CNI_AI_ID"" -gcflags="-dwarflocationlists=true" ./cns/cni-telemetry-sidecar
 
-FROM mariner-core AS compressor
+FROM mariner-core AS payload
 ARG OS
 WORKDIR /payload
 COPY --from=azure-vnet /go/bin/* /payload/
@@ -40,6 +40,8 @@ COPY --from=azure-vnet /azure-container-networking/cni/azure-$OS-swift-overlay-d
 COPY --from=azure-vnet /azure-container-networking/cni/azure-windows-multitenancy.conflist /payload/azure-multitenancy.conflist
 COPY --from=azure-vnet /azure-container-networking/cni/azure-chained-cilium.conflist /payload/azure-chained-cilium.conflist
 COPY --from=azure-vnet /azure-container-networking/telemetry/azure-vnet-telemetry.config /payload/azure-vnet-telemetry.config
+
+FROM payload AS compressor
 RUN cd /payload && sha256sum * > sum.txt
 RUN gzip --verbose --best --recursive /payload && for f in /payload/*.gz; do mv -- "$f" "${f%%.gz}"; done
 
@@ -61,8 +63,14 @@ COPY --from=dropgz /go/bin/dropgz /dropgz
 ENTRYPOINT [ "/dropgz" ]
 
 # mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0
-FROM --platform=windows/${ARCH} mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0@sha256:b4c9637e032f667c52d1eccfa31ad8c63f1b035e8639f3f48a510536bf34032b as hpc
+FROM --platform=windows/${ARCH} mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0@sha256:b4c9637e032f667c52d1eccfa31ad8c63f1b035e8639f3f48a510536bf34032b AS hpc
 
-FROM hpc as windows
-COPY --from=dropgz /go/bin/dropgz dropgz.exe
-ENTRYPOINT [ "/dropgz.exe" ]
+FROM hpc AS windows
+COPY --from=azure-vnet /go/bin/azure-vnet /azure-vnet.exe
+COPY --from=azure-vnet /go/bin/azure-vnet-stateless /azure-vnet-stateless.exe
+COPY --from=azure-vnet /go/bin/azure-vnet-ipam /azure-vnet-ipam.exe
+COPY --from=azure-vnet /go/bin/azure-vnet-telemetry /azure-vnet-telemetry.exe
+COPY --from=azure-vnet /go/bin/azure-cni-telemetry-sidecar /azure-cni-telemetry-sidecar.exe
+COPY --from=payload /payload/*.conflist /
+COPY --from=payload /payload/azure-vnet-telemetry.config /azure-vnet-telemetry.config
+ENTRYPOINT [ "powershell.exe" ]

--- a/cni/Dockerfile
+++ b/cni/Dockerfile
@@ -66,11 +66,11 @@ ENTRYPOINT [ "/dropgz" ]
 FROM --platform=windows/${ARCH} mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0@sha256:b4c9637e032f667c52d1eccfa31ad8c63f1b035e8639f3f48a510536bf34032b AS hpc
 
 FROM hpc AS windows
-COPY --from=azure-vnet /go/bin/azure-vnet /azure-vnet.exe
-COPY --from=azure-vnet /go/bin/azure-vnet-stateless /azure-vnet-stateless.exe
-COPY --from=azure-vnet /go/bin/azure-vnet-ipam /azure-vnet-ipam.exe
-COPY --from=azure-vnet /go/bin/azure-vnet-telemetry /azure-vnet-telemetry.exe
-COPY --from=azure-vnet /go/bin/azure-cni-telemetry-sidecar /azure-cni-telemetry-sidecar.exe
-COPY --from=payload /payload/*.conflist /
-COPY --from=payload /payload/azure-vnet-telemetry.config /azure-vnet-telemetry.config
+COPY --from=azure-vnet /go/bin/azure-vnet /Windows/System32/azure-vnet.exe
+COPY --from=azure-vnet /go/bin/azure-vnet-stateless /Windows/System32/azure-vnet-stateless.exe
+COPY --from=azure-vnet /go/bin/azure-vnet-ipam /Windows/System32/azure-vnet-ipam.exe
+COPY --from=azure-vnet /go/bin/azure-vnet-telemetry /Windows/System32/azure-vnet-telemetry.exe
+COPY --from=azure-vnet /go/bin/azure-cni-telemetry-sidecar /Windows/System32/azure-cni-telemetry-sidecar.exe
+COPY --from=payload /payload/*.conflist /Windows/System32/
+COPY --from=payload /payload/azure-vnet-telemetry.config /Windows/System32/azure-vnet-telemetry.config
 ENTRYPOINT [ "powershell.exe" ]

--- a/cni/Dockerfile.tmpl
+++ b/cni/Dockerfile.tmpl
@@ -66,11 +66,11 @@ ENTRYPOINT [ "/dropgz" ]
 FROM --platform=windows/${ARCH} {{.WIN_HPC_PIN}} AS hpc
 
 FROM hpc AS windows
-COPY --from=azure-vnet /go/bin/azure-vnet /azure-vnet.exe
-COPY --from=azure-vnet /go/bin/azure-vnet-stateless /azure-vnet-stateless.exe
-COPY --from=azure-vnet /go/bin/azure-vnet-ipam /azure-vnet-ipam.exe
-COPY --from=azure-vnet /go/bin/azure-vnet-telemetry /azure-vnet-telemetry.exe
-COPY --from=azure-vnet /go/bin/azure-cni-telemetry-sidecar /azure-cni-telemetry-sidecar.exe
-COPY --from=payload /payload/*.conflist /
-COPY --from=payload /payload/azure-vnet-telemetry.config /azure-vnet-telemetry.config
+COPY --from=azure-vnet /go/bin/azure-vnet /Windows/System32/azure-vnet.exe
+COPY --from=azure-vnet /go/bin/azure-vnet-stateless /Windows/System32/azure-vnet-stateless.exe
+COPY --from=azure-vnet /go/bin/azure-vnet-ipam /Windows/System32/azure-vnet-ipam.exe
+COPY --from=azure-vnet /go/bin/azure-vnet-telemetry /Windows/System32/azure-vnet-telemetry.exe
+COPY --from=azure-vnet /go/bin/azure-cni-telemetry-sidecar /Windows/System32/azure-cni-telemetry-sidecar.exe
+COPY --from=payload /payload/*.conflist /Windows/System32/
+COPY --from=payload /payload/azure-vnet-telemetry.config /Windows/System32/azure-vnet-telemetry.config
 ENTRYPOINT [ "powershell.exe" ]

--- a/cni/Dockerfile.tmpl
+++ b/cni/Dockerfile.tmpl
@@ -28,7 +28,7 @@ RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-ipam -trimpath -ldf
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet-stateless -trimpath -ldflags "-s -w -X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/stateless/main.go
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-cni-telemetry-sidecar -trimpath -ldflags "-s -w -X main.version="$VERSION" -X "$CNI_AI_PATH"="$CNI_AI_ID"" -gcflags="-dwarflocationlists=true" ./cns/cni-telemetry-sidecar
 
-FROM mariner-core AS compressor
+FROM mariner-core AS payload
 ARG OS
 WORKDIR /payload
 COPY --from=azure-vnet /go/bin/* /payload/
@@ -40,6 +40,8 @@ COPY --from=azure-vnet /azure-container-networking/cni/azure-$OS-swift-overlay-d
 COPY --from=azure-vnet /azure-container-networking/cni/azure-windows-multitenancy.conflist /payload/azure-multitenancy.conflist
 COPY --from=azure-vnet /azure-container-networking/cni/azure-chained-cilium.conflist /payload/azure-chained-cilium.conflist
 COPY --from=azure-vnet /azure-container-networking/telemetry/azure-vnet-telemetry.config /payload/azure-vnet-telemetry.config
+
+FROM payload AS compressor
 RUN cd /payload && sha256sum * > sum.txt
 RUN gzip --verbose --best --recursive /payload && for f in /payload/*.gz; do mv -- "$f" "${f%%.gz}"; done
 
@@ -61,8 +63,14 @@ COPY --from=dropgz /go/bin/dropgz /dropgz
 ENTRYPOINT [ "/dropgz" ]
 
 # {{.WIN_HPC_IMG}}
-FROM --platform=windows/${ARCH} {{.WIN_HPC_PIN}} as hpc
+FROM --platform=windows/${ARCH} {{.WIN_HPC_PIN}} AS hpc
 
-FROM hpc as windows
-COPY --from=dropgz /go/bin/dropgz dropgz.exe
-ENTRYPOINT [ "/dropgz.exe" ]
+FROM hpc AS windows
+COPY --from=azure-vnet /go/bin/azure-vnet /azure-vnet.exe
+COPY --from=azure-vnet /go/bin/azure-vnet-stateless /azure-vnet-stateless.exe
+COPY --from=azure-vnet /go/bin/azure-vnet-ipam /azure-vnet-ipam.exe
+COPY --from=azure-vnet /go/bin/azure-vnet-telemetry /azure-vnet-telemetry.exe
+COPY --from=azure-vnet /go/bin/azure-cni-telemetry-sidecar /azure-cni-telemetry-sidecar.exe
+COPY --from=payload /payload/*.conflist /
+COPY --from=payload /payload/azure-vnet-telemetry.config /azure-vnet-telemetry.config
+ENTRYPOINT [ "powershell.exe" ]

--- a/test/integration/manifests/cni/cni-installer-v1-windows.yaml
+++ b/test/integration/manifests/cni/cni-installer-v1-windows.yaml
@@ -54,22 +54,14 @@ spec:
         - name: cni-installer
           image: ${CNI_IMAGE}
           imagePullPolicy: Always
-          command:
-            - powershell.exe; $env:CONTAINER_SANDBOX_MOUNT_POINT/dropgz
+          command: ["powershell.exe", "-Command"]
           args:
-            - deploy
-            - azure-vnet
-            - -o
-            - /k/azurecni/bin/azure-vnet.exe
-            - azure-vnet-ipam
-            - -o
-            - /k/azurecni/bin/azure-vnet-ipam.exe
-            - azure-vnet-telemetry
-            - -o
-            - /k/azurecni/bin/azure-vnet-telemetry.exe
-            - azure-vnet-telemetry.config
-            - -o
-            - /k/azurecni/bin/azure-vnet-telemetry.config
+            - >-
+              New-Item -Path "C:/k/azurecni/bin" -ItemType Directory -Force | Out-Null;
+              Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/azure-vnet.exe" -Destination "C:/k/azurecni/bin/azure-vnet.exe" -Force;
+              Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/azure-vnet-ipam.exe" -Destination "C:/k/azurecni/bin/azure-vnet-ipam.exe" -Force;
+              Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/azure-vnet-telemetry.exe" -Destination "C:/k/azurecni/bin/azure-vnet-telemetry.exe" -Force;
+              Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/azure-vnet-telemetry.config" -Destination "C:/k/azurecni/bin/azure-vnet-telemetry.config" -Force
           env:
           - name: PATHEXT
             value: .COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC;.CPL;;

--- a/test/integration/manifests/cni/cni-installer-v1-windows.yaml
+++ b/test/integration/manifests/cni/cni-installer-v1-windows.yaml
@@ -58,10 +58,10 @@ spec:
           args:
             - >-
               New-Item -Path "C:/k/azurecni/bin" -ItemType Directory -Force | Out-Null;
-              Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/azure-vnet.exe" -Destination "C:/k/azurecni/bin/azure-vnet.exe" -Force;
-              Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/azure-vnet-ipam.exe" -Destination "C:/k/azurecni/bin/azure-vnet-ipam.exe" -Force;
-              Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/azure-vnet-telemetry.exe" -Destination "C:/k/azurecni/bin/azure-vnet-telemetry.exe" -Force;
-              Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/azure-vnet-telemetry.config" -Destination "C:/k/azurecni/bin/azure-vnet-telemetry.config" -Force
+              Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/Windows/System32/azure-vnet.exe" -Destination "C:/k/azurecni/bin/azure-vnet.exe" -Force;
+              Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/Windows/System32/azure-vnet-ipam.exe" -Destination "C:/k/azurecni/bin/azure-vnet-ipam.exe" -Force;
+              Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/Windows/System32/azure-vnet-telemetry.exe" -Destination "C:/k/azurecni/bin/azure-vnet-telemetry.exe" -Force;
+              Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/Windows/System32/azure-vnet-telemetry.config" -Destination "C:/k/azurecni/bin/azure-vnet-telemetry.config" -Force
           env:
           - name: PATHEXT
             value: .COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC;.CPL;;

--- a/test/integration/manifests/cns/daemonset-windows.yaml
+++ b/test/integration/manifests/cns/daemonset-windows.yaml
@@ -105,13 +105,11 @@ spec:
         - name: cni-installer
           image: acnpublic.azurecr.io/cni-dropgz:latest
           imagePullPolicy: Always
-          command:
-            - $env:CONTAINER_SANDBOX_MOUNT_POINT/dropgz
+          command: ["powershell.exe", "-Command"]
           args:
-            - deploy
-            - azure-vnet
-            - -o
-            - /k/azurecni/bin/azure-vnet.exe # // TODO: add windows cni conflist when ready
+            - >-
+              New-Item -Path "C:/k/azurecni/bin" -ItemType Directory -Force | Out-Null;
+              Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/azure-vnet.exe" -Destination "C:/k/azurecni/bin/azure-vnet.exe" -Force # // TODO: add windows cni conflist when ready
           env:
           - name: PATHEXT
             value: .COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC;.CPL;;

--- a/test/integration/manifests/cns/daemonset-windows.yaml
+++ b/test/integration/manifests/cns/daemonset-windows.yaml
@@ -109,7 +109,7 @@ spec:
           args:
             - >-
               New-Item -Path "C:/k/azurecni/bin" -ItemType Directory -Force | Out-Null;
-              Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/azure-vnet.exe" -Destination "C:/k/azurecni/bin/azure-vnet.exe" -Force # // TODO: add windows cni conflist when ready
+              Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/Windows/System32/azure-vnet.exe" -Destination "C:/k/azurecni/bin/azure-vnet.exe" -Force # // TODO: add windows cni conflist when ready
           env:
           - name: PATHEXT
             value: .COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC;.CPL;;

--- a/test/internal/kubernetes/utils_create.go
+++ b/test/internal/kubernetes/utils_create.go
@@ -457,8 +457,8 @@ func initCNSScenarioVars() (map[CNSScenario]map[corev1.OSName]cnsDetails, error)
 				clusterRoleBindingPath: cnsClusterRoleBindingPath,
 				serviceAccountPath:     cnsServiceAccountPath,
 				initContainerArgs: []string{
-					"deploy",
-					"azure-vnet", "-o", "/k/azurecni/bin/azure-vnet.exe",
+					`New-Item -Path "C:/k/azurecni/bin" -ItemType Directory -Force | Out-Null;` +
+						` Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/azure-vnet.exe" -Destination "C:/k/azurecni/bin/azure-vnet.exe" -Force`,
 				},
 				initContainerName:  initContainerNameCNI,
 				configMapPath:      cnsSwiftWindowsConfigMapPath,
@@ -495,8 +495,8 @@ func initCNSScenarioVars() (map[CNSScenario]map[corev1.OSName]cnsDetails, error)
 				clusterRoleBindingPath: cnsClusterRoleBindingPath,
 				serviceAccountPath:     cnsServiceAccountPath,
 				initContainerArgs: []string{
-					"deploy",
-					"azure-vnet-stateless", "-o", "/k/azurecni/bin/azure-vnet.exe",
+					`New-Item -Path "C:/k/azurecni/bin" -ItemType Directory -Force | Out-Null;` +
+						` Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/azure-vnet-stateless.exe" -Destination "C:/k/azurecni/bin/azure-vnet.exe" -Force`,
 				},
 				initContainerName:         initContainerNameCNI,
 				volumes:                   volumesForAzureCNIOverlayWindows(),
@@ -537,7 +537,7 @@ func initCNSScenarioVars() (map[CNSScenario]map[corev1.OSName]cnsDetails, error)
 					"deploy",
 					"azure-ipam", "-o", "/opt/cni/bin/azure-ipam",
 				},
-				initContainerName:  initContainerNameIPAM,
+				initContainerName:   initContainerNameIPAM,
 				configMapPath:       cnsNodeSubnetLinuxConfigMapPath,
 				installIPMasqAgent:  true,
 				useNodeSubnetIPMasq: true,
@@ -591,8 +591,8 @@ func initCNSScenarioVars() (map[CNSScenario]map[corev1.OSName]cnsDetails, error)
 				clusterRoleBindingPath: cnsClusterRoleBindingPath,
 				serviceAccountPath:     cnsServiceAccountPath,
 				initContainerArgs: []string{
-					"deploy",
-					"azure-vnet", "-o", "/k/azurecni/bin/azure-vnet.exe",
+					`New-Item -Path "C:/k/azurecni/bin" -ItemType Directory -Force | Out-Null;` +
+						` Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/azure-vnet.exe" -Destination "C:/k/azurecni/bin/azure-vnet.exe" -Force`,
 				},
 				initContainerName:         initContainerNameCNI,
 				volumes:                   volumesForAzureCNIOverlayWindows(),
@@ -630,8 +630,8 @@ func initCNSScenarioVars() (map[CNSScenario]map[corev1.OSName]cnsDetails, error)
 				clusterRoleBindingPath: cnsClusterRoleBindingPath,
 				serviceAccountPath:     cnsServiceAccountPath,
 				initContainerArgs: []string{
-					"deploy",
-					"azure-vnet", "-o", "/k/azurecni/bin/azure-vnet.exe",
+					`New-Item -Path "C:/k/azurecni/bin" -ItemType Directory -Force | Out-Null;` +
+						` Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/azure-vnet.exe" -Destination "C:/k/azurecni/bin/azure-vnet.exe" -Force`,
 				},
 				initContainerName:         initContainerNameCNI,
 				volumes:                   volumesForAzureCNIOverlayWindows(),

--- a/test/internal/kubernetes/utils_create.go
+++ b/test/internal/kubernetes/utils_create.go
@@ -458,7 +458,7 @@ func initCNSScenarioVars() (map[CNSScenario]map[corev1.OSName]cnsDetails, error)
 				serviceAccountPath:     cnsServiceAccountPath,
 				initContainerArgs: []string{
 					`New-Item -Path "C:/k/azurecni/bin" -ItemType Directory -Force | Out-Null;` +
-						` Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/azure-vnet.exe" -Destination "C:/k/azurecni/bin/azure-vnet.exe" -Force`,
+						` Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/Windows/System32/azure-vnet.exe" -Destination "C:/k/azurecni/bin/azure-vnet.exe" -Force`,
 				},
 				initContainerName:  initContainerNameCNI,
 				configMapPath:      cnsSwiftWindowsConfigMapPath,
@@ -496,7 +496,7 @@ func initCNSScenarioVars() (map[CNSScenario]map[corev1.OSName]cnsDetails, error)
 				serviceAccountPath:     cnsServiceAccountPath,
 				initContainerArgs: []string{
 					`New-Item -Path "C:/k/azurecni/bin" -ItemType Directory -Force | Out-Null;` +
-						` Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/azure-vnet-stateless.exe" -Destination "C:/k/azurecni/bin/azure-vnet.exe" -Force`,
+						` Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/Windows/System32/azure-vnet-stateless.exe" -Destination "C:/k/azurecni/bin/azure-vnet.exe" -Force`,
 				},
 				initContainerName:         initContainerNameCNI,
 				volumes:                   volumesForAzureCNIOverlayWindows(),
@@ -592,7 +592,7 @@ func initCNSScenarioVars() (map[CNSScenario]map[corev1.OSName]cnsDetails, error)
 				serviceAccountPath:     cnsServiceAccountPath,
 				initContainerArgs: []string{
 					`New-Item -Path "C:/k/azurecni/bin" -ItemType Directory -Force | Out-Null;` +
-						` Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/azure-vnet.exe" -Destination "C:/k/azurecni/bin/azure-vnet.exe" -Force`,
+						` Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/Windows/System32/azure-vnet.exe" -Destination "C:/k/azurecni/bin/azure-vnet.exe" -Force`,
 				},
 				initContainerName:         initContainerNameCNI,
 				volumes:                   volumesForAzureCNIOverlayWindows(),
@@ -631,7 +631,7 @@ func initCNSScenarioVars() (map[CNSScenario]map[corev1.OSName]cnsDetails, error)
 				serviceAccountPath:     cnsServiceAccountPath,
 				initContainerArgs: []string{
 					`New-Item -Path "C:/k/azurecni/bin" -ItemType Directory -Force | Out-Null;` +
-						` Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/azure-vnet.exe" -Destination "C:/k/azurecni/bin/azure-vnet.exe" -Force`,
+						` Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/Windows/System32/azure-vnet.exe" -Destination "C:/k/azurecni/bin/azure-vnet.exe" -Force`,
 				},
 				initContainerName:         initContainerNameCNI,
 				volumes:                   volumesForAzureCNIOverlayWindows(),


### PR DESCRIPTION
**Reason for Change**:

Switch the Windows CNI install path from dropgz to native PowerShell `Copy-Item` to enable proper binary signing under managed Dalec.

With dropgz, managed Dalec signs only the **outer** binary (dropgz itself) — the **inner** CNI binaries it carries are not signed. By shipping the CNI binaries as plain files in the image and having the init container copy them into place with `powershell.exe`, the actual CNI binaries become directly signable by managed Dalec.

Changes:
- Rewrites the Windows scenarios in the E2E harness to emit a PowerShell `Copy-Item` script (mirroring the daemonset manifest) instead of dropgz `deploy` args.
- Ships `azure-vnet-stateless.exe` in the Windows CNI image so the stateless suite can copy it.

Linux is unchanged and still uses dropgz.

**Issue Fixed**:
<!-- N/A -->

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:

Windows-only change; the Linux dropgz install path is untouched. Validated via the ACN PR pipeline against the three Windows E2E suites (`azure_overlay_stateless_e2e`, `win_azure_overlay_e2e`, `win_dualstackoverlay_e2e`).
