### PR TITLE
ci: trace Go builds in CodeQL PR job

### DIFF
--- a/.pipelines/templates/run-unit-tests.yaml
+++ b/.pipelines/templates/run-unit-tests.yaml
@@ -23,6 +23,31 @@ stages:
             displayName: "Install Go"
           - script: |
               set -e
+              # Go 1.21+ is statically linked and cannot be observed directly
+              # by CodeQL's LD_PRELOAD build tracer. A dynamic bash wrapper
+              # makes the Go invocations in this task visible to the tracer.
+              CODEQL_GO_SHIM_DIR="${AGENT_TEMPDIRECTORY:-/tmp}/codeql-go-tracing"
+              mkdir -p "$CODEQL_GO_SHIM_DIR"
+              REAL_GO=`command -v go`
+              if [ -z "$REAL_GO" ]; then
+                echo "##vso[task.logissue type=error]go toolchain not found on PATH; cannot install CodeQL Go tracing shim"
+                exit 1
+              fi
+              cat > "$CODEQL_GO_SHIM_DIR/go" <<EOF
+              #!/bin/bash
+              exec "$REAL_GO" "\$@"
+              EOF
+              chmod 755 "$CODEQL_GO_SHIM_DIR/go"
+              export PATH="$CODEQL_GO_SHIM_DIR:$PATH"
+              echo "CodeQL Go tracing shim: $CODEQL_GO_SHIM_DIR/go -> $REAL_GO"
+
+              # sudo's setuid boundary strips LD_PRELOAD before it starts.
+              # Pass the tracer library back through env after elevation.
+              SUDO_ENV=("PATH=$PATH")
+              if [ -n "${LD_PRELOAD:-}" ]; then
+                SUDO_ENV+=("LD_PRELOAD=$LD_PRELOAD")
+              fi
+
               make bpf-lib
               go generate ./...
               make go-junit-report
@@ -31,7 +56,7 @@ stages:
               # stdout from tee is redirected to fd 4. Take output written to fd 3 (which is the exit code of test), redirect to stdout, pipe to read from stdout then exit with that status code.
               # Read all output from fd 4 (output from tee) and write to top stdout
               { { { {
-                    sudo -E env "PATH=$PATH" make test-all;
+                    sudo -E env "${SUDO_ENV[@]}" make test-all;
                     echo $? >&3;
                     } | tee >($(go env GOPATH)/bin/go-junit-report > report.xml) >&4;
                   } 3>&1;


### PR DESCRIPTION
## Summary

- adapt the CodeQL Go tracing shim from Networking-NeuroShield PR 16619106 to the ACN Linux PR unit-test task
- wrap the statically linked Go tool with dynamic Bash so CodeQL can observe Go compiler invocations
- explicitly restore `LD_PRELOAD` after the `sudo` privilege boundary used by `make test-all`
- keep the shim and all Go compilation in the same Azure Pipelines script task

## Why

Go 1.21+ ships a statically linked `go` binary, so CodeQL build tracing based on `LD_PRELOAD` cannot observe it directly. ACN additionally runs product tests under `sudo`, which strips preload variables unless they are explicitly passed back after elevation.

## Validation

- parsed `.pipelines/templates/run-unit-tests.yaml` as YAML
- verified the shim precedes `make bpf-lib`, `go generate`, tooling builds, and `make test-all`
- replayed the generated wrapper under Bash and verified argument forwarding
- verified the shim is executable and the preload environment reaches the wrapped Go process
- `git diff --check` passes

Reference: Networking-NeuroShield PR 16619106 and https://aka.ms/codeql3000.