### PR TITLE
ci: skip global system pod precheck in k8s e2e

### DIFF
--- a/.pipelines/cni/k8s-e2e/k8s-e2e-step-template.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e-step-template.yaml
@@ -63,10 +63,12 @@ steps:
       # flakeAttempts -> flake-attempts
       # dryRun -> dry-run
 
+      # AKS-managed kube-system pods outside this pipeline must not gate CNI tests.
       ./ginkgo --nodes=${{ parameters.processes }} \
       ./e2e.test -- \
       --num-nodes=2 \
       --provider=skeleton \
+      --minStartupPods=-1 \
       --ginkgo.focus='${{ parameters.ginkgoFocus }}' \
       --ginkgo.skip="${{ parameters.ginkgoSkip }}$SKIP$GATE_SKIP" \
       --ginkgo.flakeAttempts=${{ parameters.attempts }} \

--- a/.pipelines/cni/k8s-e2e/k8s-e2e.steps.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e.steps.yaml
@@ -64,10 +64,12 @@ steps:
       # flakeAttempts -> flake-attempts
       # dryRun -> dry-run
 
+      # AKS-managed kube-system pods outside this pipeline must not gate CNI tests.
       ./ginkgo --nodes=${{ parameters.processes }} \
       ./e2e.test -- \
       --num-nodes=2 \
       --provider=skeleton \
+      --minStartupPods=-1 \
       --ginkgo.focus='${{ parameters.ginkgoFocus }}' \
       --ginkgo.skip="${{ parameters.ginkgoSkip }}$SKIP$GATE_SKIP" \
       --ginkgo.flakeAttempts=${{ parameters.attempts }} \


### PR DESCRIPTION
## What this changes

- pass `--minStartupPods=-1` to both CNI Kubernetes E2E runners
- prevent unrelated AKS-managed `kube-system` pods from blocking CNI-scoped tests during `SynchronizedBeforeSuite`
- preserve existing node, daemonset, focus, skip, and test-specific validation behavior

## Validation

- reproduced the default precheck failure on Kubernetes v1.33.13: `0 / 13` `kube-system` pods Ready and zero specs executed
- ran the pipeline-style command with `--minStartupPods=-1` against AKS and passed the selected DNS E2E spec
- confirmed the generated DNS test namespace was deleted