### PR TITLE
fix(cns): reject stale NC version replays instead of resurrecting released IPs

### DIFF
--- a/cns/kubecontroller/nodenetworkconfig/reconciler.go
+++ b/cns/kubecontroller/nodenetworkconfig/reconciler.go
@@ -23,7 +23,7 @@ import (
 )
 
 type cnsClient interface {
-	CreateOrUpdateNetworkContainerInternal(*cns.CreateNetworkContainerRequest) cnstypes.ResponseCode
+	CreateOrUpdateNetworkContainerInternalWithVersionValidation(*cns.CreateNetworkContainerRequest, bool) cnstypes.ResponseCode
 	MustEnsureNoStaleNCs(validNCIDs []string)
 }
 
@@ -120,6 +120,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 		var req *cns.CreateNetworkContainerRequest
 		var err error
+		validateVersion := false
 		switch nnc.Status.NetworkContainers[i].AssignmentMode { //nolint:exhaustive // skipping dynamic case
 		// For Overlay and Vnet Scale Scenarios
 		case v1alpha.Static:
@@ -127,6 +128,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		// For Pod Subnet scenario
 		default: // For backward compatibility, default will be treated as Dynamic too.
 			req, err = CreateNCRequestFromDynamicNC(nnc.Status.NetworkContainers[i])
+			validateVersion = true
 			// in dynamic, we will also push this NNC to the IPAM Pool Monitor when we're done.
 			listenersToNotify = append(listenersToNotify, r.ipampoolmonitorcli)
 		}
@@ -138,7 +140,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 				"assignmentMode %s", nnc.Status.NetworkContainers[i].AssignmentMode)
 		}
 
-		responseCode := r.cnscli.CreateOrUpdateNetworkContainerInternal(req)
+		responseCode := r.cnscli.CreateOrUpdateNetworkContainerInternalWithVersionValidation(req, validateVersion)
 		if err := restserver.ResponseCodeToError(responseCode); err != nil {
 			logger.Errorf("[cns-rc] Error creating or updating NC in reconcile: %v", err)
 			return reconcile.Result{}, errors.Wrap(err, "failed to create or update network container")

--- a/cns/kubecontroller/nodenetworkconfig/reconciler_test.go
+++ b/cns/kubecontroller/nodenetworkconfig/reconciler_test.go
@@ -26,10 +26,15 @@ type mockCNSClient struct {
 	state            cnsClientState
 	createOrUpdateNC func(*cns.CreateNetworkContainerRequest) cnstypes.ResponseCode
 	update           func(*v1alpha.NodeNetworkConfig) error
+	validateVersion  bool
 }
 
-func (m *mockCNSClient) CreateOrUpdateNetworkContainerInternal(req *cns.CreateNetworkContainerRequest) cnstypes.ResponseCode {
+func (m *mockCNSClient) CreateOrUpdateNetworkContainerInternalWithVersionValidation(
+	req *cns.CreateNetworkContainerRequest,
+	validateVersion bool,
+) cnstypes.ResponseCode {
 	m.state.reqsByNCID[req.NetworkContainerid] = req
+	m.validateVersion = validateVersion
 	return m.createOrUpdateNC(req)
 }
 
@@ -202,8 +207,39 @@ func TestReconcile(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 			assert.Equal(t, tt.wantCNSClientState, tt.cnsClient.state)
+			if len(tt.wantCNSClientState.reqsByNCID) > 0 {
+				assert.True(t, tt.cnsClient.validateVersion)
+			}
 		})
 	}
+}
+
+func TestReconcileStaticNCDoesNotValidateVersion(t *testing.T) {
+	staticNC := v1alpha.NetworkContainer{
+		ID:                 "nc-static",
+		AssignmentMode:     v1alpha.Static,
+		PrimaryIP:          "10.0.0.1/32",
+		SubnetAddressSpace: "10.0.0.0/24",
+		NodeIP:             "10.0.0.10",
+	}
+
+	cnsClient := mockCNSClient{
+		state:            cnsClientState{reqsByNCID: make(map[string]*cns.CreateNetworkContainerRequest)},
+		createOrUpdateNC: func(*cns.CreateNetworkContainerRequest) cnstypes.ResponseCode { return cnstypes.Success },
+		update:           func(*v1alpha.NodeNetworkConfig) error { return nil },
+	}
+	reconciler := NewReconciler(&cnsClient, func(*v1alpha.NodeNetworkConfig) error { return nil }, &cnsClient, "", false, 0)
+	reconciler.nnccli = &mockNCGetter{
+		get: func(context.Context, types.NamespacedName) (*v1alpha.NodeNetworkConfig, error) {
+			return &v1alpha.NodeNetworkConfig{
+				Status: v1alpha.NodeNetworkConfigStatus{NetworkContainers: []v1alpha.NetworkContainer{staticNC}},
+			}, nil
+		},
+	}
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{})
+	require.NoError(t, err)
+	assert.False(t, cnsClient.validateVersion)
 }
 
 func TestReconcileStaleNCs(t *testing.T) {

--- a/cns/restserver/api.go
+++ b/cns/restserver/api.go
@@ -562,7 +562,7 @@ func (service *HTTPRestService) createOrUpdateNetworkContainer(w http.ResponseWr
 			}
 		}
 
-		returnCode, returnMessage = service.saveNetworkContainerGoalState(req)
+		returnCode, returnMessage = service.saveNetworkContainerGoalState(req, false)
 
 	default:
 		returnMessage = "[Azure CNS] Error. CreateOrUpdateNetworkContainer did not receive a POST."

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -590,6 +590,25 @@ func (service *HTTPRestService) MustEnsureNoStaleNCs(validNCIDs []string) {
 
 // This API will be called by CNS RequestController on CRD update.
 func (service *HTTPRestService) CreateOrUpdateNetworkContainerInternal(req *cns.CreateNetworkContainerRequest) types.ResponseCode {
+	return service.createOrUpdateNetworkContainerInternal(req, false)
+}
+
+// CreateOrUpdateNetworkContainerInternalWithVersionValidation creates or updates an NC, additionally
+// rejecting version regressions or same-version goal drift when validateVersion is true. Callers
+// that know the incoming NC's version and content are authoritative for its NC ID (currently, the
+// NNC reconciler's dynamic/pod-subnet path) should pass true; other flows (e.g. static/SwiftV2 NCs,
+// NodeSubnet bookkeeping) that don't track a meaningful version should pass false.
+func (service *HTTPRestService) CreateOrUpdateNetworkContainerInternalWithVersionValidation(
+	req *cns.CreateNetworkContainerRequest,
+	validateVersion bool,
+) types.ResponseCode {
+	return service.createOrUpdateNetworkContainerInternal(req, validateVersion)
+}
+
+func (service *HTTPRestService) createOrUpdateNetworkContainerInternal(
+	req *cns.CreateNetworkContainerRequest,
+	validateVersion bool,
+) types.ResponseCode {
 	if req.NetworkContainerid == "" {
 		logger.Errorf("[Azure CNS] Error. NetworkContainerid is empty")
 		return types.NetworkContainerNotSpecified
@@ -648,7 +667,7 @@ func (service *HTTPRestService) CreateOrUpdateNetworkContainerInternal(req *cns.
 	}
 
 	// This will Create Or Update the NC state.
-	returnCode, returnMessage := service.saveNetworkContainerGoalState(*req)
+	returnCode, returnMessage := service.saveNetworkContainerGoalState(*req, validateVersion)
 	if returnCode != types.Success {
 		logger.Errorf("%s", returnMessage) //nolint:staticcheck // will migrate to logger/v2
 		return returnCode

--- a/cns/restserver/internalapi.go
+++ b/cns/restserver/internalapi.go
@@ -649,14 +649,13 @@ func (service *HTTPRestService) CreateOrUpdateNetworkContainerInternal(req *cns.
 
 	// This will Create Or Update the NC state.
 	returnCode, returnMessage := service.saveNetworkContainerGoalState(*req)
-
-	// If the NC was created successfully, log NC snapshot.
-	if returnCode == 0 {
-		logNCSnapshot(*req)
-		service.publishIPStateMetrics()
-	} else {
+	if returnCode != types.Success {
 		logger.Errorf("%s", returnMessage) //nolint:staticcheck // will migrate to logger/v2
+		return returnCode
 	}
+
+	logNCSnapshot(*req)
+	service.publishIPStateMetrics()
 
 	if service.Options[common.OptProgramSNATIPTables] == true {
 		returnCode, returnMessage = service.programSNATRules(req)

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -355,10 +355,10 @@ func TestCreateOrUpdateNetworkContainerInternal_RejectsStaleVersionReplay(t *tes
 		},
 	}
 
-	returnCode := svc.CreateOrUpdateNetworkContainerInternal(oldReq)
+	returnCode := svc.CreateOrUpdateNetworkContainerInternalWithVersionValidation(oldReq, true)
 
 	// Fixed behavior: the stale replay is rejected, atomically, with no partial mutation.
-	assert.Equal(t, types.NetworkContainerVersionMismatch, returnCode, "expected the stale NC replay to be rejected")
+	assert.Equal(t, types.UnsupportedNCVersion, returnCode, "expected the stale NC replay to be rejected")
 
 	containerStatus := svc.state.ContainerStatus[testNCID]
 	assert.Equal(t, "10", containerStatus.CreateNetworkContainerRequest.Version, "stored DNC version must remain 10")
@@ -423,10 +423,10 @@ func TestCreateOrUpdateNetworkContainerInternal_StaleReplayRejectionSurvivesSNAT
 		},
 	}
 
-	returnCode := svc.CreateOrUpdateNetworkContainerInternal(staleReq)
+	returnCode := svc.CreateOrUpdateNetworkContainerInternalWithVersionValidation(staleReq, true)
 
 	// The rejection must not be overwritten by SNAT programming's return code.
-	assert.Equal(t, types.NetworkContainerVersionMismatch, returnCode,
+	assert.Equal(t, types.UnsupportedNCVersion, returnCode,
 		"stale replay rejection must survive even when SNAT programming is enabled")
 
 	containerStatus := svc.state.ContainerStatus[testNCID]
@@ -476,7 +476,7 @@ func TestCreateOrUpdateNetworkContainerInternal_EqualVersionIsIdempotent(t *test
 		},
 	}
 
-	returnCode := svc.CreateOrUpdateNetworkContainerInternal(sameReq)
+	returnCode := svc.CreateOrUpdateNetworkContainerInternalWithVersionValidation(sameReq, true)
 
 	assert.Equal(t, types.Success, returnCode, "an equal-version replay must be accepted idempotently")
 	assert.Equal(t, "10", svc.state.ContainerStatus[testNCID].CreateNetworkContainerRequest.Version)
@@ -526,7 +526,7 @@ func TestCreateOrUpdateNetworkContainerInternal_HigherVersionIsAccepted(t *testi
 		},
 	}
 
-	returnCode := svc.CreateOrUpdateNetworkContainerInternal(newerReq)
+	returnCode := svc.CreateOrUpdateNetworkContainerInternalWithVersionValidation(newerReq, true)
 
 	assert.Equal(t, types.Success, returnCode, "a newer-version update must be accepted")
 	assert.Equal(t, "11", svc.state.ContainerStatus[testNCID].CreateNetworkContainerRequest.Version)
@@ -583,7 +583,7 @@ func TestCreateOrUpdateNetworkContainerInternal_MalformedVersionFailsWithoutMuta
 		},
 	}
 
-	returnCode := svc.CreateOrUpdateNetworkContainerInternal(malformedReq)
+	returnCode := svc.CreateOrUpdateNetworkContainerInternalWithVersionValidation(malformedReq, true)
 
 	assert.Equal(t, types.UnsupportedNCVersion, returnCode, "a malformed version must be rejected")
 	assert.Equal(t, "10", svc.state.ContainerStatus[testNCID].CreateNetworkContainerRequest.Version, "stored version must not be mutated")
@@ -632,9 +632,9 @@ func TestCreateOrUpdateNetworkContainerInternal_StaleReplayCannotAlterAssignedIP
 		SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{},
 	}
 
