### PR TITLE
test: uniquify FQDN LRP policy name per node pool

### DIFF
--- a/test/integration/lrp/lrp_fqdn_test.go
+++ b/test/integration/lrp/lrp_fqdn_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-container-networking/test/internal/kubernetes"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	ciliumClientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
 	"github.com/stretchr/testify/require"
 )
@@ -40,7 +41,11 @@ func TestLRPFQDN(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "true", ciliumCM.Data[enableFQDNFlag], "enable-l7-proxy not set to true in cilium-config")
 
-	_, cleanupCNP := kubernetes.MustSetupCNP(ctx, ciliumCS, fqdnCNPPath)
+	// Uniquify the FQDN policy name per pool so simultaneous per-pool runs
+	// don't collide; when POOL is unset the name stays "to-fqdn".
+	_, cleanupCNP := kubernetes.MustSetupCNP(ctx, ciliumCS, fqdnCNPPath, func(cnp *ciliumv2.CiliumNetworkPolicy) {
+		cnp.Name += poolSuffix()
+	})
 	defer cleanupCNP()
 
 	tests := []struct {

--- a/test/internal/kubernetes/utils.go
+++ b/test/internal/kubernetes/utils.go
@@ -273,8 +273,11 @@ func MustSetupLRP(ctx context.Context, clientset *cilium.Clientset, lrpPath stri
 	}
 }
 
-func MustSetupCNP(ctx context.Context, clientset *cilium.Clientset, cnpPath string) (ciliumv2.CiliumNetworkPolicy, func()) { // nolint
+func MustSetupCNP(ctx context.Context, clientset *cilium.Clientset, cnpPath string, mutators ...func(*ciliumv2.CiliumNetworkPolicy)) (ciliumv2.CiliumNetworkPolicy, func()) { // nolint
 	cnp := mustParseCNP(cnpPath)
+	for _, mutate := range mutators {
+		mutate(&cnp)
+	}
 	cnpClient := clientset.CiliumV2().CiliumNetworkPolicies(cnp.Namespace)
 	mustCreateCiliumNetworkPolicy(ctx, cnpClient, cnp)
 	return cnp, func() {

--- a/test/internal/kubernetes/utils.go
+++ b/test/internal/kubernetes/utils.go
@@ -276,6 +276,9 @@ func MustSetupLRP(ctx context.Context, clientset *cilium.Clientset, lrpPath stri
 func MustSetupCNP(ctx context.Context, clientset *cilium.Clientset, cnpPath string, mutators ...func(*ciliumv2.CiliumNetworkPolicy)) (ciliumv2.CiliumNetworkPolicy, func()) { // nolint
 	cnp := mustParseCNP(cnpPath)
 	for _, mutate := range mutators {
+		if mutate == nil {
+			continue
+		}
 		mutate(&cnp)
 	}
 	cnpClient := clientset.CiliumV2().CiliumNetworkPolicies(cnp.Namespace)


### PR DESCRIPTION
This pull request updates the way CiliumNetworkPolicy (CNP) resources are set up in integration tests to better support parallel test runs and allow for more flexible test configuration. The main changes involve making the CNP setup function more extensible by accepting optional mutators and ensuring unique policy names per test pool.

**Test extensibility and parallelism improvements:**

* [`test/internal/kubernetes/utils.go`](diffhunk://#diff-d798b821e551ad695853dddeadb73248f51f909057b02822bc76119be461fc74L276-R280): The `MustSetupCNP` function now accepts optional mutator functions, allowing callers to modify the `CiliumNetworkPolicy` object before it is created. This makes test setup more flexible and customizable.
* [`test/integration/lrp/lrp_fqdn_test.go`](diffhunk://#diff-be2376fd0eb52a03eb917dc9d7a7aa8fd8366ef60a2c9eed5c2264ebd691e60bL43-R48): The FQDN policy name is now suffixed per test pool using a mutator, preventing name collisions during simultaneous test runs.

**Dependency updates:**

* [`test/integration/lrp/lrp_fqdn_test.go`](diffhunk://#diff-be2376fd0eb52a03eb917dc9d7a7aa8fd8366ef60a2c9eed5c2264ebd691e60bR10): Added import for `ciliumv2` to support direct manipulation of `CiliumNetworkPolicy` objects