### PR TITLE
fix: add missing env vars for binary tag release channel notification

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -203,6 +203,9 @@ jobs:
       id-token: write
     env:
       TEAMS_RELEASE_CHANNEL_ID: "19:ad6cb6596adf4850910e9be3e8a7f9ab@thread.skype"
+      TEAMS_TEAM_ID: "1eb27b57-8ace-4f0e-a9a9-e6db4e9829b7"
+      NOTIFIER_URL: https://acn-notifier-bot.azurewebsites.net
+      NOTIFIER_AUDIENCE: api://3976eca5-3f9d-4528-987f-c20c1f9f27f7
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
The `notify_release_channel` job in `create-release-tag.yml` was missing `TEAMS_TEAM_ID`, `NOTIFIER_URL`, and `NOTIFIER_AUDIENCE` env vars needed by `release-cli notify`. These are set at workflow level in `scheduled-release.yaml` but were not carried over to `create-release-tag.yml`.

**Error seen after approving binary tags:**
```
Error: team-id is required (or set TEAMS_TEAM_ID)
```

Fixes the notification failure for binary tag approvals (dropgz, azure-ipam, etc.).