### PR TITLE
hack/aks: default LTS to true on release/v1.7

### DIFF
--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -27,7 +27,7 @@ PUBLIC_IP_ID         ?= /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/
 PUBLIC_IPv4          ?= $(PUBLIC_IP_ID)/$(IP_PREFIX)-$(CLUSTER)-v4
 PUBLIC_IPv6          ?= $(PUBLIC_IP_ID)/$(IP_PREFIX)-$(CLUSTER)-v6
 KUBE_PROXY_JSON_PATH ?= ./kube-proxy.json
-LTS					 ?= false
+LTS					 ?= true
 ACNS				 ?= false
 
 


### PR DESCRIPTION
Enables the AKS Long Term Support plan by default in `hack/aks/Makefile` on `release/v1.7` by changing `LTS ?= false` to `LTS ?= true`.

When `LTS=true`, the create targets append `--k8s-support-plan AKSLongTermSupport --tier premium` (via `LTS_ARGS`). The flag remains overrideable, so runs can opt out with `LTS=false`.

Note: leaves the default `K8S_VER` at 1.33 (no version bump on this branch).
