### PR TITLE
feat(cns): import legacy JSON into Bolt state

### DIFF
--- a/cns/state/import.go
+++ b/cns/state/import.go
@@ -28,6 +28,30 @@ var (
 	ErrLegacyImportSource = errors.New("cns state: invalid legacy import source")
 )
 
+// Legacy network container/IP validation sentinels. These are static
+// building blocks wrapped with contextual detail (index, field name) by
+// their callers rather than being constructed dynamically.
+var (
+	errLegacyRouteInvalidDestination     = errors.New("route has invalid destination")
+	errLegacyInvalidNetworkInterfaceMAC  = errors.New("invalid network interface MAC")
+	errLegacySubnetPrefixWithoutAddress  = errors.New("prefix length is set without an address")
+	errLegacyInvalidSubnetAddress        = errors.New("invalid subnet address")
+	errLegacySubnetAddressFamilyMismatch = errors.New("subnet address family does not match")
+	errLegacyInvalidSubnetPrefixLength   = errors.New("invalid subnet prefix length")
+	errLegacyInvalidIPAddress            = errors.New("invalid IP address")
+	errLegacyInvalidIPAddressOrPrefix    = errors.New("invalid IP address or prefix")
+)
+
+// JSON decoding sentinels shared by the legacy-import strict JSON decoder.
+var (
+	errJSONEnvelopeMissing     = errors.New("envelope is missing")
+	errJSONValueEmpty          = errors.New("json value is empty")
+	errJSONMultipleValues      = errors.New("multiple json values")
+	errJSONObjectKeyNotString  = errors.New("object key is not a string")
+	errJSONDuplicateKey        = errors.New("duplicate json key")
+	errJSONUnexpectedDelimiter = errors.New("unexpected JSON delimiter")
+)
+
 // ImportOptions identifies the legacy JSON sources and imported boot identity.
 type ImportOptions struct {
 	CNSPath             string
@@ -107,15 +131,16 @@ func (s *DB) importLegacyWithCommitHook(
 		return false, err
 	}
 	if opts.ManageEndpointState {
-		endpointData, err := readLegacyFile(ctx, readFile, opts.EndpointPath, "endpoint")
+		var endpointData []byte
+		endpointData, err = readLegacyFile(ctx, readFile, opts.EndpointPath, "endpoint")
 		if err != nil {
 			return false, err
 		}
-		if err := addLegacyEndpoints(&snapshot, endpointData); err != nil {
-			return false, err
+		if endpointErr := addLegacyEndpoints(&snapshot, endpointData); endpointErr != nil {
+			return false, endpointErr
 		}
 	}
-	if err := snapshot.Validate(); err != nil {
+	if err = snapshot.Validate(); err != nil {
 		return false, fmt.Errorf("%w: validating imported snapshot: %w", ErrLegacyImportSource, err)
 	}
 	encoded, err := encodeImportedSnapshot(snapshot)
@@ -196,20 +221,8 @@ func parseLegacyCNS(data []byte, bootID string) (Snapshot, error) {
 	if err := decodeLegacyEnvelope(data, "ContainerNetworkService", &source); err != nil {
 		return Snapshot{}, fmt.Errorf("%w: decoding legacy CNS state: %w", ErrLegacyImportSource, err)
 	}
-	if source.ContainerStatus == nil {
-		return Snapshot{}, fmt.Errorf("%w: legacy CNS container status is null", ErrLegacyImportSource)
-	}
-	if source.ContainerIDByOrchestratorContext == nil {
-		return Snapshot{}, fmt.Errorf("%w: legacy CNS orchestrator contexts are null", ErrLegacyImportSource)
-	}
-	if source.Networks == nil {
-		return Snapshot{}, fmt.Errorf("%w: legacy CNS networks are null", ErrLegacyImportSource)
-	}
-	if source.PnpIDByMacAddress == nil {
-		return Snapshot{}, fmt.Errorf("%w: legacy CNS PnP mappings are null", ErrLegacyImportSource)
-	}
-	if source.TimeStamp.IsZero() {
-		return Snapshot{}, fmt.Errorf("%w: legacy CNS timestamp is zero", ErrLegacyImportSource)
+	if err := validateLegacyCNSStatePresence(source); err != nil {
+		return Snapshot{}, err
 	}
 
 	snapshot := NewSnapshot()
@@ -226,11 +239,48 @@ func parseLegacyCNS(data []byte, bootID string) (Snapshot, error) {
 		LegacyImportComplete: true,
 	}
 
+	if err := parseLegacyContainerStatuses(&snapshot, source.ContainerStatus); err != nil {
+		return Snapshot{}, err
+	}
+	if err := parseLegacyOrchestratorContexts(&snapshot, source.ContainerIDByOrchestratorContext); err != nil {
+		return Snapshot{}, err
+	}
+	if err := parseLegacyNetworks(&snapshot, source.Networks); err != nil {
+		return Snapshot{}, err
+	}
+	if err := parseLegacyPnPMappings(&snapshot, source.PnpIDByMacAddress); err != nil {
+		return Snapshot{}, err
+	}
+	return snapshot, nil
+}
+
+// validateLegacyCNSStatePresence rejects a decoded legacy CNS document whose
+// required top-level collections were absent (JSON null) rather than empty.
+func validateLegacyCNSStatePresence(source legacyCNSState) error {
+	switch {
+	case source.ContainerStatus == nil:
+		return fmt.Errorf("%w: legacy CNS container status is null", ErrLegacyImportSource)
+	case source.ContainerIDByOrchestratorContext == nil:
+		return fmt.Errorf("%w: legacy CNS orchestrator contexts are null", ErrLegacyImportSource)
+	case source.Networks == nil:
+		return fmt.Errorf("%w: legacy CNS networks are null", ErrLegacyImportSource)
+	case source.PnpIDByMacAddress == nil:
+		return fmt.Errorf("%w: legacy CNS PnP mappings are null", ErrLegacyImportSource)
+	case source.TimeStamp.IsZero():
+		return fmt.Errorf("%w: legacy CNS timestamp is zero", ErrLegacyImportSource)
+	default:
+		return nil
+	}
+}
+
+// parseLegacyContainerStatuses validates and copies legacy network container
+// state, along with the secondary IPs each container owns, into snapshot.
+func parseLegacyContainerStatuses(snapshot *Snapshot, containerStatus map[string]legacyContainerStatus) error {
 	seenUUIDs := map[string]string{}
-	for _, ncID := range sortedKeys(source.ContainerStatus) {
-		status := source.ContainerStatus[ncID]
+	for _, ncID := range sortedKeys(containerStatus) {
+		status := containerStatus[ncID]
 		if ncID == "" || status.ID == "" || status.ID != ncID {
-			return Snapshot{}, fmt.Errorf(
+			return fmt.Errorf(
 				"%w: network container key %q does not match ID %q",
 				ErrLegacyImportSource,
 				ncID,
@@ -238,45 +288,17 @@ func parseLegacyCNS(data []byte, bootID string) (Snapshot, error) {
 			)
 		}
 		if status.CreateNetworkContainerRequest.NetworkContainerid != ncID {
-			return Snapshot{}, fmt.Errorf(
+			return fmt.Errorf(
 				"%w: network container %q request ID does not match",
 				ErrLegacyImportSource,
 				ncID,
 			)
 		}
 		if err := validateLegacyNetworkContainerRequest(status.CreateNetworkContainerRequest); err != nil {
-			return Snapshot{}, fmt.Errorf("%w: network container %q: %w", ErrLegacyImportSource, ncID, err)
+			return fmt.Errorf("%w: network container %q: %w", ErrLegacyImportSource, ncID, err)
 		}
-		for _, ipID := range sortedKeys(status.CreateNetworkContainerRequest.SecondaryIPConfigs) {
-			config := status.CreateNetworkContainerRequest.SecondaryIPConfigs[ipID]
-			parsedID, err := uuid.Parse(ipID)
-			if err != nil {
-				return Snapshot{}, fmt.Errorf("%w: network container %q has invalid IP UUID", ErrLegacyImportSource, ncID)
-			}
-			canonicalID := parsedID.String()
-			if other, ok := seenUUIDs[canonicalID]; ok {
-				return Snapshot{}, fmt.Errorf(
-					"%w: network containers %q and %q contain duplicate IP UUID",
-					ErrLegacyImportSource,
-					other,
-					ncID,
-				)
-			}
-			if _, err := netip.ParseAddr(config.IPAddress); err != nil {
-				return Snapshot{}, fmt.Errorf(
-					"%w: network container %q IP %q has invalid address",
-					ErrLegacyImportSource,
-					ncID,
-					ipID,
-				)
-			}
-			seenUUIDs[canonicalID] = ncID
-			snapshot.IPs[ipID] = IPRecord{
-				ID:        ipID,
-				IPAddress: config.IPAddress,
-				NCID:      ncID,
-				NCVersion: config.NCVersion,
-			}
+		if err := parseLegacySecondaryIPs(snapshot, ncID, status.CreateNetworkContainerRequest.SecondaryIPConfigs, seenUUIDs); err != nil {
+			return err
 		}
 		snapshot.NetworkContainers[ncID] = NewNetworkContainerRecord(
 			status.ID,
@@ -286,29 +308,84 @@ func parseLegacyCNS(data []byte, bootID string) (Snapshot, error) {
 			status.CreateNetworkContainerRequest,
 		)
 	}
+	return nil
+}
 
-	for _, contextID := range sortedKeys(source.ContainerIDByOrchestratorContext) {
-		value := source.ContainerIDByOrchestratorContext[contextID]
+// parseLegacySecondaryIPs validates the secondary IP configurations owned by
+// a single legacy network container and records them as snapshot IP records.
+// seenUUIDs tracks canonical IP UUIDs across all network containers so
+// duplicates are rejected regardless of which container declared them first.
+func parseLegacySecondaryIPs(
+	snapshot *Snapshot,
+	ncID string,
+	configs map[string]cns.SecondaryIPConfig,
+	seenUUIDs map[string]string,
+) error {
+	for _, ipID := range sortedKeys(configs) {
+		config := configs[ipID]
+		parsedID, err := uuid.Parse(ipID)
+		if err != nil {
+			return fmt.Errorf("%w: network container %q has invalid IP UUID", ErrLegacyImportSource, ncID)
+		}
+		canonicalID := parsedID.String()
+		if other, ok := seenUUIDs[canonicalID]; ok {
+			return fmt.Errorf(
+				"%w: network containers %q and %q contain duplicate IP UUID",
+				ErrLegacyImportSource,
+				other,
+				ncID,
+			)
+		}
+		if _, err := netip.ParseAddr(config.IPAddress); err != nil {
+			return fmt.Errorf(
+				"%w: network container %q IP %q has invalid address",
+				ErrLegacyImportSource,
+				ncID,
+				ipID,
+			)
+		}
+		seenUUIDs[canonicalID] = ncID
+		snapshot.IPs[ipID] = IPRecord{
+			ID:        ipID,
+			IPAddress: config.IPAddress,
+			NCID:      ncID,
+			NCVersion: config.NCVersion,
+		}
+	}
+	return nil
+}
+
+// parseLegacyOrchestratorContexts validates and copies the orchestrator
+// context to network-container-ID-list mapping into snapshot.
+func parseLegacyOrchestratorContexts(snapshot *Snapshot, contexts map[string]*string) error {
+	for _, contextID := range sortedKeys(contexts) {
+		value := contexts[contextID]
 		if contextID == "" || value == nil || *value == "" {
-			return Snapshot{}, fmt.Errorf("%w: malformed orchestrator NC list %q", ErrLegacyImportSource, contextID)
+			return fmt.Errorf("%w: malformed orchestrator NC list %q", ErrLegacyImportSource, contextID)
 		}
 		ids := strings.Split(*value, ",")
 		seen := map[string]struct{}{}
 		for _, id := range ids {
 			if id == "" || strings.TrimSpace(id) != id {
-				return Snapshot{}, fmt.Errorf("%w: malformed orchestrator NC list %q", ErrLegacyImportSource, contextID)
+				return fmt.Errorf("%w: malformed orchestrator NC list %q", ErrLegacyImportSource, contextID)
 			}
 			if _, ok := seen[id]; ok {
-				return Snapshot{}, fmt.Errorf("%w: orchestrator NC list %q contains a duplicate", ErrLegacyImportSource, contextID)
+				return fmt.Errorf("%w: orchestrator NC list %q contains a duplicate", ErrLegacyImportSource, contextID)
 			}
 			seen[id] = struct{}{}
 		}
 		snapshot.OrchestratorContexts[contextID] = ids
 	}
-	for _, name := range sortedKeys(source.Networks) {
-		record := source.Networks[name]
+	return nil
+}
+
+// parseLegacyNetworks validates and copies legacy network records, cloning
+// each network's NIC info so the snapshot does not alias the decoded source.
+func parseLegacyNetworks(snapshot *Snapshot, networks map[string]*legacyNetworkInfo) error {
+	for _, name := range sortedKeys(networks) {
+		record := networks[name]
 		if record == nil {
-			return Snapshot{}, fmt.Errorf("%w: network %q is null", ErrLegacyImportSource, name)
+			return fmt.Errorf("%w: network %q is null", ErrLegacyImportSource, name)
 		}
 		var nicInfo *wireserver.InterfaceInfo
 		if record.NicInfo != nil {
@@ -326,17 +403,24 @@ func parseLegacyCNS(data []byte, bootID string) (Snapshot, error) {
 			Options:     record.Options,
 		}
 	}
-	for _, rawMAC := range sortedKeys(source.PnpIDByMacAddress) {
+	return nil
+}
+
+// parseLegacyPnPMappings validates and copies the PnP-ID-by-MAC-address
+// mapping into snapshot, rejecting MAC addresses that canonicalize to the
+// same value.
+func parseLegacyPnPMappings(snapshot *Snapshot, mappings map[string]string) error {
+	for _, rawMAC := range sortedKeys(mappings) {
 		mac, err := canonicalMAC(rawMAC)
 		if err != nil {
-			return Snapshot{}, fmt.Errorf("%w: PnP mapping: %w", ErrLegacyImportSource, err)
+			return fmt.Errorf("%w: PnP mapping: %w", ErrLegacyImportSource, err)
 		}
 		if _, ok := snapshot.PnPIDByMAC[mac]; ok {
-			return Snapshot{}, fmt.Errorf("%w: duplicate canonical PnP MAC", ErrLegacyImportSource)
+			return fmt.Errorf("%w: duplicate canonical PnP MAC", ErrLegacyImportSource)
 		}
-		snapshot.PnPIDByMAC[mac] = source.PnpIDByMacAddress[rawMAC]
+		snapshot.PnPIDByMAC[mac] = mappings[rawMAC]
 	}
-	return snapshot, nil
+	return nil
 }
 
 func addLegacyEndpoints(snapshot *Snapshot, data []byte) error {
@@ -427,7 +511,7 @@ func validateLegacyNetworkContainerRequest(request cns.CreateNetworkContainerReq
 		if route.IPAddress != "" {
 			if _, err := netip.ParsePrefix(route.IPAddress); err != nil {
 				if _, addrErr := netip.ParseAddr(route.IPAddress); addrErr != nil {
-					return fmt.Errorf("route %d has invalid destination", index)
+					return fmt.Errorf("%w: route %d", errLegacyRouteInvalidDestination, index)
 				}
 			}
 		}
@@ -437,7 +521,7 @@ func validateLegacyNetworkContainerRequest(request cns.CreateNetworkContainerReq
 	}
 	if request.NetworkInterfaceInfo.MACAddress != "" {
 		if _, err := net.ParseMAC(request.NetworkInterfaceInfo.MACAddress); err != nil {
-			return fmt.Errorf("invalid network interface MAC")
+			return errLegacyInvalidNetworkInterfaceMAC
 		}
 	}
 	return nil
@@ -466,13 +550,13 @@ func validateLegacyIPConfiguration(config cns.IPConfiguration) error {
 func validateLegacySubnet(subnet cns.IPSubnet, expectedBits int) error {
 	if subnet.IPAddress == "" {
 		if subnet.PrefixLength != 0 {
-			return errors.New("prefix length is set without an address")
+			return errLegacySubnetPrefixWithoutAddress
 		}
 		return nil
 	}
 	address, err := netip.ParseAddr(subnet.IPAddress)
 	if err != nil {
-		return errors.New("invalid subnet address")
+		return errLegacyInvalidSubnetAddress
 	}
 	address = address.Unmap()
 	bits := 128
@@ -480,10 +564,10 @@ func validateLegacySubnet(subnet cns.IPSubnet, expectedBits int) error {
 		bits = 32
 	}
 	if expectedBits != 0 && bits != expectedBits {
-		return errors.New("subnet address family does not match")
+		return errLegacySubnetAddressFamilyMismatch
 	}
 	if int(subnet.PrefixLength) > bits {
-		return errors.New("invalid subnet prefix length")
+		return errLegacyInvalidSubnetPrefixLength
 	}
 	return nil
 }
@@ -493,7 +577,7 @@ func validateOptionalAddress(value string) error {
 		return nil
 	}
 	if _, err := netip.ParseAddr(value); err != nil {
-		return errors.New("invalid IP address")
+		return errLegacyInvalidIPAddress
 	}
 	return nil
 }
@@ -506,7 +590,7 @@ func validateOptionalIPValue(value string) error {
 		return nil
 	}
 	if _, err := netip.ParsePrefix(value); err != nil {
-		return errors.New("invalid IP address or prefix")
+		return errLegacyInvalidIPAddressOrPrefix
 	}
 	return nil
 }
@@ -612,7 +696,7 @@ func decodeLegacyEnvelope(data []byte, key string, destination any) error {
 	}
 	raw, ok := envelope[key]
 	if !ok {
-		return fmt.Errorf("missing %q envelope", key)
+		return fmt.Errorf("%w: %q", errJSONEnvelopeMissing, key)
 	}
 	return decodeStrictJSON(raw, destination)
 }
@@ -626,21 +710,21 @@ func decodeJSONDocument(data []byte, destination any) error {
 
 func decodeStrictJSON(data []byte, destination any) error {
 	if len(bytes.TrimSpace(data)) == 0 {
-		return errors.New("json value is empty")
+		return errJSONValueEmpty
 	}
 	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
-		return errors.New("json value is null")
+		return errJSONValueNull
 	}
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(destination); err != nil {
-		return err
+		return fmt.Errorf("decoding json value: %w", err)
 	}
 	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
 		if err == nil {
-			return errors.New("multiple json values")
+			return errJSONMultipleValues
 		}
-		return err
+		return fmt.Errorf("decoding trailing json value: %w", err)
 	}
 	return nil
 }
@@ -653,17 +737,21 @@ func rejectDuplicateJSONKeys(data []byte) error {
 	}
 	if _, err := decoder.Token(); !errors.Is(err, io.EOF) {
 		if err == nil {
-			return errors.New("multiple json values")
+			return errJSONMultipleValues
 		}
-		return err
+		return fmt.Errorf("decoding trailing json token: %w", err)
 	}
 	return nil
 }
 
+// scanJSONValue walks a single JSON value, recursing into objects and arrays,
+// solely to detect duplicate object keys (case-insensitively) ahead of the
+// strict decode pass. It reports the underlying decoder error wrapped, or one
+// of the static JSON sentinels, without ever constructing a dynamic error.
 func scanJSONValue(decoder *json.Decoder) error {
 	token, err := decoder.Token()
 	if err != nil {
-		return err
+		return fmt.Errorf("decoding json token: %w", err)
 	}
 	delim, ok := token.(json.Delim)
 	if !ok {
@@ -671,36 +759,51 @@ func scanJSONValue(decoder *json.Decoder) error {
 	}
 	switch delim {
 	case '{':
-		keys := map[string]struct{}{}
-		for decoder.More() {
-			keyToken, err := decoder.Token()
-			if err != nil {
-				return err
-			}
-			key, ok := keyToken.(string)
-			if !ok {
-				return errors.New("object key is not a string")
-			}
-			canonical := strings.ToLower(key)
-			if _, ok := keys[canonical]; ok {
-				return fmt.Errorf("duplicate json key %q", key)
-			}
-			keys[canonical] = struct{}{}
-			if err := scanJSONValue(decoder); err != nil {
-				return err
-			}
-		}
-		_, err = decoder.Token()
-		return err
+		return scanJSONObject(decoder)
 	case '[':
-		for decoder.More() {
-			if err := scanJSONValue(decoder); err != nil {
-				return err
-			}
-		}
-		_, err = decoder.Token()
-		return err
+		return scanJSONArray(decoder)
 	default:
-		return errors.New("unexpected JSON delimiter")
+		return errJSONUnexpectedDelimiter
 	}
+}
+
+// scanJSONObject scans the keys and values of a JSON object opened by the
+// caller, rejecting keys that duplicate a prior key case-insensitively.
+func scanJSONObject(decoder *json.Decoder) error {
+	keys := map[string]struct{}{}
+	for decoder.More() {
+		keyToken, err := decoder.Token()
+		if err != nil {
+			return fmt.Errorf("decoding json object key: %w", err)
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return errJSONObjectKeyNotString
+		}
+		canonical := strings.ToLower(key)
+		if _, ok := keys[canonical]; ok {
+			return fmt.Errorf("%w: %q", errJSONDuplicateKey, key)
+		}
+		keys[canonical] = struct{}{}
+		if err := scanJSONValue(decoder); err != nil {
+			return err
+		}
+	}
+	if _, err := decoder.Token(); err != nil {
+		return fmt.Errorf("decoding json object closing token: %w", err)
+	}
+	return nil
+}
+
+// scanJSONArray scans the elements of a JSON array opened by the caller.
+func scanJSONArray(decoder *json.Decoder) error {
+	for decoder.More() {
+		if err := scanJSONValue(decoder); err != nil {
+			return err
+		}
+	}
+	if _, err := decoder.Token(); err != nil {
+		return fmt.Errorf("decoding json array closing token: %w", err)
+	}
+	return nil
 }

--- a/cns/state/import.go
+++ b/cns/state/import.go
@@ -1,0 +1,697 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package state
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/netip"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/wireserver"
+	"github.com/google/uuid"
+)
+
+var (
+	// ErrLegacyImportTargetNotEmpty indicates that import cannot replace existing unmarked state.
+	ErrLegacyImportTargetNotEmpty = errors.New("cns state: legacy import target is not empty")
+	// ErrLegacyImportSource indicates that a legacy source is malformed or inconsistent.
+	ErrLegacyImportSource = errors.New("cns state: invalid legacy import source")
+)
+
+// ImportOptions identifies the legacy JSON sources and imported boot identity.
+type ImportOptions struct {
+	CNSPath             string
+	EndpointPath        string
+	ManageEndpointState bool
+	BootID              string
+}
+
+type readFileFunc func(string) ([]byte, error)
+
+type legacyCNSState struct {
+	Location                         string
+	NetworkType                      string
+	OrchestratorType                 string
+	NodeID                           string
+	Initialized                      bool
+	ContainerIDByOrchestratorContext map[string]*string
+	ContainerStatus                  map[string]legacyContainerStatus
+	Networks                         map[string]*legacyNetworkInfo
+	TimeStamp                        time.Time
+	PnpIDByMacAddress                map[string]string
+}
+
+type legacyContainerStatus struct {
+	ID                            string
+	VMVersion                     string
+	HostVersion                   string
+	CreateNetworkContainerRequest cns.CreateNetworkContainerRequest
+	VfpUpdateComplete             bool
+}
+
+type legacyNetworkInfo struct {
+	NetworkName string
+	NicInfo     *wireserver.InterfaceInfo
+	Options     map[string]any
+}
+
+// ImportLegacy atomically imports legacy JSON state into an initialized empty database.
+// It returns false without reading the sources after a completed import.
+func (s *DB) ImportLegacy(ctx context.Context, opts ImportOptions) (bool, error) {
+	return s.importLegacy(ctx, opts, os.ReadFile)
+}
+
+func (s *DB) importLegacy(ctx context.Context, opts ImportOptions, readFile readFileFunc) (bool, error) {
+	if err := validateImportOptions(opts); err != nil {
+		return false, err
+	}
+	if readFile == nil {
+		return false, invalidInput("legacy state reader is nil", nil)
+	}
+	if err := ctx.Err(); err != nil {
+		return false, fmt.Errorf("importing legacy state: %w", err)
+	}
+	complete, err := s.importComplete(ctx)
+	if err != nil {
+		return false, err
+	}
+	if complete {
+		return false, nil
+	}
+
+	cnsData, err := readLegacyFile(ctx, readFile, opts.CNSPath, "CNS")
+	if err != nil {
+		return false, err
+	}
+	snapshot, err := parseLegacyCNS(cnsData, opts.BootID)
+	if err != nil {
+		return false, err
+	}
+	if opts.ManageEndpointState {
+		endpointData, err := readLegacyFile(ctx, readFile, opts.EndpointPath, "endpoint")
+		if err != nil {
+			return false, err
+		}
+		if err := addLegacyEndpoints(&snapshot, endpointData); err != nil {
+			return false, err
+		}
+	}
+	if err := snapshot.Validate(); err != nil {
+		return false, fmt.Errorf("%w: validating imported snapshot: %w", ErrLegacyImportSource, err)
+	}
+	encoded, err := encodeImportedSnapshot(snapshot)
+	if err != nil {
+		return false, err
+	}
+
+	return s.update(ctx, func(tx *WriteTx) (bool, error) {
+		complete, err := legacyImportComplete(tx.tx.Bucket(bucketMetadata))
+		if err != nil {
+			return false, err
+		}
+		if complete {
+			return false, nil
+		}
+		if err := requireEmptyImportTarget(tx); err != nil {
+			return false, err
+		}
+		for _, replacement := range encoded.buckets {
+			if err := replaceJSONBucket(tx.tx, replacement.name, replacement.values); err != nil {
+				return false, err
+			}
+		}
+		meta := tx.tx.Bucket(bucketMetadata)
+		if err := meta.Put(metaKeyBootID, []byte(snapshot.Metadata.BootID)); err != nil {
+			return false, fmt.Errorf("writing import boot ID: %w", err)
+		}
+		if err := meta.Put(metaKeyAuthority, []byte(AuthorityBolt)); err != nil {
+			return false, fmt.Errorf("writing import authority: %w", err)
+		}
+		if err := meta.Put(metaKeyService, encoded.serviceMetadata); err != nil {
+			return false, fmt.Errorf("writing imported service metadata: %w", err)
+		}
+		if err := meta.Put(metaKeyLegacyImport, []byte(legacyImportMarker)); err != nil {
+			return false, fmt.Errorf("writing legacy import marker: %w", err)
+		}
+		if s.importBeforeCommit != nil {
+			if err := s.importBeforeCommit(); err != nil {
+				return false, fmt.Errorf("finishing legacy import: %w", err)
+			}
+		}
+		return true, nil
+	})
+}
+
+func validateImportOptions(opts ImportOptions) error {
+	if strings.TrimSpace(opts.CNSPath) == "" {
+		return invalidInput("legacy CNS path is empty", nil)
+	}
+	if strings.TrimSpace(opts.BootID) == "" {
+		return invalidInput("import boot ID is empty", nil)
+	}
+	if opts.ManageEndpointState && strings.TrimSpace(opts.EndpointPath) == "" {
+		return invalidInput("legacy endpoint path is empty while endpoint state is managed", nil)
+	}
+	return nil
+}
+
+func readLegacyFile(ctx context.Context, readFile readFileFunc, path, name string) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("reading legacy %s state: %w", name, err)
+	}
+	data, err := readFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading legacy %s state %q: %w", name, path, err)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("reading legacy %s state: %w", name, err)
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil, fmt.Errorf("%w: legacy %s state is empty", ErrLegacyImportSource, name)
+	}
+	return data, nil
+}
+
+func parseLegacyCNS(data []byte, bootID string) (Snapshot, error) {
+	var source legacyCNSState
+	if err := decodeLegacyEnvelope(data, "ContainerNetworkService", &source); err != nil {
+		return Snapshot{}, fmt.Errorf("%w: decoding legacy CNS state: %w", ErrLegacyImportSource, err)
+	}
+	if source.ContainerStatus == nil {
+		return Snapshot{}, fmt.Errorf("%w: legacy CNS container status is null", ErrLegacyImportSource)
+	}
+	if source.ContainerIDByOrchestratorContext == nil {
+		return Snapshot{}, fmt.Errorf("%w: legacy CNS orchestrator contexts are null", ErrLegacyImportSource)
+	}
+	if source.Networks == nil {
+		return Snapshot{}, fmt.Errorf("%w: legacy CNS networks are null", ErrLegacyImportSource)
+	}
+	if source.PnpIDByMacAddress == nil {
+		return Snapshot{}, fmt.Errorf("%w: legacy CNS PnP mappings are null", ErrLegacyImportSource)
+	}
+	if source.TimeStamp.IsZero() {
+		return Snapshot{}, fmt.Errorf("%w: legacy CNS timestamp is zero", ErrLegacyImportSource)
+	}
+
+	snapshot := NewSnapshot()
+	snapshot.Metadata = Metadata{
+		SchemaVersion:        SchemaVersion,
+		Authority:            AuthorityBolt,
+		BootID:               bootID,
+		OrchestratorType:     source.OrchestratorType,
+		NodeID:               source.NodeID,
+		Location:             source.Location,
+		NetworkType:          source.NetworkType,
+		Initialized:          source.Initialized,
+		TimeStamp:            source.TimeStamp,
+		LegacyImportComplete: true,
+	}
+
+	seenUUIDs := map[string]string{}
+	for _, ncID := range sortedKeys(source.ContainerStatus) {
+		status := source.ContainerStatus[ncID]
+		if ncID == "" || status.ID == "" || status.ID != ncID {
+			return Snapshot{}, fmt.Errorf(
+				"%w: network container key %q does not match ID %q",
+				ErrLegacyImportSource,
+				ncID,
+				status.ID,
+			)
+		}
+		if status.CreateNetworkContainerRequest.NetworkContainerid != ncID {
+			return Snapshot{}, fmt.Errorf(
+				"%w: network container %q request ID does not match",
+				ErrLegacyImportSource,
+				ncID,
+			)
+		}
+		if err := validateLegacyNetworkContainerRequest(status.CreateNetworkContainerRequest); err != nil {
+			return Snapshot{}, fmt.Errorf("%w: network container %q: %w", ErrLegacyImportSource, ncID, err)
+		}
+		for _, ipID := range sortedKeys(status.CreateNetworkContainerRequest.SecondaryIPConfigs) {
+			config := status.CreateNetworkContainerRequest.SecondaryIPConfigs[ipID]
+			parsedID, err := uuid.Parse(ipID)
+			if err != nil {
+				return Snapshot{}, fmt.Errorf("%w: network container %q has invalid IP UUID", ErrLegacyImportSource, ncID)
+			}
+			canonicalID := parsedID.String()
+			if other, ok := seenUUIDs[canonicalID]; ok {
+				return Snapshot{}, fmt.Errorf(
+					"%w: network containers %q and %q contain duplicate IP UUID",
+					ErrLegacyImportSource,
+					other,
+					ncID,
+				)
+			}
+			if _, err := netip.ParseAddr(config.IPAddress); err != nil {
+				return Snapshot{}, fmt.Errorf(
+					"%w: network container %q IP %q has invalid address",
+					ErrLegacyImportSource,
+					ncID,
+					ipID,
+				)
+			}
+			seenUUIDs[canonicalID] = ncID
+			snapshot.IPs[ipID] = IPRecord{
+				ID:        ipID,
+				IPAddress: config.IPAddress,
+				NCID:      ncID,
+				NCVersion: config.NCVersion,
+			}
+		}
+		snapshot.NetworkContainers[ncID] = NewNetworkContainerRecord(
+			status.ID,
+			status.VMVersion,
+			status.HostVersion,
+			status.VfpUpdateComplete,
+			status.CreateNetworkContainerRequest,
+		)
+	}
+
+	for _, contextID := range sortedKeys(source.ContainerIDByOrchestratorContext) {
+		value := source.ContainerIDByOrchestratorContext[contextID]
+		if contextID == "" || value == nil || *value == "" {
+			return Snapshot{}, fmt.Errorf("%w: malformed orchestrator NC list %q", ErrLegacyImportSource, contextID)
+		}
+		ids := strings.Split(*value, ",")
+		seen := map[string]struct{}{}
+		for _, id := range ids {
+			if id == "" || strings.TrimSpace(id) != id {
+				return Snapshot{}, fmt.Errorf("%w: malformed orchestrator NC list %q", ErrLegacyImportSource, contextID)
+			}
+			if _, ok := seen[id]; ok {
+				return Snapshot{}, fmt.Errorf("%w: orchestrator NC list %q contains a duplicate", ErrLegacyImportSource, contextID)
+			}
+			seen[id] = struct{}{}
+		}
+		snapshot.OrchestratorContexts[contextID] = ids
+	}
+	for _, name := range sortedKeys(source.Networks) {
+		record := source.Networks[name]
+		if record == nil {
+			return Snapshot{}, fmt.Errorf("%w: network %q is null", ErrLegacyImportSource, name)
+		}
+		var nicInfo *wireserver.InterfaceInfo
+		if record.NicInfo != nil {
+			nicInfo = &wireserver.InterfaceInfo{
+				Subnet:       record.NicInfo.Subnet,
+				Gateway:      record.NicInfo.Gateway,
+				PrimaryIP:    record.NicInfo.PrimaryIP,
+				SecondaryIPs: append([]string(nil), record.NicInfo.SecondaryIPs...),
+				IsPrimary:    record.NicInfo.IsPrimary,
+			}
+		}
+		snapshot.Networks[name] = NetworkRecord{
+			NetworkName: record.NetworkName,
+			NicInfo:     nicInfo,
+			Options:     record.Options,
+		}
+	}
+	for _, rawMAC := range sortedKeys(source.PnpIDByMacAddress) {
+		mac, err := canonicalMAC(rawMAC)
+		if err != nil {
+			return Snapshot{}, fmt.Errorf("%w: PnP mapping: %w", ErrLegacyImportSource, err)
+		}
+		if _, ok := snapshot.PnPIDByMAC[mac]; ok {
+			return Snapshot{}, fmt.Errorf("%w: duplicate canonical PnP MAC", ErrLegacyImportSource)
+		}
+		snapshot.PnPIDByMAC[mac] = source.PnpIDByMacAddress[rawMAC]
+	}
+	return snapshot, nil
+}
+
+func addLegacyEndpoints(snapshot *Snapshot, data []byte) error {
+	var envelope map[string]json.RawMessage
+	if err := decodeJSONDocument(data, &envelope); err != nil {
+		return fmt.Errorf("%w: decoding legacy endpoint state: %w", ErrLegacyImportSource, err)
+	}
+	endpointsRaw, ok := envelope["Endpoints"]
+	if !ok {
+		return fmt.Errorf("%w: legacy endpoint envelope is missing", ErrLegacyImportSource)
+	}
+	var endpoints map[string]*EndpointRecord
+	if err := decodeStrictJSON(endpointsRaw, &endpoints); err != nil {
+		return fmt.Errorf("%w: decoding legacy endpoints: %w", ErrLegacyImportSource, err)
+	}
+	if endpoints == nil {
+		return fmt.Errorf("%w: legacy endpoints are null", ErrLegacyImportSource)
+	}
+	for _, containerID := range sortedKeys(endpoints) {
+		record := endpoints[containerID]
+		if strings.TrimSpace(containerID) != containerID {
+			return fmt.Errorf("%w: legacy endpoint container ID is not canonical", ErrLegacyImportSource)
+		}
+		if record == nil {
+			return fmt.Errorf("%w: legacy endpoint %q is null", ErrLegacyImportSource, containerID)
+		}
+		normalized, err := normalizeEndpoint(containerID, *record)
+		if err != nil {
+			return fmt.Errorf("%w: legacy endpoint %q: %w", ErrLegacyImportSource, containerID, err)
+		}
+		snapshot.Endpoints[containerID] = normalized
+	}
+	if intentsRaw, ok := envelope["DeleteIntents"]; ok {
+		var intents map[string]DeleteIntent
+		if err := decodeStrictJSON(intentsRaw, &intents); err != nil {
+			return fmt.Errorf("%w: decoding legacy delete intents: %w", ErrLegacyImportSource, err)
+		}
+		if intents == nil {
+			return fmt.Errorf("%w: legacy delete intents are null", ErrLegacyImportSource)
+		}
+		for _, containerID := range sortedKeys(intents) {
+			intent, err := normalizeDeleteIntent(intents[containerID])
+			if err != nil {
+				return fmt.Errorf("%w: legacy delete intent %q: %w", ErrLegacyImportSource, containerID, err)
+			}
+			snapshot.DeleteIntents[containerID] = intent
+		}
+	}
+	assignments, owners, err := reconstructRetainedEndpointOwnership(*snapshot)
+	if err != nil {
+		return fmt.Errorf("%w: reconstructing endpoint ownership: %w", ErrLegacyImportSource, err)
+	}
+	snapshot.Assignments = assignments
+	snapshot.IPOwners = owners
+	return nil
+}
+
+func validateLegacyNetworkContainerRequest(request cns.CreateNetworkContainerRequest) error {
+	for _, item := range []struct {
+		name    string
+		address string
+	}{
+		{name: "host primary IP", address: request.HostPrimaryIP},
+		{name: "primary interface identifier", address: request.PrimaryInterfaceIdentifier},
+	} {
+		if err := validateOptionalIPValue(item.address); err != nil {
+			return fmt.Errorf("%s: %w", item.name, err)
+		}
+	}
+	for _, item := range []struct {
+		name   string
+		config cns.IPConfiguration
+	}{
+		{name: "local IP configuration", config: request.LocalIPConfiguration},
+		{name: "IP configuration", config: request.IPConfiguration},
+		{name: "IPv6 configuration", config: request.IPv6Configuration},
+	} {
+		if err := validateLegacyIPConfiguration(item.config); err != nil {
+			return fmt.Errorf("%s: %w", item.name, err)
+		}
+	}
+	for index, subnet := range request.CnetAddressSpace {
+		if err := validateLegacySubnet(subnet, 0); err != nil {
+			return fmt.Errorf("CNet address space %d: %w", index, err)
+		}
+	}
+	for index, route := range request.Routes {
+		if route.IPAddress != "" {
+			if _, err := netip.ParsePrefix(route.IPAddress); err != nil {
+				if _, addrErr := netip.ParseAddr(route.IPAddress); addrErr != nil {
+					return fmt.Errorf("route %d has invalid destination", index)
+				}
+			}
+		}
+		if err := validateOptionalAddress(route.GatewayIPAddress); err != nil {
+			return fmt.Errorf("route %d gateway: %w", index, err)
+		}
+	}
+	if request.NetworkInterfaceInfo.MACAddress != "" {
+		if _, err := net.ParseMAC(request.NetworkInterfaceInfo.MACAddress); err != nil {
+			return fmt.Errorf("invalid network interface MAC")
+		}
+	}
+	return nil
+}
+
+func validateLegacyIPConfiguration(config cns.IPConfiguration) error {
+	if err := validateLegacySubnet(config.IPSubnet, 0); err != nil {
+		return err
+	}
+	if err := validateLegacySubnet(config.IPSubnetV6, 128); err != nil {
+		return err
+	}
+	for _, address := range config.DNSServers {
+		if err := validateOptionalAddress(address); err != nil {
+			return err
+		}
+	}
+	for _, gateway := range []string{config.GatewayIPAddress, config.GatewayIPv6Address} {
+		if err := validateOptionalIPValue(gateway); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateLegacySubnet(subnet cns.IPSubnet, expectedBits int) error {
+	if subnet.IPAddress == "" {
+		if subnet.PrefixLength != 0 {
+			return errors.New("prefix length is set without an address")
+		}
+		return nil
+	}
+	address, err := netip.ParseAddr(subnet.IPAddress)
+	if err != nil {
+		return errors.New("invalid subnet address")
+	}
+	address = address.Unmap()
+	bits := 128
+	if address.Is4() {
+		bits = 32
+	}
+	if expectedBits != 0 && bits != expectedBits {
+		return errors.New("subnet address family does not match")
+	}
+	if int(subnet.PrefixLength) > bits {
+		return errors.New("invalid subnet prefix length")
+	}
+	return nil
+}
+
+func validateOptionalAddress(value string) error {
+	if value == "" {
+		return nil
+	}
+	if _, err := netip.ParseAddr(value); err != nil {
+		return errors.New("invalid IP address")
+	}
+	return nil
+}
+
+func validateOptionalIPValue(value string) error {
+	if value == "" {
+		return nil
+	}
+	if _, err := netip.ParseAddr(value); err == nil {
+		return nil
+	}
+	if _, err := netip.ParsePrefix(value); err != nil {
+		return errors.New("invalid IP address or prefix")
+	}
+	return nil
+}
+
+type importedSnapshotEncoding struct {
+	buckets         []encodedBucket
+	serviceMetadata []byte
+}
+
+func encodeImportedSnapshot(snapshot Snapshot) (importedSnapshotEncoding, error) {
+	values := []struct {
+		name   []byte
+		encode func() (map[string][]byte, error)
+	}{
+		{name: bucketNetworkContainers, encode: func() (map[string][]byte, error) {
+			return encodeJSONMap(snapshot.NetworkContainers)
+		}},
+		{name: bucketIPs, encode: func() (map[string][]byte, error) { return encodeJSONMap(snapshot.IPs) }},
+		{name: bucketNetworks, encode: func() (map[string][]byte, error) { return encodeJSONMap(snapshot.Networks) }},
+		{name: bucketOrchestratorContexts, encode: func() (map[string][]byte, error) {
+			return encodeJSONMap(snapshot.OrchestratorContexts)
+		}},
+		{name: bucketPnPIDByMAC, encode: func() (map[string][]byte, error) {
+			return encodeJSONMap(snapshot.PnPIDByMAC)
+		}},
+		{name: bucketAssignments, encode: func() (map[string][]byte, error) {
+			return encodeJSONMap(snapshot.Assignments)
+		}},
+		{name: bucketIPOwners, encode: func() (map[string][]byte, error) { return encodeJSONMap(snapshot.IPOwners) }},
+		{name: bucketEndpoints, encode: func() (map[string][]byte, error) { return encodeJSONMap(snapshot.Endpoints) }},
+		{name: bucketDeleteIntents, encode: func() (map[string][]byte, error) {
+			return encodeJSONMap(snapshot.DeleteIntents)
+		}},
+	}
+	encoded := importedSnapshotEncoding{buckets: make([]encodedBucket, 0, len(values))}
+	for _, value := range values {
+		data, err := value.encode()
+		if err != nil {
+			return importedSnapshotEncoding{}, err
+		}
+		encoded.buckets = append(encoded.buckets, encodedBucket{name: value.name, values: data})
+	}
+	var err error
+	encoded.serviceMetadata, err = json.Marshal(serviceMetadata{
+		OrchestratorType: snapshot.Metadata.OrchestratorType,
+		NodeID:           snapshot.Metadata.NodeID,
+		Location:         snapshot.Metadata.Location,
+		NetworkType:      snapshot.Metadata.NetworkType,
+		Initialized:      snapshot.Metadata.Initialized,
+		TimeStamp:        snapshot.Metadata.TimeStamp,
+	})
+	if err != nil {
+		return importedSnapshotEncoding{}, invalidInput("encoding imported service metadata", err)
+	}
+	return encoded, nil
+}
+
+func requireEmptyImportTarget(tx *WriteTx) error {
+	snapshot, err := snapshotFromTx(tx.ctx, &tx.ReadTx)
+	if err != nil {
+		return err
+	}
+	if snapshot.Metadata.Generation != 0 ||
+		snapshot.Metadata.Authority != AuthorityBolt ||
+		snapshot.Metadata.BootID != "" ||
+		snapshot.Metadata.OrchestratorType != "" ||
+		snapshot.Metadata.NodeID != "" ||
+		snapshot.Metadata.Location != "" ||
+		snapshot.Metadata.NetworkType != "" ||
+		snapshot.Metadata.Initialized ||
+		!snapshot.Metadata.TimeStamp.IsZero() ||
+		len(snapshot.NetworkContainers) != 0 ||
+		len(snapshot.IPs) != 0 ||
+		len(snapshot.Networks) != 0 ||
+		len(snapshot.OrchestratorContexts) != 0 ||
+		len(snapshot.PnPIDByMAC) != 0 ||
+		len(snapshot.Assignments) != 0 ||
+		len(snapshot.IPOwners) != 0 ||
+		len(snapshot.Endpoints) != 0 ||
+		len(snapshot.DeleteIntents) != 0 {
+		return ErrLegacyImportTargetNotEmpty
+	}
+	return nil
+}
+
+func (s *DB) importComplete(ctx context.Context) (bool, error) {
+	var complete bool
+	err := s.View(ctx, func(tx *ReadTx) error {
+		var err error
+		complete, err = legacyImportComplete(tx.tx.Bucket(bucketMetadata))
+		return err
+	})
+	if err != nil {
+		return false, fmt.Errorf("checking legacy import marker: %w", err)
+	}
+	return complete, nil
+}
+
+func decodeLegacyEnvelope(data []byte, key string, destination any) error {
+	var envelope map[string]json.RawMessage
+	if err := decodeJSONDocument(data, &envelope); err != nil {
+		return err
+	}
+	raw, ok := envelope[key]
+	if !ok {
+		return fmt.Errorf("missing %q envelope", key)
+	}
+	return decodeStrictJSON(raw, destination)
+}
+
+func decodeJSONDocument(data []byte, destination any) error {
+	if err := rejectDuplicateJSONKeys(data); err != nil {
+		return err
+	}
+	return decodeStrictJSON(data, destination)
+}
+
+func decodeStrictJSON(data []byte, destination any) error {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return errors.New("json value is empty")
+	}
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		return errors.New("json value is null")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(destination); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("multiple json values")
+		}
+		return err
+	}
+	return nil
+}
+
+func rejectDuplicateJSONKeys(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := scanJSONValue(decoder); err != nil {
+		return err
+	}
+	if _, err := decoder.Token(); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("multiple json values")
+		}
+		return err
+	}
+	return nil
+}
+
+func scanJSONValue(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delim, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+	switch delim {
+	case '{':
+		keys := map[string]struct{}{}
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return errors.New("object key is not a string")
+			}
+			canonical := strings.ToLower(key)
+			if _, ok := keys[canonical]; ok {
+				return fmt.Errorf("duplicate json key %q", key)
+			}
+			keys[canonical] = struct{}{}
+			if err := scanJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		_, err = decoder.Token()
+		return err
+	case '[':
+		for decoder.More() {
+			if err := scanJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		_, err = decoder.Token()
+		return err
+	default:
+		return errors.New("unexpected JSON delimiter")
+	}
+}

--- a/cns/state/import.go
+++ b/cns/state/import.go
@@ -72,6 +72,15 @@ func (s *DB) ImportLegacy(ctx context.Context, opts ImportOptions) (bool, error)
 }
 
 func (s *DB) importLegacy(ctx context.Context, opts ImportOptions, readFile readFileFunc) (bool, error) {
+	return s.importLegacyWithCommitHook(ctx, opts, readFile, nil)
+}
+
+func (s *DB) importLegacyWithCommitHook(
+	ctx context.Context,
+	opts ImportOptions,
+	readFile readFileFunc,
+	beforeCommit func() error,
+) (bool, error) {
 	if err := validateImportOptions(opts); err != nil {
 		return false, err
 	}
@@ -143,8 +152,8 @@ func (s *DB) importLegacy(ctx context.Context, opts ImportOptions, readFile read
 		if err := meta.Put(metaKeyLegacyImport, []byte(legacyImportMarker)); err != nil {
 			return false, fmt.Errorf("writing legacy import marker: %w", err)
 		}
-		if s.importBeforeCommit != nil {
-			if err := s.importBeforeCommit(); err != nil {
+		if beforeCommit != nil {
+			if err := beforeCommit(); err != nil {
 				return false, fmt.Errorf("finishing legacy import: %w", err)
 			}
 		}

--- a/cns/state/import_legacy_keys_test.go
+++ b/cns/state/import_legacy_keys_test.go
@@ -1,0 +1,229 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package state
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/wireserver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These fixtures mirror restserver's unexported persisted types so json.Marshal
+// emits the capitalized Go-default keys used by the legacy files.
+type capitalizedCNSStateFixture struct { //nolint:musttag
+	Location                         string
+	NetworkType                      string
+	OrchestratorType                 string
+	NodeID                           string
+	Initialized                      bool
+	ContainerIDByOrchestratorContext map[string]*capitalizedNCListFixture
+	ContainerStatus                  map[string]capitalizedContainerStatusFixture
+	Networks                         map[string]*capitalizedNetworkInfoFixture
+	TimeStamp                        time.Time
+	PnpIDByMacAddress                map[string]string
+}
+
+type capitalizedNCListFixture string
+
+type capitalizedContainerStatusFixture struct { //nolint:musttag
+	ID                            string
+	VMVersion                     string
+	HostVersion                   string
+	CreateNetworkContainerRequest cns.CreateNetworkContainerRequest
+	VfpUpdateComplete             bool
+}
+
+type capitalizedNetworkInfoFixture struct { //nolint:musttag
+	NetworkName string
+	NicInfo     *wireserver.InterfaceInfo
+	Options     map[string]any
+}
+
+type capitalizedEndpointFixture struct { //nolint:musttag
+	PodName       string
+	PodNamespace  string
+	IfnameToIPMap map[string]*capitalizedIPInfoFixture
+}
+
+type capitalizedIPInfoFixture struct { //nolint:musttag
+	IPv4               []net.IPNet
+	IPv6               []net.IPNet `json:",omitempty"`
+	HnsEndpointID      string      `json:",omitempty"`
+	HnsNetworkID       string      `json:",omitempty"`
+	HostVethName       string      `json:",omitempty"`
+	MacAddress         string      `json:",omitempty"`
+	NetworkContainerID string      `json:",omitempty"`
+	NICType            cns.NICType
+}
+
+func TestImportLegacyCapitalizedRestserverKeys(t *testing.T) {
+	request := completeNetworkContainerRequest()
+	request.NetworkContainerid = importNC1
+	request.Version = "17"
+	request.AuthorizationToken = "legacy-secret"
+	request.SecondaryIPConfigs = map[string]cns.SecondaryIPConfig{
+		importIPv4: {IPAddress: "10.0.0.4", NCVersion: 17},
+		importIPv6: {IPAddress: "fd00::4", NCVersion: 17},
+	}
+	ncList := capitalizedNCListFixture(importNC1)
+	cnsData, err := json.Marshal(map[string]any{
+		"ContainerNetworkService": capitalizedCNSStateFixture{
+			Location:         "westus2",
+			NetworkType:      "azure",
+			OrchestratorType: "KubernetesCRD",
+			NodeID:           "capitalized-node",
+			Initialized:      true,
+			ContainerIDByOrchestratorContext: map[string]*capitalizedNCListFixture{
+				"pod-capitalizedns-capitalized": &ncList,
+			},
+			ContainerStatus: map[string]capitalizedContainerStatusFixture{
+				importNC1: {
+					ID:                            importNC1,
+					VMVersion:                     "17",
+					HostVersion:                   "16",
+					CreateNetworkContainerRequest: request,
+					VfpUpdateComplete:             true,
+				},
+			},
+			Networks: map[string]*capitalizedNetworkInfoFixture{
+				"capitalized-network": {
+					NetworkName: "capitalized-network",
+					NicInfo: &wireserver.InterfaceInfo{
+						Subnet:       "10.0.0.0/24",
+						Gateway:      "10.0.0.1",
+						PrimaryIP:    "10.0.0.2",
+						SecondaryIPs: []string{"10.0.0.3"},
+						IsPrimary:    true,
+					},
+					Options: map[string]any{"mode": "legacy"},
+				},
+			},
+			TimeStamp: testNow,
+			PnpIDByMacAddress: map[string]string{
+				"00-11-22-33-44-55": "PCI\\VEN_CAPITALIZED",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	endpointData, err := json.Marshal(map[string]any{
+		"Endpoints": map[string]*capitalizedEndpointFixture{
+			"capitalized-container": {
+				PodName:      "pod-capitalized",
+				PodNamespace: "ns-capitalized",
+				IfnameToIPMap: map[string]*capitalizedIPInfoFixture{
+					"eth0": {
+						IPv4:               []net.IPNet{mustIPNet(t, "10.0.0.4/24")},
+						IPv6:               []net.IPNet{mustIPNet(t, "fd00::4/64")},
+						HnsEndpointID:      "hns-endpoint-capitalized",
+						HnsNetworkID:       "hns-network-capitalized",
+						HostVethName:       "veth-capitalized",
+						MacAddress:         "00:11:22:33:44:55",
+						NetworkContainerID: importNC1,
+						NICType:            cns.InfraNIC,
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	for _, key := range []string{
+		"Location",
+		"NetworkType",
+		"OrchestratorType",
+		"NodeID",
+		"Initialized",
+		"ContainerIDByOrchestratorContext",
+		"ContainerStatus",
+		"Networks",
+		"TimeStamp",
+		"PnpIDByMacAddress",
+		"CreateNetworkContainerRequest",
+		"AuthorizationToken",
+		"SecondaryIPConfigs",
+	} {
+		assert.Contains(t, string(cnsData), `"`+key+`"`)
+	}
+	for _, key := range []string{
+		"PodName",
+		"PodNamespace",
+		"IfnameToIPMap",
+		"IPv4",
+		"IPv6",
+		"HnsEndpointID",
+		"HnsNetworkID",
+		"HostVethName",
+		"MacAddress",
+		"NetworkContainerID",
+		"NICType",
+	} {
+		assert.Contains(t, string(endpointData), `"`+key+`"`)
+	}
+	assert.NotContains(t, string(cnsData), `"location"`)
+	assert.NotContains(t, string(endpointData), `"podName"`)
+	assert.NotContains(t, string(endpointData), `"hnsEndpointID"`)
+
+	db, _ := openTestDB(t)
+	opts := writeLegacyImportFiles(t, cnsData, endpointData, true)
+	changed, err := db.ImportLegacy(context.Background(), opts)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	snapshot := requireValidSnapshot(t, db)
+	assert.Equal(t, "westus2", snapshot.Metadata.Location)
+	assert.Equal(t, "capitalized-node", snapshot.Metadata.NodeID)
+	assert.Equal(t, testNow, snapshot.Metadata.TimeStamp)
+	assert.True(t, snapshot.Metadata.LegacyImportComplete)
+
+	record := snapshot.NetworkContainers[importNC1]
+	expectedRequest := request
+	expectedRequest.AuthorizationToken = ""
+	expectedRequest.SecondaryIPConfigs = nil
+	assert.Equal(t, "17", record.VMVersion)
+	assert.Equal(t, "16", record.HostVersion)
+	assert.True(t, record.VFPUpdateComplete)
+	assert.Equal(t, expectedRequest, record.Request)
+	assert.Equal(t, map[string]IPRecord{
+		importIPv4: {ID: importIPv4, IPAddress: "10.0.0.4", NCID: importNC1, NCVersion: 17},
+		importIPv6: {ID: importIPv6, IPAddress: "fd00::4", NCID: importNC1, NCVersion: 17},
+	}, snapshot.IPs)
+
+	assert.Equal(t, []string{importNC1}, snapshot.OrchestratorContexts["pod-capitalizedns-capitalized"])
+	assert.Equal(t, "PCI\\VEN_CAPITALIZED", snapshot.PnPIDByMAC["00:11:22:33:44:55"])
+	network := snapshot.Networks["capitalized-network"]
+	assert.Equal(t, "10.0.0.0/24", network.NicInfo.Subnet)
+	assert.Equal(t, "legacy", network.Options["mode"])
+
+	endpoint := snapshot.Endpoints["capitalized-container"]
+	assert.Equal(t, "pod-capitalized", endpoint.PodName)
+	assert.Equal(t, "ns-capitalized", endpoint.PodNamespace)
+	info := endpoint.IfnameToIPMap["eth0"]
+	assert.Equal(t, "hns-endpoint-capitalized", info.HNSEndpointID)
+	assert.Equal(t, "hns-network-capitalized", info.HNSNetworkID)
+	assert.Equal(t, "veth-capitalized", info.HostVethName)
+	assert.Equal(t, "00:11:22:33:44:55", info.MACAddress)
+	assert.Equal(t, importNC1, info.NetworkContainerID)
+	assert.Equal(t, cns.InfraNIC, info.NICType)
+	require.Len(t, info.IPv4, 1)
+	require.Len(t, info.IPv6, 1)
+	assert.Equal(t, "10.0.0.4/24", info.IPv4[0].String())
+	assert.Equal(t, "fd00::4/64", info.IPv6[0].String())
+
+	assignment := snapshot.Assignments["capitalized-container"]
+	assert.Equal(t, "capitalized-container", assignment.Pod.PodKey)
+	assert.Equal(t, "capitalized-container", assignment.Pod.InfraContainerID)
+	assert.Equal(t, "pod-capitalized", assignment.Pod.PodName)
+	assert.Equal(t, "ns-capitalized", assignment.Pod.PodNamespace)
+	assert.ElementsMatch(t, []string{importIPv4, importIPv6}, assignment.IPIDs)
+	assert.Equal(t, "capitalized-container", snapshot.IPOwners[importIPv4])
+	assert.Equal(t, "capitalized-container", snapshot.IPOwners[importIPv6])
+}

--- a/cns/state/import_legacy_keys_test.go
+++ b/cns/state/import_legacy_keys_test.go
@@ -18,7 +18,7 @@ import (
 
 // These fixtures mirror restserver's unexported persisted types so json.Marshal
 // emits the capitalized Go-default keys used by the legacy files.
-type capitalizedCNSStateFixture struct { //nolint:musttag
+type capitalizedCNSStateFixture struct { //nolint:musttag // Go-default field names reproduce the capitalized legacy wire format.
 	Location                         string
 	NetworkType                      string
 	OrchestratorType                 string
@@ -33,7 +33,7 @@ type capitalizedCNSStateFixture struct { //nolint:musttag
 
 type capitalizedNCListFixture string
 
-type capitalizedContainerStatusFixture struct { //nolint:musttag
+type capitalizedContainerStatusFixture struct { //nolint:musttag // Go-default field names reproduce the capitalized legacy wire format.
 	ID                            string
 	VMVersion                     string
 	HostVersion                   string
@@ -41,19 +41,19 @@ type capitalizedContainerStatusFixture struct { //nolint:musttag
 	VfpUpdateComplete             bool
 }
 
-type capitalizedNetworkInfoFixture struct { //nolint:musttag
+type capitalizedNetworkInfoFixture struct { //nolint:musttag // Go-default field names reproduce the capitalized legacy wire format.
 	NetworkName string
 	NicInfo     *wireserver.InterfaceInfo
 	Options     map[string]any
 }
 
-type capitalizedEndpointFixture struct { //nolint:musttag
+type capitalizedEndpointFixture struct { //nolint:musttag // Go-default field names reproduce the capitalized legacy wire format.
 	PodName       string
 	PodNamespace  string
 	IfnameToIPMap map[string]*capitalizedIPInfoFixture
 }
 
-type capitalizedIPInfoFixture struct { //nolint:musttag
+type capitalizedIPInfoFixture struct { //nolint:musttag // Go-default field names reproduce the capitalized legacy wire format.
 	IPv4               []net.IPNet
 	IPv6               []net.IPNet `json:",omitempty"`
 	HnsEndpointID      string      `json:",omitempty"`
@@ -70,15 +70,15 @@ func TestImportLegacyCapitalizedRestserverKeys(t *testing.T) {
 	request.Version = "17"
 	request.AuthorizationToken = "legacy-secret"
 	request.SecondaryIPConfigs = map[string]cns.SecondaryIPConfig{
-		importIPv4: {IPAddress: "10.0.0.4", NCVersion: 17},
-		importIPv6: {IPAddress: "fd00::4", NCVersion: 17},
+		importIPv4: {IPAddress: importIPv4Address, NCVersion: 17},
+		importIPv6: {IPAddress: importIPv6Address, NCVersion: 17},
 	}
 	ncList := capitalizedNCListFixture(importNC1)
 	cnsData, err := json.Marshal(map[string]any{
 		"ContainerNetworkService": capitalizedCNSStateFixture{
-			Location:         "westus2",
-			NetworkType:      "azure",
-			OrchestratorType: "KubernetesCRD",
+			Location:         importLocation,
+			NetworkType:      importNetworkType,
+			OrchestratorType: importOrchestratorType,
 			NodeID:           "capitalized-node",
 			Initialized:      true,
 			ContainerIDByOrchestratorContext: map[string]*capitalizedNCListFixture{
@@ -97,8 +97,8 @@ func TestImportLegacyCapitalizedRestserverKeys(t *testing.T) {
 				"capitalized-network": {
 					NetworkName: "capitalized-network",
 					NicInfo: &wireserver.InterfaceInfo{
-						Subnet:       "10.0.0.0/24",
-						Gateway:      "10.0.0.1",
+						Subnet:       importSubnetCIDR,
+						Gateway:      importGatewayIP,
 						PrimaryIP:    "10.0.0.2",
 						SecondaryIPs: []string{"10.0.0.3"},
 						IsPrimary:    true,
@@ -108,7 +108,7 @@ func TestImportLegacyCapitalizedRestserverKeys(t *testing.T) {
 			},
 			TimeStamp: testNow,
 			PnpIDByMacAddress: map[string]string{
-				"00-11-22-33-44-55": "PCI\\VEN_CAPITALIZED",
+				importPnPMAC: "PCI\\VEN_CAPITALIZED",
 			},
 		},
 	})
@@ -120,13 +120,13 @@ func TestImportLegacyCapitalizedRestserverKeys(t *testing.T) {
 				PodName:      "pod-capitalized",
 				PodNamespace: "ns-capitalized",
 				IfnameToIPMap: map[string]*capitalizedIPInfoFixture{
-					"eth0": {
-						IPv4:               []net.IPNet{mustIPNet(t, "10.0.0.4/24")},
-						IPv6:               []net.IPNet{mustIPNet(t, "fd00::4/64")},
+					importIfname: {
+						IPv4:               []net.IPNet{mustIPNet(t, importIPv4Address+"/24")},
+						IPv6:               []net.IPNet{mustIPNet(t, importIPv6Address+"/64")},
 						HnsEndpointID:      "hns-endpoint-capitalized",
 						HnsNetworkID:       "hns-network-capitalized",
 						HostVethName:       "veth-capitalized",
-						MacAddress:         "00:11:22:33:44:55",
+						MacAddress:         importMAC,
 						NetworkContainerID: importNC1,
 						NICType:            cns.InfraNIC,
 					},
@@ -157,8 +157,8 @@ func TestImportLegacyCapitalizedRestserverKeys(t *testing.T) {
 		"PodName",
 		"PodNamespace",
 		"IfnameToIPMap",
-		"IPv4",
-		"IPv6",
+		importIPv4Key,
+		importIPv6Key,
 		"HnsEndpointID",
 		"HnsNetworkID",
 		"HostVethName",
@@ -194,7 +194,7 @@ func TestImportLegacyCapitalizedRestserverKeys(t *testing.T) {
 	assert.Equal(t, expectedRequest, record.Request)
 	assert.Equal(t, map[string]IPRecord{
 		importIPv4: {ID: importIPv4, IPAddress: "10.0.0.4", NCID: importNC1, NCVersion: 17},
-		importIPv6: {ID: importIPv6, IPAddress: "fd00::4", NCID: importNC1, NCVersion: 17},
+		importIPv6: {ID: importIPv6, IPAddress: importIPv6Address, NCID: importNC1, NCVersion: 17},
 	}, snapshot.IPs)
 
 	assert.Equal(t, []string{importNC1}, snapshot.OrchestratorContexts["pod-capitalizedns-capitalized"])

--- a/cns/state/import_test.go
+++ b/cns/state/import_test.go
@@ -254,10 +254,20 @@ func TestImportLegacyReadFailures(t *testing.T) {
 func TestImportLegacySemanticFailures(t *testing.T) {
 	validCNS, validEndpoint := completeLegacyImportData(t)
 	tests := []struct {
-		name     string
-		cnsData  []byte
-		endpoint []byte
+		name              string
+		cnsData           []byte
+		endpoint          []byte
+		wantErrorContains string
 	}{
+		{
+			name: "unknown request field",
+			cnsData: mutateLegacyCNS(t, validCNS, func(state map[string]any) {
+				statuses := state["ContainerStatus"].(map[string]any)
+				request := statuses[importNC1].(map[string]any)["CreateNetworkContainerRequest"].(map[string]any)
+				request["Unexpected"] = true
+			}),
+			wantErrorContains: "unknown field",
+		},
 		{
 			name: "invalid IP UUID",
 			cnsData: mutateLegacyCNS(t, validCNS, func(state map[string]any) {
@@ -339,8 +349,9 @@ func TestImportLegacySemanticFailures(t *testing.T) {
 			cnsData: validCNS,
 			endpoint: mutateLegacyEndpoints(t, validEndpoint, func(endpoints map[string]any) {
 				info := endpointIPInfo(endpoints, "container-1", "eth0")
-				info["IPv4"] = encodeIPNets(t, "10.9.0.4/24")
+				info["ipv4"] = encodeIPNets(t, "10.9.0.4/24")
 			}),
+			wantErrorContains: "missing from inventory",
 		},
 		{
 			name:    "duplicate endpoint ownership",
@@ -353,15 +364,17 @@ func TestImportLegacySemanticFailures(t *testing.T) {
 			name:    "endpoint NC mismatch",
 			cnsData: validCNS,
 			endpoint: mutateLegacyEndpoints(t, validEndpoint, func(endpoints map[string]any) {
-				endpointIPInfo(endpoints, "container-1", "eth0")["NetworkContainerID"] = importNC2
+				endpointIPInfo(endpoints, "container-1", "eth0")["networkContainerID"] = importNC2
 			}),
+			wantErrorContains: "does not match",
 		},
 		{
 			name:    "malformed endpoint MAC",
 			cnsData: validCNS,
 			endpoint: mutateLegacyEndpoints(t, validEndpoint, func(endpoints map[string]any) {
-				endpointIPInfo(endpoints, "container-1", "eth0")["MACAddress"] = "bad-mac"
+				endpointIPInfo(endpoints, "container-1", "eth0")["macAddress"] = "bad-mac"
 			}),
+			wantErrorContains: "invalid MAC",
 		},
 		{
 			name:    "invalid delete intent",
@@ -384,6 +397,10 @@ func TestImportLegacySemanticFailures(t *testing.T) {
 			before := requireValidSnapshot(t, db)
 			changed, err := db.ImportLegacy(context.Background(), opts)
 			require.Error(t, err)
+			if tt.wantErrorContains != "" {
+				require.ErrorContains(t, err, tt.wantErrorContains)
+				assert.NotContains(t, err.Error(), "duplicate json key")
+			}
 			assert.False(t, changed)
 			assert.Equal(t, before, requireValidSnapshot(t, db))
 		})
@@ -396,9 +413,12 @@ func TestImportLegacyAtomicityReplayAndConcurrency(t *testing.T) {
 		cnsData, endpointData := completeLegacyImportData(t)
 		opts := writeLegacyImportFiles(t, cnsData, endpointData, true)
 		before := requireValidSnapshot(t, db)
-		db.importBeforeCommit = func() error { return errAbort }
-
-		changed, err := db.ImportLegacy(context.Background(), opts)
+		changed, err := db.importLegacyWithCommitHook(
+			context.Background(),
+			opts,
+			os.ReadFile,
+			func() error { return errAbort },
+		)
 		require.ErrorIs(t, err, errAbort)
 		assert.False(t, changed)
 		assert.Equal(t, before, requireValidSnapshot(t, db))

--- a/cns/state/import_test.go
+++ b/cns/state/import_test.go
@@ -26,6 +26,28 @@ const (
 	importIPv4 = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 	importIPv6 = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
 	importNet1 = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+
+	importIPv4Address            = "10.0.0.4"
+	importIPv6Address            = "fd00::4"
+	importNet1Address            = "10.1.0.4"
+	importSubnetCIDR             = "10.0.0.0/24"
+	importGatewayIP              = "10.0.0.1"
+	importNetworkType            = "azure"
+	importOrchestratorType       = "KubernetesCRD"
+	importLocation               = "westus2"
+	importBootID                 = "boot-1"
+	importCNSFileName            = "azure-cns.json"
+	importNetworkName            = "network-1"
+	importPodName                = "pod-1"
+	importPodNamespace           = "ns-1"
+	importIfname                 = "eth0"
+	importMAC                    = "00:11:22:33:44:55"
+	importMAC2                   = "00:11:22:33:44:66"
+	importPnPMAC                 = "00-11-22-33-44-55"
+	importContainerID            = "container-1"
+	importOrchestratorContextKey = "pod"
+	importIPv4Key                = "IPv4"
+	importIPv6Key                = "IPv6"
 )
 
 func TestImportLegacySuccess(t *testing.T) {
@@ -50,22 +72,22 @@ func TestImportLegacySuccess(t *testing.T) {
 			assert.Equal(t, SchemaVersion, snapshot.Metadata.SchemaVersion)
 			assert.Equal(t, AuthorityBolt, snapshot.Metadata.Authority)
 			assert.Equal(t, uint64(1), snapshot.Metadata.Generation)
-			assert.Equal(t, "boot-1", snapshot.Metadata.BootID)
+			assert.Equal(t, importBootID, snapshot.Metadata.BootID)
 			assert.True(t, snapshot.Metadata.LegacyImportComplete)
-			assert.Equal(t, "KubernetesCRD", snapshot.Metadata.OrchestratorType)
+			assert.Equal(t, importOrchestratorType, snapshot.Metadata.OrchestratorType)
 			assert.Equal(t, "node-1", snapshot.Metadata.NodeID)
 			assert.Equal(t, "eastus", snapshot.Metadata.Location)
-			assert.Equal(t, "azure", snapshot.Metadata.NetworkType)
+			assert.Equal(t, importNetworkType, snapshot.Metadata.NetworkType)
 			assert.True(t, snapshot.Metadata.Initialized)
 			assert.Equal(t, testNow, snapshot.Metadata.TimeStamp)
 
 			require.Len(t, snapshot.NetworkContainers, 2)
 			require.Len(t, snapshot.IPs, 3)
-			assert.Equal(t, "10.0.0.4", snapshot.IPs[importIPv4].IPAddress)
+			assert.Equal(t, importIPv4Address, snapshot.IPs[importIPv4].IPAddress)
 			assert.Equal(t, importNC1, snapshot.IPs[importIPv4].NCID)
 			assert.Equal(t, 7, snapshot.IPs[importIPv4].NCVersion)
-			assert.Equal(t, "fd00::4", snapshot.IPs[importIPv6].IPAddress)
-			assert.Equal(t, "10.1.0.4", snapshot.IPs[importNet1].IPAddress)
+			assert.Equal(t, importIPv6Address, snapshot.IPs[importIPv6].IPAddress)
+			assert.Equal(t, importNet1Address, snapshot.IPs[importNet1].IPAddress)
 			for _, ncID := range []string{importNC1, importNC2} {
 				record := snapshot.NetworkContainers[ncID]
 				assert.Empty(t, record.Request.AuthorizationToken)
@@ -74,9 +96,9 @@ func TestImportLegacySuccess(t *testing.T) {
 				assert.NotEmpty(t, record.Request.NetworkInterfaceInfo.MACAddress)
 			}
 			assert.Equal(t, []string{importNC1, importNC2}, snapshot.OrchestratorContexts["pod-1ns-1"])
-			assert.Equal(t, "PCI\\VEN_1234", snapshot.PnPIDByMAC["00:11:22:33:44:55"])
+			assert.Equal(t, "PCI\\VEN_1234", snapshot.PnPIDByMAC[importMAC])
 			assert.Equal(t, "network-1", snapshot.Networks["network-1"].NetworkName)
-			assert.Equal(t, "10.0.0.0/24", snapshot.Networks["network-1"].NicInfo.Subnet)
+			assert.Equal(t, importSubnetCIDR, snapshot.Networks[importNetworkName].NicInfo.Subnet)
 			assert.Equal(t, "value", snapshot.Networks["network-1"].Options["custom"])
 
 			if !tt.manageEndpoints {
@@ -87,18 +109,18 @@ func TestImportLegacySuccess(t *testing.T) {
 				return
 			}
 			require.Len(t, snapshot.Endpoints, 1)
-			endpoint := snapshot.Endpoints["container-1"]
-			assert.Equal(t, "pod-1", endpoint.PodName)
-			assert.Equal(t, "ns-1", endpoint.PodNamespace)
-			assert.Equal(t, "hns-endpoint-1", endpoint.IfnameToIPMap["eth0"].HNSEndpointID)
-			assert.Equal(t, "hns-network-1", endpoint.IfnameToIPMap["eth0"].HNSNetworkID)
-			assert.Equal(t, "veth-1", endpoint.IfnameToIPMap["eth0"].HostVethName)
-			assert.Equal(t, cns.InfraNIC, endpoint.IfnameToIPMap["eth0"].NICType)
+			endpoint := snapshot.Endpoints[importContainerID]
+			assert.Equal(t, importPodName, endpoint.PodName)
+			assert.Equal(t, importPodNamespace, endpoint.PodNamespace)
+			assert.Equal(t, "hns-endpoint-1", endpoint.IfnameToIPMap[importIfname].HNSEndpointID)
+			assert.Equal(t, "hns-network-1", endpoint.IfnameToIPMap[importIfname].HNSNetworkID)
+			assert.Equal(t, "veth-1", endpoint.IfnameToIPMap[importIfname].HostVethName)
+			assert.Equal(t, cns.InfraNIC, endpoint.IfnameToIPMap[importIfname].NICType)
 			assert.Equal(t, cns.DelegatedVMNIC, endpoint.IfnameToIPMap["net1"].NICType)
-			require.Len(t, endpoint.IfnameToIPMap["eth0"].IPv4, 1)
-			require.Len(t, endpoint.IfnameToIPMap["eth0"].IPv6, 1)
-			assert.Equal(t, []string{importIPv4, importIPv6, importNet1}, snapshot.Assignments["container-1"].IPIDs)
-			assert.Equal(t, "container-1", snapshot.IPOwners[importIPv4])
+			require.Len(t, endpoint.IfnameToIPMap[importIfname].IPv4, 1)
+			require.Len(t, endpoint.IfnameToIPMap[importIfname].IPv6, 1)
+			assert.Equal(t, []string{importIPv4, importIPv6, importNet1}, snapshot.Assignments[importContainerID].IPIDs)
+			assert.Equal(t, importContainerID, snapshot.IPOwners[importIPv4])
 			assert.Equal(t, DeleteIntent{CreatedAt: testNow.Add(-time.Minute)}, snapshot.DeleteIntents["deleted-container"])
 		})
 	}
@@ -127,25 +149,25 @@ func TestImportLegacySourceFailures(t *testing.T) {
 		{
 			name: "null NC list",
 			cnsData: mutateLegacyCNS(t, validCNS, func(state map[string]any) {
-				state["ContainerIDByOrchestratorContext"] = map[string]any{"pod": nil}
+				state["ContainerIDByOrchestratorContext"] = map[string]any{importOrchestratorContextKey: nil}
 			}),
 		},
 		{
 			name: "empty NC list",
 			cnsData: mutateLegacyCNS(t, validCNS, func(state map[string]any) {
-				state["ContainerIDByOrchestratorContext"] = map[string]any{"pod": ""}
+				state["ContainerIDByOrchestratorContext"] = map[string]any{importOrchestratorContextKey: ""}
 			}),
 		},
 		{
 			name: "wrong NC list shape",
 			cnsData: mutateLegacyCNS(t, validCNS, func(state map[string]any) {
-				state["ContainerIDByOrchestratorContext"] = map[string]any{"pod": []string{importNC1}}
+				state["ContainerIDByOrchestratorContext"] = map[string]any{importOrchestratorContextKey: []string{importNC1}}
 			}),
 		},
 		{
 			name: "malformed comma NC list",
 			cnsData: mutateLegacyCNS(t, validCNS, func(state map[string]any) {
-				state["ContainerIDByOrchestratorContext"] = map[string]any{"pod": importNC1 + ", "}
+				state["ContainerIDByOrchestratorContext"] = map[string]any{importOrchestratorContextKey: importNC1 + ", "}
 			}),
 		},
 		{name: "empty endpoint", cnsData: validCNS, endpoint: []byte{}, manage: true},
@@ -207,7 +229,7 @@ func TestImportLegacyReadFailures(t *testing.T) {
 		before := requireValidSnapshot(t, db)
 		changed, err := db.ImportLegacy(context.Background(), ImportOptions{
 			CNSPath: filepath.Join(t.TempDir(), "missing.json"),
-			BootID:  "boot-1",
+			BootID:  importBootID,
 		})
 		require.ErrorIs(t, err, os.ErrNotExist)
 		assert.False(t, changed)
@@ -219,7 +241,7 @@ func TestImportLegacyReadFailures(t *testing.T) {
 		secret := "do-not-expose"
 		changed, err := db.importLegacy(
 			context.Background(),
-			ImportOptions{CNSPath: "azure-cns.json", BootID: "boot-1"},
+			ImportOptions{CNSPath: importCNSFileName, BootID: importBootID},
 			func(string) ([]byte, error) { return nil, os.ErrPermission },
 		)
 		require.ErrorIs(t, err, os.ErrPermission)
@@ -274,7 +296,7 @@ func TestImportLegacySemanticFailures(t *testing.T) {
 				statuses := state["ContainerStatus"].(map[string]any)
 				request := statuses[importNC1].(map[string]any)["CreateNetworkContainerRequest"].(map[string]any)
 				request["SecondaryIPConfigs"] = map[string]any{
-					"not-a-uuid": map[string]any{"IPAddress": "10.0.0.4", "NCVersion": float64(7)},
+					"not-a-uuid": map[string]any{"IPAddress": importIPv4Address, "NCVersion": float64(7)},
 				}
 			}),
 		},
@@ -291,7 +313,7 @@ func TestImportLegacySemanticFailures(t *testing.T) {
 				statuses := state["ContainerStatus"].(map[string]any)
 				request := statuses[importNC2].(map[string]any)["CreateNetworkContainerRequest"].(map[string]any)
 				request["SecondaryIPConfigs"] = map[string]any{
-					importIPv4: map[string]any{"IPAddress": "10.1.0.4", "NCVersion": float64(8)},
+					importIPv4: map[string]any{"IPAddress": importNet1Address, "NCVersion": float64(8)},
 				}
 			}),
 		},
@@ -301,7 +323,7 @@ func TestImportLegacySemanticFailures(t *testing.T) {
 				statuses := state["ContainerStatus"].(map[string]any)
 				request := statuses[importNC2].(map[string]any)["CreateNetworkContainerRequest"].(map[string]any)
 				config := request["SecondaryIPConfigs"].(map[string]any)[importNet1].(map[string]any)
-				config["IPAddress"] = "10.0.0.4"
+				config["IPAddress"] = importIPv4Address
 			}),
 		},
 		{
@@ -333,22 +355,22 @@ func TestImportLegacySemanticFailures(t *testing.T) {
 		{
 			name: "dangling orchestrator mapping",
 			cnsData: mutateLegacyCNS(t, validCNS, func(state map[string]any) {
-				state["ContainerIDByOrchestratorContext"] = map[string]any{"pod": "missing-nc"}
+				state["ContainerIDByOrchestratorContext"] = map[string]any{importOrchestratorContextKey: "missing-nc"}
 			}),
 		},
 		{
 			name:    "noncanonical endpoint container identity",
 			cnsData: validCNS,
 			endpoint: mutateLegacyEndpoints(t, validEndpoint, func(endpoints map[string]any) {
-				endpoints[" container-1"] = endpoints["container-1"]
-				delete(endpoints, "container-1")
+				endpoints[" "+importContainerID] = endpoints[importContainerID]
+				delete(endpoints, importContainerID)
 			}),
 		},
 		{
 			name:    "endpoint IP absent from inventory",
 			cnsData: validCNS,
 			endpoint: mutateLegacyEndpoints(t, validEndpoint, func(endpoints map[string]any) {
-				info := endpointIPInfo(endpoints, "container-1", "eth0")
+				info := endpointIPInfo(endpoints, importContainerID, importIfname)
 				info["ipv4"] = encodeIPNets(t, "10.9.0.4/24")
 			}),
 			wantErrorContains: "missing from inventory",
@@ -357,14 +379,14 @@ func TestImportLegacySemanticFailures(t *testing.T) {
 			name:    "duplicate endpoint ownership",
 			cnsData: validCNS,
 			endpoint: mutateLegacyEndpoints(t, validEndpoint, func(endpoints map[string]any) {
-				endpoints["container-2"] = endpoints["container-1"]
+				endpoints["container-2"] = endpoints[importContainerID]
 			}),
 		},
 		{
 			name:    "endpoint NC mismatch",
 			cnsData: validCNS,
 			endpoint: mutateLegacyEndpoints(t, validEndpoint, func(endpoints map[string]any) {
-				endpointIPInfo(endpoints, "container-1", "eth0")["networkContainerID"] = importNC2
+				endpointIPInfo(endpoints, importContainerID, importIfname)["networkContainerID"] = importNC2
 			}),
 			wantErrorContains: "does not match",
 		},
@@ -372,7 +394,7 @@ func TestImportLegacySemanticFailures(t *testing.T) {
 			name:    "malformed endpoint MAC",
 			cnsData: validCNS,
 			endpoint: mutateLegacyEndpoints(t, validEndpoint, func(endpoints map[string]any) {
-				endpointIPInfo(endpoints, "container-1", "eth0")["macAddress"] = "bad-mac"
+				endpointIPInfo(endpoints, importContainerID, importIfname)["macAddress"] = "bad-mac"
 			}),
 			wantErrorContains: "invalid MAC",
 		},
@@ -530,7 +552,7 @@ func TestImportLegacyContextCancellation(t *testing.T) {
 		var reads atomic.Int32
 		changed, err := db.importLegacy(
 			ctx,
-			ImportOptions{CNSPath: "azure-cns.json", BootID: "boot-1"},
+			ImportOptions{CNSPath: importCNSFileName, BootID: importBootID},
 			func(string) ([]byte, error) {
 				reads.Add(1)
 				return nil, nil
@@ -558,7 +580,7 @@ func TestImportLegacyContextCancellation(t *testing.T) {
 		go func() {
 			_, err := db.importLegacy(
 				ctx,
-				ImportOptions{CNSPath: "azure-cns.json", BootID: "boot-1"},
+				ImportOptions{CNSPath: importCNSFileName, BootID: importBootID},
 				func(string) ([]byte, error) {
 					close(readDone)
 					return cnsData, nil
@@ -585,7 +607,7 @@ func TestImportLegacyDeterministicErrors(t *testing.T) {
 	})
 	var want string
 	for range 20 {
-		_, err := parseLegacyCNS(cnsData, "boot-1")
+		_, err := parseLegacyCNS(cnsData, importBootID)
 		require.Error(t, err)
 		assert.NotContains(t, err.Error(), "secret-token")
 		if want == "" {
@@ -596,15 +618,15 @@ func TestImportLegacyDeterministicErrors(t *testing.T) {
 	}
 }
 
-func completeLegacyImportData(t *testing.T) ([]byte, []byte) {
+func completeLegacyImportData(t *testing.T) (cnsData, endpointData []byte) {
 	t.Helper()
 	request1 := completeNetworkContainerRequest()
 	request1.NetworkContainerid = importNC1
 	request1.Version = "7"
 	request1.AuthorizationToken = "secret-token"
 	request1.SecondaryIPConfigs = map[string]cns.SecondaryIPConfig{
-		importIPv4: {IPAddress: "10.0.0.4", NCVersion: 7},
-		importIPv6: {IPAddress: "fd00::4", NCVersion: 7},
+		importIPv4: {IPAddress: importIPv4Address, NCVersion: 7},
+		importIPv6: {IPAddress: importIPv6Address, NCVersion: 7},
 	}
 	request2 := completeNetworkContainerRequest()
 	request2.NetworkContainerid = importNC2
@@ -612,15 +634,15 @@ func completeLegacyImportData(t *testing.T) ([]byte, []byte) {
 	request2.AuthorizationToken = "another-secret"
 	request2.IPConfiguration.IPSubnet.IPAddress = "10.1.0.0"
 	request2.IPConfiguration.GatewayIPAddress = "10.1.0.1"
-	request2.NetworkInterfaceInfo.MACAddress = "00:11:22:33:44:66"
+	request2.NetworkInterfaceInfo.MACAddress = importMAC2
 	request2.SecondaryIPConfigs = map[string]cns.SecondaryIPConfig{
-		importNet1: {IPAddress: "10.1.0.4", NCVersion: 8},
+		importNet1: {IPAddress: importNet1Address, NCVersion: 8},
 	}
 	ncList := importNC1 + "," + importNC2
 	cnsState := legacyCNSState{
 		Location:         "eastus",
-		NetworkType:      "azure",
-		OrchestratorType: "KubernetesCRD",
+		NetworkType:      importNetworkType,
+		OrchestratorType: importOrchestratorType,
 		NodeID:           "node-1",
 		Initialized:      true,
 		ContainerIDByOrchestratorContext: map[string]*string{
@@ -643,11 +665,11 @@ func completeLegacyImportData(t *testing.T) ([]byte, []byte) {
 			},
 		},
 		Networks: map[string]*legacyNetworkInfo{
-			"network-1": {
-				NetworkName: "network-1",
+			importNetworkName: {
+				NetworkName: importNetworkName,
 				NicInfo: &wireserver.InterfaceInfo{
-					Subnet:       "10.0.0.0/24",
-					Gateway:      "10.0.0.1",
+					Subnet:       importSubnetCIDR,
+					Gateway:      importGatewayIP,
 					PrimaryIP:    "10.0.0.2",
 					SecondaryIPs: []string{"10.0.0.3"},
 					IsPrimary:    true,
@@ -657,7 +679,7 @@ func completeLegacyImportData(t *testing.T) ([]byte, []byte) {
 		},
 		TimeStamp: testNow,
 		PnpIDByMacAddress: map[string]string{
-			"00-11-22-33-44-55": "PCI\\VEN_1234",
+			importPnPMAC: "PCI\\VEN_1234",
 		},
 	}
 	cnsData, err := json.Marshal(map[string]any{
@@ -667,32 +689,32 @@ func completeLegacyImportData(t *testing.T) ([]byte, []byte) {
 	require.NoError(t, err)
 
 	endpoint := EndpointRecord{
-		PodName:      "pod-1",
-		PodNamespace: "ns-1",
+		PodName:      importPodName,
+		PodNamespace: importPodNamespace,
 		IfnameToIPMap: map[string]*IPInfoRecord{
-			"eth0": {
-				IPv4:               []net.IPNet{mustIPNet(t, "10.0.0.4/24")},
-				IPv6:               []net.IPNet{mustIPNet(t, "fd00::4/64")},
+			importIfname: {
+				IPv4:               []net.IPNet{mustIPNet(t, importIPv4Address+"/24")},
+				IPv6:               []net.IPNet{mustIPNet(t, importIPv6Address+"/64")},
 				HNSEndpointID:      "hns-endpoint-1",
 				HNSNetworkID:       "hns-network-1",
 				HostVethName:       "veth-1",
-				MACAddress:         "00:11:22:33:44:55",
+				MACAddress:         importMAC,
 				NetworkContainerID: importNC1,
 				NICType:            cns.InfraNIC,
 			},
 			"net1": {
-				IPv4:               []net.IPNet{mustIPNet(t, "10.1.0.4/24")},
+				IPv4:               []net.IPNet{mustIPNet(t, importNet1Address+"/24")},
 				HNSEndpointID:      "hns-endpoint-2",
 				HNSNetworkID:       "hns-network-2",
 				HostVethName:       "veth-2",
-				MACAddress:         "00:11:22:33:44:66",
+				MACAddress:         importMAC2,
 				NetworkContainerID: importNC2,
 				NICType:            cns.DelegatedVMNIC,
 			},
 		},
 	}
-	endpointData, err := json.Marshal(map[string]any{
-		"Endpoints": map[string]*EndpointRecord{"container-1": &endpoint},
+	endpointData, err = json.Marshal(map[string]any{
+		"Endpoints": map[string]*EndpointRecord{importContainerID: &endpoint},
 		"DeleteIntents": map[string]DeleteIntent{
 			"deleted-container": {CreatedAt: testNow.Add(-time.Minute)},
 		},
@@ -705,9 +727,9 @@ func completeLegacyImportData(t *testing.T) ([]byte, []byte) {
 func writeLegacyImportFiles(t *testing.T, cnsData, endpointData []byte, manage bool) ImportOptions {
 	t.Helper()
 	dir := t.TempDir()
-	cnsPath := filepath.Join(dir, "azure-cns.json")
+	cnsPath := filepath.Join(dir, importCNSFileName)
 	require.NoError(t, os.WriteFile(cnsPath, cnsData, 0o600))
-	opts := ImportOptions{CNSPath: cnsPath, BootID: "boot-1", ManageEndpointState: manage}
+	opts := ImportOptions{CNSPath: cnsPath, BootID: importBootID, ManageEndpointState: manage}
 	if manage {
 		opts.EndpointPath = filepath.Join(dir, "azure-endpoints.json")
 		require.NoError(t, os.WriteFile(opts.EndpointPath, endpointData, 0o600))

--- a/cns/state/import_test.go
+++ b/cns/state/import_test.go
@@ -1,0 +1,750 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package state
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/wireserver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	importNC1  = "11111111-1111-1111-1111-111111111111"
+	importNC2  = "22222222-2222-2222-2222-222222222222"
+	importIPv4 = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	importIPv6 = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+	importNet1 = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+)
+
+func TestImportLegacySuccess(t *testing.T) {
+	tests := []struct {
+		name            string
+		manageEndpoints bool
+	}{
+		{name: "CNS only"},
+		{name: "CNS and endpoint state", manageEndpoints: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, _ := openTestDB(t)
+			cnsData, endpointData := completeLegacyImportData(t)
+			opts := writeLegacyImportFiles(t, cnsData, endpointData, tt.manageEndpoints)
+
+			changed, err := db.ImportLegacy(context.Background(), opts)
+			require.NoError(t, err)
+			assert.True(t, changed)
+
+			snapshot := requireValidSnapshot(t, db)
+			assert.Equal(t, SchemaVersion, snapshot.Metadata.SchemaVersion)
+			assert.Equal(t, AuthorityBolt, snapshot.Metadata.Authority)
+			assert.Equal(t, uint64(1), snapshot.Metadata.Generation)
+			assert.Equal(t, "boot-1", snapshot.Metadata.BootID)
+			assert.True(t, snapshot.Metadata.LegacyImportComplete)
+			assert.Equal(t, "KubernetesCRD", snapshot.Metadata.OrchestratorType)
+			assert.Equal(t, "node-1", snapshot.Metadata.NodeID)
+			assert.Equal(t, "eastus", snapshot.Metadata.Location)
+			assert.Equal(t, "azure", snapshot.Metadata.NetworkType)
+			assert.True(t, snapshot.Metadata.Initialized)
+			assert.Equal(t, testNow, snapshot.Metadata.TimeStamp)
+
+			require.Len(t, snapshot.NetworkContainers, 2)
+			require.Len(t, snapshot.IPs, 3)
+			assert.Equal(t, "10.0.0.4", snapshot.IPs[importIPv4].IPAddress)
+			assert.Equal(t, importNC1, snapshot.IPs[importIPv4].NCID)
+			assert.Equal(t, 7, snapshot.IPs[importIPv4].NCVersion)
+			assert.Equal(t, "fd00::4", snapshot.IPs[importIPv6].IPAddress)
+			assert.Equal(t, "10.1.0.4", snapshot.IPs[importNet1].IPAddress)
+			for _, ncID := range []string{importNC1, importNC2} {
+				record := snapshot.NetworkContainers[ncID]
+				assert.Empty(t, record.Request.AuthorizationToken)
+				assert.Nil(t, record.Request.SecondaryIPConfigs)
+				assert.NotEmpty(t, record.Request.EndpointPolicies)
+				assert.NotEmpty(t, record.Request.NetworkInterfaceInfo.MACAddress)
+			}
+			assert.Equal(t, []string{importNC1, importNC2}, snapshot.OrchestratorContexts["pod-1ns-1"])
+			assert.Equal(t, "PCI\\VEN_1234", snapshot.PnPIDByMAC["00:11:22:33:44:55"])
+			assert.Equal(t, "network-1", snapshot.Networks["network-1"].NetworkName)
+			assert.Equal(t, "10.0.0.0/24", snapshot.Networks["network-1"].NicInfo.Subnet)
+			assert.Equal(t, "value", snapshot.Networks["network-1"].Options["custom"])
+
+			if !tt.manageEndpoints {
+				assert.Empty(t, snapshot.Endpoints)
+				assert.Empty(t, snapshot.Assignments)
+				assert.Empty(t, snapshot.IPOwners)
+				assert.Empty(t, snapshot.DeleteIntents)
+				return
+			}
+			require.Len(t, snapshot.Endpoints, 1)
+			endpoint := snapshot.Endpoints["container-1"]
+			assert.Equal(t, "pod-1", endpoint.PodName)
+			assert.Equal(t, "ns-1", endpoint.PodNamespace)
+			assert.Equal(t, "hns-endpoint-1", endpoint.IfnameToIPMap["eth0"].HNSEndpointID)
+			assert.Equal(t, "hns-network-1", endpoint.IfnameToIPMap["eth0"].HNSNetworkID)
+			assert.Equal(t, "veth-1", endpoint.IfnameToIPMap["eth0"].HostVethName)
+			assert.Equal(t, cns.InfraNIC, endpoint.IfnameToIPMap["eth0"].NICType)
+			assert.Equal(t, cns.DelegatedVMNIC, endpoint.IfnameToIPMap["net1"].NICType)
+			require.Len(t, endpoint.IfnameToIPMap["eth0"].IPv4, 1)
+			require.Len(t, endpoint.IfnameToIPMap["eth0"].IPv6, 1)
+			assert.Equal(t, []string{importIPv4, importIPv6, importNet1}, snapshot.Assignments["container-1"].IPIDs)
+			assert.Equal(t, "container-1", snapshot.IPOwners[importIPv4])
+			assert.Equal(t, DeleteIntent{CreatedAt: testNow.Add(-time.Minute)}, snapshot.DeleteIntents["deleted-container"])
+		})
+	}
+}
+
+func TestImportLegacySourceFailures(t *testing.T) {
+	validCNS, validEndpoint := completeLegacyImportData(t)
+	tests := []struct {
+		name       string
+		cnsData    []byte
+		endpoint   []byte
+		manage     bool
+		mutateOpts func(*ImportOptions)
+	}{
+		{name: "empty CNS", cnsData: []byte{}},
+		{name: "whitespace CNS", cnsData: []byte(" \n\t")},
+		{name: "truncated CNS", cnsData: []byte(`{"ContainerNetworkService":`)},
+		{name: "malformed CNS", cnsData: []byte(`{"ContainerNetworkService":!}`)},
+		{name: "null CNS", cnsData: []byte(`null`)},
+		{name: "array CNS", cnsData: []byte(`[]`)},
+		{name: "multiple CNS values", cnsData: append(append([]byte{}, validCNS...), []byte(` {}`)...)},
+		{name: "missing CNS envelope", cnsData: []byte(`{"Other":{}}`)},
+		{name: "duplicate CNS key", cnsData: []byte(`{"ContainerNetworkService":{},"ContainerNetworkService":{}}`)},
+		{name: "wrong CNS field type", cnsData: []byte(`{"ContainerNetworkService":{"Location":7}}`)},
+		{name: "unknown relevant CNS field", cnsData: []byte(`{"ContainerNetworkService":{"Unexpected":true}}`)},
+		{
+			name: "null NC list",
+			cnsData: mutateLegacyCNS(t, validCNS, func(state map[string]any) {
+				state["ContainerIDByOrchestratorContext"] = map[string]any{"pod": nil}
+			}),
+		},
+		{
+			name: "empty NC list",
+			cnsData: mutateLegacyCNS(t, validCNS, func(state map[string]any) {
+				state["ContainerIDByOrchestratorContext"] = map[string]any{"pod": ""}
+			}),
+		},
+		{
+			name: "wrong NC list shape",
+			cnsData: mutateLegacyCNS(t, validCNS, func(state map[string]any) {
+				state["ContainerIDByOrchestratorContext"] = map[string]any{"pod": []string{importNC1}}
+			}),
+		},
+		{
+			name: "malformed comma NC list",
+			cnsData: mutateLegacyCNS(t, validCNS, func(state map[string]any) {
+				state["ContainerIDByOrchestratorContext"] = map[string]any{"pod": importNC1 + ", "}
+			}),
+		},
+		{name: "empty endpoint", cnsData: validCNS, endpoint: []byte{}, manage: true},
+		{name: "truncated endpoint", cnsData: validCNS, endpoint: []byte(`{"Endpoints":`), manage: true},
+		{name: "malformed endpoint", cnsData: validCNS, endpoint: []byte(`{"Endpoints":!}`), manage: true},
+		{name: "null endpoint", cnsData: validCNS, endpoint: []byte(`null`), manage: true},
+		{name: "array endpoint", cnsData: validCNS, endpoint: []byte(`[]`), manage: true},
+		{name: "multiple endpoint values", cnsData: validCNS, endpoint: append(append([]byte{}, validEndpoint...), []byte(` {}`)...), manage: true},
+		{name: "missing endpoint envelope", cnsData: validCNS, endpoint: []byte(`{"Other":{}}`), manage: true},
+		{name: "duplicate endpoint key", cnsData: validCNS, endpoint: []byte(`{"Endpoints":{},"endpoints":{}}`), manage: true},
+		{name: "wrong endpoint type", cnsData: validCNS, endpoint: []byte(`{"Endpoints":[]}`), manage: true},
+		{name: "wrong endpoint field type", cnsData: validCNS, endpoint: []byte(`{"Endpoints":{"container":{"podName":7}}}`), manage: true},
+		{
+			name:       "missing CNS path option",
+			cnsData:    validCNS,
+			mutateOpts: func(opts *ImportOptions) { opts.CNSPath = "" },
+		},
+		{
+			name:       "missing boot ID",
+			cnsData:    validCNS,
+			mutateOpts: func(opts *ImportOptions) { opts.BootID = "" },
+		},
+		{
+			name:       "missing endpoint path option",
+			cnsData:    validCNS,
+			endpoint:   validEndpoint,
+			manage:     true,
+			mutateOpts: func(opts *ImportOptions) { opts.EndpointPath = "" },
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, _ := openTestDB(t)
+			cnsData := tt.cnsData
+			if cnsData == nil {
+				cnsData = validCNS
+			}
+			endpointData := tt.endpoint
+			if endpointData == nil {
+				endpointData = validEndpoint
+			}
+			opts := writeLegacyImportFiles(t, cnsData, endpointData, tt.manage)
+			if tt.mutateOpts != nil {
+				tt.mutateOpts(&opts)
+			}
+			before := requireValidSnapshot(t, db)
+
+			changed, err := db.ImportLegacy(context.Background(), opts)
+			require.Error(t, err)
+			assert.False(t, changed)
+			assert.Equal(t, before, requireValidSnapshot(t, db))
+		})
+	}
+}
+
+func TestImportLegacyReadFailures(t *testing.T) {
+	t.Run("real missing CNS file", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		before := requireValidSnapshot(t, db)
+		changed, err := db.ImportLegacy(context.Background(), ImportOptions{
+			CNSPath: filepath.Join(t.TempDir(), "missing.json"),
+			BootID:  "boot-1",
+		})
+		require.ErrorIs(t, err, os.ErrNotExist)
+		assert.False(t, changed)
+		assert.Equal(t, before, requireValidSnapshot(t, db))
+	})
+
+	t.Run("injected permission failure does not expose source", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		secret := "do-not-expose"
+		changed, err := db.importLegacy(
+			context.Background(),
+			ImportOptions{CNSPath: "azure-cns.json", BootID: "boot-1"},
+			func(string) ([]byte, error) { return nil, os.ErrPermission },
+		)
+		require.ErrorIs(t, err, os.ErrPermission)
+		assert.NotContains(t, err.Error(), secret)
+		assert.False(t, changed)
+		assert.Zero(t, readMetadata(t, db).Generation)
+	})
+
+	t.Run("missing endpoint file", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		cnsData, _ := completeLegacyImportData(t)
+		opts := writeLegacyImportFiles(t, cnsData, nil, true)
+		require.NoError(t, os.Remove(opts.EndpointPath))
+		changed, err := db.ImportLegacy(context.Background(), opts)
+		require.ErrorIs(t, err, os.ErrNotExist)
+		assert.False(t, changed)
+		assert.Zero(t, readMetadata(t, db).Generation)
+	})
+
+	t.Run("endpoint is ignored when ownership is disabled", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		cnsData, _ := completeLegacyImportData(t)
+		opts := writeLegacyImportFiles(t, cnsData, []byte(`not JSON`), false)
+		opts.EndpointPath = filepath.Join(t.TempDir(), "missing-endpoint.json")
+		changed, err := db.ImportLegacy(context.Background(), opts)
+		require.NoError(t, err)
+		assert.True(t, changed)
+		assert.Empty(t, requireValidSnapshot(t, db).Endpoints)
+	})
+}
+
+func TestImportLegacySemanticFailures(t *testing.T) {
+	validCNS, validEndpoint := completeLegacyImportData(t)
+	tests := []struct {
+		name     string
+		cnsData  []byte
+		endpoint []byte
+	}{
+		{
+			name: "invalid IP UUID",
+			cnsData: mutateLegacyCNS(t, validCNS, func(state map[string]any) {
+				statuses := state["ContainerStatus"].(map[string]any)
+				request := statuses[importNC1].(map[string]any)["CreateNetworkContainerRequest"].(map[string]any)
+				request["SecondaryIPConfigs"] = map[string]any{
+					"not-a-uuid": map[string]any{"IPAddress": "10.0.0.4", "NCVersion": float64(7)},
+				}
+			}),
+		},
+		{
+			name: "mismatched NC ID",
+			cnsData: mutateLegacyCNS(t, validCNS, func(state map[string]any) {
+				status := state["ContainerStatus"].(map[string]any)[importNC1].(map[string]any)
+				status["ID"] = importNC2
+			}),
+		},
+		{
+			name: "duplicate UUID across NCs",
+			cnsData: mutateLegacyCNS(t, validCNS, func(state map[string]any) {
+				statuses := state["ContainerStatus"].(map[string]any)
+				request := statuses[importNC2].(map[string]any)["CreateNetworkContainerRequest"].(map[string]any)
+				request["SecondaryIPConfigs"] = map[string]any{
+					importIPv4: map[string]any{"IPAddress": "10.1.0.4", "NCVersion": float64(8)},
+				}
+			}),
+		},
+		{
+			name: "duplicate canonical address",
+			cnsData: mutateLegacyCNS(t, validCNS, func(state map[string]any) {
+				statuses := state["ContainerStatus"].(map[string]any)
+				request := statuses[importNC2].(map[string]any)["CreateNetworkContainerRequest"].(map[string]any)
+				config := request["SecondaryIPConfigs"].(map[string]any)[importNet1].(map[string]any)
+				config["IPAddress"] = "10.0.0.4"
+			}),
+		},
+		{
+			name: "malformed IP",
+			cnsData: mutateLegacyCNS(t, validCNS, func(state map[string]any) {
+				statuses := state["ContainerStatus"].(map[string]any)
+				request := statuses[importNC1].(map[string]any)["CreateNetworkContainerRequest"].(map[string]any)
+				config := request["SecondaryIPConfigs"].(map[string]any)[importIPv4].(map[string]any)
+				config["IPAddress"] = "bad-ip"
+			}),
+		},
+		{
+			name: "malformed prefix",
+			cnsData: mutateLegacyCNS(t, validCNS, func(state map[string]any) {
+				statuses := state["ContainerStatus"].(map[string]any)
+				request := statuses[importNC1].(map[string]any)["CreateNetworkContainerRequest"].(map[string]any)
+				ipConfig := request["IPConfiguration"].(map[string]any)
+				ipConfig["IPSubnet"].(map[string]any)["PrefixLength"] = float64(40)
+			}),
+		},
+		{
+			name: "malformed request MAC",
+			cnsData: mutateLegacyCNS(t, validCNS, func(state map[string]any) {
+				statuses := state["ContainerStatus"].(map[string]any)
+				request := statuses[importNC1].(map[string]any)["CreateNetworkContainerRequest"].(map[string]any)
+				request["NetworkInterfaceInfo"].(map[string]any)["MACAddress"] = "bad-mac"
+			}),
+		},
+		{
+			name: "dangling orchestrator mapping",
+			cnsData: mutateLegacyCNS(t, validCNS, func(state map[string]any) {
+				state["ContainerIDByOrchestratorContext"] = map[string]any{"pod": "missing-nc"}
+			}),
+		},
+		{
+			name:    "noncanonical endpoint container identity",
+			cnsData: validCNS,
+			endpoint: mutateLegacyEndpoints(t, validEndpoint, func(endpoints map[string]any) {
+				endpoints[" container-1"] = endpoints["container-1"]
+				delete(endpoints, "container-1")
+			}),
+		},
+		{
+			name:    "endpoint IP absent from inventory",
+			cnsData: validCNS,
+			endpoint: mutateLegacyEndpoints(t, validEndpoint, func(endpoints map[string]any) {
+				info := endpointIPInfo(endpoints, "container-1", "eth0")
+				info["IPv4"] = encodeIPNets(t, "10.9.0.4/24")
+			}),
+		},
+		{
+			name:    "duplicate endpoint ownership",
+			cnsData: validCNS,
+			endpoint: mutateLegacyEndpoints(t, validEndpoint, func(endpoints map[string]any) {
+				endpoints["container-2"] = endpoints["container-1"]
+			}),
+		},
+		{
+			name:    "endpoint NC mismatch",
+			cnsData: validCNS,
+			endpoint: mutateLegacyEndpoints(t, validEndpoint, func(endpoints map[string]any) {
+				endpointIPInfo(endpoints, "container-1", "eth0")["NetworkContainerID"] = importNC2
+			}),
+		},
+		{
+			name:    "malformed endpoint MAC",
+			cnsData: validCNS,
+			endpoint: mutateLegacyEndpoints(t, validEndpoint, func(endpoints map[string]any) {
+				endpointIPInfo(endpoints, "container-1", "eth0")["MACAddress"] = "bad-mac"
+			}),
+		},
+		{
+			name:    "invalid delete intent",
+			cnsData: validCNS,
+			endpoint: mutateLegacyEndpointEnvelope(t, validEndpoint, func(envelope map[string]any) {
+				envelope["DeleteIntents"] = map[string]any{
+					"deleted-container": map[string]any{"createdAt": "0001-01-01T00:00:00Z"},
+				}
+			}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, _ := openTestDB(t)
+			endpointData := tt.endpoint
+			if endpointData == nil {
+				endpointData = validEndpoint
+			}
+			opts := writeLegacyImportFiles(t, tt.cnsData, endpointData, tt.endpoint != nil)
+			before := requireValidSnapshot(t, db)
+			changed, err := db.ImportLegacy(context.Background(), opts)
+			require.Error(t, err)
+			assert.False(t, changed)
+			assert.Equal(t, before, requireValidSnapshot(t, db))
+		})
+	}
+}
+
+func TestImportLegacyAtomicityReplayAndConcurrency(t *testing.T) {
+	t.Run("staged write failure rolls back buckets and marker", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		cnsData, endpointData := completeLegacyImportData(t)
+		opts := writeLegacyImportFiles(t, cnsData, endpointData, true)
+		before := requireValidSnapshot(t, db)
+		db.importBeforeCommit = func() error { return errAbort }
+
+		changed, err := db.ImportLegacy(context.Background(), opts)
+		require.ErrorIs(t, err, errAbort)
+		assert.False(t, changed)
+		assert.Equal(t, before, requireValidSnapshot(t, db))
+	})
+
+	t.Run("replay ignores changed corrupt and missing sources", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		cnsData, endpointData := completeLegacyImportData(t)
+		opts := writeLegacyImportFiles(t, cnsData, endpointData, true)
+		changed, err := db.ImportLegacy(context.Background(), opts)
+		require.NoError(t, err)
+		require.True(t, changed)
+		updated, err := db.UpdateReadinessObservation(context.Background(), importNC1, ReadinessObservation{
+			VMVersion:         "7",
+			HostVersion:       "current",
+			VFPUpdateComplete: true,
+		})
+		require.NoError(t, err)
+		require.True(t, updated)
+		current := requireValidSnapshot(t, db)
+
+		require.NoError(t, os.WriteFile(opts.CNSPath, []byte(`not JSON`), 0o600))
+		require.NoError(t, os.Remove(opts.EndpointPath))
+		changed, err = db.ImportLegacy(context.Background(), opts)
+		require.NoError(t, err)
+		assert.False(t, changed)
+		assert.Equal(t, current, requireValidSnapshot(t, db))
+	})
+
+	t.Run("reopen replay", func(t *testing.T) {
+		db, path := openTestDB(t)
+		cnsData, endpointData := completeLegacyImportData(t)
+		opts := writeLegacyImportFiles(t, cnsData, endpointData, true)
+		changed, err := db.ImportLegacy(context.Background(), opts)
+		require.NoError(t, err)
+		require.True(t, changed)
+		imported := requireValidSnapshot(t, db)
+		require.NoError(t, db.Close())
+
+		reopened, err := Open(path, Options{})
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, reopened.Close()) })
+		require.NoError(t, os.Remove(opts.CNSPath))
+		require.NoError(t, os.Remove(opts.EndpointPath))
+		changed, err = reopened.ImportLegacy(context.Background(), opts)
+		require.NoError(t, err)
+		assert.False(t, changed)
+		assert.Equal(t, imported, requireValidSnapshot(t, reopened))
+	})
+
+	t.Run("concurrent calls commit once", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		cnsData, endpointData := completeLegacyImportData(t)
+		opts := writeLegacyImportFiles(t, cnsData, endpointData, true)
+		const callers = 16
+		start := make(chan struct{})
+		results := make(chan bool, callers)
+		errs := make(chan error, callers)
+		var wg sync.WaitGroup
+		wg.Add(callers)
+		for range callers {
+			go func() {
+				defer wg.Done()
+				<-start
+				changed, err := db.ImportLegacy(context.Background(), opts)
+				results <- changed
+				errs <- err
+			}()
+		}
+		close(start)
+		wg.Wait()
+		close(results)
+		close(errs)
+
+		var commits int
+		for changed := range results {
+			if changed {
+				commits++
+			}
+		}
+		for err := range errs {
+			require.NoError(t, err)
+		}
+		assert.Equal(t, 1, commits)
+		assert.Equal(t, uint64(1), readMetadata(t, db).Generation)
+	})
+}
+
+func TestImportLegacyRejectsNonemptyUnmarkedDatabase(t *testing.T) {
+	db, _ := openTestDB(t)
+	require.NoError(t, db.Update(context.Background(), func(tx *WriteTx) error {
+		return tx.PutMetadata(Metadata{NodeID: "current-node"})
+	}))
+	before := requireValidSnapshot(t, db)
+	cnsData, endpointData := completeLegacyImportData(t)
+	opts := writeLegacyImportFiles(t, cnsData, endpointData, true)
+
+	changed, err := db.ImportLegacy(context.Background(), opts)
+	require.ErrorIs(t, err, ErrLegacyImportTargetNotEmpty)
+	assert.False(t, changed)
+	assert.Equal(t, before, requireValidSnapshot(t, db))
+}
+
+func TestImportLegacyContextCancellation(t *testing.T) {
+	t.Run("before read", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		var reads atomic.Int32
+		changed, err := db.importLegacy(
+			ctx,
+			ImportOptions{CNSPath: "azure-cns.json", BootID: "boot-1"},
+			func(string) ([]byte, error) {
+				reads.Add(1)
+				return nil, nil
+			},
+		)
+		require.ErrorIs(t, err, context.Canceled)
+		assert.False(t, changed)
+		assert.Zero(t, reads.Load())
+		assert.Zero(t, readMetadata(t, db).Generation)
+	})
+
+	t.Run("waiting for writer gate", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		cnsData, _ := completeLegacyImportData(t)
+		db.writeGate <- struct{}{}
+		t.Cleanup(func() {
+			select {
+			case <-db.writeGate:
+			default:
+			}
+		})
+		readDone := make(chan struct{})
+		ctx, cancel := context.WithCancel(context.Background())
+		result := make(chan error, 1)
+		go func() {
+			_, err := db.importLegacy(
+				ctx,
+				ImportOptions{CNSPath: "azure-cns.json", BootID: "boot-1"},
+				func(string) ([]byte, error) {
+					close(readDone)
+					return cnsData, nil
+				},
+			)
+			result <- err
+		}()
+		<-readDone
+		cancel()
+		require.ErrorIs(t, <-result, context.Canceled)
+		<-db.writeGate
+		assert.Zero(t, readMetadata(t, db).Generation)
+		assert.False(t, readMetadata(t, db).LegacyImportComplete)
+	})
+}
+
+func TestImportLegacyDeterministicErrors(t *testing.T) {
+	cnsData, _ := completeLegacyImportData(t)
+	cnsData = mutateLegacyCNS(t, cnsData, func(state map[string]any) {
+		statuses := state["ContainerStatus"].(map[string]any)
+		request := statuses[importNC1].(map[string]any)["CreateNetworkContainerRequest"].(map[string]any)
+		request["HostPrimaryIP"] = "bad-host"
+		request["PrimaryInterfaceIdentifier"] = "bad-interface"
+	})
+	var want string
+	for range 20 {
+		_, err := parseLegacyCNS(cnsData, "boot-1")
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "secret-token")
+		if want == "" {
+			want = err.Error()
+			continue
+		}
+		assert.Equal(t, want, err.Error())
+	}
+}
+
+func completeLegacyImportData(t *testing.T) ([]byte, []byte) {
+	t.Helper()
+	request1 := completeNetworkContainerRequest()
+	request1.NetworkContainerid = importNC1
+	request1.Version = "7"
+	request1.AuthorizationToken = "secret-token"
+	request1.SecondaryIPConfigs = map[string]cns.SecondaryIPConfig{
+		importIPv4: {IPAddress: "10.0.0.4", NCVersion: 7},
+		importIPv6: {IPAddress: "fd00::4", NCVersion: 7},
+	}
+	request2 := completeNetworkContainerRequest()
+	request2.NetworkContainerid = importNC2
+	request2.Version = "8"
+	request2.AuthorizationToken = "another-secret"
+	request2.IPConfiguration.IPSubnet.IPAddress = "10.1.0.0"
+	request2.IPConfiguration.GatewayIPAddress = "10.1.0.1"
+	request2.NetworkInterfaceInfo.MACAddress = "00:11:22:33:44:66"
+	request2.SecondaryIPConfigs = map[string]cns.SecondaryIPConfig{
+		importNet1: {IPAddress: "10.1.0.4", NCVersion: 8},
+	}
+	ncList := importNC1 + "," + importNC2
+	cnsState := legacyCNSState{
+		Location:         "eastus",
+		NetworkType:      "azure",
+		OrchestratorType: "KubernetesCRD",
+		NodeID:           "node-1",
+		Initialized:      true,
+		ContainerIDByOrchestratorContext: map[string]*string{
+			"pod-1ns-1": &ncList,
+		},
+		ContainerStatus: map[string]legacyContainerStatus{
+			importNC1: {
+				ID:                            importNC1,
+				VMVersion:                     "7",
+				HostVersion:                   "6",
+				CreateNetworkContainerRequest: request1,
+				VfpUpdateComplete:             true,
+			},
+			importNC2: {
+				ID:                            importNC2,
+				VMVersion:                     "8",
+				HostVersion:                   "7",
+				CreateNetworkContainerRequest: request2,
+				VfpUpdateComplete:             false,
+			},
+		},
+		Networks: map[string]*legacyNetworkInfo{
+			"network-1": {
+				NetworkName: "network-1",
+				NicInfo: &wireserver.InterfaceInfo{
+					Subnet:       "10.0.0.0/24",
+					Gateway:      "10.0.0.1",
+					PrimaryIP:    "10.0.0.2",
+					SecondaryIPs: []string{"10.0.0.3"},
+					IsPrimary:    true,
+				},
+				Options: map[string]any{"custom": "value", "enabled": true},
+			},
+		},
+		TimeStamp: testNow,
+		PnpIDByMacAddress: map[string]string{
+			"00-11-22-33-44-55": "PCI\\VEN_1234",
+		},
+	}
+	cnsData, err := json.Marshal(map[string]any{
+		"ContainerNetworkService": cnsState,
+		"Unrelated":               map[string]any{"compatible": true},
+	})
+	require.NoError(t, err)
+
+	endpoint := EndpointRecord{
+		PodName:      "pod-1",
+		PodNamespace: "ns-1",
+		IfnameToIPMap: map[string]*IPInfoRecord{
+			"eth0": {
+				IPv4:               []net.IPNet{mustIPNet(t, "10.0.0.4/24")},
+				IPv6:               []net.IPNet{mustIPNet(t, "fd00::4/64")},
+				HNSEndpointID:      "hns-endpoint-1",
+				HNSNetworkID:       "hns-network-1",
+				HostVethName:       "veth-1",
+				MACAddress:         "00:11:22:33:44:55",
+				NetworkContainerID: importNC1,
+				NICType:            cns.InfraNIC,
+			},
+			"net1": {
+				IPv4:               []net.IPNet{mustIPNet(t, "10.1.0.4/24")},
+				HNSEndpointID:      "hns-endpoint-2",
+				HNSNetworkID:       "hns-network-2",
+				HostVethName:       "veth-2",
+				MACAddress:         "00:11:22:33:44:66",
+				NetworkContainerID: importNC2,
+				NICType:            cns.DelegatedVMNIC,
+			},
+		},
+	}
+	endpointData, err := json.Marshal(map[string]any{
+		"Endpoints": map[string]*EndpointRecord{"container-1": &endpoint},
+		"DeleteIntents": map[string]DeleteIntent{
+			"deleted-container": {CreatedAt: testNow.Add(-time.Minute)},
+		},
+		"Unrelated": map[string]any{"compatible": true},
+	})
+	require.NoError(t, err)
+	return cnsData, endpointData
+}
+
+func writeLegacyImportFiles(t *testing.T, cnsData, endpointData []byte, manage bool) ImportOptions {
+	t.Helper()
+	dir := t.TempDir()
+	cnsPath := filepath.Join(dir, "azure-cns.json")
+	require.NoError(t, os.WriteFile(cnsPath, cnsData, 0o600))
+	opts := ImportOptions{CNSPath: cnsPath, BootID: "boot-1", ManageEndpointState: manage}
+	if manage {
+		opts.EndpointPath = filepath.Join(dir, "azure-endpoints.json")
+		require.NoError(t, os.WriteFile(opts.EndpointPath, endpointData, 0o600))
+	}
+	return opts
+}
+
+func mutateLegacyCNS(t *testing.T, data []byte, mutate func(map[string]any)) []byte {
+	t.Helper()
+	var envelope map[string]any
+	require.NoError(t, json.Unmarshal(data, &envelope))
+	mutate(envelope["ContainerNetworkService"].(map[string]any))
+	result, err := json.Marshal(envelope)
+	require.NoError(t, err)
+	return result
+}
+
+func mutateLegacyEndpoints(t *testing.T, data []byte, mutate func(map[string]any)) []byte {
+	t.Helper()
+	return mutateLegacyEndpointEnvelope(t, data, func(envelope map[string]any) {
+		mutate(envelope["Endpoints"].(map[string]any))
+	})
+}
+
+func mutateLegacyEndpointEnvelope(t *testing.T, data []byte, mutate func(map[string]any)) []byte {
+	t.Helper()
+	var envelope map[string]any
+	require.NoError(t, json.Unmarshal(data, &envelope))
+	mutate(envelope)
+	result, err := json.Marshal(envelope)
+	require.NoError(t, err)
+	return result
+}
+
+func endpointIPInfo(endpoints map[string]any, containerID, ifname string) map[string]any {
+	endpoint := endpoints[containerID].(map[string]any)
+	interfaces := endpoint["ifnameToIPMap"].(map[string]any)
+	return interfaces[ifname].(map[string]any)
+}
+
+func encodeIPNets(t *testing.T, prefixes ...string) any {
+	t.Helper()
+	values := make([]net.IPNet, 0, len(prefixes))
+	for _, prefix := range prefixes {
+		values = append(values, mustIPNet(t, prefix))
+	}
+	data, err := json.Marshal(values)
+	require.NoError(t, err)
+	var result any
+	require.NoError(t, json.Unmarshal(data, &result))
+	return result
+}
+
+func mustIPNet(t *testing.T, value string) net.IPNet {
+	t.Helper()
+	ip, network, err := net.ParseCIDR(value)
+	require.NoError(t, err)
+	network.IP = ip
+	return *network
+}


### PR DESCRIPTION
Adds strict, atomic migration from the existing CNS and endpoint JSON files into the unified Bolt state store.

The full source pair is parsed and validated before one transaction; secondary-IP UUID keys and non-secret state are preserved, authorization tokens are stripped, and replay/concurrent import is marker-safe.

Stack dependency: #4786. This PR is parallel with the rollback-export PR; neither depends on the other.

Validation: cns/state unit and race tests, vet, malformed/corrupt/conflict/replay/concurrency coverage, and capitalized production legacy-key compatibility.