### PR TITLE
ci: pin aks-preview to 21.0.0b7 (upstream b9 checksum mismatch)

### DIFF
--- a/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
+++ b/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
@@ -84,7 +84,8 @@ stages:
                 addSpnToEnvironment: true
                 inlineScript: |
                   set -ex
-                  az extension add --name aks-preview
+                  # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
+                  az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
                   make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(commitID)
                   ls -lah
                   pwd
@@ -127,7 +128,8 @@ stages:
                 addSpnToEnvironment: true
                 inlineScript: |
                   set -ex
-                  az extension add --name aks-preview
+                  # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
+                  az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
                   make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(commitID)
                   ls -lah
                   pwd
@@ -157,7 +159,8 @@ stages:
               addSpnToEnvironment: true
               inlineScript: |
                 set -ex
-                az extension add --name aks-preview
+                # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
+                az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
                 make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(commitID)
                 ls -lah
                 pwd

--- a/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
+++ b/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
@@ -84,8 +84,7 @@ stages:
                 addSpnToEnvironment: true
                 inlineScript: |
                   set -ex
-                  # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
-                  az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
+                  make -C ./hack/aks azcfg AZCLI=az
                   make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(commitID)
                   ls -lah
                   pwd
@@ -128,8 +127,7 @@ stages:
                 addSpnToEnvironment: true
                 inlineScript: |
                   set -ex
-                  # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
-                  az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
+                  make -C ./hack/aks azcfg AZCLI=az
                   make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(commitID)
                   ls -lah
                   pwd
@@ -159,8 +157,7 @@ stages:
               addSpnToEnvironment: true
               inlineScript: |
                 set -ex
-                # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
-                az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
+                make -C ./hack/aks azcfg AZCLI=az
                 make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(commitID)
                 ls -lah
                 pwd

--- a/.pipelines/cni/cilium/cilium-scale-test.yaml
+++ b/.pipelines/cni/cilium/cilium-scale-test.yaml
@@ -17,8 +17,7 @@ stages:
               addSpnToEnvironment: true
               inlineScript: |
                 set -ex
