### PR TITLE
fix: [NPM] CVE hardening — patch Ubuntu, Go, and Windows base

### DIFF
--- a/.pipelines/build/dockerfiles/azure-ip-masq-merger.Dockerfile
+++ b/.pipelines/build/dockerfiles/azure-ip-masq-merger.Dockerfile
@@ -3,7 +3,7 @@
 ARG ARCH
 
 # mcr.microsoft.com/azurelinux/distroless/base:3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:178f25fadf466549d31e234b3091bf815161159f2f2bc98720bbf39f7368aff4 AS linux
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:387a603a274e74568fd7a0e6d48ef68e631990e3b5149801515fe749a74b5b29 AS linux
 ARG ARTIFACT_DIR
 
 COPY ${ARTIFACT_DIR}/bin/azure-ip-masq-merger /azure-ip-masq-merger

--- a/.pipelines/build/dockerfiles/azure-ipam.Dockerfile
+++ b/.pipelines/build/dockerfiles/azure-ipam.Dockerfile
@@ -11,7 +11,7 @@ COPY ${ARTIFACT_DIR}/bin/dropgz.exe /dropgz.exe
 ENTRYPOINT [ "/dropgz.exe" ]
 
 # mcr.microsoft.com/azurelinux/distroless/base:3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:178f25fadf466549d31e234b3091bf815161159f2f2bc98720bbf39f7368aff4 AS linux
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:387a603a274e74568fd7a0e6d48ef68e631990e3b5149801515fe749a74b5b29 AS linux
 ARG ARTIFACT_DIR .
 
 COPY ${ARTIFACT_DIR}/bin/dropgz /dropgz

--- a/.pipelines/build/dockerfiles/azure-iptables-monitor.Dockerfile
+++ b/.pipelines/build/dockerfiles/azure-iptables-monitor.Dockerfile
@@ -3,10 +3,10 @@
 ARG ARCH
 
 # mcr.microsoft.com/azurelinux/base/core:3.0
-FROM mcr.microsoft.com/azurelinux/base/core:3.0@sha256:a30e18dd24a8080ee0b72d0f998a688e99380678a407bdd7c3a0ac7417b15eb3 AS mariner-core
+FROM mcr.microsoft.com/azurelinux/base/core:3.0@sha256:8bb51342bd5eba915990ab608f91060d502bb7891a2d3d909e0419b932533029 AS mariner-core
 
 # mcr.microsoft.com/azurelinux/distroless/base:3.0
-FROM mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:178f25fadf466549d31e234b3091bf815161159f2f2bc98720bbf39f7368aff4 AS mariner-distroless
+FROM mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:387a603a274e74568fd7a0e6d48ef68e631990e3b5149801515fe749a74b5b29 AS mariner-distroless
 
 FROM mariner-core AS iptools
 RUN tdnf install -y iptables iproute

--- a/.pipelines/build/dockerfiles/cni.Dockerfile
+++ b/.pipelines/build/dockerfiles/cni.Dockerfile
@@ -11,7 +11,7 @@ COPY ${ARTIFACT_DIR}/files/ /Windows/System32/
 ENTRYPOINT [ "powershell.exe" ]
 
 # mcr.microsoft.com/azurelinux/distroless/base:3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:178f25fadf466549d31e234b3091bf815161159f2f2bc98720bbf39f7368aff4 AS linux
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:387a603a274e74568fd7a0e6d48ef68e631990e3b5149801515fe749a74b5b29 AS linux
 ARG ARTIFACT_DIR .
 
 COPY ${ARTIFACT_DIR}/bin/dropgz /dropgz

