### PR TITLE
ci: generate one signed SBOM over assembled output drop for release validation

### DIFF
--- a/.pipelines/containers/manifest-template.yaml
+++ b/.pipelines/containers/manifest-template.yaml
@@ -45,11 +45,6 @@ steps:
       inlineScript: |
         docker logout
 
-  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-    displayName: "Add SBOM Generator tool"
-    inputs:
-      BuildDropPath: "$(Build.ArtifactStagingDirectory)"
-
   - task: PublishBuildArtifacts@1
     inputs:
       artifactName: "output"

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -415,6 +415,9 @@ stages:
                 artifactName: output
                 downloadPath: $(Pipeline.Workspace)
 
+            - script: mkdir -p "$(Build.ArtifactStagingDirectory)/sbom"
+              displayName: Create SBOM staging directory
+
             - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
               displayName: Generate SBOM over full output artifact drop and sign _manifest
               inputs:

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -394,6 +394,40 @@ stages:
                 name: npm
                 platforms: linux/amd64 linux/arm64 windows/amd64
 
+    - stage: sbom
+      displayName: Generate SBOM
+      dependsOn:
+        - binaries
+        - publish
+        - publish_npm
+      variables:
+        Packaging.EnableSBOMSigning: true
+      jobs:
+        - job: sbom
+          displayName: Generate and Sign SBOM
+          pool:
+            name: "$(BUILD_POOL_NAME_DEFAULT)"
+          steps:
+            - task: DownloadBuildArtifacts@1
+              displayName: Download full output artifact drop
+              inputs:
+                buildType: current
+                artifactName: output
+                downloadPath: $(Pipeline.Workspace)
+
+            - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+              displayName: Generate SBOM over full output artifact drop and sign _manifest
+              inputs:
+                BuildDropPath: $(Pipeline.Workspace)/output
+                ManifestDirPath: $(Build.ArtifactStagingDirectory)/sbom
+
+            - task: PublishBuildArtifacts@1
+              displayName: Publish _manifest into output artifact
+              inputs:
+                artifactName: output
+                pathtoPublish: $(Build.ArtifactStagingDirectory)/sbom
+              condition: succeeded()
+
     # Cilium Podsubnet E2E tests
     - template: singletenancy/cilium/cilium-e2e-job-template.yaml
       parameters:


### PR DESCRIPTION

**Reason for Change**:

The Github Release pipeline's "Validate SBoM Manifest" step was failing signature validation on every release. The published `output` artifact is built up by ~8 parallel image jobs and each one was generating and signing its own SBOM with the same filenames. When they all merged into one artifact, the files overwrote each other where the last one wins and the signature gets mismatched. This makes the surviving `manifest.spdx.json` ending up paired with a signature from a different job and basically fail hash checksum validation. (The npm publish task also made it worse because it wasn't even signing its SBOM manifest)

Instead of 8 jobs racing to write the SBOM manifest, generate and sign one SBOM manifest over the entire output artifact, after everything is published.

## Fix

- Dropped the SBOM generation from `manifest-template.yaml`, used by individual artifact publishes
- Added a single `sbom` stage in `pipeline.yaml` that waits for all the `output` publishers, then generates and signs one SBOM covering the entire output artifact

## Issue Fixed

The GitHub Release "Validate SBoM Manifest" step now passes. The output has exactly one signed manifest that actually covers everything in it.


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
