### PR TITLE
fix: use distroless/base for ipv6-hp-bpf (Go 1.26 compat) [backport release/v1.7]

### DIFF
--- a/.pipelines/build/dockerfiles/ipv6-hp-bpf.Dockerfile
+++ b/.pipelines/build/dockerfiles/ipv6-hp-bpf.Dockerfile
@@ -1,7 +1,7 @@
 ARG ARCH
 
 
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/minimal:3.0 AS linux
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/base:3.0 AS linux
 ARG ARTIFACT_DIR
 COPY ${ARTIFACT_DIR}/lib/* /lib
 COPY ${ARTIFACT_DIR}/bin/ipv6-hp-bpf /ipv6-hp-bpf

--- a/bpf-prog/ipv6-hp-bpf/linux.Dockerfile
+++ b/bpf-prog/ipv6-hp-bpf/linux.Dockerfile
@@ -40,7 +40,7 @@ RUN if [ "$DEBUG" = "true" ]; then echo "\n#define DEBUG" >> /bpf-prog/ipv6-hp-b
 RUN GOOS=$OS CGO_ENABLED=0 go generate ./...
 RUN GOOS=$OS CGO_ENABLED=0 go build -a -o /go/bin/ipv6-hp-bpf -trimpath -ldflags "-s -w -X main.version="$VERSION"" -gcflags="-dwarflocationlists=true" .
 
-FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 AS linux
+FROM mcr.microsoft.com/azurelinux/distroless/base:3.0 AS linux
 COPY --from=go /go/bin/ipv6-hp-bpf /ipv6-hp-bpf
 COPY --from=go /usr/sbin/nft /usr/sbin/nft
 COPY --from=go /sbin/ip /sbin/ip


### PR DESCRIPTION
## Fix ipv6-hp-bpf init container crash with Go 1.26

### Problem
Cilium dualstack tests consistently fail on `release/v1.7` — cilium pods stay **Pending** indefinitely because the `start-ipv6-hp-bpf` init container crashes on startup.

### Root Cause
`ipv6-hp-bpf.Dockerfile` uses `distroless/minimal:3.0` which lacks `libssl`/`libcrypto`. Go 1.26 (Microsoft fork) with `GOEXPERIMENT=ms_nocgo_opensslcrypto` dynamically loads these libraries at runtime via `dlopen()`, even with `CGO_ENABLED=0`.

Master already uses `distroless/base:3.0` (which includes these libraries).

### Why only dualstack fails
The `ipv6-hp-bpf` container is only used in the dualstack cilium daemonset template (`daemonset-dualstack.yaml`). All other cilium tests (overlay, hubble, ebpf) don't use this init container.

### Fix
`distroless/minimal:3.0` → `distroless/base:3.0` (1 line change)

### Evidence
Consistent failures: [175731921](https://msazure.visualstudio.com/One/_build/results?buildId=175731921), [175698351](https://msazure.visualstudio.com/One/_build/results?buildId=175698351), [175591273](https://msazure.visualstudio.com/One/_build/results?buildId=175591273)

All show:
```
DaemonSet  cilium  Desired: 2, Unavailable: 2/2
Containers: cilium  Pending: 2
```