### PR TITLE
feat(cns): add dark Bolt state config contract

### DIFF
--- a/cns/azure-cns-windows.yaml
+++ b/cns/azure-cns-windows.yaml
@@ -109,5 +109,8 @@ data:
           "NodeSyncIntervalInSeconds": 30
       },
       "ChannelMode": "CRD",
-      "InitializeFromCNI": true
+      "EnableBoltStateStore": false,
+      "InitializeFromCNI": true,
+      "StateStoreBackend": "json",
+      "StateStoreMode": "normal"
     }

--- a/cns/azure-cns.yaml
+++ b/cns/azure-cns.yaml
@@ -185,7 +185,10 @@ data:
           "NodeSyncIntervalInSeconds": 30
       },
       "ChannelMode": "CRD",
+      "EnableBoltStateStore": false,
       "InitializeFromCNI": true,
+      "StateStoreBackend": "json",
+      "StateStoreMode": "normal",
       "ManageEndpointState": false,
       "ProgramSNATIPTables" : false
     }

--- a/cns/configuration/cns_config.json
+++ b/cns/configuration/cns_config.json
@@ -17,7 +17,10 @@
         "PrivateEndpoint": ""
     },
     "ChannelMode": "Direct",
+    "EnableBoltStateStore": false,
     "InitializeFromCNI": false,
+    "StateStoreBackend": "json",
+    "StateStoreMode": "normal",
     "TLSCertificatePath": "",
     "TLSPort": "10091",
     "TLSSubjectName": "",

--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -3,6 +3,7 @@ package configuration
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -22,6 +23,25 @@ const (
 	defaultConfigName = "cns_config.json"
 )
 
