### PR TITLE
feat(cns): add Bolt state observability

### DIFF
--- a/cns/state/db.go
+++ b/cns/state/db.go
@@ -14,6 +14,7 @@ import (
 
 	bolt "go.etcd.io/bbolt"
 	bolterrors "go.etcd.io/bbolt/errors"
+	"go.uber.org/zap"
 )
 
 var (
@@ -67,14 +68,30 @@ type Options struct {
 	Timeout  time.Duration
 	ReadOnly bool
 	NoSync   bool
+	Metrics  *Metrics
+	Logger   *zap.Logger
 }
 
 type DB struct {
 	db        *bolt.DB
 	writeGate chan struct{}
+	metrics   *Metrics
+	logger    *zap.Logger
 }
 
-func Open(path string, opts Options) (*DB, error) {
+func Open(path string, opts Options) (store *DB, returnErr error) {
+	if opts.Metrics != nil || opts.Logger != nil {
+		started := metricNow(opts.Metrics)
+		defer func() {
+			result := classifyResult(true, returnErr)
+			duration := metricDuration(opts.Metrics, started)
+			_ = opts.Metrics.ObserveLifecycle(LifecycleStartup, result, duration)
+			if returnErr == nil {
+				store.observeLifecycle(context.TODO(), LifecycleStartup, result, duration)
+			}
+		}()
+	}
+
 	_, statErr := os.Stat(path)
 	exists := statErr == nil
 	if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
@@ -97,7 +114,14 @@ func Open(path string, opts Options) (*DB, error) {
 		return nil, fmt.Errorf("opening cns state database: %w", err)
 	}
 
-	store := &DB{db: db, writeGate: make(chan struct{}, 1)}
+	store = &DB{
+		db:        db,
+		writeGate: make(chan struct{}, 1),
+		metrics:   opts.Metrics,
+	}
+	if opts.Logger != nil {
+		store.logger = opts.Logger.With(zap.String("component", "persistent_state"))
+	}
 	created := !exists && !opts.ReadOnly
 	if created {
 		err = store.initialize()
@@ -194,7 +218,17 @@ func (s *DB) Close() error {
 	return nil
 }
 
-func (s *DB) View(ctx context.Context, fn func(*ReadTx) error) error {
+func (s *DB) View(ctx context.Context, fn func(*ReadTx) error) (returnErr error) {
+	if s.metrics != nil {
+		started := metricNow(s.metrics)
+		defer func() {
+			_ = s.metrics.ObserveTransaction(
+				TransactionView,
+				classifyResult(true, returnErr),
+				metricDuration(s.metrics, started),
+			)
+		}()
+	}
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("viewing cns state: %w", err)
 	}
@@ -216,7 +250,17 @@ func (s *DB) Update(ctx context.Context, fn func(*WriteTx) error) error {
 	return err
 }
 
-func (s *DB) update(ctx context.Context, fn func(*WriteTx) (bool, error)) (bool, error) {
+func (s *DB) update(ctx context.Context, fn func(*WriteTx) (bool, error)) (changed bool, returnErr error) {
+	if s.metrics != nil {
+		started := metricNow(s.metrics)
+		defer func() {
+			_ = s.metrics.ObserveTransaction(
+				TransactionUpdate,
+				classifyResult(changed, returnErr),
+				metricDuration(s.metrics, started),
+			)
+		}()
+	}
 	if err := ctx.Err(); err != nil {
 		return false, fmt.Errorf("updating cns state: %w", err)
 	}

--- a/cns/state/durable_operations.go
+++ b/cns/state/durable_operations.go
@@ -219,7 +219,22 @@ func (s *DB) UpdateReadinessObservation(
 	})
 }
 
-func (s *DB) ApplyBoot(ctx context.Context, bootID string, policy BootPolicy) (bool, error) {
+func (s *DB) ApplyBoot(
+	ctx context.Context,
+	bootID string,
+	policy BootPolicy,
+) (changed bool, returnErr error) {
+	if s.metrics != nil || s.logger != nil {
+		started := metricNow(s.metrics)
+		defer func() {
+			result := classifyResult(changed, returnErr)
+			duration := metricDuration(s.metrics, started)
+			_ = s.metrics.ObserveLifecycle(LifecycleBoot, result, duration)
+			if returnErr == nil {
+				s.observeLifecycle(ctx, LifecycleBoot, result, duration)
+			}
+		}()
+	}
 	if bootID == "" {
 		return false, invalidInput("boot ID is empty", nil)
 	}

--- a/cns/state/export.go
+++ b/cns/state/export.go
@@ -97,7 +97,18 @@ func osRollbackFileOperations() rollbackFileOperations {
 
 // ExportLegacy converts one validated Bolt snapshot into both legacy JSON files.
 // It returns false without touching the files after rollback export is complete.
-func (s *DB) ExportLegacy(ctx context.Context, opts ExportOptions) (bool, error) {
+func (s *DB) ExportLegacy(ctx context.Context, opts ExportOptions) (changed bool, returnErr error) {
+	if s.metrics != nil || s.logger != nil {
+		started := metricNow(s.metrics)
+		defer func() {
+			result := classifyResult(changed, returnErr)
+			duration := metricDuration(s.metrics, started)
+			_ = s.metrics.ObserveLifecycle(LifecycleRollback, result, duration)
+			if returnErr == nil {
+				s.observeLifecycle(ctx, LifecycleRollback, result, duration)
+			}
+		}()
+	}
 	return s.exportLegacy(ctx, opts, osRollbackFileOperations())
 }
 

--- a/cns/state/import.go
+++ b/cns/state/import.go
@@ -91,7 +91,18 @@ type legacyNetworkInfo struct {
 
 // ImportLegacy atomically imports legacy JSON state into an initialized empty database.
 // It returns false without reading the sources after a completed import.
-func (s *DB) ImportLegacy(ctx context.Context, opts ImportOptions) (bool, error) {
+func (s *DB) ImportLegacy(ctx context.Context, opts ImportOptions) (changed bool, returnErr error) {
+	if s.metrics != nil || s.logger != nil {
+		started := metricNow(s.metrics)
+		defer func() {
+			result := classifyResult(changed, returnErr)
+			duration := metricDuration(s.metrics, started)
+			_ = s.metrics.ObserveLifecycle(LifecycleImport, result, duration)
+			if returnErr == nil {
+				s.observeLifecycle(ctx, LifecycleImport, result, duration)
+			}
+		}()
+	}
 	return s.importLegacy(ctx, opts, os.ReadFile)
 }
 

--- a/cns/state/logging.go
+++ b/cns/state/logging.go
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package state
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+func (s *DB) observeLifecycle(
+	ctx context.Context,
+	operation LifecycleOperation,
+	result OperationResult,
+	duration time.Duration,
+) {
+	if s.metrics == nil && s.logger == nil {
+		return
+	}
+	status, err := s.summary(ctx)
+	if err != nil {
+		return
+	}
+	_ = s.metrics.Refresh(status)
+	if s.logger == nil {
+		return
+	}
+	s.logger.Info(
+		lifecycleMessage(operation, result),
+		zap.String("backend", status.Backend),
+		zap.String("authority", string(status.Authority)),
+		zap.Uint32("schema", status.SchemaVersion),
+		zap.Uint64("generation", status.Generation),
+		zap.String("operation", string(operation)),
+		zap.String("result", string(result)),
+		zap.Int("networkContainerCount", status.Records.NetworkContainers),
+		zap.Int("ipCount", status.Records.IPs),
+		zap.Int("networkCount", status.Records.Networks),
+		zap.Int("endpointCount", status.Records.Endpoints),
+		zap.Int("assignmentCount", status.Records.Assignments),
+		zap.Int("ownerCount", status.Records.Owners),
+		zap.Int("deleteIntentCount", status.Records.DeleteIntents),
+		zap.Duration("duration", duration),
+	)
+}
+
+func lifecycleMessage(operation LifecycleOperation, result OperationResult) string {
+	switch {
+	case operation == LifecycleStartup:
+		return "persistent state opened"
+	case operation == LifecycleImport && result == ResultNoop:
+		return "persistent state import skipped"
+	case operation == LifecycleImport:
+		return "persistent state import completed"
+	case operation == LifecycleRollback && result == ResultNoop:
+		return "persistent state rollback skipped"
+	case operation == LifecycleRollback:
+		return "persistent state rollback completed"
+	case operation == LifecycleBoot && result == ResultNoop:
+		return "persistent state boot unchanged"
+	case operation == LifecycleBoot:
+		return "persistent state boot applied"
+	default:
+		return "persistent state lifecycle completed"
+	}
+}

--- a/cns/state/metrics.go
+++ b/cns/state/metrics.go
@@ -1,0 +1,304 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package state
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type TransactionOperation string
+
+const (
+	TransactionView   TransactionOperation = "view"
+	TransactionUpdate TransactionOperation = "update"
+)
+
+type LifecycleOperation string
+
+const (
+	LifecycleStartup  LifecycleOperation = "startup"
+	LifecycleImport   LifecycleOperation = "import"
+	LifecycleRollback LifecycleOperation = "rollback"
+	LifecycleBoot     LifecycleOperation = "boot"
+)
+
+type OperationResult string
+
+const (
+	ResultSuccess  OperationResult = "success"
+	ResultError    OperationResult = "error"
+	ResultCanceled OperationResult = "canceled"
+	ResultNoop     OperationResult = "noop"
+	ResultConflict OperationResult = "conflict"
+)
+
+type InvariantName string
+
+const (
+	InvariantNone       InvariantName = "none"
+	InvariantStructural InvariantName = "structural"
+	InvariantSchema     InvariantName = "schema"
+	InvariantAuthority  InvariantName = "authority"
+)
+
+type RecordType string
+
+const (
+	RecordNetworkContainer RecordType = "network_container"
+	RecordIP               RecordType = "ip"
+	RecordNetwork          RecordType = "network"
+	RecordEndpoint         RecordType = "endpoint"
+	RecordAssignment       RecordType = "assignment"
+	RecordOwner            RecordType = "owner"
+	RecordDeleteIntent     RecordType = "delete_intent"
+)
+
+var (
+	transactionOperations = map[TransactionOperation]struct{}{
+		TransactionView: {}, TransactionUpdate: {},
+	}
+	lifecycleOperations = map[LifecycleOperation]struct{}{
+		LifecycleStartup: {}, LifecycleImport: {}, LifecycleRollback: {}, LifecycleBoot: {},
+	}
+	operationResults = map[OperationResult]struct{}{
+		ResultSuccess: {}, ResultError: {}, ResultCanceled: {}, ResultNoop: {}, ResultConflict: {},
+	}
+	invariantNames = map[InvariantName]struct{}{
+		InvariantStructural: {}, InvariantSchema: {}, InvariantAuthority: {},
+	}
+	recordTypes = []RecordType{
+		RecordNetworkContainer,
+		RecordIP,
+		RecordNetwork,
+		RecordEndpoint,
+		RecordAssignment,
+		RecordOwner,
+		RecordDeleteIntent,
+	}
+)
+
+type Metrics struct {
+	transactions      *prometheus.CounterVec
+	transactionTime   *prometheus.HistogramVec
+	lifecycle         *prometheus.CounterVec
+	lifecycleTime     *prometheus.HistogramVec
+	invariantFailures *prometheus.CounterVec
+	info              *prometheus.GaugeVec
+	generation        prometheus.Gauge
+	storagePresent    prometheus.Gauge
+	databaseBytes     prometheus.Gauge
+	records           *prometheus.GaugeVec
+	now               func() time.Time
+}
+
+func NewMetrics(registerer prometheus.Registerer) (*Metrics, error) {
+	if registerer == nil {
+		return nil, errors.New("persistent state metrics registerer is nil")
+	}
+
+	durationBuckets := []float64{0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5}
+	metrics := &Metrics{
+		transactions: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "cns_persistent_state_transactions_total",
+			Help: "Total number of persistent state database transactions by operation and result.",
+		}, []string{"operation", "result"}),
+		transactionTime: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "cns_persistent_state_transaction_duration_seconds",
+			Help:    "Persistent state database transaction duration in seconds by operation and result.",
+			Buckets: durationBuckets,
+		}, []string{"operation", "result"}),
+		lifecycle: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "cns_persistent_state_lifecycle_total",
+			Help: "Total number of persistent state lifecycle operations by operation and result.",
+		}, []string{"operation", "result"}),
+		lifecycleTime: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "cns_persistent_state_lifecycle_duration_seconds",
+			Help:    "Persistent state lifecycle operation duration in seconds by operation and result.",
+			Buckets: durationBuckets,
+		}, []string{"operation", "result"}),
+		invariantFailures: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "cns_persistent_state_invariant_failures_total",
+			Help: "Total number of bounded persistent state invariant failures.",
+		}, []string{"invariant"}),
+		info: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cns_persistent_state_info",
+			Help: "Persistent state backend, authority, and schema information.",
+		}, []string{"backend", "authority", "schema"}),
+		generation: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "cns_persistent_state_generation",
+			Help: "Current committed persistent state generation.",
+		}),
+		storagePresent: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "cns_persistent_state_storage_present",
+			Help: "Whether persistent state storage is present and readable.",
+		}),
+		databaseBytes: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "cns_persistent_state_database_bytes",
+			Help: "Current persistent state database size in bytes.",
+		}),
+		records: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cns_persistent_state_records",
+			Help: "Current persistent state record count by bounded record type.",
+		}, []string{"record_type"}),
+		now: time.Now,
+	}
+
+	collectors := []prometheus.Collector{
+		metrics.transactions,
+		metrics.transactionTime,
+		metrics.lifecycle,
+		metrics.lifecycleTime,
+		metrics.invariantFailures,
+		metrics.info,
+		metrics.generation,
+		metrics.storagePresent,
+		metrics.databaseBytes,
+		metrics.records,
+	}
+	registered := make([]prometheus.Collector, 0, len(collectors))
+	for _, collector := range collectors {
+		if err := registerer.Register(collector); err != nil {
+			rollbackComplete := true
+			for _, prior := range registered {
+				rollbackComplete = registerer.Unregister(prior) && rollbackComplete
+			}
+			if !rollbackComplete {
+				return nil, fmt.Errorf(
+					"registering persistent state metrics: %w (collector rollback incomplete)",
+					err,
+				)
+			}
+			return nil, fmt.Errorf("registering persistent state metrics: %w", err)
+		}
+		registered = append(registered, collector)
+	}
+	return metrics, nil
+}
+
+func (m *Metrics) ObserveTransaction(operation TransactionOperation, result OperationResult, duration time.Duration) error {
+	if m == nil {
+		return nil
+	}
+	if _, ok := transactionOperations[operation]; !ok {
+		return fmt.Errorf("unknown persistent state transaction operation %q", operation)
+	}
+	if err := validateOperationResult(result); err != nil {
+		return err
+	}
+	if duration < 0 {
+		return errors.New("persistent state transaction duration is negative")
+	}
+	m.transactions.WithLabelValues(string(operation), string(result)).Inc()
+	m.transactionTime.WithLabelValues(string(operation), string(result)).Observe(duration.Seconds())
+	return nil
+}
+
+func (m *Metrics) ObserveLifecycle(operation LifecycleOperation, result OperationResult, duration time.Duration) error {
+	if m == nil {
+		return nil
+	}
+	if _, ok := lifecycleOperations[operation]; !ok {
+		return fmt.Errorf("unknown persistent state lifecycle operation %q", operation)
+	}
+	if err := validateOperationResult(result); err != nil {
+		return err
+	}
+	if duration < 0 {
+		return errors.New("persistent state lifecycle duration is negative")
+	}
+	m.lifecycle.WithLabelValues(string(operation), string(result)).Inc()
+	m.lifecycleTime.WithLabelValues(string(operation), string(result)).Observe(duration.Seconds())
+	return nil
+}
+
+func (m *Metrics) ObserveInvariant(name InvariantName) error {
+	if m == nil {
+		return nil
+	}
+	if _, ok := invariantNames[name]; !ok {
+		return fmt.Errorf("unknown persistent state invariant %q", name)
+	}
+	m.invariantFailures.WithLabelValues(string(name)).Inc()
+	return nil
+}
+
+func (m *Metrics) Refresh(status Status) error {
+	if m == nil {
+		return nil
+	}
+	if status.InvariantStatus != InvariantFailed {
+		if status.Backend != BackendBolt {
+			return fmt.Errorf("unknown persistent state backend %q", status.Backend)
+		}
+		if err := validateAuthority(status.Authority); err != nil {
+			return fmt.Errorf("refreshing persistent state metrics: %w", err)
+		}
+		if status.SchemaVersion != SchemaVersion {
+			return fmt.Errorf(
+				"refreshing persistent state metrics: %w: status=%d code=%d",
+				ErrSchemaMismatch,
+				status.SchemaVersion,
+				SchemaVersion,
+			)
+		}
+	}
+	m.info.Reset()
+	if status.InvariantStatus != InvariantFailed {
+		m.info.WithLabelValues(
+			status.Backend,
+			string(status.Authority),
+			strconv.FormatUint(uint64(status.SchemaVersion), 10),
+		).Set(1)
+	}
+	m.generation.Set(float64(status.Generation))
+	if status.StoragePresent {
+		m.storagePresent.Set(1)
+	} else {
+		m.storagePresent.Set(0)
+	}
+	m.databaseBytes.Set(float64(status.DatabaseBytes))
+	for _, recordType := range recordTypes {
+		m.records.WithLabelValues(string(recordType)).Set(float64(status.RecordCount(recordType)))
+	}
+	return nil
+}
+
+func validateOperationResult(result OperationResult) error {
+	if _, ok := operationResults[result]; !ok {
+		return fmt.Errorf("unknown persistent state operation result %q", result)
+	}
+	return nil
+}
+
+func classifyResult(changed bool, err error) OperationResult {
+	switch {
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return ResultCanceled
+	case errors.Is(err, ErrStaleGeneration):
+		return ResultConflict
+	case err != nil:
+		return ResultError
+	case !changed:
+		return ResultNoop
+	default:
+		return ResultSuccess
+	}
+}
+
+func metricNow(metrics *Metrics) time.Time {
+	if metrics == nil {
+		return time.Now()
+	}
+	return metrics.now()
+}
+
+func metricDuration(metrics *Metrics, started time.Time) time.Duration {
+	return metricNow(metrics).Sub(started)
+}

