### PR TITLE
test/cilium: re-sync v1.17-v1.19 base ConfigMap with aks

### DIFF
--- a/test/integration/manifests/cilium/v1.16/cilium-config/cilium-config-dualstack.yaml
+++ b/test/integration/manifests/cilium/v1.16/cilium-config/cilium-config-dualstack.yaml
@@ -72,10 +72,10 @@ data:
   tofqdns-endpoint-max-ip-per-hostname: "1000"
   tofqdns-idle-connection-grace-period: 0s
   tofqdns-max-deferred-connection-deletes: "10000"
-  tofqdns-min-ttl: "0"
+  tofqdns-min-ttl: "3600"
   tofqdns-proxy-response-max-delay: 100ms
   routing-mode: native
-  unmanaged-pod-watcher-interval: "15"
+  unmanaged-pod-watcher-interval: "0"
   vtep-cidr: ""
   vtep-endpoint: ""
   vtep-mac: ""
@@ -84,7 +84,7 @@ data:
   external-envoy-proxy: "false"
   k8s-client-qps: "5"
   k8s-client-burst: "10"
-  mesh-auth-enabled: "true"
+  mesh-auth-enabled: "false"
   mesh-auth-queue-size: "1024"
   mesh-auth-rotated-identities-queue-size: "1024"
   mesh-auth-gc-interval: "5m0s"
@@ -92,7 +92,7 @@ data:
   proxy-max-requests-per-connection: "0"
   proxy-max-connection-duration-seconds: "0"
   set-cilium-node-taints: "true"
-  unmanaged-pod-watcher-interval: "15"
+  unmanaged-pod-watcher-interval: "0"
 ## new values added for 1.16 below
   enable-ipv4-big-tcp: "false"
   enable-ipv6-big-tcp: "false"

--- a/test/integration/manifests/cilium/v1.16/cilium-config/cilium-config-hubble.yaml
+++ b/test/integration/manifests/cilium/v1.16/cilium-config/cilium-config-hubble.yaml
@@ -73,10 +73,10 @@ data:
   tofqdns-endpoint-max-ip-per-hostname: "1000"
   tofqdns-idle-connection-grace-period: 0s
   tofqdns-max-deferred-connection-deletes: "10000"
-  tofqdns-min-ttl: "0"
+  tofqdns-min-ttl: "3600"
   tofqdns-proxy-response-max-delay: 100ms
   routing-mode: native
-  unmanaged-pod-watcher-interval: "15"
+  unmanaged-pod-watcher-interval: "0"
   vtep-cidr: ""
   vtep-endpoint: ""
   vtep-mac: ""
@@ -86,7 +86,7 @@ data:
   external-envoy-proxy: "false"
   k8s-client-qps: "5"
   k8s-client-burst: "10"
-  mesh-auth-enabled: "true"
+  mesh-auth-enabled: "false"
   mesh-auth-queue-size: "1024"
   mesh-auth-rotated-identities-queue-size: "1024"
   mesh-auth-gc-interval: "5m0s"
@@ -94,7 +94,7 @@ data:
   proxy-max-requests-per-connection: "0"
   proxy-max-connection-duration-seconds: "0"
   set-cilium-node-taints: "true"
-  unmanaged-pod-watcher-interval: "15"
+  unmanaged-pod-watcher-interval: "0"
   ## new values added for 1.16 below
   enable-ipv4-big-tcp: "false"
   enable-ipv6-big-tcp: "false"

--- a/test/integration/manifests/cilium/v1.16/cilium-config/cilium-config.yaml
+++ b/test/integration/manifests/cilium/v1.16/cilium-config/cilium-config.yaml
@@ -68,10 +68,10 @@ data:
   tofqdns-endpoint-max-ip-per-hostname: "1000"
   tofqdns-idle-connection-grace-period: 0s
   tofqdns-max-deferred-connection-deletes: "10000"
-  tofqdns-min-ttl: "0"
+  tofqdns-min-ttl: "3600"
   tofqdns-proxy-response-max-delay: 100ms
   routing-mode: native
