### PR TITLE
fix(cns): create /run/xtables.lock (FileOrCreate) in e2e daemonset

### DIFF
--- a/test/integration/manifests/cns/daemonset-linux.yaml
+++ b/test/integration/manifests/cns/daemonset-linux.yaml
@@ -159,6 +159,6 @@ spec:
         - name: xtables-lock
           hostPath:
             path: /run/xtables.lock
-            type: File
+            type: FileOrCreate
       serviceAccountName: azure-cns
 


### PR DESCRIPTION
The CNS integration-test daemonset mounts /run/xtables.lock as hostPath type:File, which requires the file to already exist on the node. On kube-proxy-free (nokubeproxy) Cilium podsubnet legs that install CNS before Cilium and have no ip-masq-agent, nothing has created the lock yet, so the volume mount fails and azure-cns is stuck in Init/ContainerCreating and never becomes Ready.

Use type:FileOrCreate so kubelet creates the lock file if missing, matching the sibling ip-masq-agent test manifest which already mounts /run/xtables.lock as FileOrCreate. Managed AKS CNS (aks-rp) does not mount this path at all, so this only affects e2e test runs.

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
