### PR TITLE
Adding / Testing Draft PR Functionality to FAA

### DIFF
--- a/.github/scripts/faa-open-draft-prs.sh
+++ b/.github/scripts/faa-open-draft-prs.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Opens a draft PR from each fix.md prompt pulled from Azure DevOps, assigns the
+# GitHub Copilot coding agent to author the fix, and best-effort pings the shared
+# Teams notifier bot.
+#
+# Security: fix.md content is written only to the draft PR body (its intended
+# destination) and committed under .github/faa-fixes/. It is never echoed to logs
+# or the job summary.
+#
+# Inputs (env): GH_TOKEN, REPO, BASE_BRANCH, WORKDIR, BUILD_ID and (optional Teams)
+# NOTIFIER_ENDPOINT, NOTIFIER_API_AUDIENCE, NOTIFY_TEAM_ID, NOTIFY_CHANNEL_ID,
+# NOTIFY_CC.
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN required}"
+: "${REPO:?REPO required}"
+: "${BASE_BRANCH:?BASE_BRANCH required}"
+: "${WORKDIR:?WORKDIR required}"
+
+git config --local user.name "github-actions[bot]"
+git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+
+# meta <file> <key> — read a value from the fix.md metadata header.
+meta() { sed -n '/<!-- faa-fix:v1/,/-->/p' "$1" | sed -n "s/^$2: //p" | head -n1; }
+
+# assign_copilot <pr-number> — hand the draft PR to the Copilot coding agent by
+# assigning its bot actor. Falls back to an @copilot comment if the actor is not
+# assignable with this token.
+assign_copilot() {
+  local pr="$1" owner repo actor_id pr_id
+  owner="${REPO%%/*}"; repo="${REPO#*/}"
+  actor_id="$(gh api graphql -f query='
+    query($owner:String!,$name:String!){
+      repository(owner:$owner,name:$name){
+        suggestedActors(capabilities:[CAN_BE_ASSIGNED], first:100){
+          nodes{ login __typename ... on Bot { id } ... on User { id } }
+        }
+      }
+    }' -F owner="$owner" -F name="$repo" \
+    --jq '.data.repository.suggestedActors.nodes[] | select(.login=="copilot-swe-agent" or .login=="Copilot") | .id' 2>/dev/null | head -n1 || true)"
+  pr_id="$(gh pr view "$pr" --repo "$REPO" --json id --jq .id 2>/dev/null || true)"
+  if [ -n "$actor_id" ] && [ -n "$pr_id" ] && gh api graphql -f query='
+    mutation($assignableId:ID!,$actorIds:[ID!]!){
+      replaceActorsForAssignable(input:{assignableId:$assignableId, actorIds:$actorIds}){ clientMutationId }
+    }' -F assignableId="$pr_id" -F actorIds="$actor_id" >/dev/null 2>&1; then
+    echo "assigned Copilot coding agent to PR #$pr"
+  else
+    echo "could not assign Copilot; leaving an @copilot mention instead"
+    gh pr comment "$pr" --repo "$REPO" --body \
+      "@copilot please implement the fix described in this PR. Keep it a draft and make the smallest correct change." || true
+  fi
+}
+
+# notify_teams <pr-url> <title> <owner> — best-effort Teams ping via the shared
+# notifier bot, using the Azure OIDC login already established by the workflow.
+notify_teams() {
+  local pr_url="$1" title="$2" owner="$3"
+  if [ -z "${NOTIFIER_ENDPOINT:-}" ] || [ -z "${NOTIFIER_API_AUDIENCE:-}" ] || [ -z "${NOTIFY_TEAM_ID:-}" ] || [ -z "${NOTIFY_CHANNEL_ID:-}" ]; then
+    echo "notifier vars incomplete; skipping Teams notify"; return 0
+  fi
+  local token
+  token="$(az account get-access-token --resource "$NOTIFIER_API_AUDIENCE" --query accessToken -o tsv 2>/dev/null || true)"
+  [ -n "$token" ] || { echo "could not mint notifier token; skipping"; return 0; }
+
+  # cc mentions: configured UPNs plus the recommended owner when it is an email.
+  local mentions='[]'
+  local csv="${NOTIFY_CC:-}"
+  case "$owner" in *@*) csv="${csv:+$csv,}$owner" ;; esac
+  if [ -n "$csv" ]; then
+    mentions="$(echo "$csv" | tr ',' '\n' | sed 's/^ *//;s/ *$//' | grep -v '^$' | jq -R . | jq -s .)"
+  fi
+  local cc='null'
+  if [ "$(jq 'length' <<<"$mentions")" -gt 0 ]; then
+    cc="$(jq -n --argjson m "$mentions" '{label:"Owner", mentions:$m}')"
+  fi
+  local payload
+  payload="$(jq -n \
+    --arg source "faa-draft-pr" --arg runId "$BUILD_ID" \
+    --arg teamId "$NOTIFY_TEAM_ID" --arg channelId "$NOTIFY_CHANNEL_ID" \
+    --arg title "$title" --arg pr "$pr_url" --argjson cc "$cc" \
+    '{source:$source, runId:$runId, teamId:$teamId, channelId:$channelId,
+      title:$title, summary:("Draft PR opened for a high-confidence regression: " + $pr),
+      status:"running", severity:"warning",
+      facts:[{name:"Draft PR", value:$pr, url:$pr}], mentionChannel:true}
+     + (if $cc != null then {cc:$cc} else {} end)')"
+  local code
+  code="$(curl -sS -o /dev/null -w '%{http_code}' -X POST \
+    -H "Authorization: Bearer $token" -H "Content-Type: application/json" \
+    --data "$payload" "${NOTIFIER_ENDPOINT}/api/notifications" || echo 000)"
+  echo "notifier POST -> HTTP $code"
+}
+
+created=0
+declare -A seen
+while IFS= read -r fix; do
+  [ -n "$fix" ] || continue
+  fp="$(meta "$fix" fingerprint)"
+  title="$(meta "$fix" title)"
+  owner="$(meta "$fix" owner)"
+  if [ -z "$fp" ]; then echo "skipping $fix: no fingerprint in header"; continue; fi
+  if [ -n "${seen[$fp]:-}" ]; then echo "skipping duplicate fingerprint $fp"; continue; fi
+  seen[$fp]=1
+  [ -n "$title" ] || title="[FAA] Draft fix for regression ${fp:0:12}"
+
+  branch="faa/fix-${fp}"
+
+  # Idempotency: skip if an open PR or the branch already exists.
+  existing="$(gh pr list --repo "$REPO" --state open --head "$branch" --json number --jq 'length' 2>/dev/null || echo 0)"
+  if [ "$existing" != "0" ]; then echo "draft PR already open for $branch; skipping"; continue; fi
+  if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+    echo "branch $branch already exists; skipping"; continue
+  fi
+
+  # Create the branch carrying the prompt so it diverges from base and Copilot
+  # has fix.md in-repo to work from.
+  git switch -c "$branch" "origin/${BASE_BRANCH}" 2>/dev/null || git switch -c "$branch"
+  mkdir -p .github/faa-fixes
+  cp "$fix" ".github/faa-fixes/${fp}.md"
+  git add ".github/faa-fixes/${fp}.md"
+  git commit -m "chore(faa): draft fix prompt for ${fp:0:12}" >/dev/null
+  git push origin "$branch"
+
+  pr_url="$(gh pr create --repo "$REPO" --draft --head "$branch" --base "$BASE_BRANCH" \
+    --title "$title" --body-file "$fix")"
+  echo "opened draft PR: $pr_url"
+  pr_num="${pr_url##*/}"
+
+  assign_copilot "$pr_num"
+  notify_teams "$pr_url" "$title" "$owner"
+  created=$((created + 1))
+done < "$WORKDIR/fixlist.txt"
+
+echo "created $created draft PR(s)"
+if [ "$created" = "0" ]; then
+  echo "::notice::no new draft PRs (all fingerprints already had branches/PRs)"
+fi

--- a/.github/scripts/faa-open-draft-prs.sh
+++ b/.github/scripts/faa-open-draft-prs.sh
@@ -98,7 +98,11 @@ while IFS= read -r fix; do
   fp="$(meta "$fix" fingerprint)"
   title="$(meta "$fix" title)"
   owner="$(meta "$fix" owner)"
