### PR TITLE
fix: ignore policy-only E2E warnings

### DIFF
--- a/.pipelines/singletenancy/aks/e2e-job-template.yaml
+++ b/.pipelines/singletenancy/aks/e2e-job-template.yaml
@@ -119,11 +119,17 @@ stages:
               hybridWin: true
               service: true
               hostport: true
+          # Auto-injected policy tasks can mark an otherwise healthy job as
+          # SucceededWithIssues. This output proves all product test steps ran.
+          - bash: echo "##vso[task.setvariable variable=completed;isOutput=true]true"
+            name: markE2ECompleted
+            displayName: Mark E2E completed
 
       # can only succeed with issues in linux
       - template: ../../templates/warning-handler-job-template.yaml
         parameters:
           dependsOnToEmitWarning: ${{ parameters.name }}
+          completionOutput: markE2ECompleted.completed
           clusterName: ${{ parameters.clusterName }}-$(commitID)
           fileSearchPattern: "azure-vnet*.log"
           # continue on error only in linux case to workaround known cniv1 issue where we leak an ip

--- a/.pipelines/singletenancy/azure-cni-overlay-stateless/azure-cni-overlay-stateless-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay-stateless/azure-cni-overlay-stateless-e2e-job-template.yaml
@@ -118,11 +118,17 @@ stages:
               hostport: true
               service: true
               hybridWin: true
+          # Auto-injected policy tasks can mark an otherwise healthy job as
+          # SucceededWithIssues. This output proves all product test steps ran.
+          - bash: echo "##vso[task.setvariable variable=completed;isOutput=true]true"
+            name: markE2ECompleted
+            displayName: Mark E2E completed
 
       # can only succeed with issues in windows
       - template: ../../templates/warning-handler-job-template.yaml
         parameters:
           dependsOnToEmitWarning: ${{ parameters.name }}_windows
+          completionOutput: markE2ECompleted.completed
           clusterName: ${{ parameters.clusterName }}-$(commitID)
           fileSearchPattern: "azure-vnet*.log"
           # known windows issues that occur only in testing:

--- a/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/azure-cni-overlay/azure-cni-overlay-e2e-job-template.yaml
@@ -138,12 +138,18 @@ stages:
               hostport: true
               service: true
               hybridWin: ${{ eq(parameters.os, 'windows') }}
+          # Auto-injected policy tasks can mark an otherwise healthy job as
+          # SucceededWithIssues. This output proves all product test steps ran.
+          - bash: echo "##vso[task.setvariable variable=completed;isOutput=true]true"
+            name: markE2ECompleted
+            displayName: Mark E2E completed
 
       # can only succeed with issues in windows
       - ${{ if eq(parameters.os, 'windows') }}:
         - template: ../../templates/warning-handler-job-template.yaml
           parameters:
             dependsOnToEmitWarning: ${{ parameters.name }}_${{ parameters.os }}
+            completionOutput: markE2ECompleted.completed
             clusterName: ${{ parameters.clusterName }}-$(commitID)
             fileSearchPattern: "azure-vnet*.log"
             # known windows issues that occur only in testing:

--- a/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
+++ b/.pipelines/singletenancy/dualstack-overlay/dualstackoverlay-e2e-job-template.yaml
@@ -136,12 +136,18 @@ stages:
               service: ${{ eq(parameters.os, 'linux') }} # RUN IN LINUX NOT WINDOWS Currently broken for scenario and blocking releases, HNS is investigating.
               hostport: true
               hybridWin: ${{ eq(parameters.os, 'windows') }}
+          # Auto-injected policy tasks can mark an otherwise healthy job as
+          # SucceededWithIssues. This output proves all product test steps ran.
+          - bash: echo "##vso[task.setvariable variable=completed;isOutput=true]true"
+            name: markE2ECompleted
+            displayName: Mark E2E completed
 
       # can only succeed with issues in windows
       - ${{ if eq(parameters.os, 'windows') }}:
         - template: ../../templates/warning-handler-job-template.yaml
           parameters:
             dependsOnToEmitWarning: ${{ parameters.name }}_${{ parameters.os }}
+            completionOutput: markE2ECompleted.completed
             clusterName: ${{ parameters.clusterName }}-$(commitID)
             fileSearchPattern: "azure-vnet*.log"
             # known windows issues that occur only in testing:
@@ -169,4 +175,3 @@ stages:
           os: ${{ parameters.os }}
           cni: cniv2
           dependsOnJob: failedE2ELogs_${{ parameters.os }}
-

--- a/.pipelines/templates/warning-handler-job-template.yaml
+++ b/.pipelines/templates/warning-handler-job-template.yaml
@@ -5,12 +5,20 @@ parameters:
   searchPattern: ""
   cni: ""
   os: ""
+  completionOutput: ""
 
 jobs:
   - job: warningHandler
     displayName: "Handle E2E Warning"
     dependsOn: ${{ parameters.dependsOnToEmitWarning }}
-    condition: eq(dependencies.${{ parameters.dependsOnToEmitWarning }}.result, 'SucceededWithIssues')
+    condition: |
+      and(
+        eq(dependencies.${{ parameters.dependsOnToEmitWarning }}.result, 'SucceededWithIssues'),
+        or(
+          eq('${{ parameters.completionOutput }}', ''),
+          ne(dependencies.${{ parameters.dependsOnToEmitWarning }}.outputs['${{ parameters.completionOutput }}'], 'true')
+        )
+      )
     pool:
       name: $(BUILD_POOL_NAME_DEFAULT)
       demands:


### PR DESCRIPTION
## Summary

- mark when all product E2E steps complete successfully
- skip the CNI known-issue handler when `SucceededWithIssues` was caused only by auto-injected policy warnings
- preserve existing handling when a product test step fails before the completion marker

## Motivation

The merge-queue run for #4702 reported `E2E-AKS Windows 2022 Handle E2E Warning` as failed even though every product E2E task passed. Auto-injected Drift Management and Component Detection warnings changed the parent job result to `SucceededWithIssues`, which incorrectly triggered the CNI log-pattern handler. Since no CNI failure existed, that handler failed the stage.

## Validation

- both modified Azure Pipelines templates parse as YAML
- `git diff --check` passes
- existing warning-handler users retain their current behavior unless they explicitly provide a completion output

Related merge-queue check: https://github.com/Azure/azure-container-networking/runs/96188378742