### PR TITLE
fix(swiftv2-long-running): honour node readiness timeouts, surface unreachable nodes, decouple BYON from zonal tests

### DIFF
--- a/.pipelines/swiftv2-long-running/LONGRUNNING-TESTS.md
+++ b/.pipelines/swiftv2-long-running/LONGRUNNING-TESTS.md
@@ -210,8 +210,12 @@ pipeline.yaml
         │   ├── EnsureNodeLabels      ← re-applies labels every run (survives node replacements)
         │   ├── CreateResourceGroup   ← conditional on !infraExists
         │   ├── CreateCluster          ...
-        │   ├── NetworkingAndStorage    ...
-        │   └── DeployLinuxBYON        ...
+        │   └── NetworkingAndStorage    ...
+        │
+        ├── ByonSetup_<loc> (only when a BYON workload is enabled)
+        │   ├── (depends on AKSClusterAndNetworking_<loc>)
+        │   ├── DeployLinuxBYON        ...
+        │   └── DeployAccelnetBYON     ...
         │
         ├── LongRunningPodTests_Z<N>_<loc>  (per zone, parallel, NOT lease-gated)
         │   ├── (depends on AKSClusterAndNetworking_<loc>)
@@ -230,6 +234,7 @@ pipeline.yaml
         │
         ├── DataPathTests_<workload>_<loc> (per location × workload type, parallel, lease-gated)
         │   ├── (depends on AKSClusterAndNetworking_<loc> + AcquireLease_<loc>)
+        │   ├── BYON workloads additionally depend on ByonSetup_<loc>
         │   └── swiftv2-linux + swiftv2-linux-byon run in parallel
         │
         └── ReleaseLease_<loc> (always runs, depends on all DataPathTests)
@@ -239,6 +244,8 @@ All 4 zones run as **separate stages in parallel**, starting immediately after i
 Within each zone stage, `EnsureNodePool_Z<N>` runs first; `SetupKubeconfig` and `BuildMetricsBinary` follow; `RotatingPods` and `AlwaysOnPods` run in parallel; `LongRunningConnectivityTest` waits for both.
 
 **Note**: Long-running pod tests are **not gated by the lease** — each zone stage depends only on `AKSClusterAndNetworking_<loc>`. They start immediately after infrastructure is ready, without waiting for the lease or datapath tests.
+
+**Note**: BYON provisioning is a separate `ByonSetup_<loc>` stage rather than a job inside `AKSClusterAndNetworking_<loc>`. The zonal tests run entirely on managed node pools on `aks-1`, while BYON joins scale sets to `aks-2`, so a BYON provisioning failure has no bearing on them. Keeping BYON in the infrastructure stage made any BYON failure fail that stage, which the zonal stages' `not(failed())` condition then treated as a reason to skip. Only the BYON datapath stages depend on `ByonSetup_<loc>`.
 
 ### Idempotent Infrastructure Setup
 

--- a/.pipelines/swiftv2-long-running/scripts/create_aks.sh
+++ b/.pipelines/swiftv2-long-running/scripts/create_aks.sh
@@ -14,6 +14,7 @@ DELEGATOR_BASE_URL=${9:-"http://localhost:8080"}
 CLUSTER_COUNT=2
 PODS_PER_NODE=7
 CLUSTER_PREFIX="aks"
+STALE_NODE_THRESHOLD=1800  # seconds without a kubelet heartbeat before a Node is considered abandoned
 
 echo "Setting active subscription to $SUBSCRIPTION_ID"
 az account set --subscription "$SUBSCRIPTION_ID"
@@ -75,6 +76,38 @@ wait_for_provisioning() {
   return 1
 }
 
