### PR TITLE
ci: scan Dockerfiles recursively

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,6 +4,8 @@ updates:
   - package-ecosystem: "docker"
     directories:
       - "**/*"
+    exclude-paths:
+      - "**/*.tmpl"
     schedule:
       interval: "daily"
     commit-message:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,7 +2,8 @@
 version: 2
 updates:
   - package-ecosystem: "docker"
-    directory: "/"
+    directories:
+      - "**/*"
     schedule:
       interval: "daily"
     commit-message:


### PR DESCRIPTION
## Summary
Use Dependabot’s recursive `directories` glob so Docker updates cover manifests throughout the repository instead of only the root directory.

ACN currently has 31 Docker manifest candidates across 11 directories.

## Documentation
- https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/manage-your-dependency-security/controlling-dependencies-updated#defining-multiple-locations-for-manifest-files
- https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#exclude-paths-