### PR TITLE
fix: [NPM] make policy-owned IPSet names unique per policy and namespace

### DIFF
--- a/npm/pkg/controlplane/translation/parseSelector.go
+++ b/npm/pkg/controlplane/translation/parseSelector.go
@@ -278,8 +278,11 @@ func parsePodSelector(policyKey string, selector *metav1.LabelSelector) ([]label
 				setType = ipsets.KeyValueLabelOfPod
 			} else {
 				// "(!) + matchKey + : + multiple matchVals" case
-				// see caveat in definition of TranslatedIPSet for why the policy key must be included in the set name
-				setName = fmt.Sprintf("%s-%s", policyKey, req.Key)
+				// The policy key must be included so each policy owns its own nested list
+				// (see caveat in TranslatedIPSet). Separate the policy key and match key
+				// with ":", which neither can contain, so distinct (policy, key) pairs
+				// always produce distinct set names.
+				setName = fmt.Sprintf("%s:%s", policyKey, req.Key)
 				for _, val := range req.Values {
 					setName = util.GetIpSetFromLabelKV(setName, val)
 					members = append(members, util.GetIpSetFromLabelKV(req.Key, val))

--- a/npm/pkg/controlplane/translation/translatePolicy.go
+++ b/npm/pkg/controlplane/translation/translatePolicy.go
@@ -47,10 +47,14 @@ type podSelectorResult struct {
 type netpolPortType string
 
 const (
-	numericPortType      netpolPortType = "validport"
-	namedPortType        netpolPortType = "namedport"
-	included             bool           = true
-	ipBlocksetNameFormat                = "%s-in-ns-%s-%d-%d%s"
+	numericPortType netpolPortType = "validport"
+	namedPortType   netpolPortType = "namedport"
+	included        bool           = true
+	// ipBlocksetNameFormat separates the policy name and namespace with ":", which is not
+	// a valid character in either, so distinct (policy, namespace) pairs always produce
+	// distinct set names.
+	// Format: "<policy>:in-ns:<ns>-<setIndex>-<peerIndex><direction>".
+	ipBlocksetNameFormat = "%s:in-ns:%s-%d-%d%s"
 )
 
 // portType returns type of ports (e.g., numeric port or namedPort) given NetworkPolicyPort object.
@@ -134,14 +138,10 @@ func portRule(ruleIPSets []*ipsets.TranslatedIPSet, acl *policies.ACLPolicy, por
 	return ruleIPSets
 }
 
-// ipBlockSetName returns ipset name of the IPBlock.
-// It is our contract to format "<policyname>-in-ns-<namespace>-<ipblock index><direction of ipblock (i.e., ingress: IN, egress: OUT>"
-// as ipset name of the IPBlock.
-// For example, in case network policy object has
-// name: "test"
-// namespace: "default"
-// ingress rule
-// it returns "test-in-ns-default-0IN".
+// ipBlockSetName returns the ipset name of the IPBlock. The policy name and namespace
+// are separated by ":" (see ipBlocksetNameFormat), which neither can contain, so distinct
+// (policy, namespace) pairs always produce distinct names.
+// e.g. name "test", namespace "default", ingress (setIndex 0, peerIndex 0) -> "test:in-ns:default-0-0IN".
 func ipBlockSetName(policyName, ns string, direction policies.Direction, ipBlockSetIndex, ipBlockPeerIndex int) string {
 	return fmt.Sprintf(ipBlocksetNameFormat, policyName, ns, ipBlockSetIndex, ipBlockPeerIndex, direction)
 }

--- a/npm/pkg/controlplane/translation/translatePolicy_test.go
+++ b/npm/pkg/controlplane/translation/translatePolicy_test.go
@@ -322,17 +322,17 @@ func TestIPBlockSetName(t *testing.T) {
 		{
 			name:        "default/test (ingress)",
 			ipBlockInfo: createIPBlockInfo("test", defaultNS, policies.Ingress, policies.SrcMatch, 0, 0),
-			want:        "test-in-ns-default-0-0IN",
+			want:        "test:in-ns:default-0-0IN",
 		},
 		{
 			name:        "default/test (ingress)",
 			ipBlockInfo: createIPBlockInfo("test", defaultNS, policies.Ingress, policies.SrcMatch, 1, 0),
-			want:        "test-in-ns-default-1-0IN",
+			want:        "test:in-ns:default-1-0IN",
 		},
 		{
 			name:        "testns/test (egress)",
 			ipBlockInfo: createIPBlockInfo("test", "testns", policies.Egress, policies.DstMatch, 0, 1),
-			want:        "test-in-ns-testns-0-1OUT",
+			want:        "test:in-ns:testns-0-1OUT",
 		},
 	}
 
@@ -344,6 +344,220 @@ func TestIPBlockSetName(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestIPBlockSetNameUnambiguous checks that distinct (policy, namespace, index, direction)
+// inputs always produce distinct set names, including when a name contains the "-in-ns-"
+// separator.
+func TestIPBlockSetNameUnambiguous(t *testing.T) {
+	t.Parallel()
+
+	a := ipBlockSetName("a-in-ns-b", "c", policies.Ingress, 0, 0)
+	b := ipBlockSetName("a", "b-in-ns-c", policies.Ingress, 0, 0)
+	require.NotEqual(t, a, b, "distinct (policy, namespace) pairs must produce distinct set names")
+
+	// Distinct pairs whose names contain the "-in-ns-" separator must each be unique.
+	tuples := []struct{ policy, ns string }{
+		{"a-in-ns-b", "c"},
+		{"a", "b-in-ns-c"},
+		{"a-in-ns-b-in-ns-c", "d"},
+		{"a", "b-in-ns-c-in-ns-d"},
+		{"a-in-ns-b", "c-in-ns-d"},
+		{"a-in-ns", "b-c"},
+		{"a", "in-ns-b-c"},
+		{"a-b", "c"},
+		{"a", "b-c"},
+		{"in-ns", "in-ns"},
+		{"1", "2-3"},
+		{"1-2", "3"},
+	}
+	seen := make(map[string]string, len(tuples))
+	for _, tp := range tuples {
+		name := ipBlockSetName(tp.policy, tp.ns, policies.Ingress, 0, 0)
+		if prev, ok := seen[name]; ok {
+			t.Fatalf("(%q,%q) and %q both produced %q", tp.policy, tp.ns, prev, name)
+		}
+		seen[name] = tp.policy + "|" + tp.ns
+	}
+
+	// Direction, set index, and peer index are all part of the identity.
+	base := ipBlockSetName("p", "n", policies.Ingress, 0, 0)
+	require.NotEqual(t, base, ipBlockSetName("p", "n", policies.Egress, 0, 0), "direction must change the name")
+	require.NotEqual(t, base, ipBlockSetName("p", "n", policies.Ingress, 1, 0), "set index must change the name")
+	require.NotEqual(t, base, ipBlockSetName("p", "n", policies.Ingress, 0, 1), "peer index must change the name")
+	require.NotEqual(t,
+		ipBlockSetName("p", "n", policies.Ingress, 1, 10),
+		ipBlockSetName("p", "n", policies.Ingress, 11, 0),
+		"index boundaries must not alias")
+}
+
+// TestNestedSetNameUnambiguous checks that multi-value pod-selector nested sets get distinct
+// names for distinct (policyKey, matchKey) pairs, including label keys that contain "/".
+func TestNestedSetNameUnambiguous(t *testing.T) {
+	t.Parallel()
+
+	type tc struct {
+		name, ns, key string
+	}
+	// Pairs designed to alias under a "-" separator, plus qualified keys containing "/".
+	cases := []tc{
+		{"a-b", "ns", "c"},
+		{"a", "ns", "b-c"},
+		{"a", "ns", "example.com/team"},
+		{"a-example.com", "ns", "team"},
+		{"a", "ns", "b"},
+		{"a-b", "ns", "c-d"},
+		{"a", "other", "b-c"},
+	}
+	seen := make(map[string]string, len(cases))
+	for _, c := range cases {
+		pol := multiValueSelectorPolicy(c.name, c.ns, c.key, "x", "y")
+		npmNetPol, err := TranslatePolicy(pol, false)
+		require.NoError(t, err)
+		set := nestedSet(t, npmNetPol)
+		id := fmt.Sprintf("%s/%s|%s", c.ns, c.name, c.key)
+		if prev, ok := seen[set.Metadata.Name]; ok {
+			t.Fatalf("%s and %s both produced nested set %q", prev, id, set.Metadata.Name)
+		}
+		seen[set.Metadata.Name] = id
+	}
+}
+
+// ingressIPBlockPolicy builds a NetworkPolicy with a single ingress ipBlock CIDR peer.
+func ingressIPBlockPolicy(name, ns, cidr string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{From: []networkingv1.NetworkPolicyPeer{{IPBlock: &networkingv1.IPBlock{CIDR: cidr}}}},
+			},
+		},
+	}
+}
+
+// cidrSet returns the single CIDRBlocks TranslatedIPSet from a translated policy.
+func cidrSet(t *testing.T, npmNetPol *policies.NPMNetworkPolicy) *ipsets.TranslatedIPSet {
+	t.Helper()
+	var found *ipsets.TranslatedIPSet
+	for _, s := range npmNetPol.RuleIPSets {
+		if s.Metadata.Type == ipsets.CIDRBlocks {
+			require.Nil(t, found, "expected exactly one CIDR set per policy")
+			found = s
+		}
+	}
+	require.NotNil(t, found, "policy %s produced no CIDR set", npmNetPol.PolicyKey)
+	return found
+}
+
+// TestIPBlockTwoPolicyIsolation translates two policies whose (name, namespace) pairs
+// serialize around the "-in-ns-" separator and asserts they resolve to distinct kernel
+// sets, that each policy's ACL references its own set, and that neither set carries the
+// other's CIDR members.
+func TestIPBlockTwoPolicyIsolation(t *testing.T) {
+	t.Parallel()
+
+	// Both pairs would share a pre-hash name under the old ambiguous format.
+	first := ingressIPBlockPolicy("a-in-ns-b", "c", "198.51.100.10/32")
+	second := ingressIPBlockPolicy("a", "b-in-ns-c", "0.0.0.0/0")
+
+	firstNetPol, err := TranslatePolicy(first, false)
+	require.NoError(t, err)
+	secondNetPol, err := TranslatePolicy(second, false)
+	require.NoError(t, err)
+
+	firstSet := cidrSet(t, firstNetPol)
+	secondSet := cidrSet(t, secondNetPol)
+
+	// Distinct kernel (hashed) names: the two policies never share one IPSet.
+	require.NotEqual(t, firstSet.Metadata.GetHashedName(), secondSet.Metadata.GetHashedName(),
+		"distinct policies must map to distinct kernel sets")
+
+	// Each policy's ingress ACL references its own CIDR set.
+	requireIngressRefersTo(t, firstNetPol, firstSet.Metadata.GetHashedName())
+	requireIngressRefersTo(t, secondNetPol, secondSet.Metadata.GetHashedName())
+
+	// Members stay separated: neither set carries the other's CIDRs.
+	require.Equal(t, []string{"198.51.100.10/32"}, firstSet.Members)
+	require.ElementsMatch(t, []string{"0.0.0.0/1", "128.0.0.0/1"}, secondSet.Members)
+	require.NotContains(t, secondSet.Members, "198.51.100.10/32")
+	require.NotContains(t, firstSet.Members, "0.0.0.0/1")
+}
+
+// requireIngressRefersTo asserts that some ingress ACL source references the given set.
+func requireIngressRefersTo(t *testing.T, npmNetPol *policies.NPMNetworkPolicy, hashedName string) {
+	t.Helper()
+	for _, acl := range npmNetPol.ACLs {
+		if acl.Direction != policies.Ingress {
+			continue
+		}
+		for _, si := range acl.SrcList {
+			if si.IPSet.GetHashedName() == hashedName {
+				return
+			}
+		}
+	}
+	t.Fatalf("policy %s has no ingress ACL referencing set %s", npmNetPol.PolicyKey, hashedName)
+}
+
+// multiValueSelectorPolicy builds a policy whose target podSelector has a single
+// matchExpression (key In values) with multiple values, producing a nested-label set.
+func multiValueSelectorPolicy(name, ns, key string, values ...string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: key, Operator: metav1.LabelSelectorOpIn, Values: values},
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress:     []networkingv1.NetworkPolicyIngressRule{{}},
+		},
+	}
+}
+
+// nestedSet returns the single NestedLabelOfPod TranslatedIPSet from a translated policy.
+func nestedSet(t *testing.T, npmNetPol *policies.NPMNetworkPolicy) *ipsets.TranslatedIPSet {
+	t.Helper()
+	var found *ipsets.TranslatedIPSet
+	for _, s := range npmNetPol.PodSelectorIPSets {
+		if s.Metadata.Type == ipsets.NestedLabelOfPod {
+			require.Nil(t, found, "expected exactly one nested set per policy")
+			found = s
+		}
+	}
+	require.NotNil(t, found, "policy %s produced no nested set", npmNetPol.PolicyKey)
+	return found
+}
+
+// TestNestedSelectorTwoPolicyIsolation translates two policies whose (name, matchKey)
+// pairs serialize around the "-" separator and asserts their multi-value selector sets
+// resolve to distinct kernel sets while sharing the same child member sets.
+func TestNestedSelectorTwoPolicyIsolation(t *testing.T) {
+	t.Parallel()
+
+	// Both pairs would share a pre-hash nested name under the old ambiguous format:
+	// (ns/a-b, key c) and (ns/a, key b-c) both produced "ns/a-b-c:x:y".
+	first := multiValueSelectorPolicy("a-b", "ns", "c", "x", "y")
+	second := multiValueSelectorPolicy("a", "ns", "b-c", "x", "y")
+
+	firstNetPol, err := TranslatePolicy(first, false)
+	require.NoError(t, err)
+	secondNetPol, err := TranslatePolicy(second, false)
+	require.NoError(t, err)
+
+	firstSet := nestedSet(t, firstNetPol)
+	secondSet := nestedSet(t, secondNetPol)
+
+	// Distinct kernel (hashed) names: the two policies never share one nested set.
+	require.NotEqual(t, firstSet.Metadata.GetHashedName(), secondSet.Metadata.GetHashedName(),
+		"distinct policies must map to distinct nested sets")
+
+	// Child member sets are keyed by matchKey:value and are unaffected by the fix.
+	require.ElementsMatch(t, []string{"c:x", "c:y"}, firstSet.Members)
+	require.ElementsMatch(t, []string{"b-c:x", "b-c:y"}, secondSet.Members)
 }
 
 // Specific testsets for 0.0.0.0/0 cidr since it has special handling in the code due to limitation of ipset on linux.
