### PR TITLE
feat(hack): add transparent-tunnel CNI installer manifest

### DIFF
--- a/hack/manifests/cni-installer-transparent-tunnel.md
+++ b/hack/manifests/cni-installer-transparent-tunnel.md
@@ -9,7 +9,7 @@ datapath design.
 ## What gets installed
 
 On each node, the DaemonSet's init container extracts files out of the
-`mcr.microsoft.com/containernetworking/azure-cni` image and writes them to
+`mcr.microsoft.com/containernetworking/v2/azure-cni` image and writes them to
 the host:
 
 | Payload entry                       | Host path                                 |
@@ -28,8 +28,20 @@ unambiguously on the next pod sandbox creation.
 - **An `azure-cni` image containing transparent-tunnel mode.** The mode was added
   in PR #4319; images built before that release do not recognize
   `"mode": "transparent-tunnel"` and silently fall back to bridge mode, giving no
-  tunnel enforcement. Update the `image:` tag in the DaemonSet to the first release
-  containing the mode before installing.
+  tunnel enforcement. The manifest therefore ships with an unresolvable placeholder
+  tag that **must** be replaced before install:
+
+  ```sh
+  # pick the first release containing transparent-tunnel
+  curl -s https://mcr.microsoft.com/v2/containernetworking/v2/azure-cni/tags/list
+
+  sed -i 's|<TRANSPARENT_TUNNEL_RELEASE>|vX.Y.Z|' \
+    hack/manifests/cni-installer-transparent-tunnel.yaml
+  ```
+
+  Images are published under the dalec path
+  `mcr.microsoft.com/containernetworking/v2/azure-cni`; the older
+  `containernetworking/azure-cni` path is deprecated and will not receive the mode.
 - Linux nodes with `ipset` (userspace + `ip_set` / `xt_set` modules) and
   `iptables` installed. On Ubuntu / Debian: `sudo apt-get install -y ipset`.
 - Pod-pool secondary IPs must **not** be assigned to the host primary NIC
@@ -86,7 +98,12 @@ transparent-tunnel rules after all transparent-tunnel pods are gone.
 
 ## Image version
 
