### PR TITLE
fix(ci): harden CNI load test recovery

### DIFF
--- a/.pipelines/cni/load-test-templates/restart-node-template.yaml
+++ b/.pipelines/cni/load-test-templates/restart-node-template.yaml
@@ -14,6 +14,8 @@ steps:
       scriptType: "bash"
       addSpnToEnvironment: true
       inlineScript: |
+        set -euo pipefail
+
         clusterName=${{ parameters.clusterName }}
         region=${{ parameters.region }}
 
@@ -21,9 +23,7 @@ steps:
         make -C ./hack/aks azcfg AZCLI=az REGION=${region}
 
         echo "Restarting the nodes"
-        for val in $(az vmss list -g MC_${clusterName}_${clusterName}_${region} --query "[].name" -o tsv); do
-          make -C ./hack/aks restart-vmss AZCLI=az CLUSTER=${clusterName} REGION=${region} VMSS_NAME=$val
-        done
+        bash .pipelines/cni/load-test-templates/restart-nodes.sh
         kubectl get pods -n kube-system -owide
 
         if ! [ ${{ parameters.cni }} = 'cniv1' ]; then
@@ -36,19 +36,31 @@ steps:
         fi
 
         echo "Ensure Load-Test deployment pods are marked as ready"
-        kubectl rollout status deploy -n load-test
+        if [ ${{ parameters.os }} = 'windows' ]; then
+          deployment=win-load-test
+        else
+          deployment=load-test
+        fi
+        kubectl rollout status deployment/${deployment} -n load-test --timeout=20m
     name: "RestartNodes"
     displayName: "Restart Nodes"
 
   - ${{ if contains(parameters.os, 'windows') }}:
     - script: |
+        set -euo pipefail
+
         kubectl apply -f test/integration/manifests/load/privileged-daemonset-windows.yaml
         kubectl rollout status -n kube-system ds privileged-daemonset
 
         kubectl get pod -n kube-system -l app=privileged-daemonset,os=windows -owide
