### PR TITLE
ci: modernize LSG kernel validation pipeline

### DIFF
--- a/.pipelines/cni/lsg/lsg-cni-integration-template.yaml
+++ b/.pipelines/cni/lsg/lsg-cni-integration-template.yaml
@@ -7,54 +7,129 @@ parameters:
   vmSize: ""
   os: linux
   arch: ""
-  osSKU: Ubuntu
+  region: ""
+  networkType: ""
+  installFlag: ""
 
 stages:
   - stage: create_${{ parameters.name }}
     variables:
       commitID: $[ stagedependencies.setup.env.outputs['SetEnvVars.commitID'] ]
+      cnsVersion: $[ stagedependencies.setup.env.outputs['SetEnvVars.cnsVersion'] ]
+      cniVersion: $[ stagedependencies.setup.env.outputs['SetEnvVars.cniVersion'] ]
+      ipamVersion: $[ stagedependencies.setup.env.outputs['SetEnvVars.ipamVersion'] ]
+      ciliumVersion: $[ stagedependencies.setup.env.outputs['SetEnvVars.ciliumVersion'] ]
+      resolvedDistro: $[ stagedependencies.setup.env.outputs['SetEnvVars.resolvedDistro'] ]
+      osSKU: $[ stagedependencies.setup.env.outputs['SetEnvVars.osSKU'] ]
+      CNS_IMAGE_NAME_OVERRIDE: azure-cns
+      IPAM_IMAGE_NAME_OVERRIDE: azure-ipam
+      CNI_IMAGE_NAME_OVERRIDE: azure-cni
     pool:
       name: $(BUILD_POOL_NAME_DEFAULT)
     dependsOn:
       - setup
-    displayName: "Create Cluster - ${{ parameters.clusterName }}"
+    displayName: "Create and Configure Cluster - ${{ parameters.clusterName }}"
     jobs:
-      - ${{ if not(contains(parameters.name, 'ds')) }}:
-        - job: create_aks_cluster_with_${{ parameters.name }}
-          steps:
-            - task: AzureCLI@2
-              inputs:
-                azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
-                scriptLocation: "inlineScript"
-                scriptType: "bash"
-                addSpnToEnvironment: true
-                inlineScript: |
-                  make -C ./hack/aks azcfg AZCLI=az REGION=$(LOCATION)
-                  make -C ./hack/aks ${{ parameters.clusterType }} \
-                  AZCLI=az REGION=$(LOCATION) SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) \
-                  CLUSTER=${{ parameters.clusterName }}-$(commitID) \
-                  VM_SIZE=${{ parameters.vmSize }} \
-                  AUTOUPGRADE=none
-              name: "CreateAksCluster"
-              displayName: "Create AKS Cluster"
-      - ${{ else }}:
-        - job: create_aks_cluster_with_${{ parameters.name }}
-          steps:
-            - task: AzureCLI@2
-              inputs:
-                azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
-                scriptLocation: "inlineScript"
-                scriptType: "bash"
-                addSpnToEnvironment: true
-                inlineScript: |
-                  make -C ./hack/aks azcfg AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST)
-                  make -C ./hack/aks ${{ parameters.clusterType }} \
-                  AZCLI=az REGION=$(REGION_AKS_CLUSTER_TEST) SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) \
-                  CLUSTER=${{ parameters.clusterName }}-$(commitID) \
-                  VM_SIZE=${{ parameters.vmSize }} \
-                  AUTOUPGRADE=none
-              name: "CreateAksDSCluster"
-              displayName: "Create AKS Dualstack Cluster"
+      - job: create_aks_cluster_with_${{ parameters.name }}
+        steps:
+          - task: AzureCLI@2
+            inputs:
+              azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
+              scriptLocation: "inlineScript"
+              scriptType: "bash"
+              addSpnToEnvironment: true
+              inlineScript: |
+                set -euo pipefail
+
+                REGION="${{ parameters.region }}"
+                CLUSTER="${{ parameters.clusterName }}-$(commitID)"
+                K8S_VERSION=$(az aks get-versions --location "$REGION" --output json |
+                  jq -r '[
+                    .values[]
+                    | select(.isPreview != true)
+                    | select((.capabilities.supportPlan // []) | index("KubernetesOfficial"))
+                    | .patchVersions
+                    | keys[]
+                  ] | sort_by(split(".") | map(tonumber)) | last')
+                if [ -z "$K8S_VERSION" ] || [ "$K8S_VERSION" = "null" ]; then
+                  echo "No GA KubernetesOfficial version is available in $REGION"
+                  exit 1
+                fi
+
+                echo "Creating $CLUSTER with Kubernetes $K8S_VERSION and OS SKU $(osSKU)"
+                make -C ./hack/aks azcfg AZCLI=az REGION="$REGION"
+                make -C ./hack/aks ${{ parameters.clusterType }} \
+                  AZCLI=az REGION="$REGION" SUB=$(SUB_AZURE_NETWORK_AGENT_BUILD_VALIDATIONS) \
+                  CLUSTER="$CLUSTER" NODE_COUNT=${{ parameters.nodeCount }} \
+                  VM_SIZE=${{ parameters.vmSize }} AUTOUPGRADE=none LTS=false \
+                  K8S_VER="$K8S_VERSION" OS_SKU=$(osSKU)
+                make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER="$CLUSTER"
+
+                POOL_NAME=$(az aks nodepool list --resource-group "$CLUSTER" --cluster-name "$CLUSTER" --query '[0].name' -o tsv)
+                POOL_JSON=$(az aks nodepool show --resource-group "$CLUSTER" --cluster-name "$CLUSTER" --name "$POOL_NAME" -o json)
+                ACTUAL_OS_SKU=$(jq -r '.osSku // .properties.osSKU // empty' <<< "$POOL_JSON")
+                ACTUAL_K8S_VERSION=$(jq -r '.orchestratorVersion // .properties.orchestratorVersion // empty' <<< "$POOL_JSON")
+                NODE_IMAGE_VERSION=$(jq -r '.nodeImageVersion // .properties.nodeImageVersion // empty' <<< "$POOL_JSON")
+                if [ -z "$ACTUAL_OS_SKU" ] || [ -z "$ACTUAL_K8S_VERSION" ]; then
+                  echo "Failed to read nodepool OS SKU / Kubernetes version from az aks nodepool show output"
+                  exit 1
+                fi
+                NODE_OS_IMAGES=$(kubectl get nodes -o jsonpath='{range .items[*]}{.status.nodeInfo.osImage}{"\n"}{end}')
+
+                echo "Requested distro: $(resolvedDistro)"
+                echo "Actual OS SKU: $ACTUAL_OS_SKU"
+                echo "Actual Kubernetes version: $ACTUAL_K8S_VERSION"
+                echo "Node image version: $NODE_IMAGE_VERSION"
+                echo "Node OS images:"
+                echo "$NODE_OS_IMAGES"
+
+                [ "$ACTUAL_OS_SKU" = "$(osSKU)" ] || {
+                  echo "Expected OS SKU $(osSKU), got $ACTUAL_OS_SKU"
+                  exit 1
+                }
+                [ "$ACTUAL_K8S_VERSION" = "$K8S_VERSION" ] || {
+                  echo "Expected Kubernetes $K8S_VERSION, got $ACTUAL_K8S_VERSION"
+                  exit 1
+                }
+                [ -n "$NODE_OS_IMAGES" ] || {
+                  echo "AKS returned no nodes to validate"
+                  exit 1
+                }
+                case "$(resolvedDistro)" in
+                  jammy)
+                    EXPECTED_OS_IMAGE="Ubuntu 22.04"
+                    ;;
+                  noble)
+                    EXPECTED_OS_IMAGE="Ubuntu 24.04"
+                    ;;
+                esac
+                if grep -Fqv "$EXPECTED_OS_IMAGE" <<< "$NODE_OS_IMAGES"; then
+                  echo "Expected every node to use $EXPECTED_OS_IMAGE"
+                  exit 1
+                fi
+            name: "CreateAksCluster"
+            displayName: "Create and verify AKS cluster"
+
+          - template: ../../templates/network-install.yaml
+            parameters:
+              clusterName: ${{ parameters.clusterName }}-$(commitID)
+              networkType: ${{ parameters.networkType }}
+              azureIpamVersion: $(ipamVersion)
+              cnsVersion: $(cnsVersion)
+              cniVersion: $(cniVersion)
+              installFlag: ${{ parameters.installFlag }}
+              ciliumVersionTag: $(ciliumVersion)
+              ciliumImageRegistry: $(CILIUM_IMAGE_REGISTRY)
+              useMakefileLogCollectorDefaults: true
+
+          - template: verify-network-images.yaml
+            parameters:
+              networkType: ${{ parameters.networkType }}
+              cnsVersion: $(cnsVersion)
+              cniVersion: $(cniVersion)
+              azureIpamVersion: $(ipamVersion)
+              ciliumVersionTag: $(ciliumVersion)
+              ciliumImageRegistry: $(CILIUM_IMAGE_REGISTRY)
 
   - stage: ${{ parameters.name }}
     variables:
