### PR TITLE
fix: add allow patterns for bootp rules that are part of azl image

### DIFF
--- a/test/integration/manifests/cilium/v1.17/ebpf/common/allowed-iptables-patterns.yaml
+++ b/test/integration/manifests/cilium/v1.17/ebpf/common/allowed-iptables-patterns.yaml
@@ -7,6 +7,7 @@ data:
   filter: |
     -A FORWARD -d 168.63.129.16/32 -p tcp -m tcp --dport 32526 -j DROP
     -A FORWARD -d 168.63.129.16/32 -p tcp -m tcp --dport 80 -j DROP
+    -A INPUT -p udp --dport 68 -j ACCEPT
   global: |
     ^-N .*
     ^-P .*

--- a/test/integration/manifests/cilium/v1.17/ebpf/dualstack/static/allowed-ip6tables-patterns.yaml
+++ b/test/integration/manifests/cilium/v1.17/ebpf/dualstack/static/allowed-ip6tables-patterns.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: kube-system
 data:
   filter: |
+    -A INPUT -p udp --dport 68 -j ACCEPT
 
   global: |
     ^-N .*

--- a/test/integration/manifests/cilium/v1.18/ebpf/common/allowed-iptables-patterns.yaml
+++ b/test/integration/manifests/cilium/v1.18/ebpf/common/allowed-iptables-patterns.yaml
@@ -7,6 +7,7 @@ data:
   filter: |
     -A FORWARD -d 168.63.129.16/32 -p tcp -m tcp --dport 32526 -j DROP
     -A FORWARD -d 168.63.129.16/32 -p tcp -m tcp --dport 80 -j DROP
+    -A INPUT -p udp --dport 68 -j ACCEPT
   global: |
     ^-N .*
     ^-P .*

--- a/test/integration/manifests/cilium/v1.18/ebpf/dualstack/static/allowed-ip6tables-patterns.yaml
+++ b/test/integration/manifests/cilium/v1.18/ebpf/dualstack/static/allowed-ip6tables-patterns.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: kube-system
 data:
   filter: |
+     -A INPUT -p udp --dport 68 -j ACCEPT
 
   global: |
     ^-N .*

--- a/test/integration/manifests/cilium/v1.18/ebpf/dualstack/static/allowed-ip6tables-patterns.yaml
+++ b/test/integration/manifests/cilium/v1.18/ebpf/dualstack/static/allowed-ip6tables-patterns.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
 data:
   filter: |
-     -A INPUT -p udp --dport 68 -j ACCEPT
+    -A INPUT -p udp --dport 68 -j ACCEPT
 
   global: |
     ^-N .*

--- a/test/integration/manifests/cilium/v1.19/ebpf/common/allowed-iptables-patterns.yaml
+++ b/test/integration/manifests/cilium/v1.19/ebpf/common/allowed-iptables-patterns.yaml
@@ -7,6 +7,7 @@ data:
   filter: |
     -A FORWARD -d 168.63.129.16/32 -p tcp -m tcp --dport 32526 -j DROP
     -A FORWARD -d 168.63.129.16/32 -p tcp -m tcp --dport 80 -j DROP
+    -A INPUT -p udp --dport 68 -j ACCEPT
   global: |
     ^-N .*
     ^-P .*

--- a/test/integration/manifests/cilium/v1.19/ebpf/dualstack/static/allowed-ip6tables-patterns.yaml
+++ b/test/integration/manifests/cilium/v1.19/ebpf/dualstack/static/allowed-ip6tables-patterns.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: kube-system
 data:
   filter: |
+    -A INPUT -p udp --dport 68 -j ACCEPT
 
   global: |
     ^-N .*


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
AZL images have an iptables rule that allows port 68. It gets deleted eventually but may cause events in EBPF host routing mode.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
