### PR TITLE
ci: Restrict docker dependabot updates to Dockerfile only

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,24 +1,6 @@
 # https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:
-  - package-ecosystem: "docker"
-    directories:
-      - "**/*"
-    exclude-paths:
-      - "**/*.tmpl"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "ci"
-    labels: ["ci", "dependencies"]
-    open-pull-requests-limit: 10
-    groups:
-      all-docker-dependencies:
-        applies-to: version-updates
-        patterns: ["*"]
-    cooldown:
-      default-days: 7
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -38,6 +20,26 @@ updates:
   # =========================
   # DEFAULT BRANCH (master/main) — STAGED ROLLOUT
   # =========================
+
+  - package-ecosystem: "docker"
+    directories:
+      - "**/*"
+    exclude-paths:
+      - "**/*.tmpl"
+      - "**/*.yaml"
+      - "**/*.yml"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "ci"
+    labels: ["ci", "dependencies"]
+    open-pull-requests-limit: 10
+    groups:
+      all-docker-dependencies:
+        applies-to: version-updates
+        patterns: ["*"]
+    cooldown:
+      default-days: 7
 
   # Root go.mod (/): grouped minor+patch + allow majors concurrently
   - package-ecosystem: "gomod"
@@ -154,6 +156,27 @@ updates:
   # =========================
 
   # release/v1.7 constraints (daily);
+  - package-ecosystem: "docker"
+    directories:
+      - "**/*"
+    exclude-paths:
+      - "**/*.tmpl"
+      - "**/*.yaml"
+      - "**/*.yml"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "ci"
+    labels: ["ci", "dependencies", "release/1.7"]
+    open-pull-requests-limit: 10
+    target-branch: "release/v1.7"
+    groups:
+      all-docker-dependencies:
+        applies-to: version-updates
+        patterns: ["*"]
+    cooldown:
+      default-days: 7
+
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
@@ -223,6 +246,27 @@ updates:
       default-days: 7
 
   # release/v1.6 constraints (daily);
+  - package-ecosystem: "docker"
+    directories:
+      - "**/*"
+    exclude-paths:
+      - "**/*.tmpl"
+      - "**/*.yaml"
+      - "**/*.yml"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "ci"
+    labels: ["ci", "dependencies", "release/1.6"]
+    open-pull-requests-limit: 10
+    target-branch: "release/v1.6"
+    groups:
+      all-docker-dependencies:
+        applies-to: version-updates
+        patterns: ["*"]
+    cooldown:
+      default-days: 7
+
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Focuses dependabot on the files and locations we care about. See #4687 for an example of what we are trying to fix.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