--- a/cns/state/metrics.go
+++ b/cns/state/metrics.go
@@ -60,7 +60,26 @@ const (
 	RecordDeleteIntent     RecordType = "delete_intent"
 )
 
+const (
+	metricLabelOperation  = "operation"
+	metricLabelResult     = "result"
+	metricLabelInvariant  = "invariant"
+	metricLabelBackend    = "backend"
+	metricLabelAuthority  = "authority"
+	metricLabelSchema     = "schema"
+	metricLabelRecordType = "record_type"
+)
+
 var (
+	errNilMetricsRegisterer          = errors.New("persistent state metrics registerer is nil")
+	errUnknownTransactionOperation   = errors.New("unknown persistent state transaction operation")
+	errNegativeTransactionDuration   = errors.New("persistent state transaction duration is negative")
+	errUnknownLifecycleOperation     = errors.New("unknown persistent state lifecycle operation")
+	errNegativeLifecycleDuration     = errors.New("persistent state lifecycle duration is negative")
+	errUnknownPersistentInvariant    = errors.New("unknown persistent state invariant")
+	errUnknownPersistentStateBackend = errors.New("unknown persistent state backend")
+	errUnknownOperationResult        = errors.New("unknown persistent state operation result")
+
 	transactionOperations = map[TransactionOperation]struct{}{
 		TransactionView: {}, TransactionUpdate: {},
 	}
@@ -100,7 +119,7 @@ type Metrics struct {
 
 func NewMetrics(registerer prometheus.Registerer) (*Metrics, error) {
 	if registerer == nil {
-		return nil, errors.New("persistent state metrics registerer is nil")
+		return nil, errNilMetricsRegisterer
 	}
 
 	durationBuckets := []float64{0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5}
@@ -108,29 +127,29 @@ func NewMetrics(registerer prometheus.Registerer) (*Metrics, error) {
 		transactions: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "cns_persistent_state_transactions_total",
 			Help: "Total number of persistent state database transactions by operation and result.",
-		}, []string{"operation", "result"}),
+		}, []string{metricLabelOperation, metricLabelResult}),
 		transactionTime: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "cns_persistent_state_transaction_duration_seconds",
 			Help:    "Persistent state database transaction duration in seconds by operation and result.",
 			Buckets: durationBuckets,
