### PR TITLE
feat(network): signal CRI proxy for IB VF dismount instead of doing i…

### DIFF
--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 
 	"github.com/Azure/azure-container-networking/cns"
@@ -44,7 +45,21 @@ const (
 	noError = "0"
 	// device disabled flag 22
 	deviceDisabled = "22"
+
+	// enableIBVFDismountEnvVar, when set to a truthy value (1/true), makes CNI
+	// perform the legacy disable/dismount of the IB backend VF device. It
+	// defaults to a no-op: the disable/dismount is instead handled by an
+	// external component (the CRI proxy service), which CNI signals once its
+	// own work is done.
+	enableIBVFDismountEnvVar = "ACN_ENABLE_IB_VF_DISMOUNT"
 )
+
+// ibVFDismountEnabled reports whether CNI should perform the legacy
+// disable/dismount of the IB backend VF device. It defaults to false (no-op).
+func ibVFDismountEnabled() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(enableIBVFDismountEnvVar)))
+	return v == "1" || v == "true"
+}
 
 // ConstructEndpointID constructs endpoint name from netNsPath.
 func ConstructEndpointID(containerID string, netNsPath string, ifName string) (string, string) {
@@ -71,61 +86,15 @@ func ConstructEndpointID(containerID string, netNsPath string, ifName string) (s
 }
 
 func (nw *network) getEndpointWithVFDevice(plc platform.ExecClient, epInfo *EndpointInfo) (*endpoint, error) {
-	logger.Info("disable and dismount VF device")
-
-	// check device state before disabling and dismounting vf device
-	devicePresence, problemCode, err := getPnpDeviceState(epInfo.PnPID, plc)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get VF device state")
-	}
-
-	// state machine, use devicePresence and problemCode to determine actions
-	if devicePresence == "True" && problemCode == noError { //nolint
-		logger.Info("Device enabled and mounted")
-
-		if err := disableVFDevice(epInfo.PnPID, plc); err != nil { //nolint
-			return nil, errors.Wrap(err, "failed to disable VF device")
+	// By default CNI no longer disables/dismounts the IB VF device; that work is
+	// handled by an external component (the CRI proxy service). The legacy
+	// behavior can be re-enabled via the ACN_ENABLE_IB_VF_DISMOUNT flag.
+	if ibVFDismountEnabled() {
+		if err := nw.disableAndDismountVFDevice(plc, epInfo); err != nil {
+			return nil, err
 		}
-
-		if err := dismountVFDevice(epInfo.PnPID, plc); err != nil { //nolint
-			return nil, errors.Wrap(err, "failed to dismount VF device")
-		}
-
-		// get new pnp id after VF dismount
-		pnpDeviceID, err := getPnPDeviceID(epInfo.PnPID, plc) //nolint
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to get updated VF device ID")
-		}
-
-		// assign updated PciID back to containerd
-		epInfo.PnPID = pnpDeviceID
-	} else if devicePresence == "True" && problemCode == deviceDisabled {
-		logger.Info("Device disabled")
-		// device is disabled but not dismounted
-		if err := dismountVFDevice(epInfo.PnPID, plc); err != nil { //nolint
-			return nil, errors.Wrap(err, "failed to dismount VF device")
-		}
-
-		// get new pnp id after VF dismount
-		pnpDeviceID, err := getPnPDeviceID(epInfo.PnPID, plc) //nolint
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to get updated VF device ID")
-		}
-
-		// assign updated PciID back to containerd
-		epInfo.PnPID = pnpDeviceID
-	} else if devicePresence == "False" {
-		logger.Info("Device dismounted")
-		// device is disabled and dismounted, just get the new PciID and assign back to containerd
-		pnpDeviceID, err := getPnPDeviceID(epInfo.PnPID, plc) //nolint
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to get updated VF device ID")
-		}
-		// assign updated PciID back to containerd
-		epInfo.PnPID = pnpDeviceID
 	} else {
-		// return unexpected error and log devicePresence, problemCode
-		return nil, errors.Wrapf(err, "unexpected error with devicePresence %s and problemCode %s", devicePresence, problemCode)
+		logger.Info("Skipping IB VF disable/dismount; delegated to external component")
 	}
 
 	// Create the endpoint object.
