### PR TITLE
fix: [NPM] give IPSets distinct kernel names via a wide digest

### DIFF
--- a/npm/ipsm/ipsm_test.go
+++ b/npm/ipsm/ipsm_test.go
@@ -610,7 +610,7 @@ func TestMarshalSetMapJSON(t *testing.T) {
 	require.NoError(t, err)
 	fmt.Println(string(setMapRaw))
 
-	expect := []byte(`{"azure-npm-922816856":"test-set"}`)
+	expect := []byte(`{"azure-npm-3fmr1y4xucxg45l55kfb":"test-set"}`)
 	for key, val := range ipsMgr.setMap {
 		fmt.Printf("key: %s value: %+v\n", key, val)
 	}

--- a/npm/pkg/dataplane/ipsets/ipsetmanager.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager.go
@@ -47,10 +47,13 @@ type IPSetManager struct {
 	// This set is used based on the AddEmptySetToLists flag.
 	// If emptySet is non-nil, it should be in the kernel or ready to be created in the dirtyCache.
 	// Its reference counts are currently unaccounted for and may be incorrect.
-	emptySet   *IPSet
-	setMap     map[string]*IPSet
-	dirtyCache dirtyCacheInterface
-	ioShim     *common.IOShim
+	emptySet *IPSet
+	setMap   map[string]*IPSet
+	// kernelNameOwner maps a set's kernel name (hash of its prefixed name) to the prefixed
+	// name that owns it, so two distinct sets can't resolve to the same kernel set.
+	kernelNameOwner map[string]string
+	dirtyCache      dirtyCacheInterface
+	ioShim          *common.IOShim
 	// consecutiveApplyFailures is used in Linux to count the number of consecutive failures to apply ipsets
 	// if this count exceeds a threshold, we will panic
 	consecutiveApplyFailures int
@@ -69,11 +72,12 @@ type IPSetManagerCfg struct {
 
 func NewIPSetManager(iMgrCfg *IPSetManagerCfg, ioShim *common.IOShim) *IPSetManager {
 	return &IPSetManager{
-		iMgrCfg:    iMgrCfg,
-		emptySet:   nil, // will be set if needed in calls to AddToLists
-		setMap:     make(map[string]*IPSet),
-		dirtyCache: newDirtyCache(),
-		ioShim:     ioShim,
+		iMgrCfg:         iMgrCfg,
+		emptySet:        nil, // will be set if needed in calls to AddToLists
+		setMap:          make(map[string]*IPSet),
+		kernelNameOwner: make(map[string]string),
+		dirtyCache:      newDirtyCache(),
+		ioShim:          ioShim,
 		// set to 0 to avoid lint error for windows
 		consecutiveApplyFailures: 0,
 	}
@@ -105,6 +109,7 @@ func (iMgr *IPSetManager) ResetIPSets() error {
 	metrics.ResetIPSetEntries()
 	err := iMgr.resetIPSets()
 	iMgr.setMap = make(map[string]*IPSet)
+	iMgr.kernelNameOwner = make(map[string]string)
 	iMgr.emptySet = nil
 	iMgr.clearDirtyCache()
 	if err != nil {
@@ -119,15 +124,35 @@ func (iMgr *IPSetManager) CreateIPSets(setMetadatas []*IPSetMetadata) {
 	defer iMgr.Unlock()
 
 	for _, set := range setMetadatas {
-		_ = iMgr.createAndGetIPSet(set)
+		if _, err := iMgr.createAndGetIPSet(set); err != nil {
+			// createAndGetIPSet does not log; this is the only entry point that does not
+			// return the error to a caller, so log it here.
+			metrics.SendErrorLogAndMetric(util.IpsmID, "error: failed to create ipset: %s", err.Error())
+		}
 	}
 }
 
-func (iMgr *IPSetManager) createAndGetIPSet(setMetadata *IPSetMetadata) *IPSet {
+// claimKernelName records prefixedName as the owner of hashedName. It fails closed if a
+// different prefixed name already owns that kernel name (two distinct ipsets would otherwise
+// share one kernel set and combine their members). Re-claiming by the same owner is a no-op.
+func (iMgr *IPSetManager) claimKernelName(prefixedName, hashedName string) error {
+	if owner, ok := iMgr.kernelNameOwner[hashedName]; ok && owner != prefixedName {
+		return npmerrors.Errorf(npmerrors.CreateIPSet, false,
+			fmt.Sprintf("ipset %s resolves to kernel name %s already owned by %s", prefixedName, hashedName, owner))
+	}
+	iMgr.kernelNameOwner[hashedName] = prefixedName
+	return nil
+}
+
+func (iMgr *IPSetManager) createAndGetIPSet(setMetadata *IPSetMetadata) (*IPSet, error) {
 	prefixedName := setMetadata.GetPrefixName()
 	set, exists := iMgr.setMap[prefixedName]
 	if exists {
-		return set
+		return set, nil
+	}
+
+	if err := iMgr.claimKernelName(prefixedName, setMetadata.GetHashedName()); err != nil {
+		return nil, err
 	}
 
 	set = NewIPSet(setMetadata)
@@ -142,7 +167,11 @@ func (iMgr *IPSetManager) createAndGetIPSet(setMetadata *IPSetMetadata) *IPSet {
 	if iMgr.iMgrCfg.AddEmptySetToLists && (set.Type == KeyLabelOfNamespace || set.Type == KeyValueLabelOfNamespace) {
 		if iMgr.emptySet == nil {
 			// duplicate of code chunk above
-			iMgr.emptySet = NewIPSet(emptySetMetadata)
+			emptySet := NewIPSet(emptySetMetadata)
+			if err := iMgr.claimKernelName(emptySetPrefixName, emptySet.HashedName); err != nil {
+				return nil, err
+			}
+			iMgr.emptySet = emptySet
 			iMgr.setMap[emptySetPrefixName] = iMgr.emptySet
 			metrics.IncNumIPSets()
 			iMgr.modifyCacheForKernelCreation(iMgr.emptySet)
@@ -151,7 +180,7 @@ func (iMgr *IPSetManager) createAndGetIPSet(setMetadata *IPSetMetadata) *IPSet {
 		iMgr.addMemberToList(set, iMgr.emptySet)
 	}
 
-	return set
+	return set, nil
 }
 
 // DeleteIPSet expects the prefixed ipset name
@@ -181,7 +210,10 @@ func (iMgr *IPSetManager) AddReference(setMetadata *IPSetMetadata, referenceName
 	iMgr.Lock()
 	defer iMgr.Unlock()
 	// NOTE: any newly created IPSet will still be in the cache if an error is returned later
-	set := iMgr.createAndGetIPSet(setMetadata)
+	set, err := iMgr.createAndGetIPSet(setMetadata)
+	if err != nil {
+		return err
+	}
 	if referenceType == SelectorType && !set.canSetBeSelectorIPSet() {
 		msg := fmt.Sprintf("ipset %s is not a selector ipset it is of type %s", set.Name, set.Type.String())
 		metrics.SendErrorLogAndMetric(util.IpsmID, "error: failed to add reference: %s", msg)
@@ -268,7 +300,10 @@ func (iMgr *IPSetManager) AddToSets(addToSets []*IPSetMetadata, ip, podKey strin
 		// 1. check for errors and create a missing set
 		prefixedName := metadata.GetPrefixName()
 		// NOTE: any newly created IPSet will still be in the cache if an error is returned later
-		set := iMgr.createAndGetIPSet(metadata)
+		set, err := iMgr.createAndGetIPSet(metadata)
+		if err != nil {
+			return err
+		}
 		if set.Kind != HashSet {
 			msg := fmt.Sprintf("ipset %s is not a hash set", prefixedName)
 			metrics.SendErrorLogAndMetric(util.IpsmID, "error: failed to add to sets: %s", msg)
@@ -346,7 +381,10 @@ func (iMgr *IPSetManager) AddToLists(listMetadatas, setMetadatas []*IPSetMetadat
 	// 1. check for errors in members and create any missing sets
 	for _, setMetadata := range setMetadatas {
 		// NOTE: any newly created IPSet will still be in the cache if an error is returned later
-		set := iMgr.createAndGetIPSet(setMetadata)
+		set, err := iMgr.createAndGetIPSet(setMetadata)
+		if err != nil {
+			return err
+		}
 
 		// Nested IPSets are only supported for windows
 		// Check if we want to actually use that support
@@ -360,7 +398,10 @@ func (iMgr *IPSetManager) AddToLists(listMetadatas, setMetadatas []*IPSetMetadat
 	for _, listMetadata := range listMetadatas {
 		// 2. create the list if it's missing and check for list errors
 		// NOTE: any newly created IPSet will still be in the cache if an error is returned later
-		list := iMgr.createAndGetIPSet(listMetadata)
+		list, err := iMgr.createAndGetIPSet(listMetadata)
+		if err != nil {
+			return err
+		}
 
 		if list.Kind != ListSet {
 			msg := fmt.Sprintf("ipset %s is not a list set", list.Name)
@@ -524,6 +565,7 @@ func (iMgr *IPSetManager) modifyCacheForCacheDeletion(set *IPSet, deleteOption u
 	}
 
 	delete(iMgr.setMap, set.Name)
+	delete(iMgr.kernelNameOwner, set.HashedName)
 	metrics.DeleteIPSet(set.Name)
 	if iMgr.iMgrCfg.IPSetMode == ApplyAllIPSets {
 		iMgr.modifyCacheForKernelRemoval(set)

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_linux.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_linux.go
@@ -18,7 +18,7 @@ const (
 	ipsetFlushAndDestroyString = "ipset flush && ipset destroy"
 
 	azureNPMPrefix        = "azure-npm-"
-	azureNPMRegex         = "azure-npm-\\d+"
+	azureNPMRegex         = "azure-npm-[0-9a-z]+"
 	positiveRefsRegex     = "References: [1-9]"
 	referenceGrepLookBack = "5"
 	maxLinesToPrint       = 10

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_linux_test.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_linux_test.go
@@ -231,6 +231,67 @@ func TestDestroyNPMIPSetsCreatorSuccess(t *testing.T) {
 	require.Equal(t, 0, *destroyFailureCount, "got unexpected destroy failure count")
 }
 
+// TestAzureNPMRegexMatchesOldAndNewNames verifies the ipset-cleanup regex matches BOTH the old
+// 32-bit numeric kernel names and the new base36 names, so that on upgrade or rollback no stale
+// ipset of either format is orphaned (which would leak and could eventually exhaust ipsets).
+func TestAzureNPMRegexMatchesOldAndNewNames(t *testing.T) {
+	re := regexp.MustCompile(azureNPMRegex)
+	mustMatch := []string{
+		"azure-npm-123456",                      // old 32-bit numeric
+		"azure-npm-2900316864",                  // old numeric (reported collision value)
+		"azure-npm-3fmr1y4xucxg45l55kfb",        // new base36
+		"azure-npm-42xi2gy762uhahnxfutd",        // new base36 (ns-msobb-target)
+		util.GetHashedName("ns-some-namespace"), // whatever the current impl produces
+	}
+	for _, n := range mustMatch {
+		require.Equal(t, n, re.FindString(n), "cleanup regex must fully match %q", n)
+	}
+	for _, n := range []string{"KUBE-SERVICES", "cali-abc123", "not-azure-npm", "azure-npm-"} {
+		require.Empty(t, re.FindString(n), "cleanup regex must not match %q", n)
+	}
+}
+
+// TestDestroyMixedOldAndNewIPSets verifies the reset path flushes and destroys a mix of old
+// numeric and new base36 ipsets in a single pass (upgrade/rollback migration safety).
+func TestDestroyMixedOldAndNewIPSets(t *testing.T) {
+	calls := []testutils.TestCmd{fakeRestoreSuccessCommand, fakeRestoreSuccessCommand}
+	ioshim := common.NewMockIOShim(calls)
+	defer ioshim.VerifyCalls(t, calls)
+	iMgr := NewIPSetManager(applyAlwaysCfg, ioshim)
+
+	mixed := []string{
+		"azure-npm-123456",               // old numeric
+		"azure-npm-3fmr1y4xucxg45l55kfb", // new base36
+		"azure-npm-987654",               // old numeric
+		"azure-npm-42xi2gy762uhahnxfutd", // new base36
+	}
+	listOutput := []byte(strings.Join(mixed, "\n") + "\n")
+
+	creator, names, failedNames := iMgr.fileCreatorForFlushAll(listOutput)
+	flushLines := creator.ToString()
+	for _, n := range mixed {
+		require.Contains(t, flushLines, "-F "+n, "must flush %q (both old and new formats)", n)
+	}
+	sort.Strings(names)
+	expNames := append([]string(nil), mixed...)
+	sort.Strings(expNames)
+	require.Equal(t, expNames, names, "flush must capture all mixed-format names")
+	wasModified, err := creator.RunCommandOnceWithFile("ipset", "restore")
+	require.False(t, wasModified)
+	require.NoError(t, err)
+	require.Len(t, failedNames, 0)
+
+	creator, destroyFailureCount := iMgr.fileCreatorForDestroyAll(names, failedNames, nil)
+	destroyLines := creator.ToString()
+	for _, n := range mixed {
+		require.Contains(t, destroyLines, "-X "+n, "must destroy %q (both old and new formats)", n)
+	}
+	wasModified, err = creator.RunCommandOnceWithFile("ipset", "restore")
+	require.False(t, wasModified)
+	require.NoError(t, err)
+	require.Equal(t, 0, *destroyFailureCount)
+}
+
 func TestDestroyNPMIPSetsCreatorErrorHandling(t *testing.T) {
 	/*
 		original lines:

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_linux_test.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_linux_test.go
@@ -1031,6 +1031,29 @@ func TestCidrExceptMembers(t *testing.T) {
 	require.False(t, wasFileAltered, "file should not be altered")
 }
 
+// TestReportedPairRendersDistinctKernelSets drives two logical sets whose 32-bit names
+// previously collided all the way to the rendered restore file, and confirms each keeps its
+// own kernel set and member instead of the two being unioned into one set.
+func TestReportedPairRendersDistinctKernelSets(t *testing.T) {
+	iMgr := NewIPSetManager(applyAlwaysCfg, common.NewMockIOShim(nil))
+
+	nsSet := NewIPSetMetadata("msobb-target", Namespace)            // prefixed "ns-msobb-target"
+	podLabelSet := NewIPSetMetadata("x:YMaaIZ", KeyValueLabelOfPod) // prefixed "podlabel-x:YMaaIZ"
+	require.NotEqual(t, nsSet.GetHashedName(), podLabelSet.GetHashedName(),
+		"the two logical sets must render to distinct kernel names")
+
+	require.NoError(t, iMgr.AddToSets([]*IPSetMetadata{nsSet}, "10.0.0.10", "a"))
+	require.NoError(t, iMgr.AddToSets([]*IPSetMetadata{podLabelSet}, "10.0.0.20", "b"))
+
+	rendered := iMgr.fileCreatorForApply(1).ToString()
+
+	// Each member lands only in its own kernel set; neither set absorbs the other's IP.
+	require.Contains(t, rendered, fmt.Sprintf("-A %s 10.0.0.10", nsSet.GetHashedName()))
+	require.Contains(t, rendered, fmt.Sprintf("-A %s 10.0.0.20", podLabelSet.GetHashedName()))
+	require.NotContains(t, rendered, fmt.Sprintf("-A %s 10.0.0.20", nsSet.GetHashedName()))
+	require.NotContains(t, rendered, fmt.Sprintf("-A %s 10.0.0.10", podLabelSet.GetHashedName()))
+}
+
 func TestUpdateWithIdenticalSaveFile(t *testing.T) {
 	calls := []testutils.TestCmd{fakeRestoreSuccessCommand}
 	ioshim := common.NewMockIOShim(calls)

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_linux_test.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_linux_test.go
@@ -464,7 +464,7 @@ func TestDestroyNPMIPSets(t *testing.T) {
 				fakeRestoreSuccessCommand,
 				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "-B", "5", "-P", "References: [1-9]"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
+				{Cmd: []string{"grep", "-o", "-P", "azure-npm-[0-9a-z]+"}, ExitCode: 1},
 				fakeRestoreSuccessCommand,
 			},
 			wantErr: false,
@@ -504,7 +504,7 @@ func TestDestroyNPMIPSets(t *testing.T) {
 				fakeRestoreSuccessCommand,
 				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "-B", "5", "-P", "References: [1-9]"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
+				{Cmd: []string{"grep", "-o", "-P", "azure-npm-[0-9a-z]+"}, ExitCode: 1},
 				{Cmd: ipsetRestoreStringSlice, ExitCode: 1},
 				{Cmd: ipsetRestoreStringSlice, ExitCode: 1},
 				{Cmd: ipsetRestoreStringSlice, ExitCode: 1},
@@ -523,7 +523,7 @@ func TestDestroyNPMIPSets(t *testing.T) {
 				fakeRestoreSuccessCommand,
 				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "-B", "5", "-P", "References: [1-9]"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, Stdout: resetIPSetsListOutputString},
+				{Cmd: []string{"grep", "-o", "-P", "azure-npm-[0-9a-z]+"}, Stdout: resetIPSetsListOutputString},
 			},
 			wantErr: false,
 		},
@@ -537,7 +537,7 @@ func TestDestroyNPMIPSets(t *testing.T) {
 				fakeRestoreSuccessCommand,
 				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "-B", "5", "-P", "References: [1-9]"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, Stdout: otherIPSetsListOutput},
+				{Cmd: []string{"grep", "-o", "-P", "azure-npm-[0-9a-z]+"}, Stdout: otherIPSetsListOutput},
 				fakeRestoreSuccessCommand,
 			},
 			wantErr: false,
@@ -557,7 +557,7 @@ func TestDestroyNPMIPSets(t *testing.T) {
 				fakeRestoreSuccessCommand,
 				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "-B", "5", "-P", "References: [1-9]"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
+				{Cmd: []string{"grep", "-o", "-P", "azure-npm-[0-9a-z]+"}, ExitCode: 1},
 				fakeRestoreSuccessCommand,
 			},
 			wantErr: false,
@@ -577,7 +577,7 @@ func TestDestroyNPMIPSets(t *testing.T) {
 				fakeRestoreSuccessCommand,
 				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "-B", "5", "-P", "References: [1-9]"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
+				{Cmd: []string{"grep", "-o", "-P", "azure-npm-[0-9a-z]+"}, ExitCode: 1},
 				fakeRestoreSuccessCommand,
 			},
 			wantErr: false,
@@ -592,7 +592,7 @@ func TestDestroyNPMIPSets(t *testing.T) {
 				fakeRestoreSuccessCommand,
 				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "-B", "5", "-P", "References: [1-9]"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
+				{Cmd: []string{"grep", "-o", "-P", "azure-npm-[0-9a-z]+"}, ExitCode: 1},
 				{
 					Cmd:      ipsetRestoreStringSlice,
 					Stdout:   "Error in line 2: The set with the given name does not exist",
@@ -612,7 +612,7 @@ func TestDestroyNPMIPSets(t *testing.T) {
 				fakeRestoreSuccessCommand,
 				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "-B", "5", "-P", "References: [1-9]"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
+				{Cmd: []string{"grep", "-o", "-P", "azure-npm-[0-9a-z]+"}, ExitCode: 1},
 				{
 					Cmd:      ipsetRestoreStringSlice,
 					Stdout:   "Error in line 2: for some other error",
@@ -1850,7 +1850,7 @@ func testAndSortRestoreFileLines(t *testing.T, lines []string) []string {
 func hashedNameOfSetImpacted(t *testing.T, operation string, lines []string, lineNum int) string {
 	lineNumIndex := lineNum - 1
 	line := lines[lineNumIndex]
-	pattern := fmt.Sprintf(`\%s (azure-npm-\d+)`, operation)
+	pattern := fmt.Sprintf(`\%s (azure-npm-[0-9a-z]+)`, operation)
 	re := regexp.MustCompile(pattern)
 	results := re.FindStringSubmatch(line)
 	require.Equal(t, 2, len(results), "expected to find a match with regex pattern %s for line: %s", pattern, line)
@@ -1860,7 +1860,7 @@ func hashedNameOfSetImpacted(t *testing.T, operation string, lines []string, lin
 func memberNameOfSetImpacted(t *testing.T, lines []string, lineNum int) string {
 	lineNumIndex := lineNum - 1
 	line := lines[lineNumIndex]
-	pattern := `\-[AD] azure-npm-\d+ (.*)`
+	pattern := `\-[AD] azure-npm-[0-9a-z]+ (.*)`
 	re := regexp.MustCompile(pattern)
 	member := re.FindStringSubmatch(line)[1]
 	results := re.FindStringSubmatch(line)

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_test.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_test.go
@@ -135,6 +135,50 @@ func TestCIDRSetsDoNotMergeInManager(t *testing.T) {
 	require.Equal(t, map[string]struct{}{"b-in-ns-c/a": {}}, secondSet.NetPolReference)
 }
 
+// TestGetHashedNameDistinctForReportedPair verifies the two prefixed names that previously
+// shared a kernel name now resolve to distinct kernel names, so their members can never be
+// combined.
+func TestGetHashedNameDistinctForReportedPair(t *testing.T) {
+	nsSet := NewIPSetMetadata("msobb-target", Namespace)            // prefixed "ns-msobb-target"
+	podLabelSet := NewIPSetMetadata("x:YMaaIZ", KeyValueLabelOfPod) // prefixed "podlabel-x:YMaaIZ"
+	require.NotEqual(t, nsSet.GetHashedName(), podLabelSet.GetHashedName(),
+		"distinct ipset names must resolve to distinct kernel names")
+}
+
+// TestClaimKernelNameSingleOwner verifies the defense-in-depth invariant: a kernel name is
+// owned by a single prefixed name; the owner (and re-claims) are accepted, a different name
+// is rejected, and the name is released on delete.
+func TestClaimKernelNameSingleOwner(t *testing.T) {
+	metrics.ReinitializeAll()
+	iMgr := NewIPSetManager(applyAlwaysCfg, common.NewMockIOShim(nil))
+
+	const kernelName = "azure-npm-sharedkernelname00"
+	require.NoError(t, iMgr.claimKernelName("ns-a", kernelName))     // first owner
+	require.NoError(t, iMgr.claimKernelName("ns-a", kernelName))     // same owner re-claims (idempotent)
+	require.Error(t, iMgr.claimKernelName("podlabel-b", kernelName)) // different owner rejected
+
+	delete(iMgr.kernelNameOwner, kernelName)
+	require.NoError(t, iMgr.claimKernelName("podlabel-b", kernelName)) // free after release
+}
+
+// TestCreateIPSetKernelNameFreedOnDelete verifies DeleteIPSet releases a set's kernel name so
+// the same set can be recreated afterwards.
+func TestCreateIPSetKernelNameFreedOnDelete(t *testing.T) {
+	metrics.ReinitializeAll()
+	iMgr := NewIPSetManager(applyAlwaysCfg, common.NewMockIOShim(nil))
+
+	set := NewIPSetMetadata("msobb-target", Namespace)
+	iMgr.CreateIPSets([]*IPSetMetadata{set})
+	require.NotNil(t, iMgr.GetIPSet(set.GetPrefixName()))
+	_, owned := iMgr.kernelNameOwner[set.GetHashedName()]
+	require.True(t, owned)
+
+	iMgr.DeleteIPSet(set.GetPrefixName(), util.SoftDelete)
+	require.Nil(t, iMgr.GetIPSet(set.GetPrefixName()))
+	_, owned = iMgr.kernelNameOwner[set.GetHashedName()]
+	require.False(t, owned, "kernel name must be released on delete")
+}
+
 func TestReconcileCache(t *testing.T) {
 	type args struct {
 		cfg          *IPSetManagerCfg

--- a/npm/util/util.go
+++ b/npm/util/util.go
@@ -195,7 +195,14 @@ func AppendMap(base, new map[string]string) map[string]string {
 // hashedNameDigestLen (20) = 30 chars, within the 31-char kernel ipset name limit.
 func GetHashedName(name string) string {
 	sum := sha256.Sum256([]byte(name))
-	return AzureNpmPrefix + new(big.Int).SetBytes(sum[:]).Text(36)[:hashedNameDigestLen]
+	// Text(36) omits leading zeros, so a small digest could be shorter than
+	// hashedNameDigestLen; left-pad to a fixed width before slicing so the result is always
+	// exactly hashedNameDigestLen characters and the slice can never panic.
+	digest := new(big.Int).SetBytes(sum[:]).Text(36)
+	if len(digest) < hashedNameDigestLen {
+		digest = strings.Repeat("0", hashedNameDigestLen-len(digest)) + digest
+	}
+	return AzureNpmPrefix + digest[:hashedNameDigestLen]
 }
 
 // CompareK8sVer compares two k8s versions.

--- a/npm/util/util.go
+++ b/npm/util/util.go
@@ -92,6 +92,11 @@ func GetHashedChainName(name string) string {
 	return digest[:hashedChainDigestLen]
 }
 
+// hashedNameDigestLen is the number of base36 digest characters appended after
+// AzureNpmPrefix to form a kernel ipset name. 20 base36 chars is ~103 bits, which keeps
+// distinct ipset names from resolving to the same kernel name, and fits the 31-char limit.
+const hashedNameDigestLen = 20
+
 // SortMap sorts the map by key in alphabetical order.
 // Note: even though the map is sorted, accessing it through range will still result in random order.
 func SortMap(m *map[string]string) ([]string, []string) {
@@ -184,9 +189,13 @@ func AppendMap(base, new map[string]string) map[string]string {
 	return base
 }
 
-// GetHashedName returns hashed ipset name.
+// GetHashedName returns the kernel ipset name for the given prefixed name. It uses a wide
+// digest (not the 32-bit Hash used for iptables chain names, which is length-constrained) so
+// distinct ipset names map to distinct kernel names. The result is AzureNpmPrefix (10) +
+// hashedNameDigestLen (20) = 30 chars, within the 31-char kernel ipset name limit.
 func GetHashedName(name string) string {
-	return AzureNpmPrefix + Hash(name)
+	sum := sha256.Sum256([]byte(name))
+	return AzureNpmPrefix + new(big.Int).SetBytes(sum[:]).Text(36)[:hashedNameDigestLen]
 }
 
 // CompareK8sVer compares two k8s versions.

--- a/npm/util/util.go
+++ b/npm/util/util.go
@@ -190,9 +190,9 @@ func AppendMap(base, new map[string]string) map[string]string {
 }
 
 // GetHashedName returns the kernel ipset name for the given prefixed name. It uses a wide
-// digest (not the 32-bit Hash used for iptables chain names, which is length-constrained) so
-// distinct ipset names map to distinct kernel names. The result is AzureNpmPrefix (10) +
-// hashedNameDigestLen (20) = 30 chars, within the 31-char kernel ipset name limit.
+// digest (wider than GetHashedChainName's, since iptables chain names are more
+// length-constrained) so distinct ipset names map to distinct kernel names. The result is
+// AzureNpmPrefix (10) + hashedNameDigestLen (20) = 30 chars, within the 31-char kernel ipset name limit.
 func GetHashedName(name string) string {
 	sum := sha256.Sum256([]byte(name))
 	// Text(36) omits leading zeros, so a small digest could be shorter than

--- a/npm/util/util_test.go
+++ b/npm/util/util_test.go
@@ -477,6 +477,14 @@ func TestGetHashedName(t *testing.T) {
 	require.LessOrEqual(t, len(name), 31, "hashed name must fit the kernel ipset name limit")
 	require.True(t, strings.HasPrefix(name, AzureNpmPrefix), "hashed name must carry the azure-npm- prefix")
 
+	// The digest is left-padded to a fixed width, so every name is exactly
+	// prefix + hashedNameDigestLen characters regardless of input (a short digest can never
+	// shorten the slice and panic).
+	wantLen := len(AzureNpmPrefix) + hashedNameDigestLen
+	for _, in := range []string{"", "a", "ns-some-namespace", "podlabel-x:YMaaIZ", strings.Repeat("z", 300)} {
+		require.Len(t, GetHashedName(in), wantLen, "hashed name must be fixed width for %q", in)
+	}
+
 	// Distinct inputs (incl. the reported pair) produce distinct kernel names.
 	require.NotEqual(t, GetHashedName("ns-msobb-target"), GetHashedName("podlabel-x:YMaaIZ"))
 	require.NotEqual(t, GetHashedName("ns-a"), GetHashedName("ns-b"))

--- a/npm/util/util_test.go
+++ b/npm/util/util_test.go
@@ -489,3 +489,28 @@ func TestGetHashedName(t *testing.T) {
 	require.NotEqual(t, GetHashedName("ns-msobb-target"), GetHashedName("podlabel-x:YMaaIZ"))
 	require.NotEqual(t, GetHashedName("ns-a"), GetHashedName("ns-b"))
 }
+
+// TestHashedNameGoldenVectors pins the exact output of the kernel-name and chain-name digests
+// to values computed independently (base36 of the SHA-256 digest), so any accidental change to
+// the algorithm, encoding, or padding is caught. These names are stable across architectures
+// and restarts because they derive only from crypto/sha256 and math/big, not a seeded hash.
+func TestHashedNameGoldenVectors(t *testing.T) {
+	// azure-npm- + base36(sha256(name)) left-padded/truncated to 20 chars.
+	ipsetVectors := map[string]string{
+		"ns-test":           "azure-npm-343gyx4g1wf87lwlewvk",
+		"podlabel-x:YMaaIZ": "azure-npm-61b0uqiiz2delucbmvi2",
+		"ns-msobb-target":   "azure-npm-42xi2gy762uhahnxfutd",
+	}
+	for in, want := range ipsetVectors {
+		require.Equal(t, want, GetHashedName(in), "GetHashedName(%q) golden vector", in)
+	}
+
+	// base36(sha256(key) mod 36^10) left-padded/truncated to 10 chars.
+	chainVectors := map[string]string{
+		"x/test1":                             "jo5gdwc4t2",
+		"msobb-server/trusted-namespace-only": "7d7a0cfguo",
+	}
+	for in, want := range chainVectors {
+		require.Equal(t, want, GetHashedChainName(in), "GetHashedChainName(%q) golden vector", in)
+	}
+}

--- a/npm/util/util_test.go
+++ b/npm/util/util_test.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -467,4 +468,16 @@ func TestGetHashedChainName(t *testing.T) {
 	// Distinct policy keys produce distinct digests.
 	require.NotEqual(t, GetHashedChainName("y/test2"), GetHashedChainName("z/test3"))
 	require.NotEqual(t, GetHashedChainName("ns-a/p"), GetHashedChainName("ns-b/p"))
+}
+
+func TestGetHashedName(t *testing.T) {
+	// Deterministic and within the 31-char kernel ipset name limit.
+	name := GetHashedName("ns-some-namespace")
+	require.Equal(t, name, GetHashedName("ns-some-namespace"), "hashed name must be deterministic")
+	require.LessOrEqual(t, len(name), 31, "hashed name must fit the kernel ipset name limit")
+	require.True(t, strings.HasPrefix(name, AzureNpmPrefix), "hashed name must carry the azure-npm- prefix")
+
+	// Distinct inputs (incl. the reported pair) produce distinct kernel names.
+	require.NotEqual(t, GetHashedName("ns-msobb-target"), GetHashedName("podlabel-x:YMaaIZ"))
+	require.NotEqual(t, GetHashedName("ns-a"), GetHashedName("ns-b"))
 }


### PR DESCRIPTION
**Reason for Change**:

An IPSet's kernel name was `AzureNpmPrefix` + a 32-bit FNV of its prefixed name.
Because that digest is narrow, two distinct ipset names could map to the **same**
kernel name — NPM would then create one kernel set for both and combine their
members.

This derives the kernel name from a **wide digest** of the prefixed name, so
distinct ipset names map to distinct kernel names:

```
GetHashedName = AzureNpmPrefix (10) + 20 base36 chars = 30  (<= 31-char ipset limit)
```

This is kept **separate** from the 32-bit `util.Hash` still used for iptables chain
names (`AZURE-NPM-INGRESS-<hash>`), which are more tightly length-constrained (28
chars) — so the wider ipset name does not affect chain names. The kernel-set
enumeration regex (`azureNPMRegex`) is widened to match the new names.

As a defense-in-depth invariant, `IPSetManager` tracks the prefixed name that owns
each kernel name (`claimKernelName`) and fails closed if a different name would
claim an already-owned kernel name; the owner is released on delete and re-claiming
by the same owner is a no-op.

**Issue Fixed**:


**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/) (`fix:`)
- [x] includes documentation (inline rationale on `GetHashedName`, `claimKernelName`)
- [x] adds unit tests (`TestGetHashedName`, `TestGetHashedNameDistinctForReportedPair`, `TestClaimKernelNameSingleOwner`, `TestCreateIPSetKernelNameFreedOnDelete`)
- [x] relevant PR labels added

**Notes**:

- Renames all `azure-npm-*` kernel sets (one-time). NPM removes ACLs then resets all
  ipsets on boot, so a pod restart reconciles the rename.
- `go test ./npm/...` passes except two environment-only failures that also fail on the
  base branch: `npm/cmd` (`iptables-nft-save` needs root) and `controllers/v1` (Prometheus
  metric registration).
