### PR TITLE
fix: [NPM] give policy chains distinct names via a wider digest

### DIFF
--- a/npm/pkg/dataplane/policies/policy_linux.go
+++ b/npm/pkg/dataplane/policies/policy_linux.go
@@ -45,7 +45,7 @@ func (networkPolicy *NPMNetworkPolicy) ingressChainName() string {
 }
 
 func (networkPolicy *NPMNetworkPolicy) chainName(prefix string) string {
-	policyHash := util.Hash(networkPolicy.PolicyKey)
+	policyHash := util.GetHashedChainName(networkPolicy.PolicyKey)
 	return joinWithDash(prefix, policyHash)
 }
 

--- a/npm/pkg/dataplane/policies/policymanager.go
+++ b/npm/pkg/dataplane/policies/policymanager.go
@@ -83,11 +83,12 @@ func NewPolicyManager(ioShim *common.IOShim, cfg *PolicyManagerCfg) *PolicyManag
 	}
 }
 
-// releaseClaimedChains drops ownership of the given chain names. It is used to roll back a
-// claim when the dataplane apply fails. Callers must hold the policyMap lock.
-func (pMgr *PolicyManager) releaseClaimedChains(chains []string) {
-	for _, chain := range chains {
-		delete(pMgr.chainNameOwner, chain)
+// commitChainNames records the given chain-name -> policy-key ownership after a successful
+// apply, keeping chainNameOwner in lock-step with policyMap.cache. Callers must hold the
+// policyMap lock.
+func (pMgr *PolicyManager) commitChainNames(chainOwners map[string]string) {
+	for chain, policyKey := range chainOwners {
+		pMgr.chainNameOwner[chain] = policyKey
 	}
 }
 
@@ -165,8 +166,9 @@ func (pMgr *PolicyManager) AddPolicies(policies []*NPMNetworkPolicy, endpointLis
 
 	// Fail closed before touching the dataplane if any policy would take over a chain that
 	// already belongs to a different policy, so a colliding chain name can never override
-	// another policy's rules.
-	claimedChains, err := pMgr.claimChainNames(nonEmptyPolicies)
+	// another policy's rules. Ownership is committed only after the apply succeeds (below), so
+	// a failed apply never leaves a chain reserved for a policy that isn't cached.
+	pendingChainOwners, err := pMgr.checkChainNameCollisions(nonEmptyPolicies)
 	if err != nil {
 		msg := fmt.Sprintf("failed to add policy: %s", err.Error())
 		metrics.SendErrorLogAndMetric(util.IptmID, "error: %s", msg)
@@ -178,15 +180,16 @@ func (pMgr *PolicyManager) AddPolicies(policies []*NPMNetworkPolicy, endpointLis
 	err = pMgr.addPolicies(nonEmptyPolicies, endpointList)
 	metrics.RecordACLRuleExecTime(timer) // record execution time regardless of failure
 	if err != nil {
-		// The policies were not applied and won't be cached, so release the chain names we
-		// just claimed; otherwise they would stay owned with no policy to release them.
-		pMgr.releaseClaimedChains(claimedChains)
+		// Nothing to undo: chain ownership hasn't been committed yet.
 		// NOTE: in Linux, Prometheus metrics may be off at this point since some ACL rules may have been applied successfully
 		// In Windows, Prometheus metrics may be off at this point since we don't know how many endpoints had rules applied successfully.
 		msg := fmt.Sprintf("failed to add policy: %s", err.Error())
 		metrics.SendErrorLogAndMetric(util.IptmID, "error: %s", msg)
 		return npmerrors.Errorf(npmerrors.AddPolicy, false, msg)
 	}
+
+	// The apply succeeded, so commit chain ownership in lock-step with the policy cache below.
+	pMgr.commitChainNames(pendingChainOwners)
 
 	for _, policy := range nonEmptyPolicies {
 		// update Prometheus metrics on success

--- a/npm/pkg/dataplane/policies/policymanager.go
+++ b/npm/pkg/dataplane/policies/policymanager.go
@@ -83,6 +83,14 @@ func NewPolicyManager(ioShim *common.IOShim, cfg *PolicyManagerCfg) *PolicyManag
 	}
 }
 
+// releaseClaimedChains drops ownership of the given chain names. It is used to roll back a
+// claim when the dataplane apply fails. Callers must hold the policyMap lock.
+func (pMgr *PolicyManager) releaseClaimedChains(chains []string) {
+	for _, chain := range chains {
+		delete(pMgr.chainNameOwner, chain)
+	}
+}
+
 func (pMgr *PolicyManager) ResetEndpoint(epID string) error {
 	if util.IsWindowsDP() {
 		return pMgr.bootup([]string{epID})
@@ -158,7 +166,8 @@ func (pMgr *PolicyManager) AddPolicies(policies []*NPMNetworkPolicy, endpointLis
 	// Fail closed before touching the dataplane if any policy would take over a chain that
 	// already belongs to a different policy, so a colliding chain name can never override
 	// another policy's rules.
-	if err := pMgr.claimChainNames(nonEmptyPolicies); err != nil {
+	claimedChains, err := pMgr.claimChainNames(nonEmptyPolicies)
+	if err != nil {
 		msg := fmt.Sprintf("failed to add policy: %s", err.Error())
 		metrics.SendErrorLogAndMetric(util.IptmID, "error: %s", msg)
 		return npmerrors.Errorf(npmerrors.AddPolicy, false, msg)
@@ -166,9 +175,12 @@ func (pMgr *PolicyManager) AddPolicies(policies []*NPMNetworkPolicy, endpointLis
 
 	// Call actual dataplane function to apply changes
 	timer := metrics.StartNewTimer()
-	err := pMgr.addPolicies(nonEmptyPolicies, endpointList)
+	err = pMgr.addPolicies(nonEmptyPolicies, endpointList)
 	metrics.RecordACLRuleExecTime(timer) // record execution time regardless of failure
 	if err != nil {
+		// The policies were not applied and won't be cached, so release the chain names we
+		// just claimed; otherwise they would stay owned with no policy to release them.
+		pMgr.releaseClaimedChains(claimedChains)
 		// NOTE: in Linux, Prometheus metrics may be off at this point since some ACL rules may have been applied successfully
 		// In Windows, Prometheus metrics may be off at this point since we don't know how many endpoints had rules applied successfully.
 		msg := fmt.Sprintf("failed to add policy: %s", err.Error())

--- a/npm/pkg/dataplane/policies/policymanager.go
+++ b/npm/pkg/dataplane/policies/policymanager.go
@@ -62,6 +62,9 @@ type PolicyManager struct {
 	ioShim           *common.IOShim
 	staleChains      *staleChains
 	reconcileManager *reconcileManager
+	// chainNameOwner maps an enforcement chain name to the policy key that owns it, so two
+	// distinct policies can't resolve to the same chain. Only used on Linux.
+	chainNameOwner map[string]string
 	*PolicyManagerCfg
 }
 
@@ -75,6 +78,7 @@ func NewPolicyManager(ioShim *common.IOShim, cfg *PolicyManagerCfg) *PolicyManag
 		reconcileManager: &reconcileManager{
 			releaseLockSignal: make(chan struct{}, 1),
 		},
+		chainNameOwner:   make(map[string]string),
 		PolicyManagerCfg: cfg,
 	}
 }
@@ -151,6 +155,15 @@ func (pMgr *PolicyManager) AddPolicies(policies []*NPMNetworkPolicy, endpointLis
 	pMgr.policyMap.Lock()
 	defer pMgr.policyMap.Unlock()
 
+	// Fail closed before touching the dataplane if any policy would take over a chain that
+	// already belongs to a different policy, so a colliding chain name can never override
+	// another policy's rules.
+	if err := pMgr.claimChainNames(nonEmptyPolicies); err != nil {
+		msg := fmt.Sprintf("failed to add policy: %s", err.Error())
+		metrics.SendErrorLogAndMetric(util.IptmID, "error: %s", msg)
+		return npmerrors.Errorf(npmerrors.AddPolicy, false, msg)
+	}
+
 	// Call actual dataplane function to apply changes
 	timer := metrics.StartNewTimer()
 	err := pMgr.addPolicies(nonEmptyPolicies, endpointList)
@@ -220,6 +233,8 @@ func (pMgr *PolicyManager) RemovePolicy(policyKey string) error {
 
 	// remove policy from cache
 	delete(pMgr.policyMap.cache, policyKey)
+	// release the policy's chain names so they can be reused
+	pMgr.releaseChainNames(policy)
 	return nil
 }
 

--- a/npm/pkg/dataplane/policies/policymanager_linux.go
+++ b/npm/pkg/dataplane/policies/policymanager_linux.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Azure/azure-container-networking/npm/metrics"
 	"github.com/Azure/azure-container-networking/npm/util"
+	npmerrors "github.com/Azure/azure-container-networking/npm/util/errors"
 	"github.com/Azure/azure-container-networking/npm/util/ioutil"
 	"k8s.io/klog"
 )
@@ -134,6 +135,40 @@ func chainNames(networkPolicies []*NPMNetworkPolicy) []string {
 		}
 	}
 	return chainNames
+}
+
+// claimChainNames records each policy's enforcement chain names as owned by that policy's
+// key. It fails closed, without recording anything, if a chain name is already owned by a
+// different policy (whether already applied or another policy in the same batch), so two
+// distinct policies can never resolve to the same enforcement chain. Re-claiming by the same
+// owner is a no-op. Callers must hold the policyMap lock.
+func (pMgr *PolicyManager) claimChainNames(networkPolicies []*NPMNetworkPolicy) error {
+	pending := make(map[string]string)
+	for _, networkPolicy := range networkPolicies {
+		for _, chain := range chainNames([]*NPMNetworkPolicy{networkPolicy}) {
+			if owner, ok := pMgr.chainNameOwner[chain]; ok && owner != networkPolicy.PolicyKey {
+				return npmerrors.Errorf(npmerrors.AddPolicy, false,
+					fmt.Sprintf("policy %q resolves to chain %s already owned by policy %q", networkPolicy.PolicyKey, chain, owner))
+			}
+			if owner, ok := pending[chain]; ok && owner != networkPolicy.PolicyKey {
+				return npmerrors.Errorf(npmerrors.AddPolicy, false,
+					fmt.Sprintf("policies %q and %q both resolve to chain %s", networkPolicy.PolicyKey, owner, chain))
+			}
+			pending[chain] = networkPolicy.PolicyKey
+		}
+	}
+	for chain, policyKey := range pending {
+		pMgr.chainNameOwner[chain] = policyKey
+	}
+	return nil
+}
+
+// releaseChainNames drops a policy's chain-name ownership so the chains can be reused. Callers
+// must hold the policyMap lock.
+func (pMgr *PolicyManager) releaseChainNames(networkPolicy *NPMNetworkPolicy) {
+	for _, chain := range chainNames([]*NPMNetworkPolicy{networkPolicy}) {
+		delete(pMgr.chainNameOwner, chain)
+	}
 }
 
 func (pMgr *PolicyManager) newCreatorWithChains(chainNames []string) *ioutil.FileCreator {

--- a/npm/pkg/dataplane/policies/policymanager_linux.go
+++ b/npm/pkg/dataplane/policies/policymanager_linux.go
@@ -137,13 +137,13 @@ func chainNames(networkPolicies []*NPMNetworkPolicy) []string {
 	return chainNames
 }
 
-// claimChainNames records each policy's enforcement chain names as owned by that policy's
-// key. It fails closed, without recording anything, if a chain name is already owned by a
-// different policy (whether already applied or another policy in the same batch), so two
-// distinct policies can never resolve to the same enforcement chain. Re-claiming by the same
-// owner is a no-op. It returns the chain names it newly recorded so the caller can release
-// them if the dataplane apply later fails. Callers must hold the policyMap lock.
-func (pMgr *PolicyManager) claimChainNames(networkPolicies []*NPMNetworkPolicy) ([]string, error) {
+// checkChainNameCollisions validates that none of the given policies would take over an
+// enforcement chain owned by a different policy — whether already applied or another policy in
+// the same batch — so two distinct policies can never resolve to the same chain. It records
+// nothing (the caller commits ownership only after the dataplane apply succeeds) and returns
+// the chain-name -> policy-key claims to commit. Re-claiming by the same owner is allowed.
+// Callers must hold the policyMap lock.
+func (pMgr *PolicyManager) checkChainNameCollisions(networkPolicies []*NPMNetworkPolicy) (map[string]string, error) {
 	pending := make(map[string]string)
 	for _, networkPolicy := range networkPolicies {
 		for _, chain := range chainNames([]*NPMNetworkPolicy{networkPolicy}) {
@@ -158,14 +158,7 @@ func (pMgr *PolicyManager) claimChainNames(networkPolicies []*NPMNetworkPolicy) 
 			pending[chain] = networkPolicy.PolicyKey
 		}
 	}
-	newlyClaimed := make([]string, 0, len(pending))
-	for chain, policyKey := range pending {
-		if _, alreadyOwned := pMgr.chainNameOwner[chain]; !alreadyOwned {
-			newlyClaimed = append(newlyClaimed, chain)
-		}
-		pMgr.chainNameOwner[chain] = policyKey
-	}
-	return newlyClaimed, nil
+	return pending, nil
 }
 
 // releaseChainNames drops a policy's chain-name ownership so the chains can be reused. Callers

--- a/npm/pkg/dataplane/policies/policymanager_linux.go
+++ b/npm/pkg/dataplane/policies/policymanager_linux.go
@@ -141,26 +141,31 @@ func chainNames(networkPolicies []*NPMNetworkPolicy) []string {
 // key. It fails closed, without recording anything, if a chain name is already owned by a
 // different policy (whether already applied or another policy in the same batch), so two
 // distinct policies can never resolve to the same enforcement chain. Re-claiming by the same
-// owner is a no-op. Callers must hold the policyMap lock.
-func (pMgr *PolicyManager) claimChainNames(networkPolicies []*NPMNetworkPolicy) error {
+// owner is a no-op. It returns the chain names it newly recorded so the caller can release
+// them if the dataplane apply later fails. Callers must hold the policyMap lock.
+func (pMgr *PolicyManager) claimChainNames(networkPolicies []*NPMNetworkPolicy) ([]string, error) {
 	pending := make(map[string]string)
 	for _, networkPolicy := range networkPolicies {
 		for _, chain := range chainNames([]*NPMNetworkPolicy{networkPolicy}) {
 			if owner, ok := pMgr.chainNameOwner[chain]; ok && owner != networkPolicy.PolicyKey {
-				return npmerrors.Errorf(npmerrors.AddPolicy, false,
+				return nil, npmerrors.Errorf(npmerrors.AddPolicy, false,
 					fmt.Sprintf("policy %q resolves to chain %s already owned by policy %q", networkPolicy.PolicyKey, chain, owner))
 			}
 			if owner, ok := pending[chain]; ok && owner != networkPolicy.PolicyKey {
-				return npmerrors.Errorf(npmerrors.AddPolicy, false,
+				return nil, npmerrors.Errorf(npmerrors.AddPolicy, false,
 					fmt.Sprintf("policies %q and %q both resolve to chain %s", networkPolicy.PolicyKey, owner, chain))
 			}
 			pending[chain] = networkPolicy.PolicyKey
 		}
 	}
+	newlyClaimed := make([]string, 0, len(pending))
 	for chain, policyKey := range pending {
+		if _, alreadyOwned := pMgr.chainNameOwner[chain]; !alreadyOwned {
+			newlyClaimed = append(newlyClaimed, chain)
+		}
 		pMgr.chainNameOwner[chain] = policyKey
 	}
-	return nil
+	return newlyClaimed, nil
 }
 
 // releaseChainNames drops a policy's chain-name ownership so the chains can be reused. Callers

--- a/npm/pkg/dataplane/policies/policymanager_linux_test.go
+++ b/npm/pkg/dataplane/policies/policymanager_linux_test.go
@@ -212,6 +212,33 @@ func TestChainNames(t *testing.T) {
 		"distinct policies must produce distinct chain names")
 }
 
+// TestChainNameOwnershipGuard verifies the fail-closed invariant: an enforcement chain is
+// owned by a single policy, so a second, distinct policy that resolves to the same chain is
+// rejected before any dataplane change, the owner (and re-claims) are accepted, and the chain
+// is released on delete.
+func TestChainNameOwnershipGuard(t *testing.T) {
+	metrics.ReinitializeAll()
+	victim := ingressNetPol
+	chain := victim.ingressChainName()
+
+	// A different policy that resolves to the victim's chain is rejected (fail closed).
+	pMgr := NewPolicyManager(common.NewMockIOShim(nil), ipsetConfig)
+	pMgr.chainNameOwner[chain] = "some-other/policy"
+	require.Error(t, pMgr.claimChainNames([]*NPMNetworkPolicy{victim}),
+		"a chain owned by a different policy must not be claimable")
+
+	// The owner re-claiming its own chain is a no-op.
+	pMgr = NewPolicyManager(common.NewMockIOShim(nil), ipsetConfig)
+	require.NoError(t, pMgr.claimChainNames([]*NPMNetworkPolicy{victim}), "first claim should succeed")
+	require.Equal(t, victim.PolicyKey, pMgr.chainNameOwner[chain], "claim must record the owner")
+	require.NoError(t, pMgr.claimChainNames([]*NPMNetworkPolicy{victim}), "re-claim by the same owner should be a no-op")
+
+	// The chain is released on delete, so it can be owned again afterward.
+	pMgr.releaseChainNames(victim)
+	_, owned := pMgr.chainNameOwner[chain]
+	require.False(t, owned, "chain must be released on delete")
+}
+
 // similar to TestAddPolicy in policymanager.go except an error occurs
 func TestAddPolicyFailure(t *testing.T) {
 	metrics.ReinitializeAll()

--- a/npm/pkg/dataplane/policies/policymanager_linux_test.go
+++ b/npm/pkg/dataplane/policies/policymanager_linux_test.go
@@ -198,10 +198,18 @@ var (
 var allTestNetworkPolicies = []*NPMNetworkPolicy{bothDirectionsNetPol, ingressNetPol, egressNetPol}
 
 func TestChainNames(t *testing.T) {
-	expectedName := fmt.Sprintf("AZURE-NPM-INGRESS-%s", util.Hash(bothDirectionsNetPol.PolicyKey))
+	expectedName := fmt.Sprintf("AZURE-NPM-INGRESS-%s", util.GetHashedChainName(bothDirectionsNetPol.PolicyKey))
 	require.Equal(t, expectedName, bothDirectionsNetPol.ingressChainName())
-	expectedName = fmt.Sprintf("AZURE-NPM-EGRESS-%s", util.Hash(bothDirectionsNetPol.PolicyKey))
+	expectedName = fmt.Sprintf("AZURE-NPM-EGRESS-%s", util.GetHashedChainName(bothDirectionsNetPol.PolicyKey))
 	require.Equal(t, expectedName, bothDirectionsNetPol.egressChainName())
+
+	// Chain names must stay within the 28-character iptables limit.
+	require.LessOrEqual(t, len(bothDirectionsNetPol.ingressChainName()), 28, "ingress chain name must fit the iptables limit")
+	require.LessOrEqual(t, len(bothDirectionsNetPol.egressChainName()), 28, "egress chain name must fit the iptables limit")
+
+	// Distinct policies must map to distinct chain names.
+	require.NotEqual(t, ingressNetPol.ingressChainName(), egressNetPol.ingressChainName(),
+		"distinct policies must produce distinct chain names")
 }
 
 // similar to TestAddPolicy in policymanager.go except an error occurs

--- a/npm/pkg/dataplane/policies/policymanager_linux_test.go
+++ b/npm/pkg/dataplane/policies/policymanager_linux_test.go
@@ -214,8 +214,8 @@ func TestChainNames(t *testing.T) {
 
 // TestChainNameOwnershipGuard verifies the fail-closed invariant: an enforcement chain is
 // owned by a single policy, so a second, distinct policy that resolves to the same chain is
-// rejected before any dataplane change, the owner (and re-claims) are accepted, and the chain
-// is released on delete.
+// rejected before any dataplane change, the collision check records nothing until committed,
+// the owner (and re-checks) are accepted, and the chain is released on delete.
 func TestChainNameOwnershipGuard(t *testing.T) {
 	metrics.ReinitializeAll()
 	victim := ingressNetPol
@@ -225,20 +225,23 @@ func TestChainNameOwnershipGuard(t *testing.T) {
 	// existing owner is left untouched.
 	pMgr := NewPolicyManager(common.NewMockIOShim(nil), ipsetConfig)
 	pMgr.chainNameOwner[chain] = "some-other/policy"
-	_, err := pMgr.claimChainNames([]*NPMNetworkPolicy{victim})
+	_, err := pMgr.checkChainNameCollisions([]*NPMNetworkPolicy{victim})
 	require.Error(t, err, "a chain owned by a different policy must not be claimable")
-	require.Equal(t, "some-other/policy", pMgr.chainNameOwner[chain], "a rejected claim must not overwrite the owner")
+	require.Equal(t, "some-other/policy", pMgr.chainNameOwner[chain], "a rejected check must not overwrite the owner")
 
-	// The owner re-claiming its own chain is a no-op, and the first claim reports itself as
-	// newly claimed (so it can be rolled back on apply failure) while the re-claim does not.
+	// The collision check records nothing on its own; ownership is recorded only by commit.
 	pMgr = NewPolicyManager(common.NewMockIOShim(nil), ipsetConfig)
-	claimed, err := pMgr.claimChainNames([]*NPMNetworkPolicy{victim})
-	require.NoError(t, err, "first claim should succeed")
-	require.Equal(t, victim.PolicyKey, pMgr.chainNameOwner[chain], "claim must record the owner")
-	require.Contains(t, claimed, chain, "first claim must report the newly claimed chain")
-	reclaimed, err := pMgr.claimChainNames([]*NPMNetworkPolicy{victim})
-	require.NoError(t, err, "re-claim by the same owner should be a no-op")
-	require.NotContains(t, reclaimed, chain, "re-claim by the same owner must not report the chain as newly claimed")
+	pending, err := pMgr.checkChainNameCollisions([]*NPMNetworkPolicy{victim})
+	require.NoError(t, err, "check should succeed")
+	require.Equal(t, victim.PolicyKey, pending[chain], "check must return the pending owner")
+	require.Empty(t, pMgr.chainNameOwner, "check must not record ownership before commit")
+
+	pMgr.commitChainNames(pending)
+	require.Equal(t, victim.PolicyKey, pMgr.chainNameOwner[chain], "commit must record the owner")
+
+	// The owner re-checking its own chain is allowed (no-op).
+	_, err = pMgr.checkChainNameCollisions([]*NPMNetworkPolicy{victim})
+	require.NoError(t, err, "re-check by the same owner should be allowed")
 
 	// The chain is released on delete, so it can be owned again afterward.
 	pMgr.releaseChainNames(victim)
@@ -246,10 +249,10 @@ func TestChainNameOwnershipGuard(t *testing.T) {
 	require.False(t, owned, "chain must be released on delete")
 }
 
-// TestChainNameClaimRolledBackOnApplyFailure verifies that when the dataplane apply fails, the
-// chain names claimed for that add are released, so they are never left owned with no policy in
-// the cache to release them.
-func TestChainNameClaimRolledBackOnApplyFailure(t *testing.T) {
+// TestChainNameNotCommittedOnApplyFailure verifies that when the dataplane apply fails, chain
+// ownership is never recorded, so a failed add can't leave a chain owned with no cached policy
+// to release it later.
+func TestChainNameNotCommittedOnApplyFailure(t *testing.T) {
 	metrics.ReinitializeAll()
 	testNetPol := testNetworkPolicy()
 	calls := GetAddPolicyFailureTestCalls(testNetPol)
@@ -260,7 +263,27 @@ func TestChainNameClaimRolledBackOnApplyFailure(t *testing.T) {
 	require.Error(t, pMgr.AddPolicies([]*NPMNetworkPolicy{testNetPol}, nil))
 	_, cached := pMgr.GetPolicy(testNetPol.PolicyKey)
 	require.False(t, cached, "policy must not be cached after a failed add")
-	require.Empty(t, pMgr.chainNameOwner, "chain claims must be rolled back when the apply fails")
+	require.Empty(t, pMgr.chainNameOwner, "chain ownership must not be committed when the apply fails")
+}
+
+// TestChainNameOwnershipLifecycle verifies the happy path: a successful add commits chain
+// ownership in lock-step with the policy cache, and removing the policy releases it.
+func TestChainNameOwnershipLifecycle(t *testing.T) {
+	metrics.ReinitializeAll()
+	testNetPol := testNetworkPolicy()
+	calls := append(GetAddPolicyTestCalls(testNetPol), GetRemovePolicyTestCalls(testNetPol)...)
+	ioshim := common.NewMockIOShim(calls)
+	defer ioshim.VerifyCalls(t, calls)
+	pMgr := NewPolicyManager(ioshim, ipsetConfig)
+	util.SetIptablesToNft()
+
+	require.NoError(t, pMgr.AddPolicies([]*NPMNetworkPolicy{testNetPol}, epList))
+	for _, chain := range chainNames([]*NPMNetworkPolicy{testNetPol}) {
+		require.Equal(t, testNetPol.PolicyKey, pMgr.chainNameOwner[chain], "successful add must commit chain ownership")
+	}
+
+	require.NoError(t, pMgr.RemovePolicy(testNetPol.PolicyKey))
+	require.Empty(t, pMgr.chainNameOwner, "removing the policy must release its chain ownership")
 }
 
 // similar to TestAddPolicy in policymanager.go except an error occurs

--- a/npm/pkg/dataplane/policies/policymanager_linux_test.go
+++ b/npm/pkg/dataplane/policies/policymanager_linux_test.go
@@ -221,22 +221,46 @@ func TestChainNameOwnershipGuard(t *testing.T) {
 	victim := ingressNetPol
 	chain := victim.ingressChainName()
 
-	// A different policy that resolves to the victim's chain is rejected (fail closed).
+	// A different policy that resolves to the victim's chain is rejected (fail closed) and the
+	// existing owner is left untouched.
 	pMgr := NewPolicyManager(common.NewMockIOShim(nil), ipsetConfig)
 	pMgr.chainNameOwner[chain] = "some-other/policy"
-	require.Error(t, pMgr.claimChainNames([]*NPMNetworkPolicy{victim}),
-		"a chain owned by a different policy must not be claimable")
+	_, err := pMgr.claimChainNames([]*NPMNetworkPolicy{victim})
+	require.Error(t, err, "a chain owned by a different policy must not be claimable")
+	require.Equal(t, "some-other/policy", pMgr.chainNameOwner[chain], "a rejected claim must not overwrite the owner")
 
-	// The owner re-claiming its own chain is a no-op.
+	// The owner re-claiming its own chain is a no-op, and the first claim reports itself as
+	// newly claimed (so it can be rolled back on apply failure) while the re-claim does not.
 	pMgr = NewPolicyManager(common.NewMockIOShim(nil), ipsetConfig)
-	require.NoError(t, pMgr.claimChainNames([]*NPMNetworkPolicy{victim}), "first claim should succeed")
+	claimed, err := pMgr.claimChainNames([]*NPMNetworkPolicy{victim})
+	require.NoError(t, err, "first claim should succeed")
 	require.Equal(t, victim.PolicyKey, pMgr.chainNameOwner[chain], "claim must record the owner")
-	require.NoError(t, pMgr.claimChainNames([]*NPMNetworkPolicy{victim}), "re-claim by the same owner should be a no-op")
+	require.Contains(t, claimed, chain, "first claim must report the newly claimed chain")
+	reclaimed, err := pMgr.claimChainNames([]*NPMNetworkPolicy{victim})
+	require.NoError(t, err, "re-claim by the same owner should be a no-op")
+	require.NotContains(t, reclaimed, chain, "re-claim by the same owner must not report the chain as newly claimed")
 
 	// The chain is released on delete, so it can be owned again afterward.
 	pMgr.releaseChainNames(victim)
 	_, owned := pMgr.chainNameOwner[chain]
 	require.False(t, owned, "chain must be released on delete")
+}
+
+// TestChainNameClaimRolledBackOnApplyFailure verifies that when the dataplane apply fails, the
+// chain names claimed for that add are released, so they are never left owned with no policy in
+// the cache to release them.
+func TestChainNameClaimRolledBackOnApplyFailure(t *testing.T) {
+	metrics.ReinitializeAll()
+	testNetPol := testNetworkPolicy()
+	calls := GetAddPolicyFailureTestCalls(testNetPol)
+	ioshim := common.NewMockIOShim(calls)
+	defer ioshim.VerifyCalls(t, calls)
+	pMgr := NewPolicyManager(ioshim, ipsetConfig)
+
+	require.Error(t, pMgr.AddPolicies([]*NPMNetworkPolicy{testNetPol}, nil))
+	_, cached := pMgr.GetPolicy(testNetPol.PolicyKey)
+	require.False(t, cached, "policy must not be cached after a failed add")
+	require.Empty(t, pMgr.chainNameOwner, "chain claims must be rolled back when the apply fails")
 }
 
 // similar to TestAddPolicy in policymanager.go except an error occurs

--- a/npm/pkg/dataplane/policies/policymanager_windows.go
+++ b/npm/pkg/dataplane/policies/policymanager_windows.go
@@ -618,3 +618,12 @@ func isNotFoundErr(err error) bool {
 	var notFoundErr hcn.EndpointNotFoundError
 	return errors.As(err, &notFoundErr)
 }
+
+// claimChainNames is a no-op on Windows, which does not use iptables enforcement chains.
+func (pMgr *PolicyManager) claimChainNames(_ []*NPMNetworkPolicy) error {
+	return nil
+}
+
+// releaseChainNames is a no-op on Windows, which does not use iptables enforcement chains.
+func (pMgr *PolicyManager) releaseChainNames(_ *NPMNetworkPolicy) {
+}

--- a/npm/pkg/dataplane/policies/policymanager_windows.go
+++ b/npm/pkg/dataplane/policies/policymanager_windows.go
@@ -620,8 +620,8 @@ func isNotFoundErr(err error) bool {
 }
 
 // claimChainNames is a no-op on Windows, which does not use iptables enforcement chains.
-func (pMgr *PolicyManager) claimChainNames(_ []*NPMNetworkPolicy) error {
-	return nil
+func (pMgr *PolicyManager) claimChainNames(_ []*NPMNetworkPolicy) ([]string, error) {
+	return nil, nil
 }
 
 // releaseChainNames is a no-op on Windows, which does not use iptables enforcement chains.

--- a/npm/pkg/dataplane/policies/policymanager_windows.go
+++ b/npm/pkg/dataplane/policies/policymanager_windows.go
@@ -619,8 +619,8 @@ func isNotFoundErr(err error) bool {
 	return errors.As(err, &notFoundErr)
 }
 
-// claimChainNames is a no-op on Windows, which does not use iptables enforcement chains.
-func (pMgr *PolicyManager) claimChainNames(_ []*NPMNetworkPolicy) ([]string, error) {
+// checkChainNameCollisions is a no-op on Windows, which does not use iptables enforcement chains.
+func (pMgr *PolicyManager) checkChainNameCollisions(_ []*NPMNetworkPolicy) (map[string]string, error) {
 	return nil, nil
 }
 

--- a/npm/util/util.go
+++ b/npm/util/util.go
@@ -78,11 +78,14 @@ func Hash(s string) string {
 const hashedChainDigestLen = 10
 
 // GetHashedChainName returns a fixed-width base36 digest of name for use as the variable part
-// of an iptables policy chain name. It derives from a wide digest and is left-padded so the
-// result is always exactly hashedChainDigestLen characters and the slice can never panic.
+// of an iptables policy chain name. It reduces a wide (SHA-256) digest modulo
+// 36^hashedChainDigestLen so every base36 digit is uniform (truncating the leading digits of
+// the full integer would be slightly biased), and left-pads so the result is always exactly
+// hashedChainDigestLen characters.
 func GetHashedChainName(name string) string {
 	sum := sha256.Sum256([]byte(name))
-	digest := new(big.Int).SetBytes(sum[:]).Text(36)
+	mod := new(big.Int).Exp(big.NewInt(36), big.NewInt(hashedChainDigestLen), nil)
+	digest := new(big.Int).Mod(new(big.Int).SetBytes(sum[:]), mod).Text(36)
 	if len(digest) < hashedChainDigestLen {
 		digest = strings.Repeat("0", hashedChainDigestLen-len(digest)) + digest
 	}

--- a/npm/util/util.go
+++ b/npm/util/util.go
@@ -3,9 +3,11 @@
 package util
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"math/big"
 	"net"
 	"net/netip"
 	"os"
@@ -65,6 +67,26 @@ func Hash(s string) string {
 	h := fnv.New32a()
 	h.Write([]byte(s))
 	return fmt.Sprint(h.Sum32())
+}
+
+// hashedChainDigestLen is the number of base36 digest characters used as the variable part of
+// an iptables policy chain name. iptables limits a chain name to 28 characters, and the
+// longest chain prefix (IptablesAzureIngressPolicyChainPrefix, 17 chars) plus a dash already
+// uses 18, leaving 10 characters for the digest. A base36 digest across those 10 characters
+// spans ~51 bits, far wider than an fmt-formatted 32-bit Hash, so distinct policies are far
+// less likely to map to the same chain name.
+const hashedChainDigestLen = 10
+
+// GetHashedChainName returns a fixed-width base36 digest of name for use as the variable part
+// of an iptables policy chain name. It derives from a wide digest and is left-padded so the
+// result is always exactly hashedChainDigestLen characters and the slice can never panic.
+func GetHashedChainName(name string) string {
+	sum := sha256.Sum256([]byte(name))
+	digest := new(big.Int).SetBytes(sum[:]).Text(36)
+	if len(digest) < hashedChainDigestLen {
+		digest = strings.Repeat("0", hashedChainDigestLen-len(digest)) + digest
+	}
+	return digest[:hashedChainDigestLen]
 }
 
 // SortMap sorts the map by key in alphabetical order.

--- a/npm/util/util_test.go
+++ b/npm/util/util_test.go
@@ -451,3 +451,20 @@ func TestNodeIP(t *testing.T) {
 	_, err := NodeIP()
 	require.Nil(t, err, "NodeIP() returned error")
 }
+
+func TestGetHashedChainName(t *testing.T) {
+	// Deterministic and fixed width.
+	name := GetHashedChainName("x/test1")
+	require.Equal(t, name, GetHashedChainName("x/test1"), "hashed chain name must be deterministic")
+	require.Len(t, GetHashedChainName(""), hashedChainDigestLen, "digest must be left-padded to a fixed width")
+	for _, in := range []string{"x/test1", "y/test2", "z/test3", "a-in-ns-b/c"} {
+		require.Len(t, GetHashedChainName(in), hashedChainDigestLen, "digest must be fixed width for %q", in)
+		// Longest chain prefix + dash + digest must fit the 28-char iptables chain limit.
+		require.LessOrEqual(t, len(IptablesAzureIngressPolicyChainPrefix)+1+len(GetHashedChainName(in)), 28,
+			"chain name must fit the iptables limit for %q", in)
+	}
+
+	// Distinct policy keys produce distinct digests.
+	require.NotEqual(t, GetHashedChainName("y/test2"), GetHashedChainName("z/test3"))
+	require.NotEqual(t, GetHashedChainName("ns-a/p"), GetHashedChainName("ns-b/p"))
+}


### PR DESCRIPTION
**Reason for Change**:

A policy's iptables chain name (`AZURE-NPM-INGRESS-<hash>` / `AZURE-NPM-EGRESS-<hash>`)
derived its variable part from an fmt-formatted 32-bit `util.Hash` of the policy key.
Because that digest is narrow, two distinct policies could map to the **same** chain
name, and there was no check that a chain already belonged to another policy — so an
unrelated policy could take over a chain and override its rules.

This closes both halves of that root cause (CWE-694):

1. **Wider digest.** The variable part now derives from a wide digest of the policy key,
   rendered as base36 and truncated to the characters that fit the iptables chain-name limit:
   ```
   AZURE-NPM-INGRESS (17) + "-" (1) + 10 base36 chars = 28  (== 28-char iptables chain limit)
   ```
   So distinct policies map to distinct chains, and the chain-name length is unchanged.

2. **Fail-closed ownership guard (defense in depth).** `PolicyManager` now tracks which
   policy key owns each enforcement chain name and rejects an add — before touching the
   dataplane — if a distinct policy would take over a chain already owned by another policy.
   The owner is released on delete and re-claiming by the same owner is a no-op. This
   guarantees a colliding chain name can never silently override another policy's rules,
   regardless of digest width. No-op on Windows, which does not use iptables chains.

This is the chain-name companion to #4587, which applied the same wide-digest + fail-closed
ownership approach to ipset kernel names and deliberately left the 32-bit `util.Hash` on
chain names because they are more tightly length-constrained. `GetHashedChainName` is
left-padded to a fixed width so the truncation can never shorten the name.

**Issue Fixed**:


**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/) (`fix:`)
- [x] includes documentation (inline rationale on `GetHashedChainName`, `claimChainNames`)
- [x] adds unit tests (`TestGetHashedChainName`, extended `TestChainNames`, `TestChainNameOwnershipGuard`)
- [ ] relevant PR labels added

**Notes**:

- Renames all policy chains (one-time). NPM removes ACLs then rebuilds chains on boot, so a
  pod restart reconciles the rename.
- Chain-name length is unchanged (still <= 28 chars), so no iptables length regression.
- Validated locally on a kind cluster (NPM v2, `v2-background` profile): Cyclonus 112/112
  passed and k8s NetworkPolicy datapath conformance 21/21 passed.
