### PR TITLE
[release/v1.7] test: scope load-test pod readiness checks to test payloads only (#4539)

### DIFF
--- a/test/integration/datapath/datapath_linux_test.go
+++ b/test/integration/datapath/datapath_linux_test.go
@@ -131,7 +131,7 @@ func setupLinuxEnvironment(t *testing.T) {
 	})
 
 	t.Log("Waiting for pods to be running state")
-	err = kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector, nil)
+	err = kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector)
 	if err != nil {
 		t.Fatalf("Pods are not in running state due to %+v", err)
 	}
@@ -171,7 +171,7 @@ func TestDatapathLinux(t *testing.T) {
 	t.Run("Linux ping tests", func(t *testing.T) {
 		// Check goldpinger health
 		t.Run("all pods have IPs assigned", func(t *testing.T) {
-			err := kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector, nil)
+			err := kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector)
 			if err != nil {
 				t.Fatalf("Pods are not in running state due to %+v", err)
 			}

--- a/test/integration/datapath/datapath_windows_test.go
+++ b/test/integration/datapath/datapath_windows_test.go
@@ -104,7 +104,7 @@ func setupWindowsEnvironment(t *testing.T) {
 		kubernetes.MustCreateDeployment(ctx, deploymentsClient, deployment)
 
 		t.Log("Waiting for pods to be running state")
-		err = kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector, nil)
+		err = kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -114,7 +114,7 @@ func setupWindowsEnvironment(t *testing.T) {
 		t.Log("Namespace already exists")
 
 		t.Log("Checking for pods to be running state")
-		err = kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector, nil)
+		err = kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/test/integration/load/load_test.go
+++ b/test/integration/load/load_test.go
@@ -88,7 +88,7 @@ func TestLoad(t *testing.T) {
 	kubernetes.MustCreateDeployment(ctx, deploymentsClient, deployment)
 
 	t.Log("Checking pods are running")
-	err = kubernetes.WaitForPodsRunning(ctx, clientset, namespace, podLabelSelector, nil)
+	err = kubernetes.WaitForPodsRunning(ctx, clientset, namespace, podLabelSelector)
 	require.NoError(t, err)
 
 	t.Log("Repeating the scale up/down cycle")
@@ -101,7 +101,7 @@ func TestLoad(t *testing.T) {
 		kubernetes.MustScaleDeployment(ctx, deploymentsClient, deployment, clientset, namespace, podLabelSelector, testConfig.ScaleUpReplicas, testConfig.SkipWait)
 	}
 	t.Log("Checking pods are running and IP assigned")
-	err = kubernetes.WaitForPodsRunning(ctx, clientset, "", "", []string{"azuresecuritylinuxagent"})
+	err = kubernetes.WaitForPodsRunning(ctx, clientset, namespace, podLabelSelector)
 	require.NoError(t, err)
 
 	if testConfig.ValidateStateFile {

--- a/test/integration/swiftv2/swiftv2_test.go
+++ b/test/integration/swiftv2/swiftv2_test.go
@@ -65,7 +65,7 @@ func setupLinuxEnvironment(t *testing.T) {
 	}
 
 	t.Log("Waiting for pods to be running state")
-	err = kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector, nil)
+	err = kubernetes.WaitForPodsRunning(ctx, clientset, *podNamespace, podLabelSelector)
 	if err != nil {
 		t.Fatalf("Pods are not in running state due to %+v", err)
 	}

--- a/test/internal/kubernetes/utils.go
+++ b/test/internal/kubernetes/utils.go
@@ -269,13 +269,8 @@ func MustSetupCNP(ctx context.Context, clientset *cilium.Clientset, cnpPath stri
 
 func Int32ToPtr(i int32) *int32 { return &i }
 
-func WaitForPodsRunning(ctx context.Context, clientset *kubernetes.Clientset, namespace, labelselector string, excludeNamespaces []string) error {
+func WaitForPodsRunning(ctx context.Context, clientset *kubernetes.Clientset, namespace, labelselector string) error {
 	podsClient := clientset.CoreV1().Pods(namespace)
-
-	excludeSet := make(map[string]struct{}, len(excludeNamespaces))
-	for _, ns := range excludeNamespaces {
-		excludeSet[ns] = struct{}{}
-	}
 
 	checkPodIPsFn := func() error {
 		podList, err := podsClient.List(ctx, metav1.ListOptions{LabelSelector: labelselector})
@@ -289,9 +284,6 @@ func WaitForPodsRunning(ctx context.Context, clientset *kubernetes.Clientset, na
 
 		for index := range podList.Items {
 			pod := podList.Items[index]
-			if _, excluded := excludeSet[pod.Namespace]; excluded {
-				continue
-			}
 			if pod.Status.Phase == corev1.PodPending {
 				return errors.New("some pods still pending")
 			}
@@ -299,9 +291,6 @@ func WaitForPodsRunning(ctx context.Context, clientset *kubernetes.Clientset, na
 
 		for index := range podList.Items {
 			pod := podList.Items[index]
-			if _, excluded := excludeSet[pod.Namespace]; excluded {
-				continue
-			}
 			if pod.Status.PodIP == "" {
 				return errors.Errorf("Pod %s/%s has not been allocated an IP yet with reason %s", pod.Namespace, pod.Name, pod.Status.Message)
 			}

--- a/test/validate/linux_validate.go
+++ b/test/validate/linux_validate.go
@@ -3,18 +3,21 @@ package validate
 import (
 	"context"
 	"encoding/json"
+	"log"
 
 	"github.com/Azure/azure-container-networking/cns"
 	restserver "github.com/Azure/azure-container-networking/cns/restserver"
 	acnk8s "github.com/Azure/azure-container-networking/test/internal/kubernetes"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
 	validatorPod            = "k8s-app=azure-cns"
 	ciliumLabelSelector     = "k8s-app=cilium"
 	overlayClusterLabelName = "overlay"
+	loadTestPodLabel        = "load-test=true"
 )
 
 var (
@@ -313,6 +316,19 @@ func (v *Validator) validateRestartNetwork(ctx context.Context) error {
 		return errors.Wrapf(err, "failed to get node list")
 	}
 
+	// Only validate the load-test payload pods in v.namespace. If there is no
+	// payload deployed (e.g. validate-state is invoked after the load-test
+	// namespace has been cleaned up), there is nothing to validate, so skip the
+	// readiness check.
+	payloadPods, err := v.clientset.CoreV1().Pods(v.namespace).List(ctx, metav1.ListOptions{LabelSelector: loadTestPodLabel})
+	if err != nil {
+		return errors.Wrapf(err, "failed to list pods in namespace %s", v.namespace)
+	}
+	if len(payloadPods.Items) == 0 {
+		log.Printf("no test payload pods found in namespace %s, skipping restart network validation", v.namespace)
+		return nil
+	}
+
 	for index := range nodes.Items {
 		node := nodes.Items[index]
 		if node.Status.NodeInfo.OperatingSystem != string(corev1.Linux) {
@@ -332,7 +348,7 @@ func (v *Validator) validateRestartNetwork(ctx context.Context) error {
 		if err != nil {
 			return errors.Wrapf(err, "failed to exec into privileged pod %s on node %s", privilegedPod.Name, node.Name)
 		}
-		err = acnk8s.WaitForPodsRunning(ctx, v.clientset, "", "", []string{"azuresecuritylinuxagent"})
+		err = acnk8s.WaitForPodsRunning(ctx, v.clientset, v.namespace, loadTestPodLabel)
 		if err != nil {
 			return errors.Wrapf(err, "failed to wait for pods running")
 		}


### PR DESCRIPTION
Backport of #4539 to `release/v1.7`.

Cherry-picked squash merge commit 6c87e9c421515c0f586ecd87a0657563213a0ab1 (`-x`).

## Summary
Scopes the load-test pod readiness checks (TestLoad and the linux validator's post-network-restart check) to the test payloads (load-test namespace / `load-test=true` label) instead of scanning all pods across all namespaces, so transiently-Pending system pods (e.g. azuresecuritylinuxagent after node restart) no longer flake the stage. Also drops the now-unused `excludeNamespaces` parameter and dead exclusion logic.

Applied cleanly with a benign auto-merge in `test/validate/linux_validate.go`. `go vet` passes on the touched packages.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>