### PR TITLE
test/cilium: set mesh-auth-enabled to false in v1.17 configs [backport release/v1.7]

### DIFF
--- a/test/integration/manifests/cilium/v1.17/cilium-config/cilium-config-dualstack.yaml
+++ b/test/integration/manifests/cilium/v1.17/cilium-config/cilium-config-dualstack.yaml
@@ -84,7 +84,7 @@ data:
   external-envoy-proxy: "false"
   k8s-client-qps: "10"
   k8s-client-burst: "20"
-  mesh-auth-enabled: "true"
+  mesh-auth-enabled: "false"
   mesh-auth-queue-size: "1024"
   mesh-auth-rotated-identities-queue-size: "1024"
   mesh-auth-gc-interval: "5m0s"

--- a/test/integration/manifests/cilium/v1.17/cilium-config/cilium-config-hubble.yaml
+++ b/test/integration/manifests/cilium/v1.17/cilium-config/cilium-config-hubble.yaml
@@ -86,7 +86,7 @@ data:
   external-envoy-proxy: "false"
   k8s-client-qps: "10"
   k8s-client-burst: "20"
-  mesh-auth-enabled: "true"
+  mesh-auth-enabled: "false"
   mesh-auth-queue-size: "1024"
   mesh-auth-rotated-identities-queue-size: "1024"
   mesh-auth-gc-interval: "5m0s"

--- a/test/integration/manifests/cilium/v1.17/cilium-config/cilium-config.yaml
+++ b/test/integration/manifests/cilium/v1.17/cilium-config/cilium-config.yaml
@@ -80,7 +80,7 @@ data:
   external-envoy-proxy: "false"
   k8s-client-qps: "10"
   k8s-client-burst: "20"
-  mesh-auth-enabled: "true"
+  mesh-auth-enabled: "false"
   mesh-auth-queue-size: "1024"
   mesh-auth-rotated-identities-queue-size: "1024"
   mesh-auth-gc-interval: "5m0s"


### PR DESCRIPTION
## Backport of PR #4518 (partial)

Sets `mesh-auth-enabled` from `"true"` to `"false"` in all v1.17 cilium ConfigMaps.

### Problem
Cilium pods fail to start with `mesh-auth-enabled: "true"` because test clusters lack the mTLS infrastructure required for mutual authentication. This causes consistent **Cilium Dualstack** (and potentially other cilium) test failures on `release/v1.7`.

### Root Cause
PR #4518 fixed this on `master` (July 24) but was not backported to `release/v1.7`.

### Changes
- `cilium-config.yaml`: `mesh-auth-enabled: "true"` → `"false"`
- `cilium-config-dualstack.yaml`: `mesh-auth-enabled: "true"` → `"false"`
- `cilium-config-hubble.yaml`: `mesh-auth-enabled: "true"` → `"false"`

### Evidence
Pipeline failures: [175591273](https://msazure.visualstudio.com/One/_build/results?buildId=175591273), [175508499](https://msazure.visualstudio.com/One/_build/results?buildId=175508499)

Cilium status shows pods permanently Pending:
```
DaemonSet  cilium  Desired: 2, Unavailable: 2/2
Containers: cilium  Pending: 2
Errors: cilium 2 pods of DaemonSet cilium are not ready
```