### PR TITLE
[release/v1.5] feat: add EnableHomeAZ feature flag 

### DIFF
--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -33,6 +33,7 @@ type CNSConfig struct {
 	ChannelMode                 string
 	EnableAsyncPodDelete        bool
 	EnableCNIConflistGeneration bool
+	EnableHomeAz                bool
 	EnableIPAMv2                bool
 	EnablePprof                 bool
 	EnableStateMigration        bool

--- a/cns/configuration/configuration.go
+++ b/cns/configuration/configuration.go
@@ -33,7 +33,7 @@ type CNSConfig struct {
 	ChannelMode                 string
 	EnableAsyncPodDelete        bool
 	EnableCNIConflistGeneration bool
-	EnableHomeAz                bool
+	EnableHomeAZ                bool
 	EnableIPAMv2                bool
 	EnablePprof                 bool
 	EnableStateMigration        bool

--- a/cns/configuration/configuration_test.go
+++ b/cns/configuration/configuration_test.go
@@ -55,7 +55,7 @@ func TestReadConfigFromFile(t *testing.T) {
 			want: &CNSConfig{
 				ChannelMode:          "Direct",
 				InitializeFromCNI:    true,
-				EnableHomeAz:         true,
+				EnableHomeAZ:         true,
 				EnablePprof:          true,
 				EnableSubnetScarcity: true,
 				ManagedSettings: ManagedSettings{

--- a/cns/configuration/configuration_test.go
+++ b/cns/configuration/configuration_test.go
@@ -55,6 +55,7 @@ func TestReadConfigFromFile(t *testing.T) {
 			want: &CNSConfig{
 				ChannelMode:          "Direct",
 				InitializeFromCNI:    true,
+				EnableHomeAz:         true,
 				EnablePprof:          true,
 				EnableSubnetScarcity: true,
 				ManagedSettings: ManagedSettings{

--- a/cns/configuration/testdata/good.json
+++ b/cns/configuration/testdata/good.json
@@ -2,6 +2,7 @@
     "ChannelMode": "Direct",
     "InitializeFromCNI": true,
     "EnablePprof": true,
+    "EnableHomeAz": true,
     "EnableSubnetScarcity": true,
     "ManagedSettings": {
         "InfrastructureNetworkID": "abc",

--- a/cns/configuration/testdata/good.json
+++ b/cns/configuration/testdata/good.json
@@ -2,7 +2,7 @@
     "ChannelMode": "Direct",
     "InitializeFromCNI": true,
     "EnablePprof": true,
-    "EnableHomeAz": true,
+    "EnableHomeAZ": true,
     "EnableSubnetScarcity": true,
     "ManagedSettings": {
         "InfrastructureNetworkID": "abc",

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1268,7 +1268,7 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 	}
 
 	// populate the NodeInfo CRD if any scenario requires it (SwiftV2 or HomeAz)
-	if cnsconfig.EnableSwiftV2 || cnsconfig.EnableHomeAz {
+	if cnsconfig.EnableSwiftV2 || cnsconfig.EnableHomeAZ {
 		if nodeInfoErr := createOrUpdateNodeInfoCRD(ctx, kubeConfig, node); nodeInfoErr != nil {
 			return errors.Wrap(nodeInfoErr, "error creating or updating nodeinfo crd")
 		}

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1265,17 +1265,15 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 	if _, ok := node.Labels[configuration.LabelNodeSwiftV2]; ok {
 		cnsconfig.EnableSwiftV2 = true
 		cnsconfig.WatchPods = true
+	}
+
+	// populate the NodeInfo CRD if any scenario requires it (SwiftV2 or HomeAz)
+	if cnsconfig.EnableSwiftV2 || cnsconfig.EnableHomeAz {
 		if nodeInfoErr := createOrUpdateNodeInfoCRD(ctx, kubeConfig, node); nodeInfoErr != nil {
 			return errors.Wrap(nodeInfoErr, "error creating or updating nodeinfo crd")
 		}
 	}
 
-	// populate the NodeInfo CRD when HomeAz is enabled
-	if cnsconfig.EnableHomeAz {
-		if nodeInfoErr := createOrUpdateNodeInfoCRD(ctx, kubeConfig, node); nodeInfoErr != nil {
-			return errors.Wrap(nodeInfoErr, "error creating or updating nodeinfo crd for home az")
-		}
-	}
 
 	// perform state migration from CNI in case CNS is set to manage the endpoint state and has emty state
 	if cnsconfig.EnableStateMigration && !httpRestServiceImplementation.EndpointStateStore.Exists() {

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -1270,6 +1270,13 @@ func InitializeCRDState(ctx context.Context, httpRestService cns.HTTPService, cn
 		}
 	}
 
+	// populate the NodeInfo CRD when HomeAz is enabled
+	if cnsconfig.EnableHomeAz {
+		if nodeInfoErr := createOrUpdateNodeInfoCRD(ctx, kubeConfig, node); nodeInfoErr != nil {
+			return errors.Wrap(nodeInfoErr, "error creating or updating nodeinfo crd for home az")
+		}
+	}
+
 	// perform state migration from CNI in case CNS is set to manage the endpoint state and has emty state
 	if cnsconfig.EnableStateMigration && !httpRestServiceImplementation.EndpointStateStore.Exists() {
 		if err = PopulateCNSEndpointState(httpRestServiceImplementation.EndpointStateStore); err != nil {


### PR DESCRIPTION
**Reason for Change**:
Backports #4461 to `release/v1.5` <!-- change to v1.6 / v1.7 as appropriate -->.

Adds support for populating the `NodeInfo` CRD with the VM's unique ID (fetched
from IMDS), gated behind a new `EnableHomeAZ` feature flag. This is required for
the Home AZ / SwiftV2 multi-tenancy scenarios.

Changes:
- Add the `EnableHomeAZ` feature flag to `CNSConfig`, plus test data and a
  config-parsing unit test.
- On CNS startup, detect the SwiftV2 node label and, when `EnableSwiftV2` or
  `EnableHomeAZ` is set, create or update the `NodeInfo` CRD for the node
  (owner-referenced to the Node) via `createOrUpdateNodeInfoCRD`.
- Use the IMDS client to retrieve the VM unique ID and the `multitenancy` typed
  client to write the `NodeInfo` CRD.

This is a clean cherry-pick of #4461; no functional changes beyond the backport.


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