-  unmanaged-pod-watcher-interval: "15"
+  unmanaged-pod-watcher-interval: "0"
   vtep-cidr: ""
   vtep-endpoint: ""
   vtep-mac: ""
@@ -80,7 +80,7 @@ data:
   external-envoy-proxy: "false"
   k8s-client-qps: "5"
   k8s-client-burst: "10"
-  mesh-auth-enabled: "true"
+  mesh-auth-enabled: "false"
   mesh-auth-queue-size: "1024"
   mesh-auth-rotated-identities-queue-size: "1024"
   mesh-auth-gc-interval: "5m0s"
@@ -88,7 +88,7 @@ data:
   proxy-max-requests-per-connection: "0"
   proxy-max-connection-duration-seconds: "0"
   set-cilium-node-taints: "true"
-  unmanaged-pod-watcher-interval: "15"
+  unmanaged-pod-watcher-interval: "0"
 ## new values added for 1.16 below
   enable-ipv4-big-tcp: "false"
   enable-ipv6-big-tcp: "false"

--- a/test/integration/manifests/cilium/v1.17/cilium-config/cilium-config-dualstack.yaml
+++ b/test/integration/manifests/cilium/v1.17/cilium-config/cilium-config-dualstack.yaml
@@ -72,10 +72,10 @@ data:
   tofqdns-endpoint-max-ip-per-hostname: "1000"
   tofqdns-idle-connection-grace-period: 0s
   tofqdns-max-deferred-connection-deletes: "10000"
-  tofqdns-min-ttl: "0"
+  tofqdns-min-ttl: "3600"
   tofqdns-proxy-response-max-delay: 100ms
   routing-mode: native
-  unmanaged-pod-watcher-interval: "15"
+  unmanaged-pod-watcher-interval: "0"
   vtep-cidr: ""
   vtep-endpoint: ""
   vtep-mac: ""
@@ -84,7 +84,7 @@ data:
   external-envoy-proxy: "false"
   k8s-client-qps: "10"
   k8s-client-burst: "20"
-  mesh-auth-enabled: "true"
+  mesh-auth-enabled: "false"
   mesh-auth-queue-size: "1024"
   mesh-auth-rotated-identities-queue-size: "1024"
   mesh-auth-gc-interval: "5m0s"
@@ -92,7 +92,7 @@ data:
   proxy-max-requests-per-connection: "0"
   proxy-max-connection-duration-seconds: "0"
   set-cilium-node-taints: "true"
-  unmanaged-pod-watcher-interval: "15"
+  unmanaged-pod-watcher-interval: "0"
 ## new values added for 1.16 below
   enable-ipv4-big-tcp: "false"
   enable-ipv6-big-tcp: "false"

--- a/test/integration/manifests/cilium/v1.17/cilium-config/cilium-config-hubble.yaml
+++ b/test/integration/manifests/cilium/v1.17/cilium-config/cilium-config-hubble.yaml
@@ -73,10 +73,10 @@ data:
   tofqdns-endpoint-max-ip-per-hostname: "1000"
   tofqdns-idle-connection-grace-period: 0s
   tofqdns-max-deferred-connection-deletes: "10000"
-  tofqdns-min-ttl: "0"
+  tofqdns-min-ttl: "3600"
   tofqdns-proxy-response-max-delay: 100ms
   routing-mode: native
-  unmanaged-pod-watcher-interval: "15"
+  unmanaged-pod-watcher-interval: "0"
   vtep-cidr: ""
   vtep-endpoint: ""
   vtep-mac: ""
@@ -86,7 +86,7 @@ data:
   external-envoy-proxy: "false"
   k8s-client-qps: "10"
   k8s-client-burst: "20"
-  mesh-auth-enabled: "true"
+  mesh-auth-enabled: "false"
   mesh-auth-queue-size: "1024"
   mesh-auth-rotated-identities-queue-size: "1024"
   mesh-auth-gc-interval: "5m0s"
@@ -94,7 +94,7 @@ data:
   proxy-max-requests-per-connection: "0"
   proxy-max-connection-duration-seconds: "0"
   set-cilium-node-taints: "true"
