### PR TITLE
fix: [NPM] compile multi-value namespaceSelector NotIn as a single conjunction

### DIFF
--- a/npm/pkg/controlplane/translation/parseSelector.go
+++ b/npm/pkg/controlplane/translation/parseSelector.go
@@ -82,12 +82,20 @@ func flattenNameSpaceSelector(nsSelector *metav1.LabelSelector) ([]metav1.LabelS
 	}
 
 	multiValuePresent := false
+	// notInExpanded records whether a multi-value NotIn was rewritten into several
+	// single-value NotIn requirements on baseSelector. When it is, baseSelector no
+	// longer equals the input, so the original selector must not be returned as-is.
+	notInExpanded := false
 	multiValueMatchExprs := []metav1.LabelSelectorRequirement{}
 	for _, req := range nsSelector.MatchExpressions {
-		// Only In and NotIn operators of matchExprs have multiple values.
-		// NPM will ignore single value matchExprs of these operators.
+		// In/NotIn requirements carry the values; single-value requirements are added to
+		// baseSelector as-is, while multi-value requirements are handled per operator below.
+		// Exists/DoesNotExist carry no values and are added to baseSelector directly.
 		switch {
 		case req.Operator == metav1.LabelSelectorOpIn:
+			if len(req.Values) == 0 {
+				return nil, ErrEmptyMatchExpressionValues
+			}
 			for _, v := range req.Values {
 				if !isValidLabelValue(v) {
 					return nil, ErrInvalidMatchExpressionValues
@@ -104,6 +112,9 @@ func flattenNameSpaceSelector(nsSelector *metav1.LabelSelector) ([]metav1.LabelS
 				multiValueMatchExprs = append(multiValueMatchExprs, req)
 			}
 		case req.Operator == metav1.LabelSelectorOpNotIn:
+			if len(req.Values) == 0 {
+				return nil, ErrEmptyMatchExpressionValues
+			}
 			for _, v := range req.Values {
 				if !isValidLabelValue(v) {
 					return nil, ErrInvalidMatchExpressionValues
@@ -121,6 +132,7 @@ func flattenNameSpaceSelector(nsSelector *metav1.LabelSelector) ([]metav1.LabelS
 				// the rule negating another value. Keep every value as its own
 				// single-value NotIn within the same selector so all negations
 				// stay in one decision (AND).
+				notInExpanded = true
 				for _, v := range req.Values {
 					baseSelector.MatchExpressions = append(
 						baseSelector.MatchExpressions,
@@ -143,9 +155,9 @@ func flattenNameSpaceSelector(nsSelector *metav1.LabelSelector) ([]metav1.LabelS
 	// If there are no multiValue In match expressions to fan out, the baseSelector
 	// (which already carries any conjunctive NotIn expansions) is the only selector.
 	if !multiValuePresent {
-		// Preserve the original selector when nothing was rewritten so callers that
-		// compare against the input see an identical selector.
-		if len(baseSelector.MatchExpressions) == len(nsSelector.MatchExpressions) {
+		if !notInExpanded {
+			// Nothing was rewritten; return the original selector unchanged so callers
+			// that compare against the input see an identical selector.
 			return []metav1.LabelSelector{*nsSelector}, nil
 		}
 		return []metav1.LabelSelector{*baseSelector.DeepCopy()}, nil

--- a/npm/pkg/controlplane/translation/parseSelector.go
+++ b/npm/pkg/controlplane/translation/parseSelector.go
@@ -2,7 +2,6 @@ package translation
 
 import (
 	"fmt"
-
 	"regexp"
 
 	"github.com/Azure/azure-container-networking/log"
@@ -20,34 +19,47 @@ var validLabelRegex = regexp.MustCompile("(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0
 // into multiple label selectors helping with the OR condition.
 func flattenNameSpaceSelector(nsSelector *metav1.LabelSelector) ([]metav1.LabelSelector, error) {
 	/*
-			This function helps to create multiple labelSelectors when given a single multivalue nsSelector
-			Take below example: this nsSelector has 2 values in a matchSelector.
+			This function helps to create multiple labelSelectors when given a single multivalue nsSelector.
+
+			The two multi-value operators are handled differently because they carry different semantics:
+
+			In: a multi-value In is a disjunction (OR) over its values, so it is fanned out into one
+			labelSelector per value. Take below example with 2 values in a matchExpression:
 			- namespaceSelector:
 		        matchExpressions:
 		        - key: ns
-		          operator: NotIn
+		          operator: In
 		          values:
 		          - netpol-x
 		          - netpol-y
 
-			goal is to convert this single nsSelector into multiple nsSelectors to preserve OR condition
-			between multiple values of the matchExpr i.e. this function will return
+			becomes
 
 			- namespaceSelector:
 		        matchExpressions:
 		        - key: ns
-		          operator: NotIn
+		          operator: In
 		          values:
 		          - netpol-x
 			- namespaceSelector:
 		        matchExpressions:
 		        - key: ns
-		          operator: NotIn
+		          operator: In
 		          values:
 		          - netpol-y
 
-			then, translate policy will replicate each of these nsSelectors to add two different rules in iptables,
-			resulting in OR condition between the values.
+			then, translate policy will replicate each of these nsSelectors to add two different rules,
+			resulting in the OR condition between the values.
+
+			NotIn: a multi-value NotIn is a single set-membership conjunction, i.e.
+			ns NotIn [x, y] means (ns != x AND ns != y). It must NOT be fanned out into separate
+			selectors, because each generated selector becomes an independent allow rule and allow
+			rules are additive (OR): a namespace carrying one excluded value would still match the
+			rule negating the other value and be admitted. Instead, every value is kept as its own
+			single-value NotIn requirement within the same selector, so all negated conditions land
+			in a single decision (AND) and the default drop stays effective for every excluded value.
+			When a selector mixes In and NotIn, each NotIn exclusion is carried conjunctively into
+			every In branch.
 
 			Check TestFlattenNameSpaceSelector 2nd subcase for complex scenario
 	*/
@@ -72,12 +84,10 @@ func flattenNameSpaceSelector(nsSelector *metav1.LabelSelector) ([]metav1.LabelS
 	multiValuePresent := false
 	multiValueMatchExprs := []metav1.LabelSelectorRequirement{}
 	for _, req := range nsSelector.MatchExpressions {
-		// Only In and NotIn operators of matchExprs have multiple values
+		// Only In and NotIn operators of matchExprs have multiple values.
 		// NPM will ignore single value matchExprs of these operators.
-		// for multiple values, it will create a slice of them to be used for Zipping with baseSelector
-		// to create multiple nsSelectors to preserve OR condition across all labels and expressions
 		switch {
-		case (req.Operator == metav1.LabelSelectorOpIn) || (req.Operator == metav1.LabelSelectorOpNotIn):
+		case req.Operator == metav1.LabelSelectorOpIn:
 			for _, v := range req.Values {
 				if !isValidLabelValue(v) {
 					return nil, ErrInvalidMatchExpressionValues
@@ -88,8 +98,39 @@ func flattenNameSpaceSelector(nsSelector *metav1.LabelSelector) ([]metav1.LabelS
 				// for length 1, add the matchExpr to baseSelector
 				baseSelector.MatchExpressions = append(baseSelector.MatchExpressions, req)
 			} else {
+				// multi-value In is a disjunction: zip it with baseSelector to
+				// create one nsSelector per value and preserve the OR condition.
 				multiValuePresent = true
 				multiValueMatchExprs = append(multiValueMatchExprs, req)
+			}
+		case req.Operator == metav1.LabelSelectorOpNotIn:
+			for _, v := range req.Values {
+				if !isValidLabelValue(v) {
+					return nil, ErrInvalidMatchExpressionValues
+				}
+			}
+
+			if len(req.Values) == 1 {
+				// for length 1, add the matchExpr to baseSelector
+				baseSelector.MatchExpressions = append(baseSelector.MatchExpressions, req)
+			} else {
+				// A multi-value NotIn is a single set-membership conjunction
+				// (key NotIn [a, b] == key != a AND key != b), NOT a disjunction.
+				// Fanning it out into separate selectors would emit independent
+				// additive allow rules and let each excluded value be admitted by
+				// the rule negating another value. Keep every value as its own
+				// single-value NotIn within the same selector so all negations
+				// stay in one decision (AND).
+				for _, v := range req.Values {
+					baseSelector.MatchExpressions = append(
+						baseSelector.MatchExpressions,
+						metav1.LabelSelectorRequirement{
+							Key:      req.Key,
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   []string{v},
+						},
+					)
+				}
 			}
 		case (req.Operator == metav1.LabelSelectorOpExists) || (req.Operator == metav1.LabelSelectorOpDoesNotExist):
 			// since Exists and NotExists do not contain any values, NPM can safely add them to the baseSelector
@@ -99,10 +140,15 @@ func flattenNameSpaceSelector(nsSelector *metav1.LabelSelector) ([]metav1.LabelS
 		}
 	}
 
-	// If there are no multiValue NS selector match expressions
-	// return the original NsSelector
+	// If there are no multiValue In match expressions to fan out, the baseSelector
+	// (which already carries any conjunctive NotIn expansions) is the only selector.
 	if !multiValuePresent {
-		return []metav1.LabelSelector{*nsSelector}, nil
+		// Preserve the original selector when nothing was rewritten so callers that
+		// compare against the input see an identical selector.
+		if len(baseSelector.MatchExpressions) == len(nsSelector.MatchExpressions) {
+			return []metav1.LabelSelector{*nsSelector}, nil
+		}
+		return []metav1.LabelSelector{*baseSelector.DeepCopy()}, nil
 	}
 
 	// Now use the baseSelector and loop over multiValueMatchExprs to create all

--- a/npm/pkg/controlplane/translation/parseSelector_test.go
+++ b/npm/pkg/controlplane/translation/parseSelector_test.go
@@ -683,6 +683,26 @@ func TestFlattenNameSpaceSelectorMixedInAndNotIn(t *testing.T) {
 	}
 }
 
+// TestFlattenNameSpaceSelectorEmptyValues verifies that In/NotIn requirements with
+// no values are rejected (fail closed) rather than silently dropped, which could
+// otherwise widen a selector or produce no rules at all.
+func TestFlattenNameSpaceSelectorEmptyValues(t *testing.T) {
+	for _, op := range []metav1.LabelSelectorOperator{metav1.LabelSelectorOpIn, metav1.LabelSelectorOpNotIn} {
+		selector := &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      "tenant",
+					Operator: op,
+					Values:   []string{},
+				},
+			},
+		}
+		s, err := flattenNameSpaceSelector(selector)
+		require.ErrorIs(t, err, ErrEmptyMatchExpressionValues, "operator %s", op)
+		require.Nil(t, s)
+	}
+}
+
 func TestIsValidLabel(t *testing.T) {
 	good := []string{
 		"",

--- a/npm/pkg/controlplane/translation/parseSelector_test.go
+++ b/npm/pkg/controlplane/translation/parseSelector_test.go
@@ -599,6 +599,90 @@ func TestFlattenNamespaceSelectorError(t *testing.T) {
 	}
 }
 
+// TestFlattenNameSpaceSelectorMultiValueNotIn verifies that a multi-value NotIn
+// requirement is preserved as a single conjunction rather than fanned out into
+// separate selectors. Separate selectors would become independent additive allow
+// rules, so a namespace carrying one excluded value could still match the rule
+// negating a different value.
+func TestFlattenNameSpaceSelectorMultiValueNotIn(t *testing.T) {
+	selector := &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      "tenant",
+				Operator: metav1.LabelSelectorOpNotIn,
+				Values:   []string{"x", "y"},
+			},
+		},
+	}
+
+	testSelectors, err := flattenNameSpaceSelector(selector)
+	require.NoError(t, err)
+
+	expected := []metav1.LabelSelector{
+		{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      "tenant",
+					Operator: metav1.LabelSelectorOpNotIn,
+					Values:   []string{"x"},
+				},
+				{
+					Key:      "tenant",
+					Operator: metav1.LabelSelectorOpNotIn,
+					Values:   []string{"y"},
+				},
+			},
+		},
+	}
+
+	require.Equal(t, expected, testSelectors)
+}
+
+// TestFlattenNameSpaceSelectorMixedInAndNotIn verifies that multi-value In values
+// fan out into disjunctive branches while every multi-value NotIn exclusion is
+// carried conjunctively into each branch.
+func TestFlattenNameSpaceSelectorMixedInAndNotIn(t *testing.T) {
+	selector := &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      "tenant",
+				Operator: metav1.LabelSelectorOpNotIn,
+				Values:   []string{"x", "y"},
+			},
+			{
+				Key:      "role",
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"a", "b"},
+			},
+		},
+	}
+
+	testSelectors, err := flattenNameSpaceSelector(selector)
+	require.NoError(t, err)
+
+	// Two In branches, each carrying both NotIn exclusions conjunctively.
+	require.Len(t, testSelectors, 2)
+	for _, s := range testSelectors {
+		var notInValues []string
+		var inValues []string
+		for _, req := range s.MatchExpressions {
+			require.Len(t, req.Values, 1, "every requirement must be single-value after flatten")
+			switch req.Operator {
+			case metav1.LabelSelectorOpNotIn:
+				require.Equal(t, "tenant", req.Key)
+				notInValues = append(notInValues, req.Values[0])
+			case metav1.LabelSelectorOpIn:
+				require.Equal(t, "role", req.Key)
+				inValues = append(inValues, req.Values[0])
+			default:
+				t.Fatalf("unexpected operator %s", req.Operator)
+			}
+		}
+		require.ElementsMatch(t, []string{"x", "y"}, notInValues, "both exclusions must be present in every branch")
+		require.Len(t, inValues, 1)
+	}
+}
+
 func TestIsValidLabel(t *testing.T) {
 	good := []string{
 		"",

--- a/npm/pkg/controlplane/translation/translatePolicy.go
+++ b/npm/pkg/controlplane/translation/translatePolicy.go
@@ -32,6 +32,10 @@ var (
 	ErrInvalidMatchExpressionValues = errors.New(
 		"matchExpression label values must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character",
 	)
+	// ErrEmptyMatchExpressionValues is returned when an In or NotIn matchExpression carries no values.
+	// Kubernetes rejects such requirements; NPM fails closed rather than dropping the requirement,
+	// which could otherwise widen a selector (e.g. a dropped NotIn) or yield no rules at all.
+	ErrEmptyMatchExpressionValues = errors.New("In and NotIn matchExpression requirements must have at least one value")
 	// ErrUnsupportedIPAddress is returned when an unsupported IP address, such as IPV6, is used
 	ErrUnsupportedIPAddress = errors.New("unsupported IP address")
 	// ErrUnsupportedNonCIDR is returned when non-CIDR blocks are passed in with NPM Lite enabled. NPM Lite allows deny-all and allow-all policies

--- a/npm/pkg/controlplane/translation/translatePolicy_test.go
+++ b/npm/pkg/controlplane/translation/translatePolicy_test.go
@@ -1263,6 +1263,37 @@ func TestNameSpaceSelector(t *testing.T) {
 	}
 }
 
+// TestNameSpaceSelectorMultiValueNotIn verifies that a namespaceSelector with a
+// single multi-value NotIn requirement is translated (after flatten, as translateRule
+// does) into one decision carrying a negated match-set for every excluded value.
+// Emitting these as separate allow rules would be additive (OR) and admit a namespace
+// that carries any one of the excluded values.
+func TestNameSpaceSelectorMultiValueNotIn(t *testing.T) {
+	matchType := policies.SrcMatch
+	selector := &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      "tenant",
+				Operator: metav1.LabelSelectorOpNotIn,
+				Values:   []string{"x", "y"},
+			},
+		},
+	}
+
+	flattened, err := flattenNameSpaceSelector(selector)
+	require.NoError(t, err)
+	// The NotIn conjunction must stay in a single selector, not fan out.
+	require.Len(t, flattened, 1)
+
+	_, nsSelectorList := nameSpaceSelector(matchType, &flattened[0])
+
+	expected := []policies.SetInfo{
+		policies.NewSetInfo("tenant:x", ipsets.KeyValueLabelOfNamespace, nonIncluded, matchType),
+		policies.NewSetInfo("tenant:y", ipsets.KeyValueLabelOfNamespace, nonIncluded, matchType),
+	}
+	require.Equal(t, expected, nsSelectorList)
+}
+
 func TestAllowAllInternal(t *testing.T) {
 	matchType := policies.SrcMatch
 	tests := []struct {

--- a/npm/pkg/controlplane/translation/translatePolicy_test.go
+++ b/npm/pkg/controlplane/translation/translatePolicy_test.go
@@ -1295,8 +1295,9 @@ func TestNameSpaceSelectorMultiValueNotIn(t *testing.T) {
 }
 
 // nsNotInPolicy builds a NetworkPolicy that selects all local pods and, for the given
-// direction, admits peers whose namespace matches `key NotIn values`.
-func nsNotInPolicy(name, ns, key string, direction networkingv1.PolicyType, values ...string) *networkingv1.NetworkPolicy {
+// direction, admits peers whose namespace matches `key NotIn values`. When ports is
+// non-empty, the peer rule also carries those ports.
+func nsNotInPolicy(name, ns, key string, direction networkingv1.PolicyType, ports []networkingv1.NetworkPolicyPort, values ...string) *networkingv1.NetworkPolicy {
 	peer := networkingv1.NetworkPolicyPeer{
 		NamespaceSelector: &metav1.LabelSelector{
 			MatchExpressions: []metav1.LabelSelectorRequirement{
@@ -1312,25 +1313,30 @@ func nsNotInPolicy(name, ns, key string, direction networkingv1.PolicyType, valu
 		},
 	}
 	if direction == networkingv1.PolicyTypeIngress {
-		pol.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{{From: []networkingv1.NetworkPolicyPeer{peer}}}
+		pol.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{{Ports: ports, From: []networkingv1.NetworkPolicyPeer{peer}}}
 	} else {
-		pol.Spec.Egress = []networkingv1.NetworkPolicyEgressRule{{To: []networkingv1.NetworkPolicyPeer{peer}}}
+		pol.Spec.Egress = []networkingv1.NetworkPolicyEgressRule{{Ports: ports, To: []networkingv1.NetworkPolicyPeer{peer}}}
 	}
 	return pol
 }
 
 // TestTranslatePolicyMultiValueNotInConjunction is the end-to-end regression for a
 // multi-value namespaceSelector NotIn. It drives the full TranslatePolicy path (both
-// directions) and asserts every excluded value is negated within a SINGLE allow ACL
-// (a conjunction / AND). The pre-fix behavior emitted one additive allow ACL per value,
+// directions, with and without a port) and asserts the complete enforcement invariant:
+// exactly ONE allow ACL exists, it negates every excluded value within that single
+// decision (a conjunction / AND) and references no positive tenant set, and a default
+// drop is still present. The pre-fix behavior emitted one additive allow ACL per value,
 // so a namespace carrying any one excluded value matched the ACL negating another value
 // and was admitted before the default drop.
 func TestTranslatePolicyMultiValueNotInConjunction(t *testing.T) {
 	t.Parallel()
 
+	tcpPort := networkingv1.NetworkPolicyPort{Port: &intstr.IntOrString{Type: intstr.Int, IntVal: 80}}
+
 	tests := []struct {
 		name      string
 		direction networkingv1.PolicyType
+		ports     []networkingv1.NetworkPolicyPort
 		peerList  func(*policies.ACLPolicy) []policies.SetInfo
 	}{
 		{
@@ -1343,6 +1349,12 @@ func TestTranslatePolicyMultiValueNotInConjunction(t *testing.T) {
 			direction: networkingv1.PolicyTypeEgress,
 			peerList:  func(acl *policies.ACLPolicy) []policies.SetInfo { return acl.DstList },
 		},
+		{
+			name:      "ingress-with-port",
+			direction: networkingv1.PolicyTypeIngress,
+			ports:     []networkingv1.NetworkPolicyPort{tcpPort},
+			peerList:  func(acl *policies.ACLPolicy) []policies.SetInfo { return acl.SrcList },
+		},
 	}
 
 	for _, tt := range tests {
@@ -1350,40 +1362,50 @@ func TestTranslatePolicyMultiValueNotInConjunction(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			pol := nsNotInPolicy("victim", "default", "tenant", tt.direction, "attacker", "quarantine")
+			pol := nsNotInPolicy("victim", "default", "tenant", tt.direction, tt.ports, "attacker", "quarantine")
 			npmNetPol, err := TranslatePolicy(pol, false)
 			require.NoError(t, err)
 
-			// Collect every allow ACL that references either excluded tenant set.
 			excluded := map[string]bool{"tenant:attacker": true, "tenant:quarantine": true}
-			var allowACLsTouchingTenant int
-			var negatedTenantValues []string
+			var allowACLs, dropACLs int
+			var theAllow *policies.ACLPolicy
 			for i := range npmNetPol.ACLs {
 				acl := npmNetPol.ACLs[i]
-				if acl.Target != policies.Allowed {
-					continue
-				}
-				references := false
-				for _, si := range tt.peerList(acl) {
-					if excluded[si.IPSet.Name] {
-						references = true
-						// Excluded values must be a negative (Included == false) match.
-						require.False(t, si.Included,
-							"tenant set %s must be a negated match, not a positive allow", si.IPSet.Name)
-						negatedTenantValues = append(negatedTenantValues, si.IPSet.Name)
-					}
-				}
-				if references {
-					allowACLsTouchingTenant++
+				switch acl.Target {
+				case policies.Allowed:
+					allowACLs++
+					theAllow = npmNetPol.ACLs[i]
+				case policies.Dropped:
+					dropACLs++
 				}
 			}
 
-			// The fix: exactly ONE allow ACL, carrying BOTH negations together (AND).
-			// Two separate allow ACLs here would be the additive (OR) bypass.
-			require.Equal(t, 1, allowACLsTouchingTenant,
-				"excluded values must share a single allow decision, not additive allow ACLs")
-			require.ElementsMatch(t, []string{"tenant:attacker", "tenant:quarantine"}, negatedTenantValues,
+			// Full enforcement invariant: exactly one allow decision and a default drop.
+			// An additive-OR bypass would yield two allow ACLs; a missing drop or an
+			// allow-all leaking in would also be caught here.
+			require.Equal(t, 1, allowACLs, "there must be exactly one allow ACL, not additive allow ACLs")
+			require.GreaterOrEqual(t, dropACLs, 1, "the default drop must still be present")
+			require.NotNil(t, theAllow)
+
+			// The single allow ACL must negate BOTH excluded values (AND) and reference
+			// no positive tenant set.
+			var negated []string
+			for _, si := range tt.peerList(theAllow) {
+				if excluded[si.IPSet.Name] {
+					require.False(t, si.Included,
+						"tenant set %s must be a negated match, not a positive allow", si.IPSet.Name)
+					negated = append(negated, si.IPSet.Name)
+				}
+			}
+			require.ElementsMatch(t, []string{"tenant:attacker", "tenant:quarantine"}, negated,
 				"the single allow ACL must negate every excluded value")
+
+			// When a port is present it must be carried in the same allow decision,
+			// conjunctively with the negated tenant sets.
+			if len(tt.ports) > 0 {
+				require.EqualValues(t, 80, theAllow.DstPorts.Port,
+					"the port must render in the same allow ACL as the negated tenant sets")
+			}
 		})
 	}
 }

--- a/npm/pkg/controlplane/translation/translatePolicy_test.go
+++ b/npm/pkg/controlplane/translation/translatePolicy_test.go
@@ -1294,6 +1294,100 @@ func TestNameSpaceSelectorMultiValueNotIn(t *testing.T) {
 	require.Equal(t, expected, nsSelectorList)
 }
 
+// nsNotInPolicy builds a NetworkPolicy that selects all local pods and, for the given
+// direction, admits peers whose namespace matches `key NotIn values`.
+func nsNotInPolicy(name, ns, key string, direction networkingv1.PolicyType, values ...string) *networkingv1.NetworkPolicy {
+	peer := networkingv1.NetworkPolicyPeer{
+		NamespaceSelector: &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: key, Operator: metav1.LabelSelectorOpNotIn, Values: values},
+			},
+		},
+	}
+	pol := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			PolicyTypes: []networkingv1.PolicyType{direction},
+		},
+	}
+	if direction == networkingv1.PolicyTypeIngress {
+		pol.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{{From: []networkingv1.NetworkPolicyPeer{peer}}}
+	} else {
+		pol.Spec.Egress = []networkingv1.NetworkPolicyEgressRule{{To: []networkingv1.NetworkPolicyPeer{peer}}}
+	}
+	return pol
+}
+
+// TestTranslatePolicyMultiValueNotInConjunction is the end-to-end regression for a
+// multi-value namespaceSelector NotIn. It drives the full TranslatePolicy path (both
+// directions) and asserts every excluded value is negated within a SINGLE allow ACL
+// (a conjunction / AND). The pre-fix behavior emitted one additive allow ACL per value,
+// so a namespace carrying any one excluded value matched the ACL negating another value
+// and was admitted before the default drop.
+func TestTranslatePolicyMultiValueNotInConjunction(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		direction networkingv1.PolicyType
+		peerList  func(*policies.ACLPolicy) []policies.SetInfo
+	}{
+		{
+			name:      "ingress",
+			direction: networkingv1.PolicyTypeIngress,
+			peerList:  func(acl *policies.ACLPolicy) []policies.SetInfo { return acl.SrcList },
+		},
+		{
+			name:      "egress",
+			direction: networkingv1.PolicyTypeEgress,
+			peerList:  func(acl *policies.ACLPolicy) []policies.SetInfo { return acl.DstList },
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pol := nsNotInPolicy("victim", "default", "tenant", tt.direction, "attacker", "quarantine")
+			npmNetPol, err := TranslatePolicy(pol, false)
+			require.NoError(t, err)
+
+			// Collect every allow ACL that references either excluded tenant set.
+			excluded := map[string]bool{"tenant:attacker": true, "tenant:quarantine": true}
+			var allowACLsTouchingTenant int
+			var negatedTenantValues []string
+			for i := range npmNetPol.ACLs {
+				acl := npmNetPol.ACLs[i]
+				if acl.Target != policies.Allowed {
+					continue
+				}
+				references := false
+				for _, si := range tt.peerList(acl) {
+					if excluded[si.IPSet.Name] {
+						references = true
+						// Excluded values must be a negative (Included == false) match.
+						require.False(t, si.Included,
+							"tenant set %s must be a negated match, not a positive allow", si.IPSet.Name)
+						negatedTenantValues = append(negatedTenantValues, si.IPSet.Name)
+					}
+				}
+				if references {
+					allowACLsTouchingTenant++
+				}
+			}
+
+			// The fix: exactly ONE allow ACL, carrying BOTH negations together (AND).
+			// Two separate allow ACLs here would be the additive (OR) bypass.
+			require.Equal(t, 1, allowACLsTouchingTenant,
+				"excluded values must share a single allow decision, not additive allow ACLs")
+			require.ElementsMatch(t, []string{"tenant:attacker", "tenant:quarantine"}, negatedTenantValues,
+				"the single allow ACL must negate every excluded value")
+		})
+	}
+}
+
 func TestAllowAllInternal(t *testing.T) {
 	matchType := policies.SrcMatch
 	tests := []struct {

--- a/npm/pkg/controlplane/translation/translatePolicy_test.go
+++ b/npm/pkg/controlplane/translation/translatePolicy_test.go
@@ -1294,6 +1294,35 @@ func TestNameSpaceSelectorMultiValueNotIn(t *testing.T) {
 	require.Equal(t, expected, nsSelectorList)
 }
 
+// TestNameSpaceSelectorMatchLabelsAndMultiValueNotIn covers a namespaceSelector that
+// combines matchLabels with a multi-value NotIn matchExpression. The matchLabels set
+// must be ANDed into the same decision as the two negated values (a positive match plus
+// two negated matches in one ACL), matching Kubernetes' conjunction of all requirements.
+func TestNameSpaceSelectorMatchLabelsAndMultiValueNotIn(t *testing.T) {
+	matchType := policies.SrcMatch
+	selector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{"team": "blue"},
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{Key: "tenant", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"x", "y"}},
+		},
+	}
+
+	flattened, err := flattenNameSpaceSelector(selector)
+	require.NoError(t, err)
+	// matchLabels + a single conjunctive NotIn must stay in ONE selector, not fan out.
+	require.Len(t, flattened, 1)
+
+	_, nsSelectorList := nameSpaceSelector(matchType, &flattened[0])
+
+	expected := []policies.SetInfo{
+		policies.NewSetInfo("team:blue", ipsets.KeyValueLabelOfNamespace, included, matchType),
+		policies.NewSetInfo("tenant:x", ipsets.KeyValueLabelOfNamespace, nonIncluded, matchType),
+		policies.NewSetInfo("tenant:y", ipsets.KeyValueLabelOfNamespace, nonIncluded, matchType),
+	}
+	require.ElementsMatch(t, expected, nsSelectorList,
+		"matchLabels set must be ANDed with both negated tenant sets in one decision")
+}
+
 // nsNotInPolicy builds a NetworkPolicy that selects all local pods and, for the given
 // direction, admits peers whose namespace matches `key NotIn values`. When ports is
 // non-empty, the peer rule also carries those ports.
@@ -1368,7 +1397,7 @@ func TestTranslatePolicyMultiValueNotInConjunction(t *testing.T) {
 
 			excluded := map[string]bool{"tenant:attacker": true, "tenant:quarantine": true}
 			var allowACLs, dropACLs int
-			var theAllow *policies.ACLPolicy
+			var theAllow, theDrop *policies.ACLPolicy
 			for i := range npmNetPol.ACLs {
 				acl := npmNetPol.ACLs[i]
 				switch acl.Target {
@@ -1377,28 +1406,37 @@ func TestTranslatePolicyMultiValueNotInConjunction(t *testing.T) {
 					theAllow = npmNetPol.ACLs[i]
 				case policies.Dropped:
 					dropACLs++
+					theDrop = npmNetPol.ACLs[i]
 				}
 			}
 
-			// Full enforcement invariant: exactly one allow decision and a default drop.
-			// An additive-OR bypass would yield two allow ACLs; a missing drop or an
-			// allow-all leaking in would also be caught here.
+			// Full enforcement invariant: exactly one allow decision and exactly one
+			// default drop. An additive-OR bypass would yield two allow ACLs; a missing
+			// drop or an allow-all leaking in would also be caught here.
 			require.Equal(t, 1, allowACLs, "there must be exactly one allow ACL, not additive allow ACLs")
-			require.GreaterOrEqual(t, dropACLs, 1, "the default drop must still be present")
+			require.Equal(t, 1, dropACLs, "there must be exactly one default drop ACL")
 			require.NotNil(t, theAllow)
+			require.NotNil(t, theDrop)
 
-			// The single allow ACL must negate BOTH excluded values (AND) and reference
-			// no positive tenant set.
+			// The single allow ACL's peer list must be EXACTLY the two excluded values,
+			// each a negated match (Included == false) and nothing else (no stray positive
+			// set such as an all-namespaces allow).
+			allowPeers := tt.peerList(theAllow)
+			require.Len(t, allowPeers, 2, "allow ACL must reference exactly the two excluded sets and no positive set")
 			var negated []string
-			for _, si := range tt.peerList(theAllow) {
-				if excluded[si.IPSet.Name] {
-					require.False(t, si.Included,
-						"tenant set %s must be a negated match, not a positive allow", si.IPSet.Name)
-					negated = append(negated, si.IPSet.Name)
-				}
+			for _, si := range allowPeers {
+				require.True(t, excluded[si.IPSet.Name], "unexpected set %s in allow ACL", si.IPSet.Name)
+				require.False(t, si.Included, "tenant set %s must be a negated match", si.IPSet.Name)
+				require.Equal(t, ipsets.KeyValueLabelOfNamespace, si.IPSet.Type)
+				negated = append(negated, si.IPSet.Name)
 			}
 			require.ElementsMatch(t, []string{"tenant:attacker", "tenant:quarantine"}, negated,
 				"the single allow ACL must negate every excluded value")
+
+			// The default drop must be same-direction and unconditional (no peer match),
+			// so the excluded namespaces have no allow path and fall through to it.
+			require.Equal(t, theAllow.Direction, theDrop.Direction, "drop must be the same direction as the allow")
+			require.Empty(t, tt.peerList(theDrop), "the default drop must be unconditional")
 
 			// When a port is present it must be carried in the same allow decision,
 			// conjunctively with the negated tenant sets.


### PR DESCRIPTION
## Summary

A `namespaceSelector` `matchExpression` that uses `NotIn` with more than one value is a **single** set-membership requirement — `key NotIn [a, b]` means `key != a AND key != b`. The v2 selector compiler flattened multi-value `NotIn` the same way it flattens multi-value `In`, emitting one selector per value.

Because each flattened selector becomes an independent allow decision, and allow decisions are additive (OR), a namespace carrying one of the values could still be matched by the decision negating a *different* value. The result did not match Kubernetes' `LabelSelectorAsSelector` semantics for multi-value `NotIn`.

## Change

- In `flattenNameSpaceSelector`, handle `In` and `NotIn` separately:
  - **`In`** (disjunction): unchanged — still fanned out into one selector per value (OR).
  - **`NotIn`** (conjunction): keep each value as its own single-value `NotIn` requirement within the **same** selector, so every negated condition renders in one decision (AND).
  - When a selector mixes the two, `In` alternatives fan out into branches and each `NotIn` exclusion is carried conjunctively into every branch.

This keeps the default drop effective for all excluded values. Scoped to the v2 translation path (the enabled NPM datapath), consistent with the other recent `fix: [NPM]` selector/naming hardening changes.

## Tests

- `TestFlattenNameSpaceSelectorMultiValueNotIn` — multi-value `NotIn` stays a single conjunction, not fanned out.
- `TestFlattenNameSpaceSelectorMixedInAndNotIn` — `In` fans out; each `NotIn` exclusion is carried into every branch.
- `TestNameSpaceSelectorMultiValueNotIn` — the translated decision carries a negated match-set for every excluded value.
- Existing translation package tests pass unchanged.