### PR TITLE
Agent public identity guard

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,8 +3,9 @@ Use all `agents.md` files found from the repository root to the current director
 Public authorship is human-owned. Copilot and all other AI agents must never
 comment, reply, review, react, resolve threads, or edit/close/reopen public
 PR/issue text or metadata. Draft text for a human maintainer instead. Read-only
-GitHub access remains allowed. Pushes, PR creation, and workflow/release actions
-are allowed only when the current user task explicitly requests that action.
+GitHub access remains allowed. Branch pushes are allowed. PR creation and
+workflow/release actions are allowed only when the current user task explicitly
+requests that action.
 
 # Copilot Instructions for Azure Container Networking
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,11 @@
 Use all `agents.md` files found from the repository root to the current directory as instructions and context, applying them in root-to-leaf order; if instructions conflict, the `agents.md` closest to the current directory takes precedence. Use relevant repo skills from `.github/skills/` when applicable.
 
+Public identity is human-owned. Copilot and all other AI agents must never
+push, create or edit PRs/issues, comment, reply, review, react, resolve threads,
+edit public metadata, dispatch public workflows, publish artifacts, or perform
+any equivalent public mutation. This rule has no task-level exception. Prepare
+local work and draft text, then hand the public action to a human maintainer.
+
 # Copilot Instructions for Azure Container Networking
 
 ## Available Skills

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,10 +1,10 @@
 Use all `agents.md` files found from the repository root to the current directory as instructions and context, applying them in root-to-leaf order; if instructions conflict, the `agents.md` closest to the current directory takes precedence. Use relevant repo skills from `.github/skills/` when applicable.
 
-Public identity is human-owned. Copilot and all other AI agents must never
-push, create or edit PRs/issues, comment, reply, review, react, resolve threads,
-edit public metadata, dispatch public workflows, publish artifacts, or perform
-any equivalent public mutation. This rule has no task-level exception. Prepare
-local work and draft text, then hand the public action to a human maintainer.
+Public authorship is human-owned. Copilot and all other AI agents must never
+comment, reply, review, react, resolve threads, or edit/close/reopen public
+PR/issue text or metadata. Draft text for a human maintainer instead. Read-only
+GitHub access remains allowed. Pushes, PR creation, and workflow/release actions
+are allowed only when the current user task explicitly requests that action.
 
 # Copilot Instructions for Azure Container Networking
 

--- a/.github/hooks/deny-public-github-mutations.py
+++ b/.github/hooks/deny-public-github-mutations.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
-"""Fail-closed Copilot hook blocking public GitHub mutations."""
+"""Fail-closed Copilot hook blocking AI-authored GitHub communication."""
 
 from __future__ import annotations
 
 import json
-import os
 import re
 import shlex
 import sys