@@ -137,8 +106,82 @@ func (nw *network) getEndpointWithVFDevice(plc platform.ExecClient, epInfo *Endp
 		NICType:     cns.BackendNIC,
 	}
 
+	// Signal external components (the CRI proxy service) that CNI's side of the
+	// IB backend NIC work is done. Only ever done on the IB (BackendNIC) path so
+	// the global named event is never created/set for non-IB endpoints.
+	// Best-effort: do not fail endpoint creation.
+	if epInfo.NICType == cns.BackendNIC {
+		if err := signalIBWorkDone(); err != nil {
+			logger.Error("Failed to signal IB work done", zap.Error(err))
+		}
+	}
+
 	// do not create endpoint for IB NIC interface
 	return ep, nil
+}
+
+// disableAndDismountVFDevice runs the legacy state machine that disables and
+// dismounts the IB backend VF device and reassigns the resulting PnP ID back to
+// containerd. Retained behind the ACN_ENABLE_IB_VF_DISMOUNT flag.
+func (nw *network) disableAndDismountVFDevice(plc platform.ExecClient, epInfo *EndpointInfo) error {
+	logger.Info("disable and dismount VF device")
+
+	// check device state before disabling and dismounting vf device
+	devicePresence, problemCode, err := getPnpDeviceState(epInfo.PnPID, plc)
+	if err != nil {
+		return errors.Wrap(err, "failed to get VF device state")
+	}
+
+	// state machine, use devicePresence and problemCode to determine actions
+	if devicePresence == "True" && problemCode == noError { //nolint
+		logger.Info("Device enabled and mounted")
+
+		if err := disableVFDevice(epInfo.PnPID, plc); err != nil { //nolint
+			return errors.Wrap(err, "failed to disable VF device")
+		}
+
+		if err := dismountVFDevice(epInfo.PnPID, plc); err != nil { //nolint
+			return errors.Wrap(err, "failed to dismount VF device")
+		}
+
+		// get new pnp id after VF dismount
+		pnpDeviceID, err := getPnPDeviceID(epInfo.PnPID, plc) //nolint
+		if err != nil {
+			return errors.Wrap(err, "failed to get updated VF device ID")
+		}
+
+		// assign updated PciID back to containerd
+		epInfo.PnPID = pnpDeviceID
+	} else if devicePresence == "True" && problemCode == deviceDisabled {
+		logger.Info("Device disabled")
+		// device is disabled but not dismounted
+		if err := dismountVFDevice(epInfo.PnPID, plc); err != nil { //nolint
+			return errors.Wrap(err, "failed to dismount VF device")
+		}
+
+		// get new pnp id after VF dismount
+		pnpDeviceID, err := getPnPDeviceID(epInfo.PnPID, plc) //nolint
+		if err != nil {
+			return errors.Wrap(err, "failed to get updated VF device ID")
+		}
+
+		// assign updated PciID back to containerd
+		epInfo.PnPID = pnpDeviceID
+	} else if devicePresence == "False" {
+		logger.Info("Device dismounted")
+		// device is disabled and dismounted, just get the new PciID and assign back to containerd
+		pnpDeviceID, err := getPnPDeviceID(epInfo.PnPID, plc) //nolint
+		if err != nil {
+			return errors.Wrap(err, "failed to get updated VF device ID")
+		}
+		// assign updated PciID back to containerd
+		epInfo.PnPID = pnpDeviceID
+	} else {
+		// return unexpected error and log devicePresence, problemCode
+		return errors.Wrapf(err, "unexpected error with devicePresence %s and problemCode %s", devicePresence, problemCode)
+	}
+
+	return nil
 }
 
 // newEndpointImpl creates a new endpoint in the network.