-  unmanaged-pod-watcher-interval: "15"
+  unmanaged-pod-watcher-interval: "0"
   ## new values added for 1.16 below
   enable-ipv4-big-tcp: "false"
   enable-ipv6-big-tcp: "false"

--- a/test/integration/manifests/cilium/v1.17/cilium-config/cilium-config.yaml
+++ b/test/integration/manifests/cilium/v1.17/cilium-config/cilium-config.yaml
@@ -68,10 +68,10 @@ data:
   tofqdns-endpoint-max-ip-per-hostname: "1000"
   tofqdns-idle-connection-grace-period: 0s
   tofqdns-max-deferred-connection-deletes: "10000"
-  tofqdns-min-ttl: "0"
+  tofqdns-min-ttl: "3600"
   tofqdns-proxy-response-max-delay: 100ms
   routing-mode: native
-  unmanaged-pod-watcher-interval: "15"
+  unmanaged-pod-watcher-interval: "0"
   vtep-cidr: ""
   vtep-endpoint: ""
   vtep-mac: ""
@@ -80,7 +80,7 @@ data:
   external-envoy-proxy: "false"
   k8s-client-qps: "10"
   k8s-client-burst: "20"
-  mesh-auth-enabled: "true"
+  mesh-auth-enabled: "false"
   mesh-auth-queue-size: "1024"
   mesh-auth-rotated-identities-queue-size: "1024"
   mesh-auth-gc-interval: "5m0s"
@@ -88,7 +88,7 @@ data:
   proxy-max-requests-per-connection: "0"
   proxy-max-connection-duration-seconds: "0"
   set-cilium-node-taints: "true"
-  unmanaged-pod-watcher-interval: "15"
+  unmanaged-pod-watcher-interval: "0"
 ## new values added for 1.16 below
   enable-ipv4-big-tcp: "false"
   enable-ipv6-big-tcp: "false"

--- a/test/integration/manifests/cilium/v1.17/cilium-config/cilium-config.yaml
+++ b/test/integration/manifests/cilium/v1.17/cilium-config/cilium-config.yaml
@@ -125,7 +125,7 @@ data:
   enable-endpoint-lockdown-on-policy-overflow: "false"
   health-check-icmp-failure-threshold: "3"
   enable-internal-traffic-policy: "true"
-  enable-lb-ipam: "true"
+  enable-lb-ipam: "false"
   enable-non-default-deny-policies: "true"
   enable-source-ip-verification: "true"
 kind: ConfigMap

--- a/test/integration/manifests/cilium/v1.17/ebpf/dualstack/static/cilium-config.yaml
+++ b/test/integration/manifests/cilium/v1.17/ebpf/dualstack/static/cilium-config.yaml
@@ -95,7 +95,7 @@ data:
   kube-proxy-replacement: "true"
   local-router-ipv4: 169.254.23.0
   local-router-ipv6: 'fe80::'
-  mesh-auth-enabled: "true"
+  mesh-auth-enabled: "false"
   mesh-auth-gc-interval: 5m0s
   mesh-auth-queue-size: "1024"
   mesh-auth-rotated-identities-queue-size: "1024"
@@ -127,9 +127,9 @@ data:
   tofqdns-endpoint-max-ip-per-hostname: "1000"
   tofqdns-idle-connection-grace-period: 0s
   tofqdns-max-deferred-connection-deletes: "10000"
-  tofqdns-min-ttl: "0"
+  tofqdns-min-ttl: "3600"
   tofqdns-proxy-response-max-delay: 100ms
-  unmanaged-pod-watcher-interval: "15"
+  unmanaged-pod-watcher-interval: "0"
   vtep-cidr: ""
   vtep-endpoint: ""
   vtep-mac: ""

--- a/test/integration/manifests/cilium/v1.18/cilium-config/cilium-config-dualstack.yaml
+++ b/test/integration/manifests/cilium/v1.18/cilium-config/cilium-config-dualstack.yaml
@@ -72,10 +72,10 @@ data:
   tofqdns-endpoint-max-ip-per-hostname: "1000"
   tofqdns-idle-connection-grace-period: 0s
   tofqdns-max-deferred-connection-deletes: "10000"
