### PR TITLE
ci: run remaining Cilium connectivity tests

### DIFF
--- a/.pipelines/networkobservability/pipeline.yaml
+++ b/.pipelines/networkobservability/pipeline.yaml
@@ -115,7 +115,7 @@ stages:
 
         - template: ../templates/cilium-connectivity-tests.yaml
           parameters:
-            skipTests: '!pod-to-pod-encryption,!node-to-node-encryption,!check-log-errors,!to-fqdns'
+            skipTests: '!node-to-node-encryption,!check-log-errors,!no-unexpected-packet-drops'
 
         - script: |
             export DIR=${CILIUM_VERSION_TAG%.*}

--- a/.pipelines/templates/cilium-connectivity-tests.yaml
+++ b/.pipelines/templates/cilium-connectivity-tests.yaml
@@ -1,5 +1,5 @@
 parameters:
-  skipTests: '!pod-to-pod-encryption,!node-to-node-encryption,!check-log-errors,!no-unexpected-packet-drops,!to-fqdns'
+  skipTests: '!node-to-node-encryption,!check-log-errors,!no-unexpected-packet-drops'
 
 steps:
   - script: |


### PR DESCRIPTION
## What this PR does

- limits Cilium connectivity-test exclusions to `node-to-node-encryption`, `check-log-errors`, and `no-unexpected-packet-drops`
- enables `pod-to-pod-encryption` and `to-fqdns` in the shared ACN pipeline template
- aligns the network observability pipeline with the same exclusion set