-  if [ -z "$fp" ]; then echo "skipping $fix: no fingerprint in header"; continue; fi
+  # Untrusted artifact: fp flows into a git ref and a file path, so require a
+  # lowercase-hex digest (blocks bad refs and ../ path traversal).
+  case "$fp" in
+    ''|*[!0-9a-f]*) echo "skipping $fix: invalid fingerprint '$fp'"; continue ;;
+  esac
   if [ -n "${seen[$fp]:-}" ]; then echo "skipping duplicate fingerprint $fp"; continue; fi
   seen[$fp]=1
   [ -n "$title" ] || title="[FAA] Draft fix for regression ${fp:0:12}"

--- a/.github/scripts/faa-pull-artifacts.sh
+++ b/.github/scripts/faa-pull-artifacts.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Pulls the Failure Analysis Agent "failureAnalysis" artifacts (fix.md prompts)
+# from an Azure DevOps build and lists every fix.md for the next workflow step.
+#
+# Auth: an Entra (OIDC) bearer token minted from the workflow's azure/login — no
+# stored PAT. The federated identity must be a member of the ADO org with Build
+# (read).
+#
+# Security: downloaded artifacts stay in $RUNNER_TEMP (ephemeral, wiped after the
+# run). They are never uploaded with actions/upload-artifact and their contents
+# are never echoed to logs or the job summary — only filenames and counts are.
+#
+# Inputs (env): ADO_ORG, ADO_PROJECT, BUILD_ID.
+# Outputs ($GITHUB_OUTPUT): count, workdir.
+set -euo pipefail
+
+: "${ADO_ORG:?ADO_ORG required}"
+: "${ADO_PROJECT:?ADO_PROJECT required}"
+: "${BUILD_ID:?BUILD_ID required}"
+
+case "$BUILD_ID" in
+  ''|*[!0-9]*) echo "::error::buildId must be numeric: $BUILD_ID"; exit 1 ;;
+esac
+
+# ADO_ORG / ADO_PROJECT are interpolated into the Azure DevOps URL that carries
+# the OIDC bearer token, so constrain them to a safe charset (rejects spaces,
+# slashes, and other URL-significant characters) as defense in depth.
+case "$ADO_ORG" in
+  *[!A-Za-z0-9._-]*) echo "::error::ADO_ORG has unexpected characters: $ADO_ORG"; exit 1 ;;
+esac
+case "$ADO_PROJECT" in
+  *[!A-Za-z0-9._-]*) echo "::error::ADO_PROJECT has unexpected characters: $ADO_PROJECT"; exit 1 ;;
+esac
+
+# Azure DevOps resource app ID — constant across tenants. Mint a short-lived
+# token for it from the OIDC login instead of storing a PAT.
+ado_resource="499b84ac-1321-427f-aa17-267ca6975798"
+ado_token="$(az account get-access-token --resource "$ado_resource" --query accessToken -o tsv)"
+if [ -z "$ado_token" ]; then
+  echo "::error::could not mint an Azure DevOps token from the OIDC login"
+  exit 1
+fi
+auth=(-H "Authorization: Bearer $ado_token")
+
+api="https://dev.azure.com/${ADO_ORG}/${ADO_PROJECT}/_apis"
+work="$RUNNER_TEMP/faa"
+mkdir -p "$work/extracted"
+
+# Verify this is a non-PR build; PR builds already get the inline PR comment, so
+# they must not spawn a draft PR here (defense in depth — the agent already gates
+# fix.md on non-PR builds).
+build="$(curl -sS -fL "${auth[@]}" "${api}/build/builds/${BUILD_ID}?api-version=7.1")"
+reason="$(jq -r '.reason // ""' <<<"$build")"
+echo "build $BUILD_ID reason=$reason"
+if [ "$reason" = "pullRequest" ]; then
+  echo "::notice::build $BUILD_ID is a pull-request build; nothing to do"
+  echo "count=0" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+arts="$(curl -sS -fL "${auth[@]}" "${api}/build/builds/${BUILD_ID}/artifacts?api-version=7.1")"
+mapfile -t rows < <(jq -r '.value[] | select(.name | startswith("failureAnalysis")) | "\(.name)\t\(.resource.downloadUrl)"' <<<"$arts")
+if [ "${#rows[@]}" -eq 0 ]; then
+  echo "::notice::no failureAnalysis artifacts on build $BUILD_ID"
+  echo "count=0" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+for row in "${rows[@]}"; do
+  name="${row%%$'\t'*}"
+  url="${row#*$'\t'}"
+  [ -n "$url" ] || continue
+  echo "downloading artifact $name"
+  curl -sS -fL "${auth[@]}" -o "$work/${name}.zip" "$url"
+  unzip -q -o "$work/${name}.zip" -d "$work/extracted/${name}"
+done
+
+# Collect every fix.md the build produced (one per gated scenario).
+: > "$work/fixlist.txt"
+find "$work/extracted" -type f -name fix.md >> "$work/fixlist.txt" || true
+count="$(wc -l < "$work/fixlist.txt" | tr -d ' ')"
+echo "found $count fix.md file(s)"
+echo "count=$count" >> "$GITHUB_OUTPUT"
+echo "workdir=$work" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/faa-draft-pr.yaml
+++ b/.github/workflows/faa-draft-pr.yaml
@@ -77,7 +77,7 @@ jobs:
       # artifact pull and the Teams notifier. The pull depends on it, so this is
       # required — a failure here correctly fails the run.
       - name: Azure login (OIDC)
-        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/faa-draft-pr.yaml
+++ b/.github/workflows/faa-draft-pr.yaml
@@ -5,20 +5,25 @@ name: FAA Draft PR
 # The FAA runs in Azure DevOps, which cannot obtain a GitHub token, so it only
 # publishes fix.md as part of its analysis artifact. Nothing is pushed from ADO.
 # This workflow is the GitHub-side half: a maintainer runs it manually with the
-# ADO build id, and it *pulls* the artifact (using an ADO PAT), and for each
-# high-confidence non-PR regression it:
+# ADO build id, and it *pulls* the artifact (authenticating to Azure DevOps with a
+# short-lived OIDC token — no PAT), and for each high-confidence non-PR regression
+# it:
 #   1. creates branch faa/fix-<fingerprint> carrying the fix.md prompt,
 #   2. opens a draft PR with fix.md as the body,
 #   3. assigns the GitHub Copilot coding agent to author the fix,
 #   4. pings the shared Teams notifier bot (best-effort) to mention the owner.
+#
+# The step logic lives in .github/scripts/faa-pull-artifacts.sh and
+# .github/scripts/faa-open-draft-prs.sh so this file stays declarative.
 #
 # Scheduled automation is deferred; the same pull logic can later move behind a
 # `schedule:` trigger.
 #
 # Prerequisites (configure in the GitHub repo — these live outside this file):
 #   Secrets:
-#     ADO_PAT                 Azure DevOps PAT with Build (read) + Artifacts (read)
-#     AZURE_CLIENT_ID         Azure OIDC app (federated cred for this repo)
+#     AZURE_CLIENT_ID         Azure OIDC app (federated cred for this repo). Used
+#                             to mint short-lived Entra tokens for BOTH the Azure
+#                             DevOps artifact pull and the Teams notifier — no PAT.
 #     AZURE_TENANT_ID
 #     AZURE_SUBSCRIPTION_ID
 #   Variables:
@@ -29,8 +34,10 @@ name: FAA Draft PR
 #     FAA_NOTIFY_TEAM_ID      Teams team groupId
 #     FAA_NOTIFY_CHANNEL_ID   Teams channel id (19:...@thread.skype)
 #     FAA_NOTIFY_CC           optional comma-separated owner UPNs to @mention
-#   Also required: an Azure federated identity credential for this repo scoped to
-#   the notifier audience, and the GitHub Copilot coding agent enabled on the repo.
+#   Also required: the OIDC federated identity must be a member of the Azure
+#   DevOps org with Build (read), an Azure federated identity credential for this
+#   repo scoped to the notifier audience, and the GitHub Copilot coding agent
+#   enabled on the repo.
 
 on:
   workflow_dispatch:
@@ -58,7 +65,7 @@ jobs:
       contents: write       # push faa/fix-* branches
       pull-requests: write   # open draft PRs
       issues: write          # assign Copilot / comment
-      id-token: write        # Azure OIDC for the Teams notifier token
+      id-token: write        # Azure OIDC for the ADO pull and Teams notifier
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -66,11 +73,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      # Best-effort: the Teams mention step needs an AAD token minted from this
-      # login. Missing OIDC config must not fail the PR creation, so continue.
-      - name: Azure login (OIDC) for Teams notifier
-        id: azlogin
-        continue-on-error: true
+      # OIDC login mints short-lived Entra tokens for both the Azure DevOps
+      # artifact pull and the Teams notifier. The pull depends on it, so this is
+      # required — a failure here correctly fails the run.
+      - name: Azure login (OIDC)
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -82,59 +88,8 @@ jobs:
         env:
           ADO_ORG: ${{ vars.ADO_ORG }}
           ADO_PROJECT: ${{ vars.ADO_PROJECT }}
