### PR TITLE
feat(npm): allow egress to node IP on ports from l1vh annotation

### DIFF
--- a/npm/pkg/controlplane/translation/translatePolicy.go
+++ b/npm/pkg/controlplane/translation/translatePolicy.go
@@ -3,12 +3,15 @@ package translation
 import (
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/Azure/azure-container-networking/npm/pkg/dataplane/ipsets"
 	"github.com/Azure/azure-container-networking/npm/pkg/dataplane/policies"
 	"github.com/Azure/azure-container-networking/npm/util"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
 )
 
 /*
@@ -644,6 +647,40 @@ func egressPolicy(npmNetPol *policies.NPMNetworkPolicy, netPolName string, egres
 	return nil
 }
 
+// l1vhAllowedPortsAnnotation is a NetworkPolicy annotation whose value is a comma-separated
+// list of ports. Egress from the policy's selected pods to the node's IP on these ports is
+// explicitly allowed for the supported transport protocols (TCP/UDP on Windows); other
+// protocols such as ICMP or SCTP are not opened. Only consumed by the Windows dataplane.
+const l1vhAllowedPortsAnnotation = "npm.azure.com/allow-l1vh-ports"
+
+const maxPortNumber = 65535
+
+// parseNodeEgressPorts reads the l1vhAllowedPortsAnnotation and returns the valid ports.
+// Invalid tokens are skipped with a warning so a single malformed entry doesn't drop the rest.
+func parseNodeEgressPorts(annotations map[string]string) []int32 {
+	val, ok := annotations[l1vhAllowedPortsAnnotation]
+	if !ok {
+		return nil
+	}
+
+	var ports []int32
+	for _, token := range strings.Split(val, ",") {
+		token = strings.TrimSpace(token)
+		if token == "" {
+			continue
+		}
+
+		port, err := strconv.Atoi(token)
+		if err != nil || port < 1 || port > maxPortNumber {
+			klog.Warningf("[translatePolicy] ignoring invalid port %q in annotation %s (must be an integer in [1,%d])",
+				token, l1vhAllowedPortsAnnotation, maxPortNumber)
+			continue
+		}
+		ports = append(ports, int32(port))
+	}
+	return ports
+}
+
 // TranslatePolicy translates networkpolicy object to NPMNetworkPolicy object
 // and returns the NPMNetworkPolicy object.
 func TranslatePolicy(npObj *networkingv1.NetworkPolicy, npmLiteToggle bool) (*policies.NPMNetworkPolicy, error) {
@@ -676,6 +713,10 @@ func TranslatePolicy(npObj *networkingv1.NetworkPolicy, npmLiteToggle bool) (*po
 			}
 		}
 	}
+
+	// Allow egress from the selected pods to the node's IP on any ports listed in the
+	// l1vh annotation. Only the Windows dataplane consumes this (it knows the node IP).
+	npmNetPol.NodeEgressPorts = parseNodeEgressPorts(npObj.Annotations)
 
 	// ad-hoc validation to reduce code changes (modifying function signatures and returning errors in all the correct places)
 	if util.IsWindowsDP() {

--- a/npm/pkg/controlplane/translation/translatePolicy_test.go
+++ b/npm/pkg/controlplane/translation/translatePolicy_test.go
@@ -3395,3 +3395,77 @@ func TestCheckForNamedPortType(t *testing.T) {
 		})
 	}
 }
+
+func TestParseNodeEgressPorts(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    []int32
+	}{
+		{
+			name:        "nil annotations",
+			annotations: nil,
+			expected:    nil,
+		},
+		{
+			name:        "annotation missing",
+			annotations: map[string]string{"some/other": "1"},
+			expected:    nil,
+		},
+		{
+			name:        "empty value",
+			annotations: map[string]string{l1vhAllowedPortsAnnotation: ""},
+			expected:    nil,
+		},
+		{
+			name:        "single port",
+			annotations: map[string]string{l1vhAllowedPortsAnnotation: "5005"},
+			expected:    []int32{5005},
+		},
+		{
+			name:        "multiple ports with spaces",
+			annotations: map[string]string{l1vhAllowedPortsAnnotation: " 5005 , 2500 "},
+			expected:    []int32{5005, 2500},
+		},
+		{
+			name:        "skips invalid tokens",
+			annotations: map[string]string{l1vhAllowedPortsAnnotation: "5005,abc,70000,0,2500"},
+			expected:    []int32{5005, 2500},
+		},
+		{
+			name:        "all invalid",
+			annotations: map[string]string{l1vhAllowedPortsAnnotation: "abc,-1,99999"},
+			expected:    nil,
+		},
+		{
+			name:        "boundary ports",
+			annotations: map[string]string{l1vhAllowedPortsAnnotation: "1,65535"},
+			expected:    []int32{1, 65535},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, parseNodeEgressPorts(tt.annotations))
+		})
+	}
+}
+
+func TestTranslatePolicyNodeEgressPorts(t *testing.T) {
+	npObj := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "l1vh",
+			Namespace:   defaultNS,
+			Annotations: map[string]string{l1vhAllowedPortsAnnotation: "5005,2500"},
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		},
+	}
+
+	npmNetPol, err := TranslatePolicy(npObj, false)
+	require.NoError(t, err)
+	require.Equal(t, []int32{5005, 2500}, npmNetPol.NodeEgressPorts)
+}

--- a/npm/pkg/dataplane/policies/policy.go
+++ b/npm/pkg/dataplane/policies/policy.go
@@ -32,6 +32,13 @@ type NPMNetworkPolicy struct {
 	// podIP is key and endpoint ID as value
 	// Will be populated by dataplane and policy manager
 	PodEndpoints map[string]string
+	// NodeEgressPorts are ports for which egress from the selected pods to the node's IP
+	// is explicitly allowed, regardless of other egress rules in the policy. On Windows this
+	// applies to the supported transport protocols (TCP and UDP); other protocols such as
+	// ICMP or SCTP are not opened.
+	// Populated from a NetworkPolicy annotation at translation time and only consumed by the
+	// Windows dataplane, where the node IP is known.
+	NodeEgressPorts []int32
 }
 
 func NewNPMNetworkPolicy(netPolName, netPolNamespace string) *NPMNetworkPolicy {
@@ -77,6 +84,12 @@ func (netPol *NPMNetworkPolicy) numACLRulesProducedInKernel() int {
 	if hasEgress {
 		numRules++
 	}
+
+	// The Windows dataplane creates one TCP and one UDP ACL for every annotated node-egress port.
+	if util.IsWindowsDP() {
+		numRules += 2 * len(netPol.NodeEgressPorts)
+	}
+
 	return numRules
 }
 

--- a/npm/pkg/dataplane/policies/policymanager_windows.go
+++ b/npm/pkg/dataplane/policies/policymanager_windows.go
@@ -509,6 +509,27 @@ func (pMgr *PolicyManager) getSettingsFromACL(policy *NPMNetworkPolicy) ([]*NPMA
 		Priority:        priority201,
 		RuleType:        hcn.RuleTypeSwitch,
 	}
+
+	// allow egress from the selected pods to the node's IP on the annotated ports.
+	// These share the policy's ACLPolicyID so they are cleaned up with the rest of the policy on removal.
+	// The allow priority takes precedence over a deny-all egress rule, so the ports stay reachable.
+	// HNS rejects a port-scoped ACL that has no protocol, so to honor "any protocol" we emit one
+	// ACL per port for each of TCP and UDP (the protocols NPM supports on Windows).
+	nodeEgressProtocols := []Protocol{TCP, UDP}
+	for _, port := range policy.NodeEgressPorts {
+		for _, proto := range nodeEgressProtocols {
+			hnsRules = append(hnsRules, &NPMACLPolSettings{
+				Id:              policy.ACLPolicyID,
+				Action:          hcn.ActionTypeAllow,
+				Direction:       hcn.DirectionTypeOut,
+				RemoteAddresses: pMgr.NodeIP,
+				RemotePorts:     fmt.Sprintf("%d", port),
+				Protocols:       protocolNumMap[proto],
+				Priority:        allowRulePriotity,
+				RuleType:        hcn.RuleTypeSwitch,
+			})
+		}
+	}
 	return hnsRules, nil
 }
 

--- a/npm/pkg/dataplane/policies/policymanager_windows_test.go
+++ b/npm/pkg/dataplane/policies/policymanager_windows_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-container-networking/npm/metrics"
 	"github.com/Azure/azure-container-networking/npm/pkg/dataplane/ipsets"
 	dptestutils "github.com/Azure/azure-container-networking/npm/pkg/dataplane/testutils"
+	"github.com/Microsoft/hcsshim/hcn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -143,6 +144,21 @@ func TestCompareAndRemovePolicies(t *testing.T) {
 	}
 }
 
+func TestNumACLRulesProducedInKernelWithNodeEgressPorts(t *testing.T) {
+	egressACL := NewACLPolicy(Allowed, Egress)
+
+	base := &NPMNetworkPolicy{ACLs: []*ACLPolicy{egressACL}}
+	// egress ACL (1) + extra egress rule (1)
+	require.Equal(t, 2, base.numACLRulesProducedInKernel())
+
+	withPorts := &NPMNetworkPolicy{
+		ACLs:            []*ACLPolicy{egressACL},
+		NodeEgressPorts: []int32{5005, 2500},
+	}
+	// same as base plus one TCP and one UDP ACL per node egress port
+	require.Equal(t, 2+2*len(withPorts.NodeEgressPorts), withPorts.numACLRulesProducedInKernel())
+}
+
 func TestAddPolicies(t *testing.T) {
 	metrics.InitializeWindowsMetrics()
 
@@ -268,6 +284,47 @@ func TestRemovePoliciesEndpointNotFound(t *testing.T) {
 		updateLatencyCalls:      0,
 		updateFailures:          0,
 	}.test(t)
+}
+
+func TestGetSettingsFromACLNodeEgressPorts(t *testing.T) {
+	pMgr, _ := getPMgr(t)
+
+	policy := &NPMNetworkPolicy{
+		PolicyKey:       "test/node-egress",
+		ACLPolicyID:     "azure-acl-test-node-egress",
+		NodeEgressPorts: []int32{5005, 2500},
+	}
+
+	settings, err := pMgr.getSettingsFromACL(policy)
+	require.NoError(t, err)
+
+	// no policy ACLs, so: 1 readiness probe ACL + one ACL per node egress port per protocol (TCP+UDP)
+	require.Len(t, settings, 1+len(policy.NodeEgressPorts)*2)
+
+	// expect a TCP and UDP allow ACL to the node IP for each port
+	expected := map[string]struct{}{
+		"5005/6": {}, "5005/17": {},
+		"2500/6": {}, "2500/17": {},
+	}
+	nodeEgressCount := 0
+	for _, s := range settings {
+		if s.Direction != hcn.DirectionTypeOut {
+			continue
+		}
+		nodeEgressCount++
+		assert.Equal(t, policy.ACLPolicyID, s.Id)
+		assert.Equal(t, hcn.ActionTypeAllow, s.Action)
+		assert.Equal(t, ipsetConfig.NodeIP, s.RemoteAddresses)
+		assert.NotEmpty(t, s.Protocols, "port-scoped ACL must specify a protocol for HNS")
+		assert.Equal(t, "", s.LocalPorts)
+		assert.Equal(t, uint16(allowRulePriotity), s.Priority)
+		key := s.RemotePorts + "/" + s.Protocols
+		_, ok := expected[key]
+		assert.True(t, ok, "unexpected port/protocol combo %q", key)
+		delete(expected, key)
+	}
+	assert.Equal(t, len(policy.NodeEgressPorts)*2, nodeEgressCount, "wrong number of node egress ACLs")
+	assert.Empty(t, expected, "not all expected port/protocol combos were emitted")
 }
 
 // Helper functions for UTS


### PR DESCRIPTION
**Reason for Change**:
Manifold needs connectivity from pods in the L2 to services running on the L1. At the moment, we create 1 policy per pod, with a Ingress and Egress rule to the Node's IP. This PR adds support for an annotation `npm.azure.com/allow-l1vh-ports` to open up access from a pod to the node it lands on.

Eg - 
Old way:
```
# NP-1: pods on win-1 -> win-1's IP
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata: { name: allow-node-win1, namespace: l1vh-app }
spec:
  podSelector: { matchLabels: { app: worker, node: win-1 } }   # extra per-node label
  policyTypes: [Egress]
  egress:
    - to: [ ipBlock: { cidr: 10.0.0.4/32 } ]                   # hardcoded node IP
      ports: [ {port: 5005}, {port: 2500} ]
---
# NP-2: pods on win-2 -> 10.0.0.5/32   (same shape, different label+IP)
---
# NP-3: pods on win-3 -> 10.0.0.6/32
```

New way - 
```
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: allow-l1vh-node-ports
  namespace: l1vh-app
  annotations:
    npm.azure.com/allow-l1vh-ports: "5005,2500"
spec:
  podSelector: { matchLabels: { app: worker } }
```
