### PR TITLE
ci(pipeline): shift FAA schedule off midnight janitor window

### DIFF
--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -26,7 +26,7 @@ schedules:
   branches:
     include: ["master"]
   always: true
-- cron: "0 2,6,10,14,18 * * *" # 5 runs/day at 4h spacing; avoids janitor window (00:00-01:00 UTC) with 3h runtime buffer
+- cron: "0 11,15,19,23 * * *" # 4 runs/day at 11,15,19,23 UTC; avoids the midnight janitor window
   displayName: "Scheduled Failure Analysis Agent Run"
   branches:
     include: ["master"]

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -26,7 +26,7 @@ schedules:
   branches:
     include: ["master"]
   always: true
-- cron: "0 3-23/4 * * *" # Every 4 hours, offset to 03:00 UTC to avoid the midnight janitor window (00:00-01:00) and the 2am nightly
+- cron: "0 2,6,10,14,18 * * *" # 5 runs/day at 4h spacing; avoids janitor window (00:00-01:00 UTC) with 3h runtime buffer
   displayName: "Scheduled Failure Analysis Agent Run"
   branches:
     include: ["master"]

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -26,7 +26,7 @@ schedules:
   branches:
     include: ["master"]
   always: true
-- cron: "0 */4 * * *" # Every 4 hours
+- cron: "0 3-23/4 * * *" # Every 4 hours, offset to 03:00 UTC to avoid the midnight janitor window (00:00-01:00) and the 2am nightly
   displayName: "Scheduled Failure Analysis Agent Run"
   branches:
     include: ["master"]


### PR DESCRIPTION
**Reason for Change**:
Adjust the scheduled Failure Analysis Agent (FAA) run times to avoid janitor-window interference around midnight while reducing schedule density.
This reduces janitor-induced infra failures (for example, transient nodepool teardown) being analyzed as PR regressions and prevents unnecessary repeated agent usage.

**Issue Fixed**:
N/A

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
- FAA cron changed from `0 */4 * * *` to `0 11,15,19,23 * * *` in `.pipelines/pipeline.yaml`.
- New FAA UTC schedule: `11,15,19,23` (4 runs/day).
- Pipeline scheduling/config-only change; no product code changes.