@@ -12,12 +11,9 @@ from typing import Any
 
 
 DENIAL_REASON = (
-    "Repository public identity boundary: AI agents may prepare local work "
-    "but must not mutate GitHub or push as a contributor."
-)
-FORGE_CLI_PATTERN = re.compile(
-    r"(?<![\w.-])(?:[^\s;&|()]+/)?(?:gh|hub)(?:\.exe)?(?=\s|$)",
-    re.IGNORECASE,
+    "Repository public identity boundary: Copilot must not author comments, replies, "
+    "reviews, reactions, thread resolutions, or PR/issue text as the user. "
+    "Draft the exact text for the user to publish."
 )
 GITHUB_HOST_PATTERN = re.compile(
     r"(?:api\.github\.com|github\.com)",
@@ -25,14 +21,89 @@ GITHUB_HOST_PATTERN = re.compile(
 )
 HTTP_MUTATION_PATTERN = re.compile(
     r"(?:"
-    r"(?:^|\s)(?:-X|--request)(?:=|\s+)(?:POST|PUT|PATCH|DELETE)\b"
+    r"(?:^|\s)(?:-X|--request|--method)(?:=|\s+)(?:POST|PUT|PATCH|DELETE)\b"
     r"|(?:^|\s)(?:-d|--data(?:-raw|-binary|-urlencode)?)(?:=|\s)"
     r"|(?:^|\s)(?:-T|--upload-file)(?:=|\s)"
-    r"|\bmutation\b"
-    r"|\bgit-receive-pack\b"
     r")",
     re.IGNORECASE,
 )
+AUTHORSHIP_ENDPOINT_PATTERN = re.compile(
+    r"(?:"
+    r"/issues(?:\?|$)"
+    r"|/issues/\d+/comments(?:/|$)"
+    r"|/issues/comments/\d+(?:/|$)"
+    r"|/pulls/\d+/(?:comments|reviews|requested_reviewers)(?:/|$)"
+    r"|/pulls/comments/\d+(?:/|$)"
+    r"|/reactions(?:/|$)"
+    r"|/issues/\d+(?:\?|$)"
+    r"|/pulls/\d+(?:\?|$)"
+    r")",
+    re.IGNORECASE,
+)
+GRAPHQL_AUTHORSHIP_PATTERN = re.compile(
+    r"\b(?:"
+    r"addComment"
+    r"|addPullRequestReview(?:Comment|Thread)?"
+    r"|addReaction"
+    r"|closeIssue"
+    r"|deleteIssueComment"
+    r"|deletePullRequestReview(?:Comment)?"
+    r"|dismissPullRequestReview"
+    r"|lockLockable"
+    r"|markPullRequestReadyForReview"
+    r"|minimizeComment"
+    r"|removeReaction"
+    r"|reopenIssue"
+    r"|resolveReviewThread"
+    r"|submitPullRequestReview"
+    r"|unmarkIssueAsDuplicate"
+    r"|unresolveReviewThread"
+    r"|unlockLockable"
+    r"|updateIssue(?:Comment)?"
+    r"|updatePullRequest"
+    r")\b",
+    re.IGNORECASE,
+)
+MCP_AUTHORSHIP_PATTERN = re.compile(
+    r"(?:"
+    r"(?:add|create|delete|dismiss|edit|resolve|submit|unresolve|update)"
+    r".*(?:comment|reaction|review|thread)"
+    r"|(?:close|edit|lock|reopen|unlock|update)_(?:issue|pull_request)"
+    r"|create_issue"
+    r")",
+    re.IGNORECASE,
+)
+BLOCKED_GH_ACTIONS = {
+    "discussion": {
+        "close",
+        "comment",
+        "create",
+        "edit",
+        "reopen",
+    },
+    "issue": {
+        "close",
+        "comment",
+        "create",
+        "edit",
+        "lock",
+        "pin",
+        "reopen",
+        "transfer",
+        "unlock",
+        "unpin",
+    },
+    "pr": {
+        "close",
+        "comment",
+        "edit",
+        "lock",
+        "ready",
+        "reopen",
+        "review",
+        "unlock",
+    },
+}
 PROTECTED_PATHS = (
     ".github/copilot-instructions.md",
     ".github/hooks/deny-public-github-mutations.py",
@@ -57,14 +128,22 @@ WRITE_TOOLS = {
 }
 
 
-def decision(value: str, reason: str = "") -> None:
-    payload = {"permissionDecision": value}
-    if reason:
-        payload["permissionDecisionReason"] = reason
-    print(json.dumps(payload))
+def deny() -> None:
+    print(
+        json.dumps(
+            {
+                "permissionDecision": "deny",
+                "permissionDecisionReason": DENIAL_REASON,
+            }
+        )
+    )
 
 
-def tokens(command: str) -> list[str]:
+def allow() -> None:
+    print("{}")
+
+
+def shell_tokens(command: str) -> list[str]:
     try:
         lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|()")
         lexer.whitespace_split = True
@@ -74,40 +153,56 @@ def tokens(command: str) -> list[str]:
         return []
 
 
-def is_git_push(command: str) -> bool:
-    parsed = tokens(command)
-    for index, token in enumerate(parsed):
-        if os.path.basename(token).lower() not in {"git", "git.exe"}:
+def gh_authorship_denied(command: str) -> bool:
+    tokens = shell_tokens(command)
+    for index, token in enumerate(tokens):
+        if token.rsplit("/", 1)[-1].lower() not in {"gh", "gh.exe", "hub", "hub.exe"}:
             continue
-        cursor = index + 1
-        while cursor < len(parsed):
-            candidate = parsed[cursor]
-            if candidate in {"-C", "-c", "--git-dir", "--work-tree"}:
-                cursor += 2
+        segment: list[str] = []
+        for candidate in tokens[index + 1 :]:
+            if candidate in {";", "&&", "||", "|", "(", ")"}:
+                break
+            segment.append(candidate.lower())
+
+        for group, actions in BLOCKED_GH_ACTIONS.items():
+            if group not in segment:
                 continue
-            if candidate.startswith(("--git-dir=", "--work-tree=", "--namespace=")):
-                cursor += 1
-                continue
-            if candidate.startswith("-"):
-                cursor += 1
-                continue
-            return candidate.lower() in {"push", "send-pack"}
+            group_index = segment.index(group)
+            if any(action in segment[group_index + 1 :] for action in actions):
+                return True
+
+        if "api" in segment:
+            if GRAPHQL_AUTHORSHIP_PATTERN.search(command):
+                return True
+            if HTTP_MUTATION_PATTERN.search(command) and AUTHORSHIP_ENDPOINT_PATTERN.search(command):
+                return True
     return False
 
 
-def denied(payload: dict[str, Any]) -> bool:
-    tool_name = payload.get("toolName", payload.get("tool_name", ""))
-    tool_args = payload.get("toolArgs", payload.get("tool_input"))
-    if not isinstance(tool_name, str):
+def shell_command_denied(command: str) -> bool:
+    if any(path in command for path in PROTECTED_PATHS):
+        if FILE_MUTATION_PATTERN.search(command):
+            return True
+    if gh_authorship_denied(command):
         return True
+    return bool(
+        GITHUB_HOST_PATTERN.search(command)
+        and HTTP_MUTATION_PATTERN.search(command)
+        and AUTHORSHIP_ENDPOINT_PATTERN.search(command)
+    )
 
+
+def tool_denied(tool_name: str, tool_args: Any) -> bool:
     lowered_tool_name = tool_name.lower()
     normalized = tool_name.rsplit(".", 1)[-1].lower()
-    if "github" in lowered_tool_name and normalized not in {"web_fetch", "web_search"}:
+
+    if "github" in lowered_tool_name and MCP_AUTHORSHIP_PATTERN.search(normalized):
         return True
+
     if normalized in WRITE_TOOLS:
         serialized_args = json.dumps(tool_args, sort_keys=True, default=str)
         return any(path in serialized_args for path in PROTECTED_PATHS)
+
     if normalized not in {"bash", "powershell"}:
         return False
 
@@ -118,32 +213,103 @@ def denied(payload: dict[str, Any]) -> bool:
             return True
     if not isinstance(tool_args, dict):
         return True
-    command = tool_args.get("command", tool_args.get("script"))
+
+    command = tool_args.get("command")
+    if command is None:
+        command = tool_args.get("script")
     if not isinstance(command, str):
         return True
-    if any(path in command for path in PROTECTED_PATHS):
-        if FILE_MUTATION_PATTERN.search(command):
-            return True
-    return (
-        FORGE_CLI_PATTERN.search(command) is not None
-        or is_git_push(command)
-        or (
-            GITHUB_HOST_PATTERN.search(command) is not None
-            and HTTP_MUTATION_PATTERN.search(command) is not None
-        )
-    )
+    return shell_command_denied(command)
+
+
+def evaluate(payload: dict[str, Any]) -> bool:
+    tool_name = payload.get("toolName", payload.get("tool_name", ""))
+    tool_args = payload.get("toolArgs", payload.get("tool_input"))
+    if not isinstance(tool_name, str):
+        return True
+    return tool_denied(tool_name, tool_args)
+
+
+def self_test() -> None:
+    denied = [
+        {"toolName": "bash", "toolArgs": {"command": "gh pr comment 1 -b x"}},
+        {"toolName": "bash", "toolArgs": {"command": "gh issue create -t x -b y"}},
+        {
+            "toolName": "bash",
+            "toolArgs": {"command": "gh pr review 1 --approve"},
+        },
+        {
+            "toolName": "bash",
+            "toolArgs": {
+                "command": "gh api --method POST repos/o/r/issues/1/comments"
+            },
+        },
+        {
+            "toolName": "bash",
+            "toolArgs": {
+                "command": "gh api graphql -f "
+                "'query=mutation { resolveReviewThread(input:{threadId:\"x\"}) { clientMutationId } }'"
+            },
+        },
+        {"toolName": "github-mcp-server.add_issue_comment", "toolArgs": {}},
+        {"toolName": "github-mcp-server.create_pull_request_review", "toolArgs": {}},
+        {
+            "toolName": "apply_patch",
+            "toolArgs": {
+                "patch": "*** Update File: .github/hooks/public-identity-guard.json"
+            },
+        },
+        {
+            "toolName": "bash",
+            "toolArgs": {
+                "command": "rm .github/hooks/public-identity-guard.json"
+            },
+        },
+    ]
+    allowed = [
+        {"toolName": "bash", "toolArgs": {"command": "git status --short"}},
+        {"toolName": "bash", "toolArgs": {"command": "git fetch origin main"}},
+        {"toolName": "bash", "toolArgs": {"command": "git push origin HEAD"}},
+        {"toolName": "bash", "toolArgs": {"command": "gh pr view 1"}},
+        {"toolName": "bash", "toolArgs": {"command": "gh pr create --fill"}},
+        {"toolName": "bash", "toolArgs": {"command": "gh workflow run ci.yml"}},
+        {"toolName": "github-mcp-server.get_pull_request", "toolArgs": {}},
+        {"toolName": "github-mcp-server.create_pull_request", "toolArgs": {}},
+        {
+            "toolName": "bash",
+            "toolArgs": {"command": "curl https://api.github.com/repos/o/r"},
+        },
+        {
+            "toolName": "web_fetch",
+            "toolArgs": {"url": "https://github.com/o/r/pull/1"},
+        },
+        {
+            "toolName": "bash",
+            "toolArgs": {
+                "command": "stat .github/hooks/public-identity-guard.json"
+            },
+        },
+    ]
+
+    assert all(evaluate(payload) for payload in denied)
+    assert all(not evaluate(payload) for payload in allowed)
 
 
 def main() -> int:
+    if sys.argv[1:] == ["--self-test"]:
+        self_test()
+        return 0
+
     try:
         payload = json.load(sys.stdin)
     except (json.JSONDecodeError, OSError):
-        decision("deny", DENIAL_REASON)
+        deny()
         return 0
-    if not isinstance(payload, dict) or denied(payload):
-        decision("deny", DENIAL_REASON)
+
+    if not isinstance(payload, dict) or evaluate(payload):
+        deny()
     else:
-        print("{}")
+        allow()
     return 0
 
 

--- a/.github/hooks/deny-public-github-mutations.py
+++ b/.github/hooks/deny-public-github-mutations.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Fail-closed Copilot hook blocking public GitHub mutations."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import sys
+from typing import Any
+
+
+DENIAL_REASON = (
+    "Repository public identity boundary: AI agents may prepare local work "
+    "but must not mutate GitHub or push as a contributor."
+)
+FORGE_CLI_PATTERN = re.compile(
+    r"(?<![\w.-])(?:[^\s;&|()]+/)?(?:gh|hub)(?:\.exe)?(?=\s|$)",
+    re.IGNORECASE,
+)
+GITHUB_HOST_PATTERN = re.compile(
+    r"(?:api\.github\.com|github\.com)",
+    re.IGNORECASE,
+)
+HTTP_MUTATION_PATTERN = re.compile(
+    r"(?:"
+    r"(?:^|\s)(?:-X|--request)(?:=|\s+)(?:POST|PUT|PATCH|DELETE)\b"
+    r"|(?:^|\s)(?:-d|--data(?:-raw|-binary|-urlencode)?)(?:=|\s)"
+    r"|(?:^|\s)(?:-T|--upload-file)(?:=|\s)"
+    r"|\bmutation\b"
+    r"|\bgit-receive-pack\b"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def decision(value: str, reason: str = "") -> None:
+    payload = {"permissionDecision": value}
+    if reason:
+        payload["permissionDecisionReason"] = reason
+    print(json.dumps(payload))
+
+
+def tokens(command: str) -> list[str]:
+    try:
+        lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|()")
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        return list(lexer)
+    except ValueError:
+        return []
+
+
+def is_git_push(command: str) -> bool:
+    parsed = tokens(command)
+    for index, token in enumerate(parsed):
+        if os.path.basename(token).lower() not in {"git", "git.exe"}:
+            continue
+        cursor = index + 1
+        while cursor < len(parsed):
+            candidate = parsed[cursor]
+            if candidate in {"-C", "-c", "--git-dir", "--work-tree"}:
+                cursor += 2
+                continue
+            if candidate.startswith(("--git-dir=", "--work-tree=", "--namespace=")):
+                cursor += 1
+                continue
+            if candidate.startswith("-"):
+                cursor += 1
+                continue
+            return candidate.lower() in {"push", "send-pack"}
+    return False
+
+
+def denied(payload: dict[str, Any]) -> bool:
+    tool_name = payload.get("toolName", payload.get("tool_name", ""))
+    tool_args = payload.get("toolArgs", payload.get("tool_input"))
+    if not isinstance(tool_name, str):
+        return True
+
+    lowered_tool_name = tool_name.lower()
+    normalized = tool_name.rsplit(".", 1)[-1].lower()
+    if "github" in lowered_tool_name and normalized not in {"web_fetch", "web_search"}:
+        return True
+    if normalized not in {"bash", "powershell"}:
+        return False
+
+    if isinstance(tool_args, str):
+        try:
+            tool_args = json.loads(tool_args)
+        except json.JSONDecodeError:
+            return True
+    if not isinstance(tool_args, dict):
+        return True
+    command = tool_args.get("command", tool_args.get("script"))
+    if not isinstance(command, str):
+        return True
+    return (
+        FORGE_CLI_PATTERN.search(command) is not None
+        or is_git_push(command)
+        or (
+            GITHUB_HOST_PATTERN.search(command) is not None
+            and HTTP_MUTATION_PATTERN.search(command) is not None
+        )
+    )
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, OSError):
+        decision("deny", DENIAL_REASON)
+        return 0
+    if not isinstance(payload, dict) or denied(payload):
+        decision("deny", DENIAL_REASON)
+    else:
+        print("{}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/hooks/deny-public-github-mutations.py
+++ b/.github/hooks/deny-public-github-mutations.py
@@ -33,6 +33,28 @@ HTTP_MUTATION_PATTERN = re.compile(
     r")",
     re.IGNORECASE,
 )
+PROTECTED_PATHS = (
+    ".github/copilot-instructions.md",
+    ".github/hooks/deny-public-github-mutations.py",
+    ".github/hooks/public-identity-guard.json",
+    "agents.md",
+)
+FILE_MUTATION_PATTERN = re.compile(
+    r"(?:"
+    r"(?<![\w.-])(?:rm|mv|cp|install|chmod|chown|truncate|unlink)\b"
+    r"|(?:^|\s)(?:sed|perl)\s+[^\n]*-[^\n]*i"
+    r"|(?:^|\s)(?:tee|dd)\b"
+    r"|>{1,2}"
+    r")",
+    re.IGNORECASE,
+)
+WRITE_TOOLS = {
+    "apply_patch",
+    "create",
+    "edit",
+    "str_replace_editor",
+    "write",
+}
 
 
 def decision(value: str, reason: str = "") -> None:
@@ -83,6 +105,9 @@ def denied(payload: dict[str, Any]) -> bool:
     normalized = tool_name.rsplit(".", 1)[-1].lower()
     if "github" in lowered_tool_name and normalized not in {"web_fetch", "web_search"}:
         return True
+    if normalized in WRITE_TOOLS:
+        serialized_args = json.dumps(tool_args, sort_keys=True, default=str)
+        return any(path in serialized_args for path in PROTECTED_PATHS)
     if normalized not in {"bash", "powershell"}:
         return False
 
@@ -96,6 +121,9 @@ def denied(payload: dict[str, Any]) -> bool:
     command = tool_args.get("command", tool_args.get("script"))
     if not isinstance(command, str):
         return True
+    if any(path in command for path in PROTECTED_PATHS):
+        if FILE_MUTATION_PATTERN.search(command):
+            return True
     return (
         FORGE_CLI_PATTERN.search(command) is not None
         or is_git_push(command)

--- a/.github/hooks/deny-public-github-mutations.py
+++ b/.github/hooks/deny-public-github-mutations.py
@@ -69,7 +69,7 @@ MCP_AUTHORSHIP_PATTERN = re.compile(
     r"(?:add|create|delete|dismiss|edit|resolve|submit|unresolve|update)"
     r".*(?:comment|reaction|review|thread)"
     r"|(?:close|edit|lock|reopen|unlock|update)_(?:issue|pull_request)"
-    r"|create_issue"
+    r"|create_(?:issue|pull_request)"
     r")",
     re.IGNORECASE,
 )
@@ -96,6 +96,7 @@ BLOCKED_GH_ACTIONS = {
     "pr": {
         "close",
         "comment",
+        "create",
         "edit",
         "lock",
         "ready",
@@ -148,24 +149,27 @@ def allow() -> None:
     print("{}")
 
 
-def shell_tokens(command: str) -> list[str]:
+def shell_tokens(command: str) -> list[str] | None:
     try:
         lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|()")
         lexer.whitespace_split = True
         lexer.commenters = ""
         return list(lexer)
     except ValueError:
-        return []
+        return None
 
 
 def gh_authorship_denied(command: str) -> bool:
     tokens = shell_tokens(command)
+    if tokens is None:
+        return True
+
     for index, token in enumerate(tokens):
         if token.rsplit("/", 1)[-1].lower() not in {"gh", "gh.exe", "hub", "hub.exe"}:
             continue
         segment: list[str] = []
         for candidate in tokens[index + 1 :]:
-            if candidate in {";", "&&", "||", "|", "(", ")"}:
+            if candidate in {";", "&&", "||", "|", "&", "(", ")"}:
                 break
             segment.append(candidate.lower())
 
@@ -230,7 +234,7 @@ def tool_denied(tool_name: str, tool_args: Any) -> bool:
 def evaluate(payload: dict[str, Any]) -> bool:
     tool_name = payload.get("toolName", payload.get("tool_name", ""))
     tool_args = payload.get("toolArgs", payload.get("tool_input"))
-    if not isinstance(tool_name, str):
+    if not isinstance(tool_name, str) or not tool_name.strip():
         return True
     return tool_denied(tool_name, tool_args)
 
@@ -238,7 +242,9 @@ def evaluate(payload: dict[str, Any]) -> bool:
 def self_test() -> None:
     denied = [
         {"toolName": "bash", "toolArgs": {"command": "gh pr comment 1 -b x"}},
+        {"toolName": "bash", "toolArgs": {"command": "gh pr create --fill"}},
         {"toolName": "bash", "toolArgs": {"command": "gh issue create -t x -b y"}},
+        {"toolName": "bash", "toolArgs": {"command": "gh pr view 'unterminated"}},
         {
             "toolName": "bash",
             "toolArgs": {"command": "gh pr review 1 --approve"},
@@ -257,7 +263,11 @@ def self_test() -> None:
             },
         },
         {"toolName": "github-mcp-server.add_issue_comment", "toolArgs": {}},
+        {"toolName": "github-mcp-server.create_pull_request", "toolArgs": {}},
         {"toolName": "github-mcp-server.create_pull_request_review", "toolArgs": {}},
+        {"toolArgs": {}},
+        {"toolName": "", "toolArgs": {}},
+        {"toolName": "  ", "toolArgs": {}},
         {
             "toolName": "apply_patch",
             "toolArgs": {
@@ -308,10 +318,12 @@ def self_test() -> None:
         {"toolName": "bash", "toolArgs": {"command": "git fetch origin main"}},
         {"toolName": "bash", "toolArgs": {"command": "git push origin HEAD"}},
         {"toolName": "bash", "toolArgs": {"command": "gh pr view 1"}},
-        {"toolName": "bash", "toolArgs": {"command": "gh pr create --fill"}},
+        {
+            "toolName": "bash",
+            "toolArgs": {"command": "gh pr view 1 & echo comment"},
+        },
         {"toolName": "bash", "toolArgs": {"command": "gh workflow run ci.yml"}},
         {"toolName": "github-mcp-server.get_pull_request", "toolArgs": {}},
-        {"toolName": "github-mcp-server.create_pull_request", "toolArgs": {}},
         {
             "toolName": "bash",
             "toolArgs": {"command": "curl https://api.github.com/repos/o/r"},

--- a/.github/hooks/deny-public-github-mutations.py
+++ b/.github/hooks/deny-public-github-mutations.py
@@ -11,7 +11,7 @@ from typing import Any
 
 
 DENIAL_REASON = (
-    "Repository public identity boundary: Copilot must not author comments, replies, "
+    "Public identity boundary: Copilot must not author comments, replies, "
     "reviews, reactions, thread resolutions, or PR/issue text as the user. "
     "Draft the exact text for the user to publish."
 )
@@ -105,9 +105,14 @@ BLOCKED_GH_ACTIONS = {
     },
 }
 PROTECTED_PATHS = (
-    ".github/copilot-instructions.md",
-    ".github/hooks/deny-public-github-mutations.py",
-    ".github/hooks/public-identity-guard.json",
+    # Matching is substring containment, so bare filenames cover every install
+    # location without hardcoding one: the repository copy under .github/hooks,
+    # a per-user copy under ~/.copilot/hooks, and a system copy under
+    # /usr/local/libexec. Keep these location-independent so the repository and
+    # per-user copies of this script cannot drift apart.
+    "deny-public-github-mutations.py",
+    "public-identity-guard.json",
+    "copilot-instructions.md",
     "agents.md",
 )
 FILE_MUTATION_PATTERN = re.compile(
@@ -263,6 +268,38 @@ def self_test() -> None:
             "toolName": "bash",
             "toolArgs": {
                 "command": "rm .github/hooks/public-identity-guard.json"
+            },
+        },
+        # The guard must protect itself wherever it is installed, not only in
+        # the repository copy.
+        {
+            "toolName": "bash",
+            "toolArgs": {
+                "command": "rm ~/.copilot/hooks/public-identity-guard.json"
+            },
+        },
+        {
+            "toolName": "bash",
+            "toolArgs": {
+                "command": "sudo rm /opt/hooks/deny-public-github-mutations.py"
+            },
+        },
+        {
+            "toolName": "edit",
+            "toolArgs": {
+                "path": "~/.copilot/hooks/deny-public-github-mutations.py",
+                "old_str": "deny()",
+                "new_str": "allow()",
+            },
+        },
+        {
+            "toolName": "bash",
+            "toolArgs": {"command": "sed -i 's/deny/allow/' agents.md"},
+        },
+        {
+            "toolName": "bash",
+            "toolArgs": {
+                "command": "echo x > ~/.copilot/copilot-instructions.md"
             },
         },
     ]

--- a/.github/hooks/install-user-hook.sh
+++ b/.github/hooks/install-user-hook.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Installs the public identity guard as a per-user Copilot CLI hook.
+#
+# The repository copy under .github/hooks only applies to sessions started in
+# this repository. Installing it per-user applies it to every repository on this
+# machine. Both copies run the identical script, so re-run this after pulling to
+# stay in sync.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+hooks_dir="${HOME}/.copilot/hooks"
+guard="${hooks_dir}/deny-public-github-mutations.py"
+
+mkdir -p "${hooks_dir}"
+install -m 0755 "${script_dir}/deny-public-github-mutations.py" "${guard}"
+
+cat > "${hooks_dir}/public-identity-guard.json" <<EOF
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "python3 '${guard}'",
+        "powershell": "python \"\$env:USERPROFILE\\\\.copilot\\\\hooks\\\\deny-public-github-mutations.py\"",
+        "timeoutSec": 5
+      }
+    ]
+  }
+}
+EOF
+
+python3 "${guard}" --self-test
+echo "Installed public identity guard to ${hooks_dir}"
+echo "Restart Copilot CLI, then run /env to confirm the hook is loaded."

--- a/.github/hooks/public-identity-guard.json
+++ b/.github/hooks/public-identity-guard.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "python3 .github/hooks/deny-public-github-mutations.py",
+        "powershell": "python .github/hooks/deny-public-github-mutations.py",
+        "cwd": ".",
+        "timeoutSec": 5
+      }
+    ]
+  }
+}

