### PR TITLE
fix: [NPM] patch Ubuntu CVEs in the v1.6.42 linux image

### DIFF
--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -9,7 +9,7 @@ AZCLI   ?= docker run --rm -v $(AZCFG):/root/.azure -v $(KUBECFG):/root/.kube -v
 
 # overrideable defaults
 AUTOUPGRADE          ?= patch
-K8S_VER              ?= 1.35
+K8S_VER              ?= 1.31
 NODE_COUNT           ?= 2
 NODE_COUNT_WIN	     ?= $(NODE_COUNT)
 NODEUPGRADE          ?= NodeImage
@@ -25,7 +25,7 @@ PUBLIC_IP_ID         ?= /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/
 PUBLIC_IPv4          ?= $(PUBLIC_IP_ID)/$(IP_PREFIX)-$(CLUSTER)-v4
 PUBLIC_IPv6          ?= $(PUBLIC_IP_ID)/$(IP_PREFIX)-$(CLUSTER)-v6
 KUBE_PROXY_JSON_PATH ?= ./kube-proxy.json
-LTS					 ?= false
+LTS					 ?= true
 
 # overrideable variables
 SUB        ?= $(AZURE_SUBSCRIPTION)

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -9,7 +9,7 @@ AZCLI   ?= docker run --rm -v $(AZCFG):/root/.azure -v $(KUBECFG):/root/.kube -v
 
 # overrideable defaults
 AUTOUPGRADE          ?= patch
-K8S_VER              ?= 1.30
+K8S_VER              ?= 1.35
 NODE_COUNT           ?= 2
 NODE_COUNT_WIN	     ?= $(NODE_COUNT)
 NODEUPGRADE          ?= NodeImage

--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -25,7 +25,7 @@ PUBLIC_IP_ID         ?= /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/
 PUBLIC_IPv4          ?= $(PUBLIC_IP_ID)/$(IP_PREFIX)-$(CLUSTER)-v4
 PUBLIC_IPv6          ?= $(PUBLIC_IP_ID)/$(IP_PREFIX)-$(CLUSTER)-v6
 KUBE_PROXY_JSON_PATH ?= ./kube-proxy.json
-LTS					 ?= true
+LTS					 ?= false
 
 # overrideable variables
 SUB        ?= $(AZURE_SUBSCRIPTION)

--- a/npm/linux.Dockerfile
+++ b/npm/linux.Dockerfile
@@ -24,6 +24,12 @@ COPY --from=builder /usr/local/bin/azure-npm /usr/bin/azure-npm
 # libudev1:       CVE-2026-29111, CVE-2026-40225 (MEDIUM)
 # liblzma5:       CVE-2026-34743 (LOW)
 # sed:            CVE-2026-5958 (MEDIUM)
+# gzip:           CVE-2026-41991, CVE-2026-41992 (LOW)
+# libncursesw6:   CVE-2025-69720 (MEDIUM)
+# libtinfo6:      CVE-2025-69720 (MEDIUM)
+# libpam-modules: CVE-2026-54411 (MEDIUM)
+# perl-base:      CVE-2026-42496, CVE-2026-8376 (MEDIUM)
+# tar:            CVE-2025-45582, CVE-2026-5704 (MEDIUM)
 RUN apt-get update && apt-get install -y \
     iptables ipset ca-certificates \
     gpgv=2.4.4-2ubuntu17.4 \
@@ -38,6 +44,12 @@ RUN apt-get update && apt-get install -y \
     libudev1=255.4-1ubuntu8.16 \
     liblzma5=5.6.1+really5.4.5-1ubuntu0.3 \
     sed=4.9-2ubuntu0.24.04.1 \
+    gzip=1.12-1ubuntu3.2 \
+    libncursesw6=6.4+20240113-1ubuntu2.1 \
+    libtinfo6=6.4+20240113-1ubuntu2.1 \
+    libpam-modules=1.5.3-5ubuntu5.6 \
+    perl-base=5.38.2-3.2ubuntu0.3 \
+    tar=1.35+dfsg-3ubuntu0.4 \
     && apt-get autoremove -y && apt-get clean
 RUN chmod +x /usr/bin/azure-npm
 ENTRYPOINT ["/usr/bin/azure-npm", "start"]

--- a/npm/linux.Dockerfile
+++ b/npm/linux.Dockerfile
@@ -33,8 +33,8 @@ COPY --from=builder /usr/local/bin/azure-npm /usr/bin/azure-npm
 RUN apt-get update && apt-get install -y \
     iptables ipset ca-certificates \
     gpgv=2.4.4-2ubuntu17.4 \
-    libc-bin=2.39-0ubuntu8.7 \
-    libc6=2.39-0ubuntu8.7 \
+    libc-bin=2.39-0ubuntu8.8 \
+    libc6=2.39-0ubuntu8.8 \
     libtasn1-6=4.19.0-3ubuntu0.24.04.2 \
     dpkg=1.22.6ubuntu6.6 \
     libcap2=1:2.66-5ubuntu2.4 \


### PR DESCRIPTION
**Reason for Change**:

A fresh build of `npm/linux.Dockerfile` for the `v1.6.42` linux image still produced
fixable Ubuntu CVEs in packages whose base-image (`ubuntu:24.04`) versions are not
automatically upgraded during the build. This pins each still-vulnerable package to
its fixed version so the image scans clean. Packages whose CVEs are already fixed in
the base image are intentionally left unpinned.

Confirmed with a fresh (no-cache) build + scan:
```
trivy --scanners vuln image --ignore-unfixed -f table <image>
```

**Before** — `mcr.microsoft.com/containernetworking/azure-npm:v1.6.42` (ubuntu 24.04):
```
Total: 70 (UNKNOWN: 0, LOW: 29, MEDIUM: 39, HIGH: 2, CRITICAL: 0)
```

**After** — fresh no-cache build of this branch (ubuntu 24.04 OS packages):
```
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

Packages pinned:

| package | fixed version | CVEs |
| --- | --- | --- |
| gpgv | 2.4.4-2ubuntu17.4 | CVE-2025-68973 |
| libc-bin | 2.39-0ubuntu8.8 | CVE-2025-15281, CVE-2026-0861, CVE-2026-0915 |
| libc6 | 2.39-0ubuntu8.8 | CVE-2025-15281, CVE-2026-0861, CVE-2026-0915 |
| libtasn1-6 | 4.19.0-3ubuntu0.24.04.2 | CVE-2025-13151 |
| dpkg | 1.22.6ubuntu6.6 | CVE-2026-2219 |
| libcap2 | 1:2.66-5ubuntu2.4 | CVE-2026-4878 |
| libgcrypt20 | 1.10.3-2ubuntu0.1 | CVE-2026-41989 |
| libgnutls30t64 | 3.8.3-1.1ubuntu3.6 | CVE-2026-33845, CVE-2026-33846, CVE-2026-3832, CVE-2026-3833, CVE-2026-42009…42015, CVE-2026-5260, CVE-2026-5419 |
| libsystemd0 | 255.4-1ubuntu8.16 | CVE-2026-29111, CVE-2026-40225 |
| libudev1 | 255.4-1ubuntu8.16 | CVE-2026-29111, CVE-2026-40225 |
| liblzma5 | 5.6.1+really5.4.5-1ubuntu0.3 | CVE-2026-34743 |
| sed | 4.9-2ubuntu0.24.04.1 | CVE-2026-5958 |
| gzip | 1.12-1ubuntu3.2 | CVE-2026-41991, CVE-2026-41992 |
| libncursesw6 | 6.4+20240113-1ubuntu2.1 | CVE-2025-69720 |
| libtinfo6 | 6.4+20240113-1ubuntu2.1 | CVE-2025-69720 |
| libpam-modules | 1.5.3-5ubuntu5.6 | CVE-2026-54411 |
| perl-base | 5.38.2-3.2ubuntu0.3 | CVE-2026-42496, CVE-2026-8376 |
| tar | 1.35+dfsg-3ubuntu0.4 | CVE-2025-45582, CVE-2026-5704 |

`libc-bin` / `libc6`, `libsystemd0` / `libudev1`, and `libncursesw6` / `libtinfo6`
are pinned as matched pairs because each pair ships in lockstep and must resolve to
the same version; both members are pinned explicitly so a future edit to one cannot
silently pull the other back to the vulnerable base version.

---

**Additional change — `hack/aks/Makefile`: bump `K8S_VER` 1.30 → 1.31 (LTS stays enabled)** (CI unblock):

This PR's cluster-create step was failing with:
```
ERROR: (VersionNotEnabledForLTS) Cannot turn on LongTermSupport on cluster ciliume2e-... for non-LTS version 1.30.101.
```

Root cause — `release/v1.6` pins `K8S_VER ?= 1.30`, and Kubernetes **1.30 has reached
the end of its AKS lifecycle**:

- 1.30 standard/community support ended **2025-07-31**; as of now `az aks get-versions`
  no longer offers 1.30 for cluster creation at all (create list is 1.31–1.36), so new
  1.30 clusters cannot be created — with or without LTS.
- The e2e recipes create clusters via `.pipelines/templates/create-cluster.yaml`, which
  runs `make -C ./hack/aks ...` and falls back to the Makefile defaults, so the retired
  1.30 default breaks cluster creation.

Fix: bump the default to **1.31** — the lowest version AKS still offers for creation and
the version this v1.6 line's components are released for. 1.31 is offered only under the
`AKSLongTermSupport` plan, which the existing `LTS ?= true` default already provides
(`--k8s-support-plan AKSLongTermSupport --tier premium`), so **LTS stays enabled** and the
net Makefile change is just `K8S_VER 1.30 → 1.31`.

Testing on 1.31 also resolves the k8s E2E flakes seen on an interim 1.35 attempt (builds
174012327, 174016046). The `k8s-e2e` job downloads the `e2e.test` binary matching the
cluster's Kubernetes version, and 1.35 introduced two new `[sig-network] DNS` specs —
`should work with a service name that starts with a digit
[FeatureGate:RelaxedServiceNameValidation] [Alpha] [Feature:OffByDefault]` and
`should work with a search path containing an underscore and a search path with a single
dot` — that do not exist in the 1.31 test binary (verified against
`kubernetes/release-1.31`), so they no longer run.

**Issue Fixed**:


**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/) (`fix:`)
- [x] includes documentation (inline CVE comments in the Dockerfile)
- [x] adds unit tests (n/a — Dockerfile package pins)
- [x] relevant PR labels added

**Notes**:

- Scope is Linux/Ubuntu OS packages only. Remaining `gobinary` findings are Go module
  dependencies (`golang.org/x/net`, `x/sys`, `x/text`, `google.golang.org/grpc`) and are
  not addressable via Dockerfile package pins.
- Pins are exact-version and are validated by a no-cache build so CI cannot pass on a
  stale layer cache; if Ubuntu supersedes a pinned patch, the pin must be bumped to the
  new installable version.
- Also includes a `hack/aks/Makefile` CI fix bumping the default `K8S_VER` from 1.30 to
  1.31 (LTS remains enabled); see the "Additional change" section above. This supersedes
  the standalone #4592 (closed).
