### PR TITLE
Swift podsubnet E2E: use stateless CNI on AKS 1.35

### DIFF
--- a/.pipelines/cni/singletenancy/cniv2-template.yaml
+++ b/.pipelines/cni/singletenancy/cniv2-template.yaml
@@ -290,7 +290,10 @@ stages:
             parameters:
               clusterName: ${{ parameters.clusterName }}-$(commitID)
               os: ${{ parameters.os }}
-              cni: cniv2
+              ${{ if contains(parameters.clusterType, 'swift') }}:
+                cni: stateless
+              ${{ else }}:
+                cni: cniv2
               region: $(location)
               ${{ if eq(parameters.upgradeScenario, 'true') }}:
                 logType: upgradeRestartNode
@@ -312,7 +315,10 @@ stages:
             parameters:
               clusterName: ${{ parameters.clusterName }}-$(commitID)
               os: ${{ parameters.os }}
-              cni: cniv2
+              ${{ if contains(parameters.clusterType, 'swift') }}:
+                cni: stateless
+              ${{ else }}:
+                cni: cniv2
               scaleup: ${{ parameters.scaleup }}
               nodeCount: ${{ parameters.nodeCount }}
               ${{ if eq(parameters.upgradeScenario, 'true') }}:
@@ -401,7 +407,10 @@ stages:
             - template: ../load-test-templates/restart-hns-template.yaml
               parameters:
                 clusterName: ${{ parameters.clusterName }}-$(commitID)
-                cni: cniv2
+                ${{ if contains(parameters.clusterType, 'swift') }}:
+                  cni: stateless
+                ${{ else }}:
+                  cni: cniv2
         - job: deploy_pods
           displayName: "Scale Test"
           dependsOn: restart_hns
@@ -451,7 +460,10 @@ stages:
               parameters:
                 clusterName: ${{ parameters.clusterName }}-$(commitID)
                 os: ${{ parameters.os }}
-                cni: cniv2
+                ${{ if contains(parameters.clusterType, 'swift') }}:
+                  cni: stateless
+                ${{ else }}:
+                  cni: cniv2
                 scaleup: ${{ parameters.scaleup }}
                 nodeCount: ${{ parameters.nodeCountWin }}
                 jobName: "HNS_restart_cns"

--- a/.pipelines/cni/singletenancy/cniv2-template.yaml
+++ b/.pipelines/cni/singletenancy/cniv2-template.yaml
@@ -216,9 +216,9 @@ stages:
                     fi
                   fi
                   if [ "${{parameters.os}}" == "windows" ]; then
-                    sudo -E env "PATH=$PATH" make test-load CNS_ONLY=true CNS_VERSION=${CNS} CNI_VERSION=$(make cni-version) INSTALL_CNS=true INSTALL_AZURE_VNET=true CNS_IMAGE_REPO=$(CNS_IMAGE_REPO)
+                    sudo -E env "PATH=$PATH" make test-load CNS_ONLY=true CNS_VERSION=${CNS} CNI_VERSION=$(make cni-version) INSTALL_CNS=true INSTALL_AZURE_VNET_STATELESS_SWIFT=true CNS_IMAGE_REPO=$(CNS_IMAGE_REPO)
                   else
-                    sudo -E env "PATH=$PATH" make test-integration CNS_VERSION=${CNS} CNI_VERSION=$(make cni-version) INSTALL_CNS=true INSTALL_AZURE_VNET=true CNS_IMAGE_REPO=$(CNS_IMAGE_REPO)
+                    sudo -E env "PATH=$PATH" make test-integration CNS_VERSION=${CNS} CNI_VERSION=$(make cni-version) INSTALL_CNS=true INSTALL_AZURE_VNET_STATELESS_SWIFT=true CNS_IMAGE_REPO=$(CNS_IMAGE_REPO)
                   fi
               name: "swifte2e"
               displayName: "Swift Integration"
@@ -276,7 +276,10 @@ stages:
             parameters:
               clusterName: ${{ parameters.clusterName }}-$(commitID)
               os: ${{ parameters.os }}
-              cni: cniv2
+              ${{ if contains(parameters.clusterType, 'swift') }}:
+                cni: stateless
+              ${{ else }}:
+                cni: cniv2
       - job: restart_nodes
         condition: and( and( not(canceled()), not(failed()) ), or( contains(variables.CONTROL_SCENARIO, 'restartNode') , contains(variables.CONTROL_SCENARIO, 'all') ) )
         displayName: "Restart Test"
@@ -295,7 +298,10 @@ stages:
             parameters:
               clusterName: ${{ parameters.clusterName }}-$(commitID)
               os: ${{ parameters.os }}
-              cni: cniv2
+              ${{ if contains(parameters.clusterType, 'swift') }}:
+                cni: stateless
+              ${{ else }}:
+                cni: cniv2
               restartCase: "true"
       - job: restart_cns
         condition: and( and( not(canceled()), not(failed()) ), or( contains(variables.CONTROL_SCENARIO, 'restartCNS') , contains(variables.CONTROL_SCENARIO, 'all') ) )
@@ -412,7 +418,10 @@ stages:
               parameters:
                 clusterName: ${{ parameters.clusterName }}-$(commitID)
                 os: ${{ parameters.os }}
-                cni: cniv2
+                ${{ if contains(parameters.clusterType, 'swift') }}:
+                  cni: stateless
+                ${{ else }}:
+                  cni: cniv2
         - job: restart_nodes
           displayName: "Restart Test"
           dependsOn: deploy_pods
@@ -429,7 +438,10 @@ stages:
               parameters:
                 clusterName: ${{ parameters.clusterName }}-$(commitID)
                 os: ${{ parameters.os }}
-                cni: cniv2
+                ${{ if contains(parameters.clusterType, 'swift') }}:
+                  cni: stateless
+                ${{ else }}:
+                  cni: cniv2
                 restartCase: "true"
         - job: restart_cns
           displayName: "Restart and Validate CNS"

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -579,6 +579,8 @@ stages:
         clusterName: "swifte2e"
         vmSize: Standard_B2ms
         k8sVersion: ""
+        cniType: stateless
+        installFlag: INSTALL_AZURE_VNET_STATELESS_SWIFT
         dependsOn: ["test"]
 
     # AKS Swift Vnet Scale E2E tests

--- a/.pipelines/run-pipeline.yaml
+++ b/.pipelines/run-pipeline.yaml
@@ -442,6 +442,8 @@ stages:
       clusterName: "swifte2e"
       vmSize: Standard_B2ms
       k8sVersion: ""
+      cniType: stateless
+      installFlag: INSTALL_AZURE_VNET_STATELESS_SWIFT
       dependsOn: manifests
 
   # AKS Swift Vnet Scale E2E tests

--- a/.pipelines/singletenancy/aks-swift/e2e-job-template.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e-job-template.yaml
@@ -69,7 +69,7 @@ stages:
               azureIpamVersion: $(AZURE_IPAM_VERSION)
               cnsVersion: $(CNS_VERSION)
               cniVersion: $(CNI_VERSION)
-              installFlag: INSTALL_AZURE_VNET
+              installFlag: ${{ parameters.installFlag }}
               os: ${{ parameters.os }}
   - stage: ${{ parameters.name }}
     displayName: E2E-${{ parameters.displayName }}

--- a/.pipelines/singletenancy/aks-swift/e2e-job-template.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e-job-template.yaml
@@ -23,6 +23,12 @@ parameters:
   - name: dependsOn
     type: object
     default: ""
+  - name: cniType
+    type: string
+    default: "cniv2"
+  - name: installFlag
+    type: string
+    default: "INSTALL_AZURE_VNET"
 
 stages:
   - stage: ${{ parameters.clusterName }}
