### PR TITLE
fix: [NPM] forward-port IPSet and policy chain naming-uniqueness improvements (#4574, #4587, #4593) to master

### DIFF
--- a/npm/ipsm/ipsm_test.go
+++ b/npm/ipsm/ipsm_test.go
@@ -610,7 +610,7 @@ func TestMarshalSetMapJSON(t *testing.T) {
 	require.NoError(t, err)
 	fmt.Println(string(setMapRaw))
 
-	expect := []byte(`{"azure-npm-922816856":"test-set"}`)
+	expect := []byte(`{"azure-npm-3fmr1y4xucxg45l55kfb":"test-set"}`)
 	for key, val := range ipsMgr.setMap {
 		fmt.Printf("key: %s value: %+v\n", key, val)
 	}

--- a/npm/pkg/controlplane/translation/parseSelector.go
+++ b/npm/pkg/controlplane/translation/parseSelector.go
@@ -278,8 +278,11 @@ func parsePodSelector(policyKey string, selector *metav1.LabelSelector) ([]label
 				setType = ipsets.KeyValueLabelOfPod
 			} else {
 				// "(!) + matchKey + : + multiple matchVals" case
-				// see caveat in definition of TranslatedIPSet for why the policy key must be included in the set name
-				setName = fmt.Sprintf("%s-%s", policyKey, req.Key)
+				// The policy key must be included so each policy owns its own nested list
+				// (see caveat in TranslatedIPSet). Separate the policy key and match key
+				// with ":", which neither can contain, so distinct (policy, key) pairs
+				// always produce distinct set names.
+				setName = fmt.Sprintf("%s:%s", policyKey, req.Key)
 				for _, val := range req.Values {
 					setName = util.GetIpSetFromLabelKV(setName, val)
 					members = append(members, util.GetIpSetFromLabelKV(req.Key, val))

--- a/npm/pkg/controlplane/translation/translatePolicy.go
+++ b/npm/pkg/controlplane/translation/translatePolicy.go
@@ -47,10 +47,14 @@ type podSelectorResult struct {
 type netpolPortType string
 
 const (
-	numericPortType      netpolPortType = "validport"
-	namedPortType        netpolPortType = "namedport"
-	included             bool           = true
-	ipBlocksetNameFormat                = "%s-in-ns-%s-%d-%d%s"
+	numericPortType netpolPortType = "validport"
+	namedPortType   netpolPortType = "namedport"
+	included        bool           = true
+	// ipBlocksetNameFormat separates the policy name and namespace with ":", which is not
+	// a valid character in either, so distinct (policy, namespace) pairs always produce
+	// distinct set names.
+	// Format: "<policy>:in-ns:<ns>-<setIndex>-<peerIndex><direction>".
+	ipBlocksetNameFormat = "%s:in-ns:%s-%d-%d%s"
 )
 
 // portType returns type of ports (e.g., numeric port or namedPort) given NetworkPolicyPort object.
@@ -134,14 +138,10 @@ func portRule(ruleIPSets []*ipsets.TranslatedIPSet, acl *policies.ACLPolicy, por
 	return ruleIPSets
 }
 
-// ipBlockSetName returns ipset name of the IPBlock.
-// It is our contract to format "<policyname>-in-ns-<namespace>-<ipblock index><direction of ipblock (i.e., ingress: IN, egress: OUT>"
-// as ipset name of the IPBlock.
-// For example, in case network policy object has
-// name: "test"
-// namespace: "default"
-// ingress rule
-// it returns "test-in-ns-default-0IN".
+// ipBlockSetName returns the ipset name of the IPBlock. The policy name and namespace
+// are separated by ":" (see ipBlocksetNameFormat), which neither can contain, so distinct
+// (policy, namespace) pairs always produce distinct names.
+// e.g. name "test", namespace "default", ingress (setIndex 0, peerIndex 0) -> "test:in-ns:default-0-0IN".
 func ipBlockSetName(policyName, ns string, direction policies.Direction, ipBlockSetIndex, ipBlockPeerIndex int) string {
 	return fmt.Sprintf(ipBlocksetNameFormat, policyName, ns, ipBlockSetIndex, ipBlockPeerIndex, direction)
 }

--- a/npm/pkg/controlplane/translation/translatePolicy_test.go
+++ b/npm/pkg/controlplane/translation/translatePolicy_test.go
@@ -322,17 +322,17 @@ func TestIPBlockSetName(t *testing.T) {
 		{
 			name:        "default/test (ingress)",
 			ipBlockInfo: createIPBlockInfo("test", defaultNS, policies.Ingress, policies.SrcMatch, 0, 0),
-			want:        "test-in-ns-default-0-0IN",
+			want:        "test:in-ns:default-0-0IN",
 		},
 		{
 			name:        "default/test (ingress)",
 			ipBlockInfo: createIPBlockInfo("test", defaultNS, policies.Ingress, policies.SrcMatch, 1, 0),
-			want:        "test-in-ns-default-1-0IN",
+			want:        "test:in-ns:default-1-0IN",
 		},
 		{
 			name:        "testns/test (egress)",
 			ipBlockInfo: createIPBlockInfo("test", "testns", policies.Egress, policies.DstMatch, 0, 1),
-			want:        "test-in-ns-testns-0-1OUT",
+			want:        "test:in-ns:testns-0-1OUT",
 		},
 	}
 
@@ -344,6 +344,220 @@ func TestIPBlockSetName(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestIPBlockSetNameUnambiguous checks that distinct (policy, namespace, index, direction)
+// inputs always produce distinct set names, including when a name contains the "-in-ns-"
+// separator.
+func TestIPBlockSetNameUnambiguous(t *testing.T) {
+	t.Parallel()
+
+	a := ipBlockSetName("a-in-ns-b", "c", policies.Ingress, 0, 0)
+	b := ipBlockSetName("a", "b-in-ns-c", policies.Ingress, 0, 0)
+	require.NotEqual(t, a, b, "distinct (policy, namespace) pairs must produce distinct set names")
+
+	// Distinct pairs whose names contain the "-in-ns-" separator must each be unique.
+	tuples := []struct{ policy, ns string }{
+		{"a-in-ns-b", "c"},
+		{"a", "b-in-ns-c"},
+		{"a-in-ns-b-in-ns-c", "d"},
+		{"a", "b-in-ns-c-in-ns-d"},
+		{"a-in-ns-b", "c-in-ns-d"},
+		{"a-in-ns", "b-c"},
+		{"a", "in-ns-b-c"},
+		{"a-b", "c"},
+		{"a", "b-c"},
+		{"in-ns", "in-ns"},
+		{"1", "2-3"},
+		{"1-2", "3"},
+	}
+	seen := make(map[string]string, len(tuples))
+	for _, tp := range tuples {
+		name := ipBlockSetName(tp.policy, tp.ns, policies.Ingress, 0, 0)
+		if prev, ok := seen[name]; ok {
+			t.Fatalf("(%q,%q) and %q both produced %q", tp.policy, tp.ns, prev, name)
+		}
+		seen[name] = tp.policy + "|" + tp.ns
+	}
+
+	// Direction, set index, and peer index are all part of the identity.
+	base := ipBlockSetName("p", "n", policies.Ingress, 0, 0)
+	require.NotEqual(t, base, ipBlockSetName("p", "n", policies.Egress, 0, 0), "direction must change the name")
+	require.NotEqual(t, base, ipBlockSetName("p", "n", policies.Ingress, 1, 0), "set index must change the name")
+	require.NotEqual(t, base, ipBlockSetName("p", "n", policies.Ingress, 0, 1), "peer index must change the name")
+	require.NotEqual(t,
+		ipBlockSetName("p", "n", policies.Ingress, 1, 10),
+		ipBlockSetName("p", "n", policies.Ingress, 11, 0),
+		"index boundaries must not alias")
+}
+
+// TestNestedSetNameUnambiguous checks that multi-value pod-selector nested sets get distinct
+// names for distinct (policyKey, matchKey) pairs, including label keys that contain "/".
+func TestNestedSetNameUnambiguous(t *testing.T) {
+	t.Parallel()
+
+	type tc struct {
+		name, ns, key string
+	}
+	// Pairs designed to alias under a "-" separator, plus qualified keys containing "/".
+	cases := []tc{
+		{"a-b", "ns", "c"},
+		{"a", "ns", "b-c"},
+		{"a", "ns", "example.com/team"},
+		{"a-example.com", "ns", "team"},
+		{"a", "ns", "b"},
+		{"a-b", "ns", "c-d"},
+		{"a", "other", "b-c"},
+	}
+	seen := make(map[string]string, len(cases))
+	for _, c := range cases {
+		pol := multiValueSelectorPolicy(c.name, c.ns, c.key, "x", "y")
+		npmNetPol, err := TranslatePolicy(pol, false)
+		require.NoError(t, err)
+		set := nestedSet(t, npmNetPol)
+		id := fmt.Sprintf("%s/%s|%s", c.ns, c.name, c.key)
+		if prev, ok := seen[set.Metadata.Name]; ok {
+			t.Fatalf("%s and %s both produced nested set %q", prev, id, set.Metadata.Name)
+		}
+		seen[set.Metadata.Name] = id
+	}
+}
+
+// ingressIPBlockPolicy builds a NetworkPolicy with a single ingress ipBlock CIDR peer.
+func ingressIPBlockPolicy(name, ns, cidr string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{From: []networkingv1.NetworkPolicyPeer{{IPBlock: &networkingv1.IPBlock{CIDR: cidr}}}},
+			},
+		},
+	}
+}
+
+// cidrSet returns the single CIDRBlocks TranslatedIPSet from a translated policy.
+func cidrSet(t *testing.T, npmNetPol *policies.NPMNetworkPolicy) *ipsets.TranslatedIPSet {
+	t.Helper()
+	var found *ipsets.TranslatedIPSet
+	for _, s := range npmNetPol.RuleIPSets {
+		if s.Metadata.Type == ipsets.CIDRBlocks {
+			require.Nil(t, found, "expected exactly one CIDR set per policy")
+			found = s
+		}
+	}
+	require.NotNil(t, found, "policy %s produced no CIDR set", npmNetPol.PolicyKey)
+	return found
+}
+
+// TestIPBlockTwoPolicyIsolation translates two policies whose (name, namespace) pairs
+// serialize around the "-in-ns-" separator and asserts they resolve to distinct kernel
+// sets, that each policy's ACL references its own set, and that neither set carries the
+// other's CIDR members.
+func TestIPBlockTwoPolicyIsolation(t *testing.T) {
+	t.Parallel()
+
+	// Both pairs would share a pre-hash name under the old ambiguous format.
+	first := ingressIPBlockPolicy("a-in-ns-b", "c", "198.51.100.10/32")
+	second := ingressIPBlockPolicy("a", "b-in-ns-c", "0.0.0.0/0")
+
+	firstNetPol, err := TranslatePolicy(first, false)
+	require.NoError(t, err)
+	secondNetPol, err := TranslatePolicy(second, false)
+	require.NoError(t, err)
+
+	firstSet := cidrSet(t, firstNetPol)
+	secondSet := cidrSet(t, secondNetPol)
+
+	// Distinct kernel (hashed) names: the two policies never share one IPSet.
+	require.NotEqual(t, firstSet.Metadata.GetHashedName(), secondSet.Metadata.GetHashedName(),
+		"distinct policies must map to distinct kernel sets")
+
+	// Each policy's ingress ACL references its own CIDR set.
+	requireIngressRefersTo(t, firstNetPol, firstSet.Metadata.GetHashedName())
+	requireIngressRefersTo(t, secondNetPol, secondSet.Metadata.GetHashedName())
+
+	// Members stay separated: neither set carries the other's CIDRs.
+	require.Equal(t, []string{"198.51.100.10/32"}, firstSet.Members)
+	require.ElementsMatch(t, []string{"0.0.0.0/1", "128.0.0.0/1"}, secondSet.Members)
+	require.NotContains(t, secondSet.Members, "198.51.100.10/32")
+	require.NotContains(t, firstSet.Members, "0.0.0.0/1")
+}
+
+// requireIngressRefersTo asserts that some ingress ACL source references the given set.
+func requireIngressRefersTo(t *testing.T, npmNetPol *policies.NPMNetworkPolicy, hashedName string) {
+	t.Helper()
+	for _, acl := range npmNetPol.ACLs {
+		if acl.Direction != policies.Ingress {
+			continue
+		}
+		for _, si := range acl.SrcList {
+			if si.IPSet.GetHashedName() == hashedName {
+				return
+			}
+		}
+	}
+	t.Fatalf("policy %s has no ingress ACL referencing set %s", npmNetPol.PolicyKey, hashedName)
+}
+
+// multiValueSelectorPolicy builds a policy whose target podSelector has a single
+// matchExpression (key In values) with multiple values, producing a nested-label set.
+func multiValueSelectorPolicy(name, ns, key string, values ...string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: key, Operator: metav1.LabelSelectorOpIn, Values: values},
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress:     []networkingv1.NetworkPolicyIngressRule{{}},
+		},
+	}
+}
+
+// nestedSet returns the single NestedLabelOfPod TranslatedIPSet from a translated policy.
+func nestedSet(t *testing.T, npmNetPol *policies.NPMNetworkPolicy) *ipsets.TranslatedIPSet {
+	t.Helper()
+	var found *ipsets.TranslatedIPSet
+	for _, s := range npmNetPol.PodSelectorIPSets {
+		if s.Metadata.Type == ipsets.NestedLabelOfPod {
+			require.Nil(t, found, "expected exactly one nested set per policy")
+			found = s
+		}
+	}
+	require.NotNil(t, found, "policy %s produced no nested set", npmNetPol.PolicyKey)
+	return found
+}
+
+// TestNestedSelectorTwoPolicyIsolation translates two policies whose (name, matchKey)
+// pairs serialize around the "-" separator and asserts their multi-value selector sets
+// resolve to distinct kernel sets while sharing the same child member sets.
+func TestNestedSelectorTwoPolicyIsolation(t *testing.T) {
+	t.Parallel()
+
+	// Both pairs would share a pre-hash nested name under the old ambiguous format:
+	// (ns/a-b, key c) and (ns/a, key b-c) both produced "ns/a-b-c:x:y".
+	first := multiValueSelectorPolicy("a-b", "ns", "c", "x", "y")
+	second := multiValueSelectorPolicy("a", "ns", "b-c", "x", "y")
+
+	firstNetPol, err := TranslatePolicy(first, false)
+	require.NoError(t, err)
+	secondNetPol, err := TranslatePolicy(second, false)
+	require.NoError(t, err)
+
+	firstSet := nestedSet(t, firstNetPol)
+	secondSet := nestedSet(t, secondNetPol)
+
+	// Distinct kernel (hashed) names: the two policies never share one nested set.
+	require.NotEqual(t, firstSet.Metadata.GetHashedName(), secondSet.Metadata.GetHashedName(),
+		"distinct policies must map to distinct nested sets")
+
+	// Child member sets are keyed by matchKey:value and are unaffected by the fix.
+	require.ElementsMatch(t, []string{"c:x", "c:y"}, firstSet.Members)
+	require.ElementsMatch(t, []string{"b-c:x", "b-c:y"}, secondSet.Members)
 }
 
 // Specific testsets for 0.0.0.0/0 cidr since it has special handling in the code due to limitation of ipset on linux.
