### PR TITLE
fix(test): retry transient state observations

### DIFF
--- a/test/validate/validate.go
+++ b/test/validate/validate.go
@@ -200,6 +200,9 @@ func runValidationAttempts(
 		if attempts >= maxAttempts {
 			return attempts, false, lastErr
 		}
+		if err := ctx.Err(); err != nil {
+			return attempts, false, errors.Wrap(err, "waiting to retry state validation")
+		}
 		if interval <= 0 {
 			continue
 		}

--- a/test/validate/validate.go
+++ b/test/validate/validate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log"
+	"time"
 
 	acnk8s "github.com/Azure/azure-container-networking/test/internal/kubernetes"
 	"github.com/pkg/errors"
@@ -38,6 +39,8 @@ const (
 	privilegedNamespace      = "kube-system"
 	IPv4ExpectedIPCount      = 1
 	DualstackExpectedIPCount = 2
+	stateValidationAttempts  = 3
+	stateValidationInterval  = 2 * time.Second
 )
 
 type Validator struct {
@@ -131,43 +134,84 @@ func (v *Validator) validateIPs(ctx context.Context, stateFileIps stateFileIpsFu
 	}
 
 	for index := range nodes.Items {
-		// get the privileged pod
-		pod, err := acnk8s.GetPodsByNode(ctx, v.clientset, namespace, labelSelector, nodes.Items[index].Name)
-		if err != nil {
-			return errors.Wrapf(err, "failed to get privileged pod")
-		}
-		if len(pod.Items) == 0 {
-			return errors.Errorf("there are no privileged pods on node - %v", nodes.Items[index].Name)
-		}
-		podName := pod.Items[0].Name
-		// exec into the pod to get the state file
-		log.Printf("Executing command %s on pod %s, container %s", cmd, podName, containerName)
-		result, _, err := acnk8s.ExecCmdOnPod(ctx, v.clientset, namespace, podName, containerName, cmd, v.config, true)
-		if err != nil {
-			return errors.Wrapf(err, "failed to exec into privileged pod - %s", podName)
-		}
-		filePodIps, err := stateFileIps(result)
-		if err != nil {
-			return errors.Wrapf(err, "failed to get pod ips from state file on node %v", nodes.Items[index].Name)
-		}
-		if len(filePodIps) == 0 && v.restartCase {
-			log.Printf("No pods found on node %s", nodes.Items[index].Name)
-			continue
-		}
-		// get the pod ips
-		podIps := getPodIPsWithoutNodeIP(ctx, v.clientset, nodes.Items[index])
-		// include IPs from Cilium internal endpoints (reserved:ingress) that are not real K8s pods.
-		// These only exist when L7 policy is enabled, indicated by the acns-security-agent pod with cilium-envoy container.
-		if hasL7PolicyEnabled(ctx, v.clientset, nodes.Items[index].Name) {
-			podIps = append(podIps, getCiliumInternalEndpointIPs(ctx, v.clientset, v.config, nodes.Items[index].Name)...)
-		}
+		node := nodes.Items[index]
+		var comparisonErr error
+		_, converged, validationErr := runValidationAttempts(ctx, stateValidationAttempts, stateValidationInterval, func() (bool, error) {
+			pod, err := acnk8s.GetPodsByNode(ctx, v.clientset, namespace, labelSelector, node.Name)
+			if err != nil {
+				return false, errors.Wrap(err, "failed to get privileged pod")
+			}
+			if len(pod.Items) == 0 {
+				return false, errors.Errorf("there are no privileged pods on node - %v", node.Name)
+			}
+			podName := pod.Items[0].Name
+			log.Printf("Executing command %s on pod %s, container %s", cmd, podName, containerName)
+			result, _, err := acnk8s.ExecCmdOnPod(ctx, v.clientset, namespace, podName, containerName, cmd, v.config, true)
+			if err != nil {
+				return false, errors.Wrapf(err, "failed to exec into privileged pod - %s", podName)
+			}
+			filePodIps, err := stateFileIps(result)
+			if err != nil {
+				return false, errors.Wrapf(err, "failed to get pod ips from state file on node %v", node.Name)
+			}
+			if len(filePodIps) == 0 && v.restartCase {
+				log.Printf("No pods found on node %s", node.Name)
+				return true, nil
+			}
 
-		if err := compareIPs(filePodIps, podIps); err != nil {
-			return errors.Wrapf(err, "State file validation failed for %s on node %s", checkType, nodes.Items[index].Name)
+			podIps := getPodIPsWithoutNodeIP(ctx, v.clientset, node)
+			if hasL7PolicyEnabled(ctx, v.clientset, node.Name) {
+				podIps = append(podIps, getCiliumInternalEndpointIPs(ctx, v.clientset, v.config, node.Name)...)
+			}
+			comparisonErr = compareIPs(filePodIps, podIps)
+			return comparisonErr == nil, nil
+		})
+		if validationErr != nil {
+			return validationErr
+		}
+		if !converged {
+			return errors.Wrapf(comparisonErr, "State file validation failed for %s on node %s", checkType, node.Name)
 		}
 	}
 	log.Printf("State file validation for %s passed", checkType)
 	return nil
+}
+
+func runValidationAttempts(
+	ctx context.Context,
+	maxAttempts int,
+	interval time.Duration,
+	validate func() (bool, error),
+) (int, bool, error) {
+	if maxAttempts < 1 {
+		return 0, false, errors.New("validation attempts must be positive")
+	}
+
+	var lastErr error
+	for attempt := 1; ; attempt++ {
+		converged, err := validate()
+		if converged {
+			if err != nil {
+				return attempt, false, err
+			}
+			return attempt, true, nil
+		}
+		lastErr = err
+		if attempt >= maxAttempts {
+			return attempt, false, lastErr
+		}
+		if interval <= 0 {
+			continue
+		}
+
+		timer := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return attempt, false, errors.Wrap(ctx.Err(), "waiting to retry state validation")
+		case <-timer.C:
+		}
+	}
 }
 
 func validateNodeProperties(nodes *corev1.NodeList, labels map[string]string, expectedIPCount int) error {

--- a/test/validate/validate.go
+++ b/test/validate/validate.go
@@ -182,23 +182,23 @@ func runValidationAttempts(
 	maxAttempts int,
 	interval time.Duration,
 	validate func() (bool, error),
-) (int, bool, error) {
+) (attempts int, converged bool, validationErr error) {
 	if maxAttempts < 1 {
 		return 0, false, errors.New("validation attempts must be positive")
 	}
 
 	var lastErr error
-	for attempt := 1; ; attempt++ {
-		converged, err := validate()
+	for attempts = 1; ; attempts++ {
+		converged, validationErr = validate()
 		if converged {
-			if err != nil {
-				return attempt, false, err
+			if validationErr != nil {
+				return attempts, false, validationErr
 			}
-			return attempt, true, nil
+			return attempts, true, nil
 		}
-		lastErr = err
-		if attempt >= maxAttempts {
-			return attempt, false, lastErr
+		lastErr = validationErr
+		if attempts >= maxAttempts {
+			return attempts, false, lastErr
 		}
 		if interval <= 0 {
 			continue
@@ -208,7 +208,7 @@ func runValidationAttempts(
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			return attempt, false, errors.Wrap(ctx.Err(), "waiting to retry state validation")
+			return attempts, false, errors.Wrap(ctx.Err(), "waiting to retry state validation")
 		case <-timer.C:
 		}
 	}

--- a/test/validate/validate_retry_test.go
+++ b/test/validate/validate_retry_test.go
@@ -1,0 +1,103 @@
+package validate
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunValidationAttempts(t *testing.T) {
+	firstErr := errors.New("first observation failed")
+	lastErr := errors.New("last observation failed")
+	tests := []struct {
+		name          string
+		results       []bool
+		errs          []error
+		wantAttempts  int
+		wantConverged bool
+		wantErr       error
+	}{
+		{
+			name:          "first observation converges",
+			results:       []bool{true},
+			errs:          []error{nil},
+			wantAttempts:  1,
+			wantConverged: true,
+		},
+		{
+			name:          "transient observation failure",
+			results:       []bool{false, true},
+			errs:          []error{firstErr, nil},
+			wantAttempts:  2,
+			wantConverged: true,
+		},
+		{
+			name:          "transient mismatch",
+			results:       []bool{false, true},
+			errs:          []error{nil, nil},
+			wantAttempts:  2,
+			wantConverged: true,
+		},
+		{
+			name:         "returns latest exhausted error",
+			results:      []bool{false, false},
+			errs:         []error{firstErr, lastErr},
+			wantAttempts: 2,
+			wantErr:      lastErr,
+		},
+		{
+			name:         "convergence does not hide error",
+			results:      []bool{true},
+			errs:         []error{lastErr},
+			wantAttempts: 1,
+			wantErr:      lastErr,
+		},
+		{
+			name:         "exhausted mismatch",
+			results:      []bool{false, false},
+			errs:         []error{nil, nil},
+			wantAttempts: 2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			call := 0
+			attempts, converged, err := runValidationAttempts(t.Context(), len(test.results), 0, func() (bool, error) {
+				result := test.results[call]
+				err := test.errs[call]
+				call++
+				return result, err
+			})
+			require.ErrorIs(t, err, test.wantErr)
+			require.Equal(t, test.wantAttempts, attempts)
+			require.Equal(t, test.wantConverged, converged)
+			require.Equal(t, test.wantAttempts, call)
+		})
+	}
+}
+
+func TestRunValidationAttemptsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	attempts, converged, err := runValidationAttempts(ctx, 2, time.Hour, func() (bool, error) {
+		return false, errors.New("transient observation failure")
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, attempts)
+	require.False(t, converged)
+}
+
+func TestRunValidationAttemptsRejectsInvalidAttemptCount(t *testing.T) {
+	attempts, converged, err := runValidationAttempts(t.Context(), 0, 0, func() (bool, error) {
+		t.Fatal("validation callback must not run")
+		return false, nil
+	})
+	require.EqualError(t, err, "validation attempts must be positive")
+	require.Zero(t, attempts)
+	require.False(t, converged)
+}

--- a/test/validate/validate_retry_test.go
+++ b/test/validate/validate_retry_test.go
@@ -9,9 +9,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	errFirstObservation     = errors.New("first observation failed")
+	errLastObservation      = errors.New("last observation failed")
+	errTransientObservation = errors.New("transient observation failure")
+)
+
 func TestRunValidationAttempts(t *testing.T) {
-	firstErr := errors.New("first observation failed")
-	lastErr := errors.New("last observation failed")
 	tests := []struct {
 		name          string
 		results       []bool
@@ -30,7 +34,7 @@ func TestRunValidationAttempts(t *testing.T) {
 		{
 			name:          "transient observation failure",
 			results:       []bool{false, true},
-			errs:          []error{firstErr, nil},
+			errs:          []error{errFirstObservation, nil},
 			wantAttempts:  2,
 			wantConverged: true,
 		},
@@ -44,16 +48,16 @@ func TestRunValidationAttempts(t *testing.T) {
 		{
 			name:         "returns latest exhausted error",
 			results:      []bool{false, false},
-			errs:         []error{firstErr, lastErr},
+			errs:         []error{errFirstObservation, errLastObservation},
 			wantAttempts: 2,
-			wantErr:      lastErr,
+			wantErr:      errLastObservation,
 		},
 		{
 			name:         "convergence does not hide error",
 			results:      []bool{true},
-			errs:         []error{lastErr},
+			errs:         []error{errLastObservation},
 			wantAttempts: 1,
-			wantErr:      lastErr,
+			wantErr:      errLastObservation,
 		},
 		{
 			name:         "exhausted mismatch",
@@ -85,7 +89,7 @@ func TestRunValidationAttemptsCanceled(t *testing.T) {
 	cancel()
 
 	attempts, converged, err := runValidationAttempts(ctx, 2, time.Hour, func() (bool, error) {
-		return false, errors.New("transient observation failure")
+		return false, errTransientObservation
 	})
 	require.ErrorIs(t, err, context.Canceled)
 	require.Equal(t, 1, attempts)

--- a/test/validate/validate_retry_test.go
+++ b/test/validate/validate_retry_test.go
@@ -113,6 +113,21 @@ func TestRunValidationAttemptsCanceled(t *testing.T) {
 	}
 }
 
+func TestRunValidationAttemptsCanceledWhileWaiting(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
+	defer cancel()
+
+	call := 0
+	attempts, converged, err := runValidationAttempts(ctx, 2, time.Hour, func() (bool, error) {
+		call++
+		return false, errTransientObservation
+	})
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Equal(t, 1, attempts)
+	require.False(t, converged)
+	require.Equal(t, 1, call)
+}
+
 func TestRunValidationAttemptsRejectsInvalidAttemptCount(t *testing.T) {
 	attempts, converged, err := runValidationAttempts(t.Context(), 0, 0, func() (bool, error) {
 		t.Fatal("validation callback must not run")

--- a/test/validate/validate_retry_test.go
+++ b/test/validate/validate_retry_test.go
@@ -85,15 +85,32 @@ func TestRunValidationAttempts(t *testing.T) {
 }
 
 func TestRunValidationAttemptsCanceled(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
+	tests := []struct {
+		name     string
+		interval time.Duration
+	}{
+		{
+			name:     "during delayed retry",
+			interval: time.Hour,
+		},
+		{
+			name: "without retry delay",
+		},
+	}
 
-	attempts, converged, err := runValidationAttempts(ctx, 2, time.Hour, func() (bool, error) {
-		return false, errTransientObservation
-	})
-	require.ErrorIs(t, err, context.Canceled)
-	require.Equal(t, 1, attempts)
-	require.False(t, converged)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			cancel()
+
+			attempts, converged, err := runValidationAttempts(ctx, 2, test.interval, func() (bool, error) {
+				return false, errTransientObservation
+			})
+			require.ErrorIs(t, err, context.Canceled)
+			require.Equal(t, 1, attempts)
+			require.False(t, converged)
+		})
+	}
 }
 
 func TestRunValidationAttemptsRejectsInvalidAttemptCount(t *testing.T) {


### PR DESCRIPTION
## Summary

- retry transient state-observation failures and state mismatches during integration validation
- bound retries to three attempts with context-aware delays
- return the latest observation error and preserve restart-case semantics
- add executable retry-contract tests for convergence, exhaustion, cancellation, and invalid configuration

## Why

Live Windows validation returned an empty CNS debug response once while HNS and Azure VNET state were already converged. The validator immediately attempted to parse the empty response and failed the run instead of retrying the observation.

## Validation

- `go test -race ./test/validate`
- `go vet ./test/validate`