+# A Node object can outlive its VM - BYON nodes deleted out of band leave an
+# unreachable Node behind, and "kubectl wait --all" can never be satisfied by a
+# node whose kubelet is gone. Drop nodes that have not reported for a long time
+# so the readiness gate only covers nodes that still exist.
+prune_abandoned_nodes() {
+  local kubeconfig="$1" clusterName="$2"
+  local now abandoned node
+
+  now=$(date -u +%s)
+  abandoned=$(kubectl --kubeconfig "$kubeconfig" get nodes -o json \
+    | jq -r --argjson now "$now" --argjson threshold "$STALE_NODE_THRESHOLD" '
+        .items[]
+        | select(.spec.taints // [] | any(.key == "node.kubernetes.io/unreachable"))
+        | select(
+            .status.conditions[]
+            | select(.type == "Ready")
+            | .status != "True" and (.lastTransitionTime | fromdateiso8601) < ($now - $threshold)
+          )
+        | .metadata.name')
+
+  if [[ -z "$abandoned" ]]; then
+    return 0
+  fi
+
+  echo "WARNING: $clusterName has Node objects with no kubelet heartbeat for over ${STALE_NODE_THRESHOLD}s."
+  echo "         Their VMs are gone, so they will never become Ready. Removing them:"
+  for node in $abandoned; do
+    echo "  - $node"
+    kubectl --kubeconfig "$kubeconfig" delete node "$node" --ignore-not-found
+  done
+}
+
 for i in $(seq 1 "$CLUSTER_COUNT"); do
     echo "Creating cluster #$i..."
 
@@ -115,6 +148,8 @@ for i in $(seq 1 "$CLUSTER_COUNT"); do
     az aks get-credentials -g "$RG" -n "$CLUSTER_NAME" --admin --overwrite-existing \
       --file "/tmp/${CLUSTER_NAME}.kubeconfig"
     
+    prune_abandoned_nodes "/tmp/${CLUSTER_NAME}.kubeconfig" "$CLUSTER_NAME"
+
     echo "Waiting for all nodes in $CLUSTER_NAME to be Ready..."
     kubectl --kubeconfig "/tmp/${CLUSTER_NAME}.kubeconfig" wait --for=condition=Ready nodes --all --timeout=10m
 done

--- a/.pipelines/swiftv2-long-running/scripts/create_aks.sh
+++ b/.pipelines/swiftv2-long-running/scripts/create_aks.sh
@@ -14,7 +14,7 @@ DELEGATOR_BASE_URL=${9:-"http://localhost:8080"}
 CLUSTER_COUNT=2
 PODS_PER_NODE=7
 CLUSTER_PREFIX="aks"
-STALE_NODE_THRESHOLD=1800  # seconds without a kubelet heartbeat before a Node is considered abandoned
+STALE_NODE_THRESHOLD=1800  # seconds without a kubelet heartbeat before a Node is considered unrecoverable
 
 echo "Setting active subscription to $SUBSCRIPTION_ID"
 az account set --subscription "$SUBSCRIPTION_ID"
@@ -76,36 +76,39 @@ wait_for_provisioning() {
   return 1
 }
 
-# A Node object can outlive its VM - BYON nodes deleted out of band leave an
-# unreachable Node behind, and "kubectl wait --all" can never be satisfied by a
-# node whose kubelet is gone. Drop nodes that have not reported for a long time
-# so the readiness gate only covers nodes that still exist.
-prune_abandoned_nodes() {
+# "kubectl wait --all" can never be satisfied by a Node whose kubelet has stopped
+# reporting, so it burns its full timeout and then fails without saying why. Report
+# those nodes up front and fail immediately: a node unreachable this long needs its
+# backing VM repaired, and no amount of waiting will change that.
+#
+# Deliberately NOT deleting these Node objects. A stale Node usually means the VM
+# behind it is deallocated or its scale set failed to provision, so removing the
+# object would let the readiness gate pass while the cluster is silently short of
+# nodes. Fail loudly and let the VM be repaired instead.
+check_unreachable_nodes() {
   local kubeconfig="$1" clusterName="$2"
-  local now abandoned node
+  local now unreachable
 
   now=$(date -u +%s)
-  abandoned=$(kubectl --kubeconfig "$kubeconfig" get nodes -o json \
+  unreachable=$(kubectl --kubeconfig "$kubeconfig" get nodes -o json \
     | jq -r --argjson now "$now" --argjson threshold "$STALE_NODE_THRESHOLD" '
         .items[]
         | select(.spec.taints // [] | any(.key == "node.kubernetes.io/unreachable"))
-        | select(
-            .status.conditions[]
-            | select(.type == "Ready")
-            | .status != "True" and (.lastTransitionTime | fromdateiso8601) < ($now - $threshold)
-          )
-        | .metadata.name')
+        | .metadata.name as $name
+        | .status.conditions[]
+        | select(.type == "Ready")
+        | select(.status != "True" and (.lastTransitionTime | fromdateiso8601) < ($now - $threshold))
+        | "  - \($name) (Ready=\(.status) since \(.lastTransitionTime))"')
 
-  if [[ -z "$abandoned" ]]; then
+  if [[ -z "$unreachable" ]]; then
     return 0
   fi
 
-  echo "WARNING: $clusterName has Node objects with no kubelet heartbeat for over ${STALE_NODE_THRESHOLD}s."
-  echo "         Their VMs are gone, so they will never become Ready. Removing them:"
-  for node in $abandoned; do
-    echo "  - $node"
-    kubectl --kubeconfig "$kubeconfig" delete node "$node" --ignore-not-found
-  done
+  echo "##vso[task.logissue type=error]Cluster $clusterName has nodes whose kubelet stopped reporting more than ${STALE_NODE_THRESHOLD}s ago:"
+  echo "$unreachable"
+  echo "They cannot become Ready, so waiting for node readiness would only time out."
+  echo "Check the backing scale sets for a failed provisioningState or missing instances, repair them, then re-run."
+  return 1
 }
 
 for i in $(seq 1 "$CLUSTER_COUNT"); do
@@ -148,7 +151,7 @@ for i in $(seq 1 "$CLUSTER_COUNT"); do
     az aks get-credentials -g "$RG" -n "$CLUSTER_NAME" --admin --overwrite-existing \
       --file "/tmp/${CLUSTER_NAME}.kubeconfig"
     
-    prune_abandoned_nodes "/tmp/${CLUSTER_NAME}.kubeconfig" "$CLUSTER_NAME"
+    check_unreachable_nodes "/tmp/${CLUSTER_NAME}.kubeconfig" "$CLUSTER_NAME"
 
     echo "Waiting for all nodes in $CLUSTER_NAME to be Ready..."
     kubectl --kubeconfig "/tmp/${CLUSTER_NAME}.kubeconfig" wait --for=condition=Ready nodes --all --timeout=10m

--- a/.pipelines/swiftv2-long-running/scripts/create_aks.sh
+++ b/.pipelines/swiftv2-long-running/scripts/create_aks.sh
@@ -14,7 +14,7 @@ DELEGATOR_BASE_URL=${9:-"http://localhost:8080"}
 CLUSTER_COUNT=2
 PODS_PER_NODE=7
 CLUSTER_PREFIX="aks"
-STALE_NODE_THRESHOLD=1800  # seconds without a kubelet heartbeat before a Node is considered unrecoverable
+STALE_NODE_THRESHOLD=1800  # seconds a Node may stay unreachable and non-Ready before it is considered unrecoverable
 
 echo "Setting active subscription to $SUBSCRIPTION_ID"
 az account set --subscription "$SUBSCRIPTION_ID"
@@ -104,7 +104,7 @@ check_unreachable_nodes() {
     return 0
   fi
 
-  echo "##vso[task.logissue type=error]Cluster $clusterName has nodes whose kubelet stopped reporting more than ${STALE_NODE_THRESHOLD}s ago:"
+  echo "##vso[task.logissue type=error]Cluster $clusterName has nodes that have been unreachable and non-Ready for more than ${STALE_NODE_THRESHOLD}s:"
   echo "$unreachable"
   echo "They cannot become Ready, so waiting for node readiness would only time out."
   echo "Check the backing scale sets for a failed provisioningState or missing instances, repair them, then re-run."

--- a/.pipelines/swiftv2-long-running/scripts/create_vnets.sh
+++ b/.pipelines/swiftv2-long-running/scripts/create_vnets.sh
@@ -91,13 +91,18 @@ delegate_subnet() {
     local subnet_id
     subnet_id=$(az network vnet subnet show -g "$RG" --vnet-name "$vnet" -n "$subnet" --query id -o tsv)
 
-    # Check if SAL already exists — skip expensive delegation if so
-    local sal
-    sal=$(az rest --method get \
+    # Gate on the delegation GUID rather than on the link's mere presence. The GUID
+    # is what everything downstream actually consumes - GetSubnetGUID in
+    # test/integration/swiftv2/helpers/az_helpers.go reads this same field to
+    # populate the PodNetwork CR's subnetGUID. A service association link can be
+    # present by name without carrying one, and skipping on the name alone would
+    # leave that subnet permanently undelegated for the tests.
+    local delegation_guid
+    delegation_guid=$(az rest --method get \
       --url "${subnet_id}?api-version=2024-05-01" \
-      2>/dev/null | jq -r '.properties.serviceAssociationLinks[0].name // empty')
-    if [[ -n "$sal" ]]; then
-      echo "SAL already exists on $subnet in $vnet (name: $sal). Skipping delegation."
+      2>/dev/null | jq -r '.properties.serviceAssociationLinks[0].properties.subnetId // empty')
+    if [[ -n "$delegation_guid" ]]; then
+      echo "Subnet $subnet in $vnet is already delegated (GUID: $delegation_guid). Skipping delegation."
       return 0
     fi
 

--- a/.pipelines/swiftv2-long-running/scripts/create_vnets.sh
+++ b/.pipelines/swiftv2-long-running/scripts/create_vnets.sh
@@ -91,6 +91,23 @@ delegate_subnet() {
     local subnet_id
     subnet_id=$(az network vnet subnet show -g "$RG" --vnet-name "$vnet" -n "$subnet" --query id -o tsv)
 
+    # The delegation GUID lives at serviceAssociationLinks[0].properties.subnetId,
+    # which `az network vnet subnet show` does not project. Do not simplify this
+    # back to that command: the GUID would read empty for every subnet, the check
+    # below would never skip, and every run would re-delegate the entire fleet.
+    # Keep the URL relative too - a full https://management.azure.com/... form
+    # fails to derive an auth resource unless --resource is also passed.
+    local subnet_json rc=0
+    subnet_json=$(az rest --method get --url "${subnet_id}?api-version=2024-05-01" 2>/dev/null) || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        # Assume delegated when the subnet cannot be read. A spurious re-delegation
+        # is not recoverable here - the link is created with allowDelete: false, so
+        # ARM cannot remove it - whereas skipping is self-correcting, since the next
+        # run re-evaluates and delegates if the GUID is genuinely absent.
+        echo "[WARN] Could not read subnet $subnet in $vnet (az rest exit $rc); skipping delegation." >&2
+        return 0
+    fi
+
     # Gate on the delegation GUID rather than on the link's mere presence. The GUID
     # is what everything downstream actually consumes - GetSubnetGUID in
     # test/integration/swiftv2/helpers/az_helpers.go reads this same field to
@@ -98,12 +115,10 @@ delegate_subnet() {
     # present by name without carrying one, and skipping on the name alone would
     # leave that subnet permanently undelegated for the tests.
     local delegation_guid
-    delegation_guid=$(az rest --method get \
-      --url "${subnet_id}?api-version=2024-05-01" \
-      2>/dev/null | jq -r '.properties.serviceAssociationLinks[0].properties.subnetId // empty')
+    delegation_guid=$(jq -r '.properties.serviceAssociationLinks[0].properties.subnetId // empty' <<<"$subnet_json")
     if [[ -n "$delegation_guid" ]]; then
-      echo "Subnet $subnet in $vnet is already delegated (GUID: $delegation_guid). Skipping delegation."
-      return 0
+        echo "Subnet $subnet in $vnet is already delegated (GUID: $delegation_guid). Skipping delegation."
+        return 0
     fi
 
     echo "Delegating subnet: $subnet in VNet: $vnet to Subnet Delegator"

--- a/.pipelines/swiftv2-long-running/scripts/ensure_zone_nodepools.sh
+++ b/.pipelines/swiftv2-long-running/scripts/ensure_zone_nodepools.sh
@@ -100,20 +100,37 @@ count_pool_nodes() {
 wait_pool_ready() {
   local pool="$1" timeout="$2"
   local deadline=$(( $(date +%s) + timeout ))
-  local total ready
+  local total ready state last_state=""
 
   while :; do
     # A failed query is not "zero nodes", so keep polling rather than concluding
     # anything from it; a real outage still ends at the deadline below.
-    if total=$(count_pool_nodes "$pool") && [ "$total" -gt 0 ]; then
-      ready=$(kubectl --kubeconfig "$KUBECONFIG_FILE" get nodes -l agentpool="$pool" \
-        -o jsonpath='{range .items[*]}{range .status.conditions[?(@.type=="Ready")]}{.status}{"\n"}{end}{end}' \
-        | grep -c '^True$') || ready=0
-      if [ "$ready" -eq "$total" ]; then
-        return 0
+    if total=$(count_pool_nodes "$pool"); then
+      if [ "$total" -gt 0 ]; then
+        ready=$(kubectl --kubeconfig "$KUBECONFIG_FILE" get nodes -l agentpool="$pool" \
+          -o jsonpath='{range .items[*]}{range .status.conditions[?(@.type=="Ready")]}{.status}{"\n"}{end}{end}' \
+          | grep -c '^True$') || ready=0
+        if [ "$ready" -eq "$total" ]; then
+          return 0
+        fi
+        state="$ready/$total node(s) Ready"
+      else
+        state="no nodes registered yet"
       fi
+    else
+      state="node query failed, retrying"
     fi
+
+    # Report the first miss and any change after it, so the build log says why the
+    # wait is still running. Only on change: at one poll per 10s an unconditional
+    # echo would add 60 identical lines to a 10 minute wait.
+    if [ "$state" != "$last_state" ]; then
+      echo "    Waiting for pool $pool: $state"
+      last_state="$state"
+    fi
+
     if [ "$(date +%s)" -ge "$deadline" ]; then
+      echo "    Gave up waiting for pool $pool after ${timeout}s ($state)"
       return 1
     fi
     sleep 10

--- a/.pipelines/swiftv2-long-running/scripts/ensure_zone_nodepools.sh
+++ b/.pipelines/swiftv2-long-running/scripts/ensure_zone_nodepools.sh
@@ -169,7 +169,7 @@ for ZONE in $ZONES; do
   attempt=0
   node_ready=false
 
-  while [ "$node_ready" = "false" ] && [ $attempt -le $MAX_REMEDIATION_ATTEMPTS ]; do
+  while [ "$node_ready" = "false" ] && [ $attempt -lt $MAX_REMEDIATION_ATTEMPTS ]; do
     # Try a short wait first
     if wait_pool_ready "$POOL_NAME" "$INITIAL_WAIT_TIMEOUT"; then
       echo "    Node pool $POOL_NAME nodes are Ready"

--- a/.pipelines/swiftv2-long-running/scripts/ensure_zone_nodepools.sh
+++ b/.pipelines/swiftv2-long-running/scripts/ensure_zone_nodepools.sh
@@ -79,11 +79,18 @@ MAX_REMEDIATION_ATTEMPTS=2
 INITIAL_WAIT_TIMEOUT=120   # seconds – short initial wait before checking VM health
 POST_REMEDIATION_TIMEOUT=600  # seconds – longer wait after VM remediation
 
+# Returns non-zero when the cluster cannot be queried, so callers can tell "no nodes
+# are registered" apart from "the query failed". Those must not be conflated: the
+# remediation below deletes VMSS instances when it believes no node registered, and
+# losing the API server for a moment is not evidence that a VM failed to join.
 count_pool_nodes() {
-  local count
-  count=$(kubectl --kubeconfig "$KUBECONFIG_FILE" get nodes -l agentpool="$1" \
-    --no-headers 2>/dev/null | wc -l | tr -d '[:space:]') || count=0
-  echo "${count:-0}"
+  local out
+  out=$(kubectl --kubeconfig "$KUBECONFIG_FILE" get nodes -l agentpool="$1" --no-headers) || return 1
+  if [ -z "$out" ]; then
+    echo 0
+  else
+    printf '%s\n' "$out" | wc -l | tr -d '[:space:]'
+  fi
 }
 
 # "kubectl wait" exits immediately with "no matching resources found" when the
@@ -96,10 +103,11 @@ wait_pool_ready() {
   local total ready
 
   while :; do
-    total=$(count_pool_nodes "$pool")
-    if [ "$total" -gt 0 ]; then
+    # A failed query is not "zero nodes", so keep polling rather than concluding
+    # anything from it; a real outage still ends at the deadline below.
+    if total=$(count_pool_nodes "$pool") && [ "$total" -gt 0 ]; then
       ready=$(kubectl --kubeconfig "$KUBECONFIG_FILE" get nodes -l agentpool="$pool" \
-        -o jsonpath='{range .items[*]}{range .status.conditions[?(@.type=="Ready")]}{.status}{"\n"}{end}{end}' 2>/dev/null \
+        -o jsonpath='{range .items[*]}{range .status.conditions[?(@.type=="Ready")]}{.status}{"\n"}{end}{end}' \
         | grep -c '^True$') || ready=0
       if [ "$ready" -eq "$total" ]; then
         return 0
@@ -169,7 +177,13 @@ for ZONE in $ZONES; do
       break
     fi
 
-    NODE_COUNT=$(count_pool_nodes "$POOL_NAME")
+    # Never let a failed query stand in for "no node registered": that inference
+    # deletes VMSS instances below. If the count is unknown, fall back to deleting
+    # only on Azure-reported VM health.
+    if ! NODE_COUNT=$(count_pool_nodes "$POOL_NAME"); then
+      echo "    WARNING: could not query nodes for pool $POOL_NAME; remediating on Azure VM health only"
+      NODE_COUNT=-1
+    fi
     if [ "$NODE_COUNT" -eq 0 ]; then
       echo "    No Kubernetes node registered for pool $POOL_NAME after ${INITIAL_WAIT_TIMEOUT}s, checking Azure VM health..."
     else

--- a/.pipelines/swiftv2-long-running/scripts/ensure_zone_nodepools.sh
+++ b/.pipelines/swiftv2-long-running/scripts/ensure_zone_nodepools.sh
@@ -79,6 +79,39 @@ MAX_REMEDIATION_ATTEMPTS=2
 INITIAL_WAIT_TIMEOUT=120   # seconds – short initial wait before checking VM health
 POST_REMEDIATION_TIMEOUT=600  # seconds – longer wait after VM remediation
 
+count_pool_nodes() {
+  local count
+  count=$(kubectl --kubeconfig "$KUBECONFIG_FILE" get nodes -l agentpool="$1" \
+    --no-headers 2>/dev/null | wc -l | tr -d '[:space:]') || count=0
+  echo "${count:-0}"
+}
+
+# "kubectl wait" exits immediately with "no matching resources found" when the
+# selector matches nothing, so it cannot be used to wait for a node that has not
+# registered yet. Poll instead, and treat "no nodes" as not-ready rather than as
+# an instant failure.
+wait_pool_ready() {
+  local pool="$1" timeout="$2"
+  local deadline=$(( $(date +%s) + timeout ))
+  local total ready
+
+  while :; do
+    total=$(count_pool_nodes "$pool")
+    if [ "$total" -gt 0 ]; then
+      ready=$(kubectl --kubeconfig "$KUBECONFIG_FILE" get nodes -l agentpool="$pool" \
+        -o jsonpath='{range .items[*]}{range .status.conditions[?(@.type=="Ready")]}{.status}{"\n"}{end}{end}' 2>/dev/null \
+        | grep -c '^True$') || ready=0
+      if [ "$ready" -eq "$total" ]; then
+        return 0
+      fi
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      return 1
+    fi
+    sleep 10
+  done
+}
+
 for ZONE in $ZONES; do
   POOL_NAME="npz${ZONE}"
   echo "==> Checking node pool $POOL_NAME for remediator taints before waiting for Ready"
@@ -119,8 +152,7 @@ for ZONE in $ZONES; do
       fi
 
       echo "    Waiting for replacement node to become Ready (timeout ${POST_REMEDIATION_TIMEOUT}s)..."
-      kubectl --kubeconfig "$KUBECONFIG_FILE" wait --for=condition=Ready nodes \
-        -l agentpool="$POOL_NAME" --timeout="${POST_REMEDIATION_TIMEOUT}s" 2>/dev/null || true
+      wait_pool_ready "$POOL_NAME" "$POST_REMEDIATION_TIMEOUT" || true
     fi
   fi
 
@@ -131,14 +163,18 @@ for ZONE in $ZONES; do
 
   while [ "$node_ready" = "false" ] && [ $attempt -le $MAX_REMEDIATION_ATTEMPTS ]; do
     # Try a short wait first
-    if kubectl --kubeconfig "$KUBECONFIG_FILE" wait --for=condition=Ready nodes \
-        -l agentpool="$POOL_NAME" --timeout="${INITIAL_WAIT_TIMEOUT}s" 2>/dev/null; then
+    if wait_pool_ready "$POOL_NAME" "$INITIAL_WAIT_TIMEOUT"; then
       echo "    Node pool $POOL_NAME nodes are Ready"
       node_ready=true
       break
     fi
 
-    echo "    Nodes in pool $POOL_NAME not ready after ${INITIAL_WAIT_TIMEOUT}s, checking Azure VM health..."
+    NODE_COUNT=$(count_pool_nodes "$POOL_NAME")
+    if [ "$NODE_COUNT" -eq 0 ]; then
+      echo "    No Kubernetes node registered for pool $POOL_NAME after ${INITIAL_WAIT_TIMEOUT}s, checking Azure VM health..."
+    else
+      echo "    Nodes in pool $POOL_NAME not ready after ${INITIAL_WAIT_TIMEOUT}s, checking Azure VM health..."
+    fi
     attempt=$((attempt + 1))
 
     # Find the VMSS backing this node pool
@@ -165,11 +201,21 @@ for ZONE in $ZONES; do
 
       echo "    Instance $INSTANCE_ID: provisioningState=$PROV_STATE, powerState=$POWER_STATE"
 
+      UNHEALTHY_REASON=""
       if [ "$PROV_STATE" = "Failed" ] || [ "$POWER_STATE" = "VM stopped" ] || [ "$POWER_STATE" = "VM deallocated" ]; then
-        echo "    WARNING: Instance $INSTANCE_ID is in unhealthy state ($PROV_STATE / $POWER_STATE)"
-        echo "    Deleting failed instance $INSTANCE_ID from VMSS $VMSS_NAME..."
+        UNHEALTHY_REASON="in unhealthy state ($PROV_STATE / $POWER_STATE)"
+      elif [ "$NODE_COUNT" -eq 0 ]; then
+        # Azure reports the VM as healthy but kubelet never registered it, which happens
+        # when a node extension is wedged (e.g. AKSLinuxExtension stuck mid-update).
+        # Reimaging the instance is the only way to recover.
+        UNHEALTHY_REASON="provisioned in Azure but never registered as a Kubernetes node"
+      fi
 
-        # Delete the failed instance – VMSS auto-scaling will provision a replacement
+      if [ -n "$UNHEALTHY_REASON" ]; then
+        echo "    WARNING: Instance $INSTANCE_ID is $UNHEALTHY_REASON"
+        echo "    Deleting instance $INSTANCE_ID from VMSS $VMSS_NAME..."
+
+        # Delete the instance – VMSS auto-scaling will provision a replacement
         az vmss delete-instances -g "$MC_RG" -n "$VMSS_NAME" --subscription "$SUBSCRIPTION_ID" --instance-ids "$INSTANCE_ID" --no-wait || true
 
         remediated=true
@@ -189,8 +235,7 @@ for ZONE in $ZONES; do
       fi
 
       echo "    Waiting for replacement node to become Ready (timeout ${POST_REMEDIATION_TIMEOUT}s)..."
-      if kubectl --kubeconfig "$KUBECONFIG_FILE" wait --for=condition=Ready nodes \
-          -l agentpool="$POOL_NAME" --timeout="${POST_REMEDIATION_TIMEOUT}s" 2>/dev/null; then
+      if wait_pool_ready "$POOL_NAME" "$POST_REMEDIATION_TIMEOUT"; then
         echo "    Replacement node in pool $POOL_NAME is Ready"
         node_ready=true
       else
@@ -198,8 +243,7 @@ for ZONE in $ZONES; do
       fi
     else
       echo "    All VMs appear provisioned OK but K8s node not Ready. Waiting longer..."
-      if kubectl --kubeconfig "$KUBECONFIG_FILE" wait --for=condition=Ready nodes \
-          -l agentpool="$POOL_NAME" --timeout="${POST_REMEDIATION_TIMEOUT}s" 2>/dev/null; then
+      if wait_pool_ready "$POOL_NAME" "$POST_REMEDIATION_TIMEOUT"; then
         echo "    Node pool $POOL_NAME nodes are now Ready"
         node_ready=true
       else

--- a/.pipelines/swiftv2-long-running/template/infrastructure-setup-stage.yaml
+++ b/.pipelines/swiftv2-long-running/template/infrastructure-setup-stage.yaml
@@ -226,78 +226,78 @@ stages:
                 $(rgName)
                 ${{ parameters.location }}
 
-      - job: DeployLinuxBYON
-        displayName: "Join Linux BYON VMSS to AKS Cluster"
-        dependsOn:
-          - CreateCluster
-          - NetworkingAndStorage
-        condition: |
-          and(
-            ${{ parameters.enableLinuxBYON }},
-            not(failed())
-          )
-        pool:
-          vmImage: ubuntu-latest
-        steps:
-          - checkout: self
-            displayName: "Checkout main repository"
-          - checkout: Networking-Aquarius
-            displayName: "Checkout Networking-Aquarius repository"
-          - task: AzureCLI@2
-            displayName: "Deploy Linux VMSS"
-            inputs:
-              azureSubscription: $(AZURE_SERVICE_CONNECTION)
-              scriptType: bash
-              scriptLocation: scriptPath
-              scriptPath: "$(Build.SourcesDirectory)/azure-container-networking/.pipelines/swiftv2-long-running/scripts/deploy_linuxbyon.sh"
-              arguments: >
-                $(rgName)
-                $(Build.SourcesDirectory)
-                ${{ parameters.subscriptionId }}
-            env:
-              SSH_PUBLIC_KEY_SECRET_NAME: $(SSH_PUBLIC_KEY_SECRET_NAME)
-              CLUSTER_KUBECONFIG_KEYVAULT_NAME: $(CLUSTER_KUBECONFIG_KEYVAULT_NAME)
-              KEY_VAULT_RESOURCE_GROUP: $(KEY_VAULT_RESOURCE_GROUP)
-              KEY_VAULT_SUBSCRIPTION: $(KEY_VAULT_SUBSCRIPTION)
+  # BYON scale sets live in their own stage so that a BYON provisioning failure
+  # does not fail the infrastructure stage. The zonal long-running tests depend on
+  # that stage and run against managed node pools on aks-1, so they have no reason
+  # to be blocked by BYON, which joins aks-2 and is only exercised by the BYON
+  # datapath stages.
+  - ${{ if or(eq(parameters.enableLinuxBYON, true), eq(parameters.enableAccelnetBYON, true)) }}:
+    - stage: ByonSetup_${{ replace(parameters.stageLabel, '-', '_') }}
+      displayName: "Verify & Setup BYON VMSS (${{ parameters.stageLabel }})"
+      dependsOn:
+        - AKSClusterAndNetworking_${{ replace(parameters.stageLabel, '-', '_') }}
+      condition: and(eq(variables.isAllowedRun, true), succeeded())
+      variables:
+        rgName: ${{ parameters.resourceGroupName }}-${{ parameters.location }}
+      jobs:
+        - ${{ if eq(parameters.enableLinuxBYON, true) }}:
+          - job: DeployLinuxBYON
+            displayName: "Join Linux BYON VMSS to AKS Cluster"
+            pool:
+              vmImage: ubuntu-latest
+            steps:
+              - checkout: self
+                displayName: "Checkout main repository"
+              - checkout: Networking-Aquarius
+                displayName: "Checkout Networking-Aquarius repository"
+              - task: AzureCLI@2
+                displayName: "Deploy Linux VMSS"
+                inputs:
+                  azureSubscription: $(AZURE_SERVICE_CONNECTION)
+                  scriptType: bash
+                  scriptLocation: scriptPath
+                  scriptPath: "$(Build.SourcesDirectory)/azure-container-networking/.pipelines/swiftv2-long-running/scripts/deploy_linuxbyon.sh"
+                  arguments: >
+                    $(rgName)
+                    $(Build.SourcesDirectory)
+                    ${{ parameters.subscriptionId }}
+                env:
+                  SSH_PUBLIC_KEY_SECRET_NAME: $(SSH_PUBLIC_KEY_SECRET_NAME)
+                  CLUSTER_KUBECONFIG_KEYVAULT_NAME: $(CLUSTER_KUBECONFIG_KEYVAULT_NAME)
+                  KEY_VAULT_RESOURCE_GROUP: $(KEY_VAULT_RESOURCE_GROUP)
+                  KEY_VAULT_SUBSCRIPTION: $(KEY_VAULT_SUBSCRIPTION)
 
-      # Accelnet BYON - only for regions explicitly enabled by the pipeline parameters.
-      # The deploy script itself checks VMSS existence and skips if already joined.
-      - job: DeployAccelnetBYON
-        displayName: "Join Accelnet BYON VMSS to AKS Cluster"
-        dependsOn:
-          - CreateCluster
-          - NetworkingAndStorage
-        condition: |
-          and(
-            ${{ parameters.enableAccelnetBYON }},
-            not(failed())
-          )
-        timeoutInMinutes: 480
-        pool:
-          vmImage: ubuntu-latest
-        steps:
-          - checkout: self
-            displayName: "Checkout main repository"
-          - checkout: Networking-Aquarius
-            displayName: "Checkout Networking-Aquarius repository"
-          - task: AzureCLI@2
-            displayName: "Deploy Accelnet VMSS"
-            inputs:
-              azureSubscription: $(AZURE_SERVICE_CONNECTION)
-              scriptType: bash
-              scriptLocation: scriptPath
-              scriptPath: "$(Build.SourcesDirectory)/azure-container-networking/.pipelines/swiftv2-long-running/scripts/deploy_accelnetbyon.sh"
-              arguments: >
-                $(rgName)
-                ${{ parameters.location }}
-                $(Build.SourcesDirectory)
-                ${{ parameters.subscriptionId }}
-            env:
-              SSH_PUBLIC_KEY_SECRET_NAME: $(SSH_PUBLIC_KEY_SECRET_NAME)
-              CLUSTER_KUBECONFIG_KEYVAULT_NAME: $(CLUSTER_KUBECONFIG_KEYVAULT_NAME)
-              KEY_VAULT_RESOURCE_GROUP: $(KEY_VAULT_RESOURCE_GROUP)
-              KEY_VAULT_SUBSCRIPTION: $(KEY_VAULT_SUBSCRIPTION)
-              L1VH_KEYVAULT_NAME: $(L1VH_KEYVAULT_NAME)
-              L1VH_VMSS_PASSWORD_SECRET: $(L1VH_VMSS_PASSWORD_SECRET)
-              L1VH_VM_BICEP_PASSWORD_SECRET: $(L1VH_VM_BICEP_PASSWORD_SECRET)
-              L1VH_STORAGE_SECRET: $(L1VH_STORAGE_SECRET)
+        # Accelnet BYON - only for regions explicitly enabled by the pipeline parameters.
+        # The deploy script itself checks VMSS existence and skips if already joined.
+        - ${{ if eq(parameters.enableAccelnetBYON, true) }}:
+          - job: DeployAccelnetBYON
+            displayName: "Join Accelnet BYON VMSS to AKS Cluster"
+            timeoutInMinutes: 480
+            pool:
+              vmImage: ubuntu-latest
+            steps:
+              - checkout: self
+                displayName: "Checkout main repository"
+              - checkout: Networking-Aquarius
+                displayName: "Checkout Networking-Aquarius repository"
+              - task: AzureCLI@2
+                displayName: "Deploy Accelnet VMSS"
+                inputs:
+                  azureSubscription: $(AZURE_SERVICE_CONNECTION)
+                  scriptType: bash
+                  scriptLocation: scriptPath
+                  scriptPath: "$(Build.SourcesDirectory)/azure-container-networking/.pipelines/swiftv2-long-running/scripts/deploy_accelnetbyon.sh"
+                  arguments: >
+                    $(rgName)
+                    ${{ parameters.location }}
+                    $(Build.SourcesDirectory)
+                    ${{ parameters.subscriptionId }}
+                env:
+                  SSH_PUBLIC_KEY_SECRET_NAME: $(SSH_PUBLIC_KEY_SECRET_NAME)
+                  CLUSTER_KUBECONFIG_KEYVAULT_NAME: $(CLUSTER_KUBECONFIG_KEYVAULT_NAME)
+                  KEY_VAULT_RESOURCE_GROUP: $(KEY_VAULT_RESOURCE_GROUP)
+                  KEY_VAULT_SUBSCRIPTION: $(KEY_VAULT_SUBSCRIPTION)
+                  L1VH_KEYVAULT_NAME: $(L1VH_KEYVAULT_NAME)
+                  L1VH_VMSS_PASSWORD_SECRET: $(L1VH_VMSS_PASSWORD_SECRET)
+                  L1VH_VM_BICEP_PASSWORD_SECRET: $(L1VH_VM_BICEP_PASSWORD_SECRET)
+                  L1VH_STORAGE_SECRET: $(L1VH_STORAGE_SECRET)

--- a/.pipelines/swiftv2-long-running/template/long-running-pipeline-template.yaml
+++ b/.pipelines/swiftv2-long-running/template/long-running-pipeline-template.yaml
@@ -143,6 +143,7 @@ stages:
           storageAccount2: $[ stageDependencies.AKSClusterAndNetworking_${{ replace(scenario.label, '-', '_') }}.NetworkingAndStorage.outputs['CreateStorage.storageAccount2'] ]
           dependsOn:
             - AKSClusterAndNetworking_${{ replace(scenario.label, '-', '_') }}
+            - ByonSetup_${{ replace(scenario.label, '-', '_') }}
             - AcquireLease_${{ replace(scenario.label, '-', '_') }}
             - DataPathTests_swiftv2_linux_${{ replace(scenario.label, '-', '_') }}
 
@@ -160,6 +161,7 @@ stages:
           storageAccount2: $[ stageDependencies.AKSClusterAndNetworking_${{ replace(scenario.label, '-', '_') }}.NetworkingAndStorage.outputs['CreateStorage.storageAccount2'] ]
           dependsOn:
             - AKSClusterAndNetworking_${{ replace(scenario.label, '-', '_') }}
+            - ByonSetup_${{ replace(scenario.label, '-', '_') }}
             - AcquireLease_${{ replace(scenario.label, '-', '_') }}
             - DataPathTests_swiftv2_linux_byon_${{ replace(scenario.label, '-', '_') }}
 


### PR DESCRIPTION
## Why

Four defects in the SwiftV2 long-running pipeline that either hid failures or blocked unrelated tests.

**1. Node readiness waits didn't wait.** `kubectl wait --for=condition=Ready nodes -l agentpool=npz1 --timeout=120s` exits *immediately* when the selector matches nothing, and `2>/dev/null` hid the error. With `npz1` empty, a "120 second wait" returned in **0.4 seconds**. Reimage remediation never ran either — the health check only asked Azure about the VM, and Azure considered it healthy, so a VM that boots but never registers as a node fell straight through.

**2. Cluster creation failed after 10 minutes with no diagnosis.** When a kubelet stops reporting, `kubectl wait --all --timeout=10m` can never succeed. Two `aks-2` nodes had been unreachable since July, so every run paid the full timeout for an unactionable error.

**3. BYON failures killed the zonal tests.** The BYON jobs lived in the `AKSClusterAndNetworking` stage, so a BYON failure skipped the zonal `LongRunningPodTests` via their `not(failed())` condition. They're unrelated: zonal tests run on managed pools on **aks-1**, BYON joins scale sets to **aks-2**.

**4. The subnet delegation check couldn't detect delegation, and failed open.** It keyed on the link's `name` — the constant string `SubnetDelegator` on all 32 links — so it only ever answered "does a link exist". It also piped `az rest` into `jq` with stderr discarded, making *"the ARM call failed"* indistinguishable from *"not delegated"*, after which it falls through and delegates. `set -e` without `pipefail` masked it. A transient CLI failure could re-delegate a healthy subnet, which this pipeline cannot undo — the link is created with `allowDelete: false` and needs a manual release through the delegator API.

## What changed

- **`ensure_zone_nodepools.sh`** — `wait_pool_ready` polls and treats "no nodes" as not-ready, so the timeout is honoured; a pool with a healthy VM but zero registered nodes is now reimaged.
- **`create_aks.sh`** — `check_unreachable_nodes` fails fast, naming the nodes and how long they've been unreachable. It deliberately **does not delete** them: on `aks-2` those stale objects sat on top of scale sets stuck in `Failed` with real lost capacity, so deleting them would have turned the build green over broken infrastructure.
- **BYON templates** — moved into a `ByonSetup_<label>` stage, emitted only when BYON is enabled. Zonal stages no longer depend on it; the BYON datapath stages do.
- **`create_vnets.sh`** — gate on `properties.subnetId`, the field `GetSubnetGUID` (`az_helpers.go:46`) consumes. The ARM read is captured separately so a failed read skips with a warning instead of falling through — skipping self-corrects next run, a spurious re-delegation doesn't.

## Notes

`bash -n` clean, all five pipeline YAMLs parse, stage graph expanded for all four matrix scenarios. Both helpers exercised against live clusters before and after repair; the delegation gate driven through stubbed responses under `set -e` (failed read → skip, missing GUID → delegate, malformed JSON → aborts before mutating). All 32 links currently have `subnetId`, so the gate is a no-op on today's fleet.

Separate follow-up: `deploy_linuxbyon.sh` can't repair an under-capacity BYON scale set — it short-circuits when the VMSS exists and only applies `vmsscount=2` at creation, which is why `aks-2` stayed broken for two weeks.

The failing `render` check is pre-existing on master. This PR touches no Go files.