### PR TITLE
[Backport release/v1.7] ci: skip global system pod precheck in k8s e2e

### DIFF
--- a/.pipelines/cni/k8s-e2e/k8s-e2e-step-template.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e-step-template.yaml
@@ -39,10 +39,12 @@ steps:
       # flakeAttempts -> flake-attempts
       # dryRun -> dry-run
 
+      # AKS-managed kube-system pods outside this pipeline must not gate CNI tests.
       ./ginkgo --nodes=${{ parameters.processes }} \
       ./e2e.test -- \
       --num-nodes=2 \
       --provider=skeleton \
+      --minStartupPods=-1 \
       --ginkgo.focus='${{ parameters.ginkgoFocus }}' \
       --ginkgo.skip="${{ parameters.ginkgoSkip }}$SKIP" \
       --ginkgo.flakeAttempts=${{ parameters.attempts }} \

--- a/.pipelines/cni/k8s-e2e/k8s-e2e.steps.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e.steps.yaml
@@ -39,10 +39,12 @@ steps:
       # flakeAttempts -> flake-attempts
       # dryRun -> dry-run
 
+      # AKS-managed kube-system pods outside this pipeline must not gate CNI tests.
       ./ginkgo --nodes=${{ parameters.processes }} \
       ./e2e.test -- \
       --num-nodes=2 \
       --provider=skeleton \
+      --minStartupPods=-1 \
       --ginkgo.focus='${{ parameters.ginkgoFocus }}' \
       --ginkgo.skip="${{ parameters.ginkgoSkip }}$SKIP" \
       --ginkgo.flakeAttempts=${{ parameters.attempts }} \


### PR DESCRIPTION
## Backport\n\nBackport of #4559 to `release/v1.7`.\n\nCherry-picked from `ed136262afb681c8779c73fba7668aa8c24c3434`.