-          ADO_PAT: ${{ secrets.ADO_PAT }}
           BUILD_ID: ${{ inputs.buildId }}
-        run: |
-          set -euo pipefail
-
-          if [ -z "${ADO_ORG:-}" ] || [ -z "${ADO_PROJECT:-}" ] || [ -z "${ADO_PAT:-}" ]; then
-            echo "::error::ADO_ORG / ADO_PROJECT vars and ADO_PAT secret are required"
-            exit 1
-          fi
-          case "$BUILD_ID" in
-            ''|*[!0-9]*) echo "::error::buildId must be numeric: $BUILD_ID"; exit 1 ;;
-          esac
-
-          API="https://dev.azure.com/${ADO_ORG}/${ADO_PROJECT}/_apis"
-          WORK="$RUNNER_TEMP/faa"
-          mkdir -p "$WORK/extracted"
-
-          # Verify this is a non-PR build; PR builds already get the inline PR
-          # comment, so they must not spawn a draft PR here (defense in depth —
-          # the agent already gates fix.md on non-PR builds).
-          build="$(curl -sS -fL -u ":${ADO_PAT}" "${API}/build/builds/${BUILD_ID}?api-version=7.1")"
-          reason="$(jq -r '.reason // ""' <<<"$build")"
-          echo "build $BUILD_ID reason=$reason"
-          if [ "$reason" = "pullRequest" ]; then
-            echo "::notice::build $BUILD_ID is a pull-request build; nothing to do"
-            echo "count=0" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          arts="$(curl -sS -fL -u ":${ADO_PAT}" "${API}/build/builds/${BUILD_ID}/artifacts?api-version=7.1")"
-          mapfile -t rows < <(jq -r '.value[] | select(.name | startswith("failureAnalysis")) | "\(.name)\t\(.resource.downloadUrl)"' <<<"$arts")
-          if [ "${#rows[@]}" -eq 0 ]; then
-            echo "::notice::no failureAnalysis artifacts on build $BUILD_ID"
-            echo "count=0" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          for row in "${rows[@]}"; do
-            name="${row%%$'\t'*}"
-            url="${row#*$'\t'}"
-            [ -n "$url" ] || continue
-            echo "downloading artifact $name"
-            curl -sS -fL -u ":${ADO_PAT}" -o "$WORK/${name}.zip" "$url"
-            unzip -q -o "$WORK/${name}.zip" -d "$WORK/extracted/${name}"
-          done
-
-          # Collect every fix.md the build produced (one per gated scenario).
-          : > "$WORK/fixlist.txt"
-          find "$WORK/extracted" -type f -name fix.md >> "$WORK/fixlist.txt" || true
-          count="$(wc -l < "$WORK/fixlist.txt" | tr -d ' ')"
-          echo "found $count fix.md file(s)"
-          echo "count=$count" >> "$GITHUB_OUTPUT"
-          echo "workdir=$WORK" >> "$GITHUB_OUTPUT"
+        run: bash .github/scripts/faa-pull-artifacts.sh
 
       - name: Open draft PRs, assign Copilot, notify
         if: steps.pull.outputs.count != '0'
@@ -144,131 +99,9 @@ jobs:
           BASE_BRANCH: ${{ inputs.baseBranch }}
           WORKDIR: ${{ steps.pull.outputs.workdir }}
           BUILD_ID: ${{ inputs.buildId }}
-          AZ_LOGIN: ${{ steps.azlogin.outcome }}
           NOTIFIER_ENDPOINT: ${{ vars.NOTIFIER_ENDPOINT }}
           NOTIFIER_API_AUDIENCE: ${{ vars.NOTIFIER_API_AUDIENCE }}
           NOTIFY_TEAM_ID: ${{ vars.FAA_NOTIFY_TEAM_ID }}
           NOTIFY_CHANNEL_ID: ${{ vars.FAA_NOTIFY_CHANNEL_ID }}
           NOTIFY_CC: ${{ vars.FAA_NOTIFY_CC }}
-        run: |
-          set -euo pipefail
-
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
-
-          # meta <file> <key> — read a value from the fix.md metadata header.
-          meta() { sed -n '/<!-- faa-fix:v1/,/-->/p' "$1" | sed -n "s/^$2: //p" | head -n1; }
-
-          # assign_copilot <pr-number> — hand the draft PR to the Copilot coding
-          # agent by assigning its bot actor. Falls back to an @copilot comment
-          # if the actor is not assignable with this token.
-          assign_copilot() {
-            local pr="$1" owner repo actor_id pr_id
-            owner="${REPO%%/*}"; repo="${REPO#*/}"
-            actor_id="$(gh api graphql -f query='
-              query($owner:String!,$name:String!){
-                repository(owner:$owner,name:$name){
-                  suggestedActors(capabilities:[CAN_BE_ASSIGNED], first:100){
-                    nodes{ login __typename ... on Bot { id } ... on User { id } }
-                  }
-                }
-              }' -F owner="$owner" -F name="$repo" \
-              --jq '.data.repository.suggestedActors.nodes[] | select(.login=="copilot-swe-agent" or .login=="Copilot") | .id' 2>/dev/null | head -n1 || true)"
-            pr_id="$(gh pr view "$pr" --repo "$REPO" --json id --jq .id 2>/dev/null || true)"
-            if [ -n "$actor_id" ] && [ -n "$pr_id" ] && gh api graphql -f query='
-              mutation($assignableId:ID!,$actorIds:[ID!]!){
-                replaceActorsForAssignable(input:{assignableId:$assignableId, actorIds:$actorIds}){ clientMutationId }
-              }' -F assignableId="$pr_id" -F actorIds="$actor_id" >/dev/null 2>&1; then
-              echo "assigned Copilot coding agent to PR #$pr"
-            else
-              echo "could not assign Copilot; leaving an @copilot mention instead"
-              gh pr comment "$pr" --repo "$REPO" --body \
-                "@copilot please implement the fix described in this PR. Keep it a draft and make the smallest correct change." || true
-            fi
-          }
-
-          # notify_teams <pr-url> <title> <owner> — best-effort Teams ping via the
-          # shared notifier bot. Requires the Azure OIDC login to have succeeded.
-          notify_teams() {
-            local pr_url="$1" title="$2" owner="$3"
-            if [ "$AZ_LOGIN" != "success" ]; then echo "azure login unavailable; skipping Teams notify"; return 0; fi
-            if [ -z "${NOTIFIER_ENDPOINT:-}" ] || [ -z "${NOTIFIER_API_AUDIENCE:-}" ] || [ -z "${NOTIFY_TEAM_ID:-}" ] || [ -z "${NOTIFY_CHANNEL_ID:-}" ]; then
-              echo "notifier vars incomplete; skipping Teams notify"; return 0
-            fi
-            local token
-            token="$(az account get-access-token --resource "$NOTIFIER_API_AUDIENCE" --query accessToken -o tsv 2>/dev/null || true)"
-            [ -n "$token" ] || { echo "could not mint notifier token; skipping"; return 0; }
-
-            # cc mentions: configured UPNs plus the recommended owner when it is an email.
-            local mentions='[]'
-            local csv="${NOTIFY_CC:-}"
-            case "$owner" in *@*) csv="${csv:+$csv,}$owner" ;; esac
-            if [ -n "$csv" ]; then
-              mentions="$(echo "$csv" | tr ',' '\n' | sed 's/^ *//;s/ *$//' | grep -v '^$' | jq -R . | jq -s .)"
-            fi
-            local cc='null'
-            if [ "$(jq 'length' <<<"$mentions")" -gt 0 ]; then
-              cc="$(jq -n --argjson m "$mentions" '{label:"Owner", mentions:$m}')"
-            fi
-            local payload
-            payload="$(jq -n \
-              --arg source "faa-draft-pr" --arg runId "$BUILD_ID" \
-              --arg teamId "$NOTIFY_TEAM_ID" --arg channelId "$NOTIFY_CHANNEL_ID" \
-              --arg title "$title" --arg pr "$pr_url" --argjson cc "$cc" \
-              '{source:$source, runId:$runId, teamId:$teamId, channelId:$channelId,
-                title:$title, summary:("Draft PR opened for a high-confidence regression: " + $pr),
-                status:"running", severity:"warning",
-                facts:[{name:"Draft PR", value:$pr, url:$pr}], mentionChannel:true}
-               + (if $cc != null then {cc:$cc} else {} end)')"
-            local code
-            code="$(curl -sS -o /dev/null -w '%{http_code}' -X POST \
-              -H "Authorization: Bearer ${token}" -H "Content-Type: application/json" \
-              --data "$payload" "${NOTIFIER_ENDPOINT}/api/notifications" || echo 000)"
-            echo "notifier POST -> HTTP $code"
-          }
-
-          created=0
-          declare -A seen
-          while IFS= read -r fix; do
-            [ -n "$fix" ] || continue
-            fp="$(meta "$fix" fingerprint)"
-            title="$(meta "$fix" title)"
-            owner="$(meta "$fix" owner)"
-            if [ -z "$fp" ]; then echo "skipping $fix: no fingerprint in header"; continue; fi
-            if [ -n "${seen[$fp]:-}" ]; then echo "skipping duplicate fingerprint $fp"; continue; fi
-            seen[$fp]=1
-            [ -n "$title" ] || title="[FAA] Draft fix for regression ${fp:0:12}"
-
-            branch="faa/fix-${fp}"
-
-            # Idempotency: skip if an open PR or the branch already exists.
-            existing="$(gh pr list --repo "$REPO" --state open --head "$branch" --json number --jq 'length' 2>/dev/null || echo 0)"
-            if [ "$existing" != "0" ]; then echo "draft PR already open for $branch; skipping"; continue; fi
-            if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
-              echo "branch $branch already exists; skipping"; continue
-            fi
-
-            # Create the branch carrying the prompt so it diverges from base and
-            # Copilot has fix.md in-repo to work from.
-            git switch -c "$branch" "origin/${BASE_BRANCH}" 2>/dev/null || git switch -c "$branch"
-            mkdir -p .github/faa-fixes
-            cp "$fix" ".github/faa-fixes/${fp}.md"
-            git add ".github/faa-fixes/${fp}.md"
-            git commit -m "chore(faa): draft fix prompt for ${fp:0:12}" >/dev/null
-            git push origin "$branch"
-
-            pr_url="$(gh pr create --repo "$REPO" --draft --head "$branch" --base "$BASE_BRANCH" \
-              --title "$title" --body-file "$fix")"
-            echo "opened draft PR: $pr_url"
-            pr_num="${pr_url##*/}"
-
-            assign_copilot "$pr_num"
-            notify_teams "$pr_url" "$title" "$owner"
-            created=$((created + 1))
-          done < "$WORKDIR/fixlist.txt"
-
-          echo "created $created draft PR(s)"
-          if [ "$created" = "0" ]; then
-            echo "::notice::no new draft PRs (all fingerprints already had branches/PRs)"
-          fi
+        run: bash .github/scripts/faa-open-draft-prs.sh

