### PR TITLE
ci: restore LTS=false in hack/aks Makefile (accidentally flipped in #4090)

### DIFF
--- a/hack/aks/Makefile
+++ b/hack/aks/Makefile
@@ -25,7 +25,7 @@ PUBLIC_IP_ID         ?= /subscriptions/$(SUB)/resourceGroups/$(GROUP)/providers/
 PUBLIC_IPv4          ?= $(PUBLIC_IP_ID)/$(IP_PREFIX)-$(CLUSTER)-v4
 PUBLIC_IPv6          ?= $(PUBLIC_IP_ID)/$(IP_PREFIX)-$(CLUSTER)-v6
 KUBE_PROXY_JSON_PATH ?= ./kube-proxy.json
-LTS					 ?= true
+LTS					 ?= false
 
 # overrideable variables
 SUB        ?= $(AZURE_SUBSCRIPTION)


### PR DESCRIPTION
**Reason for Change**:

Fixes `VersionNotEnabledForLTS` failures at the cluster-create step on `release/v1.6` (e.g. blocking #4588):

```
ERROR: (VersionNotEnabledForLTS) Cannot turn on LongTermSupport on cluster ciliume2e-... for non-LTS version 1.30.101.
```

**Root cause** — this is *not* new to master; it's a regression on `release/v1.6`:

- `hack/aks/Makefile` originally defaulted `LTS ?= false` on `release/v1.6` (from "future proof for LTS clusters", #3620 / #3626, present in the branch since May 2025).
- PR #4090 (a `go-viper/mapstructure` vulnerability fix, Oct 2025) **inadvertently reverted that line to `LTS ?= true`** — almost certainly a rebase/conflict artifact, since #4090 only intended to bump `go.mod`/`go.sum` (its diff touches only `go.mod`, `go.sum`, and this one Makefile line).
- With `LTS=true`, every cluster recipe injects `--k8s-support-plan AKSLongTermSupport --tier premium`. E2E jobs such as `ciliume2e` create clusters via `.pipelines/templates/create-cluster.yaml`, which calls `make -C ./hack/aks ...` **without** passing `LTS=` and without an explicit `k8sVersion`, so they fall back to the default `K8S_VER=1.30`.
- This stayed green until Kubernetes **1.30 aged out of AKS LTS eligibility** (mid-2026). AKS now resolves the `1.30` alias to a non-LTS patch (`1.30.101`), so forcing LTS on fails. Nothing in the repo changed — the trigger is the external AKS version lifecycle.

**Fix**: restore the intended `LTS ?= false` default (opt-in LTS), reverting the accidental flip from #4090. LTS testing remains available by explicitly passing `LTS=true` for LTS-eligible versions.

**Issue Fixed**:
<!-- none -->

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:

Single-line change: `hack/aks/Makefile` `LTS ?= true` -> `LTS ?= false`.