@@ -376,7 +590,7 @@ func TestIPBlockIPSet(t *testing.T) {
 			ipBlockRule: &networkingv1.IPBlock{
 				CIDR: "172.17.0.0/16",
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16"}...),
 		},
 		{
 			name:        "one cidr and one element in except",
@@ -385,7 +599,7 @@ func TestIPBlockIPSet(t *testing.T) {
 				CIDR:   "172.17.0.0/16",
 				Except: []string{"172.17.1.0/24"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch"}...),
 			skipWindows:     true,
 		},
 		{
@@ -395,7 +609,7 @@ func TestIPBlockIPSet(t *testing.T) {
 				CIDR:   "172.17.0.0/16",
 				Except: []string{"172.17.1.0/24", "172.17.2.0/24"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-network-policy-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch", "172.17.2.0/24 nomatch"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test-network-policy:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch", "172.17.2.0/24 nomatch"}...),
 			skipWindows:     true,
 		},
 		{
@@ -405,7 +619,7 @@ func TestIPBlockIPSet(t *testing.T) {
 				CIDR:   "172.17.0.0/16",
 				Except: []string{"172.17.1.0/24", "172.17.2.0/24", "172.17.2.0/24"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-network-policy-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch", "172.17.2.0/24 nomatch"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test-network-policy:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch", "172.17.2.0/24 nomatch"}...),
 			skipWindows:     true,
 		},
 		{
@@ -414,7 +628,7 @@ func TestIPBlockIPSet(t *testing.T) {
 			ipBlockRule: &networkingv1.IPBlock{
 				CIDR: "0.0.0.0/0",
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1", "128.0.0.0/1"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1", "128.0.0.0/1"}...),
 		},
 		{
 			name:        "cidr: 0.0.0.0/0 and except: 10.0.0.0/1",
@@ -423,7 +637,7 @@ func TestIPBlockIPSet(t *testing.T) {
 				CIDR:   "0.0.0.0/0",
 				Except: []string{"10.0.0.0/1"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1", "128.0.0.0/1", "10.0.0.0/1 nomatch"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1", "128.0.0.0/1", "10.0.0.0/1 nomatch"}...),
 			skipWindows:     true,
 		},
 		{
@@ -433,7 +647,7 @@ func TestIPBlockIPSet(t *testing.T) {
 				CIDR:   "0.0.0.0/0",
 				Except: []string{"0.0.0.0/1"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1 nomatch", "128.0.0.0/1"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1 nomatch", "128.0.0.0/1"}...),
 			skipWindows:     true,
 		},
 		{
@@ -443,7 +657,7 @@ func TestIPBlockIPSet(t *testing.T) {
 				CIDR:   "0.0.0.0/0",
 				Except: []string{"128.0.0.0/1"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1", "128.0.0.0/1 nomatch"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1", "128.0.0.0/1 nomatch"}...),
 			skipWindows:     true,
 		},
 		{
@@ -453,7 +667,7 @@ func TestIPBlockIPSet(t *testing.T) {
 				CIDR:   "0.0.0.0/0",
 				Except: []string{"0.0.0.0/1", "128.0.0.0/1"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1 nomatch", "128.0.0.0/1 nomatch"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1 nomatch", "128.0.0.0/1 nomatch"}...),
 			skipWindows:     true,
 		},
 		{
@@ -463,7 +677,7 @@ func TestIPBlockIPSet(t *testing.T) {
 				CIDR:   "0.0.0.0/0",
 				Except: []string{"0.0.0.0/1", "128.0.0.0/1", "128.0.0.0/1"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1 nomatch", "128.0.0.0/1 nomatch"}...),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"0.0.0.0/1 nomatch", "128.0.0.0/1 nomatch"}...),
 			skipWindows:     true,
 		},
 	}
@@ -516,8 +730,8 @@ func TestIPBlockRule(t *testing.T) {
 			ipBlockRule: &networkingv1.IPBlock{
 				CIDR: "172.17.0.0/16",
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16"}...),
-			setInfo:         policies.NewSetInfo("test-in-ns-default-0-0IN", ipsets.CIDRBlocks, included, policies.SrcMatch),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16"}...),
+			setInfo:         policies.NewSetInfo("test:in-ns:default-0-0IN", ipsets.CIDRBlocks, included, policies.SrcMatch),
 		},
 		{
 			name:        "one cidr and one element in except",
@@ -526,8 +740,8 @@ func TestIPBlockRule(t *testing.T) {
 				CIDR:   "172.17.0.0/16",
 				Except: []string{"172.17.1.0/24"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch"}...),
-			setInfo:         policies.NewSetInfo("test-in-ns-default-0-0IN", ipsets.CIDRBlocks, included, policies.SrcMatch),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch"}...),
+			setInfo:         policies.NewSetInfo("test:in-ns:default-0-0IN", ipsets.CIDRBlocks, included, policies.SrcMatch),
 			skipWindows:     true,
 		},
 		{
@@ -537,8 +751,8 @@ func TestIPBlockRule(t *testing.T) {
 				CIDR:   "172.17.0.0/16",
 				Except: []string{"172.17.1.0/24", "172.17.2.0/24"},
 			},
-			translatedIPSet: ipsets.NewTranslatedIPSet("test-network-policy-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch", "172.17.2.0/24 nomatch"}...),
-			setInfo:         policies.NewSetInfo("test-network-policy-in-ns-default-0-0IN", ipsets.CIDRBlocks, included, policies.SrcMatch),
+			translatedIPSet: ipsets.NewTranslatedIPSet("test-network-policy:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch", "172.17.2.0/24 nomatch"}...),
+			setInfo:         policies.NewSetInfo("test-network-policy:in-ns:default-0-0IN", ipsets.CIDRBlocks, included, policies.SrcMatch),
 			skipWindows:     true,
 		},
 		{
@@ -588,7 +802,6 @@ func TestIPBlockRule(t *testing.T) {
 func TestPodSelector(t *testing.T) {
 	matchType := policies.DstMatch
 	policyKey := "test-ns/test-policy"
-	policyKeyWithDash := policyKey + "-"
 	tests := []struct {
 		name                    string
 		namespace               string
@@ -750,7 +963,7 @@ func TestPodSelector(t *testing.T) {
 			},
 			podSelectorIPSets: []*ipsets.TranslatedIPSet{
 				ipsets.NewTranslatedIPSet("k0:v0", ipsets.KeyValueLabelOfPod),
-				ipsets.NewTranslatedIPSet(policyKeyWithDash+"k1:v10:v11", ipsets.NestedLabelOfPod, []string{"k1:v10", "k1:v11"}...),
+				ipsets.NewTranslatedIPSet("test-ns/test-policy:k1:v10:v11", ipsets.NestedLabelOfPod, []string{"k1:v10", "k1:v11"}...),
 				ipsets.NewTranslatedIPSet("k2", ipsets.KeyLabelOfPod),
 			},
 			childPodSelectorIPSets: []*ipsets.TranslatedIPSet{
@@ -759,7 +972,7 @@ func TestPodSelector(t *testing.T) {
 			},
 			podSelectorList: []policies.SetInfo{
 				policies.NewSetInfo("k0:v0", ipsets.KeyValueLabelOfPod, included, matchType),
-				policies.NewSetInfo(policyKeyWithDash+"k1:v10:v11", ipsets.NestedLabelOfPod, included, matchType),
+				policies.NewSetInfo("test-ns/test-policy:k1:v10:v11", ipsets.NestedLabelOfPod, included, matchType),
 				policies.NewSetInfo("k2", ipsets.KeyLabelOfPod, nonIncluded, matchType),
 			},
 			skipWindows: true,
@@ -790,7 +1003,7 @@ func TestPodSelector(t *testing.T) {
 			},
 			podSelectorIPSets: []*ipsets.TranslatedIPSet{
 				ipsets.NewTranslatedIPSet("k0:v0", ipsets.KeyValueLabelOfPod),
-				ipsets.NewTranslatedIPSet(policyKeyWithDash+"k1:v10:v11", ipsets.NestedLabelOfPod, []string{"k1:v10", "k1:v11"}...),
+				ipsets.NewTranslatedIPSet("test-ns/test-policy:k1:v10:v11", ipsets.NestedLabelOfPod, []string{"k1:v10", "k1:v11"}...),
 				ipsets.NewTranslatedIPSet("k2", ipsets.KeyLabelOfPod),
 				ipsets.NewTranslatedIPSet(defaultNS, ipsets.Namespace),
 			},
@@ -800,7 +1013,7 @@ func TestPodSelector(t *testing.T) {
 			},
 			podSelectorList: []policies.SetInfo{
 				policies.NewSetInfo("k0:v0", ipsets.KeyValueLabelOfPod, included, matchType),
-				policies.NewSetInfo(policyKeyWithDash+"k1:v10:v11", ipsets.NestedLabelOfPod, included, matchType),
+				policies.NewSetInfo("test-ns/test-policy:k1:v10:v11", ipsets.NestedLabelOfPod, included, matchType),
 				policies.NewSetInfo("k2", ipsets.KeyLabelOfPod, nonIncluded, matchType),
 				policies.NewSetInfo(defaultNS, ipsets.Namespace, included, matchType),
 			},
@@ -1266,7 +1479,7 @@ func TestPeerAndPortRule(t *testing.T) {
 			{},
 		},
 		{
-			policies.NewSetInfo("test-in-ns-default-0IN", ipsets.CIDRBlocks, included, matchType),
+			policies.NewSetInfo("test:in-ns:default-0IN", ipsets.CIDRBlocks, included, matchType),
 		},
 		{
 			policies.NewSetInfo("label:src", ipsets.KeyValueLabelOfNamespace, included, matchType),
@@ -1362,7 +1575,7 @@ func TestPeerAndPortRule(t *testing.T) {
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 						SrcList: []policies.SetInfo{
-							policies.NewSetInfo("test-in-ns-default-0IN", ipsets.CIDRBlocks, included, matchType),
+							policies.NewSetInfo("test:in-ns:default-0IN", ipsets.CIDRBlocks, included, matchType),
 						},
 						DstList: []policies.SetInfo{
 							policies.NewSetInfo("serve-tcp", ipsets.NamedPorts, included, policies.DstDstMatch),
@@ -1739,14 +1952,14 @@ func TestIngressPolicy(t *testing.T) {
 					policies.NewSetInfo(defaultNS, ipsets.Namespace, included, targetPodMatchType),
 				},
 				RuleIPSets: []*ipsets.TranslatedIPSet{
-					ipsets.NewTranslatedIPSet("only-ipblock-in-ns-default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch"}...),
+					ipsets.NewTranslatedIPSet("only-ipblock:in-ns:default-0-0IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch"}...),
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 						SrcList: []policies.SetInfo{
-							policies.NewSetInfo("only-ipblock-in-ns-default-0-0IN", ipsets.CIDRBlocks, included, peerMatchType),
+							policies.NewSetInfo("only-ipblock:in-ns:default-0-0IN", ipsets.CIDRBlocks, included, peerMatchType),
 						},
 					},
 					defaultDropACL(policies.Ingress),
@@ -1898,8 +2111,8 @@ func TestIngressPolicy(t *testing.T) {
 				},
 				RuleIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("peer-nsselector-kay:peer-nsselector-value", ipsets.KeyValueLabelOfNamespace),
-					ipsets.NewTranslatedIPSet("only-peer-nsSelector-in-ns-default-0-1IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch", "172.17.2.0/24 nomatch"}...),
-					ipsets.NewTranslatedIPSet("only-peer-nsSelector-in-ns-default-0-2IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16"}...),
+					ipsets.NewTranslatedIPSet("only-peer-nsSelector:in-ns:default-0-1IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch", "172.17.2.0/24 nomatch"}...),
+					ipsets.NewTranslatedIPSet("only-peer-nsSelector:in-ns:default-0-2IN", ipsets.CIDRBlocks, []string{"172.17.0.0/16"}...),
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
@@ -1913,14 +2126,14 @@ func TestIngressPolicy(t *testing.T) {
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 						SrcList: []policies.SetInfo{
-							policies.NewSetInfo("only-peer-nsSelector-in-ns-default-0-1IN", ipsets.CIDRBlocks, included, peerMatchType),
+							policies.NewSetInfo("only-peer-nsSelector:in-ns:default-0-1IN", ipsets.CIDRBlocks, included, peerMatchType),
 						},
 					},
 					{
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 						SrcList: []policies.SetInfo{
-							policies.NewSetInfo("only-peer-nsSelector-in-ns-default-0-2IN", ipsets.CIDRBlocks, included, peerMatchType),
+							policies.NewSetInfo("only-peer-nsSelector:in-ns:default-0-2IN", ipsets.CIDRBlocks, included, peerMatchType),
 						},
 					},
 					defaultDropACL(policies.Ingress),
@@ -2096,7 +2309,7 @@ func TestIngressPolicy(t *testing.T) {
 				ACLPolicyID: "azure-acl-default-serve-tcp",
 				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("k0:v0", ipsets.KeyValueLabelOfPod),
-					ipsets.NewTranslatedIPSet("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
+					ipsets.NewTranslatedIPSet("default/serve-tcp:k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
 					ipsets.NewTranslatedIPSet("k2", ipsets.KeyLabelOfPod),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
 				},
@@ -2106,7 +2319,7 @@ func TestIngressPolicy(t *testing.T) {
 				},
 				PodSelectorList: []policies.SetInfo{
 					policies.NewSetInfo("k0:v0", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
-					policies.NewSetInfo("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, included, targetPodMatchType),
+					policies.NewSetInfo("default/serve-tcp:k1:v10:v11", ipsets.NestedLabelOfPod, included, targetPodMatchType),
 					policies.NewSetInfo("k2", ipsets.KeyLabelOfPod, nonIncluded, targetPodMatchType),
 					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
 				},
@@ -2161,7 +2374,7 @@ func TestIngressPolicy(t *testing.T) {
 					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
 				},
 				RuleIPSets: []*ipsets.TranslatedIPSet{
-					ipsets.NewTranslatedIPSet("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
+					ipsets.NewTranslatedIPSet("default/serve-tcp:k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
 					ipsets.NewTranslatedIPSet("k1:v10", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("k1:v11", ipsets.KeyValueLabelOfPod),
@@ -2171,7 +2384,7 @@ func TestIngressPolicy(t *testing.T) {
 						Target:    policies.Allowed,
 						Direction: policies.Ingress,
 						SrcList: []policies.SetInfo{
-							policies.NewSetInfo("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, included, peerMatchType),
+							policies.NewSetInfo("default/serve-tcp:k1:v10:v11", ipsets.NestedLabelOfPod, included, peerMatchType),
 							policies.NewSetInfo("default", ipsets.Namespace, included, peerMatchType),
 						},
 					},
@@ -2228,7 +2441,7 @@ func TestIngressPolicy(t *testing.T) {
 					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
 				},
 				RuleIPSets: []*ipsets.TranslatedIPSet{
-					ipsets.NewTranslatedIPSet("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
+					ipsets.NewTranslatedIPSet("default/serve-tcp:k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
 					ipsets.NewTranslatedIPSet("k1:v10", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("k1:v11", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("peer-nsselector-kay:peer-nsselector-value", ipsets.KeyValueLabelOfNamespace),
@@ -2239,7 +2452,7 @@ func TestIngressPolicy(t *testing.T) {
 						Direction: policies.Ingress,
 						SrcList: []policies.SetInfo{
 							policies.NewSetInfo("peer-nsselector-kay:peer-nsselector-value", ipsets.KeyValueLabelOfNamespace, included, peerMatchType),
-							policies.NewSetInfo("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, included, peerMatchType),
+							policies.NewSetInfo("default/serve-tcp:k1:v10:v11", ipsets.NestedLabelOfPod, included, peerMatchType),
 						},
 					},
 					{
@@ -2470,14 +2683,14 @@ func TestEgressPolicy(t *testing.T) {
 				},
 				ChildPodSelectorIPSets: []*ipsets.TranslatedIPSet{},
 				RuleIPSets: []*ipsets.TranslatedIPSet{
-					ipsets.NewTranslatedIPSet("only-ipblock-in-ns-default-0-0OUT", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch"}...),
+					ipsets.NewTranslatedIPSet("only-ipblock:in-ns:default-0-0OUT", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch"}...),
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
 						Target:    policies.Allowed,
 						Direction: policies.Egress,
 						DstList: []policies.SetInfo{
-							policies.NewSetInfo("only-ipblock-in-ns-default-0-0OUT", ipsets.CIDRBlocks, included, peerMatchType),
+							policies.NewSetInfo("only-ipblock:in-ns:default-0-0OUT", ipsets.CIDRBlocks, included, peerMatchType),
 						},
 					},
 					defaultDropACL(policies.Egress),
@@ -2725,8 +2938,8 @@ func TestEgressPolicy(t *testing.T) {
 				},
 				RuleIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("peer-nsselector-kay:peer-nsselector-value", ipsets.KeyValueLabelOfNamespace),
-					ipsets.NewTranslatedIPSet("only-peer-nsSelector-in-ns-default-0-1OUT", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch", "172.17.2.0/24 nomatch"}...),
-					ipsets.NewTranslatedIPSet("only-peer-nsSelector-in-ns-default-0-2OUT", ipsets.CIDRBlocks, []string{"172.17.0.0/16"}...),
+					ipsets.NewTranslatedIPSet("only-peer-nsSelector:in-ns:default-0-1OUT", ipsets.CIDRBlocks, []string{"172.17.0.0/16", "172.17.1.0/24 nomatch", "172.17.2.0/24 nomatch"}...),
+					ipsets.NewTranslatedIPSet("only-peer-nsSelector:in-ns:default-0-2OUT", ipsets.CIDRBlocks, []string{"172.17.0.0/16"}...),
 				},
 				ACLs: []*policies.ACLPolicy{
 					{
@@ -2740,14 +2953,14 @@ func TestEgressPolicy(t *testing.T) {
 						Target:    policies.Allowed,
 						Direction: policies.Egress,
 						DstList: []policies.SetInfo{
-							policies.NewSetInfo("only-peer-nsSelector-in-ns-default-0-1OUT", ipsets.CIDRBlocks, included, peerMatchType),
+							policies.NewSetInfo("only-peer-nsSelector:in-ns:default-0-1OUT", ipsets.CIDRBlocks, included, peerMatchType),
 						},
 					},
 					{
 						Target:    policies.Allowed,
 						Direction: policies.Egress,
 						DstList: []policies.SetInfo{
-							policies.NewSetInfo("only-peer-nsSelector-in-ns-default-0-2OUT", ipsets.CIDRBlocks, included, peerMatchType),
+							policies.NewSetInfo("only-peer-nsSelector:in-ns:default-0-2OUT", ipsets.CIDRBlocks, included, peerMatchType),
 						},
 					},
 					defaultDropACL(policies.Egress),
@@ -2827,7 +3040,7 @@ func TestEgressPolicy(t *testing.T) {
 				ACLPolicyID: "azure-acl-default-serve-tcp",
 				PodSelectorIPSets: []*ipsets.TranslatedIPSet{
 					ipsets.NewTranslatedIPSet("k0:v0", ipsets.KeyValueLabelOfPod),
-					ipsets.NewTranslatedIPSet("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
+					ipsets.NewTranslatedIPSet("default/serve-tcp:k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
 					ipsets.NewTranslatedIPSet("k2", ipsets.KeyLabelOfPod),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
 				},
@@ -2837,7 +3050,7 @@ func TestEgressPolicy(t *testing.T) {
 				},
 				PodSelectorList: []policies.SetInfo{
 					policies.NewSetInfo("k0:v0", ipsets.KeyValueLabelOfPod, included, targetPodMatchType),
-					policies.NewSetInfo("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, included, targetPodMatchType),
+					policies.NewSetInfo("default/serve-tcp:k1:v10:v11", ipsets.NestedLabelOfPod, included, targetPodMatchType),
 					policies.NewSetInfo("k2", ipsets.KeyLabelOfPod, nonIncluded, targetPodMatchType),
 					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
 				},
@@ -2892,7 +3105,7 @@ func TestEgressPolicy(t *testing.T) {
 					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
 				},
 				RuleIPSets: []*ipsets.TranslatedIPSet{
-					ipsets.NewTranslatedIPSet("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
+					ipsets.NewTranslatedIPSet("default/serve-tcp:k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
 					ipsets.NewTranslatedIPSet("default", ipsets.Namespace),
 					ipsets.NewTranslatedIPSet("k1:v10", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("k1:v11", ipsets.KeyValueLabelOfPod),
@@ -2902,7 +3115,7 @@ func TestEgressPolicy(t *testing.T) {
 						Target:    policies.Allowed,
 						Direction: policies.Egress,
 						DstList: []policies.SetInfo{
-							policies.NewSetInfo("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, included, peerMatchType),
+							policies.NewSetInfo("default/serve-tcp:k1:v10:v11", ipsets.NestedLabelOfPod, included, peerMatchType),
 							policies.NewSetInfo("default", ipsets.Namespace, included, peerMatchType),
 						},
 					},
@@ -2959,7 +3172,7 @@ func TestEgressPolicy(t *testing.T) {
 					policies.NewSetInfo("default", ipsets.Namespace, included, targetPodMatchType),
 				},
 				RuleIPSets: []*ipsets.TranslatedIPSet{
-					ipsets.NewTranslatedIPSet("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
+					ipsets.NewTranslatedIPSet("default/serve-tcp:k1:v10:v11", ipsets.NestedLabelOfPod, "k1:v10", "k1:v11"),
 					ipsets.NewTranslatedIPSet("k1:v10", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("k1:v11", ipsets.KeyValueLabelOfPod),
 					ipsets.NewTranslatedIPSet("peer-nsselector-kay:peer-nsselector-value", ipsets.KeyValueLabelOfNamespace),
@@ -2970,7 +3183,7 @@ func TestEgressPolicy(t *testing.T) {
 						Direction: policies.Egress,
 						DstList: []policies.SetInfo{
 							policies.NewSetInfo("peer-nsselector-kay:peer-nsselector-value", ipsets.KeyValueLabelOfNamespace, included, peerMatchType),
-							policies.NewSetInfo("default/serve-tcp-k1:v10:v11", ipsets.NestedLabelOfPod, included, peerMatchType),
+							policies.NewSetInfo("default/serve-tcp:k1:v10:v11", ipsets.NestedLabelOfPod, included, peerMatchType),
 						},
 					},
 					{

--- a/npm/pkg/dataplane/dataplane_linux_test.go
+++ b/npm/pkg/dataplane/dataplane_linux_test.go
@@ -131,11 +131,24 @@ func TestNetPolInBackgroundFailureToAddFirstTime(t *testing.T) {
 
 	testPolicy2 := testPolicyobj
 	testPolicy2.PolicyKey = "testpolicy2"
+	testPolicy2.RuleIPSets = ruleIPSetsWithCIDR("testcidr2")
 	testPolicy3 := testPolicyobj
 	testPolicy3.PolicyKey = "testpolicy3"
+	testPolicy3.RuleIPSets = ruleIPSetsWithCIDR("testcidr3")
 
 	calls := getBootupTestCalls()
 	calls = append(calls,
+		// background mode applies each policy's ipsets on AddPolicy (one restore per policy)
+		testutils.TestCmd{
+			Cmd:      []string{"ipset", "restore"},
+			Stdout:   "success",
+			ExitCode: 0,
+		},
+		testutils.TestCmd{
+			Cmd:      []string{"ipset", "restore"},
+			Stdout:   "success",
+			ExitCode: 0,
+		},
 		testutils.TestCmd{
 			Cmd:      []string{"ipset", "restore"},
 			Stdout:   "success",

--- a/npm/pkg/dataplane/dataplane_test.go
+++ b/npm/pkg/dataplane/dataplane_test.go
@@ -74,6 +74,17 @@ var (
 	}
 )
 
+// ruleIPSetsWithCIDR returns testPolicyobj's rule sets with a distinct CIDR set name so
+// cloned test policies each own their own ipblock set (label/namespace sets stay shared).
+func ruleIPSetsWithCIDR(cidrName string) []*ipsets.TranslatedIPSet {
+	return []*ipsets.TranslatedIPSet{
+		{Metadata: ipsets.NewIPSetMetadata("setns2", ipsets.Namespace)},
+		{Metadata: ipsets.NewIPSetMetadata("setpodkey2", ipsets.KeyLabelOfPod)},
+		{Metadata: ipsets.NewIPSetMetadata("setpodkeyval2", ipsets.KeyValueLabelOfPod)},
+		{Metadata: ipsets.NewIPSetMetadata(cidrName, ipsets.CIDRBlocks), Members: []string{"10.0.0.0/8"}},
+	}
+}
+
 func TestNewDataPlane(t *testing.T) {
 	metrics.InitializeAll()
 

--- a/npm/pkg/dataplane/ipsets/ipsetmanager.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager.go
@@ -187,6 +187,17 @@ func (iMgr *IPSetManager) AddReference(setMetadata *IPSetMetadata, referenceName
 		metrics.SendErrorLogAndMetric(util.IpsmID, "error: failed to add reference: %s", msg)
 		return npmerrors.Errorf(npmerrors.AddSelectorReference, false, msg)
 	}
+	// A CIDR (ipblock) set belongs to a single NetworkPolicy; reject a reference from a
+	// different netpol so two policies never share one set.
+	if referenceType == NetPolType && set.Type == CIDRBlocks {
+		for existingOwner := range set.NetPolReference {
+			if existingOwner != referenceName {
+				msg := fmt.Sprintf("cidr ipset %s is already owned by netpol %q; refusing reference from netpol %q", set.Name, existingOwner, referenceName)
+				metrics.SendErrorLogAndMetric(util.IpsmID, "error: failed to add reference: %s", msg)
+				return npmerrors.Errorf(npmerrors.AddNetPolReference, false, msg)
+			}
+		}
+	}
 	wasInKernel := iMgr.shouldBeInKernel(set)
 	set.addReference(referenceName, referenceType)
 	if !wasInKernel {

--- a/npm/pkg/dataplane/ipsets/ipsetmanager.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager.go
@@ -47,10 +47,13 @@ type IPSetManager struct {
 	// This set is used based on the AddEmptySetToLists flag.
 	// If emptySet is non-nil, it should be in the kernel or ready to be created in the dirtyCache.
 	// Its reference counts are currently unaccounted for and may be incorrect.
-	emptySet   *IPSet
-	setMap     map[string]*IPSet
-	dirtyCache dirtyCacheInterface
-	ioShim     *common.IOShim
+	emptySet *IPSet
+	setMap   map[string]*IPSet
+	// kernelNameOwner maps a set's kernel name (hash of its prefixed name) to the prefixed
+	// name that owns it, so two distinct sets can't resolve to the same kernel set.
+	kernelNameOwner map[string]string
+	dirtyCache      dirtyCacheInterface
+	ioShim          *common.IOShim
 	// consecutiveApplyFailures is used in Linux to count the number of consecutive failures to apply ipsets
 	// if this count exceeds a threshold, we will panic
 	consecutiveApplyFailures int
@@ -69,11 +72,12 @@ type IPSetManagerCfg struct {
 
 func NewIPSetManager(iMgrCfg *IPSetManagerCfg, ioShim *common.IOShim) *IPSetManager {
 	return &IPSetManager{
-		iMgrCfg:    iMgrCfg,
-		emptySet:   nil, // will be set if needed in calls to AddToLists
-		setMap:     make(map[string]*IPSet),
-		dirtyCache: newDirtyCache(),
-		ioShim:     ioShim,
+		iMgrCfg:         iMgrCfg,
+		emptySet:        nil, // will be set if needed in calls to AddToLists
+		setMap:          make(map[string]*IPSet),
+		kernelNameOwner: make(map[string]string),
+		dirtyCache:      newDirtyCache(),
+		ioShim:          ioShim,
 		// set to 0 to avoid lint error for windows
 		consecutiveApplyFailures: 0,
 	}
@@ -105,6 +109,7 @@ func (iMgr *IPSetManager) ResetIPSets() error {
 	metrics.ResetIPSetEntries()
 	err := iMgr.resetIPSets()
 	iMgr.setMap = make(map[string]*IPSet)
+	iMgr.kernelNameOwner = make(map[string]string)
 	iMgr.emptySet = nil
 	iMgr.clearDirtyCache()
 	if err != nil {
@@ -119,15 +124,35 @@ func (iMgr *IPSetManager) CreateIPSets(setMetadatas []*IPSetMetadata) {
 	defer iMgr.Unlock()
 
 	for _, set := range setMetadatas {
-		_ = iMgr.createAndGetIPSet(set)
+		if _, err := iMgr.createAndGetIPSet(set); err != nil {
+			// createAndGetIPSet does not log; this is the only entry point that does not
+			// return the error to a caller, so log it here.
+			metrics.SendErrorLogAndMetric(util.IpsmID, "error: failed to create ipset: %s", err.Error())
+		}
 	}
 }
 
-func (iMgr *IPSetManager) createAndGetIPSet(setMetadata *IPSetMetadata) *IPSet {
+// claimKernelName records prefixedName as the owner of hashedName. It fails closed if a
+// different prefixed name already owns that kernel name (two distinct ipsets would otherwise
+// share one kernel set and combine their members). Re-claiming by the same owner is a no-op.
+func (iMgr *IPSetManager) claimKernelName(prefixedName, hashedName string) error {
+	if owner, ok := iMgr.kernelNameOwner[hashedName]; ok && owner != prefixedName {
+		return npmerrors.Errorf(npmerrors.CreateIPSet, false,
+			fmt.Sprintf("ipset %s resolves to kernel name %s already owned by %s", prefixedName, hashedName, owner))
+	}
+	iMgr.kernelNameOwner[hashedName] = prefixedName
+	return nil
+}
+
+func (iMgr *IPSetManager) createAndGetIPSet(setMetadata *IPSetMetadata) (*IPSet, error) {
 	prefixedName := setMetadata.GetPrefixName()
 	set, exists := iMgr.setMap[prefixedName]
 	if exists {
-		return set
+		return set, nil
+	}
+
+	if err := iMgr.claimKernelName(prefixedName, setMetadata.GetHashedName()); err != nil {
+		return nil, err
 	}
 
 	set = NewIPSet(setMetadata)
@@ -142,7 +167,11 @@ func (iMgr *IPSetManager) createAndGetIPSet(setMetadata *IPSetMetadata) *IPSet {
 	if iMgr.iMgrCfg.AddEmptySetToLists && (set.Type == KeyLabelOfNamespace || set.Type == KeyValueLabelOfNamespace) {
 		if iMgr.emptySet == nil {
 			// duplicate of code chunk above
-			iMgr.emptySet = NewIPSet(emptySetMetadata)
+			emptySet := NewIPSet(emptySetMetadata)
+			if err := iMgr.claimKernelName(emptySetPrefixName, emptySet.HashedName); err != nil {
+				return nil, err
+			}
+			iMgr.emptySet = emptySet
 			iMgr.setMap[emptySetPrefixName] = iMgr.emptySet
 			metrics.IncNumIPSets()
 			iMgr.modifyCacheForKernelCreation(iMgr.emptySet)
@@ -151,7 +180,7 @@ func (iMgr *IPSetManager) createAndGetIPSet(setMetadata *IPSetMetadata) *IPSet {
 		iMgr.addMemberToList(set, iMgr.emptySet)
 	}
 
-	return set
+	return set, nil
 }
 
 // DeleteIPSet expects the prefixed ipset name
@@ -181,7 +210,10 @@ func (iMgr *IPSetManager) AddReference(setMetadata *IPSetMetadata, referenceName
 	iMgr.Lock()
 	defer iMgr.Unlock()
 	// NOTE: any newly created IPSet will still be in the cache if an error is returned later
-	set := iMgr.createAndGetIPSet(setMetadata)
+	set, err := iMgr.createAndGetIPSet(setMetadata)
+	if err != nil {
+		return err
+	}
 	if referenceType == SelectorType && !set.canSetBeSelectorIPSet() {
 		msg := fmt.Sprintf("ipset %s is not a selector ipset it is of type %s", set.Name, set.Type.String())
 		metrics.SendErrorLogAndMetric(util.IpsmID, "error: failed to add reference: %s", msg)
@@ -268,7 +300,10 @@ func (iMgr *IPSetManager) AddToSets(addToSets []*IPSetMetadata, ip, podKey strin
 		// 1. check for errors and create a missing set
 		prefixedName := metadata.GetPrefixName()
 		// NOTE: any newly created IPSet will still be in the cache if an error is returned later
-		set := iMgr.createAndGetIPSet(metadata)
+		set, err := iMgr.createAndGetIPSet(metadata)
+		if err != nil {
+			return err
+		}
 		if set.Kind != HashSet {
 			msg := fmt.Sprintf("ipset %s is not a hash set", prefixedName)
 			metrics.SendErrorLogAndMetric(util.IpsmID, "error: failed to add to sets: %s", msg)
@@ -346,7 +381,10 @@ func (iMgr *IPSetManager) AddToLists(listMetadatas, setMetadatas []*IPSetMetadat
 	// 1. check for errors in members and create any missing sets
 	for _, setMetadata := range setMetadatas {
 		// NOTE: any newly created IPSet will still be in the cache if an error is returned later
-		set := iMgr.createAndGetIPSet(setMetadata)
+		set, err := iMgr.createAndGetIPSet(setMetadata)
+		if err != nil {
+			return err
+		}
 
 		// Nested IPSets are only supported for windows
 		// Check if we want to actually use that support
@@ -360,7 +398,10 @@ func (iMgr *IPSetManager) AddToLists(listMetadatas, setMetadatas []*IPSetMetadat
 	for _, listMetadata := range listMetadatas {
 		// 2. create the list if it's missing and check for list errors
 		// NOTE: any newly created IPSet will still be in the cache if an error is returned later
-		list := iMgr.createAndGetIPSet(listMetadata)
+		list, err := iMgr.createAndGetIPSet(listMetadata)
+		if err != nil {
+			return err
+		}
 
 		if list.Kind != ListSet {
 			msg := fmt.Sprintf("ipset %s is not a list set", list.Name)
@@ -524,6 +565,7 @@ func (iMgr *IPSetManager) modifyCacheForCacheDeletion(set *IPSet, deleteOption u
 	}
 
 	delete(iMgr.setMap, set.Name)
+	delete(iMgr.kernelNameOwner, set.HashedName)
 	metrics.DeleteIPSet(set.Name)
 	if iMgr.iMgrCfg.IPSetMode == ApplyAllIPSets {
 		iMgr.modifyCacheForKernelRemoval(set)

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_linux.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_linux.go
@@ -18,7 +18,7 @@ const (
 	ipsetFlushAndDestroyString = "ipset flush && ipset destroy"
 
 	azureNPMPrefix        = "azure-npm-"
-	azureNPMRegex         = "azure-npm-\\d+"
+	azureNPMRegex         = "azure-npm-[0-9a-z]+"
 	positiveRefsRegex     = "References: [1-9]"
 	referenceGrepLookBack = "5"
 	maxLinesToPrint       = 10

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_linux_test.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_linux_test.go
@@ -231,6 +231,67 @@ func TestDestroyNPMIPSetsCreatorSuccess(t *testing.T) {
 	require.Equal(t, 0, *destroyFailureCount, "got unexpected destroy failure count")
 }
 
+// TestAzureNPMRegexMatchesOldAndNewNames verifies the ipset-cleanup regex matches BOTH the old
+// 32-bit numeric kernel names and the new base36 names, so that on upgrade or rollback no stale
+// ipset of either format is orphaned (which would leak and could eventually exhaust ipsets).
+func TestAzureNPMRegexMatchesOldAndNewNames(t *testing.T) {
+	re := regexp.MustCompile(azureNPMRegex)
+	mustMatch := []string{
+		"azure-npm-123456",                      // old 32-bit numeric
+		"azure-npm-2900316864",                  // old numeric (reported collision value)
+		"azure-npm-3fmr1y4xucxg45l55kfb",        // new base36
+		"azure-npm-42xi2gy762uhahnxfutd",        // new base36 (ns-msobb-target)
+		util.GetHashedName("ns-some-namespace"), // whatever the current impl produces
+	}
+	for _, n := range mustMatch {
+		require.Equal(t, n, re.FindString(n), "cleanup regex must fully match %q", n)
+	}
+	for _, n := range []string{"KUBE-SERVICES", "cali-abc123", "not-azure-npm", "azure-npm-"} {
+		require.Empty(t, re.FindString(n), "cleanup regex must not match %q", n)
+	}
+}
+
+// TestDestroyMixedOldAndNewIPSets verifies the reset path flushes and destroys a mix of old
+// numeric and new base36 ipsets in a single pass (upgrade/rollback migration safety).
+func TestDestroyMixedOldAndNewIPSets(t *testing.T) {
+	calls := []testutils.TestCmd{fakeRestoreSuccessCommand, fakeRestoreSuccessCommand}
+	ioshim := common.NewMockIOShim(calls)
+	defer ioshim.VerifyCalls(t, calls)
+	iMgr := NewIPSetManager(applyAlwaysCfg, ioshim)
+
+	mixed := []string{
+		"azure-npm-123456",               // old numeric
+		"azure-npm-3fmr1y4xucxg45l55kfb", // new base36
+		"azure-npm-987654",               // old numeric
+		"azure-npm-42xi2gy762uhahnxfutd", // new base36
+	}
+	listOutput := []byte(strings.Join(mixed, "\n") + "\n")
+
+	creator, names, failedNames := iMgr.fileCreatorForFlushAll(listOutput)
+	flushLines := creator.ToString()
+	for _, n := range mixed {
+		require.Contains(t, flushLines, "-F "+n, "must flush %q (both old and new formats)", n)
+	}
+	sort.Strings(names)
+	expNames := append([]string(nil), mixed...)
+	sort.Strings(expNames)
+	require.Equal(t, expNames, names, "flush must capture all mixed-format names")
+	wasModified, err := creator.RunCommandOnceWithFile("ipset", "restore")
+	require.False(t, wasModified)
+	require.NoError(t, err)
+	require.Len(t, failedNames, 0)
+
+	creator, destroyFailureCount := iMgr.fileCreatorForDestroyAll(names, failedNames, nil)
+	destroyLines := creator.ToString()
+	for _, n := range mixed {
+		require.Contains(t, destroyLines, "-X "+n, "must destroy %q (both old and new formats)", n)
+	}
+	wasModified, err = creator.RunCommandOnceWithFile("ipset", "restore")
+	require.False(t, wasModified)
+	require.NoError(t, err)
+	require.Equal(t, 0, *destroyFailureCount)
+}
+
 func TestDestroyNPMIPSetsCreatorErrorHandling(t *testing.T) {
 	/*
 		original lines:

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_linux_test.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_linux_test.go
@@ -1031,6 +1031,29 @@ func TestCidrExceptMembers(t *testing.T) {
 	require.False(t, wasFileAltered, "file should not be altered")
 }
 
+// TestReportedPairRendersDistinctKernelSets drives two logical sets whose 32-bit names
+// previously collided all the way to the rendered restore file, and confirms each keeps its
+// own kernel set and member instead of the two being unioned into one set.
+func TestReportedPairRendersDistinctKernelSets(t *testing.T) {
+	iMgr := NewIPSetManager(applyAlwaysCfg, common.NewMockIOShim(nil))
+
+	nsSet := NewIPSetMetadata("msobb-target", Namespace)            // prefixed "ns-msobb-target"
+	podLabelSet := NewIPSetMetadata("x:YMaaIZ", KeyValueLabelOfPod) // prefixed "podlabel-x:YMaaIZ"
+	require.NotEqual(t, nsSet.GetHashedName(), podLabelSet.GetHashedName(),
+		"the two logical sets must render to distinct kernel names")
+
+	require.NoError(t, iMgr.AddToSets([]*IPSetMetadata{nsSet}, "10.0.0.10", "a"))
+	require.NoError(t, iMgr.AddToSets([]*IPSetMetadata{podLabelSet}, "10.0.0.20", "b"))
+
+	rendered := iMgr.fileCreatorForApply(1).ToString()
+
+	// Each member lands only in its own kernel set; neither set absorbs the other's IP.
+	require.Contains(t, rendered, fmt.Sprintf("-A %s 10.0.0.10", nsSet.GetHashedName()))
+	require.Contains(t, rendered, fmt.Sprintf("-A %s 10.0.0.20", podLabelSet.GetHashedName()))
+	require.NotContains(t, rendered, fmt.Sprintf("-A %s 10.0.0.20", nsSet.GetHashedName()))
+	require.NotContains(t, rendered, fmt.Sprintf("-A %s 10.0.0.10", podLabelSet.GetHashedName()))
+}
+
 func TestUpdateWithIdenticalSaveFile(t *testing.T) {
 	calls := []testutils.TestCmd{fakeRestoreSuccessCommand}
 	ioshim := common.NewMockIOShim(calls)

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_linux_test.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_linux_test.go
@@ -464,7 +464,7 @@ func TestDestroyNPMIPSets(t *testing.T) {
 				fakeRestoreSuccessCommand,
 				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "-B", "5", "-P", "References: [1-9]"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
+				{Cmd: []string{"grep", "-o", "-P", "azure-npm-[0-9a-z]+"}, ExitCode: 1},
 				fakeRestoreSuccessCommand,
 			},
 			wantErr: false,
@@ -504,7 +504,7 @@ func TestDestroyNPMIPSets(t *testing.T) {
 				fakeRestoreSuccessCommand,
 				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "-B", "5", "-P", "References: [1-9]"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
+				{Cmd: []string{"grep", "-o", "-P", "azure-npm-[0-9a-z]+"}, ExitCode: 1},
 				{Cmd: ipsetRestoreStringSlice, ExitCode: 1},
 				{Cmd: ipsetRestoreStringSlice, ExitCode: 1},
 				{Cmd: ipsetRestoreStringSlice, ExitCode: 1},
@@ -523,7 +523,7 @@ func TestDestroyNPMIPSets(t *testing.T) {
 				fakeRestoreSuccessCommand,
 				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "-B", "5", "-P", "References: [1-9]"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, Stdout: resetIPSetsListOutputString},
+				{Cmd: []string{"grep", "-o", "-P", "azure-npm-[0-9a-z]+"}, Stdout: resetIPSetsListOutputString},
 			},
 			wantErr: false,
 		},
@@ -537,7 +537,7 @@ func TestDestroyNPMIPSets(t *testing.T) {
 				fakeRestoreSuccessCommand,
 				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "-B", "5", "-P", "References: [1-9]"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, Stdout: otherIPSetsListOutput},
+				{Cmd: []string{"grep", "-o", "-P", "azure-npm-[0-9a-z]+"}, Stdout: otherIPSetsListOutput},
 				fakeRestoreSuccessCommand,
 			},
 			wantErr: false,
@@ -557,7 +557,7 @@ func TestDestroyNPMIPSets(t *testing.T) {
 				fakeRestoreSuccessCommand,
 				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "-B", "5", "-P", "References: [1-9]"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
+				{Cmd: []string{"grep", "-o", "-P", "azure-npm-[0-9a-z]+"}, ExitCode: 1},
 				fakeRestoreSuccessCommand,
 			},
 			wantErr: false,
@@ -577,7 +577,7 @@ func TestDestroyNPMIPSets(t *testing.T) {
 				fakeRestoreSuccessCommand,
 				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "-B", "5", "-P", "References: [1-9]"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
+				{Cmd: []string{"grep", "-o", "-P", "azure-npm-[0-9a-z]+"}, ExitCode: 1},
 				fakeRestoreSuccessCommand,
 			},
 			wantErr: false,
@@ -592,7 +592,7 @@ func TestDestroyNPMIPSets(t *testing.T) {
 				fakeRestoreSuccessCommand,
 				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "-B", "5", "-P", "References: [1-9]"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
+				{Cmd: []string{"grep", "-o", "-P", "azure-npm-[0-9a-z]+"}, ExitCode: 1},
 				{
 					Cmd:      ipsetRestoreStringSlice,
 					Stdout:   "Error in line 2: The set with the given name does not exist",
@@ -612,7 +612,7 @@ func TestDestroyNPMIPSets(t *testing.T) {
 				fakeRestoreSuccessCommand,
 				{Cmd: []string{"ipset", "list"}, PipedToCommand: true},
 				{Cmd: []string{"grep", "-B", "5", "-P", "References: [1-9]"}, PipedToCommand: true},
-				{Cmd: []string{"grep", "-o", "-P", "azure-npm-\\d+"}, ExitCode: 1},
+				{Cmd: []string{"grep", "-o", "-P", "azure-npm-[0-9a-z]+"}, ExitCode: 1},
 				{
 					Cmd:      ipsetRestoreStringSlice,
 					Stdout:   "Error in line 2: for some other error",
@@ -1850,7 +1850,7 @@ func testAndSortRestoreFileLines(t *testing.T, lines []string) []string {
 func hashedNameOfSetImpacted(t *testing.T, operation string, lines []string, lineNum int) string {
 	lineNumIndex := lineNum - 1
 	line := lines[lineNumIndex]
-	pattern := fmt.Sprintf(`\%s (azure-npm-\d+)`, operation)
+	pattern := fmt.Sprintf(`\%s (azure-npm-[0-9a-z]+)`, operation)
 	re := regexp.MustCompile(pattern)
 	results := re.FindStringSubmatch(line)
 	require.Equal(t, 2, len(results), "expected to find a match with regex pattern %s for line: %s", pattern, line)
@@ -1860,7 +1860,7 @@ func hashedNameOfSetImpacted(t *testing.T, operation string, lines []string, lin
 func memberNameOfSetImpacted(t *testing.T, lines []string, lineNum int) string {
 	lineNumIndex := lineNum - 1
 	line := lines[lineNumIndex]
-	pattern := `\-[AD] azure-npm-\d+ (.*)`
+	pattern := `\-[AD] azure-npm-[0-9a-z]+ (.*)`
 	re := regexp.MustCompile(pattern)
 	member := re.FindStringSubmatch(line)[1]
 	results := re.FindStringSubmatch(line)

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_test.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_test.go
@@ -135,6 +135,50 @@ func TestCIDRSetsDoNotMergeInManager(t *testing.T) {
 	require.Equal(t, map[string]struct{}{"b-in-ns-c/a": {}}, secondSet.NetPolReference)
 }
 
+// TestGetHashedNameDistinctForReportedPair verifies the two prefixed names that previously
+// shared a kernel name now resolve to distinct kernel names, so their members can never be
+// combined.
+func TestGetHashedNameDistinctForReportedPair(t *testing.T) {
+	nsSet := NewIPSetMetadata("msobb-target", Namespace)            // prefixed "ns-msobb-target"
+	podLabelSet := NewIPSetMetadata("x:YMaaIZ", KeyValueLabelOfPod) // prefixed "podlabel-x:YMaaIZ"
+	require.NotEqual(t, nsSet.GetHashedName(), podLabelSet.GetHashedName(),
+		"distinct ipset names must resolve to distinct kernel names")
+}
+
+// TestClaimKernelNameSingleOwner verifies the defense-in-depth invariant: a kernel name is
+// owned by a single prefixed name; the owner (and re-claims) are accepted, a different name
+// is rejected, and the name is released on delete.
+func TestClaimKernelNameSingleOwner(t *testing.T) {
+	metrics.ReinitializeAll()
+	iMgr := NewIPSetManager(applyAlwaysCfg, common.NewMockIOShim(nil))
+
+	const kernelName = "azure-npm-sharedkernelname00"
+	require.NoError(t, iMgr.claimKernelName("ns-a", kernelName))     // first owner
+	require.NoError(t, iMgr.claimKernelName("ns-a", kernelName))     // same owner re-claims (idempotent)
+	require.Error(t, iMgr.claimKernelName("podlabel-b", kernelName)) // different owner rejected
+
+	delete(iMgr.kernelNameOwner, kernelName)
+	require.NoError(t, iMgr.claimKernelName("podlabel-b", kernelName)) // free after release
+}
+
+// TestCreateIPSetKernelNameFreedOnDelete verifies DeleteIPSet releases a set's kernel name so
+// the same set can be recreated afterwards.
+func TestCreateIPSetKernelNameFreedOnDelete(t *testing.T) {
+	metrics.ReinitializeAll()
+	iMgr := NewIPSetManager(applyAlwaysCfg, common.NewMockIOShim(nil))
+
+	set := NewIPSetMetadata("msobb-target", Namespace)
+	iMgr.CreateIPSets([]*IPSetMetadata{set})
+	require.NotNil(t, iMgr.GetIPSet(set.GetPrefixName()))
+	_, owned := iMgr.kernelNameOwner[set.GetHashedName()]
+	require.True(t, owned)
+
+	iMgr.DeleteIPSet(set.GetPrefixName(), util.SoftDelete)
+	require.Nil(t, iMgr.GetIPSet(set.GetPrefixName()))
+	_, owned = iMgr.kernelNameOwner[set.GetHashedName()]
+	require.False(t, owned, "kernel name must be released on delete")
+}
+
 func TestReconcileCache(t *testing.T) {
 	type args struct {
 		cfg          *IPSetManagerCfg

--- a/npm/pkg/dataplane/ipsets/ipsetmanager_test.go
+++ b/npm/pkg/dataplane/ipsets/ipsetmanager_test.go
@@ -76,6 +76,65 @@ var (
 	nestedPodLabelList = NewIPSetMetadata("test-nested-pod-label-list", NestedLabelOfPod)
 )
 
+// TestAddReferenceCIDRSingleOwner checks a CIDR set is bound to one netpol: the owner
+// (and re-applies) are accepted, a different netpol is rejected.
+func TestAddReferenceCIDRSingleOwner(t *testing.T) {
+	metrics.ReinitializeAll()
+	iMgr := NewIPSetManager(applyAlwaysCfg, common.NewMockIOShim(nil))
+	cidrSet := NewIPSetMetadata("a-in-ns-b:in-ns:c-0-0IN", CIDRBlocks)
+
+	require.NoError(t, iMgr.AddReference(cidrSet, "c/a-in-ns-b", NetPolType)) // owner
+	require.NoError(t, iMgr.AddReference(cidrSet, "c/a-in-ns-b", NetPolType)) // owner re-apply
+	require.Error(t, iMgr.AddReference(cidrSet, "b-in-ns-c/a", NetPolType))   // different netpol
+}
+
+// TestAddReferenceCIDROwnerReleasedOnDelete checks that once the sole owner deletes its
+// reference, a different netpol may take ownership (the guard uses live ownership).
+func TestAddReferenceCIDROwnerReleasedOnDelete(t *testing.T) {
+	metrics.ReinitializeAll()
+	iMgr := NewIPSetManager(applyAlwaysCfg, common.NewMockIOShim(nil))
+	cidrSet := NewIPSetMetadata("a-in-ns-b:in-ns:c-0-0IN", CIDRBlocks)
+
+	require.NoError(t, iMgr.AddReference(cidrSet, "c/a-in-ns-b", NetPolType)) // first owner
+	require.Error(t, iMgr.AddReference(cidrSet, "b-in-ns-c/a", NetPolType))   // rejected while owned
+	require.NoError(t, iMgr.DeleteReference(cidrSet.GetPrefixName(), "c/a-in-ns-b", NetPolType))
+	require.NoError(t, iMgr.AddReference(cidrSet, "b-in-ns-c/a", NetPolType)) // now accepted
+}
+
+// TestCIDRSetsDoNotMergeInManager applies two policies with similar names to a single
+// IPSetManager and asserts the two CIDR sets stay distinct, each holding only its own
+// members and owned only by its own netpol.
+func TestCIDRSetsDoNotMergeInManager(t *testing.T) {
+	metrics.ReinitializeAll()
+	iMgr := NewIPSetManager(applyAlwaysCfg, common.NewMockIOShim(nil))
+
+	// Post-fix names for policy c/a-in-ns-b and policy b-in-ns-c/a (would share a name pre-fix).
+	first := NewIPSetMetadata("a-in-ns-b:in-ns:c-0-0IN", CIDRBlocks)
+	second := NewIPSetMetadata("a:in-ns:b-in-ns-c-0-0IN", CIDRBlocks)
+	require.NotEqual(t, first.GetHashedName(), second.GetHashedName())
+
+	require.NoError(t, iMgr.AddToSets([]*IPSetMetadata{first}, "198.51.100.10", "c/a-in-ns-b"))
+	require.NoError(t, iMgr.AddReference(first, "c/a-in-ns-b", NetPolType))
+	require.NoError(t, iMgr.AddToSets([]*IPSetMetadata{second}, "0.0.0.0/1", "b-in-ns-c/a"))
+	require.NoError(t, iMgr.AddToSets([]*IPSetMetadata{second}, "128.0.0.0/1", "b-in-ns-c/a"))
+	require.NoError(t, iMgr.AddReference(second, "b-in-ns-c/a", NetPolType))
+
+	firstSet := iMgr.GetIPSet(first.GetPrefixName())
+	secondSet := iMgr.GetIPSet(second.GetPrefixName())
+	require.NotNil(t, firstSet)
+	require.NotNil(t, secondSet)
+
+	// Each set holds only its own members; neither carries the other's.
+	require.Equal(t, map[string]string{"198.51.100.10": "c/a-in-ns-b"}, firstSet.IPPodKey)
+	require.Len(t, secondSet.IPPodKey, 2)
+	require.NotContains(t, secondSet.IPPodKey, "198.51.100.10")
+	require.NotContains(t, firstSet.IPPodKey, "0.0.0.0/1")
+
+	// Each set is owned only by its own netpol.
+	require.Equal(t, map[string]struct{}{"c/a-in-ns-b": {}}, firstSet.NetPolReference)
+	require.Equal(t, map[string]struct{}{"b-in-ns-c/a": {}}, secondSet.NetPolReference)
+}
+
 func TestReconcileCache(t *testing.T) {
 	type args struct {
 		cfg          *IPSetManagerCfg

--- a/npm/pkg/dataplane/policies/policy_linux.go
+++ b/npm/pkg/dataplane/policies/policy_linux.go
@@ -45,7 +45,7 @@ func (networkPolicy *NPMNetworkPolicy) ingressChainName() string {
 }
 
 func (networkPolicy *NPMNetworkPolicy) chainName(prefix string) string {
-	policyHash := util.Hash(networkPolicy.PolicyKey)
+	policyHash := util.GetHashedChainName(networkPolicy.PolicyKey)
 	return joinWithDash(prefix, policyHash)
 }
 

--- a/npm/pkg/dataplane/policies/policymanager.go
+++ b/npm/pkg/dataplane/policies/policymanager.go
@@ -62,6 +62,9 @@ type PolicyManager struct {
 	ioShim           *common.IOShim
 	staleChains      *staleChains
 	reconcileManager *reconcileManager
+	// chainNameOwner maps an enforcement chain name to the policy key that owns it, so two
+	// distinct policies can't resolve to the same chain. Only used on Linux.
+	chainNameOwner map[string]string
 	*PolicyManagerCfg
 }
 
@@ -75,7 +78,17 @@ func NewPolicyManager(ioShim *common.IOShim, cfg *PolicyManagerCfg) *PolicyManag
 		reconcileManager: &reconcileManager{
 			releaseLockSignal: make(chan struct{}, 1),
 		},
+		chainNameOwner:   make(map[string]string),
 		PolicyManagerCfg: cfg,
+	}
+}
+
+// commitChainNames records the given chain-name -> policy-key ownership after a successful
+// apply, keeping chainNameOwner in lock-step with policyMap.cache. Callers must hold the
+// policyMap lock.
+func (pMgr *PolicyManager) commitChainNames(chainOwners map[string]string) {
+	for chain, policyKey := range chainOwners {
+		pMgr.chainNameOwner[chain] = policyKey
 	}
 }
 
@@ -151,17 +164,32 @@ func (pMgr *PolicyManager) AddPolicies(policies []*NPMNetworkPolicy, endpointLis
 	pMgr.policyMap.Lock()
 	defer pMgr.policyMap.Unlock()
 
+	// Fail closed before touching the dataplane if any policy would take over a chain that
+	// already belongs to a different policy, so a colliding chain name can never override
+	// another policy's rules. Ownership is committed only after the apply succeeds (below), so
+	// a failed apply never leaves a chain reserved for a policy that isn't cached.
+	pendingChainOwners, err := pMgr.checkChainNameCollisions(nonEmptyPolicies)
+	if err != nil {
+		msg := fmt.Sprintf("failed to add policy: %s", err.Error())
+		metrics.SendErrorLogAndMetric(util.IptmID, "error: %s", msg)
+		return npmerrors.Errorf(npmerrors.AddPolicy, false, msg)
+	}
+
 	// Call actual dataplane function to apply changes
 	timer := metrics.StartNewTimer()
-	err := pMgr.addPolicies(nonEmptyPolicies, endpointList)
+	err = pMgr.addPolicies(nonEmptyPolicies, endpointList)
 	metrics.RecordACLRuleExecTime(timer) // record execution time regardless of failure
 	if err != nil {
+		// Nothing to undo: chain ownership hasn't been committed yet.
 		// NOTE: in Linux, Prometheus metrics may be off at this point since some ACL rules may have been applied successfully
 		// In Windows, Prometheus metrics may be off at this point since we don't know how many endpoints had rules applied successfully.
 		msg := fmt.Sprintf("failed to add policy: %s", err.Error())
 		metrics.SendErrorLogAndMetric(util.IptmID, "error: %s", msg)
 		return npmerrors.Errorf(npmerrors.AddPolicy, false, msg)
 	}
+
+	// The apply succeeded, so commit chain ownership in lock-step with the policy cache below.
+	pMgr.commitChainNames(pendingChainOwners)
 
 	for _, policy := range nonEmptyPolicies {
 		// update Prometheus metrics on success
@@ -220,6 +248,8 @@ func (pMgr *PolicyManager) RemovePolicy(policyKey string) error {
 
 	// remove policy from cache
 	delete(pMgr.policyMap.cache, policyKey)
+	// release the policy's chain names so they can be reused
+	pMgr.releaseChainNames(policy)
 	return nil
 }
 

--- a/npm/pkg/dataplane/policies/policymanager_linux.go
+++ b/npm/pkg/dataplane/policies/policymanager_linux.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Azure/azure-container-networking/npm/metrics"
 	"github.com/Azure/azure-container-networking/npm/util"
+	npmerrors "github.com/Azure/azure-container-networking/npm/util/errors"
 	"github.com/Azure/azure-container-networking/npm/util/ioutil"
 	"k8s.io/klog"
 )
@@ -134,6 +135,38 @@ func chainNames(networkPolicies []*NPMNetworkPolicy) []string {
 		}
 	}
 	return chainNames
+}
+
+// checkChainNameCollisions validates that none of the given policies would take over an
+// enforcement chain owned by a different policy — whether already applied or another policy in
+// the same batch — so two distinct policies can never resolve to the same chain. It records
+// nothing (the caller commits ownership only after the dataplane apply succeeds) and returns
+// the chain-name -> policy-key claims to commit. Re-claiming by the same owner is allowed.
+// Callers must hold the policyMap lock.
+func (pMgr *PolicyManager) checkChainNameCollisions(networkPolicies []*NPMNetworkPolicy) (map[string]string, error) {
+	pending := make(map[string]string)
+	for _, networkPolicy := range networkPolicies {
+		for _, chain := range chainNames([]*NPMNetworkPolicy{networkPolicy}) {
+			if owner, ok := pMgr.chainNameOwner[chain]; ok && owner != networkPolicy.PolicyKey {
+				return nil, npmerrors.Errorf(npmerrors.AddPolicy, false,
+					fmt.Sprintf("policy %q resolves to chain %s already owned by policy %q", networkPolicy.PolicyKey, chain, owner))
+			}
+			if owner, ok := pending[chain]; ok && owner != networkPolicy.PolicyKey {
+				return nil, npmerrors.Errorf(npmerrors.AddPolicy, false,
+					fmt.Sprintf("policies %q and %q both resolve to chain %s", networkPolicy.PolicyKey, owner, chain))
+			}
+			pending[chain] = networkPolicy.PolicyKey
+		}
+	}
+	return pending, nil
+}
+
+// releaseChainNames drops a policy's chain-name ownership so the chains can be reused. Callers
+// must hold the policyMap lock.
+func (pMgr *PolicyManager) releaseChainNames(networkPolicy *NPMNetworkPolicy) {
+	for _, chain := range chainNames([]*NPMNetworkPolicy{networkPolicy}) {
+		delete(pMgr.chainNameOwner, chain)
+	}
 }
 
 func (pMgr *PolicyManager) newCreatorWithChains(chainNames []string) *ioutil.FileCreator {

--- a/npm/pkg/dataplane/policies/policymanager_linux_test.go
+++ b/npm/pkg/dataplane/policies/policymanager_linux_test.go
@@ -198,10 +198,92 @@ var (
 var allTestNetworkPolicies = []*NPMNetworkPolicy{bothDirectionsNetPol, ingressNetPol, egressNetPol}
 
 func TestChainNames(t *testing.T) {
-	expectedName := fmt.Sprintf("AZURE-NPM-INGRESS-%s", util.Hash(bothDirectionsNetPol.PolicyKey))
+	expectedName := fmt.Sprintf("AZURE-NPM-INGRESS-%s", util.GetHashedChainName(bothDirectionsNetPol.PolicyKey))
 	require.Equal(t, expectedName, bothDirectionsNetPol.ingressChainName())
-	expectedName = fmt.Sprintf("AZURE-NPM-EGRESS-%s", util.Hash(bothDirectionsNetPol.PolicyKey))
+	expectedName = fmt.Sprintf("AZURE-NPM-EGRESS-%s", util.GetHashedChainName(bothDirectionsNetPol.PolicyKey))
 	require.Equal(t, expectedName, bothDirectionsNetPol.egressChainName())
+
+	// Chain names must stay within the 28-character iptables limit.
+	require.LessOrEqual(t, len(bothDirectionsNetPol.ingressChainName()), 28, "ingress chain name must fit the iptables limit")
+	require.LessOrEqual(t, len(bothDirectionsNetPol.egressChainName()), 28, "egress chain name must fit the iptables limit")
+
+	// Distinct policies must map to distinct chain names.
+	require.NotEqual(t, ingressNetPol.ingressChainName(), egressNetPol.ingressChainName(),
+		"distinct policies must produce distinct chain names")
+}
+
+// TestChainNameOwnershipGuard verifies the fail-closed invariant: an enforcement chain is
+// owned by a single policy, so a second, distinct policy that resolves to the same chain is
+// rejected before any dataplane change, the collision check records nothing until committed,
+// the owner (and re-checks) are accepted, and the chain is released on delete.
+func TestChainNameOwnershipGuard(t *testing.T) {
+	metrics.ReinitializeAll()
+	victim := ingressNetPol
+	chain := victim.ingressChainName()
+
+	// A different policy that resolves to the victim's chain is rejected (fail closed) and the
+	// existing owner is left untouched.
+	pMgr := NewPolicyManager(common.NewMockIOShim(nil), ipsetConfig)
+	pMgr.chainNameOwner[chain] = "some-other/policy"
+	_, err := pMgr.checkChainNameCollisions([]*NPMNetworkPolicy{victim})
+	require.Error(t, err, "a chain owned by a different policy must not be claimable")
+	require.Equal(t, "some-other/policy", pMgr.chainNameOwner[chain], "a rejected check must not overwrite the owner")
+
+	// The collision check records nothing on its own; ownership is recorded only by commit.
+	pMgr = NewPolicyManager(common.NewMockIOShim(nil), ipsetConfig)
+	pending, err := pMgr.checkChainNameCollisions([]*NPMNetworkPolicy{victim})
+	require.NoError(t, err, "check should succeed")
+	require.Equal(t, victim.PolicyKey, pending[chain], "check must return the pending owner")
+	require.Empty(t, pMgr.chainNameOwner, "check must not record ownership before commit")
+
+	pMgr.commitChainNames(pending)
+	require.Equal(t, victim.PolicyKey, pMgr.chainNameOwner[chain], "commit must record the owner")
+
+	// The owner re-checking its own chain is allowed (no-op).
+	_, err = pMgr.checkChainNameCollisions([]*NPMNetworkPolicy{victim})
+	require.NoError(t, err, "re-check by the same owner should be allowed")
+
+	// The chain is released on delete, so it can be owned again afterward.
+	pMgr.releaseChainNames(victim)
+	_, owned := pMgr.chainNameOwner[chain]
+	require.False(t, owned, "chain must be released on delete")
+}
+
+// TestChainNameNotCommittedOnApplyFailure verifies that when the dataplane apply fails, chain
+// ownership is never recorded, so a failed add can't leave a chain owned with no cached policy
+// to release it later.
+func TestChainNameNotCommittedOnApplyFailure(t *testing.T) {
+	metrics.ReinitializeAll()
+	testNetPol := testNetworkPolicy()
+	calls := GetAddPolicyFailureTestCalls(testNetPol)
+	ioshim := common.NewMockIOShim(calls)
+	defer ioshim.VerifyCalls(t, calls)
+	pMgr := NewPolicyManager(ioshim, ipsetConfig)
+
+	require.Error(t, pMgr.AddPolicies([]*NPMNetworkPolicy{testNetPol}, nil))
+	_, cached := pMgr.GetPolicy(testNetPol.PolicyKey)
+	require.False(t, cached, "policy must not be cached after a failed add")
+	require.Empty(t, pMgr.chainNameOwner, "chain ownership must not be committed when the apply fails")
+}
+
+// TestChainNameOwnershipLifecycle verifies the happy path: a successful add commits chain
+// ownership in lock-step with the policy cache, and removing the policy releases it.
+func TestChainNameOwnershipLifecycle(t *testing.T) {
+	metrics.ReinitializeAll()
+	testNetPol := testNetworkPolicy()
+	calls := append(GetAddPolicyTestCalls(testNetPol), GetRemovePolicyTestCalls(testNetPol)...)
+	ioshim := common.NewMockIOShim(calls)
+	defer ioshim.VerifyCalls(t, calls)
+	pMgr := NewPolicyManager(ioshim, ipsetConfig)
+	util.SetIptablesToNft()
+
+	require.NoError(t, pMgr.AddPolicies([]*NPMNetworkPolicy{testNetPol}, epList))
+	for _, chain := range chainNames([]*NPMNetworkPolicy{testNetPol}) {
+		require.Equal(t, testNetPol.PolicyKey, pMgr.chainNameOwner[chain], "successful add must commit chain ownership")
+	}
+
+	require.NoError(t, pMgr.RemovePolicy(testNetPol.PolicyKey))
+	require.Empty(t, pMgr.chainNameOwner, "removing the policy must release its chain ownership")
 }
 
 // similar to TestAddPolicy in policymanager.go except an error occurs

--- a/npm/pkg/dataplane/policies/policymanager_windows.go
+++ b/npm/pkg/dataplane/policies/policymanager_windows.go
@@ -618,3 +618,12 @@ func isNotFoundErr(err error) bool {
 	var notFoundErr hcn.EndpointNotFoundError
 	return errors.As(err, &notFoundErr)
 }
+
+// checkChainNameCollisions is a no-op on Windows, which does not use iptables enforcement chains.
+func (pMgr *PolicyManager) checkChainNameCollisions(_ []*NPMNetworkPolicy) (map[string]string, error) {
+	return nil, nil
+}
+
+// releaseChainNames is a no-op on Windows, which does not use iptables enforcement chains.
+func (pMgr *PolicyManager) releaseChainNames(_ *NPMNetworkPolicy) {
+}

--- a/npm/util/util.go
+++ b/npm/util/util.go
@@ -195,7 +195,14 @@ func AppendMap(base, new map[string]string) map[string]string {
 // hashedNameDigestLen (20) = 30 chars, within the 31-char kernel ipset name limit.
 func GetHashedName(name string) string {
 	sum := sha256.Sum256([]byte(name))
-	return AzureNpmPrefix + new(big.Int).SetBytes(sum[:]).Text(36)[:hashedNameDigestLen]
+	// Text(36) omits leading zeros, so a small digest could be shorter than
+	// hashedNameDigestLen; left-pad to a fixed width before slicing so the result is always
+	// exactly hashedNameDigestLen characters and the slice can never panic.
+	digest := new(big.Int).SetBytes(sum[:]).Text(36)
+	if len(digest) < hashedNameDigestLen {
+		digest = strings.Repeat("0", hashedNameDigestLen-len(digest)) + digest
+	}
+	return AzureNpmPrefix + digest[:hashedNameDigestLen]
 }
 
 // CompareK8sVer compares two k8s versions.

--- a/npm/util/util.go
+++ b/npm/util/util.go
@@ -3,9 +3,11 @@
 package util
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"math/big"
 	"net"
 	"net/netip"
 	"os"
@@ -65,6 +67,29 @@ func Hash(s string) string {
 	h := fnv.New32a()
 	h.Write([]byte(s))
 	return fmt.Sprint(h.Sum32())
+}
+
+// hashedChainDigestLen is the number of base36 digest characters used as the variable part of
+// an iptables policy chain name. iptables limits a chain name to 28 characters, and the
+// longest chain prefix (IptablesAzureIngressPolicyChainPrefix, 17 chars) plus a dash already
+// uses 18, leaving 10 characters for the digest. A base36 digest across those 10 characters
+// spans ~51 bits, far wider than an fmt-formatted 32-bit Hash, so distinct policies are far
+// less likely to map to the same chain name.
+const hashedChainDigestLen = 10
+
+// GetHashedChainName returns a fixed-width base36 digest of name for use as the variable part
+// of an iptables policy chain name. It reduces a wide (SHA-256) digest modulo
+// 36^hashedChainDigestLen so every base36 digit is uniform (truncating the leading digits of
+// the full integer would be slightly biased), and left-pads so the result is always exactly
+// hashedChainDigestLen characters.
+func GetHashedChainName(name string) string {
+	sum := sha256.Sum256([]byte(name))
+	mod := new(big.Int).Exp(big.NewInt(36), big.NewInt(hashedChainDigestLen), nil)
+	digest := new(big.Int).Mod(new(big.Int).SetBytes(sum[:]), mod).Text(36)
+	if len(digest) < hashedChainDigestLen {
+		digest = strings.Repeat("0", hashedChainDigestLen-len(digest)) + digest
+	}
+	return digest[:hashedChainDigestLen]
 }
 
 // SortMap sorts the map by key in alphabetical order.

--- a/npm/util/util.go
+++ b/npm/util/util.go
@@ -92,6 +92,11 @@ func GetHashedChainName(name string) string {
 	return digest[:hashedChainDigestLen]
 }
 
+// hashedNameDigestLen is the number of base36 digest characters appended after
+// AzureNpmPrefix to form a kernel ipset name. 20 base36 chars is ~103 bits, which keeps
+// distinct ipset names from resolving to the same kernel name, and fits the 31-char limit.
+const hashedNameDigestLen = 20
+
 // SortMap sorts the map by key in alphabetical order.
 // Note: even though the map is sorted, accessing it through range will still result in random order.
 func SortMap(m *map[string]string) ([]string, []string) {
@@ -184,9 +189,13 @@ func AppendMap(base, new map[string]string) map[string]string {
 	return base
 }
 
-// GetHashedName returns hashed ipset name.
+// GetHashedName returns the kernel ipset name for the given prefixed name. It uses a wide
+// digest (not the 32-bit Hash used for iptables chain names, which is length-constrained) so
+// distinct ipset names map to distinct kernel names. The result is AzureNpmPrefix (10) +
+// hashedNameDigestLen (20) = 30 chars, within the 31-char kernel ipset name limit.
 func GetHashedName(name string) string {
-	return AzureNpmPrefix + Hash(name)
+	sum := sha256.Sum256([]byte(name))
+	return AzureNpmPrefix + new(big.Int).SetBytes(sum[:]).Text(36)[:hashedNameDigestLen]
 }
 
 // CompareK8sVer compares two k8s versions.

--- a/npm/util/util.go
+++ b/npm/util/util.go
@@ -190,9 +190,9 @@ func AppendMap(base, new map[string]string) map[string]string {
 }
 
 // GetHashedName returns the kernel ipset name for the given prefixed name. It uses a wide
-// digest (not the 32-bit Hash used for iptables chain names, which is length-constrained) so
-// distinct ipset names map to distinct kernel names. The result is AzureNpmPrefix (10) +
-// hashedNameDigestLen (20) = 30 chars, within the 31-char kernel ipset name limit.
+// digest (wider than GetHashedChainName's, since iptables chain names are more
+// length-constrained) so distinct ipset names map to distinct kernel names. The result is
+// AzureNpmPrefix (10) + hashedNameDigestLen (20) = 30 chars, within the 31-char kernel ipset name limit.
 func GetHashedName(name string) string {
 	sum := sha256.Sum256([]byte(name))
 	// Text(36) omits leading zeros, so a small digest could be shorter than

--- a/npm/util/util_test.go
+++ b/npm/util/util_test.go
@@ -477,6 +477,14 @@ func TestGetHashedName(t *testing.T) {
 	require.LessOrEqual(t, len(name), 31, "hashed name must fit the kernel ipset name limit")
 	require.True(t, strings.HasPrefix(name, AzureNpmPrefix), "hashed name must carry the azure-npm- prefix")
 
+	// The digest is left-padded to a fixed width, so every name is exactly
+	// prefix + hashedNameDigestLen characters regardless of input (a short digest can never
+	// shorten the slice and panic).
+	wantLen := len(AzureNpmPrefix) + hashedNameDigestLen
+	for _, in := range []string{"", "a", "ns-some-namespace", "podlabel-x:YMaaIZ", strings.Repeat("z", 300)} {
+		require.Len(t, GetHashedName(in), wantLen, "hashed name must be fixed width for %q", in)
+	}
+
 	// Distinct inputs (incl. the reported pair) produce distinct kernel names.
 	require.NotEqual(t, GetHashedName("ns-msobb-target"), GetHashedName("podlabel-x:YMaaIZ"))
 	require.NotEqual(t, GetHashedName("ns-a"), GetHashedName("ns-b"))

--- a/npm/util/util_test.go
+++ b/npm/util/util_test.go
@@ -489,3 +489,28 @@ func TestGetHashedName(t *testing.T) {
 	require.NotEqual(t, GetHashedName("ns-msobb-target"), GetHashedName("podlabel-x:YMaaIZ"))
 	require.NotEqual(t, GetHashedName("ns-a"), GetHashedName("ns-b"))
 }
+
+// TestHashedNameGoldenVectors pins the exact output of the kernel-name and chain-name digests
+// to values computed independently (base36 of the SHA-256 digest), so any accidental change to
+// the algorithm, encoding, or padding is caught. These names are stable across architectures
+// and restarts because they derive only from crypto/sha256 and math/big, not a seeded hash.
+func TestHashedNameGoldenVectors(t *testing.T) {
+	// azure-npm- + base36(sha256(name)) left-padded/truncated to 20 chars.
+	ipsetVectors := map[string]string{
+		"ns-test":           "azure-npm-343gyx4g1wf87lwlewvk",
+		"podlabel-x:YMaaIZ": "azure-npm-61b0uqiiz2delucbmvi2",
+		"ns-msobb-target":   "azure-npm-42xi2gy762uhahnxfutd",
+	}
+	for in, want := range ipsetVectors {
+		require.Equal(t, want, GetHashedName(in), "GetHashedName(%q) golden vector", in)
+	}
+
+	// base36(sha256(key) mod 36^10) left-padded/truncated to 10 chars.
+	chainVectors := map[string]string{
+		"x/test1":                             "jo5gdwc4t2",
+		"msobb-server/trusted-namespace-only": "7d7a0cfguo",
+	}
+	for in, want := range chainVectors {
+		require.Equal(t, want, GetHashedChainName(in), "GetHashedChainName(%q) golden vector", in)
+	}
+}

--- a/npm/util/util_test.go
+++ b/npm/util/util_test.go
@@ -451,3 +451,20 @@ func TestNodeIP(t *testing.T) {
 	_, err := NodeIP()
 	require.Nil(t, err, "NodeIP() returned error")
 }
+
+func TestGetHashedChainName(t *testing.T) {
+	// Deterministic and fixed width.
+	name := GetHashedChainName("x/test1")
+	require.Equal(t, name, GetHashedChainName("x/test1"), "hashed chain name must be deterministic")
+	require.Len(t, GetHashedChainName(""), hashedChainDigestLen, "digest must be left-padded to a fixed width")
+	for _, in := range []string{"x/test1", "y/test2", "z/test3", "a-in-ns-b/c"} {
+		require.Len(t, GetHashedChainName(in), hashedChainDigestLen, "digest must be fixed width for %q", in)
+		// Longest chain prefix + dash + digest must fit the 28-char iptables chain limit.
+		require.LessOrEqual(t, len(IptablesAzureIngressPolicyChainPrefix)+1+len(GetHashedChainName(in)), 28,
+			"chain name must fit the iptables limit for %q", in)
+	}
+
+	// Distinct policy keys produce distinct digests.
+	require.NotEqual(t, GetHashedChainName("y/test2"), GetHashedChainName("z/test3"))
+	require.NotEqual(t, GetHashedChainName("ns-a/p"), GetHashedChainName("ns-b/p"))
+}

--- a/npm/util/util_test.go
+++ b/npm/util/util_test.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -467,4 +468,16 @@ func TestGetHashedChainName(t *testing.T) {
 	// Distinct policy keys produce distinct digests.
 	require.NotEqual(t, GetHashedChainName("y/test2"), GetHashedChainName("z/test3"))
 	require.NotEqual(t, GetHashedChainName("ns-a/p"), GetHashedChainName("ns-b/p"))
+}
+
+func TestGetHashedName(t *testing.T) {
+	// Deterministic and within the 31-char kernel ipset name limit.
+	name := GetHashedName("ns-some-namespace")
+	require.Equal(t, name, GetHashedName("ns-some-namespace"), "hashed name must be deterministic")
+	require.LessOrEqual(t, len(name), 31, "hashed name must fit the kernel ipset name limit")
+	require.True(t, strings.HasPrefix(name, AzureNpmPrefix), "hashed name must carry the azure-npm- prefix")
+
+	// Distinct inputs (incl. the reported pair) produce distinct kernel names.
+	require.NotEqual(t, GetHashedName("ns-msobb-target"), GetHashedName("podlabel-x:YMaaIZ"))
+	require.NotEqual(t, GetHashedName("ns-a"), GetHashedName("ns-b"))
 }


### PR DESCRIPTION
**Reason for Change**:

Forward-port to `master` of three Azure NPM v2 (Linux) naming-uniqueness improvements that
were merged to `release/v1.6`. `master` still has the older naming logic, so without this
forward-port the next release cut from `master` would drop these improvements.

Each change makes an NPM-generated identifier uniquely bound to the object that owns it:

1. **Policy-owned IPSet names** — serialize policy name and namespace with a `:` delimiter
   (invalid inside k8s namespace/name/label fields) so distinct (policy, namespace) pairs
   always produce distinct pre-hash set names, plus a per-owner reference check in
   `AddReference`. Forward-port of #4574.

2. **IPSet kernel names** — derive the kernel ipset name from a wide SHA-256/base36 digest
   (30 chars, within the 31-char limit) so distinct ipset names map to distinct kernel names,
   plus an owner map that fails closed if two names would resolve to the same kernel name.
   The cleanup regex is widened to match the new names. Forward-port of #4587.

3. **Policy chain names** — derive the iptables policy chain name from a wide SHA-256/base36
   digest (10 chars, within the 28-char chain limit) so distinct policies map to distinct
   chains, plus an owner map committed only after a successful apply. Forward-port of #4593.

**Issue Fixed**:

Forward-ports:
- #4574 — release/v1.6
- #4587 — release/v1.6
- #4593 — release/v1.6

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/) (`fix:` / `test:`)
- [x] includes documentation (inline rationale carried over from the source PRs)
- [x] adds unit tests (golden vectors, name-uniqueness, owner guards, old/new cleanup migration)
- [x] relevant PR labels added

**Notes**:

- Cherry-picked with `-x` for provenance; **zero conflicts** (`master` and `release/v1.6` were
  identical on all touched NPM files).
- gofmt clean, `go build` (linux + windows) and `go vet` pass, and the changed-package unit
  tests pass on the `master` base.
- **No other NPM code needs forward-porting**: every other `npm/` difference between
  `release/v1.6` and `master` is either master-ahead (go1.24/1.26 gofmt, release/v1.4 EOL
  cleanup) or release-specific (v1.6.42 Dockerfile package pins, per-branch deploy manifests).

