### PR TITLE
[backport release/v1.7] chore: upgrade Go 1.24 → 1.26.4

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT="1.24"
+ARG VARIANT="1.26"
 FROM mcr.microsoft.com/vscode/devcontainers/go:${VARIANT}
 RUN apt-get update && \
     export DEBIAN_FRONTEND=noninteractive && \

--- a/.pipelines/build/dockerfiles/azure-ip-masq-merger.Dockerfile
+++ b/.pipelines/build/dockerfiles/azure-ip-masq-merger.Dockerfile
@@ -2,8 +2,8 @@
 # SOURCE: .pipelines/build/dockerfiles/azure-ip-masq-merger.Dockerfile.tmpl
 ARG ARCH
 
-# mcr.microsoft.com/azurelinux/distroless/minimal:3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:576d9769c0146cbf0cf7946bacf536c5758464c29eadfa03ef5090ae708e641f AS linux
+# mcr.microsoft.com/azurelinux/distroless/base:3.0
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:178f25fadf466549d31e234b3091bf815161159f2f2bc98720bbf39f7368aff4 AS linux
 ARG ARTIFACT_DIR
 
 COPY ${ARTIFACT_DIR}/bin/azure-ip-masq-merger /azure-ip-masq-merger

--- a/.pipelines/build/dockerfiles/azure-ip-masq-merger.Dockerfile
+++ b/.pipelines/build/dockerfiles/azure-ip-masq-merger.Dockerfile
@@ -2,7 +2,8 @@
 # SOURCE: .pipelines/build/dockerfiles/azure-ip-masq-merger.Dockerfile.tmpl
 ARG ARCH
 
-FROM scratch AS linux
+# mcr.microsoft.com/azurelinux/distroless/minimal:3.0
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:576d9769c0146cbf0cf7946bacf536c5758464c29eadfa03ef5090ae708e641f AS linux
 ARG ARTIFACT_DIR
 
 COPY ${ARTIFACT_DIR}/bin/azure-ip-masq-merger /azure-ip-masq-merger

--- a/.pipelines/build/dockerfiles/azure-ip-masq-merger.Dockerfile.tmpl
+++ b/.pipelines/build/dockerfiles/azure-ip-masq-merger.Dockerfile.tmpl
@@ -2,7 +2,8 @@
 # SOURCE: {{.SRC_PIPE}}
 ARG ARCH
 
-FROM scratch AS linux
+# {{.MARINER_DISTROLESS_IMG}}
+FROM --platform=linux/${ARCH} {{.MARINER_DISTROLESS_PIN}} AS linux
 ARG ARTIFACT_DIR
 
 COPY ${ARTIFACT_DIR}/bin/azure-ip-masq-merger /azure-ip-masq-merger

--- a/.pipelines/build/dockerfiles/azure-ipam.Dockerfile
+++ b/.pipelines/build/dockerfiles/azure-ipam.Dockerfile
@@ -10,8 +10,8 @@ ARG ARTIFACT_DIR .
 COPY ${ARTIFACT_DIR}/bin/dropgz.exe /dropgz.exe
 ENTRYPOINT [ "/dropgz.exe" ]
 
-
-FROM scratch AS linux
+# mcr.microsoft.com/azurelinux/distroless/minimal:3.0
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:576d9769c0146cbf0cf7946bacf536c5758464c29eadfa03ef5090ae708e641f AS linux
 ARG ARTIFACT_DIR .
 
 COPY ${ARTIFACT_DIR}/bin/dropgz /dropgz

--- a/.pipelines/build/dockerfiles/azure-ipam.Dockerfile
+++ b/.pipelines/build/dockerfiles/azure-ipam.Dockerfile
@@ -10,8 +10,8 @@ ARG ARTIFACT_DIR .
 COPY ${ARTIFACT_DIR}/bin/dropgz.exe /dropgz.exe
 ENTRYPOINT [ "/dropgz.exe" ]
 
-# mcr.microsoft.com/azurelinux/distroless/minimal:3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:576d9769c0146cbf0cf7946bacf536c5758464c29eadfa03ef5090ae708e641f AS linux
+# mcr.microsoft.com/azurelinux/distroless/base:3.0
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:178f25fadf466549d31e234b3091bf815161159f2f2bc98720bbf39f7368aff4 AS linux
 ARG ARTIFACT_DIR .
 
 COPY ${ARTIFACT_DIR}/bin/dropgz /dropgz

--- a/.pipelines/build/dockerfiles/azure-ipam.Dockerfile.tmpl
+++ b/.pipelines/build/dockerfiles/azure-ipam.Dockerfile.tmpl
@@ -10,8 +10,8 @@ ARG ARTIFACT_DIR .
 COPY ${ARTIFACT_DIR}/bin/dropgz.exe /dropgz.exe
 ENTRYPOINT [ "/dropgz.exe" ]
 
-
-FROM scratch AS linux
+# {{.MARINER_DISTROLESS_IMG}}
+FROM --platform=linux/${ARCH} {{.MARINER_DISTROLESS_PIN}} AS linux
 ARG ARTIFACT_DIR .
 
 COPY ${ARTIFACT_DIR}/bin/dropgz /dropgz

--- a/.pipelines/build/dockerfiles/azure-iptables-monitor.Dockerfile
+++ b/.pipelines/build/dockerfiles/azure-iptables-monitor.Dockerfile
@@ -5,8 +5,8 @@ ARG ARCH
 # mcr.microsoft.com/azurelinux/base/core:3.0
 FROM mcr.microsoft.com/azurelinux/base/core:3.0@sha256:4ecd6b297db85c54ec2df07145a28536c3655a3e98e54eb2364189bc4e6eac23 AS mariner-core
 
-# mcr.microsoft.com/azurelinux/distroless/minimal:3.0
-FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:576d9769c0146cbf0cf7946bacf536c5758464c29eadfa03ef5090ae708e641f AS mariner-distroless
+# mcr.microsoft.com/azurelinux/distroless/base:3.0
+FROM mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:178f25fadf466549d31e234b3091bf815161159f2f2bc98720bbf39f7368aff4 AS mariner-distroless
 
 FROM mariner-core AS iptools
 RUN tdnf install -y iptables iproute

--- a/.pipelines/build/dockerfiles/azure-iptables-monitor.Dockerfile
+++ b/.pipelines/build/dockerfiles/azure-iptables-monitor.Dockerfile
@@ -3,18 +3,20 @@
 ARG ARCH
 
 # mcr.microsoft.com/azurelinux/base/core:3.0
-FROM mcr.microsoft.com/azurelinux/base/core:3.0@sha256:a452d39c91576f5a2c983c7d3b62521fabd08e16b4a7237e24bf2be3b06e1651 AS mariner-core
+FROM mcr.microsoft.com/azurelinux/base/core:3.0@sha256:4ecd6b297db85c54ec2df07145a28536c3655a3e98e54eb2364189bc4e6eac23 AS mariner-core
 
 # mcr.microsoft.com/azurelinux/distroless/minimal:3.0
-FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:22810fd97d6ad5ec7d5bdd5b00233a3050be01d9e26b47b16cb6f1a7f178834b AS mariner-distroless
+FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:576d9769c0146cbf0cf7946bacf536c5758464c29eadfa03ef5090ae708e641f AS mariner-distroless
 
-FROM mariner-core AS iptables
-RUN tdnf install -y iptables
+FROM mariner-core AS iptools
+RUN tdnf install -y iptables iproute
 
 FROM mariner-distroless AS linux
 ARG ARTIFACT_DIR