--- a/agents.md
+++ b/agents.md
@@ -91,25 +91,21 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 
 ## 5. Public Identity Boundary
 
-**AI agents never act as contributors on public collaboration surfaces.**
+**AI agents never author public communication as maintainers or contributors.**
 
 This rule is mandatory and non-overridable for every agent, subagent, scheduled
-task, tool, and workflow in this repository. Agents must not:
+task, tool, and workflow in this repository. Agents must never post comments,
+replies, reviews, reactions, or discussion messages; resolve or dismiss review
+threads; or edit, close, reopen, lock, or otherwise change public pull request
+or issue text/metadata. Draft the exact text for a human maintainer instead.
 
-- push commits, branches, or tags;
-- create, edit, close, reopen, or merge pull requests or issues;
-- post comments, replies, reviews, reactions, labels, assignments, or
-  discussion messages;
-- resolve or dismiss review threads;
-- edit public pull request, issue, release, repository, or profile metadata;
-- dispatch, rerun, cancel, or approve public CI workflows;
-- create, edit, or delete releases, gists, packages, or other public artifacts;
-- perform equivalent mutations through `gh`, `git push`, an API, MCP server,
-  extension, browser automation, delegated agent, or scheduled prompt.
+Keep read-only GitHub capabilities available. Read-only `gh`, API, MCP, and web
+research is allowed.
 
