### PR TITLE
Fix raw byte array formatting in logs for json.RawMessage fields

### DIFF
--- a/cns/logger/cnslogger.go
+++ b/cns/logger/cnslogger.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"encoding/json"
 	"fmt"
 	"maps"
 	"os"
@@ -157,17 +158,33 @@ func (c *logger) Errorf(format string, args ...any) {
 	c.sendTraceInternal(msg, ai.ErrorLevel)
 }
 
+// toJSONString converts objects to JSON for trace logging and falls back to Go formatting.
+func toJSONString(obj any) string {
+	if obj == nil {
+		return "null"
+	}
+
+	bytes, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Sprintf("%+v", obj)
+	}
+
+	return string(bytes)
+}
+
 func (c *logger) Request(tag string, request any, err error) {
 	c.logger.Request(tag, request, err)
 	if c.th == nil || c.disableTraceLogging {
 		return
 	}
+
+	requestString := toJSONString(request)
 	var msg string
 	lvl := ai.InfoLevel
 	if err == nil {
-		msg = fmt.Sprintf("[%s] Received %T %+v.", tag, request, request)
+		msg = fmt.Sprintf("[%s] Received %T %s.", tag, request, requestString)
 	} else {
-		msg = fmt.Sprintf("[%s] Failed to decode %T %+v %s.", tag, request, request, err.Error())
+		msg = fmt.Sprintf("[%s] Failed to decode %T %s %s.", tag, request, requestString, err.Error())
 		lvl = ai.ErrorLevel
 	}
 	c.sendTraceInternal(msg, lvl)
@@ -178,16 +195,18 @@ func (c *logger) Response(tag string, response any, returnCode types.ResponseCod
 	if c.th == nil || c.disableTraceLogging {
 		return
 	}
+
+	responseString := toJSONString(response)
 	var msg string
 	lvl := ai.InfoLevel
 	switch {
 	case err == nil && returnCode == 0:
-		msg = fmt.Sprintf("[%s] Sent %T %+v.", tag, response, response)
+		msg = fmt.Sprintf("[%s] Sent %T %s.", tag, response, responseString)
 	case err != nil:
-		msg = fmt.Sprintf("[%s] Code:%s, %+v %s.", tag, returnCode.String(), response, err.Error())
+		msg = fmt.Sprintf("[%s] Code:%s, %s %s.", tag, returnCode.String(), responseString, err.Error())
 		lvl = ai.ErrorLevel
 	default:
-		msg = fmt.Sprintf("[%s] Code:%s, %+v.", tag, returnCode.String(), response)
+		msg = fmt.Sprintf("[%s] Code:%s, %s.", tag, returnCode.String(), responseString)
 	}
 	c.sendTraceInternal(msg, lvl)
 }
@@ -197,16 +216,19 @@ func (c *logger) ResponseEx(tag string, request, response any, returnCode types.
 	if c.th == nil || c.disableTraceLogging {
 		return
 	}
+
+	requestString := toJSONString(request)
+	responseString := toJSONString(response)
 	var msg string
 	lvl := ai.InfoLevel
 	switch {
 	case err == nil && returnCode == 0:
-		msg = fmt.Sprintf("[%s] Sent %T %+v %T %+v.", tag, request, request, response, response)
+		msg = fmt.Sprintf("[%s] Sent %T %s %T %s.", tag, request, requestString, response, responseString)
 	case err != nil:
-		msg = fmt.Sprintf("[%s] Code:%s, %+v, %+v, %s.", tag, returnCode.String(), request, response, err.Error())
+		msg = fmt.Sprintf("[%s] Code:%s, %s, %s, %s.", tag, returnCode.String(), requestString, responseString, err.Error())
 		lvl = ai.ErrorLevel
 	default:
-		msg = fmt.Sprintf("[%s] Code:%s, %+v, %+v.", tag, returnCode.String(), request, response)
+		msg = fmt.Sprintf("[%s] Code:%s, %s, %s.", tag, returnCode.String(), requestString, responseString)
 	}
 	c.sendTraceInternal(msg, lvl)
 }

--- a/cns/logger/cnslogger.go
+++ b/cns/logger/cnslogger.go
@@ -1,7 +1,6 @@
 package logger
 
 import (
-	"encoding/json"
 	"fmt"
 	"maps"
 	"os"
@@ -158,27 +157,13 @@ func (c *logger) Errorf(format string, args ...any) {
 	c.sendTraceInternal(msg, ai.ErrorLevel)
 }
 
-// toJSONString converts objects to JSON for trace logging and falls back to Go formatting.
-func toJSONString(obj any) string {
-	if obj == nil {
-		return "null"
-	}
-
-	bytes, err := json.Marshal(obj)
-	if err != nil {
-		return fmt.Sprintf("%+v", obj)
-	}
-
-	return string(bytes)
-}
-
 func (c *logger) Request(tag string, request any, err error) {
 	c.logger.Request(tag, request, err)
 	if c.th == nil || c.disableTraceLogging {
 		return
 	}
 
-	requestString := toJSONString(request)
+	requestString := log.ToJSONString(request)
 	var msg string
 	lvl := ai.InfoLevel
 	if err == nil {
@@ -196,7 +181,7 @@ func (c *logger) Response(tag string, response any, returnCode types.ResponseCod
 		return
 	}
 
-	responseString := toJSONString(response)
+	responseString := log.ToJSONString(response)
 	var msg string
 	lvl := ai.InfoLevel
 	switch {
@@ -217,8 +202,8 @@ func (c *logger) ResponseEx(tag string, request, response any, returnCode types.
 		return
 	}
 
-	requestString := toJSONString(request)
-	responseString := toJSONString(response)
+	requestString := log.ToJSONString(request)
+	responseString := log.ToJSONString(response)
 	var msg string
 	lvl := ai.InfoLevel
 	switch {

--- a/cns/logger/cnslogger_test.go
+++ b/cns/logger/cnslogger_test.go
@@ -1,0 +1,82 @@
+package logger
+
+import (
+	"encoding/json"
+	"testing"
+
+	ai "github.com/Azure/azure-container-networking/aitelemetry"
+	"github.com/Azure/azure-container-networking/cns/types"
+	"github.com/Azure/azure-container-networking/log"
+	"github.com/stretchr/testify/require"
+)
+
+type telemetryRecorder struct {
+	reports []ai.Report
+}
+
+func (r *telemetryRecorder) TrackLog(report ai.Report) {
+	r.reports = append(r.reports, report)
+}
+
+func (*telemetryRecorder) TrackMetric(ai.Metric) {}
+
+func (*telemetryRecorder) TrackEvent(ai.Event) {}
+
+func (*telemetryRecorder) Close(int) {}
+
+func (*telemetryRecorder) Flush() {}
+
+type rawMessagePayload struct {
+	Data json.RawMessage
+}
+
+func TestLogger_TraceLogsUseJSON(t *testing.T) {
+	request := rawMessagePayload{Data: json.RawMessage(`{"name":"request"}`)}
+	response := rawMessagePayload{Data: json.RawMessage(`{"name":"response"}`)}
+
+	tests := []struct {
+		name string
+		log  func(*logger)
+		want string
+	}{
+		{
+			name: "request",
+			log: func(c *logger) {
+				c.Request("request", request, nil)
+			},
+			want: `{"Data":{"name":"request"}}`,
+		},
+		{
+			name: "response",
+			log: func(c *logger) {
+				c.Response("response", response, types.ResponseCode(0), nil)
+			},
+			want: `{"Data":{"name":"response"}}`,
+		},
+		{
+			name: "response with request",
+			log: func(c *logger) {
+				c.ResponseEx("response-ex", request, response, types.ResponseCode(0), nil)
+			},
+			want: `{"Data":{"name":"request"}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			telemetry := &telemetryRecorder{}
+			baseLogger := log.NewLogger("trace-test", log.LevelAlert, log.TargetStderr, "")
+			t.Cleanup(baseLogger.Close)
+
+			tt.log(&logger{
+				logger:   baseLogger,
+				th:       telemetry,
+				metadata: map[string]string{},
+			})
+
+			require.Len(t, telemetry.reports, 1)
+			require.Contains(t, telemetry.reports[0].Message, tt.want)
+			require.NotContains(t, telemetry.reports[0].Message, "[123")
+		})
+	}
+}

--- a/cns/logger/cnslogger_test.go
+++ b/cns/logger/cnslogger_test.go
@@ -65,7 +65,8 @@ func TestLogger_TraceLogsUseJSON(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			telemetry := &telemetryRecorder{}
-			baseLogger := log.NewLogger("trace-test", log.LevelAlert, log.TargetStderr, "")
+			baseLogger, err := log.NewLoggerE("trace-test", log.LevelAlert, log.TargetStderr, "")
+			require.NoError(t, err)
 			t.Cleanup(baseLogger.Close)
 
 			tt.log(&logger{

--- a/log/logger.go
+++ b/log/logger.go
@@ -207,7 +207,7 @@ func ToJSONString(obj interface{}) string {
 	if obj == nil {
 		return "null"
 	}
-	
+
 	bytes, err := json.Marshal(obj)
 	if err != nil {
 		// Fall back to standard formatting if JSON marshaling fails

--- a/log/logger.go
+++ b/log/logger.go
@@ -200,10 +200,10 @@ func (logger *Logger) rotate() error {
 	return nil
 }
 
-// toJSONString converts any object to a JSON string for logging purposes.
+// ToJSONString converts any object to a JSON string for logging purposes.
 // When the object contains json.RawMessage fields, they will be properly formatted
 // instead of being shown as byte arrays. Falls back to %+v if JSON marshaling fails.
-func toJSONString(obj interface{}) string {
+func ToJSONString(obj interface{}) string {
 	if obj == nil {
 		return "null"
 	}
@@ -219,31 +219,31 @@ func toJSONString(obj interface{}) string {
 // Request logs a structured request.
 func (logger *Logger) Request(tag string, request interface{}, err error) {
 	if err == nil {
-		logger.Printf("[%s] Received %T %s.", tag, request, toJSONString(request))
+		logger.Printf("[%s] Received %T %s.", tag, request, ToJSONString(request))
 	} else {
-		logger.Errorf("[%s] Failed to decode %T %s %s.", tag, request, toJSONString(request), err.Error())
+		logger.Errorf("[%s] Failed to decode %T %s %s.", tag, request, ToJSONString(request), err.Error())
 	}
 }
 
 // Response logs a structured response.
 func (logger *Logger) Response(tag string, response interface{}, returnCode int, returnStr string, err error) {
 	if err == nil && returnCode == 0 {
-		logger.Printf("[%s] Sent %T %s.", tag, response, toJSONString(response))
+		logger.Printf("[%s] Sent %T %s.", tag, response, ToJSONString(response))
 	} else if err != nil {
-		logger.Errorf("[%s] Code:%s, %s %s.", tag, returnStr, toJSONString(response), err.Error())
+		logger.Errorf("[%s] Code:%s, %s %s.", tag, returnStr, ToJSONString(response), err.Error())
 	} else {
-		logger.Errorf("[%s] Code:%s, %s.", tag, returnStr, toJSONString(response))
+		logger.Errorf("[%s] Code:%s, %s.", tag, returnStr, ToJSONString(response))
 	}
 }
 
 // ResponseEx logs a structured response and the request associate with it.
 func (logger *Logger) ResponseEx(tag string, request interface{}, response interface{}, returnCode int, returnStr string, err error) {
 	if err == nil && returnCode == 0 {
-		logger.Printf("[%s] Sent %T %s %T %s.", tag, request, toJSONString(request), response, toJSONString(response))
+		logger.Printf("[%s] Sent %T %s %T %s.", tag, request, ToJSONString(request), response, ToJSONString(response))
 	} else if err != nil {
-		logger.Errorf("[%s] Code:%s, %s, %s %s.", tag, returnStr, toJSONString(request), toJSONString(response), err.Error())
+		logger.Errorf("[%s] Code:%s, %s, %s %s.", tag, returnStr, ToJSONString(request), ToJSONString(response), err.Error())
 	} else {
-		logger.Errorf("[%s] Code:%s, %s, %s.", tag, returnStr, toJSONString(request), toJSONString(response))
+		logger.Errorf("[%s] Code:%s, %s, %s.", tag, returnStr, ToJSONString(request), ToJSONString(response))
 	}
 }
 

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -68,19 +68,15 @@ func TestToJSONString(t *testing.T) {
 }
 
 func TestToJSONStringFallback(t *testing.T) {
-	// Create a circular reference that cannot be marshaled to JSON
 	type Circular struct {
 		Name     string
 		Referrer *Circular
 	}
 
 	circular := &Circular{Name: "test"}
-	circular.Referrer = circular // Create circular reference
+	circular.Referrer = circular
 
-	// This should fall back to %+v formatting
-	result := ToJSONString(circular)
-	assert.Contains(t, result, "test")
-	assert.Contains(t, result, "Referrer")
+	assert.Equal(t, fmt.Sprintf("%+v", circular), ToJSONString(circular))
 }
 
 func TestNewLoggerError(t *testing.T) {


### PR DESCRIPTION
## Problem

When CNS logs structures containing `json.RawMessage` fields (such as `OrchestratorContext`), it uses Go's `%+v` format specifier which outputs raw bytes as integer arrays. This makes the logs very difficult to read and understand, as shown in this example:

```
OrchestratorContext:[123 34 80 111 100 78 97 109 101 34 58 34 122 116 117 110 110 101 108 45 57 122 54 55 100 34 44 34 80 111 100 78 97 109 101 115 112 97 99 101 34 58 34 105 115 116 105 111 45 115 121 115 116 101 109 34 125]
```

These bytes actually represent the JSON string:
```json
{"PodName":"ztunnel-9z67d","PodNamespace":"istio-system"}
```

## Solution

This PR introduces a new `toJSONString` helper function in both the base logger (`log/logger.go`) and CNS logger (`cns/logger/cnslogger.go`) that properly formats objects containing `json.RawMessage` fields.

The approach:
1. Use `json.Marshal` instead of `%+v` to convert objects to strings for logging
2. This ensures `json.RawMessage` fields are properly formatted as JSON
3. Fall back to the original `%+v` formatting if JSON marshaling fails
4. Update all the structured logging methods to use this new helper function

## Example 

Before:
```
Code:FailedToAllocateIpConfig, {DesiredIPAddresses:[] PodInterfaceID:c34a4c61-eth0 InfraContainerID:c34a4c61b6b2173f7cb62945a3e9f00ea33b99e4aa6b283e714b095b7875a87b OrchestratorContext:[123 34 80 111 100 78 97 109 101 34 58 34 122 116 117 110 110 101 108 45 57 122 54 55 100 34 44 34 80 111 100 78 97 109 101 115 112 97 99 101 34 58 34 105 115 116 105 111 45 115 121 115 116 101 109 34 125] ...}
```

After:
```
Code:FailedToAllocateIpConfig, {"DesiredIPAddresses":[],"PodInterfaceID":"c34a4c61-eth0","InfraContainerID":"c34a4c61b6b2173f7cb62945a3e9f00ea33b99e4aa6b283e714b095b7875a87b","OrchestratorContext":{"PodName":"ztunnel-9z67d","PodNamespace":"istio-system"} ...}
```

Fixes #3673.

> [!WARNING]
>
> <details>
> <summary>Firewall rules blocked me from connecting to one or more addresses</summary>
>
> #### I tried to connect to the following addresses, but was blocked by firewall rules:
>
> - `cdn.fwupd.org`
>   - Triggering command: `/usr/bin/fwupdmgr refresh ` (dns block)
>
> If you need me to access, download, or install something from one of these locations, you can either:
>
> - Configure [Actions setup steps](https://gh.io/copilot/actions-setup-steps) to set up my environment, which run before the firewall is enabled
> - Add the appropriate URLs or hosts to my [firewall allow list](https://gh.io/copilot/firewall-config)
>
> </details>


---

💡 You can make Copilot smarter by setting up custom instructions, customizing its development environment and configuring Model Context Protocol (MCP) servers. Learn more [Copilot coding agent tips](https://gh.io/copilot-coding-agent-tips) in the docs.
