### PR TITLE
fix(hack/aks): make vnet create idempotent in swift-net-up and siblings

### DIFF
--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -150,12 +150,14 @@ swift-net-up: ## Create vnet, nodenet and podnet subnets
 	$(AZCLI) network vnet subnet create -g $(GROUP) --vnet-name $(VNET) --name podnet --address-prefixes 10.241.0.0/16 -o none
 
 vnetscale-swift-net-up: ## Create vnet, nodenet and podnet subnets for vnet scale
-	$(AZCLI) network vnet create -g $(GROUP) -l $(REGION) --name $(VNET) --address-prefixes 10.0.0.0/8 -o none
+	@$(AZCLI) network vnet show -g $(GROUP) --name $(VNET) -o none 2>/dev/null || \
+		$(AZCLI) network vnet create -g $(GROUP) -l $(REGION) --name $(VNET) --address-prefixes 10.0.0.0/8 -o none
 	$(AZCLI) network vnet subnet create -g $(GROUP) --vnet-name $(VNET) --name nodenet --address-prefixes 10.240.0.0/16 -o none
 	$(AZCLI) network vnet subnet create -g $(GROUP) --vnet-name $(VNET) --name podnet --address-prefixes 10.40.0.0/13 -o none
 
 overlay-net-up: ## Create vnet, nodenet subnets
-	$(AZCLI) network vnet create -g $(GROUP) -l $(REGION) --name $(VNET) --address-prefixes 10.0.0.0/8 -o none
+	@$(AZCLI) network vnet show -g $(GROUP) --name $(VNET) -o none 2>/dev/null || \
+		$(AZCLI) network vnet create -g $(GROUP) -l $(REGION) --name $(VNET) --address-prefixes 10.0.0.0/8 -o none
 	$(AZCLI) network vnet subnet create -g $(GROUP) --vnet-name $(VNET) --name nodenet --address-prefix 10.10.0.0/16 -o none
 
 ##@ AKS Clusters

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -144,7 +144,8 @@ rg-down: ## Delete resource group
 	$(AZCLI) group delete -g $(GROUP) --yes
 
 swift-net-up: ## Create vnet, nodenet and podnet subnets
-	$(AZCLI) network vnet create -g $(GROUP) -l $(REGION) --name $(VNET) --address-prefixes 10.0.0.0/8 -o none
+	@$(AZCLI) network vnet show -g $(GROUP) --name $(VNET) -o none 2>/dev/null || \
+		$(AZCLI) network vnet create -g $(GROUP) -l $(REGION) --name $(VNET) --address-prefixes 10.0.0.0/8 -o none
 	$(AZCLI) network vnet subnet create -g $(GROUP) --vnet-name $(VNET) --name nodenet --address-prefixes 10.240.0.0/16 -o none
 	$(AZCLI) network vnet subnet create -g $(GROUP) --vnet-name $(VNET) --name podnet --address-prefixes 10.241.0.0/16 -o none
 


### PR DESCRIPTION
## What
Guard `az network vnet create` with a `vnet show` in the `swift-net-up`, `vnetscale-swift-net-up`, and `overlay-net-up` targets, so create only runs when the vnet is missing.

## Why
On the persistent SwiftV2 long-running clusters, re-running `swift-net-up` failed at vnet creation with:

```
ERROR: (TagUpdateNotSupportedForVNetWithServiceStamp) Tag stampcreatorserviceinfo cannot be removed from or set to false on a virtual network that has been stamped ...
make: *** [Makefile:147: swift-net-up] Error 1
```

The vnet already exists and is stamped by the subnet delegator. `az network vnet create` tries to reset the `stampcreatorserviceinfo` tag, which Azure rejects. Skipping create when the vnet exists makes the target idempotent. This broke infra setup in the swiftv2-long-running-cluster pipeline.

## Change
- `hack/aks/Makefile`: `swift-net-up`, `vnetscale-swift-net-up`, and `overlay-net-up` run `vnet create` only when `vnet show` fails (vnet missing). Subnet creates unchanged. No behavior change on a fresh resource group.