--- a/.pipelines/build/dockerfiles/cns.Dockerfile
+++ b/.pipelines/build/dockerfiles/cns.Dockerfile
@@ -11,11 +11,11 @@ ENTRYPOINT ["azure-cns.exe"]
 EXPOSE 10090
 
 # mcr.microsoft.com/azurelinux/base/core:3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/base/core:3.0@sha256:a30e18dd24a8080ee0b72d0f998a688e99380678a407bdd7c3a0ac7417b15eb3 AS build-helper
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/base/core:3.0@sha256:8bb51342bd5eba915990ab608f91060d502bb7891a2d3d909e0419b932533029 AS build-helper
 RUN tdnf install -y iptables
 
 # mcr.microsoft.com/azurelinux/distroless/base:3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:178f25fadf466549d31e234b3091bf815161159f2f2bc98720bbf39f7368aff4 AS linux
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:387a603a274e74568fd7a0e6d48ef68e631990e3b5149801515fe749a74b5b29 AS linux
 ARG ARTIFACT_DIR .
 
 COPY --from=build-helper /usr/sbin/*tables* /usr/sbin/

--- a/.pipelines/build/dockerfiles/npm.Dockerfile
+++ b/.pipelines/build/dockerfiles/npm.Dockerfile
@@ -2,7 +2,7 @@ ARG ARCH
 
 
 # intermediate for win-ltsc2022
-FROM --platform=windows/${ARCH} mcr.microsoft.com/windows/servercore:ltsc2022@sha256:3a2a2fdfbae2f720f6fe26f2d7680146712ce330f605b02a61d624889735c72e as windows
+FROM --platform=windows/${ARCH} mcr.microsoft.com/windows/servercore:ltsc2022@sha256:6b43c814ed2a800563083ce3193e5f1951d4d6a18fd2879ff45173851db82bd5 as windows
 ARG ARTIFACT_DIR
 
 COPY ${ARTIFACT_DIR}/files/kubeconfigtemplate.yaml kubeconfigtemplate.yaml

--- a/.pipelines/build/dockerfiles/npm.Dockerfile
+++ b/.pipelines/build/dockerfiles/npm.Dockerfile
@@ -28,8 +28,8 @@ ARG ARTIFACT_DIR
 #                 CVE-2026-42009, CVE-2026-42010, CVE-2026-42011, CVE-2026-42012,
 #                 CVE-2026-42013, CVE-2026-42014, CVE-2026-42015, CVE-2026-5260,
 #                 CVE-2026-5419 (MEDIUM)
-# libsystemd0:    CVE-2026-29111, CVE-2026-40225 (MEDIUM)
-# libudev1:       CVE-2026-29111, CVE-2026-40225 (MEDIUM)
+# libsystemd0:    CVE-2026-29111, CVE-2026-40225, CVE-2026-40226 (MEDIUM)
+# libudev1:       CVE-2026-29111, CVE-2026-40225, CVE-2026-40226 (MEDIUM)
 # liblzma5:       CVE-2026-34743 (LOW)
 # sed:            CVE-2026-5958 (MEDIUM)
 # gzip:           CVE-2026-41991, CVE-2026-41992 (LOW)
@@ -48,8 +48,8 @@ RUN apt-get update && apt-get install -y \
     libcap2=1:2.66-5ubuntu2.4 \
     libgcrypt20=1.10.3-2ubuntu0.1 \
     libgnutls30t64=3.8.3-1.1ubuntu3.6 \
-    libsystemd0=255.4-1ubuntu8.16 \
-    libudev1=255.4-1ubuntu8.16 \
+    libsystemd0=255.4-1ubuntu8.17 \
+    libudev1=255.4-1ubuntu8.17 \
     liblzma5=5.6.1+really5.4.5-1ubuntu0.3 \
     sed=4.9-2ubuntu0.24.04.1 \
     gzip=1.12-1ubuntu3.2 \

--- a/.pipelines/build/dockerfiles/npm.Dockerfile
+++ b/.pipelines/build/dockerfiles/npm.Dockerfile
@@ -16,6 +16,11 @@ CMD ["npm.exe", "start", "--kubeconfig=.\\kubeconfig"]
 FROM --platform=linux/${ARCH} mcr.microsoft.com/mirror/docker/library/ubuntu:24.04 as linux
 ARG ARTIFACT_DIR
 
+# The signed/release image also passes through the pipeline's automated
+# image-patching (Copacetic) stage, but that only remediates the packages its
+# scanner reports. Some of the fixed OS packages below are not flagged by that
+# scanner, so we pin them explicitly to guarantee the fixes are applied at build
+# time regardless of scanner coverage.
 # Manually patch Ubuntu CVEs:
 # gpgv:           CVE-2025-68973 (HIGH)
 # libc-bin:       CVE-2025-15281, CVE-2026-0861, CVE-2026-0915 (MEDIUM)

--- a/.pipelines/build/dockerfiles/npm.Dockerfile
+++ b/.pipelines/build/dockerfiles/npm.Dockerfile
@@ -16,7 +16,49 @@ CMD ["npm.exe", "start", "--kubeconfig=.\\kubeconfig"]
 FROM --platform=linux/${ARCH} mcr.microsoft.com/mirror/docker/library/ubuntu:24.04 as linux
 ARG ARTIFACT_DIR
 
-RUN apt-get update && apt-get install -y iptables ipset ca-certificates && apt-get autoremove -y && apt-get clean
+# Manually patch Ubuntu CVEs:
+# gpgv:           CVE-2025-68973 (HIGH)
+# libc-bin:       CVE-2025-15281, CVE-2026-0861, CVE-2026-0915 (MEDIUM)
+# libc6:          CVE-2025-15281, CVE-2026-0861, CVE-2026-0915 (MEDIUM)
+# libtasn1-6:     CVE-2025-13151 (MEDIUM)
+# dpkg:           CVE-2026-2219 (MEDIUM)
+# libcap2:        CVE-2026-4878 (MEDIUM)
+# libgcrypt20:    CVE-2026-41989 (MEDIUM)
+# libgnutls30t64: CVE-2026-33845, CVE-2026-33846, CVE-2026-3832, CVE-2026-3833,
+#                 CVE-2026-42009, CVE-2026-42010, CVE-2026-42011, CVE-2026-42012,
+#                 CVE-2026-42013, CVE-2026-42014, CVE-2026-42015, CVE-2026-5260,
+#                 CVE-2026-5419 (MEDIUM)
+# libsystemd0:    CVE-2026-29111, CVE-2026-40225 (MEDIUM)
+# libudev1:       CVE-2026-29111, CVE-2026-40225 (MEDIUM)
+# liblzma5:       CVE-2026-34743 (LOW)
+# sed:            CVE-2026-5958 (MEDIUM)
+# gzip:           CVE-2026-41991, CVE-2026-41992 (LOW)
+# libncursesw6:   CVE-2025-69720 (MEDIUM)
+# libtinfo6:      CVE-2025-69720 (MEDIUM)
+# libpam-modules: CVE-2026-54411 (MEDIUM)
+# perl-base:      CVE-2026-42496, CVE-2026-8376 (MEDIUM)
+# tar:            CVE-2025-45582, CVE-2026-5704 (MEDIUM)
+RUN apt-get update && apt-get install -y \
+    iptables ipset ca-certificates \
+    gpgv=2.4.4-2ubuntu17.4 \
+    libc-bin=2.39-0ubuntu8.8 \
+    libc6=2.39-0ubuntu8.8 \
+    libtasn1-6=4.19.0-3ubuntu0.24.04.2 \
+    dpkg=1.22.6ubuntu6.6 \
+    libcap2=1:2.66-5ubuntu2.4 \
+    libgcrypt20=1.10.3-2ubuntu0.1 \
+    libgnutls30t64=3.8.3-1.1ubuntu3.6 \
+    libsystemd0=255.4-1ubuntu8.16 \
+    libudev1=255.4-1ubuntu8.16 \
+    liblzma5=5.6.1+really5.4.5-1ubuntu0.3 \
+    sed=4.9-2ubuntu0.24.04.1 \
+    gzip=1.12-1ubuntu3.2 \
+    libncursesw6=6.4+20240113-1ubuntu2.1 \
+    libtinfo6=6.4+20240113-1ubuntu2.1 \
+    libpam-modules=1.5.3-5ubuntu5.6 \
+    perl-base=5.38.2-3.2ubuntu0.3 \
+    tar=1.35+dfsg-3ubuntu0.4 \
+    && apt-get autoremove -y && apt-get clean
 #RUN apt-get update && \
 #    apt-get install -y \
 #      linux-libc-dev \

--- a/azure-ip-masq-merger/Dockerfile
+++ b/azure-ip-masq-merger/Dockerfile
@@ -4,10 +4,10 @@ ARG ARCH
 ARG OS
 
 # mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0@sha256:8cd7a5d81a3b482076f133f13b96fc938d1609d20ec04570eed188f70a7efcbe AS go
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0@sha256:0d009d1cb486a1a23c35dcfee3fbd82e22adf9f7ef0cf6bb35020679621d378f AS go
 
 # mcr.microsoft.com/azurelinux/distroless/base:3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:178f25fadf466549d31e234b3091bf815161159f2f2bc98720bbf39f7368aff4 AS mariner-distroless
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:387a603a274e74568fd7a0e6d48ef68e631990e3b5149801515fe749a74b5b29 AS mariner-distroless
 
 FROM go AS azure-ip-masq-merger
 ARG OS

--- a/azure-ipam/Dockerfile
+++ b/azure-ipam/Dockerfile
@@ -6,13 +6,13 @@ ARG OS_VERSION
 ARG OS
 
 # mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0@sha256:8cd7a5d81a3b482076f133f13b96fc938d1609d20ec04570eed188f70a7efcbe AS go
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0@sha256:0d009d1cb486a1a23c35dcfee3fbd82e22adf9f7ef0cf6bb35020679621d378f AS go
 
 # mcr.microsoft.com/azurelinux/base/core:3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/base/core:3.0@sha256:a30e18dd24a8080ee0b72d0f998a688e99380678a407bdd7c3a0ac7417b15eb3 AS mariner-core
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/base/core:3.0@sha256:8bb51342bd5eba915990ab608f91060d502bb7891a2d3d909e0419b932533029 AS mariner-core
 
 # mcr.microsoft.com/azurelinux/distroless/base:3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:178f25fadf466549d31e234b3091bf815161159f2f2bc98720bbf39f7368aff4 AS mariner-distroless
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:387a603a274e74568fd7a0e6d48ef68e631990e3b5149801515fe749a74b5b29 AS mariner-distroless
 
 FROM go AS azure-ipam
 ARG OS

--- a/azure-iptables-monitor/Dockerfile
+++ b/azure-iptables-monitor/Dockerfile
@@ -3,13 +3,13 @@
 ARG ARCH
 
 # mcr.microsoft.com/azurelinux/base/core:3.0
-FROM mcr.microsoft.com/azurelinux/base/core:3.0@sha256:a30e18dd24a8080ee0b72d0f998a688e99380678a407bdd7c3a0ac7417b15eb3 AS mariner-core
+FROM mcr.microsoft.com/azurelinux/base/core:3.0@sha256:8bb51342bd5eba915990ab608f91060d502bb7891a2d3d909e0419b932533029 AS mariner-core
 
 # mcr.microsoft.com/azurelinux/distroless/base:3.0
-FROM mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:178f25fadf466549d31e234b3091bf815161159f2f2bc98720bbf39f7368aff4 AS mariner-distroless
+FROM mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:387a603a274e74568fd7a0e6d48ef68e631990e3b5149801515fe749a74b5b29 AS mariner-distroless
 
 # mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0@sha256:8cd7a5d81a3b482076f133f13b96fc938d1609d20ec04570eed188f70a7efcbe AS go
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0@sha256:0d009d1cb486a1a23c35dcfee3fbd82e22adf9f7ef0cf6bb35020679621d378f AS go
 
 
 FROM go AS azure-iptables-monitor

--- a/cilium-log-collector/Dockerfile
+++ b/cilium-log-collector/Dockerfile
@@ -4,7 +4,7 @@ ARG ARCH
 ARG OS
 
 # mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0@sha256:8cd7a5d81a3b482076f133f13b96fc938d1609d20ec04570eed188f70a7efcbe AS go
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0@sha256:0d009d1cb486a1a23c35dcfee3fbd82e22adf9f7ef0cf6bb35020679621d378f AS go
 
 FROM go AS fluent-bit-plugin
 ARG VERSION

--- a/cni/Dockerfile
+++ b/cni/Dockerfile
@@ -6,13 +6,13 @@ ARG OS_VERSION
 ARG OS
 
 # mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0@sha256:8cd7a5d81a3b482076f133f13b96fc938d1609d20ec04570eed188f70a7efcbe AS go
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0@sha256:0d009d1cb486a1a23c35dcfee3fbd82e22adf9f7ef0cf6bb35020679621d378f AS go
 
 # mcr.microsoft.com/azurelinux/base/core:3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/base/core:3.0@sha256:a30e18dd24a8080ee0b72d0f998a688e99380678a407bdd7c3a0ac7417b15eb3 AS mariner-core
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/base/core:3.0@sha256:8bb51342bd5eba915990ab608f91060d502bb7891a2d3d909e0419b932533029 AS mariner-core
 
 # mcr.microsoft.com/azurelinux/distroless/base:3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:178f25fadf466549d31e234b3091bf815161159f2f2bc98720bbf39f7368aff4 AS mariner-distroless
+FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:387a603a274e74568fd7a0e6d48ef68e631990e3b5149801515fe749a74b5b29 AS mariner-distroless
 
 FROM go AS azure-vnet
 ARG OS

--- a/cns/Dockerfile
+++ b/cns/Dockerfile
@@ -5,13 +5,13 @@ ARG OS_VERSION
 ARG OS
 
 # mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0
-FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0@sha256:8cd7a5d81a3b482076f133f13b96fc938d1609d20ec04570eed188f70a7efcbe AS go
+FROM --platform=linux/${ARCH} mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0@sha256:0d009d1cb486a1a23c35dcfee3fbd82e22adf9f7ef0cf6bb35020679621d378f AS go
 
 # mcr.microsoft.com/azurelinux/base/core:3.0
-FROM mcr.microsoft.com/azurelinux/base/core:3.0@sha256:a30e18dd24a8080ee0b72d0f998a688e99380678a407bdd7c3a0ac7417b15eb3 AS mariner-core
+FROM mcr.microsoft.com/azurelinux/base/core:3.0@sha256:8bb51342bd5eba915990ab608f91060d502bb7891a2d3d909e0419b932533029 AS mariner-core
 
 # mcr.microsoft.com/azurelinux/distroless/base:3.0
-FROM mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:178f25fadf466549d31e234b3091bf815161159f2f2bc98720bbf39f7368aff4 AS mariner-distroless
+FROM mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:387a603a274e74568fd7a0e6d48ef68e631990e3b5149801515fe749a74b5b29 AS mariner-distroless
 
 FROM --platform=linux/${ARCH} go AS builder
 ARG OS

--- a/npm/dockerfile_test.go
+++ b/npm/dockerfile_test.go
@@ -1,0 +1,39 @@
+package npm
+
+import (
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	expectedWindowsGoImage  = "mcr.microsoft.com/oss/go/microsoft/golang:1.26.5@sha256:ea712a1aaf80306c19ff842ba0bfcb9ad360afd8143e70044e0d0bd6d6899887"
+	expectedServerCoreImage = "mcr.microsoft.com/windows/servercore:ltsc2022@sha256:6b43c814ed2a800563083ce3193e5f1951d4d6a18fd2879ff45173851db82bd5"
+)
+
+func TestWindowsDockerfileImagePins(t *testing.T) {
+	unsignedDockerfile := readDockerfile(t, "windows.Dockerfile")
+	signedDockerfile := readDockerfile(t, "../.pipelines/build/dockerfiles/npm.Dockerfile")
+
+	require.Contains(t, unsignedDockerfile, expectedWindowsGoImage)
+	require.Equal(t, expectedServerCoreImage, serverCoreImage(t, unsignedDockerfile))
+	require.Equal(t, expectedServerCoreImage, serverCoreImage(t, signedDockerfile))
+}
+
+func readDockerfile(t *testing.T, path string) string {
+	t.Helper()
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(content)
+}
+
+func serverCoreImage(t *testing.T, dockerfile string) string {
+	t.Helper()
+
+	match := regexp.MustCompile(`mcr\.microsoft\.com/windows/servercore:ltsc2022@sha256:[a-f0-9]+`).FindString(dockerfile)
+	require.NotEmpty(t, match)
+	return match
+}

--- a/npm/dockerfile_test.go
+++ b/npm/dockerfile_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	expectedNPMGoImage      = "mcr.microsoft.com/oss/go/microsoft/golang:1.26.5@sha256:ea712a1aaf80306c19ff842ba0bfcb9ad360afd8143e70044e0d0bd6d6899887"
+	expectedNPMGoImage      = "mcr.microsoft.com/oss/go/microsoft/golang:1.26.6@sha256:8365869fedcec3bd332a8c5704ec55152fb397ded5cfc9e57ade54f998add366"
 	expectedServerCoreImage = "mcr.microsoft.com/windows/servercore:ltsc2022@sha256:6b43c814ed2a800563083ce3193e5f1951d4d6a18fd2879ff45173851db82bd5"
 )
 

--- a/npm/dockerfile_test.go
+++ b/npm/dockerfile_test.go
@@ -9,15 +9,17 @@ import (
 )
 
 const (
-	expectedWindowsGoImage  = "mcr.microsoft.com/oss/go/microsoft/golang:1.26.5@sha256:ea712a1aaf80306c19ff842ba0bfcb9ad360afd8143e70044e0d0bd6d6899887"
+	expectedNPMGoImage      = "mcr.microsoft.com/oss/go/microsoft/golang:1.26.5@sha256:ea712a1aaf80306c19ff842ba0bfcb9ad360afd8143e70044e0d0bd6d6899887"
 	expectedServerCoreImage = "mcr.microsoft.com/windows/servercore:ltsc2022@sha256:6b43c814ed2a800563083ce3193e5f1951d4d6a18fd2879ff45173851db82bd5"
 )
 
-func TestWindowsDockerfileImagePins(t *testing.T) {
+func TestNPMDockerfileImagePins(t *testing.T) {
+	linuxDockerfile := readDockerfile(t, "linux.Dockerfile")
 	unsignedDockerfile := readDockerfile(t, "windows.Dockerfile")
 	signedDockerfile := readDockerfile(t, "../.pipelines/build/dockerfiles/npm.Dockerfile")
 
-	require.Contains(t, unsignedDockerfile, expectedWindowsGoImage)
+	require.Contains(t, linuxDockerfile, expectedNPMGoImage)
+	require.Contains(t, unsignedDockerfile, expectedNPMGoImage)
 	require.Equal(t, expectedServerCoreImage, serverCoreImage(t, unsignedDockerfile))
 	require.Equal(t, expectedServerCoreImage, serverCoreImage(t, signedDockerfile))
 }

--- a/npm/linux.Dockerfile
+++ b/npm/linux.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.5 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.5@sha256:ea712a1aaf80306c19ff842ba0bfcb9ad360afd8143e70044e0d0bd6d6899887 AS builder
 ARG VERSION
 ARG NPM_AI_PATH
 ARG NPM_AI_ID

--- a/npm/linux.Dockerfile
+++ b/npm/linux.Dockerfile
@@ -8,6 +8,48 @@ RUN MS_GO_NOSYSTEMCRYPTO=1 CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm
 
 FROM mcr.microsoft.com/mirror/docker/library/ubuntu:24.04 as linux
 COPY --from=builder /usr/local/bin/azure-npm /usr/bin/azure-npm
-RUN apt-get update && apt-get install -y iptables ipset ca-certificates && apt-get autoremove -y && apt-get clean
+# Manually patch Ubuntu CVEs:
+# gpgv:           CVE-2025-68973 (HIGH)
+# libc-bin:       CVE-2025-15281, CVE-2026-0861, CVE-2026-0915 (MEDIUM)
+# libc6:          CVE-2025-15281, CVE-2026-0861, CVE-2026-0915 (MEDIUM)
+# libtasn1-6:     CVE-2025-13151 (MEDIUM)
+# dpkg:           CVE-2026-2219 (MEDIUM)
+# libcap2:        CVE-2026-4878 (MEDIUM)
+# libgcrypt20:    CVE-2026-41989 (MEDIUM)
+# libgnutls30t64: CVE-2026-33845, CVE-2026-33846, CVE-2026-3832, CVE-2026-3833,
+#                 CVE-2026-42009, CVE-2026-42010, CVE-2026-42011, CVE-2026-42012,
+#                 CVE-2026-42013, CVE-2026-42014, CVE-2026-42015, CVE-2026-5260,
+#                 CVE-2026-5419 (MEDIUM)
+# libsystemd0:    CVE-2026-29111, CVE-2026-40225 (MEDIUM)
+# libudev1:       CVE-2026-29111, CVE-2026-40225 (MEDIUM)
+# liblzma5:       CVE-2026-34743 (LOW)
+# sed:            CVE-2026-5958 (MEDIUM)
+# gzip:           CVE-2026-41991, CVE-2026-41992 (LOW)
+# libncursesw6:   CVE-2025-69720 (MEDIUM)
+# libtinfo6:      CVE-2025-69720 (MEDIUM)
+# libpam-modules: CVE-2026-54411 (MEDIUM)
+# perl-base:      CVE-2026-42496, CVE-2026-8376 (MEDIUM)
+# tar:            CVE-2025-45582, CVE-2026-5704 (MEDIUM)
+RUN apt-get update && apt-get install -y \
+    iptables ipset ca-certificates \
+    gpgv=2.4.4-2ubuntu17.4 \
+    libc-bin=2.39-0ubuntu8.8 \
+    libc6=2.39-0ubuntu8.8 \
+    libtasn1-6=4.19.0-3ubuntu0.24.04.2 \
+    dpkg=1.22.6ubuntu6.6 \
+    libcap2=1:2.66-5ubuntu2.4 \
+    libgcrypt20=1.10.3-2ubuntu0.1 \
+    libgnutls30t64=3.8.3-1.1ubuntu3.6 \
+    libsystemd0=255.4-1ubuntu8.16 \
+    libudev1=255.4-1ubuntu8.16 \
+    liblzma5=5.6.1+really5.4.5-1ubuntu0.3 \
+    sed=4.9-2ubuntu0.24.04.1 \
+    gzip=1.12-1ubuntu3.2 \
+    libncursesw6=6.4+20240113-1ubuntu2.1 \
+    libtinfo6=6.4+20240113-1ubuntu2.1 \
+    libpam-modules=1.5.3-5ubuntu5.6 \
+    perl-base=5.38.2-3.2ubuntu0.3 \
+    tar=1.35+dfsg-3ubuntu0.4 \
+    && apt-get autoremove -y && apt-get clean
 RUN chmod +x /usr/bin/azure-npm
 ENTRYPOINT ["/usr/bin/azure-npm", "start"]

--- a/npm/linux.Dockerfile
+++ b/npm/linux.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.5@sha256:ea712a1aaf80306c19ff842ba0bfcb9ad360afd8143e70044e0d0bd6d6899887 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.6@sha256:8365869fedcec3bd332a8c5704ec55152fb397ded5cfc9e57ade54f998add366 AS builder
 ARG VERSION
 ARG NPM_AI_PATH
 ARG NPM_AI_ID

--- a/npm/linux.Dockerfile
+++ b/npm/linux.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.4 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.5 AS builder
 ARG VERSION
 ARG NPM_AI_PATH
 ARG NPM_AI_ID
@@ -20,8 +20,8 @@ COPY --from=builder /usr/local/bin/azure-npm /usr/bin/azure-npm
 #                 CVE-2026-42009, CVE-2026-42010, CVE-2026-42011, CVE-2026-42012,
 #                 CVE-2026-42013, CVE-2026-42014, CVE-2026-42015, CVE-2026-5260,
 #                 CVE-2026-5419 (MEDIUM)
-# libsystemd0:    CVE-2026-29111, CVE-2026-40225 (MEDIUM)
-# libudev1:       CVE-2026-29111, CVE-2026-40225 (MEDIUM)
+# libsystemd0:    CVE-2026-29111, CVE-2026-40225, CVE-2026-40226 (MEDIUM)
+# libudev1:       CVE-2026-29111, CVE-2026-40225, CVE-2026-40226 (MEDIUM)
 # liblzma5:       CVE-2026-34743 (LOW)
 # sed:            CVE-2026-5958 (MEDIUM)
 # gzip:           CVE-2026-41991, CVE-2026-41992 (LOW)
@@ -40,8 +40,8 @@ RUN apt-get update && apt-get install -y \
     libcap2=1:2.66-5ubuntu2.4 \
     libgcrypt20=1.10.3-2ubuntu0.1 \
     libgnutls30t64=3.8.3-1.1ubuntu3.6 \
-    libsystemd0=255.4-1ubuntu8.16 \
-    libudev1=255.4-1ubuntu8.16 \
+    libsystemd0=255.4-1ubuntu8.17 \
+    libudev1=255.4-1ubuntu8.17 \
     liblzma5=5.6.1+really5.4.5-1ubuntu0.3 \
     sed=4.9-2ubuntu0.24.04.1 \
     gzip=1.12-1ubuntu3.2 \

--- a/npm/windows.Dockerfile
+++ b/npm/windows.Dockerfile
@@ -1,5 +1,5 @@
 ARG OS_VERSION
-FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.26.5 AS builder
+FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.26.5@sha256:ea712a1aaf80306c19ff842ba0bfcb9ad360afd8143e70044e0d0bd6d6899887 AS builder
 ARG VERSION
 ARG NPM_AI_PATH
 ARG NPM_AI_ID
@@ -8,7 +8,7 @@ COPY . .
 RUN MS_GO_NOSYSTEMCRYPTO=1 GOOS=windows CGO_ENABLED=0 go build -v -o /usr/local/bin/azure-npm.exe -ldflags "-s -w -X main.version="$VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" -gcflags="-dwarflocationlists=true" npm/cmd/*.go
 
 # intermediate for win-ltsc2022
-FROM mcr.microsoft.com/windows/servercore:ltsc2022@sha256:3a2a2fdfbae2f720f6fe26f2d7680146712ce330f605b02a61d624889735c72e as windows
+FROM mcr.microsoft.com/windows/servercore:ltsc2022@sha256:6b43c814ed2a800563083ce3193e5f1951d4d6a18fd2879ff45173851db82bd5 as windows
 COPY --from=builder /usr/local/src/npm/examples/windows/kubeconfigtemplate.yaml kubeconfigtemplate.yaml
 COPY --from=builder /usr/local/src/npm/examples/windows/setkubeconfigpath.ps1 setkubeconfigpath.ps1
 COPY --from=builder /usr/local/src/npm/examples/windows/setkubeconfigpath-capz.ps1 setkubeconfigpath-capz.ps1

--- a/npm/windows.Dockerfile
+++ b/npm/windows.Dockerfile
@@ -1,5 +1,5 @@
 ARG OS_VERSION
-FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.26.5@sha256:ea712a1aaf80306c19ff842ba0bfcb9ad360afd8143e70044e0d0bd6d6899887 AS builder
+FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.26.6@sha256:8365869fedcec3bd332a8c5704ec55152fb397ded5cfc9e57ade54f998add366 AS builder
 ARG VERSION
 ARG NPM_AI_PATH
 ARG NPM_AI_ID

--- a/npm/windows.Dockerfile
+++ b/npm/windows.Dockerfile
@@ -1,5 +1,5 @@
 ARG OS_VERSION
-FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.26.4 AS builder
+FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.26.5 AS builder
 ARG VERSION
 ARG NPM_AI_PATH
 ARG NPM_AI_ID


### PR DESCRIPTION
## Summary

CVE hardening for the signed and unsigned Azure NPM images:

- Pins patched Ubuntu runtime packages.
- Builds NPM with MS Go `1.26.6` and current fixed Go module versions.
- Refreshes both Windows release paths from Server Core LTSC 2022 build `20348.4405` to `20348.5499`.
- Adds a regression test preventing the signed and unsigned Windows base pins from drifting.

Local artifact validation resolves every **Windows-applicable Go finding** from the tracker list. Ubuntu package findings are Linux-only. Final Windows OS-layer closure still requires the signed pipeline's Windows-capable Qualys/Defender scan of the published child digest.

## Changes

### 1. Pin patched Ubuntu packages (signed + unsigned)

Pins the fixed package versions in:

- `.pipelines/build/dockerfiles/npm.Dockerfile` (signed release image)
- `npm/linux.Dockerfile` (unsigned image)

Covers `gpgv`, `libc-bin`, `libc6`, `libtasn1-6`, `dpkg`, `libcap2`, `libgcrypt20`, `libgnutls30t64`, `libsystemd0`, `libudev1`, `liblzma5`, `sed`, `gzip`, `libncursesw6`, `libtinfo6`, `libpam-modules`, `perl-base`, and `tar`. `libssl3t64` is not pinned because the base already contains a fixed version.

### 2. Update the Windows and Linux Go binary

- Bumps the NPM builder from Go `1.26.4` to `1.26.6`.
- Pins both NPM Dockerfile builders immutably:
  `mcr.microsoft.com/oss/go/microsoft/golang:1.26.6@sha256:8365869f...d366`.
- The branch uses `x/net v0.57.0`, `x/sys v0.47.0`, `x/text v0.40.0`, and grpc `v1.82.1`.
- `install-go.sh` resolves the signed NPM compiler from the OS-specific Dockerfile, so signed and unsigned Windows binaries use the same pinned builder.

These versions meet or exceed every current fixed-version threshold reported for the Windows `npm.exe`.

### 3. Refresh the Windows Server Core base (signed + unsigned)

Both Windows Dockerfiles now use Server Core LTSC 2022 build `20348.5499`:

`mcr.microsoft.com/windows/servercore:ltsc2022@sha256:6b43c814...82bd5`

Updated:

- `.pipelines/build/dockerfiles/npm.Dockerfile`
- `npm/windows.Dockerfile`

The previous pin was build `20348.4405` from November 2025. `npm/dockerfile_test.go` now verifies both release paths use the same current Server Core pin and that both Linux and Windows NPM builders remain pinned to MS Go 1.26.6.

## Verification

### Linux

- Built and scanned the NPM Linux image with Trivy.
- **0** OS-package findings with an available fix.
- **0** Go-binary findings.
- Remaining Linux findings have no upstream fix available.

### Windows

- Scanned the exact published `v1.6.48-0` Windows child:
  `sha256:c9882c7e...067a70`.
- The old Ubuntu package rows are **platform N/A** for Windows.
- The published Windows `npm.exe` currently has 44 fixable Go findings.
- Rebuilt `npm.exe` with this branch and verified embedded versions with `go version -m`:
  Go `1.26.6`, `x/net v0.57.0`, `x/sys v0.47.0`, `x/text v0.40.0`, grpc `v1.82.1`.
- Trivy scan of the rebuilt binary: **0 findings**.
- Built the complete Windows/amd64 OCI image on the refreshed Server Core base.
- Trivy scan of that image: **0 Go-binary findings**.
- `go test ./npm -run TestNPMDockerfileImagePins -count=1` passes.

### Signed OneBranch validation

Official build [176714445](https://dev.azure.com/msazure/One/_build/results?buildId=176714445) ran against exact GitHub SHA `06620e55c57ef53c459e8aac248183cac288fbaf`.

All NPM packaging, signing, platform-image, and manifest jobs succeeded. The overall pipeline failed later in unrelated AKS/Cilium E2E stages.

Published signed validation image:

`acnpublic.azurecr.io/artifact/dd590928-4e04-48cb-9d3d-ee06c5f0e17f/official/npm:v1.8.12-15-g06620e55c`

- Manifest digest: `sha256:e049ec35d2ca54e218c77705a8e079d6e65600a02bcedb4fd41a5faec937aec9`
- Linux/amd64: `sha256:3c595ed81a0a11e7fb1a307c5e04d22f5727001be700f3906e8c944ea4f51707`
- Linux/arm64: `sha256:9c28dac95b2e2e3593b134f129f35f50ece794366218ade24fb1309fe2a74ef8`
- Windows/amd64 (`10.0.20348.5499`): `sha256:43c73a3f859044c9c578cf09088bd4f3cabb86312f4a938df13552f443995986`

Exact-digest Trivy results with the current database:

- Linux/amd64: **0 fixable findings**, 0 Go findings; 14 OS findings without upstream fixes.
- Linux/arm64: **0 fixable findings**, 0 Go findings; the same 14 OS findings without upstream fixes.
- Windows/amd64: **0 Go findings**.
- Row-level reconciliation against `npm-cve-status-v1.6.48-0.xlsx`: **0 remaining matches across all 219 workbook rows**.

OneBranch attached signed payloads to the Windows child and final manifest. The generated Windows SDL artifact also reports 0 malware findings.

### Required release validation

Trivy reports `OS: null` for Windows Server Core and therefore cannot attest Windows OS-component CVEs. Before claiming complete Windows-image remediation:

1. Publish the final production release tag from the validated source.
2. Re-run Trivy against each final production child digest.
3. Run Qualys/Defender against the exact final Windows child digest.

## Relationship to #4680

Rebased on current `master`, including #4680's signed NPM build and manifest publication fixes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
