### PR TITLE
ci: add dependabot stale version bumps catch-all

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -149,6 +149,31 @@ updates:
     cooldown:
       default-days: 7
 
+  # Catch-all (master/default branch only): every remaining Go module that does
+  # not have its own dedicated entry above.
+  - package-ecosystem: "gomod"
+    directories:
+      - "**/*"
+    exclude-paths:
+      - "azure-ipam/**"
+      - "dropgz/**"
+      - "zapai/**"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "12:00"  # UTC
+    commit-message:
+      prefix: "deps"
+    labels: ["dependencies"]
+    open-pull-requests-limit: 2
+    groups:
+      all-go-minor-and-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    cooldown:
+      default-days: 7
+
   # =========================
   # RELEASE BRANCHES — keep daily for v1.5, v1.6, and v1.7
   # =========================


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
Allows dependabot to bump stale dependencies for all go.mods in the repo such as cilium-log-collector, azure-ip-masq-merger, or azure-iptables-monitor. While these previously received security bumps to their go.mod, other dependencies would just go stale.

`"**/*"` should match all go.mod inside a directory (should not match root go.mod)

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
