### PR TITLE
ci: use ACR images for Kubernetes e2e tests

### DIFF
--- a/.pipelines/cni/k8s-e2e/acnpublic-repo-list.yaml
+++ b/.pipelines/cni/k8s-e2e/acnpublic-repo-list.yaml
@@ -1,0 +1,12 @@
+gcAuthenticatedRegistry: acnpublic.azurecr.io/authenticated-image-pulling
+promoterE2eRegistry: acnpublic.azurecr.io/e2e-test-images
+buildImageRegistry: acnpublic.azurecr.io/build-image
+# These repositories remain absent so pull-failure and authenticated-pull tests fail closed.
+invalidRegistry: acnpublic.azurecr.io/invalid
+gcEtcdRegistry: acnpublic.azurecr.io
+gcRegistry: acnpublic.azurecr.io
+sigStorageRegistry: acnpublic.azurecr.io/sig-storage
+privateRegistry: acnpublic.azurecr.io/k8s-authenticated-test
+microsoftRegistry: acnpublic.azurecr.io/mcr
+dockerLibraryRegistry: acnpublic.azurecr.io/library
+cloudProviderGcpRegistry: acnpublic.azurecr.io/cloud-provider-gcp

--- a/.pipelines/cni/k8s-e2e/k8s-e2e-job-template.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e-job-template.yaml
@@ -38,6 +38,10 @@ jobs:
             # explictly unzip and strip directories from ginkgo and e2e.test
             tar -xvzf kubernetes-test-linux-amd64.tar.gz --strip-components=3 kubernetes/test/bin/ginkgo kubernetes/test/bin/e2e.test
 
+            kubeTestRepoList="$PWD/.pipelines/cni/k8s-e2e/acnpublic-repo-list.yaml"
+            test -f "$kubeTestRepoList"
+            echo "##vso[task.setvariable variable=KUBE_TEST_REPO_LIST]$kubeTestRepoList"
+
         displayName: "Setup Environment"
       - ${{ if contains(parameters.os, 'windows') }}:
           - script: |
@@ -74,6 +78,7 @@ jobs:
               os: ${{ parameters.os }}
               processes: 8
               attempts: 3
+
       - ${{ if eq(parameters.portforward, true) }}:
           - template: ../k8s-e2e/k8s-e2e-step-template.yaml
             parameters:
@@ -146,4 +151,3 @@ jobs:
               os: ${{ parameters.os }}
               processes: 8
               attempts: 3
-

--- a/.pipelines/cni/k8s-e2e/k8s-e2e-step-template.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e-step-template.yaml
@@ -63,6 +63,8 @@ steps:
       # flakeAttempts -> flake-attempts
       # dryRun -> dry-run
 
+      : "${KUBE_TEST_REPO_LIST:?KUBE_TEST_REPO_LIST must point to the ACR registry override file}"
+
       ./ginkgo --nodes=${{ parameters.processes }} \
       ./e2e.test -- \
       --num-nodes=2 \

--- a/.pipelines/cni/k8s-e2e/k8s-e2e.jobs.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e.jobs.yaml
@@ -41,6 +41,10 @@ jobs:
             # explictly unzip and strip directories from ginkgo and e2e.test
             tar -xvzf kubernetes-test-linux-amd64.tar.gz --strip-components=3 kubernetes/test/bin/ginkgo kubernetes/test/bin/e2e.test
 
+            kubeTestRepoList="$PWD/.pipelines/cni/k8s-e2e/acnpublic-repo-list.yaml"
+            test -f "$kubeTestRepoList"
+            echo "##vso[task.setvariable variable=KUBE_TEST_REPO_LIST]$kubeTestRepoList"
+
         displayName: "Setup Environment"
       - ${{ if contains(parameters.os, 'windows') }}:
           - script: |

