### PR TITLE
fix(cns): reject stale NC version replays instead of resurrecting released IPs

### DIFF
--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -649,14 +649,13 @@ func (service *HTTPRestService) CreateOrUpdateNetworkContainerInternal(req *cns.
 
 	// This will Create Or Update the NC state.
 	returnCode, returnMessage := service.saveNetworkContainerGoalState(*req)
-
-	// If the NC was created successfully, log NC snapshot.
-	if returnCode == 0 {
-		logNCSnapshot(*req)
-		service.publishIPStateMetrics()
-	} else {
+	if returnCode != types.Success {
 		logger.Errorf("%s", returnMessage) //nolint:staticcheck // will migrate to logger/v2
+		return returnCode
 	}
+
+	logNCSnapshot(*req)
+	service.publishIPStateMetrics()
 
 	if service.Options[common.OptProgramSNATIPTables] == true {
 		returnCode, returnMessage = service.programSNATRules(req)

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -16,6 +16,8 @@ import (
 	"testing"
 	"time"
 
+	acncommon "github.com/Azure/azure-container-networking/common"
+
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/common"
 	"github.com/Azure/azure-container-networking/cns/configuration"
@@ -304,14 +306,13 @@ func TestCreateAndUpdateNCWithSecondaryIPNCVersion(t *testing.T) {
 	}
 }
 
-// TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP is a deterministic
+// TestCreateOrUpdateNetworkContainerInternal_RejectsStaleVersionReplay is a deterministic
 // regression test for the NC-version-replay bug: CNS already has NC version 10 in local state and a
 // matching host (NMAgent-programmed) version of 10. An incoming NC request carrying an older DNC/NNC
 // version (5) for the same NC, referencing a secondary IP ID that was already released and removed from
 // PodIPConfigState, must now be rejected atomically: no stored state may change, and the released IP
 // must remain absent (not recreated as Available or PendingProgramming).
-// See nc-version-replay-repro-handoff.md for the full analysis.
-func TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP(t *testing.T) {
+func TestCreateOrUpdateNetworkContainerInternal_RejectsStaleVersionReplay(t *testing.T) {
 	restartService()
 	setEnv(t)
 	setOrchestratorTypeInternal(cns.KubernetesCRD)
@@ -372,9 +373,70 @@ func TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsRele
 	assert.Equal(t, types.Available, currentIPState.GetState())
 }
 
+// TestCreateOrUpdateNetworkContainerInternal_StaleReplayRejectionSurvivesSNATProgramming is a regression
+// test for a follow-on bug: when SNAT reconciliation is enabled (OptProgramSNATIPTables), CNS used to
+// unconditionally call programSNATRules after saveNetworkContainerGoalState, overwriting a
+// NetworkContainerVersionMismatch rejection with whatever programSNATRules returned - silently hiding
+// the rejection from callers such as the NNC reconciler. This asserts that CNS now returns immediately
+// on rejection, before SNAT programming is even attempted.
+func TestCreateOrUpdateNetworkContainerInternal_StaleReplayRejectionSurvivesSNATProgramming(t *testing.T) {
+	restartService()
+	setEnv(t)
+	setOrchestratorTypeInternal(cns.KubernetesCRD)
+	svc.state.ContainerStatus = make(map[string]containerstatus)
+	svc.PodIPConfigState = make(map[string]cns.IPConfigurationStatus)
+
+	// Enable SNAT programming, as in the affected managed-Cilium deployment configuration.
+	svc.Options[acncommon.OptProgramSNATIPTables] = true
+	// service.iptables is deliberately left nil (its zero value): if the fix regresses and
+	// programSNATRules is reached, calling a method on it would panic, making any regression loud
+	// and obvious rather than silently returning Success.
+
+	testNCID := "666bd5c9-89f2-4b5d-b8d0-616894d6d151"
+	currentIPID := uuid.New().String()
+
+	// Arrange: CNS already has NC version 10 in local state, with host (NMAgent-programmed) version 10 too.
+	svc.state.ContainerStatus[testNCID] = containerstatus{
+		ID:          testNCID,
+		VMVersion:   "10",
+		HostVersion: "10",
+		CreateNetworkContainerRequest: cns.CreateNetworkContainerRequest{
+			NetworkContainerid:   testNCID,
+			NetworkContainerType: dockerContainerType,
+			Version:              "10",
+			IPConfiguration: cns.IPConfiguration{
+				IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+			},
+			SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+				currentIPID: newSecondaryIPConfig("10.0.0.6", 10),
+			},
+		},
+	}
+	svc.PodIPConfigState[currentIPID] = newPodState("10.0.0.6", currentIPID, testNCID, types.Available, 10)
+
+	// Act: replay an older DNC/NNC payload (version 5) for the same NC.
+	staleReq := &cns.CreateNetworkContainerRequest{
+		NetworkContainerid:   testNCID,
+		NetworkContainerType: dockerContainerType,
+		Version:              "5",
+		IPConfiguration: cns.IPConfiguration{
+			IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+		},
+	}
+
+	returnCode := svc.CreateOrUpdateNetworkContainerInternal(staleReq)
+
+	// The rejection must not be overwritten by SNAT programming's return code.
+	assert.Equal(t, types.NetworkContainerVersionMismatch, returnCode,
+		"stale replay rejection must survive even when SNAT programming is enabled")
+
+	containerStatus := svc.state.ContainerStatus[testNCID]
+	assert.Equal(t, "10", containerStatus.CreateNetworkContainerRequest.Version, "stored DNC version must remain 10")
+}
+
 // TestCreateOrUpdateNetworkContainerInternal_EqualVersionIsIdempotent verifies that replaying the same
-// (currently stored) DNC/NNC version is accepted and idempotent, per the "incoming = stored" case in the
-// proposed correctness guard in nc-version-replay-repro-handoff.md.
+// (currently stored) DNC/NNC version is accepted and idempotent (the "incoming == stored" case of the
+// version-comparison guard in saveNetworkContainerGoalState).
 func TestCreateOrUpdateNetworkContainerInternal_EqualVersionIsIdempotent(t *testing.T) {
 	restartService()
 	setEnv(t)
@@ -422,8 +484,8 @@ func TestCreateOrUpdateNetworkContainerInternal_EqualVersionIsIdempotent(t *test
 }
 
 // TestCreateOrUpdateNetworkContainerInternal_HigherVersionIsAccepted verifies that a newer DNC/NNC
-// version is still accepted and reconciled normally, per the "incoming > stored" case in the proposed
-// correctness guard in nc-version-replay-repro-handoff.md.
+// version is still accepted and reconciled normally (the "incoming > stored" case of the
+// version-comparison guard in saveNetworkContainerGoalState).
 func TestCreateOrUpdateNetworkContainerInternal_HigherVersionIsAccepted(t *testing.T) {
 	restartService()
 	setEnv(t)
@@ -481,8 +543,7 @@ func TestCreateOrUpdateNetworkContainerInternal_HigherVersionIsAccepted(t *testi
 }
 
 // TestCreateOrUpdateNetworkContainerInternal_MalformedVersionFailsWithoutMutation verifies that a
-// non-numeric incoming or stored version is rejected without mutating any state, per
-// nc-version-replay-repro-handoff.md's "malformed versions fail without mutation" requirement.
+// non-numeric incoming or stored version is rejected without mutating any state.
 func TestCreateOrUpdateNetworkContainerInternal_MalformedVersionFailsWithoutMutation(t *testing.T) {
 	restartService()
 	setEnv(t)
@@ -581,9 +642,9 @@ func TestCreateOrUpdateNetworkContainerInternal_StaleReplayCannotAlterAssignedIP
 	assert.Equal(t, types.Assigned, assignedIPState.GetState(), "assigned IP state must be unchanged")
 }
 
-// TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP_ClusterData is a
-// regression test using real data captured from a live AKS standalone cluster (Phase 1-2 of the guarded
-// cluster reproduction in nc-version-replay-repro-handoff.md), instead of synthetic IDs:
+// TestCreateOrUpdateNetworkContainerInternal_RejectsStaleVersionReplay_ClusterData is a
+// regression test using real data captured from a live AKS standalone test cluster, instead of
+// synthetic IDs:
 //   - NC ID c51b224b-b747-4063-b470-3676a74f13e8 was observed on node aks-gmp32-53174927-vmss000000.
 //   - Version 1 of that NC (captured while held-demand pods were still occupying IPs) assigned
 //     secondary IP d9ac4eef-344a-4025-99b6-96c6c6e2ec71 / 10.241.0.69.
@@ -595,7 +656,7 @@ func TestCreateOrUpdateNetworkContainerInternal_StaleReplayCannotAlterAssignedIP
 // This verifies the fix using the same real, cluster-derived data: feeding a stale (version 1) replay
 // of the NC payload against locally-stored state reflecting the newer (version 8) baseline must now be
 // rejected, and the released address must remain absent.
-func TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP_ClusterData(t *testing.T) {
+func TestCreateOrUpdateNetworkContainerInternal_RejectsStaleVersionReplay_ClusterData(t *testing.T) {
 	restartService()
 	setEnv(t)
 	setOrchestratorTypeInternal(cns.KubernetesCRD)

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -304,6 +304,71 @@ func TestCreateAndUpdateNCWithSecondaryIPNCVersion(t *testing.T) {
 	}
 }
 
+// TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP is a deterministic
+// reproduction of the NC-version-replay bug: CNS already has NC version 10 in local state and a matching
+// host (NMAgent-programmed) version of 10. An incoming NC request carrying an older DNC/NNC version (5)
+// for the same NC, referencing a secondary IP ID that was already released and removed from
+// PodIPConfigState, is currently accepted and the released IP is incorrectly recreated as Available
+// (instead of being rejected as stale, or at minimum recreated as PendingProgramming).
+// See nc-version-replay-repro-handoff.md for the full analysis.
+func TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP(t *testing.T) {
+	restartService()
+	setEnv(t)
+	setOrchestratorTypeInternal(cns.KubernetesCRD)
+	svc.state.ContainerStatus = make(map[string]containerstatus)
+	svc.PodIPConfigState = make(map[string]cns.IPConfigurationStatus)
+
+	testNCID := "555ac5c9-89f2-4b5d-b8d0-616894d6d150"
+	currentIPID := uuid.New().String()
+	oldIPID := uuid.New().String() // belonged to an older NC payload; already released and removed from state
+
+	// Arrange: CNS already has NC version 10 in local state, with host (NMAgent-programmed) version 10 too.
+	svc.state.ContainerStatus[testNCID] = containerstatus{
+		ID:          testNCID,
+		VMVersion:   "10",
+		HostVersion: "10",
+		CreateNetworkContainerRequest: cns.CreateNetworkContainerRequest{
+			NetworkContainerid:   testNCID,
+			NetworkContainerType: dockerContainerType,
+			Version:              "10",
+			IPConfiguration: cns.IPConfiguration{
+				IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+			},
+			SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+				currentIPID: newSecondaryIPConfig("10.0.0.6", 10),
+			},
+		},
+	}
+	svc.PodIPConfigState[currentIPID] = newPodState("10.0.0.6", currentIPID, testNCID, types.Available, 10)
+	// oldIPID intentionally absent from svc.PodIPConfigState: it was already released.
+
+	// Act: replay an older DNC/NNC payload (version 5) for the same NC, still referencing the released oldIPID.
+	oldReq := &cns.CreateNetworkContainerRequest{
+		NetworkContainerid:   testNCID,
+		NetworkContainerType: dockerContainerType,
+		Version:              "5",
+		IPConfiguration: cns.IPConfiguration{
+			IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+		},
+		SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+			oldIPID: newSecondaryIPConfig("10.0.0.99", 5),
+		},
+	}
+
+	returnCode := svc.CreateOrUpdateNetworkContainerInternal(oldReq)
+
+	// Current (buggy) behavior: the stale replay is accepted.
+	require.Equal(t, types.Success, returnCode, "expected the stale NC replay to currently be accepted (demonstrating the bug)")
+
+	containerStatus := svc.state.ContainerStatus[testNCID]
+	assert.Equal(t, "5", containerStatus.CreateNetworkContainerRequest.Version, "stored DNC version incorrectly drops from 10 to 5")
+	assert.Equal(t, "10", containerStatus.HostVersion, "host version should remain unchanged")
+
+	oldIPState, exists := svc.PodIPConfigState[oldIPID]
+	require.True(t, exists, "old IP incorrectly recreated in PodIPConfigState")
+	assert.Equal(t, types.Available, oldIPState.GetState(), "old IP incorrectly enters Available instead of PendingProgramming")
+}
+
 func TestSyncHostNCVersion(t *testing.T) {
 	// cns.KubernetesCRD has one more logic compared to other orchestrator type, so test both of them
 	orchestratorTypes := []string{cns.Kubernetes, cns.KubernetesCRD}

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -16,14 +16,13 @@ import (
 	"testing"
 	"time"
 
-	acncommon "github.com/Azure/azure-container-networking/common"
-
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/common"
 	"github.com/Azure/azure-container-networking/cns/configuration"
 	"github.com/Azure/azure-container-networking/cns/fakes"
 	"github.com/Azure/azure-container-networking/cns/imds"
 	"github.com/Azure/azure-container-networking/cns/types"
+	acncommon "github.com/Azure/azure-container-networking/common"
 	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	nma "github.com/Azure/azure-container-networking/nmagent"
 	"github.com/Azure/azure-container-networking/store"
@@ -645,7 +644,7 @@ func TestCreateOrUpdateNetworkContainerInternal_StaleReplayCannotAlterAssignedIP
 // TestCreateOrUpdateNetworkContainerInternal_RejectsStaleVersionReplay_ClusterData is a
 // regression test using real data captured from a live AKS standalone test cluster, instead of
 // synthetic IDs:
-//   - NC ID c51b224b-b747-4063-b470-3676a74f13e8 was observed on node aks-gmp32-53174927-vmss000000.
+//   - NC ID c51b224b-b747-4063-b470-3676a74f13e8 was observed on a node in the test cluster.
 //   - Version 1 of that NC (captured while held-demand pods were still occupying IPs) assigned
 //     secondary IP d9ac4eef-344a-4025-99b6-96c6c6e2ec71 / 10.241.0.69.
 //   - After releasing the held-demand pods, the live NNC advanced to version 8 and that IP ID was

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -369,6 +369,81 @@ func TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsRele
 	assert.Equal(t, types.Available, oldIPState.GetState(), "old IP incorrectly enters Available instead of PendingProgramming")
 }
 
+// TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP_ClusterData replays
+// the same bug using real data captured from a live AKS standalone cluster (Phase 1-2 of the guarded
+// cluster reproduction in nc-version-replay-repro-handoff.md), instead of synthetic IDs:
+//   - NC ID c51b224b-b747-4063-b470-3676a74f13e8 was observed on node aks-gmp32-53174927-vmss000000.
+//   - Version 1 of that NC (captured while held-demand pods were still occupying IPs) assigned
+//     secondary IP d9ac4eef-344a-4025-99b6-96c6c6e2ec71 / 10.241.0.69.
+//   - After releasing the held-demand pods, the live NNC advanced to version 8 and that IP ID was
+//     confirmed absent from the current ipAssignments set (i.e. genuinely released cluster-side).
+//
+// This demonstrates the same code path resurrects a real, cluster-released address as Available when
+// fed a stale (version 1) replay of the NC payload against locally-stored state reflecting the newer
+// (version 8) baseline.
+func TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP_ClusterData(t *testing.T) {
+	restartService()
+	setEnv(t)
+	setOrchestratorTypeInternal(cns.KubernetesCRD)
+	svc.state.ContainerStatus = make(map[string]containerstatus)
+	svc.PodIPConfigState = make(map[string]cns.IPConfigurationStatus)
+
+	const (
+		clusterNCID       = "c51b224b-b747-4063-b470-3676a74f13e8"
+		clusterHostVer    = "8"
+		clusterOldVer     = "1"
+		currentIPID       = "1fdc5ace-15e9-482a-a751-8aac094cda99" // still present at version 8, per phase 2 capture
+		releasedIPID      = "d9ac4eef-344a-4025-99b6-96c6c6e2ec71" // released by version 8, per phase 2 capture
+		releasedIPAddress = "10.241.0.69"
+	)
+
+	// Arrange: CNS reflects the real cluster baseline captured in Phase 2 -- NC at version 8, host
+	// version 8, with only the currently-assigned IP present in local state.
+	svc.state.ContainerStatus[clusterNCID] = containerstatus{
+		ID:          clusterNCID,
+		VMVersion:   clusterHostVer,
+		HostVersion: clusterHostVer,
+		CreateNetworkContainerRequest: cns.CreateNetworkContainerRequest{
+			NetworkContainerid:   clusterNCID,
+			NetworkContainerType: dockerContainerType,
+			Version:              clusterHostVer,
+			IPConfiguration: cns.IPConfiguration{
+				IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+			},
+			SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+				currentIPID: newSecondaryIPConfig("10.241.0.64", 8),
+			},
+		},
+	}
+	svc.PodIPConfigState[currentIPID] = newPodState("10.241.0.64", currentIPID, clusterNCID, types.Available, 8)
+	// releasedIPID intentionally absent: confirmed released by the live cluster capture in Phase 2.
+
+	// Act: replay the real Phase 1 (version 1) NC payload referencing the now-released cluster IP.
+	oldReq := &cns.CreateNetworkContainerRequest{
+		NetworkContainerid:   clusterNCID,
+		NetworkContainerType: dockerContainerType,
+		Version:              clusterOldVer,
+		IPConfiguration: cns.IPConfiguration{
+			IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+		},
+		SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+			releasedIPID: newSecondaryIPConfig(releasedIPAddress, 1),
+		},
+	}
+
+	returnCode := svc.CreateOrUpdateNetworkContainerInternal(oldReq)
+
+	require.Equal(t, types.Success, returnCode, "expected the stale cluster-captured NC replay to currently be accepted (demonstrating the bug)")
+
+	containerStatus := svc.state.ContainerStatus[clusterNCID]
+	assert.Equal(t, clusterOldVer, containerStatus.CreateNetworkContainerRequest.Version, "stored DNC version incorrectly drops from 8 to 1")
+	assert.Equal(t, clusterHostVer, containerStatus.HostVersion, "host version should remain unchanged")
+
+	releasedIPState, exists := svc.PodIPConfigState[releasedIPID]
+	require.True(t, exists, "cluster-released IP incorrectly recreated in PodIPConfigState")
+	assert.Equal(t, types.Available, releasedIPState.GetState(), "cluster-released IP incorrectly enters Available instead of PendingProgramming")
+}
+
 func TestSyncHostNCVersion(t *testing.T) {
 	// cns.KubernetesCRD has one more logic compared to other orchestrator type, so test both of them
 	orchestratorTypes := []string{cns.Kubernetes, cns.KubernetesCRD}

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -305,11 +305,11 @@ func TestCreateAndUpdateNCWithSecondaryIPNCVersion(t *testing.T) {
 }
 
 // TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP is a deterministic
-// reproduction of the NC-version-replay bug: CNS already has NC version 10 in local state and a matching
-// host (NMAgent-programmed) version of 10. An incoming NC request carrying an older DNC/NNC version (5)
-// for the same NC, referencing a secondary IP ID that was already released and removed from
-// PodIPConfigState, is currently accepted and the released IP is incorrectly recreated as Available
-// (instead of being rejected as stale, or at minimum recreated as PendingProgramming).
+// regression test for the NC-version-replay bug: CNS already has NC version 10 in local state and a
+// matching host (NMAgent-programmed) version of 10. An incoming NC request carrying an older DNC/NNC
+// version (5) for the same NC, referencing a secondary IP ID that was already released and removed from
+// PodIPConfigState, must now be rejected atomically: no stored state may change, and the released IP
+// must remain absent (not recreated as Available or PendingProgramming).
 // See nc-version-replay-repro-handoff.md for the full analysis.
 func TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP(t *testing.T) {
 	restartService()
@@ -357,30 +357,244 @@ func TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsRele
 
 	returnCode := svc.CreateOrUpdateNetworkContainerInternal(oldReq)
 
-	// Current (buggy) behavior: the stale replay is accepted.
-	require.Equal(t, types.Success, returnCode, "expected the stale NC replay to currently be accepted (demonstrating the bug)")
+	// Fixed behavior: the stale replay is rejected, atomically, with no partial mutation.
+	assert.Equal(t, types.NetworkContainerVersionMismatch, returnCode, "expected the stale NC replay to be rejected")
 
 	containerStatus := svc.state.ContainerStatus[testNCID]
-	assert.Equal(t, "5", containerStatus.CreateNetworkContainerRequest.Version, "stored DNC version incorrectly drops from 10 to 5")
+	assert.Equal(t, "10", containerStatus.CreateNetworkContainerRequest.Version, "stored DNC version must remain 10")
 	assert.Equal(t, "10", containerStatus.HostVersion, "host version should remain unchanged")
 
-	oldIPState, exists := svc.PodIPConfigState[oldIPID]
-	require.True(t, exists, "old IP incorrectly recreated in PodIPConfigState")
-	assert.Equal(t, types.Available, oldIPState.GetState(), "old IP incorrectly enters Available instead of PendingProgramming")
+	_, exists := svc.PodIPConfigState[oldIPID]
+	assert.False(t, exists, "old IP must not be recreated in PodIPConfigState")
+
+	currentIPState, exists := svc.PodIPConfigState[currentIPID]
+	require.True(t, exists, "current IP must be unaffected by the rejected stale replay")
+	assert.Equal(t, types.Available, currentIPState.GetState())
 }
 
-// TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP_ClusterData replays
-// the same bug using real data captured from a live AKS standalone cluster (Phase 1-2 of the guarded
+// TestCreateOrUpdateNetworkContainerInternal_EqualVersionIsIdempotent verifies that replaying the same
+// (currently stored) DNC/NNC version is accepted and idempotent, per the "incoming = stored" case in the
+// proposed correctness guard in nc-version-replay-repro-handoff.md.
+func TestCreateOrUpdateNetworkContainerInternal_EqualVersionIsIdempotent(t *testing.T) {
+	restartService()
+	setEnv(t)
+	setOrchestratorTypeInternal(cns.KubernetesCRD)
+	svc.state.ContainerStatus = make(map[string]containerstatus)
+	svc.PodIPConfigState = make(map[string]cns.IPConfigurationStatus)
+
+	testNCID := "555ac5c9-89f2-4b5d-b8d0-616894d6d150"
+	currentIPID := uuid.New().String()
+
+	svc.state.ContainerStatus[testNCID] = containerstatus{
+		ID:          testNCID,
+		VMVersion:   "10",
+		HostVersion: "10",
+		CreateNetworkContainerRequest: cns.CreateNetworkContainerRequest{
+			NetworkContainerid:   testNCID,
+			NetworkContainerType: dockerContainerType,
+			Version:              "10",
+			IPConfiguration: cns.IPConfiguration{
+				IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+			},
+			SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+				currentIPID: newSecondaryIPConfig("10.0.0.6", 10),
+			},
+		},
+	}
+	svc.PodIPConfigState[currentIPID] = newPodState("10.0.0.6", currentIPID, testNCID, types.Available, 10)
+
+	sameReq := &cns.CreateNetworkContainerRequest{
+		NetworkContainerid:   testNCID,
+		NetworkContainerType: dockerContainerType,
+		Version:              "10",
+		IPConfiguration: cns.IPConfiguration{
+			IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+		},
+		SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+			currentIPID: newSecondaryIPConfig("10.0.0.6", 10),
+		},
+	}
+
+	returnCode := svc.CreateOrUpdateNetworkContainerInternal(sameReq)
+
+	assert.Equal(t, types.Success, returnCode, "an equal-version replay must be accepted idempotently")
+	assert.Equal(t, "10", svc.state.ContainerStatus[testNCID].CreateNetworkContainerRequest.Version)
+}
+
+// TestCreateOrUpdateNetworkContainerInternal_HigherVersionIsAccepted verifies that a newer DNC/NNC
+// version is still accepted and reconciled normally, per the "incoming > stored" case in the proposed
+// correctness guard in nc-version-replay-repro-handoff.md.
+func TestCreateOrUpdateNetworkContainerInternal_HigherVersionIsAccepted(t *testing.T) {
+	restartService()
+	setEnv(t)
+	setOrchestratorTypeInternal(cns.KubernetesCRD)
+	svc.state.ContainerStatus = make(map[string]containerstatus)
+	svc.PodIPConfigState = make(map[string]cns.IPConfigurationStatus)
+
+	testNCID := "555ac5c9-89f2-4b5d-b8d0-616894d6d150"
+	currentIPID := uuid.New().String()
+	newIPID := uuid.New().String()
+
+	svc.state.ContainerStatus[testNCID] = containerstatus{
+		ID:          testNCID,
+		VMVersion:   "10",
+		HostVersion: "10",
+		CreateNetworkContainerRequest: cns.CreateNetworkContainerRequest{
+			NetworkContainerid:   testNCID,
+			NetworkContainerType: dockerContainerType,
+			Version:              "10",
+			IPConfiguration: cns.IPConfiguration{
+				IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+			},
+			SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+				currentIPID: newSecondaryIPConfig("10.0.0.6", 10),
+			},
+		},
+	}
+	svc.PodIPConfigState[currentIPID] = newPodState("10.0.0.6", currentIPID, testNCID, types.Available, 10)
+
+	newerReq := &cns.CreateNetworkContainerRequest{
+		NetworkContainerid:   testNCID,
+		NetworkContainerType: dockerContainerType,
+		Version:              "11",
+		IPConfiguration: cns.IPConfiguration{
+			IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+		},
+		SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+			newIPID: newSecondaryIPConfig("10.0.0.7", 11),
+		},
+	}
+
+	returnCode := svc.CreateOrUpdateNetworkContainerInternal(newerReq)
+
+	assert.Equal(t, types.Success, returnCode, "a newer-version update must be accepted")
+	assert.Equal(t, "11", svc.state.ContainerStatus[testNCID].CreateNetworkContainerRequest.Version)
+
+	newIPState, exists := svc.PodIPConfigState[newIPID]
+	require.True(t, exists)
+	// host version (10) has not yet caught up to the newly accepted NC version (11), so the new IP
+	// correctly awaits host programming rather than being marked Available.
+	assert.Equal(t, types.PendingProgramming, newIPState.GetState())
+	// the old IP, no longer present in the newer request, must have been removed
+	_, oldExists := svc.PodIPConfigState[currentIPID]
+	assert.False(t, oldExists)
+}
+
+// TestCreateOrUpdateNetworkContainerInternal_MalformedVersionFailsWithoutMutation verifies that a
+// non-numeric incoming or stored version is rejected without mutating any state, per
+// nc-version-replay-repro-handoff.md's "malformed versions fail without mutation" requirement.
+func TestCreateOrUpdateNetworkContainerInternal_MalformedVersionFailsWithoutMutation(t *testing.T) {
+	restartService()
+	setEnv(t)
+	setOrchestratorTypeInternal(cns.KubernetesCRD)
+	svc.state.ContainerStatus = make(map[string]containerstatus)
+	svc.PodIPConfigState = make(map[string]cns.IPConfigurationStatus)
+
+	testNCID := "555ac5c9-89f2-4b5d-b8d0-616894d6d150"
+	currentIPID := uuid.New().String()
+
+	svc.state.ContainerStatus[testNCID] = containerstatus{
+		ID:          testNCID,
+		VMVersion:   "10",
+		HostVersion: "10",
+		CreateNetworkContainerRequest: cns.CreateNetworkContainerRequest{
+			NetworkContainerid:   testNCID,
+			NetworkContainerType: dockerContainerType,
+			Version:              "10",
+			IPConfiguration: cns.IPConfiguration{
+				IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+			},
+			SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+				currentIPID: newSecondaryIPConfig("10.0.0.6", 10),
+			},
+		},
+	}
+	svc.PodIPConfigState[currentIPID] = newPodState("10.0.0.6", currentIPID, testNCID, types.Available, 10)
+
+	malformedReq := &cns.CreateNetworkContainerRequest{
+		NetworkContainerid:   testNCID,
+		NetworkContainerType: dockerContainerType,
+		Version:              "not-a-number",
+		IPConfiguration: cns.IPConfiguration{
+			IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+		},
+		SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+			currentIPID: newSecondaryIPConfig("10.0.0.6", 10),
+		},
+	}
+
+	returnCode := svc.CreateOrUpdateNetworkContainerInternal(malformedReq)
+
+	assert.Equal(t, types.UnsupportedNCVersion, returnCode, "a malformed version must be rejected")
+	assert.Equal(t, "10", svc.state.ContainerStatus[testNCID].CreateNetworkContainerRequest.Version, "stored version must not be mutated")
+}
+
+// TestCreateOrUpdateNetworkContainerInternal_StaleReplayCannotAlterAssignedIP verifies that even if a
+// stale replay were somehow processed, an already-Assigned secondary IP is never altered or removed --
+// this exercises the pre-existing Assigned-IP protection in updateIPConfigsStateUntransacted, which the
+// new version guard must not weaken.
+func TestCreateOrUpdateNetworkContainerInternal_StaleReplayCannotAlterAssignedIP(t *testing.T) {
+	restartService()
+	setEnv(t)
+	setOrchestratorTypeInternal(cns.KubernetesCRD)
+	svc.state.ContainerStatus = make(map[string]containerstatus)
+	svc.PodIPConfigState = make(map[string]cns.IPConfigurationStatus)
+
+	testNCID := "555ac5c9-89f2-4b5d-b8d0-616894d6d150"
+	assignedIPID := uuid.New().String()
+
+	svc.state.ContainerStatus[testNCID] = containerstatus{
+		ID:          testNCID,
+		VMVersion:   "10",
+		HostVersion: "10",
+		CreateNetworkContainerRequest: cns.CreateNetworkContainerRequest{
+			NetworkContainerid:   testNCID,
+			NetworkContainerType: dockerContainerType,
+			Version:              "10",
+			IPConfiguration: cns.IPConfiguration{
+				IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+			},
+			SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+				assignedIPID: newSecondaryIPConfig("10.0.0.6", 10),
+			},
+		},
+	}
+	svc.PodIPConfigState[assignedIPID] = newPodState("10.0.0.6", assignedIPID, testNCID, types.Assigned, 10)
+
+	// A stale replay (version 5) that no longer references the assigned IP at all.
+	staleReq := &cns.CreateNetworkContainerRequest{
+		NetworkContainerid:   testNCID,
+		NetworkContainerType: dockerContainerType,
+		Version:              "5",
+		IPConfiguration: cns.IPConfiguration{
+			IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+		},
+		SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{},
+	}
+
+	returnCode := svc.CreateOrUpdateNetworkContainerInternal(staleReq)
+
+	assert.Equal(t, types.NetworkContainerVersionMismatch, returnCode, "the stale replay must be rejected before it can reach IP config deletion logic")
+
+	assignedIPState, exists := svc.PodIPConfigState[assignedIPID]
+	require.True(t, exists, "assigned IP must not be removed by a rejected stale replay")
+	assert.Equal(t, types.Assigned, assignedIPState.GetState(), "assigned IP state must be unchanged")
+}
+
+// TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP_ClusterData is a
+// regression test using real data captured from a live AKS standalone cluster (Phase 1-2 of the guarded
 // cluster reproduction in nc-version-replay-repro-handoff.md), instead of synthetic IDs:
 //   - NC ID c51b224b-b747-4063-b470-3676a74f13e8 was observed on node aks-gmp32-53174927-vmss000000.
 //   - Version 1 of that NC (captured while held-demand pods were still occupying IPs) assigned
 //     secondary IP d9ac4eef-344a-4025-99b6-96c6c6e2ec71 / 10.241.0.69.
 //   - After releasing the held-demand pods, the live NNC advanced to version 8 and that IP ID was
