### PR TITLE
fix: remove dropgz from Windows azure-ipam image

### DIFF
--- a/.pipelines/build/dockerfiles/azure-ipam.Dockerfile
+++ b/.pipelines/build/dockerfiles/azure-ipam.Dockerfile
@@ -7,8 +7,9 @@ ARG ARCH
 FROM --platform=windows/${ARCH} mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0@sha256:b4c9637e032f667c52d1eccfa31ad8c63f1b035e8639f3f48a510536bf34032b as windows
 ARG ARTIFACT_DIR .
 
-COPY ${ARTIFACT_DIR}/bin/dropgz.exe /dropgz.exe
-ENTRYPOINT [ "/dropgz.exe" ]
+COPY ${ARTIFACT_DIR}/bin/azure-ipam.exe /Windows/System32/azure-ipam.exe
+COPY ${ARTIFACT_DIR}/files/azilium.conflist /Windows/System32/azilium.conflist
+ENTRYPOINT [ "powershell.exe" ]
 
 # mcr.microsoft.com/azurelinux/distroless/base:3.0
 FROM --platform=linux/${ARCH} mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:387a603a274e74568fd7a0e6d48ef68e631990e3b5149801515fe749a74b5b29 AS linux

--- a/.pipelines/build/dockerfiles/azure-ipam.Dockerfile.tmpl
+++ b/.pipelines/build/dockerfiles/azure-ipam.Dockerfile.tmpl
@@ -7,8 +7,9 @@ ARG ARCH
 FROM --platform=windows/${ARCH} {{.WIN_HPC_PIN}} as windows
 ARG ARTIFACT_DIR .
 
-COPY ${ARTIFACT_DIR}/bin/dropgz.exe /dropgz.exe
-ENTRYPOINT [ "/dropgz.exe" ]
+COPY ${ARTIFACT_DIR}/bin/azure-ipam.exe /Windows/System32/azure-ipam.exe
+COPY ${ARTIFACT_DIR}/files/azilium.conflist /Windows/System32/azilium.conflist
+ENTRYPOINT [ "powershell.exe" ]
 
 # {{.MARINER_DISTROLESS_IMG}}
 FROM --platform=linux/${ARCH} {{.MARINER_DISTROLESS_PIN}} AS linux

--- a/.pipelines/run-pipeline.yaml
+++ b/.pipelines/run-pipeline.yaml
@@ -124,7 +124,7 @@ stages:
               archiveName: azure-ipam
               archiveVersion: $(AZURE_IPAM_VERSION)
               imageTag: $(Build.BuildNumber)
-              packageWithDropGZ: True
+              packageWithDropGZ: False
             cni:
               name: cni
               extraArgs: '--build-arg CNI_AI_PATH=$(CNI_AI_PATH) --build-arg CNI_AI_ID=$(CNI_AI_ID)'

--- a/azure-ipam/Dockerfile
+++ b/azure-ipam/Dockerfile
@@ -47,5 +47,6 @@ ENTRYPOINT [ "/dropgz" ]
 # mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0
 FROM --platform=windows/${ARCH} mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0@sha256:b4c9637e032f667c52d1eccfa31ad8c63f1b035e8639f3f48a510536bf34032b AS hpc
 FROM hpc AS windows
-COPY --from=dropgz /go/bin/dropgz dropgz.exe
-ENTRYPOINT [ "/dropgz.exe" ]
+COPY --from=azure-ipam /go/bin/azure-ipam /Windows/System32/azure-ipam.exe
+COPY --from=azure-ipam /azure-ipam/azilium.conflist /Windows/System32/azilium.conflist
+ENTRYPOINT [ "powershell.exe" ]

--- a/azure-ipam/Dockerfile.tmpl
+++ b/azure-ipam/Dockerfile.tmpl
@@ -47,5 +47,6 @@ ENTRYPOINT [ "/dropgz" ]
 # {{.WIN_HPC_IMG}}
 FROM --platform=windows/${ARCH} {{.WIN_HPC_PIN}} AS hpc
 FROM hpc AS windows
-COPY --from=dropgz /go/bin/dropgz dropgz.exe
-ENTRYPOINT [ "/dropgz.exe" ]
+COPY --from=azure-ipam /go/bin/azure-ipam /Windows/System32/azure-ipam.exe
+COPY --from=azure-ipam /azure-ipam/azilium.conflist /Windows/System32/azilium.conflist
+ENTRYPOINT [ "powershell.exe" ]


### PR DESCRIPTION
**Reason for Change**:

Align Windows Azure IPAM packaging with the managed dalec image: ship `azure-ipam.exe` and `azilium.conflist` directly and use PowerShell as the entrypoint. Linux continues to use `/dropgz`.

**Issue Fixed**:

N/A

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] relevant PR labels added

**Notes**:

Built and inspected both platform images. DaemonSets are unchanged because no Windows DaemonSet consumes the Azure IPAM image.