+type StateStoreBackend string
+
+const (
+	StateStoreBackendJSON StateStoreBackend = "json"
+	StateStoreBackendBolt StateStoreBackend = "bolt"
+)
+
+type StateStoreMode string
+
+const (
+	StateStoreModeNormal         StateStoreMode = "normal"
+	StateStoreModeRollbackToJSON StateStoreMode = "rollback-to-json"
+)
+
+var (
+	ErrInvalidStateStoreConfig      = errors.New("configuration: invalid state store configuration")
+	ErrStateStoreFeatureUnavailable = errors.New("configuration: bolt state store feature unavailable")
+)
+
 type CNSConfig struct {
 	AZRSettings                     AZRSettings
 	AsyncPodDeletePath              string
@@ -30,6 +50,7 @@ type CNSConfig struct {
 	ChannelMode                     string
 	EnableAPIServerHealthPing       bool
 	EnableAsyncPodDelete            bool
+	EnableBoltStateStore            bool
 	EnableCNIConflistGeneration     bool
 	EnableHomeAZ                    bool
 	EnableIPAMv2                    bool
@@ -51,6 +72,8 @@ type CNSConfig struct {
 	MellanoxMonitorIntervalSecs     int
 	MetricsBindAddress              string
 	ProgramSNATIPTables             bool
+	StateStoreBackend               StateStoreBackend
+	StateStoreMode                  StateStoreMode
 	SyncHostNCTimeoutMs             int
 	SyncHostNCVersionIntervalMs     int
 	TLSCertificatePath              string
@@ -65,6 +88,36 @@ type CNSConfig struct {
 	GRPCSettings                    GRPCSettings
 	MinTLSVersion                   string
 	MtlsClientCertSubjectName       string
+}
+
+func (cnsconfig CNSConfig) ValidateStateStore() error {
+	backend := cnsconfig.StateStoreBackend
+	if backend == "" {
+		backend = StateStoreBackendJSON
+	}
+	switch backend {
+	case StateStoreBackendJSON, StateStoreBackendBolt:
+	default:
+		return fmt.Errorf("%w: backend %q", ErrInvalidStateStoreConfig, backend)
+	}
+
+	mode := cnsconfig.StateStoreMode
+	if mode == "" {
+		mode = StateStoreModeNormal
+	}
+	switch mode {
+	case StateStoreModeNormal, StateStoreModeRollbackToJSON:
+	default:
+		return fmt.Errorf("%w: mode %q", ErrInvalidStateStoreConfig, mode)
+	}
+
+	boltEnabled := cnsconfig.EnableBoltStateStore
+	boltSelected := backend == StateStoreBackendBolt
+	rollbackSelected := mode == StateStoreModeRollbackToJSON
+	if boltEnabled || boltSelected || rollbackSelected {
+		return ErrStateStoreFeatureUnavailable
+	}
+	return nil
 }
 
 type TelemetrySettings struct {
@@ -223,6 +276,12 @@ func SetCNSConfigDefaults(config *CNSConfig) {
 
 	if config.ChannelMode == "" {
 		config.ChannelMode = cns.Direct
+	}
+	if config.StateStoreBackend == "" {
+		config.StateStoreBackend = StateStoreBackendJSON
+	}
+	if config.StateStoreMode == "" {
+		config.StateStoreMode = StateStoreModeNormal
 	}
 	if config.MetricsBindAddress == "" {
 		config.MetricsBindAddress = ":9090"

--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -3,6 +3,7 @@ package configuration
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -22,6 +23,25 @@ const (
 	defaultConfigName = "cns_config.json"
 )
 
+type StateStoreBackend string
+
+const (
+	StateStoreBackendJSON StateStoreBackend = "json"
+	StateStoreBackendBolt StateStoreBackend = "bolt"
+)
+
+type StateStoreMode string
+
+const (
+	StateStoreModeNormal         StateStoreMode = "normal"
+	StateStoreModeRollbackToJSON StateStoreMode = "rollback-to-json"
+)
+
+var (
+	ErrInvalidStateStoreConfig      = errors.New("configuration: invalid state store configuration")
+	ErrStateStoreFeatureUnavailable = errors.New("configuration: bolt state store feature unavailable")
+)
+
 type CNSConfig struct {
 	AZRSettings                     AZRSettings
 	AsyncPodDeletePath              string
@@ -30,6 +50,7 @@ type CNSConfig struct {
 	ChannelMode                     string
 	EnableAPIServerHealthPing       bool
 	EnableAsyncPodDelete            bool
+	EnableBoltStateStore            bool
 	EnableCNIConflistGeneration     bool
 	EnableHomeAZ                    bool
 	EnableIPAMv2                    bool
@@ -52,6 +73,8 @@ type CNSConfig struct {
 	MellanoxMonitorIntervalSecs     int
 	MetricsBindAddress              string
 	ProgramSNATIPTables             bool
+	StateStoreBackend               StateStoreBackend
+	StateStoreMode                  StateStoreMode
 	SyncHostNCTimeoutMs             int
 	SyncHostNCVersionIntervalMs     int
 	TLSCertificatePath              string
@@ -66,6 +89,36 @@ type CNSConfig struct {
 	GRPCSettings                    GRPCSettings
 	MinTLSVersion                   string
 	MtlsClientCertSubjectName       string
+}
+
+func (cnsconfig CNSConfig) ValidateStateStore() error {
+	backend := cnsconfig.StateStoreBackend
+	if backend == "" {
+		backend = StateStoreBackendJSON
+	}
+	switch backend {
+	case StateStoreBackendJSON, StateStoreBackendBolt:
+	default:
+		return fmt.Errorf("%w: backend %q", ErrInvalidStateStoreConfig, backend)
+	}
+
+	mode := cnsconfig.StateStoreMode
+	if mode == "" {
+		mode = StateStoreModeNormal
+	}
+	switch mode {
+	case StateStoreModeNormal, StateStoreModeRollbackToJSON:
+	default:
+		return fmt.Errorf("%w: mode %q", ErrInvalidStateStoreConfig, mode)
+	}
+
+	boltEnabled := cnsconfig.EnableBoltStateStore
+	boltSelected := backend == StateStoreBackendBolt
+	rollbackSelected := mode == StateStoreModeRollbackToJSON
+	if boltEnabled || boltSelected || rollbackSelected {
+		return ErrStateStoreFeatureUnavailable
+	}
+	return nil
 }
 
 type TelemetrySettings struct {
@@ -224,6 +277,12 @@ func SetCNSConfigDefaults(config *CNSConfig) {
 
 	if config.ChannelMode == "" {
 		config.ChannelMode = cns.Direct
+	}
+	if config.StateStoreBackend == "" {
+		config.StateStoreBackend = StateStoreBackendJSON
+	}
+	if config.StateStoreMode == "" {
+		config.StateStoreMode = StateStoreModeNormal
 	}
 	if config.MetricsBindAddress == "" {
 		config.MetricsBindAddress = ":9090"

--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -39,7 +39,7 @@ const (
 
 var (
 	ErrInvalidStateStoreConfig      = errors.New("configuration: invalid state store configuration")
-	ErrStateStoreFeatureUnavailable = errors.New("configuration: bolt state store feature unavailable")
+	ErrStateStoreFeatureUnavailable = errors.New("configuration: state store feature selection unavailable")
 )
 
 type CNSConfig struct {

--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-container-networking/cns"
-	"github.com/Azure/azure-container-networking/cns/logger"
 	loggerv2 "github.com/Azure/azure-container-networking/cns/logger/v2"
 	"github.com/Azure/azure-container-networking/common"
 	"github.com/pkg/errors"
@@ -203,7 +202,7 @@ func ReadConfig(cmdLineConfigPath string) (*CNSConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	logger.Printf("[Configuration] Using config path: %s", configpath)
+	log.Printf("[configuration] using config path: %s", configpath)
 	return readConfigFromFile(configpath)
 }
 

--- a/cns/configuration/configuration_test.go
+++ b/cns/configuration/configuration_test.go
@@ -54,11 +54,14 @@ func TestReadConfigFromFile(t *testing.T) {
 			path: "testdata/good.json",
 			want: &CNSConfig{
 				ChannelMode:            "Direct",
+				EnableBoltStateStore:   false,
 				InitializeFromCNI:      true,
 				EnableHomeAZ:           true,
 				EnablePprof:            true,
 				EnableSubnetScarcity:   true,
 				EnableSwiftV1DualStack: true,
+				StateStoreBackend:      StateStoreBackendJSON,
+				StateStoreMode:         StateStoreModeNormal,
 				ManagedSettings: ManagedSettings{
 					PrivateEndpoint:           "abc",
 					InfrastructureNetworkID:   "abc",
@@ -198,7 +201,9 @@ func TestSetCNSConfigDefaults(t *testing.T) {
 			name: "unset defaults",
 			in:   CNSConfig{},
 			want: CNSConfig{
-				ChannelMode: "Direct",
+				ChannelMode:       "Direct",
+				StateStoreBackend: StateStoreBackendJSON,
+				StateStoreMode:    StateStoreModeNormal,
 				ManagedSettings: ManagedSettings{
 					NodeSyncIntervalInSeconds: 30,
 				},
@@ -233,7 +238,10 @@ func TestSetCNSConfigDefaults(t *testing.T) {
 		{
 			name: "don't overwrite set values",
 			in: CNSConfig{
-				ChannelMode: "Other",
+				ChannelMode:          "Other",
+				EnableBoltStateStore: true,
+				StateStoreBackend:    StateStoreBackendBolt,
+				StateStoreMode:       StateStoreModeRollbackToJSON,
 				ManagedSettings: ManagedSettings{
 					NodeSyncIntervalInSeconds: 1,
 				},
@@ -263,7 +271,10 @@ func TestSetCNSConfigDefaults(t *testing.T) {
 				MtlsClientCertSubjectName: "example.com",
 			},
 			want: CNSConfig{
-				ChannelMode: "Other",
+				ChannelMode:          "Other",
+				EnableBoltStateStore: true,
+				StateStoreBackend:    StateStoreBackendBolt,
+				StateStoreMode:       StateStoreModeRollbackToJSON,
 				ManagedSettings: ManagedSettings{
 					NodeSyncIntervalInSeconds: 1,
 				},
@@ -301,6 +312,215 @@ func TestSetCNSConfigDefaults(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			SetCNSConfigDefaults(&tt.in)
 			assert.Equal(t, tt.want, tt.in)
+		})
+	}
+}
+
+func TestCNSConfigValidateStateStore(t *testing.T) {
+	tests := []struct {
+		name                 string
+		enableBoltStateStore bool
+		enableStateMigration bool
+		backend              StateStoreBackend
+		mode                 StateStoreMode
+		wantErr              error
+	}{
+		{
+			name:    "json normal",
+			backend: StateStoreBackendJSON,
+			mode:    StateStoreModeNormal,
+		},
+		{
+			name:    "json rollback",
+			backend: StateStoreBackendJSON,
+			mode:    StateStoreModeRollbackToJSON,
+			wantErr: ErrStateStoreFeatureUnavailable,
+		},
+		{
+			name:    "bolt normal",
+			backend: StateStoreBackendBolt,
+			mode:    StateStoreModeNormal,
+			wantErr: ErrStateStoreFeatureUnavailable,
+		},
+		{
+			name:    "bolt rollback",
+			backend: StateStoreBackendBolt,
+			mode:    StateStoreModeRollbackToJSON,
+			wantErr: ErrStateStoreFeatureUnavailable,
+		},
+		{
+			name:                 "enabled json normal",
+			enableBoltStateStore: true,
+			backend:              StateStoreBackendJSON,
+			mode:                 StateStoreModeNormal,
+			wantErr:              ErrStateStoreFeatureUnavailable,
+		},
+		{
+			name:                 "enabled json rollback",
+			enableBoltStateStore: true,
+			backend:              StateStoreBackendJSON,
+			mode:                 StateStoreModeRollbackToJSON,
+			wantErr:              ErrStateStoreFeatureUnavailable,
+		},
+		{
+			name:                 "enabled bolt normal",
+			enableBoltStateStore: true,
+			backend:              StateStoreBackendBolt,
+			mode:                 StateStoreModeNormal,
+			wantErr:              ErrStateStoreFeatureUnavailable,
+		},
+		{
+			name:                 "enabled bolt rollback",
+			enableBoltStateStore: true,
+			backend:              StateStoreBackendBolt,
+			mode:                 StateStoreModeRollbackToJSON,
+			wantErr:              ErrStateStoreFeatureUnavailable,
+		},
+		{
+			name:                 "migration json normal",
+			enableStateMigration: true,
+			backend:              StateStoreBackendJSON,
+			mode:                 StateStoreModeNormal,
+		},
+		{
+			name:                 "migration json rollback",
+			enableStateMigration: true,
+			backend:              StateStoreBackendJSON,
+			mode:                 StateStoreModeRollbackToJSON,
+			wantErr:              ErrStateStoreFeatureUnavailable,
+		},
+		{
+			name:                 "migration bolt normal",
+			enableStateMigration: true,
+			backend:              StateStoreBackendBolt,
+			mode:                 StateStoreModeNormal,
+			wantErr:              ErrStateStoreFeatureUnavailable,
+		},
+		{
+			name:                 "migration bolt rollback",
+			enableStateMigration: true,
+			backend:              StateStoreBackendBolt,
+			mode:                 StateStoreModeRollbackToJSON,
+			wantErr:              ErrStateStoreFeatureUnavailable,
+		},
+		{
+			name:                 "migration enabled json normal",
+			enableBoltStateStore: true,
+			enableStateMigration: true,
+			backend:              StateStoreBackendJSON,
+			mode:                 StateStoreModeNormal,
+			wantErr:              ErrStateStoreFeatureUnavailable,
+		},
+		{
+			name:                 "migration enabled json rollback",
+			enableBoltStateStore: true,
+			enableStateMigration: true,
+			backend:              StateStoreBackendJSON,
+			mode:                 StateStoreModeRollbackToJSON,
+			wantErr:              ErrStateStoreFeatureUnavailable,
+		},
+		{
+			name:                 "migration enabled bolt normal",
+			enableBoltStateStore: true,
+			enableStateMigration: true,
+			backend:              StateStoreBackendBolt,
+			mode:                 StateStoreModeNormal,
+			wantErr:              ErrStateStoreFeatureUnavailable,
+		},
+		{
+			name:                 "migration enabled bolt rollback",
+			enableBoltStateStore: true,
+			enableStateMigration: true,
+			backend:              StateStoreBackendBolt,
+			mode:                 StateStoreModeRollbackToJSON,
+			wantErr:              ErrStateStoreFeatureUnavailable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := CNSConfig{
+				EnableBoltStateStore: tt.enableBoltStateStore,
+				EnableStateMigration: tt.enableStateMigration,
+				StateStoreBackend:    tt.backend,
+				StateStoreMode:       tt.mode,
+			}
+
+			err := config.ValidateStateStore()
+			if tt.wantErr == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestCNSConfigValidateStateStoreDefaultsAndInvalidEnums(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  CNSConfig
+		wantErr error
+	}{
+		{
+			name:   "zero value uses JSON normal",
+			config: CNSConfig{},
+		},
+		{
+			name: "enabled with default backend and mode",
+			config: CNSConfig{
+				EnableBoltStateStore: true,
+			},
+			wantErr: ErrStateStoreFeatureUnavailable,
+		},
+		{
+			name: "bolt with default mode",
+			config: CNSConfig{
+				StateStoreBackend: StateStoreBackendBolt,
+			},
+			wantErr: ErrStateStoreFeatureUnavailable,
+		},
+		{
+			name: "rollback with default backend",
+			config: CNSConfig{
+				StateStoreMode: StateStoreModeRollbackToJSON,
+			},
+			wantErr: ErrStateStoreFeatureUnavailable,
+		},
+		{
+			name: "invalid backend",
+			config: CNSConfig{
+				StateStoreBackend: "sqlite",
+				StateStoreMode:    StateStoreModeNormal,
+			},
+			wantErr: ErrInvalidStateStoreConfig,
+		},
+		{
+			name: "invalid mode",
+			config: CNSConfig{
+				StateStoreBackend: StateStoreBackendJSON,
+				StateStoreMode:    "restore",
+			},
+			wantErr: ErrInvalidStateStoreConfig,
+		},
+		{
+			name: "invalid backend and mode",
+			config: CNSConfig{
+				StateStoreBackend: "sqlite",
+				StateStoreMode:    "restore",
+			},
+			wantErr: ErrInvalidStateStoreConfig,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.ValidateStateStore()
+			if tt.wantErr == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, tt.wantErr)
 		})
 	}
 }

--- a/cns/configuration/testdata/good.json
+++ b/cns/configuration/testdata/good.json
@@ -1,6 +1,9 @@
 {
     "ChannelMode": "Direct",
+    "EnableBoltStateStore": false,
     "InitializeFromCNI": true,
+    "StateStoreBackend": "json",
+    "StateStoreMode": "normal",
     "EnablePprof": true,
     "EnableHomeAZ": true,
     "EnableSubnetScarcity": true,

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -566,6 +566,10 @@ func main() {
 		}
 	}
 	configuration.SetCNSConfigDefaults(cnsconfig)
+	if err := cnsconfig.ValidateStateStore(); err != nil {
+		logger.Errorf("fatal: invalid CNS state store configuration: %v", err)
+		os.Exit(1)
+	}
 
 	disableTelemetry := cnsconfig.TelemetrySettings.DisableAll
 	if !disableTelemetry {

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -567,6 +567,10 @@ func main() {
 		}
 	}
 	configuration.SetCNSConfigDefaults(cnsconfig)
+	if err := cnsconfig.ValidateStateStore(); err != nil {
+		logger.Errorf("fatal: invalid CNS state store configuration: %v", err)
+		os.Exit(1)
+	}
 
 	disableTelemetry := cnsconfig.TelemetrySettings.DisableAll
 	if !disableTelemetry {

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -567,8 +567,12 @@ func main() {
 		}
 	}
 	configuration.SetCNSConfigDefaults(cnsconfig)
-	if err := cnsconfig.ValidateStateStore(); err != nil {
-		logger.Errorf("fatal: invalid CNS state store configuration: %v", err)
+	if err = cnsconfig.ValidateStateStore(); err != nil {
+		if errors.Is(err, configuration.ErrStateStoreFeatureUnavailable) {
+			logger.Errorf("fatal: CNS state store feature unavailable: %v", err) //nolint:staticcheck // main still uses the legacy global logger
+		} else {
+			logger.Errorf("fatal: invalid CNS state store configuration: %v", err) //nolint:staticcheck // main still uses the legacy global logger
+		}
 		os.Exit(1)
 	}
 

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -566,7 +566,9 @@ func main() {
 		}
 	}
 	configuration.SetCNSConfigDefaults(cnsconfig)
-	if err := cnsconfig.ValidateStateStore(); err != nil {
+	err = cnsconfig.ValidateStateStore()
+	if err != nil {
+		//nolint:staticcheck // SA1019 preserve logging before logger v2 configuration is available
 		logger.Errorf("fatal: invalid CNS state store configuration: %v", err)
 		os.Exit(1)
 	}

--- a/test/e2e/manifests/cilium/v1.14/cns/configmap.yaml
+++ b/test/e2e/manifests/cilium/v1.14/cns/configmap.yaml
@@ -22,7 +22,10 @@ data:
           "NodeSyncIntervalInSeconds": 30
       },
       "ChannelMode": "CRD",
+      "EnableBoltStateStore": false,
       "InitializeFromCNI": false,
+      "StateStoreBackend": "json",
+      "StateStoreMode": "normal",
       "ManageEndpointState": true,
       "ProgramSNATIPTables": false,
       "EnableCNIConflistGeneration": true,

--- a/test/integration/manifests/cilium/cns-write-ovly.yaml
+++ b/test/integration/manifests/cilium/cns-write-ovly.yaml
@@ -214,7 +214,10 @@ data:
           "NodeSyncIntervalInSeconds": 30
       },
       "ChannelMode": "CRD",
+      "EnableBoltStateStore": false,
       "InitializeFromCNI": false,
+      "StateStoreBackend": "json",
+      "StateStoreMode": "normal",
       "ManageEndpointState": true,
       "ProgramSNATIPTables": false,
       "EnableCNIConflistGeneration": true,

--- a/test/integration/manifests/cnsconfig/azcnichainedciliumconfigmap.yaml
+++ b/test/integration/manifests/cnsconfig/azcnichainedciliumconfigmap.yaml
@@ -14,9 +14,12 @@ data:
       "EnableIPAMv2": true,
       "EnableK8sDevicePlugin": true,
       "EnableLoggerV2": true,
+      "EnableBoltStateStore": false,
       "EnableStateMigration": true,
       "EnableSubnetScarcity": false,
       "InitializeFromCNI": false,
+      "StateStoreBackend": "json",
+      "StateStoreMode": "normal",
       "Logger": {
         "file": {
           "filepath": "/var/log/azure-cns/azure-cns.log",

--- a/test/integration/manifests/cnsconfig/azurecnidualstackoverlaylinuxconfigmap.yaml
+++ b/test/integration/manifests/cnsconfig/azurecnidualstackoverlaylinuxconfigmap.yaml
@@ -28,9 +28,12 @@ data:
       "EnableAsyncPodDelete": false,
       "EnableCNIConflistGeneration": true,
       "EnableIPAMv2": true,
+      "EnableBoltStateStore": false,
       "EnableStateMigration": false,
       "EnableSubnetScarcity": false,
       "InitializeFromCNI": true,
+      "StateStoreBackend": "json",
+      "StateStoreMode": "normal",
       "ManageEndpointState": false,
       "ProgramSNATIPTables": false
     }

--- a/test/integration/manifests/cnsconfig/azurecnidualstackoverlaywindowsconfigmap.yaml
+++ b/test/integration/manifests/cnsconfig/azurecnidualstackoverlaywindowsconfigmap.yaml
@@ -28,9 +28,12 @@ data:
       "EnableAsyncPodDelete": false,
       "EnableCNIConflistGeneration": false,
       "EnableIPAMv2": true,
+      "EnableBoltStateStore": false,
       "EnableStateMigration": false,
       "EnableSubnetScarcity": false,
       "InitializeFromCNI": true,
+      "StateStoreBackend": "json",
+      "StateStoreMode": "normal",
       "ManageEndpointState": false,
       "MetricsBindAddress": ":10092",
       "ProgramSNATIPTables": false

--- a/test/integration/manifests/cnsconfig/azurecnioverlaylinuxconfigmap.yaml
+++ b/test/integration/manifests/cnsconfig/azurecnioverlaylinuxconfigmap.yaml
@@ -28,9 +28,12 @@ data:
       "EnableAsyncPodDelete": true,
       "EnableCNIConflistGeneration": true,
       "EnableIPAMv2": true,
+      "EnableBoltStateStore": false,
       "EnableStateMigration": false,
       "EnableSubnetScarcity": false,
       "InitializeFromCNI": true,
+      "StateStoreBackend": "json",
+      "StateStoreMode": "normal",
       "ManageEndpointState": false,
       "ProgramSNATIPTables": false
     }

--- a/test/integration/manifests/cnsconfig/azurecnioverlaywindowsconfigmap.yaml
+++ b/test/integration/manifests/cnsconfig/azurecnioverlaywindowsconfigmap.yaml
@@ -28,9 +28,12 @@ data:
       "EnableAsyncPodDelete": true,
       "EnableCNIConflistGeneration": false,
       "EnableIPAMv2": true,
+      "EnableBoltStateStore": false,
       "EnableStateMigration": false,
       "EnableSubnetScarcity": false,
       "InitializeFromCNI": true,
+      "StateStoreBackend": "json",
+      "StateStoreMode": "normal",
       "ManageEndpointState": false,
       "MetricsBindAddress": ":10092",
       "ProgramSNATIPTables": false

--- a/test/integration/manifests/cnsconfig/azurestatelesscnioverlaywindowsconfigmap.yaml
+++ b/test/integration/manifests/cnsconfig/azurestatelesscnioverlaywindowsconfigmap.yaml
@@ -28,9 +28,12 @@ data:
       "EnableAsyncPodDelete": true,
       "EnableCNIConflistGeneration": false,
       "EnableIPAMv2": true,
+      "EnableBoltStateStore": false,
       "EnableStateMigration": false,
       "EnableSubnetScarcity": false,
       "InitializeFromCNI": false,
+      "StateStoreBackend": "json",
+      "StateStoreMode": "normal",
       "ManageEndpointState": true,
       "MetricsBindAddress": ":10092",
       "ProgramSNATIPTables": false

--- a/test/integration/manifests/cnsconfig/ciliumconfigmap.yaml
+++ b/test/integration/manifests/cnsconfig/ciliumconfigmap.yaml
@@ -28,9 +28,12 @@ data:
       "EnableAsyncPodDelete": true,
       "EnableCNIConflistGeneration": true,
       "EnableIPAMv2": true,
+      "EnableBoltStateStore": false,
       "EnableStateMigration": false,
       "EnableSubnetScarcity": false,
       "InitializeFromCNI": false,
+      "StateStoreBackend": "json",
+      "StateStoreMode": "normal",
       "ManageEndpointState": true,
       "ProgramSNATIPTables": true
     }

--- a/test/integration/manifests/cnsconfig/ciliumnodesubnetconfigmap.yaml
+++ b/test/integration/manifests/cnsconfig/ciliumnodesubnetconfigmap.yaml
@@ -28,9 +28,12 @@ data:
       "EnableAsyncPodDelete": true,
       "EnableCNIConflistGeneration": true,
       "EnableIPAMv2": true,
+      "EnableBoltStateStore": false,
       "EnableStateMigration": false,
       "EnableSubnetScarcity": false,
       "InitializeFromCNI": false,
+      "StateStoreBackend": "json",
+      "StateStoreMode": "normal",
       "ManageEndpointState": true,
       "ProgramSNATIPTables": false
     }

--- a/test/integration/manifests/cnsconfig/overlayconfigmap.yaml
+++ b/test/integration/manifests/cnsconfig/overlayconfigmap.yaml
@@ -28,9 +28,12 @@ data:
       "EnableAsyncPodDelete": true,
       "EnableCNIConflistGeneration": true,
       "EnableIPAMv2": true,
+      "EnableBoltStateStore": false,
       "EnableStateMigration": false,
       "EnableSubnetScarcity": false,
       "InitializeFromCNI": false,
+      "StateStoreBackend": "json",
+      "StateStoreMode": "normal",
       "ManageEndpointState": true,
       "ProgramSNATIPTables": false
     }

--- a/test/integration/manifests/cnsconfig/swiftlinuxconfigmap.yaml
+++ b/test/integration/manifests/cnsconfig/swiftlinuxconfigmap.yaml
@@ -25,9 +25,12 @@ data:
       "ChannelMode": "CRD",
       "EnableAsyncPodDelete": true,
       "EnableIPAMv2": true,
+      "EnableBoltStateStore": false,
       "EnableStateMigration": false,
       "EnableSubnetScarcity": false,
       "InitializeFromCNI": true,
+      "StateStoreBackend": "json",
+      "StateStoreMode": "normal",
       "ManageEndpointState": false,
       "ProgramSNATIPTables": false
     }

--- a/test/integration/manifests/cnsconfig/swiftwindowsconfigmap.yaml
+++ b/test/integration/manifests/cnsconfig/swiftwindowsconfigmap.yaml
@@ -25,9 +25,12 @@ data:
       "ChannelMode": "CRD",
       "EnableAsyncPodDelete": true,
       "EnableIPAMv2": true,
+      "EnableBoltStateStore": false,
       "EnableStateMigration": false,
       "EnableSubnetScarcity": false,
       "InitializeFromCNI": true,
+      "StateStoreBackend": "json",
+      "StateStoreMode": "normal",
       "ManageEndpointState": false,
       "ProgramSNATIPTables": false
     }


### PR DESCRIPTION
## What this does

Defines the typed CNS configuration contract for selecting a persistent-state backend while keeping the feature completely dark:

- `EnableBoltStateStore`, default `false`
- `StateStoreBackend`: `json` or `bolt`, default `json`
- `StateStoreMode`: `normal` or `rollback-to-json`, default `normal`

Existing configurations continue to use JSON. Invalid enum values fail startup, and every request for Bolt, feature enablement, or rollback currently fails with a feature-unavailable error until later runtime slices activate those paths. `EnableStateMigration` retains its existing ownership-migration meaning.

## Validation

- Configuration unit and race tests
- CNS service build and vet
- Targeted lint for changed code
- Source JSON and embedded ConfigMap JSON parsing
- Dockerfile render-drift check

## Release plan

This PR intentionally adds no bbolt dependency, storage implementation, migration behavior, or runtime activation. It establishes the dark, backward-compatible configuration surface first.