### PR TITLE
test: add strict persistent-state summary validation

### DIFF
--- a/test/validate/cmd/summarydiff/main.go
+++ b/test/validate/cmd/summarydiff/main.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	statevalidate "github.com/Azure/azure-container-networking/test/validate"
+)
+
+type options struct {
+	baselinePath    string
+	candidatePath   string
+	expectedBackend statevalidate.StateBackend
+}
+
+type summaryStats struct {
+	Checks      int `json:"checks"`
+	LivePods    int `json:"livePods"`
+	ExpectedIPs int `json:"expectedIPs"`
+	ActualIPs   int `json:"actualIPs"`
+}
+
+type compareOutput struct {
+	Baseline  summaryStats `json:"baseline"`
+	Candidate summaryStats `json:"candidate"`
+}
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
+	opts, err := parseOptions(args, stderr)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+
+	baseline, err := readSummary(opts.baselinePath, opts.expectedBackend)
+	if err != nil {
+		fmt.Fprintf(stderr, "reading baseline summary: %v\n", err)
+		return 2
+	}
+	candidate, err := readSummary(opts.candidatePath, opts.expectedBackend)
+	if err != nil {
+		fmt.Fprintf(stderr, "reading candidate summary: %v\n", err)
+		return 2
+	}
+
+	output := compareOutput{
+		Baseline:  aggregate(baseline),
+		Candidate: aggregate(candidate),
+	}
+	if err := json.NewEncoder(stdout).Encode(output); err != nil {
+		fmt.Fprintf(stderr, "encoding comparison output: %v\n", err)
+		return 2
+	}
+
+	if err := statevalidate.CompareValidationSummaries(baseline, candidate, opts.expectedBackend); err != nil {
+		fmt.Fprintf(stderr, "summary comparison failed: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func parseOptions(args []string, stderr io.Writer) (options, error) {
+	flags := flag.NewFlagSet("summarydiff", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+
+	var opts options
+	flags.StringVar(&opts.baselinePath, "baseline", "", "path to baseline validation summary JSON")
+	flags.StringVar(&opts.candidatePath, "candidate", "", "path to candidate validation summary JSON")
+	expectedBackend := flags.String("expected-backend", "", "required state backend")
+	if err := flags.Parse(args); err != nil {
+		return options{}, err
+	}
+	if flags.NArg() != 0 {
+		return options{}, fmt.Errorf("unexpected positional arguments: %v", flags.Args())
+	}
+
+	opts.expectedBackend = statevalidate.StateBackend(*expectedBackend)
+	var missing []string
+	if opts.baselinePath == "" {
+		missing = append(missing, "-baseline")
+	}
+	if opts.candidatePath == "" {
+		missing = append(missing, "-candidate")
+	}
+	if opts.expectedBackend == "" {
+		missing = append(missing, "-expected-backend")
+	}
+	if len(missing) != 0 {
+		return options{}, fmt.Errorf("required flags missing: %v", missing)
+	}
+	return opts, nil
+}
+
+func readSummary(path string, expectedBackend statevalidate.StateBackend) (statevalidate.ValidationSummary, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return statevalidate.ValidationSummary{}, fmt.Errorf("reading %q: %w", path, err)
+	}
+
+	summary, err := statevalidate.DecodeValidationSummary(bytes.NewReader(raw), expectedBackend)
+	if err != nil {
+		return statevalidate.ValidationSummary{}, fmt.Errorf("decoding %q: %w", path, err)
+	}
+	return summary, nil
+}
+
+func aggregate(summary statevalidate.ValidationSummary) summaryStats {
+	stats := summaryStats{Checks: len(summary.Checks)}
+	for i := range summary.Checks {
+		stats.LivePods += summary.Checks[i].LivePodCount
+		stats.ExpectedIPs += len(summary.Checks[i].Expected)
+		stats.ActualIPs += len(summary.Checks[i].Actual)
+	}
+	return stats
+}

--- a/test/validate/cmd/summarydiff/main.go
+++ b/test/validate/cmd/summarydiff/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -28,6 +29,8 @@ type compareOutput struct {
 	Baseline  summaryStats `json:"baseline"`
 	Candidate summaryStats `json:"candidate"`
 }
+
+var errInvalidArguments = errors.New("summarydiff: invalid arguments")
 
 func main() {
 	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
@@ -62,9 +65,16 @@ func run(args []string, stdout, stderr io.Writer) int {
 
 	if err := statevalidate.CompareValidationSummaries(baseline, candidate, opts.expectedBackend); err != nil {
 		fmt.Fprintf(stderr, "summary comparison failed: %v\n", err)
-		return 1
+		return comparisonExitCode(err)
 	}
 	return 0
+}
+
+func comparisonExitCode(err error) int {
+	if errors.Is(err, statevalidate.ErrSummaryRegression) {
+		return 1
+	}
+	return 2
 }
 
 func parseOptions(args []string, stderr io.Writer) (options, error) {
@@ -76,10 +86,10 @@ func parseOptions(args []string, stderr io.Writer) (options, error) {
 	flags.StringVar(&opts.candidatePath, "candidate", "", "path to candidate validation summary JSON")
 	expectedBackend := flags.String("expected-backend", "", "required state backend")
 	if err := flags.Parse(args); err != nil {
-		return options{}, err
+		return options{}, fmt.Errorf("%w: parsing flags: %w", errInvalidArguments, err)
 	}
 	if flags.NArg() != 0 {
-		return options{}, fmt.Errorf("unexpected positional arguments: %v", flags.Args())
+		return options{}, fmt.Errorf("%w: unexpected positional arguments: %v", errInvalidArguments, flags.Args())
 	}
 
 	opts.expectedBackend = statevalidate.StateBackend(*expectedBackend)
@@ -94,7 +104,7 @@ func parseOptions(args []string, stderr io.Writer) (options, error) {
 		missing = append(missing, "-expected-backend")
 	}
 	if len(missing) != 0 {
-		return options{}, fmt.Errorf("required flags missing: %v", missing)
+		return options{}, fmt.Errorf("%w: required flags missing: %v", errInvalidArguments, missing)
 	}
 	return opts, nil
 }

--- a/test/validate/cmd/summarydiff/main.go
+++ b/test/validate/cmd/summarydiff/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -28,6 +29,11 @@ type compareOutput struct {
 	Baseline  summaryStats `json:"baseline"`
 	Candidate summaryStats `json:"candidate"`
 }
+
+var (
+	errUnexpectedPositionalArguments = errors.New("unexpected positional arguments")
+	errRequiredFlagsMissing          = errors.New("required flags missing")
+)
 
 func main() {
 	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
@@ -62,7 +68,10 @@ func run(args []string, stdout, stderr io.Writer) int {
 
 	if err := statevalidate.CompareValidationSummaries(baseline, candidate, opts.expectedBackend); err != nil {
 		fmt.Fprintf(stderr, "summary comparison failed: %v\n", err)
-		return 1
+		if errors.Is(err, statevalidate.ErrSummaryRegression) {
+			return 1
+		}
+		return 2
 	}
 	return 0
 }
@@ -76,10 +85,10 @@ func parseOptions(args []string, stderr io.Writer) (options, error) {
 	flags.StringVar(&opts.candidatePath, "candidate", "", "path to candidate validation summary JSON")
 	expectedBackend := flags.String("expected-backend", "", "required state backend")
 	if err := flags.Parse(args); err != nil {
-		return options{}, err
+		return options{}, fmt.Errorf("parsing options: %w", err)
 	}
 	if flags.NArg() != 0 {
-		return options{}, fmt.Errorf("unexpected positional arguments: %v", flags.Args())
+		return options{}, fmt.Errorf("%w: %v", errUnexpectedPositionalArguments, flags.Args())
 	}
 
 	opts.expectedBackend = statevalidate.StateBackend(*expectedBackend)
@@ -94,8 +103,9 @@ func parseOptions(args []string, stderr io.Writer) (options, error) {
 		missing = append(missing, "-expected-backend")
 	}
 	if len(missing) != 0 {
-		return options{}, fmt.Errorf("required flags missing: %v", missing)
+		return options{}, fmt.Errorf("%w: %v", errRequiredFlagsMissing, missing)
 	}
+
 	return opts, nil
 }
 

--- a/test/validate/cmd/summarydiff/main_test.go
+++ b/test/validate/cmd/summarydiff/main_test.go
@@ -3,11 +3,114 @@ package main
 import (
 	"bytes"
 	"net/netip"
+	"os"
+	"path/filepath"
 	"testing"
 
 	statevalidate "github.com/Azure/azure-container-networking/test/validate"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRun(t *testing.T) {
+	const (
+		baseline = `{
+			"stateBackend": "json",
+			"checks": [{
+				"checkName": "endpoint-state",
+				"nodeName": "node-1",
+				"livePodCount": 1,
+				"expected": [{"podID": "namespace/pod", "ip": "10.0.0.2"}],
+				"actual": [{"podID": "namespace/pod", "ip": "10.0.0.2"}]
+			}]
+		}`
+		regressed = `{
+			"stateBackend": "json",
+			"checks": [{
+				"checkName": "endpoint-state",
+				"nodeName": "node-1",
+				"livePodCount": 1,
+				"expected": [{"podID": "namespace/pod", "ip": "10.0.0.3"}],
+				"actual": [{"podID": "namespace/pod", "ip": "10.0.0.3"}]
+			}]
+		}`
+		wrongBackend = `{
+			"stateBackend": "bolt",
+			"checks": [{
+				"checkName": "endpoint-state",
+				"nodeName": "node-1",
+				"livePodCount": 1,
+				"expected": [{"podID": "namespace/pod", "ip": "10.0.0.2"}],
+				"actual": [{"podID": "namespace/pod", "ip": "10.0.0.2"}]
+			}]
+		}`
+	)
+
+	tests := []struct {
+		name       string
+		candidate  string
+		wantCode   int
+		wantStdout string
+		wantStderr string
+	}{
+		{
+			name:       "matching summaries",
+			candidate:  baseline,
+			wantCode:   0,
+			wantStdout: `{"baseline":{"checks":1,"livePods":1,"expectedIPs":1,"actualIPs":1},"candidate":{"checks":1,"livePods":1,"expectedIPs":1,"actualIPs":1}}`,
+		},
+		{
+			name:       "summary regression",
+			candidate:  regressed,
+			wantCode:   1,
+			wantStdout: `{"baseline":{"checks":1,"livePods":1,"expectedIPs":1,"actualIPs":1},"candidate":{"checks":1,"livePods":1,"expectedIPs":1,"actualIPs":1}}`,
+			wantStderr: "summary comparison failed: validation summary regression",
+		},
+		{
+			name:       "wrong candidate backend",
+			candidate:  wrongBackend,
+			wantCode:   2,
+			wantStderr: `reading candidate summary: decoding`,
+		},
+		{
+			name:       "malformed candidate",
+			candidate:  `{"stateBackend":`,
+			wantCode:   2,
+			wantStderr: `reading candidate summary: decoding`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tempDir := t.TempDir()
+			baselinePath := filepath.Join(tempDir, "baseline.json")
+			candidatePath := filepath.Join(tempDir, "candidate.json")
+			require.NoError(t, os.WriteFile(baselinePath, []byte(baseline), 0o600))
+			require.NoError(t, os.WriteFile(candidatePath, []byte(tt.candidate), 0o600))
+
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			gotCode := run([]string{
+				"-baseline", baselinePath,
+				"-candidate", candidatePath,
+				"-expected-backend", "json",
+			}, &stdout, &stderr)
+
+			require.Equal(t, tt.wantCode, gotCode)
+			if tt.wantStdout == "" {
+				require.Empty(t, stdout.String())
+			} else {
+				require.JSONEq(t, tt.wantStdout, stdout.String())
+			}
+			if tt.wantStderr == "" {
+				require.Empty(t, stderr.String())
+			} else {
+				require.Contains(t, stderr.String(), tt.wantStderr)
+			}
+		})
+	}
+}
 
 func TestParseOptions(t *testing.T) {
 	tests := []struct {

--- a/test/validate/cmd/summarydiff/main_test.go
+++ b/test/validate/cmd/summarydiff/main_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"net/netip"
+	"testing"
+
+	statevalidate "github.com/Azure/azure-container-networking/test/validate"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		want    options
+		wantErr string
+	}{
+		{
+			name: "all required flags",
+			args: []string{
+				"-baseline", "before.json",
+				"-candidate", "after.json",
+				"-expected-backend", "backend",
+			},
+			want: options{
+				baselinePath:    "before.json",
+				candidatePath:   "after.json",
+				expectedBackend: "backend",
+			},
+		},
+		{
+			name:    "all required flags missing",
+			wantErr: "[-baseline -candidate -expected-backend]",
+		},
+		{
+			name:    "expected backend missing",
+			args:    []string{"-baseline", "before.json", "-candidate", "after.json"},
+			wantErr: "-expected-backend",
+		},
+		{
+			name:    "positional argument",
+			args:    []string{"extra", "-baseline", "before.json", "-candidate", "after.json", "-expected-backend", "backend"},
+			wantErr: "unexpected positional arguments",
+		},
+		{
+			name:    "unknown flag",
+			args:    []string{"-unknown"},
+			wantErr: "flag provided but not defined",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			got, err := parseOptions(tt.args, &stderr)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestAggregate(t *testing.T) {
+	summary := statevalidate.ValidationSummary{
+		Checks: []statevalidate.ValidationCheckSummary{
+			{
+				LivePodCount: 2,
+				Expected: []statevalidate.PodIPIdentity{
+					{PodID: "pod-1", IP: netip.MustParseAddr("10.0.0.2")},
+					{PodID: "pod-2", IP: netip.MustParseAddr("10.0.0.3")},
+				},
+				Actual: []statevalidate.PodIPIdentity{
+					{PodID: "pod-1", IP: netip.MustParseAddr("10.0.0.2")},
+					{PodID: "pod-2", IP: netip.MustParseAddr("10.0.0.3")},
+				},
+			},
+			{
+				LivePodCount: 1,
+				Expected: []statevalidate.PodIPIdentity{
+					{PodID: "pod-3", IP: netip.MustParseAddr("fd00::2")},
+				},
+				Actual: []statevalidate.PodIPIdentity{
+					{PodID: "pod-3", IP: netip.MustParseAddr("fd00::2")},
+				},
+			},
+		},
+	}
+
+	require.Equal(t, summaryStats{
+		Checks:      2,
+		LivePods:    3,
+		ExpectedIPs: 3,
+		ActualIPs:   3,
+	}, aggregate(summary))
+}

--- a/test/validate/cmd/summarydiff/main_test.go
+++ b/test/validate/cmd/summarydiff/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"fmt"
+	"io"
 	"net/netip"
 	"os"
 	"path/filepath"
@@ -9,6 +11,15 @@ import (
 
 	statevalidate "github.com/Azure/azure-container-networking/test/validate"
 	"github.com/stretchr/testify/require"
+)
+
+const (
+	baselineFlag        = "-baseline"
+	candidateFlag       = "-candidate"
+	expectedBackendFlag = "-expected-backend"
+	baselineFile        = "before.json"
+	candidateFile       = "after.json"
+	backendValue        = "backend"
 )
 
 func TestRun(t *testing.T) {
@@ -92,9 +103,9 @@ func TestRun(t *testing.T) {
 			var stdout bytes.Buffer
 			var stderr bytes.Buffer
 			gotCode := run([]string{
-				"-baseline", baselinePath,
-				"-candidate", candidatePath,
-				"-expected-backend", "json",
+				baselineFlag, baselinePath,
+				candidateFlag, candidatePath,
+				expectedBackendFlag, "json",
 			}, &stdout, &stderr)
 
 			require.Equal(t, tt.wantCode, gotCode)
@@ -112,6 +123,13 @@ func TestRun(t *testing.T) {
 	}
 }
 
+func TestComparisonExitCode(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, 1, comparisonExitCode(fmt.Errorf("comparing summaries: %w", statevalidate.ErrSummaryRegression)))
+	require.Equal(t, 2, comparisonExitCode(io.ErrUnexpectedEOF))
+}
+
 func TestParseOptions(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -122,14 +140,14 @@ func TestParseOptions(t *testing.T) {
 		{
 			name: "all required flags",
 			args: []string{
-				"-baseline", "before.json",
-				"-candidate", "after.json",
-				"-expected-backend", "backend",
+				baselineFlag, baselineFile,
+				candidateFlag, candidateFile,
+				expectedBackendFlag, backendValue,
 			},
 			want: options{
-				baselinePath:    "before.json",
-				candidatePath:   "after.json",
-				expectedBackend: "backend",
+				baselinePath:    baselineFile,
+				candidatePath:   candidateFile,
+				expectedBackend: backendValue,
 			},
 		},
 		{
@@ -138,12 +156,12 @@ func TestParseOptions(t *testing.T) {
 		},
 		{
 			name:    "expected backend missing",
-			args:    []string{"-baseline", "before.json", "-candidate", "after.json"},
-			wantErr: "-expected-backend",
+			args:    []string{baselineFlag, baselineFile, candidateFlag, candidateFile},
+			wantErr: expectedBackendFlag,
 		},
 		{
 			name:    "positional argument",
-			args:    []string{"extra", "-baseline", "before.json", "-candidate", "after.json", "-expected-backend", "backend"},
+			args:    []string{"extra", baselineFlag, baselineFile, candidateFlag, candidateFile, expectedBackendFlag, backendValue},
 			wantErr: "unexpected positional arguments",
 		},
 		{

--- a/test/validate/cmd/summarydiff/main_test.go
+++ b/test/validate/cmd/summarydiff/main_test.go
@@ -11,6 +11,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	baselineFlag        = "-baseline"
+	candidateFlag       = "-candidate"
+	expectedBackendFlag = "-expected-backend"
+	beforePath          = "before.json"
+	afterPath           = "after.json"
+	testBackend         = "backend"
+)
+
 func TestRun(t *testing.T) {
 	const (
 		baseline = `{
@@ -92,9 +101,9 @@ func TestRun(t *testing.T) {
 			var stdout bytes.Buffer
 			var stderr bytes.Buffer
 			gotCode := run([]string{
-				"-baseline", baselinePath,
-				"-candidate", candidatePath,
-				"-expected-backend", "json",
+				baselineFlag, baselinePath,
+				candidateFlag, candidatePath,
+				expectedBackendFlag, "json",
 			}, &stdout, &stderr)
 
 			require.Equal(t, tt.wantCode, gotCode)
@@ -122,28 +131,28 @@ func TestParseOptions(t *testing.T) {
 		{
 			name: "all required flags",
 			args: []string{
-				"-baseline", "before.json",
-				"-candidate", "after.json",
-				"-expected-backend", "backend",
+				baselineFlag, beforePath,
+				candidateFlag, afterPath,
+				expectedBackendFlag, testBackend,
 			},
 			want: options{
-				baselinePath:    "before.json",
-				candidatePath:   "after.json",
-				expectedBackend: "backend",
+				baselinePath:    beforePath,
+				candidatePath:   afterPath,
+				expectedBackend: testBackend,
 			},
 		},
 		{
 			name:    "all required flags missing",
-			wantErr: "[-baseline -candidate -expected-backend]",
+			wantErr: "[" + baselineFlag + " " + candidateFlag + " " + expectedBackendFlag + "]",
 		},
 		{
 			name:    "expected backend missing",
-			args:    []string{"-baseline", "before.json", "-candidate", "after.json"},
-			wantErr: "-expected-backend",
+			args:    []string{baselineFlag, beforePath, candidateFlag, afterPath},
+			wantErr: expectedBackendFlag,
 		},
 		{
 			name:    "positional argument",
-			args:    []string{"extra", "-baseline", "before.json", "-candidate", "after.json", "-expected-backend", "backend"},
+			args:    []string{"extra", baselineFlag, beforePath, candidateFlag, afterPath, expectedBackendFlag, testBackend},
 			wantErr: "unexpected positional arguments",
 		},
 		{

--- a/test/validate/summary.go
+++ b/test/validate/summary.go
@@ -1,0 +1,330 @@
+package validate
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/netip"
+	"sort"
+	"strings"
+)
+
+// StateBackend identifies the state implementation observed by a validation run.
+type StateBackend string
+
+// PodIPIdentity identifies one pod and IP pair in observed state.
+type PodIPIdentity struct {
+	PodID string     `json:"podID"`
+	IP    netip.Addr `json:"ip"`
+}
+
+// ValidationCheckSummary records the exact state observed by one check on one node.
+type ValidationCheckSummary struct {
+	CheckName    string          `json:"checkName"`
+	NodeName     string          `json:"nodeName"`
+	LivePodCount int             `json:"livePodCount"`
+	Expected     []PodIPIdentity `json:"expected"`
+	Actual       []PodIPIdentity `json:"actual"`
+}
+
+// ValidationSummary records backend and per-check state identities.
+type ValidationSummary struct {
+	StateBackend StateBackend             `json:"stateBackend"`
+	Checks       []ValidationCheckSummary `json:"checks"`
+}
+
+type validationSummaryWire struct {
+	StateBackend *StateBackend                 `json:"stateBackend"`
+	Checks       *[]validationCheckSummaryWire `json:"checks"`
+}
+
+type validationCheckSummaryWire struct {
+	CheckName    *string          `json:"checkName"`
+	NodeName     *string          `json:"nodeName"`
+	LivePodCount *int             `json:"livePodCount"`
+	Expected     *[]PodIPIdentity `json:"expected"`
+	Actual       *[]PodIPIdentity `json:"actual"`
+}
+
+type validationCheckID struct {
+	name string
+	node string
+}
+
+// ErrSummaryRegression identifies a validation summary mismatch.
+var ErrSummaryRegression = errors.New("validation summary regression")
+
+// DecodeValidationSummary strictly decodes and validates one summary.
+func DecodeValidationSummary(r io.Reader, expectedBackend StateBackend) (ValidationSummary, error) {
+	decoder := json.NewDecoder(r)
+	decoder.DisallowUnknownFields()
+
+	var wire validationSummaryWire
+	if err := decoder.Decode(&wire); err != nil {
+		return ValidationSummary{}, fmt.Errorf("decoding validation summary: %w", err)
+	}
+
+	var trailing json.RawMessage
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return ValidationSummary{}, errors.New("decoding validation summary: multiple JSON values")
+		}
+		return ValidationSummary{}, fmt.Errorf("decoding validation summary trailer: %w", err)
+	}
+
+	summary, err := validationSummaryFromWire(wire)
+	if err != nil {
+		return ValidationSummary{}, err
+	}
+	if err := ValidateValidationSummary(summary, expectedBackend); err != nil {
+		return ValidationSummary{}, err
+	}
+	return summary, nil
+}
+
+// ValidateValidationSummary validates the backend, shape, identities, and check results.
+func ValidateValidationSummary(summary ValidationSummary, expectedBackend StateBackend) error {
+	if err := validateBackend(expectedBackend, "expected"); err != nil {
+		return err
+	}
+	if err := validateBackend(summary.StateBackend, "summary"); err != nil {
+		return err
+	}
+	if summary.StateBackend != expectedBackend {
+		return fmt.Errorf("summary backend %q does not match expected backend %q", summary.StateBackend, expectedBackend)
+	}
+	if summary.Checks == nil {
+		return errors.New("summary checks are missing")
+	}
+	if len(summary.Checks) == 0 {
+		return errors.New("summary has no checks")
+	}
+
+	checks := make(map[validationCheckID]struct{}, len(summary.Checks))
+	for i := range summary.Checks {
+		check := summary.Checks[i]
+		if err := validateIdentifier(check.CheckName, "name"); err != nil {
+			return fmt.Errorf("check %d: %w", i, err)
+		}
+		if err := validateIdentifier(check.NodeName, "node name"); err != nil {
+			return fmt.Errorf("check %q: %w", check.CheckName, err)
+		}
+		if check.LivePodCount < 0 {
+			return fmt.Errorf("check %q on node %q has negative live pod count %d", check.CheckName, check.NodeName, check.LivePodCount)
+		}
+		if check.Expected == nil {
+			return fmt.Errorf("check %q on node %q is missing expected state", check.CheckName, check.NodeName)
+		}
+		if check.Actual == nil {
+			return fmt.Errorf("check %q on node %q is missing actual state", check.CheckName, check.NodeName)
+		}
+		if check.LivePodCount > 0 && len(check.Expected) == 0 {
+			return fmt.Errorf(
+				"check %q on node %q has %d live pods but empty expected state",
+				check.CheckName,
+				check.NodeName,
+				check.LivePodCount,
+			)
+		}
+
+		key := checkKey(check)
+		if _, ok := checks[key]; ok {
+			return fmt.Errorf("duplicate check %q on node %q", check.CheckName, check.NodeName)
+		}
+		checks[key] = struct{}{}
+
+		if err := ComparePodIPIdentities(check.Expected, check.Actual); err != nil {
+			return fmt.Errorf("check %q on node %q: %w", check.CheckName, check.NodeName, err)
+		}
+	}
+	return nil
+}
+
+// ComparePodIPIdentities requires exact pod and IP identity equality.
+func ComparePodIPIdentities(expected, actual []PodIPIdentity) error {
+	expectedSet, err := podIPIdentitySet(expected)
+	if err != nil {
+		return fmt.Errorf("invalid expected state: %w", err)
+	}
+	actualSet, err := podIPIdentitySet(actual)
+	if err != nil {
+		return fmt.Errorf("invalid actual state: %w", err)
+	}
+
+	missing := identityDifference(expectedSet, actualSet)
+	unexpected := identityDifference(actualSet, expectedSet)
+	if len(missing) != 0 || len(unexpected) != 0 {
+		return fmt.Errorf("pod/IP identity mismatch: missing=%v unexpected=%v", missing, unexpected)
+	}
+	return nil
+}
+
+// CompareValidationSummaries requires exact check, live-pod, pod, and IP identity equality.
+func CompareValidationSummaries(baseline, candidate ValidationSummary, expectedBackend StateBackend) error {
+	if err := ValidateValidationSummary(baseline, expectedBackend); err != nil {
+		return fmt.Errorf("invalid baseline summary: %w", err)
+	}
+	if err := ValidateValidationSummary(candidate, expectedBackend); err != nil {
+		return fmt.Errorf("invalid candidate summary: %w", err)
+	}
+
+	baselineChecks := make(map[validationCheckID]ValidationCheckSummary, len(baseline.Checks))
+	for i := range baseline.Checks {
+		baselineChecks[checkKey(baseline.Checks[i])] = baseline.Checks[i]
+	}
+
+	for i := range candidate.Checks {
+		candidateCheck := candidate.Checks[i]
+		key := checkKey(candidateCheck)
+		baselineCheck, ok := baselineChecks[key]
+		if !ok {
+			return fmt.Errorf(
+				"%w: unexpected check %q on node %q",
+				ErrSummaryRegression,
+				candidateCheck.CheckName,
+				candidateCheck.NodeName,
+			)
+		}
+		if candidateCheck.LivePodCount != baselineCheck.LivePodCount {
+			return fmt.Errorf(
+				"%w: check %q on node %q live pod count changed from %d to %d",
+				ErrSummaryRegression,
+				candidateCheck.CheckName,
+				candidateCheck.NodeName,
+				baselineCheck.LivePodCount,
+				candidateCheck.LivePodCount,
+			)
+		}
+		if err := ComparePodIPIdentities(baselineCheck.Expected, candidateCheck.Expected); err != nil {
+			return fmt.Errorf(
+				"%w: check %q on node %q expected state changed: %v",
+				ErrSummaryRegression,
+				candidateCheck.CheckName,
+				candidateCheck.NodeName,
+				err,
+			)
+		}
+		if err := ComparePodIPIdentities(baselineCheck.Actual, candidateCheck.Actual); err != nil {
+			return fmt.Errorf(
+				"%w: check %q on node %q actual state changed: %v",
+				ErrSummaryRegression,
+				candidateCheck.CheckName,
+				candidateCheck.NodeName,
+				err,
+			)
+		}
+		delete(baselineChecks, key)
+	}
+
+	if len(baselineChecks) != 0 {
+		missing := make([]string, 0, len(baselineChecks))
+		for _, check := range baselineChecks {
+			missing = append(missing, fmt.Sprintf("%s/%s", check.CheckName, check.NodeName))
+		}
+		sort.Strings(missing)
+		return fmt.Errorf("%w: candidate is missing checks %v", ErrSummaryRegression, missing)
+	}
+	return nil
+}
+
+func validationSummaryFromWire(wire validationSummaryWire) (ValidationSummary, error) {
+	if wire.StateBackend == nil {
+		return ValidationSummary{}, errors.New("summary stateBackend is missing")
+	}
+	if wire.Checks == nil {
+		return ValidationSummary{}, errors.New("summary checks are missing")
+	}
+
+	summary := ValidationSummary{
+		StateBackend: *wire.StateBackend,
+		Checks:       make([]ValidationCheckSummary, len(*wire.Checks)),
+	}
+	for i := range *wire.Checks {
+		check := (*wire.Checks)[i]
+		switch {
+		case check.CheckName == nil:
+			return ValidationSummary{}, fmt.Errorf("check %d checkName is missing", i)
+		case check.NodeName == nil:
+			return ValidationSummary{}, fmt.Errorf("check %d nodeName is missing", i)
+		case check.LivePodCount == nil:
+			return ValidationSummary{}, fmt.Errorf("check %d livePodCount is missing", i)
+		case check.Expected == nil:
+			return ValidationSummary{}, fmt.Errorf("check %d expected state is missing", i)
+		case check.Actual == nil:
+			return ValidationSummary{}, fmt.Errorf("check %d actual state is missing", i)
+		}
+		summary.Checks[i] = ValidationCheckSummary{
+			CheckName:    *check.CheckName,
+			NodeName:     *check.NodeName,
+			LivePodCount: *check.LivePodCount,
+			Expected:     *check.Expected,
+			Actual:       *check.Actual,
+		}
+	}
+	return summary, nil
+}
+
+func validateBackend(backend StateBackend, source string) error {
+	value := string(backend)
+	if value == "" {
+		return fmt.Errorf("%s backend is empty", source)
+	}
+	if strings.TrimSpace(value) != value {
+		return fmt.Errorf("%s backend %q contains surrounding whitespace", source, backend)
+	}
+	return nil
+}
+
+func validateIdentifier(value, field string) error {
+	if value == "" {
+		return fmt.Errorf("%s is empty", field)
+	}
+	if strings.TrimSpace(value) != value {
+		return fmt.Errorf("%s %q contains surrounding whitespace", field, value)
+	}
+	return nil
+}
+
+func podIPIdentitySet(identities []PodIPIdentity) (map[PodIPIdentity]struct{}, error) {
+	set := make(map[PodIPIdentity]struct{}, len(identities))
+	owners := make(map[netip.Addr]string, len(identities))
+	for i := range identities {
+		identity := identities[i]
+		if err := validateIdentifier(identity.PodID, "pod ID"); err != nil {
+			return nil, fmt.Errorf("identity %d: %w", i, err)
+		}
+		if !identity.IP.IsValid() {
+			return nil, fmt.Errorf("identity %d for pod %q has an invalid IP", i, identity.PodID)
+		}
+		identity.IP = identity.IP.Unmap()
+		if _, ok := set[identity]; ok {
+			return nil, fmt.Errorf("duplicate identity %s", formatIdentity(identity))
+		}
+		if owner, ok := owners[identity.IP]; ok {
+			return nil, fmt.Errorf("duplicate IP %s for pods %q and %q", identity.IP, owner, identity.PodID)
+		}
+		set[identity] = struct{}{}
+		owners[identity.IP] = identity.PodID
+	}
+	return set, nil
+}
+
+func identityDifference(left, right map[PodIPIdentity]struct{}) []string {
+	diff := make([]string, 0)
+	for identity := range left {
+		if _, ok := right[identity]; !ok {
+			diff = append(diff, formatIdentity(identity))
+		}
+	}
+	sort.Strings(diff)
+	return diff
+}
+
+func formatIdentity(identity PodIPIdentity) string {
+	return identity.PodID + "/" + identity.IP.String()
+}
+
+func checkKey(check ValidationCheckSummary) validationCheckID {
+	return validationCheckID{name: check.CheckName, node: check.NodeName}
+}

--- a/test/validate/summary.go
+++ b/test/validate/summary.go
@@ -52,8 +52,15 @@ type validationCheckID struct {
 	node string
 }
 
-// ErrSummaryRegression identifies a validation summary mismatch.
-var ErrSummaryRegression = errors.New("validation summary regression")
+var (
+	// ErrSummaryRegression identifies a validation summary mismatch.
+	ErrSummaryRegression = errors.New("validation summary regression")
+
+	errInvalidSummary    = errors.New("validate: invalid summary")
+	errInvalidBackend    = errors.New("validate: invalid backend")
+	errInvalidIdentifier = errors.New("validate: invalid identifier")
+	errInvalidIdentity   = errors.New("validate: invalid pod/IP identity")
+)
 
 // DecodeValidationSummary strictly decodes and validates one summary.
 func DecodeValidationSummary(r io.Reader, expectedBackend StateBackend) (ValidationSummary, error) {
@@ -68,7 +75,7 @@ func DecodeValidationSummary(r io.Reader, expectedBackend StateBackend) (Validat
 	var trailing json.RawMessage
 	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
 		if err == nil {
-			return ValidationSummary{}, errors.New("decoding validation summary: multiple JSON values")
+			return ValidationSummary{}, fmt.Errorf("%w: multiple JSON values", errInvalidSummary)
 		}
 		return ValidationSummary{}, fmt.Errorf("decoding validation summary trailer: %w", err)
 	}
@@ -77,14 +84,14 @@ func DecodeValidationSummary(r io.Reader, expectedBackend StateBackend) (Validat
 	if err != nil {
 		return ValidationSummary{}, err
 	}
-	if err := ValidateValidationSummary(summary, expectedBackend); err != nil {
+	if err := CheckSummary(summary, expectedBackend); err != nil {
 		return ValidationSummary{}, err
 	}
 	return summary, nil
 }
 
-// ValidateValidationSummary validates the backend, shape, identities, and check results.
-func ValidateValidationSummary(summary ValidationSummary, expectedBackend StateBackend) error {
+// CheckSummary validates the backend, shape, identities, and check results.
+func CheckSummary(summary ValidationSummary, expectedBackend StateBackend) error {
 	if err := validateBackend(expectedBackend, "expected"); err != nil {
 		return err
 	}
@@ -92,13 +99,18 @@ func ValidateValidationSummary(summary ValidationSummary, expectedBackend StateB
 		return err
 	}
 	if summary.StateBackend != expectedBackend {
-		return fmt.Errorf("summary backend %q does not match expected backend %q", summary.StateBackend, expectedBackend)
+		return fmt.Errorf(
+			"%w: summary backend %q does not match expected backend %q",
+			errInvalidSummary,
+			summary.StateBackend,
+			expectedBackend,
+		)
 	}
 	if summary.Checks == nil {
-		return errors.New("summary checks are missing")
+		return fmt.Errorf("summary checks are missing: %w", errInvalidSummary)
 	}
 	if len(summary.Checks) == 0 {
-		return errors.New("summary has no checks")
+		return fmt.Errorf("%w: summary has no checks", errInvalidSummary)
 	}
 
 	checks := make(map[validationCheckID]struct{}, len(summary.Checks))
@@ -111,17 +123,34 @@ func ValidateValidationSummary(summary ValidationSummary, expectedBackend StateB
 			return fmt.Errorf("check %q: %w", check.CheckName, err)
 		}
 		if check.LivePodCount < 0 {
-			return fmt.Errorf("check %q on node %q has negative live pod count %d", check.CheckName, check.NodeName, check.LivePodCount)
+			return fmt.Errorf(
+				"%w: check %q on node %q has negative live pod count %d",
+				errInvalidSummary,
+				check.CheckName,
+				check.NodeName,
+				check.LivePodCount,
+			)
 		}
 		if check.Expected == nil {
-			return fmt.Errorf("check %q on node %q is missing expected state", check.CheckName, check.NodeName)
+			return fmt.Errorf(
+				"%w: check %q on node %q is missing expected state",
+				errInvalidSummary,
+				check.CheckName,
+				check.NodeName,
+			)
 		}
 		if check.Actual == nil {
-			return fmt.Errorf("check %q on node %q is missing actual state", check.CheckName, check.NodeName)
+			return fmt.Errorf(
+				"%w: check %q on node %q is missing actual state",
+				errInvalidSummary,
+				check.CheckName,
+				check.NodeName,
+			)
 		}
 		if check.LivePodCount > 0 && len(check.Expected) == 0 {
 			return fmt.Errorf(
-				"check %q on node %q has %d live pods but empty expected state",
+				"%w: check %q on node %q has %d live pods but empty expected state",
+				errInvalidSummary,
 				check.CheckName,
 				check.NodeName,
 				check.LivePodCount,
@@ -130,7 +159,12 @@ func ValidateValidationSummary(summary ValidationSummary, expectedBackend StateB
 
 		key := checkKey(check)
 		if _, ok := checks[key]; ok {
-			return fmt.Errorf("duplicate check %q on node %q", check.CheckName, check.NodeName)
+			return fmt.Errorf(
+				"%w: duplicate check %q on node %q",
+				errInvalidSummary,
+				check.CheckName,
+				check.NodeName,
+			)
 		}
 		checks[key] = struct{}{}
 
@@ -155,17 +189,22 @@ func ComparePodIPIdentities(expected, actual []PodIPIdentity) error {
 	missing := identityDifference(expectedSet, actualSet)
 	unexpected := identityDifference(actualSet, expectedSet)
 	if len(missing) != 0 || len(unexpected) != 0 {
-		return fmt.Errorf("pod/IP identity mismatch: missing=%v unexpected=%v", missing, unexpected)
+		return fmt.Errorf(
+			"pod/IP identity mismatch: missing=%v unexpected=%v: %w",
+			missing,
+			unexpected,
+			errInvalidIdentity,
+		)
 	}
 	return nil
 }
 
 // CompareValidationSummaries requires exact check, live-pod, pod, and IP identity equality.
 func CompareValidationSummaries(baseline, candidate ValidationSummary, expectedBackend StateBackend) error {
-	if err := ValidateValidationSummary(baseline, expectedBackend); err != nil {
+	if err := CheckSummary(baseline, expectedBackend); err != nil {
 		return fmt.Errorf("invalid baseline summary: %w", err)
 	}
-	if err := ValidateValidationSummary(candidate, expectedBackend); err != nil {
+	if err := CheckSummary(candidate, expectedBackend); err != nil {
 		return fmt.Errorf("invalid candidate summary: %w", err)
 	}
 
@@ -198,7 +237,7 @@ func CompareValidationSummaries(baseline, candidate ValidationSummary, expectedB
 		}
 		if err := ComparePodIPIdentities(baselineCheck.Expected, candidateCheck.Expected); err != nil {
 			return fmt.Errorf(
-				"%w: check %q on node %q expected state changed: %v",
+				"%w: check %q on node %q expected state changed: %w",
 				ErrSummaryRegression,
 				candidateCheck.CheckName,
 				candidateCheck.NodeName,
@@ -207,7 +246,7 @@ func CompareValidationSummaries(baseline, candidate ValidationSummary, expectedB
 		}
 		if err := ComparePodIPIdentities(baselineCheck.Actual, candidateCheck.Actual); err != nil {
 			return fmt.Errorf(
-				"%w: check %q on node %q actual state changed: %v",
+				"%w: check %q on node %q actual state changed: %w",
 				ErrSummaryRegression,
 				candidateCheck.CheckName,
 				candidateCheck.NodeName,
@@ -230,10 +269,10 @@ func CompareValidationSummaries(baseline, candidate ValidationSummary, expectedB
 
 func validationSummaryFromWire(wire validationSummaryWire) (ValidationSummary, error) {
 	if wire.StateBackend == nil {
-		return ValidationSummary{}, errors.New("summary stateBackend is missing")
+		return ValidationSummary{}, fmt.Errorf("summary stateBackend is missing: %w", errInvalidSummary)
 	}
 	if wire.Checks == nil {
-		return ValidationSummary{}, errors.New("summary checks are missing")
+		return ValidationSummary{}, fmt.Errorf("summary checks are missing: %w", errInvalidSummary)
 	}
 
 	summary := ValidationSummary{
@@ -244,15 +283,15 @@ func validationSummaryFromWire(wire validationSummaryWire) (ValidationSummary, e
 		check := (*wire.Checks)[i]
 		switch {
 		case check.CheckName == nil:
-			return ValidationSummary{}, fmt.Errorf("check %d checkName is missing", i)
+			return ValidationSummary{}, fmt.Errorf("%w: check %d checkName is missing", errInvalidSummary, i)
 		case check.NodeName == nil:
-			return ValidationSummary{}, fmt.Errorf("check %d nodeName is missing", i)
+			return ValidationSummary{}, fmt.Errorf("%w: check %d nodeName is missing", errInvalidSummary, i)
 		case check.LivePodCount == nil:
-			return ValidationSummary{}, fmt.Errorf("check %d livePodCount is missing", i)
+			return ValidationSummary{}, fmt.Errorf("%w: check %d livePodCount is missing", errInvalidSummary, i)
 		case check.Expected == nil:
-			return ValidationSummary{}, fmt.Errorf("check %d expected state is missing", i)
+			return ValidationSummary{}, fmt.Errorf("%w: check %d expected state is missing", errInvalidSummary, i)
 		case check.Actual == nil:
-			return ValidationSummary{}, fmt.Errorf("check %d actual state is missing", i)
+			return ValidationSummary{}, fmt.Errorf("%w: check %d actual state is missing", errInvalidSummary, i)
 		}
 		summary.Checks[i] = ValidationCheckSummary{
 			CheckName:    *check.CheckName,
@@ -268,20 +307,20 @@ func validationSummaryFromWire(wire validationSummaryWire) (ValidationSummary, e
 func validateBackend(backend StateBackend, source string) error {
 	value := string(backend)
 	if value == "" {
-		return fmt.Errorf("%s backend is empty", source)
+		return fmt.Errorf("%w: %s backend is empty", errInvalidBackend, source)
 	}
 	if strings.TrimSpace(value) != value {
-		return fmt.Errorf("%s backend %q contains surrounding whitespace", source, backend)
+		return fmt.Errorf("%w: %s backend %q contains surrounding whitespace", errInvalidBackend, source, backend)
 	}
 	return nil
 }
 
 func validateIdentifier(value, field string) error {
 	if value == "" {
-		return fmt.Errorf("%s is empty", field)
+		return fmt.Errorf("%w: %s is empty", errInvalidIdentifier, field)
 	}
 	if strings.TrimSpace(value) != value {
-		return fmt.Errorf("%s %q contains surrounding whitespace", field, value)
+		return fmt.Errorf("%w: %s %q contains surrounding whitespace", errInvalidIdentifier, field, value)
 	}
 	return nil
 }
@@ -295,14 +334,20 @@ func podIPIdentitySet(identities []PodIPIdentity) (map[PodIPIdentity]struct{}, e
 			return nil, fmt.Errorf("identity %d: %w", i, err)
 		}
 		if !identity.IP.IsValid() {
-			return nil, fmt.Errorf("identity %d for pod %q has an invalid IP", i, identity.PodID)
+			return nil, fmt.Errorf("identity %d for pod %q has an invalid IP: %w", i, identity.PodID, errInvalidIdentity)
 		}
 		identity.IP = identity.IP.Unmap()
 		if _, ok := set[identity]; ok {
-			return nil, fmt.Errorf("duplicate identity %s", formatIdentity(identity))
+			return nil, fmt.Errorf("duplicate identity %s: %w", formatIdentity(identity), errInvalidIdentity)
 		}
 		if owner, ok := owners[identity.IP]; ok {
-			return nil, fmt.Errorf("duplicate IP %s for pods %q and %q", identity.IP, owner, identity.PodID)
+			return nil, fmt.Errorf(
+				"duplicate IP %s for pods %q and %q: %w",
+				identity.IP,
+				owner,
+				identity.PodID,
+				errInvalidIdentity,
+			)
 		}
 		set[identity] = struct{}{}
 		owners[identity.IP] = identity.PodID

--- a/test/validate/summary.go
+++ b/test/validate/summary.go
@@ -52,8 +52,32 @@ type validationCheckID struct {
 	node string
 }
 
-// ErrSummaryRegression identifies a validation summary mismatch.
-var ErrSummaryRegression = errors.New("validation summary regression")
+var (
+	// ErrSummaryRegression identifies a validation summary mismatch.
+	ErrSummaryRegression = errors.New("validation summary regression")
+
+	errMultipleJSONValues             = errors.New("multiple JSON values")
+	errSummaryBackendMismatch         = errors.New("summary backend mismatch")
+	errSummaryChecksMissing           = errors.New("summary checks are missing")
+	errSummaryHasNoChecks             = errors.New("summary has no checks")
+	errNegativeLivePodCount           = errors.New("negative live pod count")
+	errMissingExpectedState           = errors.New("expected state is missing")
+	errMissingActualState             = errors.New("actual state is missing")
+	errLivePodsWithEmptyExpectedState = errors.New("live pods with empty expected state")
+	errDuplicateCheck                 = errors.New("duplicate check")
+	errPodIPIdentityMismatch          = errors.New("pod/IP identity mismatch")
+	errSummaryStateBackendMissing     = errors.New("summary stateBackend is missing")
+	errCheckNameMissing               = errors.New("checkName is missing")
+	errCheckNodeNameMissing           = errors.New("nodeName is missing")
+	errCheckLivePodCountMissing       = errors.New("livePodCount is missing")
+	errBackendEmpty                   = errors.New("backend is empty")
+	errBackendWhitespace              = errors.New("backend contains surrounding whitespace")
+	errIdentifierEmpty                = errors.New("identifier is empty")
+	errIdentifierWhitespace           = errors.New("identifier contains surrounding whitespace")
+	errInvalidIdentityIP              = errors.New("invalid IP")
+	errDuplicateIdentity              = errors.New("duplicate identity")
+	errDuplicateIP                    = errors.New("duplicate IP")
+)
 
 // DecodeValidationSummary strictly decodes and validates one summary.
 func DecodeValidationSummary(r io.Reader, expectedBackend StateBackend) (ValidationSummary, error) {
@@ -68,7 +92,7 @@ func DecodeValidationSummary(r io.Reader, expectedBackend StateBackend) (Validat
 	var trailing json.RawMessage
 	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
 		if err == nil {
-			return ValidationSummary{}, errors.New("decoding validation summary: multiple JSON values")
+			return ValidationSummary{}, errMultipleJSONValues
 		}
 		return ValidationSummary{}, fmt.Errorf("decoding validation summary trailer: %w", err)
 	}
@@ -77,14 +101,14 @@ func DecodeValidationSummary(r io.Reader, expectedBackend StateBackend) (Validat
 	if err != nil {
 		return ValidationSummary{}, err
 	}
-	if err := ValidateValidationSummary(summary, expectedBackend); err != nil {
+	if err := CheckSummary(summary, expectedBackend); err != nil {
 		return ValidationSummary{}, err
 	}
 	return summary, nil
 }
 
-// ValidateValidationSummary validates the backend, shape, identities, and check results.
-func ValidateValidationSummary(summary ValidationSummary, expectedBackend StateBackend) error {
+// CheckSummary validates the backend, shape, identities, and check results.
+func CheckSummary(summary ValidationSummary, expectedBackend StateBackend) error {
 	if err := validateBackend(expectedBackend, "expected"); err != nil {
 		return err
 	}
@@ -92,13 +116,18 @@ func ValidateValidationSummary(summary ValidationSummary, expectedBackend StateB
 		return err
 	}
 	if summary.StateBackend != expectedBackend {
-		return fmt.Errorf("summary backend %q does not match expected backend %q", summary.StateBackend, expectedBackend)
+		return fmt.Errorf(
+			"summary backend %q does not match expected backend %q: %w",
+			summary.StateBackend,
+			expectedBackend,
+			errSummaryBackendMismatch,
+		)
 	}
 	if summary.Checks == nil {
-		return errors.New("summary checks are missing")
+		return errSummaryChecksMissing
 	}
 	if len(summary.Checks) == 0 {
-		return errors.New("summary has no checks")
+		return errSummaryHasNoChecks
 	}
 
 	checks := make(map[validationCheckID]struct{}, len(summary.Checks))
@@ -111,26 +140,48 @@ func ValidateValidationSummary(summary ValidationSummary, expectedBackend StateB
 			return fmt.Errorf("check %q: %w", check.CheckName, err)
 		}
 		if check.LivePodCount < 0 {
-			return fmt.Errorf("check %q on node %q has negative live pod count %d", check.CheckName, check.NodeName, check.LivePodCount)
-		}
-		if check.Expected == nil {
-			return fmt.Errorf("check %q on node %q is missing expected state", check.CheckName, check.NodeName)
-		}
-		if check.Actual == nil {
-			return fmt.Errorf("check %q on node %q is missing actual state", check.CheckName, check.NodeName)
-		}
-		if check.LivePodCount > 0 && len(check.Expected) == 0 {
 			return fmt.Errorf(
-				"check %q on node %q has %d live pods but empty expected state",
+				"check %q on node %q has negative live pod count %d: %w",
 				check.CheckName,
 				check.NodeName,
 				check.LivePodCount,
+				errNegativeLivePodCount,
+			)
+		}
+		if check.Expected == nil {
+			return fmt.Errorf(
+				"check %q on node %q is missing expected state: %w",
+				check.CheckName,
+				check.NodeName,
+				errMissingExpectedState,
+			)
+		}
+		if check.Actual == nil {
+			return fmt.Errorf(
+				"check %q on node %q is missing actual state: %w",
+				check.CheckName,
+				check.NodeName,
+				errMissingActualState,
+			)
+		}
+		if check.LivePodCount > 0 && len(check.Expected) == 0 {
+			return fmt.Errorf(
+				"check %q on node %q has %d live pods but empty expected state: %w",
+				check.CheckName,
+				check.NodeName,
+				check.LivePodCount,
+				errLivePodsWithEmptyExpectedState,
 			)
 		}
 
 		key := checkKey(check)
 		if _, ok := checks[key]; ok {
-			return fmt.Errorf("duplicate check %q on node %q", check.CheckName, check.NodeName)
+			return fmt.Errorf(
+				"duplicate check %q on node %q: %w",
+				check.CheckName,
+				check.NodeName,
+				errDuplicateCheck,
+			)
 		}
 		checks[key] = struct{}{}
 
@@ -155,17 +206,22 @@ func ComparePodIPIdentities(expected, actual []PodIPIdentity) error {
 	missing := identityDifference(expectedSet, actualSet)
 	unexpected := identityDifference(actualSet, expectedSet)
 	if len(missing) != 0 || len(unexpected) != 0 {
-		return fmt.Errorf("pod/IP identity mismatch: missing=%v unexpected=%v", missing, unexpected)
+		return fmt.Errorf(
+			"pod/IP identity mismatch: missing=%v unexpected=%v: %w",
+			missing,
+			unexpected,
+			errPodIPIdentityMismatch,
+		)
 	}
 	return nil
 }
 
 // CompareValidationSummaries requires exact check, live-pod, pod, and IP identity equality.
 func CompareValidationSummaries(baseline, candidate ValidationSummary, expectedBackend StateBackend) error {
-	if err := ValidateValidationSummary(baseline, expectedBackend); err != nil {
+	if err := CheckSummary(baseline, expectedBackend); err != nil {
 		return fmt.Errorf("invalid baseline summary: %w", err)
 	}
-	if err := ValidateValidationSummary(candidate, expectedBackend); err != nil {
+	if err := CheckSummary(candidate, expectedBackend); err != nil {
 		return fmt.Errorf("invalid candidate summary: %w", err)
 	}
 
@@ -198,7 +254,7 @@ func CompareValidationSummaries(baseline, candidate ValidationSummary, expectedB
 		}
 		if err := ComparePodIPIdentities(baselineCheck.Expected, candidateCheck.Expected); err != nil {
 			return fmt.Errorf(
-				"%w: check %q on node %q expected state changed: %v",
+				"%w: check %q on node %q expected state changed: %w",
 				ErrSummaryRegression,
 				candidateCheck.CheckName,
 				candidateCheck.NodeName,
@@ -207,7 +263,7 @@ func CompareValidationSummaries(baseline, candidate ValidationSummary, expectedB
 		}
 		if err := ComparePodIPIdentities(baselineCheck.Actual, candidateCheck.Actual); err != nil {
 			return fmt.Errorf(
-				"%w: check %q on node %q actual state changed: %v",
+				"%w: check %q on node %q actual state changed: %w",
 				ErrSummaryRegression,
 				candidateCheck.CheckName,
 				candidateCheck.NodeName,
@@ -230,10 +286,10 @@ func CompareValidationSummaries(baseline, candidate ValidationSummary, expectedB
 
 func validationSummaryFromWire(wire validationSummaryWire) (ValidationSummary, error) {
 	if wire.StateBackend == nil {
-		return ValidationSummary{}, errors.New("summary stateBackend is missing")
+		return ValidationSummary{}, errSummaryStateBackendMissing
 	}
 	if wire.Checks == nil {
-		return ValidationSummary{}, errors.New("summary checks are missing")
+		return ValidationSummary{}, errSummaryChecksMissing
 	}
 
 	summary := ValidationSummary{
@@ -244,15 +300,15 @@ func validationSummaryFromWire(wire validationSummaryWire) (ValidationSummary, e
 		check := (*wire.Checks)[i]
 		switch {
 		case check.CheckName == nil:
-			return ValidationSummary{}, fmt.Errorf("check %d checkName is missing", i)
+			return ValidationSummary{}, fmt.Errorf("check %d: %w", i, errCheckNameMissing)
 		case check.NodeName == nil:
-			return ValidationSummary{}, fmt.Errorf("check %d nodeName is missing", i)
+			return ValidationSummary{}, fmt.Errorf("check %d: %w", i, errCheckNodeNameMissing)
 		case check.LivePodCount == nil:
-			return ValidationSummary{}, fmt.Errorf("check %d livePodCount is missing", i)
+			return ValidationSummary{}, fmt.Errorf("check %d: %w", i, errCheckLivePodCountMissing)
 		case check.Expected == nil:
-			return ValidationSummary{}, fmt.Errorf("check %d expected state is missing", i)
+			return ValidationSummary{}, fmt.Errorf("check %d: %w", i, errMissingExpectedState)
 		case check.Actual == nil:
-			return ValidationSummary{}, fmt.Errorf("check %d actual state is missing", i)
+			return ValidationSummary{}, fmt.Errorf("check %d: %w", i, errMissingActualState)
 		}
 		summary.Checks[i] = ValidationCheckSummary{
 			CheckName:    *check.CheckName,
@@ -268,20 +324,20 @@ func validationSummaryFromWire(wire validationSummaryWire) (ValidationSummary, e
 func validateBackend(backend StateBackend, source string) error {
 	value := string(backend)
 	if value == "" {
-		return fmt.Errorf("%s backend is empty", source)
+		return fmt.Errorf("%s backend is empty: %w", source, errBackendEmpty)
 	}
 	if strings.TrimSpace(value) != value {
-		return fmt.Errorf("%s backend %q contains surrounding whitespace", source, backend)
+		return fmt.Errorf("%s backend %q contains surrounding whitespace: %w", source, backend, errBackendWhitespace)
 	}
 	return nil
 }
 
 func validateIdentifier(value, field string) error {
 	if value == "" {
-		return fmt.Errorf("%s is empty", field)
+		return fmt.Errorf("%s is empty: %w", field, errIdentifierEmpty)
 	}
 	if strings.TrimSpace(value) != value {
-		return fmt.Errorf("%s %q contains surrounding whitespace", field, value)
+		return fmt.Errorf("%s %q contains surrounding whitespace: %w", field, value, errIdentifierWhitespace)
 	}
 	return nil
 }
@@ -295,14 +351,25 @@ func podIPIdentitySet(identities []PodIPIdentity) (map[PodIPIdentity]struct{}, e
 			return nil, fmt.Errorf("identity %d: %w", i, err)
 		}
 		if !identity.IP.IsValid() {
-			return nil, fmt.Errorf("identity %d for pod %q has an invalid IP", i, identity.PodID)
+			return nil, fmt.Errorf(
+				"identity %d for pod %q has an invalid IP: %w",
+				i,
+				identity.PodID,
+				errInvalidIdentityIP,
+			)
 		}
 		identity.IP = identity.IP.Unmap()
 		if _, ok := set[identity]; ok {
-			return nil, fmt.Errorf("duplicate identity %s", formatIdentity(identity))
+			return nil, fmt.Errorf("duplicate identity %s: %w", formatIdentity(identity), errDuplicateIdentity)
 		}
 		if owner, ok := owners[identity.IP]; ok {
-			return nil, fmt.Errorf("duplicate IP %s for pods %q and %q", identity.IP, owner, identity.PodID)
+			return nil, fmt.Errorf(
+				"duplicate IP %s for pods %q and %q: %w",
+				identity.IP,
+				owner,
+				identity.PodID,
+				errDuplicateIP,
+			)
 		}
 		set[identity] = struct{}{}
 		owners[identity.IP] = identity.PodID

--- a/test/validate/summary_test.go
+++ b/test/validate/summary_test.go
@@ -1,0 +1,472 @@
+package validate
+
+import (
+	"errors"
+	"net/netip"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const testStateBackend StateBackend = "test-backend"
+
+func TestDecodeValidationSummary(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		backend StateBackend
+		wantErr string
+	}{
+		{
+			name:    "valid",
+			raw:     `{"stateBackend":"test-backend","checks":[{"checkName":"state","nodeName":"node-1","livePodCount":1,"expected":[{"podID":"ns/pod/uid","ip":"10.0.0.2"}],"actual":[{"podID":"ns/pod/uid","ip":"10.0.0.2"}]}]}`,
+			backend: testStateBackend,
+		},
+		{
+			name:    "malformed JSON",
+			raw:     `{`,
+			backend: testStateBackend,
+			wantErr: "decoding validation summary",
+		},
+		{
+			name:    "unknown field",
+			raw:     `{"stateBackend":"test-backend","checks":[],"unknown":true}`,
+			backend: testStateBackend,
+			wantErr: "unknown field",
+		},
+		{
+			name:    "trailing JSON value",
+			raw:     `{"stateBackend":"test-backend","checks":[]} {}`,
+			backend: testStateBackend,
+			wantErr: "multiple JSON values",
+		},
+		{
+			name:    "invalid IP",
+			raw:     `{"stateBackend":"test-backend","checks":[{"checkName":"state","nodeName":"node-1","livePodCount":1,"expected":[{"podID":"pod","ip":"bad"}],"actual":[]}]}`,
+			backend: testStateBackend,
+			wantErr: "ParseAddr",
+		},
+		{
+			name:    "missing state backend",
+			raw:     `{"checks":[]}`,
+			backend: testStateBackend,
+			wantErr: "stateBackend is missing",
+		},
+		{
+			name:    "missing required checks",
+			raw:     `{"stateBackend":"test-backend"}`,
+			backend: testStateBackend,
+			wantErr: "summary checks are missing",
+		},
+		{
+			name:    "missing check name",
+			raw:     `{"stateBackend":"test-backend","checks":[{"nodeName":"node-1","livePodCount":0,"expected":[],"actual":[]}]}`,
+			backend: testStateBackend,
+			wantErr: "checkName is missing",
+		},
+		{
+			name:    "missing live pod count",
+			raw:     `{"stateBackend":"test-backend","checks":[{"checkName":"state","nodeName":"node-1","expected":[],"actual":[]}]}`,
+			backend: testStateBackend,
+			wantErr: "livePodCount is missing",
+		},
+		{
+			name:    "missing expected state",
+			raw:     `{"stateBackend":"test-backend","checks":[{"checkName":"state","nodeName":"node-1","livePodCount":0,"actual":[]}]}`,
+			backend: testStateBackend,
+			wantErr: "expected state is missing",
+		},
+		{
+			name:    "missing actual state",
+			raw:     `{"stateBackend":"test-backend","checks":[{"checkName":"state","nodeName":"node-1","livePodCount":0,"expected":[]}]}`,
+			backend: testStateBackend,
+			wantErr: "actual state is missing",
+		},
+		{
+			name:    "wrong backend",
+			raw:     `{"stateBackend":"other","checks":[]}`,
+			backend: testStateBackend,
+			wantErr: "does not match",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := DecodeValidationSummary(strings.NewReader(tt.raw), tt.backend)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestValidateValidationSummary(t *testing.T) {
+	valid := validValidationSummary()
+	tests := []struct {
+		name    string
+		mutate  func(*ValidationSummary)
+		backend StateBackend
+		wantErr string
+	}{
+		{
+			name:    "valid dual-stack state",
+			backend: testStateBackend,
+		},
+		{
+			name: "valid empty state without live pods",
+			mutate: func(summary *ValidationSummary) {
+				summary.Checks[0].LivePodCount = 0
+				summary.Checks[0].Expected = []PodIPIdentity{}
+				summary.Checks[0].Actual = []PodIPIdentity{}
+			},
+			backend: testStateBackend,
+		},
+		{
+			name:    "empty expected backend",
+			backend: "",
+			wantErr: "expected backend is empty",
+		},
+		{
+			name: "empty summary backend",
+			mutate: func(summary *ValidationSummary) {
+				summary.StateBackend = ""
+			},
+			backend: testStateBackend,
+			wantErr: "summary backend is empty",
+		},
+		{
+			name: "backend whitespace",
+			mutate: func(summary *ValidationSummary) {
+				summary.StateBackend = " test-backend"
+			},
+			backend: testStateBackend,
+			wantErr: "surrounding whitespace",
+		},
+		{
+			name: "wrong backend",
+			mutate: func(summary *ValidationSummary) {
+				summary.StateBackend = "other"
+			},
+			backend: testStateBackend,
+			wantErr: "does not match",
+		},
+		{
+			name: "missing checks",
+			mutate: func(summary *ValidationSummary) {
+				summary.Checks = nil
+			},
+			backend: testStateBackend,
+			wantErr: "checks are missing",
+		},
+		{
+			name: "empty checks",
+			mutate: func(summary *ValidationSummary) {
+				summary.Checks = []ValidationCheckSummary{}
+			},
+			backend: testStateBackend,
+			wantErr: "has no checks",
+		},
+		{
+			name: "empty check name",
+			mutate: func(summary *ValidationSummary) {
+				summary.Checks[0].CheckName = " "
+			},
+			backend: testStateBackend,
+			wantErr: "surrounding whitespace",
+		},
+		{
+			name: "empty node name",
+			mutate: func(summary *ValidationSummary) {
+				summary.Checks[0].NodeName = ""
+			},
+			backend: testStateBackend,
+			wantErr: "node name is empty",
+		},
+		{
+			name: "negative live pod count",
+			mutate: func(summary *ValidationSummary) {
+				summary.Checks[0].LivePodCount = -1
+			},
+			backend: testStateBackend,
+			wantErr: "negative live pod count",
+		},
+		{
+			name: "missing expected state",
+			mutate: func(summary *ValidationSummary) {
+				summary.Checks[0].Expected = nil
+			},
+			backend: testStateBackend,
+			wantErr: "missing expected state",
+		},
+		{
+			name: "missing actual state",
+			mutate: func(summary *ValidationSummary) {
+				summary.Checks[0].Actual = nil
+			},
+			backend: testStateBackend,
+			wantErr: "missing actual state",
+		},
+		{
+			name: "live pods with empty expected state",
+			mutate: func(summary *ValidationSummary) {
+				summary.Checks[0].Expected = []PodIPIdentity{}
+				summary.Checks[0].Actual = []PodIPIdentity{}
+			},
+			backend: testStateBackend,
+			wantErr: "live pods but empty expected state",
+		},
+		{
+			name: "duplicate check",
+			mutate: func(summary *ValidationSummary) {
+				summary.Checks = append(summary.Checks, summary.Checks[0])
+			},
+			backend: testStateBackend,
+			wantErr: "duplicate check",
+		},
+		{
+			name: "expected and actual differ",
+			mutate: func(summary *ValidationSummary) {
+				summary.Checks[0].Actual[0].PodID = "other-pod"
+			},
+			backend: testStateBackend,
+			wantErr: "pod/IP identity mismatch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			summary := cloneValidationSummary(valid)
+			if tt.mutate != nil {
+				tt.mutate(&summary)
+			}
+			err := ValidateValidationSummary(summary, tt.backend)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestComparePodIPIdentities(t *testing.T) {
+	pod1v4 := testIdentity("pod-1", "10.0.0.2")
+	pod1v6 := testIdentity("pod-1", "fd00::2")
+	tests := []struct {
+		name     string
+		expected []PodIPIdentity
+		actual   []PodIPIdentity
+		wantErr  string
+	}{
+		{
+			name:     "exact reordered identities",
+			expected: []PodIPIdentity{pod1v4, pod1v6},
+			actual:   []PodIPIdentity{pod1v6, pod1v4},
+		},
+		{
+			name:     "missing identity",
+			expected: []PodIPIdentity{pod1v4, pod1v6},
+			actual:   []PodIPIdentity{pod1v4},
+			wantErr:  "missing=[pod-1/fd00::2]",
+		},
+		{
+			name:     "unexpected identity",
+			expected: []PodIPIdentity{pod1v4},
+			actual:   []PodIPIdentity{pod1v4, pod1v6},
+			wantErr:  "unexpected=[pod-1/fd00::2]",
+		},
+		{
+			name:     "changed pod identity",
+			expected: []PodIPIdentity{pod1v4},
+			actual:   []PodIPIdentity{testIdentity("pod-2", "10.0.0.2")},
+			wantErr:  "missing=[pod-1/10.0.0.2]",
+		},
+		{
+			name:     "empty pod ID",
+			expected: []PodIPIdentity{{IP: netip.MustParseAddr("10.0.0.2")}},
+			actual:   []PodIPIdentity{},
+			wantErr:  "pod ID is empty",
+		},
+		{
+			name:     "invalid IP",
+			expected: []PodIPIdentity{{PodID: "pod-1"}},
+			actual:   []PodIPIdentity{},
+			wantErr:  "invalid IP",
+		},
+		{
+			name:     "duplicate identity",
+			expected: []PodIPIdentity{pod1v4, pod1v4},
+			actual:   []PodIPIdentity{},
+			wantErr:  "duplicate identity",
+		},
+		{
+			name:     "duplicate actual identity",
+			expected: []PodIPIdentity{pod1v4},
+			actual:   []PodIPIdentity{pod1v4, pod1v4},
+			wantErr:  "invalid actual state: duplicate identity",
+		},
+		{
+			name:     "duplicate IP across pods",
+			expected: []PodIPIdentity{pod1v4, testIdentity("pod-2", "10.0.0.2")},
+			actual:   []PodIPIdentity{},
+			wantErr:  "duplicate IP",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ComparePodIPIdentities(tt.expected, tt.actual)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestCompareValidationSummaries(t *testing.T) {
+	baseline := validValidationSummary()
+	tests := []struct {
+		name    string
+		mutate  func(*ValidationSummary)
+		wantErr string
+	}{
+		{
+			name: "exact reordered summary",
+			mutate: func(summary *ValidationSummary) {
+				summary.Checks[0].Expected[0], summary.Checks[0].Expected[1] =
+					summary.Checks[0].Expected[1], summary.Checks[0].Expected[0]
+				summary.Checks[0].Actual[0], summary.Checks[0].Actual[1] =
+					summary.Checks[0].Actual[1], summary.Checks[0].Actual[0]
+			},
+		},
+		{
+			name: "missing check",
+			mutate: func(summary *ValidationSummary) {
+				summary.Checks = summary.Checks[:0]
+			},
+			wantErr: "summary has no checks",
+		},
+		{
+			name: "unexpected check",
+			mutate: func(summary *ValidationSummary) {
+				check := summary.Checks[0]
+				check.CheckName = "other"
+				summary.Checks = append(summary.Checks, check)
+			},
+			wantErr: "unexpected check",
+		},
+		{
+			name: "reduced live pod count",
+			mutate: func(summary *ValidationSummary) {
+				summary.Checks[0].LivePodCount--
+			},
+			wantErr: "live pod count changed",
+		},
+		{
+			name: "increased live pod count",
+			mutate: func(summary *ValidationSummary) {
+				summary.Checks[0].LivePodCount++
+			},
+			wantErr: "live pod count changed",
+		},
+		{
+			name: "reduced identities",
+			mutate: func(summary *ValidationSummary) {
+				summary.Checks[0].Expected = summary.Checks[0].Expected[:1]
+				summary.Checks[0].Actual = summary.Checks[0].Actual[:1]
+			},
+			wantErr: "expected state changed",
+		},
+		{
+			name: "changed pod and IP identity",
+			mutate: func(summary *ValidationSummary) {
+				replacement := testIdentity("pod-2", "10.0.0.9")
+				summary.Checks[0].Expected[0] = replacement
+				summary.Checks[0].Actual[0] = replacement
+			},
+			wantErr: "expected state changed",
+		},
+		{
+			name: "duplicate candidate check",
+			mutate: func(summary *ValidationSummary) {
+				summary.Checks = append(summary.Checks, summary.Checks[0])
+			},
+			wantErr: "duplicate check",
+		},
+		{
+			name: "wrong candidate backend",
+			mutate: func(summary *ValidationSummary) {
+				summary.StateBackend = "other"
+			},
+			wantErr: "invalid candidate summary",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			candidate := cloneValidationSummary(baseline)
+			if tt.mutate != nil {
+				tt.mutate(&candidate)
+			}
+			err := CompareValidationSummaries(baseline, candidate, testStateBackend)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+			if strings.Contains(tt.wantErr, "state changed") || strings.Contains(tt.wantErr, "live pod count") {
+				require.True(t, errors.Is(err, ErrSummaryRegression))
+			}
+		})
+	}
+}
+
+func TestCompareValidationSummariesRejectsMissingCheck(t *testing.T) {
+	baseline := validValidationSummary()
+	second := baseline.Checks[0]
+	second.CheckName = "second"
+	baseline.Checks = append(baseline.Checks, second)
+
+	candidate := cloneValidationSummary(baseline)
+	candidate.Checks = candidate.Checks[:1]
+
+	err := CompareValidationSummaries(baseline, candidate, testStateBackend)
+	require.ErrorContains(t, err, "candidate is missing checks [second/node-1]")
+	require.ErrorIs(t, err, ErrSummaryRegression)
+}
+
+func validValidationSummary() ValidationSummary {
+	identities := []PodIPIdentity{
+		testIdentity("ns/pod/uid", "10.0.0.2"),
+		testIdentity("ns/pod/uid", "fd00::2"),
+	}
+	return ValidationSummary{
+		StateBackend: testStateBackend,
+		Checks: []ValidationCheckSummary{{
+			CheckName:    "state",
+			NodeName:     "node-1",
+			LivePodCount: 1,
+			Expected:     append([]PodIPIdentity(nil), identities...),
+			Actual:       append([]PodIPIdentity(nil), identities...),
+		}},
+	}
+}
+
+func cloneValidationSummary(summary ValidationSummary) ValidationSummary {
+	cloned := summary
+	cloned.Checks = append([]ValidationCheckSummary(nil), summary.Checks...)
+	for i := range cloned.Checks {
+		cloned.Checks[i].Expected = append([]PodIPIdentity(nil), summary.Checks[i].Expected...)
+		cloned.Checks[i].Actual = append([]PodIPIdentity(nil), summary.Checks[i].Actual...)
+	}
+	return cloned
+}
+
+func testIdentity(podID, ip string) PodIPIdentity {
+	return PodIPIdentity{PodID: podID, IP: netip.MustParseAddr(ip)}
+}

--- a/test/validate/summary_test.go
+++ b/test/validate/summary_test.go
@@ -1,7 +1,6 @@
 package validate
 
 import (
-	"errors"
 	"net/netip"
 	"strings"
 	"testing"
@@ -11,6 +10,14 @@ import (
 
 const testStateBackend StateBackend = "test-backend"
 
+const (
+	testOtherBackend         = "other"
+	testInvalidIP            = "invalid IP"
+	testMissingExpectedState = "missing expected state"
+	testMissingActualState   = "missing actual state"
+	testDuplicateCheck       = "duplicate check"
+)
+
 func TestDecodeValidationSummary(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -19,8 +26,17 @@ func TestDecodeValidationSummary(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:    "valid",
-			raw:     `{"stateBackend":"test-backend","checks":[{"checkName":"state","nodeName":"node-1","livePodCount":1,"expected":[{"podID":"ns/pod/uid","ip":"10.0.0.2"}],"actual":[{"podID":"ns/pod/uid","ip":"10.0.0.2"}]}]}`,
+			name: "valid",
+			raw: `{
+				"stateBackend":"test-backend",
+				"checks":[{
+					"checkName":"state",
+					"nodeName":"node-1",
+					"livePodCount":1,
+					"expected":[{"podID":"ns/pod/uid","ip":"10.0.0.2"}],
+					"actual":[{"podID":"ns/pod/uid","ip":"10.0.0.2"}]
+				}]
+			}`,
 			backend: testStateBackend,
 		},
 		{
@@ -42,7 +58,7 @@ func TestDecodeValidationSummary(t *testing.T) {
 			wantErr: "multiple JSON values",
 		},
 		{
-			name:    "invalid IP",
+			name:    testInvalidIP,
 			raw:     `{"stateBackend":"test-backend","checks":[{"checkName":"state","nodeName":"node-1","livePodCount":1,"expected":[{"podID":"pod","ip":"bad"}],"actual":[]}]}`,
 			backend: testStateBackend,
 			wantErr: "ParseAddr",
@@ -72,13 +88,13 @@ func TestDecodeValidationSummary(t *testing.T) {
 			wantErr: "livePodCount is missing",
 		},
 		{
-			name:    "missing expected state",
+			name:    testMissingExpectedState,
 			raw:     `{"stateBackend":"test-backend","checks":[{"checkName":"state","nodeName":"node-1","livePodCount":0,"actual":[]}]}`,
 			backend: testStateBackend,
 			wantErr: "expected state is missing",
 		},
 		{
-			name:    "missing actual state",
+			name:    testMissingActualState,
 			raw:     `{"stateBackend":"test-backend","checks":[{"checkName":"state","nodeName":"node-1","livePodCount":0,"expected":[]}]}`,
 			backend: testStateBackend,
 			wantErr: "actual state is missing",
@@ -103,7 +119,7 @@ func TestDecodeValidationSummary(t *testing.T) {
 	}
 }
 
-func TestValidateValidationSummary(t *testing.T) {
+func TestCheckSummary(t *testing.T) {
 	valid := validValidationSummary()
 	tests := []struct {
 		name    string
@@ -148,7 +164,7 @@ func TestValidateValidationSummary(t *testing.T) {
 		{
 			name: "wrong backend",
 			mutate: func(summary *ValidationSummary) {
-				summary.StateBackend = "other"
+				summary.StateBackend = testOtherBackend
 			},
 			backend: testStateBackend,
 			wantErr: "does not match",
@@ -194,7 +210,7 @@ func TestValidateValidationSummary(t *testing.T) {
 			wantErr: "negative live pod count",
 		},
 		{
-			name: "missing expected state",
+			name: testMissingExpectedState,
 			mutate: func(summary *ValidationSummary) {
 				summary.Checks[0].Expected = nil
 			},
@@ -202,7 +218,7 @@ func TestValidateValidationSummary(t *testing.T) {
 			wantErr: "missing expected state",
 		},
 		{
-			name: "missing actual state",
+			name: testMissingActualState,
 			mutate: func(summary *ValidationSummary) {
 				summary.Checks[0].Actual = nil
 			},
@@ -219,7 +235,7 @@ func TestValidateValidationSummary(t *testing.T) {
 			wantErr: "live pods but empty expected state",
 		},
 		{
-			name: "duplicate check",
+			name: testDuplicateCheck,
 			mutate: func(summary *ValidationSummary) {
 				summary.Checks = append(summary.Checks, summary.Checks[0])
 			},
@@ -242,7 +258,7 @@ func TestValidateValidationSummary(t *testing.T) {
 			if tt.mutate != nil {
 				tt.mutate(&summary)
 			}
-			err := ValidateValidationSummary(summary, tt.backend)
+			err := CheckSummary(summary, tt.backend)
 			if tt.wantErr == "" {
 				require.NoError(t, err)
 				return
@@ -291,7 +307,7 @@ func TestComparePodIPIdentities(t *testing.T) {
 			wantErr:  "pod ID is empty",
 		},
 		{
-			name:     "invalid IP",
+			name:     testInvalidIP,
 			expected: []PodIPIdentity{{PodID: "pod-1"}},
 			actual:   []PodIPIdentity{},
 			wantErr:  "invalid IP",
@@ -338,10 +354,12 @@ func TestCompareValidationSummaries(t *testing.T) {
 		{
 			name: "exact reordered summary",
 			mutate: func(summary *ValidationSummary) {
-				summary.Checks[0].Expected[0], summary.Checks[0].Expected[1] =
-					summary.Checks[0].Expected[1], summary.Checks[0].Expected[0]
-				summary.Checks[0].Actual[0], summary.Checks[0].Actual[1] =
-					summary.Checks[0].Actual[1], summary.Checks[0].Actual[0]
+				summary.Checks[0].Expected[0],
+					summary.Checks[0].Expected[1] = summary.Checks[0].Expected[1],
+					summary.Checks[0].Expected[0]
+				summary.Checks[0].Actual[0],
+					summary.Checks[0].Actual[1] = summary.Checks[0].Actual[1],
+					summary.Checks[0].Actual[0]
 			},
 		},
 		{
@@ -401,7 +419,7 @@ func TestCompareValidationSummaries(t *testing.T) {
 		{
 			name: "wrong candidate backend",
 			mutate: func(summary *ValidationSummary) {
-				summary.StateBackend = "other"
+				summary.StateBackend = testOtherBackend
 			},
 			wantErr: "invalid candidate summary",
 		},
@@ -420,7 +438,7 @@ func TestCompareValidationSummaries(t *testing.T) {
 			}
 			require.ErrorContains(t, err, tt.wantErr)
 			if strings.Contains(tt.wantErr, "state changed") || strings.Contains(tt.wantErr, "live pod count") {
-				require.True(t, errors.Is(err, ErrSummaryRegression))
+				require.ErrorIs(t, err, ErrSummaryRegression)
 			}
 		})
 	}

--- a/test/validate/summary_test.go
+++ b/test/validate/summary_test.go
@@ -1,7 +1,6 @@
 package validate
 
 import (
-	"errors"
 	"net/netip"
 	"strings"
 	"testing"
@@ -11,6 +10,14 @@ import (
 
 const testStateBackend StateBackend = "test-backend"
 
+const (
+	wantErrInvalidIP            = "invalid IP"
+	wantErrMissingExpectedState = "missing expected state"
+	wantErrMissingActualState   = "missing actual state"
+	otherBackend                = "other"
+	wantErrDuplicateCheck       = "duplicate check"
+)
+
 func TestDecodeValidationSummary(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -19,8 +26,10 @@ func TestDecodeValidationSummary(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:    "valid",
-			raw:     `{"stateBackend":"test-backend","checks":[{"checkName":"state","nodeName":"node-1","livePodCount":1,"expected":[{"podID":"ns/pod/uid","ip":"10.0.0.2"}],"actual":[{"podID":"ns/pod/uid","ip":"10.0.0.2"}]}]}`,
+			name: "valid",
+			raw: `{"stateBackend":"test-backend","checks":[{"checkName":"state","nodeName":"node-1",
+				"livePodCount":1,"expected":[{"podID":"ns/pod/uid","ip":"10.0.0.2"}],
+				"actual":[{"podID":"ns/pod/uid","ip":"10.0.0.2"}]}]}`,
 			backend: testStateBackend,
 		},
 		{
@@ -103,7 +112,7 @@ func TestDecodeValidationSummary(t *testing.T) {
 	}
 }
 
-func TestValidateValidationSummary(t *testing.T) {
+func TestCheckSummary(t *testing.T) {
 	valid := validValidationSummary()
 	tests := []struct {
 		name    string
@@ -148,7 +157,7 @@ func TestValidateValidationSummary(t *testing.T) {
 		{
 			name: "wrong backend",
 			mutate: func(summary *ValidationSummary) {
-				summary.StateBackend = "other"
+				summary.StateBackend = otherBackend
 			},
 			backend: testStateBackend,
 			wantErr: "does not match",
@@ -199,7 +208,7 @@ func TestValidateValidationSummary(t *testing.T) {
 				summary.Checks[0].Expected = nil
 			},
 			backend: testStateBackend,
-			wantErr: "missing expected state",
+			wantErr: wantErrMissingExpectedState,
 		},
 		{
 			name: "missing actual state",
@@ -207,7 +216,7 @@ func TestValidateValidationSummary(t *testing.T) {
 				summary.Checks[0].Actual = nil
 			},
 			backend: testStateBackend,
-			wantErr: "missing actual state",
+			wantErr: wantErrMissingActualState,
 		},
 		{
 			name: "live pods with empty expected state",
@@ -224,7 +233,7 @@ func TestValidateValidationSummary(t *testing.T) {
 				summary.Checks = append(summary.Checks, summary.Checks[0])
 			},
 			backend: testStateBackend,
-			wantErr: "duplicate check",
+			wantErr: wantErrDuplicateCheck,
 		},
 		{
 			name: "expected and actual differ",
@@ -242,7 +251,7 @@ func TestValidateValidationSummary(t *testing.T) {
 			if tt.mutate != nil {
 				tt.mutate(&summary)
 			}
-			err := ValidateValidationSummary(summary, tt.backend)
+			err := CheckSummary(summary, tt.backend)
 			if tt.wantErr == "" {
 				require.NoError(t, err)
 				return
@@ -294,7 +303,7 @@ func TestComparePodIPIdentities(t *testing.T) {
 			name:     "invalid IP",
 			expected: []PodIPIdentity{{PodID: "pod-1"}},
 			actual:   []PodIPIdentity{},
-			wantErr:  "invalid IP",
+			wantErr:  wantErrInvalidIP,
 		},
 		{
 			name:     "duplicate identity",
@@ -338,10 +347,8 @@ func TestCompareValidationSummaries(t *testing.T) {
 		{
 			name: "exact reordered summary",
 			mutate: func(summary *ValidationSummary) {
-				summary.Checks[0].Expected[0], summary.Checks[0].Expected[1] =
-					summary.Checks[0].Expected[1], summary.Checks[0].Expected[0]
-				summary.Checks[0].Actual[0], summary.Checks[0].Actual[1] =
-					summary.Checks[0].Actual[1], summary.Checks[0].Actual[0]
+				summary.Checks[0].Expected[0], summary.Checks[0].Expected[1] = summary.Checks[0].Expected[1], summary.Checks[0].Expected[0]
+				summary.Checks[0].Actual[0], summary.Checks[0].Actual[1] = summary.Checks[0].Actual[1], summary.Checks[0].Actual[0]
 			},
 		},
 		{
@@ -355,7 +362,7 @@ func TestCompareValidationSummaries(t *testing.T) {
 			name: "unexpected check",
 			mutate: func(summary *ValidationSummary) {
 				check := summary.Checks[0]
-				check.CheckName = "other"
+				check.CheckName = otherBackend
 				summary.Checks = append(summary.Checks, check)
 			},
 			wantErr: "unexpected check",
@@ -396,12 +403,12 @@ func TestCompareValidationSummaries(t *testing.T) {
 			mutate: func(summary *ValidationSummary) {
 				summary.Checks = append(summary.Checks, summary.Checks[0])
 			},
-			wantErr: "duplicate check",
+			wantErr: wantErrDuplicateCheck,
 		},
 		{
 			name: "wrong candidate backend",
 			mutate: func(summary *ValidationSummary) {
-				summary.StateBackend = "other"
+				summary.StateBackend = otherBackend
 			},
 			wantErr: "invalid candidate summary",
 		},
@@ -420,7 +427,7 @@ func TestCompareValidationSummaries(t *testing.T) {
 			}
 			require.ErrorContains(t, err, tt.wantErr)
 			if strings.Contains(tt.wantErr, "state changed") || strings.Contains(tt.wantErr, "live pod count") {
-				require.True(t, errors.Is(err, ErrSummaryRegression))
+				require.ErrorIs(t, err, ErrSummaryRegression)
 			}
 		})
 	}


### PR DESCRIPTION
## What this does

Adds product-independent validation primitives and a `summarydiff` CLI for persistent-state lifecycle tests. The model records exact backend, check, node, live-pod, pod, and IP identities rather than relying on aggregate counts.

Validation rejects malformed or incomplete summaries, unexpected fields, duplicate identities/checks, backend mismatches, missing or additional checks, changed live-pod counts, and any expected/actual pod-IP divergence. Live-pod scenarios cannot report empty expected state.

## Gate behavior

`summarydiff` uses explicit exit codes:

- `0`: exact match
- `1`: valid summaries with a state regression
- `2`: usage, read, decode, validation, or output error

The CLI tests exercise all three paths. The regression fixture preserves identical aggregate counts while changing the IP identity, ensuring a count-only false pass is impossible.

## Validation

- Unit and race tests
- `go vet ./test/validate/...`
- CLI smoke and diff checks
- Independent review, including focused re-review of exit-code coverage

This PR changes no product code or existing E2E lane.