### PR TITLE
feat(cns): wire Bolt startup lifecycle

### DIFF
--- a/cns/restserver/durable_state_adapter.go
+++ b/cns/restserver/durable_state_adapter.go
@@ -85,7 +85,7 @@ type durableCacheProjection struct {
 func NewDurableStateLifecycle(
 	service *HTTPRestService,
 	db *state.DB,
-) (restore func(context.Context) error, close func() error, err error) {
+) (restore func(context.Context) error, closeFn func() error, err error) {
 	adapter, err := newDurableStateAdapter(service, db)
 	if err != nil {
 		return nil, nil, err

--- a/cns/restserver/durable_state_adapter.go
+++ b/cns/restserver/durable_state_adapter.go
@@ -80,6 +80,19 @@ type durableCacheProjection struct {
 	pnpIDByMACAddress map[string]string
 }
 
+// NewDurableStateLifecycle binds the Bolt durable-state adapter to the service
+// while leaving lifecycle ownership with the startup coordinator.
+func NewDurableStateLifecycle(
+	service *HTTPRestService,
+	db *state.DB,
+) (restore func(context.Context) error, close func() error, err error) {
+	adapter, err := newDurableStateAdapter(service, db)
+	if err != nil {
+		return nil, nil, err
+	}
+	return adapter.restore, adapter.Close, nil
+}
+
 func newDurableStateAdapter(service *HTTPRestService, db *state.DB) (*durableStateAdapter, error) {
 	if db == nil {
 		return nil, errNilDurableStateDB

--- a/cns/service/bolt_startup.go
+++ b/cns/service/bolt_startup.go
@@ -1,0 +1,263 @@
+// Copyright 2026 Microsoft. All rights reserved.
+// MIT License
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Azure/azure-container-networking/cns/restserver"
+	"github.com/Azure/azure-container-networking/cns/state"
+	"github.com/Azure/azure-container-networking/platform"
+	"github.com/Azure/azure-container-networking/processlock"
+	"github.com/Azure/azure-container-networking/store"
+)
+
+type boltStartupMode uint8
+
+const (
+	boltStartupNormal boltStartupMode = iota
+	boltStartupRollback
+)
+
+type boltPersistentStateConfig struct {
+	paths               persistentStatePaths
+	mode                boltStartupMode
+	manageEndpointState bool
+	bootPolicy          state.BootPolicy
+	options             state.Options
+}
+
+type boltPersistentStateDependencies struct {
+	createDirectory func(string) error
+	newFileLock     func(string) (processlock.Interface, error)
+	openStore       func(string, processlock.Interface) (store.KeyValueStore, error)
+	openDB          func(context.Context, string, state.Options) (*state.DB, error)
+	currentBootID   func() (string, error)
+	attachBolt      func(*state.DB) (persistentStateAttachment, error)
+	restoreJSON     func(context.Context, store.KeyValueStore, store.KeyValueStore) error
+}
+
+func productionBoltPersistentStateDependencies(
+	service *restserver.HTTPRestService,
+	restoreJSON func(context.Context, store.KeyValueStore, store.KeyValueStore) error,
+) boltPersistentStateDependencies {
+	return boltPersistentStateDependencies{
+		createDirectory: platform.CreateDirectory,
+		newFileLock:     processlock.NewFileLock,
+		openStore: func(path string, lock processlock.Interface) (store.KeyValueStore, error) {
+			return store.NewJsonFileStore(path, lock, nil)
+		},
+		openDB:        state.OpenContext,
+		currentBootID: platform.BootID,
+		attachBolt: func(db *state.DB) (persistentStateAttachment, error) {
+			restore, close, err := restserver.NewDurableStateLifecycle(service, db)
+			if err != nil {
+				return persistentStateAttachment{}, err
+			}
+			return persistentStateAttachment{restore: restore, close: close}, nil
+		},
+		restoreJSON: restoreJSON,
+	}
+}
+
+func newBoltPersistentStateStartup(
+	ctx context.Context,
+	config boltPersistentStateConfig,
+	start func(context.Context) error,
+	deps boltPersistentStateDependencies,
+) (*persistentStateStartup, error) {
+	if err := validateBoltStartup(config, start, deps); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("initializing Bolt persistent state: %w", err)
+	}
+
+	startup := &persistentStateStartup{start: start}
+	if err := deps.createDirectory(config.paths.stateDirectory); err != nil {
+		return nil, fmt.Errorf("creating state store directory: %w", err)
+	}
+
+	stateLock, err := acquireLegacyLock(ctx, config.paths.stateLockFile, deps.newFileLock)
+	if err != nil {
+		return nil, fmt.Errorf("acquiring state store lock: %w", err)
+	}
+	startup.locks = append(startup.locks, stateLock)
+
+	endpointLock, lockErr := acquireLegacyLock(ctx, config.paths.endpointLockFile, deps.newFileLock)
+	if lockErr != nil {
+		return nil, startup.closeAfterError(fmt.Errorf("acquiring endpoint state store lock: %w", lockErr))
+	}
+	startup.locks = append(startup.locks, endpointLock)
+
+	db, err := deps.openDB(ctx, config.paths.databaseFile, config.options)
+	if err != nil {
+		return nil, startup.closeAfterError(err)
+	}
+	closeDBAfterError := func(startupErr error) error {
+		return errors.Join(startupErr, db.Close(), startup.Close())
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, closeDBAfterError(fmt.Errorf("opening Bolt persistent state: %w", err))
+	}
+	status, err := db.Status(ctx)
+	if err != nil {
+		return nil, closeDBAfterError(err)
+	}
+	if status.InvariantStatus != state.InvariantHealthy {
+		return nil, closeDBAfterError(fmt.Errorf("persistent state invariant %q failed", status.FailedInvariant))
+	}
+
+	if config.mode == boltStartupRollback {
+		if _, err := db.ExportLegacy(ctx, state.ExportOptions{
+			CNSJSONPath:      config.paths.stateFile,
+			EndpointJSONPath: config.paths.endpointFile,
+		}); err != nil {
+			return nil, closeDBAfterError(err)
+		}
+		status, err := db.Status(ctx)
+		if err != nil {
+			return nil, closeDBAfterError(err)
+		}
+		if status.Authority != state.AuthorityJSON || !status.RollbackExported {
+			return nil, closeDBAfterError(errors.New("rollback export did not establish JSON authority"))
+		}
+		if err := db.Close(); err != nil {
+			return nil, errors.Join(err, startup.Close())
+		}
+		if err := initializeRollbackJSON(ctx, startup, config, deps); err != nil {
+			return nil, startup.closeAfterError(err)
+		}
+		return startup, nil
+	}
+
+	bootID, err := deps.currentBootID()
+	if err != nil {
+		return nil, closeDBAfterError(fmt.Errorf("getting current boot ID: %w", err))
+	}
+	importOptions := state.ImportOptions{
+		CNSPath:             config.paths.stateFile,
+		EndpointPath:        config.paths.endpointFile,
+		ManageEndpointState: config.manageEndpointState,
+		BootID:              bootID,
+	}
+	switch status.Authority {
+	case state.AuthorityBolt:
+		if _, err := db.ImportLegacy(ctx, importOptions); err != nil {
+			return nil, closeDBAfterError(err)
+		}
+	case state.AuthorityJSON:
+		if _, err := db.ReimportLegacy(ctx, importOptions, config.bootPolicy); err != nil {
+			return nil, closeDBAfterError(err)
+		}
+	default:
+		return nil, closeDBAfterError(fmt.Errorf("unsupported persistent state authority %q", status.Authority))
+	}
+	if _, err := db.ApplyBoot(ctx, bootID, config.bootPolicy); err != nil {
+		return nil, closeDBAfterError(err)
+	}
+	if _, err := db.RefreshMetrics(ctx); err != nil {
+		return nil, closeDBAfterError(err)
+	}
+	attachment, err := deps.attachBolt(db)
+	if err != nil {
+		return nil, closeDBAfterError(fmt.Errorf("attaching Bolt persistent state: %w", err))
+	}
+	startup.attachments = append(startup.attachments, attachment)
+	return startup, nil
+}
+
+func initializeRollbackJSON(
+	ctx context.Context,
+	startup *persistentStateStartup,
+	config boltPersistentStateConfig,
+	deps boltPersistentStateDependencies,
+) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("initializing rollback JSON state: %w", err)
+	}
+	if err := deps.createDirectory(config.paths.endpointDirectory); err != nil {
+		return fmt.Errorf("creating endpoint state store directory: %w", err)
+	}
+	var err error
+	startup.stateStore, err = deps.openStore(config.paths.stateFile, startup.locks[0])
+	if err != nil {
+		return fmt.Errorf("opening rollback state store: %w", err)
+	}
+	if config.manageEndpointState {
+		startup.endpointStateStore, err = deps.openStore(config.paths.endpointFile, startup.locks[1])
+		if err != nil {
+			return fmt.Errorf("opening rollback endpoint state store: %w", err)
+		}
+	}
+	return startup.attach(
+		func(restoreCtx context.Context) error {
+			return deps.restoreJSON(restoreCtx, startup.stateStore, startup.endpointStateStore)
+		},
+		func() error { return nil },
+	)
+}
+
+func acquireLegacyLock(
+	ctx context.Context,
+	path string,
+	newLock func(string) (processlock.Interface, error),
+) (processlock.Interface, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	lock, err := newLock(path)
+	if err != nil {
+		return nil, err
+	}
+	if err := lock.Lock(); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, errors.Join(err, lock.Unlock())
+	}
+	return lock, nil
+}
+
+func validateBoltStartup(
+	config boltPersistentStateConfig,
+	start func(context.Context) error,
+	deps boltPersistentStateDependencies,
+) error {
+	switch {
+	case start == nil:
+		return errors.New("persistent state start callback is nil")
+	case config.mode != boltStartupNormal && config.mode != boltStartupRollback:
+		return errors.New("persistent state startup mode is invalid")
+	case config.paths.stateDirectory == "":
+		return errors.New("persistent state directory is empty")
+	case config.paths.databaseFile == "":
+		return errors.New("persistent state database path is empty")
+	case config.paths.stateFile == "":
+		return errors.New("legacy CNS state path is empty")
+	case config.paths.stateLockFile == "":
+		return errors.New("legacy CNS lock path is empty")
+	case config.paths.endpointFile == "":
+		return errors.New("legacy endpoint state path is empty")
+	case config.paths.endpointLockFile == "":
+		return errors.New("legacy endpoint lock path is empty")
+	case deps.createDirectory == nil:
+		return errors.New("persistent state directory creator is nil")
+	case deps.newFileLock == nil:
+		return errors.New("persistent state lock factory is nil")
+	case deps.openDB == nil:
+		return errors.New("persistent state database opener is nil")
+	case config.mode == boltStartupNormal && deps.currentBootID == nil:
+		return errors.New("persistent state boot ID provider is nil")
+	case config.mode == boltStartupNormal && deps.attachBolt == nil:
+		return errors.New("persistent state Bolt attachment is nil")
+	case config.mode == boltStartupRollback && deps.openStore == nil:
+		return errors.New("persistent state JSON opener is nil")
+	case config.mode == boltStartupRollback && deps.restoreJSON == nil:
+		return errors.New("persistent state JSON restore callback is nil")
+	}
+	return nil
+}

