### PR TITLE
fix: resolve secondary VF to netvsc master and retry DHCP discover on MANA nodes

### DIFF
--- a/network/endpoint_test.go
+++ b/network/endpoint_test.go
@@ -324,6 +324,10 @@ var _ = Describe("Test Endpoint", func() {
 		})
 		// TODO: Add secondary endpoint client test coverage in a different way
 		Context("When secondary endpoint client is used", func() {
+			var restoreMasterResolution func()
+			BeforeEach(func() { restoreMasterResolution = setStubMasterResolution() })
+			AfterEach(func() { restoreMasterResolution() })
+
 			_, ipnet, _ := net.ParseCIDR("0.0.0.0/0")
 			nw := &network{
 				Endpoints: map[string]*endpoint{},

--- a/network/resolve_master_interface_linux_test.go
+++ b/network/resolve_master_interface_linux_test.go
@@ -1,0 +1,95 @@
+//go:build linux
+// +build linux
+
+package network
+
+import (
+	"net"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	vishnetlink "github.com/vishvananda/netlink"
+)
+
+// test interface name constants shared across master-resolution tests.
+const (
+	testMasterIface = "eth1"       // upper/master interface (netvsc) name
+	testVFIface     = "enP12217s2" // SR-IOV VF bonded to testMasterIface (shares its MAC)
+)
+
+var errStubLinkNotFound = errors.New("stub: link not found by index")
+
+// permissiveNetlinkClient resolves any interface to itself (MasterIndex == 0),
+// except testVFIface which is treated as a VF enslaved to testMasterIface. It lets
+// tests exercise AddEndpoints without touching the real netlink socket while still
+// preserving each interface name (so mocks keyed on names like "badeth" still work).
+type permissiveNetlinkClient struct{}
+
+func (permissiveNetlinkClient) LinkByName(name string) (vishnetlink.Link, error) {
+	if name == testVFIface {
+		return &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{Name: testVFIface, Index: 5, MasterIndex: 2}}, nil
+	}
+	return &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{Name: name, Index: 2, MasterIndex: 0}}, nil
+}
+
+func (permissiveNetlinkClient) LinkByIndex(index int) (vishnetlink.Link, error) {
+	if index == 2 {
+		return &vishnetlink.Dummy{LinkAttrs: vishnetlink.LinkAttrs{Name: testMasterIface, Index: 2, MasterIndex: 0}}, nil
+	}
+	return nil, errStubLinkNotFound
+}
+
+// setStubMasterResolution installs the permissive netlink client into the package
+// resolver and returns a function that restores the previous client. Usable from both
+// standard tests and Ginkgo BeforeEach/AfterEach blocks.
+func setStubMasterResolution() (restore func()) {
+	original := masterNl
+	masterNl = permissiveNetlinkClient{}
+	return func() { masterNl = original }
+}
+
+// stubMasterResolution installs the permissive netlink client and restores the
+// original on test cleanup.
+func stubMasterResolution(t *testing.T) {
+	t.Helper()
+	t.Cleanup(setStubMasterResolution())
+}
+
+// vfReturningNetIO is a netio.NetIOInterface whose MAC lookup returns a bare VF
+// name, emulating an accelerated-networking node where net.Interfaces() enumerated
+// the VF before its netvsc master.
+type vfReturningNetIO struct{ vfName string }
+
+func (v *vfReturningNetIO) GetNetworkInterfaceByName(name string) (*net.Interface, error) {
+	return &net.Interface{Name: name, Index: 5}, nil
+}
+
+func (v *vfReturningNetIO) GetNetworkInterfaceAddrs(*net.Interface) ([]net.Addr, error) {
+	return []net.Addr{}, nil
+}
+
+func (v *vfReturningNetIO) GetNetworkInterfaceByMac(mac net.HardwareAddr) (*net.Interface, error) {
+	return &net.Interface{Name: v.vfName, HardwareAddr: mac, Index: 5}, nil
+}
+
+// TestSecondaryAddEndpointsResolvesMaster proves that when the MAC lookup returns
+// the bare SR-IOV VF, AddEndpoints resolves it to the netvsc master before the
+// interface name is recorded/moved into the pod netns.
+func TestSecondaryAddEndpointsResolvesMaster(t *testing.T) {
+	stubMasterResolution(t) // VF (testVFIface) is enslaved to master (testMasterIface)
+
+	mac, _ := net.ParseMAC("ab:cd:ef:12:34:56")
+	client := &SecondaryEndpointClient{
+		netioshim: &vfReturningNetIO{vfName: testVFIface},
+		ep:        &endpoint{SecondaryInterfaces: make(map[string]*InterfaceInfo)},
+	}
+	epInfo := &EndpointInfo{MacAddress: mac}
+
+	require.NoError(t, client.AddEndpoints(epInfo))
+	require.Equal(t, testMasterIface, epInfo.IfName, "bare VF must be resolved to its netvsc master before use")
+	_, ok := client.ep.SecondaryInterfaces[testMasterIface]
+	require.True(t, ok, "master interface should be recorded, not the bare VF")
+	_, vfRecorded := client.ep.SecondaryInterfaces[testVFIface]
+	require.False(t, vfRecorded, "bare VF must not be recorded as the secondary interface")
+}

--- a/network/resolve_master_interface_windows_test.go
+++ b/network/resolve_master_interface_windows_test.go
@@ -1,0 +1,11 @@
+//go:build windows
+// +build windows
+
+package network
+
+// setStubMasterResolution is a no-op on Windows: the secondary endpoint client
+// master-resolution path is Linux-only. Provided so cross-platform tests in
+// endpoint_test.go compile and run on Windows.
+func setStubMasterResolution() (restore func()) {
+	return func() {}
+}

--- a/network/secondary_endpoint_client_linux.go
+++ b/network/secondary_endpoint_client_linux.go
@@ -19,7 +19,19 @@ import (
 
 const (
 	NetworkNotReadyErrorMsg = "network is not ready"
+
+	// dhcpDiscoverTimeout is the per-attempt deadline for a single DHCP Discover.
+	dhcpDiscoverTimeout = 3 * time.Second
+	// dhcpDiscoverAttempts is the number of DHCP Discover attempts. On accelerated
+	// networking (MANA) nodes the freshly moved interface may not have carrier yet
+	// and a single Discover can race datapath readiness or be lost, so we retransmit
+	// like a standard DHCP client instead of failing the whole CNI ADD.
+	dhcpDiscoverAttempts = 3
 )
+
+// dhcpDiscoverRetryDelay is the backoff between DHCP Discover attempts. It is a var
+// so tests can shorten it.
+var dhcpDiscoverRetryDelay = 1 * time.Second
 
 var errorSecondaryEndpointClient = errors.New("SecondaryEndpointClient Error")
 
@@ -191,13 +203,26 @@ func (client *SecondaryEndpointClient) ConfigureContainerInterfacesAndRoutes(epI
 	ifInfo.Routes = append(ifInfo.Routes, epInfo.Routes...)
 
 	// issue dhcp discover packet to ensure mapping created for dns via wireserver to work
-	// we do not use the response for anything
-	numSecs := 3
-	timeout := time.Duration(numSecs) * time.Second
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(timeout))
-	defer cancel()
+	// we do not use the response for anything.
+	// Retry with backoff: on accelerated networking (MANA) nodes the moved interface
+	// may not have carrier immediately, so a single Discover can race datapath readiness
+	// or be dropped. Retransmitting avoids failing the CNI ADD with a spurious timeout.
 	logger.Info("Sending DHCP packet", zap.Any("macAddress", epInfo.MacAddress), zap.String("ifName", epInfo.IfName))
-	err := client.dhcpClient.DiscoverRequest(ctx, epInfo.MacAddress, epInfo.IfName)
+	var err error
+	for attempt := 1; attempt <= dhcpDiscoverAttempts; attempt++ {
+		ctx, cancel := context.WithTimeout(context.Background(), dhcpDiscoverTimeout)
+		err = client.dhcpClient.DiscoverRequest(ctx, epInfo.MacAddress, epInfo.IfName)
+		cancel()
+		if err == nil {
+			break
+		}
+		logger.Error("DHCP discover attempt failed",
+			zap.Int("attempt", attempt), zap.Int("maxAttempts", dhcpDiscoverAttempts),
+			zap.String("ifName", epInfo.IfName), zap.Error(err))
+		if attempt < dhcpDiscoverAttempts {
+			time.Sleep(dhcpDiscoverRetryDelay)
+		}
+	}
 	if err != nil {
 		return errors.Wrap(err, NetworkNotReadyErrorMsg+" - failed to issue dhcp discover packet to create mapping in host")
 	}

--- a/network/secondary_endpoint_client_linux.go
+++ b/network/secondary_endpoint_client_linux.go
@@ -80,11 +80,13 @@ type linkResolver interface {
 type vishLinkResolver struct{}
 
 func (vishLinkResolver) LinkByName(name string) (vishnetlink.Link, error) {
-	return vishnetlink.LinkByName(name)
+	link, err := vishnetlink.LinkByName(name)
+	return link, errors.Wrapf(err, "netlink LinkByName %q", name)
 }
 
 func (vishLinkResolver) LinkByIndex(index int) (vishnetlink.Link, error) {
-	return vishnetlink.LinkByIndex(index)
+	link, err := vishnetlink.LinkByIndex(index)
+	return link, errors.Wrapf(err, "netlink LinkByIndex %d", index)
 }
 
 // masterNl is the netlink client used by resolveMasterInterface. Overridable in tests.

--- a/network/secondary_endpoint_client_linux.go
+++ b/network/secondary_endpoint_client_linux.go
@@ -209,7 +209,7 @@ func (client *SecondaryEndpointClient) ConfigureContainerInterfacesAndRoutes(epI
 	// Retry with backoff: on accelerated networking (MANA) nodes the moved interface
 	// may not have carrier immediately, so a single Discover can race datapath readiness
 	// or be dropped. Retransmitting avoids failing the CNI ADD with a spurious timeout.
-	logger.Info("Sending DHCP packet", zap.Any("macAddress", epInfo.MacAddress), zap.String("ifName", epInfo.IfName))
+	logger.Info("Sending DHCP packet", zap.Stringer("macAddress", epInfo.MacAddress), zap.String("ifName", epInfo.IfName))
 	var err error
 	for attempt := 1; attempt <= dhcpDiscoverAttempts; attempt++ {
 		ctx, cancel := context.WithTimeout(context.Background(), dhcpDiscoverTimeout)
@@ -218,7 +218,9 @@ func (client *SecondaryEndpointClient) ConfigureContainerInterfacesAndRoutes(epI
 		if err == nil {
 			break
 		}
-		logger.Error("DHCP discover attempt failed",
+		// Transient: a Discover can be lost before the interface has carrier. Log at
+		// Warn since the retry usually succeeds; the final failure is returned below.
+		logger.Warn("DHCP discover attempt failed, will retry",
 			zap.Int("attempt", attempt), zap.Int("maxAttempts", dhcpDiscoverAttempts),
 			zap.String("ifName", epInfo.IfName), zap.Error(err))
 		if attempt < dhcpDiscoverAttempts {

--- a/network/secondary_endpoint_client_linux.go
+++ b/network/secondary_endpoint_client_linux.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Azure/azure-container-networking/network/networkutils"
 	"github.com/Azure/azure-container-networking/platform"
 	"github.com/pkg/errors"
+	vishnetlink "github.com/vishvananda/netlink"
 	"go.uber.org/zap"
 )
 
@@ -57,15 +58,67 @@ func NewSecondaryEndpointClient(
 	return client
 }
 
+// linkResolver abstracts the vishvananda/netlink link lookups used by
+// resolveMasterInterface so it can be unit tested without a real netlink socket.
+type linkResolver interface {
+	LinkByName(name string) (vishnetlink.Link, error)
+	LinkByIndex(index int) (vishnetlink.Link, error)
+}
+
+type vishLinkResolver struct{}
+
+func (vishLinkResolver) LinkByName(name string) (vishnetlink.Link, error) {
+	return vishnetlink.LinkByName(name)
+}
+
+func (vishLinkResolver) LinkByIndex(index int) (vishnetlink.Link, error) {
+	return vishnetlink.LinkByIndex(index)
+}
+
+// masterNl is the netlink client used by resolveMasterInterface. Overridable in tests.
+var masterNl linkResolver = vishLinkResolver{}
+
+// resolveMasterInterface returns the netvsc upper (master) device name for the given
+// interface. On accelerated-networking nodes the SR-IOV VF and its netvsc master share
+// a MAC; the VF has a non-zero MasterIndex while the master does not. Only the master may
+// be moved into a pod netns, so a VF name is resolved up to its master. A name that is
+// already the master (or has no master) is returned unchanged.
+func resolveMasterInterface(name string) (string, error) {
+	link, err := masterNl.LinkByName(name)
+	if err != nil {
+		return "", errors.Wrapf(err, "get link %q", name)
+	}
+	masterIndex := link.Attrs().MasterIndex
+	if masterIndex == 0 {
+		return name, nil
+	}
+	master, err := masterNl.LinkByIndex(masterIndex)
+	if err != nil {
+		return "", errors.Wrapf(err, "get master link by index %d", masterIndex)
+	}
+	return master.Attrs().Name, nil
+}
+
 func (client *SecondaryEndpointClient) AddEndpoints(epInfo *EndpointInfo) error {
 	iface, err := client.netioshim.GetNetworkInterfaceByMac(epInfo.MacAddress)
 	if err != nil {
 		return newErrorSecondaryEndpointClient(err)
 	}
 
-	epInfo.IfName = iface.Name
-	if _, exists := client.ep.SecondaryInterfaces[iface.Name]; exists {
-		return newErrorSecondaryEndpointClient(errors.New(iface.Name + " already exists"))
+	// On accelerated-networking nodes the MAC is shared by the SR-IOV VF and its
+	// netvsc upper (master) device, and GetNetworkInterfaceByMac may return either
+	// one depending on kernel enumeration order. Only the upper device may be moved
+	// into the pod network namespace; moving the bare VF breaks the bond and fails
+	// later with "no such network interface". Resolve to the upper device here so
+	// the rest of the flow operates on the correct interface regardless of order.
+	ifName, err := resolveMasterInterface(iface.Name)
+	if err != nil {
+		return newErrorSecondaryEndpointClient(err)
+	}
+
+	epInfo.IfName = ifName
+	if _, exists := client.ep.SecondaryInterfaces[ifName]; exists {
+		return newErrorSecondaryEndpointClient(errors.New(ifName + " already exists"))
 	}
 
 	ipconfigs := make([]*IPConfig, len(epInfo.IPAddresses))
@@ -73,8 +126,8 @@ func (client *SecondaryEndpointClient) AddEndpoints(epInfo *EndpointInfo) error 
 		ipconfigs[i] = &IPConfig{Address: ipconfig}
 	}
 
-	client.ep.SecondaryInterfaces[iface.Name] = &InterfaceInfo{
-		Name:              iface.Name,
+	client.ep.SecondaryInterfaces[ifName] = &InterfaceInfo{
+		Name:              ifName,
 		MacAddress:        epInfo.MacAddress,
 		IPConfigs:         ipconfigs,
 		NICType:           epInfo.NICType,

--- a/network/secondary_endpoint_linux_test.go
+++ b/network/secondary_endpoint_linux_test.go
@@ -25,6 +25,7 @@ func (m *mockDHCPFail) DiscoverRequest(context.Context, net.HardwareAddr, string
 }
 
 func TestSecondaryAddEndpoints(t *testing.T) {
+	stubMasterResolution(t) // resolve testMasterIface ("eth1") to itself; VF to its master
 	nl := netlink.NewMockNetlink(false, "")
 	plc := platform.NewMockExecClient(false)
 	mac, _ := net.ParseMAC("ab:cd:ef:12:34:56")

--- a/network/secondary_endpoint_linux_test.go
+++ b/network/secondary_endpoint_linux_test.go
@@ -24,6 +24,21 @@ func (m *mockDHCPFail) DiscoverRequest(context.Context, net.HardwareAddr, string
 	return errors.New("mock DHCP discover request failed")
 }
 
+// mockDHCPFailThenSucceed fails failures times before succeeding, emulating a MANA
+// interface that gains carrier after a couple of Discover attempts.
+type mockDHCPFailThenSucceed struct {
+	failures int
+	calls    int
+}
+
+func (m *mockDHCPFailThenSucceed) DiscoverRequest(context.Context, net.HardwareAddr, string) error {
+	m.calls++
+	if m.calls <= m.failures {
+		return errors.New("mock DHCP discover request transient failure")
+	}
+	return nil
+}
+
 func TestSecondaryAddEndpoints(t *testing.T) {
 	stubMasterResolution(t) // resolve testMasterIface ("eth1") to itself; VF to its master
 	nl := netlink.NewMockNetlink(false, "")
@@ -400,7 +415,38 @@ func TestSecondaryConfigureContainerInterfacesAndRoutes(t *testing.T) {
 			wantErr:    true,
 			wantErrMsg: NetworkNotReadyErrorMsg,
 		},
+		{
+			name: "Configure Interface and routes DHCP discover recovers after transient failures",
+			client: &SecondaryEndpointClient{
+				netlink:        netlink.NewMockNetlink(false, ""),
+				plClient:       platform.NewMockExecClient(false),
+				netUtilsClient: networkutils.NewNetworkUtils(nl, plc),
+				netioshim:      netio.NewMockNetIO(false, 0),
+				dhcpClient:     &mockDHCPFailThenSucceed{failures: dhcpDiscoverAttempts - 1},
+				ep:             &endpoint{SecondaryInterfaces: map[string]*InterfaceInfo{"eth1": {Name: "eth1"}}},
+			},
+			epInfo: &EndpointInfo{
+				IfName: "eth1",
+				IPAddresses: []net.IPNet{
+					{
+						IP:   net.ParseIP("192.168.0.4"),
+						Mask: net.CIDRMask(subnetv4Mask, ipv4Bits),
+					},
+				},
+				Routes: []RouteInfo{
+					{
+						Dst: net.IPNet{IP: net.ParseIP("192.168.0.4"), Mask: net.CIDRMask(ipv4FullMask, ipv4Bits)},
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
+
+	// shorten retry backoff so the failure/recovery cases don't slow the suite
+	oldDelay := dhcpDiscoverRetryDelay
+	dhcpDiscoverRetryDelay = 0
+	defer func() { dhcpDiscoverRetryDelay = oldDelay }()
 
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
## Summary

This PR fixes **two distinct defects** in the SwiftV2 secondary-endpoint setup path on accelerated-networking (MANA) Linux nodes. Both were observed together on a SwiftV2 MANA node under heavy multitenant-pod churn, and both surface as a failed CNI ADD.

### 1. Enslaved VF moved into the pod netns instead of the netvsc master

On MANA nodes the SR-IOV **VF** and its **netvsc upper (master)** device share a MAC address. `SecondaryEndpointClient.AddEndpoints` calls `GetNetworkInterfaceByMac`, which may return **either** device depending on kernel enumeration order, and then moves that interface into the pod network namespace. When the bare **VF** wins the race, moving it breaks the netvsc bond (the host reclaims the VF), and the ADD fails later with:

```
SecondaryEndpointClient Error: route ip+net: no such network interface
```

Only the **master** may be moved into the pod netns (the VF then follows).

**Why this recurred, and the relationship to #4414.** The delegated-NIC MAC is resolved in **two independent places**:
- **Plugin site** (`cni/network` `findInterfaceByMAC` → `MasterIfName`): #4414 added `resolveMasterInterface` here.
- **Secondary-endpoint site** (`SecondaryEndpointClient.AddEndpoints` → `netio.GetNetworkInterfaceByMac` → `epInfo.IfName`): this returns the **first** interface matching the MAC (`net.Interfaces()` is ordered by ascending ifindex) with **no** master resolution.

For a delegated NIC the entire add flow — the netns move, link setup, IP assignment and route add — operates on `epInfo.IfName`, i.e. **the secondary site's own lookup**. The plugin's `MasterIfName` is not consulted on the add path (it is only used at delete time), so **#4414 did not change which interface is actually moved** for delegated NICs; it fixed the analogous lookup in the plugin but not the site that performs the move.

Under normal enumeration the netvsc **master** (e.g. `eth1`, low ifindex) is matched first, so the secondary site moves the master and the flow succeeds — which is why this was not seen before. The failure surfaces only when the first MAC match becomes the **VF**: after repeated delegated-NIC attach/detach the VF reaches a very high ifindex and a transient just-hotplugged empty-name state, so it wins the match. The secondary client then moves the enslaved VF, breaking the netvsc bond; the VF is torn down/renamed in the pod netns and the immediately following IP/route setup fails with `route ip+net: no such network interface`. This PR fixes the **secondary site** so it deterministically resolves the MAC up to the netvsc master regardless of enumeration order. (This is also distinct from the endpoint-ordering fix in #4421, shipped in v1.8.8+, and reproduces even with #4421 present.) On the SwiftV2 MANA node the VF reached a very high ifindex (~1795) from repeated delegated-NIC attach/detach, so it frequently appeared in the just-hotplugged empty-name state and won the enumeration race — 162 confirmed VF-first moves.

### 2. Single DHCP Discover times out before the interface has carrier

After the interface is moved, `ConfigureContainerInterfacesAndRoutes` issues a DHCP Discover (to create the wireserver/DNS mapping). It sent **exactly one** Discover with a fixed 3s deadline and **no retransmission**. On MANA nodes the freshly-moved interface may not have **carrier** yet (the netvsc↔VF bond and the host datapath are still converging), so that lone packet is dropped/unanswered and the whole ADD fails with:

```
network is not ready - failed to issue dhcp discover packet to create mapping in host
```

The problematic node showed **159** co-occurring `timed out waiting for replies` events. A longer single timeout does not help — the packet was already lost while the link was down; the client has to **send again** after carrier converges.

## Fix

Both fixes are self-contained in `network/secondary_endpoint_client_linux.go`:

- **VF → master resolution:** before moving the MAC-matched interface into the pod netns, resolve it up to its netvsc master via a small, netlink-mockable `resolveMasterInterface` (`MasterIndex` lookup). A device that is already the master (or has no master) is returned unchanged.
- **DHCP Discover retry:** retransmit the Discover with bounded backoff (3 attempts, 1s apart, fresh per-attempt context) — standard RFC 2131 client behavior — instead of failing after a single lost packet.

## Repro / validation

- **SwiftV2 MANA node evidence:** production `azure-vnet` logs from the affected node — 162 VF-first moves (`dev1795 → master dev5`) and 159 DHCP timeouts.
- **Deterministic repro:** manually moving the bare VF (`ip link set … netns`) reproduces the `route ip+net: no such network interface` failure.
- **Unit tests** (`network` package, all green):
  - `TestSecondaryAddEndpointsResolvesMaster` — VF name is resolved to its master before the netns move.
  - `TestSecondaryConfigureContainerInterfacesAndRoutes` — new cases: DHCP recovers after transient failures, and still fails after exhausting all attempts.
- `go build`, `go vet`, `gofmt`, `gci`, and CI-equivalent `golangci-lint` (`--new-from-rev`) all clean.

> **Note on natural repro:** on statically-provisioned lab nodes (`aks-nic-secondary-count=N`) the N VFs stay attached, so pod/PNI churn never drives the VF ifindex up and the enumeration race does not trigger. The SwiftV2 MANA node hit it via dynamic delegated-NIC attach/detach (VF ifindex ~1795). The production logs plus the deterministic manual repro are the justification for defect #1.

