### PR TITLE
[Backport release/v1.6] test: cap linux arm64 image builds at 2 in parallel

### DIFF
--- a/.pipelines/pipeline.yaml
+++ b/.pipelines/pipeline.yaml
@@ -162,6 +162,7 @@ stages:
           pool:
             name: "$(BUILD_POOL_NAME_LINUX_ARM64)"
           strategy:
+            maxParallel: 2
             matrix:
               azure_ipam_linux_arm64:
                 arch: arm64


### PR DESCRIPTION
## Backport

Backport of #4532 to `release/v1.6`.

Cherry-picked from `e0ae571e53a1d2cb6fb108b4350d9f2d8baa660b`, adapted to the release branch pipeline layout.