--- a/cns/service/bolt_startup.go
+++ b/cns/service/bolt_startup.go
@@ -15,6 +15,27 @@ import (
 	"github.com/Azure/azure-container-networking/store"
 )
 
+var (
+	errPersistentInvariantFailed    = errors.New("persistent state invariant failed")
+	errRollbackJSONAuthorityMissing = errors.New("rollback export did not establish JSON authority")
+	errUnsupportedStateAuthority    = errors.New("unsupported persistent state authority")
+	errNilStateStartCallback        = errors.New("persistent state start callback is nil")
+	errInvalidStateStartupMode      = errors.New("persistent state startup mode is invalid")
+	errEmptyStateDirectory          = errors.New("persistent state directory is empty")
+	errEmptyStateDatabasePath       = errors.New("persistent state database path is empty")
+	errEmptyLegacyCNSPath           = errors.New("legacy CNS state path is empty")
+	errEmptyLegacyCNSLockPath       = errors.New("legacy CNS lock path is empty")
+	errEmptyLegacyEndpointPath      = errors.New("legacy endpoint state path is empty")
+	errEmptyLegacyEndpointLockPath  = errors.New("legacy endpoint lock path is empty")
+	errNilStateDirectoryCreator     = errors.New("persistent state directory creator is nil")
+	errNilStateLockFactory          = errors.New("persistent state lock factory is nil")
+	errNilStateDatabaseOpener       = errors.New("persistent state database opener is nil")
+	errNilStateBootIDProvider       = errors.New("persistent state boot ID provider is nil")
+	errNilStateBoltAttachment       = errors.New("persistent state Bolt attachment is nil")
+	errNilStateJSONOpener           = errors.New("persistent state JSON opener is nil")
+	errNilStateJSONRestoreCallback  = errors.New("persistent state JSON restore callback is nil")
+)
+
 type boltStartupMode uint8
 
 const (
@@ -53,11 +74,11 @@ func productionBoltPersistentStateDependencies(
 		openDB:        state.OpenContext,
 		currentBootID: platform.BootID,
 		attachBolt: func(db *state.DB) (persistentStateAttachment, error) {
-			restore, close, err := restserver.NewDurableStateLifecycle(service, db)
+			restore, closeFn, err := restserver.NewDurableStateLifecycle(service, db)
 			if err != nil {
-				return persistentStateAttachment{}, err
+				return persistentStateAttachment{}, fmt.Errorf("creating durable state lifecycle: %w", err)
 			}
-			return persistentStateAttachment{restore: restore, close: close}, nil
+			return persistentStateAttachment{restore: restore, close: closeFn}, nil
 		},
 		restoreJSON: restoreJSON,
 	}
@@ -69,16 +90,16 @@ func newBoltPersistentStateStartup(
 	start func(context.Context) error,
 	deps boltPersistentStateDependencies,
 ) (*persistentStateStartup, error) {
-	if err := validateBoltStartup(config, start, deps); err != nil {
-		return nil, err
+	if validationErr := validateBoltStartup(config, start, deps); validationErr != nil {
+		return nil, validationErr
 	}
-	if err := ctx.Err(); err != nil {
-		return nil, fmt.Errorf("initializing Bolt persistent state: %w", err)
+	if contextErr := ctx.Err(); contextErr != nil {
+		return nil, fmt.Errorf("initializing Bolt persistent state: %w", contextErr)
 	}
 
 	startup := &persistentStateStartup{start: start}
-	if err := deps.createDirectory(config.paths.stateDirectory); err != nil {
-		return nil, fmt.Errorf("creating state store directory: %w", err)
+	if directoryErr := deps.createDirectory(config.paths.stateDirectory); directoryErr != nil {
+		return nil, fmt.Errorf("creating state store directory: %w", directoryErr)
 	}
 
 	stateLock, err := acquireLegacyLock(ctx, config.paths.stateLockFile, deps.newFileLock)
@@ -93,50 +114,50 @@ func newBoltPersistentStateStartup(
 	}
 	startup.locks = append(startup.locks, endpointLock)
 
-	db, err := deps.openDB(ctx, config.paths.databaseFile, config.options)
-	if err != nil {
-		return nil, startup.closeAfterError(err)
+	db, openErr := deps.openDB(ctx, config.paths.databaseFile, config.options)
+	if openErr != nil {
+		return nil, startup.closeAfterError(openErr)
 	}
 	closeDBAfterError := func(startupErr error) error {
 		return errors.Join(startupErr, db.Close(), startup.Close())
 	}
-	if err := ctx.Err(); err != nil {
-		return nil, closeDBAfterError(fmt.Errorf("opening Bolt persistent state: %w", err))
+	if contextErr := ctx.Err(); contextErr != nil {
+		return nil, closeDBAfterError(fmt.Errorf("opening Bolt persistent state: %w", contextErr))
 	}
-	status, err := db.Status(ctx)
-	if err != nil {
-		return nil, closeDBAfterError(err)
+	status, statusErr := db.Status(ctx)
+	if statusErr != nil {
+		return nil, closeDBAfterError(statusErr)
 	}
 	if status.InvariantStatus != state.InvariantHealthy {
-		return nil, closeDBAfterError(fmt.Errorf("persistent state invariant %q failed", status.FailedInvariant))
+		return nil, closeDBAfterError(fmt.Errorf("%w: %q", errPersistentInvariantFailed, status.FailedInvariant))
 	}
 
 	if config.mode == boltStartupRollback {
-		if _, err := db.ExportLegacy(ctx, state.ExportOptions{
+		if _, exportErr := db.ExportLegacy(ctx, state.ExportOptions{
 			CNSJSONPath:      config.paths.stateFile,
 			EndpointJSONPath: config.paths.endpointFile,
-		}); err != nil {
-			return nil, closeDBAfterError(err)
+		}); exportErr != nil {
+			return nil, closeDBAfterError(exportErr)
 		}
-		status, err := db.Status(ctx)
-		if err != nil {
-			return nil, closeDBAfterError(err)
+		rollbackStatus, rollbackStatusErr := db.Status(ctx)
+		if rollbackStatusErr != nil {
+			return nil, closeDBAfterError(rollbackStatusErr)
 		}
-		if status.Authority != state.AuthorityJSON || !status.RollbackExported {
-			return nil, closeDBAfterError(errors.New("rollback export did not establish JSON authority"))
+		if rollbackStatus.Authority != state.AuthorityJSON || !rollbackStatus.RollbackExported {
+			return nil, closeDBAfterError(errRollbackJSONAuthorityMissing)
 		}
-		if err := db.Close(); err != nil {
-			return nil, errors.Join(err, startup.Close())
+		if closeErr := db.Close(); closeErr != nil {
+			return nil, errors.Join(closeErr, startup.Close())
 		}
-		if err := initializeRollbackJSON(ctx, startup, config, deps); err != nil {
-			return nil, startup.closeAfterError(err)
+		if initializeErr := initializeRollbackJSON(ctx, startup, config, deps); initializeErr != nil {
+			return nil, startup.closeAfterError(initializeErr)
 		}
 		return startup, nil
 	}
 
-	bootID, err := deps.currentBootID()
-	if err != nil {
-		return nil, closeDBAfterError(fmt.Errorf("getting current boot ID: %w", err))
+	bootID, bootIDErr := deps.currentBootID()
+	if bootIDErr != nil {
+		return nil, closeDBAfterError(fmt.Errorf("getting current boot ID: %w", bootIDErr))
 	}
 	importOptions := state.ImportOptions{
 		CNSPath:             config.paths.stateFile,
@@ -146,25 +167,25 @@ func newBoltPersistentStateStartup(
 	}
 	switch status.Authority {
 	case state.AuthorityBolt:
-		if _, err := db.ImportLegacy(ctx, importOptions); err != nil {
-			return nil, closeDBAfterError(err)
+		if _, importErr := db.ImportLegacy(ctx, importOptions); importErr != nil {
+			return nil, closeDBAfterError(importErr)
 		}
 	case state.AuthorityJSON:
-		if _, err := db.ReimportLegacy(ctx, importOptions, config.bootPolicy); err != nil {
-			return nil, closeDBAfterError(err)
+		if _, reimportErr := db.ReimportLegacy(ctx, importOptions, config.bootPolicy); reimportErr != nil {
+			return nil, closeDBAfterError(reimportErr)
 		}
 	default:
-		return nil, closeDBAfterError(fmt.Errorf("unsupported persistent state authority %q", status.Authority))
+		return nil, closeDBAfterError(fmt.Errorf("%w: %q", errUnsupportedStateAuthority, status.Authority))
 	}
-	if _, err := db.ApplyBoot(ctx, bootID, config.bootPolicy); err != nil {
-		return nil, closeDBAfterError(err)
+	if _, bootErr := db.ApplyBoot(ctx, bootID, config.bootPolicy); bootErr != nil {
+		return nil, closeDBAfterError(bootErr)
 	}
-	if _, err := db.RefreshMetrics(ctx); err != nil {
-		return nil, closeDBAfterError(err)
+	if _, metricsErr := db.RefreshMetrics(ctx); metricsErr != nil {
+		return nil, closeDBAfterError(metricsErr)
 	}
-	attachment, err := deps.attachBolt(db)
-	if err != nil {
-		return nil, closeDBAfterError(fmt.Errorf("attaching Bolt persistent state: %w", err))
+	attachment, attachmentErr := deps.attachBolt(db)
+	if attachmentErr != nil {
+		return nil, closeDBAfterError(fmt.Errorf("attaching Bolt persistent state: %w", attachmentErr))
 	}
 	startup.attachments = append(startup.attachments, attachment)
 	return startup, nil
@@ -207,17 +228,17 @@ func acquireLegacyLock(
 	newLock func(string) (processlock.Interface, error),
 ) (processlock.Interface, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("acquiring legacy state lock: %w", err)
 	}
 	lock, err := newLock(path)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating legacy state lock: %w", err)
 	}
-	if err := lock.Lock(); err != nil {
-		return nil, err
+	if lockErr := lock.Lock(); lockErr != nil {
+		return nil, fmt.Errorf("locking legacy state: %w", lockErr)
 	}
-	if err := ctx.Err(); err != nil {
-		return nil, errors.Join(err, lock.Unlock())
+	if contextErr := ctx.Err(); contextErr != nil {
+		return nil, errors.Join(contextErr, lock.Unlock())
 	}
 	return lock, nil
 }
@@ -229,35 +250,35 @@ func validateBoltStartup(
 ) error {
 	switch {
 	case start == nil:
-		return errors.New("persistent state start callback is nil")
+		return errNilStateStartCallback
 	case config.mode != boltStartupNormal && config.mode != boltStartupRollback:
-		return errors.New("persistent state startup mode is invalid")
+		return errInvalidStateStartupMode
 	case config.paths.stateDirectory == "":
-		return errors.New("persistent state directory is empty")
+		return errEmptyStateDirectory
 	case config.paths.databaseFile == "":
-		return errors.New("persistent state database path is empty")
+		return errEmptyStateDatabasePath
 	case config.paths.stateFile == "":
-		return errors.New("legacy CNS state path is empty")
+		return errEmptyLegacyCNSPath
 	case config.paths.stateLockFile == "":
-		return errors.New("legacy CNS lock path is empty")
+		return errEmptyLegacyCNSLockPath
 	case config.paths.endpointFile == "":
-		return errors.New("legacy endpoint state path is empty")
+		return errEmptyLegacyEndpointPath
 	case config.paths.endpointLockFile == "":
-		return errors.New("legacy endpoint lock path is empty")
+		return errEmptyLegacyEndpointLockPath
 	case deps.createDirectory == nil:
-		return errors.New("persistent state directory creator is nil")
+		return errNilStateDirectoryCreator
 	case deps.newFileLock == nil:
-		return errors.New("persistent state lock factory is nil")
+		return errNilStateLockFactory
 	case deps.openDB == nil:
-		return errors.New("persistent state database opener is nil")
+		return errNilStateDatabaseOpener
 	case config.mode == boltStartupNormal && deps.currentBootID == nil:
-		return errors.New("persistent state boot ID provider is nil")
+		return errNilStateBootIDProvider
 	case config.mode == boltStartupNormal && deps.attachBolt == nil:
-		return errors.New("persistent state Bolt attachment is nil")
+		return errNilStateBoltAttachment
 	case config.mode == boltStartupRollback && deps.openStore == nil:
-		return errors.New("persistent state JSON opener is nil")
+		return errNilStateJSONOpener
 	case config.mode == boltStartupRollback && deps.restoreJSON == nil:
-		return errors.New("persistent state JSON restore callback is nil")
+		return errNilStateJSONRestoreCallback
 	}
 	return nil
 }

--- a/cns/service/bolt_startup_test.go
+++ b/cns/service/bolt_startup_test.go
@@ -1,0 +1,535 @@
+// Copyright 2026 Microsoft. All rights reserved.
+// MIT License
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-container-networking/cns/state"
+	"github.com/Azure/azure-container-networking/processlock"
+	"github.com/Azure/azure-container-networking/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type startupTestLock struct {
+	name        string
+	events      *[]string
+	lockCalls   int
+	unlockCalls int
+	lockErr     error
+}
+
+func (l *startupTestLock) Lock() error {
+	l.lockCalls++
+	*l.events = append(*l.events, "lock:"+l.name)
+	return l.lockErr
+}
+
+func (l *startupTestLock) Unlock() error {
+	l.unlockCalls++
+	*l.events = append(*l.events, "unlock:"+l.name)
+	return nil
+}
+
+func TestBoltPersistentStateStartupFirstImportAndRestart(t *testing.T) {
+	paths := writeStartupLegacyState(t, "node-before-migration")
+	var events []string
+	deps, locks, restoreCount, closeCount := startupTestDependencies(t, &events)
+	listenerCount := 0
+	config := boltPersistentStateConfig{
+		paths:               paths,
+		mode:                boltStartupNormal,
+		manageEndpointState: true,
+		options:             state.Options{Timeout: 50 * time.Millisecond},
+	}
+
+	startup, err := newBoltPersistentStateStartup(context.Background(), config, func(context.Context) error {
+		listenerCount++
+		events = append(events, "listener")
+		return nil
+	}, deps)
+	require.NoError(t, err)
+	require.Zero(t, listenerCount)
+	require.NoError(t, startup.Start(context.Background()))
+	require.Equal(t, 1, listenerCount)
+	require.Equal(t, 1, *restoreCount)
+	require.Equal(t, []string{"lock:state", "lock:endpoint", "restore", "listener"}, events)
+	require.NoError(t, startup.Close())
+	require.Equal(t, 1, *closeCount)
+	require.Equal(t, 1, (*locks)[0].unlockCalls)
+	require.Equal(t, 1, (*locks)[1].unlockCalls)
+	assert.Equal(t, "unlock:endpoint", events[len(events)-2])
+	assert.Equal(t, "unlock:state", events[len(events)-1])
+
+	db, err := state.Open(paths.databaseFile, state.Options{})
+	require.NoError(t, err)
+	snapshot, err := db.Snapshot(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, state.AuthorityBolt, snapshot.Metadata.Authority)
+	assert.True(t, snapshot.Metadata.LegacyImportComplete)
+	assert.Equal(t, "boot-1", snapshot.Metadata.BootID)
+	assert.Equal(t, "node-before-migration", snapshot.Metadata.NodeID)
+	require.NoError(t, db.Close())
+
+	require.NoError(t, os.WriteFile(paths.stateFile, []byte(`not JSON`), 0o600))
+	require.NoError(t, os.Remove(paths.endpointFile))
+	events = nil
+	deps, _, restoreCount, closeCount = startupTestDependencies(t, &events)
+	restarted, err := newBoltPersistentStateStartup(context.Background(), config, func(context.Context) error {
+		listenerCount++
+		return nil
+	}, deps)
+	require.NoError(t, err)
+	require.NoError(t, restarted.Start(context.Background()))
+	require.Equal(t, 2, listenerCount)
+	require.Equal(t, 1, *restoreCount)
+	require.NoError(t, restarted.Close())
+	require.Equal(t, 1, *closeCount)
+	db, err = state.Open(paths.databaseFile, state.Options{})
+	require.NoError(t, err)
+	restartedSnapshot, err := db.Snapshot(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, snapshot.Metadata.Generation, restartedSnapshot.Metadata.Generation)
+	assert.Equal(t, snapshot.Metadata.BootID, restartedSnapshot.Metadata.BootID)
+	require.NoError(t, db.Close())
+
+	events = nil
+	deps, _, _, _ = startupTestDependencies(t, &events)
+	deps.currentBootID = func() (string, error) { return "boot-2", nil }
+	newBoot, err := newBoltPersistentStateStartup(context.Background(), config, func(context.Context) error {
+		listenerCount++
+		return nil
+	}, deps)
+	require.NoError(t, err)
+	require.NoError(t, newBoot.Start(context.Background()))
+	require.NoError(t, newBoot.Close())
+	db, err = state.Open(paths.databaseFile, state.Options{})
+	require.NoError(t, err)
+	newBootSnapshot, err := db.Snapshot(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "boot-2", newBootSnapshot.Metadata.BootID)
+	assert.Equal(t, restartedSnapshot.Metadata.Generation+1, newBootSnapshot.Metadata.Generation)
+	require.NoError(t, db.Close())
+}
+
+func TestBoltPersistentStateStartupRollbackAndReupgrade(t *testing.T) {
+	paths := writeStartupLegacyState(t, "node-before-rollback")
+	var events []string
+	deps, _, _, _ := startupTestDependencies(t, &events)
+	config := boltPersistentStateConfig{
+		paths:               paths,
+		mode:                boltStartupNormal,
+		manageEndpointState: true,
+		options:             state.Options{Timeout: 50 * time.Millisecond},
+	}
+	startup, err := newBoltPersistentStateStartup(
+		context.Background(),
+		config,
+		func(context.Context) error { return nil },
+		deps,
+	)
+	require.NoError(t, err)
+	require.NoError(t, startup.Start(context.Background()))
+	require.NoError(t, startup.Close())
+
+	events = nil
+	deps, _, _, _ = startupTestDependencies(t, &events)
+	var restoredNode string
+	deps.restoreJSON = func(_ context.Context, stateStore, endpointStore store.KeyValueStore) error {
+		var cnsState struct {
+			NodeID string
+		}
+		if err := stateStore.Read("ContainerNetworkService", &cnsState); err != nil {
+			return err
+		}
+		var endpoints map[string]any
+		if err := endpointStore.Read("Endpoints", &endpoints); err != nil {
+			return err
+		}
+		restoredNode = cnsState.NodeID
+		events = append(events, "json-restore")
+		return nil
+	}
+	config.mode = boltStartupRollback
+	listenerCount := 0
+	rollback, err := newBoltPersistentStateStartup(context.Background(), config, func(context.Context) error {
+		listenerCount++
+		events = append(events, "listener")
+		return nil
+	}, deps)
+	require.NoError(t, err)
+	require.Zero(t, listenerCount)
+	require.NotNil(t, rollback.stateStore)
+	require.NotNil(t, rollback.endpointStateStore)
+	require.NoError(t, rollback.Start(context.Background()))
+	require.Equal(t, 1, listenerCount)
+	require.Equal(t, "node-before-rollback", restoredNode)
+	require.Equal(t, []string{"lock:state", "lock:endpoint", "json-restore", "listener"}, events)
+	require.NoError(t, rollback.Close())
+
+	mutateStartupNodeID(t, paths.stateFile, "node-after-rollback")
+	events = nil
+	deps, _, restoreCount, closeCount := startupTestDependencies(t, &events)
+	deps.currentBootID = func() (string, error) { return "boot-2", nil }
+	config.mode = boltStartupNormal
+	reupgrade, err := newBoltPersistentStateStartup(context.Background(), config, func(context.Context) error {
+		listenerCount++
+		return nil
+	}, deps)
+	require.NoError(t, err)
+	require.NoError(t, reupgrade.Start(context.Background()))
+	require.Equal(t, 2, listenerCount)
+	require.Equal(t, 1, *restoreCount)
+	require.NoError(t, reupgrade.Close())
+	require.Equal(t, 1, *closeCount)
+
+	db, err := state.Open(paths.databaseFile, state.Options{})
+	require.NoError(t, err)
+	defer db.Close()
+	snapshot, err := db.Snapshot(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, state.AuthorityBolt, snapshot.Metadata.Authority)
+	assert.False(t, snapshot.Metadata.RollbackExportComplete)
+	assert.True(t, snapshot.Metadata.LegacyImportComplete)
+	assert.Equal(t, "boot-2", snapshot.Metadata.BootID)
+	assert.Equal(t, "node-after-rollback", snapshot.Metadata.NodeID)
+}
+
+func TestBoltPersistentStateStartupFailuresGateListenerAndReleaseLocks(t *testing.T) {
+	bootErr := errors.New("boot provider failure")
+	attachErr := errors.New("adapter failure")
+	openErr := errors.New("open failure")
+	tests := []struct {
+		name   string
+		mutate func(*boltPersistentStateDependencies, *boltPersistentStateConfig)
+		want   error
+	}{
+		{
+			name: "open",
+			mutate: func(deps *boltPersistentStateDependencies, _ *boltPersistentStateConfig) {
+				deps.openDB = func(context.Context, string, state.Options) (*state.DB, error) { return nil, openErr }
+			},
+			want: openErr,
+		},
+		{
+			name: "boot identity",
+			mutate: func(deps *boltPersistentStateDependencies, _ *boltPersistentStateConfig) {
+				deps.currentBootID = func() (string, error) { return "", bootErr }
+			},
+			want: bootErr,
+		},
+		{
+			name: "adapter",
+			mutate: func(deps *boltPersistentStateDependencies, _ *boltPersistentStateConfig) {
+				deps.attachBolt = func(*state.DB) (persistentStateAttachment, error) {
+					return persistentStateAttachment{}, attachErr
+				}
+			},
+			want: attachErr,
+		},
+		{
+			name: "malformed import",
+			mutate: func(_ *boltPersistentStateDependencies, config *boltPersistentStateConfig) {
+				require.NoError(t, os.WriteFile(config.paths.stateFile, []byte(`not JSON`), 0o600))
+			},
+			want: state.ErrLegacyImportSource,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			paths := writeStartupLegacyState(t, "node-1")
+			var events []string
+			deps, locks, _, _ := startupTestDependencies(t, &events)
+			config := boltPersistentStateConfig{
+				paths:               paths,
+				mode:                boltStartupNormal,
+				manageEndpointState: true,
+				options:             state.Options{Timeout: 50 * time.Millisecond},
+			}
+			tt.mutate(&deps, &config)
+			listenerCount := 0
+			startup, err := newBoltPersistentStateStartup(context.Background(), config, func(context.Context) error {
+				listenerCount++
+				return nil
+			}, deps)
+			require.ErrorIs(t, err, tt.want)
+			require.Nil(t, startup)
+			require.Zero(t, listenerCount)
+			for _, lock := range *locks {
+				require.Equal(t, 1, lock.unlockCalls)
+			}
+			if !errors.Is(tt.want, openErr) {
+				db, reopenErr := state.Open(paths.databaseFile, state.Options{Timeout: 50 * time.Millisecond})
+				require.NoError(t, reopenErr)
+				require.NoError(t, db.Close())
+			}
+		})
+	}
+}
+
+func TestBoltPersistentStateStartupRestoreFailureClosesDatabase(t *testing.T) {
+	paths := writeStartupLegacyState(t, "node-1")
+	var events []string
+	deps, locks, _, closeCount := startupTestDependencies(t, &events)
+	restoreErr := errors.New("projection failure")
+	deps.attachBolt = func(db *state.DB) (persistentStateAttachment, error) {
+		return persistentStateAttachment{
+			restore: func(context.Context) error { return restoreErr },
+			close: func() error {
+				*closeCount++
+				return db.Close()
+			},
+		}, nil
+	}
+	listenerCount := 0
+	startup, err := newBoltPersistentStateStartup(context.Background(), boltPersistentStateConfig{
+		paths:               paths,
+		mode:                boltStartupNormal,
+		manageEndpointState: true,
+	}, func(context.Context) error {
+		listenerCount++
+		return nil
+	}, deps)
+	require.NoError(t, err)
+	err = startup.Start(context.Background())
+	require.ErrorIs(t, err, restoreErr)
+	require.Zero(t, listenerCount)
+	require.Equal(t, 1, *closeCount)
+	for _, lock := range *locks {
+		require.Equal(t, 1, lock.unlockCalls)
+	}
+	reopened, err := state.Open(paths.databaseFile, state.Options{Timeout: 50 * time.Millisecond})
+	require.NoError(t, err)
+	require.NoError(t, reopened.Close())
+}
+
+func TestBoltPersistentStateStartupLockFailures(t *testing.T) {
+	lockErr := errors.New("legacy lock failure")
+	for _, tt := range []struct {
+		name     string
+		failCall int
+	}{
+		{name: "state lock", failCall: 1},
+		{name: "endpoint lock", failCall: 2},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			paths := writeStartupLegacyState(t, "node-1")
+			var events []string
+			deps, locks, _, _ := startupTestDependencies(t, &events)
+			lockCalls := 0
+			deps.newFileLock = func(path string) (processlock.Interface, error) {
+				lockCalls++
+				name := "state"
+				if filepath.Base(path) == "endpoint.lock" {
+					name = "endpoint"
+				}
+				lock := &startupTestLock{name: name, events: &events}
+				if lockCalls == tt.failCall {
+					lock.lockErr = lockErr
+				}
+				*locks = append(*locks, lock)
+				return lock, nil
+			}
+			listenerCount := 0
+			startup, err := newBoltPersistentStateStartup(context.Background(), boltPersistentStateConfig{
+				paths:               paths,
+				mode:                boltStartupNormal,
+				manageEndpointState: true,
+			}, func(context.Context) error {
+				listenerCount++
+				return nil
+			}, deps)
+			require.ErrorIs(t, err, lockErr)
+			require.Nil(t, startup)
+			require.Zero(t, listenerCount)
+			require.NoFileExists(t, paths.databaseFile)
+			if tt.failCall == 2 {
+				require.Equal(t, 1, (*locks)[0].unlockCalls)
+			}
+			require.Equal(t, 0, (*locks)[tt.failCall-1].unlockCalls)
+		})
+	}
+}
+
+func TestBoltPersistentStateStartupCancellationAndDBLockTimeout(t *testing.T) {
+	t.Run("canceled before startup", func(t *testing.T) {
+		paths := writeStartupLegacyState(t, "node-1")
+		var events []string
+		deps, locks, _, _ := startupTestDependencies(t, &events)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		listenerCount := 0
+		startup, err := newBoltPersistentStateStartup(ctx, boltPersistentStateConfig{
+			paths:               paths,
+			mode:                boltStartupNormal,
+			manageEndpointState: true,
+		}, func(context.Context) error {
+			listenerCount++
+			return nil
+		}, deps)
+		require.ErrorIs(t, err, context.Canceled)
+		require.Nil(t, startup)
+		require.Zero(t, listenerCount)
+		require.Empty(t, *locks)
+	})
+
+	t.Run("database locked", func(t *testing.T) {
+		paths := writeStartupLegacyState(t, "node-1")
+		held, err := state.Open(paths.databaseFile, state.Options{})
+		require.NoError(t, err)
+		defer held.Close()
+		var events []string
+		deps, locks, _, _ := startupTestDependencies(t, &events)
+		listenerCount := 0
+		started := time.Now()
+		startup, err := newBoltPersistentStateStartup(context.Background(), boltPersistentStateConfig{
+			paths:               paths,
+			mode:                boltStartupNormal,
+			manageEndpointState: true,
+			options:             state.Options{Timeout: 30 * time.Millisecond},
+		}, func(context.Context) error {
+			listenerCount++
+			return nil
+		}, deps)
+		require.Error(t, err)
+		require.Nil(t, startup)
+		require.Zero(t, listenerCount)
+		assert.Less(t, time.Since(started), time.Second)
+		for _, lock := range *locks {
+			require.Equal(t, 1, lock.unlockCalls)
+		}
+	})
+
+	t.Run("canceled while opening database", func(t *testing.T) {
+		paths := writeStartupLegacyState(t, "node-1")
+		var events []string
+		deps, locks, _, _ := startupTestDependencies(t, &events)
+		deps.openDB = func(ctx context.Context, _ string, _ state.Options) (*state.DB, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+		listenerCount := 0
+		startup, err := newBoltPersistentStateStartup(ctx, boltPersistentStateConfig{
+			paths:               paths,
+			mode:                boltStartupNormal,
+			manageEndpointState: true,
+		}, func(context.Context) error {
+			listenerCount++
+			return nil
+		}, deps)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Nil(t, startup)
+		require.Zero(t, listenerCount)
+		for _, lock := range *locks {
+			require.Equal(t, 1, lock.unlockCalls)
+		}
+	})
+}
+
+func startupTestDependencies(
+	t *testing.T,
+	events *[]string,
+) (boltPersistentStateDependencies, *[]*startupTestLock, *int, *int) {
+	t.Helper()
+	var locks []*startupTestLock
+	restoreCount := 0
+	closeCount := 0
+	deps := boltPersistentStateDependencies{
+		createDirectory: func(path string) error { return os.MkdirAll(path, 0o755) },
+		newFileLock: func(path string) (processlock.Interface, error) {
+			name := "state"
+			if filepath.Base(path) == "endpoint.lock" {
+				name = "endpoint"
+			}
+			lock := &startupTestLock{name: name, events: events}
+			locks = append(locks, lock)
+			return lock, nil
+		},
+		openStore: func(path string, lock processlock.Interface) (store.KeyValueStore, error) {
+			return store.NewJsonFileStore(path, lock, nil)
+		},
+		openDB:        state.OpenContext,
+		currentBootID: func() (string, error) { return "boot-1", nil },
+		attachBolt: func(db *state.DB) (persistentStateAttachment, error) {
+			return persistentStateAttachment{
+				restore: func(ctx context.Context) error {
+					restoreCount++
+					if _, err := db.Snapshot(ctx); err != nil {
+						return err
+					}
+					*events = append(*events, "restore")
+					return nil
+				},
+				close: func() error {
+					closeCount++
+					return db.Close()
+				},
+			}, nil
+		},
+		restoreJSON: func(context.Context, store.KeyValueStore, store.KeyValueStore) error { return nil },
+	}
+	return deps, &locks, &restoreCount, &closeCount
+}
+
+func writeStartupLegacyState(t *testing.T, nodeID string) persistentStatePaths {
+	t.Helper()
+	base := t.TempDir()
+	stateDirectory := filepath.Join(base, "state")
+	endpointDirectory := filepath.Join(base, "endpoint")
+	require.NoError(t, os.MkdirAll(stateDirectory, 0o755))
+	require.NoError(t, os.MkdirAll(endpointDirectory, 0o755))
+	paths := persistentStatePaths{
+		stateDirectory:    stateDirectory,
+		stateFile:         filepath.Join(stateDirectory, "azure-cns.json"),
+		databaseFile:      filepath.Join(stateDirectory, "azure-cns.db"),
+		stateLockFile:     filepath.Join(base, "state.lock"),
+		endpointDirectory: endpointDirectory,
+		endpointFile:      filepath.Join(endpointDirectory, "azure-endpoints.json"),
+		endpointLockFile:  filepath.Join(base, "endpoint.lock"),
+	}
+	cnsData, err := json.Marshal(map[string]any{
+		"ContainerNetworkService": map[string]any{
+			"Location":                         "eastus",
+			"NetworkType":                      "azure",
+			"OrchestratorType":                 "KubernetesCRD",
+			"NodeID":                           nodeID,
+			"Initialized":                      true,
+			"ContainerIDByOrchestratorContext": map[string]any{},
+			"ContainerStatus":                  map[string]any{},
+			"Networks":                         map[string]any{},
+			"TimeStamp":                        time.Now().UTC(),
+			"PnpIDByMacAddress":                map[string]any{},
+		},
+	})
+	require.NoError(t, err)
+	endpointData, err := json.Marshal(map[string]any{
+		"Endpoints":     map[string]any{},
+		"DeleteIntents": map[string]any{},
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(paths.stateFile, cnsData, 0o600))
+	require.NoError(t, os.WriteFile(paths.endpointFile, endpointData, 0o600))
+	return paths
+}
+
+func mutateStartupNodeID(t *testing.T, path, nodeID string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var envelope map[string]any
+	require.NoError(t, json.Unmarshal(data, &envelope))
+	envelope["ContainerNetworkService"].(map[string]any)["NodeID"] = nodeID
+	data, err = json.Marshal(envelope)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+}

--- a/cns/service/bolt_startup_test.go
+++ b/cns/service/bolt_startup_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,12 +20,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	errBoltBootProvider = errors.New("boot provider failure")
+	errBoltAdapter      = errors.New("adapter failure")
+	errBoltOpen         = errors.New("open failure")
+	errBoltProjection   = errors.New("projection failure")
+	errBoltLegacyLock   = errors.New("legacy lock failure")
+)
+
+const startupEndpointLockFile = "endpoint.lock"
+
 type startupTestLock struct {
 	name        string
 	events      *[]string
 	lockCalls   int
 	unlockCalls int
 	lockErr     error
+}
+
+func TestProductionBoltPersistentStateDependencies(t *testing.T) {
+	deps := productionBoltPersistentStateDependencies(
+		nil,
+		func(context.Context, store.KeyValueStore, store.KeyValueStore) error { return nil },
+	)
+	assert.NotNil(t, deps.createDirectory)
+	assert.NotNil(t, deps.newFileLock)
+	assert.NotNil(t, deps.openStore)
+	assert.NotNil(t, deps.openDB)
+	assert.NotNil(t, deps.currentBootID)
+	assert.NotNil(t, deps.attachBolt)
+	assert.NotNil(t, deps.restoreJSON)
 }
 
 func (l *startupTestLock) Lock() error {
@@ -147,12 +172,12 @@ func TestBoltPersistentStateStartupRollbackAndReupgrade(t *testing.T) {
 		var cnsState struct {
 			NodeID string
 		}
-		if err := stateStore.Read("ContainerNetworkService", &cnsState); err != nil {
-			return err
+		if readErr := stateStore.Read("ContainerNetworkService", &cnsState); readErr != nil {
+			return fmt.Errorf("reading rollback CNS state: %w", readErr)
 		}
 		var endpoints map[string]any
-		if err := endpointStore.Read("Endpoints", &endpoints); err != nil {
-			return err
+		if readErr := endpointStore.Read("Endpoints", &endpoints); readErr != nil {
+			return fmt.Errorf("reading rollback endpoint state: %w", readErr)
 		}
 		restoredNode = cnsState.NodeID
 		events = append(events, "json-restore")
@@ -204,9 +229,6 @@ func TestBoltPersistentStateStartupRollbackAndReupgrade(t *testing.T) {
 }
 
 func TestBoltPersistentStateStartupFailuresGateListenerAndReleaseLocks(t *testing.T) {
-	bootErr := errors.New("boot provider failure")
-	attachErr := errors.New("adapter failure")
-	openErr := errors.New("open failure")
 	tests := []struct {
 		name   string
 		mutate func(*boltPersistentStateDependencies, *boltPersistentStateConfig)
@@ -215,25 +237,27 @@ func TestBoltPersistentStateStartupFailuresGateListenerAndReleaseLocks(t *testin
 		{
 			name: "open",
 			mutate: func(deps *boltPersistentStateDependencies, _ *boltPersistentStateConfig) {
-				deps.openDB = func(context.Context, string, state.Options) (*state.DB, error) { return nil, openErr }
+				deps.openDB = func(context.Context, string, state.Options) (*state.DB, error) {
+					return nil, errBoltOpen
+				}
 			},
-			want: openErr,
+			want: errBoltOpen,
 		},
 		{
 			name: "boot identity",
 			mutate: func(deps *boltPersistentStateDependencies, _ *boltPersistentStateConfig) {
-				deps.currentBootID = func() (string, error) { return "", bootErr }
+				deps.currentBootID = func() (string, error) { return "", errBoltBootProvider }
 			},
-			want: bootErr,
+			want: errBoltBootProvider,
 		},
 		{
 			name: "adapter",
 			mutate: func(deps *boltPersistentStateDependencies, _ *boltPersistentStateConfig) {
 				deps.attachBolt = func(*state.DB) (persistentStateAttachment, error) {
-					return persistentStateAttachment{}, attachErr
+					return persistentStateAttachment{}, errBoltAdapter
 				}
 			},
-			want: attachErr,
+			want: errBoltAdapter,
 		},
 		{
 			name: "malformed import",
@@ -266,7 +290,7 @@ func TestBoltPersistentStateStartupFailuresGateListenerAndReleaseLocks(t *testin
 			for _, lock := range *locks {
 				require.Equal(t, 1, lock.unlockCalls)
 			}
-			if !errors.Is(tt.want, openErr) {
+			if !errors.Is(tt.want, errBoltOpen) {
 				db, reopenErr := state.Open(paths.databaseFile, state.Options{Timeout: 50 * time.Millisecond})
 				require.NoError(t, reopenErr)
 				require.NoError(t, db.Close())
@@ -279,10 +303,9 @@ func TestBoltPersistentStateStartupRestoreFailureClosesDatabase(t *testing.T) {
 	paths := writeStartupLegacyState(t, "node-1")
 	var events []string
 	deps, locks, _, closeCount := startupTestDependencies(t, &events)
-	restoreErr := errors.New("projection failure")
 	deps.attachBolt = func(db *state.DB) (persistentStateAttachment, error) {
 		return persistentStateAttachment{
-			restore: func(context.Context) error { return restoreErr },
+			restore: func(context.Context) error { return errBoltProjection },
 			close: func() error {
 				*closeCount++
 				return db.Close()
@@ -300,7 +323,7 @@ func TestBoltPersistentStateStartupRestoreFailureClosesDatabase(t *testing.T) {
 	}, deps)
 	require.NoError(t, err)
 	err = startup.Start(context.Background())
-	require.ErrorIs(t, err, restoreErr)
+	require.ErrorIs(t, err, errBoltProjection)
 	require.Zero(t, listenerCount)
 	require.Equal(t, 1, *closeCount)
 	for _, lock := range *locks {
@@ -312,7 +335,6 @@ func TestBoltPersistentStateStartupRestoreFailureClosesDatabase(t *testing.T) {
 }
 
 func TestBoltPersistentStateStartupLockFailures(t *testing.T) {
-	lockErr := errors.New("legacy lock failure")
 	for _, tt := range []struct {
 		name     string
 		failCall int
@@ -328,12 +350,12 @@ func TestBoltPersistentStateStartupLockFailures(t *testing.T) {
 			deps.newFileLock = func(path string) (processlock.Interface, error) {
 				lockCalls++
 				name := "state"
-				if filepath.Base(path) == "endpoint.lock" {
+				if filepath.Base(path) == startupEndpointLockFile {
 					name = "endpoint"
 				}
 				lock := &startupTestLock{name: name, events: &events}
 				if lockCalls == tt.failCall {
-					lock.lockErr = lockErr
+					lock.lockErr = errBoltLegacyLock
 				}
 				*locks = append(*locks, lock)
 				return lock, nil
@@ -347,7 +369,7 @@ func TestBoltPersistentStateStartupLockFailures(t *testing.T) {
 				listenerCount++
 				return nil
 			}, deps)
-			require.ErrorIs(t, err, lockErr)
+			require.ErrorIs(t, err, errBoltLegacyLock)
 			require.Nil(t, startup)
 			require.Zero(t, listenerCount)
 			require.NoFileExists(t, paths.databaseFile)
@@ -414,7 +436,7 @@ func TestBoltPersistentStateStartupCancellationAndDBLockTimeout(t *testing.T) {
 		deps, locks, _, _ := startupTestDependencies(t, &events)
 		deps.openDB = func(ctx context.Context, _ string, _ state.Options) (*state.DB, error) {
 			<-ctx.Done()
-			return nil, ctx.Err()
+			return nil, fmt.Errorf("waiting for startup cancellation: %w", ctx.Err())
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		defer cancel()
@@ -439,16 +461,21 @@ func TestBoltPersistentStateStartupCancellationAndDBLockTimeout(t *testing.T) {
 func startupTestDependencies(
 	t *testing.T,
 	events *[]string,
-) (boltPersistentStateDependencies, *[]*startupTestLock, *int, *int) {
+) (
+	deps boltPersistentStateDependencies,
+	locksOut *[]*startupTestLock,
+	restoreCountOut *int,
+	closeCountOut *int,
+) {
 	t.Helper()
 	var locks []*startupTestLock
 	restoreCount := 0
 	closeCount := 0
-	deps := boltPersistentStateDependencies{
+	deps = boltPersistentStateDependencies{
 		createDirectory: func(path string) error { return os.MkdirAll(path, 0o755) },
 		newFileLock: func(path string) (processlock.Interface, error) {
 			name := "state"
-			if filepath.Base(path) == "endpoint.lock" {
+			if filepath.Base(path) == startupEndpointLockFile {
 				name = "endpoint"
 			}
 			lock := &startupTestLock{name: name, events: events}
@@ -465,7 +492,7 @@ func startupTestDependencies(
 				restore: func(ctx context.Context) error {
 					restoreCount++
 					if _, err := db.Snapshot(ctx); err != nil {
-						return err
+						return fmt.Errorf("reading startup test snapshot: %w", err)
 					}
 					*events = append(*events, "restore")
 					return nil
@@ -495,7 +522,7 @@ func writeStartupLegacyState(t *testing.T, nodeID string) persistentStatePaths {
 		stateLockFile:     filepath.Join(base, "state.lock"),
 		endpointDirectory: endpointDirectory,
 		endpointFile:      filepath.Join(endpointDirectory, "azure-endpoints.json"),
-		endpointLockFile:  filepath.Join(base, "endpoint.lock"),
+		endpointLockFile:  filepath.Join(base, startupEndpointLockFile),
 	}
 	cnsData, err := json.Marshal(map[string]any{
 		"ContainerNetworkService": map[string]any{

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -740,14 +740,7 @@ func main() {
 	}
 
 	persistentState, err := newJSONPersistentStateStartup(
-		persistentStatePaths{
-			stateDirectory:    storeFileLocation,
-			stateFile:         storeFileLocation + name + ".json",
-			stateLockFile:     platform.CNILockPath + name + store.LockExtension,
-			endpointDirectory: endpointStorePath,
-			endpointFile:      endpointStorePath + endpointStoreName + ".json",
-			endpointLockFile:  platform.CNILockPath + endpointStoreName + store.LockExtension,
-		},
+		resolvePersistentStatePaths(storeFileLocation, endpointStorePath),
 		cnsconfig.ManageEndpointState,
 		func(context.Context) error {
 			return httpRemoteRestService.Start(&config)

--- a/cns/service/persistent_state.go
+++ b/cns/service/persistent_state.go
@@ -19,9 +19,12 @@ var (
 	errNilPersistentStateCloseCallback   = errors.New("persistent state close callback is nil")
 )
 
+const persistentStateLockExtension = store.LockExtension
+
 type persistentStatePaths struct {
 	stateDirectory    string
 	stateFile         string
+	databaseFile      string
 	stateLockFile     string
 	endpointDirectory string
 	endpointFile      string
@@ -145,8 +148,8 @@ func (s *persistentStateStartup) Close() error {
 				closeErrs = append(closeErrs, err)
 			}
 		}
-		for _, lock := range s.locks {
-			if err := lock.Unlock(); err != nil && !errors.Is(err, processlock.ErrInvalidFile) {
+		for i := len(s.locks) - 1; i >= 0; i-- {
+			if err := s.locks[i].Unlock(); err != nil && !errors.Is(err, processlock.ErrInvalidFile) {
 				closeErrs = append(closeErrs, err)
 			}
 		}

--- a/cns/service/persistent_state_linux.go
+++ b/cns/service/persistent_state_linux.go
@@ -3,4 +3,27 @@
 
 package main
 
-const defaultEndpointStorePath = "/var/run/azure-cns/"
+import "github.com/Azure/azure-container-networking/platform"
+
+const (
+	defaultEndpointStorePath = "/var/run/azure-cns/"
+	defaultStateStorePath    = "/var/lib/azure-network/"
+)
+
+func resolvePersistentStatePaths(stateDirectory, endpointDirectory string) persistentStatePaths {
+	if stateDirectory == "" {
+		stateDirectory = defaultStateStorePath
+	}
+	if endpointDirectory == "" {
+		endpointDirectory = defaultEndpointStorePath
+	}
+	return persistentStatePaths{
+		stateDirectory:    stateDirectory,
+		stateFile:         stateDirectory + name + ".json",
+		databaseFile:      stateDirectory + name + ".db",
+		stateLockFile:     platform.CNILockPath + name + persistentStateLockExtension,
+		endpointDirectory: endpointDirectory,
+		endpointFile:      endpointDirectory + endpointStoreName + ".json",
+		endpointLockFile:  platform.CNILockPath + endpointStoreName + persistentStateLockExtension,
+	}
+}

--- a/cns/service/persistent_state_linux_test.go
+++ b/cns/service/persistent_state_linux_test.go
@@ -1,0 +1,30 @@
+//go:build linux
+
+// Copyright 2026 Microsoft. All rights reserved.
+// MIT License
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolvePersistentStatePaths(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		paths := resolvePersistentStatePaths("", "")
+		require.Equal(t, "/var/lib/azure-network/azure-cns.json", paths.stateFile)
+		require.Equal(t, "/var/lib/azure-network/azure-cns.db", paths.databaseFile)
+		require.Equal(t, "/var/run/azure-cns/azure-endpoints.json", paths.endpointFile)
+		require.Equal(t, "/var/run/azure-vnet/azure-cns.lock", paths.stateLockFile)
+		require.Equal(t, "/var/run/azure-vnet/azure-endpoints.lock", paths.endpointLockFile)
+	})
+
+	t.Run("configured directories preserve legacy concatenation", func(t *testing.T) {
+		paths := resolvePersistentStatePaths("/custom/cns/", "/custom/endpoints/")
+		require.Equal(t, "/custom/cns/azure-cns.json", paths.stateFile)
+		require.Equal(t, "/custom/cns/azure-cns.db", paths.databaseFile)
+		require.Equal(t, "/custom/endpoints/azure-endpoints.json", paths.endpointFile)
+	})
+}

--- a/cns/service/persistent_state_windows.go
+++ b/cns/service/persistent_state_windows.go
@@ -3,4 +3,26 @@
 
 package main
 
-const defaultEndpointStorePath = "/k/azurecns/"
+const (
+	defaultEndpointStorePath = "/k/azurecns/"
+	defaultStateStorePath    = ""
+)
+
+func resolvePersistentStatePaths(stateDirectory, endpointDirectory string) persistentStatePaths {
+	statePrefix := stateDirectory
+	if stateDirectory == "" {
+		stateDirectory = "."
+	}
+	if endpointDirectory == "" {
+		endpointDirectory = defaultEndpointStorePath
+	}
+	return persistentStatePaths{
+		stateDirectory:    stateDirectory,
+		stateFile:         statePrefix + name + ".json",
+		databaseFile:      statePrefix + name + ".db",
+		stateLockFile:     name + persistentStateLockExtension,
+		endpointDirectory: endpointDirectory,
+		endpointFile:      endpointDirectory + endpointStoreName + ".json",
+		endpointLockFile:  endpointStoreName + persistentStateLockExtension,
+	}
+}

--- a/cns/service/persistent_state_windows_test.go
+++ b/cns/service/persistent_state_windows_test.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+// Copyright 2026 Microsoft. All rights reserved.
+// MIT License
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolvePersistentStatePaths(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		paths := resolvePersistentStatePaths("", "")
+		require.Equal(t, ".", paths.stateDirectory)
+		require.Equal(t, "azure-cns.json", paths.stateFile)
+		require.Equal(t, "azure-cns.db", paths.databaseFile)
+		require.Equal(t, "/k/azurecns/azure-endpoints.json", paths.endpointFile)
+		require.Equal(t, "azure-cns.lock", paths.stateLockFile)
+		require.Equal(t, "azure-endpoints.lock", paths.endpointLockFile)
+	})
+
+	t.Run("configured directories preserve legacy concatenation", func(t *testing.T) {
+		paths := resolvePersistentStatePaths(`C:\cns\`, `C:\endpoints\`)
+		require.Equal(t, `C:\cns\azure-cns.json`, paths.stateFile)
+		require.Equal(t, `C:\cns\azure-cns.db`, paths.databaseFile)
+		require.Equal(t, `C:\endpoints\azure-endpoints.json`, paths.endpointFile)
+	})
+}

--- a/cns/state/db.go
+++ b/cns/state/db.go
@@ -24,6 +24,7 @@ var (
 	errUnknownAuthority = errors.New("unknown authority")
 	errInvalidUint32    = errors.New("invalid uint32 encoding length")
 	errInvalidUint64    = errors.New("invalid uint64 encoding length")
+	errNilOpenContext   = errors.New("opening cns state database: context is nil")
 )
 
 const defaultOpenTimeout = 5 * time.Second
@@ -87,7 +88,7 @@ func Open(path string, opts Options) (store *DB, returnErr error) {
 // startup cancellation through observability and bounded lock waits.
 func OpenContext(ctx context.Context, path string, opts Options) (store *DB, returnErr error) {
 	if ctx == nil {
-		return nil, errors.New("opening cns state database: context is nil")
+		return nil, errNilOpenContext
 	}
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("opening cns state database: %w", err)
@@ -128,12 +129,12 @@ func OpenContext(ctx context.Context, path string, opts Options) (store *DB, ret
 		}
 		return nil, fmt.Errorf("opening cns state database: %w", err)
 	}
-	if err := ctx.Err(); err != nil {
+	if contextErr := ctx.Err(); contextErr != nil {
 		_ = db.Close()
 		if !exists && !opts.ReadOnly {
 			_ = os.Remove(path)
 		}
-		return nil, fmt.Errorf("opening cns state database: %w", err)
+		return nil, fmt.Errorf("opening cns state database: %w", contextErr)
 	}
 
 	store = &DB{

--- a/cns/state/db.go
+++ b/cns/state/db.go
@@ -80,6 +80,18 @@ type DB struct {
 }
 
 func Open(path string, opts Options) (store *DB, returnErr error) {
+	return OpenContext(context.TODO(), path, opts)
+}
+
+// OpenContext opens and validates a persistent state database while preserving
+// startup cancellation through observability and bounded lock waits.
+func OpenContext(ctx context.Context, path string, opts Options) (store *DB, returnErr error) {
+	if ctx == nil {
+		return nil, errors.New("opening cns state database: context is nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("opening cns state database: %w", err)
+	}
 	if opts.Metrics != nil || opts.Logger != nil {
 		started := metricNow(opts.Metrics)
 		defer func() {
@@ -87,7 +99,7 @@ func Open(path string, opts Options) (store *DB, returnErr error) {
 			duration := metricDuration(opts.Metrics, started)
 			_ = opts.Metrics.ObserveLifecycle(LifecycleStartup, result, duration)
 			if returnErr == nil {
-				store.observeLifecycle(context.TODO(), LifecycleStartup, result, duration)
+				store.observeLifecycle(ctx, LifecycleStartup, result, duration)
 			}
 		}()
 	}
@@ -108,8 +120,18 @@ func Open(path string, opts Options) (store *DB, returnErr error) {
 		NoSync:   opts.NoSync,
 	})
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, fmt.Errorf("opening cns state database: %w", ctxErr)
+		}
 		if isBoltCorruption(err) {
 			return nil, corrupt("opening cns state database", err)
+		}
+		return nil, fmt.Errorf("opening cns state database: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		_ = db.Close()
+		if !exists && !opts.ReadOnly {
+			_ = os.Remove(path)
 		}
 		return nil, fmt.Errorf("opening cns state database: %w", err)
 	}
@@ -127,6 +149,11 @@ func Open(path string, opts Options) (store *DB, returnErr error) {
 		err = store.initialize()
 	} else {
 		err = store.validate()
+	}
+	if err == nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			err = fmt.Errorf("opening cns state database: %w", ctxErr)
+		}
 	}
 	if err != nil {
 		_ = db.Close()

--- a/cns/state/db_test.go
+++ b/cns/state/db_test.go
@@ -398,7 +398,7 @@ func TestOpenRejectsNonBoltFile(t *testing.T) {
 
 func TestOpenContextCancellation(t *testing.T) {
 	t.Run("nil context", func(t *testing.T) {
-		db, err := OpenContext(nil, filepath.Join(t.TempDir(), "state.db"), Options{})
+		db, err := OpenContext(nil, filepath.Join(t.TempDir(), "state.db"), Options{}) //nolint:staticcheck // Verifies the fail-closed nil-context guard.
 		require.Error(t, err)
 		require.Nil(t, db)
 	})

--- a/cns/state/db_test.go
+++ b/cns/state/db_test.go
@@ -396,6 +396,25 @@ func TestOpenRejectsNonBoltFile(t *testing.T) {
 	require.ErrorIs(t, err, ErrCorrupt)
 }
 
+func TestOpenContextCancellation(t *testing.T) {
+	t.Run("nil context", func(t *testing.T) {
+		db, err := OpenContext(nil, filepath.Join(t.TempDir(), "state.db"), Options{})
+		require.Error(t, err)
+		require.Nil(t, db)
+	})
+
+	t.Run("canceled before open", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "state.db")
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		db, err := OpenContext(ctx, path, Options{})
+		require.ErrorIs(t, err, context.Canceled)
+		require.Nil(t, db)
+		_, statErr := os.Stat(path)
+		require.ErrorIs(t, statErr, os.ErrNotExist)
+	})
+}
+
 func createValidClosedDB(t *testing.T) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "azure-cns.db")

--- a/cns/state/import.go
+++ b/cns/state/import.go
@@ -250,8 +250,8 @@ func (s *DB) reimportLegacyWithCommitHook(
 		return false, err
 	}
 	applyImportedBootPolicy(&snapshot, policy)
-	if err := snapshot.Validate(); err != nil {
-		return false, fmt.Errorf("%w: validating reimported snapshot: %w", ErrLegacyImportSource, err)
+	if validationErr := snapshot.Validate(); validationErr != nil {
+		return false, fmt.Errorf("%w: validating reimported snapshot: %w", ErrLegacyImportSource, validationErr)
 	}
 	encoded, err := encodeImportedSnapshot(snapshot)
 	if err != nil {
@@ -328,7 +328,8 @@ func applyImportedBootPolicy(snapshot *Snapshot, policy BootPolicy) {
 		snapshot.IPOwners = map[string]string{}
 	}
 	if policy.ResetReadiness {
-		for id, record := range snapshot.NetworkContainers {
+		for id := range snapshot.NetworkContainers {
+			record := snapshot.NetworkContainers[id]
 			record.HostVersion = ""
 			record.VFPUpdateComplete = false
 			snapshot.NetworkContainers[id] = record

--- a/cns/state/import.go
+++ b/cns/state/import.go
@@ -26,6 +26,8 @@ var (
 	ErrLegacyImportTargetNotEmpty = errors.New("cns state: legacy import target is not empty")
 	// ErrLegacyImportSource indicates that a legacy source is malformed or inconsistent.
 	ErrLegacyImportSource = errors.New("cns state: invalid legacy import source")
+	// ErrLegacyReimportState indicates that the database is not in the completed rollback state.
+	ErrLegacyReimportState = errors.New("cns state: legacy reimport requires JSON authority")
 )
 
 // Legacy network container/IP validation sentinels. These are static
@@ -133,26 +135,9 @@ func (s *DB) importLegacyWithCommitHook(
 		return false, nil
 	}
 
-	cnsData, err := readLegacyFile(ctx, readFile, opts.CNSPath, "CNS")
+	snapshot, err := readLegacySnapshot(ctx, opts, readFile)
 	if err != nil {
 		return false, err
-	}
-	snapshot, err := parseLegacyCNS(cnsData, opts.BootID)
-	if err != nil {
-		return false, err
-	}
-	if opts.ManageEndpointState {
-		var endpointData []byte
-		endpointData, err = readLegacyFile(ctx, readFile, opts.EndpointPath, "endpoint")
-		if err != nil {
-			return false, err
-		}
-		if endpointErr := addLegacyEndpoints(&snapshot, endpointData); endpointErr != nil {
-			return false, endpointErr
-		}
-	}
-	if err = snapshot.Validate(); err != nil {
-		return false, fmt.Errorf("%w: validating imported snapshot: %w", ErrLegacyImportSource, err)
 	}
 	encoded, err := encodeImportedSnapshot(snapshot)
 	if err != nil {
@@ -195,6 +180,150 @@ func (s *DB) importLegacyWithCommitHook(
 		}
 		return true, nil
 	})
+}
+
+// ReimportLegacy atomically replaces a completed rollback database from the
+// authoritative legacy JSON pair and returns authority to Bolt.
+func (s *DB) ReimportLegacy(
+	ctx context.Context,
+	opts ImportOptions,
+	policy BootPolicy,
+) (changed bool, returnErr error) {
+	if s.metrics != nil || s.logger != nil {
+		started := metricNow(s.metrics)
+		defer func() {
+			result := classifyResult(changed, returnErr)
+			duration := metricDuration(s.metrics, started)
+			_ = s.metrics.ObserveLifecycle(LifecycleImport, result, duration)
+			if returnErr == nil {
+				s.observeLifecycle(ctx, LifecycleImport, result, duration)
+			}
+		}()
+	}
+	return s.reimportLegacy(ctx, opts, policy, os.ReadFile)
+}
+
+func (s *DB) reimportLegacy(
+	ctx context.Context,
+	opts ImportOptions,
+	policy BootPolicy,
+	readFile readFileFunc,
+) (bool, error) {
+	opts.ManageEndpointState = true
+	if err := validateImportOptions(opts); err != nil {
+		return false, err
+	}
+	if readFile == nil {
+		return false, invalidInput("legacy state reader is nil", nil)
+	}
+	if err := ctx.Err(); err != nil {
+		return false, fmt.Errorf("reimporting legacy state: %w", err)
+	}
+
+	var eligible bool
+	if err := s.View(ctx, func(tx *ReadTx) error {
+		meta, err := tx.Metadata()
+		if err != nil {
+			return err
+		}
+		eligible = meta.Authority == AuthorityJSON && meta.RollbackExportComplete
+		return nil
+	}); err != nil {
+		return false, fmt.Errorf("checking legacy reimport state: %w", err)
+	}
+	if !eligible {
+		return false, ErrLegacyReimportState
+	}
+
+	snapshot, err := readLegacySnapshot(ctx, opts, readFile)
+	if err != nil {
+		return false, err
+	}
+	applyImportedBootPolicy(&snapshot, policy)
+	if err := snapshot.Validate(); err != nil {
+		return false, fmt.Errorf("%w: validating reimported snapshot: %w", ErrLegacyImportSource, err)
+	}
+	encoded, err := encodeImportedSnapshot(snapshot)
+	if err != nil {
+		return false, err
+	}
+
+	return s.update(ctx, func(tx *WriteTx) (bool, error) {
+		meta, err := tx.Metadata()
+		if err != nil {
+			return false, err
+		}
+		if meta.Authority != AuthorityJSON || !meta.RollbackExportComplete {
+			return false, ErrLegacyReimportState
+		}
+		for _, replacement := range encoded.buckets {
+			if err := replaceJSONBucket(tx.tx, replacement.name, replacement.values); err != nil {
+				return false, err
+			}
+		}
+		metadata := tx.tx.Bucket(bucketMetadata)
+		if err := metadata.Put(metaKeyBootID, []byte(snapshot.Metadata.BootID)); err != nil {
+			return false, fmt.Errorf("writing reimport boot ID: %w", err)
+		}
+		if err := metadata.Put(metaKeyAuthority, []byte(AuthorityBolt)); err != nil {
+			return false, fmt.Errorf("writing reimport authority: %w", err)
+		}
+		if err := metadata.Put(metaKeyService, encoded.serviceMetadata); err != nil {
+			return false, fmt.Errorf("writing reimported service metadata: %w", err)
+		}
+		if err := metadata.Put(metaKeyLegacyImport, []byte(legacyImportMarker)); err != nil {
+			return false, fmt.Errorf("writing legacy import marker: %w", err)
+		}
+		if err := metadata.Delete(metaKeyRollbackExport); err != nil {
+			return false, fmt.Errorf("clearing rollback export marker: %w", err)
+		}
+		if s.importBeforeCommit != nil {
+			if err := s.importBeforeCommit(); err != nil {
+				return false, fmt.Errorf("finishing legacy reimport: %w", err)
+			}
+		}
+		return true, nil
+	})
+}
+
+func readLegacySnapshot(ctx context.Context, opts ImportOptions, readFile readFileFunc) (Snapshot, error) {
+	cnsData, err := readLegacyFile(ctx, readFile, opts.CNSPath, "CNS")
+	if err != nil {
+		return Snapshot{}, err
+	}
+	snapshot, err := parseLegacyCNS(cnsData, opts.BootID)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	if opts.ManageEndpointState {
+		endpointData, err := readLegacyFile(ctx, readFile, opts.EndpointPath, "endpoint")
+		if err != nil {
+			return Snapshot{}, err
+		}
+		if err := addLegacyEndpoints(&snapshot, endpointData); err != nil {
+			return Snapshot{}, err
+		}
+	}
+	if err := snapshot.Validate(); err != nil {
+		return Snapshot{}, fmt.Errorf("%w: validating imported snapshot: %w", ErrLegacyImportSource, err)
+	}
+	return snapshot, nil
+}
+
+func applyImportedBootPolicy(snapshot *Snapshot, policy BootPolicy) {
+	snapshot.DeleteIntents = map[string]DeleteIntent{}
+	if policy.ClearEndpoints {
+		snapshot.Endpoints = map[string]EndpointRecord{}
+		snapshot.Assignments = map[string]AssignmentRecord{}
+		snapshot.IPOwners = map[string]string{}
+	}
+	if policy.ResetReadiness {
+		for id, record := range snapshot.NetworkContainers {
+			record.HostVersion = ""
+			record.VFPUpdateComplete = false
+			snapshot.NetworkContainers[id] = record
+		}
+	}
 }
 
 func validateImportOptions(opts ImportOptions) error {

--- a/cns/state/import.go
+++ b/cns/state/import.go
@@ -209,6 +209,16 @@ func (s *DB) reimportLegacy(
 	policy BootPolicy,
 	readFile readFileFunc,
 ) (bool, error) {
+	return s.reimportLegacyWithCommitHook(ctx, opts, policy, readFile, nil)
+}
+
+func (s *DB) reimportLegacyWithCommitHook(
+	ctx context.Context,
+	opts ImportOptions,
+	policy BootPolicy,
+	readFile readFileFunc,
+	beforeCommit func() error,
+) (bool, error) {
 	opts.ManageEndpointState = true
 	if err := validateImportOptions(opts); err != nil {
 		return false, err
@@ -277,8 +287,8 @@ func (s *DB) reimportLegacy(
 		if err := metadata.Delete(metaKeyRollbackExport); err != nil {
 			return false, fmt.Errorf("clearing rollback export marker: %w", err)
 		}
-		if s.importBeforeCommit != nil {
-			if err := s.importBeforeCommit(); err != nil {
+		if beforeCommit != nil {
+			if err := beforeCommit(); err != nil {
 				return false, fmt.Errorf("finishing legacy reimport: %w", err)
 			}
 		}

--- a/cns/state/reimport_test.go
+++ b/cns/state/reimport_test.go
@@ -120,14 +120,19 @@ func TestReimportLegacyFailuresAreAtomic(t *testing.T) {
 		require.True(t, changed)
 		before := requireValidSnapshot(t, db)
 		injected := errors.New("injected reimport failure")
-		db.importBeforeCommit = func() error { return injected }
 
-		changed, err = db.ReimportLegacy(context.Background(), ImportOptions{
-			CNSPath:             paths.CNSJSONPath,
-			EndpointPath:        paths.EndpointJSONPath,
-			ManageEndpointState: true,
-			BootID:              "new-boot",
-		}, BootPolicy{})
+		changed, err = db.reimportLegacyWithCommitHook(
+			context.Background(),
+			ImportOptions{
+				CNSPath:             paths.CNSJSONPath,
+				EndpointPath:        paths.EndpointJSONPath,
+				ManageEndpointState: true,
+				BootID:              "new-boot",
+			},
+			BootPolicy{},
+			os.ReadFile,
+			func() error { return injected },
+		)
 		require.ErrorIs(t, err, injected)
 		assert.False(t, changed)
 		assert.Equal(t, before, requireValidSnapshot(t, db))

--- a/cns/state/reimport_test.go
+++ b/cns/state/reimport_test.go
@@ -1,0 +1,168 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package state
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestReimportLegacyReplacesRolledBackState(t *testing.T) {
+	ctx := context.Background()
+	db, _ := openPopulatedExportDB(t)
+	metrics, err := NewMetrics(prometheus.NewRegistry())
+	require.NoError(t, err)
+	db.metrics = metrics
+	db.logger = zap.NewNop()
+	before := requireValidSnapshot(t, db)
+	paths := exportPaths(t)
+	changed, err := db.ExportLegacy(ctx, paths)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	cnsData := mutateLegacyCNS(t, readRollbackFile(t, paths.CNSJSONPath), func(source map[string]any) {
+		source["NodeID"] = "node-after-rollback"
+	})
+	endpointData := mutateLegacyEndpoints(t, readRollbackFile(t, paths.EndpointJSONPath), func(endpoints map[string]any) {
+		endpoints["container-1"].(map[string]any)["PodName"] = "pod-after-rollback"
+	})
+	require.NoError(t, os.WriteFile(paths.CNSJSONPath, cnsData, 0o600))
+	require.NoError(t, os.WriteFile(paths.EndpointJSONPath, endpointData, 0o600))
+
+	changed, err = db.ReimportLegacy(ctx, ImportOptions{
+		CNSPath:             paths.CNSJSONPath,
+		EndpointPath:        paths.EndpointJSONPath,
+		ManageEndpointState: true,
+		BootID:              "boot-after-rollback",
+	}, BootPolicy{ResetReadiness: true})
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	after := requireValidSnapshot(t, db)
+	assert.Equal(t, AuthorityBolt, after.Metadata.Authority)
+	assert.True(t, after.Metadata.LegacyImportComplete)
+	assert.False(t, after.Metadata.RollbackExportComplete)
+	assert.Equal(t, "boot-after-rollback", after.Metadata.BootID)
+	assert.Equal(t, before.Metadata.Generation+2, after.Metadata.Generation)
+	assert.Equal(t, "node-after-rollback", after.Metadata.NodeID)
+	assert.Equal(t, "pod-after-rollback", after.Endpoints["container-1"].PodName)
+	assert.Empty(t, after.DeleteIntents)
+	for _, record := range after.NetworkContainers {
+		assert.Empty(t, record.HostVersion)
+		assert.False(t, record.VFPUpdateComplete)
+	}
+
+	path := db.db.Path()
+	require.NoError(t, db.Close())
+	reopened, err := Open(path, Options{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = reopened.Close() })
+	restarted := requireValidSnapshot(t, reopened)
+	assert.Equal(t, after, restarted)
+}
+
+func TestReimportLegacyClearsEndpointsByBootPolicy(t *testing.T) {
+	db, _ := openPopulatedExportDB(t)
+	paths := exportPaths(t)
+	changed, err := db.ExportLegacy(context.Background(), paths)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	changed, err = db.ReimportLegacy(context.Background(), ImportOptions{
+		CNSPath:             paths.CNSJSONPath,
+		EndpointPath:        paths.EndpointJSONPath,
+		ManageEndpointState: true,
+		BootID:              "new-boot",
+	}, BootPolicy{ClearEndpoints: true})
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	snapshot := requireValidSnapshot(t, db)
+	assert.Empty(t, snapshot.Endpoints)
+	assert.Empty(t, snapshot.Assignments)
+	assert.Empty(t, snapshot.IPOwners)
+}
+
+func TestReimportLegacyFailuresAreAtomic(t *testing.T) {
+	t.Run("malformed source", func(t *testing.T) {
+		db, _ := openPopulatedExportDB(t)
+		paths := exportPaths(t)
+		changed, err := db.ExportLegacy(context.Background(), paths)
+		require.NoError(t, err)
+		require.True(t, changed)
+		before := requireValidSnapshot(t, db)
+		require.NoError(t, os.WriteFile(paths.EndpointJSONPath, []byte(`not JSON`), 0o600))
+
+		changed, err = db.ReimportLegacy(context.Background(), ImportOptions{
+			CNSPath:             paths.CNSJSONPath,
+			EndpointPath:        paths.EndpointJSONPath,
+			ManageEndpointState: true,
+			BootID:              "new-boot",
+		}, BootPolicy{})
+		require.ErrorIs(t, err, ErrLegacyImportSource)
+		assert.False(t, changed)
+		assert.Equal(t, before, requireValidSnapshot(t, db))
+	})
+
+	t.Run("commit fault", func(t *testing.T) {
+		db, _ := openPopulatedExportDB(t)
+		paths := exportPaths(t)
+		changed, err := db.ExportLegacy(context.Background(), paths)
+		require.NoError(t, err)
+		require.True(t, changed)
+		before := requireValidSnapshot(t, db)
+		injected := errors.New("injected reimport failure")
+		db.importBeforeCommit = func() error { return injected }
+
+		changed, err = db.ReimportLegacy(context.Background(), ImportOptions{
+			CNSPath:             paths.CNSJSONPath,
+			EndpointPath:        paths.EndpointJSONPath,
+			ManageEndpointState: true,
+			BootID:              "new-boot",
+		}, BootPolicy{})
+		require.ErrorIs(t, err, injected)
+		assert.False(t, changed)
+		assert.Equal(t, before, requireValidSnapshot(t, db))
+	})
+
+	t.Run("Bolt authoritative", func(t *testing.T) {
+		db, _ := openPopulatedExportDB(t)
+		changed, err := db.ReimportLegacy(context.Background(), ImportOptions{
+			CNSPath:             "unused-cns.json",
+			EndpointPath:        "unused-endpoints.json",
+			ManageEndpointState: true,
+			BootID:              "new-boot",
+		}, BootPolicy{})
+		require.ErrorIs(t, err, ErrLegacyReimportState)
+		assert.False(t, changed)
+	})
+
+	t.Run("canceled", func(t *testing.T) {
+		db, _ := openPopulatedExportDB(t)
+		paths := exportPaths(t)
+		changed, err := db.ExportLegacy(context.Background(), paths)
+		require.NoError(t, err)
+		require.True(t, changed)
+		before := requireValidSnapshot(t, db)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		changed, err = db.ReimportLegacy(ctx, ImportOptions{
+			CNSPath:             paths.CNSJSONPath,
+			EndpointPath:        paths.EndpointJSONPath,
+			ManageEndpointState: true,
+			BootID:              "new-boot",
+		}, BootPolicy{})
+		require.ErrorIs(t, err, context.Canceled)
+		assert.False(t, changed)
+		assert.Equal(t, before, requireValidSnapshot(t, db))
+	})
+}

--- a/cns/state/reimport_test.go
+++ b/cns/state/reimport_test.go
@@ -15,6 +15,10 @@ import (
 	"go.uber.org/zap"
 )
 
+var errInjectedReimport = errors.New("injected reimport failure")
+
+const reimportTestNewBoot = "new-boot"
+
 func TestReimportLegacyReplacesRolledBackState(t *testing.T) {
 	ctx := context.Background()
 	db, _ := openPopulatedExportDB(t)
@@ -80,7 +84,7 @@ func TestReimportLegacyClearsEndpointsByBootPolicy(t *testing.T) {
 		CNSPath:             paths.CNSJSONPath,
 		EndpointPath:        paths.EndpointJSONPath,
 		ManageEndpointState: true,
-		BootID:              "new-boot",
+		BootID:              reimportTestNewBoot,
 	}, BootPolicy{ClearEndpoints: true})
 	require.NoError(t, err)
 	require.True(t, changed)
@@ -105,7 +109,7 @@ func TestReimportLegacyFailuresAreAtomic(t *testing.T) {
 			CNSPath:             paths.CNSJSONPath,
 			EndpointPath:        paths.EndpointJSONPath,
 			ManageEndpointState: true,
-			BootID:              "new-boot",
+			BootID:              reimportTestNewBoot,
 		}, BootPolicy{})
 		require.ErrorIs(t, err, ErrLegacyImportSource)
 		assert.False(t, changed)
@@ -119,21 +123,19 @@ func TestReimportLegacyFailuresAreAtomic(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, changed)
 		before := requireValidSnapshot(t, db)
-		injected := errors.New("injected reimport failure")
-
 		changed, err = db.reimportLegacyWithCommitHook(
 			context.Background(),
 			ImportOptions{
 				CNSPath:             paths.CNSJSONPath,
 				EndpointPath:        paths.EndpointJSONPath,
 				ManageEndpointState: true,
-				BootID:              "new-boot",
+				BootID:              reimportTestNewBoot,
 			},
 			BootPolicy{},
 			os.ReadFile,
-			func() error { return injected },
+			func() error { return errInjectedReimport },
 		)
-		require.ErrorIs(t, err, injected)
+		require.ErrorIs(t, err, errInjectedReimport)
 		assert.False(t, changed)
 		assert.Equal(t, before, requireValidSnapshot(t, db))
 	})
@@ -144,7 +146,7 @@ func TestReimportLegacyFailuresAreAtomic(t *testing.T) {
 			CNSPath:             "unused-cns.json",
 			EndpointPath:        "unused-endpoints.json",
 			ManageEndpointState: true,
-			BootID:              "new-boot",
+			BootID:              reimportTestNewBoot,
 		}, BootPolicy{})
 		require.ErrorIs(t, err, ErrLegacyReimportState)
 		assert.False(t, changed)


### PR DESCRIPTION
## Scope
Wires fail-closed Bolt open, import/reimport, rollback export, boot policy, metrics refresh, and listener gating into the extracted startup lifecycle.

## Draft dependency caveat
This PR is opened early for review and CI on top of the draft runtime adapter. Its ancestor base is a temporary multi-parent integration branch. **Do not merge until R1 and its engine/foundation prerequisites merge.**

## Behavior
Startup failures never start the listener and never fall back to stale JSON. Rollback must establish JSON authority before JSON startup.

## Evidence
Linux/Windows lint and state/restserver/service race tests pass.