--- a/.github/workflows/faa-draft-pr.yaml
+++ b/.github/workflows/faa-draft-pr.yaml
@@ -1,0 +1,274 @@
+name: FAA Draft PR
+
+# Opens a draft pull request from a Failure Analysis Agent "fix.md" prompt.
+#
+# The FAA runs in Azure DevOps, which cannot obtain a GitHub token, so it only
+# publishes fix.md as part of its analysis artifact. Nothing is pushed from ADO.
+# This workflow is the GitHub-side half: a maintainer runs it manually with the
+# ADO build id, and it *pulls* the artifact (using an ADO PAT), and for each
+# high-confidence non-PR regression it:
+#   1. creates branch faa/fix-<fingerprint> carrying the fix.md prompt,
+#   2. opens a draft PR with fix.md as the body,
+#   3. assigns the GitHub Copilot coding agent to author the fix,
+#   4. pings the shared Teams notifier bot (best-effort) to mention the owner.
+#
+# Scheduled automation is deferred; the same pull logic can later move behind a
+# `schedule:` trigger.
+#
+# Prerequisites (configure in the GitHub repo — these live outside this file):
+#   Secrets:
+#     ADO_PAT                 Azure DevOps PAT with Build (read) + Artifacts (read)
+#     AZURE_CLIENT_ID         Azure OIDC app (federated cred for this repo)
+#     AZURE_TENANT_ID
+#     AZURE_SUBSCRIPTION_ID
+#   Variables:
+#     ADO_ORG                 Azure DevOps organization (e.g. msazure)
+#     ADO_PROJECT             Azure DevOps project (e.g. One)
+#     NOTIFIER_ENDPOINT       ACN notifier bot base URL (Teams ping; optional)
+#     NOTIFIER_API_AUDIENCE   AAD audience for the notifier (api://...)
+#     FAA_NOTIFY_TEAM_ID      Teams team groupId
+#     FAA_NOTIFY_CHANNEL_ID   Teams channel id (19:...@thread.skype)
+#     FAA_NOTIFY_CC           optional comma-separated owner UPNs to @mention
+#   Also required: an Azure federated identity credential for this repo scoped to
+#   the notifier audience, and the GitHub Copilot coding agent enabled on the repo.
+
+on:
+  workflow_dispatch:
+    inputs:
+      buildId:
+        description: 'Azure DevOps build id whose failureAnalysis artifact to pull'
+        required: true
+        type: string
+      baseBranch:
+        description: 'Base branch for the draft PR(s)'
+        required: false
+        default: 'master'
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: faa-draft-pr-${{ inputs.buildId }}
+  cancel-in-progress: false
+
+jobs:
+  open-draft-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write       # push faa/fix-* branches
+      pull-requests: write   # open draft PRs
+      issues: write          # assign Copilot / comment
+      id-token: write        # Azure OIDC for the Teams notifier token
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.baseBranch }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Best-effort: the Teams mention step needs an AAD token minted from this
+      # login. Missing OIDC config must not fail the PR creation, so continue.
+      - name: Azure login (OIDC) for Teams notifier
+        id: azlogin
+        continue-on-error: true
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Pull failureAnalysis artifact from Azure DevOps
+        id: pull
+        env:
+          ADO_ORG: ${{ vars.ADO_ORG }}
+          ADO_PROJECT: ${{ vars.ADO_PROJECT }}
+          ADO_PAT: ${{ secrets.ADO_PAT }}
+          BUILD_ID: ${{ inputs.buildId }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${ADO_ORG:-}" ] || [ -z "${ADO_PROJECT:-}" ] || [ -z "${ADO_PAT:-}" ]; then
+            echo "::error::ADO_ORG / ADO_PROJECT vars and ADO_PAT secret are required"
+            exit 1
+          fi
+          case "$BUILD_ID" in
+            ''|*[!0-9]*) echo "::error::buildId must be numeric: $BUILD_ID"; exit 1 ;;
+          esac
+
+          API="https://dev.azure.com/${ADO_ORG}/${ADO_PROJECT}/_apis"
+          WORK="$RUNNER_TEMP/faa"
+          mkdir -p "$WORK/extracted"
+
+          # Verify this is a non-PR build; PR builds already get the inline PR
+          # comment, so they must not spawn a draft PR here (defense in depth —
+          # the agent already gates fix.md on non-PR builds).
+          build="$(curl -sS -fL -u ":${ADO_PAT}" "${API}/build/builds/${BUILD_ID}?api-version=7.1")"
+          reason="$(jq -r '.reason // ""' <<<"$build")"
+          echo "build $BUILD_ID reason=$reason"
+          if [ "$reason" = "pullRequest" ]; then
+            echo "::notice::build $BUILD_ID is a pull-request build; nothing to do"
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          arts="$(curl -sS -fL -u ":${ADO_PAT}" "${API}/build/builds/${BUILD_ID}/artifacts?api-version=7.1")"
+          mapfile -t rows < <(jq -r '.value[] | select(.name | startswith("failureAnalysis")) | "\(.name)\t\(.resource.downloadUrl)"' <<<"$arts")
+          if [ "${#rows[@]}" -eq 0 ]; then
+            echo "::notice::no failureAnalysis artifacts on build $BUILD_ID"
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          for row in "${rows[@]}"; do
+            name="${row%%$'\t'*}"
+            url="${row#*$'\t'}"
+            [ -n "$url" ] || continue
+            echo "downloading artifact $name"
+            curl -sS -fL -u ":${ADO_PAT}" -o "$WORK/${name}.zip" "$url"
+            unzip -q -o "$WORK/${name}.zip" -d "$WORK/extracted/${name}"
+          done
+
+          # Collect every fix.md the build produced (one per gated scenario).
+          : > "$WORK/fixlist.txt"
+          find "$WORK/extracted" -type f -name fix.md >> "$WORK/fixlist.txt" || true
+          count="$(wc -l < "$WORK/fixlist.txt" | tr -d ' ')"
+          echo "found $count fix.md file(s)"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "workdir=$WORK" >> "$GITHUB_OUTPUT"
+
+      - name: Open draft PRs, assign Copilot, notify
+        if: steps.pull.outputs.count != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BASE_BRANCH: ${{ inputs.baseBranch }}
+          WORKDIR: ${{ steps.pull.outputs.workdir }}
+          BUILD_ID: ${{ inputs.buildId }}
+          AZ_LOGIN: ${{ steps.azlogin.outcome }}
+          NOTIFIER_ENDPOINT: ${{ vars.NOTIFIER_ENDPOINT }}
+          NOTIFIER_API_AUDIENCE: ${{ vars.NOTIFIER_API_AUDIENCE }}
+          NOTIFY_TEAM_ID: ${{ vars.FAA_NOTIFY_TEAM_ID }}
+          NOTIFY_CHANNEL_ID: ${{ vars.FAA_NOTIFY_CHANNEL_ID }}
+          NOTIFY_CC: ${{ vars.FAA_NOTIFY_CC }}
+        run: |
+          set -euo pipefail
+
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+
+          # meta <file> <key> — read a value from the fix.md metadata header.
+          meta() { sed -n '/<!-- faa-fix:v1/,/-->/p' "$1" | sed -n "s/^$2: //p" | head -n1; }
+
+          # assign_copilot <pr-number> — hand the draft PR to the Copilot coding
+          # agent by assigning its bot actor. Falls back to an @copilot comment
+          # if the actor is not assignable with this token.
+          assign_copilot() {
+            local pr="$1" owner repo actor_id pr_id
+            owner="${REPO%%/*}"; repo="${REPO#*/}"
+            actor_id="$(gh api graphql -f query='
+              query($owner:String!,$name:String!){
+                repository(owner:$owner,name:$name){
+                  suggestedActors(capabilities:[CAN_BE_ASSIGNED], first:100){
+                    nodes{ login __typename ... on Bot { id } ... on User { id } }
+                  }
+                }
+              }' -F owner="$owner" -F name="$repo" \
+              --jq '.data.repository.suggestedActors.nodes[] | select(.login=="copilot-swe-agent" or .login=="Copilot") | .id' 2>/dev/null | head -n1 || true)"
+            pr_id="$(gh pr view "$pr" --repo "$REPO" --json id --jq .id 2>/dev/null || true)"
+            if [ -n "$actor_id" ] && [ -n "$pr_id" ] && gh api graphql -f query='
+              mutation($assignableId:ID!,$actorIds:[ID!]!){
+                replaceActorsForAssignable(input:{assignableId:$assignableId, actorIds:$actorIds}){ clientMutationId }
+              }' -F assignableId="$pr_id" -F actorIds="$actor_id" >/dev/null 2>&1; then
+              echo "assigned Copilot coding agent to PR #$pr"
+            else
+              echo "could not assign Copilot; leaving an @copilot mention instead"
+              gh pr comment "$pr" --repo "$REPO" --body \
+                "@copilot please implement the fix described in this PR. Keep it a draft and make the smallest correct change." || true
+            fi
+          }
+
+          # notify_teams <pr-url> <title> <owner> — best-effort Teams ping via the
+          # shared notifier bot. Requires the Azure OIDC login to have succeeded.
+          notify_teams() {
+            local pr_url="$1" title="$2" owner="$3"
+            if [ "$AZ_LOGIN" != "success" ]; then echo "azure login unavailable; skipping Teams notify"; return 0; fi
+            if [ -z "${NOTIFIER_ENDPOINT:-}" ] || [ -z "${NOTIFIER_API_AUDIENCE:-}" ] || [ -z "${NOTIFY_TEAM_ID:-}" ] || [ -z "${NOTIFY_CHANNEL_ID:-}" ]; then
+              echo "notifier vars incomplete; skipping Teams notify"; return 0
+            fi
+            local token
+            token="$(az account get-access-token --resource "$NOTIFIER_API_AUDIENCE" --query accessToken -o tsv 2>/dev/null || true)"
+            [ -n "$token" ] || { echo "could not mint notifier token; skipping"; return 0; }
+
+            # cc mentions: configured UPNs plus the recommended owner when it is an email.
+            local mentions='[]'
+            local csv="${NOTIFY_CC:-}"
+            case "$owner" in *@*) csv="${csv:+$csv,}$owner" ;; esac
+            if [ -n "$csv" ]; then
+              mentions="$(echo "$csv" | tr ',' '\n' | sed 's/^ *//;s/ *$//' | grep -v '^$' | jq -R . | jq -s .)"
+            fi
+            local cc='null'
+            if [ "$(jq 'length' <<<"$mentions")" -gt 0 ]; then
+              cc="$(jq -n --argjson m "$mentions" '{label:"Owner", mentions:$m}')"
+            fi
+            local payload
+            payload="$(jq -n \
+              --arg source "faa-draft-pr" --arg runId "$BUILD_ID" \
+              --arg teamId "$NOTIFY_TEAM_ID" --arg channelId "$NOTIFY_CHANNEL_ID" \
+              --arg title "$title" --arg pr "$pr_url" --argjson cc "$cc" \
+              '{source:$source, runId:$runId, teamId:$teamId, channelId:$channelId,
+                title:$title, summary:("Draft PR opened for a high-confidence regression: " + $pr),
+                status:"running", severity:"warning",
+                facts:[{name:"Draft PR", value:$pr, url:$pr}], mentionChannel:true}
+               + (if $cc != null then {cc:$cc} else {} end)')"
+            local code
+            code="$(curl -sS -o /dev/null -w '%{http_code}' -X POST \
+              -H "Authorization: Bearer ${token}" -H "Content-Type: application/json" \
+              --data "$payload" "${NOTIFIER_ENDPOINT}/api/notifications" || echo 000)"
+            echo "notifier POST -> HTTP $code"
+          }
+
+          created=0
+          declare -A seen
+          while IFS= read -r fix; do
+            [ -n "$fix" ] || continue
+            fp="$(meta "$fix" fingerprint)"
+            title="$(meta "$fix" title)"
+            owner="$(meta "$fix" owner)"
+            if [ -z "$fp" ]; then echo "skipping $fix: no fingerprint in header"; continue; fi
+            if [ -n "${seen[$fp]:-}" ]; then echo "skipping duplicate fingerprint $fp"; continue; fi
+            seen[$fp]=1
+            [ -n "$title" ] || title="[FAA] Draft fix for regression ${fp:0:12}"
+
+            branch="faa/fix-${fp}"
+
+            # Idempotency: skip if an open PR or the branch already exists.
+            existing="$(gh pr list --repo "$REPO" --state open --head "$branch" --json number --jq 'length' 2>/dev/null || echo 0)"
+            if [ "$existing" != "0" ]; then echo "draft PR already open for $branch; skipping"; continue; fi
+            if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+              echo "branch $branch already exists; skipping"; continue
+            fi
+
+            # Create the branch carrying the prompt so it diverges from base and
+            # Copilot has fix.md in-repo to work from.
+            git switch -c "$branch" "origin/${BASE_BRANCH}" 2>/dev/null || git switch -c "$branch"
+            mkdir -p .github/faa-fixes
+            cp "$fix" ".github/faa-fixes/${fp}.md"
+            git add ".github/faa-fixes/${fp}.md"
+            git commit -m "chore(faa): draft fix prompt for ${fp:0:12}" >/dev/null
+            git push origin "$branch"
+
+            pr_url="$(gh pr create --repo "$REPO" --draft --head "$branch" --base "$BASE_BRANCH" \
+              --title "$title" --body-file "$fix")"
+            echo "opened draft PR: $pr_url"
+            pr_num="${pr_url##*/}"
+
+            assign_copilot "$pr_num"
+            notify_teams "$pr_url" "$title" "$owner"
+            created=$((created + 1))
+          done < "$WORKDIR/fixlist.txt"
+
+          echo "created $created draft PR(s)"
+          if [ "$created" = "0" ]; then
+            echo "::notice::no new draft PRs (all fingerprints already had branches/PRs)"
+          fi