-Read-only research is allowed. Agents may prepare local worktrees, local
-commits, patches, draft text, and exact commands for a human maintainer to run.
-Stop at that handoff boundary. A task request never grants an exception.
+Code publishing actions (including `git push` and pull request creation) and
+workflow/release mutations are allowed only when the current user task
+explicitly requests that public action. Do not infer authorization from a
+general request to implement, fix, review, or validate code.
 
 ## 6. PR Workflow
 
@@ -124,9 +120,11 @@ git worktree add -b "$BRANCH" "$WT" origin/master
 cd "$WT"                                # then run all subsequent commands here
 ```
 
-Run all edits, builds, tests, and local commits from inside `$WT`. Stop before
-push, PR creation, review, or any other public mutation; provide the maintainer
-with the local branch, patch, draft text, and exact commands they can run.
+Run all edits, builds, tests, and local commits from inside `$WT`. Unless the
+current task explicitly requests publishing, stop before push, PR creation, or
+workflow/release mutation and provide the maintainer with the exact commands.
+Always stop before public comments, replies, reviews, thread resolution, or
+PR/issue text edits; those remain human-only even when publishing is requested.
 After the maintainer confirms that the work was merged or abandoned, prune with
 `git worktree remove "$WT"` and `git branch -D "$BRANCH"`. The shared root is
 read-only — only use it for inspection (e.g. `git worktree list`, `git fetch`),

--- a/agents.md
+++ b/agents.md
@@ -89,7 +89,29 @@ For multi-step tasks, state a brief plan:
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
-## 5. PR Workflow
+## 5. Public Identity Boundary
+
+**AI agents never act as contributors on public collaboration surfaces.**
+
+This rule is mandatory and non-overridable for every agent, subagent, scheduled
+task, tool, and workflow in this repository. Agents must not:
+
+- push commits, branches, or tags;
+- create, edit, close, reopen, or merge pull requests or issues;
+- post comments, replies, reviews, reactions, labels, assignments, or
+  discussion messages;
+- resolve or dismiss review threads;
+- edit public pull request, issue, release, repository, or profile metadata;
+- dispatch, rerun, cancel, or approve public CI workflows;
+- create, edit, or delete releases, gists, packages, or other public artifacts;
+- perform equivalent mutations through `gh`, `git push`, an API, MCP server,
+  extension, browser automation, delegated agent, or scheduled prompt.
+
+Read-only research is allowed. Agents may prepare local worktrees, local
+commits, patches, draft text, and exact commands for a human maintainer to run.
+Stop at that handoff boundary. A task request never grants an exception.
+
+## 6. PR Workflow
 
 **All local agent work MUST happen in a dedicated git worktree, never in the shared repo root.** The repo root is shared across concurrent agent sessions; mutating it causes parallel branches, working trees, and build artifacts (`output/`, `bin/`) to collide. From the repo root, create a worktree under the active session folder before touching files:
 
@@ -102,7 +124,13 @@ git worktree add -b "$BRANCH" "$WT" origin/master
 cd "$WT"                                # then run all subsequent commands here
 ```
 
