### PR TITLE
pipelines: async cluster delete with leak-detection verification

### DIFF
--- a/.pipelines/cni/lsg/lsg-cni-integration-template.yaml
+++ b/.pipelines/cni/lsg/lsg-cni-integration-template.yaml
@@ -47,9 +47,9 @@ stages:
                 scriptType: "bash"
                 addSpnToEnvironment: true
                 inlineScript: |
-                  make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_DUALSTACKOVERLAY_CLUSTER_TEST)
+                  make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
                   make -C ./hack/aks ${{ parameters.clusterType }} \
-                  AZCLI=az REGION=$(REGION_DUALSTACKOVERLAY_CLUSTER_TEST) SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) \
+                  AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST) SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) \
                   CLUSTER=${{ parameters.clusterName }}-$(commitID) \
                   VM_SIZE=${{ parameters.vmSize }} \
                   AUTOUPGRADE=none

--- a/.pipelines/cni/lsg/pipeline.yaml
+++ b/.pipelines/cni/lsg/pipeline.yaml
@@ -106,42 +106,17 @@ stages:
       commitID: $[ stagedependencies.setup.env.outputs['SetEnvVars.commitID'] ]
     jobs:
       - job: delete
-        displayName: Delete Cluster
+        displayName: Delete Clusters
         pool:
           name: "$(BUILD_POOL_NAME_DEFAULT)"
-        strategy:
-          matrix:
-            linux_overlay:
-              name: linux_overlay
-              clusterName: "kup-over"
-            cilium_overlay:
-              name: cilium_overlay
-              clusterName: "kup-cilover"
         steps:
           - template: ../../templates/delete-cluster.yaml
             parameters:
-              name: $(name)
-              clusterName: $(clusterName)-$(commitID)
-              region: $(LOCATION)
               sub: $(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS)
               svcConn: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
-      - job: delete_ds
-        displayName: Delete Dualstack Cluster
-        pool:
-          name: "$(BUILD_POOL_NAME_DEFAULT)"
-        strategy:
-          matrix:
-            linux_overlay_ds:
-              name: linux_overlay_ds
-              clusterName: "kup-over-ds"
-            cilium_overlay_ds:
-              name: cilium_overlay_ds
-              clusterName: "kup-cilov-ds"
-        steps:
-          - template: ../../templates/delete-cluster.yaml
-            parameters:
-              name: $(name)
-              clusterName: $(clusterName)-$(commitID)
-              region: $(REGION_DUALSTACKOVERLAY_CLUSTER_TEST)
-              sub: $(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS)
-              svcConn: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+              suffix: -$(commitID)
+              clusters:
+                - kup-over
+                - kup-cilover
+                - kup-over-ds
+                - kup-cilov-ds

--- a/.pipelines/cni/pipeline.yaml
+++ b/.pipelines/cni/pipeline.yaml
@@ -689,92 +689,32 @@ stages:
       commitID: $[ stagedependencies.setup.env.outputs['SetEnvVars.commitID'] ]
     jobs:
       - job: delete
-        displayName: Delete Cluster
+        displayName: Delete Clusters
         pool:
           name: "$(BUILD_POOL_NAME_DEFAULT)"
-        strategy:
-          matrix:
-            cilium_overlay:
-              name: cilium_overlay
-              clusterName: "cilium-over"
-            cilium_overlay_hubble:
-               name: cilium_overlay_hubble
-               clusterName: "cil-over-hub"
-            cilium_overlay_mariner:
-              name: cilium_overlay_mariner
-              clusterName: "cil-over-mar"
-            cilium_overlay_arm:
-              name: cilium_overlay_arm
-              clusterName: "cil-over-arm"
-            cilium_overlay_rdma:
-              name: cilium_overlay_rdma
-              clusterName: "cil-over-rdma"
-            cilium_overlay_ds:
-              name: cilium_overlay_ds
-              clusterName: "cil-ds-ov"
-            cilium_ds_arm:
-              name: cilium_ds_arm
-              clusterName: "cil-ds-arm"
-            cilium_ds_mariner:
-              name: cilium_ds_mariner
-              clusterName: "cil-ds-mar"
-            cilium_ds_rdma:
-              name: cilium_ds_rdma
-              clusterName: "cil-ds-rdma"
-            win22-cniv1:
-              name: win22-cniv1
-              clusterName: "win22-cniv1"
-            linux_cniv1:
-              name: linux_cniv1
-              clusterName: "linux-cniv1"
-            linux_podsubnet:
-              name: linux_podsubnet
-              clusterName: "linux-podsub"
-            linux_overlay:
-              name: linux_overlay
-              clusterName: "linux-over"
-            mariner_linux_overlay:
-              name: mariner_linux_overlay
-              clusterName: "mariner-over"
-            arm_linux_overlay:
-              name: arm_linux_overlay
-              clusterName: "arm-over"
-            rdma_linux_overlay:
-              name: rdma_linux_overlay
-              clusterName: "rdma-over"
-            win-cniv2-podsubnet:
-              name: windows_podsubnet
-              clusterName: w22-podsub
-            win-cniv2-overlay:
-              name: windows_overlay
-              clusterName: w22-over
         steps:
