### PR TITLE
test: cover the async delete create event received while CNS runs

### DIFF
--- a/hack/scripts/async-delete-test.sh
+++ b/hack/scripts/async-delete-test.sh
@@ -48,3 +48,77 @@ do
     fi
 done
 
+# The loop above stops CNS before it deletes the Pod, so the pending delete file
+# is always on disk before CNS starts and CNS reads it in the startup directory
+# scan. When CNS runs but does not answer, the file instead appears while the
+# fsnotify watcher listens. That is a different code path and it must release the
+# IP without a CNS restart. SIGSTOP gives that state: the socket stays open, the
+# CNI request times out after 15s, and the kernel queues the create event until
+# SIGCONT. shareProcessNamespace on the daemonset lets the debug container signal
+# the CNS process.
+echo "verify async delete for a create event received while CNS runs"
+kubectl rollout status deployment busybox
+
+busybox_pod=$(kubectl get pods -l k8s-app=busybox --no-headers -o custom-columns=NAME:.metadata.name | head -1)
+if [ -z "$busybox_pod" ]; then
+    echo "##[error]no busybox pod found"
+    exit 1
+fi
+node_name=$(kubectl get pod $busybox_pod -o jsonpath='{.spec.nodeName}')
+cns_pod=$(kubectl get pods -l k8s-app=azure-cns -n kube-system -o jsonpath="{.items[?(@.spec.nodeName=='$node_name')].metadata.name}")
+if [ -z "$cns_pod" ]; then
+    echo "##[error]no CNS pod on node $node_name"
+    exit 1
+fi
+
+cns_pid=$(kubectl exec -i $cns_pod -c debug -n kube-system -- sh -c 'for p in /proc/[0-9]*; do if [ "$(cat $p/comm 2>/dev/null)" = "azure-cns" ]; then echo ${p#/proc/}; fi; done' | tr -d '\r' | head -1)
+if [ -z "$cns_pid" ]; then
+    echo "##[error]azure-cns process not visible from the debug container. is shareProcessNamespace set on the daemonset?"
+    exit 1
+fi
+
+restarts_before=$(kubectl get pod $cns_pod -n kube-system -o jsonpath='{.status.containerStatuses[?(@.name=="cns-container")].restartCount}')
+
+echo "stop the CNS process $cns_pid so the CNI cannot reach it"
+kubectl exec -i $cns_pod -c debug -n kube-system -- sh -c "kill -STOP $cns_pid"
+
+echo "delete busybox pod $busybox_pod. the CNI DEL waits for the 15s CNS request timeout"
+kubectl delete pod $busybox_pod --timeout=120s
+
+echo "check the CNI wrote a pending delete while CNS was stopped"
+pending_file=$(kubectl exec -i $cns_pod -c debug -n kube-system -- ls /var/run/azure-vnet/deleteIDs)
+
+echo "resume the CNS process"
+kubectl exec -i $cns_pod -c debug -n kube-system -- sh -c "kill -CONT $cns_pid"
+
+if [ -z "$pending_file" ]; then
+    echo "##[error]async delete failure. the CNI wrote no file, so the async delete path did not run."
+    exit 1
+fi
+echo "pending deletes"
+echo $pending_file
+
+echo "wait up to 60s for CNS to process the create event"
+waited=0
+while [ $waited -lt 60 ]; do
+    sleep 5s
+    waited=$((waited + 5))
+    live_file=$(kubectl exec -i $cns_pod -c debug -n kube-system -- ls /var/run/azure-vnet/deleteIDs)
+    if [ -z "$live_file" ]; then
+        break
+    fi
+done
+
+if [ -n "$live_file" ]; then
+    echo "##[error]async delete failure. CNS did not process the create event. file still exists in deleteIDs directory."
+    exit 1
+fi
+
+restarts_after=$(kubectl get pod $cns_pod -n kube-system -o jsonpath='{.status.containerStatuses[?(@.name=="cns-container")].restartCount}')
+if [ "$restarts_before" != "$restarts_after" ]; then
+    echo "##[error]async delete failure. CNS restarted, so the startup scan processed the file instead of the create event."
+    exit 1
+fi
+
+echo "async delete success for the create event"
+

