### PR TITLE
test: add cilium-config ConfigMap RBAC to eBPF cilium agent ClusterRole

### DIFF
--- a/test/integration/manifests/cilium/v1.17/ebpf/common/cilium-agent-clusterrole.yaml
+++ b/test/integration/manifests/cilium/v1.17/ebpf/common/cilium-agent-clusterrole.yaml
@@ -123,3 +123,13 @@ rules:
   - ciliumnodes
   verbs:
   - patch
+- apiGroups:
+  - ""
+  resourceNames:
+  - cilium-config
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch

--- a/test/integration/manifests/cilium/v1.18/ebpf/common/cilium-agent-clusterrole.yaml
+++ b/test/integration/manifests/cilium/v1.18/ebpf/common/cilium-agent-clusterrole.yaml
@@ -123,3 +123,13 @@ rules:
   - ciliumnodes
   verbs:
   - patch
+- apiGroups:
+  - ""
+  resourceNames:
+  - cilium-config
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch

--- a/test/integration/manifests/cilium/v1.19/ebpf/common/cilium-agent-clusterrole.yaml
+++ b/test/integration/manifests/cilium/v1.19/ebpf/common/cilium-agent-clusterrole.yaml
@@ -123,3 +123,13 @@ rules:
   - ciliumnodes
   verbs:
   - patch
+- apiGroups:
+  - ""
+  resourceNames:
+  - cilium-config
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
The eBPF cilium agent ClusterRole was missing the configmaps rule that the non-eBPF ClusterRole (test/integration/manifests/cilium/v1.19/cilium-agent/ files/clusterrole.yaml) already grants. Cilium's dynamicconfig reflector is enabled by default and lists/watches the cilium-config ConfigMap in kube-system, so eBPF-dataplane e2e legs logged a continuous RBAC error:

  configmaps "cilium-config" is forbidden: User
  "system:serviceaccount:kube-system:cilium" cannot list resource
  "configmaps" in API group "" in the namespace "kube-system"

Add the same name-scoped rule (resourceNames: [cilium-config], verbs: list/watch) to the v1.17/v1.18/v1.19 eBPF ClusterRoles to bring them in sync with the non-eBPF role and silence the benign error loop.