-The DaemonSet pins
-`mcr.microsoft.com/containernetworking/azure-cni:v1.5.16` only as a
-placeholder. Bump to whatever azure-cni release first includes the
-transparent-tunnel conflist payload (built from `cni/Dockerfile`).
+The DaemonSet ships with the unresolvable placeholder tag
+`mcr.microsoft.com/containernetworking/v2/azure-cni:<TRANSPARENT_TUNNEL_RELEASE>`.
+Replace it with whatever azure-cni release first includes the
+`azure-transparent-tunnel.conflist` payload (added to `cni/Dockerfile`,
+`cni/Dockerfile.tmpl` and `.pipelines/build/scripts/cni.sh` in PR #4319).
+
+The placeholder is intentional: pinning a currently-published tag would install
+an azure-vnet that does not know the mode, and it would fall back to bridge mode
+without enforcing anything. A pull failure is the safer default.

--- a/hack/manifests/cni-installer-transparent-tunnel.md
+++ b/hack/manifests/cni-installer-transparent-tunnel.md
@@ -1,0 +1,92 @@
+# Transparent-tunnel CNI installer
+
+Installs the `azure-vnet` CNI plugin in **transparent-tunnel** mode on every
+Linux node. In this mode the plugin forces every pod-to-pod packet onto the
+host's physical NIC so the Azure VFP layer enforces NSG / ASG rules even for
+same-node flows. See `docs/transparent-tunnel.md` (in PR #4319) for the
+datapath design.
+
+## What gets installed
+
+On each node, the DaemonSet's init container extracts files out of the
+`mcr.microsoft.com/containernetworking/azure-cni` image and writes them to
+the host:
+
+| Payload entry                       | Host path                                 |
+|-------------------------------------|-------------------------------------------|
+| `azure-vnet`                        | `/opt/cni/bin/azure-vnet`                 |
+| `azure-vnet-ipam`                   | `/opt/cni/bin/azure-vnet-ipam`            |
+| `azure-vnet-telemetry`              | `/opt/cni/bin/azure-vnet-telemetry`       |
+| `azure-transparent-tunnel.conflist` | `/etc/cni/net.d/10-azure.conflist`        |
+
+The conflist name `10-azure.conflist` is intentional &mdash; it replaces
+whatever stock conflist is in `/etc/cni/net.d` so kubelet picks transparent-tunnel
+unambiguously on the next pod sandbox creation.
+
+## Prerequisites
+
+- **An `azure-cni` image containing transparent-tunnel mode.** The mode was added
+  in PR #4319; images built before that release do not recognize
+  `"mode": "transparent-tunnel"` and silently fall back to bridge mode, giving no
+  tunnel enforcement. Update the `image:` tag in the DaemonSet to the first release
+  containing the mode before installing.
+- Linux nodes with `ipset` (userspace + `ip_set` / `xt_set` modules) and
+  `iptables` installed. On Ubuntu / Debian: `sudo apt-get install -y ipset`.
+- Pod-pool secondary IPs must **not** be assigned to the host primary NIC
+  by anything other than `azure-vnet`. AKS handles this via CNS; on
+  self-managed clusters using cloud-init or netplan to claim secondaries
+  will short-circuit pod traffic via the host's `local` table.
+- No legacy host bridge should keep pod traffic off the physical NIC.
+  Transparent-tunnel needs pod packets to reach the physical NIC so VFP sees
+  same-node traffic.
+
+## Install
+
+```sh
+kubectl apply -f hack/manifests/cni-installer-transparent-tunnel.yaml
+```
+
+After every DaemonSet pod reaches `Running`, kill any leftover pods on
+the node (or just wait &mdash; new pods will be scheduled with the new
+conflist):
+
+```sh
+kubectl rollout status ds/azure-cni-transparent-tunnel -n kube-system
+```
+
+## Verify
+
+On any worker:
+
+```sh
+ls -l /opt/cni/bin/azure-vnet
+cat /etc/cni/net.d/10-azure.conflist           # must contain "mode": "transparent-tunnel"
+sudo ipset list azure-tt-local-pods            # one entry per local pod
+sudo iptables -t mangle -S PREROUTING | grep MARK | head
+sudo iptables -t raw     -S PREROUTING | grep NOTRACK
+sudo ip rule  show | grep '0x3 lookup 101'
+sudo ip route show table 101
+```
+
+A correctly programmed host shows: 1 MARK rule per local pod veth (`mark 0x3`),
+1 NOTRACK rule referencing `azure-tt-local-pods src,dst`, 1 `fwmark 0x3 lookup 101`
+ip rule, and `default via <gw> dev eth0` in table 101.
+
+## Uninstall
+
+```sh
+kubectl delete -f hack/manifests/cni-installer-transparent-tunnel.yaml
+```
+
+This stops shipping the conflist + binary to new nodes but does **not**
+roll back existing shared kernel state (ipset, NOTRACK rule, ip rule, table
+101). To restore a stock CNI on an existing node, drop a different conflist
+into `/etc/cni/net.d` and reboot the node, or manually remove the shared
+transparent-tunnel rules after all transparent-tunnel pods are gone.
+
+## Image version
+
+The DaemonSet pins
+`mcr.microsoft.com/containernetworking/azure-cni:v1.5.16` only as a
+placeholder. Bump to whatever azure-cni release first includes the
+transparent-tunnel conflist payload (built from `cni/Dockerfile`).

--- a/hack/manifests/cni-installer-transparent-tunnel.yaml
+++ b/hack/manifests/cni-installer-transparent-tunnel.yaml
@@ -55,12 +55,17 @@ spec:
           effect: NoSchedule
       initContainers:
         - name: azure-cni-transparent-tunnel
-          # NOTE: transparent-tunnel mode requires an azure-cni image built from a
-          # release that contains the mode. Older images do not recognize it and
-          # silently fall back to bridge mode with no tunnel enforcement, so this
-          # tag must be updated to the first release containing transparent-tunnel
-          # before this manifest is used.
-          image: mcr.microsoft.com/containernetworking/azure-cni:v1.5.16
+          # REQUIRED: replace <TRANSPARENT_TUNNEL_RELEASE> with the first azure-cni
+          # release that contains transparent-tunnel mode (added in PR #4319).
+          #
+          # The tag is deliberately left as an unresolvable placeholder rather than
+          # pinned to a current release: an older image does not recognize
+          # "mode": "transparent-tunnel" and silently falls back to bridge mode with
+          # no tunnel enforcement at all. A failed image pull is a loud, obvious
+          # error; a silent fallback to an unenforced datapath is not.
+          #
+          # Available tags: https://mcr.microsoft.com/v2/containernetworking/v2/azure-cni/tags/list
+          image: mcr.microsoft.com/containernetworking/v2/azure-cni:<TRANSPARENT_TUNNEL_RELEASE>
           imagePullPolicy: Always
           command: ["/dropgz"]
           args:

--- a/hack/manifests/cni-installer-transparent-tunnel.yaml
+++ b/hack/manifests/cni-installer-transparent-tunnel.yaml
@@ -1,0 +1,97 @@
+# Transparent-tunnel CNI installer
+#
+# Drops the azure-vnet binary + a `mode: transparent-tunnel` conflist onto
+# each Linux node's /opt/cni/bin and /etc/cni/net.d. The conflist is written
+# as 10-azure.conflist, replacing whatever conflist is already there, so
+# kubelet picks it up unambiguously on the next pod sandbox creation.
+#
+# Host prerequisites (must be in place before applying):
+#   - `ipset` userspace tool + the `ip_set` / `xt_set` kernel modules
+#   - `iptables` (legacy or nft, matching whichever azure-vnet was built for)
+#   - Pod-pool secondary IPs must not be assigned to the host primary NIC
+#     by anything other than azure-vnet (e.g. cloud-init / netplan must
+#     leave the secondaries alone). On AKS this is handled by CNS.
+#
+# Do not deploy alongside any host bridge that keeps pod traffic off the
+# physical NIC; transparent-tunnel relies on VFP seeing same-node traffic.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: azure-cni-transparent-tunnel
+  namespace: kube-system
+  labels:
+    app: azure-cni-transparent-tunnel
+spec:
+  selector:
+    matchLabels:
+      k8s-app: azure-cni-transparent-tunnel
+  template:
+    metadata:
+      labels:
+        k8s-app: azure-cni-transparent-tunnel
+      annotations:
+        cluster-autoscaler.kubernetes.io/daemonset-pod: "true"
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: type
+                    operator: NotIn
+                    values:
+                      - virtual-kubelet
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+      priorityClassName: system-node-critical
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - operator: "Exists"
+          effect: NoExecute
+        - operator: "Exists"
+          effect: NoSchedule
+      initContainers:
+        - name: azure-cni-transparent-tunnel
+          # NOTE: transparent-tunnel mode requires an azure-cni image built from a
+          # release that contains the mode. Older images do not recognize it and
+          # silently fall back to bridge mode with no tunnel enforcement, so this
+          # tag must be updated to the first release containing transparent-tunnel
+          # before this manifest is used.
+          image: mcr.microsoft.com/containernetworking/azure-cni:v1.5.16
+          imagePullPolicy: Always
+          command: ["/dropgz"]
+          args:
+            - deploy
+            - azure-vnet
+            - -o
+            - /opt/cni/bin/azure-vnet
+            - azure-vnet-ipam
+            - -o
+            - /opt/cni/bin/azure-vnet-ipam
+            - azure-vnet-telemetry
+            - -o
+            - /opt/cni/bin/azure-vnet-telemetry
+            - azure-transparent-tunnel.conflist
+            - -o
+            - /etc/cni/net.d/10-azure.conflist
+          volumeMounts:
+            - name: cni-bin
+              mountPath: /opt/cni/bin
+            - name: cni-conflist
+              mountPath: /etc/cni/net.d
+      containers:
+        - name: pause
+          image: mcr.microsoft.com/oss/kubernetes/pause:3.6
+      hostNetwork: true
+      volumes:
+        - name: cni-conflist
+          hostPath:
+            path: /etc/cni/net.d
+            type: Directory
+        - name: cni-bin
+          hostPath:
+            path: /opt/cni/bin
+            type: Directory


### PR DESCRIPTION
## Summary

Adds a `hack/manifests` DaemonSet that installs `azure-vnet` in **transparent-tunnel**
mode on Linux nodes, plus the operator-facing doc for it.

This is the installer half of #4319, split out per review feedback so that PR stays
scoped to the CNI implementation.

| File | Purpose |
|---|---|
| `hack/manifests/cni-installer-transparent-tunnel.yaml` | DaemonSet; dropgz-extracts `azure-vnet` + the transparent-tunnel conflist onto each node |
| `hack/manifests/cni-installer-transparent-tunnel.md` | Prerequisites, install, verify, uninstall, and known limitations |

The init container writes the conflist as `10-azure.conflist`, deliberately replacing
the stock conflist so kubelet picks the mode up unambiguously on the next sandbox
creation. It follows the existing `cni-installer.yaml` / `cni-installer-v1.yaml`
pattern in this directory.

## :warning: Blocked — do not merge yet

This manifest is **inert until both of the following land**:

1. **#4319 merges.** It adds the `azure-transparent-tunnel.conflist` payload entry to
   `cni/Dockerfile`, `cni/Dockerfile.tmpl` and `.pipelines/build/scripts/cni.sh`.
   Without it, the `azure-transparent-tunnel.conflist -o ...` arg has nothing to
   extract and dropgz fails.
2. **An azure-cni release is cut** containing that payload.

## Why the image tag is a placeholder

```yaml
image: mcr.microsoft.com/containernetworking/v2/azure-cni:<TRANSPARENT_TUNNEL_RELEASE>
```

That tag does not resolve, and that is deliberate. An azure-cni build predating
#4319 does not recognize `"mode": "transparent-tunnel"` — it does not error, it
**silently falls back to bridge mode**, so pods come up healthy with zero tunnel
enforcement and no NSG application to same-node traffic. Pinning a currently-published
tag would make that silent misconfiguration the default behavior.

A failed image pull is loud and immediately diagnosable. A silently unenforced
datapath is not. The doc gives the one-liner to resolve it:

```sh
curl -s https://mcr.microsoft.com/v2/containernetworking/v2/azure-cni/tags/list
sed -i 's|<TRANSPARENT_TUNNEL_RELEASE>|vX.Y.Z|' hack/manifests/cni-installer-transparent-tunnel.yaml
```

## Review feedback already applied

- @QxBytes ([#4319 r3470890672](https://github.com/Azure/azure-container-networking/pull/4319#discussion_r3470890672)) — the manifest pointed at the deprecated
  `containernetworking/azure-cni` path. Now uses the managed-dalec path
  `containernetworking/v2/azure-cni`, confirmed against the live tag list
  (`containernetworking/v2/azure-cni` → `v1.8.11`; the legacy path tops out in the
  `v1.5.x` line and will not receive the mode).

## Testing

- `kubectl apply --dry-run=client -f` / YAML schema parse — clean.
- Full functional validation is deferred until a release with the payload exists;
  the manifest cannot be meaningfully applied before then.

## Related

- Depends on #4319 (transparent-tunnel CNI mode + conflist payload)
- Datapath design: `docs/transparent-tunnel.md` (in #4319)
