### PR TITLE
fix: repair the three failures keeping Test Windows red

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -119,6 +119,7 @@ jobs:
           go-version: ${{ needs.setup.outputs.go-version }}
 
       - name: Run Windows Tests
+        shell: bash
         run: |
           go test -timeout 30m -covermode atomic -coverprofile=windows-coverage.out ./cns/... ./npm/... ./cni/... ./platform/...
           go tool cover -func=windows-coverage.out

--- a/cni/network/network_windows_test.go
+++ b/cni/network/network_windows_test.go
@@ -1284,7 +1284,7 @@ func TestPluginWindowsAdd(t *testing.T) {
 						NetNsPath:         "bc526fae-4ba0-4e80-bc90-ad721e5850bf",
 						NetNs:             "bc526fae-4ba0-4e80-bc90-ad721e5850bf",
 						HostSubnetPrefix:  "<nil>",
-						Options:           map[string]interface{}{},
+						Options:           nil, // delegated NICs get no host-namespace options
 						// matches with cns ip configuration
 						IPAddresses: []net.IPNet{
 							{
@@ -1355,6 +1355,11 @@ func TestPluginWindowsAdd(t *testing.T) {
 				// ensure the endpoint data  and options are separate entities when in separate endpoint infos
 				epInfo1 := epInfos[0]
 				epInfo2 := epInfos[1]
+				// map iteration order is random; mutate the endpoint that owns an Options map,
+				// as delegated NICs carry nil Options
+				if epInfo1.Options == nil {
+					epInfo1, epInfo2 = epInfo2, epInfo1
+				}
 				epInfo1.Data["dummy"] = "dummy value"
 				epInfo1.Options["dummy"] = "another dummy value"
 				require.NotEqual(t, epInfo1.Data, epInfo2.Data)

--- a/cns/networkcontainers/networkcontainers_windows.go
+++ b/cns/networkcontainers/networkcontainers_windows.go
@@ -90,8 +90,8 @@ func setWeakHostOnInterface(ipAddress, ncID string) error {
 	}
 
 	if targetIface == nil {
-		errval := "[Azerrvalure CNS] Was not able to find the interface with ip " + ipAddress + " to enable weak host send/receive"
-		logger.Printf(errval)
+		errval := "[Azure CNS] Was not able to find the interface with ip " + ipAddress + " to enable weak host send/receive"
+		logger.Printf("%s", errval) //nolint:staticcheck // SA1019: file predates the cns/logger/v2 migration
 		return errors.New(errval)
 	}
 


### PR DESCRIPTION
**Reason for Change**:

The `Test Windows` job of the Unit Tests workflow has failed on every run since April — 0 green runs in the last 100+ ([example failed run](https://github.com/Azure/azure-container-networking/actions/runs/31688885515)). Three independent defects combine, and the first one hid the other two:

- **Workflow**: the test step has no `shell:` key, so it runs under pwsh. pwsh splits the bare token `-coverprofile=windows-coverage.out` at the dot, so `go test` receives a stray `.out` package pattern and `go tool cover` receives an extra argument:

  ```
  FAIL	.out [setup failed]
  too many arguments
  For usage information, run "go tool cover -help"
  ```

  The step now runs under bash. Bash also fails the step on the first failing command; pwsh only propagates the last exit code, which would otherwise let a failing `go test` slip through once the cover line works.

- **Test**: `88eb82f79` (#4404) intentionally leaves `EndpointInfo.Options` nil for delegated NICs, but `TestPluginWindowsAdd/Add_Happy_Path_Swiftv2` still expected `map[string]interface{}{}` for the `FrontendNIC` endpoint. The expectation is now `nil`, and the aliasing check mutates the endpoint that owns an `Options` map, because map iteration order can hand it the nil one and panic. Product behavior is unchanged.

- **CNS**: `logger.Printf(errval)` in `cns/networkcontainers/networkcontainers_windows.go` uses a non-constant format string. That fails the printf vet check `go test` runs, so the package did not build on Windows. It now uses an explicit `"%s"` format, and the mangled `[Azerrvalure CNS]` log prefix is repaired.

**Issue Fixed**:

N/A.

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation (N/A — test and CI fix)
- [ ] adds unit tests (N/A — repairs existing tests; no new code paths)
- [ ] relevant PR labels added

**Notes**:

Verified locally: `GOOS=windows go vet ./cns/networkcontainers/ ./cni/network/` is clean on this branch and reproduces the printf failure on `master`; the `cni/network` Windows test binary cross-compiles (`GOOS=windows go test -c`); a `GOOS=windows go vet -printf` sweep over `./cns/... ./npm/... ./cni/... ./platform/...` reports nothing further, so no other package keeps the job red. The `Test Windows` run on this PR is the end-to-end verification.