-                # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
-                az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
+                make -C ./hack/aks azcfg AZCLI=az
 
                 subscriptionId="$(az account list --query "[?isDefault].id" --output tsv)"
                 make -C ./hack/aks AZCLI=az ${CLUSTER_TYPE} CLUSTER=${CLUSTER} GROUP=${RESOURCE_GROUP} REGION=${LOCATION} NODE_COUNT=5 VM_SIZE=${VMSIZE} SUB=${subscriptionId} || {

--- a/.pipelines/cni/cilium/cilium-scale-test.yaml
+++ b/.pipelines/cni/cilium/cilium-scale-test.yaml
@@ -17,7 +17,8 @@ stages:
               addSpnToEnvironment: true
               inlineScript: |
                 set -ex
-                az extension add --name aks-preview
+                # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
+                az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
 
                 subscriptionId="$(az account list --query "[?isDefault].id" --output tsv)"
                 make -C ./hack/aks AZCLI=az ${CLUSTER_TYPE} CLUSTER=${CLUSTER} GROUP=${RESOURCE_GROUP} REGION=${LOCATION} NODE_COUNT=5 VM_SIZE=${VMSIZE} SUB=${subscriptionId} || {

--- a/.pipelines/cni/load-test-templates/pod-deployment-template.yaml
+++ b/.pipelines/cni/load-test-templates/pod-deployment-template.yaml
@@ -18,7 +18,8 @@ steps:
       addSpnToEnvironment: true
       inlineScript: |
         set -ex
-        az extension add --name aks-preview
+        # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
+        az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
         make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
         cd test/integration/load
         scale=$(( ${{ parameters.scaleup }} * ${{ parameters.nodeCount }} ))

--- a/.pipelines/cni/load-test-templates/pod-deployment-template.yaml
+++ b/.pipelines/cni/load-test-templates/pod-deployment-template.yaml
@@ -18,8 +18,7 @@ steps:
       addSpnToEnvironment: true
       inlineScript: |
         set -ex
-        # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
-        az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
+        make -C ./hack/aks azcfg AZCLI=az
         make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
         cd test/integration/load
         scale=$(( ${{ parameters.scaleup }} * ${{ parameters.nodeCount }} ))

--- a/.pipelines/cni/lsg/kernel-upgrade-template.yaml
+++ b/.pipelines/cni/lsg/kernel-upgrade-template.yaml
@@ -10,7 +10,8 @@ steps:
       addSpnToEnvironment: true
       inlineScript: |
         set -ex
-        az extension add --name aks-preview
+        # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
+        az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
         make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
     retryCountOnTaskFailure: 3
     displayName: "Set Kubeconfig"

--- a/.pipelines/cni/lsg/kernel-upgrade-template.yaml
+++ b/.pipelines/cni/lsg/kernel-upgrade-template.yaml
@@ -10,8 +10,7 @@ steps:
       addSpnToEnvironment: true
       inlineScript: |
         set -ex
-        # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
-        az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
+        make -C ./hack/aks azcfg AZCLI=az
         make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
     retryCountOnTaskFailure: 3
     displayName: "Set Kubeconfig"

--- a/.pipelines/cni/lsg/lsg-cni-integration-template.yaml
+++ b/.pipelines/cni/lsg/lsg-cni-integration-template.yaml
@@ -114,7 +114,7 @@ stages:
                 inlineScript: |
                   set -ex
                   # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
-                  az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
+                  make -C ./hack/aks azcfg AZCLI=az
                   make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(commitID)
                   ls -lah
                   pwd

--- a/.pipelines/cni/lsg/lsg-cni-integration-template.yaml
+++ b/.pipelines/cni/lsg/lsg-cni-integration-template.yaml
@@ -113,7 +113,8 @@ stages:
                 addSpnToEnvironment: true
                 inlineScript: |
                   set -ex
-                  az extension add --name aks-preview
+                  # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
+                  az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
                   make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(commitID)
                   ls -lah
                   pwd

--- a/.pipelines/npm/npm-conformance-tests-latest-release.yaml
+++ b/.pipelines/npm/npm-conformance-tests-latest-release.yaml
@@ -126,8 +126,7 @@ jobs:
 
             if [[ $(AZURE_CLUSTER) == *ws22 ]] # * is used for pattern matching
             then
-              # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
-              az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
+              make -C ./hack/aks azcfg AZCLI=az
 
               echo "creating WS22 Cluster";
               az aks create \

--- a/.pipelines/npm/npm-conformance-tests-latest-release.yaml
+++ b/.pipelines/npm/npm-conformance-tests-latest-release.yaml
@@ -126,8 +126,8 @@ jobs:
 
             if [[ $(AZURE_CLUSTER) == *ws22 ]] # * is used for pattern matching
             then
-              az extension add --name aks-preview
-              az extension update --name aks-preview
+              # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
+              az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
 
               echo "creating WS22 Cluster";
               az aks create \

--- a/.pipelines/npm/npm-cyc-win-tests-latest-release.yaml
+++ b/.pipelines/npm/npm-cyc-win-tests-latest-release.yaml
@@ -66,8 +66,8 @@ jobs:
           scriptLocation: "inlineScript"
           failOnStderr: true
           inlineScript: |
-            az extension add --name aks-preview
-            az extension update --name aks-preview
+            # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
+            az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
 
             export CLUSTER_NAME=$(RESOURCE_GROUP)
 

--- a/.pipelines/npm/npm-cyc-win-tests-latest-release.yaml
+++ b/.pipelines/npm/npm-cyc-win-tests-latest-release.yaml
@@ -66,8 +66,7 @@ jobs:
           scriptLocation: "inlineScript"
           failOnStderr: true
           inlineScript: |
-            # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
-            az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
+            make -C ./hack/aks azcfg AZCLI=az
 
             export CLUSTER_NAME=$(RESOURCE_GROUP)
 

--- a/.pipelines/npm/npm-scale-test.yaml
+++ b/.pipelines/npm/npm-scale-test.yaml
@@ -133,8 +133,7 @@ jobs:
           condition: succeeded()
           inlineScript: |
             set -e
-            # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
-            az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
+            make -C ./hack/aks azcfg AZCLI=az
 
             echo "Creating resource group named $(RESOURCE_GROUP)"
             az group create --name $(RESOURCE_GROUP) -l $(LOCATION) -o table

--- a/.pipelines/npm/npm-scale-test.yaml
+++ b/.pipelines/npm/npm-scale-test.yaml
@@ -133,8 +133,8 @@ jobs:
           condition: succeeded()
           inlineScript: |
             set -e
-            az extension add --name aks-preview
-            az extension update --name aks-preview
+            # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
+            az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
 
             echo "Creating resource group named $(RESOURCE_GROUP)"
             az group create --name $(RESOURCE_GROUP) -l $(LOCATION) -o table

--- a/.pipelines/templates/create-cluster-steps.yaml
+++ b/.pipelines/templates/create-cluster-steps.yaml
@@ -23,12 +23,6 @@ steps:
         set -e
         echo "Check az version"
         az version
-        if ${{ lower(contains(parameters.clusterType, 'dualstack')) }}
-        then
-          echo "Install az cli extension preview"
-          # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
-          az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
-        fi
 
         if ! [ -z ${{ parameters.k8sVersion }} ]; then
           echo "Set K8S_VER with ${{ parameters.k8sVersion }}"

--- a/.pipelines/templates/create-cluster-steps.yaml
+++ b/.pipelines/templates/create-cluster-steps.yaml
@@ -26,8 +26,8 @@ steps:
         if ${{ lower(contains(parameters.clusterType, 'dualstack')) }}
         then
           echo "Install az cli extension preview"
-          az extension add --name aks-preview
-          az extension update --name aks-preview
+          # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
+          az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
         fi
 
         if ! [ -z ${{ parameters.k8sVersion }} ]; then

--- a/.pipelines/templates/create-cluster-swiftv2.yaml
+++ b/.pipelines/templates/create-cluster-swiftv2.yaml
@@ -16,12 +16,6 @@ jobs:
             set -e
             echo "Check az version"
             az version
-            if ${{ lower(contains(parameters.clusterType, 'dualstack')) }}
-            then
-              echo "Install az cli extension preview"
-              # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
-              az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
-            fi
             mkdir -p ~/.kube/
             make -C ./hack/aks azcfg AZCLI=az REGION=${{ parameters.region }}
 

--- a/.pipelines/templates/create-cluster-swiftv2.yaml
+++ b/.pipelines/templates/create-cluster-swiftv2.yaml
@@ -19,8 +19,8 @@ jobs:
             if ${{ lower(contains(parameters.clusterType, 'dualstack')) }}
             then
               echo "Install az cli extension preview"
-              az extension add --name aks-preview
-              az extension update --name aks-preview
+              # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
+              az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
             fi
             mkdir -p ~/.kube/
             make -C ./hack/aks azcfg AZCLI=az REGION=${{ parameters.region }}

--- a/.pipelines/templates/create-cluster.jobs.yaml
+++ b/.pipelines/templates/create-cluster.jobs.yaml
@@ -39,7 +39,8 @@ jobs:
             mkdir -p ~/.kube/
             # make -C ./hack/aks azcfg AZCLI=az REGION=${{ parameters.region }}
 
-            az extension add --name aks-preview --upgrade
+            # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
+            az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
 
             make -C ./hack/aks ${{ parameters.clusterType }} \
             AZCLI=az REGION=${{ parameters.region }} SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) \

--- a/.pipelines/templates/create-cluster.jobs.yaml
+++ b/.pipelines/templates/create-cluster.jobs.yaml
@@ -37,10 +37,7 @@ jobs:
             fi
 
             mkdir -p ~/.kube/
-            # make -C ./hack/aks azcfg AZCLI=az REGION=${{ parameters.region }}
-
-            # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
-            az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
+            make -C ./hack/aks azcfg AZCLI=az REGION=${{ parameters.region }}
 
             make -C ./hack/aks ${{ parameters.clusterType }} \
             AZCLI=az REGION=${{ parameters.region }} SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) \

