### PR TITLE
test(cns): harden Bolt state engine

### DIFF
--- a/.github/scripts/check-go-coverage.sh
+++ b/.github/scripts/check-go-coverage.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+export LC_ALL=C
+
+if [[ $# -ne 1 || ! "$1" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+	echo "usage: $0 <minimum-percent>" >&2
+	exit 2
+fi
+
+awk -v threshold="$1" '
+	$1 == "total:" && $(NF - 1) == "(statements)" && $NF ~ /^[0-9]+([.][0-9]+)?%$/ {
+		total = $NF
+		sub(/%$/, "", total)
+		found++
+	}
+	END {
+		if (found != 1) {
+			print "coverage check: malformed go tool cover report" > "/dev/stderr"
+			exit 2
+		}
+		if ((total + 0) < (threshold + 0)) {
+			printf "coverage check: %.1f%% is below %.1f%%\n", total, threshold > "/dev/stderr"
+			exit 1
+		}
+		printf "coverage check: %.1f%% meets %.1f%% threshold\n", total, threshold
+	}
+'

--- a/.github/scripts/check-go-coverage.sh
+++ b/.github/scripts/check-go-coverage.sh
@@ -3,26 +3,84 @@
 set -euo pipefail
 export LC_ALL=C
 
-if [[ $# -ne 1 || ! "$1" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
-	echo "usage: $0 <minimum-percent>" >&2
+if [[ $# -ne 2 || ! "$2" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+	echo "usage: $0 <coverprofile> <minimum-percent>" >&2
 	exit 2
 fi
 
-awk -v threshold="$1" '
-	$1 == "total:" && $(NF - 1) == "(statements)" && $NF ~ /^[0-9]+([.][0-9]+)?%$/ {
-		total = $NF
-		sub(/%$/, "", total)
-		found++
-	}
-	END {
-		if (found != 1) {
-			print "coverage check: malformed go tool cover report" > "/dev/stderr"
+profile="$1"
+threshold="$2"
+if [[ ! -f "$profile" || ! -r "$profile" ]]; then
+	echo "coverage check: cannot read profile $profile" >&2
+	exit 2
+fi
+awk -v threshold="$threshold" '
+	BEGIN {
+		if ((threshold + 0) > 100) {
+			print "coverage check: minimum percent must not exceed 100" > "/dev/stderr"
+			invalid = 1
 			exit 2
 		}
-		if ((total + 0) < (threshold + 0)) {
-			printf "coverage check: %.1f%% is below %.1f%%\n", total, threshold > "/dev/stderr"
+	}
+
+	function malformed(detail) {
+		printf "coverage check: malformed profile at line %d: %s\n", NR, detail > "/dev/stderr"
+		invalid = 1
+		exit 2
+	}
+
+	NR == 1 {
+		if ($0 !~ /^mode: (set|count|atomic)$/) {
+			malformed("invalid mode header")
+		}
+		header = 1
+		next
+	}
+
+	$1 == "mode:" {
+		malformed("multiple mode headers")
+	}
+
+	{
+		if (NF != 3) {
+			malformed("data row must have three fields")
+		}
+		if ($1 !~ /^.+:[0-9]+\.[0-9]+,[0-9]+\.[0-9]+$/) {
+			malformed("invalid source range")
+		}
+		if ($2 !~ /^[0-9]+$/) {
+			malformed("statement count is not a non-negative integer")
+		}
+		if ($3 !~ /^[0-9]+$/) {
+			malformed("execution count is not a non-negative integer")
+		}
+		statements = $2 + 0
+		total += statements
+		if (($3 + 0) > 0) {
+			covered += statements
+		}
+		rows++
+	}
+
+	END {
+		if (invalid) {
+			exit 2
+		}
+		if (header != 1 || rows == 0) {
+			print "coverage check: profile has no data rows" > "/dev/stderr"
+			exit 2
+		}
+		if (total <= 0) {
+			print "coverage check: profile has zero statements" > "/dev/stderr"
+			exit 2
+		}
+		percent = covered * 100 / total
+		if ((covered * 100) < ((threshold + 0) * total)) {
+			printf "coverage check: %d/%d statements = %.9f%% is below %.6f%%\n", \
+				covered, total, percent, threshold > "/dev/stderr"
 			exit 1
 		}
-		printf "coverage check: %.1f%% meets %.1f%% threshold\n", total, threshold
+		printf "coverage check: %d/%d statements = %.9f%% meets %.6f%% threshold\n", \
+			covered, total, percent, threshold
 	}
-'
+' "$profile"

--- a/.github/scripts/check-go-coverage_test.sh
+++ b/.github/scripts/check-go-coverage_test.sh
@@ -3,20 +3,78 @@
 set -euo pipefail
 
 script="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/check-go-coverage.sh"
+work_dir="${CNS_STATE_COVERAGE_TEST_DIR:-$(pwd)/output/coverage-check-tests}"
+profile="$work_dir/profile.out"
+mkdir -p "$work_dir"
+trap 'rm -rf "$work_dir"' EXIT
 
-report() {
-	printf 'example.go:1:\tExample\t100.0%%\ntotal:\t(statements)\t%s%%\n' "$1"
+write_profile() {
+	local covered="$1"
+	local uncovered="$2"
+	cat >"$profile" <<EOF
+mode: atomic
+example.go:1.1,1.2 $covered 1
+example.go:2.1,2.2 $uncovered 0
+EOF
 }
 
-report 90.1 | "$script" 90 >/dev/null
-report 90.0 | "$script" 90 >/dev/null
+expect_pass() {
+	local name="$1"
+	if ! "$script" "$profile" 90 >/dev/null; then
+		echo "$name unexpectedly failed" >&2
+		exit 1
+	fi
+}
 
-if report 89.9 | "$script" 90 >/dev/null 2>&1; then
-	echo "below-threshold coverage unexpectedly passed" >&2
+expect_fail() {
+	local name="$1"
+	if "$script" "$profile" 90 >/dev/null 2>&1; then
+		echo "$name unexpectedly passed" >&2
+		exit 1
+	fi
+}
+
+for percentage in 8995 8997 8999; do
+	write_profile "$percentage" "$((10000 - percentage))"
+	expect_fail "${percentage:0:2}.${percentage:2} percent"
+done
+
+write_profile 9000 1000
+output="$("$script" "$profile" 90)"
+grep -Fq "9000/10000 statements = 90.000000000%" <<<"$output"
+
+write_profile 9001 999
+expect_pass "above-threshold coverage"
+
+if "$script" "$work_dir/missing.out" 90 >/dev/null 2>&1; then
+	echo "missing profile unexpectedly passed" >&2
 	exit 1
 fi
 
-if printf 'not a coverage report\n' | "$script" 90 >/dev/null 2>&1; then
-	echo "malformed coverage unexpectedly passed" >&2
+malformed_profiles=(
+	""
+	"mode: unknown"
+	"mode: atomic"
+	$'mode: atomic\nmode: atomic'
+	$'mode: atomic\nnot-a-data-row'
+	$'mode: atomic\nexample.go:bad 1 1'
+	$'mode: atomic\nexample.go:1.1,1.2 words 1'
+	$'mode: atomic\nexample.go:1.1,1.2 -1 1'
+	$'mode: atomic\nexample.go:1.1,1.2 1 words'
+	$'mode: atomic\nexample.go:1.1,1.2 1 -1'
+	$'mode: atomic\nexample.go:1.1,1.2 0 1'
+)
+for contents in "${malformed_profiles[@]}"; do
+	printf '%s\n' "$contents" >"$profile"
+	expect_fail "malformed profile"
+done
+
+write_profile 1 0
+if "$script" "$profile" invalid >/dev/null 2>&1; then
+	echo "invalid threshold unexpectedly passed" >&2
+	exit 1
+fi
+if "$script" "$profile" 100.1 >/dev/null 2>&1; then
+	echo "threshold above 100 unexpectedly passed" >&2
 	exit 1
 fi

--- a/.github/scripts/check-go-coverage_test.sh
+++ b/.github/scripts/check-go-coverage_test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/check-go-coverage.sh"
+
+report() {
+	printf 'example.go:1:\tExample\t100.0%%\ntotal:\t(statements)\t%s%%\n' "$1"
+}
+
+report 90.1 | "$script" 90 >/dev/null
+report 90.0 | "$script" 90 >/dev/null
+
+if report 89.9 | "$script" 90 >/dev/null 2>&1; then
+	echo "below-threshold coverage unexpectedly passed" >&2
+	exit 1
+fi
+
+if printf 'not a coverage report\n' | "$script" 90 >/dev/null 2>&1; then
+	echo "malformed coverage unexpectedly passed" >&2
+	exit 1
+fi

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -97,6 +97,10 @@ jobs:
 
           (exit "$test_exit")
 
+      - name: Enforce cns/state coverage
+        if: matrix.os == 'ubuntu-24.04'
+        run: make test-state-coverage
+
       - name: Upload Linux Coverage
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:

--- a/Makefile
+++ b/Makefile
@@ -926,8 +926,8 @@ test-state-coverage: ## enforce the cns/state statement coverage threshold.
 		.github/scripts/check-go-coverage_test.sh; \
 		go test -mod=readonly -buildvcs=false -race -shuffle=on -count=1 \
 			-covermode=atomic -coverprofile="$(CNS_STATE_COVERAGE_PROFILE)" ./cns/state; \
-		go tool cover -func="$(CNS_STATE_COVERAGE_PROFILE)" | \
-			.github/scripts/check-go-coverage.sh "$(CNS_STATE_COVERAGE_THRESHOLD)"
+		.github/scripts/check-go-coverage.sh \
+			"$(CNS_STATE_COVERAGE_PROFILE)" "$(CNS_STATE_COVERAGE_THRESHOLD)"
 
 test-integration: ## run all integration tests.
 	AZURE_IPAM_VERSION=$(AZURE_IPAM_VERSION) \

--- a/Makefile
+++ b/Makefile
@@ -906,6 +906,8 @@ workspace: ## Set up the Go workspace.
 ##@ Test
 
 COVER_PKG ?= .
+CNS_STATE_COVERAGE_THRESHOLD ?= 90
+CNS_STATE_COVERAGE_PROFILE ?= $(OUTPUT_DIR)/cns-state-coverage.out
 #Restart case is used for cni load test pipeline for restarting the nodes cluster.
 RESTART_CASE ?= false
 # CNI type is a key to direct the types of state validation done on a cluster.
@@ -916,6 +918,16 @@ test-all: test-azure-ipam test-azure-ip-masq-merger test-azure-iptables-monitor 
 test-main:
 	go test -mod=readonly -buildvcs=false -tags "unit" --skip 'TestE2E*' -race -covermode atomic -coverprofile=coverage-main.out $(COVER_PKG)/...
 	go tool cover -func=coverage-main.out
+
+test-state-coverage: ## enforce the cns/state statement coverage threshold.
+	@set -euo pipefail; \
+		$(MKDIR) "$(dir $(CNS_STATE_COVERAGE_PROFILE))"; \
+		trap 'rm -f "$(CNS_STATE_COVERAGE_PROFILE)"' EXIT; \
+		.github/scripts/check-go-coverage_test.sh; \
+		go test -mod=readonly -buildvcs=false -race -shuffle=on -count=1 \
+			-covermode=atomic -coverprofile="$(CNS_STATE_COVERAGE_PROFILE)" ./cns/state; \
+		go tool cover -func="$(CNS_STATE_COVERAGE_PROFILE)" | \
+			.github/scripts/check-go-coverage.sh "$(CNS_STATE_COVERAGE_THRESHOLD)"
 
 test-integration: ## run all integration tests.
 	AZURE_IPAM_VERSION=$(AZURE_IPAM_VERSION) \

--- a/cns/state/benchmark_test.go
+++ b/cns/state/benchmark_test.go
@@ -1,0 +1,166 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package state
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var nodeInventorySizes = []int{250, 500, 1000}
+
+func BenchmarkSnapshot(b *testing.B) {
+	for _, size := range nodeInventorySizes {
+		b.Run(fmt.Sprintf("inventory=%d", size), func(b *testing.B) {
+			db := openBenchmarkDB(b)
+			durable := benchmarkDurableState(size)
+			changed, err := db.ReplaceDurableState(context.Background(), 0, durable)
+			require.NoError(b, err)
+			require.True(b, changed)
+
+			b.ReportAllocs()
+			for b.Loop() {
+				snapshot, err := db.Snapshot(context.Background())
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(snapshot.IPs) != size {
+					b.Fatalf("snapshot has %d IPs, want %d", len(snapshot.IPs), size)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkApplyNetworkContainerReplacement(b *testing.B) {
+	for _, size := range nodeInventorySizes {
+		b.Run(fmt.Sprintf("inventory=%d", size), func(b *testing.B) {
+			db := openBenchmarkDB(b)
+			durable := benchmarkDurableState(size)
+			changed, err := db.ReplaceDurableState(context.Background(), 0, durable)
+			require.NoError(b, err)
+			require.True(b, changed)
+			replacement := benchmarkNCIPs(durable, "benchmark-nc-0")
+
+			b.ReportAllocs()
+			for b.Loop() {
+				changed, err := db.ApplyNetworkContainer(
+					context.Background(),
+					durable.NetworkContainers["benchmark-nc-0"],
+					replacement,
+				)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if !changed {
+					b.Fatal("replacement unexpectedly reported no change")
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkAssignReleaseTransaction(b *testing.B) {
+	for _, size := range nodeInventorySizes {
+		b.Run(fmt.Sprintf("inventory=%d", size), func(b *testing.B) {
+			db := openBenchmarkDB(b)
+			durable := benchmarkDurableState(size)
+			changed, err := db.ReplaceDurableState(context.Background(), 0, durable)
+			require.NoError(b, err)
+			require.True(b, changed)
+
+			ip := durable.IPs[benchmarkIPID(0)]
+			assignment := testAssignment("benchmark-container", "benchmark-pod", "benchmark-ns", ip.ID)
+			endpoint := EndpointRecord{
+				PodName:      assignment.Pod.PodName,
+				PodNamespace: assignment.Pod.PodNamespace,
+				IfnameToIPMap: map[string]*IPInfoRecord{
+					"eth0": {
+						IPv4:               []net.IPNet{mustIPNetValue(ip.IPAddress, 24)},
+						NetworkContainerID: ip.NCID,
+					},
+				},
+			}
+			now := time.Date(2026, time.July, 24, 0, 0, 0, 0, time.UTC)
+
+			b.ReportAllocs()
+			for b.Loop() {
+				changed, err := db.AssignEndpoint(
+					context.Background(),
+					assignment,
+					endpoint,
+					now,
+					testDeleteIntentTTL,
+				)
+				if err != nil || !changed {
+					b.Fatalf("assigning endpoint: changed=%t err=%v", changed, err)
+				}
+				changed, err = db.ReleaseEndpoint(context.Background(), assignment.Pod, now)
+				if err != nil || !changed {
+					b.Fatalf("releasing endpoint: changed=%t err=%v", changed, err)
+				}
+				changed, err = db.DeleteEndpointRecord(context.Background(), assignment.Pod.InfraContainerID)
+				if err != nil || !changed {
+					b.Fatalf("deleting endpoint: changed=%t err=%v", changed, err)
+				}
+				pruned, err := db.PruneDeleteIntents(
+					context.Background(),
+					now.Add(testDeleteIntentTTL),
+					testDeleteIntentTTL,
+				)
+				if err != nil || pruned != 1 {
+					b.Fatalf("pruning delete intent: count=%d err=%v", pruned, err)
+				}
+			}
+		})
+	}
+}
+
+func openBenchmarkDB(b *testing.B) *DB {
+	b.Helper()
+	db, err := Open(filepath.Join(b.TempDir(), "state.db"), Options{NoSync: true})
+	require.NoError(b, err)
+	b.Cleanup(func() { require.NoError(b, db.Close()) })
+	return db
+}
+
+func benchmarkDurableState(size int) DurableState {
+	const ipsPerNC = 50
+	durable := NewDurableState()
+	for index := range size {
+		ncIndex := index / ipsPerNC
+		ncID := fmt.Sprintf("benchmark-nc-%d", ncIndex)
+		if _, ok := durable.NetworkContainers[ncID]; !ok {
+			durable.NetworkContainers[ncID] = testNetworkContainer(ncID)
+			durable.OrchestratorContexts[fmt.Sprintf("benchmark-context-%d", ncIndex)] = []string{ncID}
+		}
+		durable.IPs[benchmarkIPID(index)] = IPRecord{
+			ID:        benchmarkIPID(index),
+			IPAddress: fmt.Sprintf("10.%d.%d.%d", 100+index/62500, (index/250)%250, index%250+1),
+			NCID:      ncID,
+			NCVersion: 1,
+		}
+	}
+	return durable
+}
+
+func benchmarkNCIPs(durable DurableState, ncID string) []IPRecord {
+	records := make([]IPRecord, 0)
+	for _, id := range sortedKeys(durable.IPs) {
+		if durable.IPs[id].NCID == ncID {
+			records = append(records, durable.IPs[id])
+		}
+	}
+	return records
+}
+
+func benchmarkIPID(index int) string {
+	return fmt.Sprintf("20000000-0000-4000-8000-%012d", index+1)
+}

--- a/cns/state/benchmark_test.go
+++ b/cns/state/benchmark_test.go
@@ -82,7 +82,7 @@ func BenchmarkAssignReleaseTransaction(b *testing.B) {
 				PodName:      assignment.Pod.PodName,
 				PodNamespace: assignment.Pod.PodNamespace,
 				IfnameToIPMap: map[string]*IPInfoRecord{
-					"eth0": {
+					exportIfnameEth0: {
 						IPv4:               []net.IPNet{mustIPNetValue(ip.IPAddress, 24)},
 						NetworkContainerID: ip.NCID,
 					},

--- a/cns/state/coverage_test.go
+++ b/cns/state/coverage_test.go
@@ -1,0 +1,949 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package state
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	bolt "go.etcd.io/bbolt"
+)
+
+func TestOwnershipNormalizationRejectsMalformedRecords(t *testing.T) {
+	validPod := PodIdentity{
+		PodKey:           "container",
+		InfraContainerID: "container",
+		PodName:          "pod",
+		PodNamespace:     "namespace",
+	}
+	podTests := []struct {
+		name   string
+		mutate func(*PodIdentity)
+	}{
+		{name: "empty pod key", mutate: func(pod *PodIdentity) { pod.PodKey = "" }},
+		{name: "empty infra container", mutate: func(pod *PodIdentity) { pod.InfraContainerID = "" }},
+		{name: "pod key differs without interface", mutate: func(pod *PodIdentity) { pod.PodKey = "other" }},
+		{name: "interface differs from pod key", mutate: func(pod *PodIdentity) { pod.InterfaceID = "other" }},
+		{name: "empty pod name", mutate: func(pod *PodIdentity) { pod.PodName = "" }},
+		{name: "empty pod namespace", mutate: func(pod *PodIdentity) { pod.PodNamespace = "" }},
+	}
+	for _, tt := range podTests {
+		t.Run("pod/"+tt.name, func(t *testing.T) {
+			pod := validPod
+			tt.mutate(&pod)
+			_, err := normalizePodIdentity(pod, true)
+			require.ErrorIs(t, err, ErrInvalidInput)
+		})
+	}
+
+	t.Run("pod normalization", func(t *testing.T) {
+		pod := validPod
+		pod.PodKey = " container "
+		pod.InfraContainerID = " container "
+		pod.PodName = " pod "
+		pod.PodNamespace = " namespace "
+		got, err := normalizePodIdentity(pod, true)
+		require.NoError(t, err)
+		assert.Equal(t, validPod, got)
+	})
+
+	assignmentTests := []struct {
+		name   string
+		record AssignmentRecord
+	}{
+		{name: "no IPs", record: AssignmentRecord{Pod: validPod}},
+		{name: "empty IP", record: AssignmentRecord{Pod: validPod, IPIDs: []string{""}}},
+		{name: "duplicate IP", record: AssignmentRecord{Pod: validPod, IPIDs: []string{"ip", " ip "}}},
+	}
+	for _, tt := range assignmentTests {
+		t.Run("assignment/"+tt.name, func(t *testing.T) {
+			_, err := normalizeAssignment(tt.record, true)
+			require.ErrorIs(t, err, ErrInvalidInput)
+		})
+	}
+
+	validEndpoint := EndpointRecord{
+		PodName:      "pod",
+		PodNamespace: "namespace",
+		IfnameToIPMap: map[string]*IPInfoRecord{
+			"eth0": {
+				IPv4: []net.IPNet{mustIPNetValue("10.0.0.4", 24)},
+			},
+		},
+	}
+	endpointTests := []struct {
+		name        string
+		containerID string
+		record      EndpointRecord
+	}{
+		{name: "empty container", record: validEndpoint},
+		{
+			name:        "empty pod name",
+			containerID: "container",
+			record: EndpointRecord{
+				PodNamespace:  "namespace",
+				IfnameToIPMap: validEndpoint.IfnameToIPMap,
+			},
+		},
+		{
+			name:        "empty pod namespace",
+			containerID: "container",
+			record: EndpointRecord{
+				PodName:       "pod",
+				IfnameToIPMap: validEndpoint.IfnameToIPMap,
+			},
+		},
+		{
+			name:        "no interfaces",
+			containerID: "container",
+			record:      EndpointRecord{PodName: "pod", PodNamespace: "namespace"},
+		},
+		{
+			name:        "empty interface",
+			containerID: "container",
+			record: EndpointRecord{
+				PodName:       "pod",
+				PodNamespace:  "namespace",
+				IfnameToIPMap: map[string]*IPInfoRecord{" ": {}},
+			},
+		},
+		{
+			name:        "duplicate normalized interface",
+			containerID: "container",
+			record: EndpointRecord{
+				PodName:      "pod",
+				PodNamespace: "namespace",
+				IfnameToIPMap: map[string]*IPInfoRecord{
+					"eth0":   {IPv4: []net.IPNet{mustIPNetValue("10.0.0.4", 24)}},
+					" eth0 ": {IPv4: []net.IPNet{mustIPNetValue("10.0.0.5", 24)}},
+				},
+			},
+		},
+		{
+			name:        "null interface",
+			containerID: "container",
+			record: EndpointRecord{
+				PodName:       "pod",
+				PodNamespace:  "namespace",
+				IfnameToIPMap: map[string]*IPInfoRecord{"eth0": nil},
+			},
+		},
+		{
+			name:        "invalid MAC",
+			containerID: "container",
+			record: EndpointRecord{
+				PodName:      "pod",
+				PodNamespace: "namespace",
+				IfnameToIPMap: map[string]*IPInfoRecord{
+					"eth0": {IPv4: []net.IPNet{mustIPNetValue("10.0.0.4", 24)}, MACAddress: "bad"},
+				},
+			},
+		},
+		{
+			name:        "no IPs",
+			containerID: "container",
+			record: EndpointRecord{
+				PodName:       "pod",
+				PodNamespace:  "namespace",
+				IfnameToIPMap: map[string]*IPInfoRecord{"eth0": {}},
+			},
+		},
+		{
+			name:        "IPv6 in IPv4 list",
+			containerID: "container",
+			record: EndpointRecord{
+				PodName:      "pod",
+				PodNamespace: "namespace",
+				IfnameToIPMap: map[string]*IPInfoRecord{
+					"eth0": {IPv4: []net.IPNet{mustIPNetValue("fd00::4", 64)}},
+				},
+			},
+		},
+		{
+			name:        "IPv4 in IPv6 list",
+			containerID: "container",
+			record: EndpointRecord{
+				PodName:      "pod",
+				PodNamespace: "namespace",
+				IfnameToIPMap: map[string]*IPInfoRecord{
+					"eth0": {IPv6: []net.IPNet{mustIPNetValue("10.0.0.4", 24)}},
+				},
+			},
+		},
+	}
+	for _, tt := range endpointTests {
+		t.Run("endpoint/"+tt.name, func(t *testing.T) {
+			_, err := normalizeEndpoint(tt.containerID, tt.record)
+			require.ErrorIs(t, err, ErrInvalidInput)
+		})
+	}
+}
+
+func TestNormalizeDurableStateRejectsMalformedMappings(t *testing.T) {
+	valid := NewDurableState()
+	valid.NetworkContainers["nc"] = testNetworkContainer("nc")
+	valid.IPs["ip"] = IPRecord{ID: "ip", IPAddress: "10.0.0.4", NCID: "nc"}
+	valid.Networks["network"] = NetworkRecord{NetworkName: "network"}
+	valid.OrchestratorContexts["context"] = []string{"nc"}
+	valid.PnPIDByMAC["00:11:22:33:44:55"] = "pnp"
+
+	tests := []struct {
+		name   string
+		mutate func(*DurableState)
+	}{
+		{
+			name: "network container key mismatch",
+			mutate: func(value *DurableState) {
+				value.NetworkContainers = map[string]NetworkContainerRecord{"other": testNetworkContainer("nc")}
+			},
+		},
+		{
+			name: "network container request mismatch",
+			mutate: func(value *DurableState) {
+				record := testNetworkContainer("nc")
+				record.Request.NetworkContainerid = "other"
+				value.NetworkContainers = map[string]NetworkContainerRecord{"nc": record}
+			},
+		},
+		{
+			name:   "IP key mismatch",
+			mutate: func(value *DurableState) { value.IPs = map[string]IPRecord{"other": valid.IPs["ip"]} },
+		},
+		{
+			name: "network key mismatch",
+			mutate: func(value *DurableState) {
+				value.Networks = map[string]NetworkRecord{"other": valid.Networks["network"]}
+			},
+		},
+		{
+			name: "empty orchestrator context",
+			mutate: func(value *DurableState) {
+				value.OrchestratorContexts = map[string][]string{"": {"nc"}}
+			},
+		},
+		{
+			name:   "invalid MAC",
+			mutate: func(value *DurableState) { value.PnPIDByMAC = map[string]string{"bad": "pnp"} },
+		},
+		{
+			name:   "empty PnP ID",
+			mutate: func(value *DurableState) { value.PnPIDByMAC = map[string]string{"00:11:22:33:44:55": ""} },
+		},
+		{
+			name: "duplicate canonical MAC",
+			mutate: func(value *DurableState) {
+				value.PnPIDByMAC = map[string]string{
+					"00:11:22:33:44:55": "one",
+					"00-11-22-33-44-55": "two",
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := DurableState{
+				NetworkContainers:    cloneMap(valid.NetworkContainers),
+				IPs:                  cloneMap(valid.IPs),
+				Networks:             cloneMap(valid.Networks),
+				OrchestratorContexts: cloneMap(valid.OrchestratorContexts),
+				PnPIDByMAC:           cloneMap(valid.PnPIDByMAC),
+			}
+			tt.mutate(&input)
+			_, err := normalizeDurableState(input)
+			require.ErrorIs(t, err, ErrInvalidInput)
+		})
+	}
+}
+
+func TestLegacyNetworkValidationRejectsMalformedFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*cns.CreateNetworkContainerRequest)
+	}{
+		{
+			name: "invalid host primary IP",
+			mutate: func(request *cns.CreateNetworkContainerRequest) {
+				request.HostPrimaryIP = "bad"
+			},
+		},
+		{
+			name: "invalid local IPv6 family",
+			mutate: func(request *cns.CreateNetworkContainerRequest) {
+				request.LocalIPConfiguration.IPSubnetV6.IPAddress = "10.0.0.1"
+			},
+		},
+		{
+			name: "invalid DNS server",
+			mutate: func(request *cns.CreateNetworkContainerRequest) {
+				request.IPConfiguration.DNSServers = []string{"bad"}
+			},
+		},
+		{
+			name: "invalid gateway",
+			mutate: func(request *cns.CreateNetworkContainerRequest) {
+				request.IPConfiguration.GatewayIPAddress = "bad"
+			},
+		},
+		{
+			name: "prefix without address",
+			mutate: func(request *cns.CreateNetworkContainerRequest) {
+				request.IPv6Configuration.IPSubnet.PrefixLength = 64
+			},
+		},
+		{
+			name: "invalid subnet address",
+			mutate: func(request *cns.CreateNetworkContainerRequest) {
+				request.IPConfiguration.IPSubnet.IPAddress = "bad"
+			},
+		},
+		{
+			name: "invalid subnet prefix",
+			mutate: func(request *cns.CreateNetworkContainerRequest) {
+				request.IPConfiguration.IPSubnet.PrefixLength = 33
+			},
+		},
+		{
+			name: "invalid route destination",
+			mutate: func(request *cns.CreateNetworkContainerRequest) {
+				request.Routes = []cns.Route{{IPAddress: "bad"}}
+			},
+		},
+		{
+			name: "invalid route gateway",
+			mutate: func(request *cns.CreateNetworkContainerRequest) {
+				request.Routes = []cns.Route{{GatewayIPAddress: "bad"}}
+			},
+		},
+		{
+			name: "invalid MAC",
+			mutate: func(request *cns.CreateNetworkContainerRequest) {
+				request.NetworkInterfaceInfo.MACAddress = "bad"
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := completeNetworkContainerRequest()
+			tt.mutate(&request)
+			require.Error(t, validateLegacyNetworkContainerRequest(request))
+		})
+	}
+}
+
+func TestTransactionInputErrorsPreserveState(t *testing.T) {
+	db, _ := openTestDB(t)
+	validEndpoint := testEndpoint("pod", "namespace", "10.0.0.4", "")
+	validAssignment := testAssignment("container", "pod", "namespace", "ip")
+	tests := []struct {
+		name string
+		run  func(*WriteTx) error
+	}{
+		{name: "network container empty ID", run: func(tx *WriteTx) error {
+			return tx.PutNetworkContainer(NetworkContainerRecord{})
+		}},
+		{name: "network container request mismatch", run: func(tx *WriteTx) error {
+			record := testNetworkContainer("nc")
+			record.Request.NetworkContainerid = "other"
+			return tx.PutNetworkContainer(record)
+		}},
+		{name: "IP empty ID", run: func(tx *WriteTx) error { return tx.PutIP(IPRecord{}) }},
+		{name: "network empty name", run: func(tx *WriteTx) error { return tx.PutNetwork(NetworkRecord{}) }},
+		{name: "context empty ID", run: func(tx *WriteTx) error {
+			return tx.PutOrchestratorContext("", nil)
+		}},
+		{name: "PnP invalid MAC", run: func(tx *WriteTx) error { return tx.PutPnPID("bad", "pnp") }},
+		{name: "PnP empty ID", run: func(tx *WriteTx) error {
+			return tx.PutPnPID("00:11:22:33:44:55", "")
+		}},
+		{name: "assignment malformed", run: func(tx *WriteTx) error {
+			return tx.PutAssignment(AssignmentRecord{})
+		}},
+		{name: "owner empty IP", run: func(tx *WriteTx) error { return tx.PutIPOwner("", "pod") }},
+		{name: "owner empty pod", run: func(tx *WriteTx) error { return tx.PutIPOwner("ip", "") }},
+		{name: "endpoint empty container", run: func(tx *WriteTx) error {
+			return tx.PutEndpoint("", validEndpoint)
+		}},
+		{name: "delete intent empty container", run: func(tx *WriteTx) error {
+			return tx.PutDeleteIntent("", DeleteIntent{CreatedAt: testNow})
+		}},
+		{name: "delete intent zero timestamp", run: func(tx *WriteTx) error {
+			return tx.PutDeleteIntent("container", DeleteIntent{})
+		}},
+		{name: "delete empty durable ID", run: func(tx *WriteTx) error {
+			return tx.DeleteNetworkContainer("")
+		}},
+		{name: "delete empty ownership ID", run: func(tx *WriteTx) error {
+			return tx.DeleteAssignment("")
+		}},
+		{name: "valid assignment missing inventory", run: func(tx *WriteTx) error {
+			return tx.PutAssignment(validAssignment)
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := readMetadata(t, db).Generation
+			err := db.Update(context.Background(), tt.run)
+			require.ErrorIs(t, err, ErrInvalidInput)
+			assert.Equal(t, before, readMetadata(t, db).Generation)
+		})
+	}
+}
+
+func TestTransactionCorruptionFaultsAreCategorized(t *testing.T) {
+	tests := []struct {
+		name       string
+		bucketName []byte
+		run        func(*bolt.Tx) error
+	}{
+		{
+			name:       "get missing bucket",
+			bucketName: bucketIPs,
+			run: func(tx *bolt.Tx) error {
+				_, err := getJSONValue[IPRecord](
+					&ReadTx{tx: tx, ctx: context.Background()},
+					bucketIPs,
+					"ip",
+				)
+				return err
+			},
+		},
+		{
+			name:       "list missing bucket",
+			bucketName: bucketIPs,
+			run: func(tx *bolt.Tx) error {
+				_, err := listJSONValues[IPRecord](
+					&ReadTx{tx: tx, ctx: context.Background()},
+					bucketIPs,
+				)
+				return err
+			},
+		},
+		{
+			name:       "put missing bucket",
+			bucketName: bucketIPs,
+			run: func(tx *bolt.Tx) error {
+				return putJSONValue(tx, bucketIPs, "ip", IPRecord{ID: "ip"})
+			},
+		},
+		{
+			name:       "delete missing bucket",
+			bucketName: bucketAssignments,
+			run: func(tx *bolt.Tx) error {
+				return deleteJSONValue(tx, bucketAssignments, "pod")
+			},
+		},
+		{
+			name:       "replace missing bucket",
+			bucketName: bucketNetworks,
+			run: func(tx *bolt.Tx) error {
+				return replaceJSONBucket(tx, bucketNetworks, map[string][]byte{})
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, _ := openTestDB(t)
+			err := db.db.Update(func(tx *bolt.Tx) error {
+				require.NoError(t, tx.DeleteBucket(tt.bucketName))
+				require.ErrorIs(t, tt.run(tx), ErrCorrupt)
+				return errAbort
+			})
+			require.ErrorIs(t, err, errAbort)
+		})
+	}
+
+	t.Run("malformed stored value", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		putRaw(t, db, bucketIPs, []byte("ip"), []byte(`{"id":`))
+		require.NoError(t, db.View(context.Background(), func(tx *ReadTx) error {
+			_, err := tx.GetIP("ip")
+			require.ErrorIs(t, err, ErrCorrupt)
+			_, err = tx.ListIPs()
+			require.ErrorIs(t, err, ErrCorrupt)
+			return nil
+		}))
+	})
+}
+
+func TestValidationHelpersPreserveErrorCategories(t *testing.T) {
+	require.NoError(t, validateNonemptyKeys(bucketIPs, map[string]int{"ip": 1}))
+	require.ErrorIs(t, validateNonemptyKeys(bucketIPs, map[string]int{"": 1}), ErrInconsistentState)
+
+	require.NoError(t, validateOptionalAddress(""))
+	require.NoError(t, validateOptionalAddress("10.0.0.1"))
+	require.Error(t, validateOptionalAddress("bad"))
+	require.NoError(t, validateOptionalIPValue("10.0.0.0/24"))
+
+	_, err := endpointsEqual(
+		EndpointRecord{},
+		EndpointRecord{},
+	)
+	require.ErrorIs(t, err, ErrInvalidInput)
+	_, err = endpointsEqual(
+		testEndpoint("pod", "namespace", "10.0.0.4", ""),
+		EndpointRecord{},
+	)
+	require.ErrorIs(t, err, ErrInvalidInput)
+	require.True(t, errors.Is(invalidInput("detail", errAbort), ErrInvalidInput))
+	require.True(t, errors.Is(corrupt("detail", errAbort), ErrCorrupt))
+}
+
+func TestReleaseIdentityRejectsConflictingOwnership(t *testing.T) {
+	snapshot := completeSnapshot()
+	tests := []struct {
+		name   string
+		mutate func(*Snapshot)
+		pod    PodIdentity
+	}{
+		{
+			name: "retained endpoint pod mismatch",
+			pod: PodIdentity{
+				PodKey:           "iface-primary",
+				InfraContainerID: "container-1",
+				InterfaceID:      "iface-primary",
+				PodName:          "other",
+				PodNamespace:     "ns-1",
+			},
+		},
+		{
+			name: "assignment infra container mismatch",
+			pod: PodIdentity{
+				PodKey:           "iface-primary",
+				InfraContainerID: "other-container",
+				InterfaceID:      "iface-primary",
+				PodName:          "pod-1",
+				PodNamespace:     "ns-1",
+			},
+		},
+		{
+			name: "container assignment pod mismatch",
+			mutate: func(value *Snapshot) {
+				delete(value.Endpoints, "container-1")
+				record := value.Assignments["iface-primary"]
+				record.Pod.PodName = "other"
+				value.Assignments["iface-primary"] = record
+			},
+			pod: PodIdentity{
+				PodKey:           "unknown-interface",
+				InfraContainerID: "container-1",
+				InterfaceID:      "unknown-interface",
+				PodName:          "pod-1",
+				PodNamespace:     "ns-1",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			candidate := cloneSnapshot(snapshot)
+			if tt.mutate != nil {
+				tt.mutate(&candidate)
+			}
+			require.ErrorIs(t, validateReleaseIdentity(candidate, tt.pod), ErrInvalidInput)
+		})
+	}
+}
+
+func TestSnapshotValidationAdditionalErrorPaths(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Snapshot)
+		want   error
+	}{
+		{
+			name: "network container record has empty ID",
+			mutate: func(snapshot *Snapshot) {
+				snapshot.NetworkContainers["nc-1"] = NetworkContainerRecord{}
+			},
+			want: ErrInconsistentState,
+		},
+		{
+			name:   "IP record has empty ID",
+			mutate: func(snapshot *Snapshot) { snapshot.IPs["ip-v4"] = IPRecord{} },
+			want:   ErrInconsistentState,
+		},
+		{
+			name: "IP record has empty address",
+			mutate: func(snapshot *Snapshot) {
+				record := snapshot.IPs["ip-v4"]
+				record.IPAddress = ""
+				snapshot.IPs["ip-v4"] = record
+			},
+			want: ErrCorrupt,
+		},
+		{
+			name: "IP record has empty network container",
+			mutate: func(snapshot *Snapshot) {
+				record := snapshot.IPs["ip-v4"]
+				record.NCID = ""
+				snapshot.IPs["ip-v4"] = record
+			},
+			want: ErrInconsistentState,
+		},
+		{
+			name:   "network record has empty name",
+			mutate: func(snapshot *Snapshot) { snapshot.Networks["network-1"] = NetworkRecord{} },
+			want:   ErrInconsistentState,
+		},
+		{
+			name: "assignment record has empty pod key",
+			mutate: func(snapshot *Snapshot) {
+				record := snapshot.Assignments["iface-primary"]
+				record.Pod.PodKey = ""
+				snapshot.Assignments["iface-primary"] = record
+			},
+			want: ErrInconsistentState,
+		},
+		{
+			name: "assignment contains empty IP",
+			mutate: func(snapshot *Snapshot) {
+				record := snapshot.Assignments["iface-primary"]
+				record.IPIDs = []string{""}
+				snapshot.Assignments["iface-primary"] = record
+			},
+			want: ErrInconsistentState,
+		},
+		{
+			name:   "owner is empty",
+			mutate: func(snapshot *Snapshot) { snapshot.IPOwners["ip-v4"] = "" },
+			want:   ErrInconsistentState,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			snapshot := completeSnapshot()
+			tt.mutate(&snapshot)
+			require.ErrorIs(t, snapshot.Validate(), tt.want)
+		})
+	}
+
+	ipNetTests := []struct {
+		name         string
+		value        net.IPNet
+		expectedBits int
+	}{
+		{name: "invalid IP", value: net.IPNet{IP: net.IP{1, 2}, Mask: net.CIDRMask(24, 32)}, expectedBits: 32},
+		{name: "wrong mask size", value: mustIPNetValue("10.0.0.4", 24), expectedBits: 128},
+		{name: "IPv6 in IPv4", value: mustIPNetValue("fd00::4", 64), expectedBits: 32},
+		{name: "IPv4 in IPv6", value: mustIPNetValue("10.0.0.4", 24), expectedBits: 128},
+	}
+	for _, tt := range ipNetTests {
+		t.Run("IPNet/"+tt.name, func(t *testing.T) {
+			_, err := validateIPNet(tt.value, tt.expectedBits)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestDurableOperationAdditionalInputErrors(t *testing.T) {
+	db, _ := openTestDB(t)
+	record := testNetworkContainer("nc")
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "network container record invalid",
+			run: func() error {
+				_, err := db.ApplyNetworkContainer(context.Background(), NetworkContainerRecord{}, nil)
+				return err
+			},
+		},
+		{
+			name: "IP has empty ID",
+			run: func() error {
+				_, err := db.ApplyNetworkContainer(context.Background(), record, []IPRecord{{NCID: "nc"}})
+				return err
+			},
+		},
+		{
+			name: "IP references another network container",
+			run: func() error {
+				_, err := db.ApplyNetworkContainer(
+					context.Background(),
+					record,
+					[]IPRecord{{ID: "ip", NCID: "other"}},
+				)
+				return err
+			},
+		},
+		{
+			name: "duplicate IP ID",
+			run: func() error {
+				_, err := db.ApplyNetworkContainer(
+					context.Background(),
+					record,
+					[]IPRecord{
+						{ID: "ip", IPAddress: "10.0.0.4", NCID: "nc"},
+						{ID: "ip", IPAddress: "10.0.0.5", NCID: "nc"},
+					},
+				)
+				return err
+			},
+		},
+		{
+			name: "delete empty network container",
+			run: func() error {
+				_, err := db.DeleteNetworkContainer(context.Background(), "")
+				return err
+			},
+		},
+		{
+			name: "readiness empty network container",
+			run: func() error {
+				_, err := db.UpdateReadinessObservation(context.Background(), "", ReadinessObservation{})
+				return err
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.ErrorIs(t, tt.run(), ErrInvalidInput)
+			assert.Zero(t, readMetadata(t, db).Generation)
+		})
+	}
+}
+
+func TestOwnershipOperationAdditionalInputErrors(t *testing.T) {
+	db, _ := openTestDB(t)
+	validAssignment := testAssignment("container", "pod", "namespace", "ip")
+	validEndpoint := testEndpoint("pod", "namespace", "10.0.0.4", "")
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "assignment and endpoint pod mismatch",
+			run: func() error {
+				endpoint := validEndpoint
+				endpoint.PodName = "other"
+				_, err := db.AssignEndpoint(
+					context.Background(),
+					validAssignment,
+					endpoint,
+					testNow,
+					testDeleteIntentTTL,
+				)
+				return err
+			},
+		},
+		{
+			name: "assignment zero current time",
+			run: func() error {
+				_, err := db.AssignEndpoint(
+					context.Background(),
+					validAssignment,
+					validEndpoint,
+					time.Time{},
+					testDeleteIntentTTL,
+				)
+				return err
+			},
+		},
+		{
+			name: "assignment nonpositive TTL",
+			run: func() error {
+				_, err := db.AssignEndpoint(
+					context.Background(),
+					validAssignment,
+					validEndpoint,
+					testNow,
+					0,
+				)
+				return err
+			},
+		},
+		{
+			name: "release zero timestamp",
+			run: func() error {
+				_, err := db.ReleaseEndpoint(context.Background(), validAssignment.Pod, time.Time{})
+				return err
+			},
+		},
+		{
+			name: "patch pod mismatch",
+			run: func() error {
+				endpoint := validEndpoint
+				endpoint.PodNamespace = "other"
+				_, err := db.PatchEndpoint(
+					context.Background(),
+					validAssignment.Pod,
+					endpoint,
+					testNow,
+					testDeleteIntentTTL,
+				)
+				return err
+			},
+		},
+		{
+			name: "delete empty endpoint",
+			run: func() error {
+				_, err := db.DeleteEndpointRecord(context.Background(), "")
+				return err
+			},
+		},
+		{
+			name: "prune zero timestamp",
+			run: func() error {
+				_, err := db.PruneDeleteIntents(context.Background(), time.Time{}, testDeleteIntentTTL)
+				return err
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.ErrorIs(t, tt.run(), ErrInvalidInput)
+			assert.Zero(t, readMetadata(t, db).Generation)
+		})
+	}
+}
+
+func TestAdditionalLegacyImportStructuralErrors(t *testing.T) {
+	valid, _ := completeLegacyImportData(t)
+	tests := []struct {
+		name   string
+		mutate func(map[string]any)
+	}{
+		{
+			name: "orchestrator contexts null",
+			mutate: func(source map[string]any) {
+				source["ContainerIDByOrchestratorContext"] = nil
+			},
+		},
+		{name: "networks null", mutate: func(source map[string]any) { source["Networks"] = nil }},
+		{
+			name: "PnP mappings null",
+			mutate: func(source map[string]any) {
+				source["PnpIDByMacAddress"] = nil
+			},
+		},
+		{name: "zero timestamp", mutate: func(source map[string]any) { source["TimeStamp"] = "0001-01-01T00:00:00Z" }},
+		{
+			name: "network record null",
+			mutate: func(source map[string]any) {
+				source["Networks"].(map[string]any)["network-1"] = nil
+			},
+		},
+		{
+			name: "invalid PnP MAC",
+			mutate: func(source map[string]any) {
+				source["PnpIDByMacAddress"] = map[string]any{"bad": "pnp"}
+			},
+		},
+		{
+			name: "duplicate canonical PnP MAC",
+			mutate: func(source map[string]any) {
+				source["PnpIDByMacAddress"] = map[string]any{
+					"00:11:22:33:44:55": "one",
+					"00-11-22-33-44-55": "two",
+				}
+			},
+		},
+		{
+			name: "duplicate orchestrator network container",
+			mutate: func(source map[string]any) {
+				source["ContainerIDByOrchestratorContext"] = map[string]any{"context": "nc,nc"}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := mutateLegacyCNS(t, valid, tt.mutate)
+			_, err := parseLegacyCNS(data, "boot")
+			require.ErrorIs(t, err, ErrLegacyImportSource)
+		})
+	}
+}
+
+func TestAdditionalLegacyEndpointStructuralErrors(t *testing.T) {
+	cnsData, valid := completeLegacyImportData(t)
+	tests := []struct {
+		name   string
+		mutate func(map[string]any)
+	}{
+		{name: "endpoints null", mutate: func(envelope map[string]any) { envelope["Endpoints"] = nil }},
+		{
+			name: "endpoint record null",
+			mutate: func(envelope map[string]any) {
+				envelope["Endpoints"].(map[string]any)["container-1"] = nil
+			},
+		},
+		{
+			name: "noncanonical container ID",
+			mutate: func(envelope map[string]any) {
+				endpoints := envelope["Endpoints"].(map[string]any)
+				endpoints[" container "] = endpoints["container-1"]
+				delete(endpoints, "container-1")
+			},
+		},
+		{
+			name: "delete intents null",
+			mutate: func(envelope map[string]any) {
+				envelope["DeleteIntents"] = nil
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			snapshot, err := parseLegacyCNS(cnsData, "boot")
+			require.NoError(t, err)
+			data := mutateLegacyEndpointEnvelope(t, valid, tt.mutate)
+			require.ErrorIs(t, addLegacyEndpoints(&snapshot, data), ErrLegacyImportSource)
+		})
+	}
+}
+
+func TestStrictDecoderErrorPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "empty", data: nil},
+		{name: "null", data: []byte(" null ")},
+		{name: "multiple values", data: []byte(`{} {}`)},
+		{name: "malformed trailing value", data: []byte(`{} {`)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var destination map[string]any
+			require.Error(t, decodeStrictJSON(tt.data, &destination))
+		})
+	}
+}
+
+func TestMetadataMarkerHelpersRejectMissingBuckets(t *testing.T) {
+	db, _ := openTestDB(t)
+	err := db.db.Update(func(tx *bolt.Tx) error {
+		require.NoError(t, tx.DeleteBucket(bucketMetadata))
+		_, importErr := legacyImportComplete(tx.Bucket(bucketMetadata))
+		require.ErrorIs(t, importErr, ErrCorrupt)
+		_, exportErr := rollbackExportComplete(tx.Bucket(bucketMetadata))
+		require.ErrorIs(t, exportErr, ErrCorrupt)
+		require.ErrorIs(t, setRollbackExportComplete(tx), ErrCorrupt)
+		return errAbort
+	})
+	require.ErrorIs(t, err, errAbort)
+}
+
+func TestEncodingRejectsUnsupportedNetworkOptions(t *testing.T) {
+	durable := NewDurableState()
+	durable.Networks["network"] = NetworkRecord{
+		NetworkName: "network",
+		Options:     map[string]any{"unsupported": make(chan struct{})},
+	}
+	_, err := encodeDurableState(durable)
+	require.ErrorIs(t, err, ErrInvalidInput)
+
+	db, _ := openTestDB(t)
+	require.NoError(t, db.db.Update(func(tx *bolt.Tx) error {
+		err := putJSONValue(tx, bucketNetworks, "network", durable.Networks["network"])
+		require.ErrorIs(t, err, ErrInvalidInput)
+		return nil
+	}))
+}

--- a/cns/state/coverage_test.go
+++ b/cns/state/coverage_test.go
@@ -5,7 +5,6 @@ package state
 
 import (
 	"context"
-	"errors"
 	"net"
 	"testing"
 	"time"
@@ -16,12 +15,30 @@ import (
 	bolt "go.etcd.io/bbolt"
 )
 
+const (
+	hardeningContainerID       = "container"
+	hardeningNamespace         = "namespace"
+	hardeningBadValue          = "bad"
+	hardeningNetworkName       = "network"
+	hardeningPnPID             = "pnp"
+	hardeningInvalidMACCase    = "invalid MAC"
+	hardeningEmptyPnPIDCase    = "empty PnP ID"
+	hardeningOtherContainerID  = "other-container"
+	hardeningOtherPodName      = "other-pod"
+	hardeningContainerID2      = "container-2"
+	hardeningMultipleValues    = "multiple values"
+	hardeningUnsupportedOption = "unsupported"
+	hardeningLocation          = "eastus"
+	hardeningStateNamespace    = "state-machine"
+	hardeningNet1              = "net1"
+)
+
 func TestOwnershipNormalizationRejectsMalformedRecords(t *testing.T) {
 	validPod := PodIdentity{
-		PodKey:           "container",
-		InfraContainerID: "container",
-		PodName:          "pod",
-		PodNamespace:     "namespace",
+		PodKey:           hardeningContainerID,
+		InfraContainerID: hardeningContainerID,
+		PodName:          importOrchestratorContextKey,
+		PodNamespace:     hardeningNamespace,
 	}
 	podTests := []struct {
 		name   string
@@ -29,8 +46,8 @@ func TestOwnershipNormalizationRejectsMalformedRecords(t *testing.T) {
 	}{
 		{name: "empty pod key", mutate: func(pod *PodIdentity) { pod.PodKey = "" }},
 		{name: "empty infra container", mutate: func(pod *PodIdentity) { pod.InfraContainerID = "" }},
-		{name: "pod key differs without interface", mutate: func(pod *PodIdentity) { pod.PodKey = "other" }},
-		{name: "interface differs from pod key", mutate: func(pod *PodIdentity) { pod.InterfaceID = "other" }},
+		{name: "pod key differs without interface", mutate: func(pod *PodIdentity) { pod.PodKey = testMismatchValue }},
+		{name: "interface differs from pod key", mutate: func(pod *PodIdentity) { pod.InterfaceID = testMismatchValue }},
 		{name: "empty pod name", mutate: func(pod *PodIdentity) { pod.PodName = "" }},
 		{name: "empty pod namespace", mutate: func(pod *PodIdentity) { pod.PodNamespace = "" }},
 	}
@@ -70,11 +87,11 @@ func TestOwnershipNormalizationRejectsMalformedRecords(t *testing.T) {
 	}
 
 	validEndpoint := EndpointRecord{
-		PodName:      "pod",
-		PodNamespace: "namespace",
+		PodName:      importOrchestratorContextKey,
+		PodNamespace: hardeningNamespace,
 		IfnameToIPMap: map[string]*IPInfoRecord{
-			"eth0": {
-				IPv4: []net.IPNet{mustIPNetValue("10.0.0.4", 24)},
+			exportIfnameEth0: {
+				IPv4: []net.IPNet{mustIPNetValue(exportIPv4Address, 24)},
 			},
 		},
 	}
@@ -86,94 +103,100 @@ func TestOwnershipNormalizationRejectsMalformedRecords(t *testing.T) {
 		{name: "empty container", record: validEndpoint},
 		{
 			name:        "empty pod name",
-			containerID: "container",
+			containerID: hardeningContainerID,
 			record: EndpointRecord{
-				PodNamespace:  "namespace",
+				PodNamespace:  hardeningNamespace,
 				IfnameToIPMap: validEndpoint.IfnameToIPMap,
 			},
 		},
 		{
 			name:        "empty pod namespace",
-			containerID: "container",
+			containerID: hardeningContainerID,
 			record: EndpointRecord{
-				PodName:       "pod",
+				PodName:       importOrchestratorContextKey,
 				IfnameToIPMap: validEndpoint.IfnameToIPMap,
 			},
 		},
 		{
 			name:        "no interfaces",
-			containerID: "container",
-			record:      EndpointRecord{PodName: "pod", PodNamespace: "namespace"},
+			containerID: hardeningContainerID,
+			record: EndpointRecord{
+				PodName:      importOrchestratorContextKey,
+				PodNamespace: hardeningNamespace,
+			},
 		},
 		{
 			name:        "empty interface",
-			containerID: "container",
+			containerID: hardeningContainerID,
 			record: EndpointRecord{
-				PodName:       "pod",
-				PodNamespace:  "namespace",
+				PodName:       importOrchestratorContextKey,
+				PodNamespace:  hardeningNamespace,
 				IfnameToIPMap: map[string]*IPInfoRecord{" ": {}},
 			},
 		},
 		{
 			name:        "duplicate normalized interface",
-			containerID: "container",
+			containerID: hardeningContainerID,
 			record: EndpointRecord{
-				PodName:      "pod",
-				PodNamespace: "namespace",
+				PodName:      importOrchestratorContextKey,
+				PodNamespace: hardeningNamespace,
 				IfnameToIPMap: map[string]*IPInfoRecord{
-					"eth0":   {IPv4: []net.IPNet{mustIPNetValue("10.0.0.4", 24)}},
-					" eth0 ": {IPv4: []net.IPNet{mustIPNetValue("10.0.0.5", 24)}},
+					exportIfnameEth0: {IPv4: []net.IPNet{mustIPNetValue(exportIPv4Address, 24)}},
+					" eth0 ":         {IPv4: []net.IPNet{mustIPNetValue(exportSecondaryIPv4, 24)}}, //nolint:gocritic // intentionally noncanonical key
 				},
 			},
 		},
 		{
 			name:        "null interface",
-			containerID: "container",
+			containerID: hardeningContainerID,
 			record: EndpointRecord{
-				PodName:       "pod",
-				PodNamespace:  "namespace",
-				IfnameToIPMap: map[string]*IPInfoRecord{"eth0": nil},
+				PodName:       importOrchestratorContextKey,
+				PodNamespace:  hardeningNamespace,
+				IfnameToIPMap: map[string]*IPInfoRecord{exportIfnameEth0: nil},
 			},
 		},
 		{
-			name:        "invalid MAC",
-			containerID: "container",
+			name:        hardeningInvalidMACCase,
+			containerID: hardeningContainerID,
 			record: EndpointRecord{
-				PodName:      "pod",
-				PodNamespace: "namespace",
+				PodName:      importOrchestratorContextKey,
+				PodNamespace: hardeningNamespace,
 				IfnameToIPMap: map[string]*IPInfoRecord{
-					"eth0": {IPv4: []net.IPNet{mustIPNetValue("10.0.0.4", 24)}, MACAddress: "bad"},
+					exportIfnameEth0: {
+						IPv4:       []net.IPNet{mustIPNetValue(exportIPv4Address, 24)},
+						MACAddress: hardeningBadValue,
+					},
 				},
 			},
 		},
 		{
 			name:        "no IPs",
-			containerID: "container",
+			containerID: hardeningContainerID,
 			record: EndpointRecord{
-				PodName:       "pod",
-				PodNamespace:  "namespace",
-				IfnameToIPMap: map[string]*IPInfoRecord{"eth0": {}},
+				PodName:       importOrchestratorContextKey,
+				PodNamespace:  hardeningNamespace,
+				IfnameToIPMap: map[string]*IPInfoRecord{exportIfnameEth0: {}},
 			},
 		},
 		{
 			name:        "IPv6 in IPv4 list",
-			containerID: "container",
+			containerID: hardeningContainerID,
 			record: EndpointRecord{
-				PodName:      "pod",
-				PodNamespace: "namespace",
+				PodName:      importOrchestratorContextKey,
+				PodNamespace: hardeningNamespace,
 				IfnameToIPMap: map[string]*IPInfoRecord{
-					"eth0": {IPv4: []net.IPNet{mustIPNetValue("fd00::4", 64)}},
+					exportIfnameEth0: {IPv4: []net.IPNet{mustIPNetValue(exportIPv6Address, 64)}},
 				},
 			},
 		},
 		{
 			name:        "IPv4 in IPv6 list",
-			containerID: "container",
+			containerID: hardeningContainerID,
 			record: EndpointRecord{
-				PodName:      "pod",
-				PodNamespace: "namespace",
+				PodName:      importOrchestratorContextKey,
+				PodNamespace: hardeningNamespace,
 				IfnameToIPMap: map[string]*IPInfoRecord{
-					"eth0": {IPv6: []net.IPNet{mustIPNetValue("10.0.0.4", 24)}},
+					exportIfnameEth0: {IPv6: []net.IPNet{mustIPNetValue(exportIPv4Address, 24)}},
 				},
 			},
 		},
@@ -189,10 +212,10 @@ func TestOwnershipNormalizationRejectsMalformedRecords(t *testing.T) {
 func TestNormalizeDurableStateRejectsMalformedMappings(t *testing.T) {
 	valid := NewDurableState()
 	valid.NetworkContainers["nc"] = testNetworkContainer("nc")
-	valid.IPs["ip"] = IPRecord{ID: "ip", IPAddress: "10.0.0.4", NCID: "nc"}
-	valid.Networks["network"] = NetworkRecord{NetworkName: "network"}
+	valid.IPs["ip"] = IPRecord{ID: "ip", IPAddress: exportIPv4Address, NCID: "nc"}
+	valid.Networks[hardeningNetworkName] = NetworkRecord{NetworkName: hardeningNetworkName}
 	valid.OrchestratorContexts["context"] = []string{"nc"}
-	valid.PnPIDByMAC["00:11:22:33:44:55"] = "pnp"
+	valid.PnPIDByMAC[testMACAddress] = hardeningPnPID
 
 	tests := []struct {
 		name   string
@@ -201,25 +224,27 @@ func TestNormalizeDurableStateRejectsMalformedMappings(t *testing.T) {
 		{
 			name: "network container key mismatch",
 			mutate: func(value *DurableState) {
-				value.NetworkContainers = map[string]NetworkContainerRecord{"other": testNetworkContainer("nc")}
+				value.NetworkContainers = map[string]NetworkContainerRecord{testMismatchValue: testNetworkContainer("nc")}
 			},
 		},
 		{
 			name: "network container request mismatch",
 			mutate: func(value *DurableState) {
 				record := testNetworkContainer("nc")
-				record.Request.NetworkContainerid = "other"
+				record.Request.NetworkContainerid = testMismatchValue
 				value.NetworkContainers = map[string]NetworkContainerRecord{"nc": record}
 			},
 		},
 		{
-			name:   "IP key mismatch",
-			mutate: func(value *DurableState) { value.IPs = map[string]IPRecord{"other": valid.IPs["ip"]} },
+			name: "IP key mismatch",
+			mutate: func(value *DurableState) {
+				value.IPs = map[string]IPRecord{testMismatchValue: valid.IPs["ip"]}
+			},
 		},
 		{
 			name: "network key mismatch",
 			mutate: func(value *DurableState) {
-				value.Networks = map[string]NetworkRecord{"other": valid.Networks["network"]}
+				value.Networks = map[string]NetworkRecord{testMismatchValue: valid.Networks[hardeningNetworkName]}
 			},
 		},
 		{
@@ -229,19 +254,23 @@ func TestNormalizeDurableStateRejectsMalformedMappings(t *testing.T) {
 			},
 		},
 		{
-			name:   "invalid MAC",
-			mutate: func(value *DurableState) { value.PnPIDByMAC = map[string]string{"bad": "pnp"} },
+			name: hardeningInvalidMACCase,
+			mutate: func(value *DurableState) {
+				value.PnPIDByMAC = map[string]string{hardeningBadValue: hardeningPnPID}
+			},
 		},
 		{
-			name:   "empty PnP ID",
-			mutate: func(value *DurableState) { value.PnPIDByMAC = map[string]string{"00:11:22:33:44:55": ""} },
+			name: hardeningEmptyPnPIDCase,
+			mutate: func(value *DurableState) {
+				value.PnPIDByMAC = map[string]string{testMACAddress: ""}
+			},
 		},
 		{
 			name: "duplicate canonical MAC",
 			mutate: func(value *DurableState) {
 				value.PnPIDByMAC = map[string]string{
-					"00:11:22:33:44:55": "one",
-					"00-11-22-33-44-55": "two",
+					testMACAddress: "one",
+					importPnPMAC:   "two",
 				}
 			},
 		},
@@ -270,7 +299,7 @@ func TestLegacyNetworkValidationRejectsMalformedFields(t *testing.T) {
 		{
 			name: "invalid host primary IP",
 			mutate: func(request *cns.CreateNetworkContainerRequest) {
-				request.HostPrimaryIP = "bad"
+				request.HostPrimaryIP = hardeningBadValue
 			},
 		},
 		{
@@ -282,13 +311,13 @@ func TestLegacyNetworkValidationRejectsMalformedFields(t *testing.T) {
 		{
 			name: "invalid DNS server",
 			mutate: func(request *cns.CreateNetworkContainerRequest) {
-				request.IPConfiguration.DNSServers = []string{"bad"}
+				request.IPConfiguration.DNSServers = []string{hardeningBadValue}
 			},
 		},
 		{
 			name: "invalid gateway",
 			mutate: func(request *cns.CreateNetworkContainerRequest) {
-				request.IPConfiguration.GatewayIPAddress = "bad"
+				request.IPConfiguration.GatewayIPAddress = hardeningBadValue
 			},
 		},
 		{
@@ -300,7 +329,7 @@ func TestLegacyNetworkValidationRejectsMalformedFields(t *testing.T) {
 		{
 			name: "invalid subnet address",
 			mutate: func(request *cns.CreateNetworkContainerRequest) {
-				request.IPConfiguration.IPSubnet.IPAddress = "bad"
+				request.IPConfiguration.IPSubnet.IPAddress = hardeningBadValue
 			},
 		},
 		{
@@ -312,19 +341,19 @@ func TestLegacyNetworkValidationRejectsMalformedFields(t *testing.T) {
 		{
 			name: "invalid route destination",
 			mutate: func(request *cns.CreateNetworkContainerRequest) {
-				request.Routes = []cns.Route{{IPAddress: "bad"}}
+				request.Routes = []cns.Route{{IPAddress: hardeningBadValue}}
 			},
 		},
 		{
 			name: "invalid route gateway",
 			mutate: func(request *cns.CreateNetworkContainerRequest) {
-				request.Routes = []cns.Route{{GatewayIPAddress: "bad"}}
+				request.Routes = []cns.Route{{GatewayIPAddress: hardeningBadValue}}
 			},
 		},
 		{
-			name: "invalid MAC",
+			name: hardeningInvalidMACCase,
 			mutate: func(request *cns.CreateNetworkContainerRequest) {
-				request.NetworkInterfaceInfo.MACAddress = "bad"
+				request.NetworkInterfaceInfo.MACAddress = hardeningBadValue
 			},
 		},
 	}
@@ -339,8 +368,13 @@ func TestLegacyNetworkValidationRejectsMalformedFields(t *testing.T) {
 
 func TestTransactionInputErrorsPreserveState(t *testing.T) {
 	db, _ := openTestDB(t)
-	validEndpoint := testEndpoint("pod", "namespace", "10.0.0.4", "")
-	validAssignment := testAssignment("container", "pod", "namespace", "ip")
+	validEndpoint := coverageEndpoint(importOrchestratorContextKey, hardeningNamespace, exportIPv4Address, "")
+	validAssignment := coverageAssignment(
+		hardeningContainerID,
+		importOrchestratorContextKey,
+		hardeningNamespace,
+		"ip",
+	)
 	tests := []struct {
 		name string
 		run  func(*WriteTx) error
@@ -350,7 +384,7 @@ func TestTransactionInputErrorsPreserveState(t *testing.T) {
 		}},
 		{name: "network container request mismatch", run: func(tx *WriteTx) error {
 			record := testNetworkContainer("nc")
-			record.Request.NetworkContainerid = "other"
+			record.Request.NetworkContainerid = testMismatchValue
 			return tx.PutNetworkContainer(record)
 		}},
 		{name: "IP empty ID", run: func(tx *WriteTx) error { return tx.PutIP(IPRecord{}) }},
@@ -358,14 +392,18 @@ func TestTransactionInputErrorsPreserveState(t *testing.T) {
 		{name: "context empty ID", run: func(tx *WriteTx) error {
 			return tx.PutOrchestratorContext("", nil)
 		}},
-		{name: "PnP invalid MAC", run: func(tx *WriteTx) error { return tx.PutPnPID("bad", "pnp") }},
+		{name: "PnP invalid MAC", run: func(tx *WriteTx) error {
+			return tx.PutPnPID(hardeningBadValue, hardeningPnPID)
+		}},
 		{name: "PnP empty ID", run: func(tx *WriteTx) error {
-			return tx.PutPnPID("00:11:22:33:44:55", "")
+			return tx.PutPnPID(testMACAddress, "")
 		}},
 		{name: "assignment malformed", run: func(tx *WriteTx) error {
 			return tx.PutAssignment(AssignmentRecord{})
 		}},
-		{name: "owner empty IP", run: func(tx *WriteTx) error { return tx.PutIPOwner("", "pod") }},
+		{name: "owner empty IP", run: func(tx *WriteTx) error {
+			return tx.PutIPOwner("", importOrchestratorContextKey)
+		}},
 		{name: "owner empty pod", run: func(tx *WriteTx) error { return tx.PutIPOwner("ip", "") }},
 		{name: "endpoint empty container", run: func(tx *WriteTx) error {
 			return tx.PutEndpoint("", validEndpoint)
@@ -374,7 +412,7 @@ func TestTransactionInputErrorsPreserveState(t *testing.T) {
 			return tx.PutDeleteIntent("", DeleteIntent{CreatedAt: testNow})
 		}},
 		{name: "delete intent zero timestamp", run: func(tx *WriteTx) error {
-			return tx.PutDeleteIntent("container", DeleteIntent{})
+			return tx.PutDeleteIntent(hardeningContainerID, DeleteIntent{})
 		}},
 		{name: "delete empty durable ID", run: func(tx *WriteTx) error {
 			return tx.DeleteNetworkContainer("")
@@ -436,7 +474,7 @@ func TestTransactionCorruptionFaultsAreCategorized(t *testing.T) {
 			name:       "delete missing bucket",
 			bucketName: bucketAssignments,
 			run: func(tx *bolt.Tx) error {
-				return deleteJSONValue(tx, bucketAssignments, "pod")
+				return deleteJSONValue(tx, bucketAssignments, importOrchestratorContextKey)
 			},
 		},
 		{
@@ -507,7 +545,7 @@ func TestValidationHelpersPreserveErrorCategories(t *testing.T) {
 
 	require.NoError(t, validateOptionalAddress(""))
 	require.NoError(t, validateOptionalAddress("10.0.0.1"))
-	require.Error(t, validateOptionalAddress("bad"))
+	require.Error(t, validateOptionalAddress(hardeningBadValue))
 	require.NoError(t, validateOptionalIPValue("10.0.0.0/24"))
 
 	_, err := endpointsEqual(
@@ -516,12 +554,12 @@ func TestValidationHelpersPreserveErrorCategories(t *testing.T) {
 	)
 	require.ErrorIs(t, err, ErrInvalidInput)
 	_, err = endpointsEqual(
-		testEndpoint("pod", "namespace", "10.0.0.4", ""),
+		coverageEndpoint(importOrchestratorContextKey, hardeningNamespace, exportIPv4Address, ""),
 		EndpointRecord{},
 	)
 	require.ErrorIs(t, err, ErrInvalidInput)
-	require.True(t, errors.Is(invalidInput("detail", errAbort), ErrInvalidInput))
-	require.True(t, errors.Is(corrupt("detail", errAbort), ErrCorrupt))
+	require.ErrorIs(t, invalidInput("detail", errAbort), ErrInvalidInput)
+	require.ErrorIs(t, corrupt("detail", errAbort), ErrCorrupt)
 }
 
 func TestReleaseIdentityRejectsConflictingOwnership(t *testing.T) {
@@ -534,37 +572,37 @@ func TestReleaseIdentityRejectsConflictingOwnership(t *testing.T) {
 		{
 			name: "retained endpoint pod mismatch",
 			pod: PodIdentity{
-				PodKey:           "iface-primary",
+				PodKey:           testIfacePrimary,
 				InfraContainerID: "container-1",
-				InterfaceID:      "iface-primary",
-				PodName:          "other",
-				PodNamespace:     "ns-1",
+				InterfaceID:      testIfacePrimary,
+				PodName:          testMismatchValue,
+				PodNamespace:     exportPodNamespace,
 			},
 		},
 		{
 			name: "assignment infra container mismatch",
 			pod: PodIdentity{
-				PodKey:           "iface-primary",
-				InfraContainerID: "other-container",
-				InterfaceID:      "iface-primary",
+				PodKey:           testIfacePrimary,
+				InfraContainerID: hardeningOtherContainerID,
+				InterfaceID:      testIfacePrimary,
 				PodName:          "pod-1",
-				PodNamespace:     "ns-1",
+				PodNamespace:     exportPodNamespace,
 			},
 		},
 		{
 			name: "container assignment pod mismatch",
 			mutate: func(value *Snapshot) {
 				delete(value.Endpoints, "container-1")
-				record := value.Assignments["iface-primary"]
-				record.Pod.PodName = "other"
-				value.Assignments["iface-primary"] = record
+				record := value.Assignments[testIfacePrimary]
+				record.Pod.PodName = testMismatchValue
+				value.Assignments[testIfacePrimary] = record
 			},
 			pod: PodIdentity{
 				PodKey:           "unknown-interface",
 				InfraContainerID: "container-1",
 				InterfaceID:      "unknown-interface",
 				PodName:          "pod-1",
-				PodNamespace:     "ns-1",
+				PodNamespace:     exportPodNamespace,
 			},
 		},
 	}
@@ -623,18 +661,18 @@ func TestSnapshotValidationAdditionalErrorPaths(t *testing.T) {
 		{
 			name: "assignment record has empty pod key",
 			mutate: func(snapshot *Snapshot) {
-				record := snapshot.Assignments["iface-primary"]
+				record := snapshot.Assignments[testIfacePrimary]
 				record.Pod.PodKey = ""
-				snapshot.Assignments["iface-primary"] = record
+				snapshot.Assignments[testIfacePrimary] = record
 			},
 			want: ErrInconsistentState,
 		},
 		{
 			name: "assignment contains empty IP",
 			mutate: func(snapshot *Snapshot) {
-				record := snapshot.Assignments["iface-primary"]
+				record := snapshot.Assignments[testIfacePrimary]
 				record.IPIDs = []string{""}
-				snapshot.Assignments["iface-primary"] = record
+				snapshot.Assignments[testIfacePrimary] = record
 			},
 			want: ErrInconsistentState,
 		},
@@ -658,9 +696,9 @@ func TestSnapshotValidationAdditionalErrorPaths(t *testing.T) {
 		expectedBits int
 	}{
 		{name: "invalid IP", value: net.IPNet{IP: net.IP{1, 2}, Mask: net.CIDRMask(24, 32)}, expectedBits: 32},
-		{name: "wrong mask size", value: mustIPNetValue("10.0.0.4", 24), expectedBits: 128},
+		{name: "wrong mask size", value: mustIPNetValue(exportIPv4Address, 24), expectedBits: 128},
 		{name: "IPv6 in IPv4", value: mustIPNetValue("fd00::4", 64), expectedBits: 32},
-		{name: "IPv4 in IPv6", value: mustIPNetValue("10.0.0.4", 24), expectedBits: 128},
+		{name: "IPv4 in IPv6", value: mustIPNetValue(exportIPv4Address, 24), expectedBits: 128},
 	}
 	for _, tt := range ipNetTests {
 		t.Run("IPNet/"+tt.name, func(t *testing.T) {
@@ -697,7 +735,7 @@ func TestDurableOperationAdditionalInputErrors(t *testing.T) {
 				_, err := db.ApplyNetworkContainer(
 					context.Background(),
 					record,
-					[]IPRecord{{ID: "ip", NCID: "other"}},
+					[]IPRecord{{ID: "ip", NCID: testMismatchValue}},
 				)
 				return err
 			},
@@ -709,8 +747,8 @@ func TestDurableOperationAdditionalInputErrors(t *testing.T) {
 					context.Background(),
 					record,
 					[]IPRecord{
-						{ID: "ip", IPAddress: "10.0.0.4", NCID: "nc"},
-						{ID: "ip", IPAddress: "10.0.0.5", NCID: "nc"},
+						{ID: "ip", IPAddress: exportIPv4Address, NCID: "nc"},
+						{ID: "ip", IPAddress: exportSecondaryIPv4, NCID: "nc"},
 					},
 				)
 				return err
@@ -741,8 +779,13 @@ func TestDurableOperationAdditionalInputErrors(t *testing.T) {
 
 func TestOwnershipOperationAdditionalInputErrors(t *testing.T) {
 	db, _ := openTestDB(t)
-	validAssignment := testAssignment("container", "pod", "namespace", "ip")
-	validEndpoint := testEndpoint("pod", "namespace", "10.0.0.4", "")
+	validAssignment := coverageAssignment(
+		hardeningContainerID,
+		importOrchestratorContextKey,
+		hardeningNamespace,
+		"ip",
+	)
+	validEndpoint := coverageEndpoint(importOrchestratorContextKey, hardeningNamespace, exportIPv4Address, "")
 	tests := []struct {
 		name string
 		run  func() error
@@ -751,7 +794,7 @@ func TestOwnershipOperationAdditionalInputErrors(t *testing.T) {
 			name: "assignment and endpoint pod mismatch",
 			run: func() error {
 				endpoint := validEndpoint
-				endpoint.PodName = "other"
+				endpoint.PodName = testMismatchValue
 				_, err := db.AssignEndpoint(
 					context.Background(),
 					validAssignment,
@@ -832,7 +875,7 @@ func TestOwnershipOperationAdditionalInputErrors(t *testing.T) {
 			name: "patch pod mismatch",
 			run: func() error {
 				endpoint := validEndpoint
-				endpoint.PodNamespace = "other"
+				endpoint.PodNamespace = testMismatchValue
 				_, err := db.PatchEndpoint(
 					context.Background(),
 					validAssignment.Pod,
@@ -895,15 +938,15 @@ func TestAdditionalLegacyImportStructuralErrors(t *testing.T) {
 		{
 			name: "invalid PnP MAC",
 			mutate: func(source map[string]any) {
-				source["PnpIDByMacAddress"] = map[string]any{"bad": "pnp"}
+				source["PnpIDByMacAddress"] = map[string]any{hardeningBadValue: hardeningPnPID}
 			},
 		},
 		{
 			name: "duplicate canonical PnP MAC",
 			mutate: func(source map[string]any) {
 				source["PnpIDByMacAddress"] = map[string]any{
-					"00:11:22:33:44:55": "one",
-					"00-11-22-33-44-55": "two",
+					testMACAddress: "one",
+					importPnPMAC:   "two",
 				}
 			},
 		},
@@ -968,7 +1011,7 @@ func TestStrictDecoderErrorPaths(t *testing.T) {
 	}{
 		{name: "empty", data: nil},
 		{name: "null", data: []byte(" null ")},
-		{name: "multiple values", data: []byte(`{} {}`)},
+		{name: hardeningMultipleValues, data: []byte(`{} {}`)},
 		{name: "malformed trailing value", data: []byte(`{} {`)},
 	}
 	for _, tt := range tests {
@@ -995,17 +1038,56 @@ func TestMetadataMarkerHelpersRejectMissingBuckets(t *testing.T) {
 
 func TestEncodingRejectsUnsupportedNetworkOptions(t *testing.T) {
 	durable := NewDurableState()
-	durable.Networks["network"] = NetworkRecord{
-		NetworkName: "network",
-		Options:     map[string]any{"unsupported": make(chan struct{})},
+	durable.Networks[hardeningNetworkName] = NetworkRecord{
+		NetworkName: hardeningNetworkName,
+		Options:     map[string]any{hardeningUnsupportedOption: make(chan struct{})},
 	}
 	_, err := encodeDurableState(durable)
 	require.ErrorIs(t, err, ErrInvalidInput)
 
 	db, _ := openTestDB(t)
 	require.NoError(t, db.db.Update(func(tx *bolt.Tx) error {
-		err := putJSONValue(tx, bucketNetworks, "network", durable.Networks["network"])
+		err := putJSONValue(
+			tx,
+			bucketNetworks,
+			hardeningNetworkName,
+			durable.Networks[hardeningNetworkName],
+		)
 		require.ErrorIs(t, err, ErrInvalidInput)
 		return nil
 	}))
+}
+
+func coverageAssignment(
+	containerID,
+	podName,
+	podNamespace string,
+	ipIDs ...string,
+) AssignmentRecord {
+	return AssignmentRecord{
+		Pod: PodIdentity{
+			PodKey:           containerID,
+			InfraContainerID: containerID,
+			PodName:          podName,
+			PodNamespace:     podNamespace,
+		},
+		IPIDs: ipIDs,
+	}
+}
+
+func coverageEndpoint(podName, podNamespace, address, ncID string) EndpointRecord {
+	return EndpointRecord{
+		PodName:      podName,
+		PodNamespace: podNamespace,
+		IfnameToIPMap: map[string]*IPInfoRecord{
+			testEth0: {
+				IPv4: []net.IPNet{{
+					IP:   net.ParseIP(address),
+					Mask: net.CIDRMask(24, 32),
+				}},
+				MACAddress:         testMACAddress,
+				NetworkContainerID: ncID,
+			},
+		},
+	}
 }

--- a/cns/state/coverage_test.go
+++ b/cns/state/coverage_test.go
@@ -540,9 +540,6 @@ func TestMetadataReadRejectsCorruptValues(t *testing.T) {
 }
 
 func TestValidationHelpersPreserveErrorCategories(t *testing.T) {
-	require.NoError(t, validateNonemptyKeys(bucketIPs, map[string]int{"ip": 1}))
-	require.ErrorIs(t, validateNonemptyKeys(bucketIPs, map[string]int{"": 1}), ErrInconsistentState)
-
 	require.NoError(t, validateOptionalAddress(""))
 	require.NoError(t, validateOptionalAddress("10.0.0.1"))
 	require.Error(t, validateOptionalAddress(hardeningBadValue))

--- a/cns/state/coverage_test.go
+++ b/cns/state/coverage_test.go
@@ -472,6 +472,35 @@ func TestTransactionCorruptionFaultsAreCategorized(t *testing.T) {
 	})
 }
 
+func TestMetadataReadRejectsCorruptValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   []byte
+		value []byte
+	}{
+		{name: "schema version", key: metaKeySchemaVersion, value: []byte{1}},
+		{name: "authority", key: metaKeyAuthority, value: []byte("invalid")},
+		{name: "generation", key: metaKeyGeneration, value: []byte{1}},
+		{name: "legacy import marker", key: metaKeyLegacyImport, value: []byte("invalid")},
+		{name: "rollback export marker", key: metaKeyRollbackExport, value: []byte("invalid")},
+		{name: "service metadata", key: metaKeyService, value: []byte(`{"initialized":`)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, _ := openTestDB(t)
+			require.NoError(t, db.db.Update(func(tx *bolt.Tx) error {
+				return tx.Bucket(bucketMetadata).Put(tt.key, tt.value)
+			}))
+
+			err := db.View(context.Background(), func(tx *ReadTx) error {
+				_, err := tx.Metadata()
+				return err
+			})
+			require.ErrorIs(t, err, ErrCorrupt)
+		})
+	}
+}
+
 func TestValidationHelpersPreserveErrorCategories(t *testing.T) {
 	require.NoError(t, validateNonemptyKeys(bucketIPs, map[string]int{"ip": 1}))
 	require.ErrorIs(t, validateNonemptyKeys(bucketIPs, map[string]int{"": 1}), ErrInconsistentState)
@@ -760,9 +789,42 @@ func TestOwnershipOperationAdditionalInputErrors(t *testing.T) {
 			},
 		},
 		{
+			name: "release malformed pod",
+			run: func() error {
+				_, err := db.ReleaseEndpoint(context.Background(), PodIdentity{}, testNow)
+				return err
+			},
+		},
+		{
 			name: "release zero timestamp",
 			run: func() error {
 				_, err := db.ReleaseEndpoint(context.Background(), validAssignment.Pod, time.Time{})
+				return err
+			},
+		},
+		{
+			name: "patch malformed pod",
+			run: func() error {
+				_, err := db.PatchEndpoint(
+					context.Background(),
+					PodIdentity{},
+					validEndpoint,
+					testNow,
+					testDeleteIntentTTL,
+				)
+				return err
+			},
+		},
+		{
+			name: "patch malformed endpoint",
+			run: func() error {
+				_, err := db.PatchEndpoint(
+					context.Background(),
+					validAssignment.Pod,
+					EndpointRecord{},
+					testNow,
+					testDeleteIntentTTL,
+				)
 				return err
 			},
 		},

--- a/cns/state/fuzz_test.go
+++ b/cns/state/fuzz_test.go
@@ -1,0 +1,239 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package state
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const maxFuzzStateBytes = 128 << 10
+
+func FuzzStrictLegacyCNSImport(f *testing.F) {
+	valid, _ := completeLegacyImportData(f)
+	for _, seed := range [][]byte{
+		valid,
+		{},
+		[]byte("null"),
+		[]byte(`{"ContainerNetworkService":{}}`),
+		[]byte(`{"ContainerNetworkService":{},"containernetworkservice":{}}`),
+		[]byte(`{"ContainerNetworkService":{"unknown":true}}`),
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > maxFuzzStateBytes {
+			t.Skip()
+		}
+		snapshot, err := parseLegacyCNS(data, "fuzz-boot")
+		if err != nil {
+			return
+		}
+		require.NoError(t, snapshot.Validate())
+		for id, record := range snapshot.NetworkContainers {
+			require.Empty(t, record.Request.AuthorizationToken, id)
+			require.Nil(t, record.Request.SecondaryIPConfigs, id)
+		}
+	})
+}
+
+func FuzzStrictLegacyEndpointImport(f *testing.F) {
+	cnsData, valid := completeLegacyImportData(f)
+	for _, seed := range [][]byte{
+		valid,
+		{},
+		[]byte("null"),
+		[]byte(`{"Endpoints":{}}`),
+		[]byte(`{"Endpoints":null}`),
+		[]byte(`{"Endpoints":{},"endpoints":{}}`),
+		[]byte(`{"Endpoints":{},"DeleteIntents":null}`),
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > maxFuzzStateBytes {
+			t.Skip()
+		}
+		snapshot, err := parseLegacyCNS(cnsData, "fuzz-boot")
+		require.NoError(t, err)
+		if err := addLegacyEndpoints(&snapshot, data); err != nil {
+			return
+		}
+		require.NoError(t, snapshot.Validate())
+	})
+}
+
+func FuzzSnapshotValidationAndStrictRecordDecoding(f *testing.F) {
+	validSnapshot, err := json.Marshal(completeSnapshot())
+	require.NoError(f, err)
+	validIP, err := json.Marshal(completeSnapshot().IPs["ip-v4"])
+	require.NoError(f, err)
+	for _, seed := range []struct {
+		kind byte
+		data []byte
+	}{
+		{kind: 0, data: validSnapshot},
+		{kind: 1, data: validIP},
+		{kind: 2, data: []byte(`{"id":"nc-1","request":{"NetworkContainerid":"nc-1"}}`)},
+		{kind: 3, data: []byte(`{"podName":"pod","ifnameToIPMap":{}}`)},
+		{kind: 0, data: []byte("null")},
+		{kind: 1, data: []byte(`{"id":"a","ID":"b"}`)},
+		{kind: 2, data: []byte(`{} {}`)},
+	} {
+		f.Add(seed.kind, seed.data)
+	}
+
+	f.Fuzz(func(t *testing.T, kind byte, data []byte) {
+		if len(data) > maxFuzzStateBytes {
+			t.Skip()
+		}
+		switch kind % 4 {
+		case 0:
+			var snapshot Snapshot
+			if err := decodeStrictJSON(data, &snapshot); err != nil {
+				return
+			}
+			_ = snapshot.Validate()
+		case 1:
+			var record IPRecord
+			_ = decodeJSONValue(data, &record)
+		case 2:
+			var record NetworkContainerRecord
+			_ = decodeJSONValue(data, &record)
+		case 3:
+			var record EndpointRecord
+			_ = decodeJSONValue(data, &record)
+		}
+	})
+}
+
+func FuzzExportImportRoundTrip(f *testing.F) {
+	f.Add([]byte{1, 2, 3, 4})
+	f.Add([]byte{4, 1, 0xff})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) == 0 || len(data) > 64 {
+			t.Skip()
+		}
+		ncCount := 1 + int(data[0]%4)
+		ipsPerNC := 1 + int(data[len(data)-1]%4)
+		durable := fuzzDurableState(ncCount, ipsPerNC)
+
+		dir := t.TempDir()
+		source, err := Open(filepath.Join(dir, "source.db"), Options{NoSync: true})
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, source.Close()) })
+		changed, err := source.ReplaceDurableState(context.Background(), 0, durable)
+		require.NoError(t, err)
+		require.True(t, changed)
+		require.NoError(t, source.Update(context.Background(), func(tx *WriteTx) error {
+			return tx.PutMetadata(Metadata{
+				BootID:           "source-boot",
+				OrchestratorType: "KubernetesCRD",
+				NodeID:           "node-fuzz",
+				Location:         "eastus",
+				NetworkType:      "azure",
+				Initialized:      true,
+				TimeStamp:        time.Date(2026, time.July, 24, 0, 0, 0, 0, time.UTC),
+			})
+		}))
+		before, err := source.Snapshot(context.Background())
+		require.NoError(t, err)
+
+		opts := ExportOptions{
+			CNSJSONPath:      filepath.Join(dir, "rollback", "azure-cns.json"),
+			EndpointJSONPath: filepath.Join(dir, "rollback", "azure-endpoints.json"),
+		}
+		changed, err = source.ExportLegacy(context.Background(), opts)
+		require.NoError(t, err)
+		require.True(t, changed)
+		exported, err := os.ReadFile(opts.CNSJSONPath)
+		require.NoError(t, err)
+		require.NotContains(t, string(exported), "fuzz-secret")
+
+		target, err := Open(filepath.Join(dir, "target.db"), Options{NoSync: true})
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, target.Close()) })
+		changed, err = target.ImportLegacy(context.Background(), ImportOptions{
+			CNSPath:             opts.CNSJSONPath,
+			EndpointPath:        opts.EndpointJSONPath,
+			ManageEndpointState: true,
+			BootID:              "target-boot",
+		})
+		require.NoError(t, err)
+		require.True(t, changed)
+		after, err := target.Snapshot(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, before.NetworkContainers, after.NetworkContainers)
+		require.Equal(t, before.IPs, after.IPs)
+		require.Equal(t, before.Networks, after.Networks)
+		require.Equal(t, before.OrchestratorContexts, after.OrchestratorContexts)
+		require.Equal(t, before.PnPIDByMAC, after.PnPIDByMAC)
+	})
+}
+
+func fuzzDurableState(ncCount, ipsPerNC int) DurableState {
+	durable := NewDurableState()
+	for ncIndex := range ncCount {
+		ncID := fmt.Sprintf("nc-%d", ncIndex)
+		request := completeNetworkContainerRequest()
+		request.AuthorizationToken = "fuzz-secret"
+		record := NewNetworkContainerRecord(ncID, "2", "1", true, request)
+		durable.NetworkContainers[ncID] = record
+		for ipIndex := range ipsPerNC {
+			id := fmt.Sprintf("00000000-0000-4000-8000-%012d", ncIndex*16+ipIndex+1)
+			address := netip.AddrFrom4([4]byte{10, 64 + byte(ncIndex), 0, byte(ipIndex + 4)})
+			if ipIndex%2 == 1 {
+				address = netip.AddrFrom16([16]byte{0xfd, byte(ncIndex + 1), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, byte(ipIndex + 4)})
+			}
+			durable.IPs[id] = IPRecord{
+				ID:        id,
+				IPAddress: address.String(),
+				NCID:      ncID,
+				NCVersion: 2,
+			}
+		}
+		durable.OrchestratorContexts[fmt.Sprintf("context-%d", ncIndex)] = []string{ncID}
+		durable.PnPIDByMAC[fmt.Sprintf("02:00:00:00:%02x:%02x", ncIndex, ncIndex+1)] = "pnp-" + ncID
+		durable.Networks["network-"+ncID] = NetworkRecord{NetworkName: "network-" + ncID}
+	}
+	return durable
+}
+
+func TestStrictJSONRejectsTrailingAndDuplicateValues(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "empty", data: nil},
+		{name: "null", data: []byte("null")},
+		{name: "multiple values", data: []byte(`{} {}`)},
+		{name: "case-insensitive duplicate", data: []byte(`{"id":"a","ID":"b"}`)},
+		{name: "nested duplicate", data: []byte(`{"outer":{"a":1,"A":2}}`)},
+		{name: "invalid closing delimiter", data: []byte(`{"outer":[1,2}`)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var destination map[string]any
+			require.Error(t, decodeJSONDocument(tt.data, &destination))
+		})
+	}
+}
+
+func TestStrictJSONAcceptsBoundedNestedDocument(t *testing.T) {
+	data := []byte(`{"array":[1,{"nested":true},null],"object":{"value":"ok"}}`)
+	var destination map[string]any
+	require.NoError(t, decodeJSONDocument(data, &destination))
+	require.Equal(t, "ok", destination["object"].(map[string]any)["value"])
+}

--- a/cns/state/fuzz_test.go
+++ b/cns/state/fuzz_test.go
@@ -40,7 +40,8 @@ func FuzzStrictLegacyCNSImport(f *testing.F) {
 			return
 		}
 		require.NoError(t, snapshot.Validate())
-		for id, record := range snapshot.NetworkContainers {
+		for id := range snapshot.NetworkContainers {
+			record := snapshot.NetworkContainers[id]
 			require.Empty(t, record.Request.AuthorizationToken, id)
 			require.Nil(t, record.Request.SecondaryIPConfigs, id)
 		}
@@ -75,7 +76,7 @@ func FuzzStrictLegacyEndpointImport(f *testing.F) {
 }
 
 func FuzzSnapshotValidationAndStrictRecordDecoding(f *testing.F) {
-	validSnapshot, err := json.Marshal(completeSnapshot())
+	validSnapshot, err := json.Marshal(completeSnapshot()) //nolint:musttag // snapshot includes legacy wire structs with default JSON field names
 	require.NoError(f, err)
 	validIP, err := json.Marshal(completeSnapshot().IPs["ip-v4"])
 	require.NoError(f, err)
@@ -140,10 +141,10 @@ func FuzzExportImportRoundTrip(f *testing.F) {
 		require.NoError(t, source.Update(context.Background(), func(tx *WriteTx) error {
 			return tx.PutMetadata(Metadata{
 				BootID:           "source-boot",
-				OrchestratorType: "KubernetesCRD",
+				OrchestratorType: importOrchestratorType,
 				NodeID:           "node-fuzz",
-				Location:         "eastus",
-				NetworkType:      "azure",
+				Location:         hardeningLocation,
+				NetworkType:      exportNetworkType,
 				Initialized:      true,
 				TimeStamp:        time.Date(2026, time.July, 24, 0, 0, 0, 0, time.UTC),
 			})
@@ -218,7 +219,7 @@ func TestStrictJSONRejectsTrailingAndDuplicateValues(t *testing.T) {
 	}{
 		{name: "empty", data: nil},
 		{name: "null", data: []byte("null")},
-		{name: "multiple values", data: []byte(`{} {}`)},
+		{name: hardeningMultipleValues, data: []byte(`{} {}`)},
 		{name: "case-insensitive duplicate", data: []byte(`{"id":"a","ID":"b"}`)},
 		{name: "nested duplicate", data: []byte(`{"outer":{"a":1,"A":2}}`)},
 		{name: "invalid closing delimiter", data: []byte(`{"outer":[1,2}`)},

--- a/cns/state/hardening_test.go
+++ b/cns/state/hardening_test.go
@@ -1,0 +1,604 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package state
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"net"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	stateMachineNCCount = 3
+	stateMachineSteps   = 72
+)
+
+type stateMachineContainer struct {
+	active       bool
+	endpoint     bool
+	retained     bool
+	patchVersion int
+	intent       time.Time
+}
+
+type stateMachineModel struct {
+	containers [stateMachineNCCount]stateMachineContainer
+	inventory  map[string]IPRecord
+	bootID     string
+}
+
+func TestRandomizedMultiNCStateMachine(t *testing.T) {
+	for _, seed := range []int64{12001, 12017, 12031} {
+		t.Run(fmt.Sprintf("seed=%d", seed), func(t *testing.T) {
+			runRandomizedMultiNCStateMachine(t, seed)
+		})
+	}
+}
+
+func runRandomizedMultiNCStateMachine(t *testing.T, seed int64) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "state.db")
+	db, err := Open(path, Options{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	model := seedStateMachineInventory(t, db)
+	now := time.Date(2026, time.July, 24, 1, 0, 0, 0, time.UTC)
+	require.NoError(t, db.Update(context.Background(), func(tx *WriteTx) error {
+		return tx.PutMetadata(Metadata{
+			BootID:           "initial-boot",
+			OrchestratorType: "KubernetesCRD",
+			NodeID:           "node-state-machine",
+			Location:         "eastus",
+			NetworkType:      "azure",
+			Initialized:      true,
+			TimeStamp:        now,
+		})
+	}))
+	model.bootID = "initial-boot"
+	assertStateMachineModel(t, db, model)
+
+	rng := rand.New(rand.NewSource(seed)) //nolint:gosec // A fixed seed makes the state-machine sequence reproducible.
+	for step := range stateMachineSteps {
+		index := rng.Intn(stateMachineNCCount)
+		switch rng.Intn(8) {
+		case 0:
+			assignStateMachineContainer(t, db, &model, index, now.Add(time.Duration(step)*time.Second))
+		case 1:
+			releaseStateMachineContainer(t, db, &model, index, now.Add(time.Duration(step)*time.Second))
+		case 2:
+			patchStateMachineContainer(t, db, &model, index, now.Add(time.Duration(step)*time.Second))
+		case 3:
+			deleteStateMachineEndpoint(t, db, &model, index)
+		case 4:
+			pruneStateMachineIntents(t, db, &model, now.Add(2*testDeleteIntentTTL+time.Duration(step)*time.Second))
+		case 5:
+			updateStateMachineInventory(t, db, &model, index, step)
+		case 6:
+			applyStateMachineBoot(t, db, &model, step, rng.Intn(2) == 0)
+		case 7:
+			require.NoError(t, db.Close())
+			db, err = Open(path, Options{})
+			require.NoError(t, err)
+		}
+		assertStateMachineModel(t, db, model)
+	}
+
+	before := requireValidSnapshot(t, db)
+	opts := ExportOptions{
+		CNSJSONPath:      filepath.Join(t.TempDir(), "rollback", "azure-cns.json"),
+		EndpointJSONPath: filepath.Join(t.TempDir(), "rollback", "azure-endpoints.json"),
+	}
+	changed, err := db.ExportLegacy(context.Background(), opts)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	replayed, _ := openTestDB(t)
+	changed, err = replayed.ImportLegacy(context.Background(), ImportOptions{
+		CNSPath:             opts.CNSJSONPath,
+		EndpointPath:        opts.EndpointJSONPath,
+		ManageEndpointState: true,
+		BootID:              "replayed-boot",
+	})
+	require.NoError(t, err)
+	require.True(t, changed)
+	after := requireValidSnapshot(t, replayed)
+	assert.Equal(t, before.NetworkContainers, after.NetworkContainers)
+	assert.Equal(t, before.IPs, after.IPs)
+	assert.Equal(t, before.Networks, after.Networks)
+	assert.Equal(t, before.OrchestratorContexts, after.OrchestratorContexts)
+	assert.Equal(t, before.PnPIDByMAC, after.PnPIDByMAC)
+	assert.Equal(t, sortedKeys(before.Endpoints), sortedKeys(after.Endpoints))
+	for key, endpoint := range before.Endpoints {
+		equal, err := endpointsEqual(endpoint, after.Endpoints[key])
+		require.NoError(t, err)
+		assert.True(t, equal, key)
+	}
+	assert.Equal(t, before.DeleteIntents, after.DeleteIntents)
+}
+
+func seedStateMachineInventory(t *testing.T, db *DB) stateMachineModel {
+	t.Helper()
+	model := stateMachineModel{inventory: map[string]IPRecord{}}
+	for index := range stateMachineNCCount {
+		records := stateMachineIPs(index, 1)
+		_, err := db.ApplyNetworkContainer(
+			context.Background(),
+			testNetworkContainer(stateMachineNCID(index)),
+			records,
+		)
+		require.NoError(t, err)
+		for _, record := range records {
+			model.inventory[record.ID] = record
+		}
+	}
+	return model
+}
+
+func assignStateMachineContainer(
+	t *testing.T,
+	db *DB,
+	model *stateMachineModel,
+	index int,
+	now time.Time,
+) {
+	t.Helper()
+	state := &model.containers[index]
+	if state.active || !state.intent.IsZero() {
+		return
+	}
+	endpoint := stateMachineEndpoint(index, state.patchVersion)
+	for _, assignment := range stateMachineAssignments(index) {
+		changed, err := db.AssignEndpoint(
+			context.Background(),
+			assignment,
+			endpoint,
+			now,
+			testDeleteIntentTTL,
+		)
+		require.NoError(t, err)
+		require.True(t, changed)
+	}
+	state.active = true
+	state.endpoint = true
+	state.retained = false
+}
+
+func releaseStateMachineContainer(
+	t *testing.T,
+	db *DB,
+	model *stateMachineModel,
+	index int,
+	now time.Time,
+) {
+	t.Helper()
+	state := &model.containers[index]
+	if !state.active {
+		return
+	}
+	pod := stateMachineAssignments(index)[0].Pod
+	if state.retained {
+		pod.PodKey = stateMachineContainerID(index)
+		pod.InterfaceID = ""
+	}
+	changed, err := db.ReleaseEndpoint(context.Background(), pod, now)
+	require.NoError(t, err)
+	require.True(t, changed)
+	state.active = false
+	state.retained = false
+	state.intent = now.UTC()
+}
+
+func patchStateMachineContainer(
+	t *testing.T,
+	db *DB,
+	model *stateMachineModel,
+	index int,
+	now time.Time,
+) {
+	t.Helper()
+	state := &model.containers[index]
+	if !state.active {
+		return
+	}
+	pod := stateMachineAssignments(index)[0].Pod
+	if state.retained {
+		pod.PodKey = stateMachineContainerID(index)
+		pod.InterfaceID = ""
+	}
+	state.patchVersion++
+	changed, err := db.PatchEndpoint(
+		context.Background(),
+		pod,
+		stateMachineEndpoint(index, state.patchVersion),
+		now,
+		testDeleteIntentTTL,
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
+}
+
+func deleteStateMachineEndpoint(t *testing.T, db *DB, model *stateMachineModel, index int) {
+	t.Helper()
+	state := &model.containers[index]
+	if state.active || !state.endpoint {
+		return
+	}
+	changed, err := db.DeleteEndpointRecord(context.Background(), stateMachineContainerID(index))
+	require.NoError(t, err)
+	require.True(t, changed)
+	state.endpoint = false
+}
+
+func pruneStateMachineIntents(t *testing.T, db *DB, model *stateMachineModel, now time.Time) {
+	t.Helper()
+	want := 0
+	for index := range stateMachineNCCount {
+		state := &model.containers[index]
+		if !state.intent.IsZero() && !deleteIntentLive(DeleteIntent{CreatedAt: state.intent}, now, testDeleteIntentTTL) {
+			state.intent = time.Time{}
+			want++
+		}
+	}
+	got, err := db.PruneDeleteIntents(context.Background(), now, testDeleteIntentTTL)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func updateStateMachineInventory(
+	t *testing.T,
+	db *DB,
+	model *stateMachineModel,
+	index, version int,
+) {
+	t.Helper()
+	if model.containers[index].endpoint {
+		return
+	}
+	records := stateMachineIPs(index, version+2)
+	changed, err := db.ApplyNetworkContainer(
+		context.Background(),
+		testNetworkContainer(stateMachineNCID(index)),
+		records,
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
+	for _, record := range records {
+		model.inventory[record.ID] = record
+	}
+}
+
+func applyStateMachineBoot(
+	t *testing.T,
+	db *DB,
+	model *stateMachineModel,
+	step int,
+	clearEndpoints bool,
+) {
+	t.Helper()
+	bootID := fmt.Sprintf("boot-%d", step)
+	changed, err := db.ApplyBoot(context.Background(), bootID, BootPolicy{
+		ClearEndpoints: clearEndpoints,
+		ResetReadiness: step%3 == 0,
+	})
+	require.NoError(t, err)
+	require.True(t, changed)
+	model.bootID = bootID
+	for index := range stateMachineNCCount {
+		state := &model.containers[index]
+		state.intent = time.Time{}
+		if clearEndpoints {
+			state.active = false
+			state.endpoint = false
+			state.retained = false
+			continue
+		}
+		state.active = state.endpoint
+		state.retained = state.endpoint
+	}
+}
+
+func assertStateMachineModel(t *testing.T, db *DB, model stateMachineModel) {
+	t.Helper()
+	snapshot := requireValidSnapshot(t, db)
+	assert.Equal(t, model.bootID, snapshot.Metadata.BootID)
+	assert.Equal(t, model.inventory, snapshot.IPs)
+
+	wantAssignments := map[string]AssignmentRecord{}
+	wantOwners := map[string]string{}
+	wantEndpoints := map[string]EndpointRecord{}
+	wantIntents := map[string]DeleteIntent{}
+	for index, state := range model.containers {
+		containerID := stateMachineContainerID(index)
+		if state.endpoint {
+			wantEndpoints[containerID] = stateMachineEndpoint(index, state.patchVersion)
+		}
+		if !state.intent.IsZero() {
+			wantIntents[containerID] = DeleteIntent{CreatedAt: state.intent}
+		}
+		if !state.active {
+			continue
+		}
+		assignments := stateMachineAssignments(index)
+		if state.retained {
+			assignments = []AssignmentRecord{{
+				Pod: PodIdentity{
+					PodKey:           containerID,
+					InfraContainerID: containerID,
+					PodName:          stateMachinePodName(index),
+					PodNamespace:     "state-machine",
+				},
+				IPIDs: stateMachineIPIDs(index),
+			}}
+		}
+		for _, assignment := range assignments {
+			wantAssignments[assignment.Pod.PodKey] = assignment
+			for _, ipID := range assignment.IPIDs {
+				wantOwners[ipID] = assignment.Pod.PodKey
+			}
+		}
+	}
+	assert.Equal(t, wantAssignments, snapshot.Assignments)
+	assert.Equal(t, wantOwners, snapshot.IPOwners)
+	assert.Equal(t, sortedKeys(wantEndpoints), sortedKeys(snapshot.Endpoints))
+	for key, want := range wantEndpoints {
+		equal, err := endpointsEqual(want, snapshot.Endpoints[key])
+		require.NoError(t, err)
+		assert.True(t, equal, key)
+	}
+	assert.Equal(t, wantIntents, snapshot.DeleteIntents)
+}
+
+func stateMachineAssignments(index int) []AssignmentRecord {
+	ids := stateMachineIPIDs(index)
+	containerID := stateMachineContainerID(index)
+	return []AssignmentRecord{
+		{
+			Pod: PodIdentity{
+				PodKey:           fmt.Sprintf("interface-%d-primary", index),
+				InfraContainerID: containerID,
+				InterfaceID:      fmt.Sprintf("interface-%d-primary", index),
+				PodName:          stateMachinePodName(index),
+				PodNamespace:     "state-machine",
+			},
+			IPIDs: []string{ids[0], ids[1]},
+		},
+		{
+			Pod: PodIdentity{
+				PodKey:           fmt.Sprintf("interface-%d-secondary", index),
+				InfraContainerID: containerID,
+				InterfaceID:      fmt.Sprintf("interface-%d-secondary", index),
+				PodName:          stateMachinePodName(index),
+				PodNamespace:     "state-machine",
+			},
+			IPIDs: []string{ids[2]},
+		},
+	}
+}
+
+func stateMachineEndpoint(index, patchVersion int) EndpointRecord {
+	records := stateMachineIPs(index, 1)
+	return EndpointRecord{
+		PodName:      stateMachinePodName(index),
+		PodNamespace: "state-machine",
+		IfnameToIPMap: map[string]*IPInfoRecord{
+			"eth0": {
+				IPv4:               []net.IPNet{mustIPNetValue(records[0].IPAddress, 24)},
+				IPv6:               []net.IPNet{mustIPNetValue(records[1].IPAddress, 64)},
+				HostVethName:       fmt.Sprintf("veth-%d-%d", index, patchVersion),
+				MACAddress:         fmt.Sprintf("02:00:00:10:%02x:%02x", index, index+1),
+				NetworkContainerID: stateMachineNCID(index),
+			},
+			"net1": {
+				IPv4:               []net.IPNet{mustIPNetValue(records[2].IPAddress, 24)},
+				HostVethName:       fmt.Sprintf("net1-%d-%d", index, patchVersion),
+				MACAddress:         fmt.Sprintf("02:00:00:20:%02x:%02x", index, index+1),
+				NetworkContainerID: stateMachineNCID(index),
+			},
+		},
+	}
+}
+
+func stateMachineIPs(index, version int) []IPRecord {
+	ids := stateMachineIPIDs(index)
+	return []IPRecord{
+		{
+			ID:        ids[0],
+			IPAddress: fmt.Sprintf("10.%d.0.10", 80+index),
+			NCID:      stateMachineNCID(index),
+			NCVersion: version,
+		},
+		{
+			ID:        ids[1],
+			IPAddress: fmt.Sprintf("fd%02x::10", 80+index),
+			NCID:      stateMachineNCID(index),
+			NCVersion: version,
+		},
+		{
+			ID:        ids[2],
+			IPAddress: fmt.Sprintf("10.%d.1.10", 80+index),
+			NCID:      stateMachineNCID(index),
+			NCVersion: version,
+		},
+	}
+}
+
+func stateMachineIPIDs(index int) []string {
+	return []string{
+		fmt.Sprintf("10000000-0000-4000-8000-%012d", index*16+1),
+		fmt.Sprintf("10000000-0000-4000-8000-%012d", index*16+2),
+		fmt.Sprintf("10000000-0000-4000-8000-%012d", index*16+3),
+	}
+}
+
+func stateMachineNCID(index int) string {
+	return fmt.Sprintf("state-machine-nc-%d", index)
+}
+
+func stateMachineContainerID(index int) string {
+	return fmt.Sprintf("state-machine-container-%d", index)
+}
+
+func stateMachinePodName(index int) string {
+	return fmt.Sprintf("state-machine-pod-%d", index)
+}
+
+func mustIPNetValue(address string, bits int) net.IPNet {
+	ip := net.ParseIP(address)
+	totalBits := 128
+	if ipv4 := ip.To4(); ipv4 != nil {
+		ip = ipv4
+		totalBits = 32
+	}
+	return net.IPNet{IP: ip, Mask: net.CIDRMask(bits, totalBits)}
+}
+
+func TestConcurrentImportExportBootAndGateCancellation(t *testing.T) {
+	cnsData, endpointData := completeLegacyImportData(t)
+	importDB, _ := openTestDB(t)
+	importOpts := writeLegacyImportFiles(t, cnsData, endpointData, true)
+	exportDB, _ := openPopulatedExportDB(t)
+	exportOpts := exportPaths(t)
+	bootDB, _ := openTestDB(t)
+	writeSnapshot(t, bootDB, completeSnapshot())
+	gateDB, _ := openTestDB(t)
+	gateDB.writeGate <- struct{}{}
+	t.Cleanup(func() {
+		select {
+		case <-gateDB.writeGate:
+		default:
+		}
+	})
+	gateCtx, cancelGate := context.WithCancel(context.Background())
+	t.Cleanup(cancelGate)
+
+	type result struct {
+		name string
+		err  error
+	}
+	start := make(chan struct{})
+	gateStarted := make(chan struct{})
+	results := make(chan result, 4)
+	var ready sync.WaitGroup
+	ready.Add(4)
+	go func() {
+		ready.Done()
+		<-start
+		_, err := importDB.ImportLegacy(context.Background(), importOpts)
+		results <- result{name: "import", err: err}
+	}()
+	go func() {
+		ready.Done()
+		<-start
+		_, err := exportDB.ExportLegacy(context.Background(), exportOpts)
+		results <- result{name: "export", err: err}
+	}()
+	go func() {
+		ready.Done()
+		<-start
+		_, err := bootDB.ApplyBoot(
+			context.Background(),
+			"concurrent-boot",
+			BootPolicy{ClearEndpoints: true, ResetReadiness: true},
+		)
+		results <- result{name: "boot", err: err}
+	}()
+	go func() {
+		ready.Done()
+		<-start
+		close(gateStarted)
+		_, err := gateDB.ApplyBoot(gateCtx, "canceled-boot", BootPolicy{})
+		results <- result{name: "gate cancellation", err: err}
+	}()
+	ready.Wait()
+	close(start)
+	<-gateStarted
+	cancelGate()
+
+	for range 4 {
+		got := <-results
+		if got.name == "gate cancellation" {
+			require.ErrorIs(t, got.err, context.Canceled)
+			continue
+		}
+		require.NoError(t, got.err, got.name)
+	}
+	<-gateDB.writeGate
+
+	requireValidSnapshot(t, importDB)
+	requireValidSnapshot(t, exportDB)
+	requireValidSnapshot(t, bootDB)
+	requireValidSnapshot(t, gateDB)
+	assert.Equal(t, "concurrent-boot", readMetadata(t, bootDB).BootID)
+	assert.Empty(t, readMetadata(t, gateDB).BootID)
+}
+
+func TestConcurrentConflictingOwnersHaveSingleWinner(t *testing.T) {
+	db, _ := openTestDB(t)
+	assignment, endpoint := seedOwnershipInventory(t, db)
+	other := assignment
+	other.Pod = PodIdentity{
+		PodKey:           "other-container",
+		InfraContainerID: "other-container",
+		PodName:          "other-pod",
+		PodNamespace:     "ns-1",
+	}
+	otherEndpoint := endpoint
+	otherEndpoint.PodName = other.Pod.PodName
+
+	start := make(chan struct{})
+	results := make(chan error, 2)
+	var ready sync.WaitGroup
+	ready.Add(2)
+	for _, candidate := range []struct {
+		assignment AssignmentRecord
+		endpoint   EndpointRecord
+	}{
+		{assignment: assignment, endpoint: endpoint},
+		{assignment: other, endpoint: otherEndpoint},
+	} {
+		go func() {
+			ready.Done()
+			<-start
+			_, err := db.AssignEndpoint(
+				context.Background(),
+				candidate.assignment,
+				candidate.endpoint,
+				testNow,
+				testDeleteIntentTTL,
+			)
+			results <- err
+		}()
+	}
+	ready.Wait()
+	close(start)
+
+	successes := 0
+	conflicts := 0
+	for range 2 {
+		err := <-results
+		switch {
+		case err == nil:
+			successes++
+		case errors.Is(err, ErrIPAlreadyAssigned):
+			conflicts++
+		default:
+			require.NoError(t, err)
+		}
+	}
+	assert.Equal(t, 1, successes)
+	assert.Equal(t, 1, conflicts)
+	snapshot := requireValidSnapshot(t, db)
+	assert.Len(t, snapshot.Assignments, 1)
+	assert.Len(t, snapshot.IPOwners, len(assignment.IPIDs))
+}

--- a/cns/state/hardening_test.go
+++ b/cns/state/hardening_test.go
@@ -57,10 +57,10 @@ func runRandomizedMultiNCStateMachine(t *testing.T, seed int64) {
 	require.NoError(t, db.Update(context.Background(), func(tx *WriteTx) error {
 		return tx.PutMetadata(Metadata{
 			BootID:           "initial-boot",
-			OrchestratorType: "KubernetesCRD",
+			OrchestratorType: importOrchestratorType,
 			NodeID:           "node-state-machine",
-			Location:         "eastus",
-			NetworkType:      "azure",
+			Location:         hardeningLocation,
+			NetworkType:      exportNetworkType,
 			Initialized:      true,
 			TimeStamp:        now,
 		})
@@ -337,7 +337,7 @@ func assertStateMachineModel(t *testing.T, db *DB, model stateMachineModel) {
 					PodKey:           containerID,
 					InfraContainerID: containerID,
 					PodName:          stateMachinePodName(index),
-					PodNamespace:     "state-machine",
+					PodNamespace:     hardeningStateNamespace,
 				},
 				IPIDs: stateMachineIPIDs(index),
 			}}
@@ -370,7 +370,7 @@ func stateMachineAssignments(index int) []AssignmentRecord {
 				InfraContainerID: containerID,
 				InterfaceID:      fmt.Sprintf("interface-%d-primary", index),
 				PodName:          stateMachinePodName(index),
-				PodNamespace:     "state-machine",
+				PodNamespace:     hardeningStateNamespace,
 			},
 			IPIDs: []string{ids[0], ids[1]},
 		},
@@ -380,7 +380,7 @@ func stateMachineAssignments(index int) []AssignmentRecord {
 				InfraContainerID: containerID,
 				InterfaceID:      fmt.Sprintf("interface-%d-secondary", index),
 				PodName:          stateMachinePodName(index),
-				PodNamespace:     "state-machine",
+				PodNamespace:     hardeningStateNamespace,
 			},
 			IPIDs: []string{ids[2]},
 		},
@@ -391,16 +391,16 @@ func stateMachineEndpoint(index, patchVersion int) EndpointRecord {
 	records := stateMachineIPs(index, 1)
 	return EndpointRecord{
 		PodName:      stateMachinePodName(index),
-		PodNamespace: "state-machine",
+		PodNamespace: hardeningStateNamespace,
 		IfnameToIPMap: map[string]*IPInfoRecord{
-			"eth0": {
+			exportIfnameEth0: {
 				IPv4:               []net.IPNet{mustIPNetValue(records[0].IPAddress, 24)},
 				IPv6:               []net.IPNet{mustIPNetValue(records[1].IPAddress, 64)},
 				HostVethName:       fmt.Sprintf("veth-%d-%d", index, patchVersion),
 				MACAddress:         fmt.Sprintf("02:00:00:10:%02x:%02x", index, index+1),
 				NetworkContainerID: stateMachineNCID(index),
 			},
-			"net1": {
+			hardeningNet1: {
 				IPv4:               []net.IPNet{mustIPNetValue(records[2].IPAddress, 24)},
 				HostVethName:       fmt.Sprintf("net1-%d-%d", index, patchVersion),
 				MACAddress:         fmt.Sprintf("02:00:00:20:%02x:%02x", index, index+1),
@@ -586,10 +586,10 @@ func TestConcurrentConflictingOwnersHaveSingleWinner(t *testing.T) {
 	assignment, endpoint := seedOwnershipInventory(t, db)
 	other := assignment
 	other.Pod = PodIdentity{
-		PodKey:           "other-container",
-		InfraContainerID: "other-container",
-		PodName:          "other-pod",
-		PodNamespace:     "ns-1",
+		PodKey:           hardeningOtherContainerID,
+		InfraContainerID: hardeningOtherContainerID,
+		PodName:          hardeningOtherPodName,
+		PodNamespace:     exportPodNamespace,
 	}
 	otherEndpoint := endpoint
 	otherEndpoint.PodName = other.Pod.PodName

--- a/cns/state/hardening_test.go
+++ b/cns/state/hardening_test.go
@@ -296,6 +296,7 @@ func applyStateMachineBoot(
 	model.bootID = bootID
 	for index := range stateMachineNCCount {
 		state := &model.containers[index]
+		wasActive := state.active
 		state.intent = time.Time{}
 		if clearEndpoints {
 			state.active = false
@@ -304,7 +305,7 @@ func applyStateMachineBoot(
 			continue
 		}
 		state.active = state.endpoint
-		state.retained = state.endpoint
+		state.retained = state.endpoint && (state.retained || !wasActive)
 	}
 }
 
@@ -461,6 +462,43 @@ func mustIPNetValue(address string, bits int) net.IPNet {
 		totalBits = 32
 	}
 	return net.IPNet{IP: ip, Mask: net.CIDRMask(bits, totalBits)}
+}
+
+func TestLegacyImportRollbackRoundTrip(t *testing.T) {
+	cnsData, endpointData := completeLegacyImportData(t)
+	source, _ := openTestDB(t)
+	importOpts := writeLegacyImportFiles(t, cnsData, endpointData, true)
+	changed, err := source.ImportLegacy(context.Background(), importOpts)
+	require.NoError(t, err)
+	require.True(t, changed)
+	imported := requireValidSnapshot(t, source)
+
+	exportOpts := exportPaths(t)
+	changed, err = source.ExportLegacy(context.Background(), exportOpts)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	reimportedDB, _ := openTestDB(t)
+	changed, err = reimportedDB.ImportLegacy(context.Background(), ImportOptions{
+		CNSPath:             exportOpts.CNSJSONPath,
+		EndpointPath:        exportOpts.EndpointJSONPath,
+		ManageEndpointState: true,
+		BootID:              "reimported-boot",
+	})
+	require.NoError(t, err)
+	require.True(t, changed)
+	reimported := requireValidSnapshot(t, reimportedDB)
+
+	assert.Equal(t, logicalRoundTripSnapshot(imported), logicalRoundTripSnapshot(reimported))
+}
+
+func logicalRoundTripSnapshot(snapshot Snapshot) Snapshot {
+	snapshot.Metadata.Authority = ""
+	snapshot.Metadata.Generation = 0
+	snapshot.Metadata.BootID = ""
+	snapshot.Metadata.LegacyImportComplete = false
+	snapshot.Metadata.RollbackExportComplete = false
+	return snapshot
 }
 
 func TestConcurrentImportExportBootAndGateCancellation(t *testing.T) {

--- a/cns/state/import_test.go
+++ b/cns/state/import_test.go
@@ -618,7 +618,7 @@ func TestImportLegacyDeterministicErrors(t *testing.T) {
 	}
 }
 
-func completeLegacyImportData(t *testing.T) (cnsData, endpointData []byte) {
+func completeLegacyImportData(t testing.TB) (cnsData, endpointData []byte) {
 	t.Helper()
 	request1 := completeNetworkContainerRequest()
 	request1.NetworkContainerid = importNC1
@@ -783,7 +783,7 @@ func encodeIPNets(t *testing.T, prefixes ...string) any {
 	return result
 }
 
-func mustIPNet(t *testing.T, value string) net.IPNet {
+func mustIPNet(t testing.TB, value string) net.IPNet {
 	t.Helper()
 	ip, network, err := net.ParseCIDR(value)
 	require.NoError(t, err)

--- a/cns/state/ownership_operations_test.go
+++ b/cns/state/ownership_operations_test.go
@@ -264,23 +264,23 @@ func TestAssignEndpointRejectsIdentityConflicts(t *testing.T) {
 		{
 			name: "container already belongs to another pod",
 			changeRequest: func(assignment *AssignmentRecord, endpoint *EndpointRecord) {
-				assignment.Pod.PodName = "other-pod"
-				endpoint.PodName = "other-pod"
+				assignment.Pod.PodName = hardeningOtherPodName
+				endpoint.PodName = hardeningOtherPodName
 			},
 		},
 		{
 			name: "pod changes containers before release",
 			changeRequest: func(assignment *AssignmentRecord, _ *EndpointRecord) {
-				assignment.Pod.PodKey = "container-2"
-				assignment.Pod.InfraContainerID = "container-2"
+				assignment.Pod.PodKey = hardeningContainerID2
+				assignment.Pod.InfraContainerID = hardeningContainerID2
 			},
 		},
 		{
 			name:        "pod changes containers while endpoint retained",
 			retainFirst: true,
 			changeRequest: func(assignment *AssignmentRecord, _ *EndpointRecord) {
-				assignment.Pod.PodKey = "container-2"
-				assignment.Pod.InfraContainerID = "container-2"
+				assignment.Pod.PodKey = hardeningContainerID2
+				assignment.Pod.InfraContainerID = hardeningContainerID2
 			},
 		},
 	}
@@ -339,7 +339,7 @@ func TestConcurrentDuplicateOwnership(t *testing.T) {
 			endpoint:   testEndpoint("pod-1", testIPv4Address),
 		},
 		{
-			assignment: testAssignment("container-2", "pod-2", testIPID1),
+			assignment: testAssignment(hardeningContainerID2, "pod-2", testIPID1),
 			endpoint:   testEndpoint("pod-2", testIPv4Address),
 		},
 	}
@@ -482,7 +482,7 @@ func TestAssignRequiresRetainedEndpointCleanupBeforeContainerChange(t *testing.T
 
 	_, err = db.AssignEndpoint(
 		context.Background(),
-		testAssignment("container-2", "pod-1", testIPID2),
+		testAssignment(hardeningContainerID2, "pod-1", testIPID2),
 		testEndpoint("pod-1", testIPv4Address2),
 		testNow.Add(testDeleteIntentTTL),
 		testDeleteIntentTTL,

--- a/cns/state/ownership_operations_test.go
+++ b/cns/state/ownership_operations_test.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net"
 	"sync"
@@ -178,6 +179,19 @@ func TestAssignEndpoint(t *testing.T) {
 		assert.False(t, changed)
 		assert.Equal(t, before+1, readMetadata(t, db).Generation)
 
+		changedEndpoint := deepCloneEndpoint(t, endpoint)
+		changedEndpoint.IfnameToIPMap["eth0"].HostVethName = "changed-veth"
+		_, err = db.AssignEndpoint(
+			context.Background(),
+			assignment,
+			changedEndpoint,
+			testNow,
+			testDeleteIntentTTL,
+		)
+		require.ErrorIs(t, err, ErrInvalidInput)
+		assert.Contains(t, err.Error(), "PatchEndpoint")
+		assert.Equal(t, before+1, readMetadata(t, db).Generation)
+
 		changedAssignment := assignment
 		changedAssignment.IPIDs = []string{testIPv4ID}
 		_, err = db.AssignEndpoint(
@@ -239,6 +253,72 @@ func TestAssignEndpoint(t *testing.T) {
 		require.ErrorIs(t, err, ErrInvalidInput)
 		assert.Empty(t, requireValidSnapshot(t, db).Assignments)
 	})
+}
+
+func TestAssignEndpointRejectsIdentityConflicts(t *testing.T) {
+	tests := []struct {
+		name          string
+		retainFirst   bool
+		changeRequest func(*AssignmentRecord, *EndpointRecord)
+	}{
+		{
+			name: "container already belongs to another pod",
+			changeRequest: func(assignment *AssignmentRecord, endpoint *EndpointRecord) {
+				assignment.Pod.PodName = "other-pod"
+				endpoint.PodName = "other-pod"
+			},
+		},
+		{
+			name: "pod changes containers before release",
+			changeRequest: func(assignment *AssignmentRecord, _ *EndpointRecord) {
+				assignment.Pod.PodKey = "container-2"
+				assignment.Pod.InfraContainerID = "container-2"
+			},
+		},
+		{
+			name:        "pod changes containers while endpoint retained",
+			retainFirst: true,
+			changeRequest: func(assignment *AssignmentRecord, _ *EndpointRecord) {
+				assignment.Pod.PodKey = "container-2"
+				assignment.Pod.InfraContainerID = "container-2"
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, _ := openTestDB(t)
+			assignment, endpoint := seedOwnershipInventory(t, db)
+			changed, err := db.AssignEndpoint(
+				context.Background(),
+				assignment,
+				endpoint,
+				testNow,
+				testDeleteIntentTTL,
+			)
+			require.NoError(t, err)
+			require.True(t, changed)
+
+			if tt.retainFirst {
+				changed, err = db.ReleaseEndpoint(context.Background(), assignment.Pod, testNow)
+				require.NoError(t, err)
+				require.True(t, changed)
+			}
+			before := readMetadata(t, db).Generation
+			requestedEndpoint := deepCloneEndpoint(t, endpoint)
+			tt.changeRequest(&assignment, &requestedEndpoint)
+
+			_, err = db.AssignEndpoint(
+				context.Background(),
+				assignment,
+				requestedEndpoint,
+				testNow,
+				testDeleteIntentTTL,
+			)
+			require.ErrorIs(t, err, ErrInvalidInput)
+			assert.Equal(t, before, readMetadata(t, db).Generation)
+			requireValidSnapshot(t, db)
+		})
+	}
 }
 
 func TestConcurrentDuplicateOwnership(t *testing.T) {
@@ -556,6 +636,24 @@ func TestOwnershipFailuresRollback(t *testing.T) {
 		)
 		require.ErrorIs(t, err, ErrInvalidInput)
 		assert.Equal(t, before, requireValidSnapshot(t, db))
+	})
+
+	t.Run("corrupt inventory preflight", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		assignment, endpoint := seedOwnershipInventory(t, db)
+		beforeGeneration := readMetadata(t, db).Generation
+		putRaw(t, db, bucketIPs, []byte("ip-v4"), []byte(`{"id":`))
+
+		_, err := db.AssignEndpoint(
+			context.Background(),
+			assignment,
+			endpoint,
+			testNow,
+			testDeleteIntentTTL,
+		)
+		require.ErrorIs(t, err, ErrCorrupt)
+		assert.Equal(t, beforeGeneration, readMetadata(t, db).Generation)
+		assert.Nil(t, rawValue(t, db, bucketAssignments, []byte(assignment.Pod.PodKey)))
 	})
 
 	t.Run("callback failure", func(t *testing.T) {
@@ -902,6 +1000,15 @@ func testEndpoint(podName, address string) EndpointRecord {
 			},
 		},
 	}
+}
+
+func deepCloneEndpoint(t *testing.T, endpoint EndpointRecord) EndpointRecord {
+	t.Helper()
+	data, err := json.Marshal(endpoint)
+	require.NoError(t, err)
+	var cloned EndpointRecord
+	require.NoError(t, json.Unmarshal(data, &cloned))
+	return cloned
 }
 
 func requireValidSnapshot(t *testing.T, db *DB) Snapshot {

--- a/cns/state/storage_linux_test.go
+++ b/cns/state/storage_linux_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package state
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStorageMetadataAfterDatabaseFileRemoval(t *testing.T) {
+	db, path := openTestDB(t)
+	require.NoError(t, os.Remove(path))
+
+	metadata, err := db.StorageMetadata()
+	require.NoError(t, err)
+	assert.Equal(t, StorageBackendBolt, metadata.Backend)
+	assert.False(t, metadata.FilePresent)
+	assert.Zero(t, metadata.FileSizeBytes)
+}


### PR DESCRIPTION
## Scope
Adds the fuzz, property, race, benchmark, and raw coverage gate for the unified CNS Bolt engine.

## Draft dependency caveat
This PR is opened early for review and CI. Its base, `users/rbtr/bolt-engine-complete-v5`, is a temporary integration branch joining #4788 and #4789. **Do not merge this PR until both sibling migration PRs merge.** It will then be rebased or retargeted to the permanent parent without expanding scope.

## Behavior
Test-only hardening; no production path or shipped default changes.

## Evidence
Engine-only race/shuffle suites pass and raw `cns/state` coverage exceeds 91%.