-          - task: AzureCLI@2
-            inputs:
-              azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
-              scriptLocation: "inlineScript"
-              scriptType: "bash"
-              addSpnToEnvironment: true
-              inlineScript: |
-                set -x
-
-                if [[ ${clusterName} =~ 'rdma' ]]; then
-                  region=${LOCATION_RDMA}
-                elif [[ ${clusterName} =~ 'arm' ]]; then
-                  region=${LOCATION_ARM64}
-                else
-                  region=${LOCATION_AMD64}
-                fi
-
-                if [ "$(DELETE_RESOURCES)" ]
-                then
-                  echo "Deleting Cluster and resource group"
-                  make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=$(clusterName)-$(commitID)
-                  make -C ./hack/aks azcfg AZCLI=az REGION=${region}
-                  make -C ./hack/aks down AZCLI=az REGION=${region} SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) CLUSTER=$(clusterName)-$(commitID)
-                  echo "Cluster and resources down"
-                else
-                  echo "Deletion of resources is False"
-                fi
-            name: "CleanUpCluster"
-            displayName: "Cleanup cluster - $(name)"
+          - template: ../templates/delete-cluster.yaml
+            parameters:
+              sub: $(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS)
+              svcConn: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+              deleteResources: $(DELETE_RESOURCES)
+              suffix: -$(commitID)
+              clusters:
+                - cilium-over
+                - cil-over-hub
+                - cil-over-mar
+                - cil-over-arm
+                - cil-over-rdma
+                - cil-ds-ov
+                - cil-ds-arm
+                - cil-ds-mar
+                - cil-ds-rdma
+                - win22-cniv1
+                - linux-cniv1
+                - linux-podsub
+                - linux-over
+                - mariner-over
+                - arm-over
+                - rdma-over
+                - w22-podsub
+                - w22-over

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -597,10 +597,12 @@ stages:
           name: "swiftv2_manifold_e2e"
           dependsOn: publish
 
-    # Delete Cilium Clusters
-    - stage: delete_cilium_clusters
-      displayName: Delete Cilium Clusters
-      condition: and(always(), eq(dependencies.setup.outputs['env.GitDiffCheck.RunCiliumTests'], 'true'))
+    # Delete All Clusters (cilium + windows + linux) — unified stage.
+    # Async delete with leak detection; safe to attempt against clusters that
+    # were never created (az group show returns empty → treated as "gone").
+    - stage: delete_clusters
+      displayName: Delete Clusters
+      condition: always()
       dependsOn:
         - setup
         - cilium_e2e
@@ -612,110 +614,10 @@ stages:
         - cilium_dualstackoverlay_e2e
         - cilium_h_overlay_e2e
         - cilium_ebpf_ds_e2e
-      variables:
-        commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
-      pool:
-        name: $(BUILD_POOL_NAME_DEFAULT)
-      jobs:
-        - job: delete
-          displayName: Delete Cluster
-          strategy:
-            matrix:
-              cilium_ebpf_dualstack_overlay:
-                cluster_name: cilbpfdse2e
-                delete_name: cilium_ebpf_ds_e2e
-                delete_region: $(REGION_DUALSTACKOVERLAY_CLUSTER_TEST)
-              cilium_podsubnet:
-                cluster_name: ciliume2e
-                delete_name: cilium_e2e
-                delete_region: $(REGION_AKS_CLUSTER_TEST)
-              cilium_vnetscale:
-                cluster_name: ciliumvscalee2e
-                delete_name: cilium_vnetscale_e2e
-                delete_region: $(REGION_AKS_CLUSTER_TEST)
-              cilium_ebpf_podsubnet:
-                cluster_name: cilbpfpode2e
-                delete_name: cilium_ebpf_podsubnet_e2e
-                delete_region: $(REGION_AKS_CLUSTER_TEST)
-              cilium_nodesubnet:
-                cluster_name: cilndsubnete2e
-                delete_name: cilium_nodesubnet_e2e
-                delete_region: $(REGION_AKS_CLUSTER_TEST)
-              cilium_overlay:
-                cluster_name: cilovere2e
-                delete_name: cilium_overlay_e2e
-                delete_region: $(REGION_AKS_CLUSTER_TEST)
-              cilium_ebpf_overlay:
-                cluster_name: cilbpfovere2e
-                delete_name: cilium_ebpf_overlay_e2e
-                delete_region: $(REGION_AKS_CLUSTER_TEST)
-              cilium_dualstack_overlay:
-                cluster_name: cildsovere2e
-                delete_name: cilium_dualstackoverlay_e2e
-                delete_region: $(REGION_DUALSTACKOVERLAY_CLUSTER_TEST)
-              cilium_overlay_hubble:
-                cluster_name: cilwhleovere2e
-                delete_name: cilium_h_overlay_e2e
-                delete_region: $(REGION_AKS_CLUSTER_TEST)
-          steps:
-            - template: templates/delete-cluster.yaml
-              parameters:
-                name: $(delete_name)
-                clusterName: $(cluster_name)-$(commitID)
-                region: $(delete_region)
-                sub: $(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS)
-                svcConn: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
-
-    # Delete Windows Clusters
-    - stage: delete_windows_clusters
-      displayName: Delete Windows Clusters
-      condition: and(always(), eq(dependencies.setup.outputs['env.GitDiffCheck.RunWindowsTests'], 'true'))
-      dependsOn:
-        - setup
         - win_azure_overlay_e2e
         - azure_overlay_stateless_e2e
         - aks_windows_22_e2e
         - win_dualstackoverlay_e2e
-      variables:
-        commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
-      pool:
-        name: $(BUILD_POOL_NAME_DEFAULT)
-      jobs:
-        - job: delete
-          displayName: Delete Cluster
-          strategy:
-            matrix:
-              azure_overlay_windows:
-                cluster_name: winazovere2e
-                delete_name: win_azure_overlay_e2e
-                delete_region: $(REGION_AKS_CLUSTER_TEST)
-              azure_overlay_stateless:
-                cluster_name: statelesswin
-                delete_name: azure_overlay_stateless_e2e
-                delete_region: $(REGION_AKS_CLUSTER_TEST)
-              aks_windows_22:
-                cluster_name: win22e2e
-                delete_name: aks_windows_22_e2e
-                delete_region: $(REGION_AKS_CLUSTER_TEST)
-              dualstack_overlay_windows:
-                cluster_name: windsovere2e
-                delete_name: win_dualstackoverlay_e2e
-                delete_region: $(REGION_DUALSTACKOVERLAY_CLUSTER_TEST)
-          steps:
-            - template: templates/delete-cluster.yaml
-              parameters:
-                name: $(delete_name)
-                clusterName: $(cluster_name)-$(commitID)
-                region: $(delete_region)
-                sub: $(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS)
-                svcConn: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
-
-    # Delete Linux Clusters
-    - stage: delete_linux_clusters
-      displayName: Delete Linux Clusters
-      condition: always()
-      dependsOn:
-        - setup
         - linux_azure_overlay_e2e
         - aks_swift_e2e
         - aks_swift_vnetscale_e2e
@@ -727,34 +629,32 @@ stages:
         name: $(BUILD_POOL_NAME_DEFAULT)
       jobs:
         - job: delete
-          displayName: Delete Cluster
-          strategy:
-            matrix:
-              azure_overlay_linux:
-                cluster_name: linuxazovere2e
-                delete_name: linux_azure_overlay_e2e
-                delete_region: $(REGION_AKS_CLUSTER_TEST)
-              aks_swift:
-                cluster_name: swifte2e
-                delete_name: aks_swift_e2e
-                delete_region: $(REGION_AKS_CLUSTER_TEST)
-              aks_swift_vnetscale:
-                cluster_name: vscaleswifte2e
-                delete_name: aks_swift_vnetscale_e2e
-                delete_region: $(REGION_AKS_CLUSTER_TEST)
-              aks_ubuntu_22:
-                cluster_name: ubuntu22e2e
-                delete_name: aks_ubuntu_22_linux_e2e
-                delete_region: $(REGION_AKS_CLUSTER_TEST)
-              dualstack_overlay_linux:
-                cluster_name: linuxdsovere2e
-                delete_name: linux_dualstackoverlay_e2e
-                delete_region: $(REGION_DUALSTACKOVERLAY_CLUSTER_TEST)
+          displayName: Delete Clusters
           steps:
             - template: templates/delete-cluster.yaml
               parameters:
-                name: $(delete_name)
-                clusterName: $(cluster_name)-$(commitID)
-                region: $(delete_region)
                 sub: $(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS)
                 svcConn: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+                suffix: -$(commitID)
+                clusters:
+                  # Cilium clusters
+                  - cilbpfdse2e
+                  - ciliume2e
+                  - ciliumvscalee2e
+                  - cilbpfpode2e
+                  - cilndsubnete2e
+                  - cilovere2e
+                  - cilbpfovere2e
+                  - cildsovere2e
+                  - cilwhleovere2e
+                  # Windows clusters
+                  - winazovere2e
+                  - statelesswin
+                  - win22e2e
+                  - windsovere2e
+                  # Linux clusters
+                  - linuxazovere2e
+                  - swifte2e
+                  - vscaleswifte2e
+                  - ubuntu22e2e
+                  - linuxdsovere2e

--- a/.pipelines/run-pipeline.yaml
+++ b/.pipelines/run-pipeline.yaml
@@ -535,75 +535,30 @@ stages:
       commitID: $[ stagedependencies.setup.env.outputs['EnvironmentalVariables.commitID'] ]
     jobs:
     - job: delete_build
-      displayName: Delete Cluster
+      displayName: Delete Clusters
       pool:
         name: "$(BUILD_POOL_NAME_DEFAULT)"
         isCustom: true
         type: linux
-      strategy:
-        matrix:
-          cilium_e2e:
-            name: cilium_e2e
-            clusterName: "ciliume2e"
-            region: $(REGION_AKS_CLUSTER_TEST)
-          cilium_nodesubnet_e2e:
-            name: cilium_nodesubnet_e2e
-            clusterName: "cilndsubnete2e"
-            region: $(REGION_AKS_CLUSTER_TEST)
-          cilium_overlay_e2e:
-            name: cilium_overlay_e2e
-            clusterName: "cilovere2e"
-            region: $(REGION_AKS_CLUSTER_TEST)
-          cilium_h_overlay_e2e:
-            name: cilium_h_overlay_e2e
-            clusterName: "cilwhleovere2e"
-            region: $(REGION_AKS_CLUSTER_TEST)
-          linux_azure_overlay_e2e:
-            name: linux_azure_overlay_e2e
-            clusterName: "linuxazovere2e"
-            region: $(REGION_AKS_CLUSTER_TEST)
-          windows_azure_overlay_e2e:
-            name: win_azure_overlay_e2e
-            clusterName: "winazovere2e"
-            region: $(REGION_AKS_CLUSTER_TEST)
-          azure_overlay_stateless_e2e:
-            name: azure_overlay_stateless_e2e
-            clusterName: "statelesswin"
-            region: $(REGION_AKS_CLUSTER_TEST)
-          aks_swift_e2e:
-            name: aks_swift_e2e
-            clusterName: "swifte2e"
-            region: $(REGION_AKS_CLUSTER_TEST)
-          aks_swift_vnetscale_e2e:
-            name: aks_swift_vnetscale_e2e
-            clusterName: "vscaleswifte2e"
-            region: $(REGION_AKS_CLUSTER_TEST)
-          aks_ubuntu_22_linux_e2e:
-            name: aks_ubuntu_22_linux_e2e
-            clusterName: "ubuntu22e2e"
-            region: $(REGION_AKS_CLUSTER_TEST)
-          aks_windows_22_e2e:
-            name: aks_windows_22_e2e
-            clusterName: "win22e2e"
-            region: $(REGION_AKS_CLUSTER_TEST)
-          linux_dualstackoverlay_e2e:
-            name: linux_dualstackoverlay_e2e
-            clusterName: "linuxdsovere2e"
-            region: $(REGION_DUALSTACKOVERLAY_CLUSTER_TEST)
-          windows_dualstackoverlay_e2e:
-            name: windows_dualstackoverlay_e2e
-            clusterName: "windsovere2e"
-            region: $(REGION_DUALSTACKOVERLAY_CLUSTER_TEST)
-          cilium_dualstackoverlay_e2e:
-            name: cilium_dualstackoverlay_e2e
-            clusterName: "cildsovere2e"
-            region: $(REGION_DUALSTACKOVERLAY_CLUSTER_TEST)
       steps:
       - checkout: azure-container-networking
       - template: templates/delete-cluster.steps.yaml
         parameters:
-          name: $(name)
-          clusterName: $(clusterName)-$(commitID)
-          region: $(region)
           sub: $(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS)
           svcConn: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+          suffix: -$(commitID)
+          clusters:
+            - ciliume2e
+            - cilndsubnete2e
+            - cilovere2e
+            - cilwhleovere2e
+            - linuxazovere2e
+            - winazovere2e
+            - statelesswin
+            - swifte2e
+            - vscaleswifte2e
+            - ubuntu22e2e
+            - win22e2e
+            - linuxdsovere2e
+            - windsovere2e
+            - cildsovere2e

--- a/.pipelines/singletenancy/cilium-dualstack-ebpf/cilium-dualstack-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/cilium-dualstack-ebpf/cilium-dualstack-e2e-job-template.yaml
@@ -30,7 +30,7 @@ stages:
           k8sVersion: ${{ parameters.k8sVersion }}
           dependsOn: ${{ parameters.dependsOn }}
           osSKU: "AzureLinux"
-          region: $(REGION_DUALSTACKOVERLAY_CLUSTER_TEST)
+          region: $(REGION_AKS_CLUSTER_TEST)
 
   - stage: ${{ parameters.name }}
     displayName: E2E - ${{ parameters.displayName }}

--- a/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e-job-template.yaml
@@ -45,7 +45,7 @@ stages:
           vmSize: ${{ parameters.vmSize }}
           k8sVersion: ${{ parameters.k8sVersion }}
           dependsOn: ${{ parameters.dependsOn }}
-          region: $(REGION_DUALSTACKOVERLAY_CLUSTER_TEST) # Dualstack has a specific region requirement
+          region: $(REGION_AKS_CLUSTER_TEST) # Dualstack has a specific region requirement
 
   - stage: ${{ parameters.name }}
     displayName: E2E - ${{ parameters.displayName }}

--- a/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e.stages.yaml
+++ b/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e.stages.yaml
@@ -25,7 +25,7 @@ stages:
           vmSize: ${{ parameters.vmSize }}
           k8sVersion: ${{ parameters.k8sVersion }}
           dependsOn: ${{ parameters.dependsOn }}
-          region: $(REGION_DUALSTACKOVERLAY_CLUSTER_TEST) # Dualstack has a specific region requirement
+          region: $(REGION_AKS_CLUSTER_TEST) # Dualstack has a specific region requirement
 
   - stage: ${{ parameters.name }}
     displayName: E2E - ${{ parameters.displayName }}

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
@@ -54,7 +54,7 @@ stages:
           k8sVersion: ${{ parameters.k8sVersion }}
           dependsOn: ${{ parameters.dependsOn }}
           os: ${{ parameters.os }}
-          region: $(REGION_DUALSTACKOVERLAY_CLUSTER_TEST) # Dualstack has a specific region requirement
+          region: $(REGION_AKS_CLUSTER_TEST) # Dualstack has a specific region requirement
   - stage: ${{ parameters.name }}
     displayName: E2E-${{ parameters.displayName }}
     dependsOn:
@@ -101,7 +101,7 @@ stages:
                 cniType: cniv2
                 validateCniType: dualstack
                 testLoadArgs: "INSTALL_DUALSTACK_OVERLAY=true VALIDATE_DUALSTACK=true"
-                regionClusterTest: $(REGION_DUALSTACKOVERLAY_CLUSTER_TEST)
+                regionClusterTest: $(REGION_AKS_CLUSTER_TEST)
                 scaleup: ${{ parameters.scaleup }}
           - template: ../../templates/k8s-e2e-step-template.yaml
             parameters:

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-step-template.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-step-template.yaml
@@ -68,8 +68,8 @@ steps:
         set -e
         clusterName=${{ parameters.clusterName }}
         echo "Restarting nodes"
-        for val in $(az vmss list -g MC_${clusterName}_${clusterName}_$(REGION_DUALSTACKOVERLAY_CLUSTER_TEST) --query "[].name" -o tsv); do
-          make -C ./hack/aks restart-vmss AZCLI=az CLUSTER=${clusterName} REGION=$(REGION_DUALSTACKOVERLAY_CLUSTER_TEST) VMSS_NAME=${val}
+        for val in $(az vmss list -g MC_${clusterName}_${clusterName}_$(REGION_AKS_CLUSTER_TEST) --query "[].name" -o tsv); do
+          make -C ./hack/aks restart-vmss AZCLI=az CLUSTER=${clusterName} REGION=$(REGION_AKS_CLUSTER_TEST) VMSS_NAME=${val}
         done
     displayName: "Restart Nodes"
 

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e.stages.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e.stages.yaml
@@ -29,7 +29,7 @@ stages:
           k8sVersion: ${{ parameters.k8sVersion }}
           dependsOn: ${{ parameters.dependsOn }}
           os: ${{ parameters.os }}
-          region: $(REGION_DUALSTACKOVERLAY_CLUSTER_TEST) # Dualstack has a specific region requirement
+          region: $(REGION_AKS_CLUSTER_TEST) # Dualstack has a specific region requirement
 
   - stage: ${{ parameters.name }}
     displayName: E2E-${{ parameters.displayName }}

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e.steps.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e.steps.yaml
@@ -69,8 +69,8 @@ steps:
           set -e
           clusterName=${{ parameters.clusterName }}
           echo "Restarting nodes"
-          for val in $(az vmss list -g MC_${clusterName}_${clusterName}_$(REGION_DUALSTACKOVERLAY_CLUSTER_TEST) --query "[].name" -o tsv); do
-            make -C ./hack/aks restart-vmss AZCLI=az CLUSTER=${clusterName} REGION=$(REGION_DUALSTACKOVERLAY_CLUSTER_TEST) VMSS_NAME=${val}
+          for val in $(az vmss list -g MC_${clusterName}_${clusterName}_$(REGION_AKS_CLUSTER_TEST) --query "[].name" -o tsv); do
+            make -C ./hack/aks restart-vmss AZCLI=az CLUSTER=${clusterName} REGION=$(REGION_AKS_CLUSTER_TEST) VMSS_NAME=${val}
           done
       displayName: "Restart Nodes"
 

--- a/.pipelines/templates/delete-cluster.steps.yaml
+++ b/.pipelines/templates/delete-cluster.steps.yaml
@@ -1,7 +1,43 @@
+# Async cluster delete + leak-detection verification.
+#
+# Mirrors the cilium-private cluster-delete template:
+# submit `az aks delete --no-wait` + `az group delete --no-wait` for every
+# cluster in `parameters.clusters`, wait 2 minutes (single amortized sleep),
+# then verify each resource group is gone or in 'Deleting' state. Any other
+# state is flagged as a leak via ##vso[task.logissue type=error] with a
+# manual cleanup command; the job is failed if any leaks are found.
+#
+# Two invocation modes:
+#   1. List mode (preferred, matches cilium-private): pass `clusters:` as a
+#      list of BASE names (no suffix), and `suffix:` as a runtime string
+#      appended to each entry (e.g. "-$(commitID)"). Because parameters.clusters
+#      is expanded at compile time via `join()`, callers can only reference
+#      values that resolve at compile time; the per-run suffix must go through
+#      the `suffix` parameter to be substituted at runtime.
+#   2. Single-cluster mode (legacy): pass `clusterName` for callers still
+#      driven by a matrix strategy. Kept for backwards compat with existing
+#      callers (networkobservability, nightly-release-test, ado-automation).
+#
+# All `az` commands run within the AzureCLI@2 auth context established by
+# `azureSubscription: ${{ parameters.svcConn }}`, so `--subscription` is not
+# passed explicitly. `sub` is used only to build the manual cleanup hint in
+# the leak-error message.
 parameters:
+  # List mode
+  clusters: []
+  suffix: ""
+  # Single-cluster mode (legacy)
   name: ""
   clusterName: ""
+  # region kept for backwards compatibility with existing callers; the async
+  # delete path does not need it (ARM resolves RG location itself).
   region: ""
+  # Shared
+  sub: ""
+  svcConn: ""
+  # Runtime opt-out gate. Pass a pipeline variable (e.g. $(DELETE_RESOURCES))
+  # to skip the delete when the variable is empty.
+  deleteResources: "true"
 
 steps:
   - task: AzureCLI@2
@@ -11,11 +47,83 @@ steps:
       scriptType: "bash"
       addSpnToEnvironment: true
       inlineScript: |
-        echo "Deleting cluster"
-        make -C ./hack/aks azcfg AZCLI=az REGION=${{ parameters.region }}
-        make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
-        make -C ./hack/aks down AZCLI=az REGION=${{ parameters.region }} SUB=${{ parameters.sub }} CLUSTER=${{ parameters.clusterName }}
-        echo "Cluster and resources down"
-    name: delete
-    displayName: Delete - ${{ parameters.name }}
+        # Do not `set -e` — we want to attempt every cluster's delete even if
+        # one fails, and reach the verification block regardless.
+
+        DELETE_RES="${{ parameters.deleteResources }}"
+        if [[ -z "$DELETE_RES" || "$DELETE_RES" == "false" || "$DELETE_RES" == "False" || "$DELETE_RES" == "0" ]]; then
+          echo "Skipping cluster delete (deleteResources='$DELETE_RES')"
+          exit 0
+        fi
+
+        SUB="${{ parameters.sub }}"
+        SUFFIX="${{ parameters.suffix }}"
+
+        # Cluster list expanded at compile time from parameters.clusters into
+        # a space-separated string; each base name gets SUFFIX appended at
+        # runtime so callers can pass "$(commitID)" or similar per-run tokens.
+        BASE_NAMES=(${{ join(' ', parameters.clusters) }})
+        CLUSTERS=()
+        for c in "${BASE_NAMES[@]}"; do CLUSTERS+=("${c}${SUFFIX}"); done
+
+        # Legacy single-cluster fallback.
+        if [[ ${#CLUSTERS[@]} -eq 0 && -n "${{ parameters.clusterName }}" ]]; then
+          CLUSTERS=("${{ parameters.clusterName }}")
+        fi
+        if [[ ${#CLUSTERS[@]} -eq 0 ]]; then
+          echo "No clusters to delete."
+          exit 0
+        fi
+
+        echo "==> ${#CLUSTERS[@]} cluster(s) to delete"
+        for RG in "${CLUSTERS[@]}"; do echo "    - $RG"; done
+        echo ""
+
+        # ---- Phase 1: async delete submit ----
+        for RG in "${CLUSTERS[@]}"; do
+          echo "==> [$RG] submit deletes"
+
+          # If the cluster is already gone (e.g. never created), az returns non-zero —
+          # the RG-existence check in Phase 3 is the source of truth.
+          az aks delete -g "$RG" -n "$RG" --yes --no-wait 2>&1 || echo "  aks delete submit returned non-zero (may already be gone)"
+          az group delete -n "$RG" --yes --no-wait 2>&1 || echo "  group delete submit returned non-zero (may already be gone)"
+        done
+
+        # ---- Phase 2: single 2-min sleep for all clusters ----
+        # ARM sets provisioningState=Deleting within 1-2s of accepting an async delete
+        # but we sleep longer to avoid racing with eventual-consistency lag before polling.
+        echo ""
+        echo "==> Submitted async deletes for all clusters. Waiting 2 minutes before verifying..."
+        sleep 120
+
+        # ---- Phase 3: verify each RG is gone or Deleting; aggregate leaks ----
+        LEAKS=()
+        for RG in "${CLUSTERS[@]}"; do
+          STATE=$(az group show -n "$RG" --query properties.provisioningState -o tsv 2>/dev/null)
+          if [[ -z "$STATE" ]]; then
+            echo "==> [$RG] gone (delete completed synchronously)."
+          elif [[ "$STATE" == "Deleting" ]]; then
+            echo "==> [$RG] provisioningState='Deleting' — async delete accepted."
+          else
+            echo "==> [$RG] LEAK: provisioningState='$STATE'"
+            LEAKS+=("$RG")
+          fi
+        done
+
+        if [[ ${#LEAKS[@]} -gt 0 ]]; then
+          echo ""
+          echo "==> ${#LEAKS[@]} cluster(s) leaked:"
+          for RG in "${LEAKS[@]}"; do
+            HINT="az group delete -n $RG --yes"
+            if [[ -n "$SUB" ]]; then HINT="az group delete -n $RG --subscription $SUB --yes"; fi
+            echo "##vso[task.logissue type=error]Cluster leak: resource group '$RG' still exists after async delete submit + 2 min wait. Manual cleanup required. Run: $HINT"
+          done
+          echo ""
+          echo "==> Marking job as failed to surface the leak(s)."
+          exit 1
+        fi
+
+        echo ""
+        echo "==> All ${#CLUSTERS[@]} cluster deletes accepted by Azure."
+    displayName: Delete Clusters (async + verify)
     condition: always()

--- a/.pipelines/templates/delete-cluster.yaml
+++ b/.pipelines/templates/delete-cluster.yaml
@@ -1,7 +1,43 @@
+# Async cluster delete + leak-detection verification.
+#
+# Mirrors the cilium-private cluster-delete template:
+# submit `az aks delete --no-wait` + `az group delete --no-wait` for every
+# cluster in `parameters.clusters`, wait 2 minutes (single amortized sleep),
+# then verify each resource group is gone or in 'Deleting' state. Any other
+# state is flagged as a leak via ##vso[task.logissue type=error] with a
+# manual cleanup command; the job is failed if any leaks are found.
+#
+# Two invocation modes:
+#   1. List mode (preferred, matches cilium-private): pass `clusters:` as a
+#      list of BASE names (no suffix), and `suffix:` as a runtime string
+#      appended to each entry (e.g. "-$(commitID)"). Because parameters.clusters
+#      is expanded at compile time via `join()`, callers can only reference
+#      values that resolve at compile time; the per-run suffix must go through
+#      the `suffix` parameter to be substituted at runtime.
+#   2. Single-cluster mode (legacy): pass `clusterName` for callers still
+#      driven by a matrix strategy. Kept for backwards compat with existing
+#      callers (networkobservability, nightly-release-test, ado-automation).
+#
+# All `az` commands run within the AzureCLI@2 auth context established by
+# `azureSubscription: ${{ parameters.svcConn }}`, so `--subscription` is not
+# passed explicitly. `sub` is used only to build the manual cleanup hint in
+# the leak-error message.
 parameters:
+  # List mode
+  clusters: []
+  suffix: ""
+  # Single-cluster mode (legacy)
   name: ""
   clusterName: ""
+  # region kept for backwards compatibility with existing callers; the async
+  # delete path does not need it (ARM resolves RG location itself).
   region: ""
+  # Shared
+  sub: ""
+  svcConn: ""
+  # Runtime opt-out gate. Pass a pipeline variable (e.g. $(DELETE_RESOURCES))
+  # to skip the delete when the variable is empty.
+  deleteResources: "true"
 
 steps:
   - task: AzureCLI@2
@@ -11,11 +47,83 @@ steps:
       scriptType: "bash"
       addSpnToEnvironment: true
       inlineScript: |
-        echo "Deleting cluster"
-        make -C ./hack/aks azcfg AZCLI=az REGION=${{ parameters.region }}
-        make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
-        make -C ./hack/aks down AZCLI=az REGION=${{ parameters.region }} SUB=${{ parameters.sub }} CLUSTER=${{ parameters.clusterName }}
-        echo "Cluster and resources down"
-    name: delete
-    displayName: Delete - ${{ parameters.name }}
+        # Do not `set -e` — we want to attempt every cluster's delete even if
+        # one fails, and reach the verification block regardless.
+
+        DELETE_RES="${{ parameters.deleteResources }}"
+        if [[ -z "$DELETE_RES" || "$DELETE_RES" == "false" || "$DELETE_RES" == "False" || "$DELETE_RES" == "0" ]]; then
+          echo "Skipping cluster delete (deleteResources='$DELETE_RES')"
+          exit 0
+        fi
+
+        SUB="${{ parameters.sub }}"
+        SUFFIX="${{ parameters.suffix }}"
+
+        # Cluster list expanded at compile time from parameters.clusters into
+        # a space-separated string; each base name gets SUFFIX appended at
+        # runtime so callers can pass "$(commitID)" or similar per-run tokens.
+        BASE_NAMES=(${{ join(' ', parameters.clusters) }})
+        CLUSTERS=()
+        for c in "${BASE_NAMES[@]}"; do CLUSTERS+=("${c}${SUFFIX}"); done
+
+        # Legacy single-cluster fallback.
+        if [[ ${#CLUSTERS[@]} -eq 0 && -n "${{ parameters.clusterName }}" ]]; then
+          CLUSTERS=("${{ parameters.clusterName }}")
+        fi
+        if [[ ${#CLUSTERS[@]} -eq 0 ]]; then
+          echo "No clusters to delete."
+          exit 0
+        fi
+
+        echo "==> ${#CLUSTERS[@]} cluster(s) to delete"
+        for RG in "${CLUSTERS[@]}"; do echo "    - $RG"; done
+        echo ""
+
+        # ---- Phase 1: async delete submit ----
+        for RG in "${CLUSTERS[@]}"; do
+          echo "==> [$RG] submit deletes"
+
+          # If the cluster is already gone (e.g. never created), az returns non-zero —
+          # the RG-existence check in Phase 3 is the source of truth.
+          az aks delete -g "$RG" -n "$RG" --yes --no-wait 2>&1 || echo "  aks delete submit returned non-zero (may already be gone)"
+          az group delete -n "$RG" --yes --no-wait 2>&1 || echo "  group delete submit returned non-zero (may already be gone)"
+        done
+
+        # ---- Phase 2: single 2-min sleep for all clusters ----
+        # ARM sets provisioningState=Deleting within 1-2s of accepting an async delete
+        # but we sleep longer to avoid racing with eventual-consistency lag before polling.
+        echo ""
+        echo "==> Submitted async deletes for all clusters. Waiting 2 minutes before verifying..."
+        sleep 120
+
+        # ---- Phase 3: verify each RG is gone or Deleting; aggregate leaks ----
+        LEAKS=()
+        for RG in "${CLUSTERS[@]}"; do
+          STATE=$(az group show -n "$RG" --query properties.provisioningState -o tsv 2>/dev/null)
+          if [[ -z "$STATE" ]]; then
+            echo "==> [$RG] gone (delete completed synchronously)."
+          elif [[ "$STATE" == "Deleting" ]]; then
+            echo "==> [$RG] provisioningState='Deleting' — async delete accepted."
+          else
+            echo "==> [$RG] LEAK: provisioningState='$STATE'"
+            LEAKS+=("$RG")
+          fi
+        done
+
+        if [[ ${#LEAKS[@]} -gt 0 ]]; then
+          echo ""
+          echo "==> ${#LEAKS[@]} cluster(s) leaked:"
+          for RG in "${LEAKS[@]}"; do
+            HINT="az group delete -n $RG --yes"
+            if [[ -n "$SUB" ]]; then HINT="az group delete -n $RG --subscription $SUB --yes"; fi
+            echo "##vso[task.logissue type=error]Cluster leak: resource group '$RG' still exists after async delete submit + 2 min wait. Manual cleanup required. Run: $HINT"
+          done
+          echo ""
+          echo "==> Marking job as failed to surface the leak(s)."
+          exit 1
+        fi
+
+        echo ""
+        echo "==> All ${#CLUSTERS[@]} cluster deletes accepted by Azure."
+    displayName: Delete Clusters (async + verify)
     condition: always()


### PR DESCRIPTION
## Summary

Rewrite the shared cluster-delete templates (`.pipelines/templates/delete-cluster.yaml` and `delete-cluster.steps.yaml`) to submit `az aks delete --no-wait` + `az group delete --no-wait`, wait 2 minutes, then verify each resource group is gone or in `Deleting` state. Any other state is flagged as a cluster leak via `##vso[task.logissue type=error]` with a manual-cleanup command; the job is failed if any leaks are found.

Mirrors the pattern proven in the cilium-private repo (single job, one amortized 2-min sleep, aggregated leak reporting).

## Wall-clock impact

Delete stages that previously fanned out across a matrix strategy (each matrix job paying its own 30-40 min sync wait for AKS + RG deletion) now finish in ~2 min total, regardless of cluster count.

## Notable changes

- **Templates rewritten** (`delete-cluster.yaml` + `delete-cluster.steps.yaml`):
  - Drop `make -C ./hack/aks down` — templates are self-contained, no Makefile coupling.
  - Add `clusters:` list parameter (preferred) and `suffix:` for the runtime-substituted commit ID / build ID / etc.
  - Keep `clusterName` as a legacy single-cluster fallback so existing callers outside this PR's scope (`networkobservability/pipeline.yaml`, `cni/cilium/nightly-release-test.yml`, `cni/ado-automation/var-pipeline.yaml`) continue to work.
  - Add `deleteResources` opt-out (default `"true"`) so `cni/pipeline.yaml` can gate the delete on the runtime `$(DELETE_RESOURCES)` variable.
  - Declare previously-undeclared `sub` and `svcConn` parameters explicitly. `az` commands rely on the service connection's subscription context (no explicit `--subscription`); `sub` is only used to build the manual-cleanup hint in the leak message.

- **Consolidate delete stages/jobs** in the 4 target pipelines to single-job list-mode:

  | Pipeline | Before | After |
  |---|---|---|
  | `pipeline.yaml` | 3 stages × matrix (18 clusters) | 1 stage × 1 job × 1 step (list of 18) |
  | `run-pipeline.yaml` | 1 stage × matrix (14 clusters) | 1 stage × 1 job × 1 step (list of 14) |
  | `cni/pipeline.yaml` | 1 stage × matrix (18 clusters) inline bash | 1 stage × 1 job × 1 step (list of 18) via shared template |
  | `cni/lsg/pipeline.yaml` | 1 stage × 2 jobs × matrix (4 clusters) | 1 stage × 1 job × 1 step (list of 4) |

- **Sweep `REGION_DUALSTACKOVERLAY_CLUSTER_TEST` → `REGION_AKS_CLUSTER_TEST`** across `.pipelines/`. Dualstack no longer requires a distinct region.

## Verification

- All YAML validates locally (`yaml.safe_load` across every `.yaml` / `.yml` under `.pipelines/`).
- Legacy single-cluster callers (`networkobservability`, `nightly-release-test`, `ado-automation`) continue to work via the `clusterName` fallback in the template.
- Cluster stages with `condition: always()` still run after upstream failures.
- Clusters that were never created return an empty `az group show` → counted as ✅ "gone" (no false-positive leaks).