-		}, []string{"operation", "result"}),
+		}, []string{metricLabelOperation, metricLabelResult}),
 		lifecycle: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "cns_persistent_state_lifecycle_total",
 			Help: "Total number of persistent state lifecycle operations by operation and result.",
-		}, []string{"operation", "result"}),
+		}, []string{metricLabelOperation, metricLabelResult}),
 		lifecycleTime: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "cns_persistent_state_lifecycle_duration_seconds",
 			Help:    "Persistent state lifecycle operation duration in seconds by operation and result.",
 			Buckets: durationBuckets,
-		}, []string{"operation", "result"}),
+		}, []string{metricLabelOperation, metricLabelResult}),
 		invariantFailures: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "cns_persistent_state_invariant_failures_total",
 			Help: "Total number of bounded persistent state invariant failures.",
-		}, []string{"invariant"}),
+		}, []string{metricLabelInvariant}),
 		info: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cns_persistent_state_info",
 			Help: "Persistent state backend, authority, and schema information.",
-		}, []string{"backend", "authority", "schema"}),
+		}, []string{metricLabelBackend, metricLabelAuthority, metricLabelSchema}),
 		generation: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "cns_persistent_state_generation",
 			Help: "Current committed persistent state generation.",
@@ -146,7 +165,7 @@ func NewMetrics(registerer prometheus.Registerer) (*Metrics, error) {
 		records: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cns_persistent_state_records",
 			Help: "Current persistent state record count by bounded record type.",
-		}, []string{"record_type"}),
+		}, []string{metricLabelRecordType}),
 		now: time.Now,
 	}
 
@@ -187,13 +206,13 @@ func (m *Metrics) ObserveTransaction(operation TransactionOperation, result Oper
 		return nil
 	}
 	if _, ok := transactionOperations[operation]; !ok {
-		return fmt.Errorf("unknown persistent state transaction operation %q", operation)
+		return fmt.Errorf("%w: %q", errUnknownTransactionOperation, operation)
 	}
 	if err := validateOperationResult(result); err != nil {
 		return err
 	}
 	if duration < 0 {
-		return errors.New("persistent state transaction duration is negative")
+		return errNegativeTransactionDuration
 	}
 	m.transactions.WithLabelValues(string(operation), string(result)).Inc()
 	m.transactionTime.WithLabelValues(string(operation), string(result)).Observe(duration.Seconds())
@@ -205,13 +224,13 @@ func (m *Metrics) ObserveLifecycle(operation LifecycleOperation, result Operatio
 		return nil
 	}
 	if _, ok := lifecycleOperations[operation]; !ok {
-		return fmt.Errorf("unknown persistent state lifecycle operation %q", operation)
+		return fmt.Errorf("%w: %q", errUnknownLifecycleOperation, operation)
 	}
 	if err := validateOperationResult(result); err != nil {
 		return err
 	}
 	if duration < 0 {
-		return errors.New("persistent state lifecycle duration is negative")
+		return errNegativeLifecycleDuration
 	}
 	m.lifecycle.WithLabelValues(string(operation), string(result)).Inc()
 	m.lifecycleTime.WithLabelValues(string(operation), string(result)).Observe(duration.Seconds())
@@ -223,7 +242,7 @@ func (m *Metrics) ObserveInvariant(name InvariantName) error {
 		return nil
 	}
 	if _, ok := invariantNames[name]; !ok {
-		return fmt.Errorf("unknown persistent state invariant %q", name)
+		return fmt.Errorf("%w: %q", errUnknownPersistentInvariant, name)
 	}
 	m.invariantFailures.WithLabelValues(string(name)).Inc()
 	return nil
@@ -235,7 +254,7 @@ func (m *Metrics) Refresh(status Status) error {
 	}
 	if status.InvariantStatus != InvariantFailed {
 		if status.Backend != BackendBolt {
-			return fmt.Errorf("unknown persistent state backend %q", status.Backend)
+			return fmt.Errorf("%w: %q", errUnknownPersistentStateBackend, status.Backend)
 		}
 		if err := validateAuthority(status.Authority); err != nil {
 			return fmt.Errorf("refreshing persistent state metrics: %w", err)
@@ -272,7 +291,7 @@ func (m *Metrics) Refresh(status Status) error {
 
 func validateOperationResult(result OperationResult) error {
 	if _, ok := operationResults[result]; !ok {
-		return fmt.Errorf("unknown persistent state operation result %q", result)
+		return fmt.Errorf("%w: %q", errUnknownOperationResult, result)
 	}
 	return nil
 }

--- a/cns/state/observability_test.go
+++ b/cns/state/observability_test.go
@@ -1,0 +1,513 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package state
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	bolt "go.etcd.io/bbolt"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestNewMetricsRegistration(t *testing.T) {
+	t.Run("descriptors", func(t *testing.T) {
+		registry := prometheus.NewRegistry()
+		metrics, err := NewMetrics(registry)
+		require.NoError(t, err)
+		require.NoError(t, metrics.ObserveTransaction(TransactionView, ResultSuccess, 0))
+		require.NoError(t, metrics.ObserveLifecycle(LifecycleStartup, ResultSuccess, 0))
+		require.NoError(t, metrics.ObserveInvariant(InvariantStructural))
+		require.NoError(t, metrics.Refresh(Status{
+			Backend: BackendBolt, Authority: AuthorityBolt, SchemaVersion: SchemaVersion,
+		}))
+
+		families, err := registry.Gather()
+		require.NoError(t, err)
+		wantHelp := map[string]string{
+			"cns_persistent_state_transactions_total":           "Total number of persistent state database transactions by operation and result.",
+			"cns_persistent_state_transaction_duration_seconds": "Persistent state database transaction duration in seconds by operation and result.",
+			"cns_persistent_state_lifecycle_total":              "Total number of persistent state lifecycle operations by operation and result.",
+			"cns_persistent_state_lifecycle_duration_seconds":   "Persistent state lifecycle operation duration in seconds by operation and result.",
+			"cns_persistent_state_invariant_failures_total":     "Total number of bounded persistent state invariant failures.",
+			"cns_persistent_state_info":                         "Persistent state backend, authority, and schema information.",
+			"cns_persistent_state_generation":                   "Current committed persistent state generation.",
+			"cns_persistent_state_storage_present":              "Whether persistent state storage is present and readable.",
+			"cns_persistent_state_database_bytes":               "Current persistent state database size in bytes.",
+			"cns_persistent_state_records":                      "Current persistent state record count by bounded record type.",
+		}
+		wantLabels := map[string][]string{
+			"cns_persistent_state_transactions_total":           {"operation", "result"},
+			"cns_persistent_state_transaction_duration_seconds": {"operation", "result"},
+			"cns_persistent_state_lifecycle_total":              {"operation", "result"},
+			"cns_persistent_state_lifecycle_duration_seconds":   {"operation", "result"},
+			"cns_persistent_state_invariant_failures_total":     {"invariant"},
+			"cns_persistent_state_info":                         {"backend", "authority", "schema"},
+			"cns_persistent_state_generation":                   {},
+			"cns_persistent_state_storage_present":              {},
+			"cns_persistent_state_database_bytes":               {},
+			"cns_persistent_state_records":                      {"record_type"},
+		}
+		for name, help := range wantHelp {
+			family := findMetricFamily(t, families, name)
+			assert.Equal(t, help, family.GetHelp())
+			require.NotEmpty(t, family.Metric)
+			var labels []string
+			for _, label := range family.Metric[0].Label {
+				labels = append(labels, label.GetName())
+			}
+			assert.ElementsMatch(t, wantLabels[name], labels)
+		}
+	})
+
+	t.Run("nil and duplicate registerer", func(t *testing.T) {
+		_, err := NewMetrics(nil)
+		require.Error(t, err)
+
+		registry := prometheus.NewRegistry()
+		metrics, err := NewMetrics(registry)
+		require.NoError(t, err)
+		require.NoError(t, metrics.ObserveTransaction(TransactionView, ResultSuccess, 0))
+		require.NoError(t, metrics.ObserveLifecycle(LifecycleStartup, ResultSuccess, 0))
+		require.NoError(t, metrics.ObserveInvariant(InvariantStructural))
+		require.NoError(t, metrics.Refresh(Status{
+			Backend: BackendBolt, Authority: AuthorityBolt, SchemaVersion: SchemaVersion,
+		}))
+		_, err = NewMetrics(registry)
+		require.Error(t, err)
+		families, gatherErr := registry.Gather()
+		require.NoError(t, gatherErr)
+		assert.Len(t, families, 10)
+	})
+
+	t.Run("partial registration rolls back", func(t *testing.T) {
+		registerer := &failingRegisterer{failAt: 3}
+		_, err := NewMetrics(registerer)
+		require.Error(t, err)
+		assert.Equal(t, 2, registerer.unregistered)
+	})
+
+	t.Run("partial registration reports incomplete rollback", func(t *testing.T) {
+		registerer := &failingRegisterer{failAt: 2, failUnregister: true}
+		_, err := NewMetrics(registerer)
+		require.ErrorContains(t, err, "collector rollback incomplete")
+	})
+}
+
+func TestMetricsValidateBoundedInputs(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics, err := NewMetrics(registry)
+	require.NoError(t, err)
+
+	require.Error(t, metrics.ObserveTransaction("dynamic", ResultSuccess, time.Second))
+	require.Error(t, metrics.ObserveTransaction(TransactionView, "dynamic", time.Second))
+	require.Error(t, metrics.ObserveTransaction(TransactionView, ResultSuccess, -time.Second))
+	require.Error(t, metrics.ObserveLifecycle("dynamic", ResultSuccess, time.Second))
+	require.Error(t, metrics.ObserveLifecycle(LifecycleBoot, ResultSuccess, -time.Second))
+	require.Error(t, metrics.ObserveInvariant("dynamic"))
+	require.NoError(t, (*Metrics)(nil).ObserveTransaction(TransactionView, ResultSuccess, 0))
+	require.NoError(t, (*Metrics)(nil).ObserveLifecycle(LifecycleBoot, ResultSuccess, 0))
+	require.NoError(t, (*Metrics)(nil).ObserveInvariant(InvariantStructural))
+	require.NoError(t, (*Metrics)(nil).Refresh(Status{}))
+	require.Error(t, metrics.Refresh(Status{Backend: "dynamic", Authority: AuthorityBolt, SchemaVersion: SchemaVersion}))
+	require.Error(t, metrics.Refresh(Status{Backend: BackendBolt, Authority: "dynamic", SchemaVersion: SchemaVersion}))
+	require.Error(t, metrics.Refresh(Status{Backend: BackendBolt, Authority: AuthorityBolt, SchemaVersion: SchemaVersion + 1}))
+	require.NoError(t, metrics.Refresh(Status{InvariantStatus: InvariantFailed}))
+	assert.Zero(t, Status{}.RecordCount("dynamic"))
+}
+
+func TestTransactionMetricsClassifyResults(t *testing.T) {
+	db, registry, metrics := openObservedTestDB(t, nil)
+	base := time.Date(2026, time.July, 24, 1, 0, 0, 0, time.UTC)
+	var clockMu sync.Mutex
+	metrics.now = func() time.Time {
+		clockMu.Lock()
+		defer clockMu.Unlock()
+		base = base.Add(250 * time.Millisecond)
+		return base
+	}
+
+	require.NoError(t, db.View(context.Background(), func(*ReadTx) error { return nil }))
+	require.ErrorIs(t, db.View(context.Background(), func(*ReadTx) error { return errAbort }), errAbort)
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, db.View(canceled, func(*ReadTx) error { return nil }), context.Canceled)
+
+	require.NoError(t, db.Update(context.Background(), func(tx *WriteTx) error {
+		return tx.PutMetadata(Metadata{Initialized: true})
+	}))
+	require.ErrorIs(t, db.Update(context.Background(), func(*WriteTx) error { return errAbort }), errAbort)
+	changed, err := db.update(context.Background(), func(*WriteTx) (bool, error) { return false, nil })
+	require.NoError(t, err)
+	assert.False(t, changed)
+	_, err = db.ReplaceDurableState(context.Background(), 99, NewDurableState())
+	require.ErrorIs(t, err, ErrStaleGeneration)
+	require.ErrorIs(t, db.Update(canceled, func(*WriteTx) error { return nil }), context.Canceled)
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+	assert.Equal(t, float64(1), counterValue(t, families, "cns_persistent_state_transactions_total", map[string]string{
+		"operation": "update", "result": "success",
+	}))
+	for _, result := range []string{"error", "noop", "conflict", "canceled"} {
+		assert.Equal(t, float64(1), counterValue(t, families, "cns_persistent_state_transactions_total", map[string]string{
+			"operation": "update", "result": result,
+		}))
+	}
+	assert.Equal(t, uint64(1), histogramCount(t, families, "cns_persistent_state_transaction_duration_seconds", map[string]string{
+		"operation": "update", "result": "success",
+	}))
+	assert.Equal(t, 0.25, histogramSum(t, families, "cns_persistent_state_transaction_duration_seconds", map[string]string{
+		"operation": "update", "result": "success",
+	}))
+}
+
+func TestLifecycleMetricsAndLogs(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	db, registry, _ := openObservedTestDB(t, zap.New(core))
+
+	changed, err := db.ApplyBoot(context.Background(), "boot-1", BootPolicy{})
+	require.NoError(t, err)
+	assert.True(t, changed)
+	changed, err = db.ApplyBoot(context.Background(), "boot-1", BootPolicy{})
+	require.NoError(t, err)
+	assert.False(t, changed)
+	_, err = db.ApplyBoot(context.Background(), "", BootPolicy{})
+	require.Error(t, err)
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = db.ApplyBoot(canceled, "boot-2", BootPolicy{})
+	require.ErrorIs(t, err, context.Canceled)
+
+	cnsData, endpointData := completeLegacyImportData(t)
+	importDB, importRegistry, _ := openObservedTestDB(t, nil)
+	importOpts := writeLegacyImportFiles(t, cnsData, endpointData, true)
+	changed, err = importDB.ImportLegacy(context.Background(), importOpts)
+	require.NoError(t, err)
+	assert.True(t, changed)
+	changed, err = importDB.ImportLegacy(context.Background(), importOpts)
+	require.NoError(t, err)
+	assert.False(t, changed)
+	_, err = importDB.ImportLegacy(context.Background(), ImportOptions{})
+	require.Error(t, err)
+	exportOpts := exportPaths(t)
+	changed, err = importDB.ExportLegacy(context.Background(), exportOpts)
+	require.NoError(t, err)
+	assert.True(t, changed)
+	changed, err = importDB.ExportLegacy(context.Background(), exportOpts)
+	require.NoError(t, err)
+	assert.False(t, changed)
+	_, err = importDB.ExportLegacy(context.Background(), ExportOptions{})
+	require.Error(t, err)
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+	assert.Equal(t, float64(1), counterValue(t, families, "cns_persistent_state_lifecycle_total", map[string]string{
+		"operation": "startup", "result": "success",
+	}))
+	assert.Equal(t, float64(1), counterValue(t, families, "cns_persistent_state_lifecycle_total", map[string]string{
+		"operation": "boot", "result": "success",
+	}))
+	assert.Equal(t, float64(1), counterValue(t, families, "cns_persistent_state_lifecycle_total", map[string]string{
+		"operation": "boot", "result": "noop",
+	}))
+	assert.Equal(t, float64(1), counterValue(t, families, "cns_persistent_state_lifecycle_total", map[string]string{
+		"operation": "boot", "result": "error",
+	}))
+	assert.Equal(t, float64(1), counterValue(t, families, "cns_persistent_state_lifecycle_total", map[string]string{
+		"operation": "boot", "result": "canceled",
+	}))
+	assert.Equal(t, uint64(1), histogramCount(t, families, "cns_persistent_state_lifecycle_duration_seconds", map[string]string{
+		"operation": "boot", "result": "success",
+	}))
+
+	importFamilies, err := importRegistry.Gather()
+	require.NoError(t, err)
+	for _, operation := range []string{"import", "rollback"} {
+		for _, result := range []string{"success", "noop"} {
+			assert.Equal(t, float64(1), counterValue(t, importFamilies, "cns_persistent_state_lifecycle_total", map[string]string{
+				"operation": operation, "result": result,
+			}))
+		}
+		assert.Equal(t, float64(1), counterValue(t, importFamilies, "cns_persistent_state_lifecycle_total", map[string]string{
+			"operation": operation, "result": "error",
+		}))
+	}
+
+	messages := logs.All()
+	require.Len(t, messages, 3)
+	assert.Equal(t, "persistent state opened", messages[0].Message)
+	assert.Equal(t, "persistent state boot applied", messages[1].Message)
+	assert.Equal(t, "persistent state boot unchanged", messages[2].Message)
+	fields := messages[1].ContextMap()
+	assert.Equal(t, BackendBolt, fields["backend"])
+	assert.Equal(t, string(AuthorityBolt), fields["authority"])
+	assert.EqualValues(t, SchemaVersion, fields["schema"])
+	assert.EqualValues(t, 1, fields["generation"])
+	assert.Equal(t, "boot", fields["operation"])
+	assert.Equal(t, "success", fields["result"])
+	assert.NotContains(t, fields, "path")
+	assert.NotContains(t, fields, "error")
+}
+
+func TestStartupErrorMetricIsReturnedWithoutLogging(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics, err := NewMetrics(registry)
+	require.NoError(t, err)
+	core, logs := observer.New(zap.InfoLevel)
+	_, err = Open(filepath.Join(t.TempDir(), "missing", "azure-cns.db"), Options{
+		Metrics: metrics,
+		Logger:  zap.New(core),
+	})
+	require.Error(t, err)
+	assert.Empty(t, logs.All())
+
+	families, gatherErr := registry.Gather()
+	require.NoError(t, gatherErr)
+	assert.Equal(t, float64(1), counterValue(t, families, "cns_persistent_state_lifecycle_total", map[string]string{
+		"operation": "startup", "result": "error",
+	}))
+}
+
+func TestStatusAndGaugeRefresh(t *testing.T) {
+	db, registry, _ := openObservedTestDB(t, nil)
+	snapshot := completeSnapshot()
+	snapshot.Metadata.BootID = "sensitive-boot"
+	snapshot.Metadata.NodeID = "sensitive-node"
+	writeSnapshot(t, db, snapshot)
+	require.NoError(t, db.Update(context.Background(), func(tx *WriteTx) error {
+		return tx.PutMetadata(snapshot.Metadata)
+	}))
+
+	status, err := db.RefreshMetrics(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, BackendBolt, status.Backend)
+	assert.Equal(t, AuthorityBolt, status.Authority)
+	assert.True(t, status.BootPresent)
+	assert.True(t, status.StoragePresent)
+	assert.Positive(t, status.DatabaseBytes)
+	assert.Equal(t, InvariantHealthy, status.InvariantStatus)
+	assert.Equal(t, RecordCounts{
+		NetworkContainers: len(snapshot.NetworkContainers),
+		IPs:               len(snapshot.IPs),
+		Networks:          len(snapshot.Networks),
+		Endpoints:         len(snapshot.Endpoints),
+		Assignments:       len(snapshot.Assignments),
+		Owners:            len(snapshot.IPOwners),
+		DeleteIntents:     len(snapshot.DeleteIntents),
+	}, status.Records)
+
+	data, err := json.Marshal(status)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "sensitive-boot")
+	assert.NotContains(t, string(data), "sensitive-node")
+	assert.NotContains(t, string(data), "path")
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+	assert.Equal(t, float64(status.Generation), gaugeValue(t, families, "cns_persistent_state_generation", nil))
+	assert.Equal(t, float64(status.DatabaseBytes), gaugeValue(t, families, "cns_persistent_state_database_bytes", nil))
+	assert.Equal(t, float64(status.Records.IPs), gaugeValue(t, families, "cns_persistent_state_records", map[string]string{
+		"record_type": "ip",
+	}))
+	assert.Equal(t, float64(1), gaugeValue(t, families, "cns_persistent_state_info", map[string]string{
+		"backend": "bbolt", "authority": "bolt", "schema": "1",
+	}))
+	assertBoundedMetricLabels(t, families)
+}
+
+func TestStatusInvalidClosedAndCanceled(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*testing.T, *DB)
+		want   InvariantName
+	}{
+		{
+			name: "logical structure",
+			mutate: func(t *testing.T, db *DB) {
+				snapshot := completeSnapshot()
+				snapshot.IPOwners["ip-v4"] = "missing-assignment"
+				writeSnapshot(t, db, snapshot)
+			},
+			want: InvariantStructural,
+		},
+		{
+			name: "schema",
+			mutate: func(t *testing.T, db *DB) {
+				putRaw(t, db, bucketMetadata, metaKeySchemaVersion, encodeUint32(SchemaVersion+1))
+			},
+			want: InvariantSchema,
+		},
+		{
+			name: "authority",
+			mutate: func(t *testing.T, db *DB) {
+				putRaw(t, db, bucketMetadata, metaKeyAuthority, []byte("dynamic"))
+			},
+			want: InvariantAuthority,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, registry, _ := openObservedTestDB(t, nil)
+			tt.mutate(t, db)
+			status, err := db.Status(context.Background())
+			require.NoError(t, err)
+			assert.Equal(t, InvariantFailed, status.InvariantStatus)
+			assert.Equal(t, tt.want, status.FailedInvariant)
+			families, gatherErr := registry.Gather()
+			require.NoError(t, gatherErr)
+			assert.Equal(t, float64(1), counterValue(t, families, "cns_persistent_state_invariant_failures_total", map[string]string{
+				"invariant": string(tt.want),
+			}))
+		})
+	}
+
+	db, _, _ := openObservedTestDB(t, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := db.Status(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+	require.NoError(t, db.Close())
+	_, err = db.Status(context.Background())
+	require.ErrorIs(t, err, bolt.ErrDatabaseNotOpen)
+}
+
+func TestMetricsConcurrentUse(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics, err := NewMetrics(registry)
+	require.NoError(t, err)
+	status := Status{Backend: BackendBolt, Authority: AuthorityBolt, SchemaVersion: SchemaVersion}
+
+	const workers = 32
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			require.NoError(t, metrics.ObserveTransaction(TransactionView, ResultSuccess, time.Millisecond))
+			require.NoError(t, metrics.ObserveLifecycle(LifecycleBoot, ResultNoop, time.Millisecond))
+			require.NoError(t, metrics.ObserveInvariant(InvariantStructural))
+			if err := metrics.Refresh(status); err != nil {
+				t.Errorf("refresh metrics: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+	assert.Equal(t, float64(workers), counterValue(t, families, "cns_persistent_state_transactions_total", map[string]string{
+		"operation": "view", "result": "success",
+	}))
+}
+
+func openObservedTestDB(t *testing.T, logger *zap.Logger) (*DB, *prometheus.Registry, *Metrics) {
+	t.Helper()
+	registry := prometheus.NewRegistry()
+	metrics, err := NewMetrics(registry)
+	require.NoError(t, err)
+	db, err := Open(filepath.Join(t.TempDir(), "azure-cns.db"), Options{Metrics: metrics, Logger: logger})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := db.Close()
+		require.True(t, err == nil || errors.Is(err, bolt.ErrDatabaseNotOpen))
+	})
+	return db, registry, metrics
+}
+
+type failingRegisterer struct {
+	calls          int
+	failAt         int
+	unregistered   int
+	failUnregister bool
+}
+
+func (r *failingRegisterer) Register(prometheus.Collector) error {
+	r.calls++
+	if r.calls == r.failAt {
+		return errors.New("register failure")
+	}
+	return nil
+}
+
+func (r *failingRegisterer) MustRegister(...prometheus.Collector) {}
+
+func (r *failingRegisterer) Unregister(prometheus.Collector) bool {
+	r.unregistered++
+	return !r.failUnregister
+}
+
+func findMetricFamily(t *testing.T, families []*dto.MetricFamily, name string) *dto.MetricFamily {
+	t.Helper()
+	for _, family := range families {
+		if family.GetName() == name {
+			return family
+		}
+	}
+	t.Fatalf("metric family %q not found", name)
+	return nil
+}
+
+func findMetric(t *testing.T, family *dto.MetricFamily, labels map[string]string) *dto.Metric {
+	t.Helper()
+	for _, metric := range family.Metric {
+		got := map[string]string{}
+		for _, label := range metric.Label {
+			got[label.GetName()] = label.GetValue()
+		}
+		if (len(labels) == 0 && len(got) == 0) || assert.ObjectsAreEqual(labels, got) {
+			return metric
+		}
+	}
+	t.Fatalf("metric %q labels %v not found", family.GetName(), labels)
+	return nil
+}
+
+func counterValue(t *testing.T, families []*dto.MetricFamily, name string, labels map[string]string) float64 {
+	t.Helper()
+	return findMetric(t, findMetricFamily(t, families, name), labels).GetCounter().GetValue()
+}
+
+func gaugeValue(t *testing.T, families []*dto.MetricFamily, name string, labels map[string]string) float64 {
+	t.Helper()
+	return findMetric(t, findMetricFamily(t, families, name), labels).GetGauge().GetValue()
+}
+
+func histogramCount(t *testing.T, families []*dto.MetricFamily, name string, labels map[string]string) uint64 {
+	t.Helper()
+	return findMetric(t, findMetricFamily(t, families, name), labels).GetHistogram().GetSampleCount()
+}
+
+func histogramSum(t *testing.T, families []*dto.MetricFamily, name string, labels map[string]string) float64 {
+	t.Helper()
+	return findMetric(t, findMetricFamily(t, families, name), labels).GetHistogram().GetSampleSum()
+}
+
+func assertBoundedMetricLabels(t *testing.T, families []*dto.MetricFamily) {
+	t.Helper()
+	allowedNames := map[string]struct{}{
+		"operation": {}, "result": {}, "invariant": {}, "backend": {}, "authority": {}, "schema": {}, "record_type": {},
+	}
+	for _, family := range families {
+		for _, metric := range family.Metric {
+			for _, label := range metric.Label {
+				_, ok := allowedNames[label.GetName()]
+				assert.True(t, ok, "%s has unexpected label %q", family.GetName(), label.GetName())
+				for _, prohibited := range []string{"node-", "pod-", "10.", "fd00", "/", "secret"} {
+					assert.NotContains(t, label.GetValue(), prohibited)
+				}
+			}
+		}
+	}
+}

