### PR TITLE
[backport release/v1.6] ci: self-heal aks-preview install (upstream b9 checksum mismatch)

### DIFF
--- a/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
+++ b/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
@@ -78,7 +78,7 @@ stages:
                 addSpnToEnvironment: true
                 inlineScript: |
                   set -ex
-                  az extension add --name aks-preview
+                  make -C ./hack/aks azcfg AZCLI=az
                   make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(commitID)
                   ls -lah
                   pwd
@@ -151,7 +151,7 @@ stages:
                 addSpnToEnvironment: true
                 inlineScript: |
                   set -ex
-                  az extension add --name aks-preview
+                  make -C ./hack/aks azcfg AZCLI=az
                   make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(commitID)
                   ls -lah
                   pwd

--- a/.pipelines/cni/cilium/cilium-scale-test.yaml
+++ b/.pipelines/cni/cilium/cilium-scale-test.yaml
@@ -17,7 +17,7 @@ stages:
               addSpnToEnvironment: true
               inlineScript: |
                 set -ex
-                az extension add --name aks-preview
+                make -C ./hack/aks azcfg AZCLI=az
 
                 subscriptionId="$(az account list --query "[?isDefault].id" --output tsv)"
                 make -C ./hack/aks AZCLI=az ${CLUSTER_TYPE} CLUSTER=${CLUSTER} GROUP=${RESOURCE_GROUP} REGION=${LOCATION} NODE_COUNT=5 VM_SIZE=${VMSIZE} SUB=${subscriptionId} || {

--- a/.pipelines/cni/load-test-templates/pod-deployment-template.yaml
+++ b/.pipelines/cni/load-test-templates/pod-deployment-template.yaml
@@ -17,7 +17,7 @@ steps:
       addSpnToEnvironment: true
       inlineScript: |
         set -ex
-        az extension add --name aks-preview
+        make -C ./hack/aks azcfg AZCLI=az
         make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
         cd test/integration/load
         scale=$(( ${{ parameters.scaleup }} * ${{ parameters.nodeCount }} ))

--- a/.pipelines/cni/lsg/kernel-upgrade-template.yaml
+++ b/.pipelines/cni/lsg/kernel-upgrade-template.yaml
@@ -10,7 +10,7 @@ steps:
       addSpnToEnvironment: true
       inlineScript: |
         set -ex
-        az extension add --name aks-preview
+        make -C ./hack/aks azcfg AZCLI=az
         make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
     retryCountOnTaskFailure: 3
     displayName: "Set Kubeconfig"

--- a/.pipelines/cni/lsg/lsg-cni-intergration-template.yaml
+++ b/.pipelines/cni/lsg/lsg-cni-intergration-template.yaml
@@ -87,7 +87,7 @@ stages:
                 addSpnToEnvironment: true
                 inlineScript: |
                   set -ex
-                  az extension add --name aks-preview
+                  make -C ./hack/aks azcfg AZCLI=az
                   make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(commitID)
                   ls -lah
                   pwd

--- a/.pipelines/npm/npm-conformance-tests-latest-release.yaml
+++ b/.pipelines/npm/npm-conformance-tests-latest-release.yaml
@@ -126,8 +126,7 @@ jobs:
 
             if [[ $(AZURE_CLUSTER) == *ws22 ]] # * is used for pattern matching
             then
-              az extension add --name aks-preview
-              az extension update --name aks-preview
+              make -C ./hack/aks azcfg AZCLI=az
 
               echo "creating WS22 Cluster";
               az aks create \

--- a/.pipelines/npm/npm-cyc-win-tests-latest-release.yaml
+++ b/.pipelines/npm/npm-cyc-win-tests-latest-release.yaml
@@ -66,8 +66,7 @@ jobs:
           scriptLocation: "inlineScript"
           failOnStderr: true
           inlineScript: |
-            az extension add --name aks-preview
-            az extension update --name aks-preview
+            make -C ./hack/aks azcfg AZCLI=az
 
             export CLUSTER_NAME=$(RESOURCE_GROUP)
 

--- a/.pipelines/npm/npm-scale-test.yaml
+++ b/.pipelines/npm/npm-scale-test.yaml
@@ -133,8 +133,7 @@ jobs:
           condition: succeeded()
           inlineScript: |
             set -e
-            az extension add --name aks-preview
-            az extension update --name aks-preview
+            make -C ./hack/aks azcfg AZCLI=az
 
             echo "Creating resource group named $(RESOURCE_GROUP)"
             az group create --name $(RESOURCE_GROUP) -l $(LOCATION) -o table

--- a/.pipelines/templates/create-cluster-steps.yaml
+++ b/.pipelines/templates/create-cluster-steps.yaml
@@ -23,12 +23,6 @@ steps:
         set -e
         echo "Check az version"
         az version
-        if ${{ lower(contains(parameters.clusterType, 'dualstack')) }}
-        then
-          echo "Install az cli extension preview"
-          az extension add --name aks-preview
-          az extension update --name aks-preview
-        fi
 
         if ! [ -z ${{ parameters.k8sVersion }} ]; then
           echo "Set K8S_VER with ${{ parameters.k8sVersion }}"

--- a/.pipelines/templates/create-cluster-swiftv2.yaml
+++ b/.pipelines/templates/create-cluster-swiftv2.yaml
@@ -16,12 +16,6 @@ jobs:
             set -e
             echo "Check az version"
             az version
-            if ${{ lower(contains(parameters.clusterType, 'dualstack')) }}
-            then
-              echo "Install az cli extension preview"
-              az extension add --name aks-preview
-              az extension update --name aks-preview
-            fi
             mkdir -p ~/.kube/
             make -C ./hack/aks azcfg AZCLI=az REGION=${{ parameters.region }}
 

--- a/.pipelines/templates/create-cluster.jobs.yaml
+++ b/.pipelines/templates/create-cluster.jobs.yaml
@@ -37,9 +37,7 @@ jobs:
             fi
 
             mkdir -p ~/.kube/
-            # make -C ./hack/aks azcfg AZCLI=az REGION=${{ parameters.region }}
-
-            az extension add --name aks-preview --upgrade
+            make -C ./hack/aks azcfg AZCLI=az REGION=${{ parameters.region }}
 
             make -C ./hack/aks ${{ parameters.clusterType }} \
             AZCLI=az REGION=${{ parameters.region }} SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) \

