### PR TITLE
test: enable service traffic policy e2e tests

### DIFF
--- a/.pipelines/cni/k8s-e2e/k8s-e2e-job-template.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e-job-template.yaml
@@ -146,3 +146,4 @@ jobs:
               os: ${{ parameters.os }}
               processes: 8
               attempts: 3
+

--- a/.pipelines/cni/k8s-e2e/k8s-e2e-job-template.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e-job-template.yaml
@@ -74,6 +74,7 @@ jobs:
               os: ${{ parameters.os }}
               processes: 8
               attempts: 3
+
       - ${{ if eq(parameters.portforward, true) }}:
           - template: ../k8s-e2e/k8s-e2e-step-template.yaml
             parameters:
@@ -89,7 +90,7 @@ jobs:
             parameters:
               testName: Service Conformance
               name: service
-              ginkgoFocus: 'Services.*\[Conformance\].*'
+              ginkgoFocus: 'Services.*(\[Conformance\]|internalTrafficPolicy|externalTrafficPolicy).*'
               ginkgoSkip: ""
               os: ${{ parameters.os }}
               processes: 8
@@ -99,7 +100,7 @@ jobs:
             parameters:
               testName: Service Conformance|Cilium
               name: service
-              ginkgoFocus: 'Services.*\[Conformance\].*'
+              ginkgoFocus: 'Services.*(\[Conformance\]|internalTrafficPolicy|externalTrafficPolicy).*'
               ginkgoSkip: "should serve endpoints on same port and different protocols" # Cilium does not support this feature. For more info on test: https://github.com/kubernetes/kubernetes/blame/e602e9e03cd744c23dde9fee09396812dd7bdd93/test/conformance/testdata/conformance.yaml#L1780-L1788
               os: ${{ parameters.os }}
               processes: 8
@@ -146,4 +147,3 @@ jobs:
               os: ${{ parameters.os }}
               processes: 8
               attempts: 3
-

--- a/.pipelines/cni/k8s-e2e/k8s-e2e-job-template.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e-job-template.yaml
@@ -74,7 +74,6 @@ jobs:
               os: ${{ parameters.os }}
               processes: 8
               attempts: 3
-
       - ${{ if eq(parameters.portforward, true) }}:
           - template: ../k8s-e2e/k8s-e2e-step-template.yaml
             parameters:

--- a/.pipelines/cni/k8s-e2e/k8s-e2e.jobs.yaml
+++ b/.pipelines/cni/k8s-e2e/k8s-e2e.jobs.yaml
@@ -92,7 +92,7 @@ jobs:
             parameters:
               testName: Service Conformance
               name: service
-              ginkgoFocus: 'Services.*\[Conformance\].*'
+              ginkgoFocus: 'Services.*(\[Conformance\]|internalTrafficPolicy|externalTrafficPolicy).*'
               ginkgoSkip: ""
               os: ${{ parameters.os }}
               processes: 8
@@ -102,7 +102,7 @@ jobs:
             parameters:
               testName: Service Conformance|Cilium
               name: service
-              ginkgoFocus: 'Services.*\[Conformance\].*'
+              ginkgoFocus: 'Services.*(\[Conformance\]|internalTrafficPolicy|externalTrafficPolicy).*'
               ginkgoSkip: "should serve endpoints on same port and different protocols" # Cilium does not support this feature. For more info on test: https://github.com/kubernetes/kubernetes/blame/e602e9e03cd744c23dde9fee09396812dd7bdd93/test/conformance/testdata/conformance.yaml#L1780-L1788
               os: ${{ parameters.os }}
               processes: 8


### PR DESCRIPTION
## Summary
- include upstream Kubernetes Services tests for `internalTrafficPolicy` and `externalTrafficPolicy` in the existing service test focus
- apply the selector to both ACN and Cilium service validation templates
- preserve the existing Kubernetes Service `[Conformance]` coverage and Cilium-specific skip

This follows the test approach from azure-networking/cilium-private#1137 by running the upstream `test/e2e` Service traffic-policy scenarios.

## Validation
- parsed both modified Azure Pipelines YAML templates
- verified the focus expression matches ITP, ETP, and existing Service conformance test names