### PR TITLE
fix: allowlist all CILIUM_ rules in iptables monitor

### DIFF
--- a/azure-iptables-monitor/iptables_monitor_test.go
+++ b/azure-iptables-monitor/iptables_monitor_test.go
@@ -264,6 +264,47 @@ func TestHasUnexpectedRules(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "cilium raw DNS notrack rules allowlisted",
+			currentRules: []string{
+				"-A CILIUM_OUTPUT_raw -d 10.244.0.13/32 -p tcp -m tcp --dport 53 -j CT --notrack",
+				"-A CILIUM_OUTPUT_raw -s 10.244.0.13/32 -p tcp -m tcp --sport 53 -j CT --notrack",
+				"-A CILIUM_OUTPUT_raw -d 10.244.0.13/32 -p udp -m udp --dport 53 -j CT --notrack",
+				"-A CILIUM_OUTPUT_raw -s 10.244.0.13/32 -p udp -m udp --sport 53 -j CT --notrack",
+				"-A CILIUM_PRE_raw -d 10.244.0.13/32 -p tcp -m tcp --dport 53 -j CT --notrack",
+				"-A CILIUM_PRE_raw -s 10.244.0.13/32 -p tcp -m tcp --sport 53 -j CT --notrack",
+				"-A CILIUM_PRE_raw -d 10.244.0.13/32 -p udp -m udp --dport 53 -j CT --notrack",
+				"-A CILIUM_PRE_raw -s 10.244.0.13/32 -p udp -m udp --sport 53 -j CT --notrack",
+				"-A CILIUM_FORWARD -o lxc+ -m comment --comment \"cilium: any->cluster on lxc+ forward accept\" -j ACCEPT",
+				"-A CILIUM_POST_nat -s 10.244.0.0/24 ! -d 10.244.0.0/24 -o eth0 -j MASQUERADE",
+			},
+			allowedPatterns: []string{
+				`^-A CILIUM_\S+ `,
+			},
+			expected: false,
+		},
+		{
+			name: "cilium ip6 raw DNS notrack rules allowlisted",
+			currentRules: []string{
+				"-A CILIUM_OUTPUT_raw -d fd00::13/128 -p tcp -m tcp --dport 53 -j CT --notrack",
+				"-A CILIUM_PRE_raw -s fd00::13/128 -p udp -m udp --sport 53 -j CT --notrack",
+			},
+			allowedPatterns: []string{
+				`^-A CILIUM_\S+ `,
+			},
+			expected: false,
+		},
+		{
+			name: "cilium chain pattern does not match non-cilium chains",
+			currentRules: []string{
+				"-A OUTPUT -d 10.244.0.13/32 -p tcp -m tcp --dport 53 -j CT --notrack",
+				"-A MY_CUSTOM_CHAIN -j ACCEPT",
+			},
+			allowedPatterns: []string{
+				`^-A CILIUM_\S+ `,
+			},
+			expected: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/test/integration/manifests/cilium/v1.17/ebpf/common/allowed-iptables-patterns.yaml
+++ b/test/integration/manifests/cilium/v1.17/ebpf/common/allowed-iptables-patterns.yaml
@@ -19,6 +19,7 @@ data:
     ^.*--comment.*cilium:
     ^.*--comment.*cilium-feeder:
     ^.*--comment.*AKS managed: added by AgentBaker
+    ^-A CILIUM_\S+ 
   mangle: |
     -A FORWARD -d 168.63.129.16/32 -p tcp -m tcp --dport 80 -j DROP
     -A FORWARD -d 168.63.129.16/32 -p tcp -m tcp --dport 32526 -j DROP

--- a/test/integration/manifests/cilium/v1.17/ebpf/dualstack/static/allowed-ip6tables-patterns.yaml
+++ b/test/integration/manifests/cilium/v1.17/ebpf/dualstack/static/allowed-ip6tables-patterns.yaml
@@ -18,6 +18,7 @@ data:
     ^.*--comment.*cilium:
     ^.*--comment.*cilium-feeder:
     ^.*--comment.*AKS managed: added by AgentBaker
+    ^-A CILIUM_\S+ 
   mangle: |
 
   nat: |

--- a/test/integration/manifests/cilium/v1.18/ebpf/common/allowed-iptables-patterns.yaml
+++ b/test/integration/manifests/cilium/v1.18/ebpf/common/allowed-iptables-patterns.yaml
@@ -19,6 +19,7 @@ data:
     ^.*--comment.*cilium:
     ^.*--comment.*cilium-feeder:
     ^.*--comment.*AKS managed: added by AgentBaker
+    ^-A CILIUM_\S+ 
   mangle: |
     -A FORWARD -d 168.63.129.16/32 -p tcp -m tcp --dport 80 -j DROP
     -A FORWARD -d 168.63.129.16/32 -p tcp -m tcp --dport 32526 -j DROP

--- a/test/integration/manifests/cilium/v1.18/ebpf/dualstack/static/allowed-ip6tables-patterns.yaml
+++ b/test/integration/manifests/cilium/v1.18/ebpf/dualstack/static/allowed-ip6tables-patterns.yaml
@@ -18,6 +18,7 @@ data:
     ^.*--comment.*cilium:
     ^.*--comment.*cilium-feeder:
     ^.*--comment.*AKS managed: added by AgentBaker
+    ^-A CILIUM_\S+ 
   mangle: |
 
   nat: |

--- a/test/integration/manifests/cilium/v1.19/ebpf/common/allowed-iptables-patterns.yaml
+++ b/test/integration/manifests/cilium/v1.19/ebpf/common/allowed-iptables-patterns.yaml
@@ -19,6 +19,7 @@ data:
     ^.*--comment.*cilium:
     ^.*--comment.*cilium-feeder:
     ^.*--comment.*AKS managed: added by AgentBaker
+    ^-A CILIUM_\S+ 
   mangle: |
     -A FORWARD -d 168.63.129.16/32 -p tcp -m tcp --dport 80 -j DROP
     -A FORWARD -d 168.63.129.16/32 -p tcp -m tcp --dport 32526 -j DROP

--- a/test/integration/manifests/cilium/v1.19/ebpf/dualstack/static/allowed-ip6tables-patterns.yaml
+++ b/test/integration/manifests/cilium/v1.19/ebpf/dualstack/static/allowed-ip6tables-patterns.yaml
@@ -18,6 +18,7 @@ data:
     ^.*--comment.*cilium:
     ^.*--comment.*cilium-feeder:
     ^.*--comment.*AKS managed: added by AgentBaker
+    ^-A CILIUM_\S+ 
   mangle: |
 
   nat: |


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Allowlists new cilium rules in our tests to match aks. Rules associated with the CILIUM chains we assume to be managed by upstream and do not flag as user-added.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Upstream cilium now adds iptables rules that do not have the cilium comment so making the allowlist for iptables monitor more lenient.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests
- [X] relevant PR labels added

**Notes**:
