### PR TITLE
feat(cns): add gated persistent state handlers

### DIFF
--- a/cns/restserver/persistent_state.go
+++ b/cns/restserver/persistent_state.go
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package restserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Azure/azure-container-networking/cns/state"
+)
+
+type statusProvider func(context.Context) (state.Status, error)
+
+type snapshotProvider func(context.Context) (state.Snapshot, error)
+
+type PersistentStateStatusHandler struct {
+	status statusProvider
+}
+
+func NewPersistentStateStatusHandler(
+	status func(context.Context) (state.Status, error),
+) (*PersistentStateStatusHandler, error) {
+	if status == nil {
+		return nil, errors.New("persistent state status provider is nil")
+	}
+	return &PersistentStateStatusHandler{status: status}, nil
+}
+
+func (h *PersistentStateStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !allowGET(w, r) {
+		return
+	}
+	status, err := h.status(r.Context())
+	if err != nil {
+		writePersistentStateError(w, err)
+		return
+	}
+	writeJSON(w, status)
+}
+
+type PersistentStateSnapshotHandler struct {
+	snapshot snapshotProvider
+	enabled  bool
+}
+
+func NewPersistentStateSnapshotHandler(
+	snapshot func(context.Context) (state.Snapshot, error),
+	enabled bool,
+) (*PersistentStateSnapshotHandler, error) {
+	if snapshot == nil {
+		return nil, errors.New("persistent state snapshot provider is nil")
+	}
+	return &PersistentStateSnapshotHandler{
+		snapshot: snapshot,
+		enabled:  enabled,
+	}, nil
+}
+
+func (h *PersistentStateSnapshotHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !allowGET(w, r) {
+		return
+	}
+	if !h.enabled {
+		http.NotFound(w, r)
+		return
+	}
+	snapshot, err := h.snapshot(r.Context())
+	if err != nil {
+		writePersistentStateError(w, err)
+		return
+	}
+	writeJSON(w, persistentStateSnapshotResponse(snapshot))
+}
+
+type persistentStateSnapshotResponse state.Snapshot
+
+func (r persistentStateSnapshotResponse) MarshalJSON() ([]byte, error) {
+	data, err := json.Marshal(state.Snapshot(r))
+	if err != nil {
+		return nil, fmt.Errorf("encoding persistent state snapshot: %w", err)
+	}
+	var document map[string]any
+	if err := json.Unmarshal(data, &document); err != nil {
+		return nil, fmt.Errorf("sanitizing persistent state snapshot: %w", err)
+	}
+	removeAuthorizationTokens(document)
+	return json.Marshal(document)
+}
+
+func removeAuthorizationTokens(value any) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, child := range typed {
+			if strings.EqualFold(key, "authorizationToken") {
+				delete(typed, key)
+				continue
+			}
+			removeAuthorizationTokens(child)
+		}
+	case []any:
+		for _, child := range typed {
+			removeAuthorizationTokens(child)
+		}
+	}
+}
+
+func allowGET(w http.ResponseWriter, r *http.Request) bool {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return false
+	}
+	if r.Body != nil && r.ContentLength != 0 {
+		http.Error(w, "request body is not allowed", http.StatusBadRequest)
+		return false
+	}
+	return true
+}
+
+func writePersistentStateError(w http.ResponseWriter, err error) {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		http.Error(w, "request canceled", http.StatusRequestTimeout)
+		return
+	}
+	http.Error(w, "persistent state unavailable", http.StatusServiceUnavailable)
+}
+
+func writeJSON(w http.ResponseWriter, value any) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		http.Error(w, "encoding persistent state response", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(append(data, '\n'))
+}

--- a/cns/restserver/persistent_state.go
+++ b/cns/restserver/persistent_state.go
@@ -14,6 +14,11 @@ import (
 	"github.com/Azure/azure-container-networking/cns/state"
 )
 
+var (
+	errNilPersistentStateStatusProvider   = errors.New("persistent state status provider is nil")
+	errNilPersistentStateSnapshotProvider = errors.New("persistent state snapshot provider is nil")
+)
+
 type statusProvider func(context.Context) (state.Status, error)
 
 type snapshotProvider func(context.Context) (state.Snapshot, error)