-  tofqdns-min-ttl: "0"
+  tofqdns-min-ttl: "3600"
   tofqdns-proxy-response-max-delay: 100ms
   routing-mode: native
-  unmanaged-pod-watcher-interval: "15"
+  unmanaged-pod-watcher-interval: "0"
   vtep-cidr: ""
   vtep-endpoint: ""
   vtep-mac: ""
@@ -84,7 +84,7 @@ data:
   external-envoy-proxy: "false"
   k8s-client-qps: "10"
   k8s-client-burst: "20"
-  mesh-auth-enabled: "true"
+  mesh-auth-enabled: "false"
   mesh-auth-queue-size: "1024"
   mesh-auth-rotated-identities-queue-size: "1024"
   mesh-auth-gc-interval: "5m0s"

--- a/test/integration/manifests/cilium/v1.18/cilium-config/cilium-config-hubble.yaml
+++ b/test/integration/manifests/cilium/v1.18/cilium-config/cilium-config-hubble.yaml
@@ -73,10 +73,10 @@ data:
   tofqdns-endpoint-max-ip-per-hostname: "1000"
   tofqdns-idle-connection-grace-period: 0s
   tofqdns-max-deferred-connection-deletes: "10000"
-  tofqdns-min-ttl: "0"
+  tofqdns-min-ttl: "3600"
   tofqdns-proxy-response-max-delay: 100ms
   routing-mode: native
-  unmanaged-pod-watcher-interval: "15"
+  unmanaged-pod-watcher-interval: "0"
   vtep-cidr: ""
   vtep-endpoint: ""
   vtep-mac: ""
@@ -86,7 +86,7 @@ data:
   external-envoy-proxy: "false"
   k8s-client-qps: "10"
   k8s-client-burst: "20"
-  mesh-auth-enabled: "true"
+  mesh-auth-enabled: "false"
   mesh-auth-queue-size: "1024"
   mesh-auth-rotated-identities-queue-size: "1024"
   mesh-auth-gc-interval: "5m0s"

--- a/test/integration/manifests/cilium/v1.18/cilium-config/cilium-config.yaml
+++ b/test/integration/manifests/cilium/v1.18/cilium-config/cilium-config.yaml
@@ -68,10 +68,10 @@ data:
   tofqdns-endpoint-max-ip-per-hostname: "1000"
   tofqdns-idle-connection-grace-period: 0s
   tofqdns-max-deferred-connection-deletes: "10000"
-  tofqdns-min-ttl: "0"
+  tofqdns-min-ttl: "3600"
   tofqdns-proxy-response-max-delay: 100ms
   routing-mode: native
-  unmanaged-pod-watcher-interval: "15"
+  unmanaged-pod-watcher-interval: "0"
   vtep-cidr: ""
   vtep-endpoint: ""
   vtep-mac: ""
@@ -80,7 +80,7 @@ data:
   external-envoy-proxy: "false"
   k8s-client-qps: "10"
   k8s-client-burst: "20"
-  mesh-auth-enabled: "true"
+  mesh-auth-enabled: "false"
   mesh-auth-queue-size: "1024"
   mesh-auth-rotated-identities-queue-size: "1024"
   mesh-auth-gc-interval: "5m0s"

--- a/test/integration/manifests/cilium/v1.18/cilium-config/cilium-config.yaml
+++ b/test/integration/manifests/cilium/v1.18/cilium-config/cilium-config.yaml
@@ -126,7 +126,7 @@ data:
   enable-internal-traffic-policy: "true"
   enable-lb-ipam: "false"
   enable-non-default-deny-policies: "true"
-  enable-source-ip-verification: "false"
+  enable-source-ip-verification: "true"
 ## new values for 1.18
   # bpf-policy-stats-map-max specifies the maximum number of entries in global
   # policy stats map

--- a/test/integration/manifests/cilium/v1.18/ebpf/dualstack/static/cilium-config.yaml
+++ b/test/integration/manifests/cilium/v1.18/ebpf/dualstack/static/cilium-config.yaml
@@ -95,7 +95,7 @@ data:
   kube-proxy-replacement: "true"
   local-router-ipv4: 169.254.23.0
   local-router-ipv6: 'fe80::'