@@ -102,6 +108,8 @@ stages:
               name: ${{ parameters.name }}
               clusterName: ${{ parameters.clusterName }}-$(commitID)
               scaleup: 100
+              cniType: ${{ parameters.cniType }}
+              installFlag: ${{ parameters.installFlag }}
           - template: ../../templates/k8s-e2e-step-template.yaml
             parameters:
               sub: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
@@ -123,11 +131,11 @@ stages:
             parameters:
               clusterName: ${{ parameters.clusterName }}-$(commitID)
               os: ${{ parameters.os }}
-              cni: cniv2
+              cni: ${{ parameters.cniType }}
 
       - template: ../../templates/failure-analysis.job.yaml
         parameters:
           clusterName: ${{ parameters.clusterName }}-$(commitID)
           os: ${{ parameters.os }}
-          cni: cniv2
+          cni: ${{ parameters.cniType }}
 

--- a/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
@@ -47,7 +47,7 @@ steps:
 
       CNS=${CNS_VERSION:-$(make cns-version)}
       CNI=${CNI_VERSION:-$(make cni-version)}
-      sudo -E env "PATH=$PATH" make test-load SCALE_UP=32 OS_TYPE=linux CNI_TYPE=cniv2 VALIDATE_STATEFILE=true INSTALL_AZURE_VNET=true CNS_VERSION=${CNS} CNI_VERSION=${CNI} CLEANUP=true
+      sudo -E env "PATH=$PATH" make test-load SCALE_UP=32 OS_TYPE=linux CNI_TYPE=stateless VALIDATE_STATEFILE=true INSTALL_AZURE_VNET_STATELESS_SWIFT=true CNS_VERSION=${CNS} CNI_VERSION=${CNI} CLEANUP=true
     retryCountOnTaskFailure: 3
     name: "aksswifte2e"
     displayName: "Run AKS Swift E2E"
@@ -84,7 +84,7 @@ steps:
 
         cd ../../..
         echo "Validating Node Restart"
-        make test-validate-state OS_TYPE=linux RESTART_CASE=true CNI_TYPE=cniv2
+        make test-validate-state OS_TYPE=linux RESTART_CASE=true CNI_TYPE=stateless
         kubectl delete ns load-test
     displayName: "Validate Node Restart"
     retryCountOnTaskFailure: 3

--- a/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e-step-template.yaml
@@ -2,6 +2,8 @@ parameters:
   name: ""
   clusterName: ""
   scaleup: ""
+  cniType: "cniv2"
+  installFlag: "INSTALL_AZURE_VNET"
 
 steps:
   - bash: |
@@ -47,7 +49,7 @@ steps:
 
       CNS=${CNS_VERSION:-$(make cns-version)}
       CNI=${CNI_VERSION:-$(make cni-version)}
-      sudo -E env "PATH=$PATH" make test-load SCALE_UP=32 OS_TYPE=linux CNI_TYPE=stateless VALIDATE_STATEFILE=true INSTALL_AZURE_VNET_STATELESS_SWIFT=true CNS_VERSION=${CNS} CNI_VERSION=${CNI} CLEANUP=true
+      sudo -E env "PATH=$PATH" make test-load SCALE_UP=32 OS_TYPE=linux CNI_TYPE=${{ parameters.cniType }} VALIDATE_STATEFILE=true ${{ parameters.installFlag }}=true CNS_VERSION=${CNS} CNI_VERSION=${CNI} CLEANUP=true
     retryCountOnTaskFailure: 3
     name: "aksswifte2e"
     displayName: "Run AKS Swift E2E"
@@ -84,7 +86,7 @@ steps:
 
         cd ../../..
         echo "Validating Node Restart"
-        make test-validate-state OS_TYPE=linux RESTART_CASE=true CNI_TYPE=stateless
+        make test-validate-state OS_TYPE=linux RESTART_CASE=true CNI_TYPE=${{ parameters.cniType }}
         kubectl delete ns load-test
     displayName: "Validate Node Restart"
     retryCountOnTaskFailure: 3

