### PR TITLE
ci: fix overlapping Dependabot Go directories

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -155,11 +155,14 @@ updates:
   # not have its own dedicated entry above.
   - package-ecosystem: "gomod"
     directories:
-      - "**/*"
-    exclude-paths:
-      - "azure-ipam/**"
-      - "dropgz/**"
-      - "zapai/**"
+      - "/azure-ip-masq-merger"
+      - "/azure-iptables-monitor"
+      - "/bpf-prog/ipv6-hp-bpf"
+      - "/cilium-log-collector"
+      - "/pkgerrlint"
+      - "/tools/azure-npm-to-cilium-validator"
+      - "/tools/failure-agent"
+      - "/tools/release"
     schedule:
       interval: "weekly"
       day: "sunday"


### PR DESCRIPTION
## Summary

- replace the recursive Go module catch-all with explicit module directories
- prevent overlap with the dedicated root, azure-ipam, dropgz, and zapai configurations
- retain Dependabot coverage for all 12 Go modules

## Context

GitHub rejected the configuration because the `gomod` catch-all overlapped other update entries for the default branch.