### PR TITLE
feat(cns): project unified endpoint state

### DIFF
--- a/cns/restserver/durable_state_adapter.go
+++ b/cns/restserver/durable_state_adapter.go
@@ -650,16 +650,27 @@ func buildDurableCacheProjection(snapshot state.Snapshot) (durableCacheProjectio
 		}
 		projection.pnpIDByMACAddress[mac.String()] = pnpID
 	}
+	if err := projectDurableSessionState(snapshot, &projection, unassignedIPStates); err != nil {
+		return durableCacheProjection{}, err
+	}
+	return projection, nil
+}
+
+func projectDurableSessionState(
+	snapshot state.Snapshot,
+	projection *durableCacheProjection,
+	unassignedIPStates map[string]types.IPState,
+) error {
 	for containerID, record := range snapshot.Endpoints {
 		endpoint, err := projectEndpoint(record)
 		if err != nil {
-			return durableCacheProjection{}, fmt.Errorf("projecting endpoint %q: %w", containerID, err)
+			return fmt.Errorf("projecting endpoint %q: %w", containerID, err)
 		}
 		projection.endpointState[containerID] = endpoint
 	}
 	for podKey, assignment := range snapshot.Assignments {
 		if assignment.Pod.PodKey != podKey {
-			return durableCacheProjection{}, fmt.Errorf(
+			return fmt.Errorf(
 				"%w: assignment=%q pod=%q",
 				errProjectedAssignmentKey,
 				podKey,
@@ -668,7 +679,7 @@ func buildDurableCacheProjection(snapshot state.Snapshot) (durableCacheProjectio
 		}
 		endpoint, ok := snapshot.Endpoints[assignment.Pod.InfraContainerID]
 		if !ok {
-			return durableCacheProjection{}, fmt.Errorf(
+			return fmt.Errorf(
 				"%w: assignment=%q endpoint=%q",
 				errMissingProjectedEndpoint,
 				podKey,
@@ -680,7 +691,7 @@ func buildDurableCacheProjection(snapshot state.Snapshot) (durableCacheProjectio
 		for _, ipID := range ipIDs {
 			ipStatus, ok := projection.ipConfigState[ipID]
 			if !ok {
-				return durableCacheProjection{}, fmt.Errorf(
+				return fmt.Errorf(
 					"%w: assignment=%q ip=%q",
 					errMissingProjectedIP,
 					podKey,
@@ -689,7 +700,7 @@ func buildDurableCacheProjection(snapshot state.Snapshot) (durableCacheProjectio
 			}
 			owner, ok := snapshot.IPOwners[ipID]
 			if !ok {
-				return durableCacheProjection{}, fmt.Errorf(
+				return fmt.Errorf(
 					"%w: assignment=%q ip=%q",
 					errMissingProjectedOwner,
 					podKey,
@@ -697,7 +708,7 @@ func buildDurableCacheProjection(snapshot state.Snapshot) (durableCacheProjectio
 				)
 			}
 			if owner != podKey {
-				return durableCacheProjection{}, fmt.Errorf(
+				return fmt.Errorf(
 					"%w: assignment=%q ip=%q owner=%q",
 					errMismatchedProjectedOwner,
 					podKey,
@@ -715,7 +726,7 @@ func buildDurableCacheProjection(snapshot state.Snapshot) (durableCacheProjectio
 	for ipID, owner := range snapshot.IPOwners {
 		assignment, ok := snapshot.Assignments[owner]
 		if !ok {
-			return durableCacheProjection{}, fmt.Errorf(
+			return fmt.Errorf(
 				"%w: ip=%q assignment=%q",
 				errMissingProjectedAssignment,
 				ipID,
@@ -723,7 +734,7 @@ func buildDurableCacheProjection(snapshot state.Snapshot) (durableCacheProjectio
 			)
 		}
 		if !containsString(assignment.IPIDs, ipID) {
-			return durableCacheProjection{}, fmt.Errorf(
+			return fmt.Errorf(
 				"%w: ip=%q assignment=%q",
 				errProjectedAssignmentMissingIP,
 				ipID,
@@ -745,7 +756,7 @@ func buildDurableCacheProjection(snapshot state.Snapshot) (durableCacheProjectio
 			projection.ipConfigState[ipID] = durableStatus
 		}
 	}
-	return projection, nil
+	return nil
 }
 
 type projectedPodInfo struct {

--- a/cns/restserver/durable_state_adapter.go
+++ b/cns/restserver/durable_state_adapter.go
@@ -54,11 +54,12 @@ type durableStateAdapter struct {
 
 	// mu is acquired before the HTTPRestService lock. Callers must not hold the
 	// service lock; the adapter applies complete projections under that lock.
-	mu         sync.Mutex
-	projected  bool
-	generation uint64
-	closeOnce  sync.Once
-	closeErr   error
+	mu                   sync.Mutex
+	projectEndpointState bool
+	projected            bool
+	generation           uint64
+	closeOnce            sync.Once
+	closeErr             error
 }
 
 type durableServiceMetadata struct {
@@ -75,6 +76,9 @@ type durableCacheProjection struct {
 	metadata          durableServiceMetadata
 	containerStatus   map[string]containerstatus
 	ipConfigState     map[string]cns.IPConfigurationStatus
+	durableIPState    map[string]cns.IPConfigurationStatus
+	ipIDsByPodKey     map[string][]string
+	endpointState     map[string]*EndpointInfo
 	networks          map[string]*networkInfo
 	orchestratorNCs   map[string]*ncList
 	pnpIDByMACAddress map[string]string
@@ -85,15 +89,20 @@ type durableCacheProjection struct {
 func NewDurableStateLifecycle(
 	service *HTTPRestService,
 	db *state.DB,
+	projectEndpointState bool,
 ) (restore func(context.Context) error, closeFn func() error, err error) {
-	adapter, err := newDurableStateAdapter(service, db)
+	adapter, err := newDurableStateAdapter(service, db, projectEndpointState)
 	if err != nil {
 		return nil, nil, err
 	}
 	return adapter.restore, adapter.Close, nil
 }
 
-func newDurableStateAdapter(service *HTTPRestService, db *state.DB) (*durableStateAdapter, error) {
+func newDurableStateAdapter(
+	service *HTTPRestService,
+	db *state.DB,
+	projectEndpointState bool,
+) (*durableStateAdapter, error) {
 	if db == nil {
 		return nil, errNilDurableStateDB
 	}
@@ -123,12 +132,13 @@ func newDurableStateAdapter(service *HTTPRestService, db *state.DB) (*durableSta
 		},
 		status: db.Status,
 		close:  db.Close,
-	})
+	}, projectEndpointState)
 }
 
 func newDurableStateAdapterWithOperations(
 	service *HTTPRestService,
 	operations durableStateOperations,
+	projectEndpointState bool,
 ) (*durableStateAdapter, error) {
 	switch {
 	case service == nil:
@@ -146,7 +156,11 @@ func newDurableStateAdapterWithOperations(
 	case operations.close == nil:
 		return nil, errNilDurableCloseOperation
 	}
-	return &durableStateAdapter{service: service, store: operations}, nil
+	return &durableStateAdapter{
+		service:              service,
+		store:                operations,
+		projectEndpointState: projectEndpointState,
+	}, nil
 }
 
 func (a *durableStateAdapter) restore(ctx context.Context) error {
@@ -474,7 +488,15 @@ func (a *durableStateAdapter) applyProjection(projection durableCacheProjection)
 	a.service.state.ContainerIDByOrchestratorContext = projection.orchestratorNCs
 	a.service.state.Networks = projection.networks
 	a.service.state.PnpIDByMacAddress = projection.pnpIDByMACAddress
-	a.service.PodIPConfigState = projection.ipConfigState
+	if a.projectEndpointState {
+		// Delete intents have no legacy cache equivalent. They remain authoritative
+		// in the unified database and are intentionally absent from this projection.
+		a.service.PodIPConfigState = projection.ipConfigState
+		a.service.PodIPIDByPodInterfaceKey = projection.ipIDsByPodKey
+		a.service.EndpointState = projection.endpointState
+	} else {
+		a.service.PodIPConfigState = projection.durableIPState
+	}
 	a.generation = projection.generation
 	a.projected = true
 }
@@ -517,12 +539,16 @@ func buildDurableCacheProjection(snapshot state.Snapshot) (durableCacheProjectio
 		},
 		containerStatus:   make(map[string]containerstatus, len(snapshot.NetworkContainers)),
 		ipConfigState:     make(map[string]cns.IPConfigurationStatus, len(snapshot.IPs)),
+		durableIPState:    make(map[string]cns.IPConfigurationStatus, len(snapshot.IPs)),
+		ipIDsByPodKey:     make(map[string][]string, len(snapshot.Assignments)),
+		endpointState:     make(map[string]*EndpointInfo, len(snapshot.Endpoints)),
 		networks:          make(map[string]*networkInfo, len(snapshot.Networks)),
 		orchestratorNCs:   make(map[string]*ncList, len(snapshot.OrchestratorContexts)),
 		pnpIDByMACAddress: make(map[string]string, len(snapshot.PnPIDByMAC)),
 	}
 
 	hostVersions := make(map[string]int, len(snapshot.NetworkContainers))
+	unassignedIPStates := make(map[string]types.IPState, len(snapshot.IPs))
 	for id := range snapshot.NetworkContainers {
 		record := snapshot.NetworkContainers[id]
 		request, err := cloneJSON(record.Request)
@@ -576,12 +602,11 @@ func buildDurableCacheProjection(snapshot state.Snapshot) (durableCacheProjectio
 			IPAddress: record.IPAddress,
 			NCID:      record.NCID,
 		}
-		ipStatus.WithStateMiddleware(stateTransitionMiddleware)
 		ipState := types.Available
 		if hostVersion < record.NCVersion {
 			ipState = types.PendingProgramming
 		}
-		ipStatus.SetState(ipState)
+		unassignedIPStates[id] = ipState
 		projection.ipConfigState[id] = ipStatus
 	}
 
@@ -617,7 +642,227 @@ func buildDurableCacheProjection(snapshot state.Snapshot) (durableCacheProjectio
 		}
 		projection.pnpIDByMACAddress[mac.String()] = pnpID
 	}
+	for containerID, record := range snapshot.Endpoints {
+		endpoint, err := projectEndpoint(record)
+		if err != nil {
+			return durableCacheProjection{}, fmt.Errorf("projecting endpoint %q: %w", containerID, err)
+		}
+		projection.endpointState[containerID] = endpoint
+	}
+	for podKey, assignment := range snapshot.Assignments {
+		if assignment.Pod.PodKey != podKey {
+			return durableCacheProjection{}, fmt.Errorf(
+				"assignment key %q does not match projected pod key %q",
+				podKey,
+				assignment.Pod.PodKey,
+			)
+		}
+		endpoint, ok := snapshot.Endpoints[assignment.Pod.InfraContainerID]
+		if !ok {
+			return durableCacheProjection{}, fmt.Errorf(
+				"assignment %q references missing projected endpoint %q",
+				podKey,
+				assignment.Pod.InfraContainerID,
+			)
+		}
+		podInfo := newProjectedPodInfo(assignment.Pod, len(endpoint.IfnameToIPMap) > 1)
+		ipIDs := append([]string(nil), assignment.IPIDs...)
+		for _, ipID := range ipIDs {
+			ipStatus, ok := projection.ipConfigState[ipID]
+			if !ok {
+				return durableCacheProjection{}, fmt.Errorf(
+					"assignment %q references missing projected IP %q",
+					podKey,
+					ipID,
+				)
+			}
+			owner, ok := snapshot.IPOwners[ipID]
+			if !ok {
+				return durableCacheProjection{}, fmt.Errorf(
+					"assignment %q IP %q has no projected owner",
+					podKey,
+					ipID,
+				)
+			}
+			if owner != podKey {
+				return durableCacheProjection{}, fmt.Errorf(
+					"assignment %q IP %q is owned by %q",
+					podKey,
+					ipID,
+					owner,
+				)
+			}
+			ipStatus.PodInfo = podInfo
+			ipStatus.SetState(types.Assigned)
+			ipStatus.WithStateMiddleware(stateTransitionMiddleware)
+			projection.ipConfigState[ipID] = ipStatus
+		}
+		projection.ipIDsByPodKey[podKey] = ipIDs
+	}
+	for ipID, owner := range snapshot.IPOwners {
+		assignment, ok := snapshot.Assignments[owner]
+		if !ok {
+			return durableCacheProjection{}, fmt.Errorf(
+				"IP %q references missing projected assignment %q",
+				ipID,
+				owner,
+			)
+		}
+		if !containsString(assignment.IPIDs, ipID) {
+			return durableCacheProjection{}, fmt.Errorf(
+				"IP %q owner %q does not contain the IP",
+				ipID,
+				owner,
+			)
+		}
+	}
+	for ipID, ipStatus := range projection.ipConfigState {
+		durableStatus := cns.IPConfigurationStatus{
+			ID:        ipStatus.ID,
+			IPAddress: ipStatus.IPAddress,
+			NCID:      ipStatus.NCID,
+		}
+		durableStatus.SetState(unassignedIPStates[ipID])
+		durableStatus.WithStateMiddleware(stateTransitionMiddleware)
+		projection.durableIPState[ipID] = durableStatus
+		if ipStatus.PodInfo == nil {
+			projection.ipConfigState[ipID] = durableStatus
+		}
+	}
 	return projection, nil
+}
+
+type projectedPodInfo struct {
+	podKey           string
+	infraContainerID string
+	interfaceID      string
+	name             string
+	namespace        string
+	secondary        bool
+}
+
+func newProjectedPodInfo(pod state.PodIdentity, secondary bool) *projectedPodInfo {
+	return &projectedPodInfo{
+		podKey:           pod.PodKey,
+		infraContainerID: pod.InfraContainerID,
+		interfaceID:      pod.InterfaceID,
+		name:             pod.PodName,
+		namespace:        pod.PodNamespace,
+		secondary:        secondary,
+	}
+}
+
+func (p *projectedPodInfo) InfraContainerID() string {
+	return p.infraContainerID
+}
+
+func (p *projectedPodInfo) InterfaceID() string {
+	return p.interfaceID
+}
+
+func (p *projectedPodInfo) Key() string {
+	return p.podKey
+}
+
+func (p *projectedPodInfo) Name() string {
+	return p.name
+}
+
+func (p *projectedPodInfo) Namespace() string {
+	return p.namespace
+}
+
+func (p *projectedPodInfo) OrchestratorContext() (json.RawMessage, error) {
+	return json.Marshal(cns.KubernetesPodInfo{
+		PodName:      p.name,
+		PodNamespace: p.namespace,
+	})
+}
+
+func (p *projectedPodInfo) MarshalJSON() ([]byte, error) {
+	version := any(cns.InfraIDPodInfoScheme)
+	if p.interfaceID != "" {
+		version = cns.InterfaceIDPodInfoScheme
+	}
+	return json.Marshal(struct {
+		cns.KubernetesPodInfo
+		PodInfraContainerID   string
+		PodInterfaceID        string
+		Version               any
+		SecondaryInterfaceSet bool
+	}{
+		KubernetesPodInfo: cns.KubernetesPodInfo{
+			PodName:      p.name,
+			PodNamespace: p.namespace,
+		},
+		PodInfraContainerID:   p.infraContainerID,
+		PodInterfaceID:        p.interfaceID,
+		Version:               version,
+		SecondaryInterfaceSet: p.secondary,
+	})
+}
+
+func (p *projectedPodInfo) Equals(other cns.PodInfo) bool {
+	return other != nil && p.podKey == other.Key()
+}
+
+func (p *projectedPodInfo) String() string {
+	return fmt.Sprintf(
+		"InfraContainerID: [%s], InterfaceID: [%s], Key: [%s], Name: [%s], Namespace: [%s]",
+		p.infraContainerID,
+		p.interfaceID,
+		p.podKey,
+		p.name,
+		p.namespace,
+	)
+}
+
+func (p *projectedPodInfo) SecondaryInterfacesExist() bool {
+	return p.secondary
+}
+
+func projectEndpoint(record state.EndpointRecord) (*EndpointInfo, error) {
+	endpoint := &EndpointInfo{
+		PodName:       record.PodName,
+		PodNamespace:  record.PodNamespace,
+		IfnameToIPMap: make(map[string]*IPInfo, len(record.IfnameToIPMap)),
+	}
+	for ifname, infoRecord := range record.IfnameToIPMap {
+		if infoRecord == nil {
+			return nil, fmt.Errorf("interface %q is nil", ifname)
+		}
+		endpoint.IfnameToIPMap[ifname] = &IPInfo{
+			IPv4:               cloneIPNets(infoRecord.IPv4),
+			IPv6:               cloneIPNets(infoRecord.IPv6),
+			HnsEndpointID:      infoRecord.HNSEndpointID,
+			HnsNetworkID:       infoRecord.HNSNetworkID,
+			HostVethName:       infoRecord.HostVethName,
+			MacAddress:         infoRecord.MACAddress,
+			NetworkContainerID: infoRecord.NetworkContainerID,
+			NICType:            infoRecord.NICType,
+		}
+	}
+	return endpoint, nil
+}
+
+func cloneIPNets(values []net.IPNet) []net.IPNet {
+	cloned := make([]net.IPNet, len(values))
+	for i := range values {
+		cloned[i] = net.IPNet{
+			IP:   append(net.IP(nil), values[i].IP...),
+			Mask: append(net.IPMask(nil), values[i].Mask...),
+		}
+	}
+	return cloned
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
 }
 
 func cloneJSON[T any](input T) (T, error) {

--- a/cns/restserver/durable_state_adapter.go
+++ b/cns/restserver/durable_state_adapter.go
@@ -20,24 +20,32 @@ import (
 )
 
 var (
-	errNilDurableStateDB           = errors.New("durable state database is nil")
-	errNilDurableRestService       = errors.New("rest service is nil")
-	errNilDurableRestServiceState  = errors.New("rest service state is nil")
-	errNilDurableSnapshotOperation = errors.New("durable state snapshot operation is nil")
-	errNilDurableReplaceOperation  = errors.New("durable state replace operation is nil")
-	errNilDurableMetadataOperation = errors.New("durable state metadata operation is nil")
-	errNilDurableStatusOperation   = errors.New("durable state status operation is nil")
-	errNilDurableCloseOperation    = errors.New("durable state close operation is nil")
-	errDurableStateNotProjected    = errors.New("durable state has not been projected")
-	errUnexpectedDurableBackend    = errors.New("unexpected durable state backend")
-	errUnexpectedDurableAuthority  = errors.New("unexpected durable state authority")
-	errUnexpectedDurableSchema     = errors.New("unexpected durable state schema version")
-	errDurableInvariantFailed      = errors.New("durable state invariant failed")
-	errInvalidProjectionSchema     = errors.New("durable state projection schema version is invalid")
-	errInvalidProjectionAuthority  = errors.New("durable state projection authority is invalid")
-	errMissingProjectedNC          = errors.New("missing projected network container")
-	errEmptyProjectedNCHostVersion = errors.New("projected network container host version is empty")
-	errProjectedNCIDContainsComma  = errors.New("projected network container ID contains a comma")
+	errNilDurableStateDB            = errors.New("durable state database is nil")
+	errNilDurableRestService        = errors.New("rest service is nil")
+	errNilDurableRestServiceState   = errors.New("rest service state is nil")
+	errNilDurableSnapshotOperation  = errors.New("durable state snapshot operation is nil")
+	errNilDurableReplaceOperation   = errors.New("durable state replace operation is nil")
+	errNilDurableMetadataOperation  = errors.New("durable state metadata operation is nil")
+	errNilDurableStatusOperation    = errors.New("durable state status operation is nil")
+	errNilDurableCloseOperation     = errors.New("durable state close operation is nil")
+	errDurableStateNotProjected     = errors.New("durable state has not been projected")
+	errUnexpectedDurableBackend     = errors.New("unexpected durable state backend")
+	errUnexpectedDurableAuthority   = errors.New("unexpected durable state authority")
+	errUnexpectedDurableSchema      = errors.New("unexpected durable state schema version")
+	errDurableInvariantFailed       = errors.New("durable state invariant failed")
+	errInvalidProjectionSchema      = errors.New("durable state projection schema version is invalid")
+	errInvalidProjectionAuthority   = errors.New("durable state projection authority is invalid")
+	errMissingProjectedNC           = errors.New("missing projected network container")
+	errEmptyProjectedNCHostVersion  = errors.New("projected network container host version is empty")
+	errProjectedNCIDContainsComma   = errors.New("projected network container ID contains a comma")
+	errProjectedAssignmentKey       = errors.New("projected assignment key does not match pod key")
+	errMissingProjectedEndpoint     = errors.New("missing projected endpoint")
+	errMissingProjectedIP           = errors.New("missing projected IP")
+	errMissingProjectedOwner        = errors.New("missing projected IP owner")
+	errMismatchedProjectedOwner     = errors.New("projected IP owner does not match assignment")
+	errMissingProjectedAssignment   = errors.New("missing projected assignment")
+	errProjectedAssignmentMissingIP = errors.New("projected assignment does not contain owned IP")
+	errNilProjectedInterface        = errors.New("projected endpoint interface is nil")
 )
 
 type durableStateOperations struct {
@@ -652,7 +660,8 @@ func buildDurableCacheProjection(snapshot state.Snapshot) (durableCacheProjectio
 	for podKey, assignment := range snapshot.Assignments {
 		if assignment.Pod.PodKey != podKey {
 			return durableCacheProjection{}, fmt.Errorf(
-				"assignment key %q does not match projected pod key %q",
+				"%w: assignment=%q pod=%q",
+				errProjectedAssignmentKey,
 				podKey,
 				assignment.Pod.PodKey,
 			)
@@ -660,7 +669,8 @@ func buildDurableCacheProjection(snapshot state.Snapshot) (durableCacheProjectio
 		endpoint, ok := snapshot.Endpoints[assignment.Pod.InfraContainerID]
 		if !ok {
 			return durableCacheProjection{}, fmt.Errorf(
-				"assignment %q references missing projected endpoint %q",
+				"%w: assignment=%q endpoint=%q",
+				errMissingProjectedEndpoint,
 				podKey,
 				assignment.Pod.InfraContainerID,
 			)
@@ -671,7 +681,8 @@ func buildDurableCacheProjection(snapshot state.Snapshot) (durableCacheProjectio
 			ipStatus, ok := projection.ipConfigState[ipID]
 			if !ok {
 				return durableCacheProjection{}, fmt.Errorf(
-					"assignment %q references missing projected IP %q",
+					"%w: assignment=%q ip=%q",
+					errMissingProjectedIP,
 					podKey,
 					ipID,
 				)
@@ -679,14 +690,16 @@ func buildDurableCacheProjection(snapshot state.Snapshot) (durableCacheProjectio
 			owner, ok := snapshot.IPOwners[ipID]
 			if !ok {
 				return durableCacheProjection{}, fmt.Errorf(
-					"assignment %q IP %q has no projected owner",
+					"%w: assignment=%q ip=%q",
+					errMissingProjectedOwner,
 					podKey,
 					ipID,
 				)
 			}
 			if owner != podKey {
 				return durableCacheProjection{}, fmt.Errorf(
-					"assignment %q IP %q is owned by %q",
+					"%w: assignment=%q ip=%q owner=%q",
+					errMismatchedProjectedOwner,
 					podKey,
 					ipID,
 					owner,
@@ -703,20 +716,23 @@ func buildDurableCacheProjection(snapshot state.Snapshot) (durableCacheProjectio
 		assignment, ok := snapshot.Assignments[owner]
 		if !ok {
 			return durableCacheProjection{}, fmt.Errorf(
-				"IP %q references missing projected assignment %q",
+				"%w: ip=%q assignment=%q",
+				errMissingProjectedAssignment,
 				ipID,
 				owner,
 			)
 		}
 		if !containsString(assignment.IPIDs, ipID) {
 			return durableCacheProjection{}, fmt.Errorf(
-				"IP %q owner %q does not contain the IP",
+				"%w: ip=%q assignment=%q",
+				errProjectedAssignmentMissingIP,
 				ipID,
 				owner,
 			)
 		}
 	}
-	for ipID, ipStatus := range projection.ipConfigState {
+	for ipID := range projection.ipConfigState {
+		ipStatus := projection.ipConfigState[ipID]
 		durableStatus := cns.IPConfigurationStatus{
 			ID:        ipStatus.ID,
 			IPAddress: ipStatus.IPAddress,
@@ -773,10 +789,14 @@ func (p *projectedPodInfo) Namespace() string {
 }
 
 func (p *projectedPodInfo) OrchestratorContext() (json.RawMessage, error) {
-	return json.Marshal(cns.KubernetesPodInfo{
+	data, err := json.Marshal(cns.KubernetesPodInfo{
 		PodName:      p.name,
 		PodNamespace: p.namespace,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("encoding projected pod orchestrator context: %w", err)
+	}
+	return data, nil
 }
 
 func (p *projectedPodInfo) MarshalJSON() ([]byte, error) {
@@ -784,12 +804,12 @@ func (p *projectedPodInfo) MarshalJSON() ([]byte, error) {
 	if p.interfaceID != "" {
 		version = cns.InterfaceIDPodInfoScheme
 	}
-	return json.Marshal(struct {
+	data, err := json.Marshal(struct {
 		cns.KubernetesPodInfo
-		PodInfraContainerID   string
-		PodInterfaceID        string
-		Version               any
-		SecondaryInterfaceSet bool
+		PodInfraContainerID   string `json:"PodInfraContainerID"`
+		PodInterfaceID        string `json:"PodInterfaceID"`
+		Version               any    `json:"Version"`
+		SecondaryInterfaceSet bool   `json:"SecondaryInterfaceSet"`
 	}{
 		KubernetesPodInfo: cns.KubernetesPodInfo{
 			PodName:      p.name,
@@ -800,6 +820,10 @@ func (p *projectedPodInfo) MarshalJSON() ([]byte, error) {
 		Version:               version,
 		SecondaryInterfaceSet: p.secondary,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("encoding projected pod info: %w", err)
+	}
+	return data, nil
 }
 
 func (p *projectedPodInfo) Equals(other cns.PodInfo) bool {
@@ -829,7 +853,7 @@ func projectEndpoint(record state.EndpointRecord) (*EndpointInfo, error) {
 	}
 	for ifname, infoRecord := range record.IfnameToIPMap {
 		if infoRecord == nil {
-			return nil, fmt.Errorf("interface %q is nil", ifname)
+			return nil, fmt.Errorf("%w: %q", errNilProjectedInterface, ifname)
 		}
 		endpoint.IfnameToIPMap[ifname] = &IPInfo{
 			IPv4:               cloneIPNets(infoRecord.IPv4),

--- a/cns/restserver/durable_state_adapter_test.go
+++ b/cns/restserver/durable_state_adapter_test.go
@@ -137,7 +137,7 @@ func TestDurableStateAdapterProjection(t *testing.T) {
 	service := newAdapterTestService()
 	originalEndpoint := service.EndpointState["existing-endpoint"]
 	originalAssignments := append([]string{}, service.PodIPIDByPodInterfaceKey["existing-pod"]...)
-	adapter, err := newDurableStateAdapterWithOperations(service, store.operations())
+	adapter, err := newDurableStateAdapterWithOperations(service, store.operations(), true)
 	require.NoError(t, err)
 
 	require.NoError(t, adapter.restore(context.Background()))
@@ -145,14 +145,18 @@ func TestDurableStateAdapterProjection(t *testing.T) {
 	generation, projected := adapter.cacheGeneration()
 	assert.True(t, projected)
 	assert.Equal(t, uint64(7), generation)
-	assert.Same(t, originalEndpoint, service.EndpointState["existing-endpoint"])
-	assert.Equal(t, originalAssignments, service.PodIPIDByPodInterfaceKey["existing-pod"])
-	assert.NotContains(t, service.EndpointState, "persisted-endpoint")
+	assert.NotSame(t, originalEndpoint, service.EndpointState["container-a"])
+	assert.NotEqual(t, originalAssignments, service.PodIPIDByPodInterfaceKey["if-a"])
+	assert.NotContains(t, service.EndpointState, "existing-endpoint")
 
 	snapshot.NetworkContainers[adapterTestNCID] = state.NetworkContainerRecord{}
 	snapshot.Networks["network-1"].Options["nested"].(map[string]any)["key"] = "mutated"
+	snapshot.Assignments["if-a"].IPIDs[0] = "mutated"
+	snapshot.Endpoints["container-a"].IfnameToIPMap["eth0"].IPv4[0].IP[0] = 192
 	assert.Equal(t, adapterTestNCID, service.state.ContainerStatus[adapterTestNCID].ID)
 	assert.Equal(t, "value", service.state.Networks["network-1"].Options["nested"].(map[string]any)["key"])
+	assert.Equal(t, "11111111-1111-1111-1111-111111111111", service.PodIPIDByPodInterfaceKey["if-a"][0])
+	assert.Equal(t, "10.0.0.4", service.EndpointState["container-a"].IfnameToIPMap["eth0"].IPv4[0].IP.String())
 
 	service.state.Location = "same-generation-no-op"
 	require.NoError(t, adapter.restore(context.Background()))
@@ -197,6 +201,50 @@ func TestDurableStateAdapterProjectionFailureIsAtomic(t *testing.T) {
 			},
 		},
 		{
+			name: "malformed endpoint prefix",
+			mutate: func(snapshot *state.Snapshot) {
+				snapshot.Endpoints["container-a"].IfnameToIPMap["eth0"].IPv4[0].Mask = net.IPMask{0xff, 0}
+			},
+		},
+		{
+			name: "malformed endpoint MAC",
+			mutate: func(snapshot *state.Snapshot) {
+				snapshot.Endpoints["container-a"].IfnameToIPMap["eth0"].MACAddress = "not-a-mac"
+			},
+		},
+		{
+			name: "nil endpoint interface",
+			mutate: func(snapshot *state.Snapshot) {
+				snapshot.Endpoints["container-a"].IfnameToIPMap["eth0"] = nil
+			},
+		},
+		{
+			name: "missing endpoint",
+			mutate: func(snapshot *state.Snapshot) {
+				delete(snapshot.Endpoints, "container-a")
+			},
+		},
+		{
+			name: "missing assignment IP",
+			mutate: func(snapshot *state.Snapshot) {
+				delete(snapshot.IPs, "11111111-1111-1111-1111-111111111111")
+			},
+		},
+		{
+			name: "missing owner",
+			mutate: func(snapshot *state.Snapshot) {
+				delete(snapshot.IPOwners, "11111111-1111-1111-1111-111111111111")
+			},
+		},
+		{
+			name: "duplicate assignment ownership",
+			mutate: func(snapshot *state.Snapshot) {
+				assignment := snapshot.Assignments["if-a"]
+				assignment.IPIDs = append(assignment.IPIDs, "44444444-4444-4444-4444-444444444444")
+				snapshot.Assignments["if-a"] = assignment
+			},
+		},
+		{
 			name: "missing projection metadata",
 			mutate: func(snapshot *state.Snapshot) {
 				snapshot.Metadata.Authority = ""
@@ -209,7 +257,7 @@ func TestDurableStateAdapterProjectionFailureIsAtomic(t *testing.T) {
 			service := newAdapterTestService()
 			initial := completeAdapterSnapshot(1)
 			store := newAdapterTestStore(initial)
-			adapter, err := newDurableStateAdapterWithOperations(service, store.operations())
+			adapter, err := newDurableStateAdapterWithOperations(service, store.operations(), true)
 			require.NoError(t, err)
 			require.NoError(t, adapter.restore(context.Background()))
 			before := durableCacheFingerprint(service, adapter)
@@ -225,11 +273,63 @@ func TestDurableStateAdapterProjectionFailureIsAtomic(t *testing.T) {
 	}
 }
 
+func TestDurableStateAdapterEndpointProjectionDisabled(t *testing.T) {
+	service := newAdapterTestService()
+	originalEndpoint := service.EndpointState["existing-endpoint"]
+	originalAssignments := append([]string(nil), service.PodIPIDByPodInterfaceKey["existing-pod"]...)
+	store := newAdapterTestStore(completeAdapterSnapshot(1))
+	adapter, err := newDurableStateAdapterWithOperations(service, store.operations(), false)
+	require.NoError(t, err)
+
+	require.NoError(t, adapter.restore(context.Background()))
+	assert.Len(t, service.state.ContainerStatus, 2)
+	assert.Len(t, service.PodIPConfigState, 4)
+	pending := service.PodIPConfigState["11111111-1111-1111-1111-111111111111"]
+	assert.Equal(
+		t,
+		types.PendingProgramming,
+		pending.GetState(),
+	)
+	assert.Nil(t, pending.PodInfo)
+	available := service.PodIPConfigState["33333333-3333-3333-3333-333333333333"]
+	assert.Equal(
+		t,
+		types.Available,
+		available.GetState(),
+	)
+	assert.Same(t, originalEndpoint, service.EndpointState["existing-endpoint"])
+	assert.Equal(t, originalAssignments, service.PodIPIDByPodInterfaceKey["existing-pod"])
+	assert.Len(t, service.EndpointState, 1)
+	assert.Len(t, service.PodIPIDByPodInterfaceKey, 1)
+}
+
+func TestDurableStateAdapterPreflightsEndpointProjectionBeforeDurableMutation(t *testing.T) {
+	service := newAdapterTestService()
+	store := newAdapterTestStore(completeAdapterSnapshot(1))
+	adapter, err := newDurableStateAdapterWithOperations(service, store.operations(), true)
+	require.NoError(t, err)
+	require.NoError(t, adapter.restore(context.Background()))
+	before := durableCacheFingerprint(service, adapter)
+
+	store.mu.Lock()
+	store.snapshot.Endpoints["container-a"].IfnameToIPMap["eth0"].MACAddress = "invalid"
+	generation := store.snapshot.Metadata.Generation
+	store.mu.Unlock()
+
+	err = adapter.putNetwork(context.Background(), state.NetworkRecord{NetworkName: "must-not-commit"})
+	require.Error(t, err)
+	assert.Equal(t, before, durableCacheFingerprint(service, adapter))
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	assert.Equal(t, generation, store.snapshot.Metadata.Generation)
+	assert.NotContains(t, store.snapshot.Networks, "must-not-commit")
+}
+
 func TestDurableStateAdapterCommitOrderingAndFailures(t *testing.T) {
 	snapshot := completeAdapterSnapshot(3)
 	service := newAdapterTestService()
 	store := newAdapterTestStore(snapshot)
-	adapter, err := newDurableStateAdapterWithOperations(service, store.operations())
+	adapter, err := newDurableStateAdapterWithOperations(service, store.operations(), true)
 	require.NoError(t, err)
 	require.NoError(t, adapter.restore(context.Background()))
 
@@ -237,12 +337,18 @@ func TestDurableStateAdapterCommitOrderingAndFailures(t *testing.T) {
 	record.VMVersion = "9"
 	record.HostVersion = "9"
 	record.Request.Version = "9"
-	ips := []state.IPRecord{{
+	ips := make([]state.IPRecord, 0, 3)
+	for _, ip := range snapshot.IPs {
+		if ip.NCID == "nc-1" {
+			ips = append(ips, ip)
+		}
+	}
+	ips = append(ips, state.IPRecord{
 		ID:        "ip-new",
 		IPAddress: "10.0.0.99",
 		NCID:      adapterTestNCID,
 		NCVersion: 9,
-	}}
+	})
 	store.beforeReplace = func() {
 		assert.Equal(t, "2", service.state.ContainerStatus[adapterTestNCID].VMVersion)
 		assert.NotContains(t, service.PodIPConfigState, "ip-new")
@@ -304,7 +410,7 @@ func TestDurableStateAdapterCommitOrderingAndFailures(t *testing.T) {
 func TestDurableStateAdapterDurableOperations(t *testing.T) {
 	service := newAdapterTestService()
 	store := newAdapterTestStore(emptyAdapterSnapshot(0))
-	adapter, err := newDurableStateAdapterWithOperations(service, store.operations())
+	adapter, err := newDurableStateAdapterWithOperations(service, store.operations(), true)
 	require.NoError(t, err)
 	require.NoError(t, adapter.restore(context.Background()))
 
@@ -354,9 +460,9 @@ func TestDurableStateAdapterStaleWritersDoNotLoseState(t *testing.T) {
 
 	db, err := state.Open(filepath.Join(baseDir, "state.db"), state.Options{})
 	require.NoError(t, err)
-	first, err := newDurableStateAdapter(newAdapterTestService(), db)
+	first, err := newDurableStateAdapter(newAdapterTestService(), db, true)
 	require.NoError(t, err)
-	second, err := newDurableStateAdapter(newAdapterTestService(), db)
+	second, err := newDurableStateAdapter(newAdapterTestService(), db, true)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = first.Close() })
 
@@ -398,6 +504,7 @@ func TestDurableStateAdapterStaleWritersDoNotLoseState(t *testing.T) {
 		name    string
 		adapter *durableStateAdapter
 	}
+
 	successes := 0
 	for result := range results {
 		if result.err == nil {
@@ -427,6 +534,45 @@ func TestDurableStateAdapterStaleWritersDoNotLoseState(t *testing.T) {
 	assert.Contains(t, snapshot.Networks, "second")
 }
 
+func TestDurableStateAdapterConcurrentRestore(t *testing.T) {
+	store := newAdapterTestStore(completeAdapterSnapshot(1))
+	service := newAdapterTestService()
+	adapter, err := newDurableStateAdapterWithOperations(service, store.operations(), true)
+	require.NoError(t, err)
+	require.NoError(t, adapter.restore(context.Background()))
+
+	newer := completeAdapterSnapshot(2)
+	newer.Metadata.Location = "new-location"
+	newer.Endpoints["container-a"].IfnameToIPMap["eth0"].HostVethName = "new-veth"
+	store.mu.Lock()
+	store.snapshot = newer
+	store.mu.Unlock()
+
+	const restoreCount = 8
+	start := make(chan struct{})
+	errs := make(chan error, restoreCount)
+	var restores sync.WaitGroup
+	restores.Add(restoreCount)
+	for range restoreCount {
+		go func() {
+			defer restores.Done()
+			<-start
+			errs <- adapter.restore(context.Background())
+		}()
+	}
+	close(start)
+	restores.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, uint64(2), adapter.generation)
+	assert.Equal(t, "new-location", service.state.Location)
+	assert.Equal(t, "new-veth", service.EndpointState["container-a"].IfnameToIPMap["eth0"].HostVethName)
+	assertAdapterProjection(t, service, newer)
+}
+
 func TestDurableStateAdapterRestartRestoreAndClose(t *testing.T) {
 	baseDir, err := os.MkdirTemp(".", ".durable-adapter-restart-*")
 	require.NoError(t, err)
@@ -436,21 +582,43 @@ func TestDurableStateAdapterRestartRestoreAndClose(t *testing.T) {
 	db, err := state.Open(path, state.Options{})
 	require.NoError(t, err)
 	firstService := newAdapterTestService()
-	first, err := newDurableStateAdapter(firstService, db)
+	first, err := newDurableStateAdapter(firstService, db, true)
 	require.NoError(t, err)
 	require.NoError(t, first.restore(context.Background()))
-	record := adapterNetworkContainer("nc")
-	record.Request.AuthorizationToken = "must-not-persist"
-	record.Request.SecondaryIPConfigs = map[string]cns.SecondaryIPConfig{"embedded": {IPAddress: "10.0.0.8"}}
-	require.NoError(t, first.applyNetworkContainer(context.Background(), record, []state.IPRecord{{
-		ID: "ip", IPAddress: adapterTestIPv4, NCID: "nc", NCVersion: 2,
-	}}))
+	session := completeAdapterSnapshot(0)
+	for _, ncID := range []string{adapterTestNCID, "nc-2"} {
+		record := session.NetworkContainers[ncID]
+		record.Request.AuthorizationToken = "must-not-persist"
+		record.Request.SecondaryIPConfigs = map[string]cns.SecondaryIPConfig{
+			"embedded": {IPAddress: "10.0.0.8"},
+		}
+		var ips []state.IPRecord
+		for _, ip := range session.IPs {
+			if ip.NCID == ncID {
+				ips = append(ips, ip)
+			}
+		}
+		require.NoError(t, first.applyNetworkContainer(context.Background(), record, ips))
+	}
+	for _, podKey := range []string{"if-a", "container-b"} {
+		assignment := session.Assignments[podKey]
+		changed, assignErr := db.AssignEndpoint(
+			context.Background(),
+			assignment,
+			session.Endpoints[assignment.Pod.InfraContainerID],
+			time.Unix(200, 0).UTC(),
+			time.Hour,
+		)
+		require.NoError(t, assignErr)
+		require.True(t, changed)
+	}
+	require.NoError(t, first.restore(context.Background()))
 	require.NoError(t, first.putNetwork(context.Background(), state.NetworkRecord{
 		NetworkName: "network",
 		NicInfo:     &wireserver.InterfaceInfo{Subnet: adapterTestSubnet},
 		Options:     map[string]any{"nested": map[string]any{"enabled": true}},
 	}))
-	require.NoError(t, first.putOrchestratorContext(context.Background(), "pod", []string{"nc"}))
+	require.NoError(t, first.putOrchestratorContext(context.Background(), "pod", []string{"nc-1", "nc-2"}))
 	require.NoError(t, first.putPnPID(context.Background(), "00-11-22-33-44-55", "pnp"))
 	require.NoError(t, first.putServiceMetadata(context.Background(), durableServiceMetadata{
 		OrchestratorType: cns.KubernetesCRD,
@@ -460,6 +628,14 @@ func TestDurableStateAdapterRestartRestoreAndClose(t *testing.T) {
 		Initialized:      true,
 		TimeStamp:        time.Unix(100, 0).UTC(),
 	}))
+	require.NoError(t, db.Update(context.Background(), func(tx *state.WriteTx) error {
+		return tx.PutDeleteIntent("delete-only", state.DeleteIntent{CreatedAt: time.Unix(300, 0).UTC()})
+	}))
+	require.NoError(t, first.restore(context.Background()))
+	require.NoError(t, first.putNetwork(context.Background(), state.NetworkRecord{NetworkName: "intent-preserving"}))
+	snapshotBeforeRestart, err := db.Snapshot(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, snapshotBeforeRestart.DeleteIntents, "delete-only")
 	want := durableCacheFingerprint(firstService, first)
 	require.NoError(t, first.Close())
 	require.NoError(t, first.Close())
@@ -467,23 +643,26 @@ func TestDurableStateAdapterRestartRestoreAndClose(t *testing.T) {
 	reopened, err := state.Open(path, state.Options{})
 	require.NoError(t, err)
 	secondService := newAdapterTestService()
-	second, err := newDurableStateAdapter(secondService, reopened)
+	second, err := newDurableStateAdapter(secondService, reopened, true)
 	require.NoError(t, err)
 	require.NoError(t, second.restore(context.Background()))
 	assert.Equal(t, want, durableCacheFingerprint(secondService, second))
-	assert.Empty(t, secondService.state.ContainerStatus["nc"].CreateNetworkContainerRequest.AuthorizationToken)
+	assert.Empty(t, secondService.state.ContainerStatus["nc-1"].CreateNetworkContainerRequest.AuthorizationToken)
 	assert.NotContains(
 		t,
-		secondService.state.ContainerStatus["nc"].CreateNetworkContainerRequest.SecondaryIPConfigs,
+		secondService.state.ContainerStatus["nc-1"].CreateNetworkContainerRequest.SecondaryIPConfigs,
 		"embedded",
 	)
+	restartedSnapshot, err := reopened.Snapshot(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, restartedSnapshot.DeleteIntents, "delete-only")
 	require.NoError(t, second.Close())
 }
 
 func TestDurableStateAdapterCloseErrorIsStable(t *testing.T) {
 	store := newAdapterTestStore(emptyAdapterSnapshot(0))
 	store.closeErr = errAdapterCloseFailure
-	adapter, err := newDurableStateAdapterWithOperations(newAdapterTestService(), store.operations())
+	adapter, err := newDurableStateAdapterWithOperations(newAdapterTestService(), store.operations(), true)
 	require.NoError(t, err)
 	require.ErrorIs(t, adapter.Close(), errAdapterCloseFailure)
 	require.ErrorIs(t, adapter.Close(), errAdapterCloseFailure)
@@ -495,10 +674,10 @@ func TestDurableStateAdapterConstructorValidation(t *testing.T) {
 	store := newAdapterTestStore(emptyAdapterSnapshot(0))
 	operations := store.operations()
 
-	adapter, err := newDurableStateAdapterWithOperations(nil, operations)
+	adapter, err := newDurableStateAdapterWithOperations(nil, operations, true)
 	require.Error(t, err)
 	assert.Nil(t, adapter)
-	adapter, err = newDurableStateAdapter(service, nil)
+	adapter, err = newDurableStateAdapter(service, nil, true)
 	require.Error(t, err)
 	assert.Nil(t, adapter)
 
@@ -516,7 +695,7 @@ func TestDurableStateAdapterConstructorValidation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			invalid := operations
 			tt.mutate(&invalid)
-			adapter, err := newDurableStateAdapterWithOperations(service, invalid)
+			adapter, err := newDurableStateAdapterWithOperations(service, invalid, true)
 			require.Error(t, err)
 			assert.Nil(t, adapter)
 		})
@@ -562,7 +741,19 @@ func completeAdapterSnapshot(generation uint64) state.Snapshot {
 	}
 	snapshot.IPs["22222222-2222-2222-2222-222222222222"] = state.IPRecord{
 		ID:        "22222222-2222-2222-2222-222222222222",
+		IPAddress: "2001:db8::4",
+		NCID:      "nc-1",
+		NCVersion: 2,
+	}
+	snapshot.IPs["33333333-3333-3333-3333-333333333333"] = state.IPRecord{
+		ID:        "33333333-3333-3333-3333-333333333333",
 		IPAddress: "10.0.1.4",
+		NCID:      "nc-2",
+		NCVersion: 2,
+	}
+	snapshot.IPs["44444444-4444-4444-4444-444444444444"] = state.IPRecord{
+		ID:        "44444444-4444-4444-4444-444444444444",
+		IPAddress: "10.0.1.5",
 		NCID:      "nc-2",
 		NCVersion: 2,
 	}
@@ -578,11 +769,80 @@ func completeAdapterSnapshot(generation uint64) state.Snapshot {
 	}
 	snapshot.OrchestratorContexts["pod-a"] = []string{"nc-1", "nc-2"}
 	snapshot.PnPIDByMAC["00:11:22:33:44:55"] = "pnp-1"
-	snapshot.Endpoints["persisted-endpoint"] = state.EndpointRecord{
-		PodName:       "must-not-project",
-		IfnameToIPMap: map[string]*state.IPInfoRecord{},
+	snapshot.Endpoints["container-a"] = state.EndpointRecord{
+		PodName:      "pod-a",
+		PodNamespace: "namespace-a",
+		IfnameToIPMap: map[string]*state.IPInfoRecord{
+			"eth0": {
+				IPv4:               []net.IPNet{testIPNet("10.0.0.4/24")},
+				IPv6:               []net.IPNet{testIPNet("2001:db8::4/64")},
+				HNSEndpointID:      "hns-endpoint-a",
+				HNSNetworkID:       "hns-network-a",
+				HostVethName:       "veth-a",
+				MACAddress:         "00:11:22:33:44:55",
+				NetworkContainerID: "nc-1",
+				NICType:            cns.InfraNIC,
+			},
+			"net1": {
+				IPv4:               []net.IPNet{testIPNet("10.0.1.4/32")},
+				HNSEndpointID:      "hns-endpoint-b",
+				HNSNetworkID:       "hns-network-b",
+				HostVethName:       "veth-b",
+				MACAddress:         "00:11:22:33:44:66",
+				NetworkContainerID: "nc-2",
+				NICType:            cns.DelegatedVMNIC,
+			},
+		},
+	}
+	snapshot.Assignments["if-a"] = state.AssignmentRecord{
+		Pod: state.PodIdentity{
+			PodKey:           "if-a",
+			InfraContainerID: "container-a",
+			InterfaceID:      "if-a",
+			PodName:          "pod-a",
+			PodNamespace:     "namespace-a",
+		},
+		IPIDs: []string{
+			"11111111-1111-1111-1111-111111111111",
+			"22222222-2222-2222-2222-222222222222",
+			"33333333-3333-3333-3333-333333333333",
+		},
+	}
+	snapshot.Endpoints["container-b"] = state.EndpointRecord{
+		PodName:      "pod-b",
+		PodNamespace: "namespace-b",
+		IfnameToIPMap: map[string]*state.IPInfoRecord{
+			"eth0": {
+				IPv4:               []net.IPNet{testIPNet("10.0.1.5/24")},
+				NetworkContainerID: "nc-2",
+				NICType:            cns.InfraNIC,
+			},
+		},
+	}
+	snapshot.Assignments["container-b"] = state.AssignmentRecord{
+		Pod: state.PodIdentity{
+			PodKey:           "container-b",
+			InfraContainerID: "container-b",
+			PodName:          "pod-b",
+			PodNamespace:     "namespace-b",
+		},
+		IPIDs: []string{"44444444-4444-4444-4444-444444444444"},
+	}
+	for podKey, assignment := range snapshot.Assignments {
+		for _, ipID := range assignment.IPIDs {
+			snapshot.IPOwners[ipID] = podKey
+		}
 	}
 	return snapshot
+}
+
+func testIPNet(prefix string) net.IPNet {
+	ip, network, err := net.ParseCIDR(prefix)
+	if err != nil {
+		panic(err)
+	}
+	network.IP = ip
+	return *network
 }
 
 func emptyAdapterSnapshot(generation uint64) state.Snapshot {
@@ -630,11 +890,18 @@ func assertAdapterProjection(t *testing.T, service *HTTPRestService, snapshot st
 		service.state.ContainerStatus[adapterTestNCID].CreateNetworkContainerRequest.Routes,
 	)
 	assert.Empty(t, service.state.ContainerStatus[adapterTestNCID].CreateNetworkContainerRequest.AuthorizationToken)
-	require.Len(t, service.PodIPConfigState, 2)
-	pending := service.PodIPConfigState["11111111-1111-1111-1111-111111111111"]
-	available := service.PodIPConfigState["22222222-2222-2222-2222-222222222222"]
-	assert.Equal(t, types.PendingProgramming, pending.GetState())
-	assert.Equal(t, types.Available, available.GetState())
+	require.Len(t, service.PodIPConfigState, 4)
+	for id := range service.PodIPConfigState {
+		status := service.PodIPConfigState[id]
+		assert.Equal(t, types.Assigned, status.GetState(), id)
+		require.NotNil(t, status.PodInfo, id)
+	}
+	assert.Equal(t, "if-a", service.PodIPConfigState["11111111-1111-1111-1111-111111111111"].PodInfo.Key())
+	assert.Equal(t, "container-a", service.PodIPConfigState["11111111-1111-1111-1111-111111111111"].PodInfo.InfraContainerID())
+	assert.Equal(t, "if-a", service.PodIPConfigState["11111111-1111-1111-1111-111111111111"].PodInfo.InterfaceID())
+	assert.True(t, service.PodIPConfigState["11111111-1111-1111-1111-111111111111"].PodInfo.SecondaryInterfacesExist())
+	assert.Equal(t, "container-b", service.PodIPConfigState["44444444-4444-4444-4444-444444444444"].PodInfo.Key())
+	assert.False(t, service.PodIPConfigState["44444444-4444-4444-4444-444444444444"].PodInfo.SecondaryInterfacesExist())
 	assert.Equal(
 		t,
 		adapterTestIPv4,
@@ -645,6 +912,27 @@ func assertAdapterProjection(t *testing.T, service *HTTPRestService, snapshot st
 	assert.Equal(t, snapshot.Networks["network-1"].Options, service.state.Networks["network-1"].Options)
 	assert.Equal(t, ncList("nc-1,nc-2"), *service.state.ContainerIDByOrchestratorContext["pod-a"])
 	assert.Equal(t, "pnp-1", service.state.PnpIDByMacAddress["00:11:22:33:44:55"])
+	assert.Equal(
+		t,
+		[]string{
+			"11111111-1111-1111-1111-111111111111",
+			"22222222-2222-2222-2222-222222222222",
+			"33333333-3333-3333-3333-333333333333",
+		},
+		service.PodIPIDByPodInterfaceKey["if-a"],
+	)
+	require.Len(t, service.EndpointState, 2)
+	eth0 := service.EndpointState["container-a"].IfnameToIPMap["eth0"]
+	wantEth0 := snapshot.Endpoints["container-a"].IfnameToIPMap["eth0"]
+	assert.Equal(t, wantEth0.IPv4, eth0.IPv4)
+	assert.Equal(t, wantEth0.IPv6, eth0.IPv6)
+	assert.Equal(t, wantEth0.HNSEndpointID, eth0.HnsEndpointID)
+	assert.Equal(t, wantEth0.HNSNetworkID, eth0.HnsNetworkID)
+	assert.Equal(t, wantEth0.HostVethName, eth0.HostVethName)
+	assert.Equal(t, wantEth0.MACAddress, eth0.MacAddress)
+	assert.Equal(t, wantEth0.NetworkContainerID, eth0.NetworkContainerID)
+	assert.Equal(t, wantEth0.NICType, eth0.NICType)
+	assert.Equal(t, cns.DelegatedVMNIC, service.EndpointState["container-a"].IfnameToIPMap["net1"].NICType)
 }
 
 type adapterCacheFingerprint struct {
@@ -656,6 +944,8 @@ type adapterCacheFingerprint struct {
 	Networks        map[string]state.NetworkRecord
 	OrchestratorNCs map[string]string
 	PnPIDs          map[string]string
+	Assignments     map[string][]string
+	Endpoints       map[string]*EndpointInfo
 }
 
 type adapterIPFingerprint struct {
@@ -663,6 +953,10 @@ type adapterIPFingerprint struct {
 	IPAddress string
 	NCID      string
 	State     types.IPState
+	PodKey    string
+	InfraID   string
+	Interface string
+	Secondary bool
 }
 
 func durableCacheFingerprint(service *HTTPRestService, adapter *durableStateAdapter) adapterCacheFingerprint {
@@ -687,12 +981,24 @@ func durableCacheFingerprint(service *HTTPRestService, adapter *durableStateAdap
 		Networks:        make(map[string]state.NetworkRecord, len(service.state.Networks)),
 		OrchestratorNCs: make(map[string]string, len(service.state.ContainerIDByOrchestratorContext)),
 		PnPIDs:          make(map[string]string, len(service.state.PnpIDByMacAddress)),
+		Assignments:     make(map[string][]string, len(service.PodIPIDByPodInterfaceKey)),
+	}
+	fingerprint.Endpoints, err = cloneJSON(service.EndpointState)
+	if err != nil {
+		panic(err)
 	}
 	for id := range service.PodIPConfigState {
 		status := service.PodIPConfigState[id]
-		fingerprint.IPs[id] = adapterIPFingerprint{
+		value := adapterIPFingerprint{
 			ID: status.ID, IPAddress: status.IPAddress, NCID: status.NCID, State: status.GetState(),
 		}
+		if status.PodInfo != nil {
+			value.PodKey = status.PodInfo.Key()
+			value.InfraID = status.PodInfo.InfraContainerID()
+			value.Interface = status.PodInfo.InterfaceID()
+			value.Secondary = status.PodInfo.SecondaryInterfacesExist()
+		}
+		fingerprint.IPs[id] = value
 	}
 	for name, network := range service.state.Networks {
 		record, err := cloneJSON(state.NetworkRecord{
@@ -710,6 +1016,9 @@ func durableCacheFingerprint(service *HTTPRestService, adapter *durableStateAdap
 	}
 	for macAddress, pnpID := range service.state.PnpIDByMacAddress {
 		fingerprint.PnPIDs[macAddress] = pnpID
+	}
+	for podKey, ipIDs := range service.PodIPIDByPodInterfaceKey {
+		fingerprint.Assignments[podKey] = append([]string(nil), ipIDs...)
 	}
 	return fingerprint
 }

--- a/cns/restserver/durable_state_adapter_test.go
+++ b/cns/restserver/durable_state_adapter_test.go
@@ -39,6 +39,8 @@ const (
 	adapterTestNetwork     = "10.0.0.0"
 	adapterTestDNS         = "10.0.0.10"
 	adapterTestContainerB  = "container-b"
+	adapterTestPrimaryIPID = "11111111-1111-1111-1111-111111111111"
+	adapterTestIPv6ID      = "22222222-2222-2222-2222-222222222222"
 	adapterTestThirdIPID   = "33333333-3333-3333-3333-333333333333"
 	adapterTestSecondaryIF = "net1"
 	adapterTestPodKeyA     = "if-a"
@@ -162,7 +164,7 @@ func TestDurableStateAdapterProjection(t *testing.T) {
 	snapshot.Endpoints["container-a"].IfnameToIPMap[InfraInterfaceName].IPv4[0].IP[0] = 192
 	assert.Equal(t, adapterTestNCID, service.state.ContainerStatus[adapterTestNCID].ID)
 	assert.Equal(t, "value", service.state.Networks["network-1"].Options["nested"].(map[string]any)["key"])
-	assert.Equal(t, "11111111-1111-1111-1111-111111111111", service.PodIPIDByPodInterfaceKey["if-a"][0])
+	assert.Equal(t, adapterTestPrimaryIPID, service.PodIPIDByPodInterfaceKey["if-a"][0])
 	assert.Equal(t, adapterTestIPv4, service.EndpointState["container-a"].IfnameToIPMap[InfraInterfaceName].IPv4[0].IP.String())
 
 	service.state.Location = "same-generation-no-op"
@@ -234,13 +236,13 @@ func TestDurableStateAdapterProjectionFailureIsAtomic(t *testing.T) {
 		{
 			name: "missing assignment IP",
 			mutate: func(snapshot *state.Snapshot) {
-				delete(snapshot.IPs, "11111111-1111-1111-1111-111111111111")
+				delete(snapshot.IPs, adapterTestPrimaryIPID)
 			},
 		},
 		{
 			name: "missing owner",
 			mutate: func(snapshot *state.Snapshot) {
-				delete(snapshot.IPOwners, "11111111-1111-1111-1111-111111111111")
+				delete(snapshot.IPOwners, adapterTestPrimaryIPID)
 			},
 		},
 		{
@@ -291,7 +293,7 @@ func TestDurableStateAdapterEndpointProjectionDisabled(t *testing.T) {
 	require.NoError(t, adapter.restore(context.Background()))
 	assert.Len(t, service.state.ContainerStatus, 2)
 	assert.Len(t, service.PodIPConfigState, 4)
-	pending := service.PodIPConfigState["11111111-1111-1111-1111-111111111111"]
+	pending := service.PodIPConfigState[adapterTestPrimaryIPID]
 	assert.Equal(
 		t,
 		types.PendingProgramming,
@@ -740,14 +742,14 @@ func completeAdapterSnapshot(generation uint64) state.Snapshot {
 	second := adapterNetworkContainer(adapterTestNCID2)
 	second.HostVersion = "3"
 	snapshot.NetworkContainers[adapterTestNCID2] = second
-	snapshot.IPs["11111111-1111-1111-1111-111111111111"] = state.IPRecord{
-		ID:        "11111111-1111-1111-1111-111111111111",
+	snapshot.IPs[adapterTestPrimaryIPID] = state.IPRecord{
+		ID:        adapterTestPrimaryIPID,
 		IPAddress: adapterTestIPv4,
 		NCID:      adapterTestNCID,
 		NCVersion: 2,
 	}
-	snapshot.IPs["22222222-2222-2222-2222-222222222222"] = state.IPRecord{
-		ID:        "22222222-2222-2222-2222-222222222222",
+	snapshot.IPs[adapterTestIPv6ID] = state.IPRecord{
+		ID:        adapterTestIPv6ID,
 		IPAddress: "2001:db8::4",
 		NCID:      adapterTestNCID,
 		NCVersion: 2,
@@ -810,8 +812,8 @@ func completeAdapterSnapshot(generation uint64) state.Snapshot {
 			PodNamespace:     "namespace-a",
 		},
 		IPIDs: []string{
-			"11111111-1111-1111-1111-111111111111",
-			"22222222-2222-2222-2222-222222222222",
+			adapterTestPrimaryIPID,
+			adapterTestIPv6ID,
 			adapterTestThirdIPID,
 		},
 	}
@@ -903,17 +905,17 @@ func assertAdapterProjection(t *testing.T, service *HTTPRestService, snapshot st
 		assert.Equal(t, types.Assigned, status.GetState(), id)
 		require.NotNil(t, status.PodInfo, id)
 	}
-	assert.Equal(t, "if-a", service.PodIPConfigState["11111111-1111-1111-1111-111111111111"].PodInfo.Key())
-	assert.Equal(t, "container-a", service.PodIPConfigState["11111111-1111-1111-1111-111111111111"].PodInfo.InfraContainerID())
-	assert.Equal(t, "if-a", service.PodIPConfigState["11111111-1111-1111-1111-111111111111"].PodInfo.InterfaceID())
-	assert.True(t, service.PodIPConfigState["11111111-1111-1111-1111-111111111111"].PodInfo.SecondaryInterfacesExist())
+	assert.Equal(t, adapterTestPodKeyA, service.PodIPConfigState[adapterTestPrimaryIPID].PodInfo.Key())
+	assert.Equal(t, "container-a", service.PodIPConfigState[adapterTestPrimaryIPID].PodInfo.InfraContainerID())
+	assert.Equal(t, adapterTestPodKeyA, service.PodIPConfigState[adapterTestPrimaryIPID].PodInfo.InterfaceID())
+	assert.True(t, service.PodIPConfigState[adapterTestPrimaryIPID].PodInfo.SecondaryInterfacesExist())
 	assert.Equal(t, adapterTestContainerB, service.PodIPConfigState["44444444-4444-4444-4444-444444444444"].PodInfo.Key())
 	assert.False(t, service.PodIPConfigState["44444444-4444-4444-4444-444444444444"].PodInfo.SecondaryInterfacesExist())
 	assert.Equal(
 		t,
 		adapterTestIPv4,
 		service.state.ContainerStatus[adapterTestNCID].CreateNetworkContainerRequest.
-			SecondaryIPConfigs["11111111-1111-1111-1111-111111111111"].IPAddress,
+			SecondaryIPConfigs[adapterTestPrimaryIPID].IPAddress,
 	)
 	assert.Equal(t, snapshot.Networks["network-1"].NicInfo, service.state.Networks["network-1"].NicInfo)
 	assert.Equal(t, snapshot.Networks["network-1"].Options, service.state.Networks["network-1"].Options)
@@ -922,8 +924,8 @@ func assertAdapterProjection(t *testing.T, service *HTTPRestService, snapshot st
 	assert.Equal(
 		t,
 		[]string{
-			"11111111-1111-1111-1111-111111111111",
-			"22222222-2222-2222-2222-222222222222",
+			adapterTestPrimaryIPID,
+			adapterTestIPv6ID,
 			adapterTestThirdIPID,
 		},
 		service.PodIPIDByPodInterfaceKey["if-a"],
@@ -1032,8 +1034,8 @@ func durableCacheFingerprint(service *HTTPRestService, adapter *durableStateAdap
 
 func TestBuildDurableCacheProjectionRejectsInvalidIPFamily(t *testing.T) {
 	snapshot := completeAdapterSnapshot(1)
-	snapshot.IPs["11111111-1111-1111-1111-111111111111"] = state.IPRecord{
-		ID: "11111111-1111-1111-1111-111111111111", IPAddress: net.IP{}.String(), NCID: adapterTestNCID,
+	snapshot.IPs[adapterTestPrimaryIPID] = state.IPRecord{
+		ID: adapterTestPrimaryIPID, IPAddress: net.IP{}.String(), NCID: adapterTestNCID,
 	}
 	_, err := buildDurableCacheProjection(snapshot)
 	require.Error(t, err)

--- a/cns/restserver/durable_state_adapter_test.go
+++ b/cns/restserver/durable_state_adapter_test.go
@@ -31,12 +31,19 @@ var (
 
 const (
 	adapterTestNCID        = "nc-1"
+	adapterTestNCID2       = "nc-2"
 	adapterTestIPv4        = "10.0.0.4"
 	adapterTestSubnet      = "10.0.0.0/24"
 	adapterTestLocation    = "azure"
 	adapterTestNetworkType = "underlay"
 	adapterTestNetwork     = "10.0.0.0"
 	adapterTestDNS         = "10.0.0.10"
+	adapterTestContainerB  = "container-b"
+	adapterTestThirdIPID   = "33333333-3333-3333-3333-333333333333"
+	adapterTestSecondaryIF = "net1"
+	adapterTestPodKeyA     = "if-a"
+	adapterTestMAC         = "00:11:22:33:44:55"
+	adapterTestContainerID = "container-1"
 )
 
 type adapterTestStore struct {
@@ -152,11 +159,11 @@ func TestDurableStateAdapterProjection(t *testing.T) {
 	snapshot.NetworkContainers[adapterTestNCID] = state.NetworkContainerRecord{}
 	snapshot.Networks["network-1"].Options["nested"].(map[string]any)["key"] = "mutated"
 	snapshot.Assignments["if-a"].IPIDs[0] = "mutated"
-	snapshot.Endpoints["container-a"].IfnameToIPMap["eth0"].IPv4[0].IP[0] = 192
+	snapshot.Endpoints["container-a"].IfnameToIPMap[InfraInterfaceName].IPv4[0].IP[0] = 192
 	assert.Equal(t, adapterTestNCID, service.state.ContainerStatus[adapterTestNCID].ID)
 	assert.Equal(t, "value", service.state.Networks["network-1"].Options["nested"].(map[string]any)["key"])
 	assert.Equal(t, "11111111-1111-1111-1111-111111111111", service.PodIPIDByPodInterfaceKey["if-a"][0])
-	assert.Equal(t, "10.0.0.4", service.EndpointState["container-a"].IfnameToIPMap["eth0"].IPv4[0].IP.String())
+	assert.Equal(t, adapterTestIPv4, service.EndpointState["container-a"].IfnameToIPMap[InfraInterfaceName].IPv4[0].IP.String())
 
 	service.state.Location = "same-generation-no-op"
 	require.NoError(t, adapter.restore(context.Background()))
@@ -203,19 +210,19 @@ func TestDurableStateAdapterProjectionFailureIsAtomic(t *testing.T) {
 		{
 			name: "malformed endpoint prefix",
 			mutate: func(snapshot *state.Snapshot) {
-				snapshot.Endpoints["container-a"].IfnameToIPMap["eth0"].IPv4[0].Mask = net.IPMask{0xff, 0}
+				snapshot.Endpoints["container-a"].IfnameToIPMap[InfraInterfaceName].IPv4[0].Mask = net.IPMask{0xff, 0}
 			},
 		},
 		{
 			name: "malformed endpoint MAC",
 			mutate: func(snapshot *state.Snapshot) {
-				snapshot.Endpoints["container-a"].IfnameToIPMap["eth0"].MACAddress = "not-a-mac"
+				snapshot.Endpoints["container-a"].IfnameToIPMap[InfraInterfaceName].MACAddress = "not-a-mac"
 			},
 		},
 		{
 			name: "nil endpoint interface",
 			mutate: func(snapshot *state.Snapshot) {
-				snapshot.Endpoints["container-a"].IfnameToIPMap["eth0"] = nil
+				snapshot.Endpoints["container-a"].IfnameToIPMap[InfraInterfaceName] = nil
 			},
 		},
 		{
@@ -291,7 +298,7 @@ func TestDurableStateAdapterEndpointProjectionDisabled(t *testing.T) {
 		pending.GetState(),
 	)
 	assert.Nil(t, pending.PodInfo)
-	available := service.PodIPConfigState["33333333-3333-3333-3333-333333333333"]
+	available := service.PodIPConfigState[adapterTestThirdIPID]
 	assert.Equal(
 		t,
 		types.Available,
@@ -312,7 +319,7 @@ func TestDurableStateAdapterPreflightsEndpointProjectionBeforeDurableMutation(t 
 	before := durableCacheFingerprint(service, adapter)
 
 	store.mu.Lock()
-	store.snapshot.Endpoints["container-a"].IfnameToIPMap["eth0"].MACAddress = "invalid"
+	store.snapshot.Endpoints["container-a"].IfnameToIPMap[InfraInterfaceName].MACAddress = "invalid"
 	generation := store.snapshot.Metadata.Generation
 	store.mu.Unlock()
 
@@ -339,7 +346,7 @@ func TestDurableStateAdapterCommitOrderingAndFailures(t *testing.T) {
 	record.Request.Version = "9"
 	ips := make([]state.IPRecord, 0, 3)
 	for _, ip := range snapshot.IPs {
-		if ip.NCID == "nc-1" {
+		if ip.NCID == adapterTestNCID {
 			ips = append(ips, ip)
 		}
 	}
@@ -438,12 +445,12 @@ func TestDurableStateAdapterDurableOperations(t *testing.T) {
 	assert.Contains(t, service.PodIPConfigState, "ip")
 	assert.Contains(t, service.state.Networks, "network")
 	assert.Equal(t, ncList("nc"), *service.state.ContainerIDByOrchestratorContext["pod"])
-	assert.Equal(t, "pnp", service.state.PnpIDByMacAddress["00:11:22:33:44:55"])
+	assert.Equal(t, "pnp", service.state.PnpIDByMacAddress[adapterTestMAC])
 	assert.Equal(t, "node", service.state.NodeID)
 	assert.Equal(t, uint64(5), adapter.generation)
 
 	require.NoError(t, adapter.deleteOrchestratorContext(context.Background(), "pod"))
-	require.NoError(t, adapter.deletePnPID(context.Background(), "00:11:22:33:44:55"))
+	require.NoError(t, adapter.deletePnPID(context.Background(), adapterTestMAC))
 	require.NoError(t, adapter.deleteNetwork(context.Background(), "network"))
 	require.NoError(t, adapter.deleteNetworkContainer(context.Background(), "nc"))
 	assert.Empty(t, service.state.ContainerStatus)
@@ -543,7 +550,7 @@ func TestDurableStateAdapterConcurrentRestore(t *testing.T) {
 
 	newer := completeAdapterSnapshot(2)
 	newer.Metadata.Location = "new-location"
-	newer.Endpoints["container-a"].IfnameToIPMap["eth0"].HostVethName = "new-veth"
+	newer.Endpoints["container-a"].IfnameToIPMap[InfraInterfaceName].HostVethName = "new-veth"
 	store.mu.Lock()
 	store.snapshot = newer
 	store.mu.Unlock()
@@ -569,7 +576,7 @@ func TestDurableStateAdapterConcurrentRestore(t *testing.T) {
 
 	assert.Equal(t, uint64(2), adapter.generation)
 	assert.Equal(t, "new-location", service.state.Location)
-	assert.Equal(t, "new-veth", service.EndpointState["container-a"].IfnameToIPMap["eth0"].HostVethName)
+	assert.Equal(t, "new-veth", service.EndpointState["container-a"].IfnameToIPMap[InfraInterfaceName].HostVethName)
 	assertAdapterProjection(t, service, newer)
 }
 
@@ -586,7 +593,7 @@ func TestDurableStateAdapterRestartRestoreAndClose(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, first.restore(context.Background()))
 	session := completeAdapterSnapshot(0)
-	for _, ncID := range []string{adapterTestNCID, "nc-2"} {
+	for _, ncID := range []string{adapterTestNCID, adapterTestNCID2} {
 		record := session.NetworkContainers[ncID]
 		record.Request.AuthorizationToken = "must-not-persist"
 		record.Request.SecondaryIPConfigs = map[string]cns.SecondaryIPConfig{
@@ -600,7 +607,7 @@ func TestDurableStateAdapterRestartRestoreAndClose(t *testing.T) {
 		}
 		require.NoError(t, first.applyNetworkContainer(context.Background(), record, ips))
 	}
-	for _, podKey := range []string{"if-a", "container-b"} {
+	for _, podKey := range []string{adapterTestPodKeyA, adapterTestContainerB} {
 		assignment := session.Assignments[podKey]
 		changed, assignErr := db.AssignEndpoint(
 			context.Background(),
@@ -618,7 +625,7 @@ func TestDurableStateAdapterRestartRestoreAndClose(t *testing.T) {
 		NicInfo:     &wireserver.InterfaceInfo{Subnet: adapterTestSubnet},
 		Options:     map[string]any{"nested": map[string]any{"enabled": true}},
 	}))
-	require.NoError(t, first.putOrchestratorContext(context.Background(), "pod", []string{"nc-1", "nc-2"}))
+	require.NoError(t, first.putOrchestratorContext(context.Background(), "pod", []string{adapterTestNCID, adapterTestNCID2}))
 	require.NoError(t, first.putPnPID(context.Background(), "00-11-22-33-44-55", "pnp"))
 	require.NoError(t, first.putServiceMetadata(context.Background(), durableServiceMetadata{
 		OrchestratorType: cns.KubernetesCRD,
@@ -647,10 +654,10 @@ func TestDurableStateAdapterRestartRestoreAndClose(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, second.restore(context.Background()))
 	assert.Equal(t, want, durableCacheFingerprint(secondService, second))
-	assert.Empty(t, secondService.state.ContainerStatus["nc-1"].CreateNetworkContainerRequest.AuthorizationToken)
+	assert.Empty(t, secondService.state.ContainerStatus[adapterTestNCID].CreateNetworkContainerRequest.AuthorizationToken)
 	assert.NotContains(
 		t,
-		secondService.state.ContainerStatus["nc-1"].CreateNetworkContainerRequest.SecondaryIPConfigs,
+		secondService.state.ContainerStatus[adapterTestNCID].CreateNetworkContainerRequest.SecondaryIPConfigs,
 		"embedded",
 	)
 	restartedSnapshot, err := reopened.Snapshot(context.Background())
@@ -730,9 +737,9 @@ func completeAdapterSnapshot(generation uint64) state.Snapshot {
 	snapshot.Metadata.Initialized = true
 	snapshot.Metadata.TimeStamp = time.Unix(50, 0).UTC()
 	snapshot.NetworkContainers[adapterTestNCID] = adapterNetworkContainer(adapterTestNCID)
-	second := adapterNetworkContainer("nc-2")
+	second := adapterNetworkContainer(adapterTestNCID2)
 	second.HostVersion = "3"
-	snapshot.NetworkContainers["nc-2"] = second
+	snapshot.NetworkContainers[adapterTestNCID2] = second
 	snapshot.IPs["11111111-1111-1111-1111-111111111111"] = state.IPRecord{
 		ID:        "11111111-1111-1111-1111-111111111111",
 		IPAddress: adapterTestIPv4,
@@ -742,19 +749,19 @@ func completeAdapterSnapshot(generation uint64) state.Snapshot {
 	snapshot.IPs["22222222-2222-2222-2222-222222222222"] = state.IPRecord{
 		ID:        "22222222-2222-2222-2222-222222222222",
 		IPAddress: "2001:db8::4",
-		NCID:      "nc-1",
+		NCID:      adapterTestNCID,
 		NCVersion: 2,
 	}
-	snapshot.IPs["33333333-3333-3333-3333-333333333333"] = state.IPRecord{
-		ID:        "33333333-3333-3333-3333-333333333333",
+	snapshot.IPs[adapterTestThirdIPID] = state.IPRecord{
+		ID:        adapterTestThirdIPID,
 		IPAddress: "10.0.1.4",
-		NCID:      "nc-2",
+		NCID:      adapterTestNCID2,
 		NCVersion: 2,
 	}
 	snapshot.IPs["44444444-4444-4444-4444-444444444444"] = state.IPRecord{
 		ID:        "44444444-4444-4444-4444-444444444444",
 		IPAddress: "10.0.1.5",
-		NCID:      "nc-2",
+		NCID:      adapterTestNCID2,
 		NCVersion: 2,
 	}
 	snapshot.Networks["network-1"] = state.NetworkRecord{
@@ -767,29 +774,29 @@ func completeAdapterSnapshot(generation uint64) state.Snapshot {
 		},
 		Options: map[string]any{"nested": map[string]any{"key": "value"}},
 	}
-	snapshot.OrchestratorContexts["pod-a"] = []string{"nc-1", "nc-2"}
-	snapshot.PnPIDByMAC["00:11:22:33:44:55"] = "pnp-1"
+	snapshot.OrchestratorContexts["pod-a"] = []string{adapterTestNCID, adapterTestNCID2}
+	snapshot.PnPIDByMAC[adapterTestMAC] = "pnp-1"
 	snapshot.Endpoints["container-a"] = state.EndpointRecord{
 		PodName:      "pod-a",
 		PodNamespace: "namespace-a",
 		IfnameToIPMap: map[string]*state.IPInfoRecord{
-			"eth0": {
+			InfraInterfaceName: {
 				IPv4:               []net.IPNet{testIPNet("10.0.0.4/24")},
 				IPv6:               []net.IPNet{testIPNet("2001:db8::4/64")},
 				HNSEndpointID:      "hns-endpoint-a",
 				HNSNetworkID:       "hns-network-a",
 				HostVethName:       "veth-a",
-				MACAddress:         "00:11:22:33:44:55",
-				NetworkContainerID: "nc-1",
+				MACAddress:         adapterTestMAC,
+				NetworkContainerID: adapterTestNCID,
 				NICType:            cns.InfraNIC,
 			},
-			"net1": {
+			adapterTestSecondaryIF: {
 				IPv4:               []net.IPNet{testIPNet("10.0.1.4/32")},
 				HNSEndpointID:      "hns-endpoint-b",
 				HNSNetworkID:       "hns-network-b",
 				HostVethName:       "veth-b",
 				MACAddress:         "00:11:22:33:44:66",
-				NetworkContainerID: "nc-2",
+				NetworkContainerID: adapterTestNCID2,
 				NICType:            cns.DelegatedVMNIC,
 			},
 		},
@@ -805,24 +812,24 @@ func completeAdapterSnapshot(generation uint64) state.Snapshot {
 		IPIDs: []string{
 			"11111111-1111-1111-1111-111111111111",
 			"22222222-2222-2222-2222-222222222222",
-			"33333333-3333-3333-3333-333333333333",
+			adapterTestThirdIPID,
 		},
 	}
-	snapshot.Endpoints["container-b"] = state.EndpointRecord{
+	snapshot.Endpoints[adapterTestContainerB] = state.EndpointRecord{
 		PodName:      "pod-b",
 		PodNamespace: "namespace-b",
 		IfnameToIPMap: map[string]*state.IPInfoRecord{
-			"eth0": {
+			InfraInterfaceName: {
 				IPv4:               []net.IPNet{testIPNet("10.0.1.5/24")},
-				NetworkContainerID: "nc-2",
+				NetworkContainerID: adapterTestNCID2,
 				NICType:            cns.InfraNIC,
 			},
 		},
 	}
-	snapshot.Assignments["container-b"] = state.AssignmentRecord{
+	snapshot.Assignments[adapterTestContainerB] = state.AssignmentRecord{
 		Pod: state.PodIdentity{
-			PodKey:           "container-b",
-			InfraContainerID: "container-b",
+			PodKey:           adapterTestContainerB,
+			InfraContainerID: adapterTestContainerB,
 			PodName:          "pod-b",
 			PodNamespace:     "namespace-b",
 		},
@@ -900,7 +907,7 @@ func assertAdapterProjection(t *testing.T, service *HTTPRestService, snapshot st
 	assert.Equal(t, "container-a", service.PodIPConfigState["11111111-1111-1111-1111-111111111111"].PodInfo.InfraContainerID())
 	assert.Equal(t, "if-a", service.PodIPConfigState["11111111-1111-1111-1111-111111111111"].PodInfo.InterfaceID())
 	assert.True(t, service.PodIPConfigState["11111111-1111-1111-1111-111111111111"].PodInfo.SecondaryInterfacesExist())
-	assert.Equal(t, "container-b", service.PodIPConfigState["44444444-4444-4444-4444-444444444444"].PodInfo.Key())
+	assert.Equal(t, adapterTestContainerB, service.PodIPConfigState["44444444-4444-4444-4444-444444444444"].PodInfo.Key())
 	assert.False(t, service.PodIPConfigState["44444444-4444-4444-4444-444444444444"].PodInfo.SecondaryInterfacesExist())
 	assert.Equal(
 		t,
@@ -911,19 +918,19 @@ func assertAdapterProjection(t *testing.T, service *HTTPRestService, snapshot st
 	assert.Equal(t, snapshot.Networks["network-1"].NicInfo, service.state.Networks["network-1"].NicInfo)
 	assert.Equal(t, snapshot.Networks["network-1"].Options, service.state.Networks["network-1"].Options)
 	assert.Equal(t, ncList("nc-1,nc-2"), *service.state.ContainerIDByOrchestratorContext["pod-a"])
-	assert.Equal(t, "pnp-1", service.state.PnpIDByMacAddress["00:11:22:33:44:55"])
+	assert.Equal(t, "pnp-1", service.state.PnpIDByMacAddress[adapterTestMAC])
 	assert.Equal(
 		t,
 		[]string{
 			"11111111-1111-1111-1111-111111111111",
 			"22222222-2222-2222-2222-222222222222",
-			"33333333-3333-3333-3333-333333333333",
+			adapterTestThirdIPID,
 		},
 		service.PodIPIDByPodInterfaceKey["if-a"],
 	)
 	require.Len(t, service.EndpointState, 2)
-	eth0 := service.EndpointState["container-a"].IfnameToIPMap["eth0"]
-	wantEth0 := snapshot.Endpoints["container-a"].IfnameToIPMap["eth0"]
+	eth0 := service.EndpointState["container-a"].IfnameToIPMap[InfraInterfaceName]
+	wantEth0 := snapshot.Endpoints["container-a"].IfnameToIPMap[InfraInterfaceName]
 	assert.Equal(t, wantEth0.IPv4, eth0.IPv4)
 	assert.Equal(t, wantEth0.IPv6, eth0.IPv6)
 	assert.Equal(t, wantEth0.HNSEndpointID, eth0.HnsEndpointID)
@@ -932,7 +939,7 @@ func assertAdapterProjection(t *testing.T, service *HTTPRestService, snapshot st
 	assert.Equal(t, wantEth0.MACAddress, eth0.MacAddress)
 	assert.Equal(t, wantEth0.NetworkContainerID, eth0.NetworkContainerID)
 	assert.Equal(t, wantEth0.NICType, eth0.NICType)
-	assert.Equal(t, cns.DelegatedVMNIC, service.EndpointState["container-a"].IfnameToIPMap["net1"].NICType)
+	assert.Equal(t, cns.DelegatedVMNIC, service.EndpointState["container-a"].IfnameToIPMap[adapterTestSecondaryIF].NICType)
 }
 
 type adapterCacheFingerprint struct {

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -92,6 +92,11 @@ type iptablesGetter interface {
 	GetIPTablesLegacy() (iptablesLegacyClient, error)
 }
 
+type stateRestoreLogger interface {
+	Printf(string, ...any)
+	Errorf(string, ...any)
+}
+
 // HTTPRestService represents http listener for CNS - Container Networking Service.
 type HTTPRestService struct {
 	*cns.Service
@@ -122,6 +127,7 @@ type HTTPRestService struct {
 	mtpncClient                mtpncClient
 	nodeinfoClient             nodeinfoClient
 	nodeName                   string
+	stateRestoreLogger         stateRestoreLogger
 }
 
 type CNIConflistGenerator interface {
@@ -272,6 +278,7 @@ func NewHTTPRestService(config *common.ServiceConfig, wscli interfaceGetter, wsp
 		homeAzMonitor:            homeAzMonitor,
 		cniConflistGenerator:     gen,
 		imdsClient:               imdsClient,
+		stateRestoreLogger:       logger.Log,
 	}, nil
 }
 

--- a/cns/restserver/util.go
+++ b/cns/restserver/util.go
@@ -98,6 +98,15 @@ func (service *HTTPRestService) saveState() error {
 
 // restoreState restores CNS state from persistent store.
 func (service *HTTPRestService) restoreState() {
+	restoreLogger := service.stateRestoreLogger
+	if restoreLogger == nil {
+		restoreLogger = logger.Log
+	}
+	if restoreFromJSON, ok := service.Options[acn.OptRestoreStateFromJSON].(bool); ok && !restoreFromJSON {
+		restoreLogger.Printf("persistent state JSON restore skipped")
+		return
+	}
+
 	logger.Printf("[Azure CNS] restoreState")
 
 	// Skip if a store is not provided.
@@ -122,8 +131,7 @@ func (service *HTTPRestService) restoreState() {
 
 	if service.Options[acn.OptManageEndpointState] == true {
 		if service.EndpointStateStore == nil {
-			//nolint:staticcheck // TODO: migrate to zap
-			logger.Errorf("[Azure CNS]  OptManageEndpointState is enabled but EndpointStateStore is not initialized; endpoint state persistence/restoration is disabled.")
+			restoreLogger.Errorf("[Azure CNS]  OptManageEndpointState is enabled but EndpointStateStore is not initialized; endpoint state persistence/restoration is disabled.")
 			return
 		}
 		err := service.EndpointStateStore.Read(EndpointStoreKey, &service.EndpointState)

--- a/cns/restserver/util_test.go
+++ b/cns/restserver/util_test.go
@@ -1,6 +1,8 @@
 package restserver
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Azure/azure-container-networking/cns"
@@ -10,6 +12,33 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type stateRestoreLogRecorder struct {
+	info     []string
+	failures []string
+}
+
+func (l *stateRestoreLogRecorder) Printf(format string, args ...any) {
+	l.info = append(l.info, fmt.Sprintf(format, args...))
+}
+
+func (l *stateRestoreLogRecorder) Errorf(format string, args ...any) {
+	l.failures = append(l.failures, fmt.Sprintf(format, args...))
+}
+
+func (l *stateRestoreLogRecorder) messages() (info, failures string) {
+	return strings.Join(l.info, "\n"), strings.Join(l.failures, "\n")
+}
+
+type readCountingStore struct {
+	store.KeyValueStore
+	reads int
+}
+
+func (s *readCountingStore) Read(key string, value interface{}) error {
+	s.reads++
+	return s.KeyValueStore.Read(key, value)
+}
 
 func TestAreNCsPresent(t *testing.T) {
 	present := ncList("present")
@@ -183,6 +212,70 @@ func TestRestoreState(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUnifiedInitSkipsJSONStateRestore(t *testing.T) {
+	mainStore := &readCountingStore{KeyValueStore: store.NewMockStore("")}
+	logs := &stateRestoreLogRecorder{}
+	options := map[string]interface{}{
+		acn.OptCnsURL:               "tcp://127.0.0.1:0",
+		acn.OptCnsPort:              "",
+		acn.OptManageEndpointState:  true,
+		acn.OptRestoreStateFromJSON: false,
+	}
+	svc := HTTPRestService{
+		Service: &cns.Service{
+			Service: &common.Service{Options: options},
+		},
+		store: mainStore,
+		state: &httpRestServiceState{
+			Networks: make(map[string]*networkInfo),
+		},
+		EndpointState: map[string]*EndpointInfo{
+			"container-1": {PodName: "bolt-pod"},
+		},
+		stateRestoreLogger: logs,
+	}
+
+	require.NoError(t, svc.Init(&common.ServiceConfig{
+		Store:       mainStore,
+		ChannelMode: cns.Direct,
+	}))
+	require.NotNil(t, svc.Listener)
+	assert.Zero(t, mainStore.reads)
+	require.Contains(t, svc.EndpointState, "container-1")
+	assert.Equal(t, "bolt-pod", svc.EndpointState["container-1"].PodName)
+
+	info, failures := logs.messages()
+	assert.Equal(t, "persistent state JSON restore skipped", info)
+	assert.Empty(t, failures)
+}
+
+func TestJSONRestoreMissingEndpointStorePreservesError(t *testing.T) {
+	mainStore := &readCountingStore{KeyValueStore: store.NewMockStore("")}
+	require.NoError(t, mainStore.Write(storeKey, &httpRestServiceState{}))
+	logs := &stateRestoreLogRecorder{}
+	svc := HTTPRestService{
+		Service: &cns.Service{
+			Service: &common.Service{Options: map[string]interface{}{
+				acn.OptManageEndpointState: true,
+			}},
+		},
+		store:              mainStore,
+		state:              &httpRestServiceState{},
+		EndpointState:      make(map[string]*EndpointInfo),
+		stateRestoreLogger: logs,
+	}
+
+	svc.restoreState()
+	assert.Equal(t, 1, mainStore.reads)
+	info, failures := logs.messages()
+	assert.Empty(t, info)
+	assert.Equal(
+		t,
+		"[Azure CNS]  OptManageEndpointState is enabled but EndpointStateStore is not initialized; endpoint state persistence/restoration is disabled.",
+		failures,
+	)
 }
 
 // test to check if nc can be deleted from ncList for Delete() method

--- a/cns/restserver/util_test.go
+++ b/cns/restserver/util_test.go
@@ -37,7 +37,10 @@ type readCountingStore struct {
 
 func (s *readCountingStore) Read(key string, value interface{}) error {
 	s.reads++
-	return s.KeyValueStore.Read(key, value)
+	if err := s.KeyValueStore.Read(key, value); err != nil {
+		return fmt.Errorf("reading counted state: %w", err)
+	}
+	return nil
 }
 
 func TestAreNCsPresent(t *testing.T) {
@@ -232,7 +235,7 @@ func TestUnifiedInitSkipsJSONStateRestore(t *testing.T) {
 			Networks: make(map[string]*networkInfo),
 		},
 		EndpointState: map[string]*EndpointInfo{
-			"container-1": {PodName: "bolt-pod"},
+			adapterTestContainerID: {PodName: "bolt-pod"},
 		},
 		stateRestoreLogger: logs,
 	}
@@ -243,8 +246,8 @@ func TestUnifiedInitSkipsJSONStateRestore(t *testing.T) {
 	}))
 	require.NotNil(t, svc.Listener)
 	assert.Zero(t, mainStore.reads)
-	require.Contains(t, svc.EndpointState, "container-1")
-	assert.Equal(t, "bolt-pod", svc.EndpointState["container-1"].PodName)
+	require.Contains(t, svc.EndpointState, adapterTestContainerID)
+	assert.Equal(t, "bolt-pod", svc.EndpointState[adapterTestContainerID].PodName)
 
 	info, failures := logs.messages()
 	assert.Equal(t, "persistent state JSON restore skipped", info)

--- a/cns/service/bolt_startup.go
+++ b/cns/service/bolt_startup.go
@@ -57,7 +57,7 @@ type boltPersistentStateDependencies struct {
 	openStore       func(string, processlock.Interface) (store.KeyValueStore, error)
 	openDB          func(context.Context, string, state.Options) (*state.DB, error)
 	currentBootID   func() (string, error)
-	attachBolt      func(*state.DB) (persistentStateAttachment, error)
+	attachBolt      func(*state.DB, bool) (persistentStateAttachment, error)
 	restoreJSON     func(context.Context, store.KeyValueStore, store.KeyValueStore) error
 }
 
@@ -73,8 +73,8 @@ func productionBoltPersistentStateDependencies(
 		},
 		openDB:        state.OpenContext,
 		currentBootID: platform.BootID,
-		attachBolt: func(db *state.DB) (persistentStateAttachment, error) {
-			restore, closeFn, err := restserver.NewDurableStateLifecycle(service, db)
+		attachBolt: func(db *state.DB, projectEndpointState bool) (persistentStateAttachment, error) {
+			restore, closeFn, err := restserver.NewDurableStateLifecycle(service, db, projectEndpointState)
 			if err != nil {
 				return persistentStateAttachment{}, fmt.Errorf("creating durable state lifecycle: %w", err)
 			}
@@ -183,7 +183,7 @@ func newBoltPersistentStateStartup(
 	if _, metricsErr := db.RefreshMetrics(ctx); metricsErr != nil {
 		return nil, closeDBAfterError(metricsErr)
 	}
-	attachment, attachmentErr := deps.attachBolt(db)
+	attachment, attachmentErr := deps.attachBolt(db, config.manageEndpointState)
 	if attachmentErr != nil {
 		return nil, closeDBAfterError(fmt.Errorf("attaching Bolt persistent state: %w", attachmentErr))
 	}

--- a/cns/service/bolt_startup_test.go
+++ b/cns/service/bolt_startup_test.go
@@ -253,7 +253,7 @@ func TestBoltPersistentStateStartupFailuresGateListenerAndReleaseLocks(t *testin
 		{
 			name: "adapter",
 			mutate: func(deps *boltPersistentStateDependencies, _ *boltPersistentStateConfig) {
-				deps.attachBolt = func(*state.DB) (persistentStateAttachment, error) {
+				deps.attachBolt = func(*state.DB, bool) (persistentStateAttachment, error) {
 					return persistentStateAttachment{}, errBoltAdapter
 				}
 			},
@@ -303,7 +303,9 @@ func TestBoltPersistentStateStartupRestoreFailureClosesDatabase(t *testing.T) {
 	paths := writeStartupLegacyState(t, "node-1")
 	var events []string
 	deps, locks, _, closeCount := startupTestDependencies(t, &events)
-	deps.attachBolt = func(db *state.DB) (persistentStateAttachment, error) {
+	var projectEndpointState bool
+	deps.attachBolt = func(db *state.DB, project bool) (persistentStateAttachment, error) {
+		projectEndpointState = project
 		return persistentStateAttachment{
 			restore: func(context.Context) error { return errBoltProjection },
 			close: func() error {
@@ -322,6 +324,7 @@ func TestBoltPersistentStateStartupRestoreFailureClosesDatabase(t *testing.T) {
 		return nil
 	}, deps)
 	require.NoError(t, err)
+	require.True(t, projectEndpointState)
 	err = startup.Start(context.Background())
 	require.ErrorIs(t, err, errBoltProjection)
 	require.Zero(t, listenerCount)
@@ -487,7 +490,7 @@ func startupTestDependencies(
 		},
 		openDB:        state.OpenContext,
 		currentBootID: func() (string, error) { return "boot-1", nil },
-		attachBolt: func(db *state.DB) (persistentStateAttachment, error) {
+		attachBolt: func(db *state.DB, _ bool) (persistentStateAttachment, error) {
 			return persistentStateAttachment{
 				restore: func(ctx context.Context) error {
 					restoreCount++

--- a/cns/service/endpoint_state_provider.go
+++ b/cns/service/endpoint_state_provider.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Microsoft. All rights reserved.
+// MIT License
+
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+type endpointStateProvider string
+
+const (
+	endpointStateProviderJSON    endpointStateProvider = "json"
+	endpointStateProviderUnified endpointStateProvider = "unified"
+)
+
+const productionEndpointStateProvider = endpointStateProviderJSON
+
+type endpointStateStartupFactory func() (*persistentStateStartup, error)
+
+func newEndpointStateStartup(
+	provider endpointStateProvider,
+	jsonFactory endpointStateStartupFactory,
+	unifiedFactory endpointStateStartupFactory,
+) (*persistentStateStartup, error) {
+	var factory endpointStateStartupFactory
+	switch provider {
+	case endpointStateProviderJSON:
+		factory = jsonFactory
+	case endpointStateProviderUnified:
+		factory = unifiedFactory
+	default:
+		return nil, fmt.Errorf("unsupported endpoint state provider %q", provider)
+	}
+	if factory == nil {
+		return nil, errors.New("endpoint state startup factory is nil")
+	}
+	return factory()
+}

--- a/cns/service/endpoint_state_provider.go
+++ b/cns/service/endpoint_state_provider.go
@@ -17,6 +17,10 @@ const (
 
 const productionEndpointStateProvider = endpointStateProviderJSON
 
+func (provider endpointStateProvider) restoresStateFromJSON() bool {
+	return provider == endpointStateProviderJSON
+}
+
 type endpointStateStartupFactory func() (*persistentStateStartup, error)
 
 func newEndpointStateStartup(

--- a/cns/service/endpoint_state_provider.go
+++ b/cns/service/endpoint_state_provider.go
@@ -8,6 +8,11 @@ import (
 	"fmt"
 )
 
+var (
+	errUnsupportedEndpointStateProvider = errors.New("unsupported endpoint state provider")
+	errNilEndpointStateStartupFactory   = errors.New("endpoint state startup factory is nil")
+)
+
 type endpointStateProvider string
 
 const (
@@ -35,10 +40,10 @@ func newEndpointStateStartup(
 	case endpointStateProviderUnified:
 		factory = unifiedFactory
 	default:
-		return nil, fmt.Errorf("unsupported endpoint state provider %q", provider)
+		return nil, fmt.Errorf("%w: %q", errUnsupportedEndpointStateProvider, provider)
 	}
 	if factory == nil {
-		return nil, errors.New("endpoint state startup factory is nil")
+		return nil, errNilEndpointStateStartupFactory
 	}
 	return factory()
 }

--- a/cns/service/endpoint_state_provider_test.go
+++ b/cns/service/endpoint_state_provider_test.go
@@ -11,6 +11,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	errUnifiedDatabaseOpened = errors.New("unified database opener called")
+	errUnifiedRestore        = errors.New("unified restore failed")
+)
+
 func TestEndpointStateProviderSelection(t *testing.T) {
 	assert.True(t, productionEndpointStateProvider.restoresStateFromJSON())
 
@@ -26,7 +31,7 @@ func TestEndpointStateProviderSelection(t *testing.T) {
 			},
 			func() (*persistentStateStartup, error) {
 				unifiedCalls++
-				return nil, errors.New("unified database opener called")
+				return nil, errUnifiedDatabaseOpened
 			},
 		)
 		require.NoError(t, err)
@@ -56,7 +61,6 @@ func TestEndpointStateProviderSelection(t *testing.T) {
 	})
 
 	t.Run("unified failure does not fall back", func(t *testing.T) {
-		unifiedErr := errors.New("unified restore failed")
 		jsonCalls := 0
 		startup, err := newEndpointStateStartup(
 			endpointStateProviderUnified,
@@ -65,10 +69,10 @@ func TestEndpointStateProviderSelection(t *testing.T) {
 				return &persistentStateStartup{}, nil
 			},
 			func() (*persistentStateStartup, error) {
-				return nil, unifiedErr
+				return nil, errUnifiedRestore
 			},
 		)
-		require.ErrorIs(t, err, unifiedErr)
+		require.ErrorIs(t, err, errUnifiedRestore)
 		assert.Nil(t, startup)
 		assert.Zero(t, jsonCalls)
 	})

--- a/cns/service/endpoint_state_provider_test.go
+++ b/cns/service/endpoint_state_provider_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestEndpointStateProviderSelection(t *testing.T) {
+	assert.True(t, productionEndpointStateProvider.restoresStateFromJSON())
+
 	t.Run("production JSON does not open unified state", func(t *testing.T) {
 		jsonStartup := &persistentStateStartup{}
 		jsonCalls := 0
@@ -34,6 +36,8 @@ func TestEndpointStateProviderSelection(t *testing.T) {
 	})
 
 	t.Run("internal unified selection", func(t *testing.T) {
+		assert.False(t, endpointStateProviderUnified.restoresStateFromJSON())
+
 		unifiedStartup := &persistentStateStartup{}
 		jsonCalls := 0
 		startup, err := newEndpointStateStartup(

--- a/cns/service/endpoint_state_provider_test.go
+++ b/cns/service/endpoint_state_provider_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Microsoft. All rights reserved.
+// MIT License
+
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndpointStateProviderSelection(t *testing.T) {
+	t.Run("production JSON does not open unified state", func(t *testing.T) {
+		jsonStartup := &persistentStateStartup{}
+		jsonCalls := 0
+		unifiedCalls := 0
+		startup, err := newEndpointStateStartup(
+			productionEndpointStateProvider,
+			func() (*persistentStateStartup, error) {
+				jsonCalls++
+				return jsonStartup, nil
+			},
+			func() (*persistentStateStartup, error) {
+				unifiedCalls++
+				return nil, errors.New("unified database opener called")
+			},
+		)
+		require.NoError(t, err)
+		assert.Same(t, jsonStartup, startup)
+		assert.Equal(t, 1, jsonCalls)
+		assert.Zero(t, unifiedCalls)
+	})
+
+	t.Run("internal unified selection", func(t *testing.T) {
+		unifiedStartup := &persistentStateStartup{}
+		jsonCalls := 0
+		startup, err := newEndpointStateStartup(
+			endpointStateProviderUnified,
+			func() (*persistentStateStartup, error) {
+				jsonCalls++
+				return &persistentStateStartup{}, nil
+			},
+			func() (*persistentStateStartup, error) {
+				return unifiedStartup, nil
+			},
+		)
+		require.NoError(t, err)
+		assert.Same(t, unifiedStartup, startup)
+		assert.Zero(t, jsonCalls)
+	})
+
+	t.Run("unified failure does not fall back", func(t *testing.T) {
+		unifiedErr := errors.New("unified restore failed")
+		jsonCalls := 0
+		startup, err := newEndpointStateStartup(
+			endpointStateProviderUnified,
+			func() (*persistentStateStartup, error) {
+				jsonCalls++
+				return &persistentStateStartup{}, nil
+			},
+			func() (*persistentStateStartup, error) {
+				return nil, unifiedErr
+			},
+		)
+		require.ErrorIs(t, err, unifiedErr)
+		assert.Nil(t, startup)
+		assert.Zero(t, jsonCalls)
+	})
+
+	t.Run("unsupported selection", func(t *testing.T) {
+		calls := 0
+		factory := func() (*persistentStateStartup, error) {
+			calls++
+			return &persistentStateStartup{}, nil
+		}
+		startup, err := newEndpointStateStartup(endpointStateProvider("unsupported"), factory, factory)
+		require.Error(t, err)
+		assert.Nil(t, startup)
+		assert.Zero(t, calls)
+	})
+
+	t.Run("selected factory is required", func(t *testing.T) {
+		startup, err := newEndpointStateStartup(endpointStateProviderUnified, func() (*persistentStateStartup, error) {
+			return &persistentStateStartup{}, nil
+		}, nil)
+		require.Error(t, err)
+		assert.Nil(t, startup)
+	})
+}

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -791,6 +791,7 @@ func main() {
 	httpRemoteRestService.SetOption(acn.OptHttpResponseHeaderTimeout, httpResponseHeaderTimeout)
 	httpRemoteRestService.SetOption(acn.OptProgramSNATIPTables, cnsconfig.ProgramSNATIPTables)
 	httpRemoteRestService.SetOption(acn.OptManageEndpointState, cnsconfig.ManageEndpointState)
+	httpRemoteRestService.SetOption(acn.OptRestoreStateFromJSON, productionEndpointStateProvider.restoresStateFromJSON())
 	httpRemoteRestService.SetOption(acn.OptEnableStaleHNSCleanupOnNCCreate, cnsconfig.EnableStaleHNSCleanupOnNCCreate)
 
 	// Create default ext network if commandline option is set

--- a/cns/service/main.go
+++ b/cns/service/main.go
@@ -739,12 +739,18 @@ func main() {
 		logger.Printf("EndpointStoreState path is %s", endpointStorePath+endpointStoreName+".json") //nolint:staticcheck // main still uses the legacy global logger
 	}
 
-	persistentState, err := newJSONPersistentStateStartup(
-		resolvePersistentStatePaths(storeFileLocation, endpointStorePath),
-		cnsconfig.ManageEndpointState,
-		func(context.Context) error {
-			return httpRemoteRestService.Start(&config)
+	persistentState, err := newEndpointStateStartup(
+		productionEndpointStateProvider,
+		func() (*persistentStateStartup, error) {
+			return newJSONPersistentStateStartup(
+				resolvePersistentStatePaths(storeFileLocation, endpointStorePath),
+				cnsconfig.ManageEndpointState,
+				func(context.Context) error {
+					return httpRemoteRestService.Start(&config)
+				},
+			)
 		},
+		nil,
 	)
 	if err != nil {
 		logger.Errorf("Failed to initialize persistent state: %v", err) //nolint:staticcheck // main still uses the legacy global logger

--- a/common/config.go
+++ b/common/config.go
@@ -104,6 +104,9 @@ const (
 	// Enable CNS to manage endpoint state
 	OptManageEndpointState = "manage-endpoint-state"
 
+	// Restore CNS state from legacy JSON stores
+	OptRestoreStateFromJSON = "restore-state-from-json"
+
 	// Enable CNS to clean up stale HNS resources when a NIC/MAC is reused by a new NC
 	OptEnableStaleHNSCleanupOnNCCreate = "enable-stale-hns-cleanup-on-nc-create"
 


### PR DESCRIPTION
## Scope
Adds endpoint/session projection, provider selection, restart restoration, and the shared projection/cache invariants.

## Draft dependency caveat
This PR is opened early for review and CI on top of the draft startup lifecycle. **Do not merge until R2 and all inherited temporary-base prerequisites merge.**

## Behavior
Projection is still dark; JSON remains the production provider until activation. Failed projection never mutates the live cache.

## Evidence
Linux/Windows lint and state/restserver/service race tests pass.