### PR TITLE
fix: add succeeded() to conditional in conditional tests

### DIFF
--- a/.pipelines/singletenancy/aks/e2e-job-template.yaml
+++ b/.pipelines/singletenancy/aks/e2e-job-template.yaml
@@ -36,9 +36,12 @@ parameters:
 stages:
   - stage: ${{ parameters.clusterName }}
     displayName: ${{ parameters.displayName }} - Create Cluster
-    condition: or(
-        eq('${{ parameters.os }}', 'linux'),
-        and(eq('${{ parameters.os }}', 'windows'), eq(dependencies.setup.outputs['env.GitDiffCheck.RunWindowsTests'], 'true'))
+    condition: and(
+        succeeded(),
+        or(
+          eq('${{ parameters.os }}', 'linux'),
+          and(eq('${{ parameters.os }}', 'windows'), eq(dependencies.setup.outputs['env.GitDiffCheck.RunWindowsTests'], 'true'))
+        )
       )
     dependsOn:
       - ${{ parameters.dependsOn }}

--- a/.pipelines/singletenancy/azure-cni-overlay-stateless/azure-cni-overlay-stateless-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay-stateless/azure-cni-overlay-stateless-e2e-job-template.yaml
@@ -24,7 +24,7 @@ parameters:
 stages:
   - stage: ${{ parameters.clusterName }}
     displayName: ${{ parameters.displayName }} - Create Cluster
-    condition: eq(dependencies.setup.outputs['env.GitDiffCheck.RunWindowsTests'], 'true')
+    condition: and(succeeded(), eq(dependencies.setup.outputs['env.GitDiffCheck.RunWindowsTests'], 'true'))
     dependsOn:
       - ${{ parameters.dependsOn }}
       - setup

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
@@ -30,9 +30,12 @@ parameters:
 stages:
   - stage: ${{ parameters.clusterName }}
     displayName: ${{ parameters.displayName }} - Create Cluster
-    condition: or(
-        eq('${{ parameters.os }}', 'linux'),
-        and(eq('${{ parameters.os }}', 'windows'), eq(dependencies.setup.outputs['env.GitDiffCheck.RunWindowsTests'], 'true'))
+    condition: and(
+        succeeded(),
+        or(
+          eq('${{ parameters.os }}', 'linux'),
+          and(eq('${{ parameters.os }}', 'windows'), eq(dependencies.setup.outputs['env.GitDiffCheck.RunWindowsTests'], 'true'))
+        )
       )
     dependsOn:
       - ${{ parameters.dependsOn }}

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
@@ -30,9 +30,12 @@ parameters:
 stages:
   - stage: ${{ parameters.clusterName }}
     displayName: ${{ parameters.displayName }} - Create Cluster
-    condition: or(
-        eq('${{ parameters.os }}', 'linux'),
-        and(eq('${{ parameters.os }}', 'windows'), eq(dependencies.setup.outputs['env.GitDiffCheck.RunWindowsTests'], 'true'))
+    condition: and(
+        succeeded(),
+        or(
+          eq('${{ parameters.os }}', 'linux'),
+          and(eq('${{ parameters.os }}', 'windows'), eq(dependencies.setup.outputs['env.GitDiffCheck.RunWindowsTests'], 'true'))
+        )
       )
     dependsOn:
       - ${{ parameters.dependsOn }}


### PR DESCRIPTION
the default conditional is succeeded() when no condition: block is specified however, when adding a condition block, succeeded() is not automatically added meaning if a dependsOn stage fails, the stage can still run if we do not explicitly include succeeded()

if no condition: block is specified, succeeded() is the condition, and a skipped stage is not considered succeeded() so it does not run (which is why the windows E2E stages don't have the conditional- they depend on the cluster create stage prior which DOES have the conditional)

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