--- a/.pipelines/failure-agent-teams-bot/scripts/notify-incident.sh
+++ b/.pipelines/failure-agent-teams-bot/scripts/notify-incident.sh
@@ -69,6 +69,10 @@ pr_number="$(jq -r '.pullRequestNumber // ""' "$INCIDENT")"
 recommended_action="$(jq -r '.recommendedAction // ""' "$INCIDENT")"
 retention="$(jq -r '.retentionDecision // ""' "$INCIDENT")"
 
+# A fix.md next to the incident means the agent produced a draft-fix prompt that
+# the FAA Draft PR workflow can turn into a draft PR.
+fix_md="$(dirname "$INCIDENT")/fix.md"
+
 # Compact confidence, e.g. "high (0.87)".
 conf_pretty="$(jq -rn --argjson c "$confidence" '($c * 100 | floor) / 100 | tostring')"
 
@@ -100,6 +104,7 @@ status_args=(
 
 status_args+=(--fact "Confidence|${band} (${conf_pretty})")
 [[ -n "$category" ]] && status_args+=(--fact "Category|${category}")
+[[ -f "$fix_md" ]] && status_args+=(--fact "Draft fix|prompt ready → draft PR")
 
 stage_job="$(printf '%s / %s' "$stage" "$job" | sed 's#^ / ##; s# / $##')"
 [[ -n "$stage_job" ]] && status_args+=(--fact "Stage / Job|${stage_job}")
@@ -145,6 +150,9 @@ if [[ -n "$recommended_action" ]]; then
 fi
 if [[ -n "$retention" ]]; then
   reply="$(printf '%s\n\n_Cluster retention: %s_' "$reply" "$retention")"
+fi
+if [[ -f "$fix_md" ]]; then
+  reply="$(printf '%s\n\n**Draft fix prompt**\nA draft-fix prompt (fix.md) was produced; the FAA Draft PR workflow can open a draft PR from it.' "$reply")"
 fi
 
 notify_reply --text "$reply" --tag "diagnosis" --severity "$severity"

--- a/.pipelines/templates/failure-analysis.job.yaml
+++ b/.pipelines/templates/failure-analysis.job.yaml
@@ -187,6 +187,9 @@ jobs:
             echo "##vso[task.uploadsummary]$REPORT"
             cp "$REPORT" "$OUT_DIR/report.md"
             cp "$(Agent.TempDirectory)/analysis/incident.json" "$OUT_DIR/incident.json" 2>/dev/null || true
+            # fix.md is only written for high-confidence regressions on non-PR
+            # builds; ship it when present so the draft-PR workflow can pull it.
+            cp "$(Agent.TempDirectory)/analysis/fix.md" "$OUT_DIR/fix.md" 2>/dev/null || true
           fi
         displayName: "Publish analysis summary"
         condition: succeededOrFailed()

--- a/tools/failure-agent/internal/fixprompt/fixprompt.go
+++ b/tools/failure-agent/internal/fixprompt/fixprompt.go
@@ -113,6 +113,7 @@ func Render(inc model.Incident) string {
 
 	b.WriteString("## Instructions for the coding agent\n\n")
 	b.WriteString("- Implement the smallest change that resolves the root cause above; do not refactor unrelated code.\n")
+	b.WriteString("- Follow the repository conventions in `agents.md` (root-to-leaf, closest wins) and apply any relevant skills under `.github/skills/`.\n")
 	b.WriteString("- Keep the pull request a **draft**. Do not mark it ready for review.\n")
 	fmt.Fprintf(&b, "- Reference fingerprint `%s` in the pull request description.\n", inc.Fingerprint)
 	b.WriteString("- If the proposed direction is wrong, say why in the PR and implement the correct fix instead.\n")

--- a/tools/failure-agent/internal/fixprompt/fixprompt.go
+++ b/tools/failure-agent/internal/fixprompt/fixprompt.go
@@ -1,0 +1,194 @@
+// Package fixprompt renders "fix.md": a Copilot-ready prompt describing a
+// high-confidence regression and the fix direction, plus a machine-readable
+// metadata header. The failure-agent only writes it as an artifact; nothing is
+// dispatched from Azure DevOps (which cannot obtain a GitHub token). An
+// independent, manually-triggered GitHub workflow later pulls the artifact and
+// turns fix.md into a draft pull request assigned to the GitHub Copilot coding
+// agent.
+package fixprompt
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Azure/azure-container-networking/tools/failure-agent/internal/model"
+)
+
+// FileName is the artifact the agent writes and the workflow looks for.
+const FileName = "fix.md"
+
+// fingerprintShortLen bounds the fingerprint slice used in the title and branch.
+const fingerprintShortLen = 12
+
+// maxSnippets bounds how many evidence snippets are embedded in the prompt so it
+// stays a focused instruction rather than a log dump.
+const maxSnippets = 3
+
+// ShouldEmit reports whether a fix.md should be written for this run. A fix
+// prompt is only useful for a non-PR build (PR builds already get the inline PR
+// comment) that the LLM analyzed with high confidence as a regression in the
+// change under test and for which it proposed a fix direction to ground the
+// prompt. This mirrors the gate the draft-PR workflow expects.
+func ShouldEmit(rc model.RunContext, inc model.Incident) bool {
+	return !rc.IsPR &&
+		inc.AnalysisStatus == model.StatusAnalyzed &&
+		inc.Category == model.CategoryPRRegression &&
+		inc.ConfidenceBand == model.BandHigh &&
+		strings.TrimSpace(inc.ProposedFix) != ""
+}
+
+// Title is the draft-PR title derived from the incident. It is also emitted in
+// the metadata header so the workflow does not have to reconstruct it.
+func Title(inc model.Incident) string {
+	pipeline := strings.TrimSpace(inc.PipelineName)
+	if pipeline == "" {
+		pipeline = "pipeline"
+	}
+	return fmt.Sprintf("[FAA] Draft fix: %s regression (%s)", pipeline, shortFingerprint(inc.Fingerprint))
+}
+
+// WriteFile renders the prompt and writes it as fix.md into dir, returning the
+// path written.
+func WriteFile(dir string, inc model.Incident) (string, error) {
+	path := filepath.Join(dir, FileName)
+	if err := os.WriteFile(path, []byte(Render(inc)), 0o644); err != nil {
+		return "", fmt.Errorf("writing %s: %w", FileName, err)
+	}
+	return path, nil
+}
+
+// Render produces the fix.md body: a metadata header the workflow parses, then a
+// grounded instruction for the coding agent to author the smallest correct fix
+// and keep the pull request a draft.
+func Render(inc model.Incident) string {
+	var b strings.Builder
+
+	writeMetadata(&b, inc)
+
+	fmt.Fprintf(&b, "# %s\n\n", Title(inc))
+	b.WriteString("A non-PR Azure DevOps pipeline build failed and the Failure Analysis Agent " +
+		"classified it as a **high-confidence code regression** in the change under test. " +
+		"Author the smallest correct fix and open it as a **draft** pull request for human " +
+		"review — do not mark it ready for review.\n\n")
+
+	b.WriteString("## Failure context\n\n")
+	b.WriteString("| Field | Value |\n|---|---|\n")
+	writeRow(&b, "Pipeline", inc.PipelineName)
+	writeRow(&b, "Stage / Job", strings.Join(nonEmpty(inc.Stage, inc.Job), " / "))
+	writeRow(&b, "Failing commit", inc.Commit)
+	writeRow(&b, "Fingerprint", inc.Fingerprint)
+	writeRow(&b, "Category", fmt.Sprintf("%s (%s, %.2f)", inc.Category, inc.ConfidenceBand, inc.Confidence))
+	b.WriteString("\n")
+
+	b.WriteString("## Root cause\n\n")
+	fmt.Fprintf(&b, "%s\n\n", emptyDash(inc.RootCauseSummary))
+
+	if strings.TrimSpace(inc.NodeAssessment) != "" {
+		b.WriteString("## Node / nodepool health\n\n")
+		fmt.Fprintf(&b, "%s\n\n", inc.NodeAssessment)
+	}
+
+	b.WriteString("## Proposed fix direction\n\n")
+	fmt.Fprintf(&b, "%s\n\n", emptyDash(inc.ProposedFix))
+
+	if strings.TrimSpace(inc.RecommendedAction) != "" {
+		b.WriteString("## Recommended action\n\n")
+		fmt.Fprintf(&b, "%s\n\n", inc.RecommendedAction)
+	}
+
+	if len(inc.TopEvidence) > 0 {
+		b.WriteString("## Top evidence\n\n")
+		for _, e := range inc.TopEvidence {
+			if strings.TrimSpace(e) == "" {
+				continue
+			}
+			fmt.Fprintf(&b, "- `%s`\n", strings.ReplaceAll(e, "`", "'"))
+		}
+		b.WriteString("\n")
+	}
+
+	writeSnippets(&b, inc.ErrorSnippets)
+
+	b.WriteString("## Instructions for the coding agent\n\n")
+	b.WriteString("- Implement the smallest change that resolves the root cause above; do not refactor unrelated code.\n")
+	b.WriteString("- Keep the pull request a **draft**. Do not mark it ready for review.\n")
+	fmt.Fprintf(&b, "- Reference fingerprint `%s` in the pull request description.\n", inc.Fingerprint)
+	b.WriteString("- If the proposed direction is wrong, say why in the PR and implement the correct fix instead.\n")
+
+	return b.String()
+}
+
+// writeMetadata emits the machine-readable header the workflow parses. It is an
+// HTML comment so it stays invisible in rendered markdown. Values are forced to
+// a single line so the header remains line-oriented for shell parsing.
+func writeMetadata(b *strings.Builder, inc model.Incident) {
+	b.WriteString("<!-- faa-fix:v1\n")
+	writeMetaField(b, "fingerprint", inc.Fingerprint)
+	writeMetaField(b, "title", Title(inc))
+	writeMetaField(b, "category", string(inc.Category))
+	writeMetaField(b, "confidence", fmt.Sprintf("%.2f", inc.Confidence))
+	writeMetaField(b, "confidenceBand", string(inc.ConfidenceBand))
+	writeMetaField(b, "pipeline", inc.PipelineName)
+	writeMetaField(b, "buildId", inc.BuildID)
+	writeMetaField(b, "commit", inc.Commit)
+	writeMetaField(b, "owner", inc.RecommendedOwner)
+	b.WriteString("-->\n\n")
+}
+
+func writeMetaField(b *strings.Builder, key, value string) {
+	fmt.Fprintf(b, "%s: %s\n", key, oneLine(value))
+}
+
+func writeSnippets(b *strings.Builder, snippets []model.ErrorSnippet) {
+	if len(snippets) == 0 {
+		return
+	}
+	b.WriteString("## Evidence snippets\n\n")
+	for i, sn := range snippets {
+		if i >= maxSnippets {
+			break
+		}
+		fmt.Fprintf(b, "**%s:%d**\n\n", sn.File, sn.Line)
+		b.WriteString("```text\n")
+		b.WriteString(sn.Snippet)
+		b.WriteString("\n```\n\n")
+	}
+}
+
+func writeRow(b *strings.Builder, key, val string) {
+	fmt.Fprintf(b, "| %s | %s |\n", key, emptyDash(val))
+}
+
+func shortFingerprint(fp string) string {
+	if len(fp) > fingerprintShortLen {
+		return fp[:fingerprintShortLen]
+	}
+	return fp
+}
+
+// oneLine collapses a value to a single line so it is safe inside the
+// line-oriented metadata header.
+func oneLine(s string) string {
+	s = strings.ReplaceAll(s, "\r", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	return strings.TrimSpace(s)
+}
+
+func emptyDash(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "—"
+	}
+	return s
+}
+
+func nonEmpty(vals ...string) []string {
+	out := make([]string, 0, len(vals))
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}

--- a/tools/failure-agent/internal/fixprompt/fixprompt_test.go
+++ b/tools/failure-agent/internal/fixprompt/fixprompt_test.go
@@ -91,6 +91,7 @@ func TestRenderContainsSections(t *testing.T) {
 		"## Evidence snippets",
 		"cilium.log:42",
 		"## Instructions for the coding agent",
+		"agents.md",
 		"draft",
 	} {
 		if !strings.Contains(md, want) {

--- a/tools/failure-agent/internal/fixprompt/fixprompt_test.go
+++ b/tools/failure-agent/internal/fixprompt/fixprompt_test.go
@@ -1,0 +1,174 @@
+package fixprompt
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-container-networking/tools/failure-agent/internal/model"
+)
+
+// gatedIncident is a high-confidence pr_regression incident that passes the gate.
+func gatedIncident() model.Incident {
+	return model.Incident{
+		PipelineName:     "Azure CNI Cilium",
+		BuildID:          "123456",
+		Commit:           "abc1234",
+		Stage:            "Cilium",
+		Job:              "e2e",
+		Fingerprint:      "deadbeefcafef00dbaadf00d",
+		Category:         model.CategoryPRRegression,
+		Confidence:       0.87,
+		ConfidenceBand:   model.BandHigh,
+		RootCauseSummary: "The new CNI conflist drops egress traffic.",
+		RecommendedOwner: "johnpayne@microsoft.com",
+		ProposedFix:      "Restore the egress accept rule in the conflist template.",
+		AnalysisStatus:   model.StatusAnalyzed,
+		TopEvidence:      []string{"iptables DROP on egress chain"},
+		ErrorSnippets: []model.ErrorSnippet{
+			{File: "cilium.log", Line: 42, Snippet: "level=error msg=egress blocked"},
+		},
+	}
+}
+
+func TestShouldEmit(t *testing.T) {
+	nonPR := model.RunContext{IsPR: false}
+	tests := []struct {
+		name string
+		rc   model.RunContext
+		inc  model.Incident
+		want bool
+	}{
+		{"gated", nonPR, gatedIncident(), true},
+		{"pr build", model.RunContext{IsPR: true}, gatedIncident(), false},
+		{
+			name: "not analyzed",
+			rc:   nonPR,
+			inc:  func() model.Incident { i := gatedIncident(); i.AnalysisStatus = model.StatusAnalysisFailed; return i }(),
+			want: false,
+		},
+		{
+			name: "wrong category",
+			rc:   nonPR,
+			inc:  func() model.Incident { i := gatedIncident(); i.Category = model.CategoryKnownFlake; return i }(),
+			want: false,
+		},
+		{
+			name: "not high confidence",
+			rc:   nonPR,
+			inc:  func() model.Incident { i := gatedIncident(); i.ConfidenceBand = model.BandMedium; return i }(),
+			want: false,
+		},
+		{
+			name: "no proposed fix",
+			rc:   nonPR,
+			inc:  func() model.Incident { i := gatedIncident(); i.ProposedFix = "  "; return i }(),
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ShouldEmit(tc.rc, tc.inc); got != tc.want {
+				t.Errorf("ShouldEmit = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRenderContainsSections(t *testing.T) {
+	md := Render(gatedIncident())
+
+	for _, want := range []string{
+		"<!-- faa-fix:v1",
+		"# [FAA] Draft fix: Azure CNI Cilium regression (deadbeefcafe)",
+		"## Failure context",
+		"## Root cause",
+		"The new CNI conflist drops egress traffic.",
+		"## Proposed fix direction",
+		"Restore the egress accept rule",
+		"## Top evidence",
+		"## Evidence snippets",
+		"cilium.log:42",
+		"## Instructions for the coding agent",
+		"draft",
+	} {
+		if !strings.Contains(md, want) {
+			t.Errorf("rendered fix.md missing %q", want)
+		}
+	}
+}
+
+// TestRenderMetadataHeader verifies the header is a line-oriented block the
+// workflow can parse, and that free-text values stay on a single line.
+func TestRenderMetadataHeader(t *testing.T) {
+	inc := gatedIncident()
+	inc.RecommendedOwner = "team\nowner@microsoft.com"
+
+	meta := parseMetadata(t, Render(inc))
+
+	checks := map[string]string{
+		"fingerprint":    "deadbeefcafef00dbaadf00d",
+		"category":       "pr_regression",
+		"confidence":     "0.87",
+		"confidenceBand": "high",
+		"pipeline":       "Azure CNI Cilium",
+		"buildId":        "123456",
+		"commit":         "abc1234",
+		"owner":          "team owner@microsoft.com",
+	}
+	for k, want := range checks {
+		if got := meta[k]; got != want {
+			t.Errorf("metadata[%q] = %q, want %q", k, got, want)
+		}
+	}
+	if !strings.HasPrefix(meta["title"], "[FAA] Draft fix:") {
+		t.Errorf("metadata title = %q", meta["title"])
+	}
+}
+
+func TestWriteFile(t *testing.T) {
+	dir := t.TempDir()
+	inc := gatedIncident()
+
+	path, err := WriteFile(dir, inc)
+	if err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if path != filepath.Join(dir, FileName) {
+		t.Errorf("path = %q", path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(data) != Render(inc) {
+		t.Error("file content does not match Render output")
+	}
+}
+
+// parseMetadata extracts the key: value pairs from the faa-fix header block.
+func parseMetadata(t *testing.T, md string) map[string]string {
+	t.Helper()
+	start := strings.Index(md, "<!-- faa-fix:v1")
+	if start < 0 {
+		t.Fatal("no faa-fix metadata header")
+	}
+	end := strings.Index(md[start:], "-->")
+	if end < 0 {
+		t.Fatal("unterminated metadata header")
+	}
+	block := md[start : start+end]
+	out := map[string]string{}
+	for _, line := range strings.Split(block, "\n") {
+		if strings.HasPrefix(line, "<!--") {
+			continue
+		}
+		key, val, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		out[strings.TrimSpace(key)] = strings.TrimSpace(val)
+	}
+	return out
+}

--- a/tools/failure-agent/main.go
+++ b/tools/failure-agent/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Azure/azure-container-networking/tools/failure-agent/internal/collect"
 	"github.com/Azure/azure-container-networking/tools/failure-agent/internal/command"
 	"github.com/Azure/azure-container-networking/tools/failure-agent/internal/fingerprint"
+	"github.com/Azure/azure-container-networking/tools/failure-agent/internal/fixprompt"
 	"github.com/Azure/azure-container-networking/tools/failure-agent/internal/live"
 	"github.com/Azure/azure-container-networking/tools/failure-agent/internal/model"
 	"github.com/Azure/azure-container-networking/tools/failure-agent/internal/publish"
@@ -244,12 +245,36 @@ func run(ctx context.Context, logger *zap.Logger, opts options, cl classifier, k
 		zap.String("report", filepath.Join(opts.output, report.MarkdownFile)),
 	)
 
+	// fix.md is an artifact, not a PR write-back, so it is emitted regardless of
+	// --dry-run. It only crosses to GitHub when the independent draft-PR workflow
+	// is run manually and pulls this build's artifacts.
+	writeFixPrompt(logger, opts.output, rc, inc)
+
 	if !opts.dryRun {
 		if err := publishToPR(ctx, logger, rc, fp, inc); err != nil {
 			logger.Warn("failed to publish analysis to pull request", zap.Error(err))
 		}
 	}
 	return nil
+}
+
+// writeFixPrompt emits fix.md when the incident is a high-confidence regression
+// on a non-PR build. A failure to write it is logged but never fails the run:
+// the report and incident artifacts are already on disk.
+func writeFixPrompt(logger *zap.Logger, outputDir string, rc model.RunContext, inc model.Incident) {
+	if !fixprompt.ShouldEmit(rc, inc) {
+		return
+	}
+	path, err := fixprompt.WriteFile(outputDir, inc)
+	if err != nil {
+		logger.Warn("failed to write fix prompt", zap.Error(err))
+		return
+	}
+	logger.Info("fix prompt written",
+		zap.String("event", "fix_prompt_written"),
+		zap.String("fingerprint", inc.Fingerprint),
+		zap.String("path", path),
+	)
 }
 
 // handleDuplicate is taken when an unresolved incident with the same fingerprint

--- a/tools/failure-agent/pipeline_test.go
+++ b/tools/failure-agent/pipeline_test.go
@@ -87,6 +87,67 @@ func TestRunEndToEnd(t *testing.T) {
 	if !strings.Contains(string(md), "acn-failure-agent:"+inc.Fingerprint) {
 		t.Error("expected fingerprint marker in report.md")
 	}
+
+	// A cluster bring-up failure is not a pr_regression, so no fix prompt.
+	if _, err := os.Stat(filepath.Join(out, "fix.md")); !os.IsNotExist(err) {
+		t.Error("did not expect fix.md for a non-regression incident")
+	}
+}
+
+// TestRunEmitsFixPromptWhenGated verifies that a high-confidence pr_regression on
+// a non-PR build writes fix.md, even under --dry-run (it is an artifact, not a PR
+// write-back).
+func TestRunEmitsFixPromptWhenGated(t *testing.T) {
+	out := t.TempDir()
+	cl := &fakeClassifier{result: model.Classification{
+		Category:         model.CategoryPRRegression,
+		Confidence:       0.85,
+		RootCauseSummary: "The change under test broke the CNI conflist.",
+		TopEvidence:      []string{"egress traffic dropped"},
+		ProposedFix:      "Restore the egress accept rule.",
+		Source:           "llm",
+	}}
+	opts := bundleOptions(t, out)
+
+	if err := run(context.Background(), zap.NewNop(), opts, cl, noopStore{}, noopCollector{}, noopCollector{}); err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+
+	inc := readIncident(t, out)
+	data, err := os.ReadFile(filepath.Join(out, "fix.md"))
+	if err != nil {
+		t.Fatalf("expected fix.md: %v", err)
+	}
+	if !strings.Contains(string(data), inc.Fingerprint) {
+		t.Error("expected fingerprint in fix.md")
+	}
+	if !strings.Contains(string(data), "Draft fix") {
+		t.Error("expected draft-fix title in fix.md")
+	}
+}
+
+// TestRunSkipsFixPromptOnPRBuild verifies the gate excludes PR builds: they get
+// the inline PR comment instead of a fix prompt.
+func TestRunSkipsFixPromptOnPRBuild(t *testing.T) {
+	t.Setenv("BUILD_REASON", "PullRequest")
+	t.Setenv("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER", "42")
+
+	out := t.TempDir()
+	cl := &fakeClassifier{result: model.Classification{
+		Category:         model.CategoryPRRegression,
+		Confidence:       0.85,
+		RootCauseSummary: "regression",
+		ProposedFix:      "fix it",
+		Source:           "llm",
+	}}
+	opts := bundleOptions(t, out)
+
+	if err := run(context.Background(), zap.NewNop(), opts, cl, noopStore{}, noopCollector{}, noopCollector{}); err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(out, "fix.md")); !os.IsNotExist(err) {
+		t.Error("did not expect fix.md for a PR build")
+	}
 }
 
 func TestRunRequiresInput(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
 feat: add a knob to the frobnitz
or
 fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
The Failure Analysis Agent (FAA) runs in Azure DevOps, which cannot obtain a
GitHub token, so ADO cannot open PRs directly. This adds a decoupled, two-part
draft-PR flow:

1. **FAA (Go agent)** — for non-PR, high-confidence `pr_regression` failures, the
 agent emits a `fix.md` artifact: a self-contained prompt (evidence + proposed
 fix) intended for a GitHub Copilot coding agent, with an explicit pointer to
 follow the repo's `agents.md` (root-to-leaf) and relevant `.github/skills`. It
 is an artifact only, with no GitHub write-back from ADO.
2. **Independent GitHub workflow** (`faa-draft-pr.yaml`) — manually dispatched;
 pulls the `fix.md` artifact from an ADO build via **Azure OIDC** (no stored
 PAT), opens an idempotent draft PR (`faa/fix-<fingerprint>`) with `fix.md` as
 the body, assigns the Copilot coding agent, and pings the existing Teams
 notifier bot. The workflow is declarative; its logic lives in reviewable,
 versioned scripts under `.github/scripts/`.
3. **Teams notification** — the existing incident ping now explicitly indicates
 when a draft-fix prompt (`fix.md`) was produced.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
N/A

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [x] includes documentation <!-- inline Prerequisites/usage docs in faa-draft-pr.yaml + script headers -->
- [x] adds unit tests <!-- fixprompt gate/render tests + e2e emit/skip tests in pipeline_test.go -->
- [ ] relevant PR labels added

**Notes**:

- The `fix.md` gate requires a **non-PR**, high-confidence `pr_regression`
 incident; PR builds get the existing inline PR comment instead.
- Auth is PAT-free for the ADO pull: the workflow uses **Azure OIDC**
 (`azure/login`) to mint a short-lived Entra token for the ADO artifact API,
 and the built-in `github.token` for push/`gh pr create`. The OIDC service
 principal needs Build (read) on the ADO org. Assigning/triggering the Copilot
 agent may still need a PAT/App token if downstream automation must fire on
 assignment (deferred follow-up).
- Pulled artifacts stay in `$RUNNER_TEMP` only — never uploaded or written to
 the run summary. Workflow inputs are validated (numeric `buildId`; charset-
 constrained `ADO_ORG`/`ADO_PROJECT`).
- Deferred follow-ups: scheduled/per-issue trigger for the workflow, and
 owner→UPN resolution for Teams mentions.
- Validation: `go build`/`go vet`/`gofmt`/`go test ./...` clean; `actionlint`
 clean; a forced local run produced a consistent `incident.json` + `fix.md`.