### PR TITLE
refactor: extract CNS persistent state startup

### DIFF
--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -63,7 +63,6 @@ import (
 	"github.com/Azure/azure-container-networking/log"
 	"github.com/Azure/azure-container-networking/nmagent"
 	"github.com/Azure/azure-container-networking/platform"
-	"github.com/Azure/azure-container-networking/processlock"
 	localtls "github.com/Azure/azure-container-networking/server/tls"
 	"github.com/Azure/azure-container-networking/store"
 	"github.com/Azure/azure-container-networking/telemetry"
@@ -95,8 +94,6 @@ const (
 	name                              = "azure-cns"
 	pluginName                        = "azure-vnet"
 	endpointStoreName                 = "azure-endpoints"
-	endpointStoreLocationLinux        = "/var/run/azure-cns/"
-	endpointStoreLocationWindows      = "/k/azurecns/"
 	defaultCNINetworkConfigFileName   = "10-azure.conflist"
 	dncApiVersion                     = "?api-version=2018-03-01"
 	poolIPAMRefreshRateInMilliseconds = 1000
@@ -363,11 +360,7 @@ func init() {
 
 	// Fill EndpointStatePath based on the platform
 	if endpointStorePath = os.Getenv("CNSStoreFilePath"); endpointStorePath == "" {
-		if runtime.GOOS == "windows" {
-			endpointStorePath = endpointStoreLocationWindows
-		} else {
-			endpointStorePath = endpointStoreLocationLinux
-		}
+		endpointStorePath = defaultEndpointStorePath
 	}
 	go func() {
 		// Wait until receiving a signal.
@@ -530,9 +523,10 @@ func main() {
 
 	// Initialize CNS.
 	var (
-		err                error
-		config             common.ServiceConfig
-		endpointStateStore store.KeyValueStore
+		err                   error
+		config                common.ServiceConfig
+		endpointStateStore    store.KeyValueStore
+		httpRemoteRestService *restserver.HTTPRestService
 	)
 
 	config.Version = version
@@ -732,50 +726,34 @@ func main() {
 	// Log platform information.
 	logger.Printf("Running on %v", platform.GetOSInfo())
 
-	err = platform.CreateDirectory(storeFileLocation)
-	if err != nil {
-		logger.Errorf("Failed to create File Store directory %s, due to Error:%v", storeFileLocation, err.Error())
-		return
-	}
-
-	lockclient, err := processlock.NewFileLock(platform.CNILockPath + name + store.LockExtension)
-	if err != nil {
-		logger.Printf("Error initializing file lock:%v", err)
-		return
-	}
-
-	// Create the key value store.
-	storeFileName := storeFileLocation + name + ".json"
-	config.Store, err = store.NewJsonFileStore(storeFileName, lockclient, nil)
-	if err != nil {
-		logger.Errorf("Failed to create store file: %s, due to error %v\n", storeFileName, err)
-		return
-	}
-
-	// Initialize endpoint state store if cns is managing endpoint state.
 	if cnsconfig.ManageEndpointState {
 		logger.Printf("[Azure CNS] Configured to manage endpoints state")
-		endpointStoreLock, err := processlock.NewFileLock(platform.CNILockPath + endpointStoreName + store.LockExtension) // nolint
-		if err != nil {
-			logger.Printf("Error initializing endpoint state file lock:%v", err)
-			return
-		}
-		defer endpointStoreLock.Unlock() // nolint
-
-		err = platform.CreateDirectory(endpointStorePath)
-		if err != nil {
-			logger.Errorf("Failed to create File Store directory %s, due to Error:%v", storeFileLocation, err.Error())
-			return
-		}
-		// Create the key value store.
-		storeFileName := endpointStorePath + endpointStoreName + ".json"
-		logger.Printf("EndpointStoreState path is %s", storeFileName)
-		endpointStateStore, err = store.NewJsonFileStore(storeFileName, endpointStoreLock, nil)
-		if err != nil {
-			logger.Errorf("Failed to create endpoint state store file: %s, due to error %v\n", storeFileName, err)
-			return
-		}
+		logger.Printf("EndpointStoreState path is %s", endpointStorePath+endpointStoreName+".json")
 	}
+
+	persistentState, err := newJSONPersistentStateStartup(
+		persistentStatePaths{
+			stateDirectory:    storeFileLocation,
+			stateFile:         storeFileLocation + name + ".json",
+			stateLockFile:     platform.CNILockPath + name + store.LockExtension,
+			endpointDirectory: endpointStorePath,
+			endpointFile:      endpointStorePath + endpointStoreName + ".json",
+			endpointLockFile:  platform.CNILockPath + endpointStoreName + store.LockExtension,
+		},
+		cnsconfig.ManageEndpointState,
+		func(context.Context) error {
+			return httpRemoteRestService.Start(&config)
+		},
+	)
+	if err != nil {
+		logger.Errorf("Failed to initialize persistent state: %v", err)
+		return
+	}
+	defer func() {
+		_ = persistentState.Close()
+	}()
+	config.Store = persistentState.stateStore
+	endpointStateStore = persistentState.endpointStateStore
 
 	wsProxy := wireserver.Proxy{
 		Host:       cnsconfig.WireserverIP,
@@ -789,7 +767,7 @@ func main() {
 	}
 
 	imdsClient := imds.NewClient()
-	httpRemoteRestService, err := restserver.NewHTTPRestService(&config, wsclient, &wsProxy, &restserver.IPtablesProvider{}, nmaClient,
+	httpRemoteRestService, err = restserver.NewHTTPRestService(&config, wsclient, &wsProxy, &restserver.IPtablesProvider{}, nmaClient,
 		endpointStateStore, conflistGenerator, homeAzMonitor, imdsClient)
 	if err != nil {
 		logger.Errorf("Failed to create CNS object, err:%v.\n", err)
@@ -1037,7 +1015,7 @@ func main() {
 			httpRemoteRestService.RegisterPProfEndpoints()
 		}
 
-		err = httpRemoteRestService.Start(&config)
+		err = persistentState.Start(rootCtx)
 		if err != nil {
 			logger.Errorf("Failed to start CNS, err:%v.\n", err)
 			return
@@ -1167,7 +1145,7 @@ func main() {
 		httpRemoteRestService.Stop()
 	}
 
-	if err = lockclient.Unlock(); err != nil {
+	if err = persistentState.Close(); err != nil {
 		logger.Errorf("lockclient cns unlock error:%v", err)
 	}
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -727,8 +727,8 @@ func main() {
 	logger.Printf("Running on %v", platform.GetOSInfo())
 
 	if cnsconfig.ManageEndpointState {
-		logger.Printf("[Azure CNS] Configured to manage endpoints state")
-		logger.Printf("EndpointStoreState path is %s", endpointStorePath+endpointStoreName+".json")
+		logger.Printf("[Azure CNS] Configured to manage endpoints state")                           //nolint:staticcheck // main still uses the legacy global logger
+		logger.Printf("EndpointStoreState path is %s", endpointStorePath+endpointStoreName+".json") //nolint:staticcheck // main still uses the legacy global logger
 	}
 
 	persistentState, err := newJSONPersistentStateStartup(
@@ -746,7 +746,7 @@ func main() {
 		},
 	)
 	if err != nil {
-		logger.Errorf("Failed to initialize persistent state: %v", err)
+		logger.Errorf("Failed to initialize persistent state: %v", err) //nolint:staticcheck // main still uses the legacy global logger
 		return
 	}
 	defer func() {
@@ -1146,7 +1146,7 @@ func main() {
 	}
 
 	if err = persistentState.Close(); err != nil {
-		logger.Errorf("lockclient cns unlock error:%v", err)
+		logger.Errorf("persistent state close error: %v", err) //nolint:staticcheck // main still uses the legacy global logger
 	}
 
 	logger.Printf("CNS exited")

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -62,7 +62,6 @@ import (
 	"github.com/Azure/azure-container-networking/log"
 	"github.com/Azure/azure-container-networking/nmagent"
 	"github.com/Azure/azure-container-networking/platform"
-	"github.com/Azure/azure-container-networking/processlock"
 	localtls "github.com/Azure/azure-container-networking/server/tls"
 	"github.com/Azure/azure-container-networking/store"
 	"github.com/Azure/azure-container-networking/telemetry"
@@ -94,8 +93,6 @@ const (
 	name                              = "azure-cns"
 	pluginName                        = "azure-vnet"
 	endpointStoreName                 = "azure-endpoints"
-	endpointStoreLocationLinux        = "/var/run/azure-cns/"
-	endpointStoreLocationWindows      = "/k/azurecns/"
 	defaultCNINetworkConfigFileName   = "10-azure.conflist"
 	dncApiVersion                     = "?api-version=2018-03-01"
 	poolIPAMRefreshRateInMilliseconds = 1000
@@ -362,11 +359,7 @@ func init() {
 
 	// Fill EndpointStatePath based on the platform
 	if endpointStorePath = os.Getenv("CNSStoreFilePath"); endpointStorePath == "" {
-		if runtime.GOOS == "windows" {
-			endpointStorePath = endpointStoreLocationWindows
-		} else {
-			endpointStorePath = endpointStoreLocationLinux
-		}
+		endpointStorePath = defaultEndpointStorePath
 	}
 	go func() {
 		// Wait until receiving a signal.
@@ -529,9 +522,10 @@ func main() {
 
 	// Initialize CNS.
 	var (
-		err                error
-		config             common.ServiceConfig
-		endpointStateStore store.KeyValueStore
+		err                   error
+		config                common.ServiceConfig
+		endpointStateStore    store.KeyValueStore
+		httpRemoteRestService *restserver.HTTPRestService
 	)
 
 	config.Version = version
@@ -731,50 +725,34 @@ func main() {
 	// Log platform information.
 	logger.Printf("Running on %v", platform.GetOSInfo())
 
-	err = platform.CreateDirectory(storeFileLocation)
-	if err != nil {
-		logger.Errorf("Failed to create File Store directory %s, due to Error:%v", storeFileLocation, err.Error())
-		return
-	}
-
-	lockclient, err := processlock.NewFileLock(platform.CNILockPath + name + store.LockExtension)
-	if err != nil {
-		logger.Printf("Error initializing file lock:%v", err)
-		return
-	}
-
-	// Create the key value store.
-	storeFileName := storeFileLocation + name + ".json"
-	config.Store, err = store.NewJsonFileStore(storeFileName, lockclient, nil)
-	if err != nil {
-		logger.Errorf("Failed to create store file: %s, due to error %v\n", storeFileName, err)
-		return
-	}
-
-	// Initialize endpoint state store if cns is managing endpoint state.
 	if cnsconfig.ManageEndpointState {
 		logger.Printf("[Azure CNS] Configured to manage endpoints state")
-		endpointStoreLock, err := processlock.NewFileLock(platform.CNILockPath + endpointStoreName + store.LockExtension) // nolint
-		if err != nil {
-			logger.Printf("Error initializing endpoint state file lock:%v", err)
-			return
-		}
-		defer endpointStoreLock.Unlock() // nolint
-
-		err = platform.CreateDirectory(endpointStorePath)
-		if err != nil {
-			logger.Errorf("Failed to create File Store directory %s, due to Error:%v", storeFileLocation, err.Error())
-			return
-		}
-		// Create the key value store.
-		storeFileName := endpointStorePath + endpointStoreName + ".json"
-		logger.Printf("EndpointStoreState path is %s", storeFileName)
-		endpointStateStore, err = store.NewJsonFileStore(storeFileName, endpointStoreLock, nil)
-		if err != nil {
-			logger.Errorf("Failed to create endpoint state store file: %s, due to error %v\n", storeFileName, err)
-			return
-		}
+		logger.Printf("EndpointStoreState path is %s", endpointStorePath+endpointStoreName+".json")
 	}
+
+	persistentState, err := newJSONPersistentStateStartup(
+		persistentStatePaths{
+			stateDirectory:    storeFileLocation,
+			stateFile:         storeFileLocation + name + ".json",
+			stateLockFile:     platform.CNILockPath + name + store.LockExtension,
+			endpointDirectory: endpointStorePath,
+			endpointFile:      endpointStorePath + endpointStoreName + ".json",
+			endpointLockFile:  platform.CNILockPath + endpointStoreName + store.LockExtension,
+		},
+		cnsconfig.ManageEndpointState,
+		func(context.Context) error {
+			return httpRemoteRestService.Start(&config)
+		},
+	)
+	if err != nil {
+		logger.Errorf("Failed to initialize persistent state: %v", err)
+		return
+	}
+	defer func() {
+		_ = persistentState.Close()
+	}()
+	config.Store = persistentState.stateStore
+	endpointStateStore = persistentState.endpointStateStore
 
 	wsProxy := wireserver.Proxy{
 		Host:       cnsconfig.WireserverIP,
@@ -788,7 +766,7 @@ func main() {
 	}
 
 	imdsClient := imds.NewClient()
-	httpRemoteRestService, err := restserver.NewHTTPRestService(&config, wsclient, &wsProxy, &restserver.IPtablesProvider{}, nmaClient,
+	httpRemoteRestService, err = restserver.NewHTTPRestService(&config, wsclient, &wsProxy, &restserver.IPtablesProvider{}, nmaClient,
 		endpointStateStore, conflistGenerator, homeAzMonitor, imdsClient)
 	if err != nil {
 		logger.Errorf("Failed to create CNS object, err:%v.\n", err)
@@ -1036,7 +1014,7 @@ func main() {
 			httpRemoteRestService.RegisterPProfEndpoints()
 		}
 
-		err = httpRemoteRestService.Start(&config)
+		err = persistentState.Start(rootCtx)
 		if err != nil {
 			logger.Errorf("Failed to start CNS, err:%v.\n", err)
 			return
@@ -1166,7 +1144,7 @@ func main() {
 		httpRemoteRestService.Stop()
 	}
 
-	if err = lockclient.Unlock(); err != nil {
+	if err = persistentState.Close(); err != nil {
 		logger.Errorf("lockclient cns unlock error:%v", err)
 	}
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -726,8 +726,8 @@ func main() {
 	logger.Printf("Running on %v", platform.GetOSInfo())
 
 	if cnsconfig.ManageEndpointState {
-		logger.Printf("[Azure CNS] Configured to manage endpoints state")
-		logger.Printf("EndpointStoreState path is %s", endpointStorePath+endpointStoreName+".json")
+		logger.Printf("[Azure CNS] Configured to manage endpoints state")                           //nolint:staticcheck // logger/v2 is not initialized yet
+		logger.Printf("EndpointStoreState path is %s", endpointStorePath+endpointStoreName+".json") //nolint:staticcheck // logger/v2 is not initialized yet
 	}
 
 	persistentState, err := newJSONPersistentStateStartup(
@@ -745,7 +745,7 @@ func main() {
 		},
 	)
 	if err != nil {
-		logger.Errorf("Failed to initialize persistent state: %v", err)
+		logger.Errorf("persistent state initialization failed: %v", err) //nolint:staticcheck // logger/v2 is not initialized yet
 		return
 	}
 	defer func() {

--- a/cns/service/persistent_state.go
+++ b/cns/service/persistent_state.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Microsoft. All rights reserved.
+// MIT License
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/Azure/azure-container-networking/platform"
+	"github.com/Azure/azure-container-networking/processlock"
+	"github.com/Azure/azure-container-networking/store"
+)
+
+type persistentStatePaths struct {
+	stateDirectory    string
+	stateFile         string
+	stateLockFile     string
+	endpointDirectory string
+	endpointFile      string
+	endpointLockFile  string
+}
+
+type persistentStateDependencies struct {
+	createDirectory func(string) error
+	newFileLock     func(string) (processlock.Interface, error)
+	openStore       func(string, processlock.Interface) (store.KeyValueStore, error)
+}
+
+type persistentStateStartup struct {
+	stateStore         store.KeyValueStore
+	endpointStateStore store.KeyValueStore
+	start              func(context.Context) error
+	locks              []processlock.Interface
+	closeOnce          sync.Once
+	closeErr           error
+}
+
+func newPersistentStateStartup(
+	paths persistentStatePaths,
+	manageEndpointState bool,
+	start func(context.Context) error,
+	deps persistentStateDependencies,
+) (*persistentStateStartup, error) {
+	startup := &persistentStateStartup{start: start}
+
+	if err := deps.createDirectory(paths.stateDirectory); err != nil {
+		return nil, fmt.Errorf("creating state store directory: %w", err)
+	}
+
+	stateLock, err := deps.newFileLock(paths.stateLockFile)
+	if err != nil {
+		return nil, fmt.Errorf("creating state store lock: %w", err)
+	}
+	startup.locks = append(startup.locks, stateLock)
+
+	startup.stateStore, err = deps.openStore(paths.stateFile, stateLock)
+	if err != nil {
+		return nil, startup.closeAfterError(fmt.Errorf("opening state store: %w", err))
+	}
+
+	if !manageEndpointState {
+		return startup, nil
+	}
+
+	endpointLock, err := deps.newFileLock(paths.endpointLockFile)
+	if err != nil {
+		return nil, startup.closeAfterError(fmt.Errorf("creating endpoint state store lock: %w", err))
+	}
+	startup.locks = append(startup.locks, endpointLock)
+
+	if err := deps.createDirectory(paths.endpointDirectory); err != nil {
+		return nil, startup.closeAfterError(fmt.Errorf("creating endpoint state store directory: %w", err))
+	}
+
+	startup.endpointStateStore, err = deps.openStore(paths.endpointFile, endpointLock)
+	if err != nil {
+		return nil, startup.closeAfterError(fmt.Errorf("opening endpoint state store: %w", err))
+	}
+
+	return startup, nil
+}
+
+func newJSONPersistentStateStartup(
+	paths persistentStatePaths,
+	manageEndpointState bool,
+	start func(context.Context) error,
+) (*persistentStateStartup, error) {
+	return newPersistentStateStartup(paths, manageEndpointState, start, persistentStateDependencies{
+		createDirectory: platform.CreateDirectory,
+		newFileLock:     processlock.NewFileLock,
+		openStore: func(path string, lock processlock.Interface) (store.KeyValueStore, error) {
+			return store.NewJsonFileStore(path, lock, nil)
+		},
+	})
+}
+
+func (s *persistentStateStartup) Start(ctx context.Context) error {
+	if err := s.start(ctx); err != nil {
+		return errors.Join(err, s.Close())
+	}
+	return nil
+}
+
+func (s *persistentStateStartup) Close() error {
+	s.closeOnce.Do(func() {
+		var closeErrs []error
+		for _, lock := range s.locks {
+			if err := lock.Unlock(); err != nil && !errors.Is(err, processlock.ErrInvalidFile) {
+				closeErrs = append(closeErrs, err)
+			}
+		}
+		s.closeErr = errors.Join(closeErrs...)
+	})
+	return s.closeErr
+}
+
+func (s *persistentStateStartup) closeAfterError(err error) error {
+	return errors.Join(err, s.Close())
+}

--- a/cns/service/persistent_state.go
+++ b/cns/service/persistent_state.go
@@ -71,7 +71,7 @@ func newPersistentStateStartup(
 	}
 	startup.locks = append(startup.locks, endpointLock)
 
-	if err := deps.createDirectory(paths.endpointDirectory); err != nil {
+	if err = deps.createDirectory(paths.endpointDirectory); err != nil {
 		return nil, startup.closeAfterError(fmt.Errorf("creating endpoint state store directory: %w", err))
 	}
 

--- a/cns/service/persistent_state.go
+++ b/cns/service/persistent_state.go
@@ -71,7 +71,8 @@ func newPersistentStateStartup(
 	}
 	startup.locks = append(startup.locks, endpointLock)
 
-	if err := deps.createDirectory(paths.endpointDirectory); err != nil {
+	err = deps.createDirectory(paths.endpointDirectory)
+	if err != nil {
 		return nil, startup.closeAfterError(fmt.Errorf("creating endpoint state store directory: %w", err))
 	}
 

--- a/cns/service/persistent_state_linux.go
+++ b/cns/service/persistent_state_linux.go
@@ -1,0 +1,6 @@
+// Copyright 2026 Microsoft. All rights reserved.
+// MIT License
+
+package main
+
+const defaultEndpointStorePath = "/var/run/azure-cns/"

--- a/cns/service/persistent_state_test.go
+++ b/cns/service/persistent_state_test.go
@@ -1,0 +1,274 @@
+// Copyright 2026 Microsoft. All rights reserved.
+// MIT License
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-container-networking/processlock"
+	"github.com/Azure/azure-container-networking/store"
+	"github.com/stretchr/testify/require"
+)
+
+type trackedFileLock struct {
+	unlockCalls int
+	unlockErr   error
+}
+
+func (*trackedFileLock) Lock() error {
+	return nil
+}
+
+func (l *trackedFileLock) Unlock() error {
+	l.unlockCalls++
+	return l.unlockErr
+}
+
+func TestNewPersistentStateStartup_GatesStartOnFailure(t *testing.T) {
+	failureErr := errors.New("startup failure")
+
+	tests := []struct {
+		name              string
+		failDirectoryCall int
+		failLockCall      int
+		failStoreCall     int
+		wantUnlocks       int
+	}{
+		{
+			name:              "state directory",
+			failDirectoryCall: 1,
+		},
+		{
+			name:         "state lock",
+			failLockCall: 1,
+		},
+		{
+			name:          "state store",
+			failStoreCall: 1,
+			wantUnlocks:   1,
+		},
+		{
+			name:         "endpoint lock",
+			failLockCall: 2,
+			wantUnlocks:  1,
+		},
+		{
+			name:              "endpoint directory",
+			failDirectoryCall: 2,
+			wantUnlocks:       2,
+		},
+		{
+			name:          "endpoint store",
+			failStoreCall: 2,
+			wantUnlocks:   2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				directoryCalls int
+				lockCalls      int
+				storeCalls     int
+				locks          []*trackedFileLock
+				startCalled    bool
+			)
+
+			startup, err := newPersistentStateStartup(
+				testPersistentStatePaths(),
+				true,
+				func(context.Context) error {
+					startCalled = true
+					return nil
+				},
+				persistentStateDependencies{
+					createDirectory: func(string) error {
+						directoryCalls++
+						if directoryCalls == tt.failDirectoryCall {
+							return failureErr
+						}
+						return nil
+					},
+					newFileLock: func(string) (processlock.Interface, error) {
+						lockCalls++
+						if lockCalls == tt.failLockCall {
+							return nil, failureErr
+						}
+						lock := &trackedFileLock{}
+						locks = append(locks, lock)
+						return lock, nil
+					},
+					openStore: func(path string, _ processlock.Interface) (store.KeyValueStore, error) {
+						storeCalls++
+						if storeCalls == tt.failStoreCall {
+							return nil, failureErr
+						}
+						return store.NewMockStore(path), nil
+					},
+				},
+			)
+
+			require.ErrorIs(t, err, failureErr)
+			require.Nil(t, startup)
+			require.False(t, startCalled)
+
+			var unlocks int
+			for _, lock := range locks {
+				unlocks += lock.unlockCalls
+			}
+			require.Equal(t, tt.wantUnlocks, unlocks)
+		})
+	}
+}
+
+func TestPersistentStateStartup_StartPropagatesContextAndCleansUpFailure(t *testing.T) {
+	startErr := errors.New("listener failure")
+	cleanupErr := errors.New("cleanup failure")
+	stateLock := &trackedFileLock{}
+	endpointLock := &trackedFileLock{unlockErr: cleanupErr}
+	locks := []processlock.Interface{stateLock, endpointLock}
+	lockIndex := 0
+
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "startup-context")
+	var receivedCtx context.Context
+
+	startup, err := newPersistentStateStartup(
+		testPersistentStatePaths(),
+		true,
+		func(ctx context.Context) error {
+			receivedCtx = ctx
+			return startErr
+		},
+		persistentStateDependencies{
+			createDirectory: func(string) error { return nil },
+			newFileLock: func(string) (processlock.Interface, error) {
+				lock := locks[lockIndex]
+				lockIndex++
+				return lock, nil
+			},
+			openStore: func(path string, _ processlock.Interface) (store.KeyValueStore, error) {
+				return store.NewMockStore(path), nil
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	err = startup.Start(ctx)
+	require.ErrorIs(t, err, startErr)
+	require.ErrorIs(t, err, cleanupErr)
+	require.Same(t, ctx, receivedCtx)
+	require.Equal(t, 1, stateLock.unlockCalls)
+	require.Equal(t, 1, endpointLock.unlockCalls)
+
+	require.ErrorIs(t, startup.Close(), cleanupErr)
+	require.Equal(t, 1, stateLock.unlockCalls)
+	require.Equal(t, 1, endpointLock.unlockCalls)
+}
+
+func TestNewPersistentStateStartup_EndpointStateDisabled(t *testing.T) {
+	var (
+		directories []string
+		lockFiles   []string
+		storeFiles  []string
+		lock        trackedFileLock
+	)
+
+	startup, err := newPersistentStateStartup(
+		testPersistentStatePaths(),
+		false,
+		func(context.Context) error { return nil },
+		persistentStateDependencies{
+			createDirectory: func(path string) error {
+				directories = append(directories, path)
+				return nil
+			},
+			newFileLock: func(path string) (processlock.Interface, error) {
+				lockFiles = append(lockFiles, path)
+				return &lock, nil
+			},
+			openStore: func(path string, _ processlock.Interface) (store.KeyValueStore, error) {
+				storeFiles = append(storeFiles, path)
+				return store.NewMockStore(path), nil
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, startup.stateStore)
+	require.Nil(t, startup.endpointStateStore)
+	require.Equal(t, []string{"state-dir"}, directories)
+	require.Equal(t, []string{"state.lock"}, lockFiles)
+	require.Equal(t, []string{"state.json"}, storeFiles)
+	require.NoError(t, startup.Start(context.Background()))
+	require.NoError(t, startup.Close())
+	require.Equal(t, 1, lock.unlockCalls)
+}
+
+func TestJSONPersistentStateStartup(t *testing.T) {
+	baseDir, err := os.MkdirTemp(".", ".persistent-state-test-*")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, os.RemoveAll(baseDir))
+	})
+
+	stateDirectory := filepath.Join(baseDir, "state") + string(os.PathSeparator)
+	endpointDirectory := filepath.Join(baseDir, "endpoint") + string(os.PathSeparator)
+	stateLockFile := filepath.Join(baseDir, "locks", "state.lock")
+	endpointLockFile := filepath.Join(baseDir, "locks", "endpoint.lock")
+	paths := persistentStatePaths{
+		stateDirectory:    stateDirectory,
+		stateFile:         stateDirectory + "azure-cns.json",
+		stateLockFile:     stateLockFile,
+		endpointDirectory: endpointDirectory,
+		endpointFile:      endpointDirectory + "azure-endpoints.json",
+		endpointLockFile:  endpointLockFile,
+	}
+
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "startup-context")
+	var startup *persistentStateStartup
+	startup, err = newJSONPersistentStateStartup(paths, true, func(receivedCtx context.Context) error {
+		require.Same(t, ctx, receivedCtx)
+
+		require.NoError(t, startup.stateStore.Lock(time.Second))
+		require.NoError(t, startup.stateStore.Write("state", map[string]string{"backend": "json"}))
+		require.NoError(t, startup.endpointStateStore.Lock(time.Second))
+		require.NoError(t, startup.endpointStateStore.Write("endpoint", "10.0.0.4"))
+		return nil
+	})
+	require.NoError(t, err)
+	require.NoError(t, startup.Start(ctx))
+	require.NoError(t, startup.Close())
+
+	for _, file := range []string{paths.stateFile, paths.endpointFile} {
+		contents, readErr := os.ReadFile(file)
+		require.NoError(t, readErr)
+		require.True(t, json.Valid(contents), "invalid JSON in %s", file)
+		require.Equal(t, ".json", filepath.Ext(file))
+	}
+
+	for _, lockFile := range []string{stateLockFile, endpointLockFile} {
+		lock, lockErr := processlock.NewFileLock(lockFile)
+		require.NoError(t, lockErr)
+		require.NoError(t, lock.Lock())
+		require.NoError(t, lock.Unlock())
+	}
+}
+
+func testPersistentStatePaths() persistentStatePaths {
+	return persistentStatePaths{
+		stateDirectory:    "state-dir",
+		stateFile:         "state.json",
+		stateLockFile:     "state.lock",
+		endpointDirectory: "endpoint-dir",
+		endpointFile:      "endpoint.json",
+		endpointLockFile:  "endpoint.lock",
+	}
+}

--- a/cns/service/persistent_state_test.go
+++ b/cns/service/persistent_state_test.go
@@ -17,6 +17,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	errPersistentStateStartup = errors.New("startup failure")
+	errPersistentStateStart   = errors.New("listener failure")
+	errPersistentStateCleanup = errors.New("cleanup failure")
+)
+
 type trackedFileLock struct {
 	unlockCalls int
 	unlockErr   error
@@ -32,8 +38,6 @@ func (l *trackedFileLock) Unlock() error {
 }
 
 func TestNewPersistentStateStartup_GatesStartOnFailure(t *testing.T) {
-	failureErr := errors.New("startup failure")
-
 	tests := []struct {
 		name              string
 		failDirectoryCall int
@@ -92,14 +96,14 @@ func TestNewPersistentStateStartup_GatesStartOnFailure(t *testing.T) {
 					createDirectory: func(string) error {
 						directoryCalls++
 						if directoryCalls == tt.failDirectoryCall {
-							return failureErr
+							return errPersistentStateStartup
 						}
 						return nil
 					},
 					newFileLock: func(string) (processlock.Interface, error) {
 						lockCalls++
 						if lockCalls == tt.failLockCall {
-							return nil, failureErr
+							return nil, errPersistentStateStartup
 						}
 						lock := &trackedFileLock{}
 						locks = append(locks, lock)
@@ -108,14 +112,14 @@ func TestNewPersistentStateStartup_GatesStartOnFailure(t *testing.T) {
 					openStore: func(path string, _ processlock.Interface) (store.KeyValueStore, error) {
 						storeCalls++
 						if storeCalls == tt.failStoreCall {
-							return nil, failureErr
+							return nil, errPersistentStateStartup
 						}
 						return store.NewMockStore(path), nil
 					},
 				},
 			)
 
-			require.ErrorIs(t, err, failureErr)
+			require.ErrorIs(t, err, errPersistentStateStartup)
 			require.Nil(t, startup)
 			require.False(t, startCalled)
 
@@ -129,23 +133,21 @@ func TestNewPersistentStateStartup_GatesStartOnFailure(t *testing.T) {
 }
 
 func TestPersistentStateStartup_StartPropagatesContextAndCleansUpFailure(t *testing.T) {
-	startErr := errors.New("listener failure")
-	cleanupErr := errors.New("cleanup failure")
 	stateLock := &trackedFileLock{}
-	endpointLock := &trackedFileLock{unlockErr: cleanupErr}
+	endpointLock := &trackedFileLock{unlockErr: errPersistentStateCleanup}
 	locks := []processlock.Interface{stateLock, endpointLock}
 	lockIndex := 0
 
 	type contextKey struct{}
 	ctx := context.WithValue(context.Background(), contextKey{}, "startup-context")
-	var receivedCtx context.Context
+	var receivedValue any
 
 	startup, err := newPersistentStateStartup(
 		testPersistentStatePaths(),
 		true,
 		func(ctx context.Context) error {
-			receivedCtx = ctx
-			return startErr
+			receivedValue = ctx.Value(contextKey{})
+			return errPersistentStateStart
 		},
 		persistentStateDependencies{
 			createDirectory: func(string) error { return nil },
@@ -162,13 +164,13 @@ func TestPersistentStateStartup_StartPropagatesContextAndCleansUpFailure(t *test
 	require.NoError(t, err)
 
 	err = startup.Start(ctx)
-	require.ErrorIs(t, err, startErr)
-	require.ErrorIs(t, err, cleanupErr)
-	require.Same(t, ctx, receivedCtx)
+	require.ErrorIs(t, err, errPersistentStateStart)
+	require.ErrorIs(t, err, errPersistentStateCleanup)
+	require.Equal(t, "startup-context", receivedValue)
 	require.Equal(t, 1, stateLock.unlockCalls)
 	require.Equal(t, 1, endpointLock.unlockCalls)
 
-	require.ErrorIs(t, startup.Close(), cleanupErr)
+	require.ErrorIs(t, startup.Close(), errPersistentStateCleanup)
 	require.Equal(t, 1, stateLock.unlockCalls)
 	require.Equal(t, 1, endpointLock.unlockCalls)
 }

--- a/cns/service/persistent_state_test.go
+++ b/cns/service/persistent_state_test.go
@@ -22,6 +22,12 @@ type trackedFileLock struct {
 	unlockErr   error
 }
 
+var (
+	errPersistentStateStartup  = errors.New("startup failure")
+	errPersistentStateListener = errors.New("listener failure")
+	errPersistentStateCleanup  = errors.New("cleanup failure")
+)
+
 func (*trackedFileLock) Lock() error {
 	return nil
 }
@@ -31,9 +37,17 @@ func (l *trackedFileLock) Unlock() error {
 	return l.unlockErr
 }
 
-func TestNewPersistentStateStartup_GatesStartOnFailure(t *testing.T) {
-	failureErr := errors.New("startup failure")
+type startRecorder struct {
+	ctx context.Context
+	err error
+}
 
+func (r *startRecorder) start(ctx context.Context) error {
+	r.ctx = ctx
+	return r.err
+}
+
+func TestNewPersistentStateStartup_GatesStartOnFailure(t *testing.T) {
 	tests := []struct {
 		name              string
 		failDirectoryCall int
@@ -92,14 +106,14 @@ func TestNewPersistentStateStartup_GatesStartOnFailure(t *testing.T) {
 					createDirectory: func(string) error {
 						directoryCalls++
 						if directoryCalls == tt.failDirectoryCall {
-							return failureErr
+							return errPersistentStateStartup
 						}
 						return nil
 					},
 					newFileLock: func(string) (processlock.Interface, error) {
 						lockCalls++
 						if lockCalls == tt.failLockCall {
-							return nil, failureErr
+							return nil, errPersistentStateStartup
 						}
 						lock := &trackedFileLock{}
 						locks = append(locks, lock)
@@ -108,14 +122,14 @@ func TestNewPersistentStateStartup_GatesStartOnFailure(t *testing.T) {
 					openStore: func(path string, _ processlock.Interface) (store.KeyValueStore, error) {
 						storeCalls++
 						if storeCalls == tt.failStoreCall {
-							return nil, failureErr
+							return nil, errPersistentStateStartup
 						}
 						return store.NewMockStore(path), nil
 					},
 				},
 			)
 
-			require.ErrorIs(t, err, failureErr)
+			require.ErrorIs(t, err, errPersistentStateStartup)
 			require.Nil(t, startup)
 			require.False(t, startCalled)
 
@@ -129,24 +143,19 @@ func TestNewPersistentStateStartup_GatesStartOnFailure(t *testing.T) {
 }
 
 func TestPersistentStateStartup_StartPropagatesContextAndCleansUpFailure(t *testing.T) {
-	startErr := errors.New("listener failure")
-	cleanupErr := errors.New("cleanup failure")
 	stateLock := &trackedFileLock{}
-	endpointLock := &trackedFileLock{unlockErr: cleanupErr}
+	endpointLock := &trackedFileLock{unlockErr: errPersistentStateCleanup}
 	locks := []processlock.Interface{stateLock, endpointLock}
 	lockIndex := 0
 
 	type contextKey struct{}
 	ctx := context.WithValue(context.Background(), contextKey{}, "startup-context")
-	var receivedCtx context.Context
+	recorder := startRecorder{err: errPersistentStateListener}
 
 	startup, err := newPersistentStateStartup(
 		testPersistentStatePaths(),
 		true,
-		func(ctx context.Context) error {
-			receivedCtx = ctx
-			return startErr
-		},
+		recorder.start,
 		persistentStateDependencies{
 			createDirectory: func(string) error { return nil },
 			newFileLock: func(string) (processlock.Interface, error) {
@@ -162,13 +171,13 @@ func TestPersistentStateStartup_StartPropagatesContextAndCleansUpFailure(t *test
 	require.NoError(t, err)
 
 	err = startup.Start(ctx)
-	require.ErrorIs(t, err, startErr)
-	require.ErrorIs(t, err, cleanupErr)
-	require.Same(t, ctx, receivedCtx)
+	require.ErrorIs(t, err, errPersistentStateListener)
+	require.ErrorIs(t, err, errPersistentStateCleanup)
+	require.Same(t, ctx, recorder.ctx)
 	require.Equal(t, 1, stateLock.unlockCalls)
 	require.Equal(t, 1, endpointLock.unlockCalls)
 
-	require.ErrorIs(t, startup.Close(), cleanupErr)
+	require.ErrorIs(t, startup.Close(), errPersistentStateCleanup)
 	require.Equal(t, 1, stateLock.unlockCalls)
 	require.Equal(t, 1, endpointLock.unlockCalls)
 }

--- a/cns/service/persistent_state_windows.go
+++ b/cns/service/persistent_state_windows.go
@@ -1,0 +1,6 @@
+// Copyright 2026 Microsoft. All rights reserved.
+// MIT License
+
+package main
+
+const defaultEndpointStorePath = "/k/azurecns/"


### PR DESCRIPTION
## What this does

Extracts the existing JSON persistent-state startup sequence from `cns/service/main.go` into a focused lifecycle component without changing backend behavior. Platform-specific state paths move behind build-tagged files.

The extraction preserves startup ordering, lock lifetime, listener gating, endpoint-store disablement, and cleanup semantics.

## Validation

- CNS service unit tests and race tests
- `go vet ./cns/service/`
- Windows cross-compilation
- Failure-point, cancellation, cleanup, endpoint-disabled, and real JSON persistence tests

## Release plan

This is an independent preparatory slice for the CNS persistent-state backend work. It contains no Bolt dependency, migration logic, feature flag, or behavior change.