--- a/.pipelines/cni/k8s-e2e/k8s-e2e.steps.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e.steps.yaml
@@ -64,6 +64,8 @@ steps:
       # flakeAttempts -> flake-attempts
       # dryRun -> dry-run
 
+      : "${KUBE_TEST_REPO_LIST:?KUBE_TEST_REPO_LIST must point to the ACR registry override file}"
+
       ./ginkgo --nodes=${{ parameters.processes }} \
       ./e2e.test -- \
       --num-nodes=2 \

--- a/.pipelines/cni/k8s-e2e/mirror-k8s-e2e-images.sh
+++ b/.pipelines/cni/k8s-e2e/mirror-k8s-e2e-images.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+	echo "usage: $0 <e2e.test path> <ACR name> <ACR subscription>" >&2
+	exit 1
+fi
+
+e2e_test=$1
+acr_name=$2
+acr_subscription=$3
+
+if [[ ! -x "$e2e_test" ]]; then
+	echo "e2e.test is not executable: $e2e_test" >&2
+	exit 1
+fi
+
+image_list=$(mktemp)
+trap 'rm -f "$image_list"' EXIT
+"$e2e_test" --list-images >"$image_list"
+
+mapfile -t images < <(sort -u "$image_list")
+if [[ ${#images[@]} -eq 0 ]]; then
+	echo "e2e.test returned no images" >&2
+	exit 1
+fi
+
+echo "Processing ${#images[@]} Kubernetes test images for $acr_name"
+for source in "${images[@]}"; do
+	case "$source" in
+	registry.k8s.io/*)
+		destination=${source#registry.k8s.io/}
+		;;
+	mcr.microsoft.com/*)
+		destination=mcr/${source#mcr.microsoft.com/}
+		;;
+	docker.io/library/*)
+		destination=library/${source#docker.io/library/}
+		;;
+	gcr.io/authenticated-image-pulling/* | gcr.io/k8s-authenticated-test/* | invalid.registry.k8s.io/*)
+		echo "Skipping intentionally unavailable test image $source"
+		continue
+		;;
+	*)
+		echo "Skipping image without a Kubernetes registry override: $source"
+		continue
+		;;
+	esac
+
+	echo "Importing $source as $destination"
+	az acr import \
+		--subscription "$acr_subscription" \
+		--name "$acr_name" \
+		--source "$source" \
+		--image "$destination" \
+		--force \
+		--output none
+done

--- a/.pipelines/templates/k8s-e2e-step-template.yaml
+++ b/.pipelines/templates/k8s-e2e-step-template.yaml
@@ -37,6 +37,10 @@ steps:
         # explicitly unzip and strip directories from ginkgo and e2e.test
         tar -xvzf kubernetes-test-linux-amd64.tar.gz --strip-components=3 kubernetes/test/bin/ginkgo kubernetes/test/bin/e2e.test
 
+        kubeTestRepoList="$PWD/.pipelines/cni/k8s-e2e/acnpublic-repo-list.yaml"
+        test -f "$kubeTestRepoList"
+        echo "##vso[task.setvariable variable=KUBE_TEST_REPO_LIST]$kubeTestRepoList"
+
     displayName: "Setup k8s E2E Environment"
   - ${{ if contains(parameters.os, 'windows') }}:
       - script: |


### PR DESCRIPTION
## Summary
- route Kubernetes e2e workload images through `acnpublic.azurecr.io` with `KUBE_TEST_REPO_LIST`
- cover both classic and OneBranch shared e2e pipeline templates
- add a version-aware helper that imports the images reported by the matching `e2e.test` binary
- retain intentionally unavailable image repositories for negative/authenticated pull tests

## Validation
- ran the existing datapath focus/skip pattern against an AKS Azure CNI Overlay cluster on Kubernetes v1.35.5
- 22/22 datapath specs passed with 8 Ginkgo workers
- validated repo-list compatibility with Kubernetes v1.25.16 and v1.35.5
- validated pipeline YAML and mirror helper failure handling