### PR TITLE
fix(cns): make DeleteEndpointStateHandler idempotent

### DIFF
--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -1202,10 +1202,6 @@ func (service *HTTPRestService) DeleteEndpointStateHandler(w http.ResponseWriter
 			Message:    fmt.Sprintf("[DeleteEndpointStateHandler] Failed to delete endpoint state for %s with error: %s", endpointID, err.Error()),
 		}
 
-		if errors.Is(err, ErrEndpointStateNotFound) {
-			response.ReturnCode = types.NotFound
-		}
-
 		err = common.Encode(w, &response)
 		logger.Response(opName, response, response.ReturnCode, err) //nolint:staticcheck // reason: using deprecated call until migration to new API
 		return
@@ -1226,8 +1222,10 @@ func (service *HTTPRestService) DeleteEndpointStateHelper(endpointID string) err
 	logger.Printf("[deleteEndpointState] Deleting Endpoint state from state file %s", endpointID) //nolint:staticcheck // reason: using deprecated call until migration to new API
 	_, endpointExist := service.EndpointState[endpointID]
 	if !endpointExist {
+		// CNI DEL is required to be idempotent per the CNI spec, so a missing endpoint is not an error.
+		// The kubelet retries DEL on failure, which previously caused a retry storm (ICM 830677663).
 		logger.Printf("[deleteEndpointState] endpoint could not be found in the statefile %s", endpointID) //nolint:staticcheck // reason: using deprecated call until migration to new API
-		return fmt.Errorf("[deleteEndpointState] endpoint %s: %w", endpointID, ErrEndpointStateNotFound)
+		return nil
 	}
 
 	// Delete the endpoint from the state

--- a/cns/restserver/ipam_test.go
+++ b/cns/restserver/ipam_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"net/netip"
 	"strconv"
 	"testing"
@@ -2513,4 +2515,54 @@ func TestStatelessCNIStateFile(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestDeleteEndpointStateHelper_MissingIsSuccess verifies that deleting an endpoint
+// that is not present in the statefile returns success (idempotent no-op).
+// This is required by the CNI DEL contract; see ICM 830677663 for the regression
+// this test guards against.
+func TestDeleteEndpointStateHelper_MissingIsSuccess(t *testing.T) {
+	svc := getTestService(cns.KubernetesCRD)
+	svc.EndpointStateStore = store.NewMockStore("")
+	svc.EndpointState = map[string]*EndpointInfo{}
+
+	err := svc.DeleteEndpointStateHelper("unknown-container-id")
+	require.NoError(t, err)
+	assert.Empty(t, svc.EndpointState)
+}
+
+// TestDeleteEndpointStateHelper_DoubleDeleteIdempotent verifies that a second
+// delete for the same endpoint after a successful first delete also returns nil.
+func TestDeleteEndpointStateHelper_DoubleDeleteIdempotent(t *testing.T) {
+	svc := getTestService(cns.KubernetesCRD)
+	svc.EndpointStateStore = store.NewMockStore("")
+	endpointID := "container-id-double-delete"
+	svc.EndpointState = map[string]*EndpointInfo{
+		endpointID: {PodName: "pod1", PodNamespace: "default", IfnameToIPMap: map[string]*IPInfo{}},
+	}
+
+	require.NoError(t, svc.DeleteEndpointStateHelper(endpointID))
+	assert.NotContains(t, svc.EndpointState, endpointID)
+
+	require.NoError(t, svc.DeleteEndpointStateHelper(endpointID))
+	assert.NotContains(t, svc.EndpointState, endpointID)
+}
+
+// TestDeleteEndpointStateHandler_MissingReturnsSuccess verifies that the HTTP
+// handler reports Success (not NotFound / UnexpectedError) when the endpoint is
+// absent, so idempotent CNI DEL retries do not fail.
+func TestDeleteEndpointStateHandler_MissingReturnsSuccess(t *testing.T) {
+	svc := getTestService(cns.KubernetesCRD)
+	svc.EndpointStateStore = store.NewMockStore("")
+	svc.EndpointState = map[string]*EndpointInfo{}
+
+	req, err := http.NewRequest(http.MethodDelete, cns.EndpointPath+"unknown-container-id", http.NoBody)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+
+	svc.DeleteEndpointStateHandler(w, req)
+
+	var resp cns.Response
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, types.Success, resp.ReturnCode)
 }


### PR DESCRIPTION
## Incident

SwiftV2 CNI DEL retry storm on AzureML Singularity nodes (`azml-prod-centralus-azhub-36 / nd96v0100002a`). CNI DEL failed with:

```
[DeleteEndpointStateHandler] Failed to delete endpoint state for <id> with error:
[deleteEndpointState] endpoint <id>: endpoint state could not be found in the statefile
```

kubelet retries DEL indefinitely; pod stays stuck.

## Root cause

CNI DEL is required to be idempotent per the CNI spec, but CNS's endpoint DELETE API returned `types.NotFound` (wrapped as error) when the endpoint was not in the statefile. Combined with the client transport in `cns/client/client.go` dropping the response when `ReturnCode != 0`, the caller's NotFound-tolerance branch in `network/manager.go` was unreachable, so the error surfaced as a hard CNI DEL failure.

Kusto shows the specific trigger: for a SwiftV2 pod with both InfraNIC and FrontendNIC on one endpointID, the InfraNIC iteration's IPAM release removes the whole endpoint from the statefile via `removeEndpointState`; a subsequent `DeleteEndpointState` call for the same endpointID then returns NotFound, which today is fatal.

## Fix

Make `HTTPRestService.DeleteEndpointStateHelper` return `nil` when the endpoint is not in the statefile. Keep the existing `[deleteEndpointState] endpoint could not be found in the statefile` log so the situation remains observable. Remove the now-unreachable NotFound branch in `DeleteEndpointStateHandler`.

This makes the API correct by construction for every current and future caller.

## Non-goals

- No change to the CNI DEL loop in `cni/network/network.go`.
- No change to `network/manager.go DeleteState` (the now-dead NotFound branch there is out of scope).
- No change to `cns/client/client.go`.

## Tests

Added to `cns/restserver/ipam_test.go`:

- `TestDeleteEndpointStateHelper_MissingIsSuccess` — direct helper call on absent endpoint returns nil.
- `TestDeleteEndpointStateHelper_DoubleDeleteIdempotent` — second delete after successful first returns nil.
- `TestDeleteEndpointStateHandler_MissingReturnsSuccess` — HTTP handler returns `Success` (not `NotFound` / `UnexpectedError`) for an absent endpoint.

`go test ./cns/restserver/... -count=1 -race`: all pass.