@@ -70,82 +145,8 @@ stages:
       - setup
     displayName: "CNIv2 Test - ${{ parameters.name }}"
     jobs:
-      - ${{ if contains(parameters.name, 'linux') }}:
-        - job: integration
-          displayName: "Integration Test - ${{ parameters.name }}"
-          steps:
-            - task: AzureCLI@2
-              inputs:
-                azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
-                scriptLocation: "inlineScript"
-                scriptType: "bash"
-                addSpnToEnvironment: true
-                inlineScript: |
-                  echo cns version - $(cnsVersion)
-                  echo cni version - $(cniVersion)
-
-                  echo "Start Integration Tests on Overlay Cluster"
-                  make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(commitID)
-                  kubectl cluster-info
-                  kubectl get po -owide -A
-                  if [[ ${{ parameters.clusterType }} =~ "dualstack-overlay-byocni-up" ]]; then
-                    echo "Installing Azure CNI Dualstack Overlay"
-                    sudo -E env "PATH=$PATH" make test-load CNS_ONLY=true INSTALL_CNS=true INSTALL_DUALSTACK_OVERLAY=true CNS_VERSION=$(cnsVersion) CNI_VERSION=$(cniVersion) CNS_IMAGE_REPO=$(CNS_IMAGE_REPO) CNI_IMAGE_REPO=$(CNI_IMAGE_REPO)
-                  else
-                    echo "Installing Azure CNI Overlay"
-                    sudo -E env "PATH=$PATH" make test-load CNS_ONLY=true INSTALL_CNS=true INSTALL_AZURE_CNI_OVERLAY=true CNS_VERSION=$(cnsVersion) CNI_VERSION=$(cniVersion) CNS_IMAGE_REPO=$(CNS_IMAGE_REPO) CNI_IMAGE_REPO=$(CNI_IMAGE_REPO)
-                  fi
-
-              name: "overlaye2e"
-              displayName: "Overlay Integration"
-              retryCountOnTaskFailure: 2
-      - ${{ if contains(parameters.name, 'cilium') }}:
-        - job: integration
-          displayName: "Deploy Cilium Components"
-          steps:
-            - task: AzureCLI@2
-              displayName: "Install Cilium, CNS, and ip-masq-agent"
-              retryCountOnTaskFailure: 2
-              inputs:
-                azureSubscription: $(BUILD_VALIDATIONS_SERVICE_CONNECTION)
-                scriptLocation: "inlineScript"
-                scriptType: "bash"
-                addSpnToEnvironment: true
-                inlineScript: |
-                  set -ex
-                  # aks-preview pinned: Azure/azure-cli-extensions#10101 (b9 checksum mismatch)
-                  make -C ./hack/aks azcfg AZCLI=az
-                  make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}-$(commitID)
-                  ls -lah
-                  pwd
-                  kubectl cluster-info
-                  kubectl get po -owide -A
-
-                  echo "install Cilium ${CILIUM_VERSION_TAG}"
-                  export DIR=$(echo ${CILIUM_VERSION_TAG#v} | cut -d. -f1,2)
-                  echo "installing files from ${DIR}"
-
-                  if [[ ${{ parameters.clusterType }} =~ "dualstack-byocni" ]]; then
-                    export DUALSTACK_PATH="-dualstack"
-                    echo "Installing Cilium Dualstack"
-                  fi
-
-                  echo "deploy Cilium ConfigMap"
-                  kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-config/cilium-config${DUALSTACK_PATH}.yaml
-
-                  # Passes Cilium image to daemonset and deployment
-                  kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-agent/files
-                  kubectl apply -f test/integration/manifests/cilium/v${DIR}/cilium-operator/files
-
-                  envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY},${IPV6_IMAGE_REGISTRY},${IPV6_HP_BPF_VERSION}' < test/integration/manifests/cilium/v${DIR}/cilium-agent/templates/daemonset${DUALSTACK_PATH}.yaml | kubectl apply -f -
-                  envsubst '${CILIUM_VERSION_TAG},${CILIUM_IMAGE_REGISTRY}' < test/integration/manifests/cilium/v${DIR}/cilium-operator/templates/deployment.yaml | kubectl apply -f -
-                  kubectl get po -owide -A
-                  echo "Deploy Azure-CNS"
-                  sudo -E env "PATH=$PATH" make test-load CNS_ONLY=true AZURE_IPAM_VERSION=$(ipamVersion) CNS_VERSION=$(cnsVersion) INSTALL_CNS=true INSTALL_OVERLAY=true CNS_IMAGE_REPO=$(CNS_IMAGE_REPO) IPAM_IMAGE_REPO=$(IPAM_IMAGE_REPO)
-                  kubectl get po -owide -A
       - job: kernel_upgrade
         displayName: "Kernel Node Upgrade"
-        dependsOn: integration
         steps:
           - template: kernel-upgrade-template.yaml
             parameters:
@@ -176,7 +177,7 @@ stages:
               clusterName: ${{ parameters.clusterName }}-$(commitID)
               os: ${{ parameters.os }}
               cni: ${{ parameters.cni }}
-              region: $(LOCATION)
+              region: ${{ parameters.region }}
           - template: ../load-test-templates/validate-state-template.yaml
             parameters:
               clusterName: ${{ parameters.clusterName }}-$(commitID)
@@ -267,7 +268,6 @@ stages:
       - job: failedE2ELogs
         displayName: "Failure Logs"
         dependsOn:
-          - integration
           - kernel_upgrade
           - deploy_pods
           - restart_nodes

--- a/.pipelines/cni/lsg/lsg-cni-integration-template.yaml
+++ b/.pipelines/cni/lsg/lsg-cni-integration-template.yaml
@@ -44,16 +44,18 @@ stages:
 
                 REGION="${{ parameters.region }}"
                 CLUSTER="${{ parameters.clusterName }}-$(commitID)"
+                K8S_MINOR=$(cut -d. -f1,2 <<< "$(K8S_VER)")
                 K8S_VERSION=$(az aks get-versions --location "$REGION" --output json |
-                  jq -r '[
+                  jq -r --arg minor "$K8S_MINOR" '[
                     .values[]
+                    | select(.version == $minor)
                     | select(.isPreview != true)
                     | select((.capabilities.supportPlan // []) | index("KubernetesOfficial"))
                     | .patchVersions
                     | keys[]
                   ] | sort_by(split(".") | map(tonumber)) | last')
                 if [ -z "$K8S_VERSION" ] || [ "$K8S_VERSION" = "null" ]; then
-                  echo "No GA KubernetesOfficial version is available in $REGION"
+                  echo "No GA KubernetesOfficial patch for Kubernetes $K8S_MINOR is available in $REGION"
                   exit 1
                 fi
 

--- a/.pipelines/cni/lsg/lsg-cni-integration-template.yaml
+++ b/.pipelines/cni/lsg/lsg-cni-integration-template.yaml
@@ -44,18 +44,16 @@ stages:
 
                 REGION="${{ parameters.region }}"
                 CLUSTER="${{ parameters.clusterName }}-$(commitID)"
-                K8S_MINOR=$(cut -d. -f1,2 <<< "$(K8S_VER)")
                 K8S_VERSION=$(az aks get-versions --location "$REGION" --output json |
-                  jq -r --arg minor "$K8S_MINOR" '[
+                  jq -r '[
                     .values[]
-                    | select(.version == $minor)
                     | select(.isPreview != true)
                     | select((.capabilities.supportPlan // []) | index("KubernetesOfficial"))
                     | .patchVersions
                     | keys[]
                   ] | sort_by(split(".") | map(tonumber)) | last')
                 if [ -z "$K8S_VERSION" ] || [ "$K8S_VERSION" = "null" ]; then
-                  echo "No GA KubernetesOfficial patch for Kubernetes $K8S_MINOR is available in $REGION"
+                  echo "No GA KubernetesOfficial version is available in $REGION"
                   exit 1
                 fi
 

--- a/.pipelines/cni/lsg/lsg-cni-integration-template.yaml
+++ b/.pipelines/cni/lsg/lsg-cni-integration-template.yaml
@@ -44,16 +44,12 @@ stages:
 
                 REGION="${{ parameters.region }}"
                 CLUSTER="${{ parameters.clusterName }}-$(commitID)"
-                K8S_VERSION=$(az aks get-versions --location "$REGION" --output json |
-                  jq -r '[
-                    .values[]
-                    | select(.isPreview != true)
-                    | select((.capabilities.supportPlan // []) | index("KubernetesOfficial"))
-                    | .patchVersions
-                    | keys[]
-                  ] | sort_by(split(".") | map(tonumber)) | last')
-                if [ -z "$K8S_VERSION" ] || [ "$K8S_VERSION" = "null" ]; then
-                  echo "No GA KubernetesOfficial version is available in $REGION"
+                if [ "${K8S_VER:-__use-default__}" = "__use-default__" ]; then
+                  unset K8S_VER
+                fi
+                K8S_VERSION=$(make -s -C ./hack/aks vars | sed -n 's/^K8S_VER=//p')
+                if [ -z "$K8S_VERSION" ]; then
+                  echo "Failed to resolve K8S_VER from hack/aks/Makefile"
                   exit 1
                 fi
 
@@ -88,10 +84,17 @@ stages:
                   echo "Expected OS SKU $(osSKU), got $ACTUAL_OS_SKU"
                   exit 1
                 }
-                [ "$ACTUAL_K8S_VERSION" = "$K8S_VERSION" ] || {
-                  echo "Expected Kubernetes $K8S_VERSION, got $ACTUAL_K8S_VERSION"
-                  exit 1
-                }
+                if [[ "$K8S_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+                  [[ "$ACTUAL_K8S_VERSION" == "$K8S_VERSION".* ]] || {
+                    echo "Expected Kubernetes $K8S_VERSION.x, got $ACTUAL_K8S_VERSION"
+                    exit 1
+                  }
+                else
+                  [ "$ACTUAL_K8S_VERSION" = "$K8S_VERSION" ] || {
+                    echo "Expected Kubernetes $K8S_VERSION, got $ACTUAL_K8S_VERSION"
+                    exit 1
+                  }
+                fi
                 [ -n "$NODE_OS_IMAGES" ] || {
                   echo "AKS returned no nodes to validate"
                   exit 1

--- a/.pipelines/cni/lsg/lsg-cni-integration-template.yaml
+++ b/.pipelines/cni/lsg/lsg-cni-integration-template.yaml
@@ -10,6 +10,7 @@ parameters:
   region: ""
   networkType: ""
   installFlag: ""
+  ciliumConnectivitySkipTests: '!pod-to-pod-encryption,!node-to-node-encryption,!check-log-errors,!no-unexpected-packet-drops,!to-fqdns'
 
 stages:
   - stage: create_${{ parameters.name }}
@@ -233,6 +234,8 @@ stages:
             name: "GetCluster"
             displayName: "Get AKS Cluster"
           - template: ../../templates/cilium-connectivity-tests.yaml
+            parameters:
+              skipTests: ${{ parameters.ciliumConnectivitySkipTests }}
       - ${{ if contains(parameters.cni, 'cilium') }}:
         - template: ../k8s-e2e/k8s-e2e-job-template.yaml
           parameters:

--- a/.pipelines/cni/lsg/pipeline.yaml
+++ b/.pipelines/cni/lsg/pipeline.yaml
@@ -20,27 +20,58 @@ stages:
           name: "$(BUILD_POOL_NAME_DEFAULT)"
         steps:
           - script: |
+              set -euo pipefail
+
               echo "Setting up environment"
               go version
               echo "##vso[task.setvariable variable=commitID;isOutput=true]$(echo $(make revision)-$(Build.BuildId))"
               echo "##vso[task.setvariable variable=cnsVersion;isOutput=true]$(CNS_VERSION)"
               echo "##vso[task.setvariable variable=cniVersion;isOutput=true]$(CNI_VERSION)"
               echo "##vso[task.setvariable variable=ipamVersion;isOutput=true]$(IPAM_VERSION)"
+              echo "##vso[task.setvariable variable=ciliumVersion;isOutput=true]$(CILIUM_VERSION_TAG)"
 
               echo "------"
               echo Queued by $(Build.QueuedBy)
               echo "Runtime Variables passed"
+              echo "DistroVersion : $(DistroVersion)"
               echo "KernelType : $(KernelType)"
               echo "KernelVersion : $(KernelVersion)"
               echo "ProposedRepoVersion : $(ProposedRepoVersion)"
+              echo "CNS_VERSION : $(CNS_VERSION)"
+              echo "IPAM_VERSION : $(IPAM_VERSION)"
+              echo "CILIUM_VERSION_TAG : $(CILIUM_VERSION_TAG)"
               echo "------"
+
+              DISTRO=$(echo "$(DistroVersion)" | tr '[:upper:]' '[:lower:]')
+              case "$DISTRO" in
+                jammy)
+                  OS_SKU=Ubuntu2204
+                  if [[ "$(KernelType)" == *"lts-24.04"* ]]; then
+                    echo "##vso[task.logissue type=warning]KernelType $(KernelType) is unusual for Jammy; trusting the LSG-provided tuple"
+                  fi
+                  ;;
+                noble)
+                  OS_SKU=Ubuntu2404
+                  if [[ "$(KernelVersion)" == *"~22.04"* ]]; then
+                    echo "##vso[task.logissue type=warning]KernelVersion $(KernelVersion) is unusual for Noble; trusting the LSG-provided tuple"
+                  fi
+                  ;;
+                *)
+                  echo "DistroVersion must be either jammy or noble, got: $(DistroVersion)"
+                  exit 1
+                  ;;
+              esac
+              echo "Resolved OS SKU : $OS_SKU"
+              echo "##vso[task.setvariable variable=resolvedDistro;isOutput=true]$DISTRO"
+              echo "##vso[task.setvariable variable=osSKU;isOutput=true]$OS_SKU"
+
               echo "KernelType Check"
               Kernel=$(KernelType)
-              if [ $Kernel = 'proposed-azure' ]; then
+              if [ "$Kernel" = 'proposed-azure' ]; then
                 echo "KernelType is $Kernel , change to linux-azure"
                 Kernel=linux-azure
               fi
-              if [ $Kernel = 'proposed-edge' ]; then
+              if [ "$Kernel" = 'proposed-edge' ]; then
                 echo "KernelType is $Kernel , change to linux-azure-edge"
                 Kernel=linux-azure-edge
               fi
@@ -59,6 +90,9 @@ stages:
       vmSize: Standard_B2ms
       arch: amd64
       cni: cniv2
+      region: $(LOCATION)
+      networkType: azure-cni-overlay
+      installFlag: INSTALL_AZURE_CNI_OVERLAY
 
   - template: lsg-cni-integration-template.yaml
     parameters:
@@ -69,6 +103,9 @@ stages:
       vmSize: Standard_B2ms
       arch: amd64
       cni: cilium
+      region: $(LOCATION)
+      networkType: cilium-overlay
+      installFlag: INSTALL_OVERLAY
 
   # Dualstack
   - template: lsg-cni-integration-template.yaml
@@ -80,6 +117,9 @@ stages:
       vmSize: Standard_B2ms
       arch: amd64
       cni: dualstack
+      region: $(REGION_AKS_CLUSTER_TEST)
+      networkType: azure-cni-dualstack-overlay
+      installFlag: INSTALL_DUALSTACK_OVERLAY
 
   - template: lsg-cni-integration-template.yaml
     parameters:
@@ -90,6 +130,9 @@ stages:
       vmSize: Standard_B2ms
       arch: amd64
       cni: cilium_dualstack
+      region: $(REGION_AKS_CLUSTER_TEST)
+      networkType: cilium-dualstack
+      installFlag: INSTALL_OVERLAY
 
   - stage: delete_resources
     displayName: "Delete Resources"

--- a/.pipelines/cni/lsg/pipeline.yaml
+++ b/.pipelines/cni/lsg/pipeline.yaml
@@ -133,6 +133,7 @@ stages:
       region: $(REGION_AKS_CLUSTER_TEST)
       networkType: cilium-dualstack
       installFlag: INSTALL_OVERLAY
+      ciliumConnectivitySkipTests: '!pod-to-pod-encryption,!node-to-node-encryption,!check-log-errors,!no-unexpected-packet-drops,!to-fqdns,!egress-to-specific-namespace-ccnp,!ingress-from-specific-namespace-ccnp,!client-egress-to-cidrgroup-deny,!client-egress-to-cidrgroup-deny-by-label,!host-firewall-egress,!host-firewall-ingress,!host-firewall-egress-to-fqdns'
 
   - stage: delete_resources
     displayName: "Delete Resources"

--- a/.pipelines/cni/lsg/pipeline.yaml
+++ b/.pipelines/cni/lsg/pipeline.yaml
@@ -77,6 +77,14 @@ stages:
               fi
               echo "Final KernelType : $Kernel"
               echo "##vso[task.setvariable variable=kernelType;isOutput=true]$Kernel"
+
+              RUN_NAME="${DISTRO}-${Kernel}-$(KernelVersion)-$(Build.BuildId)"
+              for invalid in '"' '/' '\' ':' '<' '>' "'" '|' '?' '@' '*'; do
+                RUN_NAME="${RUN_NAME//"$invalid"/-}"
+              done
+              RUN_NAME="${RUN_NAME%.}"
+              echo "Run name : $RUN_NAME"
+              echo "##vso[build.updatebuildnumber]$RUN_NAME"
             name: "SetEnvVars"
             displayName: "Set Environment Variables"
             condition: always()

--- a/.pipelines/cni/lsg/pipeline.yaml
+++ b/.pipelines/cni/lsg/pipeline.yaml
@@ -98,7 +98,7 @@ stages:
       vmSize: ${VM_SIZE}
       arch: amd64
       cni: cniv2
-      region: $(LOCATION_AMD64)
+      region: $(LOCATION)
       networkType: azure-cni-overlay
       installFlag: INSTALL_AZURE_CNI_OVERLAY
 
@@ -111,7 +111,7 @@ stages:
       vmSize: ${VM_SIZE_CILIUM}
       arch: amd64
       cni: cilium
-      region: $(LOCATION_AMD64)
+      region: $(LOCATION)
       networkType: cilium-overlay
       installFlag: INSTALL_OVERLAY
 
@@ -125,7 +125,7 @@ stages:
       vmSize: ${VM_SIZE}
       arch: amd64
       cni: dualstack
-      region: $(LOCATION_AMD64)
+      region: $(REGION_AKS_CLUSTER_TEST)
       networkType: azure-cni-dualstack-overlay
       installFlag: INSTALL_DUALSTACK_OVERLAY
 
@@ -138,7 +138,7 @@ stages:
       vmSize: ${VM_SIZE_CILIUM}
       arch: amd64
       cni: cilium_dualstack
-      region: $(LOCATION_AMD64)
+      region: $(REGION_AKS_CLUSTER_TEST)
       networkType: cilium-dualstack
       installFlag: INSTALL_OVERLAY
       ciliumConnectivitySkipTests: '!pod-to-pod-encryption,!node-to-node-encryption,!check-log-errors,!no-unexpected-packet-drops,!to-fqdns,!egress-to-specific-namespace-ccnp,!ingress-from-specific-namespace-ccnp,!client-egress-to-cidrgroup-deny,!client-egress-to-cidrgroup-deny-by-label,!host-firewall-egress,!host-firewall-ingress,!host-firewall-egress-to-fqdns'

--- a/.pipelines/cni/lsg/pipeline.yaml
+++ b/.pipelines/cni/lsg/pipeline.yaml
@@ -87,10 +87,10 @@ stages:
       clusterType: overlay-byocni-up
       clusterName: "kup-over"
       nodeCount: 2
-      vmSize: Standard_B2ms
+      vmSize: ${VM_SIZE}
       arch: amd64
       cni: cniv2
-      region: $(LOCATION)
+      region: $(LOCATION_AMD64)
       networkType: azure-cni-overlay
       installFlag: INSTALL_AZURE_CNI_OVERLAY
 
@@ -100,10 +100,10 @@ stages:
       clusterType: overlay-byocni-nokubeproxy-up
       clusterName: "kup-cilover"
       nodeCount: 2
-      vmSize: Standard_B2ms
+      vmSize: ${VM_SIZE_CILIUM}
       arch: amd64
       cni: cilium
-      region: $(LOCATION)
+      region: $(LOCATION_AMD64)
       networkType: cilium-overlay
       installFlag: INSTALL_OVERLAY
 
@@ -114,10 +114,10 @@ stages:
       clusterType: dualstack-overlay-byocni-up
       clusterName: "kup-over-ds"
       nodeCount: 2
-      vmSize: Standard_B2ms
+      vmSize: ${VM_SIZE}
       arch: amd64
       cni: dualstack
-      region: $(REGION_AKS_CLUSTER_TEST)
+      region: $(LOCATION_AMD64)
       networkType: azure-cni-dualstack-overlay
       installFlag: INSTALL_DUALSTACK_OVERLAY
 
@@ -127,10 +127,10 @@ stages:
       clusterType: dualstack-byocni-nokubeproxy-up
       clusterName: "kup-cilov-ds"
       nodeCount: 2
-      vmSize: Standard_B2ms
+      vmSize: ${VM_SIZE_CILIUM}
       arch: amd64
       cni: cilium_dualstack
-      region: $(REGION_AKS_CLUSTER_TEST)
+      region: $(LOCATION_AMD64)
       networkType: cilium-dualstack
       installFlag: INSTALL_OVERLAY
       ciliumConnectivitySkipTests: '!pod-to-pod-encryption,!node-to-node-encryption,!check-log-errors,!no-unexpected-packet-drops,!to-fqdns,!egress-to-specific-namespace-ccnp,!ingress-from-specific-namespace-ccnp,!client-egress-to-cidrgroup-deny,!client-egress-to-cidrgroup-deny-by-label,!host-firewall-egress,!host-firewall-ingress,!host-firewall-egress-to-fqdns'

--- a/.pipelines/cni/lsg/verify-network-images.yaml
+++ b/.pipelines/cni/lsg/verify-network-images.yaml
@@ -1,0 +1,74 @@
+parameters:
+  networkType: ""
+  cnsVersion: ""
+  cniVersion: ""
+  azureIpamVersion: ""
+  ciliumVersionTag: ""
+  ciliumImageRegistry: ""
+
+steps:
+  - bash: |
+      set -e
+      resolve_registry() {
+        case "$1" in
+          ACN)
+            echo acnpublic.azurecr.io
+            ;;
+          MCR)
+            echo mcr.microsoft.com/containernetworking
+            ;;
+          *)
+            echo "Unsupported image repository selector: $1" >&2
+            return 1
+            ;;
+        esac
+      }
+
+      CNS_REGISTRY=$(resolve_registry "$(CNS_IMAGE_REPO)")
+      mapfile -t NETWORK_IMAGES < <(kubectl get daemonset azure-cns -n kube-system \
+        -o jsonpath='{range .spec.template.spec.initContainers[*]}{.image}{"\n"}{end}{range .spec.template.spec.containers[*]}{.image}{"\n"}{end}')
+      printf 'Installed CNS/IPAM images:\n%s\n' "${NETWORK_IMAGES[*]}"
+      printf '%s\n' "${NETWORK_IMAGES[@]}" | grep -Fx "${CNS_REGISTRY}/azure-cns:${{ parameters.cnsVersion }}"
+      if [[ "${{ parameters.networkType }}" == cilium-* ]]; then
+        IPAM_REGISTRY=$(resolve_registry "$(IPAM_IMAGE_REPO)")
+        printf '%s\n' "${NETWORK_IMAGES[@]}" | grep -Fx "${IPAM_REGISTRY}/azure-ipam:${{ parameters.azureIpamVersion }}"
+      else
+        CNI_REGISTRY=$(resolve_registry "$(CNI_IMAGE_REPO)")
+        printf '%s\n' "${NETWORK_IMAGES[@]}" | grep -Fx "${CNI_REGISTRY}/azure-cni:${{ parameters.cniVersion }}"
+      fi
+    displayName: "Verify CNS and IPAM images"
+
+  - ${{ if startsWith(parameters.networkType, 'cilium') }}:
+    - bash: |
+        set -e
+        EXPECTED_AGENT="${{ parameters.ciliumImageRegistry }}/cilium/cilium-distroless:${{ parameters.ciliumVersionTag }}"
+        EXPECTED_INIT="${{ parameters.ciliumImageRegistry }}/cilium/cilium-distroless-init:${{ parameters.ciliumVersionTag }}"
+        EXPECTED_OPERATOR="${{ parameters.ciliumImageRegistry }}/cilium/operator-generic:${{ parameters.ciliumVersionTag }}"
+
+        ACTUAL_AGENT=$(kubectl get daemonset cilium -n kube-system -o jsonpath='{.spec.template.spec.containers[?(@.name=="cilium-agent")].image}')
+        ACTUAL_OPERATOR=$(kubectl get deployment cilium-operator -n kube-system -o jsonpath='{.spec.template.spec.containers[0].image}')
+        mapfile -t INIT_IMAGES < <(kubectl get daemonset cilium -n kube-system -o jsonpath='{range .spec.template.spec.initContainers[*]}{.image}{"\n"}{end}')
+
+        [ "$ACTUAL_AGENT" = "$EXPECTED_AGENT" ] || {
+          echo "Expected Cilium agent image $EXPECTED_AGENT, got $ACTUAL_AGENT"
+          exit 1
+        }
+        [ "$ACTUAL_OPERATOR" = "$EXPECTED_OPERATOR" ] || {
+          echo "Expected Cilium operator image $EXPECTED_OPERATOR, got $ACTUAL_OPERATOR"
+          exit 1
+        }
+        CILIUM_INIT_COUNT=0
+        for image in "${INIT_IMAGES[@]}"; do
+          if [[ "$image" == */cilium/cilium-distroless-init:* ]]; then
+            CILIUM_INIT_COUNT=$((CILIUM_INIT_COUNT + 1))
+            [ "$image" = "$EXPECTED_INIT" ] || {
+              echo "Expected Cilium init image $EXPECTED_INIT, got $image"
+              exit 1
+            }
+          fi
+        done
+        [ "$CILIUM_INIT_COUNT" -gt 0 ] || {
+          echo "No distroless Cilium init containers were found"
+          exit 1
+        }
+      displayName: "Verify distroless Cilium images"

--- a/.pipelines/cni/lsg/verify-network-images.yaml
+++ b/.pipelines/cni/lsg/verify-network-images.yaml
@@ -46,7 +46,7 @@ steps:
         EXPECTED_OPERATOR="${{ parameters.ciliumImageRegistry }}/cilium/operator-generic:${{ parameters.ciliumVersionTag }}"
 
         ACTUAL_AGENT=$(kubectl get daemonset cilium -n kube-system -o jsonpath='{.spec.template.spec.containers[?(@.name=="cilium-agent")].image}')
-        ACTUAL_OPERATOR=$(kubectl get deployment cilium-operator -n kube-system -o jsonpath='{.spec.template.spec.containers[0].image}')
+        ACTUAL_OPERATOR=$(kubectl get deployment cilium-operator -n kube-system -o jsonpath='{.spec.template.spec.containers[?(@.name=="cilium-operator")].image}')
         mapfile -t INIT_IMAGES < <(kubectl get daemonset cilium -n kube-system -o jsonpath='{range .spec.template.spec.initContainers[*]}{.image}{"\n"}{end}')
 
         [ "$ACTUAL_AGENT" = "$EXPECTED_AGENT" ] || {

--- a/.pipelines/templates/cilium-cli.yaml
+++ b/.pipelines/templates/cilium-cli.yaml
@@ -5,12 +5,15 @@ steps:
       if [[ ${CILIUM_VERSION_TAG#v} =~ ^1.1[1-3].[0-9]{1,2}|1.1[1-3].[0-9]{1,2}-[0-9]{1,6} ]]; then
         echo "Cilium Agent Version ${BASH_REMATCH[0]}"
         CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable-v0.14.txt)
+        SUPPORTS_TEST_CONCURRENCY=false
       elif [[ ${CILIUM_VERSION_TAG#v} =~ ^1.1[1-4].[0-9]{1,2}|1.1[1-4].[0-9]{1,2}-[0-9]{1,6} ]]; then
         echo "Cilium Agent Version ${BASH_REMATCH[0]}"
         CILIUM_CLI_VERSION=v0.15.22
+        SUPPORTS_TEST_CONCURRENCY=false
       else
         echo "Cilium Agent Version ${CILIUM_VERSION_TAG}"
         CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
+        SUPPORTS_TEST_CONCURRENCY=true
       fi
       CLI_ARCH=amd64
       if [ "$(uname -m)" = "aarch64" ]; then CLI_ARCH=arm64; fi
@@ -23,5 +26,6 @@ steps:
       set +e
       cilium status
       cilium version
+      echo "##vso[task.setvariable variable=SUPPORTS_TEST_CONCURRENCY]${SUPPORTS_TEST_CONCURRENCY}"
     name: "installCiliumCLI"
     displayName: "Install Cilium CLI"

--- a/.pipelines/templates/cilium-connectivity-tests.yaml
+++ b/.pipelines/templates/cilium-connectivity-tests.yaml
@@ -3,11 +3,16 @@ parameters:
 
 steps:
   - script: |
-      if ! cilium connectivity test --connect-timeout 4s --request-timeout 30s --test ${{ parameters.skipTests }} --force-deploy
+      CONCURRENCY_FLAG=""
+      if [[ "$(SUPPORTS_TEST_CONCURRENCY)" == "true" ]]; then
+        CONCURRENCY_FLAG="--test-concurrency 5"
+      fi
+
+      if ! cilium connectivity test --connect-timeout 4s --request-timeout 30s --test ${{ parameters.skipTests }} --force-deploy ${CONCURRENCY_FLAG}
       then
         echo "--- Connectivity Tests failed! ---"
         echo "--- Running Connectivity Tests with --debug ---"
-        cilium connectivity test --debug --connect-timeout 4s --request-timeout 30s --test ${{ parameters.skipTests }} --force-deploy
+        cilium connectivity test --debug --connect-timeout 4s --request-timeout 30s --test ${{ parameters.skipTests }} --force-deploy ${CONCURRENCY_FLAG}
       fi
     name: "CiliumConnectivityTests"
     displayName: "Run Cilium Connectivity Tests"

--- a/.pipelines/templates/network-install.yaml
+++ b/.pipelines/templates/network-install.yaml
@@ -23,6 +23,15 @@ parameters:
   - name: nightly
     type: boolean
     default: false
+  - name: ciliumVersionTag
+    type: string
+    default: ""
+  - name: ciliumImageRegistry
+    type: string
+    default: ""
+  - name: useMakefileLogCollectorDefaults
+    type: boolean
+    default: false
 
 steps:
   - task: KubectlInstaller@0
@@ -92,6 +101,19 @@ steps:
         set -e
         kubectl cluster-info
 
+        CILIUM_DIR=""
+        CILIUM_ARGS=()
+        if [ -n "${{ parameters.ciliumVersionTag }}" ]; then
+          CILIUM_DIR=$(echo "${{ parameters.ciliumVersionTag }}" | sed 's/^v//' | cut -d. -f1,2)
+          CILIUM_ARGS+=(
+            "DIR=${CILIUM_DIR}"
+            "CILIUM_VERSION_TAG=${{ parameters.ciliumVersionTag }}"
+          )
+        fi
+        if [ -n "${{ parameters.ciliumImageRegistry }}" ]; then
+          CILIUM_ARGS+=("CILIUM_IMAGE_REGISTRY=${{ parameters.ciliumImageRegistry }}")
+        fi
+
         configure_ebpf() {
           export AZURE_IPTABLES_MONITOR_IMAGE_REGISTRY=acnpublic.azurecr.io
           export AZURE_IPTABLES_MONITOR_TAG=$(make azure-iptables-monitor-version)
@@ -111,27 +133,27 @@ steps:
         case "${{ parameters.networkType }}" in
           cilium-podsubnet)
             unset DIR CILIUM_VERSION_TAG
-            make -C ./hack/aks deploy-cilium WAIT_FOR_CILIUM=false
+            make -C ./hack/aks deploy-cilium WAIT_FOR_CILIUM=false "${CILIUM_ARGS[@]}"
             ;;
           cilium-nodesubnet)
             unset DIR CILIUM_VERSION_TAG
-            make -C ./hack/aks deploy-cilium WAIT_FOR_CILIUM=false
+            make -C ./hack/aks deploy-cilium WAIT_FOR_CILIUM=false "${CILIUM_ARGS[@]}"
             ;;
           cilium-overlay)
             NIGHTLY_TAG="$CILIUM_VERSION_TAG"
             unset DIR CILIUM_VERSION_TAG
             if [ "${{ parameters.testHubble }}" = "True" ]; then
-              make -C ./hack/aks deploy-cilium-hubble WAIT_FOR_CILIUM=false
+              make -C ./hack/aks deploy-cilium-hubble WAIT_FOR_CILIUM=false "${CILIUM_ARGS[@]}"
             elif [ "$NIGHTLY_TAG" = "cilium-nightly-pipeline" ] || [ "${{ parameters.nightly }}" = "True" ]; then
               make -C ./hack/aks deploy-cilium-nightly WAIT_FOR_CILIUM=false
             else
-              make -C ./hack/aks deploy-cilium WAIT_FOR_CILIUM=false
+              make -C ./hack/aks deploy-cilium WAIT_FOR_CILIUM=false "${CILIUM_ARGS[@]}"
             fi
             ;;
           cilium-dualstack)
             configure_dualstack
             unset DIR CILIUM_VERSION_TAG
-            make -C ./hack/aks deploy-cilium-dualstack WAIT_FOR_CILIUM=false
+            make -C ./hack/aks deploy-cilium-dualstack WAIT_FOR_CILIUM=false "${CILIUM_ARGS[@]}"
             ;;
           cilium-ebpf-podsubnet)
             configure_ebpf
@@ -152,9 +174,15 @@ steps:
             ;;
         esac
 
-        export CILIUM_LOG_COLLECTOR_IMAGE_REGISTRY=${CILIUM_LOG_COLLECTOR_IMAGE_REGISTRY_OVERRIDE:-acnpublic.azurecr.io}
-        export CILIUM_LOG_COLLECTOR_VERSION_TAG=${CILIUM_LOG_COLLECTOR_VERSION_TAG_OVERRIDE:-$(make cilium-log-collector-version)}
-        make -C ./hack/aks add-cilium-log-collector
+        LOG_COLLECTOR_ARGS=()
+        if [ -n "$CILIUM_DIR" ]; then
+          LOG_COLLECTOR_ARGS+=("DIR=${CILIUM_DIR}")
+        fi
+        if [ "${{ parameters.useMakefileLogCollectorDefaults }}" != "True" ]; then
+          export CILIUM_LOG_COLLECTOR_IMAGE_REGISTRY=${CILIUM_LOG_COLLECTOR_IMAGE_REGISTRY_OVERRIDE:-acnpublic.azurecr.io}
+          export CILIUM_LOG_COLLECTOR_VERSION_TAG=${CILIUM_LOG_COLLECTOR_VERSION_TAG_OVERRIDE:-$(make cilium-log-collector-version)}
+        fi
+        make -C ./hack/aks add-cilium-log-collector "${LOG_COLLECTOR_ARGS[@]}"
         kubectl get pods -A -o wide
       displayName: Install Cilium networking
 


### PR DESCRIPTION
**Reason for Change**:

LSG kernel validation needs additional distro testing.  Adds framework to include more distros.
#### Notable changes
- New variable added to tuple for queuing pipeline `DistroVersion`. Currently accepts Jammy/Noble. Looking at Focal support as well.
- Leverages the network-install template to lower the amount of flakes present in pipeline
- Increase VMSku to match CNI Release Test - Dualstack was dealing with burst cpu exhaustion during scale testing
- Updates connectivity test template to use concurrency and matches test skips

**Issue Fixed**:

N/A

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [x] relevant PR labels added

**Notes**:
Validating runs
- Jammy: https://msazure.visualstudio.com/One/_build/results?buildId=179233124&view=results
- Noble: https://msazure.visualstudio.com/One/_build/results?buildId=179233075&view=results
