### PR TITLE
Create infrastructure code owners/team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,3 +17,21 @@
 /bpf-prog/                  @camrynl @QxBytes @santhoshmprabhu
 /azure-ip-masq-merger/      @QxBytes @santhoshmprabhu
 /azure-iptables-monitor/    @QxBytes @santhoshmprabhu
+
+# Infrastructure rules follow component rules so that the last match preempts
+# component ownership for build, dependency, script, and test configuration.
+go.mod                      @azure/acn-infra
+go.sum                      @azure/acn-infra
+Makefile                    @azure/acn-infra
+*.mk                        @azure/acn-infra
+*Dockerfile*                @azure/acn-infra
+scripts/                    @azure/acn-infra
+*.sh                        @azure/acn-infra
+*.ps1                       @azure/acn-infra
+/.pipelines/**/*.yaml       @azure/acn-infra
+/.pipelines/**/*.yml        @azure/acn-infra
+/test/**/*.yaml             @azure/acn-infra
+/test/**/*.yml              @azure/acn-infra
+
+# Workflow changes need infrastructure and administrative review requests.
+/.github/workflows/         @azure/acn-infra @azure/acn-admins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,7 @@
 /.github/                   @azure/acn-admins
 /cns/                       @azure/acn-cns-reviewers
 /cni/                       @azure/acn-cni-reviewers
-/dropgz/                    @rbtr @camrynl @paulyufan2 @ashvindeodhar @thatmattlong
+/dropgz/                    @rbtr @camrynl @ashvindeodhar @thatmattlong
 /npm/                       @azure/acn-npm-reviewers
 /zapai/                     @rbtr @ZetaoZhuang
 /bpf-prog/                  @camrynl @QxBytes @santhoshmprabhu


### PR DESCRIPTION
Preempt component ownership for Go module files, Dockerfiles, Makefiles, scripts, and test/pipeline YAML. 
Component ownership means that broad changes such as updating go.mod version or Dockfile base images - which span the entire repo - require an unmanageable number of auto-assigned codeowner reviewers for each component. Those owners generally don't have context on such infrastructure changes. This creates an infra team of members who have been driving such changes and will be able to assess them cross-repo and provide quality review.