### PR TITLE
feat(cns): add inert Bolt state adapter

### DIFF
--- a/cns/restserver/durable_state_adapter.go
+++ b/cns/restserver/durable_state_adapter.go
@@ -19,6 +19,27 @@ import (
 	"github.com/Azure/azure-container-networking/cns/types"
 )
 
+var (
+	errNilDurableStateDB           = errors.New("durable state database is nil")
+	errNilDurableRestService       = errors.New("rest service is nil")
+	errNilDurableRestServiceState  = errors.New("rest service state is nil")
+	errNilDurableSnapshotOperation = errors.New("durable state snapshot operation is nil")
+	errNilDurableReplaceOperation  = errors.New("durable state replace operation is nil")
+	errNilDurableMetadataOperation = errors.New("durable state metadata operation is nil")
+	errNilDurableStatusOperation   = errors.New("durable state status operation is nil")
+	errNilDurableCloseOperation    = errors.New("durable state close operation is nil")
+	errDurableStateNotProjected    = errors.New("durable state has not been projected")
+	errUnexpectedDurableBackend    = errors.New("unexpected durable state backend")
+	errUnexpectedDurableAuthority  = errors.New("unexpected durable state authority")
+	errUnexpectedDurableSchema     = errors.New("unexpected durable state schema version")
+	errDurableInvariantFailed      = errors.New("durable state invariant failed")
+	errInvalidProjectionSchema     = errors.New("durable state projection schema version is invalid")
+	errInvalidProjectionAuthority  = errors.New("durable state projection authority is invalid")
+	errMissingProjectedNC          = errors.New("missing projected network container")
+	errEmptyProjectedNCHostVersion = errors.New("projected network container host version is empty")
+	errProjectedNCIDContainsComma  = errors.New("projected network container ID contains a comma")
+)
+
 type durableStateOperations struct {
 	snapshot       func(context.Context) (state.Snapshot, error)
 	replace        func(context.Context, uint64, state.DurableState) (bool, error)
@@ -61,7 +82,7 @@ type durableCacheProjection struct {
 
 func newDurableStateAdapter(service *HTTPRestService, db *state.DB) (*durableStateAdapter, error) {
 	if db == nil {
-		return nil, errors.New("durable state database is nil")
+		return nil, errNilDurableStateDB
 	}
 	return newDurableStateAdapterWithOperations(service, durableStateOperations{
 		snapshot: db.Snapshot,
@@ -70,7 +91,7 @@ func newDurableStateAdapter(service *HTTPRestService, db *state.DB) (*durableSta
 			err := db.Update(ctx, func(tx *state.WriteTx) error {
 				current, err := tx.Metadata()
 				if err != nil {
-					return err
+					return fmt.Errorf("reading durable state metadata: %w", err)
 				}
 				if current.Generation != expectedGeneration {
 					return fmt.Errorf(
@@ -82,7 +103,10 @@ func newDurableStateAdapter(service *HTTPRestService, db *state.DB) (*durableSta
 				}
 				return tx.PutMetadata(metadata)
 			})
-			return err == nil, err
+			if err != nil {
+				return false, fmt.Errorf("updating durable state metadata: %w", err)
+			}
+			return true, nil
 		},
 		status: db.Status,
 		close:  db.Close,
@@ -95,19 +119,19 @@ func newDurableStateAdapterWithOperations(
 ) (*durableStateAdapter, error) {
 	switch {
 	case service == nil:
-		return nil, errors.New("rest service is nil")
+		return nil, errNilDurableRestService
 	case service.state == nil:
-		return nil, errors.New("rest service state is nil")
+		return nil, errNilDurableRestServiceState
 	case operations.snapshot == nil:
-		return nil, errors.New("durable state snapshot operation is nil")
+		return nil, errNilDurableSnapshotOperation
 	case operations.replace == nil:
-		return nil, errors.New("durable state replace operation is nil")
+		return nil, errNilDurableReplaceOperation
 	case operations.updateMetadata == nil:
-		return nil, errors.New("durable state metadata operation is nil")
+		return nil, errNilDurableMetadataOperation
 	case operations.status == nil:
-		return nil, errors.New("durable state status operation is nil")
+		return nil, errNilDurableStatusOperation
 	case operations.close == nil:
-		return nil, errors.New("durable state close operation is nil")
+		return nil, errNilDurableCloseOperation
 	}
 	return &durableStateAdapter{service: service, store: operations}, nil
 }
@@ -169,7 +193,7 @@ func (a *durableStateAdapter) applyNetworkContainer(
 	}
 	normalized, err := cloneJSON(normalized)
 	if err != nil {
-		return fmt.Errorf("%w: cloning network container %q: %v", state.ErrInvalidInput, record.ID, err)
+		return fmt.Errorf("%w: cloning network container %q: %w", state.ErrInvalidInput, record.ID, err)
 	}
 	inventory := make(map[string]state.IPRecord, len(ips))
 	for _, ip := range ips {
@@ -225,7 +249,7 @@ func (a *durableStateAdapter) putNetwork(ctx context.Context, record state.Netwo
 	}
 	cloned, err := cloneJSON(record)
 	if err != nil {
-		return fmt.Errorf("%w: cloning network %q: %v", state.ErrInvalidInput, record.NetworkName, err)
+		return fmt.Errorf("%w: cloning network %q: %w", state.ErrInvalidInput, record.NetworkName, err)
 	}
 	return a.updateDurable(ctx, func(candidate *state.DurableState) error {
 		candidate.Networks[record.NetworkName] = cloned
@@ -267,7 +291,7 @@ func (a *durableStateAdapter) deleteOrchestratorContext(ctx context.Context, id 
 func (a *durableStateAdapter) putPnPID(ctx context.Context, macAddress, pnpID string) error {
 	mac, err := net.ParseMAC(macAddress)
 	if err != nil {
-		return fmt.Errorf("%w: invalid MAC address %q: %v", state.ErrInvalidInput, macAddress, err)
+		return fmt.Errorf("%w: invalid MAC address %q: %w", state.ErrInvalidInput, macAddress, err)
 	}
 	if pnpID == "" {
 		return fmt.Errorf("%w: PnP ID is empty", state.ErrInvalidInput)
@@ -281,7 +305,7 @@ func (a *durableStateAdapter) putPnPID(ctx context.Context, macAddress, pnpID st
 func (a *durableStateAdapter) deletePnPID(ctx context.Context, macAddress string) error {
 	mac, err := net.ParseMAC(macAddress)
 	if err != nil {
-		return fmt.Errorf("%w: invalid MAC address %q: %v", state.ErrInvalidInput, macAddress, err)
+		return fmt.Errorf("%w: invalid MAC address %q: %w", state.ErrInvalidInput, macAddress, err)
 	}
 	return a.updateDurable(ctx, func(candidate *state.DurableState) error {
 		delete(candidate.PnPIDByMAC, mac.String())
@@ -340,10 +364,10 @@ func (a *durableStateAdapter) updateDurable(
 		PnPIDByMAC:           snapshot.PnPIDByMAC,
 	})
 	if err != nil {
-		return fmt.Errorf("%w: cloning durable state: %v", state.ErrInvalidInput, err)
+		return fmt.Errorf("%w: cloning durable state: %w", state.ErrInvalidInput, err)
 	}
-	if err := mutate(&durable); err != nil {
-		return err
+	if mutateErr := mutate(&durable); mutateErr != nil {
+		return mutateErr
 	}
 	candidate := snapshot
 	candidate.NetworkContainers = durable.NetworkContainers
@@ -370,7 +394,7 @@ func (a *durableStateAdapter) updateDurable(
 
 func (a *durableStateAdapter) currentSnapshot(ctx context.Context) (state.Snapshot, error) {
 	if !a.projected {
-		return state.Snapshot{}, errors.New("durable state has not been projected")
+		return state.Snapshot{}, errDurableStateNotProjected
 	}
 	snapshot, err := a.store.snapshot(ctx)
 	if err != nil {
@@ -405,13 +429,13 @@ func (a *durableStateAdapter) verifyStatus(ctx context.Context, expectedGenerati
 	}
 	switch {
 	case status.Backend != state.BackendBolt:
-		return fmt.Errorf("unexpected durable state backend %q", status.Backend)
+		return fmt.Errorf("%w: %q", errUnexpectedDurableBackend, status.Backend)
 	case status.Authority != state.AuthorityBolt:
-		return fmt.Errorf("unexpected durable state authority %q", status.Authority)
+		return fmt.Errorf("%w: %q", errUnexpectedDurableAuthority, status.Authority)
 	case status.SchemaVersion != state.SchemaVersion:
-		return fmt.Errorf("unexpected durable state schema version %d", status.SchemaVersion)
+		return fmt.Errorf("%w: %d", errUnexpectedDurableSchema, status.SchemaVersion)
 	case status.InvariantStatus != state.InvariantHealthy:
-		return fmt.Errorf("durable state invariant %q failed", status.FailedInvariant)
+		return fmt.Errorf("%w: %q", errDurableInvariantFailed, status.FailedInvariant)
 	case status.Generation != expectedGeneration:
 		return fmt.Errorf(
 			"%w: expected=%d actual=%d",
@@ -463,15 +487,9 @@ func buildDurableCacheProjection(snapshot state.Snapshot) (durableCacheProjectio
 	}
 	switch {
 	case snapshot.Metadata.SchemaVersion != state.SchemaVersion:
-		return durableCacheProjection{}, fmt.Errorf(
-			"durable state projection schema version %d is invalid",
-			snapshot.Metadata.SchemaVersion,
-		)
+		return durableCacheProjection{}, fmt.Errorf("%w: %d", errInvalidProjectionSchema, snapshot.Metadata.SchemaVersion)
 	case snapshot.Metadata.Authority != state.AuthorityBolt:
-		return durableCacheProjection{}, fmt.Errorf(
-			"durable state projection authority %q is invalid",
-			snapshot.Metadata.Authority,
-		)
+		return durableCacheProjection{}, fmt.Errorf("%w: %q", errInvalidProjectionAuthority, snapshot.Metadata.Authority)
 	}
 
 	projection := durableCacheProjection{
@@ -492,7 +510,8 @@ func buildDurableCacheProjection(snapshot state.Snapshot) (durableCacheProjectio
 	}
 
 	hostVersions := make(map[string]int, len(snapshot.NetworkContainers))
-	for id, record := range snapshot.NetworkContainers {
+	for id := range snapshot.NetworkContainers {
+		record := snapshot.NetworkContainers[id]
 		request, err := cloneJSON(record.Request)
 		if err != nil {
 			return durableCacheProjection{}, fmt.Errorf("cloning network container %q request: %w", id, err)
@@ -522,12 +541,13 @@ func buildDurableCacheProjection(snapshot state.Snapshot) (durableCacheProjectio
 	for id, record := range snapshot.IPs {
 		nc, ok := projection.containerStatus[record.NCID]
 		if !ok {
-			return durableCacheProjection{}, fmt.Errorf("ip %q references missing projected network container %q", id, record.NCID)
+			return durableCacheProjection{}, fmt.Errorf("%w: IP %q network container %q", errMissingProjectedNC, id, record.NCID)
 		}
 		hostVersion, ok := hostVersions[record.NCID]
 		if !ok {
 			return durableCacheProjection{}, fmt.Errorf(
-				"ip %q network container %q has an empty host version",
+				"%w: IP %q network container %q",
+				errEmptyProjectedNCHostVersion,
 				id,
 				record.NCID,
 			)
@@ -567,7 +587,8 @@ func buildDurableCacheProjection(snapshot state.Snapshot) (durableCacheProjectio
 		for _, ncID := range ncIDs {
 			if strings.Contains(ncID, ",") {
 				return durableCacheProjection{}, fmt.Errorf(
-					"orchestrator context %q network container %q contains a comma",
+					"%w: orchestrator context %q network container %q",
+					errProjectedNCIDContainsComma,
 					id,
 					ncID,
 				)
@@ -590,10 +611,10 @@ func cloneJSON[T any](input T) (T, error) {
 	var output T
 	data, err := json.Marshal(input)
 	if err != nil {
-		return output, err
+		return output, fmt.Errorf("marshaling cloned value: %w", err)
 	}
 	if err := json.Unmarshal(data, &output); err != nil {
-		return output, err
+		return output, fmt.Errorf("unmarshaling cloned value: %w", err)
 	}
 	return output, nil
 }

--- a/cns/restserver/durable_state_adapter.go
+++ b/cns/restserver/durable_state_adapter.go
@@ -1,0 +1,599 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package restserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/state"
+	"github.com/Azure/azure-container-networking/cns/types"
+)
+
+type durableStateOperations struct {
+	snapshot       func(context.Context) (state.Snapshot, error)
+	replace        func(context.Context, uint64, state.DurableState) (bool, error)
+	updateMetadata func(context.Context, uint64, state.Metadata) (bool, error)
+	status         func(context.Context) (state.Status, error)
+	close          func() error
+}
+
+type durableStateAdapter struct {
+	service *HTTPRestService
+	store   durableStateOperations
+
+	// mu is acquired before the HTTPRestService lock. Callers must not hold the
+	// service lock; the adapter applies complete projections under that lock.
+	mu         sync.Mutex
+	projected  bool
+	generation uint64
+	closeOnce  sync.Once
+	closeErr   error
+}
+
+type durableServiceMetadata struct {
+	OrchestratorType string
+	NodeID           string
+	Location         string
+	NetworkType      string
+	Initialized      bool
+	TimeStamp        time.Time
+}
+
+type durableCacheProjection struct {
+	generation        uint64
+	metadata          durableServiceMetadata
+	containerStatus   map[string]containerstatus
+	ipConfigState     map[string]cns.IPConfigurationStatus
+	networks          map[string]*networkInfo
+	orchestratorNCs   map[string]*ncList
+	pnpIDByMACAddress map[string]string
+}
+
+func newDurableStateAdapter(service *HTTPRestService, db *state.DB) (*durableStateAdapter, error) {
+	if db == nil {
+		return nil, errors.New("durable state database is nil")
+	}
+	return newDurableStateAdapterWithOperations(service, durableStateOperations{
+		snapshot: db.Snapshot,
+		replace:  db.ReplaceDurableState,
+		updateMetadata: func(ctx context.Context, expectedGeneration uint64, metadata state.Metadata) (bool, error) {
+			err := db.Update(ctx, func(tx *state.WriteTx) error {
+				current, err := tx.Metadata()
+				if err != nil {
+					return err
+				}
+				if current.Generation != expectedGeneration {
+					return fmt.Errorf(
+						"%w: expected=%d actual=%d",
+						state.ErrStaleGeneration,
+						expectedGeneration,
+						current.Generation,
+					)
+				}
+				return tx.PutMetadata(metadata)
+			})
+			return err == nil, err
+		},
+		status: db.Status,
+		close:  db.Close,
+	})
+}
+
+func newDurableStateAdapterWithOperations(
+	service *HTTPRestService,
+	operations durableStateOperations,
+) (*durableStateAdapter, error) {
+	switch {
+	case service == nil:
+		return nil, errors.New("rest service is nil")
+	case service.state == nil:
+		return nil, errors.New("rest service state is nil")
+	case operations.snapshot == nil:
+		return nil, errors.New("durable state snapshot operation is nil")
+	case operations.replace == nil:
+		return nil, errors.New("durable state replace operation is nil")
+	case operations.updateMetadata == nil:
+		return nil, errors.New("durable state metadata operation is nil")
+	case operations.status == nil:
+		return nil, errors.New("durable state status operation is nil")
+	case operations.close == nil:
+		return nil, errors.New("durable state close operation is nil")
+	}
+	return &durableStateAdapter{service: service, store: operations}, nil
+}
+
+func (a *durableStateAdapter) restore(ctx context.Context) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	snapshot, err := a.store.snapshot(ctx)
+	if err != nil {
+		return err
+	}
+	projection, err := buildDurableCacheProjection(snapshot)
+	if err != nil {
+		return err
+	}
+	if err := a.verifyStatus(ctx, projection.generation); err != nil {
+		return err
+	}
+	if a.projected {
+		switch {
+		case projection.generation == a.generation:
+			return nil
+		case projection.generation < a.generation:
+			return fmt.Errorf(
+				"%w: projected=%d database=%d",
+				state.ErrStaleGeneration,
+				a.generation,
+				projection.generation,
+			)
+		}
+	}
+	a.applyProjection(projection)
+	return nil
+}
+
+func (a *durableStateAdapter) applyNetworkContainer(
+	ctx context.Context,
+	record state.NetworkContainerRecord,
+	ips []state.IPRecord,
+) error {
+	if record.Request.NetworkContainerid != record.ID {
+		return fmt.Errorf(
+			"%w: network container ID %q does not match request ID %q",
+			state.ErrInvalidInput,
+			record.ID,
+			record.Request.NetworkContainerid,
+		)
+	}
+	normalized := state.NewNetworkContainerRecord(
+		record.ID,
+		record.VMVersion,
+		record.HostVersion,
+		record.VFPUpdateComplete,
+		record.Request,
+	)
+	if record.ID == "" {
+		return fmt.Errorf("%w: network container ID is empty", state.ErrInvalidInput)
+	}
+	normalized, err := cloneJSON(normalized)
+	if err != nil {
+		return fmt.Errorf("%w: cloning network container %q: %v", state.ErrInvalidInput, record.ID, err)
+	}
+	inventory := make(map[string]state.IPRecord, len(ips))
+	for _, ip := range ips {
+		switch {
+		case ip.ID == "":
+			return fmt.Errorf("%w: IP ID is empty", state.ErrInvalidInput)
+		case ip.NCID != record.ID:
+			return fmt.Errorf(
+				"%w: IP %q NC %q does not match network container %q",
+				state.ErrInvalidInput,
+				ip.ID,
+				ip.NCID,
+				record.ID,
+			)
+		}
+		if _, exists := inventory[ip.ID]; exists {
+			return fmt.Errorf("%w: duplicate IP ID %q", state.ErrInvalidInput, ip.ID)
+		}
+		inventory[ip.ID] = ip
+	}
+	return a.updateDurable(ctx, func(candidate *state.DurableState) error {
+		candidate.NetworkContainers[record.ID] = normalized
+		for id, ip := range candidate.IPs {
+			if ip.NCID == record.ID {
+				delete(candidate.IPs, id)
+			}
+		}
+		for id, ip := range inventory {
+			candidate.IPs[id] = ip
+		}
+		return nil
+	})
+}
+
+func (a *durableStateAdapter) deleteNetworkContainer(ctx context.Context, id string) error {
+	if id == "" {
+		return fmt.Errorf("%w: network container ID is empty", state.ErrInvalidInput)
+	}
+	return a.updateDurable(ctx, func(candidate *state.DurableState) error {
+		delete(candidate.NetworkContainers, id)
+		for ipID, ip := range candidate.IPs {
+			if ip.NCID == id {
+				delete(candidate.IPs, ipID)
+			}
+		}
+		return nil
+	})
+}
+
+func (a *durableStateAdapter) putNetwork(ctx context.Context, record state.NetworkRecord) error {
+	if record.NetworkName == "" {
+		return fmt.Errorf("%w: network name is empty", state.ErrInvalidInput)
+	}
+	cloned, err := cloneJSON(record)
+	if err != nil {
+		return fmt.Errorf("%w: cloning network %q: %v", state.ErrInvalidInput, record.NetworkName, err)
+	}
+	return a.updateDurable(ctx, func(candidate *state.DurableState) error {
+		candidate.Networks[record.NetworkName] = cloned
+		return nil
+	})
+}
+
+func (a *durableStateAdapter) deleteNetwork(ctx context.Context, name string) error {
+	if name == "" {
+		return fmt.Errorf("%w: network name is empty", state.ErrInvalidInput)
+	}
+	return a.updateDurable(ctx, func(candidate *state.DurableState) error {
+		delete(candidate.Networks, name)
+		return nil
+	})
+}
+
+func (a *durableStateAdapter) putOrchestratorContext(ctx context.Context, id string, ncIDs []string) error {
+	if id == "" {
+		return fmt.Errorf("%w: orchestrator context ID is empty", state.ErrInvalidInput)
+	}
+	ids := append([]string{}, ncIDs...)
+	return a.updateDurable(ctx, func(candidate *state.DurableState) error {
+		candidate.OrchestratorContexts[id] = ids
+		return nil
+	})
+}
+
+func (a *durableStateAdapter) deleteOrchestratorContext(ctx context.Context, id string) error {
+	if id == "" {
+		return fmt.Errorf("%w: orchestrator context ID is empty", state.ErrInvalidInput)
+	}
+	return a.updateDurable(ctx, func(candidate *state.DurableState) error {
+		delete(candidate.OrchestratorContexts, id)
+		return nil
+	})
+}
+
+func (a *durableStateAdapter) putPnPID(ctx context.Context, macAddress, pnpID string) error {
+	mac, err := net.ParseMAC(macAddress)
+	if err != nil {
+		return fmt.Errorf("%w: invalid MAC address %q: %v", state.ErrInvalidInput, macAddress, err)
+	}
+	if pnpID == "" {
+		return fmt.Errorf("%w: PnP ID is empty", state.ErrInvalidInput)
+	}
+	return a.updateDurable(ctx, func(candidate *state.DurableState) error {
+		candidate.PnPIDByMAC[mac.String()] = pnpID
+		return nil
+	})
+}
+
+func (a *durableStateAdapter) deletePnPID(ctx context.Context, macAddress string) error {
+	mac, err := net.ParseMAC(macAddress)
+	if err != nil {
+		return fmt.Errorf("%w: invalid MAC address %q: %v", state.ErrInvalidInput, macAddress, err)
+	}
+	return a.updateDurable(ctx, func(candidate *state.DurableState) error {
+		delete(candidate.PnPIDByMAC, mac.String())
+		return nil
+	})
+}
+
+func (a *durableStateAdapter) putServiceMetadata(ctx context.Context, metadata durableServiceMetadata) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	snapshot, err := a.currentSnapshot(ctx)
+	if err != nil {
+		return err
+	}
+	candidate := snapshot
+	candidate.Metadata.OrchestratorType = metadata.OrchestratorType
+	candidate.Metadata.NodeID = metadata.NodeID
+	candidate.Metadata.Location = metadata.Location
+	candidate.Metadata.NetworkType = metadata.NetworkType
+	candidate.Metadata.Initialized = metadata.Initialized
+	candidate.Metadata.TimeStamp = metadata.TimeStamp
+	projection, err := buildDurableCacheProjection(candidate)
+	if err != nil {
+		return err
+	}
+	changed, err := a.store.updateMetadata(ctx, a.generation, candidate.Metadata)
+	if err != nil {
+		return err
+	}
+	generation, err := a.committedGeneration(ctx, changed)
+	if err != nil {
+		return err
+	}
+	projection.generation = generation
+	a.applyProjection(projection)
+	return nil
+}
+
+func (a *durableStateAdapter) updateDurable(
+	ctx context.Context,
+	mutate func(*state.DurableState) error,
+) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	snapshot, err := a.currentSnapshot(ctx)
+	if err != nil {
+		return err
+	}
+	durable, err := cloneJSON(state.DurableState{
+		NetworkContainers:    snapshot.NetworkContainers,
+		IPs:                  snapshot.IPs,
+		Networks:             snapshot.Networks,
+		OrchestratorContexts: snapshot.OrchestratorContexts,
+		PnPIDByMAC:           snapshot.PnPIDByMAC,
+	})
+	if err != nil {
+		return fmt.Errorf("%w: cloning durable state: %v", state.ErrInvalidInput, err)
+	}
+	if err := mutate(&durable); err != nil {
+		return err
+	}
+	candidate := snapshot
+	candidate.NetworkContainers = durable.NetworkContainers
+	candidate.IPs = durable.IPs
+	candidate.Networks = durable.Networks
+	candidate.OrchestratorContexts = durable.OrchestratorContexts
+	candidate.PnPIDByMAC = durable.PnPIDByMAC
+	projection, err := buildDurableCacheProjection(candidate)
+	if err != nil {
+		return err
+	}
+	changed, err := a.store.replace(ctx, a.generation, durable)
+	if err != nil {
+		return err
+	}
+	generation, err := a.committedGeneration(ctx, changed)
+	if err != nil {
+		return err
+	}
+	projection.generation = generation
+	a.applyProjection(projection)
+	return nil
+}
+
+func (a *durableStateAdapter) currentSnapshot(ctx context.Context) (state.Snapshot, error) {
+	if !a.projected {
+		return state.Snapshot{}, errors.New("durable state has not been projected")
+	}
+	snapshot, err := a.store.snapshot(ctx)
+	if err != nil {
+		return state.Snapshot{}, err
+	}
+	if snapshot.Metadata.Generation != a.generation {
+		return state.Snapshot{}, fmt.Errorf(
+			"%w: projected=%d database=%d",
+			state.ErrStaleGeneration,
+			a.generation,
+			snapshot.Metadata.Generation,
+		)
+	}
+	return snapshot, nil
+}
+
+func (a *durableStateAdapter) committedGeneration(ctx context.Context, changed bool) (uint64, error) {
+	expected := a.generation
+	if changed {
+		expected++
+	}
+	if err := a.verifyStatus(ctx, expected); err != nil {
+		return 0, err
+	}
+	return expected, nil
+}
+
+func (a *durableStateAdapter) verifyStatus(ctx context.Context, expectedGeneration uint64) error {
+	status, err := a.store.status(ctx)
+	if err != nil {
+		return err
+	}
+	switch {
+	case status.Backend != state.BackendBolt:
+		return fmt.Errorf("unexpected durable state backend %q", status.Backend)
+	case status.Authority != state.AuthorityBolt:
+		return fmt.Errorf("unexpected durable state authority %q", status.Authority)
+	case status.SchemaVersion != state.SchemaVersion:
+		return fmt.Errorf("unexpected durable state schema version %d", status.SchemaVersion)
+	case status.InvariantStatus != state.InvariantHealthy:
+		return fmt.Errorf("durable state invariant %q failed", status.FailedInvariant)
+	case status.Generation != expectedGeneration:
+		return fmt.Errorf(
+			"%w: expected=%d actual=%d",
+			state.ErrStaleGeneration,
+			expectedGeneration,
+			status.Generation,
+		)
+	}
+	return nil
+}
+
+func (a *durableStateAdapter) applyProjection(projection durableCacheProjection) {
+	a.service.Lock()
+	defer a.service.Unlock()
+
+	a.service.state.OrchestratorType = projection.metadata.OrchestratorType
+	a.service.state.NodeID = projection.metadata.NodeID
+	a.service.state.Location = projection.metadata.Location
+	a.service.state.NetworkType = projection.metadata.NetworkType
+	a.service.state.Initialized = projection.metadata.Initialized
+	a.service.state.TimeStamp = projection.metadata.TimeStamp
+	a.service.state.ContainerStatus = projection.containerStatus
+	a.service.state.ContainerIDByOrchestratorContext = projection.orchestratorNCs
+	a.service.state.Networks = projection.networks
+	a.service.state.PnpIDByMacAddress = projection.pnpIDByMACAddress
+	a.service.PodIPConfigState = projection.ipConfigState
+	a.generation = projection.generation
+	a.projected = true
+}
+
+func (a *durableStateAdapter) cacheGeneration() (uint64, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.generation, a.projected
+}
+
+func (a *durableStateAdapter) Close() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.closeOnce.Do(func() {
+		a.closeErr = a.store.close()
+	})
+	return a.closeErr
+}
+
+func buildDurableCacheProjection(snapshot state.Snapshot) (durableCacheProjection, error) {
+	if err := snapshot.Validate(); err != nil {
+		return durableCacheProjection{}, fmt.Errorf("validating durable state projection: %w", err)
+	}
+	switch {
+	case snapshot.Metadata.SchemaVersion != state.SchemaVersion:
+		return durableCacheProjection{}, fmt.Errorf(
+			"durable state projection schema version %d is invalid",
+			snapshot.Metadata.SchemaVersion,
+		)
+	case snapshot.Metadata.Authority != state.AuthorityBolt:
+		return durableCacheProjection{}, fmt.Errorf(
+			"durable state projection authority %q is invalid",
+			snapshot.Metadata.Authority,
+		)
+	}
+
+	projection := durableCacheProjection{
+		generation: snapshot.Metadata.Generation,
+		metadata: durableServiceMetadata{
+			OrchestratorType: snapshot.Metadata.OrchestratorType,
+			NodeID:           snapshot.Metadata.NodeID,
+			Location:         snapshot.Metadata.Location,
+			NetworkType:      snapshot.Metadata.NetworkType,
+			Initialized:      snapshot.Metadata.Initialized,
+			TimeStamp:        snapshot.Metadata.TimeStamp,
+		},
+		containerStatus:   make(map[string]containerstatus, len(snapshot.NetworkContainers)),
+		ipConfigState:     make(map[string]cns.IPConfigurationStatus, len(snapshot.IPs)),
+		networks:          make(map[string]*networkInfo, len(snapshot.Networks)),
+		orchestratorNCs:   make(map[string]*ncList, len(snapshot.OrchestratorContexts)),
+		pnpIDByMACAddress: make(map[string]string, len(snapshot.PnPIDByMAC)),
+	}
+
+	hostVersions := make(map[string]int, len(snapshot.NetworkContainers))
+	for id, record := range snapshot.NetworkContainers {
+		request, err := cloneJSON(record.Request)
+		if err != nil {
+			return durableCacheProjection{}, fmt.Errorf("cloning network container %q request: %w", id, err)
+		}
+		request.SecondaryIPConfigs = make(map[string]cns.SecondaryIPConfig)
+		projection.containerStatus[id] = containerstatus{
+			ID:                            record.ID,
+			VMVersion:                     record.VMVersion,
+			HostVersion:                   record.HostVersion,
+			CreateNetworkContainerRequest: request,
+			VfpUpdateComplete:             record.VFPUpdateComplete,
+		}
+		if record.HostVersion != "" {
+			hostVersion, err := strconv.Atoi(record.HostVersion)
+			if err != nil {
+				return durableCacheProjection{}, fmt.Errorf(
+					"converting network container %q host version %q: %w",
+					id,
+					record.HostVersion,
+					err,
+				)
+			}
+			hostVersions[id] = hostVersion
+		}
+	}
+
+	for id, record := range snapshot.IPs {
+		nc, ok := projection.containerStatus[record.NCID]
+		if !ok {
+			return durableCacheProjection{}, fmt.Errorf("ip %q references missing projected network container %q", id, record.NCID)
+		}
+		hostVersion, ok := hostVersions[record.NCID]
+		if !ok {
+			return durableCacheProjection{}, fmt.Errorf(
+				"ip %q network container %q has an empty host version",
+				id,
+				record.NCID,
+			)
+		}
+		nc.CreateNetworkContainerRequest.SecondaryIPConfigs[id] = cns.SecondaryIPConfig{
+			IPAddress: record.IPAddress,
+			NCVersion: record.NCVersion,
+		}
+		projection.containerStatus[record.NCID] = nc
+
+		ipStatus := cns.IPConfigurationStatus{
+			ID:        id,
+			IPAddress: record.IPAddress,
+			NCID:      record.NCID,
+		}
+		ipStatus.WithStateMiddleware(stateTransitionMiddleware)
+		ipState := types.Available
+		if hostVersion < record.NCVersion {
+			ipState = types.PendingProgramming
+		}
+		ipStatus.SetState(ipState)
+		projection.ipConfigState[id] = ipStatus
+	}
+
+	for name, record := range snapshot.Networks {
+		cloned, err := cloneJSON(record)
+		if err != nil {
+			return durableCacheProjection{}, fmt.Errorf("cloning network %q: %w", name, err)
+		}
+		projection.networks[name] = &networkInfo{
+			NetworkName: cloned.NetworkName,
+			NicInfo:     cloned.NicInfo,
+			Options:     cloned.Options,
+		}
+	}
+	for id, ncIDs := range snapshot.OrchestratorContexts {
+		for _, ncID := range ncIDs {
+			if strings.Contains(ncID, ",") {
+				return durableCacheProjection{}, fmt.Errorf(
+					"orchestrator context %q network container %q contains a comma",
+					id,
+					ncID,
+				)
+			}
+		}
+		value := ncList(strings.Join(ncIDs, ","))
+		projection.orchestratorNCs[id] = &value
+	}
+	for macAddress, pnpID := range snapshot.PnPIDByMAC {
+		mac, err := net.ParseMAC(macAddress)
+		if err != nil {
+			return durableCacheProjection{}, fmt.Errorf("parsing PnP MAC address %q: %w", macAddress, err)
+		}
+		projection.pnpIDByMACAddress[mac.String()] = pnpID
+	}
+	return projection, nil
+}
+
+func cloneJSON[T any](input T) (T, error) {
+	var output T
+	data, err := json.Marshal(input)
+	if err != nil {
+		return output, err
+	}
+	if err := json.Unmarshal(data, &output); err != nil {
+		return output, err
+	}
+	return output, nil
+}

--- a/cns/restserver/durable_state_adapter_test.go
+++ b/cns/restserver/durable_state_adapter_test.go
@@ -6,6 +6,7 @@ package restserver
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -20,6 +21,22 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	bolterrors "go.etcd.io/bbolt/errors"
+)
+
+var (
+	errAdapterCommitFailure   = errors.New("commit failed")
+	errAdapterMetadataFailure = errors.New("metadata commit failed")
+	errAdapterCloseFailure    = errors.New("close failed")
+)
+
+const (
+	adapterTestNCID        = "nc-1"
+	adapterTestIPv4        = "10.0.0.4"
+	adapterTestSubnet      = "10.0.0.0/24"
+	adapterTestLocation    = "azure"
+	adapterTestNetworkType = "underlay"
+	adapterTestNetwork     = "10.0.0.0"
+	adapterTestDNS         = "10.0.0.10"
 )
 
 type adapterTestStore struct {
@@ -48,7 +65,7 @@ func (s *adapterTestStore) operations() durableStateOperations {
 			s.mu.Lock()
 			defer s.mu.Unlock()
 			if err := ctx.Err(); err != nil {
-				return state.Snapshot{}, err
+				return state.Snapshot{}, fmt.Errorf("reading adapter test snapshot: %w", err)
 			}
 			return s.snapshot, nil
 		},
@@ -59,7 +76,7 @@ func (s *adapterTestStore) operations() durableStateOperations {
 				s.beforeReplace()
 			}
 			if err := ctx.Err(); err != nil {
-				return false, err
+				return false, fmt.Errorf("replacing adapter test state: %w", err)
 			}
 			if s.replaceErr != nil {
 				return false, s.replaceErr
@@ -82,7 +99,7 @@ func (s *adapterTestStore) operations() durableStateOperations {
 				s.beforeMetadata()
 			}
 			if err := ctx.Err(); err != nil {
-				return false, err
+				return false, fmt.Errorf("updating adapter test metadata: %w", err)
 			}
 			if s.metadataErr != nil {
 				return false, s.metadataErr
@@ -98,7 +115,7 @@ func (s *adapterTestStore) operations() durableStateOperations {
 			s.mu.Lock()
 			defer s.mu.Unlock()
 			if err := ctx.Err(); err != nil {
-				return state.Status{}, err
+				return state.Status{}, fmt.Errorf("reading adapter test status: %w", err)
 			}
 			if s.statusErr != nil {
 				return state.Status{}, s.statusErr
@@ -132,9 +149,9 @@ func TestDurableStateAdapterProjection(t *testing.T) {
 	assert.Equal(t, originalAssignments, service.PodIPIDByPodInterfaceKey["existing-pod"])
 	assert.NotContains(t, service.EndpointState, "persisted-endpoint")
 
-	snapshot.NetworkContainers["nc-1"] = state.NetworkContainerRecord{}
+	snapshot.NetworkContainers[adapterTestNCID] = state.NetworkContainerRecord{}
 	snapshot.Networks["network-1"].Options["nested"].(map[string]any)["key"] = "mutated"
-	assert.Equal(t, "nc-1", service.state.ContainerStatus["nc-1"].ID)
+	assert.Equal(t, adapterTestNCID, service.state.ContainerStatus[adapterTestNCID].ID)
 	assert.Equal(t, "value", service.state.Networks["network-1"].Options["nested"].(map[string]any)["key"])
 
 	service.state.Location = "same-generation-no-op"
@@ -166,9 +183,9 @@ func TestDurableStateAdapterProjectionFailureIsAtomic(t *testing.T) {
 		{
 			name: "invalid host version",
 			mutate: func(snapshot *state.Snapshot) {
-				record := snapshot.NetworkContainers["nc-1"]
+				record := snapshot.NetworkContainers[adapterTestNCID]
 				record.HostVersion = "not-a-version"
-				snapshot.NetworkContainers["nc-1"] = record
+				snapshot.NetworkContainers[adapterTestNCID] = record
 			},
 		},
 		{
@@ -216,27 +233,27 @@ func TestDurableStateAdapterCommitOrderingAndFailures(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, adapter.restore(context.Background()))
 
-	record := snapshot.NetworkContainers["nc-1"]
+	record := snapshot.NetworkContainers[adapterTestNCID]
 	record.VMVersion = "9"
 	record.HostVersion = "9"
 	record.Request.Version = "9"
 	ips := []state.IPRecord{{
 		ID:        "ip-new",
 		IPAddress: "10.0.0.99",
-		NCID:      "nc-1",
+		NCID:      adapterTestNCID,
 		NCVersion: 9,
 	}}
 	store.beforeReplace = func() {
-		assert.Equal(t, "2", service.state.ContainerStatus["nc-1"].VMVersion)
+		assert.Equal(t, "2", service.state.ContainerStatus[adapterTestNCID].VMVersion)
 		assert.NotContains(t, service.PodIPConfigState, "ip-new")
 	}
 	require.NoError(t, adapter.applyNetworkContainer(context.Background(), record, ips))
 	store.beforeReplace = nil
-	assert.Equal(t, "9", service.state.ContainerStatus["nc-1"].VMVersion)
+	assert.Equal(t, "9", service.state.ContainerStatus[adapterTestNCID].VMVersion)
 	assert.Contains(t, service.PodIPConfigState, "ip-new")
 	assert.Equal(t, uint64(4), adapter.generation)
 	store.mu.Lock()
-	assert.Equal(t, "9", store.snapshot.NetworkContainers["nc-1"].VMVersion)
+	assert.Equal(t, "9", store.snapshot.NetworkContainers[adapterTestNCID].VMVersion)
 	assert.Contains(t, store.snapshot.IPs, "ip-new")
 	store.mu.Unlock()
 
@@ -244,7 +261,7 @@ func TestDurableStateAdapterCommitOrderingAndFailures(t *testing.T) {
 		name string
 		err  error
 	}{
-		{name: "commit", err: errors.New("commit failed")},
+		{name: "commit", err: errAdapterCommitFailure},
 		{name: "stale", err: state.ErrStaleGeneration},
 		{name: "read only", err: bolterrors.ErrDatabaseReadOnly},
 		{name: "canceled", err: context.Canceled},
@@ -255,8 +272,8 @@ func TestDurableStateAdapterCommitOrderingAndFailures(t *testing.T) {
 			store.mu.Lock()
 			store.replaceErr = tt.err
 			store.mu.Unlock()
-			err := adapter.putNetwork(context.Background(), state.NetworkRecord{NetworkName: "not-committed"})
-			require.ErrorIs(t, err, tt.err)
+			operationErr := adapter.putNetwork(context.Background(), state.NetworkRecord{NetworkName: "not-committed"})
+			require.ErrorIs(t, operationErr, tt.err)
 			assert.Equal(t, before, durableCacheFingerprint(service, adapter))
 			store.mu.Lock()
 			assert.NotContains(t, store.snapshot.Networks, "not-committed")
@@ -267,7 +284,7 @@ func TestDurableStateAdapterCommitOrderingAndFailures(t *testing.T) {
 
 	before := durableCacheFingerprint(service, adapter)
 	store.mu.Lock()
-	store.metadataErr = errors.New("metadata commit failed")
+	store.metadataErr = errAdapterMetadataFailure
 	store.mu.Unlock()
 	err = adapter.putServiceMetadata(context.Background(), durableServiceMetadata{NodeID: "not-committed"})
 	require.Error(t, err)
@@ -293,11 +310,11 @@ func TestDurableStateAdapterDurableOperations(t *testing.T) {
 
 	record := adapterNetworkContainer("nc")
 	require.NoError(t, adapter.applyNetworkContainer(context.Background(), record, []state.IPRecord{{
-		ID: "ip", IPAddress: "10.0.0.4", NCID: "nc", NCVersion: 2,
+		ID: "ip", IPAddress: adapterTestIPv4, NCID: "nc", NCVersion: 2,
 	}}))
 	require.NoError(t, adapter.putNetwork(context.Background(), state.NetworkRecord{
 		NetworkName: "network",
-		NicInfo:     &wireserver.InterfaceInfo{Subnet: "10.0.0.0/24", SecondaryIPs: []string{"10.0.0.4"}},
+		NicInfo:     &wireserver.InterfaceInfo{Subnet: adapterTestSubnet, SecondaryIPs: []string{adapterTestIPv4}},
 		Options:     map[string]any{"mode": "bridge"},
 	}))
 	require.NoError(t, adapter.putOrchestratorContext(context.Background(), "pod", []string{"nc"}))
@@ -305,8 +322,8 @@ func TestDurableStateAdapterDurableOperations(t *testing.T) {
 	require.NoError(t, adapter.putServiceMetadata(context.Background(), durableServiceMetadata{
 		OrchestratorType: cns.KubernetesCRD,
 		NodeID:           "node",
-		Location:         "azure",
-		NetworkType:      "underlay",
+		Location:         adapterTestLocation,
+		NetworkType:      adapterTestNetworkType,
 		Initialized:      true,
 		TimeStamp:        time.Unix(100, 0).UTC(),
 	}))
@@ -426,11 +443,11 @@ func TestDurableStateAdapterRestartRestoreAndClose(t *testing.T) {
 	record.Request.AuthorizationToken = "must-not-persist"
 	record.Request.SecondaryIPConfigs = map[string]cns.SecondaryIPConfig{"embedded": {IPAddress: "10.0.0.8"}}
 	require.NoError(t, first.applyNetworkContainer(context.Background(), record, []state.IPRecord{{
-		ID: "ip", IPAddress: "10.0.0.4", NCID: "nc", NCVersion: 2,
+		ID: "ip", IPAddress: adapterTestIPv4, NCID: "nc", NCVersion: 2,
 	}}))
 	require.NoError(t, first.putNetwork(context.Background(), state.NetworkRecord{
 		NetworkName: "network",
-		NicInfo:     &wireserver.InterfaceInfo{Subnet: "10.0.0.0/24"},
+		NicInfo:     &wireserver.InterfaceInfo{Subnet: adapterTestSubnet},
 		Options:     map[string]any{"nested": map[string]any{"enabled": true}},
 	}))
 	require.NoError(t, first.putOrchestratorContext(context.Background(), "pod", []string{"nc"}))
@@ -438,8 +455,8 @@ func TestDurableStateAdapterRestartRestoreAndClose(t *testing.T) {
 	require.NoError(t, first.putServiceMetadata(context.Background(), durableServiceMetadata{
 		OrchestratorType: cns.KubernetesCRD,
 		NodeID:           "node",
-		Location:         "azure",
-		NetworkType:      "underlay",
+		Location:         adapterTestLocation,
+		NetworkType:      adapterTestNetworkType,
 		Initialized:      true,
 		TimeStamp:        time.Unix(100, 0).UTC(),
 	}))
@@ -464,13 +481,12 @@ func TestDurableStateAdapterRestartRestoreAndClose(t *testing.T) {
 }
 
 func TestDurableStateAdapterCloseErrorIsStable(t *testing.T) {
-	closeErr := errors.New("close failed")
 	store := newAdapterTestStore(emptyAdapterSnapshot(0))
-	store.closeErr = closeErr
+	store.closeErr = errAdapterCloseFailure
 	adapter, err := newDurableStateAdapterWithOperations(newAdapterTestService(), store.operations())
 	require.NoError(t, err)
-	require.ErrorIs(t, adapter.Close(), closeErr)
-	require.ErrorIs(t, adapter.Close(), closeErr)
+	require.ErrorIs(t, adapter.Close(), errAdapterCloseFailure)
+	require.ErrorIs(t, adapter.Close(), errAdapterCloseFailure)
 	assert.Equal(t, 1, store.closeCalls)
 }
 
@@ -530,18 +546,18 @@ func completeAdapterSnapshot(generation uint64) state.Snapshot {
 	snapshot := emptyAdapterSnapshot(generation)
 	snapshot.Metadata.OrchestratorType = cns.KubernetesCRD
 	snapshot.Metadata.NodeID = "node-1"
-	snapshot.Metadata.Location = "azure"
-	snapshot.Metadata.NetworkType = "underlay"
+	snapshot.Metadata.Location = adapterTestLocation
+	snapshot.Metadata.NetworkType = adapterTestNetworkType
 	snapshot.Metadata.Initialized = true
 	snapshot.Metadata.TimeStamp = time.Unix(50, 0).UTC()
-	snapshot.NetworkContainers["nc-1"] = adapterNetworkContainer("nc-1")
+	snapshot.NetworkContainers[adapterTestNCID] = adapterNetworkContainer(adapterTestNCID)
 	second := adapterNetworkContainer("nc-2")
 	second.HostVersion = "3"
 	snapshot.NetworkContainers["nc-2"] = second
 	snapshot.IPs["11111111-1111-1111-1111-111111111111"] = state.IPRecord{
 		ID:        "11111111-1111-1111-1111-111111111111",
-		IPAddress: "10.0.0.4",
-		NCID:      "nc-1",
+		IPAddress: adapterTestIPv4,
+		NCID:      adapterTestNCID,
 		NCVersion: 2,
 	}
 	snapshot.IPs["22222222-2222-2222-2222-222222222222"] = state.IPRecord{
@@ -553,10 +569,10 @@ func completeAdapterSnapshot(generation uint64) state.Snapshot {
 	snapshot.Networks["network-1"] = state.NetworkRecord{
 		NetworkName: "network-1",
 		NicInfo: &wireserver.InterfaceInfo{
-			Subnet:       "10.0.0.0/24",
-			Gateway:      "10.0.0.1",
+			Subnet:       adapterTestSubnet,
+			Gateway:      gatewayIP,
 			PrimaryIP:    "10.0.0.2",
-			SecondaryIPs: []string{"10.0.0.4"},
+			SecondaryIPs: []string{adapterTestIPv4},
 		},
 		Options: map[string]any{"nested": map[string]any{"key": "value"}},
 	}
@@ -584,11 +600,11 @@ func adapterNetworkContainer(id string) state.NetworkContainerRecord {
 		NetworkContainerid: id,
 		Version:            "2",
 		IPConfiguration: cns.IPConfiguration{
-			IPSubnet:         cns.IPSubnet{IPAddress: "10.0.0.0", PrefixLength: 24},
-			GatewayIPAddress: "10.0.0.1",
-			DNSServers:       []string{"10.0.0.10"},
+			IPSubnet:         cns.IPSubnet{IPAddress: adapterTestNetwork, PrefixLength: 24},
+			GatewayIPAddress: gatewayIP,
+			DNSServers:       []string{adapterTestDNS},
 		},
-		Routes: []cns.Route{{IPAddress: "0.0.0.0/0", GatewayIPAddress: "10.0.0.1"}},
+		Routes: []cns.Route{{IPAddress: "0.0.0.0/0", GatewayIPAddress: gatewayIP}},
 	})
 }
 
@@ -608,8 +624,12 @@ func assertAdapterProjection(t *testing.T, service *HTTPRestService, snapshot st
 	assert.Equal(t, snapshot.Metadata.NodeID, service.state.NodeID)
 	assert.Equal(t, snapshot.Metadata.OrchestratorType, service.state.OrchestratorType)
 	assert.Equal(t, snapshot.Metadata.TimeStamp, service.state.TimeStamp)
-	assert.Equal(t, snapshot.NetworkContainers["nc-1"].Request.Routes, service.state.ContainerStatus["nc-1"].CreateNetworkContainerRequest.Routes)
-	assert.Empty(t, service.state.ContainerStatus["nc-1"].CreateNetworkContainerRequest.AuthorizationToken)
+	assert.Equal(
+		t,
+		snapshot.NetworkContainers[adapterTestNCID].Request.Routes,
+		service.state.ContainerStatus[adapterTestNCID].CreateNetworkContainerRequest.Routes,
+	)
+	assert.Empty(t, service.state.ContainerStatus[adapterTestNCID].CreateNetworkContainerRequest.AuthorizationToken)
 	require.Len(t, service.PodIPConfigState, 2)
 	pending := service.PodIPConfigState["11111111-1111-1111-1111-111111111111"]
 	available := service.PodIPConfigState["22222222-2222-2222-2222-222222222222"]
@@ -617,8 +637,8 @@ func assertAdapterProjection(t *testing.T, service *HTTPRestService, snapshot st
 	assert.Equal(t, types.Available, available.GetState())
 	assert.Equal(
 		t,
-		"10.0.0.4",
-		service.state.ContainerStatus["nc-1"].CreateNetworkContainerRequest.
+		adapterTestIPv4,
+		service.state.ContainerStatus[adapterTestNCID].CreateNetworkContainerRequest.
 			SecondaryIPConfigs["11111111-1111-1111-1111-111111111111"].IPAddress,
 	)
 	assert.Equal(t, snapshot.Networks["network-1"].NicInfo, service.state.Networks["network-1"].NicInfo)
@@ -668,7 +688,8 @@ func durableCacheFingerprint(service *HTTPRestService, adapter *durableStateAdap
 		OrchestratorNCs: make(map[string]string, len(service.state.ContainerIDByOrchestratorContext)),
 		PnPIDs:          make(map[string]string, len(service.state.PnpIDByMacAddress)),
 	}
-	for id, status := range service.PodIPConfigState {
+	for id := range service.PodIPConfigState {
+		status := service.PodIPConfigState[id]
 		fingerprint.IPs[id] = adapterIPFingerprint{
 			ID: status.ID, IPAddress: status.IPAddress, NCID: status.NCID, State: status.GetState(),
 		}
@@ -696,7 +717,7 @@ func durableCacheFingerprint(service *HTTPRestService, adapter *durableStateAdap
 func TestBuildDurableCacheProjectionRejectsInvalidIPFamily(t *testing.T) {
 	snapshot := completeAdapterSnapshot(1)
 	snapshot.IPs["11111111-1111-1111-1111-111111111111"] = state.IPRecord{
-		ID: "11111111-1111-1111-1111-111111111111", IPAddress: net.IP{}.String(), NCID: "nc-1",
+		ID: "11111111-1111-1111-1111-111111111111", IPAddress: net.IP{}.String(), NCID: adapterTestNCID,
 	}
 	_, err := buildDurableCacheProjection(snapshot)
 	require.Error(t, err)

--- a/cns/restserver/durable_state_adapter_test.go
+++ b/cns/restserver/durable_state_adapter_test.go
@@ -1,0 +1,703 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package restserver
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/state"
+	"github.com/Azure/azure-container-networking/cns/types"
+	"github.com/Azure/azure-container-networking/cns/wireserver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	bolterrors "go.etcd.io/bbolt/errors"
+)
+
+type adapterTestStore struct {
+	mu             sync.Mutex
+	snapshot       state.Snapshot
+	replaceErr     error
+	metadataErr    error
+	statusErr      error
+	closeErr       error
+	closeCalls     int
+	beforeReplace  func()
+	beforeMetadata func()
+}
+
+func newAdapterTestStore(snapshot state.Snapshot) *adapterTestStore {
+	cloned, err := cloneJSON(snapshot)
+	if err != nil {
+		panic(err)
+	}
+	return &adapterTestStore{snapshot: cloned}
+}
+
+func (s *adapterTestStore) operations() durableStateOperations {
+	return durableStateOperations{
+		snapshot: func(ctx context.Context) (state.Snapshot, error) {
+			s.mu.Lock()
+			defer s.mu.Unlock()
+			if err := ctx.Err(); err != nil {
+				return state.Snapshot{}, err
+			}
+			return s.snapshot, nil
+		},
+		replace: func(ctx context.Context, expected uint64, durable state.DurableState) (bool, error) {
+			s.mu.Lock()
+			defer s.mu.Unlock()
+			if s.beforeReplace != nil {
+				s.beforeReplace()
+			}
+			if err := ctx.Err(); err != nil {
+				return false, err
+			}
+			if s.replaceErr != nil {
+				return false, s.replaceErr
+			}
+			if s.snapshot.Metadata.Generation != expected {
+				return false, state.ErrStaleGeneration
+			}
+			s.snapshot.NetworkContainers = durable.NetworkContainers
+			s.snapshot.IPs = durable.IPs
+			s.snapshot.Networks = durable.Networks
+			s.snapshot.OrchestratorContexts = durable.OrchestratorContexts
+			s.snapshot.PnPIDByMAC = durable.PnPIDByMAC
+			s.snapshot.Metadata.Generation++
+			return true, nil
+		},
+		updateMetadata: func(ctx context.Context, expected uint64, metadata state.Metadata) (bool, error) {
+			s.mu.Lock()
+			defer s.mu.Unlock()
+			if s.beforeMetadata != nil {
+				s.beforeMetadata()
+			}
+			if err := ctx.Err(); err != nil {
+				return false, err
+			}
+			if s.metadataErr != nil {
+				return false, s.metadataErr
+			}
+			if s.snapshot.Metadata.Generation != expected {
+				return false, state.ErrStaleGeneration
+			}
+			metadata.Generation++
+			s.snapshot.Metadata = metadata
+			return true, nil
+		},
+		status: func(ctx context.Context) (state.Status, error) {
+			s.mu.Lock()
+			defer s.mu.Unlock()
+			if err := ctx.Err(); err != nil {
+				return state.Status{}, err
+			}
+			if s.statusErr != nil {
+				return state.Status{}, s.statusErr
+			}
+			return healthyAdapterStatus(s.snapshot.Metadata.Generation), nil
+		},
+		close: func() error {
+			s.mu.Lock()
+			defer s.mu.Unlock()
+			s.closeCalls++
+			return s.closeErr
+		},
+	}
+}
+
+func TestDurableStateAdapterProjection(t *testing.T) {
+	snapshot := completeAdapterSnapshot(7)
+	store := newAdapterTestStore(snapshot)
+	service := newAdapterTestService()
+	originalEndpoint := service.EndpointState["existing-endpoint"]
+	originalAssignments := append([]string{}, service.PodIPIDByPodInterfaceKey["existing-pod"]...)
+	adapter, err := newDurableStateAdapterWithOperations(service, store.operations())
+	require.NoError(t, err)
+
+	require.NoError(t, adapter.restore(context.Background()))
+	assertAdapterProjection(t, service, snapshot)
+	generation, projected := adapter.cacheGeneration()
+	assert.True(t, projected)
+	assert.Equal(t, uint64(7), generation)
+	assert.Same(t, originalEndpoint, service.EndpointState["existing-endpoint"])
+	assert.Equal(t, originalAssignments, service.PodIPIDByPodInterfaceKey["existing-pod"])
+	assert.NotContains(t, service.EndpointState, "persisted-endpoint")
+
+	snapshot.NetworkContainers["nc-1"] = state.NetworkContainerRecord{}
+	snapshot.Networks["network-1"].Options["nested"].(map[string]any)["key"] = "mutated"
+	assert.Equal(t, "nc-1", service.state.ContainerStatus["nc-1"].ID)
+	assert.Equal(t, "value", service.state.Networks["network-1"].Options["nested"].(map[string]any)["key"])
+
+	service.state.Location = "same-generation-no-op"
+	require.NoError(t, adapter.restore(context.Background()))
+	assert.Equal(t, "same-generation-no-op", service.state.Location)
+
+	before := durableCacheFingerprint(service, adapter)
+	store.mu.Lock()
+	store.snapshot.Metadata.Generation = 6
+	store.mu.Unlock()
+	require.ErrorIs(t, adapter.restore(context.Background()), state.ErrStaleGeneration)
+	assert.Equal(t, before, durableCacheFingerprint(service, adapter))
+
+	newer := completeAdapterSnapshot(8)
+	newer.Metadata.Location = "new-location"
+	store.mu.Lock()
+	store.snapshot = newer
+	store.mu.Unlock()
+	require.NoError(t, adapter.restore(context.Background()))
+	assert.Equal(t, "new-location", service.state.Location)
+	assert.Equal(t, uint64(8), adapter.generation)
+}
+
+func TestDurableStateAdapterProjectionFailureIsAtomic(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*state.Snapshot)
+	}{
+		{
+			name: "invalid host version",
+			mutate: func(snapshot *state.Snapshot) {
+				record := snapshot.NetworkContainers["nc-1"]
+				record.HostVersion = "not-a-version"
+				snapshot.NetworkContainers["nc-1"] = record
+			},
+		},
+		{
+			name: "late network clone failure",
+			mutate: func(snapshot *state.Snapshot) {
+				record := snapshot.Networks["network-1"]
+				record.Options["unsupported"] = make(chan struct{})
+				snapshot.Networks["network-1"] = record
+			},
+		},
+		{
+			name: "missing projection metadata",
+			mutate: func(snapshot *state.Snapshot) {
+				snapshot.Metadata.Authority = ""
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := newAdapterTestService()
+			initial := completeAdapterSnapshot(1)
+			store := newAdapterTestStore(initial)
+			adapter, err := newDurableStateAdapterWithOperations(service, store.operations())
+			require.NoError(t, err)
+			require.NoError(t, adapter.restore(context.Background()))
+			before := durableCacheFingerprint(service, adapter)
+
+			failed := completeAdapterSnapshot(2)
+			tt.mutate(&failed)
+			store.mu.Lock()
+			store.snapshot = failed
+			store.mu.Unlock()
+			require.Error(t, adapter.restore(context.Background()))
+			assert.Equal(t, before, durableCacheFingerprint(service, adapter))
+		})
+	}
+}
+
+func TestDurableStateAdapterCommitOrderingAndFailures(t *testing.T) {
+	snapshot := completeAdapterSnapshot(3)
+	service := newAdapterTestService()
+	store := newAdapterTestStore(snapshot)
+	adapter, err := newDurableStateAdapterWithOperations(service, store.operations())
+	require.NoError(t, err)
+	require.NoError(t, adapter.restore(context.Background()))
+
+	record := snapshot.NetworkContainers["nc-1"]
+	record.VMVersion = "9"
+	record.HostVersion = "9"
+	record.Request.Version = "9"
+	ips := []state.IPRecord{{
+		ID:        "ip-new",
+		IPAddress: "10.0.0.99",
+		NCID:      "nc-1",
+		NCVersion: 9,
+	}}
+	store.beforeReplace = func() {
+		assert.Equal(t, "2", service.state.ContainerStatus["nc-1"].VMVersion)
+		assert.NotContains(t, service.PodIPConfigState, "ip-new")
+	}
+	require.NoError(t, adapter.applyNetworkContainer(context.Background(), record, ips))
+	store.beforeReplace = nil
+	assert.Equal(t, "9", service.state.ContainerStatus["nc-1"].VMVersion)
+	assert.Contains(t, service.PodIPConfigState, "ip-new")
+	assert.Equal(t, uint64(4), adapter.generation)
+	store.mu.Lock()
+	assert.Equal(t, "9", store.snapshot.NetworkContainers["nc-1"].VMVersion)
+	assert.Contains(t, store.snapshot.IPs, "ip-new")
+	store.mu.Unlock()
+
+	failures := []struct {
+		name string
+		err  error
+	}{
+		{name: "commit", err: errors.New("commit failed")},
+		{name: "stale", err: state.ErrStaleGeneration},
+		{name: "read only", err: bolterrors.ErrDatabaseReadOnly},
+		{name: "canceled", err: context.Canceled},
+	}
+	for _, tt := range failures {
+		t.Run(tt.name, func(t *testing.T) {
+			before := durableCacheFingerprint(service, adapter)
+			store.mu.Lock()
+			store.replaceErr = tt.err
+			store.mu.Unlock()
+			err := adapter.putNetwork(context.Background(), state.NetworkRecord{NetworkName: "not-committed"})
+			require.ErrorIs(t, err, tt.err)
+			assert.Equal(t, before, durableCacheFingerprint(service, adapter))
+			store.mu.Lock()
+			assert.NotContains(t, store.snapshot.Networks, "not-committed")
+			store.replaceErr = nil
+			store.mu.Unlock()
+		})
+	}
+
+	before := durableCacheFingerprint(service, adapter)
+	store.mu.Lock()
+	store.metadataErr = errors.New("metadata commit failed")
+	store.mu.Unlock()
+	err = adapter.putServiceMetadata(context.Background(), durableServiceMetadata{NodeID: "not-committed"})
+	require.Error(t, err)
+	assert.Equal(t, before, durableCacheFingerprint(service, adapter))
+	store.mu.Lock()
+	assert.NotEqual(t, "not-committed", store.snapshot.Metadata.NodeID)
+	store.metadataErr = nil
+	store.mu.Unlock()
+
+	before = durableCacheFingerprint(service, adapter)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, adapter.putNetwork(ctx, state.NetworkRecord{NetworkName: "canceled"}), context.Canceled)
+	assert.Equal(t, before, durableCacheFingerprint(service, adapter))
+}
+
+func TestDurableStateAdapterDurableOperations(t *testing.T) {
+	service := newAdapterTestService()
+	store := newAdapterTestStore(emptyAdapterSnapshot(0))
+	adapter, err := newDurableStateAdapterWithOperations(service, store.operations())
+	require.NoError(t, err)
+	require.NoError(t, adapter.restore(context.Background()))
+
+	record := adapterNetworkContainer("nc")
+	require.NoError(t, adapter.applyNetworkContainer(context.Background(), record, []state.IPRecord{{
+		ID: "ip", IPAddress: "10.0.0.4", NCID: "nc", NCVersion: 2,
+	}}))
+	require.NoError(t, adapter.putNetwork(context.Background(), state.NetworkRecord{
+		NetworkName: "network",
+		NicInfo:     &wireserver.InterfaceInfo{Subnet: "10.0.0.0/24", SecondaryIPs: []string{"10.0.0.4"}},
+		Options:     map[string]any{"mode": "bridge"},
+	}))
+	require.NoError(t, adapter.putOrchestratorContext(context.Background(), "pod", []string{"nc"}))
+	require.NoError(t, adapter.putPnPID(context.Background(), "00-11-22-33-44-55", "pnp"))
+	require.NoError(t, adapter.putServiceMetadata(context.Background(), durableServiceMetadata{
+		OrchestratorType: cns.KubernetesCRD,
+		NodeID:           "node",
+		Location:         "azure",
+		NetworkType:      "underlay",
+		Initialized:      true,
+		TimeStamp:        time.Unix(100, 0).UTC(),
+	}))
+
+	assert.Contains(t, service.state.ContainerStatus, "nc")
+	assert.Contains(t, service.PodIPConfigState, "ip")
+	assert.Contains(t, service.state.Networks, "network")
+	assert.Equal(t, ncList("nc"), *service.state.ContainerIDByOrchestratorContext["pod"])
+	assert.Equal(t, "pnp", service.state.PnpIDByMacAddress["00:11:22:33:44:55"])
+	assert.Equal(t, "node", service.state.NodeID)
+	assert.Equal(t, uint64(5), adapter.generation)
+
+	require.NoError(t, adapter.deleteOrchestratorContext(context.Background(), "pod"))
+	require.NoError(t, adapter.deletePnPID(context.Background(), "00:11:22:33:44:55"))
+	require.NoError(t, adapter.deleteNetwork(context.Background(), "network"))
+	require.NoError(t, adapter.deleteNetworkContainer(context.Background(), "nc"))
+	assert.Empty(t, service.state.ContainerStatus)
+	assert.Empty(t, service.PodIPConfigState)
+	assert.Empty(t, service.state.Networks)
+	assert.Empty(t, service.state.ContainerIDByOrchestratorContext)
+	assert.Empty(t, service.state.PnpIDByMacAddress)
+}
+
+func TestDurableStateAdapterStaleWritersDoNotLoseState(t *testing.T) {
+	baseDir, err := os.MkdirTemp(".", ".durable-adapter-concurrency-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, os.RemoveAll(baseDir)) })
+
+	db, err := state.Open(filepath.Join(baseDir, "state.db"), state.Options{})
+	require.NoError(t, err)
+	first, err := newDurableStateAdapter(newAdapterTestService(), db)
+	require.NoError(t, err)
+	second, err := newDurableStateAdapter(newAdapterTestService(), db)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = first.Close() })
+
+	require.NoError(t, first.restore(context.Background()))
+	require.NoError(t, second.restore(context.Background()))
+	firstBefore := durableCacheFingerprint(first.service, first)
+	secondBefore := durableCacheFingerprint(second.service, second)
+	start := make(chan struct{})
+	results := make(chan struct {
+		name    string
+		adapter *durableStateAdapter
+		err     error
+	}, 2)
+	var writers sync.WaitGroup
+	writers.Add(2)
+	go func() {
+		defer writers.Done()
+		<-start
+		results <- struct {
+			name    string
+			adapter *durableStateAdapter
+			err     error
+		}{"first", first, first.putNetwork(context.Background(), state.NetworkRecord{NetworkName: "first"})}
+	}()
+	go func() {
+		defer writers.Done()
+		<-start
+		results <- struct {
+			name    string
+			adapter *durableStateAdapter
+			err     error
+		}{"second", second, second.putNetwork(context.Background(), state.NetworkRecord{NetworkName: "second"})}
+	}()
+	close(start)
+	writers.Wait()
+	close(results)
+
+	var staleWriter struct {
+		name    string
+		adapter *durableStateAdapter
+	}
+	successes := 0
+	for result := range results {
+		if result.err == nil {
+			successes++
+			continue
+		}
+		require.ErrorIs(t, result.err, state.ErrStaleGeneration)
+		staleWriter.name = result.name
+		staleWriter.adapter = result.adapter
+	}
+	require.Equal(t, 1, successes)
+	require.NotNil(t, staleWriter.adapter)
+	if staleWriter.adapter == first {
+		assert.Equal(t, firstBefore, durableCacheFingerprint(first.service, first))
+	} else {
+		assert.Equal(t, secondBefore, durableCacheFingerprint(second.service, second))
+	}
+
+	require.NoError(t, staleWriter.adapter.restore(context.Background()))
+	require.NoError(
+		t,
+		staleWriter.adapter.putNetwork(context.Background(), state.NetworkRecord{NetworkName: staleWriter.name}),
+	)
+	snapshot, err := db.Snapshot(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, snapshot.Networks, "first")
+	assert.Contains(t, snapshot.Networks, "second")
+}
+
+func TestDurableStateAdapterRestartRestoreAndClose(t *testing.T) {
+	baseDir, err := os.MkdirTemp(".", ".durable-adapter-restart-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, os.RemoveAll(baseDir)) })
+	path := filepath.Join(baseDir, "state.db")
+
+	db, err := state.Open(path, state.Options{})
+	require.NoError(t, err)
+	firstService := newAdapterTestService()
+	first, err := newDurableStateAdapter(firstService, db)
+	require.NoError(t, err)
+	require.NoError(t, first.restore(context.Background()))
+	record := adapterNetworkContainer("nc")
+	record.Request.AuthorizationToken = "must-not-persist"
+	record.Request.SecondaryIPConfigs = map[string]cns.SecondaryIPConfig{"embedded": {IPAddress: "10.0.0.8"}}
+	require.NoError(t, first.applyNetworkContainer(context.Background(), record, []state.IPRecord{{
+		ID: "ip", IPAddress: "10.0.0.4", NCID: "nc", NCVersion: 2,
+	}}))
+	require.NoError(t, first.putNetwork(context.Background(), state.NetworkRecord{
+		NetworkName: "network",
+		NicInfo:     &wireserver.InterfaceInfo{Subnet: "10.0.0.0/24"},
+		Options:     map[string]any{"nested": map[string]any{"enabled": true}},
+	}))
+	require.NoError(t, first.putOrchestratorContext(context.Background(), "pod", []string{"nc"}))
+	require.NoError(t, first.putPnPID(context.Background(), "00-11-22-33-44-55", "pnp"))
+	require.NoError(t, first.putServiceMetadata(context.Background(), durableServiceMetadata{
+		OrchestratorType: cns.KubernetesCRD,
+		NodeID:           "node",
+		Location:         "azure",
+		NetworkType:      "underlay",
+		Initialized:      true,
+		TimeStamp:        time.Unix(100, 0).UTC(),
+	}))
+	want := durableCacheFingerprint(firstService, first)
+	require.NoError(t, first.Close())
+	require.NoError(t, first.Close())
+
+	reopened, err := state.Open(path, state.Options{})
+	require.NoError(t, err)
+	secondService := newAdapterTestService()
+	second, err := newDurableStateAdapter(secondService, reopened)
+	require.NoError(t, err)
+	require.NoError(t, second.restore(context.Background()))
+	assert.Equal(t, want, durableCacheFingerprint(secondService, second))
+	assert.Empty(t, secondService.state.ContainerStatus["nc"].CreateNetworkContainerRequest.AuthorizationToken)
+	assert.NotContains(
+		t,
+		secondService.state.ContainerStatus["nc"].CreateNetworkContainerRequest.SecondaryIPConfigs,
+		"embedded",
+	)
+	require.NoError(t, second.Close())
+}
+
+func TestDurableStateAdapterCloseErrorIsStable(t *testing.T) {
+	closeErr := errors.New("close failed")
+	store := newAdapterTestStore(emptyAdapterSnapshot(0))
+	store.closeErr = closeErr
+	adapter, err := newDurableStateAdapterWithOperations(newAdapterTestService(), store.operations())
+	require.NoError(t, err)
+	require.ErrorIs(t, adapter.Close(), closeErr)
+	require.ErrorIs(t, adapter.Close(), closeErr)
+	assert.Equal(t, 1, store.closeCalls)
+}
+
+func TestDurableStateAdapterConstructorValidation(t *testing.T) {
+	service := newAdapterTestService()
+	store := newAdapterTestStore(emptyAdapterSnapshot(0))
+	operations := store.operations()
+
+	adapter, err := newDurableStateAdapterWithOperations(nil, operations)
+	require.Error(t, err)
+	assert.Nil(t, adapter)
+	adapter, err = newDurableStateAdapter(service, nil)
+	require.Error(t, err)
+	assert.Nil(t, adapter)
+
+	tests := []struct {
+		name   string
+		mutate func(*durableStateOperations)
+	}{
+		{name: "snapshot", mutate: func(ops *durableStateOperations) { ops.snapshot = nil }},
+		{name: "replace", mutate: func(ops *durableStateOperations) { ops.replace = nil }},
+		{name: "metadata", mutate: func(ops *durableStateOperations) { ops.updateMetadata = nil }},
+		{name: "status", mutate: func(ops *durableStateOperations) { ops.status = nil }},
+		{name: "close", mutate: func(ops *durableStateOperations) { ops.close = nil }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			invalid := operations
+			tt.mutate(&invalid)
+			adapter, err := newDurableStateAdapterWithOperations(service, invalid)
+			require.Error(t, err)
+			assert.Nil(t, adapter)
+		})
+	}
+}
+
+func newAdapterTestService() *HTTPRestService {
+	return &HTTPRestService{
+		state: &httpRestServiceState{
+			ContainerStatus:                  map[string]containerstatus{"old": {ID: "old"}},
+			ContainerIDByOrchestratorContext: map[string]*ncList{},
+			Networks:                         map[string]*networkInfo{},
+			joinedNetworks:                   map[string]struct{}{"joined": {}},
+			PnpIDByMacAddress:                map[string]string{},
+		},
+		PodIPConfigState: map[string]cns.IPConfigurationStatus{},
+		PodIPIDByPodInterfaceKey: map[string][]string{
+			"existing-pod": {"existing-ip"},
+		},
+		EndpointState: map[string]*EndpointInfo{
+			"existing-endpoint": {PodName: "existing"},
+		},
+	}
+}
+
+func completeAdapterSnapshot(generation uint64) state.Snapshot {
+	snapshot := emptyAdapterSnapshot(generation)
+	snapshot.Metadata.OrchestratorType = cns.KubernetesCRD
+	snapshot.Metadata.NodeID = "node-1"
+	snapshot.Metadata.Location = "azure"
+	snapshot.Metadata.NetworkType = "underlay"
+	snapshot.Metadata.Initialized = true
+	snapshot.Metadata.TimeStamp = time.Unix(50, 0).UTC()
+	snapshot.NetworkContainers["nc-1"] = adapterNetworkContainer("nc-1")
+	second := adapterNetworkContainer("nc-2")
+	second.HostVersion = "3"
+	snapshot.NetworkContainers["nc-2"] = second
+	snapshot.IPs["11111111-1111-1111-1111-111111111111"] = state.IPRecord{
+		ID:        "11111111-1111-1111-1111-111111111111",
+		IPAddress: "10.0.0.4",
+		NCID:      "nc-1",
+		NCVersion: 2,
+	}
+	snapshot.IPs["22222222-2222-2222-2222-222222222222"] = state.IPRecord{
+		ID:        "22222222-2222-2222-2222-222222222222",
+		IPAddress: "10.0.1.4",
+		NCID:      "nc-2",
+		NCVersion: 2,
+	}
+	snapshot.Networks["network-1"] = state.NetworkRecord{
+		NetworkName: "network-1",
+		NicInfo: &wireserver.InterfaceInfo{
+			Subnet:       "10.0.0.0/24",
+			Gateway:      "10.0.0.1",
+			PrimaryIP:    "10.0.0.2",
+			SecondaryIPs: []string{"10.0.0.4"},
+		},
+		Options: map[string]any{"nested": map[string]any{"key": "value"}},
+	}
+	snapshot.OrchestratorContexts["pod-a"] = []string{"nc-1", "nc-2"}
+	snapshot.PnPIDByMAC["00:11:22:33:44:55"] = "pnp-1"
+	snapshot.Endpoints["persisted-endpoint"] = state.EndpointRecord{
+		PodName:       "must-not-project",
+		IfnameToIPMap: map[string]*state.IPInfoRecord{},
+	}
+	return snapshot
+}
+
+func emptyAdapterSnapshot(generation uint64) state.Snapshot {
+	snapshot := state.NewSnapshot()
+	snapshot.Metadata = state.Metadata{
+		SchemaVersion: state.SchemaVersion,
+		Authority:     state.AuthorityBolt,
+		Generation:    generation,
+	}
+	return snapshot
+}
+
+func adapterNetworkContainer(id string) state.NetworkContainerRecord {
+	return state.NewNetworkContainerRecord(id, "2", "1", true, cns.CreateNetworkContainerRequest{
+		NetworkContainerid: id,
+		Version:            "2",
+		IPConfiguration: cns.IPConfiguration{
+			IPSubnet:         cns.IPSubnet{IPAddress: "10.0.0.0", PrefixLength: 24},
+			GatewayIPAddress: "10.0.0.1",
+			DNSServers:       []string{"10.0.0.10"},
+		},
+		Routes: []cns.Route{{IPAddress: "0.0.0.0/0", GatewayIPAddress: "10.0.0.1"}},
+	})
+}
+
+func healthyAdapterStatus(generation uint64) state.Status {
+	return state.Status{
+		Backend:         state.BackendBolt,
+		Authority:       state.AuthorityBolt,
+		SchemaVersion:   state.SchemaVersion,
+		Generation:      generation,
+		InvariantStatus: state.InvariantHealthy,
+	}
+}
+
+func assertAdapterProjection(t *testing.T, service *HTTPRestService, snapshot state.Snapshot) {
+	t.Helper()
+	require.Len(t, service.state.ContainerStatus, 2)
+	assert.Equal(t, snapshot.Metadata.NodeID, service.state.NodeID)
+	assert.Equal(t, snapshot.Metadata.OrchestratorType, service.state.OrchestratorType)
+	assert.Equal(t, snapshot.Metadata.TimeStamp, service.state.TimeStamp)
+	assert.Equal(t, snapshot.NetworkContainers["nc-1"].Request.Routes, service.state.ContainerStatus["nc-1"].CreateNetworkContainerRequest.Routes)
+	assert.Empty(t, service.state.ContainerStatus["nc-1"].CreateNetworkContainerRequest.AuthorizationToken)
+	require.Len(t, service.PodIPConfigState, 2)
+	pending := service.PodIPConfigState["11111111-1111-1111-1111-111111111111"]
+	available := service.PodIPConfigState["22222222-2222-2222-2222-222222222222"]
+	assert.Equal(t, types.PendingProgramming, pending.GetState())
+	assert.Equal(t, types.Available, available.GetState())
+	assert.Equal(
+		t,
+		"10.0.0.4",
+		service.state.ContainerStatus["nc-1"].CreateNetworkContainerRequest.
+			SecondaryIPConfigs["11111111-1111-1111-1111-111111111111"].IPAddress,
+	)
+	assert.Equal(t, snapshot.Networks["network-1"].NicInfo, service.state.Networks["network-1"].NicInfo)
+	assert.Equal(t, snapshot.Networks["network-1"].Options, service.state.Networks["network-1"].Options)
+	assert.Equal(t, ncList("nc-1,nc-2"), *service.state.ContainerIDByOrchestratorContext["pod-a"])
+	assert.Equal(t, "pnp-1", service.state.PnpIDByMacAddress["00:11:22:33:44:55"])
+}
+
+type adapterCacheFingerprint struct {
+	Generation      uint64
+	Projected       bool
+	Metadata        durableServiceMetadata
+	Containers      map[string]containerstatus
+	IPs             map[string]adapterIPFingerprint
+	Networks        map[string]state.NetworkRecord
+	OrchestratorNCs map[string]string
+	PnPIDs          map[string]string
+}
+
+type adapterIPFingerprint struct {
+	ID        string
+	IPAddress string
+	NCID      string
+	State     types.IPState
+}
+
+func durableCacheFingerprint(service *HTTPRestService, adapter *durableStateAdapter) adapterCacheFingerprint {
+	generation, projected := adapter.cacheGeneration()
+	containers, err := cloneJSON(service.state.ContainerStatus)
+	if err != nil {
+		panic(err)
+	}
+	fingerprint := adapterCacheFingerprint{
+		Generation: generation,
+		Projected:  projected,
+		Metadata: durableServiceMetadata{
+			OrchestratorType: service.state.OrchestratorType,
+			NodeID:           service.state.NodeID,
+			Location:         service.state.Location,
+			NetworkType:      service.state.NetworkType,
+			Initialized:      service.state.Initialized,
+			TimeStamp:        service.state.TimeStamp,
+		},
+		Containers:      containers,
+		IPs:             make(map[string]adapterIPFingerprint, len(service.PodIPConfigState)),
+		Networks:        make(map[string]state.NetworkRecord, len(service.state.Networks)),
+		OrchestratorNCs: make(map[string]string, len(service.state.ContainerIDByOrchestratorContext)),
+		PnPIDs:          make(map[string]string, len(service.state.PnpIDByMacAddress)),
+	}
+	for id, status := range service.PodIPConfigState {
+		fingerprint.IPs[id] = adapterIPFingerprint{
+			ID: status.ID, IPAddress: status.IPAddress, NCID: status.NCID, State: status.GetState(),
+		}
+	}
+	for name, network := range service.state.Networks {
+		record, err := cloneJSON(state.NetworkRecord{
+			NetworkName: network.NetworkName,
+			NicInfo:     network.NicInfo,
+			Options:     network.Options,
+		})
+		if err != nil {
+			panic(err)
+		}
+		fingerprint.Networks[name] = record
+	}
+	for id, ncs := range service.state.ContainerIDByOrchestratorContext {
+		fingerprint.OrchestratorNCs[id] = string(*ncs)
+	}
+	for macAddress, pnpID := range service.state.PnpIDByMacAddress {
+		fingerprint.PnPIDs[macAddress] = pnpID
+	}
+	return fingerprint
+}
+
+func TestBuildDurableCacheProjectionRejectsInvalidIPFamily(t *testing.T) {
+	snapshot := completeAdapterSnapshot(1)
+	snapshot.IPs["11111111-1111-1111-1111-111111111111"] = state.IPRecord{
+		ID: "11111111-1111-1111-1111-111111111111", IPAddress: net.IP{}.String(), NCID: "nc-1",
+	}
+	_, err := buildDurableCacheProjection(snapshot)
+	require.Error(t, err)
+}

--- a/cns/service/persistent_state.go
+++ b/cns/service/persistent_state.go
@@ -14,6 +14,11 @@ import (
 	"github.com/Azure/azure-container-networking/store"
 )
 
+var (
+	errNilPersistentStateRestoreCallback = errors.New("persistent state restore callback is nil")
+	errNilPersistentStateCloseCallback   = errors.New("persistent state close callback is nil")
+)
+
 type persistentStatePaths struct {
 	stateDirectory    string
 	stateFile         string
@@ -117,17 +122,17 @@ func (s *persistentStateStartup) Start(ctx context.Context) error {
 
 func (s *persistentStateStartup) attach(
 	restore func(context.Context) error,
-	close func() error,
+	closeFn func() error,
 ) error {
 	switch {
 	case restore == nil:
-		return errors.New("persistent state restore callback is nil")
-	case close == nil:
-		return errors.New("persistent state close callback is nil")
+		return errNilPersistentStateRestoreCallback
+	case closeFn == nil:
+		return errNilPersistentStateCloseCallback
 	}
 	s.attachments = append(s.attachments, persistentStateAttachment{
 		restore: restore,
-		close:   close,
+		close:   closeFn,
 	})
 	return nil
 }

--- a/cns/service/persistent_state.go
+++ b/cns/service/persistent_state.go
@@ -29,10 +29,16 @@ type persistentStateDependencies struct {
 	openStore       func(string, processlock.Interface) (store.KeyValueStore, error)
 }
 
+type persistentStateAttachment struct {
+	restore func(context.Context) error
+	close   func() error
+}
+
 type persistentStateStartup struct {
 	stateStore         store.KeyValueStore
 	endpointStateStore store.KeyValueStore
 	start              func(context.Context) error
+	attachments        []persistentStateAttachment
 	locks              []processlock.Interface
 	closeOnce          sync.Once
 	closeErr           error
@@ -98,15 +104,42 @@ func newJSONPersistentStateStartup(
 }
 
 func (s *persistentStateStartup) Start(ctx context.Context) error {
+	for _, attachment := range s.attachments {
+		if err := attachment.restore(ctx); err != nil {
+			return errors.Join(err, s.Close())
+		}
+	}
 	if err := s.start(ctx); err != nil {
 		return errors.Join(err, s.Close())
 	}
 	return nil
 }
 
+func (s *persistentStateStartup) attach(
+	restore func(context.Context) error,
+	close func() error,
+) error {
+	switch {
+	case restore == nil:
+		return errors.New("persistent state restore callback is nil")
+	case close == nil:
+		return errors.New("persistent state close callback is nil")
+	}
+	s.attachments = append(s.attachments, persistentStateAttachment{
+		restore: restore,
+		close:   close,
+	})
+	return nil
+}
+
 func (s *persistentStateStartup) Close() error {
 	s.closeOnce.Do(func() {
 		var closeErrs []error
+		for i := len(s.attachments) - 1; i >= 0; i-- {
+			if err := s.attachments[i].close(); err != nil {
+				closeErrs = append(closeErrs, err)
+			}
+		}
 		for _, lock := range s.locks {
 			if err := lock.Unlock(); err != nil && !errors.Is(err, processlock.ErrInvalidFile) {
 				closeErrs = append(closeErrs, err)

--- a/cns/service/persistent_state_test.go
+++ b/cns/service/persistent_state_test.go
@@ -175,6 +175,132 @@ func TestPersistentStateStartup_StartPropagatesContextAndCleansUpFailure(t *test
 	require.Equal(t, 1, endpointLock.unlockCalls)
 }
 
+func TestPersistentStateStartup_AttachmentRestoreGatesListenerAndOwnsClose(t *testing.T) {
+	restoreErr := errors.New("restore failure")
+	closeErr := errors.New("adapter close failure")
+	lock := &trackedFileLock{}
+	listenerStarted := false
+	closeCalls := 0
+
+	startup, err := newPersistentStateStartup(
+		testPersistentStatePaths(),
+		false,
+		func(context.Context) error {
+			listenerStarted = true
+			return nil
+		},
+		persistentStateDependencies{
+			createDirectory: func(string) error { return nil },
+			newFileLock: func(string) (processlock.Interface, error) {
+				return lock, nil
+			},
+			openStore: func(path string, _ processlock.Interface) (store.KeyValueStore, error) {
+				return store.NewMockStore(path), nil
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.NoError(t, startup.attach(
+		func(context.Context) error { return restoreErr },
+		func() error {
+			closeCalls++
+			return closeErr
+		},
+	))
+
+	err = startup.Start(context.Background())
+	require.ErrorIs(t, err, restoreErr)
+	require.ErrorIs(t, err, closeErr)
+	require.False(t, listenerStarted)
+	require.Equal(t, 1, closeCalls)
+	require.Equal(t, 1, lock.unlockCalls)
+
+	require.ErrorIs(t, startup.Close(), closeErr)
+	require.Equal(t, 1, closeCalls)
+	require.Equal(t, 1, lock.unlockCalls)
+}
+
+func TestPersistentStateStartup_AttachmentClosesOnListenerFailure(t *testing.T) {
+	listenerErr := errors.New("listener failure")
+	closeErr := errors.New("adapter close failure")
+	lock := &trackedFileLock{}
+	restored := false
+	closeCalls := 0
+
+	startup, err := newPersistentStateStartup(
+		testPersistentStatePaths(),
+		false,
+		func(context.Context) error { return listenerErr },
+		persistentStateDependencies{
+			createDirectory: func(string) error { return nil },
+			newFileLock: func(string) (processlock.Interface, error) {
+				return lock, nil
+			},
+			openStore: func(path string, _ processlock.Interface) (store.KeyValueStore, error) {
+				return store.NewMockStore(path), nil
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.NoError(t, startup.attach(
+		func(context.Context) error {
+			restored = true
+			return nil
+		},
+		func() error {
+			closeCalls++
+			return closeErr
+		},
+	))
+
+	err = startup.Start(context.Background())
+	require.ErrorIs(t, err, listenerErr)
+	require.ErrorIs(t, err, closeErr)
+	require.True(t, restored)
+	require.Equal(t, 1, closeCalls)
+	require.Equal(t, 1, lock.unlockCalls)
+}
+
+func TestPersistentStateStartup_AttachmentClosesOnceOnShutdown(t *testing.T) {
+	lock := &trackedFileLock{}
+	closeCalls := 0
+	startup, err := newPersistentStateStartup(
+		testPersistentStatePaths(),
+		false,
+		func(context.Context) error { return nil },
+		persistentStateDependencies{
+			createDirectory: func(string) error { return nil },
+			newFileLock: func(string) (processlock.Interface, error) {
+				return lock, nil
+			},
+			openStore: func(path string, _ processlock.Interface) (store.KeyValueStore, error) {
+				return store.NewMockStore(path), nil
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.NoError(t, startup.attach(
+		func(context.Context) error { return nil },
+		func() error {
+			closeCalls++
+			return nil
+		},
+	))
+
+	require.NoError(t, startup.Start(context.Background()))
+	require.NoError(t, startup.Close())
+	require.NoError(t, startup.Close())
+	require.Equal(t, 1, closeCalls)
+	require.Equal(t, 1, lock.unlockCalls)
+}
+
+func TestPersistentStateStartup_AttachmentValidation(t *testing.T) {
+	startup := &persistentStateStartup{}
+	require.Error(t, startup.attach(nil, func() error { return nil }))
+	require.Error(t, startup.attach(func(context.Context) error { return nil }, nil))
+	require.Empty(t, startup.attachments)
+}
+
 func TestNewPersistentStateStartup_EndpointStateDisabled(t *testing.T) {
 	var (
 		directories []string

--- a/cns/service/persistent_state_test.go
+++ b/cns/service/persistent_state_test.go
@@ -21,6 +21,7 @@ var (
 	errPersistentStateStartup = errors.New("startup failure")
 	errPersistentStateStart   = errors.New("listener failure")
 	errPersistentStateCleanup = errors.New("cleanup failure")
+	errPersistentStateRestore = errors.New("restore failure")
 )
 
 type trackedFileLock struct {
@@ -176,8 +177,6 @@ func TestPersistentStateStartup_StartPropagatesContextAndCleansUpFailure(t *test
 }
 
 func TestPersistentStateStartup_AttachmentRestoreGatesListenerAndOwnsClose(t *testing.T) {
-	restoreErr := errors.New("restore failure")
-	closeErr := errors.New("adapter close failure")
 	lock := &trackedFileLock{}
 	listenerStarted := false
 	closeCalls := 0
@@ -201,28 +200,26 @@ func TestPersistentStateStartup_AttachmentRestoreGatesListenerAndOwnsClose(t *te
 	)
 	require.NoError(t, err)
 	require.NoError(t, startup.attach(
-		func(context.Context) error { return restoreErr },
+		func(context.Context) error { return errPersistentStateRestore },
 		func() error {
 			closeCalls++
-			return closeErr
+			return errPersistentStateCleanup
 		},
 	))
 
 	err = startup.Start(context.Background())
-	require.ErrorIs(t, err, restoreErr)
-	require.ErrorIs(t, err, closeErr)
+	require.ErrorIs(t, err, errPersistentStateRestore)
+	require.ErrorIs(t, err, errPersistentStateCleanup)
 	require.False(t, listenerStarted)
 	require.Equal(t, 1, closeCalls)
 	require.Equal(t, 1, lock.unlockCalls)
 
-	require.ErrorIs(t, startup.Close(), closeErr)
+	require.ErrorIs(t, startup.Close(), errPersistentStateCleanup)
 	require.Equal(t, 1, closeCalls)
 	require.Equal(t, 1, lock.unlockCalls)
 }
 
 func TestPersistentStateStartup_AttachmentClosesOnListenerFailure(t *testing.T) {
-	listenerErr := errors.New("listener failure")
-	closeErr := errors.New("adapter close failure")
 	lock := &trackedFileLock{}
 	restored := false
 	closeCalls := 0
@@ -230,7 +227,7 @@ func TestPersistentStateStartup_AttachmentClosesOnListenerFailure(t *testing.T) 
 	startup, err := newPersistentStateStartup(
 		testPersistentStatePaths(),
 		false,
-		func(context.Context) error { return listenerErr },
+		func(context.Context) error { return errPersistentStateStart },
 		persistentStateDependencies{
 			createDirectory: func(string) error { return nil },
 			newFileLock: func(string) (processlock.Interface, error) {
@@ -249,13 +246,13 @@ func TestPersistentStateStartup_AttachmentClosesOnListenerFailure(t *testing.T) 
 		},
 		func() error {
 			closeCalls++
-			return closeErr
+			return errPersistentStateCleanup
 		},
 	))
 
 	err = startup.Start(context.Background())
-	require.ErrorIs(t, err, listenerErr)
-	require.ErrorIs(t, err, closeErr)
+	require.ErrorIs(t, err, errPersistentStateStart)
+	require.ErrorIs(t, err, errPersistentStateCleanup)
 	require.True(t, restored)
 	require.Equal(t, 1, closeCalls)
 	require.Equal(t, 1, lock.unlockCalls)


### PR DESCRIPTION
## Scope
Adds the inert durable-state adapter, projection boundary, generation checks, and startup-owned lifecycle attachment.

## Draft dependency caveat
This PR is opened early for review and CI. Its base, `users/rbtr/bolt-runtime-base-v4`, is a temporary integration branch joining the draft observability work with #4563, #4564, and #4565. **Do not merge until those foundations and the import/rollback engine fork have merged.**

## Behavior
The adapter has no supported external Bolt mode in this PR; JSON remains the shipped default.

## Evidence
Linux/Windows lint and state/restserver/service race tests pass.