--- a/network/endpoint_windows.go
+++ b/network/endpoint_windows.go
@@ -178,7 +178,7 @@ func (nw *network) disableAndDismountVFDevice(plc platform.ExecClient, epInfo *E
 		epInfo.PnPID = pnpDeviceID
 	} else {
 		// return unexpected error and log devicePresence, problemCode
-		return errors.Wrapf(err, "unexpected error with devicePresence %s and problemCode %s", devicePresence, problemCode)
+		return fmt.Errorf("unexpected error with devicePresence %s and problemCode %s", devicePresence, problemCode)
 	}
 
 	return nil

--- a/network/endpoint_windows_test.go
+++ b/network/endpoint_windows_test.go
@@ -470,7 +470,7 @@ func TestGetPnPDeviceStateUnHappyPath(t *testing.T) {
 }
 
 // endpoint creation is not required for IB
-func TestNewEndpointImplHnsv2ForIBHappyPath(t *testing.T) {
+func TestNewEndpointImplHnsv2ForIBDefaultNoDismount(t *testing.T) {
 	nw := &network{
 		Endpoints: map[string]*endpoint{},
 	}
@@ -492,16 +492,34 @@ func TestNewEndpointImplHnsv2ForIBHappyPath(t *testing.T) {
 		PnPID:      pnpID,
 	}
 
-	// Happy Path
-	endpoint, err := nw.newEndpointImpl(nil, netlink.NewMockNetlink(false, ""), platform.NewMockExecClient(false),
-		netio.NewMockNetIO(false, 0), NewMockEndpointClient(nil), NewMockNamespaceClient(), iptables.NewClient(), &mockDHCP{}, epInfo)
+	// By default (flag unset) CNI must NOT disable/dismount the VF device. Fail
+	// the test if any disable/dismount powershell command is executed.
+	mockExecClient := platform.NewMockExecClient(false)
+	mockExecClient.SetPowershellCommandResponder(func(cmd string) (string, error) {
+		if strings.Contains(cmd, "Disable-PnpDevice") || strings.Contains(cmd, "Dismount-VMHostAssignableDevice") {
+			t.Errorf("unexpected disable/dismount command executed by default: %s", cmd)
+		}
+		return "", nil
+	})
 
-	if endpoint != nil || err != nil {
-		t.Fatalf("Endpoint is created for IB due to %v", err)
+	endpoint, err := nw.newEndpointImpl(nil, netlink.NewMockNetlink(false, ""), mockExecClient,
+		netio.NewMockNetIO(false, 0), NewMockEndpointClient(nil), NewMockNamespaceClient(), iptables.NewClient(), &mockDHCP{}, epInfo)
+	if err != nil {
+		t.Fatalf("Unexpected error creating IB endpoint by default: %v", err)
+	}
+	if endpoint == nil {
+		t.Fatal("Expected a non-nil endpoint for IB backend NIC")
+	}
+	if endpoint.NICType != cns.BackendNIC {
+		t.Fatalf("Expected NICType %s, got %s", cns.BackendNIC, endpoint.NICType)
 	}
 }
 
-func TestNewEndpointImplHnsv2ForIBUnHappyPath(t *testing.T) {
+func TestNewEndpointImplHnsv2ForIBLegacyDismountError(t *testing.T) {
+	// Legacy behavior: when the dismount flag is enabled, errors from the
+	// disable/dismount state machine must propagate.
+	t.Setenv(enableIBVFDismountEnvVar, "true")
+
 	nw := &network{
 		Endpoints: map[string]*endpoint{},
 	}
@@ -522,14 +540,16 @@ func TestNewEndpointImplHnsv2ForIBUnHappyPath(t *testing.T) {
 		PnPID:      pnpID,
 	}
 
-	// Set UnHappy Path
-	_, err := nw.newEndpointImpl(nil, netlink.NewMockNetlink(false, ""), platform.NewMockExecClient(true),
+	mockExecClient := platform.NewMockExecClient(false)
+	mockExecClient.SetPowershellCommandResponder(func(_ string) (string, error) {
+		return "", platform.ErrMockExec
+	})
+
+	_, err := nw.newEndpointImpl(nil, netlink.NewMockNetlink(false, ""), mockExecClient,
 		netio.NewMockNetIO(false, 0), NewMockEndpointClient(nil), NewMockNamespaceClient(), iptables.NewClient(), &mockDHCP{}, epInfo)
-
 	if err == nil {
-		t.Fatal("Failed to test Endpoint creation for IB with unhappy path")
+		t.Fatal("Expected error from legacy IB disable/dismount path")
 	}
-
 	if !errors.Is(err, platform.ErrMockExec) {
 		t.Fatalf("Unexpected Error:%v; Error should be %v", err, platform.ErrMockExec)
 	}

--- a/network/ib_signal_windows.go
+++ b/network/ib_signal_windows.go
@@ -40,14 +40,12 @@ func signalNamedEvent(eventName string) error {
 	if err != nil {
 		// CreateEvent returns ERROR_ALREADY_EXISTS as err even on success (handle is valid).
 		if !errors.Is(err, windows.ERROR_ALREADY_EXISTS) {
-			logger.Error("Failed to create IB ready event", zap.String("event", eventName), zap.Error(err))
 			return errors.Wrap(err, "failed to create IB ready event")
 		}
 	}
 	defer windows.CloseHandle(handle) //nolint:errcheck // best-effort cleanup
 
 	if err := windows.SetEvent(handle); err != nil {
-		logger.Error("Failed to set IB ready event", zap.String("event", eventName), zap.Error(err))
 		return errors.Wrap(err, "failed to set IB ready event")
 	}
 

--- a/network/ib_signal_windows.go
+++ b/network/ib_signal_windows.go
@@ -31,7 +31,6 @@ func signalIBWorkDone() error {
 func signalNamedEvent(eventName string) error {
 	name, err := windows.UTF16PtrFromString(eventName)
 	if err != nil {
-		logger.Error("Failed to encode IB ready event name", zap.String("event", eventName), zap.Error(err))
 		return errors.Wrap(err, "failed to encode IB ready event name")
 	}
 

--- a/network/ib_signal_windows.go
+++ b/network/ib_signal_windows.go
@@ -1,0 +1,57 @@
+// Copyright 2017 Microsoft. All rights reserved.
+// MIT License
+
+package network
+
+import (
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+	"golang.org/x/sys/windows"
+)
+
+// ibReadyEventName is the single global named object CNI uses to signal external
+// components (e.g. the CRI proxy service) that CNI's side of the IB backend NIC
+// work is done. It lives in the Global\ namespace so a service running in a
+// different session can open/wait on it.
+const ibReadyEventName = `Global\AzureCNI-IB-Ready`
+
+// signalIBWorkDone signals external components that CNI has finished its side of
+// the IB backend NIC work. It creates (or opens) an auto-reset Windows global
+// named event and sets it, releasing any waiter (the CRI proxy service).
+//
+// This is best-effort: a failure to signal is logged but does not fail endpoint
+// creation, since the CRI proxy can also poll/retry.
+func signalIBWorkDone() error {
+	return signalNamedEvent(ibReadyEventName)
+}
+
+// signalNamedEvent creates (or opens) an auto-reset Windows named event and sets
+// it. Split out from signalIBWorkDone so it can be unit tested with a
+// non-elevated (session-local) event name.
+func signalNamedEvent(eventName string) error {
+	name, err := windows.UTF16PtrFromString(eventName)
+	if err != nil {
+		logger.Error("Failed to encode IB ready event name", zap.String("event", eventName), zap.Error(err))
+		return errors.Wrap(err, "failed to encode IB ready event name")
+	}
+
+	// manualReset=0 (auto-reset), initialState=0 (non-signaled). Creates the event
+	// if it does not exist, otherwise opens the existing one.
+	handle, err := windows.CreateEvent(nil, 0, 0, name)
+	if err != nil {
+		// CreateEvent returns ERROR_ALREADY_EXISTS as err even on success (handle is valid).
+		if !errors.Is(err, windows.ERROR_ALREADY_EXISTS) {
+			logger.Error("Failed to create IB ready event", zap.String("event", eventName), zap.Error(err))
+			return errors.Wrap(err, "failed to create IB ready event")
+		}
+	}
+	defer windows.CloseHandle(handle) //nolint:errcheck // best-effort cleanup
+
+	if err := windows.SetEvent(handle); err != nil {
+		logger.Error("Failed to set IB ready event", zap.String("event", eventName), zap.Error(err))
+		return errors.Wrap(err, "failed to set IB ready event")
+	}
+
+	logger.Info("Signaled IB work done to external components", zap.String("event", eventName))
+	return nil
+}

--- a/network/ib_signal_windows_test.go
+++ b/network/ib_signal_windows_test.go
@@ -1,0 +1,64 @@
+// Copyright 2017 Microsoft. All rights reserved.
+// MIT License
+
+//go:build windows
+// +build windows
+
+package network
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestIBVFDismountEnabled(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		set   bool
+		want  bool
+	}{
+		{name: "unset defaults to no-op", set: false, want: false},
+		{name: "empty is no-op", value: "", set: true, want: false},
+		{name: "zero is no-op", value: "0", set: true, want: false},
+		{name: "false is no-op", value: "false", set: true, want: false},
+		{name: "one enables", value: "1", set: true, want: true},
+		{name: "true enables", value: "true", set: true, want: true},
+		{name: "mixed case true enables", value: "TrUe", set: true, want: true},
+		{name: "padded true enables", value: "  true  ", set: true, want: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			os.Unsetenv(enableIBVFDismountEnvVar)
+			if tc.set {
+				t.Setenv(enableIBVFDismountEnvVar, tc.value)
+			}
+			if got := ibVFDismountEnabled(); got != tc.want {
+				t.Fatalf("ibVFDismountEnabled()=%v, want %v (env=%q set=%v)", got, tc.want, tc.value, tc.set)
+			}
+		})
+	}
+}
+
+func TestSignalNamedEvent(t *testing.T) {
+	// Use a session-local (Local\) unique name so the test does not require the
+	// SeCreateGlobalPrivilege that the production Global\ event needs.
+	eventName := fmt.Sprintf(`Local\AzureCNI-IB-Test-%d`, os.Getpid())
+
+	if err := signalNamedEvent(eventName); err != nil {
+		t.Fatalf("signalNamedEvent(%q) unexpected error: %v", eventName, err)
+	}
+
+	// Signalling again must succeed (event already exists, handle is reopened).
+	if err := signalNamedEvent(eventName); err != nil {
+		t.Fatalf("signalNamedEvent(%q) second call unexpected error: %v", eventName, err)
+	}
+}
+
+func TestSignalIBWorkDoneUsesGlobalName(t *testing.T) {
+	if ibReadyEventName != `Global\AzureCNI-IB-Ready` {
+		t.Fatalf("ibReadyEventName changed unexpectedly: %q", ibReadyEventName)
+	}
+}


### PR DESCRIPTION
…t in CNI

On the Windows IB (BackendNIC) path, CNI previously disabled and dismounted the IB VF device itself. That responsibility now moves to an external component (the CRI proxy service).

- Gate the legacy disable/dismount state machine behind the ACN_ENABLE_IB_VF_DISMOUNT env flag, defaulting to a no-op (reversible).
- Signal external components via a single Windows global named event (Global\AzureCNI-IB-Ready) once CNI's IB work is done. The event is only ever created/set on the IB (BackendNIC) path; non-IB pods never write it.
- Best-effort signalling: failures are logged, endpoint creation still succeeds.
- Add unit tests for the flag parsing, the named-event signal helper, and the default no-op vs legacy flag-on endpoint paths.

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