--- a/.pipelines/templates/create-cluster.yaml
+++ b/.pipelines/templates/create-cluster.yaml
@@ -25,12 +25,6 @@ jobs:
             set -e
             echo "Check az version"
             az version
-            if ${{ lower(contains(parameters.clusterType, 'dualstack')) }}
-            then
-              echo "Install az cli extension preview"
-              az extension add --name aks-preview
-              az extension update --name aks-preview
-            fi
 
             if ! [ -z ${K8S_VERSION} ]; then
               echo "Default k8s version, $(make -C ./hack/aks vars | grep K8S | cut -d'=' -f 2), is manually set to ${K8S_VERSION}"

--- a/.pipelines/templates/create-multitenant-cluster.steps.yaml
+++ b/.pipelines/templates/create-multitenant-cluster.steps.yaml
@@ -32,12 +32,6 @@ steps:
       set -e
       echo "Check az version"
       az version
-      if ${{ lower(contains(parameters.clusterType, 'dualstack')) }}
-      then
-        echo "Install az cli extension preview"
-        az extension add --name aks-preview
-        az extension update --name aks-preview
-      fi
       mkdir -p ~/.kube/
       make -C ./hack/aks azcfg AZCLI=az REGION=${{ parameters.region }}
 

--- a/.pipelines/templates/delete-cluster.steps.yaml
+++ b/.pipelines/templates/delete-cluster.steps.yaml
@@ -12,9 +12,7 @@ steps:
       addSpnToEnvironment: true
       inlineScript: |
         echo "Deleting cluster"