-	returnCode := svc.CreateOrUpdateNetworkContainerInternal(staleReq)
+	returnCode := svc.CreateOrUpdateNetworkContainerInternalWithVersionValidation(staleReq, true)
 
-	assert.Equal(t, types.NetworkContainerVersionMismatch, returnCode, "the stale replay must be rejected before it can reach IP config deletion logic")
+	assert.Equal(t, types.UnsupportedNCVersion, returnCode, "the stale replay must be rejected before it can reach IP config deletion logic")
 
 	assignedIPState, exists := svc.PodIPConfigState[assignedIPID]
 	require.True(t, exists, "assigned IP must not be removed by a rejected stale replay")
@@ -705,9 +705,9 @@ func TestCreateOrUpdateNetworkContainerInternal_RejectsStaleVersionReplay_Cluste
 		},
 	}
 
-	returnCode := svc.CreateOrUpdateNetworkContainerInternal(oldReq)
+	returnCode := svc.CreateOrUpdateNetworkContainerInternalWithVersionValidation(oldReq, true)
 
-	assert.Equal(t, types.NetworkContainerVersionMismatch, returnCode, "expected the stale cluster-captured NC replay to be rejected")
+	assert.Equal(t, types.UnsupportedNCVersion, returnCode, "expected the stale cluster-captured NC replay to be rejected")
 
 	containerStatus := svc.state.ContainerStatus[clusterNCID]
 	assert.Equal(t, clusterHostVer, containerStatus.CreateNetworkContainerRequest.Version, "stored DNC version must remain 8")

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -16,6 +16,8 @@ import (
 	"testing"
 	"time"
 
+	acncommon "github.com/Azure/azure-container-networking/common"
+
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/common"
 	"github.com/Azure/azure-container-networking/cns/configuration"
@@ -304,14 +306,13 @@ func TestCreateAndUpdateNCWithSecondaryIPNCVersion(t *testing.T) {
 	}
 }
 
-// TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP is a deterministic
+// TestCreateOrUpdateNetworkContainerInternal_RejectsStaleVersionReplay is a deterministic
 // regression test for the NC-version-replay bug: CNS already has NC version 10 in local state and a
 // matching host (NMAgent-programmed) version of 10. An incoming NC request carrying an older DNC/NNC
 // version (5) for the same NC, referencing a secondary IP ID that was already released and removed from
 // PodIPConfigState, must now be rejected atomically: no stored state may change, and the released IP
 // must remain absent (not recreated as Available or PendingProgramming).
-// See nc-version-replay-repro-handoff.md for the full analysis.
-func TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP(t *testing.T) {
+func TestCreateOrUpdateNetworkContainerInternal_RejectsStaleVersionReplay(t *testing.T) {
 	restartService()
 	setEnv(t)
 	setOrchestratorTypeInternal(cns.KubernetesCRD)
@@ -372,9 +373,70 @@ func TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsRele
 	assert.Equal(t, types.Available, currentIPState.GetState())
 }
 
+// TestCreateOrUpdateNetworkContainerInternal_StaleReplayRejectionSurvivesSNATProgramming is a regression
+// test for a follow-on bug: when SNAT reconciliation is enabled (OptProgramSNATIPTables), CNS used to
+// unconditionally call programSNATRules after saveNetworkContainerGoalState, overwriting a
+// NetworkContainerVersionMismatch rejection with whatever programSNATRules returned - silently hiding
+// the rejection from callers such as the NNC reconciler. This asserts that CNS now returns immediately
+// on rejection, before SNAT programming is even attempted.
+func TestCreateOrUpdateNetworkContainerInternal_StaleReplayRejectionSurvivesSNATProgramming(t *testing.T) {
+	restartService()
+	setEnv(t)
+	setOrchestratorTypeInternal(cns.KubernetesCRD)
+	svc.state.ContainerStatus = make(map[string]containerstatus)
+	svc.PodIPConfigState = make(map[string]cns.IPConfigurationStatus)
+
+	// Enable SNAT programming, as in the affected managed-Cilium deployment configuration.
+	svc.Options[acncommon.OptProgramSNATIPTables] = true
+	// service.iptables is deliberately left nil (its zero value): if the fix regresses and
+	// programSNATRules is reached, calling a method on it would panic, making any regression loud
+	// and obvious rather than silently returning Success.
+
+	testNCID := "666bd5c9-89f2-4b5d-b8d0-616894d6d151"
+	currentIPID := uuid.New().String()
+
+	// Arrange: CNS already has NC version 10 in local state, with host (NMAgent-programmed) version 10 too.
+	svc.state.ContainerStatus[testNCID] = containerstatus{
+		ID:          testNCID,
+		VMVersion:   "10",
+		HostVersion: "10",
+		CreateNetworkContainerRequest: cns.CreateNetworkContainerRequest{
+			NetworkContainerid:   testNCID,
+			NetworkContainerType: dockerContainerType,
+			Version:              "10",
+			IPConfiguration: cns.IPConfiguration{
+				IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+			},
+			SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+				currentIPID: newSecondaryIPConfig("10.0.0.6", 10),
+			},
+		},
+	}
+	svc.PodIPConfigState[currentIPID] = newPodState("10.0.0.6", currentIPID, testNCID, types.Available, 10)
+
+	// Act: replay an older DNC/NNC payload (version 5) for the same NC.
+	staleReq := &cns.CreateNetworkContainerRequest{
+		NetworkContainerid:   testNCID,
+		NetworkContainerType: dockerContainerType,
+		Version:              "5",
+		IPConfiguration: cns.IPConfiguration{
+			IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+		},
+	}
+
+	returnCode := svc.CreateOrUpdateNetworkContainerInternal(staleReq)
+
+	// The rejection must not be overwritten by SNAT programming's return code.
+	assert.Equal(t, types.NetworkContainerVersionMismatch, returnCode,
+		"stale replay rejection must survive even when SNAT programming is enabled")
+
+	containerStatus := svc.state.ContainerStatus[testNCID]
+	assert.Equal(t, "10", containerStatus.CreateNetworkContainerRequest.Version, "stored DNC version must remain 10")
+}
+
 // TestCreateOrUpdateNetworkContainerInternal_EqualVersionIsIdempotent verifies that replaying the same