--- a/.pipelines/singletenancy/aks-swift/e2e.stages.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e.stages.yaml
@@ -7,6 +7,8 @@ parameters:
   k8sVersion: ""
   os: ""
   dependsOn: ""
+  cniType: "cniv2"
+  installFlag: "INSTALL_AZURE_VNET"
 
 stages:
   - stage: ${{ parameters.clusterName }}
@@ -90,6 +92,8 @@ stages:
               name: ${{ parameters.name }}
               clusterName: ${{ parameters.clusterName }}-$(commitID)
               scaleup: 100
+              cniType: ${{ parameters.cniType }}
+              installFlag: ${{ parameters.installFlag }}
 
       - template: ../../cni/k8s-e2e/k8s-e2e.jobs.yaml
         parameters:
@@ -119,4 +123,4 @@ stages:
             parameters:
               clusterName: ${{ parameters.clusterName }}-$(commitID)
               os: ${{ parameters.os }}
-              cni: cniv2
+              cni: ${{ parameters.cniType }}

--- a/.pipelines/singletenancy/aks-swift/e2e.steps.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e.steps.yaml
@@ -37,7 +37,7 @@ steps:
       kubectl cluster-info
       kubectl get po -owide -A
       sudo -E env "PATH=$PATH" make test-load \
-        SCALE_UP=32 OS_TYPE=linux CNI_TYPE=cniv2 VALIDATE_STATEFILE=true INSTALL_AZURE_VNET=true CLEANUP=true \
+        SCALE_UP=32 OS_TYPE=linux CNI_TYPE=stateless VALIDATE_STATEFILE=true INSTALL_AZURE_VNET_STATELESS_SWIFT=true CLEANUP=true \
         CNS_VERSION=$(CNS_VERSION) CNI_VERSION=$(CNI_VERSION) \
         CNS_IMAGE_NAME_OVERRIDE=$(CNS_IMAGE_NAME_OVERRIDE) CNI_IMAGE_NAME_OVERRIDE=$(CNI_IMAGE_NAME_OVERRIDE)
     retryCountOnTaskFailure: 3
@@ -76,7 +76,7 @@ steps:
 
         cd ../../..
         echo "Validating Node Restart"
-        make test-validate-state OS_TYPE=linux RESTART_CASE=true CNI_TYPE=cniv2
+        make test-validate-state OS_TYPE=linux RESTART_CASE=true CNI_TYPE=stateless
         kubectl delete ns load-test
     displayName: "Validate Node Restart"
     retryCountOnTaskFailure: 3

--- a/.pipelines/singletenancy/aks-swift/e2e.steps.yaml
+++ b/.pipelines/singletenancy/aks-swift/e2e.steps.yaml
@@ -2,6 +2,8 @@ parameters:
   name: ""
   clusterName: ""
   scaleup: ""
+  cniType: "cniv2"
+  installFlag: "INSTALL_AZURE_VNET"
 
 steps:
   - bash: |
@@ -37,7 +39,7 @@ steps:
       kubectl cluster-info
       kubectl get po -owide -A
       sudo -E env "PATH=$PATH" make test-load \
-        SCALE_UP=32 OS_TYPE=linux CNI_TYPE=stateless VALIDATE_STATEFILE=true INSTALL_AZURE_VNET_STATELESS_SWIFT=true CLEANUP=true \
+        SCALE_UP=32 OS_TYPE=linux CNI_TYPE=${{ parameters.cniType }} VALIDATE_STATEFILE=true ${{ parameters.installFlag }}=true CLEANUP=true \
         CNS_VERSION=$(CNS_VERSION) CNI_VERSION=$(CNI_VERSION) \
         CNS_IMAGE_NAME_OVERRIDE=$(CNS_IMAGE_NAME_OVERRIDE) CNI_IMAGE_NAME_OVERRIDE=$(CNI_IMAGE_NAME_OVERRIDE)
     retryCountOnTaskFailure: 3