--- a/.pipelines/templates/create-cluster.yaml
+++ b/.pipelines/templates/create-cluster.yaml
@@ -28,9 +28,6 @@ jobs:
             az version
             if ${{ lower(contains(parameters.clusterType, 'dualstack')) }}
             then
-              echo "Install az cli extension preview"
-              # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
-              az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
               export POD_CIDRS="10.244.0.0/16,fdd5:a27a:b4bc:99d6::/64"
             fi
 

--- a/.pipelines/templates/create-cluster.yaml
+++ b/.pipelines/templates/create-cluster.yaml
@@ -29,8 +29,8 @@ jobs:
             if ${{ lower(contains(parameters.clusterType, 'dualstack')) }}
             then
               echo "Install az cli extension preview"
-              az extension add --name aks-preview
-              az extension update --name aks-preview
+              # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
+              az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
               export POD_CIDRS="10.244.0.0/16,fdd5:a27a:b4bc:99d6::/64"
             fi
 

--- a/.pipelines/templates/create-multitenant-cluster.steps.yaml
+++ b/.pipelines/templates/create-multitenant-cluster.steps.yaml
@@ -35,8 +35,8 @@ steps:
       if ${{ lower(contains(parameters.clusterType, 'dualstack')) }}
       then
         echo "Install az cli extension preview"
