### PR TITLE
feat(platform): add boot identity helpers

### DIFF
--- a/platform/boot_id_linux.go
+++ b/platform/boot_id_linux.go
@@ -1,0 +1,34 @@
+// Copyright 2017 Microsoft. All rights reserved.
+// MIT License
+
+package platform
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+const linuxBootIDPath = "/proc/sys/kernel/random/boot_id"
+
+type bootIDReader func(string) ([]byte, error)
+
+// BootID returns the identity of the current Linux boot.
+func BootID() (string, error) {
+	return bootID(os.ReadFile)
+}
+
+func bootID(read bootIDReader) (string, error) {
+	data, err := read(linuxBootIDPath)
+	if err != nil {
+		return "", fmt.Errorf("read linux boot ID: %w", err)
+	}
+
+	id := strings.TrimSpace(string(data))
+	if id == "" {
+		return "", errors.New("linux boot ID is empty")
+	}
+
+	return id, nil
+}

--- a/platform/boot_id_linux.go
+++ b/platform/boot_id_linux.go
@@ -12,6 +12,8 @@ import (
 
 const linuxBootIDPath = "/proc/sys/kernel/random/boot_id"
 
+var errEmptyLinuxBootID = errors.New("platform: linux boot ID is empty")
+
 type bootIDReader func(string) ([]byte, error)
 
 // BootID returns the identity of the current Linux boot.
@@ -27,7 +29,7 @@ func bootID(read bootIDReader) (string, error) {
 
 	id := strings.TrimSpace(string(data))
 	if id == "" {
-		return "", errors.New("linux boot ID is empty")
+		return "", errEmptyLinuxBootID
 	}
 
 	return id, nil

--- a/platform/boot_id_linux.go
+++ b/platform/boot_id_linux.go
@@ -12,6 +12,8 @@ import (
 
 const linuxBootIDPath = "/proc/sys/kernel/random/boot_id"
 
+var errLinuxBootIDEmpty = errors.New("platform: linux boot ID is empty")
+
 type bootIDReader func(string) ([]byte, error)
 
 // BootID returns the identity of the current Linux boot.
@@ -27,7 +29,7 @@ func bootID(read bootIDReader) (string, error) {
 
 	id := strings.TrimSpace(string(data))
 	if id == "" {
-		return "", errors.New("linux boot ID is empty")
+		return "", errLinuxBootIDEmpty
 	}
 
 	return id, nil

--- a/platform/boot_id_linux_test.go
+++ b/platform/boot_id_linux_test.go
@@ -1,0 +1,71 @@
+// Copyright 2017 Microsoft. All rights reserved.
+// MIT License
+
+package platform
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBootIDReaderBoundary(t *testing.T) {
+	t.Parallel()
+
+	errRead := errors.New("read failure")
+	tests := []struct {
+		name    string
+		data    string
+		readErr error
+		want    string
+		wantErr string
+	}{
+		{
+			name: "value",
+			data: "550e8400-e29b-41d4-a716-446655440000",
+			want: "550e8400-e29b-41d4-a716-446655440000",
+		},
+		{
+			name: "surrounding whitespace",
+			data: "\t 550e8400-e29b-41d4-a716-446655440000 \r\n",
+			want: "550e8400-e29b-41d4-a716-446655440000",
+		},
+		{
+			name:    "empty value",
+			data:    " \r\n\t",
+			wantErr: "linux boot ID is empty",
+		},
+		{
+			name:    "read failure",
+			readErr: errRead,
+			wantErr: "read linux boot ID: read failure",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			calls := 0
+			read := func(path string) ([]byte, error) {
+				calls++
+				require.Equal(t, linuxBootIDPath, path)
+				return []byte(test.data), test.readErr
+			}
+
+			got, err := bootID(read)
+			if test.wantErr != "" {
+				require.EqualError(t, err, test.wantErr)
+				require.Empty(t, got)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.want, got)
+			}
+			require.Equal(t, 1, calls)
+			if test.readErr != nil {
+				require.ErrorIs(t, err, test.readErr)
+			}
+		})
+	}
+}

--- a/platform/boot_id_linux_test.go
+++ b/platform/boot_id_linux_test.go
@@ -10,10 +10,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testBootID = "550e8400-e29b-41d4-a716-446655440000"
+
+var errBootIDRead = errors.New("read failure")
+
 func TestBootIDReaderBoundary(t *testing.T) {
 	t.Parallel()
 
-	errRead := errors.New("read failure")
 	tests := []struct {
 		name    string
 		data    string
@@ -23,22 +26,22 @@ func TestBootIDReaderBoundary(t *testing.T) {
 	}{
 		{
 			name: "value",
-			data: "550e8400-e29b-41d4-a716-446655440000",
-			want: "550e8400-e29b-41d4-a716-446655440000",
+			data: testBootID,
+			want: testBootID,
 		},
 		{
 			name: "surrounding whitespace",
-			data: "\t 550e8400-e29b-41d4-a716-446655440000 \r\n",
-			want: "550e8400-e29b-41d4-a716-446655440000",
+			data: "\t " + testBootID + " \r\n",
+			want: testBootID,
 		},
 		{
 			name:    "empty value",
 			data:    " \r\n\t",
-			wantErr: "linux boot ID is empty",
+			wantErr: errEmptyLinuxBootID.Error(),
 		},
 		{
 			name:    "read failure",
-			readErr: errRead,
+			readErr: errBootIDRead,
 			wantErr: "read linux boot ID: read failure",
 		},
 	}

--- a/platform/boot_id_linux_test.go
+++ b/platform/boot_id_linux_test.go
@@ -10,10 +10,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testBootID = "550e8400-e29b-41d4-a716-446655440000"
+
+var errBootIDRead = errors.New("read failure")
+
 func TestBootIDReaderBoundary(t *testing.T) {
 	t.Parallel()
 
-	errRead := errors.New("read failure")
 	tests := []struct {
 		name    string
 		data    string
@@ -23,22 +26,22 @@ func TestBootIDReaderBoundary(t *testing.T) {
 	}{
 		{
 			name: "value",
-			data: "550e8400-e29b-41d4-a716-446655440000",
-			want: "550e8400-e29b-41d4-a716-446655440000",
+			data: testBootID,
+			want: testBootID,
 		},
 		{
 			name: "surrounding whitespace",
-			data: "\t 550e8400-e29b-41d4-a716-446655440000 \r\n",
-			want: "550e8400-e29b-41d4-a716-446655440000",
+			data: "\t " + testBootID + " \r\n",
+			want: testBootID,
 		},
 		{
 			name:    "empty value",
 			data:    " \r\n\t",
-			wantErr: "linux boot ID is empty",
+			wantErr: "platform: linux boot ID is empty",
 		},
 		{
 			name:    "read failure",
-			readErr: errRead,
+			readErr: errBootIDRead,
 			wantErr: "read linux boot ID: read failure",
 		},
 	}

--- a/platform/boot_id_windows.go
+++ b/platform/boot_id_windows.go
@@ -1,0 +1,43 @@
+// Copyright 2017 Microsoft. All rights reserved.
+// MIT License
+
+package platform
+
+import (
+	"fmt"
+	"strconv"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+const (
+	windowsBootIDRegistryPath = `SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management\PrefetchParameters`
+	windowsBootIDValueName    = "BootId"
+)
+
+type bootIDQuery func() (uint64, error)
+
+// BootID returns the identity of the current Windows boot.
+func BootID() (string, error) {
+	return bootID(queryBootIDRegistry)
+}
+
+func queryBootIDRegistry() (uint64, error) {
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE, windowsBootIDRegistryPath, registry.READ)
+	if err != nil {
+		return 0, err
+	}
+	defer key.Close()
+
+	id, _, err := key.GetIntegerValue(windowsBootIDValueName)
+	return id, err
+}
+
+func bootID(query bootIDQuery) (string, error) {
+	id, err := query()
+	if err != nil {
+		return "", fmt.Errorf("query windows boot ID: %w", err)
+	}
+
+	return strconv.FormatUint(id, 10), nil
+}

--- a/platform/boot_id_windows.go
+++ b/platform/boot_id_windows.go
@@ -23,14 +23,24 @@ func BootID() (string, error) {
 }
 
 func queryBootIDRegistry() (uint64, error) {
-	key, err := registry.OpenKey(registry.LOCAL_MACHINE, windowsBootIDRegistryPath, registry.READ)
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE, windowsBootIDRegistryPath, registry.QUERY_VALUE)
 	if err != nil {
 		return 0, err
 	}
 	defer key.Close()
 
-	id, _, err := key.GetIntegerValue(windowsBootIDValueName)
-	return id, err
+	id, valueType, err := key.GetIntegerValue(windowsBootIDValueName)
+	if err != nil {
+		return 0, err
+	}
+	return validateBootIDRegistryValue(id, valueType)
+}
+
+func validateBootIDRegistryValue(id uint64, valueType uint32) (uint64, error) {
+	if valueType != registry.DWORD {
+		return 0, fmt.Errorf("unexpected boot ID registry type %d", valueType)
+	}
+	return id, nil
 }
 
 func bootID(query bootIDQuery) (string, error) {

--- a/platform/boot_id_windows.go
+++ b/platform/boot_id_windows.go
@@ -4,6 +4,7 @@
 package platform
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -15,28 +16,37 @@ const (
 	windowsBootIDValueName    = "BootId"
 )
 
-type bootIDQuery func() (uint64, error)
+var errWindowsBootIDNotDWORD = errors.New("platform: boot ID registry value is not a DWORD")
+
+type bootIDQuery func() (uint64, uint32, error)
 
 // BootID returns the identity of the current Windows boot.
 func BootID() (string, error) {
 	return bootID(queryBootIDRegistry)
 }
 
-func queryBootIDRegistry() (uint64, error) {
-	key, err := registry.OpenKey(registry.LOCAL_MACHINE, windowsBootIDRegistryPath, registry.READ)
+func queryBootIDRegistry() (id uint64, valueType uint32, err error) {
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE, windowsBootIDRegistryPath, registry.QUERY_VALUE)
 	if err != nil {
-		return 0, err
+		return 0, 0, fmt.Errorf("open boot ID registry key: %w", err)
 	}
 	defer key.Close()
 
-	id, _, err := key.GetIntegerValue(windowsBootIDValueName)
-	return id, err
+	id, valueType, err = key.GetIntegerValue(windowsBootIDValueName)
+	if err != nil {
+		return 0, 0, fmt.Errorf("get boot ID registry value: %w", err)
+	}
+
+	return id, valueType, nil
 }
 
 func bootID(query bootIDQuery) (string, error) {
-	id, err := query()
+	id, valueType, err := query()
 	if err != nil {
 		return "", fmt.Errorf("query windows boot ID: %w", err)
+	}
+	if valueType != registry.DWORD {
+		return "", fmt.Errorf("%w: %d", errWindowsBootIDNotDWORD, valueType)
 	}
 
 	return strconv.FormatUint(id, 10), nil

--- a/platform/boot_id_windows.go
+++ b/platform/boot_id_windows.go
@@ -4,6 +4,7 @@
 package platform
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -15,6 +16,8 @@ const (
 	windowsBootIDValueName    = "BootId"
 )
 
+var errUnexpectedBootIDRegistryType = errors.New("platform: unexpected boot ID registry type")
+
 type bootIDQuery func() (uint64, error)
 
 // BootID returns the identity of the current Windows boot.
@@ -25,20 +28,20 @@ func BootID() (string, error) {
 func queryBootIDRegistry() (uint64, error) {
 	key, err := registry.OpenKey(registry.LOCAL_MACHINE, windowsBootIDRegistryPath, registry.QUERY_VALUE)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("open boot ID registry key: %w", err)
 	}
 	defer key.Close()
 
 	id, valueType, err := key.GetIntegerValue(windowsBootIDValueName)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("read boot ID registry value: %w", err)
 	}
 	return validateBootIDRegistryValue(id, valueType)
 }
 
 func validateBootIDRegistryValue(id uint64, valueType uint32) (uint64, error) {
 	if valueType != registry.DWORD {
-		return 0, fmt.Errorf("unexpected boot ID registry type %d", valueType)
+		return 0, fmt.Errorf("%w: %d", errUnexpectedBootIDRegistryType, valueType)
 	}
 	return id, nil
 }

--- a/platform/boot_id_windows_test.go
+++ b/platform/boot_id_windows_test.go
@@ -1,0 +1,62 @@
+//go:build windows
+
+// Copyright 2017 Microsoft. All rights reserved.
+// MIT License
+
+package platform
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBootIDNativeQueryBoundary(t *testing.T) {
+	t.Parallel()
+
+	errRegistry := errors.New("registry failure")
+	tests := []struct {
+		name     string
+		id       uint64
+		queryErr error
+		want     string
+		wantErr  string
+	}{
+		{
+			name: "DWORD value conversion",
+			id:   uint64(^uint32(0)),
+			want: "4294967295",
+		},
+		{
+			name:     "registry failure",
+			queryErr: errRegistry,
+			wantErr:  "query windows boot ID: registry failure",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			calls := 0
+			query := func() (uint64, error) {
+				calls++
+				return test.id, test.queryErr
+			}
+
+			got, err := bootID(query)
+			if test.wantErr != "" {
+				require.EqualError(t, err, test.wantErr)
+				require.Empty(t, got)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.want, got)
+			}
+			require.Equal(t, 1, calls)
+			if test.queryErr != nil {
+				require.ErrorIs(t, err, test.queryErr)
+			}
+		})
+	}
+}

--- a/platform/boot_id_windows_test.go
+++ b/platform/boot_id_windows_test.go
@@ -10,27 +10,38 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows/registry"
 )
+
+var errBootIDRegistry = errors.New("registry failure")
 
 func TestBootIDNativeQueryBoundary(t *testing.T) {
 	t.Parallel()
 
-	errRegistry := errors.New("registry failure")
 	tests := []struct {
-		name     string
-		id       uint64
-		queryErr error
-		want     string
-		wantErr  string
+		name      string
+		id        uint64
+		valueType uint32
+		queryErr  error
+		wantCause error
+		want      string
+		wantErr   string
 	}{
 		{
-			name: "DWORD value conversion",
-			id:   uint64(^uint32(0)),
-			want: "4294967295",
+			name:      "DWORD value conversion",
+			id:        uint64(^uint32(0)),
+			valueType: registry.DWORD,
+			want:      "4294967295",
+		},
+		{
+			name:      "non DWORD registry value",
+			valueType: registry.QWORD,
+			wantErr:   "platform: boot ID registry value is not a DWORD: 11",
+			wantCause: errWindowsBootIDNotDWORD,
 		},
 		{
 			name:     "registry failure",
-			queryErr: errRegistry,
+			queryErr: errBootIDRegistry,
 			wantErr:  "query windows boot ID: registry failure",
 		},
 	}
@@ -40,9 +51,9 @@ func TestBootIDNativeQueryBoundary(t *testing.T) {
 			t.Parallel()
 
 			calls := 0
-			query := func() (uint64, error) {
+			query := func() (uint64, uint32, error) {
 				calls++
-				return test.id, test.queryErr
+				return test.id, test.valueType, test.queryErr
 			}
 
 			got, err := bootID(query)
@@ -56,6 +67,9 @@ func TestBootIDNativeQueryBoundary(t *testing.T) {
 			require.Equal(t, 1, calls)
 			if test.queryErr != nil {
 				require.ErrorIs(t, err, test.queryErr)
+			}
+			if test.wantCause != nil {
+				require.ErrorIs(t, err, test.wantCause)
 			}
 		})
 	}

--- a/platform/boot_id_windows_test.go
+++ b/platform/boot_id_windows_test.go
@@ -71,6 +71,6 @@ func TestValidateBootIDRegistryValue(t *testing.T) {
 	require.Equal(t, uint64(42), id)
 
 	id, err = validateBootIDRegistryValue(42, registry.QWORD)
-	require.EqualError(t, err, "unexpected boot ID registry type 11")
+	require.EqualError(t, err, "platform: unexpected boot ID registry type: 11")
 	require.Zero(t, id)
 }

--- a/platform/boot_id_windows_test.go
+++ b/platform/boot_id_windows_test.go
@@ -10,12 +10,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows/registry"
 )
+
+var errBootIDRegistry = errors.New("registry failure")
 
 func TestBootIDNativeQueryBoundary(t *testing.T) {
 	t.Parallel()
 
-	errRegistry := errors.New("registry failure")
 	tests := []struct {
 		name     string
 		id       uint64
@@ -30,7 +32,7 @@ func TestBootIDNativeQueryBoundary(t *testing.T) {
 		},
 		{
 			name:     "registry failure",
-			queryErr: errRegistry,
+			queryErr: errBootIDRegistry,
 			wantErr:  "query windows boot ID: registry failure",
 		},
 	}
@@ -59,4 +61,16 @@ func TestBootIDNativeQueryBoundary(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateBootIDRegistryValue(t *testing.T) {
+	t.Parallel()
+
+	id, err := validateBootIDRegistryValue(42, registry.DWORD)
+	require.NoError(t, err)
+	require.Equal(t, uint64(42), id)
+
+	id, err = validateBootIDRegistryValue(42, registry.QWORD)
+	require.EqualError(t, err, "unexpected boot ID registry type 11")
+	require.Zero(t, id)
 }


### PR DESCRIPTION
## Summary

- add an uncalled cross-platform `platform.BootID()` helper for future CNS state lifecycle work
- read Linux boot identity from `/proc/sys/kernel/random/boot_id`
- read the kubelet-compatible Windows `BootId` registry DWORD through native Go APIs
- keep OS-specific behavior isolated in `_linux.go` and `_windows.go` files

## Scope

This is an additive prerequisite only. It has no runtime caller and does not change CNS behavior.

## Validation

- `go test -race ./platform`
- `go vet ./platform`
- Windows platform test cross-compilation
- independent code review found no correctness or platform issues
