### PR TITLE
fix: skip aks-preview install if already present to avoid checksum failures

### DIFF
--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -86,8 +86,8 @@ azlogin: ## Login and set account to $SUB
 	@$(AZCLI) account set -s $(SUB)
 
 azcfg: ## Set the $AZCLI to use aks-preview
-	@$(AZCLI) extension add --name aks-preview --yes
-	@$(AZCLI) extension update --name aks-preview
+	@$(AZCLI) extension show --name aks-preview &>/dev/null || $(AZCLI) extension add --name aks-preview --yes
+	@$(AZCLI) extension update --name aks-preview || true
 
 ip:
 	$(AZCLI) network public-ip create --name $(IP_PREFIX)-$(CLUSTER)-$(IPVERSION) \


### PR DESCRIPTION
## Problem
The `az extension add --name aks-preview` command fails with:
```
ERROR: The checksum of the extension does not match the expected value.
```
This blocks all integration tests that create clusters.

## Fix
- Skip install if `aks-preview` is already present on the agent
- Tolerate `az extension update` failures gracefully (CDN propagation issues)

## Change
```makefile
# Before
@$(AZCLI) extension add --name aks-preview --yes
@$(AZCLI) extension update --name aks-preview

# After
@$(AZCLI) extension show --name aks-preview &>/dev/null || $(AZCLI) extension add --name aks-preview --yes
@$(AZCLI) extension update --name aks-preview || true
```