### PR TITLE
test: cap linux arm64 image builds at 2 in parallel

### DIFF
--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -236,6 +236,7 @@ stages:
           pool:
             name: "$(BUILD_POOL_NAME_LINUX_ARM64)"
           strategy:
+            maxParallel: 2
             matrix:
               ${{ if eq(parameters.buildIpam, true) }}:
                 azure_ipam_linux_arm64:


### PR DESCRIPTION
The arm64 container matrix currently fans out to all matrix legs at once, which contributes to ARM/ACR throttling and disk pressure on the shared arm64 pool. Cap it at 2 concurrent jobs.


Copilot-Session: 2c6ff0c8-ce09-441d-acdd-1a124f688d31

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
