### PR TITLE
feat(cns): export Bolt state for JSON rollback

### DIFF
--- a/cns/state/export.go
+++ b/cns/state/export.go
@@ -106,6 +106,15 @@ func (s *DB) exportLegacy(
 	opts ExportOptions,
 	files rollbackFileOperations,
 ) (bool, error) {
+	return s.exportLegacyWithCommitHook(ctx, opts, files, nil)
+}
+
+func (s *DB) exportLegacyWithCommitHook(
+	ctx context.Context,
+	opts ExportOptions,
+	files rollbackFileOperations,
+	beforeCommit func() error,
+) (bool, error) {
 	if err := validateExportOptions(opts); err != nil {
 		return false, err
 	}
@@ -164,8 +173,8 @@ func (s *DB) exportLegacy(
 		if err := setRollbackExportComplete(tx.tx); err != nil {
 			return false, err
 		}
-		if s.exportBeforeCommit != nil {
-			if err := s.exportBeforeCommit(); err != nil {
+		if beforeCommit != nil {
+			if err := beforeCommit(); err != nil {
 				return false, fmt.Errorf("finishing rollback export: %w", err)
 			}
 		}
@@ -175,6 +184,17 @@ func (s *DB) exportLegacy(
 		return false, fmt.Errorf("marking JSON state authoritative: %w", err)
 	}
 	return changed, nil
+}
+
+func setRollbackExportComplete(tx *bolt.Tx) error {
+	metadata := tx.Bucket(bucketMetadata)
+	if metadata == nil {
+		return corrupt(fmt.Sprintf("missing bucket %q", bucketMetadata), nil)
+	}
+	if err := metadata.Put(metaKeyRollbackExport, []byte(rollbackExportMarker)); err != nil {
+		return fmt.Errorf("writing rollback export marker: %w", err)
+	}
+	return nil
 }
 
 func validateExportOptions(opts ExportOptions) error {

--- a/cns/state/export.go
+++ b/cns/state/export.go
@@ -145,37 +145,37 @@ func (s *DB) exportLegacyWithCommitHook(
 	if err != nil {
 		return false, err
 	}
-	if err := writeRollbackFile(ctx, files, opts.CNSJSONPath, cnsData); err != nil {
-		return false, err
+	if writeErr := writeRollbackFile(ctx, files, opts.CNSJSONPath, cnsData); writeErr != nil {
+		return false, writeErr
 	}
-	if err := writeRollbackFile(ctx, files, opts.EndpointJSONPath, endpointData); err != nil {
-		return false, err
+	if writeErr := writeRollbackFile(ctx, files, opts.EndpointJSONPath, endpointData); writeErr != nil {
+		return false, writeErr
 	}
-	if err := ctx.Err(); err != nil {
-		return false, fmt.Errorf("exporting legacy state: %w", err)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return false, fmt.Errorf("exporting legacy state: %w", ctxErr)
 	}
 
 	changed, err := s.updateLocked(ctx, func(tx *WriteTx) (bool, error) {
-		meta, err := tx.Metadata()
-		if err != nil {
-			return false, err
+		meta, txErr := tx.Metadata()
+		if txErr != nil {
+			return false, txErr
 		}
-		if err := validateRollbackExportState(meta.Authority, meta.RollbackExportComplete); err != nil {
-			return false, err
+		if validateErr := validateRollbackExportState(meta.Authority, meta.RollbackExportComplete); validateErr != nil {
+			return false, validateErr
 		}
 		if meta.RollbackExportComplete {
 			return false, nil
 		}
 		meta.Authority = AuthorityJSON
-		if err := tx.PutMetadata(meta); err != nil {
-			return false, err
+		if putErr := tx.PutMetadata(meta); putErr != nil {
+			return false, putErr
 		}
-		if err := setRollbackExportComplete(tx.tx); err != nil {
-			return false, err
+		if markErr := setRollbackExportComplete(tx.tx); markErr != nil {
+			return false, markErr
 		}
 		if beforeCommit != nil {
-			if err := beforeCommit(); err != nil {
-				return false, fmt.Errorf("finishing rollback export: %w", err)
+			if commitErr := beforeCommit(); commitErr != nil {
+				return false, fmt.Errorf("finishing rollback export: %w", commitErr)
 			}
 		}
 		return true, nil
@@ -234,8 +234,8 @@ func (s *DB) rollbackSnapshotLocked(ctx context.Context) (Snapshot, bool, error)
 		if err != nil {
 			return err
 		}
-		if err := validateRollbackExportState(meta.Authority, meta.RollbackExportComplete); err != nil {
-			return err
+		if validateErr := validateRollbackExportState(meta.Authority, meta.RollbackExportComplete); validateErr != nil {
+			return validateErr
 		}
 		if meta.RollbackExportComplete {
 			complete = true
@@ -248,15 +248,15 @@ func (s *DB) rollbackSnapshotLocked(ctx context.Context) (Snapshot, bool, error)
 		return snapshot.Validate()
 	})
 	if err != nil {
-		return Snapshot{}, false, err
+		return Snapshot{}, false, fmt.Errorf("reading rollback snapshot: %w", err)
 	}
 	if err := ctx.Err(); err != nil {
-		return Snapshot{}, false, err
+		return Snapshot{}, false, fmt.Errorf("reading rollback snapshot: %w", err)
 	}
 	return snapshot, complete, nil
 }
 
-func encodeRollbackFiles(snapshot Snapshot) ([]byte, []byte, error) {
+func encodeRollbackFiles(snapshot Snapshot) (cnsData, endpointData []byte, err error) {
 	cnsState := rollbackCNSState{
 		Location:                         snapshot.Metadata.Location,
 		NetworkType:                      snapshot.Metadata.NetworkType,
@@ -280,7 +280,8 @@ func encodeRollbackFiles(snapshot Snapshot) ([]byte, []byte, error) {
 			Options:     network.Options,
 		}
 	}
-	for ncID, record := range snapshot.NetworkContainers {
+	for ncID := range snapshot.NetworkContainers {
+		record := snapshot.NetworkContainers[ncID]
 		request := record.Request
 		request.AuthorizationToken = ""
 		request.SecondaryIPConfigs = map[string]cns.SecondaryIPConfig{}
@@ -327,13 +328,13 @@ func encodeRollbackFiles(snapshot Snapshot) ([]byte, []byte, error) {
 		endpoints[containerID] = legacyEndpoint
 	}
 
-	cnsData, err := json.MarshalIndent(map[string]any{
+	cnsData, err = json.MarshalIndent(map[string]any{
 		"ContainerNetworkService": cnsState,
 	}, "", "\t")
 	if err != nil {
 		return nil, nil, fmt.Errorf("encoding rollback CNS state: %w", err)
 	}
-	endpointData, err := json.MarshalIndent(map[string]any{
+	endpointData, err = json.MarshalIndent(map[string]any{
 		"DeleteIntents": snapshot.DeleteIntents,
 		"Endpoints":     endpoints,
 	}, "", "\t")
@@ -390,7 +391,7 @@ func writeAll(writer io.Writer, data []byte) error {
 	for len(data) != 0 {
 		written, err := writer.Write(data)
 		if err != nil {
-			return err
+			return fmt.Errorf("writing rollback data: %w", err)
 		}
 		if written == 0 {
 			return io.ErrShortWrite

--- a/cns/state/export.go
+++ b/cns/state/export.go
@@ -1,0 +1,381 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package state
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/wireserver"
+	bolt "go.etcd.io/bbolt"
+	bolterrors "go.etcd.io/bbolt/errors"
+)
+
+// ExportOptions identifies both legacy JSON rollback destinations.
+type ExportOptions struct {
+	CNSJSONPath      string
+	EndpointJSONPath string
+}
+
+type rollbackCNSState struct {
+	Location                         string                             `json:"Location"`
+	NetworkType                      string                             `json:"NetworkType"`
+	OrchestratorType                 string                             `json:"OrchestratorType"`
+	NodeID                           string                             `json:"NodeID"`
+	Initialized                      bool                               `json:"Initialized"`
+	ContainerIDByOrchestratorContext map[string]*string                 `json:"ContainerIDByOrchestratorContext"`
+	ContainerStatus                  map[string]rollbackContainerStatus `json:"ContainerStatus"`
+	Networks                         map[string]*rollbackNetworkInfo    `json:"Networks"`
+	TimeStamp                        time.Time                          `json:"TimeStamp"`
+	PnpIDByMacAddress                map[string]string                  `json:"PnpIDByMacAddress"`
+}
+
+type rollbackContainerStatus struct {
+	ID                            string                            `json:"ID"`
+	VMVersion                     string                            `json:"VMVersion"`
+	HostVersion                   string                            `json:"HostVersion"`
+	CreateNetworkContainerRequest cns.CreateNetworkContainerRequest `json:"CreateNetworkContainerRequest"`
+	VfpUpdateComplete             bool                              `json:"VfpUpdateComplete"`
+}
+
+type rollbackNetworkInfo struct {
+	NetworkName string                    `json:"NetworkName"`
+	NicInfo     *wireserver.InterfaceInfo `json:"NicInfo"`
+	Options     map[string]any            `json:"Options"`
+}
+
+type rollbackEndpointInfo struct {
+	PodName       string                     `json:"PodName"`
+	PodNamespace  string                     `json:"PodNamespace"`
+	IfnameToIPMap map[string]*rollbackIPInfo `json:"IfnameToIPMap"`
+}
+
+type rollbackIPInfo struct {
+	IPv4               []net.IPNet `json:"IPv4"`
+	IPv6               []net.IPNet `json:"IPv6,omitempty"`
+	HnsEndpointID      string      `json:"HnsEndpointID,omitempty"`
+	HnsNetworkID       string      `json:"HnsNetworkID,omitempty"`
+	HostVethName       string      `json:"HostVethName,omitempty"`
+	MacAddress         string      `json:"MacAddress,omitempty"`
+	NetworkContainerID string      `json:"NetworkContainerID,omitempty"`
+	NICType            cns.NICType `json:"NICType"`
+}
+
+type rollbackTemporaryFile interface {
+	io.WriteCloser
+	Name() string
+	Sync() error
+}
+
+type rollbackFileOperations struct {
+	mkdirAll       func(string, fs.FileMode) error
+	createTemp     func(string, string) (rollbackTemporaryFile, error)
+	remove         func(string) error
+	durableReplace func(string, string) error
+}
+
+func osRollbackFileOperations() rollbackFileOperations {
+	return rollbackFileOperations{
+		mkdirAll: os.MkdirAll,
+		createTemp: func(dir, pattern string) (rollbackTemporaryFile, error) {
+			return os.CreateTemp(dir, pattern)
+		},
+		remove:         os.Remove,
+		durableReplace: durableReplace,
+	}
+}
+
+// ExportLegacy converts one validated Bolt snapshot into both legacy JSON files.
+// It returns false without touching the files after rollback export is complete.
+func (s *DB) ExportLegacy(ctx context.Context, opts ExportOptions) (bool, error) {
+	return s.exportLegacy(ctx, opts, osRollbackFileOperations())
+}
+
+func (s *DB) exportLegacy(
+	ctx context.Context,
+	opts ExportOptions,
+	files rollbackFileOperations,
+) (bool, error) {
+	if err := validateExportOptions(opts); err != nil {
+		return false, err
+	}
+	if err := validateRollbackFileOperations(files); err != nil {
+		return false, err
+	}
+	if err := ctx.Err(); err != nil {
+		return false, fmt.Errorf("exporting legacy state: %w", err)
+	}
+	if err := s.acquireWriteGate(ctx); err != nil {
+		return false, fmt.Errorf("exporting legacy state: %w", err)
+	}
+	defer s.releaseWriteGate()
+
+	if s.db.IsReadOnly() {
+		return false, fmt.Errorf("exporting legacy state: %w", bolterrors.ErrDatabaseReadOnly)
+	}
+
+	snapshot, complete, err := s.rollbackSnapshotLocked(ctx)
+	if err != nil {
+		return false, fmt.Errorf("exporting legacy state: %w", err)
+	}
+	if complete {
+		return false, nil
+	}
+
+	cnsData, endpointData, err := encodeRollbackFiles(snapshot)
+	if err != nil {
+		return false, err
+	}
+	if err := writeRollbackFile(ctx, files, opts.CNSJSONPath, cnsData); err != nil {
+		return false, err
+	}
+	if err := writeRollbackFile(ctx, files, opts.EndpointJSONPath, endpointData); err != nil {
+		return false, err
+	}
+	if err := ctx.Err(); err != nil {
+		return false, fmt.Errorf("exporting legacy state: %w", err)
+	}
+
+	changed, err := s.updateLocked(ctx, func(tx *WriteTx) (bool, error) {
+		meta, err := tx.Metadata()
+		if err != nil {
+			return false, err
+		}
+		if err := validateRollbackExportState(meta.Authority, meta.RollbackExportComplete); err != nil {
+			return false, err
+		}
+		if meta.RollbackExportComplete {
+			return false, nil
+		}
+		meta.Authority = AuthorityJSON
+		if err := tx.PutMetadata(meta); err != nil {
+			return false, err
+		}
+		if err := setRollbackExportComplete(tx.tx); err != nil {
+			return false, err
+		}
+		if s.exportBeforeCommit != nil {
+			if err := s.exportBeforeCommit(); err != nil {
+				return false, fmt.Errorf("finishing rollback export: %w", err)
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("marking JSON state authoritative: %w", err)
+	}
+	return changed, nil
+}
+
+func validateExportOptions(opts ExportOptions) error {
+	if strings.TrimSpace(opts.CNSJSONPath) == "" {
+		return invalidInput("rollback CNS path is empty", nil)
+	}
+	if strings.TrimSpace(opts.EndpointJSONPath) == "" {
+		return invalidInput("rollback endpoint path is empty", nil)
+	}
+	cnsPath, err := filepath.Abs(opts.CNSJSONPath)
+	if err != nil {
+		return invalidInput("resolving rollback CNS path", err)
+	}
+	endpointPath, err := filepath.Abs(opts.EndpointJSONPath)
+	if err != nil {
+		return invalidInput("resolving rollback endpoint path", err)
+	}
+	if filepath.Clean(cnsPath) == filepath.Clean(endpointPath) {
+		return invalidInput("rollback paths must be distinct", nil)
+	}
+	return nil
+}
+
+func validateRollbackFileOperations(files rollbackFileOperations) error {
+	if files.mkdirAll == nil || files.createTemp == nil || files.remove == nil || files.durableReplace == nil {
+		return invalidInput("rollback file operations are incomplete", nil)
+	}
+	return nil
+}
+
+func (s *DB) rollbackSnapshotLocked(ctx context.Context) (Snapshot, bool, error) {
+	var snapshot Snapshot
+	var complete bool
+	err := s.db.View(func(tx *bolt.Tx) error {
+		readTx := &ReadTx{tx: tx, ctx: ctx}
+		meta, err := readTx.Metadata()
+		if err != nil {
+			return err
+		}
+		if err := validateRollbackExportState(meta.Authority, meta.RollbackExportComplete); err != nil {
+			return err
+		}
+		if meta.RollbackExportComplete {
+			complete = true
+			return nil
+		}
+		snapshot, err = snapshotFromTx(ctx, readTx)
+		if err != nil {
+			return err
+		}
+		return snapshot.Validate()
+	})
+	if err != nil {
+		return Snapshot{}, false, err
+	}
+	if err := ctx.Err(); err != nil {
+		return Snapshot{}, false, err
+	}
+	return snapshot, complete, nil
+}
+
+func encodeRollbackFiles(snapshot Snapshot) ([]byte, []byte, error) {
+	cnsState := rollbackCNSState{
+		Location:                         snapshot.Metadata.Location,
+		NetworkType:                      snapshot.Metadata.NetworkType,
+		OrchestratorType:                 snapshot.Metadata.OrchestratorType,
+		NodeID:                           snapshot.Metadata.NodeID,
+		Initialized:                      snapshot.Metadata.Initialized,
+		ContainerIDByOrchestratorContext: make(map[string]*string, len(snapshot.OrchestratorContexts)),
+		ContainerStatus:                  make(map[string]rollbackContainerStatus, len(snapshot.NetworkContainers)),
+		Networks:                         make(map[string]*rollbackNetworkInfo, len(snapshot.Networks)),
+		TimeStamp:                        snapshot.Metadata.TimeStamp,
+		PnpIDByMacAddress:                snapshot.PnPIDByMAC,
+	}
+	for contextID, ncIDs := range snapshot.OrchestratorContexts {
+		value := strings.Join(ncIDs, ",")
+		cnsState.ContainerIDByOrchestratorContext[contextID] = &value
+	}
+	for name, network := range snapshot.Networks {
+		cnsState.Networks[name] = &rollbackNetworkInfo{
+			NetworkName: network.NetworkName,
+			NicInfo:     network.NicInfo,
+			Options:     network.Options,
+		}
+	}
+	for ncID, record := range snapshot.NetworkContainers {
+		request := record.Request
+		request.AuthorizationToken = ""
+		request.SecondaryIPConfigs = map[string]cns.SecondaryIPConfig{}
+		for ipID, ip := range snapshot.IPs {
+			if ip.NCID != ncID {
+				continue
+			}
+			request.SecondaryIPConfigs[ipID] = cns.SecondaryIPConfig{
+				IPAddress: ip.IPAddress,
+				NCVersion: ip.NCVersion,
+			}
+		}
+		cnsState.ContainerStatus[ncID] = rollbackContainerStatus{
+			ID:                            record.ID,
+			VMVersion:                     record.VMVersion,
+			HostVersion:                   record.HostVersion,
+			CreateNetworkContainerRequest: request,
+			VfpUpdateComplete:             record.VFPUpdateComplete,
+		}
+	}
+
+	endpoints := make(map[string]*rollbackEndpointInfo, len(snapshot.Endpoints))
+	for containerID, endpoint := range snapshot.Endpoints {
+		legacyEndpoint := &rollbackEndpointInfo{
+			PodName:       endpoint.PodName,
+			PodNamespace:  endpoint.PodNamespace,
+			IfnameToIPMap: make(map[string]*rollbackIPInfo, len(endpoint.IfnameToIPMap)),
+		}
+		for ifname, info := range endpoint.IfnameToIPMap {
+			if info == nil {
+				continue
+			}
+			legacyEndpoint.IfnameToIPMap[ifname] = &rollbackIPInfo{
+				IPv4:               info.IPv4,
+				IPv6:               info.IPv6,
+				HnsEndpointID:      info.HNSEndpointID,
+				HnsNetworkID:       info.HNSNetworkID,
+				HostVethName:       info.HostVethName,
+				MacAddress:         info.MACAddress,
+				NetworkContainerID: info.NetworkContainerID,
+				NICType:            info.NICType,
+			}
+		}
+		endpoints[containerID] = legacyEndpoint
+	}
+
+	cnsData, err := json.MarshalIndent(map[string]any{
+		"ContainerNetworkService": cnsState,
+	}, "", "\t")
+	if err != nil {
+		return nil, nil, fmt.Errorf("encoding rollback CNS state: %w", err)
+	}
+	endpointData, err := json.MarshalIndent(map[string]any{
+		"DeleteIntents": snapshot.DeleteIntents,
+		"Endpoints":     endpoints,
+	}, "", "\t")
+	if err != nil {
+		return nil, nil, fmt.Errorf("encoding rollback endpoint state: %w", err)
+	}
+	return cnsData, endpointData, nil
+}
+
+func writeRollbackFile(
+	ctx context.Context,
+	files rollbackFileOperations,
+	path string,
+	data []byte,
+) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("writing rollback file %q: %w", path, err)
+	}
+	parent := filepath.Dir(path)
+	if err := files.mkdirAll(parent, 0o755); err != nil {
+		return fmt.Errorf("creating rollback directory %q: %w", parent, err)
+	}
+	file, err := files.createTemp(parent, filepath.Base(path)+".rollback-*")
+	if err != nil {
+		return fmt.Errorf("creating rollback temp file for %q: %w", path, err)
+	}
+	tempPath := file.Name()
+	removeTemp := true
+	defer func() {
+		if removeTemp {
+			_ = files.remove(tempPath)
+		}
+	}()
+
+	if err := writeAll(file, data); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("writing rollback temp file for %q: %w", path, err)
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("syncing rollback temp file for %q: %w", path, err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("closing rollback temp file for %q: %w", path, err)
+	}
+	if err := files.durableReplace(tempPath, path); err != nil {
+		return fmt.Errorf("replacing rollback file %q: %w", path, err)
+	}
+	removeTemp = false
+	return nil
+}
+
+func writeAll(writer io.Writer, data []byte) error {
+	for len(data) != 0 {
+		written, err := writer.Write(data)
+		if err != nil {
+			return err
+		}
+		if written == 0 {
+			return io.ErrShortWrite
+		}
+		data = data[written:]
+	}
+	return nil
+}

--- a/cns/state/export_replace_linux.go
+++ b/cns/state/export_replace_linux.go
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package state
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Azure/azure-container-networking/platform"
+)
+
+type syncDirectory interface {
+	Sync() error
+	Close() error
+}
+
+func durableReplace(source, destination string) error {
+	return durableReplaceWith(source, destination, platform.ReplaceFile, func(path string) (syncDirectory, error) {
+		return os.Open(path)
+	})
+}
+
+func durableReplaceWith(
+	source string,
+	destination string,
+	replace func(string, string) error,
+	openDirectory func(string) (syncDirectory, error),
+) error {
+	if err := replace(source, destination); err != nil {
+		return fmt.Errorf("atomic replace: %w", err)
+	}
+	parentPath := filepath.Dir(destination)
+	parent, err := openDirectory(parentPath)
+	if err != nil {
+		return fmt.Errorf("opening parent directory %q: %w", parentPath, err)
+	}
+	if err := parent.Sync(); err != nil {
+		_ = parent.Close()
+		return fmt.Errorf("syncing parent directory %q: %w", parentPath, err)
+	}
+	if err := parent.Close(); err != nil {
+		return fmt.Errorf("closing parent directory %q: %w", parentPath, err)
+	}
+	return nil
+}

--- a/cns/state/export_replace_linux_test.go
+++ b/cns/state/export_replace_linux_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package state
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type faultSyncDirectory struct {
+	syncErr  error
+	closeErr error
+	closed   bool
+}
+
+func (f *faultSyncDirectory) Sync() error {
+	return f.syncErr
+}
+
+func (f *faultSyncDirectory) Close() error {
+	f.closed = true
+	return f.closeErr
+}
+
+func TestDurableReplaceLinux(t *testing.T) {
+	t.Run("real replace and permissions", func(t *testing.T) {
+		dir := t.TempDir()
+		source := filepath.Join(dir, "source")
+		destination := filepath.Join(dir, "destination")
+		require.NoError(t, os.WriteFile(source, []byte("new"), 0o600))
+		require.NoError(t, os.WriteFile(destination, []byte("old"), 0o400))
+		require.NoError(t, durableReplace(source, destination))
+		data, err := os.ReadFile(destination)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("new"), data)
+		_, err = os.Stat(source)
+		require.ErrorIs(t, err, os.ErrNotExist)
+		info, err := os.Stat(destination)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	})
+
+	t.Run("replace failure does not open parent", func(t *testing.T) {
+		var opened bool
+		err := durableReplaceWith(
+			"source",
+			"destination",
+			func(string, string) error { return errRollbackFault },
+			func(string) (syncDirectory, error) {
+				opened = true
+				return nil, nil
+			},
+		)
+		require.ErrorIs(t, err, errRollbackFault)
+		assert.False(t, opened)
+	})
+
+	t.Run("parent open sync and close failures", func(t *testing.T) {
+		tests := []struct {
+			name       string
+			openErr    error
+			syncErr    error
+			closeErr   error
+			wantClosed bool
+		}{
+			{name: "open", openErr: errRollbackFault},
+			{name: "sync", syncErr: errRollbackFault, wantClosed: true},
+			{name: "close", closeErr: errRollbackFault, wantClosed: true},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				directory := &faultSyncDirectory{syncErr: tt.syncErr, closeErr: tt.closeErr}
+				err := durableReplaceWith(
+					"source",
+					filepath.Join("parent", "destination"),
+					func(string, string) error { return nil },
+					func(path string) (syncDirectory, error) {
+						assert.Equal(t, "parent", path)
+						return directory, tt.openErr
+					},
+				)
+				require.ErrorIs(t, err, errRollbackFault)
+				assert.Equal(t, tt.wantClosed, directory.closed)
+			})
+		}
+	})
+}
+
+func TestExportLegacyInjectedPermissionFailure(t *testing.T) {
+	db, _ := openPopulatedExportDB(t)
+	opts := exportPaths(t)
+	files := osRollbackFileOperations()
+	files.mkdirAll = func(string, os.FileMode) error { return os.ErrPermission }
+	changed, err := db.exportLegacy(context.Background(), opts, files)
+	require.ErrorIs(t, err, os.ErrPermission)
+	assert.False(t, changed)
+	assertRollbackDestinationsMissing(t, opts)
+	assertNoRollbackTemps(t, opts)
+	assert.Equal(t, AuthorityBolt, readMetadata(t, db).Authority)
+}
+
+func TestExportLegacyReadOnlyParent(t *testing.T) {
+	db, _ := openPopulatedExportDB(t)
+	parent := filepath.Join(t.TempDir(), "read-only")
+	require.NoError(t, os.Mkdir(parent, 0o500))
+	t.Cleanup(func() { require.NoError(t, os.Chmod(parent, 0o700)) })
+
+	probe := filepath.Join(parent, "probe")
+	if err := os.WriteFile(probe, []byte("probe"), 0o600); err == nil {
+		require.NoError(t, os.Remove(probe))
+		t.Skip("filesystem permissions are not enforced for this user")
+	}
+
+	opts := ExportOptions{
+		CNSJSONPath:      filepath.Join(parent, "cns", "azure-cns.json"),
+		EndpointJSONPath: filepath.Join(t.TempDir(), "azure-endpoints.json"),
+	}
+	changed, err := db.ExportLegacy(context.Background(), opts)
+	require.Error(t, err)
+	assert.False(t, changed)
+	assertRollbackDestinationsMissing(t, opts)
+	assertNoRollbackTemps(t, opts)
+	assert.Equal(t, AuthorityBolt, readMetadata(t, db).Authority)
+}

--- a/cns/state/export_replace_windows.go
+++ b/cns/state/export_replace_windows.go
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package state
+
+import (
+	"fmt"
+
+	"github.com/Azure/azure-container-networking/platform"
+)
+
+func durableReplace(source, destination string) error {
+	return durableReplaceWith(source, destination, platform.ReplaceFile)
+}
+
+func durableReplaceWith(
+	source string,
+	destination string,
+	replace func(string, string) error,
+) error {
+	if err := replace(source, destination); err != nil {
+		return fmt.Errorf("write-through replace: %w", err)
+	}
+	return nil
+}

--- a/cns/state/export_replace_windows_test.go
+++ b/cns/state/export_replace_windows_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package state
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDurableReplaceWindowsUsesWriteThroughReplacement(t *testing.T) {
+	var source, destination string
+	err := durableReplaceWith("source", "destination", func(gotSource, gotDestination string) error {
+		source = gotSource
+		destination = gotDestination
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "source", source)
+	assert.Equal(t, "destination", destination)
+
+	injected := errors.New("replace failure")
+	err = durableReplaceWith("source", "destination", func(string, string) error {
+		return injected
+	})
+	require.ErrorIs(t, err, injected)
+}

--- a/cns/state/export_replace_windows_test.go
+++ b/cns/state/export_replace_windows_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var errReplaceFailure = errors.New("replace failure")
+
 func TestDurableReplaceWindowsUsesWriteThroughReplacement(t *testing.T) {
 	var source, destination string
 	err := durableReplaceWith("source", "destination", func(gotSource, gotDestination string) error {
@@ -22,9 +24,8 @@ func TestDurableReplaceWindowsUsesWriteThroughReplacement(t *testing.T) {
 	assert.Equal(t, "source", source)
 	assert.Equal(t, "destination", destination)
 
-	injected := errors.New("replace failure")
 	err = durableReplaceWith("source", "destination", func(string, string) error {
-		return injected
+		return errReplaceFailure
 	})
-	require.ErrorIs(t, err, injected)
+	require.ErrorIs(t, err, errReplaceFailure)
 }

--- a/cns/state/export_test.go
+++ b/cns/state/export_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/fs"
 	"net"
 	"os"
@@ -35,6 +36,17 @@ const (
 	exportIPv4 = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 	exportIPv6 = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
 	exportNet1 = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+
+	exportIPv4Address   = "10.0.0.4"
+	exportIPv6Address   = "fd00::4"
+	exportIfnameEth0    = "eth0"
+	exportNodeID        = "node-1"
+	exportNetworkName   = "network-1"
+	exportGatewayIPv4   = "10.0.0.1"
+	exportSecondaryIPv4 = "10.0.0.5"
+	exportContainerID   = "container-1"
+	exportPodName       = "pod-1"
+	exportPodNamespace  = "ns-1"
 )
 
 type rollbackFailureStage string
@@ -58,14 +70,14 @@ func (f *faultRollbackFile) Write(data []byte) (int, error) {
 	if f.stage == rollbackFailureWrite {
 		return 0, errRollbackFault
 	}
-	return f.rollbackTemporaryFile.Write(data)
+	return f.rollbackTemporaryFile.Write(data) //nolint:wrapcheck // test double forwards the underlying temp file's error unchanged for fault-injection identity checks
 }
 
 func (f *faultRollbackFile) Sync() error {
 	if f.stage == rollbackFailureSync {
 		return errRollbackFault
 	}
-	return f.rollbackTemporaryFile.Sync()
+	return f.rollbackTemporaryFile.Sync() //nolint:wrapcheck // test double forwards the underlying temp file's error unchanged for fault-injection identity checks
 }
 
 func (f *faultRollbackFile) Close() error {
@@ -73,7 +85,7 @@ func (f *faultRollbackFile) Close() error {
 	if f.stage == rollbackFailureClose {
 		return errors.Join(err, errRollbackFault)
 	}
-	return err
+	return err //nolint:wrapcheck // test double forwards the underlying temp file's error unchanged for fault-injection identity checks
 }
 
 func TestExportLegacySuccess(t *testing.T) {
@@ -117,6 +129,7 @@ func TestExportLegacySuccess(t *testing.T) {
 	var cnsEnvelope map[string]json.RawMessage
 	require.NoError(t, json.Unmarshal(cnsData, &cnsEnvelope))
 	var exported rollbackCNSState
+	//nolint:musttag // embeds legacy cns.CreateNetworkContainerRequest, untagged by design for field-name JSON compatibility
 	require.NoError(t, json.Unmarshal(cnsEnvelope["ContainerNetworkService"], &exported))
 	assert.Equal(t, before.Metadata.Location, exported.Location)
 	assert.Equal(t, before.Metadata.NetworkType, exported.NetworkType)
@@ -134,8 +147,8 @@ func TestExportLegacySuccess(t *testing.T) {
 	request := exported.ContainerStatus[exportNC1].CreateNetworkContainerRequest
 	assert.Empty(t, request.AuthorizationToken)
 	assert.Equal(t, map[string]cns.SecondaryIPConfig{
-		exportIPv4: {IPAddress: "10.0.0.4", NCVersion: 7},
-		exportIPv6: {IPAddress: "fd00::4", NCVersion: 7},
+		exportIPv4: {IPAddress: exportIPv4Address, NCVersion: 7},
+		exportIPv6: {IPAddress: exportIPv6Address, NCVersion: 7},
 	}, request.SecondaryIPConfigs)
 	require.Len(t, request.EndpointPolicies, 1)
 	assert.Equal(t, before.NetworkContainers[exportNC1].Request.EndpointPolicies[0].Type, request.EndpointPolicies[0].Type)
@@ -146,30 +159,30 @@ func TestExportLegacySuccess(t *testing.T) {
 		string(request.EndpointPolicies[0].Settings),
 	)
 	assert.Equal(t, before.NetworkContainers[exportNC1].Request.NetworkInterfaceInfo, request.NetworkInterfaceInfo)
-	require.NotNil(t, exported.Networks["network-1"].NicInfo)
-	assert.Equal(t, before.Networks["network-1"].NicInfo, exported.Networks["network-1"].NicInfo)
-	assert.Equal(t, "value", exported.Networks["network-1"].Options["custom"])
+	require.NotNil(t, exported.Networks[exportNetworkName].NicInfo)
+	assert.Equal(t, before.Networks[exportNetworkName].NicInfo, exported.Networks[exportNetworkName].NicInfo)
+	assert.Equal(t, "value", exported.Networks[exportNetworkName].Options["custom"])
 	assert.Equal(t, "PCI\\VEN_1234", exported.PnpIDByMacAddress["00:11:22:33:44:55"])
 
 	var endpointEnvelope map[string]json.RawMessage
 	require.NoError(t, json.Unmarshal(endpointData, &endpointEnvelope))
 	var endpoints map[string]*rollbackEndpointInfo
 	require.NoError(t, json.Unmarshal(endpointEnvelope["Endpoints"], &endpoints))
-	assert.Equal(t, "pod-1", endpoints["container-1"].PodName)
-	assert.Equal(t, "ns-1", endpoints["container-1"].PodNamespace)
-	assert.ElementsMatch(t, []string{"eth0", "net1"}, sortedKeys(endpoints["container-1"].IfnameToIPMap))
-	info := endpoints["container-1"].IfnameToIPMap["eth0"]
+	assert.Equal(t, exportPodName, endpoints[exportContainerID].PodName)
+	assert.Equal(t, exportPodNamespace, endpoints[exportContainerID].PodNamespace)
+	assert.ElementsMatch(t, []string{exportIfnameEth0, "net1"}, sortedKeys(endpoints[exportContainerID].IfnameToIPMap))
+	info := endpoints[exportContainerID].IfnameToIPMap[exportIfnameEth0]
 	require.Len(t, info.IPv4, 1)
-	assert.Equal(t, net.ParseIP("10.0.0.4"), info.IPv4[0].IP)
+	assert.Equal(t, net.ParseIP(exportIPv4Address), info.IPv4[0].IP)
 	require.Len(t, info.IPv6, 1)
-	assert.Equal(t, net.ParseIP("fd00::4"), info.IPv6[0].IP)
+	assert.Equal(t, net.ParseIP(exportIPv6Address), info.IPv6[0].IP)
 	assert.Equal(t, "hns-endpoint-1", info.HnsEndpointID)
 	assert.Equal(t, "hns-network-1", info.HnsNetworkID)
 	assert.Equal(t, "veth-1", info.HostVethName)
 	assert.Equal(t, "00:11:22:33:44:55", info.MacAddress)
 	assert.Equal(t, exportNC1, info.NetworkContainerID)
 	assert.Equal(t, cns.InfraNIC, info.NICType)
-	delegated := endpoints["container-1"].IfnameToIPMap["net1"]
+	delegated := endpoints[exportContainerID].IfnameToIPMap["net1"]
 	require.Len(t, delegated.IPv4, 1)
 	assert.Equal(t, net.ParseIP("10.1.0.4"), delegated.IPv4[0].IP)
 	assert.Equal(t, exportNC2, delegated.NetworkContainerID)
@@ -490,7 +503,7 @@ func TestExportLegacyConcurrencyAndWriterGate(t *testing.T) {
 			exportDone <- err
 		}()
 		<-enteredWrite
-		require.Equal(t, 1, len(db.writeGate))
+		require.Len(t, db.writeGate, 1)
 
 		callbackEntered := make(chan Metadata, 1)
 		updateDone := make(chan error, 1)
@@ -534,7 +547,7 @@ func TestExportLegacyRejectsInconsistentAuthorityMarker(t *testing.T) {
 			require.NoError(t, db.db.Update(func(tx *bolt.Tx) error {
 				metadata := tx.Bucket(bucketMetadata)
 				if err := metadata.Put(metaKeyAuthority, []byte(tt.authority)); err != nil {
-					return err
+					return fmt.Errorf("setting authority marker: %w", err)
 				}
 				if tt.marker {
 					return metadata.Put(metaKeyRollbackExport, []byte(rollbackExportMarker))
@@ -547,8 +560,8 @@ func TestExportLegacyRejectsInconsistentAuthorityMarker(t *testing.T) {
 			changed, err := db.ExportLegacy(context.Background(), opts)
 			require.ErrorIs(t, err, ErrCorrupt)
 			assert.False(t, changed)
-			assert.Equal(t, []byte(`{"newer":"cns"}`), readRollbackFile(t, opts.CNSJSONPath))
-			assert.Equal(t, []byte(`{"newer":"endpoint"}`), readRollbackFile(t, opts.EndpointJSONPath))
+			assert.JSONEq(t, `{"newer":"cns"}`, string(readRollbackFile(t, opts.CNSJSONPath)))
+			assert.JSONEq(t, `{"newer":"endpoint"}`, string(readRollbackFile(t, opts.EndpointJSONPath)))
 		})
 	}
 }
@@ -562,7 +575,7 @@ type blockingRollbackFile struct {
 func (f *blockingRollbackFile) Write(data []byte) (int, error) {
 	close(f.entered)
 	<-f.release
-	return f.rollbackTemporaryFile.Write(data)
+	return f.rollbackTemporaryFile.Write(data) //nolint:wrapcheck // test double forwards the underlying temp file's error unchanged for fault-injection identity checks
 }
 
 func faultRollbackOperations(target string, stage rollbackFailureStage) rollbackFileOperations {
@@ -599,9 +612,11 @@ func faultRollbackOperations(target string, stage rollbackFailureStage) rollback
 			return errRollbackFault
 		case rollbackFailureParentSync:
 			if err := platform.ReplaceFile(source, destination); err != nil {
-				return err
+				return err //nolint:wrapcheck // test double emulates durableReplace and must return platform.ReplaceFile's error unchanged before injecting the fault
 			}
 			return errRollbackFault
+		case rollbackFailureMkdir, rollbackFailureCreate, rollbackFailureWrite, rollbackFailureSync, rollbackFailureClose:
+			return replace(source, destination)
 		default:
 			return replace(source, destination)
 		}
@@ -609,16 +624,16 @@ func faultRollbackOperations(target string, stage rollbackFailureStage) rollback
 	return files
 }
 
-func openPopulatedExportDB(t *testing.T) (*DB, string) {
+func openPopulatedExportDB(t *testing.T) (db *DB, path string) {
 	t.Helper()
-	db, path := openTestDB(t)
+	db, path = openTestDB(t)
 
 	request1 := completeNetworkContainerRequest()
 	request1.AuthorizationToken = "secret-token"
 	record1 := NewNetworkContainerRecord(exportNC1, "7", "6", true, request1)
 	changed, err := db.ApplyNetworkContainer(context.Background(), record1, []IPRecord{
-		{ID: exportIPv4, IPAddress: "10.0.0.4", NCID: exportNC1, NCVersion: 7},
-		{ID: exportIPv6, IPAddress: "fd00::4", NCID: exportNC1, NCVersion: 7},
+		{ID: exportIPv4, IPAddress: exportIPv4Address, NCID: exportNC1, NCVersion: 7},
+		{ID: exportIPv6, IPAddress: exportIPv6Address, NCID: exportNC1, NCVersion: 7},
 	})
 	require.NoError(t, err)
 	require.True(t, changed)
@@ -633,50 +648,50 @@ func openPopulatedExportDB(t *testing.T) (*DB, string) {
 	require.True(t, changed)
 
 	require.NoError(t, db.Update(context.Background(), func(tx *WriteTx) error {
-		meta, err := tx.Metadata()
-		if err != nil {
-			return err
+		meta, metaErr := tx.Metadata()
+		if metaErr != nil {
+			return metaErr
 		}
 		meta.BootID = "export-boot"
 		meta.Location = "eastus"
 		meta.NetworkType = "azure"
 		meta.OrchestratorType = "kubernetes"
-		meta.NodeID = "node-1"
+		meta.NodeID = exportNodeID
 		meta.Initialized = true
 		meta.TimeStamp = testNow.Add(-time.Hour)
-		if err := tx.PutMetadata(meta); err != nil {
-			return err
+		if putErr := tx.PutMetadata(meta); putErr != nil {
+			return putErr
 		}
-		if err := tx.PutNetwork(NetworkRecord{
-			NetworkName: "network-1",
+		if networkErr := tx.PutNetwork(NetworkRecord{
+			NetworkName: exportNetworkName,
 			NicInfo: &wireserver.InterfaceInfo{
 				Subnet:       "10.0.0.0/24",
-				Gateway:      "10.0.0.1",
+				Gateway:      exportGatewayIPv4,
 				IsPrimary:    true,
-				PrimaryIP:    "10.0.0.4",
-				SecondaryIPs: []string{"10.0.0.5"},
+				PrimaryIP:    exportIPv4Address,
+				SecondaryIPs: []string{exportSecondaryIPv4},
 			},
 			Options: map[string]any{"custom": "value"},
-		}); err != nil {
-			return err
+		}); networkErr != nil {
+			return networkErr
 		}
-		if err := tx.PutOrchestratorContext("pod-1ns-1", []string{exportNC1, exportNC2}); err != nil {
-			return err
+		if contextErr := tx.PutOrchestratorContext("pod-1ns-1", []string{exportNC1, exportNC2}); contextErr != nil {
+			return contextErr
 		}
 		return tx.PutPnPID("00:11:22:33:44:55", "PCI\\VEN_1234")
 	}))
 
 	endpoint := completeEndpointRecord()
-	endpoint.IfnameToIPMap["eth0"].NetworkContainerID = exportNC1
+	endpoint.IfnameToIPMap[exportIfnameEth0].NetworkContainerID = exportNC1
 	endpoint.IfnameToIPMap["net1"].NetworkContainerID = exportNC2
 	changed, err = db.AssignEndpoint(
 		context.Background(),
 		AssignmentRecord{
 			Pod: PodIdentity{
-				PodKey:           "container-1",
-				InfraContainerID: "container-1",
-				PodName:          "pod-1",
-				PodNamespace:     "ns-1",
+				PodKey:           exportContainerID,
+				InfraContainerID: exportContainerID,
+				PodName:          exportPodName,
+				PodNamespace:     exportPodNamespace,
 			},
 			IPIDs: []string{exportIPv4, exportIPv6, exportNet1},
 		},

--- a/cns/state/export_test.go
+++ b/cns/state/export_test.go
@@ -1,0 +1,712 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package state
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/platform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	bolt "go.etcd.io/bbolt"
+	bolterrors "go.etcd.io/bbolt/errors"
+)
+
+var errRollbackFault = errors.New("rollback fault")
+
+const (
+	exportNC1  = "11111111-1111-1111-1111-111111111111"
+	exportNC2  = "22222222-2222-2222-2222-222222222222"
+	exportIPv4 = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	exportIPv6 = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+	exportNet1 = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+)
+
+type rollbackFailureStage string
+
+const (
+	rollbackFailureMkdir      rollbackFailureStage = "mkdir"
+	rollbackFailureCreate     rollbackFailureStage = "create"
+	rollbackFailureWrite      rollbackFailureStage = "write"
+	rollbackFailureSync       rollbackFailureStage = "sync"
+	rollbackFailureClose      rollbackFailureStage = "close"
+	rollbackFailureReplace    rollbackFailureStage = "replace"
+	rollbackFailureParentSync rollbackFailureStage = "parent sync"
+)
+
+type faultRollbackFile struct {
+	rollbackTemporaryFile
+	stage rollbackFailureStage
+}
+
+func (f *faultRollbackFile) Write(data []byte) (int, error) {
+	if f.stage == rollbackFailureWrite {
+		return 0, errRollbackFault
+	}
+	return f.rollbackTemporaryFile.Write(data)
+}
+
+func (f *faultRollbackFile) Sync() error {
+	if f.stage == rollbackFailureSync {
+		return errRollbackFault
+	}
+	return f.rollbackTemporaryFile.Sync()
+}
+
+func (f *faultRollbackFile) Close() error {
+	err := f.rollbackTemporaryFile.Close()
+	if f.stage == rollbackFailureClose {
+		return errors.Join(err, errRollbackFault)
+	}
+	return err
+}
+
+func TestExportLegacySuccess(t *testing.T) {
+	ctx := context.Background()
+	db, _ := openPopulatedExportDB(t)
+	before := requireValidSnapshot(t, db)
+	opts := exportPaths(t)
+
+	changed, err := db.ExportLegacy(ctx, opts)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	cnsData := readRollbackFile(t, opts.CNSJSONPath)
+	endpointData := readRollbackFile(t, opts.EndpointJSONPath)
+	assert.NotContains(t, string(cnsData), "secret-token")
+	assert.NotContains(t, string(cnsData), "another-secret")
+	for _, key := range []string{
+		"Location",
+		"ContainerIDByOrchestratorContext",
+		"ContainerStatus",
+		"CreateNetworkContainerRequest",
+		"SecondaryIPConfigs",
+		"Networks",
+		"PnpIDByMacAddress",
+	} {
+		assert.Contains(t, string(cnsData), `"`+key+`"`)
+	}
+	for _, key := range []string{
+		"Endpoints",
+		"DeleteIntents",
+		"PodName",
+		"IfnameToIPMap",
+		"HnsEndpointID",
+		"NetworkContainerID",
+		"NICType",
+	} {
+		assert.Contains(t, string(endpointData), `"`+key+`"`)
+	}
+	assert.NotContains(t, string(endpointData), `"podName"`)
+
+	var cnsEnvelope map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(cnsData, &cnsEnvelope))
+	var exported rollbackCNSState
+	require.NoError(t, json.Unmarshal(cnsEnvelope["ContainerNetworkService"], &exported))
+	request := exported.ContainerStatus[exportNC1].CreateNetworkContainerRequest
+	assert.Empty(t, request.AuthorizationToken)
+	assert.Equal(t, map[string]cns.SecondaryIPConfig{
+		exportIPv4: {IPAddress: "10.0.0.4", NCVersion: 7},
+		exportIPv6: {IPAddress: "fd00::4", NCVersion: 7},
+	}, request.SecondaryIPConfigs)
+	require.Len(t, request.EndpointPolicies, 1)
+	assert.Equal(t, before.NetworkContainers[exportNC1].Request.EndpointPolicies[0].Type, request.EndpointPolicies[0].Type)
+	assert.Equal(t, before.NetworkContainers[exportNC1].Request.EndpointPolicies[0].EndpointType, request.EndpointPolicies[0].EndpointType)
+	assert.JSONEq(
+		t,
+		string(before.NetworkContainers[exportNC1].Request.EndpointPolicies[0].Settings),
+		string(request.EndpointPolicies[0].Settings),
+	)
+	assert.Equal(t, before.NetworkContainers[exportNC1].Request.NetworkInterfaceInfo, request.NetworkInterfaceInfo)
+	assert.Equal(t, "value", exported.Networks["network-1"].Options["custom"])
+	assert.Equal(t, "PCI\\VEN_1234", exported.PnpIDByMacAddress["00:11:22:33:44:55"])
+
+	var endpointEnvelope map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(endpointData, &endpointEnvelope))
+	var endpoints map[string]*rollbackEndpointInfo
+	require.NoError(t, json.Unmarshal(endpointEnvelope["Endpoints"], &endpoints))
+	info := endpoints["container-1"].IfnameToIPMap["eth0"]
+	assert.Equal(t, "hns-endpoint-1", info.HnsEndpointID)
+	assert.Equal(t, "hns-network-1", info.HnsNetworkID)
+	assert.Equal(t, "veth-1", info.HostVethName)
+	assert.Equal(t, "00:11:22:33:44:55", info.MacAddress)
+	assert.Equal(t, exportNC1, info.NetworkContainerID)
+	assert.Equal(t, cns.InfraNIC, info.NICType)
+	var intents map[string]DeleteIntent
+	require.NoError(t, json.Unmarshal(endpointEnvelope["DeleteIntents"], &intents))
+	assert.Equal(t, before.DeleteIntents, intents)
+
+	for _, path := range []string{opts.CNSJSONPath, opts.EndpointJSONPath} {
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		assert.Equal(t, fs.FileMode(0o600), info.Mode().Perm())
+		parentInfo, err := os.Stat(filepath.Dir(path))
+		require.NoError(t, err)
+		assert.Equal(t, fs.FileMode(0o755), parentInfo.Mode().Perm())
+	}
+	assertNoRollbackTemps(t, opts)
+	after := requireValidSnapshot(t, db)
+	assert.Equal(t, AuthorityJSON, after.Metadata.Authority)
+	assert.True(t, after.Metadata.RollbackExportComplete)
+	assert.Equal(t, before.Metadata.Generation+1, after.Metadata.Generation)
+}
+
+func TestExportLegacyValidationAndDatabaseFailures(t *testing.T) {
+	tests := []struct {
+		name string
+		opts ExportOptions
+	}{
+		{name: "missing CNS path", opts: ExportOptions{EndpointJSONPath: "endpoint.json"}},
+		{name: "empty CNS path", opts: ExportOptions{CNSJSONPath: " \t", EndpointJSONPath: "endpoint.json"}},
+		{name: "missing endpoint path", opts: ExportOptions{CNSJSONPath: "cns.json"}},
+		{name: "same path", opts: ExportOptions{CNSJSONPath: "state.json", EndpointJSONPath: "./state.json"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, _ := openTestDB(t)
+			changed, err := db.ExportLegacy(context.Background(), tt.opts)
+			require.ErrorIs(t, err, ErrInvalidInput)
+			assert.False(t, changed)
+			assert.Zero(t, readMetadata(t, db).Generation)
+		})
+	}
+
+	t.Run("canceled", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		opts := exportPaths(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		changed, err := db.ExportLegacy(ctx, opts)
+		require.ErrorIs(t, err, context.Canceled)
+		assert.False(t, changed)
+		assertRollbackDestinationsMissing(t, opts)
+	})
+
+	t.Run("closed", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		require.NoError(t, db.Close())
+		opts := exportPaths(t)
+		changed, err := db.ExportLegacy(context.Background(), opts)
+		require.ErrorIs(t, err, bolterrors.ErrDatabaseNotOpen)
+		assert.False(t, changed)
+		assertRollbackDestinationsMissing(t, opts)
+	})
+
+	t.Run("read only", func(t *testing.T) {
+		db, path := openPopulatedExportDB(t)
+		require.NoError(t, db.Close())
+		readOnly, err := Open(path, Options{ReadOnly: true})
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, readOnly.Close()) })
+		opts := exportPaths(t)
+		changed, err := readOnly.ExportLegacy(context.Background(), opts)
+		require.ErrorIs(t, err, bolterrors.ErrDatabaseReadOnly)
+		assert.False(t, changed)
+		assertRollbackDestinationsMissing(t, opts)
+	})
+
+	t.Run("invalid snapshot", func(t *testing.T) {
+		db, _ := openPopulatedExportDB(t)
+		require.NoError(t, db.db.Update(func(tx *bolt.Tx) error {
+			return tx.Bucket(bucketIPs).Put([]byte(exportIPv4), []byte(`{"id":"broken"}`))
+		}))
+		opts := exportPaths(t)
+		changed, err := db.ExportLegacy(context.Background(), opts)
+		require.Error(t, err)
+		assert.False(t, changed)
+		assertRollbackDestinationsMissing(t, opts)
+	})
+}
+
+func TestExportLegacyFileFailuresAndReplay(t *testing.T) {
+	stages := []rollbackFailureStage{
+		rollbackFailureMkdir,
+		rollbackFailureCreate,
+		rollbackFailureWrite,
+		rollbackFailureSync,
+		rollbackFailureClose,
+		rollbackFailureReplace,
+		rollbackFailureParentSync,
+	}
+	outputs := []struct {
+		name  string
+		first bool
+	}{
+		{name: "first CNS file", first: true},
+		{name: "second endpoint file"},
+	}
+	for _, output := range outputs {
+		for _, stage := range stages {
+			t.Run(output.name+"/"+string(stage), func(t *testing.T) {
+				db, _ := openPopulatedExportDB(t)
+				before := requireValidSnapshot(t, db)
+				opts := exportPaths(t)
+				oldCNS := []byte(`{"old":"cns"}`)
+				oldEndpoint := []byte(`{"old":"endpoint"}`)
+				writeRollbackDestination(t, opts.CNSJSONPath, oldCNS)
+				writeRollbackDestination(t, opts.EndpointJSONPath, oldEndpoint)
+				target := opts.EndpointJSONPath
+				if output.first {
+					target = opts.CNSJSONPath
+				}
+
+				changed, err := db.exportLegacy(
+					context.Background(),
+					opts,
+					faultRollbackOperations(target, stage),
+				)
+				require.ErrorIs(t, err, errRollbackFault)
+				assert.False(t, changed)
+				failed := requireValidSnapshot(t, db)
+				assert.Equal(t, AuthorityBolt, failed.Metadata.Authority)
+				assert.False(t, failed.Metadata.RollbackExportComplete)
+				assert.Equal(t, before.Metadata.Generation, failed.Metadata.Generation)
+				assertNoRollbackTemps(t, opts)
+
+				if output.first && stage != rollbackFailureParentSync {
+					assert.Equal(t, oldCNS, readRollbackFile(t, opts.CNSJSONPath))
+					assert.Equal(t, oldEndpoint, readRollbackFile(t, opts.EndpointJSONPath))
+				}
+				if output.first && stage == rollbackFailureParentSync {
+					assertValidRollbackJSON(t, opts.CNSJSONPath)
+					assert.Equal(t, oldEndpoint, readRollbackFile(t, opts.EndpointJSONPath))
+				}
+				if !output.first {
+					assertValidRollbackJSON(t, opts.CNSJSONPath)
+					if stage != rollbackFailureParentSync {
+						assert.Equal(t, oldEndpoint, readRollbackFile(t, opts.EndpointJSONPath))
+					}
+				}
+
+				changed, err = db.ExportLegacy(context.Background(), opts)
+				require.NoError(t, err)
+				assert.True(t, changed)
+				assertValidRollbackJSON(t, opts.CNSJSONPath)
+				assertValidRollbackJSON(t, opts.EndpointJSONPath)
+				assertNoRollbackTemps(t, opts)
+				after := requireValidSnapshot(t, db)
+				assert.Equal(t, AuthorityJSON, after.Metadata.Authority)
+				assert.True(t, after.Metadata.RollbackExportComplete)
+				assert.Equal(t, before.Metadata.Generation+1, after.Metadata.Generation)
+			})
+		}
+	}
+}
+
+func TestCompletedExportPreservesJSONMutation(t *testing.T) {
+	db, _ := openPopulatedExportDB(t)
+	opts := exportPaths(t)
+	changed, err := db.ExportLegacy(context.Background(), opts)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	var envelope map[string]any
+	require.NoError(t, json.Unmarshal(readRollbackFile(t, opts.CNSJSONPath), &envelope))
+	cnsState := envelope["ContainerNetworkService"].(map[string]any)
+	cnsState["NodeID"] = "newer-json-node"
+	mutated, err := json.MarshalIndent(envelope, "", "\t")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(opts.CNSJSONPath, mutated, 0o600))
+
+	changed, err = db.ExportLegacy(context.Background(), opts)
+	require.NoError(t, err)
+	assert.False(t, changed)
+	assert.Equal(t, mutated, readRollbackFile(t, opts.CNSJSONPath))
+}
+
+func TestExportLegacyMarkerFailureReplayAndNoop(t *testing.T) {
+	t.Run("marker transaction failure retries both files", func(t *testing.T) {
+		db, _ := openPopulatedExportDB(t)
+		before := requireValidSnapshot(t, db)
+		opts := exportPaths(t)
+		db.exportBeforeCommit = func() error { return errAbort }
+		changed, err := db.ExportLegacy(context.Background(), opts)
+		require.ErrorIs(t, err, errAbort)
+		assert.False(t, changed)
+		assertValidRollbackJSON(t, opts.CNSJSONPath)
+		assertValidRollbackJSON(t, opts.EndpointJSONPath)
+		failed := requireValidSnapshot(t, db)
+		assert.Equal(t, AuthorityBolt, failed.Metadata.Authority)
+		assert.False(t, failed.Metadata.RollbackExportComplete)
+		assert.Equal(t, before.Metadata.Generation, failed.Metadata.Generation)
+
+		firstCNS := readRollbackFile(t, opts.CNSJSONPath)
+		firstEndpoint := readRollbackFile(t, opts.EndpointJSONPath)
+		require.NoError(t, os.WriteFile(opts.CNSJSONPath, []byte(`{"torn":"cns"}`), 0o600))
+		require.NoError(t, os.WriteFile(opts.EndpointJSONPath, []byte(`{"torn":"endpoint"}`), 0o600))
+		db.exportBeforeCommit = nil
+		changed, err = db.ExportLegacy(context.Background(), opts)
+		require.NoError(t, err)
+		assert.True(t, changed)
+		assert.Equal(t, firstCNS, readRollbackFile(t, opts.CNSJSONPath))
+		assert.Equal(t, firstEndpoint, readRollbackFile(t, opts.EndpointJSONPath))
+		assertNoRollbackTemps(t, opts)
+	})
+
+	t.Run("completed export preserves external mutation after reopen", func(t *testing.T) {
+		db, path := openPopulatedExportDB(t)
+		opts := exportPaths(t)
+		changed, err := db.ExportLegacy(context.Background(), opts)
+		require.NoError(t, err)
+		require.True(t, changed)
+		generation := readMetadata(t, db).Generation
+		cnsMutation := []byte(`{"newer":"cns"}`)
+		endpointMutation := []byte(`{"newer":"endpoint"}`)
+		require.NoError(t, os.WriteFile(opts.CNSJSONPath, cnsMutation, 0o600))
+		require.NoError(t, os.WriteFile(opts.EndpointJSONPath, endpointMutation, 0o600))
+
+		changed, err = db.ExportLegacy(context.Background(), opts)
+		require.NoError(t, err)
+		assert.False(t, changed)
+		assert.Equal(t, cnsMutation, readRollbackFile(t, opts.CNSJSONPath))
+		assert.Equal(t, endpointMutation, readRollbackFile(t, opts.EndpointJSONPath))
+		assert.Equal(t, generation, readMetadata(t, db).Generation)
+		require.NoError(t, db.Close())
+
+		reopened, err := Open(path, Options{})
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, reopened.Close()) })
+		changed, err = reopened.ExportLegacy(context.Background(), opts)
+		require.NoError(t, err)
+		assert.False(t, changed)
+		assert.Equal(t, cnsMutation, readRollbackFile(t, opts.CNSJSONPath))
+		assert.Equal(t, endpointMutation, readRollbackFile(t, opts.EndpointJSONPath))
+		assert.Equal(t, generation, readMetadata(t, reopened).Generation)
+	})
+}
+
+func TestExportLegacyConcurrencyAndWriterGate(t *testing.T) {
+	t.Run("concurrent exports transition once", func(t *testing.T) {
+		db, _ := openPopulatedExportDB(t)
+		before := requireValidSnapshot(t, db)
+		opts := exportPaths(t)
+		const callers = 12
+		start := make(chan struct{})
+		results := make(chan bool, callers)
+		errs := make(chan error, callers)
+		var wg sync.WaitGroup
+		wg.Add(callers)
+		for range callers {
+			go func() {
+				defer wg.Done()
+				<-start
+				changed, err := db.ExportLegacy(context.Background(), opts)
+				results <- changed
+				errs <- err
+			}()
+		}
+		close(start)
+		wg.Wait()
+		close(results)
+		close(errs)
+
+		var transitions int
+		for result := range results {
+			if result {
+				transitions++
+			}
+		}
+		for err := range errs {
+			require.NoError(t, err)
+		}
+		assert.Equal(t, 1, transitions)
+		assert.Equal(t, before.Metadata.Generation+1, readMetadata(t, db).Generation)
+		assertValidRollbackJSON(t, opts.CNSJSONPath)
+		assertValidRollbackJSON(t, opts.EndpointJSONPath)
+	})
+
+	t.Run("DB update waits for files and sees transition", func(t *testing.T) {
+		db, _ := openPopulatedExportDB(t)
+		before := requireValidSnapshot(t, db)
+		opts := exportPaths(t)
+		enteredWrite := make(chan struct{})
+		releaseWrite := make(chan struct{})
+		files := osRollbackFileOperations()
+		createTemp := files.createTemp
+		var blockedOnce atomic.Bool
+		files.createTemp = func(dir, pattern string) (rollbackTemporaryFile, error) {
+			file, err := createTemp(dir, pattern)
+			if err != nil {
+				return nil, err
+			}
+			if blockedOnce.CompareAndSwap(false, true) {
+				return &blockingRollbackFile{
+					rollbackTemporaryFile: file,
+					entered:               enteredWrite,
+					release:               releaseWrite,
+				}, nil
+			}
+			return file, nil
+		}
+
+		exportDone := make(chan error, 1)
+		go func() {
+			_, err := db.exportLegacy(context.Background(), opts, files)
+			exportDone <- err
+		}()
+		<-enteredWrite
+		require.Equal(t, 1, len(db.writeGate))
+
+		callbackEntered := make(chan Metadata, 1)
+		updateDone := make(chan error, 1)
+		go func() {
+			updateDone <- db.Update(context.Background(), func(tx *WriteTx) error {
+				meta, err := tx.Metadata()
+				if err == nil {
+					callbackEntered <- meta
+				}
+				return errors.Join(err, errAbort)
+			})
+		}()
+		select {
+		case <-callbackEntered:
+			t.Fatal("DB update entered while rollback files were incomplete")
+		default:
+		}
+
+		close(releaseWrite)
+		require.NoError(t, <-exportDone)
+		require.ErrorIs(t, <-updateDone, errAbort)
+		seen := <-callbackEntered
+		assert.Equal(t, AuthorityJSON, seen.Authority)
+		assert.True(t, seen.RollbackExportComplete)
+		assert.Equal(t, before.Metadata.Generation+1, seen.Generation)
+	})
+}
+
+func TestExportLegacyRejectsInconsistentAuthorityMarker(t *testing.T) {
+	tests := []struct {
+		name      string
+		authority Authority
+		marker    bool
+	}{
+		{name: "Bolt with marker", authority: AuthorityBolt, marker: true},
+		{name: "JSON without marker", authority: AuthorityJSON},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, _ := openPopulatedExportDB(t)
+			require.NoError(t, db.db.Update(func(tx *bolt.Tx) error {
+				metadata := tx.Bucket(bucketMetadata)
+				if err := metadata.Put(metaKeyAuthority, []byte(tt.authority)); err != nil {
+					return err
+				}
+				if tt.marker {
+					return metadata.Put(metaKeyRollbackExport, []byte(rollbackExportMarker))
+				}
+				return metadata.Delete(metaKeyRollbackExport)
+			}))
+			opts := exportPaths(t)
+			writeRollbackDestination(t, opts.CNSJSONPath, []byte(`{"newer":"cns"}`))
+			writeRollbackDestination(t, opts.EndpointJSONPath, []byte(`{"newer":"endpoint"}`))
+			changed, err := db.ExportLegacy(context.Background(), opts)
+			require.ErrorIs(t, err, ErrCorrupt)
+			assert.False(t, changed)
+			assert.Equal(t, []byte(`{"newer":"cns"}`), readRollbackFile(t, opts.CNSJSONPath))
+			assert.Equal(t, []byte(`{"newer":"endpoint"}`), readRollbackFile(t, opts.EndpointJSONPath))
+		})
+	}
+}
+
+type blockingRollbackFile struct {
+	rollbackTemporaryFile
+	entered chan<- struct{}
+	release <-chan struct{}
+}
+
+func (f *blockingRollbackFile) Write(data []byte) (int, error) {
+	close(f.entered)
+	<-f.release
+	return f.rollbackTemporaryFile.Write(data)
+}
+
+func faultRollbackOperations(target string, stage rollbackFailureStage) rollbackFileOperations {
+	files := osRollbackFileOperations()
+	mkdirAll := files.mkdirAll
+	files.mkdirAll = func(path string, perm fs.FileMode) error {
+		if stage == rollbackFailureMkdir && filepath.Clean(path) == filepath.Clean(filepath.Dir(target)) {
+			return errRollbackFault
+		}
+		return mkdirAll(path, perm)
+	}
+	createTemp := files.createTemp
+	files.createTemp = func(dir, pattern string) (rollbackTemporaryFile, error) {
+		destination := filepath.Join(dir, strings.TrimSuffix(pattern, ".rollback-*"))
+		if filepath.Clean(destination) != filepath.Clean(target) {
+			return createTemp(dir, pattern)
+		}
+		if stage == rollbackFailureCreate {
+			return nil, errRollbackFault
+		}
+		file, err := createTemp(dir, pattern)
+		if err != nil {
+			return nil, err
+		}
+		return &faultRollbackFile{rollbackTemporaryFile: file, stage: stage}, nil
+	}
+	replace := files.durableReplace
+	files.durableReplace = func(source, destination string) error {
+		if filepath.Clean(destination) != filepath.Clean(target) {
+			return replace(source, destination)
+		}
+		switch stage {
+		case rollbackFailureReplace:
+			return errRollbackFault
+		case rollbackFailureParentSync:
+			if err := platform.ReplaceFile(source, destination); err != nil {
+				return err
+			}
+			return errRollbackFault
+		default:
+			return replace(source, destination)
+		}
+	}
+	return files
+}
+
+func openPopulatedExportDB(t *testing.T) (*DB, string) {
+	t.Helper()
+	db, path := openTestDB(t)
+
+	request1 := completeNetworkContainerRequest()
+	request1.AuthorizationToken = "secret-token"
+	record1 := NewNetworkContainerRecord(exportNC1, "7", "6", true, request1)
+	changed, err := db.ApplyNetworkContainer(context.Background(), record1, []IPRecord{
+		{ID: exportIPv4, IPAddress: "10.0.0.4", NCID: exportNC1, NCVersion: 7},
+		{ID: exportIPv6, IPAddress: "fd00::4", NCID: exportNC1, NCVersion: 7},
+	})
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	request2 := completeNetworkContainerRequest()
+	request2.AuthorizationToken = "another-secret"
+	record2 := NewNetworkContainerRecord(exportNC2, "8", "7", true, request2)
+	changed, err = db.ApplyNetworkContainer(context.Background(), record2, []IPRecord{
+		{ID: exportNet1, IPAddress: "10.1.0.4", NCID: exportNC2, NCVersion: 8},
+	})
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	require.NoError(t, db.Update(context.Background(), func(tx *WriteTx) error {
+		meta, err := tx.Metadata()
+		if err != nil {
+			return err
+		}
+		meta.BootID = "export-boot"
+		meta.Location = "eastus"
+		meta.NetworkType = "azure"
+		meta.OrchestratorType = "kubernetes"
+		meta.NodeID = "node-1"
+		meta.Initialized = true
+		if err := tx.PutMetadata(meta); err != nil {
+			return err
+		}
+		if err := tx.PutNetwork(NetworkRecord{
+			NetworkName: "network-1",
+			Options:     map[string]any{"custom": "value"},
+		}); err != nil {
+			return err
+		}
+		if err := tx.PutOrchestratorContext("pod-1ns-1", []string{exportNC1, exportNC2}); err != nil {
+			return err
+		}
+		return tx.PutPnPID("00:11:22:33:44:55", "PCI\\VEN_1234")
+	}))
+
+	endpoint := completeEndpointRecord()
+	endpoint.IfnameToIPMap["eth0"].NetworkContainerID = exportNC1
+	endpoint.IfnameToIPMap["net1"].NetworkContainerID = exportNC2
+	changed, err = db.AssignEndpoint(
+		context.Background(),
+		AssignmentRecord{
+			Pod: PodIdentity{
+				PodKey:           "container-1",
+				InfraContainerID: "container-1",
+				PodName:          "pod-1",
+				PodNamespace:     "ns-1",
+			},
+			IPIDs: []string{exportIPv4, exportIPv6, exportNet1},
+		},
+		endpoint,
+		testNow,
+		testDeleteIntentTTL,
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	require.NoError(t, db.Update(context.Background(), func(tx *WriteTx) error {
+		return tx.PutDeleteIntent("deleted-container", DeleteIntent{CreatedAt: testNow.Add(-time.Minute)})
+	}))
+	return db, path
+}
+
+func exportPaths(t *testing.T) ExportOptions {
+	t.Helper()
+	dir := t.TempDir()
+	return ExportOptions{
+		CNSJSONPath:      filepath.Join(dir, "cns", "azure-cns.json"),
+		EndpointJSONPath: filepath.Join(dir, "endpoint", "azure-endpoints.json"),
+	}
+}
+
+func writeRollbackDestination(t *testing.T, path string, data []byte) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+}
+
+func readRollbackFile(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return data
+}
+
+func assertRollbackDestinationsMissing(t *testing.T, opts ExportOptions) {
+	t.Helper()
+	for _, path := range []string{opts.CNSJSONPath, opts.EndpointJSONPath} {
+		_, err := os.Stat(path)
+		require.ErrorIs(t, err, os.ErrNotExist)
+	}
+}
+
+func assertNoRollbackTemps(t *testing.T, opts ExportOptions) {
+	t.Helper()
+	for _, path := range []string{opts.CNSJSONPath, opts.EndpointJSONPath} {
+		matches, err := filepath.Glob(filepath.Join(filepath.Dir(path), filepath.Base(path)+".rollback-*"))
+		require.NoError(t, err)
+		assert.Empty(t, matches)
+	}
+}
+
+func assertValidRollbackJSON(t *testing.T, path string) {
+	t.Helper()
+	var value any
+	require.NoError(t, json.Unmarshal(readRollbackFile(t, path), &value))
+}
+
+func TestEncodeRollbackFilesDeterministic(t *testing.T) {
+	db, _ := openPopulatedExportDB(t)
+	snapshot := requireValidSnapshot(t, db)
+	firstCNS, firstEndpoint, err := encodeRollbackFiles(snapshot)
+	require.NoError(t, err)
+	for range 20 {
+		cnsData, endpointData, err := encodeRollbackFiles(snapshot)
+		require.NoError(t, err)
+		assert.True(t, bytes.Equal(firstCNS, cnsData))
+		assert.True(t, bytes.Equal(firstEndpoint, endpointData))
+	}
+}

--- a/cns/state/export_test.go
+++ b/cns/state/export_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io/fs"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,6 +19,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/wireserver"
 	"github.com/Azure/azure-container-networking/platform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -116,6 +118,18 @@ func TestExportLegacySuccess(t *testing.T) {
 	require.NoError(t, json.Unmarshal(cnsData, &cnsEnvelope))
 	var exported rollbackCNSState
 	require.NoError(t, json.Unmarshal(cnsEnvelope["ContainerNetworkService"], &exported))
+	assert.Equal(t, before.Metadata.Location, exported.Location)
+	assert.Equal(t, before.Metadata.NetworkType, exported.NetworkType)
+	assert.Equal(t, before.Metadata.OrchestratorType, exported.OrchestratorType)
+	assert.Equal(t, before.Metadata.NodeID, exported.NodeID)
+	assert.Equal(t, before.Metadata.Initialized, exported.Initialized)
+	assert.Equal(t, before.Metadata.TimeStamp, exported.TimeStamp)
+	require.NotNil(t, exported.ContainerIDByOrchestratorContext["pod-1ns-1"])
+	assert.Equal(
+		t,
+		exportNC1+","+exportNC2,
+		*exported.ContainerIDByOrchestratorContext["pod-1ns-1"],
+	)
 	request := exported.ContainerStatus[exportNC1].CreateNetworkContainerRequest
 	assert.Empty(t, request.AuthorizationToken)
 	assert.Equal(t, map[string]cns.SecondaryIPConfig{
@@ -131,6 +145,8 @@ func TestExportLegacySuccess(t *testing.T) {
 		string(request.EndpointPolicies[0].Settings),
 	)
 	assert.Equal(t, before.NetworkContainers[exportNC1].Request.NetworkInterfaceInfo, request.NetworkInterfaceInfo)
+	require.NotNil(t, exported.Networks["network-1"].NicInfo)
+	assert.Equal(t, before.Networks["network-1"].NicInfo, exported.Networks["network-1"].NicInfo)
 	assert.Equal(t, "value", exported.Networks["network-1"].Options["custom"])
 	assert.Equal(t, "PCI\\VEN_1234", exported.PnpIDByMacAddress["00:11:22:33:44:55"])
 
@@ -138,7 +154,13 @@ func TestExportLegacySuccess(t *testing.T) {
 	require.NoError(t, json.Unmarshal(endpointData, &endpointEnvelope))
 	var endpoints map[string]*rollbackEndpointInfo
 	require.NoError(t, json.Unmarshal(endpointEnvelope["Endpoints"], &endpoints))
+	assert.Equal(t, "pod-1", endpoints["container-1"].PodName)
+	assert.Equal(t, "ns-1", endpoints["container-1"].PodNamespace)
 	info := endpoints["container-1"].IfnameToIPMap["eth0"]
+	require.Len(t, info.IPv4, 1)
+	assert.Equal(t, net.ParseIP("10.0.0.4"), info.IPv4[0].IP)
+	require.Len(t, info.IPv6, 1)
+	assert.Equal(t, net.ParseIP("fd00::4"), info.IPv6[0].IP)
 	assert.Equal(t, "hns-endpoint-1", info.HnsEndpointID)
 	assert.Equal(t, "hns-network-1", info.HnsNetworkID)
 	assert.Equal(t, "veth-1", info.HostVethName)
@@ -332,8 +354,12 @@ func TestExportLegacyMarkerFailureReplayAndNoop(t *testing.T) {
 		db, _ := openPopulatedExportDB(t)
 		before := requireValidSnapshot(t, db)
 		opts := exportPaths(t)
-		db.exportBeforeCommit = func() error { return errAbort }
-		changed, err := db.ExportLegacy(context.Background(), opts)
+		changed, err := db.exportLegacyWithCommitHook(
+			context.Background(),
+			opts,
+			osRollbackFileOperations(),
+			func() error { return errAbort },
+		)
 		require.ErrorIs(t, err, errAbort)
 		assert.False(t, changed)
 		assertValidRollbackJSON(t, opts.CNSJSONPath)
@@ -347,7 +373,6 @@ func TestExportLegacyMarkerFailureReplayAndNoop(t *testing.T) {
 		firstEndpoint := readRollbackFile(t, opts.EndpointJSONPath)
 		require.NoError(t, os.WriteFile(opts.CNSJSONPath, []byte(`{"torn":"cns"}`), 0o600))
 		require.NoError(t, os.WriteFile(opts.EndpointJSONPath, []byte(`{"torn":"endpoint"}`), 0o600))
-		db.exportBeforeCommit = nil
 		changed, err = db.ExportLegacy(context.Background(), opts)
 		require.NoError(t, err)
 		assert.True(t, changed)
@@ -611,12 +636,20 @@ func openPopulatedExportDB(t *testing.T) (*DB, string) {
 		meta.OrchestratorType = "kubernetes"
 		meta.NodeID = "node-1"
 		meta.Initialized = true
+		meta.TimeStamp = testNow.Add(-time.Hour)
 		if err := tx.PutMetadata(meta); err != nil {
 			return err
 		}
 		if err := tx.PutNetwork(NetworkRecord{
 			NetworkName: "network-1",
-			Options:     map[string]any{"custom": "value"},
+			NicInfo: &wireserver.InterfaceInfo{
+				Subnet:       "10.0.0.0/24",
+				Gateway:      "10.0.0.1",
+				IsPrimary:    true,
+				PrimaryIP:    "10.0.0.4",
+				SecondaryIPs: []string{"10.0.0.5"},
+			},
+			Options: map[string]any{"custom": "value"},
 		}); err != nil {
 			return err
 		}

--- a/cns/state/export_test.go
+++ b/cns/state/export_test.go
@@ -47,6 +47,7 @@ const (
 	exportContainerID   = "container-1"
 	exportPodName       = "pod-1"
 	exportPodNamespace  = "ns-1"
+	exportNetworkType   = "azure"
 )
 
 type rollbackFailureStage string
@@ -654,7 +655,7 @@ func openPopulatedExportDB(t *testing.T) (db *DB, path string) {
 		}
 		meta.BootID = "export-boot"
 		meta.Location = "eastus"
-		meta.NetworkType = "azure"
+		meta.NetworkType = exportNetworkType
 		meta.OrchestratorType = "kubernetes"
 		meta.NodeID = exportNodeID
 		meta.Initialized = true

--- a/cns/state/export_test.go
+++ b/cns/state/export_test.go
@@ -130,6 +130,7 @@ func TestExportLegacySuccess(t *testing.T) {
 		exportNC1+","+exportNC2,
 		*exported.ContainerIDByOrchestratorContext["pod-1ns-1"],
 	)
+	assert.ElementsMatch(t, []string{exportNC1, exportNC2}, sortedKeys(exported.ContainerStatus))
 	request := exported.ContainerStatus[exportNC1].CreateNetworkContainerRequest
 	assert.Empty(t, request.AuthorizationToken)
 	assert.Equal(t, map[string]cns.SecondaryIPConfig{
@@ -156,6 +157,7 @@ func TestExportLegacySuccess(t *testing.T) {
 	require.NoError(t, json.Unmarshal(endpointEnvelope["Endpoints"], &endpoints))
 	assert.Equal(t, "pod-1", endpoints["container-1"].PodName)
 	assert.Equal(t, "ns-1", endpoints["container-1"].PodNamespace)
+	assert.ElementsMatch(t, []string{"eth0", "net1"}, sortedKeys(endpoints["container-1"].IfnameToIPMap))
 	info := endpoints["container-1"].IfnameToIPMap["eth0"]
 	require.Len(t, info.IPv4, 1)
 	assert.Equal(t, net.ParseIP("10.0.0.4"), info.IPv4[0].IP)
@@ -167,6 +169,11 @@ func TestExportLegacySuccess(t *testing.T) {
 	assert.Equal(t, "00:11:22:33:44:55", info.MacAddress)
 	assert.Equal(t, exportNC1, info.NetworkContainerID)
 	assert.Equal(t, cns.InfraNIC, info.NICType)
+	delegated := endpoints["container-1"].IfnameToIPMap["net1"]
+	require.Len(t, delegated.IPv4, 1)
+	assert.Equal(t, net.ParseIP("10.1.0.4"), delegated.IPv4[0].IP)
+	assert.Equal(t, exportNC2, delegated.NetworkContainerID)
+	assert.Equal(t, cns.DelegatedVMNIC, delegated.NICType)
 	var intents map[string]DeleteIntent
 	require.NoError(t, json.Unmarshal(endpointEnvelope["DeleteIntents"], &intents))
 	assert.Equal(t, before.DeleteIntents, intents)


### PR DESCRIPTION
Adds crash-safe export from one validated Bolt snapshot to the existing CNS and endpoint JSON shapes.

Both files use same-directory 0600 temporary files, fsync, atomic replacement, and platform-specific durability; the authority marker commits only after both files are durable. Torn-pair retries converge, and completed rollback never overwrites newer JSON.

Stack dependency: #4786. This PR is parallel with the legacy-import PR; neither depends on the other.

Validation: cns/state unit and race tests, vet, injected file/marker failures, replay/no-overwrite coverage, and complete two-NC/multi-NIC output assertions.