-// (currently stored) DNC/NNC version is accepted and idempotent, per the "incoming = stored" case in the
-// proposed correctness guard in nc-version-replay-repro-handoff.md.
+// (currently stored) DNC/NNC version is accepted and idempotent (the "incoming == stored" case of the
+// version-comparison guard in saveNetworkContainerGoalState).
 func TestCreateOrUpdateNetworkContainerInternal_EqualVersionIsIdempotent(t *testing.T) {
 	restartService()
 	setEnv(t)
@@ -422,8 +484,8 @@ func TestCreateOrUpdateNetworkContainerInternal_EqualVersionIsIdempotent(t *test
 }
 
 // TestCreateOrUpdateNetworkContainerInternal_HigherVersionIsAccepted verifies that a newer DNC/NNC
-// version is still accepted and reconciled normally, per the "incoming > stored" case in the proposed
-// correctness guard in nc-version-replay-repro-handoff.md.
+// version is still accepted and reconciled normally (the "incoming > stored" case of the
+// version-comparison guard in saveNetworkContainerGoalState).
 func TestCreateOrUpdateNetworkContainerInternal_HigherVersionIsAccepted(t *testing.T) {
 	restartService()
 	setEnv(t)
@@ -481,8 +543,7 @@ func TestCreateOrUpdateNetworkContainerInternal_HigherVersionIsAccepted(t *testi
 }
 
 // TestCreateOrUpdateNetworkContainerInternal_MalformedVersionFailsWithoutMutation verifies that a
-// non-numeric incoming or stored version is rejected without mutating any state, per
-// nc-version-replay-repro-handoff.md's "malformed versions fail without mutation" requirement.
+// non-numeric incoming or stored version is rejected without mutating any state.
 func TestCreateOrUpdateNetworkContainerInternal_MalformedVersionFailsWithoutMutation(t *testing.T) {
 	restartService()
 	setEnv(t)
@@ -581,9 +642,9 @@ func TestCreateOrUpdateNetworkContainerInternal_StaleReplayCannotAlterAssignedIP
 	assert.Equal(t, types.Assigned, assignedIPState.GetState(), "assigned IP state must be unchanged")
 }
 
-// TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP_ClusterData is a
-// regression test using real data captured from a live AKS standalone cluster (Phase 1-2 of the guarded
-// cluster reproduction in nc-version-replay-repro-handoff.md), instead of synthetic IDs:
+// TestCreateOrUpdateNetworkContainerInternal_RejectsStaleVersionReplay_ClusterData is a
+// regression test using real data captured from a live AKS standalone test cluster, instead of
+// synthetic IDs:
 //   - NC ID c51b224b-b747-4063-b470-3676a74f13e8 was observed on node aks-gmp32-53174927-vmss000000.
 //   - Version 1 of that NC (captured while held-demand pods were still occupying IPs) assigned
 //     secondary IP d9ac4eef-344a-4025-99b6-96c6c6e2ec71 / 10.241.0.69.
@@ -595,7 +656,7 @@ func TestCreateOrUpdateNetworkContainerInternal_StaleReplayCannotAlterAssignedIP
 // This verifies the fix using the same real, cluster-derived data: feeding a stale (version 1) replay
 // of the NC payload against locally-stored state reflecting the newer (version 8) baseline must now be
 // rejected, and the released address must remain absent.
-func TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP_ClusterData(t *testing.T) {
+func TestCreateOrUpdateNetworkContainerInternal_RejectsStaleVersionReplay_ClusterData(t *testing.T) {
 	restartService()
 	setEnv(t)
 	setOrchestratorTypeInternal(cns.KubernetesCRD)

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -304,6 +304,71 @@ func TestCreateAndUpdateNCWithSecondaryIPNCVersion(t *testing.T) {
 	}
 }
 
+// TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP is a deterministic
+// reproduction of the NC-version-replay bug: CNS already has NC version 10 in local state and a matching
+// host (NMAgent-programmed) version of 10. An incoming NC request carrying an older DNC/NNC version (5)
+// for the same NC, referencing a secondary IP ID that was already released and removed from
+// PodIPConfigState, is currently accepted and the released IP is incorrectly recreated as Available
+// (instead of being rejected as stale, or at minimum recreated as PendingProgramming).
+// See nc-version-replay-repro-handoff.md for the full analysis.
+func TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP(t *testing.T) {
+	restartService()
+	setEnv(t)
+	setOrchestratorTypeInternal(cns.KubernetesCRD)
+	svc.state.ContainerStatus = make(map[string]containerstatus)
+	svc.PodIPConfigState = make(map[string]cns.IPConfigurationStatus)
+
+	testNCID := "555ac5c9-89f2-4b5d-b8d0-616894d6d150"
+	currentIPID := uuid.New().String()
+	oldIPID := uuid.New().String() // belonged to an older NC payload; already released and removed from state
+
+	// Arrange: CNS already has NC version 10 in local state, with host (NMAgent-programmed) version 10 too.
+	svc.state.ContainerStatus[testNCID] = containerstatus{
+		ID:          testNCID,
+		VMVersion:   "10",
+		HostVersion: "10",
+		CreateNetworkContainerRequest: cns.CreateNetworkContainerRequest{
+			NetworkContainerid:   testNCID,
+			NetworkContainerType: dockerContainerType,
+			Version:              "10",
+			IPConfiguration: cns.IPConfiguration{
+				IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+			},
+			SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+				currentIPID: newSecondaryIPConfig("10.0.0.6", 10),
+			},
+		},
+	}
+	svc.PodIPConfigState[currentIPID] = newPodState("10.0.0.6", currentIPID, testNCID, types.Available, 10)
+	// oldIPID intentionally absent from svc.PodIPConfigState: it was already released.
+
+	// Act: replay an older DNC/NNC payload (version 5) for the same NC, still referencing the released oldIPID.
+	oldReq := &cns.CreateNetworkContainerRequest{
+		NetworkContainerid:   testNCID,
+		NetworkContainerType: dockerContainerType,
+		Version:              "5",
+		IPConfiguration: cns.IPConfiguration{
+			IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+		},
+		SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+			oldIPID: newSecondaryIPConfig("10.0.0.99", 5),
+		},
+	}
+
+	returnCode := svc.CreateOrUpdateNetworkContainerInternal(oldReq)
+
+	// Current (buggy) behavior: the stale replay is accepted.
+	require.Equal(t, types.Success, returnCode, "expected the stale NC replay to currently be accepted (demonstrating the bug)")
+
+	containerStatus := svc.state.ContainerStatus[testNCID]
+	assert.Equal(t, "5", containerStatus.CreateNetworkContainerRequest.Version, "stored DNC version incorrectly drops from 10 to 5")
+	assert.Equal(t, "10", containerStatus.HostVersion, "host version should remain unchanged")
+
+	oldIPState, exists := svc.PodIPConfigState[oldIPID]
+	require.True(t, exists, "old IP incorrectly recreated in PodIPConfigState")
+	assert.Equal(t, types.Available, oldIPState.GetState(), "old IP incorrectly enters Available instead of PendingProgramming")
+}
+
 func TestSyncHostNCVersion(t *testing.T) {
 	// cns.KubernetesCRD has one more logic compared to other orchestrator type, so test both of them
 	orchestratorTypes := []string{cns.Kubernetes, cns.KubernetesCRD}

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -16,14 +16,13 @@ import (
 	"testing"
 	"time"
 
-	acncommon "github.com/Azure/azure-container-networking/common"
-
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/common"
 	"github.com/Azure/azure-container-networking/cns/configuration"
 	"github.com/Azure/azure-container-networking/cns/fakes"
 	"github.com/Azure/azure-container-networking/cns/imds"
 	"github.com/Azure/azure-container-networking/cns/types"
+	acncommon "github.com/Azure/azure-container-networking/common"
 	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	nma "github.com/Azure/azure-container-networking/nmagent"
 	"github.com/Azure/azure-container-networking/store"
@@ -645,7 +644,7 @@ func TestCreateOrUpdateNetworkContainerInternal_StaleReplayCannotAlterAssignedIP
 // TestCreateOrUpdateNetworkContainerInternal_RejectsStaleVersionReplay_ClusterData is a
 // regression test using real data captured from a live AKS standalone test cluster, instead of
 // synthetic IDs:
-//   - NC ID c51b224b-b747-4063-b470-3676a74f13e8 was observed on node aks-gmp32-53174927-vmss000000.
+//   - NC ID c51b224b-b747-4063-b470-3676a74f13e8 was observed on a node in the test cluster.
 //   - Version 1 of that NC (captured while held-demand pods were still occupying IPs) assigned
 //     secondary IP d9ac4eef-344a-4025-99b6-96c6c6e2ec71 / 10.241.0.69.
 //   - After releasing the held-demand pods, the live NNC advanced to version 8 and that IP ID was

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -369,6 +369,81 @@ func TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsRele
 	assert.Equal(t, types.Available, oldIPState.GetState(), "old IP incorrectly enters Available instead of PendingProgramming")
 }
 
+// TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP_ClusterData replays
+// the same bug using real data captured from a live AKS standalone cluster (Phase 1-2 of the guarded
+// cluster reproduction in nc-version-replay-repro-handoff.md), instead of synthetic IDs:
+//   - NC ID c51b224b-b747-4063-b470-3676a74f13e8 was observed on node aks-gmp32-53174927-vmss000000.
+//   - Version 1 of that NC (captured while held-demand pods were still occupying IPs) assigned
+//     secondary IP d9ac4eef-344a-4025-99b6-96c6c6e2ec71 / 10.241.0.69.
+//   - After releasing the held-demand pods, the live NNC advanced to version 8 and that IP ID was
+//     confirmed absent from the current ipAssignments set (i.e. genuinely released cluster-side).
+//
+// This demonstrates the same code path resurrects a real, cluster-released address as Available when
+// fed a stale (version 1) replay of the NC payload against locally-stored state reflecting the newer
+// (version 8) baseline.
+func TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP_ClusterData(t *testing.T) {
+	restartService()
+	setEnv(t)
+	setOrchestratorTypeInternal(cns.KubernetesCRD)
+	svc.state.ContainerStatus = make(map[string]containerstatus)
+	svc.PodIPConfigState = make(map[string]cns.IPConfigurationStatus)
+
+	const (
+		clusterNCID       = "c51b224b-b747-4063-b470-3676a74f13e8"
+		clusterHostVer    = "8"
+		clusterOldVer     = "1"
+		currentIPID       = "1fdc5ace-15e9-482a-a751-8aac094cda99" // still present at version 8, per phase 2 capture
+		releasedIPID      = "d9ac4eef-344a-4025-99b6-96c6c6e2ec71" // released by version 8, per phase 2 capture
+		releasedIPAddress = "10.241.0.69"
+	)
+
+	// Arrange: CNS reflects the real cluster baseline captured in Phase 2 -- NC at version 8, host
+	// version 8, with only the currently-assigned IP present in local state.
+	svc.state.ContainerStatus[clusterNCID] = containerstatus{
+		ID:          clusterNCID,
+		VMVersion:   clusterHostVer,
+		HostVersion: clusterHostVer,
+		CreateNetworkContainerRequest: cns.CreateNetworkContainerRequest{
+			NetworkContainerid:   clusterNCID,
+			NetworkContainerType: dockerContainerType,
+			Version:              clusterHostVer,
+			IPConfiguration: cns.IPConfiguration{
+				IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+			},
+			SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+				currentIPID: newSecondaryIPConfig("10.241.0.64", 8),
+			},
+		},
+	}
+	svc.PodIPConfigState[currentIPID] = newPodState("10.241.0.64", currentIPID, clusterNCID, types.Available, 8)
+	// releasedIPID intentionally absent: confirmed released by the live cluster capture in Phase 2.
+
+	// Act: replay the real Phase 1 (version 1) NC payload referencing the now-released cluster IP.
+	oldReq := &cns.CreateNetworkContainerRequest{
+		NetworkContainerid:   clusterNCID,
+		NetworkContainerType: dockerContainerType,
+		Version:              clusterOldVer,
+		IPConfiguration: cns.IPConfiguration{
+			IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+		},
+		SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+			releasedIPID: newSecondaryIPConfig(releasedIPAddress, 1),
+		},
+	}
+
+	returnCode := svc.CreateOrUpdateNetworkContainerInternal(oldReq)
+
+	require.Equal(t, types.Success, returnCode, "expected the stale cluster-captured NC replay to currently be accepted (demonstrating the bug)")
+
+	containerStatus := svc.state.ContainerStatus[clusterNCID]
+	assert.Equal(t, clusterOldVer, containerStatus.CreateNetworkContainerRequest.Version, "stored DNC version incorrectly drops from 8 to 1")
+	assert.Equal(t, clusterHostVer, containerStatus.HostVersion, "host version should remain unchanged")
+
+	releasedIPState, exists := svc.PodIPConfigState[releasedIPID]
+	require.True(t, exists, "cluster-released IP incorrectly recreated in PodIPConfigState")
+	assert.Equal(t, types.Available, releasedIPState.GetState(), "cluster-released IP incorrectly enters Available instead of PendingProgramming")
+}
+
 func TestSyncHostNCVersion(t *testing.T) {
 	// cns.KubernetesCRD has one more logic compared to other orchestrator type, so test both of them
 	orchestratorTypes := []string{cns.Kubernetes, cns.KubernetesCRD}

--- a/cns/restserver/internalapi_test.go
+++ b/cns/restserver/internalapi_test.go
@@ -305,11 +305,11 @@ func TestCreateAndUpdateNCWithSecondaryIPNCVersion(t *testing.T) {
 }
 
 // TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP is a deterministic
-// reproduction of the NC-version-replay bug: CNS already has NC version 10 in local state and a matching
-// host (NMAgent-programmed) version of 10. An incoming NC request carrying an older DNC/NNC version (5)
-// for the same NC, referencing a secondary IP ID that was already released and removed from
-// PodIPConfigState, is currently accepted and the released IP is incorrectly recreated as Available
-// (instead of being rejected as stale, or at minimum recreated as PendingProgramming).
+// regression test for the NC-version-replay bug: CNS already has NC version 10 in local state and a
+// matching host (NMAgent-programmed) version of 10. An incoming NC request carrying an older DNC/NNC
+// version (5) for the same NC, referencing a secondary IP ID that was already released and removed from
+// PodIPConfigState, must now be rejected atomically: no stored state may change, and the released IP
+// must remain absent (not recreated as Available or PendingProgramming).
 // See nc-version-replay-repro-handoff.md for the full analysis.
 func TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP(t *testing.T) {
 	restartService()
@@ -357,30 +357,244 @@ func TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsRele
 
 	returnCode := svc.CreateOrUpdateNetworkContainerInternal(oldReq)
 
-	// Current (buggy) behavior: the stale replay is accepted.
-	require.Equal(t, types.Success, returnCode, "expected the stale NC replay to currently be accepted (demonstrating the bug)")
+	// Fixed behavior: the stale replay is rejected, atomically, with no partial mutation.
+	assert.Equal(t, types.NetworkContainerVersionMismatch, returnCode, "expected the stale NC replay to be rejected")
 
 	containerStatus := svc.state.ContainerStatus[testNCID]
-	assert.Equal(t, "5", containerStatus.CreateNetworkContainerRequest.Version, "stored DNC version incorrectly drops from 10 to 5")
+	assert.Equal(t, "10", containerStatus.CreateNetworkContainerRequest.Version, "stored DNC version must remain 10")
 	assert.Equal(t, "10", containerStatus.HostVersion, "host version should remain unchanged")
 
-	oldIPState, exists := svc.PodIPConfigState[oldIPID]
-	require.True(t, exists, "old IP incorrectly recreated in PodIPConfigState")
-	assert.Equal(t, types.Available, oldIPState.GetState(), "old IP incorrectly enters Available instead of PendingProgramming")
+	_, exists := svc.PodIPConfigState[oldIPID]
+	assert.False(t, exists, "old IP must not be recreated in PodIPConfigState")
+
+	currentIPState, exists := svc.PodIPConfigState[currentIPID]
+	require.True(t, exists, "current IP must be unaffected by the rejected stale replay")
+	assert.Equal(t, types.Available, currentIPState.GetState())
 }
 
-// TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP_ClusterData replays
-// the same bug using real data captured from a live AKS standalone cluster (Phase 1-2 of the guarded
+// TestCreateOrUpdateNetworkContainerInternal_EqualVersionIsIdempotent verifies that replaying the same
+// (currently stored) DNC/NNC version is accepted and idempotent, per the "incoming = stored" case in the
+// proposed correctness guard in nc-version-replay-repro-handoff.md.
+func TestCreateOrUpdateNetworkContainerInternal_EqualVersionIsIdempotent(t *testing.T) {
+	restartService()
+	setEnv(t)
+	setOrchestratorTypeInternal(cns.KubernetesCRD)
+	svc.state.ContainerStatus = make(map[string]containerstatus)
+	svc.PodIPConfigState = make(map[string]cns.IPConfigurationStatus)
+
+	testNCID := "555ac5c9-89f2-4b5d-b8d0-616894d6d150"
+	currentIPID := uuid.New().String()
+
+	svc.state.ContainerStatus[testNCID] = containerstatus{
+		ID:          testNCID,
+		VMVersion:   "10",
+		HostVersion: "10",
+		CreateNetworkContainerRequest: cns.CreateNetworkContainerRequest{
+			NetworkContainerid:   testNCID,
+			NetworkContainerType: dockerContainerType,
+			Version:              "10",
+			IPConfiguration: cns.IPConfiguration{
+				IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+			},
+			SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+				currentIPID: newSecondaryIPConfig("10.0.0.6", 10),
+			},
+		},
+	}
+	svc.PodIPConfigState[currentIPID] = newPodState("10.0.0.6", currentIPID, testNCID, types.Available, 10)
+
+	sameReq := &cns.CreateNetworkContainerRequest{
+		NetworkContainerid:   testNCID,
+		NetworkContainerType: dockerContainerType,
+		Version:              "10",
+		IPConfiguration: cns.IPConfiguration{
+			IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+		},
+		SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+			currentIPID: newSecondaryIPConfig("10.0.0.6", 10),
+		},
+	}
+
+	returnCode := svc.CreateOrUpdateNetworkContainerInternal(sameReq)
+
+	assert.Equal(t, types.Success, returnCode, "an equal-version replay must be accepted idempotently")
+	assert.Equal(t, "10", svc.state.ContainerStatus[testNCID].CreateNetworkContainerRequest.Version)
+}
+
+// TestCreateOrUpdateNetworkContainerInternal_HigherVersionIsAccepted verifies that a newer DNC/NNC
+// version is still accepted and reconciled normally, per the "incoming > stored" case in the proposed
+// correctness guard in nc-version-replay-repro-handoff.md.
+func TestCreateOrUpdateNetworkContainerInternal_HigherVersionIsAccepted(t *testing.T) {
+	restartService()
+	setEnv(t)
+	setOrchestratorTypeInternal(cns.KubernetesCRD)
+	svc.state.ContainerStatus = make(map[string]containerstatus)
+	svc.PodIPConfigState = make(map[string]cns.IPConfigurationStatus)
+
+	testNCID := "555ac5c9-89f2-4b5d-b8d0-616894d6d150"
+	currentIPID := uuid.New().String()
+	newIPID := uuid.New().String()
+
+	svc.state.ContainerStatus[testNCID] = containerstatus{
+		ID:          testNCID,
+		VMVersion:   "10",
+		HostVersion: "10",
+		CreateNetworkContainerRequest: cns.CreateNetworkContainerRequest{
+			NetworkContainerid:   testNCID,
+			NetworkContainerType: dockerContainerType,
+			Version:              "10",
+			IPConfiguration: cns.IPConfiguration{
+				IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+			},
+			SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+				currentIPID: newSecondaryIPConfig("10.0.0.6", 10),
+			},
+		},
+	}
+	svc.PodIPConfigState[currentIPID] = newPodState("10.0.0.6", currentIPID, testNCID, types.Available, 10)
+
+	newerReq := &cns.CreateNetworkContainerRequest{
+		NetworkContainerid:   testNCID,
+		NetworkContainerType: dockerContainerType,
+		Version:              "11",
+		IPConfiguration: cns.IPConfiguration{
+			IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+		},
+		SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+			newIPID: newSecondaryIPConfig("10.0.0.7", 11),
+		},
+	}
+
+	returnCode := svc.CreateOrUpdateNetworkContainerInternal(newerReq)
+
+	assert.Equal(t, types.Success, returnCode, "a newer-version update must be accepted")
+	assert.Equal(t, "11", svc.state.ContainerStatus[testNCID].CreateNetworkContainerRequest.Version)
+
+	newIPState, exists := svc.PodIPConfigState[newIPID]
+	require.True(t, exists)
+	// host version (10) has not yet caught up to the newly accepted NC version (11), so the new IP
+	// correctly awaits host programming rather than being marked Available.
+	assert.Equal(t, types.PendingProgramming, newIPState.GetState())
+	// the old IP, no longer present in the newer request, must have been removed
+	_, oldExists := svc.PodIPConfigState[currentIPID]
+	assert.False(t, oldExists)
+}
+
+// TestCreateOrUpdateNetworkContainerInternal_MalformedVersionFailsWithoutMutation verifies that a
+// non-numeric incoming or stored version is rejected without mutating any state, per
+// nc-version-replay-repro-handoff.md's "malformed versions fail without mutation" requirement.
+func TestCreateOrUpdateNetworkContainerInternal_MalformedVersionFailsWithoutMutation(t *testing.T) {
+	restartService()
+	setEnv(t)
+	setOrchestratorTypeInternal(cns.KubernetesCRD)
+	svc.state.ContainerStatus = make(map[string]containerstatus)
+	svc.PodIPConfigState = make(map[string]cns.IPConfigurationStatus)
+
+	testNCID := "555ac5c9-89f2-4b5d-b8d0-616894d6d150"
+	currentIPID := uuid.New().String()
+
+	svc.state.ContainerStatus[testNCID] = containerstatus{
+		ID:          testNCID,
+		VMVersion:   "10",
+		HostVersion: "10",
+		CreateNetworkContainerRequest: cns.CreateNetworkContainerRequest{
+			NetworkContainerid:   testNCID,
+			NetworkContainerType: dockerContainerType,
+			Version:              "10",
+			IPConfiguration: cns.IPConfiguration{
+				IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+			},
+			SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+				currentIPID: newSecondaryIPConfig("10.0.0.6", 10),
+			},
+		},
+	}
+	svc.PodIPConfigState[currentIPID] = newPodState("10.0.0.6", currentIPID, testNCID, types.Available, 10)
+
+	malformedReq := &cns.CreateNetworkContainerRequest{
+		NetworkContainerid:   testNCID,
+		NetworkContainerType: dockerContainerType,
+		Version:              "not-a-number",
+		IPConfiguration: cns.IPConfiguration{
+			IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+		},
+		SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+			currentIPID: newSecondaryIPConfig("10.0.0.6", 10),
+		},
+	}
+
+	returnCode := svc.CreateOrUpdateNetworkContainerInternal(malformedReq)
+
+	assert.Equal(t, types.UnsupportedNCVersion, returnCode, "a malformed version must be rejected")
+	assert.Equal(t, "10", svc.state.ContainerStatus[testNCID].CreateNetworkContainerRequest.Version, "stored version must not be mutated")
+}
+
+// TestCreateOrUpdateNetworkContainerInternal_StaleReplayCannotAlterAssignedIP verifies that even if a
+// stale replay were somehow processed, an already-Assigned secondary IP is never altered or removed --
+// this exercises the pre-existing Assigned-IP protection in updateIPConfigsStateUntransacted, which the
+// new version guard must not weaken.
+func TestCreateOrUpdateNetworkContainerInternal_StaleReplayCannotAlterAssignedIP(t *testing.T) {
+	restartService()
+	setEnv(t)
+	setOrchestratorTypeInternal(cns.KubernetesCRD)
+	svc.state.ContainerStatus = make(map[string]containerstatus)
+	svc.PodIPConfigState = make(map[string]cns.IPConfigurationStatus)
+
+	testNCID := "555ac5c9-89f2-4b5d-b8d0-616894d6d150"
+	assignedIPID := uuid.New().String()
+
+	svc.state.ContainerStatus[testNCID] = containerstatus{
+		ID:          testNCID,
+		VMVersion:   "10",
+		HostVersion: "10",
+		CreateNetworkContainerRequest: cns.CreateNetworkContainerRequest{
+			NetworkContainerid:   testNCID,
+			NetworkContainerType: dockerContainerType,
+			Version:              "10",
+			IPConfiguration: cns.IPConfiguration{
+				IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+			},
+			SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+				assignedIPID: newSecondaryIPConfig("10.0.0.6", 10),
+			},
+		},
+	}
+	svc.PodIPConfigState[assignedIPID] = newPodState("10.0.0.6", assignedIPID, testNCID, types.Assigned, 10)
+
+	// A stale replay (version 5) that no longer references the assigned IP at all.
+	staleReq := &cns.CreateNetworkContainerRequest{
+		NetworkContainerid:   testNCID,
+		NetworkContainerType: dockerContainerType,
+		Version:              "5",
+		IPConfiguration: cns.IPConfiguration{
+			IPSubnet: cns.IPSubnet{IPAddress: primaryIP, PrefixLength: subnetPrfixLength},
+		},
+		SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{},
+	}
+
+	returnCode := svc.CreateOrUpdateNetworkContainerInternal(staleReq)
+
+	assert.Equal(t, types.NetworkContainerVersionMismatch, returnCode, "the stale replay must be rejected before it can reach IP config deletion logic")
+
+	assignedIPState, exists := svc.PodIPConfigState[assignedIPID]
+	require.True(t, exists, "assigned IP must not be removed by a rejected stale replay")
+	assert.Equal(t, types.Assigned, assignedIPState.GetState(), "assigned IP state must be unchanged")
+}
+
+// TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP_ClusterData is a
+// regression test using real data captured from a live AKS standalone cluster (Phase 1-2 of the guarded
 // cluster reproduction in nc-version-replay-repro-handoff.md), instead of synthetic IDs:
 //   - NC ID c51b224b-b747-4063-b470-3676a74f13e8 was observed on node aks-gmp32-53174927-vmss000000.
 //   - Version 1 of that NC (captured while held-demand pods were still occupying IPs) assigned
 //     secondary IP d9ac4eef-344a-4025-99b6-96c6c6e2ec71 / 10.241.0.69.
 //   - After releasing the held-demand pods, the live NNC advanced to version 8 and that IP ID was
