### PR TITLE
fix: unblock Windows unit-test job (Go 1.26 vet + swiftv2 options)

### DIFF
--- a/cni/network/network_windows_test.go
+++ b/cni/network/network_windows_test.go
@@ -1288,7 +1288,6 @@ func TestPluginWindowsAdd(t *testing.T) {
 						NetNsPath:         "bc526fae-4ba0-4e80-bc90-ad721e5850bf",
 						NetNs:             "bc526fae-4ba0-4e80-bc90-ad721e5850bf",
 						HostSubnetPrefix:  "<nil>",
-						// non-infra NICs carry nil options (see createEpInfo); matches Linux test
 						Options:           nil,
 						// matches with cns ip configuration
 						IPAddresses: []net.IPNet{

--- a/cni/network/network_windows_test.go
+++ b/cni/network/network_windows_test.go
@@ -1288,7 +1288,8 @@ func TestPluginWindowsAdd(t *testing.T) {
 						NetNsPath:         "bc526fae-4ba0-4e80-bc90-ad721e5850bf",
 						NetNs:             "bc526fae-4ba0-4e80-bc90-ad721e5850bf",
 						HostSubnetPrefix:  "<nil>",
-						Options:           map[string]interface{}{},
+						// non-infra NICs carry nil options (see createEpInfo); matches Linux test
+						Options:           nil,
 						// matches with cns ip configuration
 						IPAddresses: []net.IPNet{
 							{

--- a/cns/networkcontainers/networkcontainers_windows.go
+++ b/cns/networkcontainers/networkcontainers_windows.go
@@ -90,9 +90,7 @@ func setWeakHostOnInterface(ipAddress, ncID string) error {
 	}
 
 	if targetIface == nil {
-		// Error is returned to the caller; no separate log needed here.
-		errval := "[Azerrvalure CNS] Was not able to find the interface with ip " + ipAddress + " to enable weak host send/receive"
-		return errors.New(errval)
+		return errors.New("interface with ip " + ipAddress + " not found to enable weak host send/receive")
 	}
 
 	ethIndexString := strconv.Itoa(targetIface.Index)

--- a/cns/networkcontainers/networkcontainers_windows.go
+++ b/cns/networkcontainers/networkcontainers_windows.go
@@ -90,8 +90,8 @@ func setWeakHostOnInterface(ipAddress, ncID string) error {
 	}
 
 	if targetIface == nil {
+		// Error is returned to the caller; no separate log needed here.
 		errval := "[Azerrvalure CNS] Was not able to find the interface with ip " + ipAddress + " to enable weak host send/receive"
-		logger.Printf(errval)
 		return errors.New(errval)
 	}
 


### PR DESCRIPTION
## Problem

The **Windows** Unit Tests job has been red on `master` since the Go 1.26 / dependency bump (green at 2026-08-03 07:03, failing every run since ~21:10, e.g. run `30885362996`). Two independent failures:

1. `cns/networkcontainers/networkcontainers_windows.go:94` — Go 1.26 `vet` rejects the non-constant format string in `logger.Printf(errval)`, so `go test ./cns/...` fails to build that package.
2. `cni/network` `TestPluginWindowsAdd/Add_Happy_Path_Swiftv2` — asserts the non-infra (Frontend) NIC's `Options` is an empty map, but the actual value is `nil`.

Both reproduce on a clean `master` checkout. This blocks every PR's Windows job.

## Fixes

1. **Drop the redundant `logger.Printf`.** The error is already returned to the caller, so no log is lost. This also avoids re-formatting a call on the deprecated global logger (which would trip `SA1019`).
2. **Expect `nil` options for the non-infra NIC on Windows.** `createEpInfo` deliberately leaves options `nil` for non-infra NICs (documented in its comment; `shallowCopyIpamAddConfigOptions` only runs for InfraNIC/legacy). The **Linux** equivalent test already expects `Options: nil` for the Frontend NIC — this aligns the Windows test with Linux and with the code. The infra NIC still expects `{}` (matches `shallowCopy`).

## Verification

- `GOOS=windows go test -vet=printf ./cns/networkcontainers/` — no longer build-fails.
- `GOOS=windows` test binary for `./cni/network/` compiles; only the `Options` assertion (the one field the CI diff flagged) changed.
- Windows tests can't execute on the Linux dev host, so CI validates the runtime assertion.