### PR TITLE
SkipDefaultRouteProgramming in CNI when delegated NIC programming is done outside of CNI

### DIFF
--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -276,11 +276,12 @@ func (invoker *CNSIPAMInvoker) Add(addConfig IPAMAddConfig) (IPAMAddResult, erro
 		}
 	}
 
+	skipDefaultRouteProgramming := response.PodConfigurations.SkipDefaultRouteProgramming
 	// Make sure default routes exist for 1 interface unless SkipDefaultRouteProgramming is set.
-	if response.SkipDefaultRouteProgramming && numInterfacesWithDefaultRoutes != 0 {
+	if skipDefaultRouteProgramming && numInterfacesWithDefaultRoutes != 0 {
 		return IPAMAddResult{}, errInvalidSkipDefaultRouteProgramming
 	}
-	if !response.SkipDefaultRouteProgramming && numInterfacesWithDefaultRoutes != expectedNumInterfacesWithDefaultRoutes {
+	if !skipDefaultRouteProgramming && numInterfacesWithDefaultRoutes != expectedNumInterfacesWithDefaultRoutes {
 		return IPAMAddResult{}, errInvalidDefaultRouting
 	}
 

--- a/cni/network/invoker_cns.go
+++ b/cni/network/invoker_cns.go
@@ -28,14 +28,17 @@ const (
 )
 
 var (
-	errEmptyCNIArgs          = errors.New("empty CNI cmd args not allowed")
-	errInvalidArgs           = errors.New("invalid arg(s)")
-	errInvalidDefaultRouting = errors.New("add result requires exactly one interface with default routes")
-	errInvalidGatewayIP      = errors.New("invalid gateway IP")
-	errInvalidIPv6Address    = errors.New("invalid IPv6 address from NetworkContainerIPv6Config")
-	errInvalidGatewayIPv6    = errors.New("invalid gateway IPv6 address")
-	overlayGatewayV6IP       = "fe80::1234:5678:9abc"
-	watcherPath              = "/var/run/azure-vnet/deleteIDs"
+	errEmptyCNIArgs                       = errors.New("empty CNI cmd args not allowed")
+	errInvalidArgs                        = errors.New("invalid arg(s)")
+	errInvalidDefaultRouting              = errors.New("add result requires exactly one interface with default routes")
+	errInvalidSkipDefaultRouteProgramming = errors.New(
+		"add result with SkipDefaultRouteProgramming requires all interfaces to skip default routes",
+	)
+	errInvalidGatewayIP   = errors.New("invalid gateway IP")
+	errInvalidIPv6Address = errors.New("invalid IPv6 address from NetworkContainerIPv6Config")
+	errInvalidGatewayIPv6 = errors.New("invalid gateway IPv6 address")
+	overlayGatewayV6IP    = "fe80::1234:5678:9abc"
+	watcherPath           = "/var/run/azure-vnet/deleteIDs"
 )
 
 type CNSIPAMInvoker struct {
@@ -273,8 +276,11 @@ func (invoker *CNSIPAMInvoker) Add(addConfig IPAMAddConfig) (IPAMAddResult, erro
 		}
 	}
 
-	// Make sure default routes exist for 1 interface
-	if numInterfacesWithDefaultRoutes != expectedNumInterfacesWithDefaultRoutes {
+	// Make sure default routes exist for 1 interface unless SkipDefaultRouteProgramming is set.
+	if response.SkipDefaultRouteProgramming && numInterfacesWithDefaultRoutes != 0 {
+		return IPAMAddResult{}, errInvalidSkipDefaultRouteProgramming
+	}
+	if !response.SkipDefaultRouteProgramming && numInterfacesWithDefaultRoutes != expectedNumInterfacesWithDefaultRoutes {
 		return IPAMAddResult{}, errInvalidDefaultRouting
 	}
 

--- a/cni/network/invoker_cns_test.go
+++ b/cni/network/invoker_cns_test.go
@@ -1899,8 +1899,10 @@ func TestCNSIPAMInvokerAddDefaultRouteProgramming(t *testing.T) {
 					requestIPs: requestIPsHandler{
 						ipconfigArgument: request,
 						result: &cns.IPConfigsResponse{
-							PodIPInfo:                   tt.podIPInfo,
-							SkipDefaultRouteProgramming: tt.skipDefaultRouteProgramming,
+							PodIPInfo: tt.podIPInfo,
+							PodConfigurations: cns.PodConfigurations{
+								SkipDefaultRouteProgramming: tt.skipDefaultRouteProgramming,
+							},
 						},
 					},
 				},

--- a/cni/network/invoker_cns_test.go
+++ b/cni/network/invoker_cns_test.go
@@ -1805,6 +1805,126 @@ func Test_getInterfaceInfoKey(t *testing.T) {
 	require.Equal("", inv.getInterfaceInfoKey(cns.BackendNIC, ""))
 }
 
+func TestCNSIPAMInvokerAddDefaultRouteProgramming(t *testing.T) {
+	infraNIC := func(skipDefaultRoutes bool) cns.PodIpInfo {
+		return cns.PodIpInfo{
+			PodIPConfig: cns.IPSubnet{
+				IPAddress:    "10.0.1.10",
+				PrefixLength: 24,
+			},
+			NetworkContainerPrimaryIPConfig: cns.IPConfiguration{
+				IPSubnet: cns.IPSubnet{
+					IPAddress:    "10.0.1.0",
+					PrefixLength: 24,
+				},
+				GatewayIPAddress: "10.0.0.1",
+			},
+			HostPrimaryIPInfo: cns.HostIPInfo{
+				Gateway:   "10.0.0.1",
+				PrimaryIP: "10.0.0.2",
+				Subnet:    "10.0.0.0/24",
+			},
+			NICType:           cns.InfraNIC,
+			SkipDefaultRoutes: skipDefaultRoutes,
+		}
+	}
+	frontendNIC := func() cns.PodIpInfo {
+		return cns.PodIpInfo{
+			PodIPConfig: cns.IPSubnet{
+				IPAddress:    "20.0.1.10",
+				PrefixLength: 24,
+			},
+			HostPrimaryIPInfo: cns.HostIPInfo{
+				Gateway:   "20.0.0.1",
+				PrimaryIP: "20.0.0.2",
+				Subnet:    "20.0.0.0/24",
+			},
+			NICType:    cns.NodeNetworkInterfaceFrontendNIC,
+			MacAddress: "12:34:56:78:9a:bc",
+		}
+	}
+
+	tests := []struct {
+		name                        string
+		skipDefaultRouteProgramming bool
+		podIPInfo                   []cns.PodIpInfo
+		wantErr                     error
+	}{
+		{
+			name:      "legacy response requires one CNI-managed owner",
+			podIPInfo: []cns.PodIpInfo{infraNIC(false)},
+		},
+		{
+			name:      "legacy response rejects no CNI-managed owner",
+			podIPInfo: []cns.PodIpInfo{infraNIC(true)},
+			wantErr:   errInvalidDefaultRouting,
+		},
+		{
+			name:                        "skip programming response requires no CNI-managed owner",
+			skipDefaultRouteProgramming: true,
+			podIPInfo:                   []cns.PodIpInfo{infraNIC(true)},
+		},
+		{
+			name:                        "skip programming response rejects a CNI-managed owner",
+			skipDefaultRouteProgramming: true,
+			podIPInfo:                   []cns.PodIpInfo{infraNIC(false)},
+			wantErr:                     errInvalidSkipDefaultRouteProgramming,
+		},
+		{
+			name:      "legacy response rejects multiple CNI-managed owners",
+			podIPInfo: []cns.PodIpInfo{infraNIC(false), frontendNIC()},
+			wantErr:   errInvalidDefaultRouting,
+		},
+		{
+			name:                        "skip programming response rejects multiple CNI-managed owners",
+			skipDefaultRouteProgramming: true,
+			podIPInfo:                   []cns.PodIpInfo{infraNIC(false), frontendNIC()},
+			wantErr:                     errInvalidSkipDefaultRouteProgramming,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testRequire := require.New(t)
+			request := cns.IPConfigsRequest{
+				PodInterfaceID:      "testcont-testifname1",
+				InfraContainerID:    "testcontainerid1",
+				OrchestratorContext: marshallPodInfo(testPodInfo),
+			}
+			invoker := &CNSIPAMInvoker{
+				podName:      testPodInfo.PodName,
+				podNamespace: testPodInfo.PodNamespace,
+				cnsClient: &MockCNSClient{
+					require: testRequire,
+					requestIPs: requestIPsHandler{
+						ipconfigArgument: request,
+						result: &cns.IPConfigsResponse{
+							PodIPInfo:                   tt.podIPInfo,
+							SkipDefaultRouteProgramming: tt.skipDefaultRouteProgramming,
+						},
+					},
+				},
+			}
+
+			_, err := invoker.Add(IPAMAddConfig{
+				nwCfg: &cni.NetworkConfig{},
+				args: &cniSkel.CmdArgs{
+					ContainerID: "testcontainerid1",
+					Netns:       "testnetns1",
+					IfName:      "testifname1",
+				},
+				options: map[string]interface{}{},
+			})
+
+			if tt.wantErr == nil {
+				testRequire.NoError(err)
+				return
+			}
+			testRequire.ErrorIs(err, tt.wantErr)
+		})
+	}
+}
+
 func TestCNSIPAMInvoker_Add_SwiftV2(t *testing.T) {
 	require := require.New(t) //nolint further usage of require without passing t
 

--- a/cni/network/invoker_cns_test.go
+++ b/cni/network/invoker_cns_test.go
@@ -1806,6 +1806,13 @@ func Test_getInterfaceInfoKey(t *testing.T) {
 }
 
 func TestCNSIPAMInvokerAddDefaultRouteProgramming(t *testing.T) {
+	const (
+		frontendGatewayIP = "20.0.0.1"
+		frontendPrimaryIP = "20.0.0.2"
+		podInterfaceID    = "testcont-testifname1"
+		containerID       = "testcontainerid1"
+	)
+
 	infraNIC := func(skipDefaultRoutes bool) cns.PodIpInfo {
 		return cns.PodIpInfo{
 			PodIPConfig: cns.IPSubnet{
@@ -1835,8 +1842,8 @@ func TestCNSIPAMInvokerAddDefaultRouteProgramming(t *testing.T) {
 				PrefixLength: 24,
 			},
 			HostPrimaryIPInfo: cns.HostIPInfo{
-				Gateway:   "20.0.0.1",
-				PrimaryIP: "20.0.0.2",
+				Gateway:   frontendGatewayIP,
+				PrimaryIP: frontendPrimaryIP,
 				Subnet:    "20.0.0.0/24",
 			},
 			NICType:    cns.NodeNetworkInterfaceFrontendNIC,
@@ -1887,8 +1894,8 @@ func TestCNSIPAMInvokerAddDefaultRouteProgramming(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			testRequire := require.New(t)
 			request := cns.IPConfigsRequest{
-				PodInterfaceID:      "testcont-testifname1",
-				InfraContainerID:    "testcontainerid1",
+				PodInterfaceID:      podInterfaceID,
+				InfraContainerID:    containerID,
 				OrchestratorContext: marshallPodInfo(testPodInfo),
 			}
 			invoker := &CNSIPAMInvoker{
@@ -1911,7 +1918,7 @@ func TestCNSIPAMInvokerAddDefaultRouteProgramming(t *testing.T) {
 			_, err := invoker.Add(IPAMAddConfig{
 				nwCfg: &cni.NetworkConfig{},
 				args: &cniSkel.CmdArgs{
-					ContainerID: "testcontainerid1",
+					ContainerID: containerID,
 					Netns:       "testnetns1",
 					IfName:      "testifname1",
 				},

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -585,6 +585,9 @@ type IPConfigResponse struct {
 type IPConfigsResponse struct {
 	PodIPInfo []PodIpInfo `json:"podIPInfo"`
 	Response  Response    `json:"response"`
+	// SkipDefaultRouteProgramming instructs CNI to skip default-route programming
+	// when no NIC requests default-route programming.
+	SkipDefaultRouteProgramming bool `json:"skipDefaultRouteProgramming,omitempty"`
 }
 
 // ClaimResourceInfoRequest is the request for the RequestClaimResourceInfo API. ClaimUID identifies

--- a/cns/NetworkContainerContract.go
+++ b/cns/NetworkContainerContract.go
@@ -581,13 +581,18 @@ type IPConfigResponse struct {
 	Response  Response
 }
 
-// IPConfigsResponse is used in CNS IPAM mode to return a slice of IP configs as a response to CNI ADD
-type IPConfigsResponse struct {
-	PodIPInfo []PodIpInfo `json:"podIPInfo"`
-	Response  Response    `json:"response"`
+// PodConfigurations defines pod-level networking behavior for CNI.
+type PodConfigurations struct {
 	// SkipDefaultRouteProgramming instructs CNI to skip default-route programming
 	// when no NIC requests default-route programming.
 	SkipDefaultRouteProgramming bool `json:"skipDefaultRouteProgramming,omitempty"`
+}
+
+// IPConfigsResponse is used in CNS IPAM mode to return a slice of IP configs as a response to CNI ADD
+type IPConfigsResponse struct {
+	PodIPInfo         []PodIpInfo       `json:"podIPInfo"`
+	Response          Response          `json:"response"`
+	PodConfigurations PodConfigurations `json:"podConfigurations"`
 }
 
 // ClaimResourceInfoRequest is the request for the RequestClaimResourceInfo API. ClaimUID identifies

--- a/cns/NetworkContainerContract_test.go
+++ b/cns/NetworkContainerContract_test.go
@@ -59,22 +59,24 @@ func TestUnmarshalPodInfo(t *testing.T) {
 	}
 }
 
-func TestIPConfigsResponseSkipDefaultRouteProgrammingJSON(t *testing.T) {
+func TestIPConfigsResponsePodConfigurationsJSON(t *testing.T) {
 	for _, tt := range []struct {
-		name      string
-		response  IPConfigsResponse
-		wantField bool
+		name          string
+		response      IPConfigsResponse
+		wantSkipField bool
 	}{
 		{
-			name:     "omitted when false",
+			name:     "empty when false",
 			response: IPConfigsResponse{},
 		},
 		{
 			name: "included when true",
 			response: IPConfigsResponse{
-				SkipDefaultRouteProgramming: true,
+				PodConfigurations: PodConfigurations{
+					SkipDefaultRouteProgramming: true,
+				},
 			},
-			wantField: true,
+			wantSkipField: true,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -83,10 +85,13 @@ func TestIPConfigsResponseSkipDefaultRouteProgrammingJSON(t *testing.T) {
 
 			var decoded map[string]any
 			assert.NoError(t, json.Unmarshal(data, &decoded))
-			value, exists := decoded["skipDefaultRouteProgramming"]
-			assert.Equal(t, tt.wantField, exists)
-			if tt.wantField {
-				assert.Equal(t, true, value)
+			value, exists := decoded["podConfigurations"]
+			assert.True(t, exists)
+			configurations := value.(map[string]any)
+			skipValue, skipExists := configurations["skipDefaultRouteProgramming"]
+			assert.Equal(t, tt.wantSkipField, skipExists)
+			if tt.wantSkipField {
+				assert.Equal(t, true, skipValue)
 			}
 		})
 	}

--- a/cns/NetworkContainerContract_test.go
+++ b/cns/NetworkContainerContract_test.go
@@ -59,6 +59,39 @@ func TestUnmarshalPodInfo(t *testing.T) {
 	}
 }
 
+func TestIPConfigsResponseSkipDefaultRouteProgrammingJSON(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		response  IPConfigsResponse
+		wantField bool
+	}{
+		{
+			name:     "omitted when false",
+			response: IPConfigsResponse{},
+		},
+		{
+			name: "included when true",
+			response: IPConfigsResponse{
+				SkipDefaultRouteProgramming: true,
+			},
+			wantField: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.response)
+			assert.NoError(t, err)
+
+			var decoded map[string]any
+			assert.NoError(t, json.Unmarshal(data, &decoded))
+			value, exists := decoded["skipDefaultRouteProgramming"]
+			assert.Equal(t, tt.wantField, exists)
+			if tt.wantField {
+				assert.Equal(t, true, value)
+			}
+		})
+	}
+}
+
 func TestNewPodInfoFromIPConfigsRequest(t *testing.T) {
 	GlobalPodInfoScheme = InterfaceIDPodInfoScheme
 	tests := []struct {

--- a/cns/NetworkContainerContract_test.go
+++ b/cns/NetworkContainerContract_test.go
@@ -80,7 +80,7 @@ func TestIPConfigsResponsePodConfigurationsJSON(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			data, err := json.Marshal(tt.response)
+			data, err := json.Marshal(tt.response) //nolint:musttag // response embeds pre-existing contract types
 			assert.NoError(t, err)
 
 			var decoded map[string]any

--- a/cns/middlewares/k8sSwiftV2.go
+++ b/cns/middlewares/k8sSwiftV2.go
@@ -98,11 +98,7 @@ func (k *K8sSWIFTv2Middleware) getIPConfig(ctx context.Context, podInfo cns.PodI
 // getSwiftV2IpConfigHelper builds the pod's SWIFT V2 delegated IP configs from its MTPNC.
 // When includeDRAAllocations is false, pods scheduled with DRA are skipped.
 // when true, DRA-delegated NICs are included.
-func (k *K8sSWIFTv2Middleware) getSwiftV2IpConfigHelper(
-	ctx context.Context,
-	podInfo cns.PodInfo,
-	includeDRAAllocations bool,
-) (ipConfigResult, error) {
+func (k *K8sSWIFTv2Middleware) getSwiftV2IpConfigHelper(ctx context.Context, podInfo cns.PodInfo, includeDRAAllocations bool) (ipConfigResult, error) {
 	// Check if the MTPNC CRD exists for the pod, if not, return error
 	mtpnc := v1alpha1.MultitenantPodNetworkConfig{}
 	mtpncNamespacedName := k8stypes.NamespacedName{Namespace: podInfo.Namespace(), Name: podInfo.Name()}

--- a/cns/middlewares/k8sSwiftV2.go
+++ b/cns/middlewares/k8sSwiftV2.go
@@ -85,25 +85,29 @@ func (k *K8sSWIFTv2Middleware) GetPodInfoForIPConfigsRequest(ctx context.Context
 	return podInfo, types.Success, ""
 }
 
-// getIPConfig returns the pod's SWIFT V2 IP configuration.
-func (k *K8sSWIFTv2Middleware) getIPConfig(ctx context.Context, podInfo cns.PodInfo) ([]cns.PodIpInfo, error) {
+// getIPConfig returns the pod's SWIFT V2 IP configuration and whether the pod is scheduled with DRA.
+func (k *K8sSWIFTv2Middleware) getIPConfig(ctx context.Context, podInfo cns.PodInfo) ([]cns.PodIpInfo, bool, error) {
 	return k.getSwiftV2IpConfigHelper(ctx, podInfo, false)
 }
 
 // getSwiftV2IpConfigHelper builds the pod's SWIFT V2 delegated IP configs from its MTPNC.
 // When includeDRAAllocations is false, pods scheduled with DRA are skipped.
 // when true, DRA-delegated NICs are included.
-func (k *K8sSWIFTv2Middleware) getSwiftV2IpConfigHelper(ctx context.Context, podInfo cns.PodInfo, includeDRAAllocations bool) ([]cns.PodIpInfo, error) {
+func (k *K8sSWIFTv2Middleware) getSwiftV2IpConfigHelper(
+	ctx context.Context,
+	podInfo cns.PodInfo,
+	includeDRAAllocations bool,
+) ([]cns.PodIpInfo, bool, error) {
 	// Check if the MTPNC CRD exists for the pod, if not, return error
 	mtpnc := v1alpha1.MultitenantPodNetworkConfig{}
 	mtpncNamespacedName := k8stypes.NamespacedName{Namespace: podInfo.Namespace(), Name: podInfo.Name()}
 	if err := k.Cli.Get(ctx, mtpncNamespacedName, &mtpnc); err != nil {
-		return nil, errors.Wrap(err, errGetMTPNC.Error())
+		return nil, false, errors.Wrap(err, errGetMTPNC.Error())
 	}
 
 	// Check if the MTPNC CRD is ready. If one of the fields is empty, return error
 	if !mtpnc.IsReady() {
-		return nil, errMTPNCNotReady
+		return nil, false, errMTPNCNotReady
 	}
 	logger.Printf("[SWIFTv2Middleware] mtpnc for pod %s is : %+v", podInfo.Name(), mtpnc)
 
@@ -113,7 +117,7 @@ func (k *K8sSWIFTv2Middleware) getSwiftV2IpConfigHelper(ctx context.Context, pod
 	// using ResourceClaims or using the legacy PN/PNI annotation, it cannot be a mix of both.
 	if !includeDRAAllocations && mtpnc.IsScheduledWithDRA() {
 		k.log().Debug("pod scheduled with DRA; skipping delegated NIC IP config for CNI", zap.String("pod", podInfo.Name()))
-		return []cns.PodIpInfo{}, nil
+		return []cns.PodIpInfo{}, true, nil
 	}
 
 	var podIPInfos []cns.PodIpInfo
@@ -122,10 +126,10 @@ func (k *K8sSWIFTv2Middleware) getSwiftV2IpConfigHelper(ctx context.Context, pod
 		// Use fields from mtpnc.Status if InterfaceInfos is empty
 		ip, prefixSize, err := utils.ParseIPAndPrefix(mtpnc.Status.PrimaryIP)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to parse mtpnc primary IP and prefix")
+			return nil, false, errors.Wrap(err, "failed to parse mtpnc primary IP and prefix")
 		}
 		if prefixSize != prefixLength {
-			return nil, errors.Wrapf(errInvalidMTPNCPrefixLength, "mtpnc primaryIP prefix length is %d", prefixSize)
+			return nil, false, errors.Wrapf(errInvalidMTPNCPrefixLength, "mtpnc primaryIP prefix length is %d", prefixSize)
 		}
 
 		podIPInfos = append(podIPInfos, cns.PodIpInfo{
@@ -158,10 +162,10 @@ func (k *K8sSWIFTv2Middleware) getSwiftV2IpConfigHelper(ctx context.Context, pod
 				// Parse MTPNC primaryIP to get the IP address and prefix length
 				ip, prefixSize, err = utils.ParseIPAndPrefix(interfaceInfo.PrimaryIP)
 				if err != nil {
-					return nil, errors.Wrap(err, "failed to parse mtpnc primary IP and prefix")
+					return nil, false, errors.Wrap(err, "failed to parse mtpnc primary IP and prefix")
 				}
 				if prefixSize != prefixLength {
-					return nil, errors.Wrapf(errInvalidMTPNCPrefixLength, "mtpnc primaryIP prefix length is %d", prefixSize)
+					return nil, false, errors.Wrapf(errInvalidMTPNCPrefixLength, "mtpnc primaryIP prefix length is %d", prefixSize)
 				}
 
 				podIPInfo := cns.PodIpInfo{
@@ -179,7 +183,7 @@ func (k *K8sSWIFTv2Middleware) getSwiftV2IpConfigHelper(ctx context.Context, pod
 				// received from MTPNC, this function assigns them for windows while linux is a no-op
 				err = k.assignSubnetPrefixLengthFields(&podIPInfo, interfaceInfo, ip)
 				if err != nil {
-					return nil, errors.Wrap(err, "failed to parse mtpnc subnetAddressSpace prefix")
+					return nil, false, errors.Wrap(err, "failed to parse mtpnc subnetAddressSpace prefix")
 				}
 				podIPInfos = append(podIPInfos, podIPInfo)
 				// for windows scenario, it is required to add default route with gatewayIP from CNS
@@ -188,13 +192,14 @@ func (k *K8sSWIFTv2Middleware) getSwiftV2IpConfigHelper(ctx context.Context, pod
 		}
 	}
 
-	return podIPInfos, nil
+	return podIPInfos, false, nil
 }
 
 // GetSwiftV2IPConfigs returns the pod's SWIFT V2 delegated IP configs INCLUDING DRA-scheduled
 // NICs (unlike getIPConfig, which skips them).
 func (k *K8sSWIFTv2Middleware) GetSwiftV2IPConfigs(ctx context.Context, podInfo cns.PodInfo) ([]cns.PodIpInfo, error) {
-	return k.getSwiftV2IpConfigHelper(ctx, podInfo, true)
+	podIPInfos, _, err := k.getSwiftV2IpConfigHelper(ctx, podInfo, true)
+	return podIPInfos, err
 }
 
 // GetPodNICMACs returns the MAC addresses of the NICs allocated to the pod, read

--- a/cns/middlewares/k8sSwiftV2.go
+++ b/cns/middlewares/k8sSwiftV2.go
@@ -85,8 +85,13 @@ func (k *K8sSWIFTv2Middleware) GetPodInfoForIPConfigsRequest(ctx context.Context
 	return podInfo, types.Success, ""
 }
 
-// getIPConfig returns the pod's SWIFT V2 IP configuration and whether the pod is scheduled with DRA.
-func (k *K8sSWIFTv2Middleware) getIPConfig(ctx context.Context, podInfo cns.PodInfo) ([]cns.PodIpInfo, bool, error) {
+type ipConfigResult struct {
+	podIPInfos        []cns.PodIpInfo
+	podConfigurations cns.PodConfigurations
+}
+
+// getIPConfig returns the pod's SWIFT V2 IP configuration for CNI.
+func (k *K8sSWIFTv2Middleware) getIPConfig(ctx context.Context, podInfo cns.PodInfo) (ipConfigResult, error) {
 	return k.getSwiftV2IpConfigHelper(ctx, podInfo, false)
 }
 
@@ -97,17 +102,17 @@ func (k *K8sSWIFTv2Middleware) getSwiftV2IpConfigHelper(
 	ctx context.Context,
 	podInfo cns.PodInfo,
 	includeDRAAllocations bool,
-) ([]cns.PodIpInfo, bool, error) {
+) (ipConfigResult, error) {
 	// Check if the MTPNC CRD exists for the pod, if not, return error
 	mtpnc := v1alpha1.MultitenantPodNetworkConfig{}
 	mtpncNamespacedName := k8stypes.NamespacedName{Namespace: podInfo.Namespace(), Name: podInfo.Name()}
 	if err := k.Cli.Get(ctx, mtpncNamespacedName, &mtpnc); err != nil {
-		return nil, false, errors.Wrap(err, errGetMTPNC.Error())
+		return ipConfigResult{}, errors.Wrap(err, errGetMTPNC.Error())
 	}
 
 	// Check if the MTPNC CRD is ready. If one of the fields is empty, return error
 	if !mtpnc.IsReady() {
-		return nil, false, errMTPNCNotReady
+		return ipConfigResult{}, errMTPNCNotReady
 	}
 	logger.Printf("[SWIFTv2Middleware] mtpnc for pod %s is : %+v", podInfo.Name(), mtpnc)
 
@@ -117,7 +122,12 @@ func (k *K8sSWIFTv2Middleware) getSwiftV2IpConfigHelper(
 	// using ResourceClaims or using the legacy PN/PNI annotation, it cannot be a mix of both.
 	if !includeDRAAllocations && mtpnc.IsScheduledWithDRA() {
 		k.log().Debug("pod scheduled with DRA; skipping delegated NIC IP config for CNI", zap.String("pod", podInfo.Name()))
-		return []cns.PodIpInfo{}, true, nil
+		return ipConfigResult{
+			podIPInfos: []cns.PodIpInfo{},
+			podConfigurations: cns.PodConfigurations{
+				SkipDefaultRouteProgramming: true,
+			},
+		}, nil
 	}
 
 	var podIPInfos []cns.PodIpInfo
@@ -126,10 +136,10 @@ func (k *K8sSWIFTv2Middleware) getSwiftV2IpConfigHelper(
 		// Use fields from mtpnc.Status if InterfaceInfos is empty
 		ip, prefixSize, err := utils.ParseIPAndPrefix(mtpnc.Status.PrimaryIP)
 		if err != nil {
-			return nil, false, errors.Wrap(err, "failed to parse mtpnc primary IP and prefix")
+			return ipConfigResult{}, errors.Wrap(err, "failed to parse mtpnc primary IP and prefix")
 		}
 		if prefixSize != prefixLength {
-			return nil, false, errors.Wrapf(errInvalidMTPNCPrefixLength, "mtpnc primaryIP prefix length is %d", prefixSize)
+			return ipConfigResult{}, errors.Wrapf(errInvalidMTPNCPrefixLength, "mtpnc primaryIP prefix length is %d", prefixSize)
 		}
 
 		podIPInfos = append(podIPInfos, cns.PodIpInfo{
@@ -162,10 +172,10 @@ func (k *K8sSWIFTv2Middleware) getSwiftV2IpConfigHelper(
 				// Parse MTPNC primaryIP to get the IP address and prefix length
 				ip, prefixSize, err = utils.ParseIPAndPrefix(interfaceInfo.PrimaryIP)
 				if err != nil {
-					return nil, false, errors.Wrap(err, "failed to parse mtpnc primary IP and prefix")
+					return ipConfigResult{}, errors.Wrap(err, "failed to parse mtpnc primary IP and prefix")
 				}
 				if prefixSize != prefixLength {
-					return nil, false, errors.Wrapf(errInvalidMTPNCPrefixLength, "mtpnc primaryIP prefix length is %d", prefixSize)
+					return ipConfigResult{}, errors.Wrapf(errInvalidMTPNCPrefixLength, "mtpnc primaryIP prefix length is %d", prefixSize)
 				}
 
 				podIPInfo := cns.PodIpInfo{
@@ -183,7 +193,7 @@ func (k *K8sSWIFTv2Middleware) getSwiftV2IpConfigHelper(
 				// received from MTPNC, this function assigns them for windows while linux is a no-op
 				err = k.assignSubnetPrefixLengthFields(&podIPInfo, interfaceInfo, ip)
 				if err != nil {
-					return nil, false, errors.Wrap(err, "failed to parse mtpnc subnetAddressSpace prefix")
+					return ipConfigResult{}, errors.Wrap(err, "failed to parse mtpnc subnetAddressSpace prefix")
 				}
 				podIPInfos = append(podIPInfos, podIPInfo)
 				// for windows scenario, it is required to add default route with gatewayIP from CNS
@@ -192,14 +202,14 @@ func (k *K8sSWIFTv2Middleware) getSwiftV2IpConfigHelper(
 		}
 	}
 
-	return podIPInfos, false, nil
+	return ipConfigResult{podIPInfos: podIPInfos}, nil
 }
 
 // GetSwiftV2IPConfigs returns the pod's SWIFT V2 delegated IP configs INCLUDING DRA-scheduled
 // NICs (unlike getIPConfig, which skips them).
 func (k *K8sSWIFTv2Middleware) GetSwiftV2IPConfigs(ctx context.Context, podInfo cns.PodInfo) ([]cns.PodIpInfo, error) {
-	podIPInfos, _, err := k.getSwiftV2IpConfigHelper(ctx, podInfo, true)
-	return podIPInfos, err
+	result, err := k.getSwiftV2IpConfigHelper(ctx, podInfo, true)
+	return result.podIPInfos, err
 }
 
 // GetPodNICMACs returns the MAC addresses of the NICs allocated to the pod, read

--- a/cns/middlewares/k8sSwiftV2_linux.go
+++ b/cns/middlewares/k8sSwiftV2_linux.go
@@ -146,7 +146,7 @@ func (k *K8sSWIFTv2Middleware) IPConfigsRequestHandlerWrapper(defaultHandler, fa
 		if err != nil {
 			return ipConfigsResp, err
 		}
-		SWIFTv2PodIPInfos, scheduledWithDRA, err := k.getIPConfig(ctx, podInfo)
+		ipConfigResult, err := k.getIPConfig(ctx, podInfo)
 		if err != nil {
 			return &cns.IPConfigsResponse{
 				Response: cns.Response{
@@ -156,7 +156,7 @@ func (k *K8sSWIFTv2Middleware) IPConfigsRequestHandlerWrapper(defaultHandler, fa
 				PodIPInfo: []cns.PodIpInfo{},
 			}, errors.Wrapf(err, "failed to get SWIFTv2 IP config : %v", req)
 		}
-		ipConfigsResp.PodIPInfo = append(ipConfigsResp.PodIPInfo, SWIFTv2PodIPInfos...)
+		ipConfigsResp.PodIPInfo = append(ipConfigsResp.PodIPInfo, ipConfigResult.podIPInfos...)
 		// Set routes for the pod
 		for i := range ipConfigsResp.PodIPInfo {
 			ipInfo := &ipConfigsResp.PodIPInfo[i]
@@ -174,7 +174,7 @@ func (k *K8sSWIFTv2Middleware) IPConfigsRequestHandlerWrapper(defaultHandler, fa
 				}
 			}
 		}
-		ipConfigsResp.SkipDefaultRouteProgramming = scheduledWithDRA
+		ipConfigsResp.PodConfigurations = ipConfigResult.podConfigurations
 		return ipConfigsResp, nil
 	}
 }

--- a/cns/middlewares/k8sSwiftV2_linux.go
+++ b/cns/middlewares/k8sSwiftV2_linux.go
@@ -146,7 +146,7 @@ func (k *K8sSWIFTv2Middleware) IPConfigsRequestHandlerWrapper(defaultHandler, fa
 		if err != nil {
 			return ipConfigsResp, err
 		}
-		SWIFTv2PodIPInfos, err := k.getIPConfig(ctx, podInfo)
+		SWIFTv2PodIPInfos, scheduledWithDRA, err := k.getIPConfig(ctx, podInfo)
 		if err != nil {
 			return &cns.IPConfigsResponse{
 				Response: cns.Response{
@@ -174,6 +174,7 @@ func (k *K8sSWIFTv2Middleware) IPConfigsRequestHandlerWrapper(defaultHandler, fa
 				}
 			}
 		}
+		ipConfigsResp.SkipDefaultRouteProgramming = scheduledWithDRA
 		return ipConfigsResp, nil
 	}
 }

--- a/cns/middlewares/k8sSwiftV2_linux_test.go
+++ b/cns/middlewares/k8sSwiftV2_linux_test.go
@@ -96,6 +96,44 @@ func TestIPConfigsRequestHandlerWrapperSuccess(t *testing.T) {
 	assert.Equal(t, err, nil)
 	assert.Equal(t, resp.PodIPInfo[2].PodIPConfig.IPAddress, "192.168.0.1")
 	assert.Equal(t, resp.PodIPInfo[2].MacAddress, "00:00:00:00:00:00")
+	assert.Equal(t, resp.SkipDefaultRouteProgramming, false)
+}
+
+func TestIPConfigsRequestHandlerWrapperScheduledWithDRA(t *testing.T) {
+	middleware := K8sSWIFTv2Middleware{Cli: mock.NewClient()}
+	t.Setenv(configuration.EnvPodCIDRs, "10.0.1.0/24")
+	t.Setenv(configuration.EnvServiceCIDRs, "10.0.0.0/16")
+	t.Setenv(configuration.EnvInfraVNETCIDRs, "10.240.0.0/16")
+
+	defaultHandler := func(context.Context, cns.IPConfigsRequest) (*cns.IPConfigsResponse, error) {
+		return &cns.IPConfigsResponse{
+			PodIPInfo: []cns.PodIpInfo{
+				{
+					PodIPConfig: cns.IPSubnet{
+						IPAddress:    "10.0.1.10",
+						PrefixLength: 32,
+					},
+					NICType: cns.InfraNIC,
+				},
+			},
+		}, nil
+	}
+	failureHandler := func(context.Context, cns.IPConfigsRequest) (*cns.IPConfigsResponse, error) {
+		return nil, nil
+	}
+	req := cns.IPConfigsRequest{
+		PodInterfaceID:   testPod12Info.InterfaceID(),
+		InfraContainerID: testPod12Info.InfraContainerID(),
+	}
+	req.OrchestratorContext, _ = testPod12Info.OrchestratorContext()
+
+	resp, err := middleware.IPConfigsRequestHandlerWrapper(defaultHandler, failureHandler)(context.TODO(), req)
+
+	assert.NilError(t, err)
+	assert.Equal(t, len(resp.PodIPInfo), 1)
+	assert.Equal(t, resp.PodIPInfo[0].NICType, cns.InfraNIC)
+	assert.Equal(t, resp.PodIPInfo[0].SkipDefaultRoutes, true)
+	assert.Equal(t, resp.SkipDefaultRouteProgramming, true)
 }
 
 func TestIPConfigsRequestHandlerWrapperFailure(t *testing.T) {
@@ -242,8 +280,9 @@ func TestGetSWIFTv2IPConfigSuccess(t *testing.T) {
 
 	middleware := K8sSWIFTv2Middleware{Cli: mock.NewClient()}
 
-	ipInfos, err := middleware.getIPConfig(context.TODO(), testPod1Info)
+	ipInfos, scheduledWithDRA, err := middleware.getIPConfig(context.TODO(), testPod1Info)
 	assert.Equal(t, err, nil)
+	assert.Equal(t, scheduledWithDRA, false)
 	// Ensure that the length of ipInfos matches the number of InterfaceInfos
 	// Adjust this according to the test setup
 	assert.Equal(t, len(ipInfos), 1)
@@ -254,8 +293,9 @@ func TestGetSWIFTv2IPConfigSuccess(t *testing.T) {
 func TestGetSWIFTv2IPConfigSharedNIC(t *testing.T) {
 	middleware := K8sSWIFTv2Middleware{Cli: mock.NewClient()}
 
-	ipInfos, err := middleware.getIPConfig(context.TODO(), testPod11Info)
+	ipInfos, scheduledWithDRA, err := middleware.getIPConfig(context.TODO(), testPod11Info)
 	assert.Equal(t, err, nil)
+	assert.Equal(t, scheduledWithDRA, false)
 	assert.Equal(t, len(ipInfos), 1)
 	assert.Equal(t, ipInfos[0].NICType, cns.DelegatedVMNIC)
 	assert.Equal(t, ipInfos[0].SharedNIC, true)
@@ -266,21 +306,22 @@ func TestGetSWIFTv2IPConfigScheduledWithDRA(t *testing.T) {
 
 	// When the pod is scheduled with DRA, dranet owns the delegated NIC, so CNS
 	// must not return its IP config to the CNI caller.
-	ipInfos, err := middleware.getIPConfig(context.TODO(), testPod12Info)
+	ipInfos, scheduledWithDRA, err := middleware.getIPConfig(context.TODO(), testPod12Info)
 	assert.Equal(t, err, nil)
 	assert.Equal(t, len(ipInfos), 0)
+	assert.Equal(t, scheduledWithDRA, true)
 }
 
 func TestGetSWIFTv2IPConfigFailure(t *testing.T) {
 	middleware := K8sSWIFTv2Middleware{Cli: mock.NewClient()}
 
 	// Pod's MTPNC doesn't exist in cache test
-	_, err := middleware.getIPConfig(context.TODO(), testPod3Info)
+	_, _, err := middleware.getIPConfig(context.TODO(), testPod3Info)
 	assert.Assert(t, strings.Contains(err.Error(), errGetMTPNC.Error()), "expected error to wrap errMTPNCNotFound, got: %v", err)
 	assert.ErrorContains(t, err, NetworkNotReadyErrorMsg)
 
 	// Pod's MTPNC is not ready test
-	_, err = middleware.getIPConfig(context.TODO(), testPod4Info)
+	_, _, err = middleware.getIPConfig(context.TODO(), testPod4Info)
 	assert.Assert(t, errors.Is(err, errMTPNCNotReady), "expected error to wrap errMTPNCNotReady, got: %v", err)
 	assert.ErrorContains(t, err, NetworkNotReadyErrorMsg)
 }
@@ -449,7 +490,7 @@ func TestNICTypeConfigSuccess(t *testing.T) {
 	middleware := K8sSWIFTv2Middleware{Cli: mock.NewClient()}
 
 	// Test Backend NIC type
-	ipInfos, err := middleware.getIPConfig(context.TODO(), testPod6Info)
+	ipInfos, _, err := middleware.getIPConfig(context.TODO(), testPod6Info)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -462,11 +503,11 @@ func TestGetSWIFTv2IPConfigMultiInterfaceFailure(t *testing.T) {
 	middleware := K8sSWIFTv2Middleware{Cli: mock.NewClient()}
 
 	// Pod's MTPNC doesn't exist in cache test
-	_, err := middleware.getIPConfig(context.TODO(), testPod3Info)
+	_, _, err := middleware.getIPConfig(context.TODO(), testPod3Info)
 	assert.ErrorContains(t, err, mock.ErrMTPNCNotFound.Error())
 
 	// Pod's MTPNC is not ready test
-	_, err = middleware.getIPConfig(context.TODO(), testPod4Info)
+	_, _, err = middleware.getIPConfig(context.TODO(), testPod4Info)
 	assert.Error(t, err, errMTPNCNotReady.Error())
 }
 
@@ -477,7 +518,7 @@ func TestGetSWIFTv2IPConfigMultiInterfaceSuccess(t *testing.T) {
 
 	middleware := K8sSWIFTv2Middleware{Cli: mock.NewClient()}
 
-	ipInfos, err := middleware.getIPConfig(context.TODO(), testPod7Info)
+	ipInfos, _, err := middleware.getIPConfig(context.TODO(), testPod7Info)
 	assert.Equal(t, err, nil)
 	// Ensure that the length of ipInfos matches the number of InterfaceInfos
 	// Adjust this according to the test setup in mock client

--- a/cns/middlewares/k8sSwiftV2_linux_test.go
+++ b/cns/middlewares/k8sSwiftV2_linux_test.go
@@ -96,7 +96,7 @@ func TestIPConfigsRequestHandlerWrapperSuccess(t *testing.T) {
 	assert.Equal(t, err, nil)
 	assert.Equal(t, resp.PodIPInfo[2].PodIPConfig.IPAddress, "192.168.0.1")
 	assert.Equal(t, resp.PodIPInfo[2].MacAddress, "00:00:00:00:00:00")
-	assert.Equal(t, resp.SkipDefaultRouteProgramming, false)
+	assert.Equal(t, resp.PodConfigurations.SkipDefaultRouteProgramming, false)
 }
 
 func TestIPConfigsRequestHandlerWrapperScheduledWithDRA(t *testing.T) {
@@ -133,7 +133,7 @@ func TestIPConfigsRequestHandlerWrapperScheduledWithDRA(t *testing.T) {
 	assert.Equal(t, len(resp.PodIPInfo), 1)
 	assert.Equal(t, resp.PodIPInfo[0].NICType, cns.InfraNIC)
 	assert.Equal(t, resp.PodIPInfo[0].SkipDefaultRoutes, true)
-	assert.Equal(t, resp.SkipDefaultRouteProgramming, true)
+	assert.Equal(t, resp.PodConfigurations.SkipDefaultRouteProgramming, true)
 }
 
 func TestIPConfigsRequestHandlerWrapperFailure(t *testing.T) {
@@ -280,25 +280,25 @@ func TestGetSWIFTv2IPConfigSuccess(t *testing.T) {
 
 	middleware := K8sSWIFTv2Middleware{Cli: mock.NewClient()}
 
-	ipInfos, scheduledWithDRA, err := middleware.getIPConfig(context.TODO(), testPod1Info)
+	result, err := middleware.getIPConfig(context.TODO(), testPod1Info)
 	assert.Equal(t, err, nil)
-	assert.Equal(t, scheduledWithDRA, false)
+	assert.Equal(t, result.podConfigurations.SkipDefaultRouteProgramming, false)
 	// Ensure that the length of ipInfos matches the number of InterfaceInfos
 	// Adjust this according to the test setup
-	assert.Equal(t, len(ipInfos), 1)
-	assert.Equal(t, ipInfos[0].NICType, cns.DelegatedVMNIC)
-	assert.Equal(t, ipInfos[0].SkipDefaultRoutes, false)
+	assert.Equal(t, len(result.podIPInfos), 1)
+	assert.Equal(t, result.podIPInfos[0].NICType, cns.DelegatedVMNIC)
+	assert.Equal(t, result.podIPInfos[0].SkipDefaultRoutes, false)
 }
 
 func TestGetSWIFTv2IPConfigSharedNIC(t *testing.T) {
 	middleware := K8sSWIFTv2Middleware{Cli: mock.NewClient()}
 
-	ipInfos, scheduledWithDRA, err := middleware.getIPConfig(context.TODO(), testPod11Info)
+	result, err := middleware.getIPConfig(context.TODO(), testPod11Info)
 	assert.Equal(t, err, nil)
-	assert.Equal(t, scheduledWithDRA, false)
-	assert.Equal(t, len(ipInfos), 1)
-	assert.Equal(t, ipInfos[0].NICType, cns.DelegatedVMNIC)
-	assert.Equal(t, ipInfos[0].SharedNIC, true)
+	assert.Equal(t, result.podConfigurations.SkipDefaultRouteProgramming, false)
+	assert.Equal(t, len(result.podIPInfos), 1)
+	assert.Equal(t, result.podIPInfos[0].NICType, cns.DelegatedVMNIC)
+	assert.Equal(t, result.podIPInfos[0].SharedNIC, true)
 }
 
 func TestGetSWIFTv2IPConfigScheduledWithDRA(t *testing.T) {
@@ -306,22 +306,32 @@ func TestGetSWIFTv2IPConfigScheduledWithDRA(t *testing.T) {
 
 	// When the pod is scheduled with DRA, dranet owns the delegated NIC, so CNS
 	// must not return its IP config to the CNI caller.
-	ipInfos, scheduledWithDRA, err := middleware.getIPConfig(context.TODO(), testPod12Info)
+	result, err := middleware.getIPConfig(context.TODO(), testPod12Info)
 	assert.Equal(t, err, nil)
-	assert.Equal(t, len(ipInfos), 0)
-	assert.Equal(t, scheduledWithDRA, true)
+	assert.Equal(t, len(result.podIPInfos), 0)
+	assert.Equal(t, result.podConfigurations.SkipDefaultRouteProgramming, true)
+}
+
+func TestGetSwiftV2IPConfigForDRANET(t *testing.T) {
+	middleware := K8sSWIFTv2Middleware{Cli: mock.NewClient()}
+
+	result, err := middleware.getSwiftV2IpConfigHelper(context.TODO(), testPod12Info, true)
+
+	assert.NilError(t, err)
+	assert.Equal(t, len(result.podIPInfos), 1)
+	assert.Equal(t, result.podConfigurations.SkipDefaultRouteProgramming, false)
 }
 
 func TestGetSWIFTv2IPConfigFailure(t *testing.T) {
 	middleware := K8sSWIFTv2Middleware{Cli: mock.NewClient()}
 
 	// Pod's MTPNC doesn't exist in cache test
-	_, _, err := middleware.getIPConfig(context.TODO(), testPod3Info)
+	_, err := middleware.getIPConfig(context.TODO(), testPod3Info)
 	assert.Assert(t, strings.Contains(err.Error(), errGetMTPNC.Error()), "expected error to wrap errMTPNCNotFound, got: %v", err)
 	assert.ErrorContains(t, err, NetworkNotReadyErrorMsg)
 
 	// Pod's MTPNC is not ready test
-	_, _, err = middleware.getIPConfig(context.TODO(), testPod4Info)
+	_, err = middleware.getIPConfig(context.TODO(), testPod4Info)
 	assert.Assert(t, errors.Is(err, errMTPNCNotReady), "expected error to wrap errMTPNCNotReady, got: %v", err)
 	assert.ErrorContains(t, err, NetworkNotReadyErrorMsg)
 }
@@ -490,12 +500,12 @@ func TestNICTypeConfigSuccess(t *testing.T) {
 	middleware := K8sSWIFTv2Middleware{Cli: mock.NewClient()}
 
 	// Test Backend NIC type
-	ipInfos, _, err := middleware.getIPConfig(context.TODO(), testPod6Info)
+	result, err := middleware.getIPConfig(context.TODO(), testPod6Info)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(ipInfos) != 0 {
-		t.Fatalf("expected 0 ipInfo, got %d", len(ipInfos))
+	if len(result.podIPInfos) != 0 {
+		t.Fatalf("expected 0 ipInfo, got %d", len(result.podIPInfos))
 	}
 }
 
@@ -503,11 +513,11 @@ func TestGetSWIFTv2IPConfigMultiInterfaceFailure(t *testing.T) {
 	middleware := K8sSWIFTv2Middleware{Cli: mock.NewClient()}
 
 	// Pod's MTPNC doesn't exist in cache test
-	_, _, err := middleware.getIPConfig(context.TODO(), testPod3Info)
+	_, err := middleware.getIPConfig(context.TODO(), testPod3Info)
 	assert.ErrorContains(t, err, mock.ErrMTPNCNotFound.Error())
 
 	// Pod's MTPNC is not ready test
-	_, _, err = middleware.getIPConfig(context.TODO(), testPod4Info)
+	_, err = middleware.getIPConfig(context.TODO(), testPod4Info)
 	assert.Error(t, err, errMTPNCNotReady.Error())
 }
 
@@ -518,14 +528,14 @@ func TestGetSWIFTv2IPConfigMultiInterfaceSuccess(t *testing.T) {
 
 	middleware := K8sSWIFTv2Middleware{Cli: mock.NewClient()}
 
-	ipInfos, _, err := middleware.getIPConfig(context.TODO(), testPod7Info)
+	result, err := middleware.getIPConfig(context.TODO(), testPod7Info)
 	assert.Equal(t, err, nil)
 	// Ensure that the length of ipInfos matches the number of InterfaceInfos
 	// Adjust this according to the test setup in mock client
 	expectedInterfaceCount := 2
-	assert.Equal(t, len(ipInfos), expectedInterfaceCount)
+	assert.Equal(t, len(result.podIPInfos), expectedInterfaceCount)
 
-	for _, ipInfo := range ipInfos {
+	for _, ipInfo := range result.podIPInfos {
 		switch ipInfo.NICType {
 		case cns.DelegatedVMNIC:
 			assert.Equal(t, ipInfo.NICType, cns.DelegatedVMNIC)

--- a/cns/middlewares/k8sSwiftV2_windows.go
+++ b/cns/middlewares/k8sSwiftV2_windows.go
@@ -200,7 +200,7 @@ func (k *K8sSWIFTv2Middleware) IPConfigsRequestHandlerWrapper(defaultHandler, fa
 		if err != nil {
 			return ipConfigsResp, err
 		}
-		SWIFTv2PodIPInfos, err := k.getIPConfig(ctx, podInfo)
+		SWIFTv2PodIPInfos, scheduledWithDRA, err := k.getIPConfig(ctx, podInfo)
 		if err != nil {
 			return &cns.IPConfigsResponse{
 				Response: cns.Response{
@@ -228,6 +228,7 @@ func (k *K8sSWIFTv2Middleware) IPConfigsRequestHandlerWrapper(defaultHandler, fa
 				}
 			}
 		}
+		ipConfigsResp.SkipDefaultRouteProgramming = scheduledWithDRA
 		return ipConfigsResp, nil
 	}
 }

--- a/cns/middlewares/k8sSwiftV2_windows.go
+++ b/cns/middlewares/k8sSwiftV2_windows.go
@@ -200,7 +200,7 @@ func (k *K8sSWIFTv2Middleware) IPConfigsRequestHandlerWrapper(defaultHandler, fa
 		if err != nil {
 			return ipConfigsResp, err
 		}
-		SWIFTv2PodIPInfos, scheduledWithDRA, err := k.getIPConfig(ctx, podInfo)
+		ipConfigResult, err := k.getIPConfig(ctx, podInfo)
 		if err != nil {
 			return &cns.IPConfigsResponse{
 				Response: cns.Response{
@@ -210,7 +210,7 @@ func (k *K8sSWIFTv2Middleware) IPConfigsRequestHandlerWrapper(defaultHandler, fa
 				PodIPInfo: []cns.PodIpInfo{},
 			}, errors.Wrapf(err, "failed to get SWIFTv2 IP config : %v", req)
 		}
-		ipConfigsResp.PodIPInfo = append(ipConfigsResp.PodIPInfo, SWIFTv2PodIPInfos...)
+		ipConfigsResp.PodIPInfo = append(ipConfigsResp.PodIPInfo, ipConfigResult.podIPInfos...)
 		// Set routes for the pod
 		for i := range ipConfigsResp.PodIPInfo {
 			ipInfo := &ipConfigsResp.PodIPInfo[i]
@@ -228,7 +228,7 @@ func (k *K8sSWIFTv2Middleware) IPConfigsRequestHandlerWrapper(defaultHandler, fa
 				}
 			}
 		}
-		ipConfigsResp.SkipDefaultRouteProgramming = scheduledWithDRA
+		ipConfigsResp.PodConfigurations = ipConfigResult.podConfigurations
 		return ipConfigsResp, nil
 	}
 }

--- a/cns/middlewares/k8sSwiftV2_windows_test.go
+++ b/cns/middlewares/k8sSwiftV2_windows_test.go
@@ -66,7 +66,23 @@ func TestIPConfigsRequestHandlerWrapperScheduledWithDRA(t *testing.T) {
 	require.Len(t, resp.PodIPInfo, 1)
 	require.Equal(t, cns.InfraNIC, resp.PodIPInfo[0].NICType)
 	require.True(t, resp.PodIPInfo[0].SkipDefaultRoutes)
-	require.True(t, resp.SkipDefaultRouteProgramming)
+	require.True(t, resp.PodConfigurations.SkipDefaultRouteProgramming)
+}
+
+func TestGetSwiftV2IPConfigForDRANET(t *testing.T) {
+	middleware := K8sSWIFTv2Middleware{Cli: mock.NewClient()}
+	podInfo := cns.NewPodInfo(
+		"5006cad4-eth0",
+		"5006cad4-e54d-472e-863d-c4bac66200a7",
+		"testpod12",
+		"testpod12namespace",
+	)
+
+	result, err := middleware.getSwiftV2IpConfigHelper(context.TODO(), podInfo, true)
+
+	require.NoError(t, err)
+	require.Len(t, result.podIPInfos, 1)
+	require.False(t, result.podConfigurations.SkipDefaultRouteProgramming)
 }
 
 func TestSetRoutesSuccess(t *testing.T) {

--- a/cns/middlewares/k8sSwiftV2_windows_test.go
+++ b/cns/middlewares/k8sSwiftV2_windows_test.go
@@ -1,6 +1,7 @@
 package middlewares
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -23,6 +24,49 @@ import (
 func TestMain(m *testing.M) {
 	logger.InitLogger("testlogs", 0, 0, "./")
 	os.Exit(m.Run())
+}
+
+func TestIPConfigsRequestHandlerWrapperScheduledWithDRA(t *testing.T) {
+	middleware := K8sSWIFTv2Middleware{Cli: mock.NewClient()}
+	t.Setenv(configuration.EnvPodCIDRs, "10.0.1.0/24")
+	t.Setenv(configuration.EnvServiceCIDRs, "10.0.0.0/16")
+	t.Setenv(configuration.EnvInfraVNETCIDRs, "10.240.0.0/16")
+
+	defaultHandler := func(context.Context, cns.IPConfigsRequest) (*cns.IPConfigsResponse, error) {
+		return &cns.IPConfigsResponse{
+			PodIPInfo: []cns.PodIpInfo{
+				{
+					PodIPConfig: cns.IPSubnet{
+						IPAddress:    "10.0.1.10",
+						PrefixLength: 32,
+					},
+					NICType: cns.InfraNIC,
+				},
+			},
+		}, nil
+	}
+	failureHandler := func(context.Context, cns.IPConfigsRequest) (*cns.IPConfigsResponse, error) {
+		return nil, nil
+	}
+	podInfo := cns.NewPodInfo(
+		"5006cad4-eth0",
+		"5006cad4-e54d-472e-863d-c4bac66200a7",
+		"testpod12",
+		"testpod12namespace",
+	)
+	req := cns.IPConfigsRequest{
+		PodInterfaceID:   podInfo.InterfaceID(),
+		InfraContainerID: podInfo.InfraContainerID(),
+	}
+	req.OrchestratorContext, _ = podInfo.OrchestratorContext()
+
+	resp, err := middleware.IPConfigsRequestHandlerWrapper(defaultHandler, failureHandler)(context.TODO(), req)
+
+	require.NoError(t, err)
+	require.Len(t, resp.PodIPInfo, 1)
+	require.Equal(t, cns.InfraNIC, resp.PodIPInfo[0].NICType)
+	require.True(t, resp.PodIPInfo[0].SkipDefaultRoutes)
+	require.True(t, resp.SkipDefaultRouteProgramming)
 }
 
 func TestSetRoutesSuccess(t *testing.T) {

--- a/cns/middlewares/mock/mockClient.go
+++ b/cns/middlewares/mock/mockClient.go
@@ -200,11 +200,12 @@ func NewClient() *Client {
 		Status: v1alpha1.MultitenantPodNetworkConfigStatus{
 			InterfaceInfos: []v1alpha1.InterfaceInfo{
 				{
-					PrimaryIP:  "192.168.12.1/32",
-					MacAddress: "00:00:00:00:00:12",
-					GatewayIP:  "10.0.0.1",
-					NCID:       "testncid12",
-					DeviceType: v1alpha1.DeviceTypeVnetNIC,
+					PrimaryIP:          "192.168.12.1/32",
+					MacAddress:         "00:00:00:00:00:12",
+					GatewayIP:          "10.0.0.1",
+					NCID:               "testncid12",
+					DeviceType:         v1alpha1.DeviceTypeVnetNIC,
+					SubnetAddressSpace: "192.168.12.0/24",
 				},
 			},
 		},

--- a/cns/middlewares/mock/mockClient.go
+++ b/cns/middlewares/mock/mockClient.go
@@ -67,6 +67,10 @@ func NewClient() *Client {
 	testPod10.Labels = make(map[string]string)
 	testPod10.Labels[configuration.LabelPodNetworkInstanceSwiftV2] = podNetwork
 
+	testPod12 := v1.Pod{}
+	testPod12.Labels = make(map[string]string)
+	testPod12.Labels[configuration.LabelPodSwiftV2] = podNetwork
+
 	testPodMtpncTerminating := v1.Pod{}
 	testPodMtpncTerminating.Labels = make(map[string]string)
 	testPodMtpncTerminating.Labels[configuration.LabelPodSwiftV2] = podNetwork
@@ -225,6 +229,7 @@ func NewClient() *Client {
 			"testpod8namespace/testpod8":                               &testPod8,
 			"testpod9namespace/testpod9":                               &testPod9,
 			"testpod10namespace/testpod10":                             &testPod10,
+			"testpod12namespace/testpod12":                             &testPod12,
 			"testpodMtpncTerminatingnamespace/testpodMtpncTerminating": &testPodMtpncTerminating,
 		},
 		mtpncCache: map[string]*v1alpha1.MultitenantPodNetworkConfig{


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->
fix: skip default route validation/programming in CNI for DRANET pods

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
when a pod is created via DRANET the goal state is not propagated to CNI. But the InfraNIC has SkipDefaultRoute = true because default routes are still programmed on the delegated NICs via NRI (DRANET). CNI fails a validation as it sees no NIC with a default route and its worldview does not account for the fact that there are other components that would program routes. Setting a property which tells CNI that it should expect no NICs with SkipDefaultRoute = false and consequentially it shall not program default routes on any NICs

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] relevant PR labels added

**Notes**:
