### PR TITLE
hack/aks: bump default E2E K8S_VER from 1.33 to 1.35

### DIFF
--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -11,7 +11,7 @@ AZCLI   ?= docker run --rm -v $(AZCFG):/root/.azure -v $(KUBECFG):/root/.kube -v
 
 # overrideable defaults
 AUTOUPGRADE          ?= patch
-K8S_VER              ?= 1.33
+K8S_VER              ?= 1.35
 NODE_COUNT           ?= 2
 NODE_COUNT_WIN	     ?= $(NODE_COUNT)
 NODEUPGRADE          ?= NodeImage

--- a/hack/aks/deploy.mk
+++ b/hack/aks/deploy.mk
@@ -1,7 +1,7 @@
 # acnpublic: acnpublic.azurecr.io
 # general cilium variables
-DIR 									?= 1.17
-CILIUM_VERSION_TAG               		?= v1.17.15-260529
+DIR 									?= 1.18
+CILIUM_VERSION_TAG               		?= v1.18.11-260622
 CILIUM_IMAGE_REGISTRY           		?= mcr.microsoft.com/containernetworking
 IPV6_IMAGE_REGISTRY						?= mcr.microsoft.com/containernetworking
 IPV6_HP_BPF_VERSION               		?= v0.0.1
@@ -10,12 +10,12 @@ CILIUM_LOG_COLLECTOR_VERSION_TAG 		?= v0.0.2-0
 CILIUM_NIGHTLY_VERSION_TAG 				?= cilium-nightly-pipeline
 
 # ebpf cilium variables
-EBPF_CILIUM_DIR				     		?= 1.17
+EBPF_CILIUM_DIR				     		?= 1.18
 # we don't use CILIUM_VERSION_TAG or CILIUM_IMAGE_REGISTRY because we want to use the version supported by ebpf
 EBPF_CILIUM_IMAGE_REGISTRY           	?= mcr.microsoft.com/containernetworking
 IPV6_HP_BPF_VERSION               		?= v0.0.1
 IPV6_IMAGE_REGISTRY           			?= mcr.microsoft.com/containernetworking
-EBPF_CILIUM_VERSION_TAG               	?= v1.17.15-260529
+EBPF_CILIUM_VERSION_TAG               	?= v1.18.11-260622
 AZURE_IPTABLES_MONITOR_IMAGE_REGISTRY	?= mcr.microsoft.com/containernetworking
 AZURE_IPTABLES_MONITOR_TAG          	?= v0.0.5-0
 AZURE_IP_MASQ_MERGER_IMAGE_REGISTRY		?= mcr.microsoft.com/containernetworking


### PR DESCRIPTION
## Problem
AKS moved **1.33 to LTS-only** support. The E2E cluster-creation steps default to `--kubernetes-version $(K8S_VER)` where `K8S_VER ?= 1.33`, so `az aks create` now fails:

```
ERROR: (K8sVersionNotSupported) Managed cluster ... is on version 1.33.13,
which is only available for Long-Term Support (LTS).
```

This breaks the PR pipeline cluster-creation for overlay / swift / vnetscale / cniv1 clusters (e.g. build 173471344).

## Fix
Bump the default `K8S_VER` from `1.33` → `1.35`, the **current AKS default** version (KubernetesOfficial GA support), giving the longest runway before it ages into LTS-only.

| Version | Support plan (westus2) |
|---|---|
| 1.31 / 1.32 / 1.33 | LTS-only (fails) |
| 1.34 | GA (ages out soonest) |
| **1.35** | GA — current AKS default ✅ |
| 1.36 | GA (newest, not default) |

## Note
`.pipelines/pipeline.yaml` still has explicit `1.30` and `1.25` pins for two matrix stages; those are deliberate old-version tests and are left unchanged. If they also fail on LTS-only they need a separate decision.