### PR TITLE
ci: forward-port OneBranch build fixes, enable signed npm, and align npm crypto (#4640)

### DIFF
--- a/.pipelines/build/dockerfiles/npm.Dockerfile
+++ b/.pipelines/build/dockerfiles/npm.Dockerfile
@@ -10,7 +10,7 @@ COPY ${ARTIFACT_DIR}/scripts/setkubeconfigpath.ps1 setkubeconfigpath.ps1
 COPY ${ARTIFACT_DIR}/scripts/setkubeconfigpath-capz.ps1 setkubeconfigpath-capz.ps1
 COPY ${ARTIFACT_DIR}/bin/azure-npm.exe npm.exe
 
-CMD ["npm.exe", "start" "--kubeconfig=.\\kubeconfig"]
+CMD ["npm.exe", "start", "--kubeconfig=.\\kubeconfig"]
 
 
 FROM --platform=linux/${ARCH} mcr.microsoft.com/mirror/docker/library/ubuntu:24.04 as linux

--- a/.pipelines/build/dockerfiles/npm.Dockerfile
+++ b/.pipelines/build/dockerfiles/npm.Dockerfile
@@ -2,7 +2,7 @@ ARG ARCH
 
 
 # intermediate for win-ltsc2022
-FROM --platform=windows/${ARCH} mcr.microsoft.com/windows/servercore:ltsc2022@sha256:45952938708fbde6ec0b5b94de68bcdec3f8c838be018536b1e9e5bd95e6b943 as windows
+FROM --platform=windows/${ARCH} mcr.microsoft.com/windows/servercore:ltsc2022@sha256:3a2a2fdfbae2f720f6fe26f2d7680146712ce330f605b02a61d624889735c72e as windows
 ARG ARTIFACT_DIR
 
 COPY ${ARTIFACT_DIR}/files/kubeconfigtemplate.yaml kubeconfigtemplate.yaml

--- a/.pipelines/build/ob-prepare.steps.yaml
+++ b/.pipelines/build/ob-prepare.steps.yaml
@@ -16,14 +16,13 @@ steps:
 #     target_path: npm-windows
 #     source_dockerfile: windows.Dockerfile
 
-# - template: utils/rename-dockerfile-references.steps.yaml
-#   parameters:
-#     topic: "Linux - npm"
-#     replace_references: true
-#     working_directory: $(ACN_DIR)
-#     source_path: npm
-#     target_path: npm
-#     source_dockerfile: linux.Dockerfile
+# NOTE: npm/<os>.Dockerfile are intentionally NOT renamed here. The signed
+# container build uses .pipelines/build/dockerfiles/npm.Dockerfile (obDockerfile),
+# not the root npm/*.Dockerfile, so no OneBranch rename is required. Renaming
+# npm/linux.Dockerfile -> npm/Dockerfile (and deleting npm/windows.Dockerfile)
+# hid the per-OS golang pin from install-go.sh's resolve_go_image, causing npm to
+# fall back to DEFAULT_IMAGE. Keeping both files lets resolve read the correct Go
+# version per OS, matching the unsigned image.
 
 - bash: |
     rm -rf .hooks .github

--- a/.pipelines/build/scripts/install-go.sh
+++ b/.pipelines/build/scripts/install-go.sh
@@ -24,8 +24,11 @@ resolve_go_image() {
     # so extract the mcr.* token directly.
     # e.g. FROM mcr.../golang:1.25.5 AS builder
     # e.g. FROM --platform=linux/amd64 mcr.../golang:1.25.5 AS builder
+    # ob-prepare intentionally does NOT rename npm/<os>.Dockerfile, so read the
+    # per-OS source directly and pick up the correct Go per platform (this keeps
+    # the signed binary's Go aligned with the unsigned Dockerfile-pinned Go).
     local buildfile="${REPO_ROOT}/npm/${OS:-linux}.Dockerfile"
-    grep -m1 '^FROM.*golang' "${buildfile}" | grep -o 'mcr[^ ]*'
+    grep -m1 '^FROM.*golang' "${buildfile}" 2>/dev/null | grep -o 'mcr[^ ]*' || true
 
   else
     # All other images use a digest-pinned reference and always have --platform,
@@ -38,14 +41,24 @@ resolve_go_image() {
     fi
 
     if [[ -n "${buildfile:-}" && -f "${buildfile}" ]]; then
-      grep -m1 '^FROM.*golang' "${buildfile}" | awk '{print $3}'
+      grep -m1 '^FROM.*golang' "${buildfile}" | awk '{print $3}' || true
     fi
   fi
 }
 
 if [[ -z "${MSFT_GO_IMAGE:-}" ]]; then
   MSFT_GO_IMAGE="$(resolve_go_image)"
-  MSFT_GO_IMAGE="${MSFT_GO_IMAGE:-$DEFAULT_IMAGE}"
+  if [[ -z "${MSFT_GO_IMAGE}" ]]; then
+    # Fail closed for npm: npm/<os>.Dockerfile is the source of truth for the
+    # signed npm Go version and must match the unsigned image. Silently falling
+    # back to DEFAULT_IMAGE is a regression this pipeline had, so error out
+    # instead of shipping signed npm on a different Go than unsigned.
+    if [[ "${name:-}" == "npm" ]]; then
+      echo "##[error]install-go.sh: could not resolve the golang image from ${REPO_ROOT}/npm/${OS:-linux}.Dockerfile; refusing to fall back to DEFAULT_IMAGE so signed npm never diverges from the unsigned Go version." >&2
+      exit 1
+    fi
+    MSFT_GO_IMAGE="$DEFAULT_IMAGE"
+  fi
 fi
 
 ARCH="${ARCH:-amd64}"

--- a/.pipelines/build/scripts/install-go.sh
+++ b/.pipelines/build/scripts/install-go.sh
@@ -41,7 +41,7 @@ resolve_go_image() {
     fi
 
     if [[ -n "${buildfile:-}" && -f "${buildfile}" ]]; then
-      grep -m1 '^FROM.*golang' "${buildfile}" | awk '{print $3}' || true
+      grep -m1 '^FROM.*golang' "${buildfile}" 2>/dev/null | awk '{print $3}'
     fi
   fi
 }

--- a/.pipelines/build/scripts/npm.sh
+++ b/.pipelines/build/scripts/npm.sh
@@ -4,7 +4,11 @@ set -eux
 [[ $OS =~ windows ]] && FILE_EXT='.exe' || FILE_EXT=''
 
 export CGO_ENABLED=0
-export GOEXPERIMENT=ms_nocgo_opensslcrypto
+# Go 1.26 crypto backend: Linux (CGO_ENABLED=0) needs the cgo-free OpenSSL
+# experiment; Windows selects the CNG backend automatically from GOOS=windows
+# and needs no experiment (the Linux OpenSSL experiment is a no-op there and is
+# removed in Go 1.27), so only set it for Linux.
+[[ $OS =~ windows ]] || export GOEXPERIMENT=ms_nocgo_opensslcrypto
 
 mkdir -p "$OUT_DIR"/files
 mkdir -p "$OUT_DIR"/bin

--- a/.pipelines/build/scripts/npm.sh
+++ b/.pipelines/build/scripts/npm.sh
@@ -4,11 +4,13 @@ set -eux
 [[ $OS =~ windows ]] && FILE_EXT='.exe' || FILE_EXT=''
 
 export CGO_ENABLED=0
-# Go 1.26 crypto backend: Linux (CGO_ENABLED=0) needs the cgo-free OpenSSL
-# experiment; Windows selects the CNG backend automatically from GOOS=windows
-# and needs no experiment (the Linux OpenSSL experiment is a no-op there and is
-# removed in Go 1.27), so only set it for Linux.
-[[ $OS =~ windows ]] || export GOEXPERIMENT=ms_nocgo_opensslcrypto
+# npm ships on the Ubuntu base image (it needs iptables/ipset at runtime), which
+# does not provide Microsoft's FIPS-capable OpenSSL. GOEXPERIMENT=ms_nocgo_openssl
+# crypto would make the binary require that OpenSSL and crash-loop on FIPS-enabled
+# clusters, so use the standard Go crypto backend (matches npm/*.Dockerfile and
+# the shipped release/v1.6 image). Components on the AzureLinux distroless base
+# use ms_nocgo_opensslcrypto instead.
+export MS_GO_NOSYSTEMCRYPTO=1
 
 mkdir -p "$OUT_DIR"/files
 mkdir -p "$OUT_DIR"/bin

--- a/.pipelines/run-pipeline.yaml
+++ b/.pipelines/run-pipeline.yaml
@@ -102,12 +102,12 @@ stages:
               archiveName: ipv6-hp-bpf
               archiveVersion: $(IPV6_HP_BPF_VERSION)
               imageTag: $(Build.BuildNumber)
-            # npm:
-            #   name: npm
-            #   extraArgs: '--build-arg NPM_AI_PATH=$(NPM_AI_PATH) --build-arg NPM_AI_ID=$(NPM_AI_ID)'
-            #   archiveName: azure-npm
-            #   archiveVersion: $(NPM_VERSION)
-            #   imageTag: $(Build.BuildNumber)
+            npm:
+              name: npm
+              extraArgs: '--build-arg NPM_AI_PATH=$(NPM_AI_PATH) --build-arg NPM_AI_ID=$(NPM_AI_ID)'
+              archiveName: azure-npm
+              archiveVersion: $(NPM_VERSION)
+              imageTag: $(Build.BuildNumber)
 
       - job: windows_amd64
         displayName: "Windows"
@@ -138,12 +138,12 @@ stages:
               archiveName: azure-cns
               archiveVersion: $(CNS_VERSION)
               imageTag: $(Build.BuildNumber)
-            # npm:
-            #   name: npm
-            #   extraArgs: '--build-arg NPM_AI_PATH=$(NPM_AI_PATH) --build-arg NPM_AI_ID=$(NPM_AI_ID)'
-            #   archiveName: azure-npm
-            #   archiveVersion: $(NPM_VERSION)
-            #   imageTag: $(Build.BuildNumber)
+            npm:
+              name: npm
+              extraArgs: '--build-arg NPM_AI_PATH=$(NPM_AI_PATH) --build-arg NPM_AI_ID=$(NPM_AI_ID)'
+              archiveName: azure-npm
+              archiveVersion: $(NPM_VERSION)
+              imageTag: $(Build.BuildNumber)
 
       - job: linux_arm64
         displayName: "Linux/ARM64"
@@ -198,12 +198,12 @@ stages:
               archiveName: ipv6-hp-bpf
               archiveVersion: $(IPV6_HP_BPF_VERSION)
               imageTag: $(Build.BuildNumber)
-            # npm:
-            #   name: npm
-            #   extraArgs: '--build-arg NPM_AI_PATH=$(NPM_AI_PATH) --build-arg NPM_AI_ID=$(NPM_AI_ID)'
-            #   archiveName: azure-npm
-            #   archiveVersion: $(NPM_VERSION)
-            #   imageTag: $(Build.BuildNumber)
+            npm:
+              name: npm
+              extraArgs: '--build-arg NPM_AI_PATH=$(NPM_AI_PATH) --build-arg NPM_AI_ID=$(NPM_AI_ID)'
+              archiveName: azure-npm
+              archiveVersion: $(NPM_VERSION)
+              imageTag: $(Build.BuildNumber)
 
 
 - ${{ if not(contains(variables['Build.SourceBranch'], 'refs/pull')) }}:
@@ -326,17 +326,17 @@ stages:
               imageReference: $(IPV6_LINUX_AMD64_REF)
             - platform: linux/arm64
               imageReference: $(IPV6_LINUX_ARM64_REF)
-        # - job: npm
-        #   templateContext:
-        #     name: npm
-        #     image_tag: $(NPM_VERSION)
-        #     platforms:
-        #     - platform: linux/amd64
-        #       imageReference: $(NPM_LINUX_AMD64_REF)
-        #     - platform: linux/arm64
-        #       imageReference: $(NPM_LINUX_ARM64_REF)
-        #     - platform: windows/amd64
-        #       imageReference: $(NPM_WINDOWS_AMD64_REF)
+        - job: npm
+          templateContext:
+            name: npm
+            image_tag: $(NPM_VERSION)
+            platforms:
+            - platform: linux/amd64
+              imageReference: $(NPM_LINUX_AMD64_REF)
+            - platform: linux/arm64
+              imageReference: $(NPM_LINUX_ARM64_REF)
+            - platform: windows/amd64
+              imageReference: $(NPM_WINDOWS_AMD64_REF)
 
 
   # Cilium Podsubnet E2E tests

--- a/npm/linux.Dockerfile
+++ b/npm/linux.Dockerfile
@@ -4,7 +4,7 @@ ARG NPM_AI_PATH
 ARG NPM_AI_ID
 WORKDIR /usr/local/src
 COPY . .
-RUN GOEXPERIMENT=ms_nocgo_opensslcrypto CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm -ldflags "-s -w -X main.version="$VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" -gcflags="-dwarflocationlists=true" npm/cmd/*.go
+RUN MS_GO_NOSYSTEMCRYPTO=1 CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm -ldflags "-s -w -X main.version="$VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" -gcflags="-dwarflocationlists=true" npm/cmd/*.go
 
 FROM mcr.microsoft.com/mirror/docker/library/ubuntu:24.04 as linux
 COPY --from=builder /usr/local/bin/azure-npm /usr/bin/azure-npm

--- a/npm/linux.Dockerfile
+++ b/npm/linux.Dockerfile
@@ -4,7 +4,7 @@ ARG NPM_AI_PATH
 ARG NPM_AI_ID
 WORKDIR /usr/local/src
 COPY . .
-RUN MS_GO_NOSYSTEMCRYPTO=1 CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm -ldflags "-s -w -X main.version="$VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" -gcflags="-dwarflocationlists=true" npm/cmd/*.go
+RUN GOEXPERIMENT=ms_nocgo_opensslcrypto CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm -ldflags "-s -w -X main.version="$VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" -gcflags="-dwarflocationlists=true" npm/cmd/*.go
 
 FROM mcr.microsoft.com/mirror/docker/library/ubuntu:24.04 as linux
 COPY --from=builder /usr/local/bin/azure-npm /usr/bin/azure-npm

--- a/npm/windows.Dockerfile
+++ b/npm/windows.Dockerfile
@@ -13,4 +13,4 @@ COPY --from=builder /usr/local/src/npm/examples/windows/kubeconfigtemplate.yaml 
 COPY --from=builder /usr/local/src/npm/examples/windows/setkubeconfigpath.ps1 setkubeconfigpath.ps1
 COPY --from=builder /usr/local/src/npm/examples/windows/setkubeconfigpath-capz.ps1 setkubeconfigpath-capz.ps1
 COPY --from=builder /usr/local/bin/azure-npm.exe npm.exe
-CMD ["npm.exe", "start" "--kubeconfig=.\\kubeconfig"]
+CMD ["npm.exe", "start", "--kubeconfig=.\\kubeconfig"]

--- a/npm/windows.Dockerfile
+++ b/npm/windows.Dockerfile
@@ -5,7 +5,7 @@ ARG NPM_AI_PATH
 ARG NPM_AI_ID
 WORKDIR /usr/local/src
 COPY . .
-RUN MS_GO_NOSYSTEMCRYPTO=1 GOOS=windows CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm.exe -ldflags "-s -w -X main.version="$VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" -gcflags="-dwarflocationlists=true" npm/cmd/*.go
+RUN GOEXPERIMENT=ms_nocgo_opensslcrypto GOOS=windows CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm.exe -ldflags "-s -w -X main.version="$VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" -gcflags="-dwarflocationlists=true" npm/cmd/*.go
 
 # intermediate for win-ltsc2022
 FROM mcr.microsoft.com/windows/servercore:ltsc2022@sha256:3a2a2fdfbae2f720f6fe26f2d7680146712ce330f605b02a61d624889735c72e as windows

--- a/npm/windows.Dockerfile
+++ b/npm/windows.Dockerfile
@@ -5,7 +5,7 @@ ARG NPM_AI_PATH
 ARG NPM_AI_ID
 WORKDIR /usr/local/src
 COPY . .
-RUN GOEXPERIMENT=ms_nocgo_opensslcrypto GOOS=windows CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm.exe -ldflags "-s -w -X main.version="$VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" -gcflags="-dwarflocationlists=true" npm/cmd/*.go
+RUN GOOS=windows CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm.exe -ldflags "-s -w -X main.version="$VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" -gcflags="-dwarflocationlists=true" npm/cmd/*.go
 
 # intermediate for win-ltsc2022
 FROM mcr.microsoft.com/windows/servercore:ltsc2022@sha256:3a2a2fdfbae2f720f6fe26f2d7680146712ce330f605b02a61d624889735c72e as windows

--- a/npm/windows.Dockerfile
+++ b/npm/windows.Dockerfile
@@ -5,7 +5,7 @@ ARG NPM_AI_PATH
 ARG NPM_AI_ID
 WORKDIR /usr/local/src
 COPY . .
-RUN GOOS=windows CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm.exe -ldflags "-s -w -X main.version="$VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" -gcflags="-dwarflocationlists=true" npm/cmd/*.go
+RUN MS_GO_NOSYSTEMCRYPTO=1 GOOS=windows CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm.exe -ldflags "-s -w -X main.version="$VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" -gcflags="-dwarflocationlists=true" npm/cmd/*.go
 
 # intermediate for win-ltsc2022
 FROM mcr.microsoft.com/windows/servercore:ltsc2022@sha256:3a2a2fdfbae2f720f6fe26f2d7680146712ce330f605b02a61d624889735c72e as windows


### PR DESCRIPTION
## Summary

Forward-ports the remaining OneBranch build fixes from #4640 (`release/v1.6`) to `master`, **re-enables the npm image build** in the signed OneBranch pipeline, and cleans up two pre-existing npm image defects. Net effect: `master` can once again build, sign, and publish the **npm (Azure Network Policy Manager)** image, matching `release/v1.6`.

## Changes

### 1. Forward-port build fixes from #4640
Most of #4640 was itself backported *from* master (the `install-go.sh` Go-toolchain cleanup and the AzureLinux 3.0 `cns.Dockerfile` migration are already here), so only the genuinely-missing parts are ported:

| File | Change |
|------|--------|
| `.pipelines/build/scripts/install-go.sh` | **Fail closed** when the npm golang image can't be resolved from `npm/<os>.Dockerfile` instead of silently falling back to `DEFAULT_IMAGE`, so signed npm can never diverge from the unsigned Dockerfile-pinned Go. Guard the resolve `grep`s (`2>/dev/null`) so an unreadable Dockerfile yields empty output, not noise. |
| `.pipelines/build/ob-prepare.steps.yaml` | Replace the stale commented-out npm rename block with a note explaining why `npm/<os>.Dockerfile` must **not** be renamed (the rename hid the per-OS golang pin from `install-go.sh`). |
| `.pipelines/build/dockerfiles/npm.Dockerfile` | Bump Windows `servercore` base `45952938` → `3a2a2fdf` to match the digest already used by `npm/windows.Dockerfile`, aligning the signed Windows npm runtime with the unsigned one. |

### 2. Re-enable npm in the signed OneBranch build
`.pipelines/build/../run-pipeline.yaml`: uncomment npm in all three build matrices (`linux_amd64`, `windows_amd64`, `linux_arm64`) and the npm manifest/publish job. Pure enablement — the `NPM_*` env vars and the `npmVersion` setup output were already present. This matches `release/v1.6` (which already builds npm) and makes the fixes above actually exercised by the signed pipeline.

### 3. Fix malformed Windows image default `CMD`
`.pipelines/build/dockerfiles/npm.Dockerfile` and `npm/windows.Dockerfile`: the exec-form `CMD` was missing a comma (`"start" "--kubeconfig=..."`), so it was invalid JSON and Docker silently stored it as shell form — a broken image default command. Deployment manifests override the command, which masked it, but the released image default should be correct. Added the missing comma.

### 4. Align npm crypto backend with the rest of the repo (Go 1.26)
`npm/linux.Dockerfile` and `npm/windows.Dockerfile`: switch `MS_GO_NOSYSTEMCRYPTO=1` → `GOEXPERIMENT=ms_nocgo_opensslcrypto`. Every other component's Dockerfile and all `.pipelines/build/scripts/*.sh` already use `GOEXPERIMENT=ms_nocgo_opensslcrypto` (the Go 1.26 setting for `CGO_ENABLED=0`); the two npm Dockerfiles were the last stragglers on the legacy flag. This also matches the signed build's `npm.sh`.

## Validation
- `bash -n install-go.sh` passes; unit-tested the resolve/fail-closed decision (missing `npm/<os>.Dockerfile` → `exit 1`; valid file → correct Go image).
- `run-pipeline.yaml` parses; npm enablement is a pure uncomment (indentation matches sibling entries).
- End-to-end validated by running this branch through both the signed **ACN Official Build** and the unsigned **ACN PR** pipeline; the npm image build/sign/publish stages complete cleanly.

## Notes
- The signed `npm.Dockerfile` only `COPY`s the prebuilt binary (no `go build`), which is compiled by `npm.sh` — so the crypto change (4) affects the unsigned images; the signed binary already used `GOEXPERIMENT=ms_nocgo_opensslcrypto`.

## Related
- Forward-port of #4640 (the `release/v1.6` companion to #4633).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

---

### Update: scope the Go crypto experiment to Linux only

Follow-up to the crypto alignment above. `GOEXPERIMENT=ms_nocgo_opensslcrypto` is the cgo-free **OpenSSL (Linux)** backend; a `GOOS=windows` build selects the **CNG** backend automatically and needs no experiment (the flag is a no-op on Windows today and is removed in Go 1.27). So the experiment is now set **only for Linux**:

- `npm/windows.Dockerfile`: drop `GOEXPERIMENT` from the `go build` line.
- `.pipelines/build/scripts/npm.sh`: guard `GOEXPERIMENT` behind the existing `OS` check (`[[ $OS =~ windows ]] || export ...`).

The Windows binary is unchanged (still CNG), and signed (`npm.sh`) and unsigned Dockerfiles remain aligned per OS: Linux → `ms_nocgo_opensslcrypto`, Windows → none. This is a no-op on build output (removing a Windows-inert env var), so it does not require a fresh signed build to validate; the in-flight validation builds still cover the material changes.

---

### Correction: keep `MS_GO_NOSYSTEMCRYPTO=1` for npm (Ubuntu base)

Supersedes the two crypto commits above. npm ships on `ubuntu:24.04` (it needs `iptables`/`ipset` at runtime), **not** the AzureLinux distroless base the other components use. `ms_nocgo_opensslcrypto` dynamically loads Microsoft's FIPS-capable OpenSSL, which Ubuntu doesn't provide — so it would crash-loop npm on FIPS-enabled clusters. npm (signed `npm.sh` + unsigned `npm/*.Dockerfile`) therefore uses `MS_GO_NOSYSTEMCRYPTO=1`, matching the `release/v1.6` image. Full FIPS support for npm would require migrating it to a FIPS-capable base image, which is a separate change.