### PR TITLE
test: add JSON persistent-state lifecycle E2E

### DIFF
--- a/.pipelines/cni/state-migration-json/README.md
+++ b/.pipelines/cni/state-migration-json/README.md
@@ -1,0 +1,28 @@
+# JSON state migration lifecycle controls
+
+This standalone Azure Pipelines source exercises the existing JSON state path on
+representative managed Azure CNI overlay clusters. It is isolated from the
+existing CNI pipelines: pull-request and continuous-integration triggers are
+disabled, and a weekly `master` schedule is declared for use after the pipeline
+is registered.
+
+Each Linux and Windows control runs:
+
+1. baseline state validation;
+2. a CNS restart without a node reboot;
+3. scale cycles with an active workload followed by another CNS restart;
+4. a node reboot and post-reboot validation;
+5. per-node CNS configuration, state, and assigned-IP JSON capture;
+6. workload cleanup and unconditional cluster deletion.
+
+The pipeline reuses the existing cluster creation, state validation, node
+restart, and cluster deletion templates. It requires the same pool,
+subscription, region, and service-connection variables as the existing CNI
+release test. Registering the pipeline or provisioning shared infrastructure is
+outside this scaffold.
+
+Run local contracts with:
+
+```bash
+bash .pipelines/cni/state-migration-json/tests/run-contract-tests.sh
+```

--- a/.pipelines/cni/state-migration-json/README.md
+++ b/.pipelines/cni/state-migration-json/README.md
@@ -26,3 +26,5 @@ Run local contracts with:
 ```bash
 bash .pipelines/cni/state-migration-json/tests/run-contract-tests.sh
 ```
+
+The contract test requires Python 3 with PyYAML installed.

--- a/.pipelines/cni/state-migration-json/pipeline.yaml
+++ b/.pipelines/cni/state-migration-json/pipeline.yaml
@@ -1,0 +1,66 @@
+trigger: none
+pr: none
+
+schedules:
+  - cron: "0 6 * * 0"
+    displayName: "Weekly JSON state lifecycle controls"
+    branches:
+      include:
+        - master
+    always: true
+
+parameters:
+  - name: deleteResources
+    displayName: "Delete test clusters after the run"
+    type: boolean
+    default: true
+  - name: scenarios
+    displayName: "JSON state control scenarios"
+    type: object
+    default:
+      - name: linux_overlay_json
+        displayName: "Linux overlay JSON control"
+        clusterName: "sm-json-linux-$(Build.BuildId)"
+        clusterType: overlay-up
+        os: linux
+        nodeCount: 2
+        nodeCountWin: 0
+        vmSize: Standard_D4s_v5
+        vmSizeWin: Standard_D4s_v5
+        osSKU: Ubuntu
+        osSkuWin: Windows2022
+        scaleup: 10
+        iterations: 2
+      - name: windows_overlay_json
+        displayName: "Windows overlay JSON control"
+        clusterName: "sm-json-win-$(Build.BuildId)"
+        clusterType: overlay-up
+        os: windows
+        nodeCount: 1
+        nodeCountWin: 2
+        vmSize: Standard_D4s_v5
+        vmSizeWin: Standard_D4s_v5
+        osSKU: Ubuntu
+        osSkuWin: Windows2022
+        scaleup: 5
+        iterations: 2
+
+stages:
+  - ${{ each scenario in parameters.scenarios }}:
+    - template: templates/json-control.stages.yaml
+      parameters:
+        name: ${{ scenario.name }}
+        displayName: ${{ scenario.displayName }}
+        clusterName: ${{ scenario.clusterName }}
+        clusterType: ${{ scenario.clusterType }}
+        region: $(LOCATION_AMD64)
+        os: ${{ scenario.os }}
+        nodeCount: ${{ scenario.nodeCount }}
+        nodeCountWin: ${{ scenario.nodeCountWin }}
+        vmSize: ${{ scenario.vmSize }}
+        vmSizeWin: ${{ scenario.vmSizeWin }}
+        osSKU: ${{ scenario.osSKU }}
+        osSkuWin: ${{ scenario.osSkuWin }}
+        scaleup: ${{ scenario.scaleup }}
+        iterations: ${{ scenario.iterations }}
+        deleteResources: ${{ parameters.deleteResources }}

--- a/.pipelines/cni/state-migration-json/pipeline.yaml
+++ b/.pipelines/cni/state-migration-json/pipeline.yaml
@@ -20,7 +20,7 @@ parameters:
     default:
       - name: linux_overlay_json
         displayName: "Linux overlay JSON control"