-Run all edits, builds, tests, commits, and `gh pr create` from inside `$WT`. After the PR merges (or is abandoned), prune with `git worktree remove "$WT"` and `git branch -D "$BRANCH"`. The shared root is read-only — only use it for inspection (e.g. `git worktree list`, `git fetch`), never to edit, build, or commit.
+Run all edits, builds, tests, and local commits from inside `$WT`. Stop before
+push, PR creation, review, or any other public mutation; provide the maintainer
+with the local branch, patch, draft text, and exact commands they can run.
+After the maintainer confirms that the work was merged or abandoned, prune with
+`git worktree remove "$WT"` and `git branch -D "$BRANCH"`. The shared root is
+read-only — only use it for inspection (e.g. `git worktree list`, `git fetch`),
+never to edit, build, or commit.
 
 **Go-specific notes (no per-worktree install):**
 - The Go module cache (`$(go env GOMODCACHE)`, default `$GOPATH/pkg/mod`) and build cache (`$(go env GOCACHE)`) are **content-addressed and concurrent-safe**; Go uses file locking. Do not try to isolate them per worktree.

--- a/agents.md
+++ b/agents.md
@@ -102,10 +102,11 @@ or issue text/metadata. Draft the exact text for a human maintainer instead.
 Keep read-only GitHub capabilities available. Read-only `gh`, API, MCP, and web
 research is allowed.
 