-  mesh-auth-enabled: "true"
+  mesh-auth-enabled: "false"
   mesh-auth-gc-interval: 5m0s
   mesh-auth-queue-size: "1024"
   mesh-auth-rotated-identities-queue-size: "1024"
@@ -127,9 +127,9 @@ data:
   tofqdns-endpoint-max-ip-per-hostname: "1000"
   tofqdns-idle-connection-grace-period: 0s
   tofqdns-max-deferred-connection-deletes: "10000"
-  tofqdns-min-ttl: "0"
+  tofqdns-min-ttl: "3600"
   tofqdns-proxy-response-max-delay: 100ms
-  unmanaged-pod-watcher-interval: "15"
+  unmanaged-pod-watcher-interval: "0"
   vtep-cidr: ""
   vtep-endpoint: ""
   vtep-mac: ""

--- a/test/integration/manifests/cilium/v1.19/cilium-config/cilium-config-dualstack.yaml
+++ b/test/integration/manifests/cilium/v1.19/cilium-config/cilium-config-dualstack.yaml
@@ -72,10 +72,10 @@ data:
   tofqdns-endpoint-max-ip-per-hostname: "1000"
   tofqdns-idle-connection-grace-period: 0s
   tofqdns-max-deferred-connection-deletes: "10000"
-  tofqdns-min-ttl: "0"
+  tofqdns-min-ttl: "3600"
   tofqdns-proxy-response-max-delay: 100ms
   routing-mode: native
-  unmanaged-pod-watcher-interval: "15s"
+  unmanaged-pod-watcher-interval: "0s"
   vtep-cidr: ""
   vtep-endpoint: ""
   vtep-mac: ""
@@ -84,7 +84,7 @@ data:
   external-envoy-proxy: "false"
   k8s-client-qps: "10"
   k8s-client-burst: "20"
-  mesh-auth-enabled: "true"
+  mesh-auth-enabled: "false"
   mesh-auth-queue-size: "1024"
   mesh-auth-rotated-identities-queue-size: "1024"
   mesh-auth-gc-interval: "5m0s"

--- a/test/integration/manifests/cilium/v1.19/cilium-config/cilium-config-hubble.yaml
+++ b/test/integration/manifests/cilium/v1.19/cilium-config/cilium-config-hubble.yaml
@@ -85,10 +85,10 @@ data:
   tofqdns-endpoint-max-ip-per-hostname: "1000"
   tofqdns-idle-connection-grace-period: 0s
   tofqdns-max-deferred-connection-deletes: "10000"
-  tofqdns-min-ttl: "0"
+  tofqdns-min-ttl: "3600"
   tofqdns-proxy-response-max-delay: 100ms
   routing-mode: native
-  unmanaged-pod-watcher-interval: "15s"
+  unmanaged-pod-watcher-interval: "0s"
   vtep-cidr: ""
   vtep-endpoint: ""
   vtep-mac: ""
@@ -98,7 +98,7 @@ data:
   external-envoy-proxy: "false"
   k8s-client-qps: "10"
   k8s-client-burst: "20"
-  mesh-auth-enabled: "true"
+  mesh-auth-enabled: "false"
   mesh-auth-queue-size: "1024"
   mesh-auth-rotated-identities-queue-size: "1024"
   mesh-auth-gc-interval: "5m0s"

--- a/test/integration/manifests/cilium/v1.19/cilium-config/cilium-config.yaml
+++ b/test/integration/manifests/cilium/v1.19/cilium-config/cilium-config.yaml
@@ -126,7 +126,7 @@ data:
   enable-internal-traffic-policy: "true"
   enable-lb-ipam: "false"
   enable-non-default-deny-policies: "true"
-  enable-source-ip-verification: "false"
+  enable-source-ip-verification: "true"
 ## new values for 1.18
   # bpf-policy-stats-map-max specifies the maximum number of entries in global
   # policy stats map

