### PR TITLE
cns: emit JSON from getInMemory debug CLI command

### DIFF
--- a/cns/cmd/cli/cli.go
+++ b/cns/cmd/cli/cli.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"sort"
@@ -90,12 +91,20 @@ func getPodCmd(ctx context.Context, client *client.Client) error {
 	return nil
 }
 
+// getInMemory prints CNS's in-memory HTTPRestServiceData as JSON, matching the
+// shape returned by the /debug/restdata HTTP endpoint. Callers (e.g. pipeline
+// health checks) that previously curled /debug/restdata can invoke this
+// command instead so they don't depend on curl/wget being present in the
+// container image.
 func getInMemory(ctx context.Context, client *client.Client) error {
 	data, err := client.GetHTTPServiceData(ctx)
 	if err != nil {
 		return err
 	}
-	fmt.Printf("PodIPIDByOrchestratorContext: %v\nPodIPConfigState: %v\n",
-		data.HTTPRestServiceData.PodIPIDByPodInterfaceKey, data.HTTPRestServiceData.PodIPConfigState)
+	out, err := json.Marshal(data.HTTPRestServiceData)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(out))
 	return nil
 }


### PR DESCRIPTION
## Description

`azure-cns -cmd getInMemory` (the debug CLI entrypoint used by the Singularity Runner pipeline pre-test-cleanup script to query `/debug/restdata` in-process) currently formats its output with Go's default `%v` verb, producing Go-struct-syntax text rather than JSON.

This silently broke the Singularity Runner pipeline's `pre-test-cleanup.sh` free-NIC verification, which historically shelled out to `curl localhost:10090/debug/restdata` on Linux — except the CNS Linux container image has **never** shipped curl (distroless-family base since 2025-06-12), so that check has been silently no-op'ing since it was introduced (2026-08-04) until it was flipped fail-closed on 2026-08-19, at which point it started hard-failing every LinuxAcc scheduled build.

## Fix

Changes `getInMemory()` in `cns/cmd/cli/cli.go` to `json.Marshal(data.HTTPRestServiceData)` instead of `%v`-formatted output. This matches the exact JSON shape already produced by the `/debug/restdata` HTTP handler (`HandleDebugRestData`), which uses the same `HTTPRestServiceData` struct — so no downstream `json.load`/grep parsing needs to change.

Companion fix in `Networking-Aquarius` (`pre-test-cleanup.sh`) replaces the curl/Invoke-WebRequest calls with `azure-cns -cmd getInMemory`, removing the external-tool dependency entirely (works identically on Linux and Windows CNS binaries, zero new dependencies).

## Testing

- `go build ./cns/...` — passes
- `go vet ./cns/...` — passes
- No existing unit tests cover this CLI command; verified live against `azure-cns-unmanaged-*` pods on `sing-winacc-persistent-centraluseuap` that the JSON output round-trips through `json.load` correctly.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>