### PR TITLE
ci(dependabot): prevent cross-major ACN self-dependency bumps on release branches

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -219,6 +219,8 @@ updates:
         versions: [">=0.35.0"]
       - dependency-name: "k8s.io/kubectl"
         versions: [">=0.35.0"]
+      - dependency-name: "github.com/Azure/azure-container-networking"
+        versions: [">=1.8.0"]
     cooldown:
       default-days: 7
 
@@ -288,5 +290,7 @@ updates:
         versions: [">=0.32.0"]
       - dependency-name: "k8s.io/kubectl"
         versions: [">=0.32.0"]
+      - dependency-name: "github.com/Azure/azure-container-networking"
+        versions: [">=1.7.0"]
     cooldown:
       default-days: 7


### PR DESCRIPTION
## Problem

Dependabot's `all-go-minor-and-patch` group on release branches was bumping `github.com/Azure/azure-container-networking` across major versions (e.g., v1.7.12 → v1.8.4 on `release/v1.7`, PR #4303). A release branch should never depend on a newer major version of itself.

## Fix

Add `ignore` rules to prevent Dependabot from proposing cross-major bumps of the repo's own package:

| Branch | Ignore rule |
|--------|-------------|
| `release/v1.7` | `github.com/Azure/azure-container-networking >= 1.8.0` |
| `release/v1.6` | `github.com/Azure/azure-container-networking >= 1.7.0` |

Applied to both the root `/` and `/azure-ipam` directory entries for each release branch.

## Related

- PR #4684 (release/v1.7): reverts the incorrect bump back to v1.7.17