### PR TITLE
test/cilium: use operator identity-management-mode for v1.19 eBPF configs

### DIFF
--- a/test/integration/manifests/cilium/v1.19/ebpf/dualstack/static/cilium-config.yaml
+++ b/test/integration/manifests/cilium/v1.19/ebpf/dualstack/static/cilium-config.yaml
@@ -138,7 +138,7 @@ data:
   # bpf-policy-stats-map-max specifies the maximum number of entries in global
   # policy stats map
   bpf-policy-stats-map-max: "65536"
-  identity-management-mode: "agent"
+  identity-management-mode: "operator"
   tofqdns-preallocate-identities: "true"
   policy-default-local-cluster: "false"    
 kind: ConfigMap

--- a/test/integration/manifests/cilium/v1.19/ebpf/overlay/static/cilium-config.yaml
+++ b/test/integration/manifests/cilium/v1.19/ebpf/overlay/static/cilium-config.yaml
@@ -158,7 +158,7 @@ data:
   # bpf-policy-stats-map-max specifies the maximum number of entries in global
   # policy stats map
   bpf-policy-stats-map-max: "65536"
-  identity-management-mode: "agent"
+  identity-management-mode: "operator"
   tofqdns-preallocate-identities:  "true"
   policy-default-local-cluster: "false"
 kind: ConfigMap

--- a/test/integration/manifests/cilium/v1.19/ebpf/podsubnet/static/cilium-config.yaml
+++ b/test/integration/manifests/cilium/v1.19/ebpf/podsubnet/static/cilium-config.yaml
@@ -158,7 +158,7 @@ data:
   # bpf-policy-stats-map-max specifies the maximum number of entries in global
   # policy stats map
   bpf-policy-stats-map-max: "65536"
-  identity-management-mode: "agent"
+  identity-management-mode: "operator"
   tofqdns-preallocate-identities:  "true"
   policy-default-local-cluster: "false"
 kind: ConfigMap


### PR DESCRIPTION
## What this PR does

The v1.19 eBPF static Cilium ConfigMaps set `identity-management-mode: "agent"`, inherited from the v1.18 configs. The v1.19 **non-eBPF** ConfigMaps already use `identity-management-mode: "operator"`, matching the AKS RP production default (operator-managed identities for Cilium `>= 1.19`).

This PR aligns the three v1.19 eBPF configs with `operator` so the eBPF datapath matches the non-eBPF v1.19 configs and production.

### Files changed
- `test/integration/manifests/cilium/v1.19/ebpf/overlay/static/cilium-config.yaml`
- `test/integration/manifests/cilium/v1.19/ebpf/dualstack/static/cilium-config.yaml`
- `test/integration/manifests/cilium/v1.19/ebpf/podsubnet/static/cilium-config.yaml`

Each: `identity-management-mode: "agent"` → `"operator"`.

### Why
- **Consistency:** v1.19 non-eBPF configs already use `operator`; the eBPF ones were stale copies of v1.18.
- **Production parity:** AKS RP sets `operator` for Cilium `>= 1.19` and `agent` for `1.18`. v1.18 configs are intentionally left as `agent`.

### Scope
Only v1.19 eBPF configs are touched. v1.18 (eBPF and non-eBPF) correctly remains `agent` and is unchanged.
