### PR TITLE
fix: support externally managed default routes for DRA pods

### DIFF
--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -28,14 +28,17 @@ const (
 )
 
 var (
-	errEmptyCNIArgs          = errors.New("empty CNI cmd args not allowed")
-	errInvalidArgs           = errors.New("invalid arg(s)")
-	errInvalidDefaultRouting = errors.New("add result requires exactly one interface with default routes")
-	errInvalidGatewayIP      = errors.New("invalid gateway IP")
-	errInvalidIPv6Address    = errors.New("invalid IPv6 address from NetworkContainerIPv6Config")
-	errInvalidGatewayIPv6    = errors.New("invalid gateway IPv6 address")
-	overlayGatewayV6IP       = "fe80::1234:5678:9abc"
-	watcherPath              = "/var/run/azure-vnet/deleteIDs"
+	errEmptyCNIArgs                           = errors.New("empty CNI cmd args not allowed")
+	errInvalidArgs                            = errors.New("invalid arg(s)")
+	errInvalidDefaultRouting                  = errors.New("add result requires exactly one interface with default routes")
+	errInvalidExternallyManagedDefaultRouting = errors.New(
+		"add result with externally managed default route requires zero interfaces with default routes",
+	)
+	errInvalidGatewayIP   = errors.New("invalid gateway IP")
+	errInvalidIPv6Address = errors.New("invalid IPv6 address from NetworkContainerIPv6Config")
+	errInvalidGatewayIPv6 = errors.New("invalid gateway IPv6 address")
+	overlayGatewayV6IP    = "fe80::1234:5678:9abc"
+	watcherPath           = "/var/run/azure-vnet/deleteIDs"
 )
 
 type CNSIPAMInvoker struct {
@@ -273,8 +276,11 @@ func (invoker *CNSIPAMInvoker) Add(addConfig IPAMAddConfig) (IPAMAddResult, erro
 		}
 	}
 
