### PR TITLE
ci: bump fluent-bit base image to v4.2.3-16

### DIFF
--- a/.pipelines/build/dockerfiles/cilium-log-collector.Dockerfile
+++ b/.pipelines/build/dockerfiles/cilium-log-collector.Dockerfile
@@ -2,6 +2,6 @@
 # SOURCE: .pipelines/build/dockerfiles/cilium-log-collector.Dockerfile.tmpl
 ARG ARCH
 
-FROM mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.3-8 as linux
+FROM mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.3-16 as linux
 ARG ARTIFACT_DIR
 COPY ${ARTIFACT_DIR}/bin/out_azure_app_insights.so /out_azure_app_insights.so

--- a/.pipelines/build/dockerfiles/cilium-log-collector.Dockerfile.tmpl
+++ b/.pipelines/build/dockerfiles/cilium-log-collector.Dockerfile.tmpl
@@ -2,6 +2,6 @@
 # SOURCE: {{.SRC_PIPE}}
 ARG ARCH
 
-FROM mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.3-8 as linux
+FROM mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.3-16 as linux
 ARG ARTIFACT_DIR
 COPY ${ARTIFACT_DIR}/bin/out_azure_app_insights.so /out_azure_app_insights.so

--- a/cilium-log-collector/Dockerfile
+++ b/cilium-log-collector/Dockerfile
@@ -13,5 +13,5 @@ WORKDIR /cilium-log-collector
 COPY ./cilium-log-collector .
 RUN go build -buildmode=c-shared -a -o out_azure_app_insights.so -trimpath -ldflags "-X main.version=$VERSION" -gcflags="-dwarflocationlists=true" .
 
-FROM mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.3-8 as linux
+FROM mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.3-16 as linux
 COPY --from=fluent-bit-plugin /cilium-log-collector/out_azure_app_insights.so /out_azure_app_insights.so

--- a/cilium-log-collector/Dockerfile.tmpl
+++ b/cilium-log-collector/Dockerfile.tmpl
@@ -13,5 +13,5 @@ WORKDIR /cilium-log-collector
 COPY ./cilium-log-collector .
 RUN go build -buildmode=c-shared -a -o out_azure_app_insights.so -trimpath -ldflags "-X main.version=$VERSION" -gcflags="-dwarflocationlists=true" .
 
-FROM mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.3-8 as linux
+FROM mcr.microsoft.com/oss/v2/fluent/fluent-bit:v4.2.3-16 as linux
 COPY --from=fluent-bit-plugin /cilium-log-collector/out_azure_app_insights.so /out_azure_app_insights.so


### PR DESCRIPTION
Bumps the cilium-log-collector fluent-bit base image from `v4.2.3-8` to `v4.2.3-16` (latest in the v4.2 minor on MCR).

Updates all build/release paths: `cilium-log-collector/Dockerfile{,.tmpl}` and `.pipelines/build/dockerfiles/cilium-log-collector.Dockerfile{,.tmpl}`.

Trivy verified new image is clean.