### PR TITLE
[swiftv2] [pod density] feat: make NICNetworkConfig cluster-scoped

### DIFF
--- a/crd/multitenancy/api/v1alpha1/nicnetworkconfig.go
+++ b/crd/multitenancy/api/v1alpha1/nicnetworkconfig.go
@@ -12,7 +12,7 @@ import (
 // +kubebuilder:object:root=true
 
 // NICNetworkConfig is the Schema for the nicnetworkconfigs API
-// +kubebuilder:resource:shortName=nicnc,scope=Namespaced
+// +kubebuilder:resource:shortName=nicnc,scope=Cluster,path=nicnetworkconfigs
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels=managed=
 // +kubebuilder:metadata:labels=owner=

--- a/crd/multitenancy/manifests/multitenancy.acn.azure.com_nicnetworkconfigs.yaml
+++ b/crd/multitenancy/manifests/multitenancy.acn.azure.com_nicnetworkconfigs.yaml
@@ -17,7 +17,7 @@ spec:
     shortNames:
     - nicnc
     singular: nicnetworkconfig
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.nodeName


### PR DESCRIPTION
A NIC is a node-level resource shared across pods regardless of namespace, so NICNetworkConfig should not be namespaced. With a namespaced CRD, pods in different namespaces sharing the same NIC/subnet would create separate NICNCs for the same NIC, and the scope/capacity checks keyed on namespace could not detect the collision.

Change the CRD scope from Namespaced to Cluster (mirroring NodeInfo/PodNetwork) and regenerate the manifest.

<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
