### PR TITLE
ci: retry cluster cleanup in merge queue

### DIFF
--- a/.pipelines/templates/delete-cluster.steps.yaml
+++ b/.pipelines/templates/delete-cluster.steps.yaml
@@ -127,3 +127,5 @@ steps:
         echo "==> All ${#CLUSTERS[@]} cluster deletes accepted by Azure."
     displayName: Delete Clusters (async + verify)
     condition: always()
+    retryCountOnTaskFailure: 1
+    continueOnError: ${{ contains(variables['Build.SourceBranch'], 'gh-readonly-queue') }}

--- a/.pipelines/templates/delete-cluster.yaml
+++ b/.pipelines/templates/delete-cluster.yaml
@@ -127,3 +127,5 @@ steps:
         echo "==> All ${#CLUSTERS[@]} cluster deletes accepted by Azure."
     displayName: Delete Clusters (async + verify)
     condition: always()
+    retryCountOnTaskFailure: 1
+    continueOnError: ${{ contains(variables['Build.SourceBranch'], 'gh-readonly-queue') }}


### PR DESCRIPTION
## Summary
- retry shared delete-cluster tasks once after a failure
- keep cleanup failures fatal for normal branches
- make cleanup failures non-fatal for `gh-readonly-queue` branches

This prevents transient resource-group deletion delays from failing merge-queue validation while retaining leak detection elsewhere.

Validated both shared templates parse with `retryCountOnTaskFailure: 1`, `condition: always()`, and the merge-queue-only `continueOnError` expression.