@@ -76,7 +78,7 @@ steps:
 
         cd ../../..
         echo "Validating Node Restart"
-        make test-validate-state OS_TYPE=linux RESTART_CASE=true CNI_TYPE=stateless
+        make test-validate-state OS_TYPE=linux RESTART_CASE=true CNI_TYPE=${{ parameters.cniType }}
         kubectl delete ns load-test
     displayName: "Validate Node Restart"
     retryCountOnTaskFailure: 3

--- a/test/integration/manifests/cnsconfig/swiftstatelesslinuxconfigmap.yaml
+++ b/test/integration/manifests/cnsconfig/swiftstatelesslinuxconfigmap.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cns-config
+  namespace: kube-system
+data:
+  cns_config.json: |
+    {
+      "TelemetrySettings": {
+          "TelemetryBatchSizeBytes": 16384,
+          "TelemetryBatchIntervalInSecs": 15,
+          "RefreshIntervalInSecs": 15,
+          "DisableAll": false,
+          "HeartBeatIntervalInMins": 30,
+          "DebugMode": false,
+          "SnapshotIntervalInMins": 60
+      },
+      "ManagedSettings": {
+          "PrivateEndpoint": "",
+          "InfrastructureNetworkID": "",
+          "NodeID": "",
+          "NodeSyncIntervalInSeconds": 30
+      },
+      "AsyncPodDeletePath": "/var/run/azure-vnet/deleteIDs",
+      "ChannelMode": "CRD",
+      "CNIConflistFilepath": "/etc/cni/net.d/10-azure.conflist",
+      "CNIConflistScenario": "swift",
+      "EnableAsyncPodDelete": true,
+      "EnableCNIConflistGeneration": true,
+      "EnableIPAMv2": true,
+      "EnableStateMigration": false,
+      "EnableSubnetScarcity": false,
+      "InitializeFromCNI": false,
+      "ManageEndpointState": true,
+      "ProgramSNATIPTables": false
+    }

--- a/test/integration/manifests/cnsconfig/swiftstatelesswindowsconfigmap.yaml
+++ b/test/integration/manifests/cnsconfig/swiftstatelesswindowsconfigmap.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cns-win-config
+  namespace: kube-system
+data:
+  cns_config.json: |
+    {
+      "TelemetrySettings": {
+          "TelemetryBatchSizeBytes": 16384,
+          "TelemetryBatchIntervalInSecs": 15,
+          "RefreshIntervalInSecs": 15,
+          "DisableAll": false,
+          "HeartBeatIntervalInMins": 30,
+          "DebugMode": false,
+          "SnapshotIntervalInMins": 60
+      },
+      "ManagedSettings": {
+          "PrivateEndpoint": "",
+          "InfrastructureNetworkID": "",
+          "NodeID": "",
+          "NodeSyncIntervalInSeconds": 30
+      },
+      "AsyncPodDeletePath": "/var/run/azure-vnet/deleteIDs",
+      "ChannelMode": "CRD",
+      "CNIConflistFilepath": "C:\\k\\azurecni\\netconf\\10-azure.conflist",
+      "CNIConflistScenario": "swift",
+      "EnableAsyncPodDelete": true,
+      "EnableCNIConflistGeneration": false,
+      "EnableIPAMv2": true,
+      "EnableStateMigration": false,
+      "EnableSubnetScarcity": false,
+      "InitializeFromCNI": false,
+      "ManageEndpointState": true,
+      "MetricsBindAddress": ":10092",
+      "ProgramSNATIPTables": false
+    }