--- a/hack/scripts/async-delete-test.sh
+++ b/hack/scripts/async-delete-test.sh
@@ -65,9 +65,9 @@ if [ -z "$busybox_pod" ]; then
     exit 1
 fi
 node_name=$(kubectl get pod $busybox_pod -o jsonpath='{.spec.nodeName}')
-cns_pod=$(kubectl get pods -l k8s-app=azure-cns -n kube-system -o jsonpath="{.items[?(@.spec.nodeName=='$node_name')].metadata.name}")
+cns_pod=$(kubectl get pods -l k8s-app=azure-cns -n kube-system --field-selector "spec.nodeName=$node_name,status.phase=Running" -o jsonpath='{.items[0].metadata.name}')
 if [ -z "$cns_pod" ]; then
-    echo "##[error]no CNS pod on node $node_name"
+    echo "##[error]no running CNS pod on node $node_name"
     exit 1
 fi
 
@@ -79,6 +79,12 @@ fi
 
 restarts_before=$(kubectl get pod $cns_pod -n kube-system -o jsonpath='{.status.containerStatuses[?(@.name=="cns-container")].restartCount}')
 
+# a paused CNS breaks every later step, so always resume it, on any exit path
+resume_cns() {
+    kubectl exec -i $cns_pod -c debug -n kube-system -- sh -c "kill -CONT $cns_pid" > /dev/null 2>&1
+}
+trap resume_cns EXIT INT TERM
+
 echo "stop the CNS process $cns_pid so the CNI cannot reach it"
 kubectl exec -i $cns_pod -c debug -n kube-system -- sh -c "kill -STOP $cns_pid"
 
@@ -86,7 +92,10 @@ echo "delete busybox pod $busybox_pod. the CNI DEL waits for the 15s CNS request
 kubectl delete pod $busybox_pod --timeout=120s
 
 echo "check the CNI wrote a pending delete while CNS was stopped"
-pending_file=$(kubectl exec -i $cns_pod -c debug -n kube-system -- ls /var/run/azure-vnet/deleteIDs)
+if ! pending_file=$(kubectl exec -i $cns_pod -c debug -n kube-system -- ls /var/run/azure-vnet/deleteIDs 2>&1); then
+    echo "##[error]could not list the deleteIDs directory: $pending_file"
+    exit 1
+fi
 
 echo "resume the CNS process"
 kubectl exec -i $cns_pod -c debug -n kube-system -- sh -c "kill -CONT $cns_pid"
@@ -96,20 +105,26 @@ if [ -z "$pending_file" ]; then
     exit 1
 fi
 echo "pending deletes"
-echo $pending_file
+echo "$pending_file"
 
 echo "wait up to 60s for CNS to process the create event"
 waited=0
+drained=false
 while [ $waited -lt 60 ]; do
     sleep 5s
     waited=$((waited + 5))
-    live_file=$(kubectl exec -i $cns_pod -c debug -n kube-system -- ls /var/run/azure-vnet/deleteIDs)
-    if [ -z "$live_file" ]; then
-        break
+    # only an empty listing that actually succeeded proves the release happened
+    if live_file=$(kubectl exec -i $cns_pod -c debug -n kube-system -- ls /var/run/azure-vnet/deleteIDs 2>&1); then
+        if [ -z "$live_file" ]; then
+            drained=true
+            break
+        fi
+    else
+        echo "could not list the deleteIDs directory, retrying: $live_file"
     fi
 done
 
-if [ -n "$live_file" ]; then
+if [ "$drained" != "true" ]; then
     echo "##[error]async delete failure. CNS did not process the create event. file still exists in deleteIDs directory."
     exit 1
 fi

--- a/test/integration/manifests/cns/daemonset-linux.yaml
+++ b/test/integration/manifests/cns/daemonset-linux.yaml
@@ -124,6 +124,9 @@ spec:
             - name: cni-conflist
               mountPath: /etc/cni/net.d
       hostNetwork: true
+      # lets the debug container signal the CNS process, which async-delete-test.sh
+      # uses to make CNS unreachable without stopping it
+      shareProcessNamespace: true
       volumes:
         - name: cni-conflist
           hostPath:

--- a/test/integration/manifests/cns/daemonset-linux.yaml
+++ b/test/integration/manifests/cns/daemonset-linux.yaml
@@ -124,8 +124,9 @@ spec:
             - name: cni-conflist
               mountPath: /etc/cni/net.d
       hostNetwork: true
-      # lets the debug container signal the CNS process, which async-delete-test.sh
-      # uses to make CNS unreachable without stopping it
+      # lets the debug container signal the CNS process. async-delete-test.sh
+      # pauses it with SIGSTOP so the CNI request times out while the container
+      # keeps running and the fsnotify watcher stays alive
       shareProcessNamespace: true
       volumes:
         - name: cni-conflist


### PR DESCRIPTION
Follows the review comment on #4768: the async delete e2e test misses the fsnotify create event and covers only the startup scan.

## What the test misses today

The script stops CNS on the node, deletes a Pod, and then starts CNS again. The pending delete file is therefore always on disk before CNS starts. CNS reads it in the startup directory scan at [`fsnotify.go:133`](https://github.com/Azure/azure-container-networking/blob/528a08e67/cns/fsnotify/fsnotify.go#L133), which keys the map by the file name and has always been correct.

The other path never runs. When CNS is up but does not answer, the CNI writes the file while the watcher listens, and the watcher takes the create event at [`fsnotify.go:166`](https://github.com/Azure/azure-container-networking/blob/528a08e67/cns/fsnotify/fsnotify.go#L166). That line held the defect that #4768 fixes. The e2e test passed on the broken code for 3 years.

## What this adds

A second stage that drives a **real CNI delete** against a CNS that never restarts:

1. Find the CNS process from the debug container and send it `SIGSTOP`. The socket stays open, so the CNI request times out instead of failing fast.
2. Delete a busybox Pod. The CNI DEL waits out the 15 second CNS request timeout, then writes the pending delete file.
3. Check that the file appeared. Without this check an unexercised path would look like a pass.
4. `SIGCONT`. The kernel queues the inotify event while the process is stopped and delivers it on resume, so the watcher gets a live create event.
5. Wait up to 60 seconds for the directory to drain. The release ticker runs every 15 seconds.
6. Fail if the file remains, or if the CNS container restarted. A restart would prove only the startup scan again.

`shareProcessNamespace: true` on the CNS test daemonset is what lets the debug container signal CNS. It is needed because the CNI delete path and the CNS watcher both use `http://localhost:10090` — `cni/network/network.go:1108` and `cns/service/main.go:1076` each call `cnsclient.New("")` — so no port or address change can break one without breaking the other, and the debug container drops all capabilities.

## Validation

Run on a live `swift-byocni` AKS cluster, 2 nodes, CNS installed from these manifests.

| CNS build | Stage 1 (startup scan) | Stage 2 (create event) |
|---|---|---|
| `v1.8.12-25-g6013330eb` (master, defect present) | pass | **fail** |
| same commit with #4768 cherry-picked | pass | pass |

Stage 1 passing on the defective build is the point: it is why this never showed up.

CNS logs from the failing run, with the doubled path the defect produces:

```
msg="successfully released IP for missed delete"
  containerID=/var/run/azure-vnet/deleteIDs/11a88a41...
msg="failed to remove file for missed delete"
  error="remove /var/run/azure-vnet/deleteIDs//var/run/azure-vnet/deleteIDs/11a88a41...: no such file or directory"
```

The same stage on the fixed build, container restart count unchanged at 0:

```
msg="received create event" event=/var/run/azure-vnet/deleteIDs/a3fc8d96...
msg="processing pending missed deletes" count=1
msg="releasing IP for missed delete" podInterfaceID=a3fc8d96-eth0 containerID=a3fc8d96...
msg="successfully released IP for missed delete"
```

## Notes

- Merge after #4768. The new stage fails on a CNS that still holds the defect, which is the point of the test.
- The stage adds about 40 seconds: 15 for the CNI timeout and up to 60 for one or two release ticks.
- `sh -n` and `bash -n` both pass. No new dependency, no new manifest, no pipeline change.