-        pods=`kubectl get pod -n kube-system -l app=privileged-daemonset,os=windows --no-headers | awk '{print $1}'`
-        for pod in $pods; do
-          kubectl exec -i -n kube-system $pod -- powershell "Restart-service kubeproxy"
+        mapfile -t pods < <(kubectl get pod -n kube-system -l app=privileged-daemonset,os=windows -o name)
+        if ((${#pods[@]} == 0)); then
+          echo "no privileged Windows pods found" >&2
+          exit 1
+        fi
+        for pod in "${pods[@]}"; do
+          kubectl exec -i -n kube-system "${pod#pod/}" -- powershell.exe -NoProfile -NonInteractive -Command \
+            '$ErrorActionPreference = "Stop"; Restart-Service kubeproxy -ErrorAction Stop; $service = Get-Service kubeproxy -ErrorAction Stop; if ($service.Status -ne "Running") { throw "kubeproxy is not running" }'
         done
       name: kubeproxy
       displayName: Restart Kubeproxy on Windows nodes

--- a/.pipelines/cni/load-test-templates/restart-nodes.sh
+++ b/.pipelines/cni/load-test-templates/restart-nodes.sh
@@ -52,6 +52,13 @@ restart_node() {
     local resource_group=""
     local vmss=""
     local instance=""
+    local status
+
+    status=$(node_ready_status "$node")
+    if [[ "$status" != "True" ]]; then
+        echo "node $node must be Ready before restart, got $status" >&2
+        return 1
+    fi
 
     provider_id=$(kubectl get node "$node" -o jsonpath='{.spec.providerID}')
     if ! parse_provider_id "$provider_id" resource_group vmss instance; then

--- a/.pipelines/cni/load-test-templates/restart-nodes.sh
+++ b/.pipelines/cni/load-test-templates/restart-nodes.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly poll_interval_seconds=10
+readonly not_ready_timeout_seconds=600
+readonly ready_timeout="20m"
+
+node_ready_status() {
+    local node=$1
+    local status
+    if ! status=$(kubectl get node "$node" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null); then
+        echo "LookupFailed"
+        return
+    fi
+    echo "${status:-Unknown}"
+}
+
+wait_for_node_not_ready() {
+    local node=$1
+    local deadline=$((SECONDS + not_ready_timeout_seconds))
+
+    while ((SECONDS < deadline)); do
+        local status
+        status=$(node_ready_status "$node")
+        if [[ "$status" != "True" && "$status" != "LookupFailed" ]]; then
+            return 0
+        fi
+        sleep "$poll_interval_seconds"
+    done
+
+    echo "node $node did not become NotReady within ${not_ready_timeout_seconds}s" >&2
+    return 1
+}
+
+parse_provider_id() {
+    local provider_id=$1
+    local -n resource_group_ref=$2
+    local -n vmss_ref=$3
+    local -n instance_ref=$4
+
+    resource_group_ref=$(awk -F/ '{ for (i = 1; i <= NF; i++) if (tolower($i) == "resourcegroups") print $(i + 1) }' <<< "$provider_id")
+    vmss_ref=$(awk -F/ '{ for (i = 1; i <= NF; i++) if (tolower($i) == "virtualmachinescalesets") print $(i + 1) }' <<< "$provider_id")
+    instance_ref=$(awk -F/ '{ for (i = 1; i <= NF; i++) if (tolower($i) == "virtualmachines") print $(i + 1) }' <<< "$provider_id")
+
+    [[ -n "$resource_group_ref" && -n "$vmss_ref" && -n "$instance_ref" ]]
+}
+
+restart_node() {
+    local node=$1
+    local provider_id
+    local resource_group=""
+    local vmss=""
+    local instance=""
+
+    provider_id=$(kubectl get node "$node" -o jsonpath='{.spec.providerID}')
+    if ! parse_provider_id "$provider_id" resource_group vmss instance; then
+        echo "failed to parse Azure provider ID for node $node: $provider_id" >&2
+        return 1
+    fi
+
+    echo "Restarting node $node as VMSS instance ${vmss}/${instance}"
+    az vmss restart --resource-group "$resource_group" --name "$vmss" --instance-ids "$instance" --no-wait
+    wait_for_node_not_ready "$node"
+    kubectl wait "node/$node" --for=condition=Ready --timeout="$ready_timeout"
+}
+
+main() {
+    local node_output
+    local -a nodes
+
+    node_output=$(kubectl get nodes -o name)
+    mapfile -t nodes < <(awk -F/ 'NF { print $NF }' <<< "$node_output" | sort)
+    if ((${#nodes[@]} == 0)); then
+        echo "no nodes found to restart" >&2
+        return 1
+    fi
+
+    for node in "${nodes[@]}"; do
+        restart_node "$node"
+    done
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/.pipelines/cni/load-test-templates/restart-nodes_test.sh
+++ b/.pipelines/cni/load-test-templates/restart-nodes_test.sh
@@ -26,3 +26,8 @@ kubectl() {
 }
 
 [[ "$(node_ready_status "unavailable-node")" == "LookupFailed" ]]
+
+if restart_node "unavailable-node"; then
+    echo "expected restart of a non-Ready node to fail" >&2
+    exit 1
+fi

--- a/.pipelines/cni/load-test-templates/restart-nodes_test.sh
+++ b/.pipelines/cni/load-test-templates/restart-nodes_test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/restart-nodes.sh"
+
+resource_group=""
+vmss=""
+instance=""
+parse_provider_id \
+    "azure:///subscriptions/sub/resourceGroups/MC_test/providers/Microsoft.Compute/virtualMachineScaleSets/aksnpwin/virtualMachines/3" \
+    resource_group vmss instance
+
+[[ "$resource_group" == "MC_test" ]]
+[[ "$vmss" == "aksnpwin" ]]
+[[ "$instance" == "3" ]]
+
+if parse_provider_id "azure:///subscriptions/sub/resourceGroups/MC_test" resource_group vmss instance; then
+    echo "expected incomplete provider ID to fail" >&2
+    exit 1
+fi
+
+kubectl() {
+    return 1
+}
+
+[[ "$(node_ready_status "unavailable-node")" == "LookupFailed" ]]

--- a/.pipelines/cni/pipeline.yaml
+++ b/.pipelines/cni/pipeline.yaml
@@ -147,38 +147,6 @@ stages:
               name: $(name)
               os: $(os)
 
-  - stage: binaries
-    displayName: Build Binaries
-    dependsOn: setup
-    pool:
-      name: $(BUILD_POOL_NAME_DEFAULT)
-      demands:
-        - agent.os -equals Linux
-        - Role -equals Build
-    jobs:
-      - job:
-        displayName: "Build k8s NPM Linux Test Suite Binary"
-        steps:
-          - bash: |
-              git clone https://github.com/kubernetes/kubernetes.git --depth=1
-              cd kubernetes
-              export PATH=$PATH:/usr/local/go/bin/
-              make WHAT=test/e2e/e2e.test
-            displayName: "Build Kubernetes e2e.test"
-          - publish: $(System.DefaultWorkingDirectory)/kubernetes/_output/local/bin/linux/amd64
-            artifact: npm_k8s
-      - job:
-        displayName: "Build k8s NPM Windows Test Suite Binary"
-        steps:
-          - bash: |
-              git clone https://github.com/kubernetes/kubernetes.git --depth=1
-              cd kubernetes
-              export PATH=$PATH:/usr/local/go/bin/
-              make WHAT=test/e2e/e2e.test
-            displayName: "Build Kubernetes e2e.test"
-          - publish: $(System.DefaultWorkingDirectory)/kubernetes/_output/local/bin/linux/amd64
-            artifact: npm_k8s_windows
-
   - stage: publish
     displayName: Publish Multiarch Manifests
     dependsOn:

--- a/.pipelines/npm/npm-cni-integration-test.yaml
+++ b/.pipelines/npm/npm-cni-integration-test.yaml
@@ -24,6 +24,21 @@ jobs:
         - agent.os -equals Linux
         - Role -equals Build
     steps:
+      - task: AzureCLI@2
+        displayName: "Setup Kubernetes E2E Environment"
+        inputs:
+          azureSubscription: ${{ parameters.sub }}
+          scriptType: "bash"
+          scriptLocation: "inlineScript"
+          inlineScript: |
+            set -e
+
+            make -C ./hack/aks set-kubeconf AZCLI=az CLUSTER=${{ parameters.clusterName }}
+            k8sVersion="v$(az aks show -g ${{ parameters.clusterName }} -n ${{ parameters.clusterName }} --query currentKubernetesVersion -o tsv)"
+            echo "Using Kubernetes E2E tests for ${k8sVersion}"
+            curl --fail --location "https://dl.k8s.io/${k8sVersion}/kubernetes-test-linux-amd64.tar.gz" --output kubernetes-test-linux-amd64.tar.gz
+            tar -xzf kubernetes-test-linux-amd64.tar.gz --strip-components=3 kubernetes/test/bin/e2e.test
+
       - ${{ if eq(parameters.os, 'linux') }}:
           - task: AzureCLI@2
             displayName: "Deploy NPM to Test Cluster"
@@ -48,13 +63,6 @@ jobs:
                 echo $FQDN
                 echo "##vso[task.setvariable variable=FQDN]$FQDN"
 
-                artifact=npm_k8s
-                echo $artifact/e2e.test
-                echo "##vso[task.setvariable variable=artifact]$artifact"
-
-          - download: current
-            artifact: npm_k8s
-
       - ${{ if eq(parameters.os, 'windows') }}:
           - task: AzureCLI@2
             displayName: "Deploy Windows NPM to Test Cluster"
@@ -73,8 +81,7 @@ jobs:
                 kubectl set image daemonset/azure-npm-win -n kube-system azure-npm=$IMAGE_REGISTRY/azure-npm:windows-amd64-${{ parameters.tag }}
                 kubectl rollout status -n kube-system daemonset/azure-npm-win
 
-                # konnectivity agent tends to fail after rollout. Give it time to recover
-                sleep 60
+                kubectl rollout status -n kube-system deployment/konnectivity-agent --timeout=6m
                 # Taint Linux (system) nodes so windows tests do not run on them
                 kubectl taint nodes -l kubernetes.azure.com/mode=system node-role.kubernetes.io/control-plane:NoSchedule
 
@@ -84,13 +91,6 @@ jobs:
                 FQDN=`az aks show -g ${{ parameters.clusterName }} -n ${{ parameters.clusterName }} --query fqdn -o tsv`
                 echo $FQDN
                 echo "##vso[task.setvariable variable=FQDN]$FQDN"
-
-                artifact=npm_k8s_windows
-                echo $artifact/e2e.test
-                echo "##vso[task.setvariable variable=artifact]$artifact"
-
-          - download: current
-            artifact: npm_k8s_windows
 
       - bash: |
           set -e
@@ -111,17 +111,15 @@ jobs:
           client should stop enforcing policies after they are deleted|\
           client should support a 'default-deny-ingress' policy"
 
-          ls -l $(Pipeline.Workspace)/$(artifact)
-          echo adding execution to $(artifact)/e2e.test
-          chmod +x $(Pipeline.Workspace)/$(artifact)/e2e.test
-          ls -l $(Pipeline.Workspace)/$(artifact)
+          chmod +x ./e2e.test
 
           KUBERNETES_SERVICE_HOST="$FQDN" KUBERNETES_SERVICE_PORT=443 \
-          $(Pipeline.Workspace)/$(artifact)/e2e.test \
+          ./e2e.test \
           --provider=local \
           --ginkgo.focus="$focus" \
           --ginkgo.skip="NetworkPolicyLegacy|SCTP" \
           --kubeconfig=$HOME/.kube/config \
+          --ginkgo.flake-attempts=3 \
           --ginkgo.timeout="2h"
         displayName: "Run Kubernetes e2e.test"
         continueOnError: ${{ parameters.continueOnError }}

--- a/.pipelines/templates/log-template.yaml
+++ b/.pipelines/templates/log-template.yaml
@@ -70,7 +70,11 @@ steps:
   
   - bash: |
       set -o pipefail
-      kubectl describe nnc -A 2>&1 | tee "$(acnLogs)/node-network-configs.txt"
+      if kubectl get crd nodenetworkconfigs.acn.azure.com >/dev/null 2>&1; then
+        kubectl describe nnc -A 2>&1 | tee "$(acnLogs)/node-network-configs.txt"
+      else
+        echo "NNC CRD is not installed; skipping collection" | tee "$(acnLogs)/node-network-configs.txt"
+      fi
     displayName: Describe Node Network Configs (NNCs)
     condition: and(always(), ne('${{ parameters.cni }}', 'cniv1')) # cniv1/nodesubnet scenarios do not have node network configs
     continueOnError: true # even if nnc doesn't exist we want to continue

--- a/test/validate/validate.go
+++ b/test/validate/validate.go
@@ -78,9 +78,11 @@ func CreateValidator(ctx context.Context, clientset *kubernetes.Clientset, confi
 	switch os {
 	case "windows":
 		checks = windowsChecksMap[cni]
-		err := acnk8s.RestartKubeProxyService(ctx, clientset, privilegedNamespace, privilegedLabelSelector, config)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to restart kubeproxy")
+		if shouldRestartKubeProxy(restartCase) {
+			err := acnk8s.RestartKubeProxyService(ctx, clientset, privilegedNamespace, privilegedLabelSelector, config)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to restart kubeproxy")
+			}
 		}
 	case "linux":
 		checks = linuxChecksMap[cni]
@@ -98,6 +100,14 @@ func CreateValidator(ctx context.Context, clientset *kubernetes.Clientset, confi
 		os:                os,
 		poolLabelSelector: poolLabelSelector,
 	}, nil
+}
+
+func shouldRestartKubeProxy(restartCase bool) bool {
+	return !restartCase
+}
+
+func canSkipEmptyRestartState(os string, restartCase bool) bool {
+	return restartCase && os != "windows"
 }
 
 // nodeSelector returns the label selector used to pick candidate nodes. It
@@ -168,7 +178,7 @@ func (v *Validator) validateIPs(ctx context.Context, stateFileIps stateFileIpsFu
 			if err != nil {
 				return false, errors.Wrapf(err, "failed to get pod ips from state file on node %v", node.Name)
 			}
-			if len(filePodIps) == 0 && v.restartCase {
+			if len(filePodIps) == 0 && canSkipEmptyRestartState(v.os, v.restartCase) {
 				log.Printf("No pods found on node %s", node.Name)
 				return true, nil
 			}

--- a/test/validate/validate.go
+++ b/test/validate/validate.go
@@ -14,13 +14,13 @@ import (
 )
 
 var privilegedDaemonSetPathMap = map[string]string{
-	"windows": "../manifests/load/privileged-daemonset-windows.yaml",
-	"linux":   "../manifests/load/privileged-daemonset.yaml",
+	windowsOS: "../manifests/load/privileged-daemonset-windows.yaml",
+	linuxOS:   "../manifests/load/privileged-daemonset.yaml",
 }
 
 var nodeSelectorMap = map[string]string{
-	"windows": "kubernetes.io/os=windows",
-	"linux":   "kubernetes.io/os=linux",
+	windowsOS: "kubernetes.io/os=windows",
+	linuxOS:   "kubernetes.io/os=linux",
 }
 
 // IPv4 overlay Linux and windows nodes must have this label
@@ -35,6 +35,8 @@ var dualstackOverlayNodeLabels = map[string]string{
 }
 
 const (
+	windowsOS                = "windows"
+	linuxOS                  = "linux"
 	privilegedLabelSelector  = "app=privileged-daemonset"
 	privilegedNamespace      = "kube-system"
 	IPv4ExpectedIPCount      = 1
@@ -76,15 +78,15 @@ func CreateValidator(ctx context.Context, clientset *kubernetes.Clientset, confi
 
 	var checks []check
 	switch os {
-	case "windows":
+	case windowsOS:
 		checks = windowsChecksMap[cni]
-		if shouldRestartKubeProxy(restartCase) {
+		if !restartCase {
 			err := acnk8s.RestartKubeProxyService(ctx, clientset, privilegedNamespace, privilegedLabelSelector, config)
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to restart kubeproxy")
 			}
 		}
-	case "linux":
+	case linuxOS:
 		checks = linuxChecksMap[cni]
 	default:
 		return nil, errors.Errorf("unsupported os: %s", os)
@@ -102,12 +104,8 @@ func CreateValidator(ctx context.Context, clientset *kubernetes.Clientset, confi
 	}, nil
 }
 
-func shouldRestartKubeProxy(restartCase bool) bool {
-	return !restartCase
-}
-
 func canSkipEmptyRestartState(os string, restartCase bool) bool {
-	return restartCase && os != "windows"
+	return restartCase && os != windowsOS
 }
 
 // nodeSelector returns the label selector used to pick candidate nodes. It
@@ -129,7 +127,7 @@ func (v *Validator) Validate(ctx context.Context) error {
 		return errors.Wrapf(err, "failed to validate state file")
 	}
 
-	if v.os == "linux" {
+	if v.os == linuxOS {
 		// We are restarting the systmemd network and checking that the connectivity works after the restart. For more details: https://github.com/cilium/cilium/issues/18706
 		log.Printf("Validating the restart network scenario")
 		err = v.validateRestartNetwork(ctx)
@@ -288,7 +286,7 @@ func (v *Validator) ValidateV4OverlayControlPlane(ctx context.Context) error {
 		return errors.Wrap(err, "failed to validate IPv4 overlay node properties")
 	}
 
-	if v.os == "windows" {
+	if v.os == windowsOS {
 		if err := validateHNSNetworkState(ctx, nodes, v.clientset, v.config); err != nil {
 			return errors.Wrap(err, "failed to validate IPv4 overlay HNS network state")
 		}
@@ -307,7 +305,7 @@ func (v *Validator) ValidateDualStackControlPlane(ctx context.Context) error {
 		return errors.Wrap(err, "failed to validate dualstack overlay node properties")
 	}
 
-	if v.os == "windows" {
+	if v.os == windowsOS {
 		if err := validateHNSNetworkState(ctx, nodes, v.clientset, v.config); err != nil {
 			return errors.Wrap(err, "failed to validate dualstack overlay HNS network state")
 		}

--- a/test/validate/validate_retry_test.go
+++ b/test/validate/validate_retry_test.go
@@ -138,11 +138,6 @@ func TestRunValidationAttemptsRejectsInvalidAttemptCount(t *testing.T) {
 	require.False(t, converged)
 }
 
-func TestShouldRestartKubeProxy(t *testing.T) {
-	require.True(t, shouldRestartKubeProxy(false))
-	require.False(t, shouldRestartKubeProxy(true))
-}
-
 func TestCanSkipEmptyRestartState(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -152,19 +147,19 @@ func TestCanSkipEmptyRestartState(t *testing.T) {
 	}{
 		{
 			name:        "linux restart",
-			os:          "linux",
+			os:          linuxOS,
 			restartCase: true,
 			want:        true,
 		},
 		{
 			name:        "windows restart",
-			os:          "windows",
+			os:          windowsOS,
 			restartCase: true,
 			want:        false,
 		},
 		{
 			name: "non-restart validation",
-			os:   "linux",
+			os:   linuxOS,
 			want: false,
 		},
 	}

--- a/test/validate/validate_retry_test.go
+++ b/test/validate/validate_retry_test.go
@@ -137,3 +137,41 @@ func TestRunValidationAttemptsRejectsInvalidAttemptCount(t *testing.T) {
 	require.Zero(t, attempts)
 	require.False(t, converged)
 }
+
+func TestShouldRestartKubeProxy(t *testing.T) {
+	require.True(t, shouldRestartKubeProxy(false))
+	require.False(t, shouldRestartKubeProxy(true))
+}
+
+func TestCanSkipEmptyRestartState(t *testing.T) {
+	tests := []struct {
+		name        string
+		os          string
+		restartCase bool
+		want        bool
+	}{
+		{
+			name:        "linux restart",
+			os:          "linux",
+			restartCase: true,
+			want:        true,
+		},
+		{
+			name:        "windows restart",
+			os:          "windows",
+			restartCase: true,
+			want:        false,
+		},
+		{
+			name: "non-restart validation",
+			os:   "linux",
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, canSkipEmptyRestartState(test.os, test.restartCase))
+		})
+	}
+}

--- a/test/validate/windows_validate.go
+++ b/test/validate/windows_validate.go
@@ -163,6 +163,9 @@ type AddressRecord struct {
 
 func hnsStateFileIPs(result []byte) (map[string]string, error) {
 	jsonType := bytes.TrimLeft(result, " \t\r\n")
+	if len(jsonType) == 0 {
+		return nil, errors.New("hns endpoint list is empty")
+	}
 	isObject := jsonType[0] == '{'
 	isArray := jsonType[0] == '['
 	hnsPodIps := make(map[string]string)

--- a/test/validate/windows_validate_test.go
+++ b/test/validate/windows_validate_test.go
@@ -1,0 +1,71 @@
+package validate
+
+import (
+	"testing"
+)
+
+func TestHNSStateFileIPs(t *testing.T) {
+	tests := []struct {
+		name      string
+		result    string
+		wantIPs   map[string]string
+		wantError bool
+	}{
+		{
+			name:      "empty output",
+			result:    "",
+			wantError: true,
+		},
+		{
+			name:      "whitespace output",
+			result:    " \r\n\t",
+			wantError: true,
+		},
+		{
+			name:   "single endpoint",
+			result: `{"MacAddress":"00-11-22-33-44-55","IPAddress":"10.0.0.4","IPv6Address":"fd00::4"}`,
+			wantIPs: map[string]string{
+				"10.0.0.4": "00-11-22-33-44-55",
+				"fd00::4":  "00-11-22-33-44-55",
+			},
+		},
+		{
+			name: "endpoint list excludes remote endpoints",
+			result: `[
+				{"MacAddress":"00-11-22-33-44-55","IPAddress":"10.0.0.4"},
+				{"MacAddress":"00-11-22-33-44-66","IPAddress":"10.0.0.5","IsRemoteEndpoint":true}
+			]`,
+			wantIPs: map[string]string{
+				"10.0.0.4": "00-11-22-33-44-55",
+			},
+		},
+		{
+			name:      "malformed output",
+			result:    "not-json",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := hnsStateFileIPs([]byte(tt.result))
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("hnsStateFileIPs() error = %v", err)
+			}
+			if len(got) != len(tt.wantIPs) {
+				t.Fatalf("hnsStateFileIPs() returned %v, want %v", got, tt.wantIPs)
+			}
+			for ip, mac := range tt.wantIPs {
+				if got[ip] != mac {
+					t.Errorf("hnsStateFileIPs()[%q] = %q, want %q", ip, got[ip], mac)
+				}
+			}
+		})
+	}
+}

--- a/test/validate/windows_validate_test.go
+++ b/test/validate/windows_validate_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 )
 
+const testMACAddress = "00-11-22-33-44-55"
+
 func TestHNSStateFileIPs(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -23,20 +25,20 @@ func TestHNSStateFileIPs(t *testing.T) {
 		},
 		{
 			name:   "single endpoint",
-			result: `{"MacAddress":"00-11-22-33-44-55","IPAddress":"10.0.0.4","IPv6Address":"fd00::4"}`,
+			result: `{"MacAddress":"` + testMACAddress + `","IPAddress":"10.0.0.4","IPv6Address":"fd00::4"}`,
 			wantIPs: map[string]string{
-				"10.0.0.4": "00-11-22-33-44-55",
-				"fd00::4":  "00-11-22-33-44-55",
+				"10.0.0.4": testMACAddress,
+				"fd00::4":  testMACAddress,
 			},
 		},
 		{
 			name: "endpoint list excludes remote endpoints",
 			result: `[
-				{"MacAddress":"00-11-22-33-44-55","IPAddress":"10.0.0.4"},
+				{"MacAddress":"` + testMACAddress + `","IPAddress":"10.0.0.4"},
 				{"MacAddress":"00-11-22-33-44-66","IPAddress":"10.0.0.5","IsRemoteEndpoint":true}
 			]`,
 			wantIPs: map[string]string{
-				"10.0.0.4": "00-11-22-33-44-55",
+				"10.0.0.4": testMACAddress,
 			},
 		},
 		{


### PR DESCRIPTION
## Problem

CNI Release Test run `177677368` exposed three recurring Windows load-test failures:

- NPM NetworkPolicy E2E failures used a Kubernetes `master` binary built once for every cluster, while the ACN PR pipeline uses the cluster-matched Kubernetes release and Ginkgo retries.
- the restart test restarted whole VM scale sets concurrently, then waited indefinitely for every load-test deployment; Windows nodes remained `Unknown` and `win-load-test` stayed at `0/100` until the worker timeout.
- state validation restarted kube-proxy a second time, indexed empty `Get-HnsEndpoint` output, and allowed empty Windows restart state to pass.

The same-base `master` run (`177604869`) showed the same NetworkPolicy and restart-timeout signatures, confirming these are harness reliability gaps rather than PR-specific product failures. The ACN PR pipeline (`95007`) does not exercise the CNI Release Test restart/load-test path.

## Changes

- download the Kubernetes E2E binary matching each AKS cluster version, wait for konnectivity readiness, and retry flaky NPM specs
- restart VMSS instances one node at a time and require a real NotReady-to-Ready transition
- target the OS-specific load-test deployment with a bounded rollout timeout
- fail fast and verify kube-proxy is running after restart
- return an explicit error for empty HNS output, avoid a duplicate kube-proxy restart, and reject empty Windows restart state
- skip NNC log collection cleanly when the CRD is absent
- remove the obsolete pipeline stage that built Kubernetes `master` E2E artifacts

## Validation

- `go test ./test/validate`
- `gopls check` on changed validator files
- `bash -n` and `shellcheck` for the restart helper and test
- restart helper provider-ID and API-failure tests
- YAML parsing for all changed pipeline templates
- staged diff whitespace validation