-        az extension add --name aks-preview
-        az extension update --name aks-preview
+        # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
+        az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
       fi
       mkdir -p ~/.kube/
       make -C ./hack/aks azcfg AZCLI=az REGION=${{ parameters.region }}

--- a/.pipelines/templates/create-multitenant-cluster.steps.yaml
+++ b/.pipelines/templates/create-multitenant-cluster.steps.yaml
@@ -32,12 +32,6 @@ steps:
       set -e
       echo "Check az version"
       az version
-      if ${{ lower(contains(parameters.clusterType, 'dualstack')) }}
-      then
-        echo "Install az cli extension preview"
-        # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
-        az extension add --name aks-preview --version 21.0.0b7 --upgrade --yes
-      fi
       mkdir -p ~/.kube/
       make -C ./hack/aks azcfg AZCLI=az REGION=${{ parameters.region }}
 

--- a/.pipelines/templates/delete-cluster.steps.yaml
+++ b/.pipelines/templates/delete-cluster.steps.yaml
@@ -12,9 +12,7 @@ steps:
       addSpnToEnvironment: true
       inlineScript: |
         echo "Deleting cluster"
-        # make -C ./hack/aks azcfg AZCLI=az REGION=${{ parameters.region }}
-        #Temp fix for azcli aks preview bug
-        az extension add --name aks-preview --version 14.0.0b3
+        make -C ./hack/aks azcfg AZCLI=az REGION=${{ parameters.region }}
         make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
         make -C ./hack/aks down AZCLI=az REGION=${{ parameters.region }} SUB=${{ parameters.sub }} CLUSTER=${{ parameters.clusterName }}
         echo "Cluster and resources down"

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -85,9 +85,13 @@ azlogin: ## Login and set account to $SUB
 	@$(AZCLI) login
 	@$(AZCLI) account set -s $(SUB)
 
-azcfg: ## Set the $AZCLI to use aks-preview
-	@$(AZCLI) extension add --name aks-preview --yes
-	@$(AZCLI) extension update --name aks-preview
+# Pinned to work around aks-preview 21.0.0b9 checksum mismatch upstream.
+# Track: https://github.com/Azure/azure-cli-extensions/issues/10101
+# Revert this pin (drop --version) once b9/b10 is republished with a matching checksum.
+AKS_PREVIEW_VERSION ?= 21.0.0b7
+
+azcfg: ## Set the $AZCLI to use aks-preview (pinned via AKS_PREVIEW_VERSION)
+	@$(AZCLI) extension add --name aks-preview --version $(AKS_PREVIEW_VERSION) --upgrade --yes
 
 ip:
 	$(AZCLI) network public-ip create --name $(IP_PREFIX)-$(CLUSTER)-$(IPVERSION) \

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -85,13 +85,20 @@ azlogin: ## Login and set account to $SUB
 	@$(AZCLI) login
 	@$(AZCLI) account set -s $(SUB)
 
-# Pinned to work around aks-preview 21.0.0b9 checksum mismatch upstream.
+# Fallback pin to work around aks-preview upstream breaks (checksum mismatches, etc.).
 # Track: https://github.com/Azure/azure-cli-extensions/issues/10101
-# Revert this pin (drop --version) once b9/b10 is republished with a matching checksum.
-AKS_PREVIEW_VERSION ?= 21.0.0b7
+# azcfg tries the latest aks-preview first; if that fails (e.g., broken upstream
+# publish like 21.0.0b9), it falls back to this known-good version so CI keeps
+# moving without a manual intervention. Bump this to the newest verified-good
+# release when needed.
+AKS_PREVIEW_FALLBACK_VERSION ?= 21.0.0b7
 
