### PR TITLE
test: allow restricting state validation to a node pool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -930,7 +930,7 @@ test-load: ## run all load tests
 		go test -timeout 40m -race -tags=load ./test/integration/load... -v
 
 test-validate-state:
-	cd test/integration/load && go test -mod=readonly -count=1 -timeout 30m -tags load --skip 'TestE2E*' -run ^TestValidateState
+	cd test/integration/load && POOL_LABEL_SELECTOR=$(POOL_LABEL_SELECTOR) go test -mod=readonly -count=1 -timeout 30m -tags load --skip 'TestE2E*' -run ^TestValidateState
 	cd ../../..
 
 test-cyclonus: ## run the cyclonus test for npm.

--- a/Makefile
+++ b/Makefile
@@ -930,7 +930,7 @@ test-load: ## run all load tests
 		go test -timeout 40m -race -tags=load ./test/integration/load... -v
 
 test-validate-state:
-	cd test/integration/load && POOL_LABEL_SELECTOR=$(POOL_LABEL_SELECTOR) go test -mod=readonly -count=1 -timeout 30m -tags load --skip 'TestE2E*' -run ^TestValidateState
+	cd test/integration/load && POOL_LABEL_SELECTOR="$(POOL_LABEL_SELECTOR)" go test -mod=readonly -count=1 -timeout 30m -tags load --skip 'TestE2E*' -run ^TestValidateState
 	cd ../../..
 
 test-cyclonus: ## run the cyclonus test for npm.

