### PR TITLE
ci: skip relaxed DNS search test on Windows

### DIFF
--- a/.pipelines/cni/k8s-e2e/k8s-e2e-step-template.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e-step-template.yaml
@@ -11,13 +11,16 @@ steps:
   - script: |
       set -ex
 
-      # ginkgoSkip cant handle only |LinuxOnly. Need to have check
+      # A single-dot DNS search suffix disables short-name expansion on Windows.
+      WINDOWS_DNS_SKIP="should work with a search path containing an underscore and a search path with a single dot"
+
+      # ginkgoSkip cant handle a leading |. Build the Windows-only skip accordingly.
       if ${{ lower(and(ge(length(parameters.ginkgoSkip), 1), eq(parameters.os, 'windows'))) }}
       then
-        SKIP="|LinuxOnly"
+        SKIP="|LinuxOnly|$WINDOWS_DNS_SKIP"
       elif ${{ lower(eq(parameters.os, 'windows')) }}
       then
-        SKIP="LinuxOnly"
+        SKIP="LinuxOnly|$WINDOWS_DNS_SKIP"
       fi
 
       # Map of upstream Kubernetes feature gates that are alpha-default-off

--- a/.pipelines/cni/k8s-e2e/k8s-e2e.steps.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e.steps.yaml
@@ -12,13 +12,16 @@ steps:
   - script: |
       set -ex
 
-      # ginkgoSkip cant handle only |LinuxOnly. Need to have check
+      # A single-dot DNS search suffix disables short-name expansion on Windows.
+      WINDOWS_DNS_SKIP="should work with a search path containing an underscore and a search path with a single dot"
+
+      # ginkgoSkip cant handle a leading |. Build the Windows-only skip accordingly.
       if ${{ lower(and(ge(length(parameters.ginkgoSkip), 1), eq(parameters.os, 'windows'))) }}
       then
-        SKIP="|LinuxOnly"
+        SKIP="|LinuxOnly|$WINDOWS_DNS_SKIP"
       elif ${{ lower(eq(parameters.os, 'windows')) }}
       then
-        SKIP="LinuxOnly"
+        SKIP="LinuxOnly|$WINDOWS_DNS_SKIP"
       fi
 
       # Map of upstream Kubernetes feature gates that are alpha-default-off


### PR DESCRIPTION
## Root cause

Kubernetes v1.35 promotes relaxed DNS search validation to GA, making `should work with a search path containing an underscore and a search path with a single dot` run unconditionally. The test configures searches as `.` and `_sip._tcp.abc_d.example.com`, then expects short names such as `kubernetes.default` to resolve.

On Windows, the leading dot disables DNS suffix expansion. A live v1.35.6 Windows pod reproduced this behavior:

- `dig +search kubernetes.default` returned no result
- `dig +search kubernetes.default.svc` returned no result
- `dig kubernetes.default.svc.cluster.local` resolved to `10.0.0.1`

This demonstrates healthy cluster DNS connectivity but incompatible resolver semantics in the upstream test. Pipeline build 173548816 showed the same failure for all short-name UDP/TCP probes, repeated for three attempts and consuming roughly 31 minutes.

## What this changes

- skip only this exact spec for Windows in both classic and OneBranch CNI Kubernetes e2e runners
- preserve the test on Linux
- preserve all other Windows DNS coverage

## Validation

- reproduced Windows short-name versus FQDN behavior on the affected AKS v1.35.6 cluster
- confirmed the target spec is absent from the Windows v1.35.6 dry-run output
- parsed both changed YAML templates and ran `git diff --check`