-azcfg: ## Set the $AZCLI to use aks-preview (pinned via AKS_PREVIEW_VERSION)
-	@$(AZCLI) extension add --name aks-preview --version $(AKS_PREVIEW_VERSION) --upgrade --yes
+azcfg: ## Install aks-preview (latest, falling back to AKS_PREVIEW_FALLBACK_VERSION on failure)
+	@$(AZCLI) extension add --name aks-preview --upgrade --yes \
+		|| { \
+			echo "aks-preview latest install failed; falling back to $(AKS_PREVIEW_FALLBACK_VERSION) (see Azure/azure-cli-extensions#10101)"; \
+			$(AZCLI) extension add --name aks-preview --version $(AKS_PREVIEW_FALLBACK_VERSION) --upgrade --yes; \
+		}
 
 ip:
 	$(AZCLI) network public-ip create --name $(IP_PREFIX)-$(CLUSTER)-$(IPVERSION) \

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -86,17 +86,13 @@ azlogin: ## Login and set account to $SUB
 	@$(AZCLI) account set -s $(SUB)
 
 # Fallback pin to work around aks-preview upstream breaks (checksum mismatches, etc.).
-# Track: https://github.com/Azure/azure-cli-extensions/issues/10101
-# azcfg tries the latest aks-preview first; if that fails (e.g., broken upstream
-# publish like 21.0.0b9), it falls back to this known-good version so CI keeps
-# moving without a manual intervention. Bump this to the newest verified-good
-# release when needed.
+# Past Issue: https://github.com/Azure/azure-cli-extensions/issues/10101
 AKS_PREVIEW_FALLBACK_VERSION ?= 21.0.0b7
 
 azcfg: ## Install aks-preview (latest, falling back to AKS_PREVIEW_FALLBACK_VERSION on failure)
 	@$(AZCLI) extension add --name aks-preview --upgrade --yes \
 		|| { \
-			echo "aks-preview latest install failed; falling back to $(AKS_PREVIEW_FALLBACK_VERSION) (see Azure/azure-cli-extensions#10101)"; \
+			echo "aks-preview latest install failed; falling back to $(AKS_PREVIEW_FALLBACK_VERSION)"; \
 			$(AZCLI) extension add --name aks-preview --version $(AKS_PREVIEW_FALLBACK_VERSION) --upgrade --yes; \
 		}
 


### PR DESCRIPTION
## Problem

Every CI job that installs the `aks-preview` az CLI extension is failing with:

```
WARNING: No stable version of 'aks-preview' to install. Preview versions allowed.
ERROR: The checksum of the extension does not match the expected value. Use --debug for more information.
make: *** [Makefile:89: azcfg] Error 1
```


## Root cause (upstream)

Tracked in **[Azure/azure-cli-extensions#10101](https://github.com/Azure/azure-cli-extensions/issues/10101)** — open as of filing.

Upstream published `aks-preview 21.0.0b9` this morning (2026-07-13):

| Time (UTC) | Commit | What |
|---|---|---|
| 04:45:20Z | [`503610d`](https://github.com/Azure/azure-cli-extensions/commit/503610d) | Source bump: setup.py VERSION → 21.0.0b9 |
| 04:55:18Z | [`fcc9bdc`](https://github.com/Azure/azure-cli-extensions/commit/fcc9bdc) | Release bot recorded expected SHA `ff4b0191…5427` in `src/index.json` |

The wheel actually served from `azcliprod.blob.core.windows.net/cli-extensions/aks_preview-21.0.0b9-py2.py3-none-any.whl` hashes to `ae641562…1854`. The index and the artifact disagree, so every `az extension add --name aks-preview` fails checksum validation.


## Fix

Pin every `az extension add --name aks-preview` call site to `21.0.0b7` — the last version confirmed intact in the upstream reporter's rollback log. Also collapse the paired `add` + `update` pattern into a single `add --version X --upgrade --yes` (since `az extension update` does not accept `--version`; `add --upgrade` is idempotent).

- `hack/aks/Makefile` exposes `AKS_PREVIEW_VERSION ?= 21.0.0b7` so bumps/reverts are one-line.
- 13 pipeline YAML call sites pinned inline with a comment linking the upstream issue.
- 2 commented-out lines in `npm-conformance-tests-latest-release.yaml` left as dead code.
- Pre-existing `--version 14.0.0b3` pin in `delete-cluster.steps.yaml` (leftover from #3607) left untouched — unrelated.

## Precedent

- #3607 pinned to `14.0.0b3` for the same class of upstream break
- #3618 reverted the pin once upstream stabilized

Same play here.

## Revert plan

Once upstream re-publishes b9 (or ships b10) with a matching checksum:

1. Bump `AKS_PREVIEW_VERSION` in `hack/aks/Makefile` or drop the pin entirely
2. Sweep the 13 inline `--version 21.0.0b7` occurrences in `.pipelines/**/*.yaml`