-//     confirmed absent from the current ipAssignments set (i.e. genuinely released cluster-side).
+//     confirmed absent from the current ipAssignments set (i.e. genuinely released cluster-side). A
+//     live-cluster replay of this exact captured version-1 payload (via a single NNC status patch on
+//     the real cluster, since reverted) reproduced the bug against the real running CNS binary too.
 //
-// This demonstrates the same code path resurrects a real, cluster-released address as Available when
-// fed a stale (version 1) replay of the NC payload against locally-stored state reflecting the newer
-// (version 8) baseline.
+// This verifies the fix using the same real, cluster-derived data: feeding a stale (version 1) replay
+// of the NC payload against locally-stored state reflecting the newer (version 8) baseline must now be
+// rejected, and the released address must remain absent.
 func TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP_ClusterData(t *testing.T) {
 	restartService()
 	setEnv(t)
@@ -433,15 +647,14 @@ func TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsRele
 
 	returnCode := svc.CreateOrUpdateNetworkContainerInternal(oldReq)
 
-	require.Equal(t, types.Success, returnCode, "expected the stale cluster-captured NC replay to currently be accepted (demonstrating the bug)")
+	assert.Equal(t, types.NetworkContainerVersionMismatch, returnCode, "expected the stale cluster-captured NC replay to be rejected")
 
 	containerStatus := svc.state.ContainerStatus[clusterNCID]
-	assert.Equal(t, clusterOldVer, containerStatus.CreateNetworkContainerRequest.Version, "stored DNC version incorrectly drops from 8 to 1")
+	assert.Equal(t, clusterHostVer, containerStatus.CreateNetworkContainerRequest.Version, "stored DNC version must remain 8")
 	assert.Equal(t, clusterHostVer, containerStatus.HostVersion, "host version should remain unchanged")
 
-	releasedIPState, exists := svc.PodIPConfigState[releasedIPID]
-	require.True(t, exists, "cluster-released IP incorrectly recreated in PodIPConfigState")
-	assert.Equal(t, types.Available, releasedIPState.GetState(), "cluster-released IP incorrectly enters Available instead of PendingProgramming")
+	_, exists := svc.PodIPConfigState[releasedIPID]
+	assert.False(t, exists, "cluster-released IP must not be recreated in PodIPConfigState")
 }
 
 func TestSyncHostNCVersion(t *testing.T) {

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -170,7 +170,6 @@ func (service *HTTPRestService) saveNetworkContainerGoalState(req cns.CreateNetw
 		// recreated as Available. This only applies to the KubernetesCRD (dynamic NNC-driven) IPAM
 		// path when both requests carry a version to compare: other orchestrator types/flows don't
 		// always populate a meaningful NC version here.
-		// See nc-version-replay-repro-handoff.md for full analysis.
 		storedVersionStr := existingNCStatus.CreateNetworkContainerRequest.Version
 		if req.NetworkContainerid != nodesubnet.NodeSubnetNCID && service.state.OrchestratorType == cns.KubernetesCRD &&
 			storedVersionStr != "" && req.Version != "" {

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -162,6 +162,33 @@ func (service *HTTPRestService) saveNetworkContainerGoalState(req cns.CreateNetw
 		hostVersion = existingNCStatus.HostVersion
 		existingSecondaryIPConfigs = existingNCStatus.CreateNetworkContainerRequest.SecondaryIPConfigs
 		vfpUpdateComplete = existingNCStatus.VfpUpdateComplete
+
+		// Guard against replay of a stale NC payload: reject (without mutating any state) an incoming
+		// DNC/NNC version that is older than the version CNS already has stored for this NC. Without
+		// this check, a stale replay would be accepted, the stored version would incorrectly move
+		// backwards, and secondary IPs already released (and removed from PodIPConfigState) could be
+		// recreated as Available. This only applies to the KubernetesCRD (dynamic NNC-driven) IPAM
+		// path when both requests carry a version to compare: other orchestrator types/flows don't
+		// always populate a meaningful NC version here.
+		// See nc-version-replay-repro-handoff.md for full analysis.
+		storedVersionStr := existingNCStatus.CreateNetworkContainerRequest.Version
+		if req.NetworkContainerid != nodesubnet.NodeSubnetNCID && service.state.OrchestratorType == cns.KubernetesCRD &&
+			storedVersionStr != "" && req.Version != "" {
+			storedVersion, storedErr := strconv.Atoi(storedVersionStr)
+			incomingVersion, incomingErr := strconv.Atoi(req.Version)
+			switch {
+			case storedErr != nil || incomingErr != nil:
+				errBuf := fmt.Sprintf(
+					"[Azure CNS] Unable to compare NC versions for %s: stored version %q, incoming version %q",
+					req.NetworkContainerid, storedVersionStr, req.Version)
+				return types.UnsupportedNCVersion, errBuf
+			case incomingVersion < storedVersion:
+				errBuf := fmt.Sprintf(
+					"[Azure CNS] Rejecting stale NC update for %s: incoming version %d is older than stored version %d",
+					req.NetworkContainerid, incomingVersion, storedVersion)
+				return types.NetworkContainerVersionMismatch, errBuf
+			}
+		}
 	}
 
 	if req.NetworkContainerid == nodesubnet.NodeSubnetNCID {

--- a/cns/types/codes.go
+++ b/cns/types/codes.go
@@ -45,6 +45,7 @@ const (
 	UnsupportedAPI                         ResponseCode = 43
 	FailedToAllocateBackendConfig          ResponseCode = 44
 	ConnectionError                        ResponseCode = 45
+	NetworkContainerVersionMismatch        ResponseCode = 46
 	UnexpectedError                        ResponseCode = 99
 	NmAgentNCVersionListError              ResponseCode = 100
 )
@@ -86,6 +87,8 @@ func (c ResponseCode) String() string {
 		return "NetworkContainerVfpProgramComplete"
 	case NetworkContainerVfpProgramPending:
 		return "NetworkContainerVfpProgramPending"
+	case NetworkContainerVersionMismatch:
+		return "NetworkContainerVersionMismatch"
 	case NetworkJoinFailed:
 		return "NetworkJoinFailed"
 	case NmAgentSupportedApisError:


### PR DESCRIPTION
## Summary

CNS's `CreateOrUpdateNetworkContainerInternal` only validated the NMAgent-reported **host** version against an incoming secondary IP's NC version when deciding `Available` vs `PendingProgramming`. It never compared the incoming DNC/NNC request's own version against the version CNS already had stored for that NC. As a result, a stale/replayed NC payload with an older version than what CNS already had could be accepted: the stored version moved backwards, and a secondary IP that had already been released (and removed from `PodIPConfigState`) was silently recreated as `Available`.

This PR adds a guard that rejects such stale replays atomically, with no partial mutation, and adds/updates unit tests (including two using data captured from a live cluster) plus a real live-cluster verification (details below).

## Root cause

- `saveNetworkContainerGoalState` (`cns/restserver/util.go`) unconditionally overwrote `service.state.ContainerStatus[ncID]` with the incoming request — including its `Version` — *before* any downstream validation ran.
- `addIPConfigStateUntransacted` decided the state of a newly-added IP using only:
  ```go
  if hostVersion < ipconfig.NCVersion {
      state = PendingProgramming
  } else {
      state = Available
  }
  ```
  where `hostVersion` is the **previously stored** host version and `ipconfig.NCVersion` comes from the **incoming (possibly stale)** request. If the host had already advanced past the incoming request's version, this condition is false, and the IP is marked `Available` even though it was already released.
- Nowhere was the incoming request's `Version` compared against the **previously stored DNC version** for the same NC before mutating state.

## Reproduction (three levels of evidence)

1. **Deterministic unit test** (synthetic data): stored NC version 10 / host version 10 with one IP `Available`; replayed an incoming request at version 5 referencing an IP that had already been released (absent from `PodIPConfigState`). Before the fix, this was accepted and the released IP was recreated as `Available`.
2. **Cluster-data unit test**: same test, but using a real NC ID, IP, and IP-config ID captured from a live AKS standalone test cluster (`35-hcpbehzadmebld177956867-dynamic`, node `aks-gmp32-53174927-vmss000000`) after growing the NC pool from version 1 to version 8 and confirming a specific IP (`10.241.0.69`, id `d9ac4eef-...`) was genuinely released.
3. **Live cluster reproduction**: on the same real node, I patched the live NNC's `status` subresource with a single, real captured version-1 payload (previously saved) against the actual version-8 state, then tailed the real running CNS pod's logs:
   ```
   Set ipId d9ac4eef-344a-4025-99b6-96c6c6e2ec71, IP 10.241.0.69 version to 1, programmed host nc version is 8
   Add IP 10.241.0.69 as Available
   ...
   NC version from NMAgent is larger than DNC, NC version from NMAgent is 8, NC version from DNC is 1   (repeated)
   ```
   This confirmed the bug against the real, running CNS binary — not just a test harness. CNS itself logs that it detected the version mismatch (NMAgent > DNC) but still applied the stale payload. The control plane did not self-correct within ~2.5 minutes (it's demand-driven, not on a timer), so the NNC status was immediately restored to the known-good version-8 baseline afterward; the cluster was verified healthy (all nodes Ready, CNS pods Running with 0 restarts, `Allocated IPs: 16` matching the real baseline) post-restore.

   Note: a currently-`Assigned` IP on that node was **not** affected by the replay — CNS correctly preserved its `Assigned` state throughout, consistent with the pre-existing (and still intact) Assigned-IP protection in `updateIPConfigsStateUntransacted`.

## Fix

In `saveNetworkContainerGoalState`, before any state mutation, compare the incoming request's `Version` against the previously stored DNC version for the same NC ID. Scoped to the `KubernetesCRD` (dynamic NNC-driven) IPAM path, and only when both stored and incoming versions are non-empty (other orchestrator types/flows don't always populate a meaningful NC version and must be unaffected):

- **incoming < stored**: reject with new `types.NetworkContainerVersionMismatch` response code; **no state is mutated**.
- **incoming == stored**: accepted, idempotent (unchanged behavior).
- **incoming > stored**: accepted and reconciled normally (unchanged behavior).
- **non-numeric stored/incoming version**: reject with `types.UnsupportedNCVersion`; no state is mutated.

Added `cns/types.NetworkContainerVersionMismatch` (`ResponseCode = 46`).

## Tests

- Updated the two reproduction tests to assert the now-fixed (correct) behavior instead of documenting the bug:
  - `TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP`
  - `TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP_ClusterData` (uses real cluster-captured NC ID/IP/version data)
- Added:
  - `TestCreateOrUpdateNetworkContainerInternal_EqualVersionIsIdempotent`
  - `TestCreateOrUpdateNetworkContainerInternal_HigherVersionIsAccepted`
  - `TestCreateOrUpdateNetworkContainerInternal_MalformedVersionFailsWithoutMutation`
  - `TestCreateOrUpdateNetworkContainerInternal_StaleReplayCannotAlterAssignedIP`
- Full `cns/...` test suite passes; `gofmt` clean; `go vet` clean (no new warnings).

## Validation commands used

```
GOTOOLCHAIN=local GOPROXY=direct GOSUMDB=off go test ./cns/restserver/... -run 'TestCreateOrUpdateNetworkContainerInternal_' -v
GOTOOLCHAIN=local GOPROXY=direct GOSUMDB=off go test ./cns/...
gofmt -l cns/restserver/internalapi_test.go cns/restserver/util.go cns/types/codes.go
GOTOOLCHAIN=local GOPROXY=direct GOSUMDB=off go vet ./cns/restserver/... ./cns/types/...
```

(The internal `GOPROXY` returned 401 in this environment for an uncached dependency; `GOTOOLCHAIN=local GOPROXY=direct GOSUMDB=off` was used as a workaround to build/test against the public Go module proxy.)
