### PR TITLE
Fix: CNI `VERSION` command succeeds without output, violates CNI spec

### DIFF
--- a/cni/network/stateless/main.go
+++ b/cni/network/stateless/main.go
@@ -153,12 +153,12 @@ func rootExecute() error {
 		return errors.Wrap(err, "Get cni state printresult error")
 	}
 
-	if cniCmd == cni.CmdVersion {
-		return errors.Wrap(err, "Execute netplugin failure")
+	if err = netPlugin.Execute(cni.PluginApi(netPlugin)); err != nil {
+		logger.Error("Failed to execute network plugin", zap.Error(err))
 	}
 
-	if err = netPlugin.Execute(cni.PluginApi(netPlugin)); err != nil {
-		return errors.Wrap(err, "Failed to execute network plugin")
+	if cniCmd == cni.CmdVersion {
+		return errors.Wrap(err, "Execute netplugin failure")
 	}
 	netPlugin.Stop()
 


### PR DESCRIPTION
**Reason for Change**:

`netPlugin.Execute` must run before the VERSION short-circuit, otherwise the plugin exits with a `0` code (SUCCESS) and no output, which violates the CNI spec.

This currently breaks CNI runtimes that depend on plugins to be spec-compliant on that command, including the [libcni](https://github.com/containernetworking/cni/blob/v1.3.0/pkg/invoke/exec.go#L165-L167) reference implementation, on all current versions of Azure Kubernetes Service (AKS).

The fix mirrors the logic of the "stateful" variant of this plugin[^1], which is not affected.

Before:
```console
$ printf '{}' | CNI_COMMAND=VERSION ./main
(exit 0; no output)
```
After:
```console
$ printf '{}' | CNI_COMMAND=VERSION ./main
{"cniVersion":"1.1.0","supportedVersions":["0.1.0","0.2.0","0.3.0","0.3.1","0.4.0","1.0.0"]}
```

[^1]: https://github.com/Azure/azure-container-networking/blob/v1.8.6/cni/network/plugin/main.go#L158-L165

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->


<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

CNI runtimes fall back on a **non-zero exit** (e.g. [libcni](https://github.com/containernetworking/cni/blob/v1.3.0/pkg/invoke/exec.go#L165-L167)). Returning `0` without output violates the CNI spec and can break callers.

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
