### PR TITLE
fix: repair pre-existing Windows unit-test failures

### DIFF
--- a/cni/network/network_windows_test.go
+++ b/cni/network/network_windows_test.go
@@ -1235,7 +1235,7 @@ func TestPluginWindowsAdd(t *testing.T) {
 						NetNsPath:         "bc526fae-4ba0-4e80-bc90-ad721e5850bf",
 						NetNs:             "bc526fae-4ba0-4e80-bc90-ad721e5850bf",
 						HostSubnetPrefix:  "20.224.0.0/16",
-						Options:           map[string]interface{}{},
+						Options:           nil,
 						// matches with cns ip configuration
 						IPAddresses: []net.IPNet{
 							{

--- a/cns/networkcontainers/networkcontainers_windows.go
+++ b/cns/networkcontainers/networkcontainers_windows.go
@@ -91,7 +91,7 @@ func setWeakHostOnInterface(ipAddress, ncID string) error {
 
 	if targetIface == nil {
 		errval := "[Azerrvalure CNS] Was not able to find the interface with ip " + ipAddress + " to enable weak host send/receive"
-		logger.Printf(errval)
+		logger.Printf("%s", errval) //nolint:staticcheck // will migrate to logger/v2
 		return errors.New(errval)
 	}
 


### PR DESCRIPTION
- cni/network/network_windows_test.go: expect Options: nil for the FrontendNIC (SwiftV2) endpoint, matching #4404 which intentionally leaves EndpointInfo.Options nil for non-infra NICs
- cns/networkcontainers/networkcontainers_windows.go: use a constant format string in logger.Printf to satisfy Go 1.26 go vet

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
fix: repair windows unit tests that block pr merge randomly


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
