### PR TITLE
fix(cns): preserve platform file selection in image builds

### DIFF
--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -21,7 +21,7 @@ ARG VERSION
 ENV GOEXPERIMENT=ms_nocgo_opensslcrypto
 WORKDIR /azure-container-networking
 COPY . .
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-cns -ldflags "-s -w -X main.version="$VERSION" -X "$CNS_AI_PATH"="$CNS_AI_ID"" -gcflags="-dwarflocationlists=true" cns/service/*.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-cns -ldflags "-s -w -X main.version="$VERSION" -X "$CNS_AI_PATH"="$CNS_AI_ID"" -gcflags="-dwarflocationlists=true" ./cns/service
 
 FROM mariner-core AS iptables
 RUN tdnf install -y iptables

--- a/cns/Dockerfile.tmpl
+++ b/cns/Dockerfile.tmpl
@@ -21,7 +21,7 @@ ARG VERSION
 ENV GOEXPERIMENT=ms_nocgo_opensslcrypto
 WORKDIR /azure-container-networking
 COPY . .
-RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-cns -ldflags "-s -w -X main.version="$VERSION" -X "$CNS_AI_PATH"="$CNS_AI_ID"" -gcflags="-dwarflocationlists=true" cns/service/*.go
+RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/azure-cns -ldflags "-s -w -X main.version="$VERSION" -X "$CNS_AI_PATH"="$CNS_AI_ID"" -gcflags="-dwarflocationlists=true" ./cns/service
 
 FROM mariner-core AS iptables
 RUN tdnf install -y iptables


### PR DESCRIPTION
## Summary

Build the CNS service package rather than passing an explicit `*.go` file list in the Dockerfile.

Explicit file lists bypass Go's OS-specific file selection, so adding `_linux.go` and `_windows.go` implementations can make both compile into the same image build. Building `./cns/service` lets the Go tool apply build constraints normally.

The rendered Dockerfile and source template are updated together.

## Validation

- Linux CNS cross-build using the Dockerfile command shape
- Windows CNS cross-build using the Dockerfile command shape
- `go test ./cns/service`
- `go vet ./cns/service`
