### PR TITLE
fix: run scheduled release on both release/v1.7 and master

### DIFF
--- a/.github/workflows/scheduled-release.yaml
+++ b/.github/workflows/scheduled-release.yaml
@@ -2,7 +2,8 @@
 # Handles: dependabot PR collection, vuln checks, tag creation, pipeline validation,
 # release channel posting, and R2D draft preparation.
 #
-# Trigger: First Friday of every month at 14:00 UTC + manual dispatch
+# Trigger: Every Friday at 14:00/14:15 UTC (check_cadence gates to first Friday)
+# Branches: release/v1.7 (14:00) and master (14:15) + manual dispatch
 #
 # ─── Teams Notification Dependency ───────────────────────────────────────────
 # Teams messages are sent via the acn-notifier-bot Azure Function App,

--- a/.github/workflows/scheduled-release.yaml
+++ b/.github/workflows/scheduled-release.yaml
@@ -18,8 +18,9 @@ name: Scheduled Release
 
 on:
   schedule:
-    # First Friday of every month at 14:00 UTC
-    - cron: "0 14 * * 5"
+    # Every Friday at 14:00/14:15 UTC — check_cadence job gates to first Friday only
+    - cron: "0 14 * * 5"   # release/v1.7
+    - cron: "15 14 * * 5"  # master
   workflow_dispatch:
     inputs:
       release_branch:
@@ -47,7 +48,7 @@ on:
         type: boolean
 
 concurrency:
-  group: scheduled-release-${{ inputs.release_branch || 'release/v1.7' }}
+  group: scheduled-release-${{ inputs.release_branch || (github.event.schedule == '15 14 * * 5' && 'master') || 'release/v1.7' }}
   cancel-in-progress: false
 
 permissions:
@@ -55,7 +56,8 @@ permissions:
   pull-requests: read
 
 env:
-  RELEASE_BRANCH: ${{ inputs.release_branch || 'release/v1.7' }}
+  # Map cron schedules to branches: 14:00 → release/v1.7, 14:15 → master
+  RELEASE_BRANCH: ${{ inputs.release_branch || (github.event.schedule == '15 14 * * 5' && 'master') || 'release/v1.7' }}
   MAX_PIPELINE_RETRIES: 5
   NOTIFIER_URL: https://acn-notifier-bot.azurewebsites.net
   NOTIFIER_AUDIENCE: api://3976eca5-3f9d-4528-987f-c20c1f9f27f7


### PR DESCRIPTION
Add second cron entry (14:15 UTC) for master branch releases. Each cron maps to its branch via `github.event.schedule`. Clarifies that cron fires every Friday — `check_cadence` job gates to first Friday only.