--- a/test/integration/manifests/cilium/v1.19/cilium-config/cilium-config.yaml
+++ b/test/integration/manifests/cilium/v1.19/cilium-config/cilium-config.yaml
@@ -68,10 +68,10 @@ data:
   tofqdns-endpoint-max-ip-per-hostname: "1000"
   tofqdns-idle-connection-grace-period: 0s
   tofqdns-max-deferred-connection-deletes: "10000"
-  tofqdns-min-ttl: "0"
+  tofqdns-min-ttl: "3600"
   tofqdns-proxy-response-max-delay: 100ms
   routing-mode: native
-  unmanaged-pod-watcher-interval: "15s"
+  unmanaged-pod-watcher-interval: "0s"
   vtep-cidr: ""
   vtep-endpoint: ""
   vtep-mac: ""
@@ -80,7 +80,7 @@ data:
   external-envoy-proxy: "false"
   k8s-client-qps: "10"
   k8s-client-burst: "20"
-  mesh-auth-enabled: "true"
+  mesh-auth-enabled: "false"
   mesh-auth-queue-size: "1024"
   mesh-auth-rotated-identities-queue-size: "1024"
   mesh-auth-gc-interval: "5m0s"

--- a/test/integration/manifests/cilium/v1.19/ebpf/dualstack/static/cilium-config.yaml
+++ b/test/integration/manifests/cilium/v1.19/ebpf/dualstack/static/cilium-config.yaml
@@ -95,7 +95,7 @@ data:
   kube-proxy-replacement: "true"
   local-router-ipv4: 169.254.23.0
   local-router-ipv6: 'fe80::'
-  mesh-auth-enabled: "true"
+  mesh-auth-enabled: "false"
   mesh-auth-gc-interval: 5m0s
   mesh-auth-queue-size: "1024"
   mesh-auth-rotated-identities-queue-size: "1024"
@@ -127,9 +127,9 @@ data:
   tofqdns-endpoint-max-ip-per-hostname: "1000"
   tofqdns-idle-connection-grace-period: 0s
   tofqdns-max-deferred-connection-deletes: "10000"
-  tofqdns-min-ttl: "0"
+  tofqdns-min-ttl: "3600"
   tofqdns-proxy-response-max-delay: 100ms
-  unmanaged-pod-watcher-interval: "15"
+  unmanaged-pod-watcher-interval: "0s"
   vtep-cidr: ""
   vtep-endpoint: ""
   vtep-mac: ""

--- a/test/integration/manifests/cilium/v1.19/ebpf/overlay/static/cilium-config.yaml
+++ b/test/integration/manifests/cilium/v1.19/ebpf/overlay/static/cilium-config.yaml
@@ -149,7 +149,7 @@ data:
   tofqdns-proxy-port: "40046"
   tofqdns-proxy-response-max-delay: 100ms
   tofqdns-server-port: "40045"
-  unmanaged-pod-watcher-interval: "0"
+  unmanaged-pod-watcher-interval: "0s"
   vtep-cidr: ""
   vtep-endpoint: ""
   vtep-mac: ""

--- a/test/integration/manifests/cilium/v1.19/ebpf/podsubnet/static/cilium-config.yaml
+++ b/test/integration/manifests/cilium/v1.19/ebpf/podsubnet/static/cilium-config.yaml
@@ -149,7 +149,7 @@ data:
   tofqdns-proxy-port: "40046"
   tofqdns-proxy-response-max-delay: 100ms
   tofqdns-server-port: "40045"
-  unmanaged-pod-watcher-interval: "0"
+  unmanaged-pod-watcher-interval: "0s"
   vtep-cidr: ""
   vtep-endpoint: ""
   vtep-mac: ""


### PR DESCRIPTION
The base cilium-config.yaml for these versions had drifted from the cilium-private test manifests and the AKS-RP product synth:
- v1.17: enable-lb-ipam was "true"; product/cilium-private use "false"
- v1.18/v1.19: enable-source-ip-verification was "false"; product/cilium-private use "true"

Align the base ConfigMaps to the product source of truth. Mode-specific variants (hubble/dualstack/ebpf overlay|podsubnet) carry intentional per-mode values and are left unchanged.