@@ -26,7 +31,7 @@ func NewPersistentStateStatusHandler(
 	status func(context.Context) (state.Status, error),
 ) (*PersistentStateStatusHandler, error) {
 	if status == nil {
-		return nil, errors.New("persistent state status provider is nil")
+		return nil, errNilPersistentStateStatusProvider
 	}
 	return &PersistentStateStatusHandler{status: status}, nil
 }
@@ -53,7 +58,7 @@ func NewPersistentStateSnapshotHandler(
 	enabled bool,
 ) (*PersistentStateSnapshotHandler, error) {
 	if snapshot == nil {
-		return nil, errors.New("persistent state snapshot provider is nil")
+		return nil, errNilPersistentStateSnapshotProvider
 	}
 	return &PersistentStateSnapshotHandler{
 		snapshot: snapshot,
@@ -80,16 +85,20 @@ func (h *PersistentStateSnapshotHandler) ServeHTTP(w http.ResponseWriter, r *htt
 type persistentStateSnapshotResponse state.Snapshot
 
 func (r persistentStateSnapshotResponse) MarshalJSON() ([]byte, error) {
-	data, err := json.Marshal(state.Snapshot(r))
+	data, err := json.Marshal(state.Snapshot(r)) //nolint:musttag // Snapshot preserves its established debug JSON field names.
 	if err != nil {
 		return nil, fmt.Errorf("encoding persistent state snapshot: %w", err)
 	}
 	var document map[string]any
-	if err := json.Unmarshal(data, &document); err != nil {
-		return nil, fmt.Errorf("sanitizing persistent state snapshot: %w", err)
+	if decodeErr := json.Unmarshal(data, &document); decodeErr != nil {
+		return nil, fmt.Errorf("sanitizing persistent state snapshot: %w", decodeErr)
 	}
 	removeAuthorizationTokens(document)
-	return json.Marshal(document)
+	sanitized, err := json.Marshal(document)
+	if err != nil {
+		return nil, fmt.Errorf("encoding sanitized persistent state snapshot: %w", err)
+	}
+	return sanitized, nil
 }
 
 func removeAuthorizationTokens(value any) {

--- a/cns/restserver/persistent_state_test.go
+++ b/cns/restserver/persistent_state_test.go
@@ -17,6 +17,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	errPersistentStateProvider = errors.New("secret path /var/lib/state")
+	errSnapshotProvider        = errors.New("provider failure")
+)
+
 func TestPersistentStateHandlerConstructors(t *testing.T) {
 	statusHandler, err := NewPersistentStateStatusHandler(nil)
 	require.Error(t, err)
@@ -38,15 +43,15 @@ func TestPersistentStateStatusHandlerContract(t *testing.T) {
 		DatabaseBytes:   4096,
 		InvariantStatus: state.InvariantHealthy,
 	}
-	var gotContext context.Context
+	contexts := make(chan context.Context, 1)
 	handler, err := NewPersistentStateStatusHandler(func(ctx context.Context) (state.Status, error) {
-		gotContext = ctx
+		contexts <- ctx
 		return safeStatus, nil
 	})
 	require.NoError(t, err)
 
 	t.Run("safe JSON", func(t *testing.T) {
-		request := httptest.NewRequest(http.MethodGet, "/persistent-state", nil)
+		request := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/persistent-state", http.NoBody)
 		response := httptest.NewRecorder()
 		handler.ServeHTTP(response, request)
 
@@ -73,7 +78,7 @@ func TestPersistentStateStatusHandlerContract(t *testing.T) {
 			"legacyImported":false,
 			"rollbackExported":false
 		}`, response.Body.String())
-		assert.Equal(t, request.Context(), gotContext)
+		assert.Equal(t, request.Context(), <-contexts)
 		assert.NotContains(t, response.Body.String(), "bootID")
 		assert.NotContains(t, response.Body.String(), "node")
 		assert.NotContains(t, response.Body.String(), "path")
@@ -88,7 +93,8 @@ func TestPersistentStateStatusHandlerContract(t *testing.T) {
 		})
 		require.NoError(t, handlerErr)
 		response := httptest.NewRecorder()
-		invalidHandler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/persistent-state", nil))
+		request := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/persistent-state", http.NoBody)
+		invalidHandler.ServeHTTP(response, request)
 		assert.Equal(t, http.StatusOK, response.Code)
 		assert.Contains(t, response.Body.String(), `"failedInvariant":"structural"`)
 	})
@@ -105,7 +111,7 @@ func TestPersistentStateHandlersProviderErrors(t *testing.T) {
 	}{
 		{name: "canceled", err: context.Canceled, status: http.StatusRequestTimeout, body: "request canceled\n"},
 		{name: "deadline", err: context.DeadlineExceeded, status: http.StatusRequestTimeout, body: "request canceled\n"},
-		{name: "provider", err: errors.New("secret path /var/lib/state"), status: http.StatusServiceUnavailable, body: "persistent state unavailable\n"},
+		{name: "provider", err: errPersistentStateProvider, status: http.StatusServiceUnavailable, body: "persistent state unavailable\n"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -114,7 +120,8 @@ func TestPersistentStateHandlersProviderErrors(t *testing.T) {
 			})
 			require.NoError(t, err)
 			response := httptest.NewRecorder()
-			handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/persistent-state", nil))
+			request := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/persistent-state", http.NoBody)
+			handler.ServeHTTP(response, request)
 			assert.Equal(t, tt.status, response.Code)
 			assert.Equal(t, tt.body, response.Body.String())
 			assert.NotContains(t, response.Body.String(), "/var/lib")
@@ -127,7 +134,7 @@ func TestPersistentStateHandlersProviderErrors(t *testing.T) {
 	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	request := httptest.NewRequest(http.MethodGet, "/persistent-state", nil).WithContext(ctx)
+	request := httptest.NewRequestWithContext(ctx, http.MethodGet, "/persistent-state", http.NoBody)
 	response := httptest.NewRecorder()
 	handler.ServeHTTP(response, request)
 	assert.Equal(t, http.StatusRequestTimeout, response.Code)
@@ -151,14 +158,16 @@ func TestPersistentStateSnapshotHandlerGateAndSanitization(t *testing.T) {
 	disabled, err := NewPersistentStateSnapshotHandler(provider, false)
 	require.NoError(t, err)
 	response := httptest.NewRecorder()
-	disabled.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/persistent-state/snapshot", nil))
+	request := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/persistent-state/snapshot", http.NoBody)
+	disabled.ServeHTTP(response, request)
 	assert.Equal(t, http.StatusNotFound, response.Code)
 	assert.Zero(t, calls)
 
 	enabled, err := NewPersistentStateSnapshotHandler(provider, true)
 	require.NoError(t, err)
 	response = httptest.NewRecorder()
-	enabled.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/persistent-state/snapshot", nil))
+	request = httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/persistent-state/snapshot", http.NoBody)
+	enabled.ServeHTTP(response, request)
 	assert.Equal(t, http.StatusOK, response.Code)
 	assert.Equal(t, "application/json", response.Header().Get("Content-Type"))
 	assert.Equal(t, 1, calls)
@@ -172,11 +181,12 @@ func TestPersistentStateSnapshotHandlerGateAndSanitization(t *testing.T) {
 func TestPersistentStateSnapshotHandlerErrors(t *testing.T) {
 	t.Run("provider", func(t *testing.T) {
 		handler, err := NewPersistentStateSnapshotHandler(func(context.Context) (state.Snapshot, error) {
-			return state.Snapshot{}, errors.New("provider failure")
+			return state.Snapshot{}, errSnapshotProvider
 		}, true)
 		require.NoError(t, err)
 		response := httptest.NewRecorder()
-		handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/persistent-state/snapshot", nil))
+		request := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/persistent-state/snapshot", http.NoBody)
+		handler.ServeHTTP(response, request)
 		assert.Equal(t, http.StatusServiceUnavailable, response.Code)
 	})
 
@@ -191,7 +201,8 @@ func TestPersistentStateSnapshotHandlerErrors(t *testing.T) {
 		}, true)
 		require.NoError(t, err)
 		response := httptest.NewRecorder()
-		handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/persistent-state/snapshot", nil))
+		request := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/persistent-state/snapshot", http.NoBody)
+		handler.ServeHTTP(response, request)
 		assert.Equal(t, http.StatusInternalServerError, response.Code)
 		assert.Equal(t, "encoding persistent state response\n", response.Body.String())
 	})
@@ -213,13 +224,20 @@ func assertCommonGETContract(t *testing.T, handler http.Handler) {
 	t.Helper()
 	t.Run("method mismatch", func(t *testing.T) {
 		response := httptest.NewRecorder()
-		handler.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/persistent-state", nil))
+		request := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/persistent-state", http.NoBody)
+		handler.ServeHTTP(response, request)
 		assert.Equal(t, http.StatusMethodNotAllowed, response.Code)
 		assert.Equal(t, http.MethodGet, response.Header().Get("Allow"))
 	})
 	t.Run("GET body rejected", func(t *testing.T) {
 		response := httptest.NewRecorder()
-		handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/persistent-state", strings.NewReader("{}")))
+		request := httptest.NewRequestWithContext(
+			context.Background(),
+			http.MethodGet,
+			"/persistent-state",
+			strings.NewReader("{}"),
+		)
+		handler.ServeHTTP(response, request)
 		assert.Equal(t, http.StatusBadRequest, response.Code)
 		assert.Equal(t, "request body is not allowed\n", response.Body.String())
 	})

--- a/cns/restserver/persistent_state_test.go
+++ b/cns/restserver/persistent_state_test.go
@@ -1,0 +1,226 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package restserver
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPersistentStateHandlerConstructors(t *testing.T) {
+	statusHandler, err := NewPersistentStateStatusHandler(nil)
+	require.Error(t, err)
+	assert.Nil(t, statusHandler)
+
+	snapshotHandler, err := NewPersistentStateSnapshotHandler(nil, false)
+	require.Error(t, err)
+	assert.Nil(t, snapshotHandler)
+}
+
+func TestPersistentStateStatusHandlerContract(t *testing.T) {
+	safeStatus := state.Status{
+		Backend:         state.BackendBolt,
+		Authority:       state.AuthorityBolt,
+		SchemaVersion:   state.SchemaVersion,
+		Generation:      7,
+		BootPresent:     true,
+		StoragePresent:  true,
+		DatabaseBytes:   4096,
+		InvariantStatus: state.InvariantHealthy,
+	}
+	var gotContext context.Context
+	handler, err := NewPersistentStateStatusHandler(func(ctx context.Context) (state.Status, error) {
+		gotContext = ctx
+		return safeStatus, nil
+	})
+	require.NoError(t, err)
+
+	t.Run("safe JSON", func(t *testing.T) {
+		request := httptest.NewRequest(http.MethodGet, "/persistent-state", nil)
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, request)
+
+		assert.Equal(t, http.StatusOK, response.Code)
+		assert.Equal(t, "application/json", response.Header().Get("Content-Type"))
+		assert.JSONEq(t, `{
+			"backend":"bbolt",
+			"authority":"bolt",
+			"schemaVersion":1,
+			"generation":7,
+			"bootPresent":true,
+			"storagePresent":true,
+			"databaseBytes":4096,
+			"records":{
+				"networkContainers":0,
+				"ips":0,
+				"networks":0,
+				"endpoints":0,
+				"assignments":0,
+				"owners":0,
+				"deleteIntents":0
+			},
+			"invariantStatus":"healthy",
+			"legacyImported":false,
+			"rollbackExported":false
+		}`, response.Body.String())
+		assert.Equal(t, request.Context(), gotContext)
+		assert.NotContains(t, response.Body.String(), "bootID")
+		assert.NotContains(t, response.Body.String(), "node")
+		assert.NotContains(t, response.Body.String(), "path")
+	})
+
+	t.Run("invalid invariant is observable", func(t *testing.T) {
+		invalidHandler, handlerErr := NewPersistentStateStatusHandler(func(context.Context) (state.Status, error) {
+			status := safeStatus
+			status.InvariantStatus = state.InvariantFailed
+			status.FailedInvariant = state.InvariantStructural
+			return status, nil
+		})
+		require.NoError(t, handlerErr)
+		response := httptest.NewRecorder()
+		invalidHandler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/persistent-state", nil))
+		assert.Equal(t, http.StatusOK, response.Code)
+		assert.Contains(t, response.Body.String(), `"failedInvariant":"structural"`)
+	})
+
+	assertCommonGETContract(t, handler)
+}
+
+func TestPersistentStateHandlersProviderErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		status int
+		body   string
+	}{
+		{name: "canceled", err: context.Canceled, status: http.StatusRequestTimeout, body: "request canceled\n"},
+		{name: "deadline", err: context.DeadlineExceeded, status: http.StatusRequestTimeout, body: "request canceled\n"},
+		{name: "provider", err: errors.New("secret path /var/lib/state"), status: http.StatusServiceUnavailable, body: "persistent state unavailable\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, err := NewPersistentStateStatusHandler(func(context.Context) (state.Status, error) {
+				return state.Status{}, tt.err
+			})
+			require.NoError(t, err)
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/persistent-state", nil))
+			assert.Equal(t, tt.status, response.Code)
+			assert.Equal(t, tt.body, response.Body.String())
+			assert.NotContains(t, response.Body.String(), "/var/lib")
+		})
+	}
+
+	handler, err := NewPersistentStateStatusHandler(func(ctx context.Context) (state.Status, error) {
+		return state.Status{}, ctx.Err()
+	})
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	request := httptest.NewRequest(http.MethodGet, "/persistent-state", nil).WithContext(ctx)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	assert.Equal(t, http.StatusRequestTimeout, response.Code)
+}
+
+func TestPersistentStateSnapshotHandlerGateAndSanitization(t *testing.T) {
+	calls := 0
+	snapshot := state.NewSnapshot()
+	snapshot.NetworkContainers["nc"] = state.NetworkContainerRecord{
+		ID: "nc",
+		Request: cns.CreateNetworkContainerRequest{
+			NetworkContainerid: "nc",
+			AuthorizationToken: "super-secret",
+		},
+	}
+	provider := func(context.Context) (state.Snapshot, error) {
+		calls++
+		return snapshot, nil
+	}
+
+	disabled, err := NewPersistentStateSnapshotHandler(provider, false)
+	require.NoError(t, err)
+	response := httptest.NewRecorder()
+	disabled.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/persistent-state/snapshot", nil))
+	assert.Equal(t, http.StatusNotFound, response.Code)
+	assert.Zero(t, calls)
+
+	enabled, err := NewPersistentStateSnapshotHandler(provider, true)
+	require.NoError(t, err)
+	response = httptest.NewRecorder()
+	enabled.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/persistent-state/snapshot", nil))
+	assert.Equal(t, http.StatusOK, response.Code)
+	assert.Equal(t, "application/json", response.Header().Get("Content-Type"))
+	assert.Equal(t, 1, calls)
+	assert.Contains(t, response.Body.String(), `"NetworkContainers"`)
+	assert.NotContains(t, strings.ToLower(response.Body.String()), "authorizationtoken")
+	assert.NotContains(t, response.Body.String(), "super-secret")
+
+	assertCommonGETContract(t, enabled)
+}
+
+func TestPersistentStateSnapshotHandlerErrors(t *testing.T) {
+	t.Run("provider", func(t *testing.T) {
+		handler, err := NewPersistentStateSnapshotHandler(func(context.Context) (state.Snapshot, error) {
+			return state.Snapshot{}, errors.New("provider failure")
+		}, true)
+		require.NoError(t, err)
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/persistent-state/snapshot", nil))
+		assert.Equal(t, http.StatusServiceUnavailable, response.Code)
+	})
+
+	t.Run("encoding", func(t *testing.T) {
+		snapshot := state.NewSnapshot()
+		snapshot.Networks["network"] = state.NetworkRecord{
+			NetworkName: "network",
+			Options:     map[string]any{"unsupported": make(chan struct{})},
+		}
+		handler, err := NewPersistentStateSnapshotHandler(func(context.Context) (state.Snapshot, error) {
+			return snapshot, nil
+		}, true)
+		require.NoError(t, err)
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/persistent-state/snapshot", nil))
+		assert.Equal(t, http.StatusInternalServerError, response.Code)
+		assert.Equal(t, "encoding persistent state response\n", response.Body.String())
+	})
+
+	t.Run("recursive sanitizer", func(t *testing.T) {
+		document := map[string]any{
+			"AuthorizationToken": "secret",
+			"nested": []any{
+				map[string]any{"authorizationtoken": "another"},
+			},
+		}
+		removeAuthorizationTokens(document)
+		assert.NotContains(t, document, "AuthorizationToken")
+		assert.NotContains(t, document["nested"].([]any)[0].(map[string]any), "authorizationtoken")
+	})
+}
+
+func assertCommonGETContract(t *testing.T, handler http.Handler) {
+	t.Helper()
+	t.Run("method mismatch", func(t *testing.T) {
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/persistent-state", nil))
+		assert.Equal(t, http.StatusMethodNotAllowed, response.Code)
+		assert.Equal(t, http.MethodGet, response.Header().Get("Allow"))
+	})
+	t.Run("GET body rejected", func(t *testing.T) {
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/persistent-state", strings.NewReader("{}")))
+		assert.Equal(t, http.StatusBadRequest, response.Code)
+		assert.Equal(t, "request body is not allowed\n", response.Body.String())
+	})
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@
 * [IPAM](ipam.md) - describes how container IP address management is done by plugins.
 * [NPM](npm.md) - describes how to setup Azure-NPM (Azure Network Policy Manager).
 * [Scripts](scripts.md) - describes how to use the scripts in this repository.
+* [CNS persistent state observability](persistent-state-observability.md) - describes Bolt state signals, status, soak checks, and debug risk.
 
 ## Code of Conduct
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/docs/persistent-state-observability.md
+++ b/docs/persistent-state-observability.md
@@ -1,0 +1,185 @@
+# CNS persistent state observability
+
+The Bolt persistent state engine provides low-cardinality metrics, safe status, and
+structured lifecycle events before it becomes a supported runtime mode. R13 does
+not activate the backend, register HTTP routes, or add runtime configuration.
+
+```mermaid
+flowchart LR
+    Caller[Future R14/R15 runtime boundary] --> DB[Persistent state DB]
+    DB --> Tx[View and Update metrics]
+    DB --> Life[Startup, import, rollback, and boot metrics]
+    DB --> Status[Safe status read]
+    Status --> Gauges[Metadata and count gauges]
+    Status --> SafeHandler[Unregistered safe-status handler]
+    DB --> Snapshot[Logical snapshot]
+    Snapshot --> Gate{Explicit debug gate}
+    Gate -->|false by default| NotFound[404]
+    Gate -->|true| DebugHandler[Unregistered debug handler]
+    DB --> Logs[Stable lifecycle success/no-op logs]
+```
+
+## Signals
+
+All metric names start with `cns_persistent_state_`.
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `info` | gauge | `backend`, `authority`, `schema` | Current backend contract |
+| `transactions_total` | counter | `operation`, `result` | Database views and updates |
+| `transaction_duration_seconds` | histogram | `operation`, `result` | Database transaction latency |
+| `lifecycle_total` | counter | `operation`, `result` | Startup, import, rollback, and boot outcomes |
+| `lifecycle_duration_seconds` | histogram | `operation`, `result` | Lifecycle latency |
+| `invariant_failures_total` | counter | `invariant` | Bounded structural, schema, or authority failures |
+| `generation` | gauge | none | Current committed generation |
+| `storage_present` | gauge | none | Storage is present and readable |
+| `database_bytes` | gauge | none | Transaction-consistent database size |
+| `records` | gauge | `record_type` | NC, IP, network, endpoint, assignment, owner, and delete-intent counts |
+
+The only label values are typed bounded values:
+
+- `operation`: `view`, `update`, `startup`, `import`, `rollback`, `boot`
+- `result`: `success`, `error`, `canceled`, `noop`, `conflict`
+- `invariant`: `structural`, `schema`, `authority`
+- `record_type`: `network_container`, `ip`, `network`, `endpoint`,
+  `assignment`, `owner`, `delete_intent`
+- `backend`, `authority`, and `schema`: known storage contract values
+
+Never add paths, node names, pod identities, IP addresses, record identifiers, or
+error messages as labels.
+
+## Dashboard queries
+
+Transaction error ratio:
+
+```promql
+sum(rate(cns_persistent_state_transactions_total{result=~"error|canceled"}[5m]))
+/
+clamp_min(sum(rate(cns_persistent_state_transactions_total[5m])), 1)
+```
+
+Transaction P99 by operation:
+
+```promql
+histogram_quantile(
+  0.99,
+  sum by (le, operation) (
+    rate(cns_persistent_state_transaction_duration_seconds_bucket[5m])
+  )
+)
+```
+
+Lifecycle failures:
+
+```promql
+sum by (operation, result) (
+  increase(cns_persistent_state_lifecycle_total{result=~"error|canceled|conflict"}[15m])
+)
+```
+
+Invariant failures:
+
+```promql
+sum by (invariant) (
+  increase(cns_persistent_state_invariant_failures_total[15m])
+)
+```
+
+Database growth rate:
+
+```promql
+deriv(cns_persistent_state_database_bytes[30m])
+```
+
+Record count changes and impossible owner excess:
+
+```promql
+delta(cns_persistent_state_records[15m])
+```
+
+```promql
+clamp_min(
+  cns_persistent_state_records{record_type="owner"}
+  - cns_persistent_state_records{record_type="ip"},
+  0
+)
+```
+
+## Suggested alerts
+
+Tune thresholds after soak data is available.
+
+| Condition | Initial duration | Severity |
+| --- | --- | --- |
+| Transaction error ratio is greater than 1% | `for: 10m` | warning |
+| Transaction error ratio is greater than 5% | `for: 5m` | critical |
+| P99 update latency is greater than 100 ms | `for: 15m` | warning |
+| Any startup/import/rollback/boot `error` or `canceled` increase | `for: 5m` | critical |
+| Any invariant failure increase | `for: 5m` | critical |
+| `storage_present == 0` in an activated deployment | `for: 5m` | critical |
+| Owners exceed inventory IPs | `for: 10m` | critical |
+| Database growth remains above the soak baseline | `for: 30m` | warning |
+
+## Safe status and debug snapshot
+
+The safe status is one consistent database read. It contains only backend,
+authority, schema, generation, boot presence, migration/rollback completion,
+storage size, bounded invariant state, and aggregate record counts. It never
+contains the database path, boot value, node identity, pod identity, IP address,
+endpoint payload, token, or raw Bolt page.
+
+When registered in a future release, a valid GET returns 200 even when
+`invariantStatus` is `failed`; the bounded failure is the status representation,
+not a transport failure. Provider failures return 503, canceled requests return
+408, method mismatches return 405, and GET requests with bodies return 400.
+
+The full logical snapshot contains pod, IP, and endpoint data. Its handler
+requires an explicit behavioral `enabled` boolean and returns 404 while disabled.
+Authorization tokens are removed before transport. The constructor is available
+for future composition, but **no route is registered and the endpoint is not
+enabled in R13**. Future callers must default the gate to false and protect the
+route as sensitive debug access.
+
+## Lifecycle logs and error ownership
+
+Successful and no-op lifecycle outcomes use stable messages:
+
+- `persistent state opened`
+- `persistent state import completed` / `persistent state import skipped`
+- `persistent state rollback completed` / `persistent state rollback skipped`
+- `persistent state boot applied` / `persistent state boot unchanged`
+
+Fields are typed and bounded: backend, authority, schema, generation, operation,
+result, duration, and aggregate record counts. Transaction hot paths do not log.
+The state package returns failures without logging them. The R14 startup adapter
+and R15 request/runtime handling boundaries own the single error log after they
+decide retry, rollback, or process-failure behavior.
+
+## Migration and rollback diagnosis
+
+1. Check `info` for the expected backend, authority, and schema.
+2. Check lifecycle counters for `import` or `rollback` errors/no-ops.
+3. Correlate lifecycle P99 with database growth and transaction errors.
+4. Check safe status for `legacyImported`, `rollbackExported`, generation, and
+   bounded invariant state.
+5. Treat schema, authority, or structural invariant failures as unsafe state;
+   do not inspect or publish raw records to diagnose them.
+6. At the R14/R15 owner boundary, retain the returned error once and apply the
+   documented retry or rollback policy.
+
+## Soak checklist
+
+- [ ] Run with a fresh Prometheus registry and confirm exactly one collector set.
+- [ ] Exercise commit, abort, no-op, conflict, cancellation, import, rollback,
+      and reboot transitions.
+- [ ] Confirm generation advances only after committed writes.
+- [ ] Confirm gauges match a safe status read after refresh.
+- [ ] Confirm no sample contains a path, pod, IP, node, record ID, or error text.
+- [ ] Confirm histogram observations require no wall-clock sleeps.
+- [ ] Run state and handler packages under `-race` with concurrent readers and
+      recorders.
+- [ ] Track database growth, transaction P99, and each record count through the
+      expected pod/NC churn workload.
+- [ ] Confirm the full snapshot remains 404 unless explicitly enabled and that
+      its response never contains `AuthorizationToken`.
+- [ ] Exercise rollback/migration replay and verify success followed by no-op.


### PR DESCRIPTION
## Scope
Adds the bounded persistent-state status handler and the token-redacted logical snapshot handler.

## Draft dependency caveat
This PR is opened early for review and CI on top of the draft observability PR. That parent still depends on the temporary #4788 + #4789 engine join. **Do not merge this PR until the observability parent and both migration siblings merge.**

## Behavior
The full snapshot route remains unregistered and default-off unless explicitly enabled; the status response exposes only stable metadata and counts.

## Evidence
Linux/Windows lint and restserver race tests pass.