### PR TITLE
fix: key async delete watcher by container ID, not full path

### DIFF
--- a/cns/fsnotify/fsnotify.go
+++ b/cns/fsnotify/fsnotify.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -56,15 +57,20 @@ func (w *watcher) releaseAll(ctx context.Context) {
 	defer w.lock.Unlock()
 	for containerID := range w.pendingDelete {
 		// read file contents
-		filepath := w.path + "/" + containerID
-		file, err := os.Open(filepath)
+		filePath := w.path + "/" + containerID
+		file, err := os.Open(filePath)
 		if err != nil {
-			w.log.Error("failed to open file", zap.Error(err))
+			// Without the file we cannot know the pod interface ID, and a
+			// release without it cannot match the assignment in CNS.
+			w.log.Error("failed to open file", zap.String("containerID", containerID), zap.String("path", filePath), zap.Error(err))
+			continue
 		}
 
 		data, errReadingFile := io.ReadAll(file)
 		if errReadingFile != nil {
-			w.log.Error("failed to read file content", zap.Error(errReadingFile))
+			w.log.Error("failed to read file content", zap.String("containerID", containerID), zap.String("path", filePath), zap.Error(errReadingFile))
+			file.Close()
+			continue
 		}
 		file.Close()
 		podInterfaceID := string(data)
@@ -92,7 +98,9 @@ func (w *watcher) watchPendingDelete(ctx context.Context) error {
 		case <-ctx.Done():
 			return errors.Wrap(ctx.Err(), "exiting watchPendingDelete")
 		case <-ticker.C:
+			w.lock.Lock()
 			n := len(w.pendingDelete)
+			w.lock.Unlock()
 			if n == 0 {
 				continue
 			}
@@ -153,7 +161,9 @@ func (w *watcher) watchFS(ctx context.Context) error {
 			}
 			w.log.Info("received create event", zap.String("event", event.Name))
 			w.lock.Lock()
-			w.pendingDelete[event.Name] = struct{}{}
+			// event.Name is the full path; the map is keyed by container ID
+			// (the file name), because releaseAll rebuilds the path from it.
+			w.pendingDelete[filepath.Base(event.Name)] = struct{}{}
 			w.lock.Unlock()
 		case watcherErr := <-watcher.Errors:
 			w.log.Error("fsnotify watcher error", zap.Error(watcherErr))
@@ -177,8 +187,8 @@ func (w *watcher) Start(ctx context.Context) error {
 
 // AddFile creates new file using the containerID as name
 func AddFile(podInterfaceID, containerID, path string) error {
-	filepath := path + "/" + containerID
-	f, err := os.Create(filepath)
+	filePath := path + "/" + containerID
+	f, err := os.Create(filePath)
 	if err != nil {
 		return errors.Wrap(err, "error creating file")
 	}
@@ -191,8 +201,8 @@ func AddFile(podInterfaceID, containerID, path string) error {
 
 // removeFile removes the file based on containerID
 func removeFile(containerID, path string) error {
-	filepath := path + "/" + containerID
-	if err := os.Remove(filepath); err != nil {
+	filePath := path + "/" + containerID
+	if err := os.Remove(filePath); err != nil {
 		return errors.Wrap(err, "error deleting file")
 	}
 	return nil

--- a/cns/fsnotify/pendingdelete_key_test.go
+++ b/cns/fsnotify/pendingdelete_key_test.go
@@ -1,0 +1,148 @@
+package fsnotify
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"go.uber.org/zap"
+)
+
+const (
+	testContainerID    = "56dba5daf3ed3aaab57f13047b0abbebfe2bdb05156896e2531beb6a2a0b15ae"
+	testPodInterfaceID = "56dba5da-eth0"
+)
+
+type recordingReleaseClient struct {
+	mu   sync.Mutex
+	reqs []cns.IPConfigsRequest
+}
+
+func (c *recordingReleaseClient) ReleaseIPs(_ context.Context, req cns.IPConfigsRequest) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.reqs = append(c.reqs, req)
+	return nil
+}
+
+func (c *recordingReleaseClient) snapshot() []cns.IPConfigsRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]cns.IPConfigsRequest(nil), c.reqs...)
+}
+
+func hasKey(w *watcher, key string) bool {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+	_, ok := w.pendingDelete[key]
+	return ok
+}
+
+func waitForKey(t *testing.T, w *watcher, key string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for !hasKey(w, key) {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for pending key %q", key)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestLiveCreateEventReleasesWithRealKeys guards the async-delete leak.
+//
+// fsnotify sets event.Name to the full path of the new file, but releaseAll
+// rebuilds the path as w.path + "/" + key. A map keyed by the full path made
+// every live-enqueued file unreadable, so the release reached CNS with an
+// empty PodInterfaceID and the pod IP stayed Assigned until the next CNS
+// restart. The map must be keyed by the container ID: the file's base name.
+func TestLiveCreateEventReleasesWithRealKeys(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "deleteIDs")
+	cli := &recordingReleaseClient{}
+	w, err := New(cli, dir, zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A pre-seeded file marks the end of the startup scan. watchFS attaches
+	// the inotify watch first and lists the directory second, so once this
+	// key appears, every later file reaches the map through a create event
+	// only. Without this handshake the test file could be picked up by the
+	// startup scan, which keys correctly even on the broken code.
+	const preseed = "preseed-scan-marker"
+	if err := AddFile("preseed-eth0", preseed, dir); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = w.watchFS(ctx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Error("watchFS did not exit after cancellation")
+		}
+	})
+	waitForKey(t, w, preseed)
+
+	// The CNI enqueues a missed delete exactly as invoker_cns.go does. Only
+	// the create event can deliver this key now. On the broken code the key
+	// is the full path and this wait times out.
+	if err := AddFile(testPodInterfaceID, testContainerID, dir); err != nil {
+		t.Fatal(err)
+	}
+	waitForKey(t, w, testContainerID)
+
+	// Drop the preseed entry so the release assertions see one request.
+	w.lock.Lock()
+	delete(w.pendingDelete, preseed)
+	w.lock.Unlock()
+	if err := os.Remove(filepath.Join(dir, preseed)); err != nil {
+		t.Fatal(err)
+	}
+
+	w.releaseAll(ctx)
+
+	reqs := cli.snapshot()
+	if len(reqs) != 1 {
+		t.Fatalf("want 1 release request, got %+v", reqs)
+	}
+	if reqs[0].PodInterfaceID != testPodInterfaceID || reqs[0].InfraContainerID != testContainerID {
+		t.Errorf("LEAK: CNS got PodInterfaceID=%q InfraContainerID=%q, want %q and %q",
+			reqs[0].PodInterfaceID, reqs[0].InfraContainerID, testPodInterfaceID, testContainerID)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, testContainerID)); statErr == nil {
+		t.Errorf("LEAK: pending delete file was left on disk")
+	}
+	if hasKey(w, testContainerID) {
+		t.Errorf("released entry must be dropped from pendingDelete")
+	}
+}
+
+// TestReleaseAllSkipsEntryWithoutFile checks the guard: an entry whose file
+// cannot be read must not produce a release, because the request would carry
+// an empty pod interface ID and can never match an assignment.
+func TestReleaseAllSkipsEntryWithoutFile(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "deleteIDs")
+	cli := &recordingReleaseClient{}
+	w, err := New(cli, dir, zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.pendingDelete["no-such-file"] = struct{}{}
+
+	w.releaseAll(context.Background())
+
+	if reqs := cli.snapshot(); len(reqs) != 0 {
+		t.Errorf("no release must be sent for an unreadable entry, got %+v", reqs)
+	}
+}


### PR DESCRIPTION
**Reason for Change**:

CNS has a safety net for missed pod deletes: the CNI leaves a file, and a watcher in CNS releases the IP later. The watcher stores the wrong map key, so this safety net has never worked while CNS runs. Each missed delete leaks one pod IP until CNS restarts. Enough leaks exhaust the node's IP pool, and every new pod fails to start. The defect ships since #2183. Telemetry shows the failure signature on hundreds of nodes each week.

The fix is small: use the file NAME as the map key, not the full path.

### When this fires

The bug needs rare conditions. That is why it survived for 3 years:

1. The file is written only when CNS is unreachable during a CNI DEL ([invoker_cns.go#L404-L410](https://github.com/Azure/azure-container-networking/blob/528a08e6748be0962f553473fa2b9fdfad09388f/cni/network/invoker_cns.go#L404-L410)). Normal operation never enters this path.
2. Only the live path is broken. The startup scan is correct. So every CNS restart heals the node and erases the evidence.
3. Impact needs weeks without a restart, pod churn during the outage window, and a small IP pool. The incident node ran an every-minute CronJob against a 16-IP pool.
4. For healthy pods, the runtime retries the delete later and the IP comes back. The permanent leaks are pods that failed during sandbox creation. containerd does not retry teardown for those.
5. The failure is silent. Each file gets 1 attempt and about 2 log lines. CNS reports success (timeline, step 4).
6. The old tests staged files before the watcher started. They only covered the correct path.

### Failure timeline on current `master`

Links point at `528a08e6`. The container ID `56dba5da…` is shortened.

**T+0s — a pod is deleted while CNS is unreachable.** The CNI cannot release the IP. It writes file `deleteIDs/56dba5da…` with content `56dba5da-eth0`, and reports success to the runtime:

```
"msg":"DEL command completed","pod":"…","error":""
```

**T+0s — the watcher stores the wrong key.** The filesystem event carries the FULL PATH. The watcher stores it as the key ([fsnotify.go#L156](https://github.com/Azure/azure-container-networking/blob/528a08e6748be0962f553473fa2b9fdfad09388f/cns/fsnotify/fsnotify.go#L156)):

```
pendingDelete["/var/run/azure-vnet/deleteIDs/56dba5da…"]
```

**T+15s — the release request is corrupt.** The worker prepends the directory to the key ([fsnotify.go#L59](https://github.com/Azure/azure-container-networking/blob/528a08e6748be0962f553473fa2b9fdfad09388f/cns/fsnotify/fsnotify.go#L59)). The result is a doubled path:

```
/var/run/azure-vnet/deleteIDs//var/run/azure-vnet/deleteIDs/56dba5da…
```

The open fails, but the loop continues ([#L60-L63](https://github.com/Azure/azure-container-networking/blob/528a08e6748be0962f553473fa2b9fdfad09388f/cns/fsnotify/fsnotify.go#L60-L63)). It reads nothing. CNS receives an empty `PodInterfaceID` and a path where a container ID belongs:

```
[releaseIPConfigsHandler] Received cns.IPConfigsRequest {DesiredIPAddresses:[] PodInterfaceID: InfraContainerID:/var/run/azure-vnet/deleteIDs/56dba5da… OrchestratorContext:[110 117 108 108] …}
```

**T+15s — CNS releases nothing, and nobody notices.** The request matches no assignment in either pod-info scheme ([Key()](https://github.com/Azure/azure-container-networking/blob/528a08e6748be0962f553473fa2b9fdfad09388f/cns/NetworkContainerContract.go#L301), [validation](https://github.com/Azure/azure-container-networking/blob/528a08e6748be0962f553473fa2b9fdfad09388f/cns/NetworkContainerContract.go#L376)). One scheme returns a success no-op. The other returns an error that the client cannot decode ([client.go#L481](https://github.com/Azure/azure-container-networking/blob/528a08e6748be0962f553473fa2b9fdfad09388f/cns/client/client.go#L481), follow-up 4). The watcher sees success in both cases.

**T+15s — the work is lost.** The watcher drops the map entry and tries to remove the file through the same doubled path ([#L78-L79](https://github.com/Azure/azure-container-networking/blob/528a08e6748be0962f553473fa2b9fdfad09388f/cns/fsnotify/fsnotify.go#L78-L79)). That fails too. The IP stays `Assigned`. The file stays on disk. Nothing retries.

**T+days — the pool is empty.** Each event pins 1 IP. Kubelet reports:

```
FailedCreatePodSandBox … AllocateIPConfig failed: not enough IPs available
```

**T+restart — the node heals and the evidence disappears.** The startup scan uses `file.Name()` — the correct key ([fsnotify.go#L136](https://github.com/Azure/azure-container-networking/blob/528a08e6748be0962f553473fa2b9fdfad09388f/cns/fsnotify/fsnotify.go#L136)). It releases everything and removes the files. This is why "restart CNS" is the known mitigation.

### The fix

- Key the map by `filepath.Base(event.Name)` — the container ID, the same key the startup scan uses.
- Skip an entry whose file cannot be read. A release with an empty pod interface ID can never match.
- Take the lock for the map-length read in `watchPendingDelete`. It raced the writer.
- Name the container ID and the path in the read-failure logs, so a stuck entry is visible.

About 20 production lines, so it cherry-picks onto the release branches.

**Issue Fixed**:

N/A — found in an IP exhaustion incident on AKS pod subnet clusters.

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation (N/A — no user-facing surface changes)
- [x] adds unit tests
- [ ] relevant PR labels added

**Notes**:

2 tests. The first drives the real `watchFS` and asserts a live-enqueued file is released with the correct keys and removed. A pre-seeded file fences the startup scan, so only the event path can deliver the test key. The second asserts an unreadable entry sends nothing to CNS.

The regression test fails when only the key line is reverted:

```
--- FAIL: TestLiveCreateEventReleasesWithRealKeys (10.05s)
    pendingdelete_key_test.go:102: timed out waiting for pending key "56dba5daf3ed…"
```

```
$ CGO_ENABLED=1 go test -race ./cns/fsnotify/ -count=50
ok  	github.com/Azure/azure-container-networking/cns/fsnotify	4.746s

$ GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build ./cns/fsnotify
```

The defect was reproduced on an AKS pod subnet cluster with CNS `v1.8.12`: reject traffic to `127.0.0.1:10090` while pods delete. Every `DEL` reports success, the IPs stay `Assigned`, and CNS receives the malformed release above.

Out of scope, each needs its own change:

1. A dropped `fsnotify` event still strands a file until restart. A follow-up will re-scan the directory periodically.
2. `AddFile` creates the file before it writes the content, and leaks the handle on a write failure.
3. `AddFile` names the file by container ID only. A multi-interface container overwrites its own entry.
4. The release clients decode the wrong response type, so `ReturnCode` is always 0 and release errors look like success.
5. The release handlers miss a `return` in the error branch and encode the response twice.
6. Failed-ADD cleanup writes a file only on connection errors. An application-level CNS error drops the release.