-//     confirmed absent from the current ipAssignments set (i.e. genuinely released cluster-side).
+//     confirmed absent from the current ipAssignments set (i.e. genuinely released cluster-side). A
+//     live-cluster replay of this exact captured version-1 payload (via a single NNC status patch on
+//     the real cluster, since reverted) reproduced the bug against the real running CNS binary too.
 //
-// This demonstrates the same code path resurrects a real, cluster-released address as Available when
-// fed a stale (version 1) replay of the NC payload against locally-stored state reflecting the newer
-// (version 8) baseline.
+// This verifies the fix using the same real, cluster-derived data: feeding a stale (version 1) replay
+// of the NC payload against locally-stored state reflecting the newer (version 8) baseline must now be
+// rejected, and the released address must remain absent.
 func TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsReleasedIP_ClusterData(t *testing.T) {
 	restartService()
 	setEnv(t)
@@ -433,15 +647,14 @@ func TestCreateOrUpdateNetworkContainerInternal_OlderVersionReplayResurrectsRele
 
 	returnCode := svc.CreateOrUpdateNetworkContainerInternal(oldReq)
 
-	require.Equal(t, types.Success, returnCode, "expected the stale cluster-captured NC replay to currently be accepted (demonstrating the bug)")
+	assert.Equal(t, types.NetworkContainerVersionMismatch, returnCode, "expected the stale cluster-captured NC replay to be rejected")
 
 	containerStatus := svc.state.ContainerStatus[clusterNCID]
-	assert.Equal(t, clusterOldVer, containerStatus.CreateNetworkContainerRequest.Version, "stored DNC version incorrectly drops from 8 to 1")
+	assert.Equal(t, clusterHostVer, containerStatus.CreateNetworkContainerRequest.Version, "stored DNC version must remain 8")
 	assert.Equal(t, clusterHostVer, containerStatus.HostVersion, "host version should remain unchanged")
 
-	releasedIPState, exists := svc.PodIPConfigState[releasedIPID]
-	require.True(t, exists, "cluster-released IP incorrectly recreated in PodIPConfigState")
-	assert.Equal(t, types.Available, releasedIPState.GetState(), "cluster-released IP incorrectly enters Available instead of PendingProgramming")
+	_, exists := svc.PodIPConfigState[releasedIPID]
+	assert.False(t, exists, "cluster-released IP must not be recreated in PodIPConfigState")
 }
 
 func TestSyncHostNCVersion(t *testing.T) {

--- a/cns/restserver/ipam_test.go
+++ b/cns/restserver/ipam_test.go
@@ -2355,7 +2355,7 @@ func createAndSaveMockNCRequest(t *testing.T, svc *HTTPRestService, ncID string,
 	require.NoError(t, err)
 
 	// save SwiftV2 NC state in CNS
-	returnCode, returnMessage := svc.saveNetworkContainerGoalState(*createNCReq)
+	returnCode, returnMessage := svc.saveNetworkContainerGoalState(*createNCReq, false)
 	require.Equal(t, types.Success, returnCode)
 	require.Empty(t, returnMessage)
 }

--- a/cns/restserver/nodesubnet.go
+++ b/cns/restserver/nodesubnet.go
@@ -22,7 +22,7 @@ func (service *HTTPRestService) UpdateIPsForNodeSubnet(secondaryIPs []netip.Addr
 
 	networkContainerRequest := nodesubnet.CreateNodeSubnetNCRequest(secondaryIPStrs)
 
-	code, msg := service.saveNetworkContainerGoalState(*networkContainerRequest)
+	code, msg := service.saveNetworkContainerGoalState(*networkContainerRequest, false)
 	if code != types.Success {
 		return errors.Errorf("failed to save fetched ips. code: %d, message %s", code, msg)
 	}

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -170,7 +170,6 @@ func (service *HTTPRestService) saveNetworkContainerGoalState(req cns.CreateNetw
 		// recreated as Available. This only applies to the KubernetesCRD (dynamic NNC-driven) IPAM
 		// path when both requests carry a version to compare: other orchestrator types/flows don't
 		// always populate a meaningful NC version here.
-		// See nc-version-replay-repro-handoff.md for full analysis.
 		storedVersionStr := existingNCStatus.CreateNetworkContainerRequest.Version
 		if req.NetworkContainerid != nodesubnet.NodeSubnetNCID && service.state.OrchestratorType == cns.KubernetesCRD &&
 			storedVersionStr != "" && req.Version != "" {

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -162,6 +162,33 @@ func (service *HTTPRestService) saveNetworkContainerGoalState(req cns.CreateNetw
 		hostVersion = existingNCStatus.HostVersion
 		existingSecondaryIPConfigs = existingNCStatus.CreateNetworkContainerRequest.SecondaryIPConfigs
 		vfpUpdateComplete = existingNCStatus.VfpUpdateComplete
+
+		// Guard against replay of a stale NC payload: reject (without mutating any state) an incoming
+		// DNC/NNC version that is older than the version CNS already has stored for this NC. Without
+		// this check, a stale replay would be accepted, the stored version would incorrectly move
+		// backwards, and secondary IPs already released (and removed from PodIPConfigState) could be
+		// recreated as Available. This only applies to the KubernetesCRD (dynamic NNC-driven) IPAM
+		// path when both requests carry a version to compare: other orchestrator types/flows don't
+		// always populate a meaningful NC version here.
+		// See nc-version-replay-repro-handoff.md for full analysis.
+		storedVersionStr := existingNCStatus.CreateNetworkContainerRequest.Version
+		if req.NetworkContainerid != nodesubnet.NodeSubnetNCID && service.state.OrchestratorType == cns.KubernetesCRD &&
+			storedVersionStr != "" && req.Version != "" {
+			storedVersion, storedErr := strconv.Atoi(storedVersionStr)
+			incomingVersion, incomingErr := strconv.Atoi(req.Version)
+			switch {
+			case storedErr != nil || incomingErr != nil:
+				errBuf := fmt.Sprintf(
+					"[Azure CNS] Unable to compare NC versions for %s: stored version %q, incoming version %q",
+					req.NetworkContainerid, storedVersionStr, req.Version)
+				return types.UnsupportedNCVersion, errBuf
+			case incomingVersion < storedVersion:
+				errBuf := fmt.Sprintf(
+					"[Azure CNS] Rejecting stale NC update for %s: incoming version %d is older than stored version %d",
+					req.NetworkContainerid, incomingVersion, storedVersion)
+				return types.NetworkContainerVersionMismatch, errBuf
+			}
+		}
 	}
 
 	if req.NetworkContainerid == nodesubnet.NodeSubnetNCID {

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -142,7 +143,10 @@ func (service *HTTPRestService) restoreState() {
 	}
 }
 
-func (service *HTTPRestService) saveNetworkContainerGoalState(req cns.CreateNetworkContainerRequest) (types.ResponseCode, string) { //nolint // legacy
+func (service *HTTPRestService) saveNetworkContainerGoalState(
+	req cns.CreateNetworkContainerRequest,
+	validateVersion bool,
+) (responseCode types.ResponseCode, message string) {
 	// we don't want to overwrite what other calls may have written
 	service.Lock()
 	defer service.Unlock()
@@ -163,29 +167,9 @@ func (service *HTTPRestService) saveNetworkContainerGoalState(req cns.CreateNetw
 		existingSecondaryIPConfigs = existingNCStatus.CreateNetworkContainerRequest.SecondaryIPConfigs
 		vfpUpdateComplete = existingNCStatus.VfpUpdateComplete
 
-		// Guard against replay of a stale NC payload: reject (without mutating any state) an incoming
-		// DNC/NNC version that is older than the version CNS already has stored for this NC. Without
-		// this check, a stale replay would be accepted, the stored version would incorrectly move
-		// backwards, and secondary IPs already released (and removed from PodIPConfigState) could be
-		// recreated as Available. This only applies to the KubernetesCRD (dynamic NNC-driven) IPAM
-		// path when both requests carry a version to compare: other orchestrator types/flows don't
-		// always populate a meaningful NC version here.
-		storedVersionStr := existingNCStatus.CreateNetworkContainerRequest.Version
-		if req.NetworkContainerid != nodesubnet.NodeSubnetNCID && service.state.OrchestratorType == cns.KubernetesCRD &&
-			storedVersionStr != "" && req.Version != "" {
-			storedVersion, storedErr := strconv.Atoi(storedVersionStr)
-			incomingVersion, incomingErr := strconv.Atoi(req.Version)
-			switch {
-			case storedErr != nil || incomingErr != nil:
-				errBuf := fmt.Sprintf(
-					"[Azure CNS] Unable to compare NC versions for %s: stored version %q, incoming version %q",
-					req.NetworkContainerid, storedVersionStr, req.Version)
-				return types.UnsupportedNCVersion, errBuf
-			case incomingVersion < storedVersion:
-				errBuf := fmt.Sprintf(
-					"[Azure CNS] Rejecting stale NC update for %s: incoming version %d is older than stored version %d",
-					req.NetworkContainerid, incomingVersion, storedVersion)
-				return types.NetworkContainerVersionMismatch, errBuf
+		if validateVersion {
+			if returnCode, returnMessage := validateNCGoalVersion(existingNCStatus.CreateNetworkContainerRequest, req); returnCode != types.Success {
+				return returnCode, returnMessage
 			}
 		}
 	}
@@ -278,6 +262,86 @@ func (service *HTTPRestService) saveNetworkContainerGoalState(req cns.CreateNetw
 
 	service.saveState()
 	return 0, ""
+}
+
+// validateNCGoalVersion rejects an incoming NC goal state that would regress the previously
+// committed DNC/NNC version for this NC, or that claims the same version as what's already
+// committed but with different content (a goal changed "under" a version that should be immutable).
+// Without this check, a stale/replayed NC payload could move the stored version backwards and
+// cause secondary IPs that were already released (and removed from PodIPConfigState) to be
+// resurrected as Available.
+func validateNCGoalVersion(
+	existing,
+	incoming cns.CreateNetworkContainerRequest,
+) (responseCode types.ResponseCode, message string) {
+	existingVersion, err := strconv.Atoi(existing.Version)
+	if err != nil {
+		return types.UnsupportedNCVersion, fmt.Sprintf(
+			"invalid committed nc version %q for nc %s: %v",
+			existing.Version,
+			incoming.NetworkContainerid,
+			err,
+		)
+	}
+
+	incomingVersion, err := strconv.Atoi(incoming.Version)
+	if err != nil {
+		return types.UnsupportedNCVersion, fmt.Sprintf(
+			"invalid incoming nc version %q for nc %s: %v",
+			incoming.Version,
+			incoming.NetworkContainerid,
+			err,
+		)
+	}
+
+	switch {
+	case incomingVersion < existingVersion:
+		return types.UnsupportedNCVersion, fmt.Sprintf(
+			"nc %s version regressed from %d to %d",
+			incoming.NetworkContainerid,
+			existingVersion,
+			incomingVersion,
+		)
+	case incomingVersion == existingVersion && !equalNNCNetworkProgrammingGoal(existing, incoming):
+		return types.InconsistentIPConfigState, fmt.Sprintf(
+			"nc %s goal changed without version advance at version %d",
+			incoming.NetworkContainerid,
+			incomingVersion,
+		)
+	default:
+		return types.Success, ""
+	}
+}
+
+// equalNNCNetworkProgrammingGoal reports whether two NC goal states describe the same thing CNS
+// should program: same primary/secondary IP configuration, host, status, and interface info.
+func equalNNCNetworkProgrammingGoal(existing, incoming cns.CreateNetworkContainerRequest) bool {
+	if existing.NetworkContainerid != incoming.NetworkContainerid ||
+		existing.NetworkContainerType != incoming.NetworkContainerType ||
+		existing.HostPrimaryIP != incoming.HostPrimaryIP ||
+		existing.NCStatus != incoming.NCStatus ||
+		existing.NetworkInterfaceInfo != incoming.NetworkInterfaceInfo ||
+		!equalIPConfiguration(existing.IPConfiguration, incoming.IPConfiguration) ||
+		len(existing.SecondaryIPConfigs) != len(incoming.SecondaryIPConfigs) {
+		return false
+	}
+
+	for ipID, existingConfig := range existing.SecondaryIPConfigs {
+		incomingConfig, ok := incoming.SecondaryIPConfigs[ipID]
+		if !ok || existingConfig.IPAddress != incomingConfig.IPAddress {
+			return false
+		}
+	}
+
+	return true
+}
+
+func equalIPConfiguration(existing, incoming cns.IPConfiguration) bool {
+	return existing.IPSubnet == incoming.IPSubnet &&
+		existing.IPSubnetV6 == incoming.IPSubnetV6 &&
+		slices.Equal(existing.DNSServers, incoming.DNSServers) &&
+		existing.GatewayIPAddress == incoming.GatewayIPAddress &&
+		existing.GatewayIPv6Address == incoming.GatewayIPv6Address
 }
 
 // This func will compute the deltaIpConfigState which needs to be updated (Added or Deleted) from the inmemory map
@@ -1032,7 +1096,7 @@ func (service *HTTPRestService) createNetworkContainers(createNetworkContainerRe
 			}
 		}
 		// Save NC Goal State details
-		saveNcReturnCode, saveNcReturnMessage := service.saveNetworkContainerGoalState(createNcReq)
+		saveNcReturnCode, saveNcReturnMessage := service.saveNetworkContainerGoalState(createNcReq, false)
 		// If NC was created successfully, log NC snapshot.
 		if saveNcReturnCode != types.Success {
 			return cns.Response{

--- a/cns/restserver/util_test.go
+++ b/cns/restserver/util_test.go
@@ -1,15 +1,241 @@
 package restserver
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/cns/common"
+	"github.com/Azure/azure-container-networking/cns/types"
 	acn "github.com/Azure/azure-container-networking/common"
+	"github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	"github.com/Azure/azure-container-networking/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const (
+	versionValidationNCID               = "version-validation-nc"
+	versionValidationSecondaryIP        = "10.0.0.6"
+	versionValidationChangedSecondaryIP = "10.0.0.7"
+	versionValidationDNSServer          = "10.0.0.10"
+	versionValidationMACAddress         = "00:11:22:33:44:55"
+	versionValidationInitialVersion     = 2
+)
+
+// TestSaveNetworkContainerGoalStateRejectsVersionRegression, TestSaveNetworkContainerGoalStateAcceptsVersionAdvance,
+// TestSaveNetworkContainerGoalStateAcceptsIdenticalVersionReplay, and
+// TestSaveNetworkContainerGoalStateRejectsEqualVersionGoalDrift exercise validateNCGoalVersion directly
+// through saveNetworkContainerGoalState(req, validateVersion=true): a version regression must be
+// rejected, a version advance must be accepted, an identical replay must be accepted idempotently, and
+// a same-version request whose actual programming goal differs from what's committed must be rejected
+// (goal drift), since the version alone would otherwise not catch a corrupted/inconsistent replay.
+func TestSaveNetworkContainerGoalStateRejectsVersionRegression(t *testing.T) {
+	svc, committed := newVersionValidationService(t)
+	incoming := cloneCreateNetworkContainerRequest(committed)
+	incoming.Version = "1"
+	for ipID, config := range incoming.SecondaryIPConfigs {
+		config.NCVersion = 1
+		incoming.SecondaryIPConfigs[ipID] = config
+	}
+
+	returnCode, message := svc.saveNetworkContainerGoalState(incoming, true)
+
+	assert.Equal(t, types.UnsupportedNCVersion, returnCode)
+	assert.Contains(t, message, "version regressed from 2 to 1")
+	assertCommittedGoalVersion(t, svc, "2")
+}
+
+func TestSaveNetworkContainerGoalStateAcceptsVersionAdvance(t *testing.T) {
+	svc, committed := newVersionValidationService(t)
+	incoming := cloneCreateNetworkContainerRequest(committed)
+	incoming.Version = "3"
+	for ipID, config := range incoming.SecondaryIPConfigs {
+		config.NCVersion = 3
+		incoming.SecondaryIPConfigs[ipID] = config
+	}
+
+	returnCode, message := svc.saveNetworkContainerGoalState(incoming, true)
+
+	assert.Equal(t, types.Success, returnCode)
+	assert.Empty(t, message)
+	assertCommittedGoalVersion(t, svc, "3")
+}
+
+func TestSaveNetworkContainerGoalStateAcceptsIdenticalVersionReplay(t *testing.T) {
+	svc, committed := newVersionValidationService(t)
+
+	returnCode, message := svc.saveNetworkContainerGoalState(cloneCreateNetworkContainerRequest(committed), true)
+
+	assert.Equal(t, types.Success, returnCode)
+	assert.Empty(t, message)
+	assertCommittedGoalVersion(t, svc, "2")
+}
+
+func TestSaveNetworkContainerGoalStateRejectsEqualVersionGoalDrift(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*cns.CreateNetworkContainerRequest)
+	}{
+		{
+			name: "host primary IP",
+			mutate: func(req *cns.CreateNetworkContainerRequest) {
+				req.HostPrimaryIP = "10.1.0.11"
+			},
+		},
+		{
+			name: "network container type",
+			mutate: func(req *cns.CreateNetworkContainerRequest) {
+				req.NetworkContainerType = cns.Kubernetes
+			},
+		},
+		{
+			name: "primary subnet",
+			mutate: func(req *cns.CreateNetworkContainerRequest) {
+				req.IPConfiguration.IPSubnet.IPAddress = "10.0.1.5"
+			},
+		},
+		{
+			name: "IPv6 subnet",
+			mutate: func(req *cns.CreateNetworkContainerRequest) {
+				req.IPConfiguration.IPSubnetV6.IPAddress = "fd00::6"
+			},
+		},
+		{
+			name: "DNS servers",
+			mutate: func(req *cns.CreateNetworkContainerRequest) {
+				req.IPConfiguration.DNSServers = []string{"10.0.0.11"}
+			},
+		},
+		{
+			name: "gateway",
+			mutate: func(req *cns.CreateNetworkContainerRequest) {
+				req.IPConfiguration.GatewayIPAddress = "10.0.0.2"
+			},
+		},
+		{
+			name: "IPv6 gateway",
+			mutate: func(req *cns.CreateNetworkContainerRequest) {
+				req.IPConfiguration.GatewayIPv6Address = "fd00::2"
+			},
+		},
+		{
+			name: "NC status",
+			mutate: func(req *cns.CreateNetworkContainerRequest) {
+				req.NCStatus = v1alpha.NCStatus("updated")
+			},
+		},
+		{
+			name: "network interface",
+			mutate: func(req *cns.CreateNetworkContainerRequest) {
+				req.NetworkInterfaceInfo.MACAddress = "00:11:22:33:44:66"
+			},
+		},
+		{
+			name: "secondary IP address",
+			mutate: func(req *cns.CreateNetworkContainerRequest) {
+				config := req.SecondaryIPConfigs["ip-id-1"]
+				config.IPAddress = versionValidationChangedSecondaryIP
+				req.SecondaryIPConfigs["ip-id-1"] = config
+			},
+		},
+		{
+			name: "secondary IP ID",
+			mutate: func(req *cns.CreateNetworkContainerRequest) {
+				config := req.SecondaryIPConfigs["ip-id-1"]
+				delete(req.SecondaryIPConfigs, "ip-id-1")
+				req.SecondaryIPConfigs["replacement-id"] = config
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, committed := newVersionValidationService(t)
+			incoming := cloneCreateNetworkContainerRequest(committed)
+			tt.mutate(&incoming)
+			before := cloneCreateNetworkContainerRequest(svc.state.ContainerStatus[versionValidationNCID].CreateNetworkContainerRequest)
+			beforeIPCount := len(svc.PodIPConfigState)
+
+			returnCode, message := svc.saveNetworkContainerGoalState(incoming, true)
+
+			assert.Equal(t, types.InconsistentIPConfigState, returnCode)
+			assert.Contains(t, message, "goal changed without version advance")
+			assert.Equal(t, before, svc.state.ContainerStatus[versionValidationNCID].CreateNetworkContainerRequest)
+			assert.Len(t, svc.PodIPConfigState, beforeIPCount)
+			assertCommittedGoalVersion(t, svc, "2")
+		})
+	}
+}
+
+func newVersionValidationService(t *testing.T) (*HTTPRestService, cns.CreateNetworkContainerRequest) {
+	t.Helper()
+
+	svc := &HTTPRestService{
+		store: store.NewMockStore(""),
+		state: &httpRestServiceState{
+			OrchestratorType: cns.KubernetesCRD,
+			ContainerStatus:  make(map[string]containerstatus),
+		},
+		PodIPConfigState: make(map[string]cns.IPConfigurationStatus),
+	}
+	req := cns.CreateNetworkContainerRequest{
+		HostPrimaryIP:        "10.1.0.10",
+		Version:              "2",
+		NetworkContainerType: cns.Docker,
+		NetworkContainerid:   versionValidationNCID,
+		IPConfiguration: cns.IPConfiguration{
+			IPSubnet: cns.IPSubnet{
+				IPAddress:    primaryIP,
+				PrefixLength: 24,
+			},
+			IPSubnetV6: cns.IPSubnet{
+				IPAddress:    "fd00::5",
+				PrefixLength: 64,
+			},
+			DNSServers:         []string{versionValidationDNSServer},
+			GatewayIPAddress:   "10.0.0.1",
+			GatewayIPv6Address: "fd00::1",
+		},
+		SecondaryIPConfigs: map[string]cns.SecondaryIPConfig{
+			"ip-id-1": {
+				IPAddress: versionValidationSecondaryIP,
+				NCVersion: versionValidationInitialVersion,
+			},
+		},
+		NCStatus: v1alpha.NCStatus("ready"),
+		NetworkInterfaceInfo: cns.NetworkInterfaceInfo{
+			MACAddress: versionValidationMACAddress,
+		},
+	}
+	req.Version = strconv.Itoa(versionValidationInitialVersion)
+
+	returnCode, message := svc.saveNetworkContainerGoalState(req, true)
+	require.Equal(t, types.Success, returnCode)
+	require.Empty(t, message)
+
+	return svc, req
+}
+
+func cloneCreateNetworkContainerRequest(req cns.CreateNetworkContainerRequest) cns.CreateNetworkContainerRequest {
+	cloned := req
+	cloned.IPConfiguration.DNSServers = append([]string(nil), req.IPConfiguration.DNSServers...)
+	cloned.SecondaryIPConfigs = make(map[string]cns.SecondaryIPConfig, len(req.SecondaryIPConfigs))
+	for ipID, config := range req.SecondaryIPConfigs {
+		cloned.SecondaryIPConfigs[ipID] = config
+	}
+	return cloned
+}
+
+func assertCommittedGoalVersion(t *testing.T, svc *HTTPRestService, want string) {
+	t.Helper()
+
+	assert.Equal(t, want, svc.state.ContainerStatus[versionValidationNCID].CreateNetworkContainerRequest.Version)
+
+	var persisted httpRestServiceState
+	require.NoError(t, svc.store.Read(storeKey, &persisted))
+	assert.Equal(t, want, persisted.ContainerStatus[versionValidationNCID].CreateNetworkContainerRequest.Version)
+}
 
 func TestAreNCsPresent(t *testing.T) {
 	present := ncList("present")

--- a/cns/types/codes.go
+++ b/cns/types/codes.go
@@ -45,7 +45,6 @@ const (
 	UnsupportedAPI                         ResponseCode = 43
 	FailedToAllocateBackendConfig          ResponseCode = 44
 	ConnectionError                        ResponseCode = 45
-	NetworkContainerVersionMismatch        ResponseCode = 46
 	UnexpectedError                        ResponseCode = 99
 	NmAgentNCVersionListError              ResponseCode = 100
 )
@@ -87,8 +86,6 @@ func (c ResponseCode) String() string {
 		return "NetworkContainerVfpProgramComplete"
 	case NetworkContainerVfpProgramPending:
 		return "NetworkContainerVfpProgramPending"
-	case NetworkContainerVersionMismatch:
-		return "NetworkContainerVersionMismatch"
 	case NetworkJoinFailed:
 		return "NetworkJoinFailed"
 	case NmAgentSupportedApisError:

--- a/cns/types/codes.go
+++ b/cns/types/codes.go
@@ -45,6 +45,7 @@ const (
 	UnsupportedAPI                         ResponseCode = 43
 	FailedToAllocateBackendConfig          ResponseCode = 44
 	ConnectionError                        ResponseCode = 45
+	NetworkContainerVersionMismatch        ResponseCode = 46
 	UnexpectedError                        ResponseCode = 99
 	NmAgentNCVersionListError              ResponseCode = 100
 )
@@ -86,6 +87,8 @@ func (c ResponseCode) String() string {
 		return "NetworkContainerVfpProgramComplete"
 	case NetworkContainerVfpProgramPending:
 		return "NetworkContainerVfpProgramPending"
+	case NetworkContainerVersionMismatch:
+		return "NetworkContainerVersionMismatch"
 	case NetworkJoinFailed:
 		return "NetworkJoinFailed"
 	case NmAgentSupportedApisError:


### PR DESCRIPTION
## Summary

CNS did not compare an incoming dynamic NNC NetworkContainer version with the version already committed for the same NC ID. A stale NNC replay could therefore move CNS state backwards and recreate a previously released secondary IP as `Available`.

This PR adds opt-in monotonic version validation for the dynamic/pod-subnet NNC path, protects startup initialization with a non-mutating preflight, preserves validation failures across the SNAT path, and moves destructive stale-NC cleanup after successful NC validation and application.

The production-code diff is approximately 197 additions and 36 deletions. Most of the PR size is regression coverage: approximately 815 added test lines.

## Root cause

`saveNetworkContainerGoalState` previously replaced the stored `CreateNetworkContainerRequest`, including its version, before checking whether the incoming DNC/NNC version was older than the committed version.

Downstream IP state reconstruction compares each secondary IP's NC version with the NMAgent host version. Once an older request had replaced the committed state, a released IP present in that stale request could be recreated as `Available`.

## Behavioral changes

### Dynamic NC version validation

The NNC reconciler enables validation only for dynamic/pod-subnet NCs. Static/SwiftV2 and other existing callers continue through the legacy non-versioned path.

For a dynamic NC:

- malformed incoming version: reject before mutation;
- no existing NC: accept a valid incoming version as the initial baseline;
- empty legacy stored version: accept the next valid dynamic update as the baseline;
- malformed non-empty stored version: reject;
- incoming version lower than stored: reject;
- incoming version equal to stored with a changed programming goal: reject;
- incoming version equal to stored with the same programming goal: accept idempotently;
- incoming version higher than stored: accept and reconcile normally.

The equal-version programming-goal comparison includes the NC identity/type, host primary IP, primary and IPv6 IP configuration, gateways, DNS servers, network-interface information, and secondary IP IDs/addresses.

It intentionally excludes:

- `AuthorizationToken`, because it is removed before persistence;
- `OrchestratorContext`, because JSON persistence can normalize `nil` to `null`;
- `NCStatus`, because it is a request-result status that may legitimately change without a version advance;
- `SecondaryIPConfig.NCVersion`, because CNS preserves the previous per-IP value for retained IPs until host programming catches up.

### Startup preflight

On every reconciliation, all NC requests are converted first and dynamic requests are validated without mutating CNS state. This occurs before the first-reconcile initializer, preventing the legacy `CreateNCs` startup path from overwriting restored version state with a lower cached version.

The apply path validates again while holding the CNS state lock, so state cannot change between preflight and mutation without being rechecked.

### SNAT error preservation

`CreateOrUpdateNetworkContainerInternal` now returns immediately when goal-state persistence returns a non-success response. SNAT programming can no longer overwrite a stale-version or other persistence failure with `Success`.

This early return applies to every existing non-success result from goal-state persistence, not only version mismatches.

### Stale-NC cleanup ordering

`MustEnsureNoStaleNCs` now runs only after all incoming NCs have passed preflight and the create/update loop has completed successfully. A rejected stale or malformed NC therefore cannot trigger cleanup first.

This PR does **not** establish a whole-NNC generation or freshness token. A stale NNC that entirely omits a newer NC ID still provides no per-NC version to compare. Solving that safely requires an authoritative uncached NNC read or a control-plane generation contract and is left as follow-up work.

## Risk assessment

### Intentional behavior and compatibility boundaries

- Validation is opt-in and limited to dynamic NNC NCs. Static/SwiftV2, NodeSubnet, multitenant, HTTP, and other legacy internal flows retain their existing behavior.
- Dynamic validation is fail-closed. A malformed version, regression, or same-version programming-goal conflict blocks that reconciliation until the NNC or persisted state is corrected.
- An empty legacy stored version is treated as unknown and the next valid dynamic update establishes the baseline.
- A legitimate control-plane version reset using the same NC ID would be rejected as a regression. The expected recovery is a new NC ID or explicit state repair; automatically accepting a lower version would reopen the replay bug.
- Version rejections reuse `UnsupportedNCVersion`, so callers cannot distinguish a stale replay from malformed version data by response code alone. Logs retain the specific reason.

### Reconciler blast radius

- Preflight is all-or-nothing: one invalid dynamic NC prevents the initializer and all NC application for that pass. This avoids partial startup mutation from a known-invalid NNC.
- NC application itself remains sequential rather than transactional. A later non-version error, persistence failure, SNAT failure, or listener failure can occur after earlier NCs were applied; retries remain responsible for convergence.
- Validation occurs before the node-IP filter because the startup initializer consumes the unfiltered NNC. A malformed dynamic NC associated with another node can therefore block startup. This preserves the invariant that the initializer cannot consume an unvalidated dynamic NC.
- Stale cleanup is skipped whenever preflight or application fails. Existing stale state can remain until a subsequent successful reconciliation.
- `MustEnsureNoStaleNCs` retains its existing assigned-IP safety behavior: an omitted stale NC with assigned IPs causes a deliberate panic rather than deletion.

### Known residual risk

The remaining important gap is NC-set freshness. Version validation protects the contents of NCs present in the incoming NNC, but cannot detect a newer local NC omitted entirely from a stale NNC snapshot. Cleanup ordering reduces mutation on explicit validation failures but does not solve this omission case.

## Regression coverage

Coverage includes:

- stale lower-version replay rejection without released-IP resurrection;
- equal-version idempotence and same-version goal drift;
- higher-version acceptance;
- malformed first-seen, incoming, and persisted versions;
- empty legacy-version baseline establishment;
- retained-IP replay where per-IP `NCVersion` differs;
- same-version NC status transitions;
- JSON file-store save/restore compatibility;
- SNAT-enabled rejection preservation;
- startup preflight before initializer, create/update, or cleanup;
- static NC version-validation bypass;
- initializer retry and successful one-time initialization;
- cleanup occurring only after successful NC validation/application.

## Validation

```text
go test ./cns/...
golangci-lint run --new-from-rev=origin/master --config=.golangci.yml --timeout=25m ./cns/...
```
