### PR TITLE
fix: keep JSON store cache unchanged after failed writes

### DIFF
--- a/store/json.go
+++ b/store/json.go
@@ -122,9 +122,25 @@ func (kvs *jsonFileStore) Write(key string, value interface{}) error {
 		return err
 	}
 
+	if kvs.data == nil {
+		kvs.data = make(map[string]*json.RawMessage, 1)
+	}
+
+	// Stage the new value, then roll it back if the store cannot be persisted, so
+	// that a failed write never leaks into a later successful flush.
+	previous, existed := kvs.data[key]
 	kvs.data[key] = &raw
 
-	return kvs.flush()
+	if err := kvs.flush(); err != nil {
+		if existed {
+			kvs.data[key] = previous
+		} else {
+			delete(kvs.data, key)
+		}
+		return err
+	}
+
+	return nil
 }
 
 // Flush commits in-memory state to persistent store.
@@ -176,6 +192,7 @@ func (kvs *jsonFileStore) flush() error {
 		return fmt.Errorf("rename temp file to state file failed:%v", err)
 	}
 
+	kvs.inSync = true
 	return nil
 }
 

--- a/store/json_test.go
+++ b/store/json_test.go
@@ -5,6 +5,7 @@ package store
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -155,6 +156,55 @@ func TestKeyValuePairsAreWrittenAndReadCorrectly(t *testing.T) {
 
 	// Cleanup.
 	os.Remove(testFileName)
+}
+
+func TestFailedWriteDoesNotPersistOnLaterWrite(t *testing.T) {
+	storeDir := filepath.Join(t.TempDir(), "missing")
+	storePath := filepath.Join(storeDir, testFileName)
+	kvs, err := NewJsonFileStore(storePath, processlock.NewMockFileLock(false), nil)
+	require.NoError(t, err)
+
+	err = kvs.Write(testKey1, &testType1{"failed", 1})
+	require.Error(t, err)
+
+	require.NoError(t, os.MkdirAll(storeDir, 0o755))
+	require.NoError(t, kvs.Write(testKey2, &testType1{"persisted", 2}))
+
+	reloaded, err := NewJsonFileStore(storePath, processlock.NewMockFileLock(false), nil)
+	require.NoError(t, err)
+
+	var value testType1
+	require.ErrorIs(t, reloaded.Read(testKey1, &value), ErrKeyNotFound)
+	require.NoError(t, reloaded.Read(testKey2, &value))
+	require.Equal(t, testType1{"persisted", 2}, value)
+}
+
+// TestFailedOverwriteRestoresPreviousValue covers the rollback path for a key
+// that already holds a value: a failed write must restore the prior value
+// rather than leaving the rejected one in the cache.
+func TestFailedOverwriteRestoresPreviousValue(t *testing.T) {
+	storeDir := t.TempDir()
+	storePath := filepath.Join(storeDir, testFileName)
+	kvs, err := NewJsonFileStore(storePath, processlock.NewMockFileLock(false), nil)
+	require.NoError(t, err)
+
+	require.NoError(t, kvs.Write(testKey1, &testType1{"original", 1}))
+
+	// Make the directory unwritable so the temp-file flush fails.
+	require.NoError(t, os.Chmod(storeDir, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(storeDir, 0o700) })
+
+	require.Error(t, kvs.Write(testKey1, &testType1{"rejected", 2}))
+
+	require.NoError(t, os.Chmod(storeDir, 0o700))
+	require.NoError(t, kvs.Write(testKey2, &testType1{"later", 3}))
+
+	reloaded, err := NewJsonFileStore(storePath, processlock.NewMockFileLock(false), nil)
+	require.NoError(t, err)
+
+	var value testType1
+	require.NoError(t, reloaded.Read(testKey1, &value))
+	require.Equal(t, testType1{"original", 1}, value, "rejected write must not survive a later flush")
 }
 
 // test case for testing newjsonfilestore idempotent

--- a/store/json_test.go
+++ b/store/json_test.go
@@ -190,13 +190,12 @@ func TestFailedOverwriteRestoresPreviousValue(t *testing.T) {
 
 	require.NoError(t, kvs.Write(testKey1, &testType1{"original", 1}))
 
-	// Make the directory unwritable so the temp-file flush fails.
-	require.NoError(t, os.Chmod(storeDir, 0o500))
-	t.Cleanup(func() { _ = os.Chmod(storeDir, 0o700) })
+	// Remove the directory so the temp-file flush fails even when tests run as root.
+	require.NoError(t, os.RemoveAll(storeDir))
 
 	require.Error(t, kvs.Write(testKey1, &testType1{"rejected", 2}))
 
-	require.NoError(t, os.Chmod(storeDir, 0o700))
+	require.NoError(t, os.MkdirAll(storeDir, 0o700))
 	require.NoError(t, kvs.Write(testKey2, &testType1{"later", 3}))
 
 	reloaded, err := NewJsonFileStore(storePath, processlock.NewMockFileLock(false), nil)


### PR DESCRIPTION
`jsonFileStore.Write` mutated its in-memory cache before flushing to disk. If the
flush failed, the rejected value stayed in the cache and was silently persisted by
the next successful write to any key.

Stage the new value, flush, and restore the previous value for that one key if the
flush fails. `flush()` now sets `inSync` on success, so `Flush()` callers no longer
force a redundant re-read.

## Tests

- `TestFailedWriteDoesNotPersistOnLaterWrite` — failed insert of a new key
- `TestFailedOverwriteRestoresPreviousValue` — failed overwrite restores the prior value

Both fail if the rollback is removed.

## Validation

- `go test -race -count=1 ./store/...`