### PR TITLE
Amaro/failure agent teams notis

### DIFF
--- a/.pipelines/failure-agent-teams-bot/notify-pipeline.yml
+++ b/.pipelines/failure-agent-teams-bot/notify-pipeline.yml
@@ -1,0 +1,116 @@
+# ----------------------------------------------------------------------------
+# failure-agent-teams-bot — Teams notification pipeline
+#
+# Posts pipeline status to the shared ACN Pipeline Notifier bot. Each
+# (NOTIFY_SOURCE, NOTIFY_RUN_ID) pair renders one Adaptive Card in Teams that
+# updates in place across stages, plus threaded replies for narrative events.
+#
+# BEFORE THIS RUNS you MUST fill in:
+#   1. pipeline-constants.yml → notifyTeamId, notifyChannelId
+#   2. Every AzureCLI@2 `azureSubscription:` below → your WIF service connection
+#   3. Backend allow-list (in the notifier repo, not here): add the WIF
+#      service-principal appid to ALLOWED_CALLERS and the team groupId to
+#      ALLOWED_TEAMS, and install the bot in your Teams team.
+#
+# Requirements on the agent: Azure CLI and jq.
+# ----------------------------------------------------------------------------
+
+pr: none
+trigger: none
+
+variables:
+  - template: pipeline-constants.yml
+
+  # WIF (Workload Identity Federation) service connection used to mint the AAD
+  # bearer scoped to notifierApiAudience.
+  - name: serviceConnection
+    value: acn-dalec-test
+
+stages:
+  - stage: run
+    displayName: "Run with Teams notifications"
+    jobs:
+      - job: work
+        displayName: "Work + notify"
+        pool:
+          name: "$(BUILD_POOL_NAME_DEFAULT)"
+        steps:
+          # --- Notify: running -------------------------------------------------
+          - task: AzureCLI@2
+            displayName: "Notify Teams — running"
+            inputs:
+              azureSubscription: $(serviceConnection)
+              scriptType: bash
+              scriptLocation: inlineScript
+              addSpnToEnvironment: true
+              inlineScript: |
+                source .pipelines/failure-agent-teams-bot/scripts/notify-bot.sh
+                notify_status \
+                  --status running --stage init \
+                  --title "failure-agent-teams-bot | $(Build.BuildNumber)" \
+                  --summary "Pipeline started." \
+                  --run-url "$(System.CollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)"
+            env:
+              NOTIFIER_ENDPOINT: $(notifierEndpoint)
+              NOTIFIER_API_AUDIENCE: $(notifierApiAudience)
+              NOTIFY_SOURCE: $(notifySource)
+              NOTIFY_RUN_ID: $(Build.BuildId)
+              NOTIFY_TEAM_ID: $(notifyTeamId)
+              NOTIFY_CHANNEL_ID: $(notifyChannelId)
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+          # --- Actual work goes here ------------------------------------------
+          - bash: |
+              set -euo pipefail
+              echo "Replace this step with the real pipeline work."
+            displayName: "Do the work"
+
+          # --- Notify: succeeded ----------------------------------------------
+          - task: AzureCLI@2
+            displayName: "Notify Teams — succeeded"
+            condition: succeeded()
+            inputs:
+              azureSubscription: $(serviceConnection)
+              scriptType: bash
+              scriptLocation: inlineScript
+              addSpnToEnvironment: true
+              inlineScript: |
+                source .pipelines/failure-agent-teams-bot/scripts/notify-bot.sh
+                notify_status \
+                  --status succeeded --stage done --severity success \
+                  --title "failure-agent-teams-bot | $(Build.BuildNumber)" \
+                  --summary "Pipeline completed successfully." \
+                  --run-url "$(System.CollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)"
+            env:
+              NOTIFIER_ENDPOINT: $(notifierEndpoint)
+              NOTIFIER_API_AUDIENCE: $(notifierApiAudience)
+              NOTIFY_SOURCE: $(notifySource)
+              NOTIFY_RUN_ID: $(Build.BuildId)
+              NOTIFY_TEAM_ID: $(notifyTeamId)
+              NOTIFY_CHANNEL_ID: $(notifyChannelId)
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+          # --- Notify: failed -------------------------------------------------
+          - task: AzureCLI@2
+            displayName: "Notify Teams — failed"
+            condition: failed()
+            inputs:
+              azureSubscription: $(serviceConnection)
+              scriptType: bash
+              scriptLocation: inlineScript
+              addSpnToEnvironment: true
+              inlineScript: |
+                source .pipelines/failure-agent-teams-bot/scripts/notify-bot.sh
+                notify_status \
+                  --status failed --stage done --severity failure \
+                  --title "failure-agent-teams-bot | $(Build.BuildNumber)" \
+                  --summary "Pipeline failed." \
+                  --run-url "$(System.CollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)"
+            env:
+              NOTIFIER_ENDPOINT: $(notifierEndpoint)
+              NOTIFIER_API_AUDIENCE: $(notifierApiAudience)
+              NOTIFY_SOURCE: $(notifySource)
+              NOTIFY_RUN_ID: $(Build.BuildId)
+              NOTIFY_TEAM_ID: $(notifyTeamId)
+              NOTIFY_CHANNEL_ID: $(notifyChannelId)
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/.pipelines/failure-agent-teams-bot/pipeline-constants.yml
+++ b/.pipelines/failure-agent-teams-bot/pipeline-constants.yml
@@ -1,0 +1,26 @@
+variables:
+# ----------------------------------------------------------------------------
+# ACN Pipeline Notifier (Teams bot) — see /src/notifier and /infra/notifier.bicep
+# in the azure-container-networking notifier repo.
+# ----------------------------------------------------------------------------
+
+# Notifier function-app endpoint. Shared bot — keep as-is.
+- name: notifierEndpoint
+  value: 'https://acn-notifier-bot.azurewebsites.net'
+
+# AAD audience the notifier validates incoming bearer tokens against.
+# Matches `apiAppId` in /infra/notifier.bicepparam. Shared bot — keep as-is.
+- name: notifierApiAudience
+  value: 'api://3976eca5-3f9d-4528-987f-c20c1f9f27f7'
+
+# Stable source identifier for cards posted by this pipeline. CHANGE ME.
+- name: notifySource
+  value: 'failure-agent-teams-bot'
+
+# Target Teams team groupId.
+- name: notifyTeamId
+  value: '1eb27b57-8ace-4f0e-a9a9-e6db4e9829b7'
+
+# Target Teams channel id (URL-decoded).
+- name: notifyChannelId
+  value: '19:e810e8f1d12741198af77c3743a2eecf@thread.skype'