--- a/cns/state/observability_test.go
+++ b/cns/state/observability_test.go
@@ -16,10 +16,14 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	bolt "go.etcd.io/bbolt"
+	bolterrors "go.etcd.io/bbolt/errors"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 )
+
+var errMetricRegistration = errors.New("register failure")
+
+const metricTestDelta = 1e-9
 
 func TestNewMetricsRegistration(t *testing.T) {
 	t.Run("descriptors", func(t *testing.T) {
@@ -48,23 +52,23 @@ func TestNewMetricsRegistration(t *testing.T) {
 			"cns_persistent_state_records":                      "Current persistent state record count by bounded record type.",
 		}
 		wantLabels := map[string][]string{
-			"cns_persistent_state_transactions_total":           {"operation", "result"},
-			"cns_persistent_state_transaction_duration_seconds": {"operation", "result"},
-			"cns_persistent_state_lifecycle_total":              {"operation", "result"},
-			"cns_persistent_state_lifecycle_duration_seconds":   {"operation", "result"},
-			"cns_persistent_state_invariant_failures_total":     {"invariant"},
-			"cns_persistent_state_info":                         {"backend", "authority", "schema"},
+			"cns_persistent_state_transactions_total":           {metricLabelOperation, metricLabelResult},
+			"cns_persistent_state_transaction_duration_seconds": {metricLabelOperation, metricLabelResult},
+			"cns_persistent_state_lifecycle_total":              {metricLabelOperation, metricLabelResult},
+			"cns_persistent_state_lifecycle_duration_seconds":   {metricLabelOperation, metricLabelResult},
+			"cns_persistent_state_invariant_failures_total":     {metricLabelInvariant},
+			"cns_persistent_state_info":                         {metricLabelBackend, metricLabelAuthority, metricLabelSchema},
 			"cns_persistent_state_generation":                   {},
 			"cns_persistent_state_storage_present":              {},
 			"cns_persistent_state_database_bytes":               {},
-			"cns_persistent_state_records":                      {"record_type"},
+			"cns_persistent_state_records":                      {metricLabelRecordType},
 		}
 		for name, help := range wantHelp {
 			family := findMetricFamily(t, families, name)
 			assert.Equal(t, help, family.GetHelp())
-			require.NotEmpty(t, family.Metric)
+			require.NotEmpty(t, family.GetMetric())
 			var labels []string
-			for _, label := range family.Metric[0].Label {
+			for _, label := range family.GetMetric()[0].GetLabel() {
 				labels = append(labels, label.GetName())
 			}
 			assert.ElementsMatch(t, wantLabels[name], labels)
@@ -157,20 +161,20 @@ func TestTransactionMetricsClassifyResults(t *testing.T) {
 
 	families, err := registry.Gather()
 	require.NoError(t, err)
-	assert.Equal(t, float64(1), counterValue(t, families, "cns_persistent_state_transactions_total", map[string]string{
-		"operation": "update", "result": "success",
-	}))
-	for _, result := range []string{"error", "noop", "conflict", "canceled"} {
-		assert.Equal(t, float64(1), counterValue(t, families, "cns_persistent_state_transactions_total", map[string]string{
-			"operation": "update", "result": result,
-		}))
+	assert.InDelta(t, float64(1), counterValue(t, families, "cns_persistent_state_transactions_total", map[string]string{
+		metricLabelOperation: string(TransactionUpdate), metricLabelResult: string(ResultSuccess),
+	}), metricTestDelta)
+	for _, result := range []OperationResult{ResultError, ResultNoop, ResultConflict, ResultCanceled} {
+		assert.InDelta(t, float64(1), counterValue(t, families, "cns_persistent_state_transactions_total", map[string]string{
+			metricLabelOperation: string(TransactionUpdate), metricLabelResult: string(result),
+		}), metricTestDelta)
 	}
 	assert.Equal(t, uint64(1), histogramCount(t, families, "cns_persistent_state_transaction_duration_seconds", map[string]string{
-		"operation": "update", "result": "success",
+		metricLabelOperation: string(TransactionUpdate), metricLabelResult: string(ResultSuccess),
 	}))
-	assert.Equal(t, 0.25, histogramSum(t, families, "cns_persistent_state_transaction_duration_seconds", map[string]string{
-		"operation": "update", "result": "success",
-	}))
+	assert.InDelta(t, 0.25, histogramSum(t, families, "cns_persistent_state_transaction_duration_seconds", map[string]string{
+		metricLabelOperation: string(TransactionUpdate), metricLabelResult: string(ResultSuccess),
+	}), metricTestDelta)
 }
 
 func TestLifecycleMetricsAndLogs(t *testing.T) {
@@ -213,36 +217,36 @@ func TestLifecycleMetricsAndLogs(t *testing.T) {
 
 	families, err := registry.Gather()
 	require.NoError(t, err)
-	assert.Equal(t, float64(1), counterValue(t, families, "cns_persistent_state_lifecycle_total", map[string]string{
-		"operation": "startup", "result": "success",
-	}))
-	assert.Equal(t, float64(1), counterValue(t, families, "cns_persistent_state_lifecycle_total", map[string]string{
-		"operation": "boot", "result": "success",
-	}))
-	assert.Equal(t, float64(1), counterValue(t, families, "cns_persistent_state_lifecycle_total", map[string]string{
-		"operation": "boot", "result": "noop",
-	}))
-	assert.Equal(t, float64(1), counterValue(t, families, "cns_persistent_state_lifecycle_total", map[string]string{
-		"operation": "boot", "result": "error",
-	}))
-	assert.Equal(t, float64(1), counterValue(t, families, "cns_persistent_state_lifecycle_total", map[string]string{
-		"operation": "boot", "result": "canceled",
-	}))
+	assert.InDelta(t, float64(1), counterValue(t, families, "cns_persistent_state_lifecycle_total", map[string]string{
+		metricLabelOperation: string(LifecycleStartup), metricLabelResult: string(ResultSuccess),
+	}), metricTestDelta)
+	assert.InDelta(t, float64(1), counterValue(t, families, "cns_persistent_state_lifecycle_total", map[string]string{
+		metricLabelOperation: string(LifecycleBoot), metricLabelResult: string(ResultSuccess),
+	}), metricTestDelta)
+	assert.InDelta(t, float64(1), counterValue(t, families, "cns_persistent_state_lifecycle_total", map[string]string{
+		metricLabelOperation: string(LifecycleBoot), metricLabelResult: string(ResultNoop),
+	}), metricTestDelta)
+	assert.InDelta(t, float64(1), counterValue(t, families, "cns_persistent_state_lifecycle_total", map[string]string{
+		metricLabelOperation: string(LifecycleBoot), metricLabelResult: string(ResultError),
+	}), metricTestDelta)
+	assert.InDelta(t, float64(1), counterValue(t, families, "cns_persistent_state_lifecycle_total", map[string]string{
+		metricLabelOperation: string(LifecycleBoot), metricLabelResult: string(ResultCanceled),
+	}), metricTestDelta)
 	assert.Equal(t, uint64(1), histogramCount(t, families, "cns_persistent_state_lifecycle_duration_seconds", map[string]string{
-		"operation": "boot", "result": "success",
+		metricLabelOperation: string(LifecycleBoot), metricLabelResult: string(ResultSuccess),
 	}))
 
 	importFamilies, err := importRegistry.Gather()
 	require.NoError(t, err)
-	for _, operation := range []string{"import", "rollback"} {
-		for _, result := range []string{"success", "noop"} {
-			assert.Equal(t, float64(1), counterValue(t, importFamilies, "cns_persistent_state_lifecycle_total", map[string]string{
-				"operation": operation, "result": result,
-			}))
+	for _, operation := range []LifecycleOperation{LifecycleImport, LifecycleRollback} {
+		for _, result := range []OperationResult{ResultSuccess, ResultNoop} {
+			assert.InDelta(t, float64(1), counterValue(t, importFamilies, "cns_persistent_state_lifecycle_total", map[string]string{
+				metricLabelOperation: string(operation), metricLabelResult: string(result),
+			}), metricTestDelta)
 		}
-		assert.Equal(t, float64(1), counterValue(t, importFamilies, "cns_persistent_state_lifecycle_total", map[string]string{
-			"operation": operation, "result": "error",
-		}))
+		assert.InDelta(t, float64(1), counterValue(t, importFamilies, "cns_persistent_state_lifecycle_total", map[string]string{
+			metricLabelOperation: string(operation), metricLabelResult: string(ResultError),
+		}), metricTestDelta)
 	}
 
 	messages := logs.All()
@@ -255,8 +259,8 @@ func TestLifecycleMetricsAndLogs(t *testing.T) {
 	assert.Equal(t, string(AuthorityBolt), fields["authority"])
 	assert.EqualValues(t, SchemaVersion, fields["schema"])
 	assert.EqualValues(t, 1, fields["generation"])
-	assert.Equal(t, "boot", fields["operation"])
-	assert.Equal(t, "success", fields["result"])
+	assert.Equal(t, string(LifecycleBoot), fields[metricLabelOperation])
+	assert.Equal(t, string(ResultSuccess), fields[metricLabelResult])
 	assert.NotContains(t, fields, "path")
 	assert.NotContains(t, fields, "error")
 }
@@ -275,9 +279,9 @@ func TestStartupErrorMetricIsReturnedWithoutLogging(t *testing.T) {
 
 	families, gatherErr := registry.Gather()
 	require.NoError(t, gatherErr)
-	assert.Equal(t, float64(1), counterValue(t, families, "cns_persistent_state_lifecycle_total", map[string]string{
-		"operation": "startup", "result": "error",
-	}))
+	assert.InDelta(t, float64(1), counterValue(t, families, "cns_persistent_state_lifecycle_total", map[string]string{
+		metricLabelOperation: string(LifecycleStartup), metricLabelResult: string(ResultError),
+	}), metricTestDelta)
 }
 
 func TestStatusAndGaugeRefresh(t *testing.T) {
@@ -316,14 +320,16 @@ func TestStatusAndGaugeRefresh(t *testing.T) {
 
 	families, err := registry.Gather()
 	require.NoError(t, err)
-	assert.Equal(t, float64(status.Generation), gaugeValue(t, families, "cns_persistent_state_generation", nil))
-	assert.Equal(t, float64(status.DatabaseBytes), gaugeValue(t, families, "cns_persistent_state_database_bytes", nil))
-	assert.Equal(t, float64(status.Records.IPs), gaugeValue(t, families, "cns_persistent_state_records", map[string]string{
-		"record_type": "ip",
-	}))
-	assert.Equal(t, float64(1), gaugeValue(t, families, "cns_persistent_state_info", map[string]string{
-		"backend": "bbolt", "authority": "bolt", "schema": "1",
-	}))
+	assert.InDelta(t, float64(status.Generation), gaugeValue(t, families, "cns_persistent_state_generation", nil), metricTestDelta)
+	assert.InDelta(t, float64(status.DatabaseBytes), gaugeValue(t, families, "cns_persistent_state_database_bytes", nil), metricTestDelta)
+	assert.InDelta(t, float64(status.Records.IPs), gaugeValue(t, families, "cns_persistent_state_records", map[string]string{
+		metricLabelRecordType: string(RecordIP),
+	}), metricTestDelta)
+	assert.InDelta(t, float64(1), gaugeValue(t, families, "cns_persistent_state_info", map[string]string{
+		metricLabelBackend:   BackendBolt,
+		metricLabelAuthority: string(AuthorityBolt),
+		metricLabelSchema:    "1",
+	}), metricTestDelta)
 	assertBoundedMetricLabels(t, families)
 }
 
@@ -367,9 +373,9 @@ func TestStatusInvalidClosedAndCanceled(t *testing.T) {
 			assert.Equal(t, tt.want, status.FailedInvariant)
 			families, gatherErr := registry.Gather()
 			require.NoError(t, gatherErr)
-			assert.Equal(t, float64(1), counterValue(t, families, "cns_persistent_state_invariant_failures_total", map[string]string{
-				"invariant": string(tt.want),
-			}))
+			assert.InDelta(t, float64(1), counterValue(t, families, "cns_persistent_state_invariant_failures_total", map[string]string{
+				metricLabelInvariant: string(tt.want),
+			}), metricTestDelta)
 		})
 	}
 
@@ -380,7 +386,7 @@ func TestStatusInvalidClosedAndCanceled(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 	require.NoError(t, db.Close())
 	_, err = db.Status(context.Background())
-	require.ErrorIs(t, err, bolt.ErrDatabaseNotOpen)
+	require.ErrorIs(t, err, bolterrors.ErrDatabaseNotOpen)
 }
 
 func TestMetricsConcurrentUse(t *testing.T) {
@@ -390,26 +396,29 @@ func TestMetricsConcurrentUse(t *testing.T) {
 	status := Status{Backend: BackendBolt, Authority: AuthorityBolt, SchemaVersion: SchemaVersion}
 
 	const workers = 32
+	errs := make(chan error, workers*4)
 	var wg sync.WaitGroup
 	wg.Add(workers)
 	for range workers {
 		go func() {
 			defer wg.Done()
-			require.NoError(t, metrics.ObserveTransaction(TransactionView, ResultSuccess, time.Millisecond))
-			require.NoError(t, metrics.ObserveLifecycle(LifecycleBoot, ResultNoop, time.Millisecond))
-			require.NoError(t, metrics.ObserveInvariant(InvariantStructural))
-			if err := metrics.Refresh(status); err != nil {
-				t.Errorf("refresh metrics: %v", err)
-			}
+			errs <- metrics.ObserveTransaction(TransactionView, ResultSuccess, time.Millisecond)
+			errs <- metrics.ObserveLifecycle(LifecycleBoot, ResultNoop, time.Millisecond)
+			errs <- metrics.ObserveInvariant(InvariantStructural)
+			errs <- metrics.Refresh(status)
 		}()
 	}
 	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
 
 	families, err := registry.Gather()
 	require.NoError(t, err)
-	assert.Equal(t, float64(workers), counterValue(t, families, "cns_persistent_state_transactions_total", map[string]string{
-		"operation": "view", "result": "success",
-	}))
+	assert.InDelta(t, float64(workers), counterValue(t, families, "cns_persistent_state_transactions_total", map[string]string{
+		metricLabelOperation: string(TransactionView), metricLabelResult: string(ResultSuccess),
+	}), metricTestDelta)
 }
 
 func openObservedTestDB(t *testing.T, logger *zap.Logger) (*DB, *prometheus.Registry, *Metrics) {
@@ -421,7 +430,7 @@ func openObservedTestDB(t *testing.T, logger *zap.Logger) (*DB, *prometheus.Regi
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		err := db.Close()
-		require.True(t, err == nil || errors.Is(err, bolt.ErrDatabaseNotOpen))
+		require.True(t, err == nil || errors.Is(err, bolterrors.ErrDatabaseNotOpen))
 	})
 	return db, registry, metrics
 }
@@ -436,7 +445,7 @@ type failingRegisterer struct {
 func (r *failingRegisterer) Register(prometheus.Collector) error {
 	r.calls++
 	if r.calls == r.failAt {
-		return errors.New("register failure")
+		return errMetricRegistration
 	}
 	return nil
 }
@@ -461,9 +470,9 @@ func findMetricFamily(t *testing.T, families []*dto.MetricFamily, name string) *
 
 func findMetric(t *testing.T, family *dto.MetricFamily, labels map[string]string) *dto.Metric {
 	t.Helper()
-	for _, metric := range family.Metric {
+	for _, metric := range family.GetMetric() {
 		got := map[string]string{}
-		for _, label := range metric.Label {
+		for _, label := range metric.GetLabel() {
 			got[label.GetName()] = label.GetValue()
 		}
 		if (len(labels) == 0 && len(got) == 0) || assert.ObjectsAreEqual(labels, got) {
@@ -497,11 +506,17 @@ func histogramSum(t *testing.T, families []*dto.MetricFamily, name string, label
 func assertBoundedMetricLabels(t *testing.T, families []*dto.MetricFamily) {
 	t.Helper()
 	allowedNames := map[string]struct{}{
-		"operation": {}, "result": {}, "invariant": {}, "backend": {}, "authority": {}, "schema": {}, "record_type": {},
+		metricLabelOperation:  {},
+		metricLabelResult:     {},
+		metricLabelInvariant:  {},
+		metricLabelBackend:    {},
+		metricLabelAuthority:  {},
+		metricLabelSchema:     {},
+		metricLabelRecordType: {},
 	}
 	for _, family := range families {
-		for _, metric := range family.Metric {
-			for _, label := range metric.Label {
+		for _, metric := range family.GetMetric() {
+			for _, label := range metric.GetLabel() {
 				_, ok := allowedNames[label.GetName()]
 				assert.True(t, ok, "%s has unexpected label %q", family.GetName(), label.GetName())
 				for _, prohibited := range []string{"node-", "pod-", "10.", "fd00", "/", "secret"} {

--- a/cns/state/status.go
+++ b/cns/state/status.go
@@ -1,0 +1,216 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package state
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+const BackendBolt = "bbolt"
+
+type InvariantStatus string
+
+const (
+	InvariantHealthy InvariantStatus = "healthy"
+	InvariantFailed  InvariantStatus = "failed"
+)
+
+type RecordCounts struct {
+	NetworkContainers int `json:"networkContainers"`
+	IPs               int `json:"ips"`
+	Networks          int `json:"networks"`
+	Endpoints         int `json:"endpoints"`
+	Assignments       int `json:"assignments"`
+	Owners            int `json:"owners"`
+	DeleteIntents     int `json:"deleteIntents"`
+}
+
+type Status struct {
+	Backend          string          `json:"backend"`
+	Authority        Authority       `json:"authority,omitempty"`
+	SchemaVersion    uint32          `json:"schemaVersion,omitempty"`
+	Generation       uint64          `json:"generation,omitempty"`
+	BootPresent      bool            `json:"bootPresent"`
+	StoragePresent   bool            `json:"storagePresent"`
+	DatabaseBytes    int64           `json:"databaseBytes"`
+	Records          RecordCounts    `json:"records"`
+	InvariantStatus  InvariantStatus `json:"invariantStatus"`
+	FailedInvariant  InvariantName   `json:"failedInvariant,omitempty"`
+	LegacyImported   bool            `json:"legacyImported"`
+	RollbackExported bool            `json:"rollbackExported"`
+}
+
+func (s Status) RecordCount(recordType RecordType) int {
+	switch recordType {
+	case RecordNetworkContainer:
+		return s.Records.NetworkContainers
+	case RecordIP:
+		return s.Records.IPs
+	case RecordNetwork:
+		return s.Records.Networks
+	case RecordEndpoint:
+		return s.Records.Endpoints
+	case RecordAssignment:
+		return s.Records.Assignments
+	case RecordOwner:
+		return s.Records.Owners
+	case RecordDeleteIntent:
+		return s.Records.DeleteIntents
+	default:
+		return 0
+	}
+}
+
+func (s *DB) Status(ctx context.Context) (Status, error) {
+	status := Status{
+		Backend:         BackendBolt,
+		InvariantStatus: InvariantHealthy,
+	}
+	err := s.View(ctx, func(tx *ReadTx) error {
+		var err error
+		status, err = statusFromTx(ctx, tx)
+		return err
+	})
+	if err != nil {
+		return Status{}, fmt.Errorf("reading persistent state status: %w", err)
+	}
+	if status.InvariantStatus == InvariantFailed {
+		_ = s.metrics.ObserveInvariant(status.FailedInvariant)
+	}
+	return status, nil
+}
+
+func (s *DB) RefreshMetrics(ctx context.Context) (Status, error) {
+	status, err := s.Status(ctx)
+	if err != nil {
+		return Status{}, err
+	}
+	if err := s.metrics.Refresh(status); err != nil {
+		return Status{}, err
+	}
+	return status, nil
+}
+
+func (s *DB) summary(ctx context.Context) (Status, error) {
+	var status Status
+	err := s.View(ctx, func(tx *ReadTx) error {
+		metadata, err := tx.Metadata()
+		if err != nil {
+			return err
+		}
+		status = Status{
+			Backend:          BackendBolt,
+			Authority:        metadata.Authority,
+			SchemaVersion:    metadata.SchemaVersion,
+			Generation:       metadata.Generation,
+			BootPresent:      metadata.BootID != "",
+			StoragePresent:   true,
+			DatabaseBytes:    tx.tx.Size(),
+			InvariantStatus:  InvariantHealthy,
+			FailedInvariant:  InvariantNone,
+			LegacyImported:   metadata.LegacyImportComplete,
+			RollbackExported: metadata.RollbackExportComplete,
+			Records: RecordCounts{
+				NetworkContainers: bucketKeyCount(tx.tx, bucketNetworkContainers),
+				IPs:               bucketKeyCount(tx.tx, bucketIPs),
+				Networks:          bucketKeyCount(tx.tx, bucketNetworks),
+				Endpoints:         bucketKeyCount(tx.tx, bucketEndpoints),
+				Assignments:       bucketKeyCount(tx.tx, bucketAssignments),
+				Owners:            bucketKeyCount(tx.tx, bucketIPOwners),
+				DeleteIntents:     bucketKeyCount(tx.tx, bucketDeleteIntents),
+			},
+		}
+		return nil
+	})
+	if err != nil {
+		return Status{}, fmt.Errorf("reading persistent state summary: %w", err)
+	}
+	return status, nil
+}
+
+func bucketKeyCount(tx *bolt.Tx, name []byte) int {
+	bucket := tx.Bucket(name)
+	if bucket == nil {
+		return 0
+	}
+	return bucket.Stats().KeyN
+}
+
+func statusFromTx(ctx context.Context, tx *ReadTx) (Status, error) {
+	status := Status{
+		Backend:         BackendBolt,
+		StoragePresent:  true,
+		DatabaseBytes:   tx.tx.Size(),
+		InvariantStatus: InvariantHealthy,
+		FailedInvariant: InvariantNone,
+	}
+	if name := metadataInvariant(tx.tx); name != InvariantNone {
+		status.InvariantStatus = InvariantFailed
+		status.FailedInvariant = name
+		return status, nil
+	}
+
+	snapshot, err := snapshotFromTx(ctx, tx)
+	if err != nil {
+		if name := boundedInvariant(err); name != InvariantNone {
+			status.InvariantStatus = InvariantFailed
+			status.FailedInvariant = name
+			return status, nil
+		}
+		return Status{}, err
+	}
+	status.Authority = snapshot.Metadata.Authority
+	status.SchemaVersion = snapshot.Metadata.SchemaVersion
+	status.Generation = snapshot.Metadata.Generation
+	status.BootPresent = snapshot.Metadata.BootID != ""
+	status.LegacyImported = snapshot.Metadata.LegacyImportComplete
+	status.RollbackExported = snapshot.Metadata.RollbackExportComplete
+	status.Records = RecordCounts{
+		NetworkContainers: len(snapshot.NetworkContainers),
+		IPs:               len(snapshot.IPs),
+		Networks:          len(snapshot.Networks),
+		Endpoints:         len(snapshot.Endpoints),
+		Assignments:       len(snapshot.Assignments),
+		Owners:            len(snapshot.IPOwners),
+		DeleteIntents:     len(snapshot.DeleteIntents),
+	}
+	if err := snapshot.Validate(); err != nil {
+		status.InvariantStatus = InvariantFailed
+		status.FailedInvariant = boundedInvariant(err)
+	}
+	return status, nil
+}
+
+func metadataInvariant(tx *bolt.Tx) InvariantName {
+	meta := tx.Bucket(bucketMetadata)
+	if meta == nil {
+		return InvariantStructural
+	}
+	version, err := decodeUint32(meta.Get(metaKeySchemaVersion))
+	if err != nil {
+		return InvariantStructural
+	}
+	if version != SchemaVersion {
+		return InvariantSchema
+	}
+	if err := validateAuthority(Authority(meta.Get(metaKeyAuthority))); err != nil {
+		return InvariantAuthority
+	}
+	return InvariantNone
+}
+
+func boundedInvariant(err error) InvariantName {
+	switch {
+	case errors.Is(err, ErrSchemaMismatch):
+		return InvariantSchema
+	case errors.Is(err, ErrCorrupt), errors.Is(err, ErrInconsistentState):
+		return InvariantStructural
+	default:
+		return InvariantStructural
+	}
+}


### PR DESCRIPTION
## Scope
Adds bounded persistent-state metrics, safe status, lifecycle logging, and transaction/invariant observability.

## Draft dependency caveat
This PR is opened early for review and CI. Its base, `users/rbtr/bolt-engine-complete-v5`, is a temporary integration branch joining #4788 and #4789. **Do not merge this PR until both sibling migration PRs merge.** It will then be rebased or retargeted to the permanent parent without expanding scope.

## Behavior
Observability is inert until the Bolt runtime is explicitly enabled; labels remain bounded and contain no pod, IP, node, path, or secret values.

## Evidence
Linux/Windows golangci-lint v2.13.2 and `cns/state` race tests pass.