--- a/test/internal/kubernetes/utils_create.go
+++ b/test/internal/kubernetes/utils_create.go
@@ -528,7 +528,7 @@ func initCNSScenarioVars() (map[CNSScenario]map[corev1.OSName]cnsDetails, error)
 				initContainerName:         initContainerNameCNI,
 				volumes:                   volumesForAzureCNIOverlayLinux(),
 				initContainerVolumeMounts: dropgzVolumeMountsForAzureCNIOverlayLinux(),
-				containerVolumeMounts:     cnsVolumeMountsForAzureCNIOverlayLinux(),
+				containerVolumeMounts:     cnsVolumeMountsForSwiftStatelessLinux(),
 				configMapPath:             cnsSwiftStatelessLinuxConfigMapPath,
 				installIPMasqAgent:        false,
 			},
@@ -989,6 +989,18 @@ func cnsVolumeMountsForAzureCNIOverlayLinux() []corev1.VolumeMount {
 			MountPath: "/etc/cni/net.d",
 		},
 	}
+}
+
+// cnsVolumeMountsForSwiftStatelessLinux mirrors cnsVolumeMountsForAzureCNIOverlayLinux but also
+// mounts the azure-endpoints hostPath into the CNS container. In stateless mode CNS owns the
+// endpoint state (ManageEndpointState=true) and persists it to /var/run/azure-cns/azure-endpoints.json.
+// Without this hostPath mount CNS writes the file to its own container filesystem, so the sidecar
+// debug container that validation execs into cannot read it and state-file validation fails.
+func cnsVolumeMountsForSwiftStatelessLinux() []corev1.VolumeMount {
+	return append(cnsVolumeMountsForAzureCNIOverlayLinux(), corev1.VolumeMount{
+		Name:      "azure-endpoints",
+		MountPath: "/var/run/azure-cns/",
+	})
 }
 
 func cnsVolumeMountsForAzureCNIOverlayWindows() []corev1.VolumeMount {

--- a/test/internal/kubernetes/utils_create.go
+++ b/test/internal/kubernetes/utils_create.go
@@ -31,7 +31,9 @@ const (
 	EnvInstallAzureVnet          CNSScenario = "INSTALL_AZURE_VNET"
 	EnvInstallAzureVnetStateless CNSScenario = "INSTALL_AZURE_VNET_STATELESS"
 	// EnvInstallAzureVnetStatelessSwift installs Swift (podsubnet) with the stateless azure-vnet CNI,
-	// where CNS owns endpoint state and synthesizes the swift conflist (CNIConflistScenario: "swift").
+	// where CNS owns endpoint state (ManageEndpointState). On Linux, CNS also synthesizes the swift
+	// conflist (CNIConflistScenario: "swift") when EnableCNIConflistGeneration is set; the Windows
+	// configmap disables conflist generation. See the swiftstateless*configmap.yaml manifests.
 	EnvInstallAzureVnetStatelessSwift CNSScenario = "INSTALL_AZURE_VNET_STATELESS_SWIFT"
 	EnvInstallOverlay                 CNSScenario = "INSTALL_OVERLAY"
 	EnvInstallAzureCNIOverlay         CNSScenario = "INSTALL_AZURE_CNI_OVERLAY"

--- a/test/internal/kubernetes/utils_create.go
+++ b/test/internal/kubernetes/utils_create.go
@@ -30,10 +30,13 @@ const (
 	EnvInstallAzilium            CNSScenario = "INSTALL_AZILIUM"
 	EnvInstallAzureVnet          CNSScenario = "INSTALL_AZURE_VNET"
 	EnvInstallAzureVnetStateless CNSScenario = "INSTALL_AZURE_VNET_STATELESS"
-	EnvInstallOverlay            CNSScenario = "INSTALL_OVERLAY"
-	EnvInstallAzureCNIOverlay    CNSScenario = "INSTALL_AZURE_CNI_OVERLAY"
-	EnvInstallDualStackOverlay   CNSScenario = "INSTALL_DUALSTACK_OVERLAY"
-	EnvInstallCNSNodeSubnet      CNSScenario = "INSTALL_CNS_NODESUBNET"
+	// EnvInstallAzureVnetStatelessSwift installs Swift (podsubnet) with the stateless azure-vnet CNI,
+	// where CNS owns endpoint state and synthesizes the swift conflist (CNIConflistScenario: "swift").
+	EnvInstallAzureVnetStatelessSwift CNSScenario = "INSTALL_AZURE_VNET_STATELESS_SWIFT"
+	EnvInstallOverlay                 CNSScenario = "INSTALL_OVERLAY"
+	EnvInstallAzureCNIOverlay         CNSScenario = "INSTALL_AZURE_CNI_OVERLAY"
+	EnvInstallDualStackOverlay        CNSScenario = "INSTALL_DUALSTACK_OVERLAY"
+	EnvInstallCNSNodeSubnet           CNSScenario = "INSTALL_CNS_NODESUBNET"
 )
 
 type cnsDetails struct {
@@ -386,6 +389,8 @@ func initCNSScenarioVars() (map[CNSScenario]map[corev1.OSName]cnsDetails, error)
 	cnsClusterRoleBindingPath := cnsManifestFolder + "/clusterrolebinding.yaml"
 	cnsSwiftLinuxConfigMapPath := cnsConfigFolder + "/swiftlinuxconfigmap.yaml"
 	cnsSwiftWindowsConfigMapPath := cnsConfigFolder + "/swiftwindowsconfigmap.yaml"
+	cnsSwiftStatelessLinuxConfigMapPath := cnsConfigFolder + "/swiftstatelesslinuxconfigmap.yaml"
+	cnsSwiftStatelessWindowsConfigMapPath := cnsConfigFolder + "/swiftstatelesswindowsconfigmap.yaml"
 	cnsCiliumConfigMapPath := cnsConfigFolder + "/ciliumconfigmap.yaml"
 	cnsNodeSubnetLinuxConfigMapPath := cnsConfigFolder + "/ciliumnodesubnetconfigmap.yaml"
 	cnsOverlayConfigMapPath := cnsConfigFolder + "/overlayconfigmap.yaml"
@@ -504,6 +509,47 @@ func initCNSScenarioVars() (map[CNSScenario]map[corev1.OSName]cnsDetails, error)
 				containerVolumeMounts:     cnsVolumeMountsForAzureCNIOverlayWindows(),
 				configMapPath:             cnsAzureStatelessCNIOverlayWindowsConfigMapPath,
 				installIPMasqAgent:        true,
+			},
+		},
+		EnvInstallAzureVnetStatelessSwift: {
+			corev1.Linux: {
+				daemonsetPath:          cnsLinuxDaemonSetPath,
+				labelSelector:          cnsLinuxLabelSelector,
+				rolePath:               cnsRolePath,
+				roleBindingPath:        cnsRoleBindingPath,
+				clusterRolePath:        cnsClusterRolePath,
+				clusterRoleBindingPath: cnsClusterRoleBindingPath,
+				serviceAccountPath:     cnsServiceAccountPath,
+				initContainerArgs: []string{
+					"deploy",
+					"azure-vnet-stateless", "-o", "/opt/cni/bin/azure-vnet",
+					"azure-vnet-telemetry", "-o", "/opt/cni/bin/azure-vnet-telemetry",
+				},
+				initContainerName:         initContainerNameCNI,
+				volumes:                   volumesForAzureCNIOverlayLinux(),
+				initContainerVolumeMounts: dropgzVolumeMountsForAzureCNIOverlayLinux(),
+				containerVolumeMounts:     cnsVolumeMountsForAzureCNIOverlayLinux(),
+				configMapPath:             cnsSwiftStatelessLinuxConfigMapPath,
+				installIPMasqAgent:        false,
+			},
+			corev1.Windows: {
+				daemonsetPath:          cnsWindowsDaemonSetPath,
+				labelSelector:          cnsWindowsLabelSelector,
+				rolePath:               cnsRolePath,
+				roleBindingPath:        cnsRoleBindingPath,
+				clusterRolePath:        cnsClusterRolePath,
+				clusterRoleBindingPath: cnsClusterRoleBindingPath,
+				serviceAccountPath:     cnsServiceAccountPath,
+				initContainerArgs: []string{
+					"deploy",
+					"azure-vnet-stateless", "-o", "/k/azurecni/bin/azure-vnet.exe",
+				},
+				initContainerName:         initContainerNameCNI,
+				volumes:                   volumesForAzureCNIOverlayWindows(),
+				initContainerVolumeMounts: dropgzVolumeMountsForAzureCNIOverlayWindows(),
+				containerVolumeMounts:     cnsVolumeMountsForAzureCNIOverlayWindows(),
+				configMapPath:             cnsSwiftStatelessWindowsConfigMapPath,
+				installIPMasqAgent:        false,
 			},
 		},
 		EnvInstallAzilium: {

--- a/test/validate/linux_validate.go
+++ b/test/validate/linux_validate.go
@@ -108,6 +108,24 @@ var linuxChecksMap = map[string][]check{
 			cmd:              azureVnetStateFileCmd,
 		},
 	},
+	"stateless": {
+		{
+			name:             "cns",
+			stateFileIPs:     cnsManagedStateFileIps,
+			podLabelSelector: validatorPod,
+			podNamespace:     privilegedNamespace,
+			containerName:    "debug",
+			cmd:              cnsManagedStateFileCmd,
+		}, // cns configmap "ManageEndpointState": true, | Endpoints managed in CNS State File
+		{
+			name:             "cns cache",
+			stateFileIPs:     cnsCacheStateFileIps,
+			podLabelSelector: validatorPod,
+			podNamespace:     privilegedNamespace,
+			containerName:    "debug",
+			cmd:              cnsCachedAssignedIPStateCmd,
+		},
+	},
 	"cilium_dualstack": {
 		{
 			name:             "cns dualstack",


### PR DESCRIPTION
## Summary
Switches the **Linux and Windows Swift (podsubnet)** E2E scenarios in the ACN **PR** and **release-test** pipelines to the **stateless** azure-vnet CNI, matching the AKS RP CNS synth default (`azure-vnet-stateless`) on **AKS 1.35**. Nodesubnet and vnetscale scenarios are unchanged. k8s 1.35 is already the pipeline default (`hack/aks/Makefile: K8S_VER ?= 1.35`).

## How "stateless" is wired
- Deploy the `azure-vnet-stateless` binary (output as `azure-vnet`)
- CNS owns endpoint state: `ManageEndpointState=true`, `InitializeFromCNI=false`
- CNS synthesizes the swift conflist: `CNIConflistScenario="swift"` (`SWIFTGenerator` → plugin `azure-vnet` + `azure-cns` IPAM)
- Validate with `CNI_TYPE=stateless`

## Changes
- **Harness:** new CNS scenario `INSTALL_AZURE_VNET_STATELESS_SWIFT` (linux+windows) in `test/internal/kubernetes/utils_create.go`
- **New configmaps:** `swiftstatelesslinuxconfigmap.yaml`, `swiftstatelesswindowsconfigmap.yaml`
- **Validation:** added `"stateless"` key to the linux validate map (windows already had one)
- **PR pipeline** (`aks-swift`): install stateless + validate `CNI_TYPE=stateless`
- **Release pipeline** (`cniv2-template`): swift branch installs stateless and validates `CNI_TYPE=stateless` for swift clusterType (base + upgrade, linux + windows); overlay paths unchanged

## Testing notes
Go files are `gofmt`-clean and parse; YAML + embedded configmap JSON validate. A full `go build`/E2E was not run locally (module proxy is auth-gated) — please run the affected pipelines to validate end-to-end.

🤖 Generated with GitHub Copilot CLI