--- a/test/integration/load/load_test.go
+++ b/test/integration/load/load_test.go
@@ -26,6 +26,9 @@ type TestConfig struct {
 	RestartCase       bool   `env:"RESTART_CASE" default:"false"`
 	Cleanup           bool   `env:"CLEANUP" default:"false"`
 	CNSOnly           bool   `env:"CNS_ONLY" default:"false"`
+	// PoolLabelSelector optionally restricts state validation to nodes matching
+	// this label selector (e.g. "agentpool=pool1"). Empty validates all nodes.
+	PoolLabelSelector string `env:"POOL_LABEL_SELECTOR" default:""`
 }
 
 const (
@@ -171,7 +174,7 @@ func TestValidateState(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	validator, err := validate.CreateValidator(ctx, clientset, config, namespace, testConfig.CNIType, testConfig.RestartCase, testConfig.OSType)
+	validator, err := validate.CreateValidator(ctx, clientset, config, namespace, testConfig.CNIType, testConfig.RestartCase, testConfig.OSType, testConfig.PoolLabelSelector)
 	require.NoError(t, err)
 
 	err = validator.Validate(ctx)
@@ -228,7 +231,7 @@ func TestValidCNSStateDuringScaleAndCNSRestartToTriggerDropgzInstall(t *testing.
 		t.Run("Validate state file", TestValidateState)
 	}
 
-	validator, err := validate.CreateValidator(ctx, clientset, config, namespace, testConfig.CNIType, testConfig.RestartCase, testConfig.OSType)
+	validator, err := validate.CreateValidator(ctx, clientset, config, namespace, testConfig.CNIType, testConfig.RestartCase, testConfig.OSType, testConfig.PoolLabelSelector)
 	require.NoError(t, err)
 
 	deployment := kubernetes.MustParseDeployment(noopDeploymentMap[testConfig.OSType])
@@ -295,7 +298,7 @@ func TestV4OverlayProperties(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
 
-	validator, err := validate.CreateValidator(ctx, clientset, config, namespace, testConfig.CNIType, testConfig.RestartCase, testConfig.OSType)
+	validator, err := validate.CreateValidator(ctx, clientset, config, namespace, testConfig.CNIType, testConfig.RestartCase, testConfig.OSType, testConfig.PoolLabelSelector)
 	require.NoError(t, err)
 
 	// validate IPv4 overlay scenarios
@@ -319,7 +322,7 @@ func TestDualStackProperties(t *testing.T) {
 	defer cancel()
 
 	t.Log("Validating the dualstack node labels")
-	validator, err := validate.CreateValidator(ctx, clientset, config, namespace, testConfig.CNIType, testConfig.RestartCase, testConfig.OSType)
+	validator, err := validate.CreateValidator(ctx, clientset, config, namespace, testConfig.CNIType, testConfig.RestartCase, testConfig.OSType, testConfig.PoolLabelSelector)
 	require.NoError(t, err)
 
 	// validate dualstack overlay scenarios

--- a/test/validate/validate.go
+++ b/test/validate/validate.go
@@ -41,13 +41,14 @@ const (
 )
 
 type Validator struct {
-	clientset   *kubernetes.Clientset
-	config      *rest.Config
-	checks      []check
-	namespace   string
-	cni         string
-	restartCase bool
-	os          string
+	clientset         *kubernetes.Clientset
+	config            *rest.Config
+	checks            []check
+	namespace         string
+	cni               string
+	restartCase       bool
+	os                string
+	poolLabelSelector string
 }
 
 type check struct {
@@ -59,7 +60,7 @@ type check struct {
 	cmd              []string
 }
 
-func CreateValidator(ctx context.Context, clientset *kubernetes.Clientset, config *rest.Config, namespace, cni string, restartCase bool, os string) (*Validator, error) {
+func CreateValidator(ctx context.Context, clientset *kubernetes.Clientset, config *rest.Config, namespace, cni string, restartCase bool, os, poolLabelSelector string) (*Validator, error) {
 	// deploy privileged pod
 	privilegedDaemonSet := acnk8s.MustParseDaemonSet(privilegedDaemonSetPathMap[os])
 	daemonsetClient := clientset.AppsV1().DaemonSets(privilegedNamespace)
@@ -85,14 +86,27 @@ func CreateValidator(ctx context.Context, clientset *kubernetes.Clientset, confi
 	}
 
 	return &Validator{
-		clientset:   clientset,
-		config:      config,
-		namespace:   namespace,
-		cni:         cni,
-		restartCase: restartCase,
-		checks:      checks,
-		os:          os,
+		clientset:         clientset,
+		config:            config,
+		namespace:         namespace,
+		cni:               cni,
+		restartCase:       restartCase,
+		checks:            checks,
+		os:                os,
+		poolLabelSelector: poolLabelSelector,
 	}, nil
+}
+
+// nodeSelector returns the label selector used to pick candidate nodes. It
+// always constrains by OS; when a pool label selector is configured (via
+// POOL_LABEL_SELECTOR) it is ANDed in so validation targets a single pool.
+// An empty poolLabelSelector reproduces the previous OS-only behavior.
+func (v *Validator) nodeSelector() string {
+	selector := nodeSelectorMap[v.os]
+	if v.poolLabelSelector != "" {
+		selector += "," + v.poolLabelSelector
+	}
+	return selector
 }
 
 func (v *Validator) Validate(ctx context.Context) error {
@@ -125,7 +139,7 @@ func (v *Validator) ValidateStateFile(ctx context.Context) error {
 
 func (v *Validator) validateIPs(ctx context.Context, stateFileIps stateFileIpsFunc, cmd []string, checkType, namespace, labelSelector, containerName string) error {
 	log.Printf("Validating %s state file for %s on %s", checkType, v.cni, v.os)
-	nodes, err := acnk8s.GetNodeListByLabelSelector(ctx, v.clientset, nodeSelectorMap[v.os])
+	nodes, err := acnk8s.GetNodeListByLabelSelector(ctx, v.clientset, v.nodeSelector())
 	if err != nil {
 		return errors.Wrapf(err, "failed to get node list")
 	}
@@ -208,7 +222,7 @@ func validateNodeProperties(nodes *corev1.NodeList, labels map[string]string, ex
 }
 
 func (v *Validator) ValidateV4OverlayControlPlane(ctx context.Context) error {
-	nodes, err := acnk8s.GetNodeListByLabelSelector(ctx, v.clientset, nodeSelectorMap[v.os])
+	nodes, err := acnk8s.GetNodeListByLabelSelector(ctx, v.clientset, v.nodeSelector())
 	if err != nil {
 		return errors.Wrap(err, "failed to get node list")
 	}
@@ -227,7 +241,7 @@ func (v *Validator) ValidateV4OverlayControlPlane(ctx context.Context) error {
 }
 
 func (v *Validator) ValidateDualStackControlPlane(ctx context.Context) error {
-	nodes, err := acnk8s.GetNodeListByLabelSelector(ctx, v.clientset, nodeSelectorMap[v.os])
+	nodes, err := acnk8s.GetNodeListByLabelSelector(ctx, v.clientset, v.nodeSelector())
 	if err != nil {
 		return errors.Wrap(err, "failed to get node list")
 	}


### PR DESCRIPTION
Add an optional POOL_LABEL_SELECTOR so TestValidateState (and the other load validators) can target a single node pool, enabling per-pool parallel runs. The Validator gains a poolLabelSelector that is ANDed onto the existing OS node selector via a new nodeSelector() helper used by all three GetNodeListByLabelSelector call sites. Plumb the value through TestConfig (env-tag) and the Makefile test-validate-state target. When unset, the selector is unchanged (OS-only), preserving today's behavior.


Copilot-Session: 01944c36-d67b-4e6e-bce7-0c312f0265c7