-	// Make sure default routes exist for 1 interface
-	if numInterfacesWithDefaultRoutes != expectedNumInterfacesWithDefaultRoutes {
+	if response.DefaultRouteExternallyManaged {
+		if numInterfacesWithDefaultRoutes != 0 {
+			return IPAMAddResult{}, errInvalidExternallyManagedDefaultRouting
+		}
+	} else if numInterfacesWithDefaultRoutes != expectedNumInterfacesWithDefaultRoutes {
 		return IPAMAddResult{}, errInvalidDefaultRouting
 	}
 

--- a/cni/network/invoker_cns_test.go
+++ b/cni/network/invoker_cns_test.go
@@ -1805,6 +1805,126 @@ func Test_getInterfaceInfoKey(t *testing.T) {
 	require.Equal("", inv.getInterfaceInfoKey(cns.BackendNIC, ""))
 }
 
+func TestCNSIPAMInvokerAddDefaultRouteOwnership(t *testing.T) {
+	infraNIC := func(skipDefaultRoutes bool) cns.PodIpInfo {
+		return cns.PodIpInfo{
+			PodIPConfig: cns.IPSubnet{
+				IPAddress:    "10.0.1.10",
+				PrefixLength: 24,
+			},
+			NetworkContainerPrimaryIPConfig: cns.IPConfiguration{
+				IPSubnet: cns.IPSubnet{
+					IPAddress:    "10.0.1.0",
+					PrefixLength: 24,
+				},
+				GatewayIPAddress: "10.0.0.1",
+			},
+			HostPrimaryIPInfo: cns.HostIPInfo{
+				Gateway:   "10.0.0.1",
+				PrimaryIP: "10.0.0.2",
+				Subnet:    "10.0.0.0/24",
+			},
+			NICType:           cns.InfraNIC,
+			SkipDefaultRoutes: skipDefaultRoutes,
+		}
+	}
+	frontendNIC := func() cns.PodIpInfo {
+		return cns.PodIpInfo{
+			PodIPConfig: cns.IPSubnet{
+				IPAddress:    "20.0.1.10",
+				PrefixLength: 24,
+			},
+			HostPrimaryIPInfo: cns.HostIPInfo{
+				Gateway:   "20.0.0.1",
+				PrimaryIP: "20.0.0.2",
+				Subnet:    "20.0.0.0/24",
+			},
+			NICType:    cns.NodeNetworkInterfaceFrontendNIC,
+			MacAddress: "12:34:56:78:9a:bc",
+		}
+	}
+
+	tests := []struct {
+		name                          string
+		defaultRouteExternallyManaged bool
+		podIPInfo                     []cns.PodIpInfo
+		wantErr                       error
+	}{
+		{
+			name:      "legacy response requires one CNI-managed owner",
+			podIPInfo: []cns.PodIpInfo{infraNIC(false)},
+		},
+		{
+			name:      "legacy response rejects no CNI-managed owner",
+			podIPInfo: []cns.PodIpInfo{infraNIC(true)},
+			wantErr:   errInvalidDefaultRouting,
+		},
+		{
+			name:                          "externally managed response requires no CNI-managed owner",
+			defaultRouteExternallyManaged: true,
+			podIPInfo:                     []cns.PodIpInfo{infraNIC(true)},
+		},
+		{
+			name:                          "externally managed response rejects a CNI-managed owner",
+			defaultRouteExternallyManaged: true,
+			podIPInfo:                     []cns.PodIpInfo{infraNIC(false)},
+			wantErr:                       errInvalidExternallyManagedDefaultRouting,
+		},
+		{
+			name:      "legacy response rejects multiple CNI-managed owners",
+			podIPInfo: []cns.PodIpInfo{infraNIC(false), frontendNIC()},
+			wantErr:   errInvalidDefaultRouting,
+		},
+		{
+			name:                          "externally managed response rejects multiple CNI-managed owners",
+			defaultRouteExternallyManaged: true,
+			podIPInfo:                     []cns.PodIpInfo{infraNIC(false), frontendNIC()},
+			wantErr:                       errInvalidExternallyManagedDefaultRouting,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testRequire := require.New(t)
+			request := cns.IPConfigsRequest{
+				PodInterfaceID:      "testcont-testifname1",
+				InfraContainerID:    "testcontainerid1",
+				OrchestratorContext: marshallPodInfo(testPodInfo),
+			}
+			invoker := &CNSIPAMInvoker{
+				podName:      testPodInfo.PodName,
+				podNamespace: testPodInfo.PodNamespace,
+				cnsClient: &MockCNSClient{
+					require: testRequire,
+					requestIPs: requestIPsHandler{
+						ipconfigArgument: request,
+						result: &cns.IPConfigsResponse{
+							PodIPInfo:                     tt.podIPInfo,
+							DefaultRouteExternallyManaged: tt.defaultRouteExternallyManaged,
+						},
+					},
+				},
+			}
+
+			_, err := invoker.Add(IPAMAddConfig{
+				nwCfg: &cni.NetworkConfig{},
+				args: &cniSkel.CmdArgs{
+					ContainerID: "testcontainerid1",
+					Netns:       "testnetns1",
+					IfName:      "testifname1",
+				},
+				options: map[string]interface{}{},
+			})
+
+			if tt.wantErr == nil {
+				testRequire.NoError(err)
+				return
+			}
+			testRequire.ErrorIs(err, tt.wantErr)
+		})
+	}
+}
+
 func TestCNSIPAMInvoker_Add_SwiftV2(t *testing.T) {
 	require := require.New(t) //nolint further usage of require without passing t
 

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -582,6 +582,8 @@ type IPConfigResponse struct {
 type IPConfigsResponse struct {
 	PodIPInfo []PodIpInfo `json:"podIPInfo"`
 	Response  Response    `json:"response"`
+	// DefaultRouteExternallyManaged indicates that a component outside CNI owns the pod's default route.
+	DefaultRouteExternallyManaged bool `json:"defaultRouteExternallyManaged,omitempty"`
 }
 
 // ClaimResourceInfoRequest is the request for the RequestClaimResourceInfo API. ClaimUID identifies

--- a/cns/NetworkContainerContract_test.go
+++ b/cns/NetworkContainerContract_test.go
@@ -59,6 +59,39 @@ func TestUnmarshalPodInfo(t *testing.T) {
 	}
 }
 
+func TestIPConfigsResponseDefaultRouteExternallyManagedJSON(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		response  IPConfigsResponse
+		wantField bool
+	}{
+		{
+			name:     "omitted when false",
+			response: IPConfigsResponse{},
+		},
+		{
+			name: "included when true",
+			response: IPConfigsResponse{
+				DefaultRouteExternallyManaged: true,
+			},
+			wantField: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.response)
+			assert.NoError(t, err)
+
+			var decoded map[string]any
+			assert.NoError(t, json.Unmarshal(data, &decoded))
+			value, exists := decoded["defaultRouteExternallyManaged"]
+			assert.Equal(t, tt.wantField, exists)
+			if tt.wantField {
+				assert.Equal(t, true, value)
+			}
+		})
+	}
+}
+
 func TestNewPodInfoFromIPConfigsRequest(t *testing.T) {
 	GlobalPodInfoScheme = InterfaceIDPodInfoScheme
 	tests := []struct {

--- a/cns/middlewares/k8sSwiftV2.go
+++ b/cns/middlewares/k8sSwiftV2.go
@@ -85,25 +85,29 @@ func (k *K8sSWIFTv2Middleware) GetPodInfoForIPConfigsRequest(ctx context.Context
 	return podInfo, types.Success, ""
 }
 
-// getIPConfig returns the pod's SWIFT V2 IP configuration.
-func (k *K8sSWIFTv2Middleware) getIPConfig(ctx context.Context, podInfo cns.PodInfo) ([]cns.PodIpInfo, error) {
+// getIPConfig returns the pod's SWIFT V2 IP configuration and whether its default route is managed outside CNI.
+func (k *K8sSWIFTv2Middleware) getIPConfig(ctx context.Context, podInfo cns.PodInfo) ([]cns.PodIpInfo, bool, error) {
 	return k.getSwiftV2IpConfigHelper(ctx, podInfo, false)
 }
 
 // getSwiftV2IpConfigHelper builds the pod's SWIFT V2 delegated IP configs from its MTPNC.
 // When includeDRAAllocations is false, pods scheduled with DRA are skipped.
 // when true, DRA-delegated NICs are included.
-func (k *K8sSWIFTv2Middleware) getSwiftV2IpConfigHelper(ctx context.Context, podInfo cns.PodInfo, includeDRAAllocations bool) ([]cns.PodIpInfo, error) {
+func (k *K8sSWIFTv2Middleware) getSwiftV2IpConfigHelper(
+	ctx context.Context,
+	podInfo cns.PodInfo,
+	includeDRAAllocations bool,
+) ([]cns.PodIpInfo, bool, error) {
 	// Check if the MTPNC CRD exists for the pod, if not, return error
 	mtpnc := v1alpha1.MultitenantPodNetworkConfig{}
 	mtpncNamespacedName := k8stypes.NamespacedName{Namespace: podInfo.Namespace(), Name: podInfo.Name()}
 	if err := k.Cli.Get(ctx, mtpncNamespacedName, &mtpnc); err != nil {
-		return nil, errors.Wrap(err, errGetMTPNC.Error())
+		return nil, false, errors.Wrap(err, errGetMTPNC.Error())
 	}
 
 	// Check if the MTPNC CRD is ready. If one of the fields is empty, return error
 	if !mtpnc.IsReady() {
-		return nil, errMTPNCNotReady
+		return nil, false, errMTPNCNotReady
 	}
 	logger.Printf("[SWIFTv2Middleware] mtpnc for pod %s is : %+v", podInfo.Name(), mtpnc)
 
@@ -113,7 +117,7 @@ func (k *K8sSWIFTv2Middleware) getSwiftV2IpConfigHelper(ctx context.Context, pod
 	// using ResourceClaims or using the legacy PN/PNI annotation, it cannot be a mix of both.
 	if !includeDRAAllocations && mtpnc.IsScheduledWithDRA() {
 		k.log().Debug("pod scheduled with DRA; skipping delegated NIC IP config for CNI", zap.String("pod", podInfo.Name()))
-		return []cns.PodIpInfo{}, nil
+		return []cns.PodIpInfo{}, true, nil
 	}
 
 	var podIPInfos []cns.PodIpInfo
@@ -122,10 +126,10 @@ func (k *K8sSWIFTv2Middleware) getSwiftV2IpConfigHelper(ctx context.Context, pod
 		// Use fields from mtpnc.Status if InterfaceInfos is empty
 		ip, prefixSize, err := utils.ParseIPAndPrefix(mtpnc.Status.PrimaryIP)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to parse mtpnc primary IP and prefix")
+			return nil, false, errors.Wrap(err, "failed to parse mtpnc primary IP and prefix")
 		}
 		if prefixSize != prefixLength {
-			return nil, errors.Wrapf(errInvalidMTPNCPrefixLength, "mtpnc primaryIP prefix length is %d", prefixSize)
+			return nil, false, errors.Wrapf(errInvalidMTPNCPrefixLength, "mtpnc primaryIP prefix length is %d", prefixSize)
 		}
 
 		podIPInfos = append(podIPInfos, cns.PodIpInfo{
@@ -158,10 +162,10 @@ func (k *K8sSWIFTv2Middleware) getSwiftV2IpConfigHelper(ctx context.Context, pod
 				// Parse MTPNC primaryIP to get the IP address and prefix length
 				ip, prefixSize, err = utils.ParseIPAndPrefix(interfaceInfo.PrimaryIP)
 				if err != nil {
-					return nil, errors.Wrap(err, "failed to parse mtpnc primary IP and prefix")
+					return nil, false, errors.Wrap(err, "failed to parse mtpnc primary IP and prefix")
 				}
 				if prefixSize != prefixLength {
-					return nil, errors.Wrapf(errInvalidMTPNCPrefixLength, "mtpnc primaryIP prefix length is %d", prefixSize)
+					return nil, false, errors.Wrapf(errInvalidMTPNCPrefixLength, "mtpnc primaryIP prefix length is %d", prefixSize)
 				}
 
 				podIPInfo := cns.PodIpInfo{
@@ -179,7 +183,7 @@ func (k *K8sSWIFTv2Middleware) getSwiftV2IpConfigHelper(ctx context.Context, pod
 				// received from MTPNC, this function assigns them for windows while linux is a no-op
 				err = k.assignSubnetPrefixLengthFields(&podIPInfo, interfaceInfo, ip)
 				if err != nil {
-					return nil, errors.Wrap(err, "failed to parse mtpnc subnetAddressSpace prefix")
+					return nil, false, errors.Wrap(err, "failed to parse mtpnc subnetAddressSpace prefix")
 				}
 				podIPInfos = append(podIPInfos, podIPInfo)
 				// for windows scenario, it is required to add default route with gatewayIP from CNS
@@ -188,13 +192,14 @@ func (k *K8sSWIFTv2Middleware) getSwiftV2IpConfigHelper(ctx context.Context, pod
 		}
 	}
 
-	return podIPInfos, nil
+	return podIPInfos, false, nil
 }
 
 // GetSwiftV2IPConfigs returns the pod's SWIFT V2 delegated IP configs INCLUDING DRA-scheduled
 // NICs (unlike getIPConfig, which skips them).
 func (k *K8sSWIFTv2Middleware) GetSwiftV2IPConfigs(ctx context.Context, podInfo cns.PodInfo) ([]cns.PodIpInfo, error) {
-	return k.getSwiftV2IpConfigHelper(ctx, podInfo, true)
+	podIPInfos, _, err := k.getSwiftV2IpConfigHelper(ctx, podInfo, true)
+	return podIPInfos, err
 }
 
 // GetPodNICMACs returns the MAC addresses of the NICs allocated to the pod, read

--- a/cns/middlewares/k8sSwiftV2_linux.go
+++ b/cns/middlewares/k8sSwiftV2_linux.go
@@ -146,7 +146,7 @@ func (k *K8sSWIFTv2Middleware) IPConfigsRequestHandlerWrapper(defaultHandler, fa
 		if err != nil {
 			return ipConfigsResp, err
 		}
-		SWIFTv2PodIPInfos, err := k.getIPConfig(ctx, podInfo)
+		SWIFTv2PodIPInfos, defaultRouteExternallyManaged, err := k.getIPConfig(ctx, podInfo)
 		if err != nil {
 			return &cns.IPConfigsResponse{
 				Response: cns.Response{
@@ -156,6 +156,7 @@ func (k *K8sSWIFTv2Middleware) IPConfigsRequestHandlerWrapper(defaultHandler, fa
 				PodIPInfo: []cns.PodIpInfo{},
 			}, errors.Wrapf(err, "failed to get SWIFTv2 IP config : %v", req)
 		}
+		ipConfigsResp.DefaultRouteExternallyManaged = defaultRouteExternallyManaged
 		ipConfigsResp.PodIPInfo = append(ipConfigsResp.PodIPInfo, SWIFTv2PodIPInfos...)
 		// Set routes for the pod
 		for i := range ipConfigsResp.PodIPInfo {

--- a/cns/middlewares/k8sSwiftV2_linux_test.go
+++ b/cns/middlewares/k8sSwiftV2_linux_test.go
@@ -98,6 +98,43 @@ func TestIPConfigsRequestHandlerWrapperSuccess(t *testing.T) {
 	assert.Equal(t, resp.PodIPInfo[2].MacAddress, "00:00:00:00:00:00")
 }
 
+func TestIPConfigsRequestHandlerWrapperScheduledWithDRA(t *testing.T) {
+	middleware := K8sSWIFTv2Middleware{Cli: mock.NewClient()}
+	t.Setenv(configuration.EnvPodCIDRs, "10.0.1.0/24")
+	t.Setenv(configuration.EnvServiceCIDRs, "10.0.0.0/16")
+	t.Setenv(configuration.EnvInfraVNETCIDRs, "10.240.0.0/16")
+
+	defaultHandler := func(context.Context, cns.IPConfigsRequest) (*cns.IPConfigsResponse, error) {
+		return &cns.IPConfigsResponse{
+			PodIPInfo: []cns.PodIpInfo{
+				{
+					PodIPConfig: cns.IPSubnet{
+						IPAddress:    "10.0.1.10",
+						PrefixLength: 32,
+					},
+					NICType: cns.InfraNIC,
+				},
+			},
+		}, nil
+	}
+	failureHandler := func(context.Context, cns.IPConfigsRequest) (*cns.IPConfigsResponse, error) {
+		return nil, nil
+	}
+	req := cns.IPConfigsRequest{
+		PodInterfaceID:   testPod12Info.InterfaceID(),
+		InfraContainerID: testPod12Info.InfraContainerID(),
+	}
+	req.OrchestratorContext, _ = testPod12Info.OrchestratorContext()
+
+	resp, err := middleware.IPConfigsRequestHandlerWrapper(defaultHandler, failureHandler)(context.TODO(), req)
+
+	assert.NilError(t, err)
+	assert.Equal(t, len(resp.PodIPInfo), 1)
+	assert.Equal(t, resp.PodIPInfo[0].NICType, cns.InfraNIC)
+	assert.Equal(t, resp.PodIPInfo[0].SkipDefaultRoutes, true)
+	assert.Equal(t, resp.DefaultRouteExternallyManaged, true)
+}
+
 func TestIPConfigsRequestHandlerWrapperFailure(t *testing.T) {
 	middleware := K8sSWIFTv2Middleware{Cli: mock.NewClient()}
 	defaultHandler := func(context.Context, cns.IPConfigsRequest) (*cns.IPConfigsResponse, error) {
@@ -242,8 +279,9 @@ func TestGetSWIFTv2IPConfigSuccess(t *testing.T) {
 
 	middleware := K8sSWIFTv2Middleware{Cli: mock.NewClient()}
 
-	ipInfos, err := middleware.getIPConfig(context.TODO(), testPod1Info)
+	ipInfos, defaultRouteExternallyManaged, err := middleware.getIPConfig(context.TODO(), testPod1Info)
 	assert.Equal(t, err, nil)
+	assert.Equal(t, defaultRouteExternallyManaged, false)
 	// Ensure that the length of ipInfos matches the number of InterfaceInfos
 	// Adjust this according to the test setup
 	assert.Equal(t, len(ipInfos), 1)
@@ -254,8 +292,9 @@ func TestGetSWIFTv2IPConfigSuccess(t *testing.T) {
 func TestGetSWIFTv2IPConfigSharedNIC(t *testing.T) {
 	middleware := K8sSWIFTv2Middleware{Cli: mock.NewClient()}
 
-	ipInfos, err := middleware.getIPConfig(context.TODO(), testPod11Info)
+	ipInfos, defaultRouteExternallyManaged, err := middleware.getIPConfig(context.TODO(), testPod11Info)
 	assert.Equal(t, err, nil)
+	assert.Equal(t, defaultRouteExternallyManaged, false)
 	assert.Equal(t, len(ipInfos), 1)
 	assert.Equal(t, ipInfos[0].NICType, cns.DelegatedVMNIC)
 	assert.Equal(t, ipInfos[0].SharedNIC, true)
@@ -266,21 +305,22 @@ func TestGetSWIFTv2IPConfigScheduledWithDRA(t *testing.T) {
 
 	// When the pod is scheduled with DRA, dranet owns the delegated NIC, so CNS
 	// must not return its IP config to the CNI caller.
-	ipInfos, err := middleware.getIPConfig(context.TODO(), testPod12Info)
+	ipInfos, defaultRouteExternallyManaged, err := middleware.getIPConfig(context.TODO(), testPod12Info)
 	assert.Equal(t, err, nil)
 	assert.Equal(t, len(ipInfos), 0)
+	assert.Equal(t, defaultRouteExternallyManaged, true)
 }
 
 func TestGetSWIFTv2IPConfigFailure(t *testing.T) {
 	middleware := K8sSWIFTv2Middleware{Cli: mock.NewClient()}
 
 	// Pod's MTPNC doesn't exist in cache test
-	_, err := middleware.getIPConfig(context.TODO(), testPod3Info)
+	_, _, err := middleware.getIPConfig(context.TODO(), testPod3Info)
 	assert.Assert(t, strings.Contains(err.Error(), errGetMTPNC.Error()), "expected error to wrap errMTPNCNotFound, got: %v", err)
 	assert.ErrorContains(t, err, NetworkNotReadyErrorMsg)
 
 	// Pod's MTPNC is not ready test
-	_, err = middleware.getIPConfig(context.TODO(), testPod4Info)
+	_, _, err = middleware.getIPConfig(context.TODO(), testPod4Info)
 	assert.Assert(t, errors.Is(err, errMTPNCNotReady), "expected error to wrap errMTPNCNotReady, got: %v", err)
 	assert.ErrorContains(t, err, NetworkNotReadyErrorMsg)
 }
@@ -449,7 +489,7 @@ func TestNICTypeConfigSuccess(t *testing.T) {
 	middleware := K8sSWIFTv2Middleware{Cli: mock.NewClient()}
 
 	// Test Backend NIC type
-	ipInfos, err := middleware.getIPConfig(context.TODO(), testPod6Info)
+	ipInfos, _, err := middleware.getIPConfig(context.TODO(), testPod6Info)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -462,11 +502,11 @@ func TestGetSWIFTv2IPConfigMultiInterfaceFailure(t *testing.T) {
 	middleware := K8sSWIFTv2Middleware{Cli: mock.NewClient()}
 
 	// Pod's MTPNC doesn't exist in cache test
-	_, err := middleware.getIPConfig(context.TODO(), testPod3Info)
+	_, _, err := middleware.getIPConfig(context.TODO(), testPod3Info)
 	assert.ErrorContains(t, err, mock.ErrMTPNCNotFound.Error())
 
 	// Pod's MTPNC is not ready test
-	_, err = middleware.getIPConfig(context.TODO(), testPod4Info)
+	_, _, err = middleware.getIPConfig(context.TODO(), testPod4Info)
 	assert.Error(t, err, errMTPNCNotReady.Error())
 }
 
@@ -477,7 +517,7 @@ func TestGetSWIFTv2IPConfigMultiInterfaceSuccess(t *testing.T) {
 
 	middleware := K8sSWIFTv2Middleware{Cli: mock.NewClient()}
 
-	ipInfos, err := middleware.getIPConfig(context.TODO(), testPod7Info)
+	ipInfos, _, err := middleware.getIPConfig(context.TODO(), testPod7Info)
 	assert.Equal(t, err, nil)
 	// Ensure that the length of ipInfos matches the number of InterfaceInfos
 	// Adjust this according to the test setup in mock client

--- a/cns/middlewares/k8sSwiftV2_windows.go
+++ b/cns/middlewares/k8sSwiftV2_windows.go
@@ -200,7 +200,7 @@ func (k *K8sSWIFTv2Middleware) IPConfigsRequestHandlerWrapper(defaultHandler, fa
 		if err != nil {
 			return ipConfigsResp, err
 		}
-		SWIFTv2PodIPInfos, err := k.getIPConfig(ctx, podInfo)
+		SWIFTv2PodIPInfos, defaultRouteExternallyManaged, err := k.getIPConfig(ctx, podInfo)
 		if err != nil {
 			return &cns.IPConfigsResponse{
 				Response: cns.Response{
@@ -210,6 +210,7 @@ func (k *K8sSWIFTv2Middleware) IPConfigsRequestHandlerWrapper(defaultHandler, fa
 				PodIPInfo: []cns.PodIpInfo{},
 			}, errors.Wrapf(err, "failed to get SWIFTv2 IP config : %v", req)
 		}
+		ipConfigsResp.DefaultRouteExternallyManaged = defaultRouteExternallyManaged
 		ipConfigsResp.PodIPInfo = append(ipConfigsResp.PodIPInfo, SWIFTv2PodIPInfos...)
 		// Set routes for the pod
 		for i := range ipConfigsResp.PodIPInfo {

--- a/cns/middlewares/k8sSwiftV2_windows_test.go
+++ b/cns/middlewares/k8sSwiftV2_windows_test.go
@@ -1,6 +1,7 @@
 package middlewares
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -23,6 +24,49 @@ import (
 func TestMain(m *testing.M) {
 	logger.InitLogger("testlogs", 0, 0, "./")
 	os.Exit(m.Run())
+}
+
+func TestIPConfigsRequestHandlerWrapperScheduledWithDRA(t *testing.T) {
+	middleware := K8sSWIFTv2Middleware{Cli: mock.NewClient()}
+	t.Setenv(configuration.EnvPodCIDRs, "10.0.1.0/24")
+	t.Setenv(configuration.EnvServiceCIDRs, "10.0.0.0/16")
+	t.Setenv(configuration.EnvInfraVNETCIDRs, "10.240.0.0/16")
+
+	defaultHandler := func(context.Context, cns.IPConfigsRequest) (*cns.IPConfigsResponse, error) {
+		return &cns.IPConfigsResponse{
+			PodIPInfo: []cns.PodIpInfo{
+				{
+					PodIPConfig: cns.IPSubnet{
+						IPAddress:    "10.0.1.10",
+						PrefixLength: 32,
+					},
+					NICType: cns.InfraNIC,
+				},
+			},
+		}, nil
+	}
+	failureHandler := func(context.Context, cns.IPConfigsRequest) (*cns.IPConfigsResponse, error) {
+		return nil, nil
+	}
+	podInfo := cns.NewPodInfo(
+		"5006cad4-eth0",
+		"5006cad4-e54d-472e-863d-c4bac66200a7",
+		"testpod12",
+		"testpod12namespace",
+	)
+	req := cns.IPConfigsRequest{
+		PodInterfaceID:   podInfo.InterfaceID(),
+		InfraContainerID: podInfo.InfraContainerID(),
+	}
+	req.OrchestratorContext, _ = podInfo.OrchestratorContext()
+
+	resp, err := middleware.IPConfigsRequestHandlerWrapper(defaultHandler, failureHandler)(context.TODO(), req)
+
+	require.NoError(t, err)
+	require.Len(t, resp.PodIPInfo, 1)
+	require.Equal(t, cns.InfraNIC, resp.PodIPInfo[0].NICType)
+	require.True(t, resp.PodIPInfo[0].SkipDefaultRoutes)
+	require.True(t, resp.DefaultRouteExternallyManaged)
 }
 
 func TestSetRoutesSuccess(t *testing.T) {

--- a/cns/middlewares/mock/mockClient.go
+++ b/cns/middlewares/mock/mockClient.go
@@ -67,6 +67,10 @@ func NewClient() *Client {
 	testPod10.Labels = make(map[string]string)
 	testPod10.Labels[configuration.LabelPodNetworkInstanceSwiftV2] = podNetwork
 
+	testPod12 := v1.Pod{}
+	testPod12.Labels = make(map[string]string)
+	testPod12.Labels[configuration.LabelPodSwiftV2] = podNetwork
+
 	testPodMtpncTerminating := v1.Pod{}
 	testPodMtpncTerminating.Labels = make(map[string]string)
 	testPodMtpncTerminating.Labels[configuration.LabelPodSwiftV2] = podNetwork
@@ -225,6 +229,7 @@ func NewClient() *Client {
 			"testpod8namespace/testpod8":                               &testPod8,
 			"testpod9namespace/testpod9":                               &testPod9,
 			"testpod10namespace/testpod10":                             &testPod10,
+			"testpod12namespace/testpod12":                             &testPod12,
 			"testpodMtpncTerminatingnamespace/testpodMtpncTerminating": &testPodMtpncTerminating,
 		},
 		mtpncCache: map[string]*v1alpha1.MultitenantPodNetworkConfig{


### PR DESCRIPTION
## Problem

For DRA pods, CNS intentionally excludes the DRA-owned `FrontendNIC` from normal CNI IPAM and returns the `InfraNIC` with `SkipDefaultRoutes=true`. CNI nevertheless required exactly one CNI-managed default-route interface, so this valid externally owned route configuration failed with zero managed owners.

## Fix

- Add an explicit response-level `DefaultRouteExternallyManaged` ownership signal.
- Keep the DRA-owned `FrontendNIC` suppressed from the normal CNI response.
- Allow zero CNI-managed default-route owners only when the signal is true, and reject conflicting/double ownership.
- Preserve legacy behavior: when the field is absent or false, exactly one CNI-managed default-route interface is still required.

## Safety

This avoids returning or programming the DRANet/NRI-owned NIC through CNI, preventing two components from owning the same NIC/default route.

## Tests

Focused tests passed:

```text
go test ./cni/network -run '^TestCNSIPAMInvokerAddDefaultRouteOwnership$' -count=1
ok github.com/Azure/azure-container-networking/cni/network 10.234s

go test ./cns -run '^TestIPConfigsResponseDefaultRouteExternallyManagedJSON$' -count=1
ok github.com/Azure/azure-container-networking/cns 8.154s

go test ./cns/middlewares -run '^TestIPConfigsRequestHandlerWrapperScheduledWithDRA$' -count=1
ok github.com/Azure/azure-container-networking/cns/middlewares 7.929s
```

## End-to-end validation

[Azure DevOps run 176998048](https://dev.azure.com/msazure/One/_build/results?buildId=176998048) deployed this change. The old `add result requires exactly one interface with default routes` error was absent; dedicated pods, NRI attachment, routing, and datapath passed, and the SharedNIC phase began.

A later SharedNIC CNS HTTP 400 is a distinct follow-up blocker. This PR does **not** claim that the full suite passed.

- ACN source commit: `189e3a1eb1a7b339cf26bec3e9695d47d7709a0e`
- Test image tag: `prefix-route-owner-189e3a1eb-20260817-135251`
- CNS: `acndev.azurecr.io/azure-cns@sha256:caccd0dfd4def961bb86ef9d84864ee02b5f092d48bd61ceaf81749990b65a14`
- CNI: `acndev.azurecr.io/azure-cni@sha256:09634e186c45005588521e816872db5a8dcaf23f0c76ed5953a26ffb9ec2b5c2`
