### PR TITLE
test: make telemetry socket close deterministic

### DIFF
--- a/telemetry/telemetrybuffer.go
+++ b/telemetry/telemetrybuffer.go
@@ -59,6 +59,7 @@ type TelemetryBuffer struct {
 	mutex       sync.Mutex
 	logger      *zap.Logger
 	plc         platform.ExecClient
+	fdName      string
 }
 
 // Buffer object holds the different types of reports
@@ -75,6 +76,7 @@ func NewTelemetryBuffer(logger *zap.Logger) *TelemetryBuffer {
 	tb.connections = make([]net.Conn, 0)
 	tb.logger = logger
 	tb.plc = platform.NewExecClient(tb.logger)
+	tb.fdName = FdName
 
 	return &tb
 }
@@ -91,7 +93,7 @@ func remove(s []net.Conn, i int) []net.Conn {
 
 // Starts Telemetry server listening on unix domain socket
 func (tb *TelemetryBuffer) StartServer() error {
-	err := tb.Listen(FdName)
+	err := tb.Listen(tb.fdName)
 	if err != nil {
 		tb.FdExists = strings.Contains(err.Error(), "in use") || strings.Contains(err.Error(), "Access is denied")
 		if tb.logger != nil {
@@ -193,11 +195,11 @@ func (tb *TelemetryBuffer) StartServer() error {
 }
 
 func (tb *TelemetryBuffer) Connect() error {
-	err := tb.Dial(FdName)
+	err := tb.Dial(tb.fdName)
 	if err == nil {
 		tb.Connected = true
 	} else if tb.FdExists {
-		tb.Cleanup(FdName)
+		_ = tb.Cleanup(tb.fdName)
 	}
 
 	return err
@@ -375,7 +377,7 @@ func (tb *TelemetryBuffer) ConnectToTelemetryService(telemetryNumRetries, teleme
 				}
 				return
 			}
-			tb.Cleanup(FdName)
+			_ = tb.Cleanup(tb.fdName)
 			tb.StartTelemetryService(path, args) // nolint
 			WaitForTelemetrySocket(telemetryNumRetries, time.Duration(telemetryWaitTimeInMilliseconds))
 		} else {

--- a/telemetry/telemetrybuffer_linux.go
+++ b/telemetry/telemetrybuffer_linux.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 )
 
 const (
@@ -18,7 +19,7 @@ const (
 
 // Dial - try to connect to/create a socket with 'name'
 func (tb *TelemetryBuffer) Dial(name string) (err error) {
-	conn, err := net.Dial("unix", fmt.Sprintf(fdTemplate, name))
+	conn, err := net.Dial("unix", fdPath(name)) //nolint:noctx // legacy Dial API has no context parameter
 	if err == nil {
 		tb.client = conn
 	}
@@ -28,7 +29,7 @@ func (tb *TelemetryBuffer) Dial(name string) (err error) {
 
 // Listen - try to create and listen on socket with 'name'
 func (tb *TelemetryBuffer) Listen(name string) (err error) {
-	conn, err := net.Listen("unix", fmt.Sprintf(fdTemplate, name))
+	conn, err := net.Listen("unix", fdPath(name)) //nolint:noctx // legacy Listen API has no context parameter
 	if err == nil {
 		tb.listener = conn
 	}
@@ -38,7 +39,17 @@ func (tb *TelemetryBuffer) Listen(name string) (err error) {
 
 // cleanup - manually remove socket
 func (tb *TelemetryBuffer) Cleanup(name string) error {
-	return os.Remove(fmt.Sprintf(fdTemplate, name))
+	if err := os.Remove(fdPath(name)); err != nil {
+		return fmt.Errorf("removing telemetry socket: %w", err)
+	}
+	return nil
+}
+
+func fdPath(name string) string {
+	if filepath.IsAbs(name) {
+		return name
+	}
+	return fmt.Sprintf(fdTemplate, name)
 }
 
 func SockExists() bool {

--- a/telemetry/telemetrybuffer_linux_test.go
+++ b/telemetry/telemetrybuffer_linux_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Microsoft. All rights reserved.
+// MIT License
+
+package telemetry
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func testFDName(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "telemetry.sock")
+}

--- a/telemetry/telemetrybuffer_test.go
+++ b/telemetry/telemetrybuffer_test.go
@@ -15,57 +15,49 @@ const telemetryConfig = "azure-vnet-telemetry.config"
 
 func createTBServer(t *testing.T) (*TelemetryBuffer, func()) {
 	tbServer := NewTelemetryBuffer(nil)
+	tbServer.fdName = testFDName(t)
 	err := tbServer.StartServer()
 	require.NoError(t, err)
 
 	return tbServer, func() {
 		tbServer.Close()
-		err := tbServer.Cleanup(FdName)
+		err := tbServer.Cleanup(tbServer.fdName)
 		require.Error(t, err)
 	}
 }
 
-// waitForServerConnCount blocks until the server's accept goroutine has
-// registered exactly want connections, or fails the test after timeout.
-// StartServer accepts connections asynchronously, so a client Connect()
-// returning does not guarantee the server has registered the connection
-// yet; racing ahead (e.g. into Close()) can leave that connection
-// unregistered and therefore unclosed by the server.
-func waitForServerConnCount(t *testing.T, tb *TelemetryBuffer, want int, timeout time.Duration) {
+func newTBClient(server *TelemetryBuffer, logger *zap.Logger) *TelemetryBuffer {
+	client := NewTelemetryBuffer(logger)
+	client.fdName = server.fdName
+	return client
+}
+
+func requireServerConnCount(t *testing.T, tb *TelemetryBuffer, want int) {
 	t.Helper()
 
-	deadline := time.Now().Add(timeout)
-	for {
+	require.Eventually(t, func() bool {
 		tb.mutex.Lock()
-		got := len(tb.connections)
-		tb.mutex.Unlock()
-
-		if got == want {
-			return
-		}
-		if time.Now().After(deadline) {
-			require.Equal(t, want, got, "timed out waiting for server to register client connections")
-			return
-		}
-		time.Sleep(time.Millisecond)
-	}
+		defer tb.mutex.Unlock()
+		return len(tb.connections) == want
+	}, 5*time.Second, time.Millisecond, "server connection count did not reach %d", want)
 }
 
 func TestStartServer(t *testing.T) {
-	_, closeTBServer := createTBServer(t)
+	tbServer, closeTBServer := createTBServer(t)
 	defer closeTBServer()
 
 	secondTBServer := NewTelemetryBuffer(nil)
+	secondTBServer.fdName = tbServer.fdName
 	err := secondTBServer.StartServer()
 	require.Error(t, err)
 }
 
 func TestConnect(t *testing.T) {
-	_, closeTBServer := createTBServer(t)
+	tbServer, closeTBServer := createTBServer(t)
 	defer closeTBServer()
 
 	logger := log.TelemetryLogger.With(zap.String("component", "cni-telemetry"))
-	tbClient := NewTelemetryBuffer(logger)
+	tbClient := newTBClient(tbServer, logger)
 	err := tbClient.Connect()
 	require.NoError(t, err)
 
@@ -76,15 +68,13 @@ func TestServerConnClose(t *testing.T) {
 	tbServer, closeTBServer := createTBServer(t)
 	defer closeTBServer()
 
-	tbClient := NewTelemetryBuffer(nil)
+	tbClient := newTBClient(tbServer, nil)
 	err := tbClient.Connect()
 	require.NoError(t, err)
 	defer tbClient.Close()
 
-	// Wait for the server to register the accepted connection before closing
-	// it; otherwise the server may not yet know about the connection when it
-	// closes, leaving it open and making the write below flaky.
-	waitForServerConnCount(t, tbServer, 1, 5*time.Second)
+	// Connect returns before the server's accept goroutine registers the socket.
+	requireServerConnCount(t, tbServer, 1)
 
 	tbServer.Close()
 
@@ -94,10 +84,10 @@ func TestServerConnClose(t *testing.T) {
 }
 
 func TestClientConnClose(t *testing.T) {
-	_, closeTBServer := createTBServer(t)
+	tbServer, closeTBServer := createTBServer(t)
 	defer closeTBServer()
 
-	tbClient := NewTelemetryBuffer(nil)
+	tbClient := newTBClient(tbServer, nil)
 	err := tbClient.Connect()
 	require.NoError(t, err)
 	tbClient.Close()
@@ -107,7 +97,7 @@ func TestCloseOnWriteError(t *testing.T) {
 	tbServer, closeTBServer := createTBServer(t)
 	defer closeTBServer()
 
-	tbClient := NewTelemetryBuffer(nil)
+	tbClient := newTBClient(tbServer, nil)
 	err := tbClient.Connect()
 	require.NoError(t, err)
 	defer tbClient.Close()
@@ -115,8 +105,7 @@ func TestCloseOnWriteError(t *testing.T) {
 	data := []byte("{\"good\":1}")
 	_, err = tbClient.Write(data)
 	require.NoError(t, err)
-	// need to wait for connection to populate in server
-	time.Sleep(1 * time.Second)
+	requireServerConnCount(t, tbServer, 1)
 	tbServer.mutex.Lock()
 	conns := tbServer.connections
 	tbServer.mutex.Unlock()
@@ -126,7 +115,7 @@ func TestCloseOnWriteError(t *testing.T) {
 	badData := []byte("} malformed json }}}")
 	_, err = tbClient.Write(badData)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
+	requireServerConnCount(t, tbServer, 0)
 	tbServer.mutex.Lock()
 	conns = tbServer.connections
 	tbServer.mutex.Unlock()
@@ -134,10 +123,10 @@ func TestCloseOnWriteError(t *testing.T) {
 }
 
 func TestWrite(t *testing.T) {
-	_, closeTBServer := createTBServer(t)
+	tbServer, closeTBServer := createTBServer(t)
 	defer closeTBServer()
 
-	tbClient := NewTelemetryBuffer(nil)
+	tbClient := newTBClient(tbServer, nil)
 	err := tbClient.Connect()
 	require.NoError(t, err)
 	defer tbClient.Close()

--- a/telemetry/telemetrybuffer_test.go
+++ b/telemetry/telemetrybuffer_test.go
@@ -25,6 +25,32 @@ func createTBServer(t *testing.T) (*TelemetryBuffer, func()) {
 	}
 }
 
+// waitForServerConnCount blocks until the server's accept goroutine has
+// registered exactly want connections, or fails the test after timeout.
+// StartServer accepts connections asynchronously, so a client Connect()
+// returning does not guarantee the server has registered the connection
+// yet; racing ahead (e.g. into Close()) can leave that connection
+// unregistered and therefore unclosed by the server.
+func waitForServerConnCount(t *testing.T, tb *TelemetryBuffer, want int, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for {
+		tb.mutex.Lock()
+		got := len(tb.connections)
+		tb.mutex.Unlock()
+
+		if got == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			require.Equal(t, want, got, "timed out waiting for server to register client connections")
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
 func TestStartServer(t *testing.T) {
 	_, closeTBServer := createTBServer(t)
 	defer closeTBServer()
@@ -54,6 +80,11 @@ func TestServerConnClose(t *testing.T) {
 	err := tbClient.Connect()
 	require.NoError(t, err)
 	defer tbClient.Close()
+
+	// Wait for the server to register the accepted connection before closing
+	// it; otherwise the server may not yet know about the connection when it
+	// closes, leaving it open and making the write below flaky.
+	waitForServerConnCount(t, tbServer, 1, 5*time.Second)
 
 	tbServer.Close()
 

--- a/telemetry/telemetrybuffer_windows_test.go
+++ b/telemetry/telemetrybuffer_windows_test.go
@@ -1,0 +1,15 @@
+// Copyright 2018 Microsoft. All rights reserved.
+// MIT License
+
+package telemetry
+
+import (
+	"strconv"
+	"testing"
+	"time"
+)
+
+func testFDName(t *testing.T) string {
+	t.Helper()
+	return FdName + "-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+}


### PR DESCRIPTION
## Summary
- wait for the server accept loop to register a connection before testing server-side close
- isolate telemetry sockets per test instead of using the machine-global `/var/run` endpoint
- replace fixed sleeps with bounded state-based waits

## Testing
- `go test -race -run "^TestServerConnClose$" -count=1000 ./telemetry`
- `go test -race -count=50 ./telemetry/...`
- golangci-lint v2.12.2 on Linux and Windows targets