### PR TITLE
feat: allow dns replies to skip conntrack

### DIFF
--- a/test/integration/manifests/cilium/v1.17/ebpf/common/allowed-iptables-patterns.yaml
+++ b/test/integration/manifests/cilium/v1.17/ebpf/common/allowed-iptables-patterns.yaml
@@ -31,6 +31,7 @@ data:
     -A SWIFT-POSTROUTING -s
   raw: |
     ^-A (PREROUTING|OUTPUT) -d 169\.254\.10\.(10|11)\/32 -p (tcp|udp) -m comment --comment "localdns: skip conntrack" -m (tcp|udp) --dport 53 -j NOTRACK$
+    ^-A OUTPUT -s 169\.254\.10\.(10|11)\/32 -p (tcp|udp) -m comment --comment "localdns: skip conntrack" -m (tcp|udp) --sport 53 -j NOTRACK$
   security: |
     -A OUTPUT -d 168.63.129.16/32 -p tcp -m tcp --dport 53 -j ACCEPT
     -A OUTPUT -d 168.63.129.16/32 -p tcp -m owner --uid-owner 0 -j ACCEPT

--- a/test/integration/manifests/cilium/v1.18/ebpf/common/allowed-iptables-patterns.yaml
+++ b/test/integration/manifests/cilium/v1.18/ebpf/common/allowed-iptables-patterns.yaml
@@ -31,6 +31,7 @@ data:
     -A SWIFT-POSTROUTING -s
   raw: |
     ^-A (PREROUTING|OUTPUT) -d 169\.254\.10\.(10|11)\/32 -p (tcp|udp) -m comment --comment "localdns: skip conntrack" -m (tcp|udp) --dport 53 -j NOTRACK$
+    ^-A OUTPUT -s 169\.254\.10\.(10|11)\/32 -p (tcp|udp) -m comment --comment "localdns: skip conntrack" -m (tcp|udp) --sport 53 -j NOTRACK$
   security: |
     -A OUTPUT -d 168.63.129.16/32 -p tcp -m tcp --dport 53 -j ACCEPT
     -A OUTPUT -d 168.63.129.16/32 -p tcp -m owner --uid-owner 0 -j ACCEPT

--- a/test/integration/manifests/cilium/v1.19/ebpf/common/allowed-iptables-patterns.yaml
+++ b/test/integration/manifests/cilium/v1.19/ebpf/common/allowed-iptables-patterns.yaml
@@ -31,6 +31,7 @@ data:
     -A SWIFT-POSTROUTING -s
   raw: |
     ^-A (PREROUTING|OUTPUT) -d 169\.254\.10\.(10|11)\/32 -p (tcp|udp) -m comment --comment "localdns: skip conntrack" -m (tcp|udp) --dport 53 -j NOTRACK$
+    ^-A OUTPUT -s 169\.254\.10\.(10|11)\/32 -p (tcp|udp) -m comment --comment "localdns: skip conntrack" -m (tcp|udp) --sport 53 -j NOTRACK$
   security: |
     -A OUTPUT -d 168.63.129.16/32 -p tcp -m tcp --dport 53 -j ACCEPT
     -A OUTPUT -d 168.63.129.16/32 -p tcp -m owner --uid-owner 0 -j ACCEPT


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
When Azure LocalDNS is in use, we want dns reply packets to skip conntrack, which is planned to be done using an iptables rule. This requires adding the rule to the list of allowed rules in iptables monitor. This has been done in RP, this PR brings the test manifest up-to-date.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:
