### PR TITLE
test: validate LRP against the cilium pod on the targeted node

### DIFF
--- a/test/integration/lrp/lrp_test.go
+++ b/test/integration/lrp/lrp_test.go
@@ -269,7 +269,7 @@ func testLRPLifecycle(t *testing.T, ctx context.Context, clientPod corev1.Pod, k
 
 	// Step 1: Validate LRP using cilium commands
 	t.Log("Step 1: Validating LRP using cilium commands")
-	validateCiliumLRP(t, ctx, cs, config)
+	validateCiliumLRP(t, ctx, cs, config, clientPod.Spec.NodeName)
 
 	// Step 2: Restart busybox pods and verify LRP still works
 	t.Log("Step 2: Restarting client pods to test persistence")
@@ -283,7 +283,7 @@ func testLRPLifecycle(t *testing.T, ctx context.Context, clientPod corev1.Pod, k
 
 	// Step 4: Validate cilium commands still show LRP
 	t.Log("Step 4: Re-validating cilium LRP after restart")
-	validateCiliumLRP(t, ctx, cs, config)
+	validateCiliumLRP(t, ctx, cs, config, restartedPod.Spec.NodeName)
 
 	// Step 5: Delete and recreate resources & restart nodelocaldns daemonset
 	t.Log("Step 5: Testing resource deletion and recreation")
@@ -332,17 +332,23 @@ func testLRPLifecycle(t *testing.T, ctx context.Context, clientPod corev1.Pod, k
 
 	// Step 7: Final cilium validation after node-local-dns restart
 	t.Log("Step 7: Final cilium validation - ensuring LRP is still active after node-local-dns restart")
-	validateCiliumLRP(t, ctx, cs, config)
+	validateCiliumLRP(t, ctx, cs, config, recreatedPod.Spec.NodeName)
 
 }
 
 // validateCiliumLRP checks that LRP is properly configured in cilium
-func validateCiliumLRP(t *testing.T, ctx context.Context, cs *k8sclient.Clientset, config *rest.Config) {
+// nodeName is the node this test targeted; validation runs against the cilium
+// pod on that node. Picking any cilium pod in the cluster is wrong once the
+// node-local-dns DaemonSet is pinned to a node pool (POOL_NODESELECTOR): cilium
+// runs on every node, so the two can land in different pools and the
+// node-local-dns lookup below then finds nothing.
+func validateCiliumLRP(t *testing.T, ctx context.Context, cs *k8sclient.Clientset, config *rest.Config, nodeName string) {
 	ciliumPods, err := cs.CoreV1().Pods(kubeSystemNamespace).List(ctx, metav1.ListOptions{
 		LabelSelector: "k8s-app=cilium",
+		FieldSelector: "spec.nodeName=" + nodeName,
 	})
 	require.NoError(t, err)
-	require.NotEmpty(t, ciliumPods.Items)
+	require.NotEmpty(t, ciliumPods.Items, "no cilium pod on node %s", nodeName)
 	ciliumPod := TakeOne(ciliumPods.Items)
 
 	// Get Kubernetes version to determine validation approach


### PR DESCRIPTION
validateCiliumLRP picked a cilium pod at random from the whole cluster, then looked for a node-local-dns pod on that pod's node. Cilium runs on every node, but the node-local-dns DaemonSet this test deploys is pinned to a single node pool when POOL_NODESELECTOR is set (#4590), so on a multi-node-pool cluster the two land in different pools:

  Using cilium pod cilium-qcd74 on node aks-nparm-26219969-vmss000000
  Error:      Should NOT be empty, but was []
  Messages:   No node-local-dns pod found on node aks-nparm-26219969-vmss000000

Because the pod is chosen with TakeOne this is flaky rather than deterministic: on one three-pool run the same suite passed on two legs and failed on two.

Select the cilium pod with a spec.nodeName field selector for the node the test actually targeted -- the node its client pod runs on -- which is the node the function's own comment already says the lookup depends on. That is one List call rather than a cluster-wide list plus a filter, and it needs no env var, so single-pool clusters behave exactly as before.