-        # make -C ./hack/aks azcfg AZCLI=az REGION=${{ parameters.region }}
-        #Temp fix for azcli aks preview bug
-        az extension add --name aks-preview --version 14.0.0b3
+        make -C ./hack/aks azcfg AZCLI=az REGION=${{ parameters.region }}
         make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
         make -C ./hack/aks down AZCLI=az REGION=${{ parameters.region }} SUB=${{ parameters.sub }} CLUSTER=${{ parameters.clusterName }}
         echo "Cluster and resources down"

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -52,9 +52,16 @@ azlogin: ## Login and set account to $SUB
 	@$(AZCLI) login
 	@$(AZCLI) account set -s $(SUB)
 
-azcfg: ## Set the $AZCLI to use aks-preview
-	@$(AZCLI) extension add --name aks-preview --yes
-	@$(AZCLI) extension update --name aks-preview
+# Fallback pin to work around aks-preview upstream breaks (checksum mismatches, etc.).
+# Past Issue: https://github.com/Azure/azure-cli-extensions/issues/10101
+AKS_PREVIEW_FALLBACK_VERSION ?= 21.0.0b7
+
+azcfg: ## Install aks-preview (latest, falling back to AKS_PREVIEW_FALLBACK_VERSION on failure)
+	@$(AZCLI) extension add --name aks-preview --upgrade --yes \
+		|| { \
+			echo "aks-preview latest install failed; falling back to $(AKS_PREVIEW_FALLBACK_VERSION)"; \
+			$(AZCLI) extension add --name aks-preview --version $(AKS_PREVIEW_FALLBACK_VERSION) --upgrade --yes; \
+		}
 
 ip:
 	$(AZCLI) network public-ip create --name $(IP_PREFIX)-$(CLUSTER)-$(IPVERSION) \


### PR DESCRIPTION
Backport of #4526 to the target release branch.

## Problem

Every CI job that installs the `aks-preview` az CLI extension is failing:

```
WARNING: No stable version of 'aks-preview' to install. Preview versions allowed.
ERROR: The checksum of the extension does not match the expected value.
make: *** [Makefile:89: azcfg] Error 1
```

Root cause: [Azure/azure-cli-extensions#10101](https://github.com/Azure/azure-cli-extensions/issues/10101) — aks-preview `21.0.0b9` was published 2026-07-13 with the wheel served from `azcliprod.blob.core.windows.net` hashing to `ae641562…1854` while `src/index.json` records `ff4b0191…5427`. Every `az extension add --name aks-preview` fails checksum validation until upstream re-publishes.

## Fix

Straight backport of #4526:

- **`hack/aks/Makefile`** — `azcfg` tries the latest aks-preview first, and on non-zero exit falls back to `$(AKS_PREVIEW_FALLBACK_VERSION)` (default `21.0.0b7`, last verified-good release).
- **`.pipelines/**/*.yaml`** — every inline `az extension add --name aks-preview` (and paired `update`) routes through `make -C ./hack/aks azcfg AZCLI=az`. Pin lives in exactly one place.
- **`create-cluster.yaml`** — dropped the dualstack-only aks-preview install block. It was redundant with the unconditional `make azcfg` call a few lines later, and the `if dualstack; then ... fi` had no other body on this branch, so removing the whole conditional avoids an empty bash block.
- **`delete-cluster.steps.yaml`** — retired the stale `14.0.0b3` inline pin (leftover from #3607).

## Behavior after merge

| Upstream state | Result |
|---|---|
| aks-preview latest is healthy | Tracks latest automatically |
| aks-preview latest is broken (today) | Falls back to `21.0.0b7`, CI keeps moving |
| Both broken | Recipe exits non-zero, job fails visibly |

## Verified locally against the broken b9

```
WARNING: No stable version of 'aks-preview' to install. Preview versions allowed.
ERROR: The checksum of the extension does not match the expected value. Use --debug for more information.
aks-preview latest install failed; falling back to 21.0.0b7
WARNING: The installed extension 'aks-preview' is in preview.
```

## Revert plan

Once upstream re-publishes `21.0.0b9` (or ships `21.0.0b10`) with a matching checksum, no action is required — the try branch will start succeeding again. Optionally bump `AKS_PREVIEW_FALLBACK_VERSION` in `hack/aks/Makefile` to the newest verified-good release.