-Code publishing actions (including `git push` and pull request creation) and
-workflow/release mutations are allowed only when the current user task
-explicitly requests that public action. Do not infer authorization from a
-general request to implement, fix, review, or validate code.
+Branch pushes are allowed and are not a public communication surface. Pull
+request creation and workflow/release mutations are allowed only when the
+current user task explicitly requests that public action. Do not infer
+authorization from a general request to implement, fix, review, or validate
+code.
 
 ## 6. PR Workflow
 
@@ -120,11 +121,12 @@ git worktree add -b "$BRANCH" "$WT" origin/master
 cd "$WT"                                # then run all subsequent commands here
 ```
 
-Run all edits, builds, tests, and local commits from inside `$WT`. Unless the
-current task explicitly requests publishing, stop before push, PR creation, or
-workflow/release mutation and provide the maintainer with the exact commands.
-Always stop before public comments, replies, reviews, thread resolution, or
-PR/issue text edits; those remain human-only even when publishing is requested.
+Run all edits, builds, tests, local commits, and branch pushes from inside `$WT`.
+Unless the current task explicitly requests publishing beyond a branch push,
+stop before PR creation or workflow/release mutation and provide the maintainer
+with the exact commands. Always stop before public comments, replies, reviews,
+thread resolution, or PR/issue text edits; those remain human-only even when
+publishing is requested.
 After the maintainer confirms that the work was merged or abandoned, prune with
 `git worktree remove "$WT"` and `git branch -D "$BRANCH"`. The shared root is
 read-only — only use it for inspection (e.g. `git worktree list`, `git fetch`),


### PR DESCRIPTION
Inspired by [Cilium's AI Policy](https://github.com/cilium/community/blob/main/AI-POLICY.md), specifically regarding communication in public forums:
> It is not acceptable to use Generative AI tools to:
> - Communicate in any Cilium community space with content that is substantially written using Generative AI tools. For example, it is not acceptable to send such text on Slack or GitHub, whether initiating or responding to discussion with other community members.

This implements a repository hook which blocks Copilot from interacting with the public repo surfaces directly - it cannot open a PR, write a PR body, create, respond to, or resolve comments, or otherwise masquerade as the user in communication channels with other users. 