-COPY --from=iptables /usr/sbin/*tables* /usr/sbin/
-COPY --from=iptables /usr/lib /usr/lib
+COPY --from=iptools /usr/sbin/*tables* /usr/sbin/
+COPY --from=iptools /usr/sbin/ip /usr/sbin/
+COPY --from=iptools /usr/lib /usr/lib
+COPY --from=iptools /usr/lib64 /usr/lib64
 COPY ${ARTIFACT_DIR}/bin/azure-iptables-monitor /azure-iptables-monitor
 COPY ${ARTIFACT_DIR}/bin/azure-block-iptables /azure-block-iptables
 

--- a/.pipelines/build/dockerfiles/cni.Dockerfile
+++ b/.pipelines/build/dockerfiles/cni.Dockerfile
@@ -9,8 +9,8 @@ ARG ARTIFACT_DIR .
 COPY ${ARTIFACT_DIR}/bin/dropgz.exe /dropgz.exe
 ENTRYPOINT [ "/dropgz.exe" ]
 
-# mcr.microsoft.com/azurelinux/distroless/minimal:3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:576d9769c0146cbf0cf7946bacf536c5758464c29eadfa03ef5090ae708e641f AS linux
+# mcr.microsoft.com/azurelinux/distroless/base:3.0
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:178f25fadf466549d31e234b3091bf815161159f2f2bc98720bbf39f7368aff4 AS linux
 ARG ARTIFACT_DIR .
 
 COPY ${ARTIFACT_DIR}/bin/dropgz /dropgz

--- a/.pipelines/build/dockerfiles/cni.Dockerfile
+++ b/.pipelines/build/dockerfiles/cni.Dockerfile
@@ -9,8 +9,8 @@ ARG ARTIFACT_DIR .
 COPY ${ARTIFACT_DIR}/bin/dropgz.exe /dropgz.exe
 ENTRYPOINT [ "/dropgz.exe" ]
 
-
-FROM scratch AS linux
+# mcr.microsoft.com/azurelinux/distroless/minimal:3.0
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:576d9769c0146cbf0cf7946bacf536c5758464c29eadfa03ef5090ae708e641f AS linux
 ARG ARTIFACT_DIR .
 
 COPY ${ARTIFACT_DIR}/bin/dropgz /dropgz

--- a/.pipelines/build/dockerfiles/cni.Dockerfile.tmpl
+++ b/.pipelines/build/dockerfiles/cni.Dockerfile.tmpl
@@ -9,8 +9,8 @@ ARG ARTIFACT_DIR .
 COPY ${ARTIFACT_DIR}/bin/dropgz.exe /dropgz.exe
 ENTRYPOINT [ "/dropgz.exe" ]
 
-
-FROM scratch AS linux
+# {{.MARINER_DISTROLESS_IMG}}
+FROM --platform=linux/${ARCH} {{.MARINER_DISTROLESS_PIN}} AS linux
 ARG ARTIFACT_DIR .
 
 COPY ${ARTIFACT_DIR}/bin/dropgz /dropgz

--- a/.pipelines/build/dockerfiles/cns.Dockerfile
+++ b/.pipelines/build/dockerfiles/cns.Dockerfile
@@ -14,8 +14,8 @@ EXPOSE 10090
 FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/base/core:3.0@sha256:4ecd6b297db85c54ec2df07145a28536c3655a3e98e54eb2364189bc4e6eac23 AS build-helper
 RUN tdnf install -y iptables
 
-# mcr.microsoft.com/azurelinux/distroless/minimal:3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:576d9769c0146cbf0cf7946bacf536c5758464c29eadfa03ef5090ae708e641f AS linux
+# mcr.microsoft.com/azurelinux/distroless/base:3.0
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:178f25fadf466549d31e234b3091bf815161159f2f2bc98720bbf39f7368aff4 AS linux
 ARG ARTIFACT_DIR .
 
 COPY --from=build-helper /usr/sbin/*tables* /usr/sbin/

--- a/.pipelines/build/dockerfiles/cns.Dockerfile
+++ b/.pipelines/build/dockerfiles/cns.Dockerfile
@@ -11,11 +11,11 @@ ENTRYPOINT ["azure-cns.exe"]
 EXPOSE 10090
 
 # mcr.microsoft.com/azurelinux/base/core:3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/base/core:3.0@sha256:94ad614201891509f6680b8d392f519df0274460417dfe6662643800822e380d AS build-helper
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/base/core:3.0@sha256:4ecd6b297db85c54ec2df07145a28536c3655a3e98e54eb2364189bc4e6eac23 AS build-helper
 RUN tdnf install -y iptables
 
 # mcr.microsoft.com/azurelinux/distroless/minimal:3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:138fe2905465e384b232ffe8ba3147de04c633a83f29d8df00d6817e3eacb0d2 AS linux
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:576d9769c0146cbf0cf7946bacf536c5758464c29eadfa03ef5090ae708e641f AS linux
 ARG ARTIFACT_DIR .
 
 COPY --from=build-helper /usr/sbin/*tables* /usr/sbin/

--- a/.pipelines/build/scripts/azure-ip-masq-merger.sh
+++ b/.pipelines/build/scripts/azure-ip-masq-merger.sh
@@ -5,6 +5,7 @@ set -eux
 FILE_EXT=''
 
 export CGO_ENABLED=0
+export GOEXPERIMENT=ms_nocgo_opensslcrypto
 
 mkdir -p "$OUT_DIR"/bin
 mkdir -p "$OUT_DIR"/files

--- a/.pipelines/build/scripts/azure-ipam.sh
+++ b/.pipelines/build/scripts/azure-ipam.sh
@@ -4,6 +4,7 @@ set -eux
 [[ $OS =~ windows ]] && FILE_EXT='.exe' || FILE_EXT=''
 
 export CGO_ENABLED=0
+export GOEXPERIMENT=ms_nocgo_opensslcrypto
 
 mkdir -p "$OUT_DIR"/bin
 mkdir -p "$OUT_DIR"/files

--- a/.pipelines/build/scripts/azure-iptables-monitor.sh
+++ b/.pipelines/build/scripts/azure-iptables-monitor.sh
@@ -5,6 +5,7 @@ set -eux
 FILE_EXT=''
 
 export CGO_ENABLED=0
+export GOEXPERIMENT=ms_nocgo_opensslcrypto
 export C_INCLUDE_PATH=/usr/include/bpf
 
 mkdir -p "$OUT_DIR"/bin

--- a/.pipelines/build/scripts/cilium-log-collector.sh
+++ b/.pipelines/build/scripts/cilium-log-collector.sh
@@ -4,6 +4,7 @@ set -eux
 [[ $OS =~ windows ]] && { echo "cilium-log-collector is not supported on Windows"; exit 1; }
 # enable cgo for -buildmode=c-shared
 export CGO_ENABLED=1
+export GOEXPERIMENT=systemcrypto
 
 mkdir -p "$OUT_DIR"/bin
 mkdir -p "$OUT_DIR"/files

--- a/.pipelines/build/scripts/cni.sh
+++ b/.pipelines/build/scripts/cni.sh
@@ -7,6 +7,7 @@ mkdir -p "$OUT_DIR"/files
 mkdir -p "$OUT_DIR"/bin
 
 export CGO_ENABLED=0
+export GOEXPERIMENT=ms_nocgo_opensslcrypto
 
 
 CNI_NET_DIR="$REPO_ROOT"/cni/network/plugin

--- a/.pipelines/build/scripts/cns.sh
+++ b/.pipelines/build/scripts/cns.sh
@@ -4,6 +4,7 @@ set -eux
 [[ $OS =~ windows ]] && FILE_EXT='.exe' || FILE_EXT=''
 
 export CGO_ENABLED=0
+export GOEXPERIMENT=ms_nocgo_opensslcrypto
 
 mkdir -p "$OUT_DIR"/files
 mkdir -p "$OUT_DIR"/bin

--- a/.pipelines/build/scripts/dropgz.sh
+++ b/.pipelines/build/scripts/dropgz.sh
@@ -21,6 +21,7 @@ function files::remove_exe_extensions() {
 [[ $OS =~ windows ]] && FILE_EXT='.exe' || FILE_EXT=''
 
 export CGO_ENABLED=0
+export GOEXPERIMENT=ms_nocgo_opensslcrypto
 
 mkdir -p "$GEN_DIR"
 mkdir -p "$OUT_DIR"/bin

--- a/.pipelines/build/scripts/install-go.sh
+++ b/.pipelines/build/scripts/install-go.sh
@@ -50,8 +50,24 @@ fi
 
 ARCH="${ARCH:-amd64}"
 
+# Remove any pre-installed Go to prevent source file contamination.
+# tar extract overlays onto the existing directory without deleting files that
+# are absent from the archive. When the agent's pre-installed Go and msft-go
+# have different source files (e.g. crypto/internal/fips140, internal/runtime),
+# both sets survive the overlay, causing redeclaration and undefined-symbol
+# build errors.
+sudo rm -rf /usr/local/go
+
 # Extract /usr/local/go from the image without needing a Docker daemon.
 # crane export streams the full image filesystem; we extract just usr/local/go.
 crane export --platform "linux/${ARCH}" "$MSFT_GO_IMAGE" - | sudo tar -xf - -C / usr/local/go
+
+# Prevent the Go toolchain from auto-downloading upstream (non-FIPS) Go.
+# With GOTOOLCHAIN=local, the build uses exactly the msft-go we just installed.
+export GOTOOLCHAIN=local
+echo "##vso[task.setvariable variable=GOTOOLCHAIN]local"
+
+# Clear any build cache left by the agent's previous Go version.
+/usr/local/go/bin/go clean -cache 2>/dev/null || true
 
 echo "##vso[task.prependpath]/usr/local/go/bin"

--- a/.pipelines/build/scripts/install-go.sh
+++ b/.pipelines/build/scripts/install-go.sh
@@ -11,9 +11,9 @@ set -euxo pipefail
 #   3. Hardcoded fallback digest below
 #
 # To update the fallback, run:
-#   IMG=mcr.microsoft.com/oss/go/microsoft/golang:1.24-azurelinux3.0
+#   IMG=mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0
 #   echo "${IMG}@$(skopeo inspect docker://${IMG} --format '{{.Digest}}')"
-DEFAULT_IMAGE="mcr.microsoft.com/oss/go/microsoft/golang:1.24-azurelinux3.0@sha256:3999f970bb52b7413ef9be2803173d4fd7f1f3c59362a98a0c78d155e3a0e59f"
+DEFAULT_IMAGE="mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0@sha256:7eaa7ec1b6c116d1b914d4699ff7726189e0dd78ff29801af48b559a5922a3d6"
 
 # Resolves the golang image from the source Dockerfile for the given $name.
 # Echoes the image reference, or empty string if it cannot be determined.

--- a/.pipelines/build/scripts/ipv6-hp-bpf.sh
+++ b/.pipelines/build/scripts/ipv6-hp-bpf.sh
@@ -38,6 +38,7 @@ function findcp::shared_library() {
 [[ $OS =~ windows ]] && FILE_EXT='.exe' || FILE_EXT=''
 
 export CGO_ENABLED=0
+export GOEXPERIMENT=ms_nocgo_opensslcrypto
 export C_INCLUDE_PATH=/usr/include/bpf
 
 mkdir -p "$OUT_DIR"/bin

--- a/.pipelines/build/scripts/npm.sh
+++ b/.pipelines/build/scripts/npm.sh
@@ -4,6 +4,7 @@ set -eux
 [[ $OS =~ windows ]] && FILE_EXT='.exe' || FILE_EXT=''
 
 export CGO_ENABLED=0
+export GOEXPERIMENT=ms_nocgo_opensslcrypto
 
 mkdir -p "$OUT_DIR"/files
 mkdir -p "$OUT_DIR"/bin

--- a/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
+++ b/.pipelines/cni/cilium/cilium-overlay-load-test-template.yaml
@@ -146,6 +146,16 @@ stages:
         displayName: "Deploy CNS and IPAM"
         dependsOn: deploy_cilium_components
         steps:
+          - script: |
+              GO_VER=$(grep '^toolchain' go.mod | sed 's/toolchain go//' | cut -d. -f1,2)
+              if [ -z "$GO_VER" ]; then GO_VER=$(grep '^go ' go.mod | awk '{print $2}' | cut -d. -f1,2); fi
+              if [ -z "$GO_VER" ]; then echo "##[error]Failed to detect Go version from go.mod"; exit 1; fi
+              echo "##vso[task.setvariable variable=GO_TOOLCHAIN_VERSION]$GO_VER"
+            displayName: "Detect Go version from go.mod"
+          - task: GoTool@0
+            inputs:
+              version: '$(GO_TOOLCHAIN_VERSION)'
+            displayName: "Install Go"
           - task: AzureCLI@2
             displayName: "Install CNS and IPAM"
             inputs:

--- a/.pipelines/cni/cilium/cilium-scale-test.yaml
+++ b/.pipelines/cni/cilium/cilium-scale-test.yaml
@@ -35,6 +35,17 @@ stages:
         pool:
           name: "$(BUILD_POOL_NAME_DEFAULT)"
         steps:
+          - script: |
+              GO_VER=$(grep '^toolchain' go.mod | sed 's/toolchain go//' | cut -d. -f1,2)
+              if [ -z "$GO_VER" ]; then GO_VER=$(grep '^go ' go.mod | awk '{print $2}' | cut -d. -f1,2); fi
+              if [ -z "$GO_VER" ]; then echo "##[error]Failed to detect Go version from go.mod"; exit 1; fi
+              echo "##vso[task.setvariable variable=GO_TOOLCHAIN_VERSION]$GO_VER"
+            displayName: "Detect Go version from go.mod"
+          - task: GoTool@0
+            inputs:
+              version: '$(GO_TOOLCHAIN_VERSION)'
+            displayName: "Install Go"
+          - template: ../../templates/cilium-cli.yaml
           - task: AzureCLI@2
             inputs:
               azureSubscription: $(TEST_SUB_SERVICE_CONNECTION)

--- a/.pipelines/cni/singletenancy/cniv2-template.yaml
+++ b/.pipelines/cni/singletenancy/cniv2-template.yaml
@@ -130,6 +130,16 @@ stages:
       - job: integration
         displayName: "Integration Test - ${{ parameters.name }}"
         steps:
+          - script: |
+              GO_VER=$(grep '^toolchain' go.mod | sed 's/toolchain go//' | cut -d. -f1,2)
+              if [ -z "$GO_VER" ]; then GO_VER=$(grep '^go ' go.mod | awk '{print $2}' | cut -d. -f1,2); fi
+              if [ -z "$GO_VER" ]; then echo "##[error]Failed to detect Go version from go.mod"; exit 1; fi
+              echo "##vso[task.setvariable variable=GO_TOOLCHAIN_VERSION]$GO_VER"
+            displayName: "Detect Go version from go.mod"
+          - task: GoTool@0
+            inputs:
+              version: '$(GO_TOOLCHAIN_VERSION)'
+            displayName: "Install Go"
           - ${{ if contains(parameters.clusterType, 'overlay') }}:
             - task: AzureCLI@2
               inputs:

--- a/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e.steps.yaml
+++ b/.pipelines/singletenancy/cilium-dualstack-overlay/cilium-dualstackoverlay-e2e.steps.yaml
@@ -19,8 +19,6 @@ steps:
     inputs:
       kubectlVersion: latest
 
-  - template: ../../templates/cilium-cli.yaml
-
   - task: AzureCLI@2
     displayName: Set cluster credentials
     inputs:

--- a/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e.steps.yaml
+++ b/.pipelines/singletenancy/cilium-overlay-withhubble/cilium-overlay-e2e.steps.yaml
@@ -21,8 +21,6 @@ steps:
     inputs:
       kubectlVersion: latest
 
-  - template: ../../templates/cilium-cli.yaml
-
   - task: AzureCLI@2
     displayName: Set cluster credentials
     inputs:

--- a/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e.steps.yaml
+++ b/.pipelines/singletenancy/cilium-overlay/cilium-overlay-e2e.steps.yaml
@@ -22,8 +22,6 @@ steps:
     inputs:
       kubectlVersion: latest
 
-  - template: ../../templates/cilium-cli.yaml
-
   - task: AzureCLI@2
     displayName: Set cluster credentials
     inputs:

--- a/.pipelines/singletenancy/cilium/cilium-e2e.steps.yaml
+++ b/.pipelines/singletenancy/cilium/cilium-e2e.steps.yaml
@@ -19,8 +19,6 @@ steps:
     inputs:
       kubectlVersion: latest
 
-  - template: ../../templates/cilium-cli.yaml
-
   - task: AzureCLI@2
     displayName: Set cluster credentials
     inputs:

--- a/.pipelines/templates/run-unit-tests.stages.yaml
+++ b/.pipelines/templates/run-unit-tests.stages.yaml
@@ -22,9 +22,18 @@ stages:
     steps:
     - checkout: azure-container-networking
 
+    - script: |
+        GO_VER=$(grep '^toolchain' go.mod | sed 's/toolchain go//' | cut -d. -f1,2)
+        if [ -z "$GO_VER" ]; then GO_VER=$(grep '^go ' go.mod | awk '{print $2}' | cut -d. -f1,2); fi
+        if [ -z "$GO_VER" ]; then echo "##[error]Failed to detect Go version from go.mod"; exit 1; fi
+        echo "##vso[task.setvariable variable=GO_TOOLCHAIN_VERSION]$GO_VER"
+        echo "Detected Go version: $GO_VER"
+      displayName: "Detect Go version from go.mod"
+
     - task: GoTool@0
       inputs:
-        version: '$(GOVERSION)'
+        version: '$(GO_TOOLCHAIN_VERSION)'
+      displayName: "Install Go"
 
     - script: |
         set -e
@@ -124,9 +133,24 @@ stages:
     steps:
     - checkout: azure-container-networking
 
+    - powershell: |
+        $gomod = $null
+        if (Test-Path "go.mod") { $gomod = "go.mod" }
+        elseif (Test-Path "azure-container-networking/go.mod") { $gomod = "azure-container-networking/go.mod" }
+        elseif (Test-Path "$(Build.SourcesDirectory)/go.mod") { $gomod = "$(Build.SourcesDirectory)/go.mod" }
+        if ($gomod) {
+          $toolchain = Select-String -Path $gomod -Pattern '^toolchain go(\d+\.\d+)' | ForEach-Object { $_.Matches[0].Groups[1].Value }
+        }
+        if (-not $toolchain -and $gomod) { $toolchain = Select-String -Path $gomod -Pattern '^go (\d+\.\d+)' | ForEach-Object { $_.Matches[0].Groups[1].Value } }
+        if (-not $toolchain) { Write-Error "Failed to detect Go version from go.mod"; exit 1 }
+        Write-Host "##vso[task.setvariable variable=GO_TOOLCHAIN_VERSION]$toolchain"
+        Write-Host "Detected Go version: $toolchain from $gomod"
+      displayName: "Detect Go version from go.mod"
+
     - task: GoTool@0
       inputs:
-        version: '$(GOVERSION)'
+        version: '$(GO_TOOLCHAIN_VERSION)'
+      displayName: "Install Go"
 
     - task: UsePythonVersion@0
       retryCountOnTaskFailure: 3

--- a/.pipelines/templates/run-unit-tests.yaml
+++ b/.pipelines/templates/run-unit-tests.yaml
@@ -12,6 +12,16 @@ stages:
           name: "$(BUILD_POOL_NAME_DEFAULT)"
         steps:
           - script: |
+              GO_VER=$(grep '^toolchain' go.mod | sed 's/toolchain go//' | cut -d. -f1,2)
+              if [ -z "$GO_VER" ]; then GO_VER=$(grep '^go ' go.mod | awk '{print $2}' | cut -d. -f1,2); fi
+              if [ -z "$GO_VER" ]; then echo "##[error]Failed to detect Go version from go.mod"; exit 1; fi
+              echo "##vso[task.setvariable variable=GO_TOOLCHAIN_VERSION]$GO_VER"
+            displayName: "Detect Go version from go.mod"
+          - task: GoTool@0
+            inputs:
+              version: '$(GO_TOOLCHAIN_VERSION)'
+            displayName: "Install Go"
+          - script: |
               set -e
               make bpf-lib
               go generate ./...
@@ -51,6 +61,22 @@ stages:
         pool:
           name: "$(BUILD_POOL_NAME_DEFAULT_WINDOWS_ALT)"
         steps:
+          - powershell: |
+              $gomod = $null
+              if (Test-Path "go.mod") { $gomod = "go.mod" }
+              elseif (Test-Path "azure-container-networking/go.mod") { $gomod = "azure-container-networking/go.mod" }
+              if ($gomod) {
+                $toolchain = Select-String -Path $gomod -Pattern '^toolchain go(\d+\.\d+)' | ForEach-Object { $_.Matches[0].Groups[1].Value }
+              }
+              if (-not $toolchain -and $gomod) { $toolchain = Select-String -Path $gomod -Pattern '^go (\d+\.\d+)' | ForEach-Object { $_.Matches[0].Groups[1].Value } }
+              if (-not $toolchain) { Write-Error "Failed to detect Go version from go.mod"; exit 1 }
+              Write-Host "##vso[task.setvariable variable=GO_TOOLCHAIN_VERSION]$toolchain"
+              Write-Host "Detected Go version: $toolchain from $gomod"
+            displayName: "Detect Go version from go.mod"
+          - task: GoTool@0
+            inputs:
+              version: '$(GO_TOOLCHAIN_VERSION)'
+            displayName: "Install Go"
           # Only run one go test per script
           - script: |
               cd azure-container-networking/
@@ -75,6 +101,16 @@ stages:
         pool:
           name: "$(BUILD_POOL_NAME_DEFAULT)"
         steps:
+          - script: |
+              GO_VER=$(grep '^toolchain' go.mod | sed 's/toolchain go//' | cut -d. -f1,2)
+              if [ -z "$GO_VER" ]; then GO_VER=$(grep '^go ' go.mod | awk '{print $2}' | cut -d. -f1,2); fi
+              if [ -z "$GO_VER" ]; then echo "##[error]Failed to detect Go version from go.mod"; exit 1; fi
+              echo "##vso[task.setvariable variable=GO_TOOLCHAIN_VERSION]$GO_VER"
+            displayName: "Detect Go version from go.mod"
+          - task: GoTool@0
+            inputs:
+              version: '$(GO_TOOLCHAIN_VERSION)'
+            displayName: "Install Go"
           - task: DownloadPipelineArtifact@2
             inputs:
               artifact: 'linux-coverage'

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ NPM_IMAGE_INFO_FILE			= azure-npm-$(NPM_VERSION).txt
 #Tools paths
 TOOLS_GO_MOD = $(REPO_ROOT)/tools.go.mod
 
+
 # Default target
 all-binaries-platforms: ## Make all platform binaries
 	@for goos in "$(GOOSES)"; do \

--- a/azure-ip-masq-merger/Dockerfile
+++ b/azure-ip-masq-merger/Dockerfile
@@ -6,8 +6,8 @@ ARG OS
 # mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0
 FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0@sha256:7eaa7ec1b6c116d1b914d4699ff7726189e0dd78ff29801af48b559a5922a3d6 AS go
 
-# mcr.microsoft.com/azurelinux/distroless/minimal:3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:576d9769c0146cbf0cf7946bacf536c5758464c29eadfa03ef5090ae708e641f AS mariner-distroless
+# mcr.microsoft.com/azurelinux/distroless/base:3.0
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:178f25fadf466549d31e234b3091bf815161159f2f2bc98720bbf39f7368aff4 AS mariner-distroless
 
 FROM go AS azure-ip-masq-merger
 ARG OS

--- a/azure-ip-masq-merger/Dockerfile
+++ b/azure-ip-masq-merger/Dockerfile
@@ -3,16 +3,20 @@
 ARG ARCH
 ARG OS
 
-# mcr.microsoft.com/oss/go/microsoft/golang:1.24-azurelinux3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.24-azurelinux3.0@sha256:bc7423b52b62e8f0281b5f7f564eb1862dc315bc57e1373c6a81e87ef3ac39ab AS go
+# mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0@sha256:7eaa7ec1b6c116d1b914d4699ff7726189e0dd78ff29801af48b559a5922a3d6 AS go
+
+# mcr.microsoft.com/azurelinux/distroless/minimal:3.0
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:576d9769c0146cbf0cf7946bacf536c5758464c29eadfa03ef5090ae708e641f AS mariner-distroless
 
 FROM go AS azure-ip-masq-merger
 ARG OS
 ARG VERSION
+ENV GOEXPERIMENT=ms_nocgo_opensslcrypto
 WORKDIR /azure-ip-masq-merger
 COPY ./azure-ip-masq-merger .
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/ip-masq-merger -trimpath -ldflags "-s -w -X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" .
 
-FROM scratch AS linux
-COPY --from=azure-ip-masq-merger /go/bin/ip-masq-merger azure-ip-masq-merger
+FROM mariner-distroless AS linux
+COPY --from=azure-ip-masq-merger /go/bin/ip-masq-merger /azure-ip-masq-merger
 ENTRYPOINT [ "/azure-ip-masq-merger" ]

--- a/azure-ip-masq-merger/Dockerfile.tmpl
+++ b/azure-ip-masq-merger/Dockerfile.tmpl
@@ -6,13 +6,17 @@ ARG OS
 # {{.GO_IMG}}
 FROM --platform=linux/${ARCH} {{.GO_PIN}} AS go
 
+# {{.MARINER_DISTROLESS_IMG}}
+FROM --platform=linux/${ARCH} {{.MARINER_DISTROLESS_PIN}} AS mariner-distroless
+
 FROM go AS azure-ip-masq-merger
 ARG OS
 ARG VERSION
+ENV GOEXPERIMENT=ms_nocgo_opensslcrypto
 WORKDIR /azure-ip-masq-merger
 COPY ./azure-ip-masq-merger .
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/ip-masq-merger -trimpath -ldflags "-s -w -X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" .
 
-FROM scratch AS linux
-COPY --from=azure-ip-masq-merger /go/bin/ip-masq-merger azure-ip-masq-merger
+FROM mariner-distroless AS linux
+COPY --from=azure-ip-masq-merger /go/bin/ip-masq-merger /azure-ip-masq-merger
 ENTRYPOINT [ "/azure-ip-masq-merger" ]

--- a/azure-ip-masq-merger/go.mod
+++ b/azure-ip-masq-merger/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/azure-container-networking/azure-ip-masq-merger
 
-go 1.23.0
+go 1.26.1
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/azure-ipam/Dockerfile
+++ b/azure-ipam/Dockerfile
@@ -5,15 +5,19 @@ ARG DROPGZ_VERSION=v0.0.12
 ARG OS_VERSION
 ARG OS
 
-# mcr.microsoft.com/oss/go/microsoft/golang:1.24-azurelinux3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.24-azurelinux3.0@sha256:bc7423b52b62e8f0281b5f7f564eb1862dc315bc57e1373c6a81e87ef3ac39ab AS go
+# mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0@sha256:7eaa7ec1b6c116d1b914d4699ff7726189e0dd78ff29801af48b559a5922a3d6 AS go
 
 # mcr.microsoft.com/azurelinux/base/core:3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/base/core:3.0@sha256:a452d39c91576f5a2c983c7d3b62521fabd08e16b4a7237e24bf2be3b06e1651 AS mariner-core
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/base/core:3.0@sha256:4ecd6b297db85c54ec2df07145a28536c3655a3e98e54eb2364189bc4e6eac23 AS mariner-core
+
+# mcr.microsoft.com/azurelinux/distroless/minimal:3.0
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:576d9769c0146cbf0cf7946bacf536c5758464c29eadfa03ef5090ae708e641f AS mariner-distroless
 
 FROM go AS azure-ipam
 ARG OS
 ARG VERSION
+ENV GOEXPERIMENT=ms_nocgo_opensslcrypto
 WORKDIR /azure-ipam
 COPY ./azure-ipam .
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-ipam -trimpath -ldflags "-s -w -X main.version="$VERSION" -X github.com/Azure/azure-container-networking/azure-ipam/internal/buildinfo.Version="$VERSION"" -gcflags="-dwarflocationlists=true" .
@@ -30,13 +34,14 @@ FROM go AS dropgz
 ARG DROPGZ_VERSION
 ARG OS
 ARG VERSION
+ENV GOEXPERIMENT=ms_nocgo_opensslcrypto
 RUN go mod download github.com/azure/azure-container-networking/dropgz@$DROPGZ_VERSION
 WORKDIR /go/pkg/mod/github.com/azure/azure-container-networking/dropgz\@$DROPGZ_VERSION
 COPY --from=compressor /payload/* pkg/embed/fs/
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/dropgz -trimpath -ldflags "-s -w -X github.com/Azure/azure-container-networking/dropgz/internal/buildinfo.Version="$VERSION"" -gcflags="-dwarflocationlists=true" main.go
 
-FROM scratch AS linux
-COPY --from=dropgz /go/bin/dropgz dropgz
+FROM mariner-distroless AS linux
+COPY --from=dropgz /go/bin/dropgz /dropgz
 ENTRYPOINT [ "/dropgz" ]
 
 # mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0

--- a/azure-ipam/Dockerfile
+++ b/azure-ipam/Dockerfile
@@ -11,8 +11,8 @@ FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.26-azu
 # mcr.microsoft.com/azurelinux/base/core:3.0
 FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/base/core:3.0@sha256:4ecd6b297db85c54ec2df07145a28536c3655a3e98e54eb2364189bc4e6eac23 AS mariner-core
 
-# mcr.microsoft.com/azurelinux/distroless/minimal:3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:576d9769c0146cbf0cf7946bacf536c5758464c29eadfa03ef5090ae708e641f AS mariner-distroless
+# mcr.microsoft.com/azurelinux/distroless/base:3.0
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:178f25fadf466549d31e234b3091bf815161159f2f2bc98720bbf39f7368aff4 AS mariner-distroless
 
 FROM go AS azure-ipam
 ARG OS

--- a/azure-ipam/Dockerfile.tmpl
+++ b/azure-ipam/Dockerfile.tmpl
@@ -11,9 +11,13 @@ FROM --platform=linux/${ARCH} {{.GO_PIN}} AS go
 # {{.MARINER_CORE_IMG}}
 FROM --platform=linux/${ARCH} {{.MARINER_CORE_PIN}} AS mariner-core
 
+# {{.MARINER_DISTROLESS_IMG}}
+FROM --platform=linux/${ARCH} {{.MARINER_DISTROLESS_PIN}} AS mariner-distroless
+
 FROM go AS azure-ipam
 ARG OS
 ARG VERSION
+ENV GOEXPERIMENT=ms_nocgo_opensslcrypto
 WORKDIR /azure-ipam
 COPY ./azure-ipam .
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-ipam -trimpath -ldflags "-s -w -X main.version="$VERSION" -X github.com/Azure/azure-container-networking/azure-ipam/internal/buildinfo.Version="$VERSION"" -gcflags="-dwarflocationlists=true" .
@@ -30,13 +34,14 @@ FROM go AS dropgz
 ARG DROPGZ_VERSION
 ARG OS
 ARG VERSION
+ENV GOEXPERIMENT=ms_nocgo_opensslcrypto
 RUN go mod download github.com/azure/azure-container-networking/dropgz@$DROPGZ_VERSION
 WORKDIR /go/pkg/mod/github.com/azure/azure-container-networking/dropgz\@$DROPGZ_VERSION
 COPY --from=compressor /payload/* pkg/embed/fs/
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/dropgz -trimpath -ldflags "-s -w -X github.com/Azure/azure-container-networking/dropgz/internal/buildinfo.Version="$VERSION"" -gcflags="-dwarflocationlists=true" main.go
 
-FROM scratch AS linux
-COPY --from=dropgz /go/bin/dropgz dropgz
+FROM mariner-distroless AS linux
+COPY --from=dropgz /go/bin/dropgz /dropgz
 ENTRYPOINT [ "/dropgz" ]
 
 # {{.WIN_HPC_IMG}}

--- a/azure-ipam/go.mod
+++ b/azure-ipam/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/azure-container-networking/azure-ipam
 
-go 1.24.2
+go 1.26.1
 
 require (
 	github.com/Azure/azure-container-networking v1.8.4

--- a/azure-iptables-monitor/Dockerfile
+++ b/azure-iptables-monitor/Dockerfile
@@ -3,18 +3,19 @@
 ARG ARCH
 
 # mcr.microsoft.com/azurelinux/base/core:3.0
-FROM mcr.microsoft.com/azurelinux/base/core:3.0@sha256:a452d39c91576f5a2c983c7d3b62521fabd08e16b4a7237e24bf2be3b06e1651 AS mariner-core
+FROM mcr.microsoft.com/azurelinux/base/core:3.0@sha256:4ecd6b297db85c54ec2df07145a28536c3655a3e98e54eb2364189bc4e6eac23 AS mariner-core
 
 # mcr.microsoft.com/azurelinux/distroless/minimal:3.0
-FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:22810fd97d6ad5ec7d5bdd5b00233a3050be01d9e26b47b16cb6f1a7f178834b AS mariner-distroless
+FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:576d9769c0146cbf0cf7946bacf536c5758464c29eadfa03ef5090ae708e641f AS mariner-distroless
 
-# mcr.microsoft.com/oss/go/microsoft/golang:1.24-azurelinux3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.24-azurelinux3.0@sha256:bc7423b52b62e8f0281b5f7f564eb1862dc315bc57e1373c6a81e87ef3ac39ab AS go
+# mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0@sha256:7eaa7ec1b6c116d1b914d4699ff7726189e0dd78ff29801af48b559a5922a3d6 AS go
 
 
 FROM go AS azure-iptables-monitor
 ARG OS
 ARG VERSION
+ENV GOEXPERIMENT=ms_nocgo_opensslcrypto
 WORKDIR /azure-iptables-monitor
 COPY ./azure-iptables-monitor .
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/iptables-monitor -trimpath -ldflags "-s -w -X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" .
@@ -30,6 +31,7 @@ COPY ./go.mod ./go.sum ./
 RUN tdnf install -y llvm clang libbpf-devel gcc binutils glibc
 # Set up C include path for BPF
 ENV C_INCLUDE_PATH=/usr/include/bpf
+ENV GOEXPERIMENT=ms_nocgo_opensslcrypto
 # Set up architecture-specific symlinks for cross-compilation support
 RUN if [ "$ARCH" = "amd64" ]; then \
         ARCH_DIR=x86_64-linux-gnu; \
@@ -48,12 +50,14 @@ RUN if [ "$ARCH" = "amd64" ]; then \
 RUN GOOS=$OS CGO_ENABLED=0 go generate ./bpf-prog/azure-block-iptables/...
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-block-iptables -trimpath -ldflags "-s -w -X main.version="$AZURE_BLOCK_IPTABLES_VERSION"" -gcflags="-dwarflocationlists=true" ./bpf-prog/azure-block-iptables/cmd/azure-block-iptables
 
-FROM mariner-core AS iptables
-RUN tdnf install -y iptables
+FROM mariner-core AS iptools
+RUN tdnf install -y iptables iproute
 
 FROM mariner-distroless AS linux
-COPY --from=iptables /usr/sbin/*tables* /usr/sbin/
-COPY --from=iptables /usr/lib /usr/lib
+COPY --from=iptools /usr/sbin/*tables* /usr/sbin/
+COPY --from=iptools /usr/sbin/ip /usr/sbin/
+COPY --from=iptools /usr/lib /usr/lib
+COPY --from=iptools /usr/lib64 /usr/lib64
 COPY --from=azure-iptables-monitor /go/bin/iptables-monitor azure-iptables-monitor
 COPY --from=azure-block-iptables /go/bin/azure-block-iptables azure-block-iptables
 

--- a/azure-iptables-monitor/Dockerfile
+++ b/azure-iptables-monitor/Dockerfile
@@ -5,8 +5,8 @@ ARG ARCH
 # mcr.microsoft.com/azurelinux/base/core:3.0
 FROM mcr.microsoft.com/azurelinux/base/core:3.0@sha256:4ecd6b297db85c54ec2df07145a28536c3655a3e98e54eb2364189bc4e6eac23 AS mariner-core
 
-# mcr.microsoft.com/azurelinux/distroless/minimal:3.0
-FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:576d9769c0146cbf0cf7946bacf536c5758464c29eadfa03ef5090ae708e641f AS mariner-distroless
+# mcr.microsoft.com/azurelinux/distroless/base:3.0
+FROM mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:178f25fadf466549d31e234b3091bf815161159f2f2bc98720bbf39f7368aff4 AS mariner-distroless
 
 # mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0
 FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0@sha256:7eaa7ec1b6c116d1b914d4699ff7726189e0dd78ff29801af48b559a5922a3d6 AS go

--- a/azure-iptables-monitor/Dockerfile.tmpl
+++ b/azure-iptables-monitor/Dockerfile.tmpl
@@ -15,6 +15,7 @@ FROM --platform=linux/${ARCH} {{.GO_PIN}} AS go
 FROM go AS azure-iptables-monitor
 ARG OS
 ARG VERSION
+ENV GOEXPERIMENT=ms_nocgo_opensslcrypto
 WORKDIR /azure-iptables-monitor
 COPY ./azure-iptables-monitor .
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/iptables-monitor -trimpath -ldflags "-s -w -X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" .
@@ -30,6 +31,7 @@ COPY ./go.mod ./go.sum ./
 RUN tdnf install -y llvm clang libbpf-devel gcc binutils glibc
 # Set up C include path for BPF
 ENV C_INCLUDE_PATH=/usr/include/bpf
+ENV GOEXPERIMENT=ms_nocgo_opensslcrypto
 # Set up architecture-specific symlinks for cross-compilation support
 RUN if [ "$ARCH" = "amd64" ]; then \
         ARCH_DIR=x86_64-linux-gnu; \

--- a/azure-iptables-monitor/go.mod
+++ b/azure-iptables-monitor/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/azure-container-networking/azure-iptables-monitor
 
-go 1.23.0
+go 1.26.1
 
 require (
 	github.com/coreos/go-iptables v0.8.0

--- a/bpf-prog/ipv6-hp-bpf/go.mod
+++ b/bpf-prog/ipv6-hp-bpf/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/azure-container-networking/bpf-prog/ipv6-hp-bpf
 
-go 1.24.0
+go 1.26.1
 
 require (
 	github.com/cilium/ebpf v0.15.0

--- a/bpf-prog/ipv6-hp-bpf/linux.Dockerfile
+++ b/bpf-prog/ipv6-hp-bpf/linux.Dockerfile
@@ -1,7 +1,7 @@
 ARG ARCH
-# IMG=mcr.microsoft.com/oss/go/microsoft/golang:1.24.13
+# IMG=mcr.microsoft.com/oss/go/microsoft/golang:1.26.5
 # echo "${IMG}@$(skopeo inspect docker://${IMG} --format '{{.Digest}}')"
-FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.24.13@sha256:f3e556c9de4dd93be774dc0fa2ce3cfa76f7744d0bacada92d1624f04ce69461 AS go
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.26.5@sha256:ea9ee4712afebb8f01e6ce443a0e8be729d6027e4ee4ea650ad4356d3a402373 AS go
 ARG VERSION
 ARG DEBUG
 ARG OS
@@ -36,6 +36,7 @@ RUN if [ "$ARCH" = "arm64" ]; then \
     cp /lib/"$ARCH"/libbsd.so.0 /tmp/lib/ && \
     cp /lib/"$ARCH"/libmd.so.0 /tmp/lib/
 ENV C_INCLUDE_PATH=/usr/include/bpf
+ENV GOEXPERIMENT=ms_nocgo_opensslcrypto
 RUN if [ "$DEBUG" = "true" ]; then echo "\n#define DEBUG" >> /bpf-prog/ipv6-hp-bpf/include/helper.h; fi
 RUN GOOS=$OS CGO_ENABLED=0 go generate ./...
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/ipv6-hp-bpf -trimpath -ldflags "-s -w -X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" .

--- a/build/images.mk
+++ b/build/images.mk
@@ -1,5 +1,5 @@
 # Source images
-export GO_IMG					?= mcr.microsoft.com/oss/go/microsoft/golang:1.24-azurelinux3.0
+export GO_IMG					?= mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0
 export MARINER_CORE_IMG			?= mcr.microsoft.com/azurelinux/base/core:3.0
 export MARINER_DISTROLESS_IMG	?= mcr.microsoft.com/azurelinux/distroless/minimal:3.0
 export WIN_HPC_IMG				?= mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0

--- a/build/images.mk
+++ b/build/images.mk
@@ -1,7 +1,7 @@
 # Source images
 export GO_IMG					?= mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0
 export MARINER_CORE_IMG			?= mcr.microsoft.com/azurelinux/base/core:3.0
-export MARINER_DISTROLESS_IMG	?= mcr.microsoft.com/azurelinux/distroless/minimal:3.0
+export MARINER_DISTROLESS_IMG	?= mcr.microsoft.com/azurelinux/distroless/base:3.0
 export WIN_HPC_IMG				?= mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0
 
 

--- a/cilium-log-collector/Dockerfile
+++ b/cilium-log-collector/Dockerfile
@@ -3,11 +3,12 @@
 ARG ARCH
 ARG OS
 
-# mcr.microsoft.com/oss/go/microsoft/golang:1.24-azurelinux3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.24-azurelinux3.0@sha256:bc7423b52b62e8f0281b5f7f564eb1862dc315bc57e1373c6a81e87ef3ac39ab AS go
+# mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0@sha256:7eaa7ec1b6c116d1b914d4699ff7726189e0dd78ff29801af48b559a5922a3d6 AS go
 
 FROM go AS fluent-bit-plugin
 ARG VERSION
+ENV GOEXPERIMENT=systemcrypto
 WORKDIR /cilium-log-collector
 COPY ./cilium-log-collector .
 RUN go build -buildmode=c-shared -a -o out_azure_app_insights.so -trimpath -ldflags "-X main.version=$VERSION" -gcflags="-dwarflocationlists=true" .

--- a/cilium-log-collector/Dockerfile.tmpl
+++ b/cilium-log-collector/Dockerfile.tmpl
@@ -8,6 +8,7 @@ FROM --platform=linux/${ARCH} {{.GO_PIN}} AS go
 
 FROM go AS fluent-bit-plugin
 ARG VERSION
+ENV GOEXPERIMENT=systemcrypto
 WORKDIR /cilium-log-collector
 COPY ./cilium-log-collector .
 RUN go build -buildmode=c-shared -a -o out_azure_app_insights.so -trimpath -ldflags "-X main.version=$VERSION" -gcflags="-dwarflocationlists=true" .

--- a/cilium-log-collector/Makefile
+++ b/cilium-log-collector/Makefile
@@ -14,7 +14,7 @@ cilium-log-collector-version: ## prints the cilium-log-collector version
 # Build the cilium-log-collector plugin "so" file
 cilium-log-collector-binary:
 	$(MKDIR) $(CILIUM_LOG_COLLECTOR_BUILD_DIR)
-	cd $(CILIUM_LOG_COLLECTOR_DIR) && go build -buildmode=c-shared -a -o $(CILIUM_LOG_COLLECTOR_BUILD_DIR)/out_azure_app_insights.so -trimpath -ldflags "-X main.version=$(CILIUM_LOG_COLLECTOR_VERSION)" -gcflags="-dwarflocationlists=true" .
+	cd $(CILIUM_LOG_COLLECTOR_DIR) && CGO_ENABLED=1 GOEXPERIMENT=systemcrypto go build -buildmode=c-shared -a -o $(CILIUM_LOG_COLLECTOR_BUILD_DIR)/out_azure_app_insights.so -trimpath -ldflags "-X main.version=$(CILIUM_LOG_COLLECTOR_VERSION)" -gcflags="-dwarflocationlists=true" .
 
 
 CILIUM_LOG_COLLECTOR_IMAGE = cilium-log-collector

--- a/cilium-log-collector/go.mod
+++ b/cilium-log-collector/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/azure-container-networking/cilium-log-collector
 
-go 1.24.1
+go 1.26.1
 
 require (
 	github.com/Azure/azure-container-networking v1.7.12

--- a/cni/Dockerfile
+++ b/cni/Dockerfile
@@ -5,17 +5,21 @@ ARG DROPGZ_VERSION=v0.0.12
 ARG OS_VERSION
 ARG OS
 
-# mcr.microsoft.com/oss/go/microsoft/golang:1.24-azurelinux3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.24-azurelinux3.0@sha256:269dfe0b7256dc91926ade7a3a2c30556648c41f23a1fee0c363520488e8e2f0 AS go
+# mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0@sha256:7eaa7ec1b6c116d1b914d4699ff7726189e0dd78ff29801af48b559a5922a3d6 AS go
 
 # mcr.microsoft.com/azurelinux/base/core:3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/base/core:3.0@sha256:94ad614201891509f6680b8d392f519df0274460417dfe6662643800822e380d AS mariner-core
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/base/core:3.0@sha256:4ecd6b297db85c54ec2df07145a28536c3655a3e98e54eb2364189bc4e6eac23 AS mariner-core
+
+# mcr.microsoft.com/azurelinux/distroless/minimal:3.0
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:576d9769c0146cbf0cf7946bacf536c5758464c29eadfa03ef5090ae708e641f AS mariner-distroless
 
 FROM go AS azure-vnet
 ARG OS
 ARG VERSION
 ARG CNI_AI_PATH
 ARG CNI_AI_ID
+ENV GOEXPERIMENT=ms_nocgo_opensslcrypto
 WORKDIR /azure-container-networking
 COPY . .
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet -trimpath -ldflags "-s -w -X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/plugin/main.go
@@ -41,6 +45,7 @@ FROM go AS dropgz
 ARG DROPGZ_VERSION
 ARG OS
 ARG VERSION
+ENV GOEXPERIMENT=ms_nocgo_opensslcrypto
 RUN go mod download github.com/azure/azure-container-networking/dropgz@$DROPGZ_VERSION
 WORKDIR /go/pkg/mod/github.com/azure/azure-container-networking/dropgz\@$DROPGZ_VERSION
 COPY --from=compressor /payload/* pkg/embed/fs/
@@ -49,8 +54,8 @@ RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/dropgz -trimpath -ldflags "-s 
 FROM scratch AS bins
 COPY --from=azure-vnet /go/bin/* /
 
-FROM scratch AS linux
-COPY --from=dropgz /go/bin/dropgz dropgz
+FROM mariner-distroless AS linux
+COPY --from=dropgz /go/bin/dropgz /dropgz
 ENTRYPOINT [ "/dropgz" ]
 
 # mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0

--- a/cni/Dockerfile
+++ b/cni/Dockerfile
@@ -11,8 +11,8 @@ FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.26-azu
 # mcr.microsoft.com/azurelinux/base/core:3.0
 FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/base/core:3.0@sha256:4ecd6b297db85c54ec2df07145a28536c3655a3e98e54eb2364189bc4e6eac23 AS mariner-core
 
-# mcr.microsoft.com/azurelinux/distroless/minimal:3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:576d9769c0146cbf0cf7946bacf536c5758464c29eadfa03ef5090ae708e641f AS mariner-distroless
+# mcr.microsoft.com/azurelinux/distroless/base:3.0
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:178f25fadf466549d31e234b3091bf815161159f2f2bc98720bbf39f7368aff4 AS mariner-distroless
 
 FROM go AS azure-vnet
 ARG OS

--- a/cni/Dockerfile.tmpl
+++ b/cni/Dockerfile.tmpl
@@ -11,11 +11,15 @@ FROM --platform=linux/${ARCH} {{.GO_PIN}} AS go
 # {{.MARINER_CORE_IMG}}
 FROM --platform=linux/${ARCH} {{.MARINER_CORE_PIN}} AS mariner-core
 
+# {{.MARINER_DISTROLESS_IMG}}
+FROM --platform=linux/${ARCH} {{.MARINER_DISTROLESS_PIN}} AS mariner-distroless
+
 FROM go AS azure-vnet
 ARG OS
 ARG VERSION
 ARG CNI_AI_PATH
 ARG CNI_AI_ID
+ENV GOEXPERIMENT=ms_nocgo_opensslcrypto
 WORKDIR /azure-container-networking
 COPY . .
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-vnet -trimpath -ldflags "-s -w -X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" cni/network/plugin/main.go
@@ -41,6 +45,7 @@ FROM go AS dropgz
 ARG DROPGZ_VERSION
 ARG OS
 ARG VERSION
+ENV GOEXPERIMENT=ms_nocgo_opensslcrypto
 RUN go mod download github.com/azure/azure-container-networking/dropgz@$DROPGZ_VERSION
 WORKDIR /go/pkg/mod/github.com/azure/azure-container-networking/dropgz\@$DROPGZ_VERSION
 COPY --from=compressor /payload/* pkg/embed/fs/
@@ -49,8 +54,8 @@ RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/dropgz -trimpath -ldflags "-s 
 FROM scratch AS bins
 COPY --from=azure-vnet /go/bin/* /
 
-FROM scratch AS linux
-COPY --from=dropgz /go/bin/dropgz dropgz
+FROM mariner-distroless AS linux
+COPY --from=dropgz /go/bin/dropgz /dropgz
 ENTRYPOINT [ "/dropgz" ]
 
 # {{.WIN_HPC_IMG}}

--- a/cni/network/invoker_azure.go
+++ b/cni/network/invoker_azure.go
@@ -78,7 +78,7 @@ func (invoker *AzureIPAMInvoker) Add(addConfig IPAMAddConfig) (IPAMAddResult, er
 		if err != nil {
 			if len(addResult.interfaceInfo) > 0 && len(addResult.interfaceInfo[invoker.getInterfaceInfoKey(cns.InfraNIC)].IPConfigs) > 0 {
 				if er := invoker.Delete(&addResult.interfaceInfo[invoker.getInterfaceInfoKey(cns.InfraNIC)].IPConfigs[0].Address, addConfig.nwCfg, nil, addConfig.options); er != nil {
-					err = invoker.plugin.Errorf("Failed to clean up IP's during Delete with error %v, after Add failed with error %w", er, err)
+					err = invoker.plugin.Errorf("Failed to clean up IP's during Delete with error %v, after Add failed with error %v", er, err)
 				}
 			} else {
 				err = fmt.Errorf("No IP's to delete on error: %v", err)

--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -4,20 +4,21 @@ ARG ARCH
 ARG OS_VERSION
 ARG OS
 
-# mcr.microsoft.com/oss/go/microsoft/golang:1.24-azurelinux3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.24-azurelinux3.0@sha256:269dfe0b7256dc91926ade7a3a2c30556648c41f23a1fee0c363520488e8e2f0 AS go
+# mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0@sha256:7eaa7ec1b6c116d1b914d4699ff7726189e0dd78ff29801af48b559a5922a3d6 AS go
 
 # mcr.microsoft.com/azurelinux/base/core:3.0
-FROM mcr.microsoft.com/azurelinux/base/core:3.0@sha256:94ad614201891509f6680b8d392f519df0274460417dfe6662643800822e380d AS mariner-core
+FROM mcr.microsoft.com/azurelinux/base/core:3.0@sha256:4ecd6b297db85c54ec2df07145a28536c3655a3e98e54eb2364189bc4e6eac23 AS mariner-core
 
 # mcr.microsoft.com/azurelinux/distroless/minimal:3.0
-FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:138fe2905465e384b232ffe8ba3147de04c633a83f29d8df00d6817e3eacb0d2 AS mariner-distroless
+FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:576d9769c0146cbf0cf7946bacf536c5758464c29eadfa03ef5090ae708e641f AS mariner-distroless
 
 FROM --platform=linux/${ARCH} go AS builder
 ARG OS
 ARG CNS_AI_ID
 ARG CNS_AI_PATH
 ARG VERSION
+ENV GOEXPERIMENT=ms_nocgo_opensslcrypto
 WORKDIR /azure-container-networking
 COPY . .
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-cns -ldflags "-s -w -X main.version="$VERSION" -X "$CNS_AI_PATH"="$CNS_AI_ID"" -gcflags="-dwarflocationlists=true" cns/service/*.go

--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -10,8 +10,8 @@ FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.26-azu
 # mcr.microsoft.com/azurelinux/base/core:3.0
 FROM mcr.microsoft.com/azurelinux/base/core:3.0@sha256:4ecd6b297db85c54ec2df07145a28536c3655a3e98e54eb2364189bc4e6eac23 AS mariner-core
 
-# mcr.microsoft.com/azurelinux/distroless/minimal:3.0
-FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:576d9769c0146cbf0cf7946bacf536c5758464c29eadfa03ef5090ae708e641f AS mariner-distroless
+# mcr.microsoft.com/azurelinux/distroless/base:3.0
+FROM mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:178f25fadf466549d31e234b3091bf815161159f2f2bc98720bbf39f7368aff4 AS mariner-distroless
 
 FROM --platform=linux/${ARCH} go AS builder
 ARG OS

--- a/cns/Dockerfile.tmpl
+++ b/cns/Dockerfile.tmpl
@@ -18,6 +18,7 @@ ARG OS
 ARG CNS_AI_ID
 ARG CNS_AI_PATH
 ARG VERSION
+ENV GOEXPERIMENT=ms_nocgo_opensslcrypto
 WORKDIR /azure-container-networking
 COPY . .
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-cns -ldflags "-s -w -X main.version="$VERSION" -X "$CNS_AI_PATH"="$CNS_AI_ID"" -gcflags="-dwarflocationlists=true" cns/service/*.go

--- a/cns/common/service.go
+++ b/cns/common/service.go
@@ -73,7 +73,7 @@ func NewService(name, version, channelMode string, store store.KeyValueStore) (*
 func (service *Service) Initialize(config *ServiceConfig) error {
 	if config == nil {
 		err := "[Azure CNS Errror] Initialize called with nil ServiceConfig."
-		logger.Errorf(err)
+		logger.Errorf("%s", err) //nolint:staticcheck // will migrate to logger/v2
 		return errors.New(err)
 	}
 

--- a/cns/networkcontainers/networkcontainers.go
+++ b/cns/networkcontainers/networkcontainers.go
@@ -52,7 +52,7 @@ func InterfaceExists(iFaceName string) (bool, error) {
 	_, err := net.InterfaceByName(iFaceName)
 	if err != nil {
 		errMsg := fmt.Sprintf("[Azure CNS] Unable to get interface by name %s. Error: %v", iFaceName, err)
-		logger.Printf(errMsg)
+		logger.Printf("%s", errMsg) //nolint:staticcheck // will migrate to logger/v2
 		return false, errors.New(errMsg)
 	}
 
@@ -126,7 +126,7 @@ func getNetworkConfig(configFilePath string) ([]byte, error) {
 
 	if flatNetConfigMap == nil {
 		msg := "[Azure CNS] " + pluginsStr + " section of the network configuration cannot be empty."
-		logger.Printf(msg)
+		logger.Printf("%s", msg) //nolint:staticcheck // will migrate to logger/v2
 		return nil, errors.New(msg)
 	}
 

--- a/cns/networkcontainers/networkcontainers_linux.go
+++ b/cns/networkcontainers/networkcontainers_linux.go
@@ -39,7 +39,7 @@ func updateInterface(createNetworkContainerRequest cns.CreateNetworkContainerReq
 	if _, err := os.Stat(netpluginConfig.path); err != nil {
 		if os.IsNotExist(err) {
 			msg := "[Azure CNS] Unable to find " + netpluginConfig.path + ", cannot continue."
-			logger.Printf(msg)
+			logger.Printf("%s", msg) //nolint:staticcheck // will migrate to logger/v2
 			return errors.New(msg)
 		}
 	}

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -149,7 +149,7 @@ func (service *HTTPRestService) createNetwork(w http.ResponseWriter, r *http.Req
 					}
 				} else {
 					returnMessage = fmt.Sprintf("[Azure CNS] Received a request to create an already existing network %v", req.NetworkName)
-					logger.Printf(returnMessage)
+					logger.Printf("%s", returnMessage) //nolint:staticcheck // will migrate to logger/v2
 				}
 
 			default:

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -78,7 +78,7 @@ func (service *HTTPRestService) SyncNodeStatus(dncEP, infraVnet, nodeID string, 
 	if err != nil {
 		returnCode = types.UnexpectedError
 		errStr = fmt.Sprintf("[Azure-CNS] Failed to sync node with error: %+v", err)
-		logger.Errorf(errStr)
+		logger.Errorf("%s", errStr) //nolint:staticcheck // will migrate to logger/v2
 		return
 	}
 
@@ -573,7 +573,7 @@ func (service *HTTPRestService) MustEnsureNoStaleNCs(validNCIDs []string) {
 			// stale NCs with assigned IPs are an unexpected CNS state which we need to alert on.
 			if assignedIPs, hasAssignedIPs := ncIDToAssignedIPs[ncID]; hasAssignedIPs {
 				msg := fmt.Sprintf("Unexpected state: found stale NC ID %s in CNS state with %d assigned IPs: %+v", ncID, len(assignedIPs), assignedIPs)
-				logger.Errorf(msg)
+				logger.Errorf("%s", msg) //nolint:staticcheck // will migrate to logger/v2
 				panic(msg)
 			}
 
@@ -655,13 +655,13 @@ func (service *HTTPRestService) CreateOrUpdateNetworkContainerInternal(req *cns.
 		logNCSnapshot(*req)
 		service.publishIPStateMetrics()
 	} else {
-		logger.Errorf(returnMessage)
+		logger.Errorf("%s", returnMessage) //nolint:staticcheck // will migrate to logger/v2
 	}
 
 	if service.Options[common.OptProgramSNATIPTables] == true {
 		returnCode, returnMessage = service.programSNATRules(req)
 		if returnCode != 0 {
-			logger.Errorf(returnMessage)
+			logger.Errorf("%s", returnMessage) //nolint:staticcheck // will migrate to logger/v2
 		}
 	}
 

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -895,7 +895,7 @@ func (service *HTTPRestService) GetExistingIPConfig(podInfo cns.PodInfo) ([]cns.
 				ipConfigExists = true
 			} else {
 				errMsg := fmt.Sprintf("Failed to get existing ipconfig for pod %+v. Pod to IPID exists, but IPID to IPConfig doesn't exist, CNS State potentially corrupt", podInfo)
-				logger.Errorf(errMsg)
+				logger.Errorf("%s", errMsg) //nolint:staticcheck // will migrate to logger/v2
 				return podIPInfo, false, errors.New(errMsg)
 			}
 		}
@@ -977,12 +977,12 @@ func (service *HTTPRestService) AssignDesiredIPConfigs(podInfo cns.PodInfo, desi
 	// assigns all IPs that were found as available to the pod
 	for i := range ipConfigsToAssign {
 		if err := service.assignIPConfig(ipConfigsToAssign[i], podInfo); err != nil {
-			logger.Errorf(err.Error())
+			logger.Errorf("%s", err.Error()) //nolint:staticcheck // will migrate to logger/v2
 			failedToAssignIP = true
 			break
 		}
 		if err := service.populateIPConfigInfoUntransacted(ipConfigsToAssign[i], &podIPInfo[numIPConfigsAssigned]); err != nil {
-			logger.Errorf(err.Error())
+			logger.Errorf("%s", err.Error()) //nolint:staticcheck // will migrate to logger/v2
 			failedToAssignIP = true
 			break
 		}
@@ -1075,13 +1075,13 @@ func (service *HTTPRestService) AssignAvailableIPConfigs(podInfo cns.PodInfo) ([
 	// assigns all IPs in the map to the pod
 	for _, ip := range ipsToAssign { //nolint:gocritic // ignore copy
 		if err := service.assignIPConfig(ip, podInfo); err != nil {
-			logger.Errorf(err.Error())
+			logger.Errorf("%s", err.Error()) //nolint:staticcheck // will migrate to logger/v2
 			failedToAssignIP = true
 			break
 		}
 
 		if err := service.populateIPConfigInfoUntransacted(ip, &podIPInfo[numIPConfigsAssigned]); err != nil {
-			logger.Errorf(err.Error())
+			logger.Errorf("%s", err.Error()) //nolint:staticcheck // will migrate to logger/v2
 			failedToAssignIP = true
 			break
 		}

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -236,13 +236,13 @@ func (service *HTTPRestService) saveNetworkContainerGoalState(req cns.CreateNetw
 			}
 		default:
 			errMsg := fmt.Sprintf("Unsupported orchestrator type: %s", service.state.OrchestratorType)
-			logger.Errorf(errMsg)
+			logger.Errorf("%s", errMsg) //nolint:staticcheck // will migrate to logger/v2
 			return types.UnsupportedOrchestratorType, errMsg
 		}
 
 	default:
 		errMsg := fmt.Sprintf("Unsupported network container type %s", req.NetworkContainerType)
-		logger.Errorf(errMsg)
+		logger.Errorf("%s", errMsg) //nolint:staticcheck // will migrate to logger/v2
 		return types.UnsupportedNetworkContainerType, errMsg
 	}
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -453,7 +453,7 @@ func sendRegisterNodeRequest(ctx context.Context, httpClient httpDoer, httpRestS
 
 	if response.StatusCode != http.StatusOK {
 		err = fmt.Errorf("[Azure CNS] Failed to register node, DNC replied with http status code %s", strconv.Itoa(response.StatusCode))
-		logger.Errorf(err.Error())
+		logger.Errorf("%s", err.Error()) //nolint:staticcheck // will migrate to logger/v2
 		return errors.Wrap(err, "failed to sendRegisterNodeRequest")
 	}
 

--- a/dropgz/go.mod
+++ b/dropgz/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/azure-container-networking/dropgz
 
-go 1.24.0
+go 1.26.1
 
 require (
 	github.com/jsternberg/zap-logfmt v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/azure-container-networking
 
-go 1.24.1
+go 1.26.1
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.1

--- a/keyvault/certrefresher_test.go
+++ b/keyvault/certrefresher_test.go
@@ -16,7 +16,6 @@ import (
 
 func TestCertRefresher(t *testing.T) {
 	ctx, cancel := testContext(t)
-	defer cancel()
 
 	// returns a different cert on every invocation, until context is done
 	tlsFn := tlsFunc(func() (tls.Certificate, error) {
@@ -34,14 +33,24 @@ func TestCertRefresher(t *testing.T) {
 	cf, err := NewCertRefresher(ctx, tlsFn, testLogger{t}, "dummy")
 	require.NoError(t, err)
 
+	var wg sync.WaitGroup
+
 	// a new cert should be loaded roughly every second
-	go func() { _ = cf.Refresh(ctx, time.Second) }()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = cf.Refresh(ctx, time.Second)
+	}()
 
 	thumbprintSet := stringSet{ts: make(map[string]struct{})}
 
 	// spin multiple concurrent readers, collecting unique thumbprints for eventual assertion
 	for i := 0; i < 10; i++ {
-		go readAndCollect(ctx, cf, &thumbprintSet, time.Millisecond*300)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			readAndCollect(ctx, cf, &thumbprintSet, time.Millisecond*300)
+		}()
 	}
 
 	waitFor := time.Second * 10
@@ -50,6 +59,11 @@ func TestCertRefresher(t *testing.T) {
 	checkEvery := time.Second
 
 	assert.Eventually(t, condFn, waitFor, checkEvery)
+
+	// cancel context and wait for all goroutines to finish before test exits,
+	// preventing data races on testing.T
+	cancel()
+	wg.Wait()
 }
 
 func TestCertRefresher_RetryUntilExpiration(t *testing.T) {

--- a/npm/linux.Dockerfile
+++ b/npm/linux.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.25.5 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.4 AS builder
 ARG VERSION
 ARG NPM_AI_PATH
 ARG NPM_AI_ID

--- a/npm/windows.Dockerfile
+++ b/npm/windows.Dockerfile
@@ -1,5 +1,5 @@
 ARG OS_VERSION
-FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.25.5 AS builder
+FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.26.4 AS builder
 ARG VERSION
 ARG NPM_AI_PATH
 ARG NPM_AI_ID

--- a/pkgerrlint/go.mod
+++ b/pkgerrlint/go.mod
@@ -1,5 +1,5 @@
 module github.com/Azure/azure-container-networking/pkgerrlint
 
-go 1.19
+go 1.26.1
 
 require github.com/pkg/errors v0.9.1

--- a/tools.go.mod
+++ b/tools.go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/azure-container-networking
 
-go 1.24.1
+go 1.26.1
 
 // To use/update leverage -modfile=tools.go.mod field in respective go commands
 tool (

--- a/tools/azure-npm-to-cilium-validator/go.mod
+++ b/tools/azure-npm-to-cilium-validator/go.mod
@@ -1,6 +1,6 @@
 module azure-npm-to-cilium-validator
 
-go 1.24.0
+go 1.26.1
 
 require (
 	github.com/Azure/azure-container-networking v1.6.21

--- a/tools/release/go.mod
+++ b/tools/release/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/azure-container-networking/tools/release
 
-go 1.23.0
+go 1.26.1
 
 require github.com/spf13/cobra v1.8.1
 

--- a/zapai/go.mod
+++ b/zapai/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/azure-container-networking/zapai
 
-go 1.24.0
+go 1.26.1
 
 require (
 	github.com/jsternberg/zap-logfmt v1.3.0


### PR DESCRIPTION
Cherry-pick of #4494 to release/v1.7.

## Changes
- Go 1.24 → 1.26.4 (go.mod, go.sum, all submodules)
- FROM scratch → mariner-distroless for cni, azure-ipam, azure-ip-masq-merger
- GOEXPERIMENT=ms_nocgo_opensslcrypto in build scripts for FIPS compliance
- Dynamic Go version detection in pipeline templates (no hardcoded versions)
- Keyvault test data race fix
- Format string fixes for Go 1.26 vet
- Updated install-go.sh fallback digest to 1.26

Original PR: #4494