### PR TITLE
ci: generate one signed SBOM over assembled output drop for release validation (backport #4570 to release/v1.6)

### DIFF
--- a/.pipelines/containers/manifest-template.yaml
+++ b/.pipelines/containers/manifest-template.yaml
@@ -45,11 +45,6 @@ steps:
       inlineScript: |
         docker logout
 
-  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-    displayName: "Add SBOM Generator tool"
-    inputs:
-      BuildDropPath: "$(Build.ArtifactStagingDirectory)"
-
   - task: PublishBuildArtifacts@1
     inputs:
       artifactName: "output"

--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -224,6 +224,42 @@ stages:
                 name: $(name)
                 platforms: $(platforms)
 
+    - stage: sbom
+      displayName: Generate SBOM
+      dependsOn:
+        - binaries
+        - publish
+      variables:
+        Packaging.EnableSBOMSigning: true
+      jobs:
+        - job: sbom
+          displayName: Generate and Sign SBOM
+          pool:
+            name: "$(BUILD_POOL_NAME_DEFAULT)"
+          steps:
+            - task: DownloadBuildArtifacts@1
+              displayName: Download full output artifact drop
+              inputs:
+                buildType: current
+                artifactName: output
+                downloadPath: $(Pipeline.Workspace)
+
+            - script: mkdir -p "$(Build.ArtifactStagingDirectory)/sbom"
+              displayName: Create SBOM staging directory
+
+            - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+              displayName: Generate SBOM over full output artifact drop and sign _manifest
+              inputs:
+                BuildDropPath: $(Pipeline.Workspace)/output
+                ManifestDirPath: $(Build.ArtifactStagingDirectory)/sbom
+
+            - task: PublishBuildArtifacts@1
+              displayName: Publish _manifest into output artifact
+              inputs:
+                artifactName: output
+                pathtoPublish: $(Build.ArtifactStagingDirectory)/sbom
+              condition: succeeded()
+
     # Cilium Podsubnet E2E tests
     - template: singletenancy/cilium/cilium-e2e-job-template.yaml
       parameters:


### PR DESCRIPTION
## Backport of #4570 to `release/v1.6`

Backports [#4570](https://github.com/Azure/azure-container-networking/pull/4570) to unblock the **v1.6.46** release (fixing the 1ES `Validate Source Build (OneBranch PT)` / SBOM signature validation failure seen when releasing the azure-npm CVE fixes).

### Reason for change
The GitHub Release pipeline's SBOM / source-build validation fails because the published `output` artifact is assembled from ~8 parallel image jobs, and each job generated and signed its own SBOM with identical filenames. When merged into a single artifact the files overwrite each other, leaving a `manifest.spdx.json` paired with a signature from a different job — which fails hash/signature validation (surfacing downstream as the missing/invalid SBOM in 1ES source-build validation).

### Fix
- Drop the per-artifact SBOM generation from `.pipelines/containers/manifest-template.yaml`.
- Add a single `sbom` stage that waits for the `output` publishers, then generates and signs **one** SBOM over the entire output artifact.

### Adaptation for `release/v1.6`
Unlike `master`, `release/v1.6` has **no separate `publish_npm` stage** — npm is published within the single `publish` stage matrix (that stage was split out on master by an unrelated refactor, #4061). So the backported `sbom` stage depends on **`binaries` + `publish` only**; depending on `publish` alone already covers all images, npm included. Referencing `publish_npm` here (as in the master version) would fail pipeline compilation on v1.6.

### Verification
Compared `release/v1.6` vs `master`: the only SBOM/source-build-relevant change required for this fix is #4570. The other SBOM-adjacent deltas on master (`publish_npm` stage, `EnableSBOMSigning` flip on the `publish` stage) come from unrelated earlier PRs (#4061, #4367) and are **not** required on v1.6.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