-        clusterName: "sm-json-linux-$(Build.BuildId)"
+        clusterName: "smj-l-$(Build.BuildId)"
         clusterType: overlay-up
         os: linux
         nodeCount: 2
@@ -33,7 +33,7 @@ parameters:
         iterations: 2
       - name: windows_overlay_json
         displayName: "Windows overlay JSON control"
-        clusterName: "sm-json-win-$(Build.BuildId)"
+        clusterName: "smj-w-$(Build.BuildId)"
         clusterType: overlay-up
         os: windows
         nodeCount: 1

--- a/.pipelines/cni/state-migration-json/scripts/capture-json-state.sh
+++ b/.pipelines/cni/state-migration-json/scripts/capture-json-state.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+os="${1:?operating system is required}"
+output_dir="${2:?output directory is required}"
+
+case "$os" in
+  linux)
+    selector="k8s-app=azure-cns"
+    ;;
+  windows)
+    selector="k8s-app=azure-cns-win"
+    ;;
+  *)
+    echo "unsupported operating system: $os" >&2
+    exit 2
+    ;;
+esac
+
+mkdir -p "$output_dir"
+kubectl get nodes -o json > "$output_dir/nodes.json"
+kubectl get pods -A -o json > "$output_dir/pods.json"
+
+mapfile -t cns_pods < <(
+  kubectl get pods -n kube-system -l "$selector" \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
+)
+if [[ ${#cns_pods[@]} -eq 0 ]]; then
+  echo "no CNS pods found for selector $selector" >&2
+  exit 1
+fi
+
+for pod in "${cns_pods[@]}"; do
+  node="$(
+    kubectl get pod "$pod" -n kube-system \
+      -o jsonpath='{.spec.nodeName}'
+  )"
+  node_dir="$output_dir/$node"
+  mkdir -p "$node_dir"
+
+  if [[ "$os" == "linux" ]]; then
+    kubectl exec "$pod" -n kube-system -- \
+      cat /etc/azure-cns/cns_config.json > "$node_dir/cns_config.json"
+    kubectl exec "$pod" -n kube-system -- \
+      cat /var/lib/azure-network/azure-cns.json > "$node_dir/azure-cns.json"
+    kubectl exec "$pod" -n kube-system -- \
+      curl --fail --silent --show-error localhost:10090/debug/ipaddresses \
+        -d '{"IPConfigStateFilter":["Assigned"]}' > "$node_dir/assigned-ip-configs.json"
+  else
+    kubectl exec "$pod" -n kube-system -- powershell -NoProfile -NonInteractive \
+      -Command "Get-Content -Raw etc/azure-cns/cns_config.json" \
+      > "$node_dir/cns_config.json"
+    kubectl exec "$pod" -n kube-system -- powershell -NoProfile -NonInteractive \
+      -Command "Get-Content -Raw k/azurecns/azure-cns.json" \
+      > "$node_dir/azure-cns.json"
+    kubectl exec "$pod" -n kube-system -- powershell -NoProfile -NonInteractive \
+      -Command 'Invoke-WebRequest -Uri 127.0.0.1:10090/debug/ipaddresses -Method Post -ContentType application/x-www-form-urlencoded -Body "{`"IPConfigStateFilter`":[`"Assigned`"]}" -UseBasicParsing | Select-Object -Expand Content' \
+      > "$node_dir/assigned-ip-configs.json"
+  fi
+
+  jq -e . "$node_dir/cns_config.json" >/dev/null
+  jq -e . "$node_dir/azure-cns.json" >/dev/null
+  jq -e . "$node_dir/assigned-ip-configs.json" >/dev/null
+done

--- a/.pipelines/cni/state-migration-json/scripts/cleanup-json-control.sh
+++ b/.pipelines/cni/state-migration-json/scripts/cleanup-json-control.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+kubectl delete namespace load-test --ignore-not-found --wait=true --timeout=15m
+kubectl delete daemonset privileged-daemonset -n kube-system --ignore-not-found

--- a/.pipelines/cni/state-migration-json/templates/active-scale-restart.steps.yaml
+++ b/.pipelines/cni/state-migration-json/templates/active-scale-restart.steps.yaml
@@ -1,0 +1,42 @@
+parameters:
+  clusterName: ""
+  os: linux
+  scaleup: 10
+  iterations: 2
+
+steps:
+  - task: AzureCLI@2
+    displayName: "Scale active workload and restart CNS"
+    inputs:
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+      scriptLocation: inlineScript
+      scriptType: bash
+      addSpnToEnvironment: true
+      inlineScript: |
+        set -euo pipefail
+        make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
+
+        pushd test/integration/load
+        VALIDATE_STATEFILE=true \
+          CLEANUP=false \
+          ITERATIONS=${{ parameters.iterations }} \
+          SCALE_UP=${{ parameters.scaleup }} \
+          OS_TYPE=${{ parameters.os }} \
+          CNI_TYPE=cniv2 \
+          go test -mod=readonly -count=1 -timeout 30m -tags load -run '^TestLoad$'
+        popd
+
+        daemon_set=azure-cns
+        if [[ "${{ parameters.os }}" == "windows" ]]; then
+          daemon_set=azure-cns-win
+        fi
+
+        kubectl rollout restart daemonset "$daemon_set" -n kube-system
+        kubectl rollout status daemonset "$daemon_set" -n kube-system --timeout=20m
+
+  - template: ../../load-test-templates/validate-state-template.yaml
+    parameters:
+      clusterName: ${{ parameters.clusterName }}
+      os: ${{ parameters.os }}
+      cni: cniv2
+      restartCase: "true"

--- a/.pipelines/cni/state-migration-json/templates/baseline-json.steps.yaml
+++ b/.pipelines/cni/state-migration-json/templates/baseline-json.steps.yaml
@@ -1,0 +1,19 @@
+parameters:
+  clusterName: ""
+  os: linux
+
+steps:
+  - task: AzureCLI@2
+    displayName: "Create baseline workload and validate JSON state"
+    inputs:
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+      scriptLocation: inlineScript
+      scriptType: bash
+      addSpnToEnvironment: true
+      inlineScript: |
+        set -euo pipefail
+        make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
+        make test-validate-state \
+          VALIDATE_STATEFILE=true \
+          OS_TYPE=${{ parameters.os }} \
+          CNI_TYPE=cniv2

--- a/.pipelines/cni/state-migration-json/templates/capture-json-state.steps.yaml
+++ b/.pipelines/cni/state-migration-json/templates/capture-json-state.steps.yaml
@@ -1,0 +1,31 @@
+parameters:
+  name: ""
+  clusterName: ""
+  os: linux
+
+steps:
+  - bash: |
+      mkdir -p "$(Build.ArtifactStagingDirectory)/state-migration-json/${{ parameters.name }}"
+    displayName: "Initialize JSON artifact directory"
+    condition: always()
+
+  - task: AzureCLI@2
+    displayName: "Capture JSON state"
+    condition: always()
+    continueOnError: true
+    inputs:
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+      scriptLocation: inlineScript
+      scriptType: bash
+      addSpnToEnvironment: true
+      inlineScript: |
+        set -euo pipefail
+        make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
+        bash .pipelines/cni/state-migration-json/scripts/capture-json-state.sh \
+          "${{ parameters.os }}" \
+          "$(Build.ArtifactStagingDirectory)/state-migration-json/${{ parameters.name }}"
+
+  - publish: $(Build.ArtifactStagingDirectory)/state-migration-json/${{ parameters.name }}
+    displayName: "Publish JSON state"
+    artifact: state-migration-json-${{ parameters.name }}-$(Build.BuildId)
+    condition: always()

--- a/.pipelines/cni/state-migration-json/templates/cleanup.steps.yaml
+++ b/.pipelines/cni/state-migration-json/templates/cleanup.steps.yaml
@@ -1,0 +1,17 @@
+parameters:
+  clusterName: ""
+
+steps:
+  - task: AzureCLI@2
+    displayName: "Remove lifecycle control workload"
+    condition: always()
+    continueOnError: true
+    inputs:
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+      scriptLocation: inlineScript
+      scriptType: bash
+      addSpnToEnvironment: true
+      inlineScript: |
+        set -euo pipefail
+        make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
+        bash .pipelines/cni/state-migration-json/scripts/cleanup-json-control.sh

--- a/.pipelines/cni/state-migration-json/templates/json-control.stages.yaml
+++ b/.pipelines/cni/state-migration-json/templates/json-control.stages.yaml
@@ -1,0 +1,136 @@
+parameters:
+  name: ""
+  displayName: ""
+  clusterName: ""
+  clusterType: overlay-up
+  region: ""
+  os: linux
+  nodeCount: 2
+  nodeCountWin: 0
+  vmSize: Standard_D4s_v5
+  vmSizeWin: Standard_D4s_v5
+  osSKU: Ubuntu
+  osSkuWin: Windows2022
+  scaleup: 10
+  iterations: 2
+  deleteResources: true
+
+stages:
+  - stage: create_${{ parameters.name }}
+    displayName: "${{ parameters.displayName }} - Create"
+    dependsOn: []
+    pool:
+      name: $(BUILD_POOL_NAME_DEFAULT)
+    jobs:
+      - job: create_cluster
+        displayName: "Create representative cluster"
+        steps:
+          - template: ../../load-test-templates/create-cluster-template.yaml
+            parameters:
+              clusterType: ${{ parameters.clusterType }}
+              clusterName: ${{ parameters.clusterName }}
+              nodeCount: ${{ parameters.nodeCount }}
+              nodeCountWin: ${{ parameters.nodeCountWin }}
+              vmSize: ${{ parameters.vmSize }}
+              vmSizeWin: ${{ parameters.vmSizeWin }}
+              region: ${{ parameters.region }}
+              osSKU: ${{ parameters.osSKU }}
+              osSkuWin: ${{ parameters.osSkuWin }}
+              os: ${{ parameters.os }}
+
+  - stage: control_${{ parameters.name }}
+    displayName: "${{ parameters.displayName }} - JSON lifecycle"
+    dependsOn: create_${{ parameters.name }}
+    pool:
+      name: $(BUILD_POOL_NAME_DEFAULT)
+    jobs:
+      - job: baseline
+        displayName: "Baseline JSON state"
+        steps:
+          - template: baseline-json.steps.yaml
+            parameters:
+              clusterName: ${{ parameters.clusterName }}
+              os: ${{ parameters.os }}
+
+      - job: same_boot_cns_restart
+        displayName: "Same-boot CNS restart"
+        dependsOn: baseline
+        steps:
+          - template: restart-cns-json.steps.yaml
+            parameters:
+              clusterName: ${{ parameters.clusterName }}
+              os: ${{ parameters.os }}
+
+      - job: active_scale_restart
+        displayName: "Active scale and CNS restart"
+        dependsOn: same_boot_cns_restart
+        steps:
+          - template: active-scale-restart.steps.yaml
+            parameters:
+              clusterName: ${{ parameters.clusterName }}
+              os: ${{ parameters.os }}
+              scaleup: ${{ parameters.scaleup }}
+              iterations: ${{ parameters.iterations }}
+
+      - job: node_reboot
+        displayName: "Node reboot"
+        dependsOn: active_scale_restart
+        timeoutInMinutes: 90
+        steps:
+          - template: ../../load-test-templates/restart-node-template.yaml
+            parameters:
+              clusterName: ${{ parameters.clusterName }}
+              os: ${{ parameters.os }}
+              cni: cniv2
+              region: ${{ parameters.region }}
+              jobName: "state_migration_json_node_reboot"
+              logType: "stateMigrationJSONNodeReboot"
+          - template: ../../load-test-templates/validate-state-template.yaml
+            parameters:
+              clusterName: ${{ parameters.clusterName }}
+              os: ${{ parameters.os }}
+              cni: cniv2
+              restartCase: "true"
+
+      - job: capture
+        displayName: "Capture JSON state artifact"
+        dependsOn:
+          - baseline
+          - same_boot_cns_restart
+          - active_scale_restart
+          - node_reboot
+        condition: always()
+        steps:
+          - template: capture-json-state.steps.yaml
+            parameters:
+              name: ${{ parameters.name }}
+              clusterName: ${{ parameters.clusterName }}
+              os: ${{ parameters.os }}
+
+      - job: cleanup_workload
+        displayName: "Clean test workload"
+        dependsOn: capture
+        condition: always()
+        steps:
+          - template: cleanup.steps.yaml
+            parameters:
+              clusterName: ${{ parameters.clusterName }}
+
+  - stage: delete_${{ parameters.name }}
+    displayName: "${{ parameters.displayName }} - Delete"
+    dependsOn:
+      - create_${{ parameters.name }}
+      - control_${{ parameters.name }}
+    condition: always()
+    pool:
+      name: $(BUILD_POOL_NAME_DEFAULT)
+    jobs:
+      - job: delete_cluster
+        displayName: "Delete representative cluster"
+        steps:
+          - template: ../../../templates/delete-cluster.yaml
+            parameters:
+              clusterName: ${{ parameters.clusterName }}
+              sub: $(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS)
+              svcConn: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+              deleteResources: ${{ parameters.deleteResources }}

--- a/.pipelines/cni/state-migration-json/templates/json-control.stages.yaml
+++ b/.pipelines/cni/state-migration-json/templates/json-control.stages.yaml
@@ -44,27 +44,20 @@ stages:
     pool:
       name: $(BUILD_POOL_NAME_DEFAULT)
     jobs:
-      - job: baseline
-        displayName: "Baseline JSON state"
+      - job: json_lifecycle
+        displayName: "Run JSON state lifecycle"
+        timeoutInMinutes: 180
         steps:
           - template: baseline-json.steps.yaml
             parameters:
               clusterName: ${{ parameters.clusterName }}
               os: ${{ parameters.os }}
 
-      - job: same_boot_cns_restart
-        displayName: "Same-boot CNS restart"
-        dependsOn: baseline
-        steps:
           - template: restart-cns-json.steps.yaml
             parameters:
               clusterName: ${{ parameters.clusterName }}
               os: ${{ parameters.os }}
 
-      - job: active_scale_restart
-        displayName: "Active scale and CNS restart"
-        dependsOn: same_boot_cns_restart
-        steps:
           - template: active-scale-restart.steps.yaml
             parameters:
               clusterName: ${{ parameters.clusterName }}
@@ -72,11 +65,6 @@ stages:
               scaleup: ${{ parameters.scaleup }}
               iterations: ${{ parameters.iterations }}
 
-      - job: node_reboot
-        displayName: "Node reboot"
-        dependsOn: active_scale_restart
-        timeoutInMinutes: 90
-        steps:
           - template: ../../load-test-templates/restart-node-template.yaml
             parameters:
               clusterName: ${{ parameters.clusterName }}
@@ -92,26 +80,12 @@ stages:
               cni: cniv2
               restartCase: "true"
 
-      - job: capture
-        displayName: "Capture JSON state artifact"
-        dependsOn:
-          - baseline
-          - same_boot_cns_restart
-          - active_scale_restart
-          - node_reboot
-        condition: always()
-        steps:
           - template: capture-json-state.steps.yaml
             parameters:
               name: ${{ parameters.name }}
               clusterName: ${{ parameters.clusterName }}
               os: ${{ parameters.os }}
 
-      - job: cleanup_workload
-        displayName: "Clean test workload"
-        dependsOn: capture
-        condition: always()
-        steps:
           - template: cleanup.steps.yaml
             parameters:
               clusterName: ${{ parameters.clusterName }}

--- a/.pipelines/cni/state-migration-json/templates/json-control.stages.yaml
+++ b/.pipelines/cni/state-migration-json/templates/json-control.stages.yaml
@@ -44,27 +44,20 @@ stages:
     pool:
       name: $(BUILD_POOL_NAME_DEFAULT)
     jobs:
-      - job: baseline
-        displayName: "Baseline JSON state"
+      - job: json_state_lifecycle
+        displayName: "JSON state lifecycle"
+        timeoutInMinutes: 180
         steps:
           - template: baseline-json.steps.yaml
             parameters:
               clusterName: ${{ parameters.clusterName }}
               os: ${{ parameters.os }}
 
-      - job: same_boot_cns_restart
-        displayName: "Same-boot CNS restart"
-        dependsOn: baseline
-        steps:
           - template: restart-cns-json.steps.yaml
             parameters:
               clusterName: ${{ parameters.clusterName }}
               os: ${{ parameters.os }}
 
-      - job: active_scale_restart
-        displayName: "Active scale and CNS restart"
-        dependsOn: same_boot_cns_restart
-        steps:
           - template: active-scale-restart.steps.yaml
             parameters:
               clusterName: ${{ parameters.clusterName }}
@@ -72,11 +65,6 @@ stages:
               scaleup: ${{ parameters.scaleup }}
               iterations: ${{ parameters.iterations }}
 
-      - job: node_reboot
-        displayName: "Node reboot"
-        dependsOn: active_scale_restart
-        timeoutInMinutes: 90
-        steps:
           - template: ../../load-test-templates/restart-node-template.yaml
             parameters:
               clusterName: ${{ parameters.clusterName }}
@@ -92,26 +80,12 @@ stages:
               cni: cniv2
               restartCase: "true"
 
-      - job: capture
-        displayName: "Capture JSON state artifact"
-        dependsOn:
-          - baseline
-          - same_boot_cns_restart
-          - active_scale_restart
-          - node_reboot
-        condition: always()
-        steps:
           - template: capture-json-state.steps.yaml
             parameters:
               name: ${{ parameters.name }}
               clusterName: ${{ parameters.clusterName }}
               os: ${{ parameters.os }}
 
-      - job: cleanup_workload
-        displayName: "Clean test workload"
-        dependsOn: capture
-        condition: always()
-        steps:
           - template: cleanup.steps.yaml
             parameters:
               clusterName: ${{ parameters.clusterName }}

--- a/.pipelines/cni/state-migration-json/templates/restart-cns-json.steps.yaml
+++ b/.pipelines/cni/state-migration-json/templates/restart-cns-json.steps.yaml
@@ -1,0 +1,30 @@
+parameters:
+  clusterName: ""
+  os: linux
+
+steps:
+  - task: AzureCLI@2
+    displayName: "Restart CNS without rebooting nodes"
+    inputs:
+      azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+      scriptLocation: inlineScript
+      scriptType: bash
+      addSpnToEnvironment: true
+      inlineScript: |
+        set -euo pipefail
+        make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
+
+        daemon_set=azure-cns
+        if [[ "${{ parameters.os }}" == "windows" ]]; then
+          daemon_set=azure-cns-win
+        fi
+
+        kubectl rollout restart daemonset "$daemon_set" -n kube-system
+        kubectl rollout status daemonset "$daemon_set" -n kube-system --timeout=20m
+
+  - template: ../../load-test-templates/validate-state-template.yaml
+    parameters:
+      clusterName: ${{ parameters.clusterName }}
+      os: ${{ parameters.os }}
+      cni: cniv2
+      restartCase: "true"

--- a/.pipelines/cni/state-migration-json/tests/pipeline_contract_test.py
+++ b/.pipelines/cni/state-migration-json/tests/pipeline_contract_test.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+import subprocess
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PIPELINE = ROOT / "pipeline.yaml"
+
+
+def load_yaml(path):
+    with path.open(encoding="utf-8") as stream:
+        return yaml.safe_load(stream)
+
+
+def template_calls(node):
+    if isinstance(node, dict):
+        template = node.get("template")
+        if isinstance(template, str):
+            yield template, node.get("parameters", {})
+        for value in node.values():
+            yield from template_calls(value)
+    elif isinstance(node, list):
+        for value in node:
+            yield from template_calls(value)
+
+
+def shell_blocks(node):
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key in {"bash", "inlineScript"} and isinstance(value, str):
+                yield value
+            yield from shell_blocks(value)
+    elif isinstance(node, list):
+        for value in node:
+            yield from shell_blocks(value)
+
+
+class PipelineContractTest(unittest.TestCase):
+    def test_yaml_sources_parse(self):
+        for path in sorted(ROOT.rglob("*.yaml")):
+            with self.subTest(path=path.relative_to(ROOT)):
+                self.assertIsNotNone(load_yaml(path))
+
+    def test_template_graph_resolves(self):
+        pending = [PIPELINE]
+        visited = set()
+
+        while pending:
+            source = pending.pop()
+            if source in visited:
+                continue
+            visited.add(source)
+            document = load_yaml(source)
+            for reference, arguments in template_calls(document):
+                target = (source.parent / reference).resolve()
+                self.assertTrue(
+                    target.is_file(),
+                    f"{source} references missing template {reference}",
+                )
+                if ROOT in target.parents:
+                    declaration = load_yaml(target).get("parameters", {})
+                    declared = (
+                        set(declaration)
+                        if isinstance(declaration, dict)
+                        else {item["name"] for item in declaration}
+                    )
+                    supplied = {
+                        name
+                        for name in arguments
+                        if not str(name).startswith("${{")
+                    }
+                    self.assertEqual(
+                        set(),
+                        supplied - declared,
+                        f"{source} supplies unknown parameters to {target}",
+                    )
+                pending.append(target)
+
+        expected = {
+            (ROOT / "templates" / name).resolve()
+            for name in (
+                "json-control.stages.yaml",
+                "baseline-json.steps.yaml",
+                "restart-cns-json.steps.yaml",
+                "active-scale-restart.steps.yaml",
+                "capture-json-state.steps.yaml",
+                "cleanup.steps.yaml",
+            )
+        }
+        self.assertTrue(expected.issubset(visited))
+
+    def test_source_is_manual_and_scheduled(self):
+        pipeline = load_yaml(PIPELINE)
+        self.assertEqual("none", pipeline["trigger"])
+        self.assertEqual("none", pipeline["pr"])
+        self.assertEqual(["master"], pipeline["schedules"][0]["branches"]["include"])
+        self.assertTrue(pipeline["schedules"][0]["always"])
+
+    def test_representative_json_controls_are_bounded(self):
+        pipeline = load_yaml(PIPELINE)
+        parameters = {item["name"]: item for item in pipeline["parameters"]}
+        scenarios = parameters["scenarios"]["default"]
+
+        self.assertEqual({"linux", "windows"}, {item["os"] for item in scenarios})
+        self.assertTrue(all(item["clusterType"] == "overlay-up" for item in scenarios))
+        self.assertTrue(all(item["name"].endswith("_json") for item in scenarios))
+        required = {
+            "name",
+            "displayName",
+            "clusterName",
+            "clusterType",
+            "os",
+            "nodeCount",
+            "nodeCountWin",
+            "vmSize",
+            "vmSizeWin",
+            "osSKU",
+            "osSkuWin",
+            "scaleup",
+            "iterations",
+        }
+        self.assertTrue(all(required.issubset(item) for item in scenarios))
+
+        source_files = [
+            path
+            for path in ROOT.rglob("*")
+            if path.is_file() and "tests" not in path.parts
+        ]
+        excluded_backend = "bo" + "lt"
+        for path in source_files:
+            with self.subTest(path=path.relative_to(ROOT)):
+                self.assertNotIn(
+                    excluded_backend,
+                    path.read_text(encoding="utf-8").lower(),
+                )
+
+    def test_lifecycle_dependency_contract(self):
+        template = load_yaml(ROOT / "templates" / "json-control.stages.yaml")
+        stages = template["stages"]
+        self.assertEqual(3, len(stages))
+        self.assertEqual([], stages[0]["dependsOn"])
+        self.assertEqual("always()", stages[2]["condition"])
+
+        jobs = stages[1]["jobs"]
+        self.assertEqual(
+            [
+                "baseline",
+                "same_boot_cns_restart",
+                "active_scale_restart",
+                "node_reboot",
+                "capture",
+                "cleanup_workload",
+            ],
+            [job["job"] for job in jobs],
+        )
+        self.assertEqual("baseline", jobs[1]["dependsOn"])
+        self.assertEqual("same_boot_cns_restart", jobs[2]["dependsOn"])
+        self.assertEqual("active_scale_restart", jobs[3]["dependsOn"])
+        self.assertEqual("always()", jobs[4]["condition"])
+        self.assertEqual("always()", jobs[5]["condition"])
+
+    def test_embedded_and_standalone_shell_parse(self):
+        shell_sources = list(sorted((ROOT / "scripts").glob("*.sh")))
+        for path in sorted(ROOT.rglob("*.yaml")):
+            for index, block in enumerate(shell_blocks(load_yaml(path))):
+                with self.subTest(path=path.relative_to(ROOT), block=index):
+                    subprocess.run(
+                        ["bash", "-n"],
+                        input=block,
+                        text=True,
+                        check=True,
+                    )
+
+        for path in shell_sources:
+            with self.subTest(path=path.relative_to(ROOT)):
+                subprocess.run(["bash", "-n", str(path)], check=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.pipelines/cni/state-migration-json/tests/pipeline_contract_test.py
+++ b/.pipelines/cni/state-migration-json/tests/pipeline_contract_test.py
@@ -145,22 +145,23 @@ class PipelineContractTest(unittest.TestCase):
         self.assertEqual("always()", stages[2]["condition"])
 
         jobs = stages[1]["jobs"]
+        self.assertEqual(["json_lifecycle"], [job["job"] for job in jobs])
+        templates = [
+            reference
+            for reference, _ in template_calls(jobs[0]["steps"])
+        ]
         self.assertEqual(
             [
-                "baseline",
-                "same_boot_cns_restart",
-                "active_scale_restart",
-                "node_reboot",
-                "capture",
-                "cleanup_workload",
+                "baseline-json.steps.yaml",
+                "restart-cns-json.steps.yaml",
+                "active-scale-restart.steps.yaml",
+                "../../load-test-templates/restart-node-template.yaml",
+                "../../load-test-templates/validate-state-template.yaml",
+                "capture-json-state.steps.yaml",
+                "cleanup.steps.yaml",
             ],
-            [job["job"] for job in jobs],
+            templates,
         )
-        self.assertEqual("baseline", jobs[1]["dependsOn"])
-        self.assertEqual("same_boot_cns_restart", jobs[2]["dependsOn"])
-        self.assertEqual("active_scale_restart", jobs[3]["dependsOn"])
-        self.assertEqual("always()", jobs[4]["condition"])
-        self.assertEqual("always()", jobs[5]["condition"])
 
     def test_embedded_and_standalone_shell_parse(self):
         shell_sources = list(sorted((ROOT / "scripts").glob("*.sh")))

--- a/.pipelines/cni/state-migration-json/tests/pipeline_contract_test.py
+++ b/.pipelines/cni/state-migration-json/tests/pipeline_contract_test.py
@@ -1,9 +1,17 @@
 #!/usr/bin/env python3
+import re
 import subprocess
 import unittest
 from pathlib import Path
 
-import yaml
+try:
+    import yaml
+except ModuleNotFoundError as error:
+    if error.name == "yaml":
+        raise SystemExit(
+            "PyYAML is required; install it with: python3 -m pip install PyYAML"
+        ) from error
+    raise
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -36,6 +44,10 @@ def shell_blocks(node):
     elif isinstance(node, list):
         for value in node:
             yield from shell_blocks(value)
+
+
+def sanitize_template_expressions(script):
+    return re.sub(r"\$\{\{.*?\}\}", "template_value", script, flags=re.DOTALL)
 
 
 class PipelineContractTest(unittest.TestCase):
@@ -146,21 +158,29 @@ class PipelineContractTest(unittest.TestCase):
 
         jobs = stages[1]["jobs"]
         self.assertEqual(
-            [
-                "baseline",
-                "same_boot_cns_restart",
-                "active_scale_restart",
-                "node_reboot",
-                "capture",
-                "cleanup_workload",
-            ],
+            ["json_state_lifecycle"],
             [job["job"] for job in jobs],
         )
-        self.assertEqual("baseline", jobs[1]["dependsOn"])
-        self.assertEqual("same_boot_cns_restart", jobs[2]["dependsOn"])
-        self.assertEqual("active_scale_restart", jobs[3]["dependsOn"])
-        self.assertEqual("always()", jobs[4]["condition"])
-        self.assertEqual("always()", jobs[5]["condition"])
+        steps = jobs[0]["steps"]
+        self.assertEqual(
+            [
+                "baseline-json.steps.yaml",
+                "restart-cns-json.steps.yaml",
+                "active-scale-restart.steps.yaml",
+                "../../load-test-templates/restart-node-template.yaml",
+                "../../load-test-templates/validate-state-template.yaml",
+                "capture-json-state.steps.yaml",
+                "cleanup.steps.yaml",
+            ],
+            [step["template"] for step in steps],
+        )
+
+        capture_steps = load_yaml(ROOT / "templates" / "capture-json-state.steps.yaml")[
+            "steps"
+        ]
+        cleanup_steps = load_yaml(ROOT / "templates" / "cleanup.steps.yaml")["steps"]
+        self.assertTrue(all(step["condition"] == "always()" for step in capture_steps))
+        self.assertEqual("always()", cleanup_steps[0]["condition"])
 
     def test_embedded_and_standalone_shell_parse(self):
         shell_sources = list(sorted((ROOT / "scripts").glob("*.sh")))
@@ -169,7 +189,7 @@ class PipelineContractTest(unittest.TestCase):
                 with self.subTest(path=path.relative_to(ROOT), block=index):
                     subprocess.run(
                         ["bash", "-n"],
-                        input=block,
+                        input=sanitize_template_expressions(block),
                         text=True,
                         check=True,
                     )

--- a/.pipelines/cni/state-migration-json/tests/run-contract-tests.sh
+++ b/.pipelines/cni/state-migration-json/tests/run-contract-tests.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+cd "$root"
+
+python3 .pipelines/cni/state-migration-json/tests/pipeline_contract_test.py

--- a/.pipelines/cni/state-migration-json/tests/run-contract-tests.sh
+++ b/.pipelines/cni/state-migration-json/tests/run-contract-tests.sh
@@ -4,4 +4,9 @@ set -euo pipefail
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
 cd "$root"
 
+if ! python3 -c 'import yaml' >/dev/null 2>&1; then
+	echo "PyYAML is required: install it with 'python3 -m pip install PyYAML'" >&2
+	exit 1
+fi
+
 python3 .pipelines/cni/state-migration-json/tests/pipeline_contract_test.py


### PR DESCRIPTION
## What this does

Adds a standalone, additive JSON-only CNS persistent-state lifecycle pipeline for Linux and Windows. It establishes the control coverage before any Bolt E2E lane is introduced.

Each scenario validates baseline state, same-boot CNS restart, active workload scale plus restart, node reboot, post-reboot state, artifact capture, and failure-safe cleanup. Existing CNI and state-migration pipelines are unchanged.

## Safety and isolation

- Manual and weekly scheduled execution only; no PR trigger
- Build-ID-scoped cluster and artifact names
- Cleanup and cluster deletion run under `always()`
- State-validation failures remain gating
- Debug capture is best-effort without masking lifecycle failures
- No Bolt configuration or product-code changes

## Validation

The six local pipeline contract tests pass, including template parameter checks, shell syntax checks, lifecycle ordering, cleanup guarantees, Build-ID isolation, and Bolt-exclusion checks.