### PR TITLE
[Backport release/v1.7] fix(test): retry transient state observations

### DIFF
--- a/test/validate/validate.go
+++ b/test/validate/validate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log"
+	"time"
 
 	acnk8s "github.com/Azure/azure-container-networking/test/internal/kubernetes"
 	"github.com/pkg/errors"
@@ -38,6 +39,8 @@ const (
 	privilegedNamespace      = "kube-system"
 	IPv4ExpectedIPCount      = 1
 	DualstackExpectedIPCount = 2
+	stateValidationAttempts  = 3
+	stateValidationInterval  = 2 * time.Second
 )
 
 type Validator struct {
@@ -131,38 +134,84 @@ func (v *Validator) validateIPs(ctx context.Context, stateFileIps stateFileIpsFu
 	}
 
 	for index := range nodes.Items {
-		// get the privileged pod
-		pod, err := acnk8s.GetPodsByNode(ctx, v.clientset, namespace, labelSelector, nodes.Items[index].Name)
-		if err != nil {
-			return errors.Wrapf(err, "failed to get privileged pod")
-		}
-		if len(pod.Items) == 0 {
-			return errors.Errorf("there are no privileged pods on node - %v", nodes.Items[index].Name)
-		}
-		podName := pod.Items[0].Name
-		// exec into the pod to get the state file
-		log.Printf("Executing command %s on pod %s, container %s", cmd, podName, containerName)
-		result, _, err := acnk8s.ExecCmdOnPod(ctx, v.clientset, namespace, podName, containerName, cmd, v.config, true)
-		if err != nil {
-			return errors.Wrapf(err, "failed to exec into privileged pod - %s", podName)
-		}
-		filePodIps, err := stateFileIps(result)
-		if err != nil {
-			return errors.Wrapf(err, "failed to get pod ips from state file on node %v", nodes.Items[index].Name)
-		}
-		if len(filePodIps) == 0 && v.restartCase {
-			log.Printf("No pods found on node %s", nodes.Items[index].Name)
-			continue
-		}
-		// get the pod ips
-		podIps := getPodIPsWithoutNodeIP(ctx, v.clientset, nodes.Items[index])
+		node := nodes.Items[index]
+		var comparisonErr error
+		_, converged, validationErr := runValidationAttempts(ctx, stateValidationAttempts, stateValidationInterval, func() (bool, error) {
+			pod, err := acnk8s.GetPodsByNode(ctx, v.clientset, namespace, labelSelector, node.Name)
+			if err != nil {
+				return false, errors.Wrap(err, "failed to get privileged pod")
+			}
+			if len(pod.Items) == 0 {
+				return false, errors.Errorf("there are no privileged pods on node - %v", node.Name)
+			}
+			podName := pod.Items[0].Name
+			log.Printf("Executing command %s on pod %s, container %s", cmd, podName, containerName)
+			result, _, err := acnk8s.ExecCmdOnPod(ctx, v.clientset, namespace, podName, containerName, cmd, v.config, true)
+			if err != nil {
+				return false, errors.Wrapf(err, "failed to exec into privileged pod - %s", podName)
+			}
+			filePodIps, err := stateFileIps(result)
+			if err != nil {
+				return false, errors.Wrapf(err, "failed to get pod ips from state file on node %v", node.Name)
+			}
+			if len(filePodIps) == 0 && v.restartCase {
+				log.Printf("No pods found on node %s", node.Name)
+				return true, nil
+			}
 
-		if err := compareIPs(filePodIps, podIps); err != nil {
-			return errors.Wrapf(err, "State file validation failed for %s on node %s", checkType, nodes.Items[index].Name)
+			podIps := getPodIPsWithoutNodeIP(ctx, v.clientset, node)
+			comparisonErr = compareIPs(filePodIps, podIps)
+			return comparisonErr == nil, nil
+		})
+		if validationErr != nil {
+			return validationErr
+		}
+		if !converged {
+			return errors.Wrapf(comparisonErr, "State file validation failed for %s on node %s", checkType, node.Name)
 		}
 	}
 	log.Printf("State file validation for %s passed", checkType)
 	return nil
+}
+
+func runValidationAttempts(
+	ctx context.Context,
+	maxAttempts int,
+	interval time.Duration,
+	validate func() (bool, error),
+) (attempts int, converged bool, validationErr error) {
+	if maxAttempts < 1 {
+		return 0, false, errors.New("validation attempts must be positive")
+	}
+
+	var lastErr error
+	for attempts = 1; ; attempts++ {
+		converged, validationErr = validate()
+		if converged {
+			if validationErr != nil {
+				return attempts, false, validationErr
+			}
+			return attempts, true, nil
+		}
+		lastErr = validationErr
+		if attempts >= maxAttempts {
+			return attempts, false, lastErr
+		}
+		if err := ctx.Err(); err != nil {
+			return attempts, false, errors.Wrap(err, "waiting to retry state validation")
+		}
+		if interval <= 0 {
+			continue
+		}
+
+		timer := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return attempts, false, errors.Wrap(ctx.Err(), "waiting to retry state validation")
+		case <-timer.C:
+		}
+	}
 }
 
 func validateNodeProperties(nodes *corev1.NodeList, labels map[string]string, expectedIPCount int) error {

--- a/test/validate/validate_retry_test.go
+++ b/test/validate/validate_retry_test.go
@@ -1,0 +1,139 @@
+package validate
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	errFirstObservation     = errors.New("first observation failed")
+	errLastObservation      = errors.New("last observation failed")
+	errTransientObservation = errors.New("transient observation failure")
+)
+
+func TestRunValidationAttempts(t *testing.T) {
+	tests := []struct {
+		name          string
+		results       []bool
+		errs          []error
+		wantAttempts  int
+		wantConverged bool
+		wantErr       error
+	}{
+		{
+			name:          "first observation converges",
+			results:       []bool{true},
+			errs:          []error{nil},
+			wantAttempts:  1,
+			wantConverged: true,
+		},
+		{
+			name:          "transient observation failure",
+			results:       []bool{false, true},
+			errs:          []error{errFirstObservation, nil},
+			wantAttempts:  2,
+			wantConverged: true,
+		},
+		{
+			name:          "transient mismatch",
+			results:       []bool{false, true},
+			errs:          []error{nil, nil},
+			wantAttempts:  2,
+			wantConverged: true,
+		},
+		{
+			name:         "returns latest exhausted error",
+			results:      []bool{false, false},
+			errs:         []error{errFirstObservation, errLastObservation},
+			wantAttempts: 2,
+			wantErr:      errLastObservation,
+		},
+		{
+			name:         "convergence does not hide error",
+			results:      []bool{true},
+			errs:         []error{errLastObservation},
+			wantAttempts: 1,
+			wantErr:      errLastObservation,
+		},
+		{
+			name:         "exhausted mismatch",
+			results:      []bool{false, false},
+			errs:         []error{nil, nil},
+			wantAttempts: 2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			call := 0
+			attempts, converged, err := runValidationAttempts(t.Context(), len(test.results), 0, func() (bool, error) {
+				result := test.results[call]
+				err := test.errs[call]
+				call++
+				return result, err
+			})
+			require.ErrorIs(t, err, test.wantErr)
+			require.Equal(t, test.wantAttempts, attempts)
+			require.Equal(t, test.wantConverged, converged)
+			require.Equal(t, test.wantAttempts, call)
+		})
+	}
+}
+
+func TestRunValidationAttemptsCanceled(t *testing.T) {
+	tests := []struct {
+		name     string
+		interval time.Duration
+	}{
+		{
+			name:     "during delayed retry",
+			interval: time.Hour,
+		},
+		{
+			name: "without retry delay",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			cancel()
+
+			attempts, converged, err := runValidationAttempts(ctx, 2, test.interval, func() (bool, error) {
+				return false, errTransientObservation
+			})
+			require.ErrorIs(t, err, context.Canceled)
+			require.Equal(t, 1, attempts)
+			require.False(t, converged)
+		})
+	}
+}
+
+func TestRunValidationAttemptsCanceledWhileWaiting(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
+	defer cancel()
+
+	call := 0
+	attempts, converged, err := runValidationAttempts(ctx, 2, time.Hour, func() (bool, error) {
+		call++
+		return false, errTransientObservation
+	})
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Equal(t, 1, attempts)
+	require.False(t, converged)
+	require.Equal(t, 1, call)
+}
+
+func TestRunValidationAttemptsRejectsInvalidAttemptCount(t *testing.T) {
+	attempts, converged, err := runValidationAttempts(t.Context(), 0, 0, func() (bool, error) {
+		t.Fatal("validation callback must not run")
+		return false, nil
+	})
+	require.EqualError(t, err, "validation attempts must be positive")
+	require.Zero(t, attempts)
+	require.False(t, converged)
+}


### PR DESCRIPTION
## Backport

Backport of #4553 to `release/v1.7`.

Cherry-picked from `0e5ed246fc81e8f8ae137621216a1a2249f979fd`, adapted to the release branch validation logic.