### PR TITLE
ci: update CNI Release Test Trigger

### DIFF
--- a/.pipelines/cni/pipeline.yaml
+++ b/.pipelines/cni/pipeline.yaml
@@ -1,4 +1,15 @@
-pr: none
+pr: 
+  branches:
+    include:
+      - master
+      - release/*
+  paths:
+    include:
+      - cni/*
+      - cns/*
+      - npm/*
+      - .pipelines/cni/*
+      
 trigger:
   tags:
     include:


### PR DESCRIPTION
This pull request updates the pipeline trigger configuration in `.pipelines/cni/pipeline.yaml` to improve control over when the pipeline runs. The main change is to enable the pipeline to be triggered only for pull requests targeting specific branches and affecting certain paths.

Pipeline trigger configuration:

* Updated the `pr` section to trigger the pipeline only for pull requests to the `master` and `release/*` branches, and only when changes are made to files under `cni/`, `cns/`, `npm/`, or `.pipelines/cni/`.<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