@@ -376,7 +590,7 @@ func TestIPBlockIPSet(t *testing.T) {
 			ipBlockRule: &networkingv1.IPBlock{
 				CIDR: "172.17.0.0/16",
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16"}...),
 		},
 		{
 			name:        "one cidr and one element in except",
@@ -385,7 +599,7 @@ func TestIPBlockIPSet(t *testing.T) {
 				CIDR:   "172.17.0.0/16",
 				Except: []string{"172.17.1.0/24"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch"}...),
 			skipWindows:     true,
 		},
 		{
@@ -395,7 +609,7 @@ func TestIPBlockIPSet(t *testing.T) {
 				CIDR:   "172.17.0.0/16",
 				Except: []string{"172.17.1.0/24", "172.17.2.0/24"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-network-policy-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch", "172.17.2.0/24 nomatch"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test-network-policy:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch", "172.17.2.0/24 nomatch"}...),
 			skipWindows:     true,
 		},
 		{
@@ -405,7 +619,7 @@ func TestIPBlockIPSet(t *testing.T) {
 				CIDR:   "172.17.0.0/16",
 				Except: []string{"172.17.1.0/24", "172.17.2.0/24", "172.17.2.0/24"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-network-policy-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch", "172.17.2.0/24 nomatch"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test-network-policy:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch", "172.17.2.0/24 nomatch"}...),
 			skipWindows:     true,
 		},
 		{
@@ -414,7 +628,7 @@ func TestIPBlockIPSet(t *testing.T) {
 			ipBlockRule: &networkingv1.IPBlock{
 				CIDR: "0.0.0.0/0",
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1", "128.0.0.0/1"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1", "128.0.0.0/1"}...),
 		},
 		{
 			name:        "cidr: 0.0.0.0/0 and except: 10.0.0.0/1",
@@ -423,7 +637,7 @@ func TestIPBlockIPSet(t *testing.T) {
 				CIDR:   "0.0.0.0/0",
 				Except: []string{"10.0.0.0/1"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1", "128.0.0.0/1", "10.0.0.0/1 nomatch"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1", "128.0.0.0/1", "10.0.0.0/1 nomatch"}...),
 			skipWindows:     true,
 		},
 		{
@@ -433,7 +647,7 @@ func TestIPBlockIPSet(t *testing.T) {
 				CIDR:   "0.0.0.0/0",
 				Except: []string{"0.0.0.0/1"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1 nomatch", "128.0.0.0/1"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1 nomatch", "128.0.0.0/1"}...),
 			skipWindows:     true,
 		},
 		{
@@ -443,7 +657,7 @@ func TestIPBlockIPSet(t *testing.T) {
 				CIDR:   "0.0.0.0/0",
 				Except: []string{"128.0.0.0/1"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1", "128.0.0.0/1 nomatch"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1", "128.0.0.0/1 nomatch"}...),
 			skipWindows:     true,
 		},
 		{
@@ -453,7 +667,7 @@ func TestIPBlockIPSet(t *testing.T) {
 				CIDR:   "0.0.0.0/0",
 				Except: []string{"0.0.0.0/1", "128.0.0.0/1"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1 nomatch", "128.0.0.0/1 nomatch"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1 nomatch", "128.0.0.0/1 nomatch"}...),
 			skipWindows:     true,
 		},
 		{
@@ -463,7 +677,7 @@ func TestIPBlockIPSet(t *testing.T) {
 				CIDR:   "0.0.0.0/0",
 				Except: []string{"0.0.0.0/1", "128.0.0.0/1", "128.0.0.0/1"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1 nomatch", "128.0.0.0/1 nomatch"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1 nomatch", "128.0.0.0/1 nomatch"}...),
 			skipWindows:     true,
 		},
 	}
@@ -516,8 +730,8 @@ func TestIPBlockRule(t *testing.T) {
 			ipBlockRule: &networkingv1.IPBlock{
 				CIDR: "172.17.0.0/16",
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16"}...),
-			setInfo:         policies.NewSetInfo("test-in-ns-default-0-0IN", ipsets.CIDRBlocks, included, policies.SrcMatch),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16"}...),
+			setInfo:         policies.NewSetInfo("test:in-ns:default-0-0IN", ipsets.CIDRBlocks, included, policies.SrcMatch),
 		},
 		{
 			name:        "one cidr and one element in except",
@@ -526,8 +740,8 @@ func TestIPBlockRule(t *testing.T) {
 				CIDR:   "172.17.0.0/16",
 				Except: []string{"172.17.1.0/24"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch"}...),
-			setInfo:         policies.NewSetInfo("test-in-ns-default-0-0IN", ipsets.CIDRBlocks, included, policies.SrcMatch),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch"}...),
+			setInfo:         policies.NewSetInfo("test:in-ns:default-0-0IN", ipsets.CIDRBlocks, included, policies.SrcMatch),
 			skipWindows:     true,
 		},
 		{
@@ -537,8 +751,8 @@ func TestIPBlockRule(t *testing.T) {
 				CIDR:   "172.17.0.0/16",
 				Except: []string{"172.17.1.0/24", "172.17.2.0/24"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-network-policy-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch", "172.17.2.0/24 nomatch"}...),
-			setInfo:         policies.NewSetInfo("test-network-policy-in-ns-default-0-0IN", ipsets.CIDRBlocks, included, policies.SrcMatch),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test-network-policy:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch", "172.17.2.0/24 nomatch"}...),
+			setInfo:         policies.NewSetInfo("test-network-policy:in-ns:default-0-0IN", ipsets.CIDRBlocks, included, policies.SrcMatch),
 			skipWindows:     true,
 		},
 		{
@@ -588,7 +802,6 @@ func TestIPBlockRule(t *testing.T) {
 func TestPodSelector(t *testing.T) {
 	matchType := policies.DstMatch
 	policyKey := "test-ns/test-policy"
-	policyKeyWithDash := policyKey + "-"
 	tests := []struct {
 		name                    string
 		namespace               string
@@ -750,7 +963,7 @@ func TestPodSelector(t *testing.T) {
 			},
 			podSelectorIPSets: []*ipsets.TranslatedIPSet{
 				ipsets.NewTranslatedIPSet("k0:v0", ipsets.KeyValueLabelOfPod),
-				ipsets.NewTranslatedIPSet(policyKeyWithDash+"k1:v10:v11", ipsets.NestedLabelOfPod, []string{"k1:v10", "k1:v11"}...),
+				ipsets.NewTranslatedIPSet("test-ns/test-policy:k1:v10:v11", ipsets.NestedLabelOfPod, []string{"k1:v10", "k1:v11"}...),
 				ipsets.NewTranslatedIPSet("k2", ipsets.KeyLabelOfPod),
 			},
 			childPodSelectorIPSets: []*ipsets.TranslatedIPSet{
@@ -759,7 +972,7 @@ func TestPodSelector(t *testing.T) {
 			},
 			podSelectorList: []policies.SetInfo{
 				policies.NewSetInfo("k0:v0", ipsets.KeyValueLabelOfPod, included, matchType),
-				policies.NewSetInfo(policyKeyWithDash+"k1:v10:v11", ipsets.NestedLabelOfPod, included, matchType),
+				policies.NewSetInfo("test-ns/test-policy:k1:v10:v11", ipsets.NestedLabelOfPod, included, matchType),
 				policies.NewSetInfo("k2", ipsets.KeyLabelOfPod, nonIncluded, matchType),
 			},
 			skipWindows: true,
@@ -790,7 +1003,7 @@ func TestPodSelector(t *testing.T) {
 			},
 			podSelectorIPSets: []*ipsets.TranslatedIPSet{
 				ipsets.NewTranslatedIPSet("k0:v0", ipsets.KeyValueLabelOfPod),
-				ipsets.NewTranslatedIPSet(policyKeyWithDash+"k1:v10:v11", ipsets.NestedLabelOfPod, []string{"k1:v10", "k1:v11"}...),
+				ipsets.NewTranslatedIPSet("test-ns/test-policy:k1:v10:v11", ipsets.NestedLabelOfPod, []string{"k1:v10", "k1:v11"}...),
 				ipsets.NewTranslatedIPSet("k2", ipsets.KeyLabelOfPod),
 				ipsets.NewTranslatedIPSet(defaultNS, ipsets.Namespace),
 			},
@@ -800,7 +1013,7 @@ func TestPodSelector(t *testing.T) {
 			},
 			podSelectorList: []policies.SetInfo{
 				policies.NewSetInfo("k0:v0", ipsets.KeyValueLabelOfPod, included, matchType),
-				policies.NewSetInfo(policyKeyWithDash+"k1:v10:v11", ipsets.NestedLabelOfPod, included, matchType),
+				policies.NewSetInfo("test-ns/test-policy:k1:v10:v11", ipsets.NestedLabelOfPod, included, matchType),
 				policies.NewSetInfo("k2", ipsets.KeyLabelOfPod, nonIncluded, matchType),
 				policies.NewSetInfo(defaultNS, ipsets.Namespace, included, matchType),
 			},
@@ -1266,7 +1479,7 @@ func TestPeerAndPortRule(t *testing.T) {
 			{},
 		},
 		{
-			policies.NewSetInfo("test-in-ns-default-0IN", ipsets.CIDRBlocks, included, matchType),
+			policies.NewSetInfo("test:in-ns:default-0IN", ipsets.CIDRBlocks, included, matchType),
 		},
 		{
 			policies.NewSetInfo("label:src", ipsets.KeyValueLabelOfNamespace, included, matchType),
@@ -1362,7 +1575,7 @@ func TestPeerAndPortRule(t *testing.T) {
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 						SrcList: []policies.SetInfo{
-							policies.NewSetInfo("test-in-ns-default-0IN", ipsets.CIDRBlocks, included, matchType),
+							policies.NewSetInfo("test:in-ns:default-0IN", ipsets.CIDRBlocks, included, matchType),
 						},
 						DstList: []policies.SetInfo{
 							policies.NewSetInfo("serve-tcp", ipsets.NamedPorts, included, policies.DstDstMatch),
@@ -1739,14 +1952,14 @@ func TestIngressPolicy(t *testing.T) {
 					policies.NewSetInfo(defaultNS, ipsets.Namespace, included, targetPodMatchType),
 				},
 				RuleIPSets: []*ipsets.TranslatedIPSet{
-					ipsets.NewTranslatedIPSet("only-ipblock-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch"}...),
+					ipsets.NewTranslatedIPSet("only-ipblock:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch"}...),
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 						SrcList: []policies.SetInfo{
-							policies.NewSetInfo("only-ipblock-in-ns-default-0-0IN", ipsets.CIDRBlocks, included, peerMatchType),
+							policies.NewSetInfo("only-ipblock:in-ns:default-0-0IN", ipsets.CIDRBlocks, included, peerMatchType),
 						},
 					},
 					defaultDropACL(policies.Ingress),
@@ -1898,8 +2111,8 @@ func TestIngressPolicy(t *testing.T) {
 				},
 				RuleIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("peer-nsselector-kay:peer-nsselector-value", ipsets.KeyValueLabelOfNamespace),
-					ipsets.NewTranslatedIPSet("only-peer-nsSelector-in-ns-default-0-1IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch", "172.17.2.0/24 nomatch"}...),
-					ipsets.NewTranslatedIPSet("only-peer-nsSelector-in-ns-default-0-2IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16"}...),
+					ipsets.NewTranslatedIPSet("only-peer-nsSelector:in-ns:default-0-1IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch", "172.17.2.0/24 nomatch"}...),
+					ipsets.NewTranslatedIPSet("only-peer-nsSelector:in-ns:default-0-2IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16"}...),
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
@@ -1913,14 +2126,14 @@ func TestIngressPolicy(t *testing.T) {
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 						SrcList: []policies.SetInfo{
-							policies.NewSetInfo("only-peer-nsSelector-in-ns-default-0-1IN", ipsets.CIDRBlocks, included, peerMatchType),
+							policies.NewSetInfo("only-peer-nsSelector:in-ns:default-0-1IN", ipsets.CIDRBlocks, included, peerMatchType),
 						},
 					},
 					{
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 						SrcList: []policies.SetInfo{
-							policies.NewSetInfo("only-peer-nsSelector-in-ns-default-0-2IN", ipsets.CIDRBlocks, included, peerMatchType),
+							policies.NewSetInfo("only-peer-nsSelector:in-ns:default-0-2IN", ipsets.CIDRBlocks, included, peerMatchType),
 						},
 					},
 					defaultDropACL(policies.Ingress),
@@ -2096,7 +2309,7 @@ func TestIngressPolicy(t *testing.T) {
 				ACLPolicyID: "azure-acl-default-serve-tcp",
 				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("k0:v0", ipsets.KeyValueLabelOfPod),
-					ipsets.NewTranslatedIPSet("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
+					ipsets.NewTranslatedIPSet("default/serve-tcp:k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
 					ipsets.NewTranslatedIPSet("k2", ipsets.KeyLabelOfPod),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
 				},
@@ -2106,7 +2319,7 @@ func TestIngressPolicy(t *testing.T) {
 				},
 				PodSelectorList: []policies.SetInfo{
 					policies.NewSetInfo("k0:v0", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
-					policies.NewSetInfo("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, included, targetPodMatchType),
+					policies.NewSetInfo("default/serve-tcp:k1:v10:v11", ipsets.NestedLabelOfPod, included, targetPodMatchType),
 					policies.NewSetInfo("k2", ipsets.KeyLabelOfPod, nonIncluded, targetPodMatchType),
 					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
 				},
@@ -2161,7 +2374,7 @@ func TestIngressPolicy(t *testing.T) {
 					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
 				},
 				RuleIPSets: []*ipsets.TranslatedIPSet{
-					ipsets.NewTranslatedIPSet("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
+					ipsets.NewTranslatedIPSet("default/serve-tcp:k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
 					ipsets.NewTranslatedIPSet("k1:v10", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("k1:v11", ipsets.KeyValueLabelOfPod),
@@ -2171,7 +2384,7 @@ func TestIngressPolicy(t *testing.T) {
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 						SrcList: []policies.SetInfo{
-							policies.NewSetInfo("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, included, peerMatchType),
+							policies.NewSetInfo("default/serve-tcp:k1:v10:v11", ipsets.NestedLabelOfPod, included, peerMatchType),
 							policies.NewSetInfo("default", ipsets.Namespace, included, peerMatchType),
 						},
 					},
@@ -2228,7 +2441,7 @@ func TestIngressPolicy(t *testing.T) {
 					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
 				},
 				RuleIPSets: []*ipsets.TranslatedIPSet{
-					ipsets.NewTranslatedIPSet("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
+					ipsets.NewTranslatedIPSet("default/serve-tcp:k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
 					ipsets.NewTranslatedIPSet("k1:v10", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("k1:v11", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("peer-nsselector-kay:peer-nsselector-value", ipsets.KeyValueLabelOfNamespace),
@@ -2239,7 +2452,7 @@ func TestIngressPolicy(t *testing.T) {
 						Direction: policies.Ingress,
 						SrcList: []policies.SetInfo{
 							policies.NewSetInfo("peer-nsselector-kay:peer-nsselector-value", ipsets.KeyValueLabelOfNamespace, included, peerMatchType),
-							policies.NewSetInfo("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, included, peerMatchType),
+							policies.NewSetInfo("default/serve-tcp:k1:v10:v11", ipsets.NestedLabelOfPod, included, peerMatchType),
 						},
 					},
 					{
@@ -2470,14 +2683,14 @@ func TestEgressPolicy(t *testing.T) {
 				},
 				ChildPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
 				RuleIPSets: []*ipsets.TranslatedIPSet{
-					ipsets.NewTranslatedIPSet("only-ipblock-in-ns-default-0-0OUT", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch"}...),
+					ipsets.NewTranslatedIPSet("only-ipblock:in-ns:default-0-0OUT", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch"}...),
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
 						Target:    policies.Allowed,
 						Direction: policies.Egress,
 						DstList: []policies.SetInfo{
-							policies.NewSetInfo("only-ipblock-in-ns-default-0-0OUT", ipsets.CIDRBlocks, included, peerMatchType),
+							policies.NewSetInfo("only-ipblock:in-ns:default-0-0OUT", ipsets.CIDRBlocks, included, peerMatchType),
 						},
 					},
 					defaultDropACL(policies.Egress),
@@ -2725,8 +2938,8 @@ func TestEgressPolicy(t *testing.T) {
 				},
 				RuleIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("peer-nsselector-kay:peer-nsselector-value", ipsets.KeyValueLabelOfNamespace),
-					ipsets.NewTranslatedIPSet("only-peer-nsSelector-in-ns-default-0-1OUT", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch", "172.17.2.0/24 nomatch"}...),
-					ipsets.NewTranslatedIPSet("only-peer-nsSelector-in-ns-default-0-2OUT", ipsets.CIDRBlocks, []string{"172.17.0.0/16"}...),
+					ipsets.NewTranslatedIPSet("only-peer-nsSelector:in-ns:default-0-1OUT", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch", "172.17.2.0/24 nomatch"}...),
+					ipsets.NewTranslatedIPSet("only-peer-nsSelector:in-ns:default-0-2OUT", ipsets.CIDRBlocks, []string{"172.17.0.0/16"}...),
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
@@ -2740,14 +2953,14 @@ func TestEgressPolicy(t *testing.T) {
 						Target:    policies.Allowed,
 						Direction: policies.Egress,
 						DstList: []policies.SetInfo{
-							policies.NewSetInfo("only-peer-nsSelector-in-ns-default-0-1OUT", ipsets.CIDRBlocks, included, peerMatchType),
+							policies.NewSetInfo("only-peer-nsSelector:in-ns:default-0-1OUT", ipsets.CIDRBlocks, included, peerMatchType),
 						},
 					},
 					{
 						Target:    policies.Allowed,
 						Direction: policies.Egress,
 						DstList: []policies.SetInfo{
-							policies.NewSetInfo("only-peer-nsSelector-in-ns-default-0-2OUT", ipsets.CIDRBlocks, included, peerMatchType),
+							policies.NewSetInfo("only-peer-nsSelector:in-ns:default-0-2OUT", ipsets.CIDRBlocks, included, peerMatchType),
 						},
 					},
 					defaultDropACL(policies.Egress),
@@ -2827,7 +3040,7 @@ func TestEgressPolicy(t *testing.T) {
 				ACLPolicyID: "azure-acl-default-serve-tcp",
 				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("k0:v0", ipsets.KeyValueLabelOfPod),
-					ipsets.NewTranslatedIPSet("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
+					ipsets.NewTranslatedIPSet("default/serve-tcp:k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
 					ipsets.NewTranslatedIPSet("k2", ipsets.KeyLabelOfPod),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
 				},
@@ -2837,7 +3050,7 @@ func TestEgressPolicy(t *testing.T) {
 				},
 				PodSelectorList: []policies.SetInfo{
 					policies.NewSetInfo("k0:v0", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
-					policies.NewSetInfo("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, included, targetPodMatchType),
+					policies.NewSetInfo("default/serve-tcp:k1:v10:v11", ipsets.NestedLabelOfPod, included, targetPodMatchType),
 					policies.NewSetInfo("k2", ipsets.KeyLabelOfPod, nonIncluded, targetPodMatchType),
 					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
 				},
@@ -2892,7 +3105,7 @@ func TestEgressPolicy(t *testing.T) {
 					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
 				},
 				RuleIPSets: []*ipsets.TranslatedIPSet{
-					ipsets.NewTranslatedIPSet("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
+					ipsets.NewTranslatedIPSet("default/serve-tcp:k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
 					ipsets.NewTranslatedIPSet("k1:v10", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("k1:v11", ipsets.KeyValueLabelOfPod),
@@ -2902,7 +3115,7 @@ func TestEgressPolicy(t *testing.T) {
 						Target:    policies.Allowed,
 						Direction: policies.Egress,
 						DstList: []policies.SetInfo{
-							policies.NewSetInfo("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, included, peerMatchType),
+							policies.NewSetInfo("default/serve-tcp:k1:v10:v11", ipsets.NestedLabelOfPod, included, peerMatchType),
 							policies.NewSetInfo("default", ipsets.Namespace, included, peerMatchType),
 						},
 					},
@@ -2959,7 +3172,7 @@ func TestEgressPolicy(t *testing.T) {
 					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
 				},
 				RuleIPSets: []*ipsets.TranslatedIPSet{
-					ipsets.NewTranslatedIPSet("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
+					ipsets.NewTranslatedIPSet("default/serve-tcp:k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
 					ipsets.NewTranslatedIPSet("k1:v10", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("k1:v11", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("peer-nsselector-kay:peer-nsselector-value", ipsets.KeyValueLabelOfNamespace),
@@ -2970,7 +3183,7 @@ func TestEgressPolicy(t *testing.T) {
 						Direction: policies.Egress,
 						DstList: []policies.SetInfo{
 							policies.NewSetInfo("peer-nsselector-kay:peer-nsselector-value", ipsets.KeyValueLabelOfNamespace, included, peerMatchType),
-							policies.NewSetInfo("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, included, peerMatchType),
+							policies.NewSetInfo("default/serve-tcp:k1:v10:v11", ipsets.NestedLabelOfPod, included, peerMatchType),
 						},
 					},
 					{

--- a/npm/pkg/dataplane/dataplane_linux_test.go
+++ b/npm/pkg/dataplane/dataplane_linux_test.go
@@ -131,11 +131,24 @@ func TestNetPolInBackgroundFailureToAddFirstTime(t *testing.T) {
 
 	testPolicy2 := testPolicyobj
 	testPolicy2.PolicyKey = "testpolicy2"
+	testPolicy2.RuleIPSets = ruleIPSetsWithCIDR("testcidr2")
 	testPolicy3 := testPolicyobj
 	testPolicy3.PolicyKey = "testpolicy3"
+	testPolicy3.RuleIPSets = ruleIPSetsWithCIDR("testcidr3")
 
 	calls := getBootupTestCalls()
 	calls = append(calls,
+		// background mode applies each policy's ipsets on AddPolicy (one restore per policy)
+		testutils.TestCmd{
+			Cmd:      []string{"ipset", "restore"},
+			Stdout:   "success",
+			ExitCode: 0,
+		},
+		testutils.TestCmd{
+			Cmd:      []string{"ipset", "restore"},
+			Stdout:   "success",
+			ExitCode: 0,
+		},
 		testutils.TestCmd{
 			Cmd:      []string{"ipset", "restore"},
 			Stdout:   "success",

--- a/npm/pkg/dataplane/dataplane_test.go
+++ b/npm/pkg/dataplane/dataplane_test.go
@@ -74,6 +74,17 @@ var (
 	}
 )
 
+// ruleIPSetsWithCIDR returns testPolicyobj's rule sets with a distinct CIDR set name so
+// cloned test policies each own their own ipblock set (label/namespace sets stay shared).
+func ruleIPSetsWithCIDR(cidrName string) []*ipsets.TranslatedIPSet {
+	return []*ipsets.TranslatedIPSet{
+		{Metadata: ipsets.NewIPSetMetadata("setns2", ipsets.Namespace)},
+		{Metadata: ipsets.NewIPSetMetadata("setpodkey2", ipsets.KeyLabelOfPod)},
+		{Metadata: ipsets.NewIPSetMetadata("setpodkeyval2", ipsets.KeyValueLabelOfPod)},
+		{Metadata: ipsets.NewIPSetMetadata(cidrName, ipsets.CIDRBlocks), Members: []string{"10.0.0.0/8"}},
+	}
+}
+
 func TestNewDataPlane(t *testing.T) {
 	metrics.InitializeAll()
 

--- a/npm/pkg/dataplane/ipsets/ipsetmanager.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager.go
@@ -187,6 +187,17 @@ func (iMgr *IPSetManager) AddReference(setMetadata *IPSetMetadata, referenceName
 		metrics.SendErrorLogAndMetric(util.IpsmID, "error: failed to add reference: %s", msg)
 		return npmerrors.Errorf(npmerrors.AddSelectorReference, false, msg)
 	}
+	// A CIDR (ipblock) set belongs to a single NetworkPolicy; reject a reference from a
+	// different netpol so two policies never share one set.
+	if referenceType == NetPolType && set.Type == CIDRBlocks {
+		for existingOwner := range set.NetPolReference {
+			if existingOwner != referenceName {
+				msg := fmt.Sprintf("cidr ipset %s is already owned by netpol %q; refusing reference from netpol %q", set.Name, existingOwner, referenceName)
+				metrics.SendErrorLogAndMetric(util.IpsmID, "error: failed to add reference: %s", msg)
+				return npmerrors.Errorf(npmerrors.AddNetPolReference, false, msg)
+			}
+		}
+	}
 	wasInKernel := iMgr.shouldBeInKernel(set)
 	set.addReference(referenceName, referenceType)
 	if !wasInKernel {

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_test.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_test.go
@@ -76,6 +76,65 @@ var (
 	nestedPodLabelList = NewIPSetMetadata("test-nested-pod-label-list", NestedLabelOfPod)
 )
 
+// TestAddReferenceCIDRSingleOwner checks a CIDR set is bound to one netpol: the owner
+// (and re-applies) are accepted, a different netpol is rejected.
+func TestAddReferenceCIDRSingleOwner(t *testing.T) {
+	metrics.ReinitializeAll()
+	iMgr := NewIPSetManager(applyAlwaysCfg, common.NewMockIOShim(nil))
+	cidrSet := NewIPSetMetadata("a-in-ns-b:in-ns:c-0-0IN", CIDRBlocks)
+
+	require.NoError(t, iMgr.AddReference(cidrSet, "c/a-in-ns-b", NetPolType)) // owner
+	require.NoError(t, iMgr.AddReference(cidrSet, "c/a-in-ns-b", NetPolType)) // owner re-apply
+	require.Error(t, iMgr.AddReference(cidrSet, "b-in-ns-c/a", NetPolType))   // different netpol
+}
+
+// TestAddReferenceCIDROwnerReleasedOnDelete checks that once the sole owner deletes its
+// reference, a different netpol may take ownership (the guard uses live ownership).
+func TestAddReferenceCIDROwnerReleasedOnDelete(t *testing.T) {
+	metrics.ReinitializeAll()
+	iMgr := NewIPSetManager(applyAlwaysCfg, common.NewMockIOShim(nil))
+	cidrSet := NewIPSetMetadata("a-in-ns-b:in-ns:c-0-0IN", CIDRBlocks)
+
+	require.NoError(t, iMgr.AddReference(cidrSet, "c/a-in-ns-b", NetPolType)) // first owner
+	require.Error(t, iMgr.AddReference(cidrSet, "b-in-ns-c/a", NetPolType))   // rejected while owned
+	require.NoError(t, iMgr.DeleteReference(cidrSet.GetPrefixName(), "c/a-in-ns-b", NetPolType))
+	require.NoError(t, iMgr.AddReference(cidrSet, "b-in-ns-c/a", NetPolType)) // now accepted
+}
+
+// TestCIDRSetsDoNotMergeInManager applies two policies with similar names to a single
+// IPSetManager and asserts the two CIDR sets stay distinct, each holding only its own
+// members and owned only by its own netpol.
+func TestCIDRSetsDoNotMergeInManager(t *testing.T) {
+	metrics.ReinitializeAll()
+	iMgr := NewIPSetManager(applyAlwaysCfg, common.NewMockIOShim(nil))
+
+	// Post-fix names for policy c/a-in-ns-b and policy b-in-ns-c/a (would share a name pre-fix).
+	first := NewIPSetMetadata("a-in-ns-b:in-ns:c-0-0IN", CIDRBlocks)
+	second := NewIPSetMetadata("a:in-ns:b-in-ns-c-0-0IN", CIDRBlocks)
+	require.NotEqual(t, first.GetHashedName(), second.GetHashedName())
+
+	require.NoError(t, iMgr.AddToSets([]*IPSetMetadata{first}, "198.51.100.10", "c/a-in-ns-b"))
+	require.NoError(t, iMgr.AddReference(first, "c/a-in-ns-b", NetPolType))
+	require.NoError(t, iMgr.AddToSets([]*IPSetMetadata{second}, "0.0.0.0/1", "b-in-ns-c/a"))
+	require.NoError(t, iMgr.AddToSets([]*IPSetMetadata{second}, "128.0.0.0/1", "b-in-ns-c/a"))
+	require.NoError(t, iMgr.AddReference(second, "b-in-ns-c/a", NetPolType))
+
+	firstSet := iMgr.GetIPSet(first.GetPrefixName())
+	secondSet := iMgr.GetIPSet(second.GetPrefixName())
+	require.NotNil(t, firstSet)
+	require.NotNil(t, secondSet)
+
+	// Each set holds only its own members; neither carries the other's.
+	require.Equal(t, map[string]string{"198.51.100.10": "c/a-in-ns-b"}, firstSet.IPPodKey)
+	require.Len(t, secondSet.IPPodKey, 2)
+	require.NotContains(t, secondSet.IPPodKey, "198.51.100.10")
+	require.NotContains(t, firstSet.IPPodKey, "0.0.0.0/1")
+
+	// Each set is owned only by its own netpol.
+	require.Equal(t, map[string]struct{}{"c/a-in-ns-b": {}}, firstSet.NetPolReference)
+	require.Equal(t, map[string]struct{}{"b-in-ns-c/a": {}}, secondSet.NetPolReference)
+}
+
 func TestReconcileCache(t *testing.T) {
 	type args struct {
 		cfg          *IPSetManagerCfg


### PR DESCRIPTION
**Reason for Change**:

Two IPSet name generators joined variable fields with a delimiter that is also
legal inside those fields, so distinct inputs could serialize to the same
pre-hash name and end up sharing a single kernel IPSet:

- **ipblock CIDR sets** used `"%s-in-ns-%s-%d-%d%s"`. Since `-in-ns-` is a valid
  substring of a DNS label, two different `(policy, namespace)` pairs could
  produce the same name.
- **multi-value pod-selector nested sets** used `"%s-%s"` (`policyKey`, `matchKey`).
  Since `-` is valid in both, two different `(policy, matchKey)` pairs in the same
  namespace could produce the same name.

This separates the variable fields with `:`, which is not a valid character in a
Kubernetes name, namespace, or label key, so distinct inputs always produce
distinct set names:

```
ipblock:  "%s:in-ns:%s-%d-%d%s"   // <policy>:in-ns:<ns>-<setIndex>-<peerIndex><direction>
nested:   "%s:%s"                 // <policyKey>:<matchKey>
```

`:` was chosen over length-prefixing because the set name also appears in iptables
comments (255-byte limit), so keeping the name short matters. The translated sets
and their ACL / selector references come from the same generators, so references
stay consistent; nested child member sets are unchanged. It also hardens
`IPSetManager.AddReference` so a CIDR ipblock set is only referenced by a single
NetworkPolicy. Existing expected-name literals are updated and regression tests are
added for both generators. Scoped to the v2 translation path (the only enabled NPM
datapath).

**Issue Fixed**:

<!-- N/A -->

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/) (`fix:`)
- [x] includes documentation (inline rationale on both format generators)
- [x] adds unit tests (`TestIPBlockSetNameUnambiguous`, `TestNestedSetNameUnambiguous`, `TestIPBlockTwoPolicyIsolation`, `TestNestedSelectorTwoPolicyIsolation`, `TestAddReferenceCIDRSingleOwner`, `TestAddReferenceCIDROwnerReleasedOnDelete`, `TestCIDRSetsDoNotMergeInManager`; existing literals updated)
- [x] relevant PR labels added

**Notes**:

- `go test ./npm/...` passes except two environment-only failures that also fail on
  the base branch: `npm/cmd` (`iptables-nft-save` needs root) and `controllers/v1`
  (Prometheus metric registration) — neither is related to this change.
- Both name changes only affect the pre-hash set name, which is hashed to a
  fixed-length kernel name, so iptables chain names are unchanged. NPM rebuilds all
  IPSets and ACL references from the NetworkPolicy objects on startup, so the
  renamed sets reconcile on a pod restart.