--- a/.pipelines/failure-agent-teams-bot/scripts/notify-bot.sh
+++ b/.pipelines/failure-agent-teams-bot/scripts/notify-bot.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+#
+# Posts pipeline status to the ACN Pipeline Notifier bot
+# (https://acn-notifier-bot.azurewebsites.net). Each (source, runId) maps to
+# one root Adaptive Card in Teams that mutates in place across stages, plus
+# threaded replies for narrative events (approvals, failures, etc.).
+#
+# Usage from a pipeline step:
+#
+#     source .pipelines/dalec-release/scripts/notify-bot.sh
+#
+#     notify_status \
+#       --status running --stage init \
+#       --title "dalec-release | $COMPONENT $TAG" \
+#       --summary "Orchestrator started." \
+#       --run-url "$ORCHESTRATOR_RUN_URL"
+#
+#     notify_reply --text "Manual approval required: $reason"
+#
+# Required environment (passed as `env:` on the AzureCLI@2 task):
+#   NOTIFIER_ENDPOINT      e.g. https://acn-notifier-bot.azurewebsites.net
+#   NOTIFIER_API_AUDIENCE  e.g. api://3976eca5-3f9d-4528-987f-c20c1f9f27f7
+#   NOTIFY_SOURCE          stable identifier, e.g. dalec-release
+#   NOTIFY_RUN_ID          stable per-build id, e.g. $(Build.BuildId)
+#   NOTIFY_TEAM_ID         Teams team groupId
+#   NOTIFY_CHANNEL_ID      Teams channel id (19:...@thread.skype)
+#
+# Authentication: the calling task MUST be AzureCLI@2 with
+# `addSpnToEnvironment: true` (or a previous `az login` against the WIF
+# service connection). We exchange that login for an AAD bearer scoped to
+# NOTIFIER_API_AUDIENCE and send it in Authorization: Bearer.
+#
+# Failures are logged but never fail the build — notifications are best-effort.
+
+set -uo pipefail
+
+notify_require_env() {
+  local missing=()
+  for var in NOTIFIER_ENDPOINT NOTIFIER_API_AUDIENCE NOTIFY_SOURCE NOTIFY_RUN_ID NOTIFY_TEAM_ID NOTIFY_CHANNEL_ID; do
+    if [[ -z "${!var:-}" ]]; then
+      missing+=("$var")
+    fi
+  done
+  if (( ${#missing[@]} > 0 )); then
+    echo "notify-bot: skipping — missing env: ${missing[*]}" >&2
+    return 1
+  fi
+}
+
+notify_mint_token() {
+  local audience="$NOTIFIER_API_AUDIENCE"
+  local token
+  if ! token="$(az account get-access-token --resource "$audience" --query accessToken -o tsv 2>/dev/null)"; then
+    echo "notify-bot: failed to mint AAD token for $audience" >&2
+    return 1
+  fi
+  if [[ -z "$token" ]]; then
+    echo "notify-bot: empty AAD token returned for $audience" >&2
+    return 1
+  fi
+  printf '%s' "$token"
+}
+
+# notify_ado_link <ado-build-url>
+#
+# Echoes a markdown-labeled link for an Azure DevOps build URL by looking up
+# the pipeline name and build number via the ADO REST API. Falls back to the
+# raw URL on parse or API failure. Requires $SYSTEM_ACCESSTOKEN (every ADO
+# job has it when 'Allow scripts to access OAuth token' is enabled).
+#
+# Supports:
+#   https://dev.azure.com/<org>/<project>/_build/results?buildId=<id>...
+#   https://<org>.visualstudio.com/<project>/_build/results?buildId=<id>...
+notify_ado_link() {
+  local url="$1"
+  if [[ -z "$url" ]]; then return 0; fi
+
+  if [[ -z "${SYSTEM_ACCESSTOKEN:-}" ]] || ! command -v jq >/dev/null 2>&1; then
+    printf '%s' "$url"
+    return 0
+  fi
+
+  local build_id host org project api_base
+  build_id="$(printf '%s' "$url" | sed -n 's/.*[?&]buildId=\([0-9]\+\).*/\1/p')"
+  host="$(printf '%s' "$url" | sed -n 's#https\?://\([^/]*\)/.*#\1#p')"
+  if [[ -z "$build_id" || -z "$host" ]]; then
+    printf '%s' "$url"
+    return 0
+  fi
+
+  if [[ "$host" == *.visualstudio.com ]]; then
+    org="${host%%.visualstudio.com}"
+    project="$(printf '%s' "$url" | sed -n 's#https\?://[^/]*/\([^/]*\)/.*#\1#p')"
+  elif [[ "$host" == "dev.azure.com" ]]; then
+    org="$(printf '%s' "$url" | sed -n 's#https\?://dev\.azure\.com/\([^/]*\)/.*#\1#p')"
+    project="$(printf '%s' "$url" | sed -n 's#https\?://dev\.azure\.com/[^/]*/\([^/]*\)/.*#\1#p')"
+  else
+    printf '%s' "$url"
+    return 0
+  fi
+
+  if [[ -z "$org" || -z "$project" ]]; then
+    printf '%s' "$url"
+    return 0
+  fi
+
+  api_base="https://dev.azure.com/${org}/${project}"
+
+  local meta
+  if ! meta="$(curl -sS -f \
+    -H "Authorization: Bearer $SYSTEM_ACCESSTOKEN" \
+    "${api_base}/_apis/build/builds/${build_id}?api-version=7.1" 2>/dev/null)"; then
+    printf '%s' "$url"
+    return 0
+  fi
+
+  local name number label
+  name="$(printf '%s' "$meta" | jq -r '.definition.name // empty')"
+  number="$(printf '%s' "$meta" | jq -r '.buildNumber // empty')"
+  if [[ -z "$name" ]]; then
+    printf '%s' "$url"
+    return 0
+  fi
+
+  label="$name"
+  [[ -n "$number" ]] && label="${label} #${number}"
+  # Escape markdown brackets in the label so it renders verbatim.
+  label="${label//\[/\\[}"
+  label="${label//\]/\\]}"
+
+  printf '[%s](%s)' "$label" "$url"
+}
+
+# notify_status --status <s> --stage <s> --title <t> [--summary <s>] [--run-url <u>] [--severity <s>]
+#                [--fact "Name|Value[|URL]"]... [--cc-label <text>] [--cc-user "<upn>[|name]"]... [--mention-channel]
+#
+# Status enum:   queued | running | succeeded | failed | canceled
+# Severity enum: info | success | warning | failure
+#
+# Each --fact adds one row to the card's FactSet. URL is optional; when given,
+# the value renders as a markdown link.
+# Each --cc-user adds one Teams mention to the cc line. Display name defaults
+# to the email prefix when not provided.
+notify_status() {
+  notify_require_env || return 0
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "notify-bot: jq not found, skipping" >&2
+    return 0
+  fi
+
+  local status="" stage="" title="" summary="" run_url="" severity="" mention_channel="" cc_label=""
+  local -a facts=()
+  local -a cc_users=()
+  while (( $# > 0 )); do
+    case "$1" in
+      --status)          status="$2";   shift 2 ;;
+      --stage)           stage="$2";    shift 2 ;;
+      --title)           title="$2";    shift 2 ;;
+      --summary)         summary="$2";  shift 2 ;;
+      --run-url)         run_url="$2";  shift 2 ;;
+      --severity)        severity="$2"; shift 2 ;;
+      --fact)            facts+=("$2"); shift 2 ;;
+      --cc-label)        cc_label="$2"; shift 2 ;;
+      --cc-user)         cc_users+=("$2"); shift 2 ;;
+      --mention-channel) mention_channel="true"; shift ;;
+      *) echo "notify-bot: unknown arg $1" >&2; return 0 ;;
+    esac
+  done
+
+  if [[ -z "$title" ]]; then
+    echo "notify-bot: --title is required" >&2
+    return 0
+  fi
+
+  local token
+  token="$(notify_mint_token)" || return 0
+
+  # Build facts JSON array. Each entry: "Name|Value" or "Name|Value|URL".
+  local facts_json="[]"
+  if [[ -n "$run_url" || ${#facts[@]} -gt 0 ]]; then
+    facts_json="$({
+      if [[ -n "$run_url" ]]; then
+        jq -n --arg url "$run_url" '{name:"Run", value:$url, url:$url}'
+      fi
+      for f in "${facts[@]}"; do
+        local fname fval furl
+        fname="${f%%|*}"
+        local rest="${f#*|}"
+        if [[ "$rest" == "$f" ]]; then
+          fval=""
+          furl=""
+        elif [[ "$rest" == *"|"* ]]; then
+          fval="${rest%%|*}"
+          furl="${rest#*|}"
+        else
+          fval="$rest"
+          furl=""
+        fi
+        jq -n --arg n "$fname" --arg v "$fval" --arg u "$furl" \
+          'if $u != "" then {name:$n, value:$v, url:$u} else {name:$n, value:$v} end'
+      done
+    } | jq -s .)"
+  fi
+
+  # Build cc JSON object when cc users were supplied.
+  local cc_json="null"
+  if (( ${#cc_users[@]} > 0 )); then
+    local mentions_json
+    mentions_json="$(printf '%s\n' "${cc_users[@]}" | jq -R . | jq -s .)"
+    cc_json="$(jq -n --arg lbl "$cc_label" --argjson m "$mentions_json" \
+      'if $lbl != "" then {label: $lbl, mentions: $m} else {mentions: $m} end')"
+  fi
+
+  local payload
+  payload="$(jq -n \
+    --arg     source         "$NOTIFY_SOURCE" \
+    --arg     runId          "$NOTIFY_RUN_ID" \
+    --arg     teamId         "$NOTIFY_TEAM_ID" \
+    --arg     channelId      "$NOTIFY_CHANNEL_ID" \
+    --arg     title          "$title" \
+    --arg     summary        "$summary" \
+    --arg     status         "$status" \
+    --arg     stage          "$stage" \
+    --arg     severity       "$severity" \
+    --argjson factsArr       "$facts_json" \
+    --argjson ccObj          "$cc_json" \
+    --arg     mentionChannel "$mention_channel" \
+    '{
+      source: $source,
+      runId: $runId,
+      teamId: $teamId,
+      channelId: $channelId,
+      title: $title
+    }
+    + (if $summary        != ""     then {summary:  $summary}  else {} end)
+    + (if $status         != ""     then {status:   $status}   else {} end)
+    + (if $stage          != ""     then {stage:    $stage}    else {} end)
+    + (if $severity       != ""     then {severity: $severity} else {} end)
+    + (if ($factsArr | length) > 0  then {facts: $factsArr}    else {} end)
+    + (if $ccObj          != null   then {cc: $ccObj}          else {} end)
+    + (if $mentionChannel == "true" then {mentionChannel: true} else {} end)
+    ')"
+
+  local http_code
+  http_code="$(curl -sS -o /tmp/notify-bot.out -w '%{http_code}' \
+    -X POST \
+    -H "Authorization: Bearer $token" \
+    -H "Content-Type: application/json" \
+    --data "$payload" \
+    "$NOTIFIER_ENDPOINT/api/notifications" || echo "000")"
+
+  if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+    echo "notify-bot: /api/notifications -> HTTP $http_code" >&2
+    head -c 500 /tmp/notify-bot.out >&2 || true
+    echo "" >&2
+    return 0
+  fi
+  echo "notify-bot: posted status=$status stage=$stage (HTTP $http_code)"
+}
+
+# notify_reply --text <message> [--tag <short tag>] [--severity <s>] [--ado-url <ado-build-url>] [--mention-channel] [--mention-user <upn>]...
+#
+# If --ado-url is given, a markdown-labeled link to the build (pipeline name +
+# build number) is appended to --text via notify_ado_link. Callers don't need
+# to pre-compute the label.
+#
+# --mention-channel emits a Teams @channel mention. --mention-user can be
+# passed multiple times to attempt user mentions by UPN/email (best-effort).
+notify_reply() {
+  notify_require_env || return 0
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "notify-bot: jq not found, skipping" >&2
+    return 0
+  fi
+
+  local text="" tag="" severity="" ado_url="" mention_channel=""
+  local -a mention_upns=()
+  while (( $# > 0 )); do
+    case "$1" in
+      --text)             text="$2";     shift 2 ;;
+      --tag)              tag="$2";      shift 2 ;;
+      --severity)         severity="$2"; shift 2 ;;
+      --ado-url)          ado_url="$2";  shift 2 ;;
+      --mention-channel)  mention_channel="true"; shift ;;
+      --mention-user)     mention_upns+=("$2"); shift 2 ;;
+      *) echo "notify-bot: unknown arg $1" >&2; return 0 ;;
+    esac
+  done
+
+  if [[ -n "$ado_url" ]]; then
+    local link
+    link="$(notify_ado_link "$ado_url")"
+    if [[ -n "$text" ]]; then
+      text="${text} ${link}"
+    else
+      text="$link"
+    fi
+  fi
+
+  if [[ -z "$text" ]]; then
+    echo "notify-bot: --text or --ado-url is required" >&2
+    return 0
+  fi
+
+  local token
+  token="$(notify_mint_token)" || return 0
+
+  # Build mentionUpns as a JSON array from the bash array.
+  local mention_upns_json="[]"
+  if (( ${#mention_upns[@]} > 0 )); then
+    mention_upns_json="$(printf '%s\n' "${mention_upns[@]}" | jq -R . | jq -s .)"
+  fi
+
+  local payload
+  payload="$(jq -n \
+    --arg source         "$NOTIFY_SOURCE" \
+    --arg runId          "$NOTIFY_RUN_ID" \
+    --arg text           "$text" \
+    --arg tag            "$tag" \
+    --arg severity       "$severity" \
+    --argjson mentionUpns "$mention_upns_json" \
+    --arg mentionChannel "$mention_channel" \
+    '{source: $source, runId: $runId, text: $text}
+     + (if $tag      != "" then {tag: $tag}           else {} end)
+     + (if $severity != "" then {severity: $severity} else {} end)
+     + (if $mentionChannel == "true" then {mentionChannel: true} else {} end)
+     + (if ($mentionUpns | length) > 0 then {mentionUpns: $mentionUpns} else {} end)')"
+
+  local http_code
+  http_code="$(curl -sS -o /tmp/notify-bot.out -w '%{http_code}' \
+    -X POST \
+    -H "Authorization: Bearer $token" \
+    -H "Content-Type: application/json" \
+    --data "$payload" \
+    "$NOTIFIER_ENDPOINT/api/notifications/reply" || echo "000")"
+
+  if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+    echo "notify-bot: /api/notifications/reply -> HTTP $http_code" >&2
+    head -c 500 /tmp/notify-bot.out >&2 || true
+    echo "" >&2
+    return 0
+  fi
+  echo "notify-bot: replied (HTTP $http_code)"
+}

--- a/.pipelines/failure-agent-teams-bot/scripts/notify-incident.sh
+++ b/.pipelines/failure-agent-teams-bot/scripts/notify-incident.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+#
+# Bridges a failure-agent incident.json to the shared ACN Pipeline Notifier bot.
+#
+# When the failure-analysis pipeline produces a confident, actionable diagnosis
+# (analyzed + confidence >= threshold + a proposed fix), this posts one
+# engineer-facing Adaptive Card (via notify_status) summarizing the diagnosis,
+# plus a threaded reply (via notify_reply) carrying the proposed fix, top
+# evidence, and recommended action — everything an on-call engineer needs to
+# start acting without opening the run.
+#
+# Usage (from an AzureCLI@2 step with addSpnToEnvironment: true):
+#   .pipelines/failure-agent-teams-bot/scripts/notify-incident.sh <incident.json> [min-confidence]
+#
+# Requires the same env as notify-bot.sh (NOTIFIER_*, NOTIFY_*), which must be
+# exported by the calling task. min-confidence defaults to 0.51.
+#
+# Best-effort: a missing file, missing jq, or a below-threshold incident is a
+# quiet no-op and never fails the build.
+
+set -uo pipefail
+
+INCIDENT="${1:-}"
+MIN_CONFIDENCE="${2:-0.51}"
+
+if [[ -z "$INCIDENT" ]]; then
+  echo "notify-incident: usage: notify-incident.sh <incident.json> [min-confidence]" >&2
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=notify-bot.sh
+source "$SCRIPT_DIR/notify-bot.sh"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "notify-incident: jq not found, skipping" >&2
+  exit 0
+fi
+
+if [[ ! -f "$INCIDENT" ]]; then
+  echo "notify-incident: no incident file at $INCIDENT, skipping" >&2
+  exit 0
+fi
+
+# --- Gate: only ping on a confident, actionable analysis --------------------
+analysis_status="$(jq -r '.analysisStatus // ""' "$INCIDENT")"
+confidence="$(jq -r '.confidence // 0' "$INCIDENT")"
+proposed_fix="$(jq -r '.proposedFix // ""' "$INCIDENT")"
+
+meets="$(jq -n --argjson c "$confidence" --argjson m "$MIN_CONFIDENCE" '$c >= $m' 2>/dev/null || echo false)"
+if [[ "$analysis_status" != "analyzed" || "$meets" != "true" || -z "$proposed_fix" ]]; then
+  echo "notify-incident: skipping — status=$analysis_status confidence=$confidence fix=$([[ -n "$proposed_fix" ]] && echo yes || echo no) (threshold $MIN_CONFIDENCE)"
+  exit 0
+fi
+
+# --- Read the fields an engineer needs --------------------------------------
+pipeline="$(jq -r '.pipelineName // ""' "$INCIDENT")"
+build_number="$(jq -r '.buildNumber // ""' "$INCIDENT")"
+category="$(jq -r '.category // ""' "$INCIDENT")"
+band="$(jq -r '.confidenceBand // ""' "$INCIDENT")"
+root_cause="$(jq -r '.rootCauseSummary // ""' "$INCIDENT")"
+owner="$(jq -r '.recommendedOwner // ""' "$INCIDENT")"
+fingerprint="$(jq -r '.fingerprint // ""' "$INCIDENT")"
+commit="$(jq -r '.commit // ""' "$INCIDENT")"
+stage="$(jq -r '.stage // ""' "$INCIDENT")"
+job="$(jq -r '.job // ""' "$INCIDENT")"
+repository="$(jq -r '.repository // ""' "$INCIDENT")"
+pr_number="$(jq -r '.pullRequestNumber // ""' "$INCIDENT")"
+recommended_action="$(jq -r '.recommendedAction // ""' "$INCIDENT")"
+retention="$(jq -r '.retentionDecision // ""' "$INCIDENT")"
+
+# Compact confidence, e.g. "high (0.87)".
+conf_pretty="$(jq -rn --argjson c "$confidence" '($c * 100 | floor) / 100 | tostring')"
+
+# Scenario line from whichever cluster fields are populated.
+scenario="$(jq -r '
+  [ .clusterType, .cni, .os, .region ]
+  | map(select(. != null and . != "")) | join(" · ")' "$INCIDENT")"
+
+# --- Root card: notify_status ----------------------------------------------
+severity="failure"
+[[ "$category" == "known_flake" ]] && severity="warning"
+
+title="Failure Analysis — ${pipeline}"
+[[ -n "$build_number" ]] && title="${title} #${build_number}"
+
+run_url=""
+if [[ -n "${SYSTEM_COLLECTIONURI:-}" && -n "${SYSTEM_TEAMPROJECT:-}" && -n "${BUILD_BUILDID:-}" ]]; then
+  run_url="${SYSTEM_COLLECTIONURI}${SYSTEM_TEAMPROJECT}/_build/results?buildId=${BUILD_BUILDID}"
+fi
+
+status_args=(
+  --status failed
+  --stage analysis
+  --severity "$severity"
+  --title "$title"
+  --summary "$root_cause"
+)
+[[ -n "$run_url" ]] && status_args+=(--run-url "$run_url")
+
+status_args+=(--fact "Confidence|${band} (${conf_pretty})")
+[[ -n "$category" ]] && status_args+=(--fact "Category|${category}")
+
+stage_job="$(printf '%s / %s' "$stage" "$job" | sed 's#^ / ##; s# / $##')"
+[[ -n "$stage_job" ]] && status_args+=(--fact "Stage / Job|${stage_job}")
+[[ -n "$scenario" ]]  && status_args+=(--fact "Scenario|${scenario}")
+[[ -n "$owner" ]]     && status_args+=(--fact "Owner|${owner}")
+[[ -n "$fingerprint" ]] && status_args+=(--fact "Fingerprint|${fingerprint:0:12}")
+[[ -n "$commit" ]]    && status_args+=(--fact "Commit|${commit:0:12}")
+if [[ -n "$pr_number" && -n "$repository" ]]; then
+  status_args+=(--fact "Pull request|#${pr_number}|https://github.com/${repository}/pull/${pr_number}")
+fi
+
+# @mention whoever queued this run so the ping lands on them in the shared
+# channel. Build.RequestedForEmail is the AAD UPN the notifier resolves; empty
+# (some scheduled/service triggers) is a quiet skip. Build.RequestedFor is the
+# display name; notify_status defaults to the email prefix when it's absent.
+initiator_upn="${BUILD_REQUESTEDFOREMAIL:-}"
+initiator_name="${BUILD_REQUESTEDFOR:-}"
+if [[ -n "$initiator_upn" ]]; then
+  status_args+=(--cc-label "Initiated by")
+  if [[ -n "$initiator_name" ]]; then
+    status_args+=(--cc-user "${initiator_upn}|${initiator_name}")
+  else
+    status_args+=(--cc-user "$initiator_upn")
+  fi
+fi
+
+notify_status "${status_args[@]}"
+
+# --- Threaded detail: notify_reply -----------------------------------------
+# Bullet the top evidence lines.
+evidence_md="$(jq -r '(.topEvidence // []) | map("- " + .) | join("\n")' "$INCIDENT")"
+
+reply="$(printf '**Proposed fix**\n%s' "$proposed_fix")"
+if [[ -n "$evidence_md" ]]; then
+  reply="$(printf '%s\n\n**Top evidence**\n%s' "$reply" "$evidence_md")"
+fi
+if [[ -n "$recommended_action" ]]; then
+  reply="$(printf '%s\n\n**Recommended action**\n%s' "$reply" "$recommended_action")"
+fi
+if [[ -n "$retention" ]]; then
+  reply="$(printf '%s\n\n_Cluster retention: %s_' "$reply" "$retention")"
+fi
+
+notify_reply --text "$reply" --tag "diagnosis" --severity "$severity"

--- a/.pipelines/failure-agent-teams-bot/scripts/notify-incident.sh
+++ b/.pipelines/failure-agent-teams-bot/scripts/notify-incident.sh
@@ -115,16 +115,20 @@ fi
 # channel. Build.RequestedForEmail is the AAD UPN the notifier resolves; empty
 # (some scheduled/service triggers) is a quiet skip. Build.RequestedFor is the
 # display name; notify_status defaults to the email prefix when it's absent.
+status_args+=(--cc-label "Initiated by")
 initiator_upn="${BUILD_REQUESTEDFOREMAIL:-}"
 initiator_name="${BUILD_REQUESTEDFOR:-}"
 if [[ -n "$initiator_upn" ]]; then
-  status_args+=(--cc-label "Initiated by")
   if [[ -n "$initiator_name" ]]; then
     status_args+=(--cc-user "${initiator_upn}|${initiator_name}")
   else
     status_args+=(--cc-user "$initiator_upn")
   fi
 fi
+
+# Always cc the failure-analysis owners so they're pinged on every card.
+status_args+=(--cc-user "johnpayne@microsoft.com|John Payne")
+status_args+=(--cc-user "behzadm@microsoft.com|Behzad Mirkhanzadeh")
 
 notify_status "${status_args[@]}"
 

--- a/.pipelines/templates/failure-analysis.job.yaml
+++ b/.pipelines/templates/failure-analysis.job.yaml
@@ -212,7 +212,7 @@ jobs:
           inlineScript: |
             bash "$(Build.SourcesDirectory)/.pipelines/failure-agent-teams-bot/scripts/notify-incident.sh" \
               "$(Agent.TempDirectory)/analysis/incident.json" \
-              "0.51"
+              "0.65"
         env:
           NOTIFIER_ENDPOINT: $(notifierEndpoint)
           NOTIFIER_API_AUDIENCE: $(notifierApiAudience)

--- a/.pipelines/templates/failure-analysis.job.yaml
+++ b/.pipelines/templates/failure-analysis.job.yaml
@@ -59,7 +59,9 @@ jobs:
         - agent.os -equals Linux
     timeoutInMinutes: 15
     variables:
-      ob_outputDirectory: $(Build.ArtifactStagingDirectory)/out
+      - template: ../failure-agent-teams-bot/pipeline-constants.yml
+      - name: ob_outputDirectory
+        value: $(Build.ArtifactStagingDirectory)/out
     steps:
       - checkout: self
 
@@ -193,3 +195,34 @@ jobs:
         artifact: failureAnalysis_${{ parameters.os }}_${{ parameters.clusterName }}
         displayName: "Publish analysis artifact"
         condition: succeededOrFailed()
+
+      # Post a Teams ping via the shared ACN Notifier bot when the diagnosis is
+      # confident and actionable (analyzed + confidence >= 0.51 + a proposed
+      # fix). Best-effort: below-threshold incidents are a quiet no-op and this
+      # step never fails the job. Requires the acn-dalec-test WIF connection and
+      # jq on the agent; see .pipelines/failure-agent-teams-bot/.
+      - task: AzureCLI@2
+        displayName: "Notify Teams on confident analysis"
+        condition: succeededOrFailed()
+        inputs:
+          azureSubscription: acn-dalec-test
+          scriptType: bash
+          scriptLocation: inlineScript
+          addSpnToEnvironment: true
+          inlineScript: |
+            bash "$(Build.SourcesDirectory)/.pipelines/failure-agent-teams-bot/scripts/notify-incident.sh" \
+              "$(Agent.TempDirectory)/analysis/incident.json" \
+              "0.51"
+        env:
+          NOTIFIER_ENDPOINT: $(notifierEndpoint)
+          NOTIFIER_API_AUDIENCE: $(notifierApiAudience)
+          NOTIFY_SOURCE: $(notifySource)
+          NOTIFY_RUN_ID: $(Build.BuildId)
+          NOTIFY_TEAM_ID: $(notifyTeamId)
+          NOTIFY_CHANNEL_ID: $(notifyChannelId)
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          SYSTEM_COLLECTIONURI: $(System.CollectionUri)
+          SYSTEM_TEAMPROJECT: $(System.TeamProject)
+          BUILD_BUILDID: $(Build.BuildId)
+          BUILD_REQUESTEDFOR: $(Build.RequestedFor)
+          BUILD_REQUESTEDFOREMAIL: $(Build.RequestedForEmail)

--- a/.pipelines/templates/pipeline-failure-analysis.job.yaml
+++ b/.pipelines/templates/pipeline-failure-analysis.job.yaml
@@ -31,7 +31,9 @@ jobs:
         - agent.os -equals Linux
     timeoutInMinutes: 10
     variables:
-      ob_outputDirectory: $(Build.ArtifactStagingDirectory)/out
+      - template: ../failure-agent-teams-bot/pipeline-constants.yml
+      - name: ob_outputDirectory
+        value: $(Build.ArtifactStagingDirectory)/out
     steps:
       - checkout: self
 
@@ -195,3 +197,34 @@ jobs:
         artifact: pipelineFailureAnalysis_${{ parameters.scope }}
         displayName: "Publish analysis artifact"
         condition: succeededOrFailed()
+
+      # Post a Teams ping via the shared ACN Notifier bot when the diagnosis is
+      # confident and actionable (analyzed + confidence >= 0.51 + a proposed
+      # fix). Best-effort: below-threshold incidents are a quiet no-op and this
+      # step never fails the job. Requires the acn-dalec-test WIF connection and
+      # jq on the agent; see .pipelines/failure-agent-teams-bot/.
+      - task: AzureCLI@2
+        displayName: "Notify Teams on confident analysis"
+        condition: succeededOrFailed()
+        inputs:
+          azureSubscription: acn-dalec-test
+          scriptType: bash
+          scriptLocation: inlineScript
+          addSpnToEnvironment: true
+          inlineScript: |
+            bash "$(Build.SourcesDirectory)/.pipelines/failure-agent-teams-bot/scripts/notify-incident.sh" \
+              "$(Agent.TempDirectory)/analysis/incident.json" \
+              "0.51"
+        env:
+          NOTIFIER_ENDPOINT: $(notifierEndpoint)
+          NOTIFIER_API_AUDIENCE: $(notifierApiAudience)
+          NOTIFY_SOURCE: $(notifySource)
+          NOTIFY_RUN_ID: $(Build.BuildId)
+          NOTIFY_TEAM_ID: $(notifyTeamId)
+          NOTIFY_CHANNEL_ID: $(notifyChannelId)
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          SYSTEM_COLLECTIONURI: $(System.CollectionUri)
+          SYSTEM_TEAMPROJECT: $(System.TeamProject)
+          BUILD_BUILDID: $(Build.BuildId)
+          BUILD_REQUESTEDFOR: $(Build.RequestedFor)
+          BUILD_REQUESTEDFOREMAIL: $(Build.RequestedForEmail)

--- a/.pipelines/templates/pipeline-failure-analysis.job.yaml
+++ b/.pipelines/templates/pipeline-failure-analysis.job.yaml
@@ -214,7 +214,7 @@ jobs:
           inlineScript: |
             bash "$(Build.SourcesDirectory)/.pipelines/failure-agent-teams-bot/scripts/notify-incident.sh" \
               "$(Agent.TempDirectory)/analysis/incident.json" \
-              "0.51"
+              "0.65"
         env:
           NOTIFIER_ENDPOINT: $(notifierEndpoint)
           NOTIFIER_API_AUDIENCE: $(notifierApiAudience)


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
 feat: add a knob to the frobnitz
or
 fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
Add Teams bot notification support to failure-analysis pipelines by porting the shared ACN notifier integration from `failure-agent-teams-bot`. This adds reusable notifier assets and wires best-effort notifications into both pipeline-failure and E2E failure-analysis jobs.

**Issue Fixed**:
Enhancement for existing failure analysis agent.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
 <!-- Common commit types:
 build: Build 🏭
 chore: Maintenance 🔧
 ci: Continuous Integration 💜
 docs: Documentation 📘
 feat: Features 🌈
 fix: Bug Fixes 🐞
 perf: Performance Improvements 🚀
 refactor: Code Refactoring 💎
 revert: Revert Change ◀️
 style: Code Style 🎶
 security: Security Fix 🛡️
 test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
- Added `.pipelines/failure-agent-teams-bot/` assets:
  - `notify-pipeline.yml`
  - `pipeline-constants.yml`
  - `scripts/notify-bot.sh`
  - `scripts/notify-incident.sh`
- Updated templates:
  - `.pipelines/templates/pipeline-failure-analysis.job.yaml`
  - `.pipelines/templates/failure-analysis.job.yaml`
- Notification step is best-effort (`condition: succeededOrFailed()`), gated by incident confidence threshold (`0.51`), and includes run initiator context (`Build.RequestedFor`, `Build.RequestedForEmail`).