### PR TITLE
feat(cns): import live CNI endpoint ownership

### DIFF
--- a/cni/api/api.go
+++ b/cni/api/api.go
@@ -16,6 +16,7 @@ type PodNetworkInterfaceInfo struct {
 	PodNamespace  string
 	PodEndpointId string
 	ContainerID   string
+	IfName        string
 	IPAddresses   []net.IPNet
 }
 

--- a/cni/network/network.go
+++ b/cni/network/network.go
@@ -215,6 +215,7 @@ func (plugin *NetPlugin) GetAllEndpointState(networkid string) (*api.AzureCNISta
 			PodNamespace:  ep.PODNameSpace,
 			PodEndpointId: ep.EndpointID,
 			ContainerID:   ep.ContainerID,
+			IfName:        ep.IfName,
 			IPAddresses:   ep.IPAddresses,
 		}
 

--- a/cns/cni_ownership_contract.go
+++ b/cns/cni_ownership_contract.go
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package cns
+
+import (
+	"context"
+	"net"
+)
+
+// CNIEndpointState is one live interface owned by stateful Azure CNI.
+// IPAddresses retain the host addresses and masks returned by CNI.
+type CNIEndpointState struct {
+	InfraContainerID string
+	PodEndpointID    string
+	PodName          string
+	PodNamespace     string
+	InterfaceKey     string
+	InterfaceName    string
+	IPAddresses      []net.IPNet
+}
+
+// CNIEndpointStateProvider reads the complete live stateful CNI endpoint set.
+type CNIEndpointStateProvider func(context.Context) ([]CNIEndpointState, error)

--- a/cns/restserver/cni_import_adapter_test.go
+++ b/cns/restserver/cni_import_adapter_test.go
@@ -23,8 +23,6 @@ var (
 )
 
 const (
-	cniImportPrimaryIPID = "11111111-1111-1111-1111-111111111111"
-	cniImportIPv6ID      = "22222222-2222-2222-2222-222222222222"
 	cniImportContainerA  = "container-a"
 	cniImportPodA        = "pod-a"
 	cniImportNamespaceA  = "namespace-a"
@@ -56,19 +54,19 @@ func TestCNIEndpointImportLifecycleKeepsStatefulProviderAvailable(t *testing.T) 
 
 	snapshot, err := db.Snapshot(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, adapterTestPodKeyA, snapshot.IPOwners[cniImportPrimaryIPID])
+	assert.Equal(t, adapterTestPodKeyA, snapshot.IPOwners[adapterTestPrimaryIPID])
 	assert.Equal(t, "if-b", snapshot.IPOwners["33333333-3333-3333-3333-333333333333"])
 	assert.Equal(t, []string{
-		cniImportPrimaryIPID,
-		cniImportIPv6ID,
+		adapterTestPrimaryIPID,
+		adapterTestIPv6ID,
 	}, snapshot.Assignments[adapterTestPodKeyA].IPIDs)
 	assert.Equal(t, adapterTestIPv4, service.EndpointState[cniImportContainerA].IfnameToIPMap[InfraInterfaceName].IPv4[0].IP.String())
 	assert.Equal(t, "2001:db8::4", service.EndpointState[cniImportContainerA].IfnameToIPMap[InfraInterfaceName].IPv6[0].IP.String())
 	assert.Equal(t, []string{
-		cniImportPrimaryIPID,
-		cniImportIPv6ID,
+		adapterTestPrimaryIPID,
+		adapterTestIPv6ID,
 	}, service.PodIPIDByPodInterfaceKey[adapterTestPodKeyA])
-	assert.Equal(t, adapterTestNCID, snapshot.IPs[cniImportPrimaryIPID].NCID)
+	assert.Equal(t, adapterTestNCID, snapshot.IPs[adapterTestPrimaryIPID].NCID)
 	assert.Contains(t, snapshot.Networks, "network-1")
 
 	_, err = provider(context.Background())

--- a/cns/restserver/cni_import_adapter_test.go
+++ b/cns/restserver/cni_import_adapter_test.go
@@ -1,0 +1,176 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package restserver
+
+import (
+	"context"
+	"errors"
+	"net"
+	"path/filepath"
+	"testing"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCNIEndpointImportLifecycleKeepsStatefulProviderAvailable(t *testing.T) {
+	db := openAdapterImportDB(t)
+	seedAdapterImportInventory(t, db)
+	service := newAdapterTestService()
+	restore, preflight, importState, closeState, err := NewCNIEndpointImportLifecycle(service, db)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, closeState()) })
+	require.NoError(t, restore(context.Background()))
+
+	providerCalls := 0
+	var provider cns.CNIEndpointStateProvider = func(ctx context.Context) ([]cns.CNIEndpointState, error) {
+		providerCalls++
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		return adapterImportRecords(t), nil
+	}
+	records, err := provider(context.Background())
+	require.NoError(t, err)
+	plan, err := preflight(context.Background(), records)
+	require.NoError(t, err)
+	require.NoError(t, importState(context.Background(), records, plan))
+
+	snapshot, err := db.Snapshot(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "if-a", snapshot.IPOwners["11111111-1111-1111-1111-111111111111"])
+	assert.Equal(t, "if-b", snapshot.IPOwners["33333333-3333-3333-3333-333333333333"])
+	assert.Equal(t, []string{
+		"11111111-1111-1111-1111-111111111111",
+		"22222222-2222-2222-2222-222222222222",
+	}, snapshot.Assignments["if-a"].IPIDs)
+	assert.Equal(t, "10.0.0.4", service.EndpointState["container-a"].IfnameToIPMap["eth0"].IPv4[0].IP.String())
+	assert.Equal(t, "2001:db8::4", service.EndpointState["container-a"].IfnameToIPMap["eth0"].IPv6[0].IP.String())
+	assert.Equal(t, []string{
+		"11111111-1111-1111-1111-111111111111",
+		"22222222-2222-2222-2222-222222222222",
+	}, service.PodIPIDByPodInterfaceKey["if-a"])
+	assert.Equal(t, "nc-1", snapshot.IPs["11111111-1111-1111-1111-111111111111"].NCID)
+	assert.Contains(t, snapshot.Networks, "network-1")
+
+	_, err = provider(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2, providerCalls)
+}
+
+func TestCNIEndpointImportAdapterProjectionFailures(t *testing.T) {
+	t.Run("prebuild failure does not commit", func(t *testing.T) {
+		db := openAdapterImportDB(t)
+		seedAdapterImportInventory(t, db)
+		service := newAdapterTestService()
+		adapter, err := newDurableStateAdapter(service, db, true)
+		require.NoError(t, err)
+		require.NoError(t, adapter.restore(context.Background()))
+		records := adapterImportRecords(t)
+		plan, err := adapter.preflightCNIEndpointImport(context.Background(), records)
+		require.NoError(t, err)
+		beforeSnapshot, err := db.Snapshot(context.Background())
+		require.NoError(t, err)
+		beforeCache := durableCacheFingerprint(service, adapter)
+		injected := errors.New("projection failure")
+		adapter.buildProjection = func(state.Snapshot) (durableCacheProjection, error) {
+			return durableCacheProjection{}, injected
+		}
+
+		err = adapter.importCNIEndpointState(context.Background(), records, plan)
+		require.ErrorIs(t, err, injected)
+		afterSnapshot, snapshotErr := db.Snapshot(context.Background())
+		require.NoError(t, snapshotErr)
+		assert.Equal(t, beforeSnapshot, afterSnapshot)
+		assert.Equal(t, beforeCache, durableCacheFingerprint(service, adapter))
+		require.NoError(t, adapter.Close())
+	})
+
+	t.Run("status failure restores committed projection", func(t *testing.T) {
+		db := openAdapterImportDB(t)
+		seedAdapterImportInventory(t, db)
+		service := newAdapterTestService()
+		adapter, err := newDurableStateAdapter(service, db, true)
+		require.NoError(t, err)
+		require.NoError(t, adapter.restore(context.Background()))
+		records := adapterImportRecords(t)
+		plan, err := adapter.preflightCNIEndpointImport(context.Background(), records)
+		require.NoError(t, err)
+		originalStatus := adapter.store.status
+		injected := errors.New("status failure")
+		adapter.store.status = func(context.Context) (state.Status, error) {
+			return state.Status{}, injected
+		}
+
+		err = adapter.importCNIEndpointState(context.Background(), records, plan)
+		require.ErrorIs(t, err, injected)
+		assert.Contains(t, service.EndpointState, "container-a")
+		snapshot, snapshotErr := db.Snapshot(context.Background())
+		require.NoError(t, snapshotErr)
+		generation, projected := adapter.cacheGeneration()
+		assert.True(t, projected)
+		assert.Equal(t, snapshot.Metadata.Generation, generation)
+		adapter.store.status = originalStatus
+		require.NoError(t, adapter.Close())
+	})
+}
+
+func openAdapterImportDB(t *testing.T) *state.DB {
+	t.Helper()
+	db, err := state.Open(filepath.Join(t.TempDir(), "state.db"), state.Options{})
+	require.NoError(t, err)
+	return db
+}
+
+func seedAdapterImportInventory(t *testing.T, db *state.DB) {
+	t.Helper()
+	snapshot := completeAdapterSnapshot(0)
+	for _, ncID := range []string{"nc-1", "nc-2"} {
+		ips := make([]state.IPRecord, 0)
+		for _, ip := range snapshot.IPs {
+			if ip.NCID == ncID {
+				ips = append(ips, ip)
+			}
+		}
+		_, err := db.ApplyNetworkContainer(context.Background(), snapshot.NetworkContainers[ncID], ips)
+		require.NoError(t, err)
+	}
+	_, err := db.ReplaceDurableState(context.Background(), 2, state.DurableState{
+		NetworkContainers:    snapshot.NetworkContainers,
+		IPs:                  snapshot.IPs,
+		Networks:             snapshot.Networks,
+		OrchestratorContexts: snapshot.OrchestratorContexts,
+		PnPIDByMAC:           snapshot.PnPIDByMAC,
+	})
+	require.NoError(t, err)
+}
+
+func adapterImportRecords(t *testing.T) []cns.CNIEndpointState {
+	t.Helper()
+	return []cns.CNIEndpointState{
+		{
+			InfraContainerID: "container-a",
+			PodEndpointID:    "if-a",
+			PodName:          "pod-a",
+			PodNamespace:     "namespace-a",
+			InterfaceKey:     "container-a-eth0",
+			InterfaceName:    "eth0",
+			IPAddresses: []net.IPNet{
+				testIPNet("10.0.0.4/24"),
+				testIPNet("2001:db8::4/64"),
+			},
+		},
+		{
+			InfraContainerID: "container-a",
+			PodEndpointID:    "if-b",
+			PodName:          "pod-a",
+			PodNamespace:     "namespace-a",
+			InterfaceKey:     "container-a-eth1",
+			InterfaceName:    "eth1",
+			IPAddresses:      []net.IPNet{testIPNet("10.0.1.4/32")},
+		},
+	}
+}

--- a/cns/restserver/cni_import_adapter_test.go
+++ b/cns/restserver/cni_import_adapter_test.go
@@ -6,6 +6,7 @@ package restserver
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"path/filepath"
 	"testing"
@@ -14,6 +15,20 @@ import (
 	"github.com/Azure/azure-container-networking/cns/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+)
+
+var (
+	errCNIImportProjection = errors.New("projection failure")
+	errCNIImportStatus     = errors.New("status failure")
+)
+
+const (
+	cniImportPrimaryIPID = "11111111-1111-1111-1111-111111111111"
+	cniImportIPv6ID      = "22222222-2222-2222-2222-222222222222"
+	cniImportContainerA  = "container-a"
+	cniImportPodA        = "pod-a"
+	cniImportNamespaceA  = "namespace-a"
+	cniImportSecondaryIF = "eth1"
 )
 
 func TestCNIEndpointImportLifecycleKeepsStatefulProviderAvailable(t *testing.T) {
@@ -28,8 +43,8 @@ func TestCNIEndpointImportLifecycleKeepsStatefulProviderAvailable(t *testing.T) 
 	providerCalls := 0
 	var provider cns.CNIEndpointStateProvider = func(ctx context.Context) ([]cns.CNIEndpointState, error) {
 		providerCalls++
-		if err := ctx.Err(); err != nil {
-			return nil, err
+		if contextErr := ctx.Err(); contextErr != nil {
+			return nil, fmt.Errorf("reading CNI endpoint state: %w", contextErr)
 		}
 		return adapterImportRecords(t), nil
 	}
@@ -41,19 +56,19 @@ func TestCNIEndpointImportLifecycleKeepsStatefulProviderAvailable(t *testing.T) 
 
 	snapshot, err := db.Snapshot(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, "if-a", snapshot.IPOwners["11111111-1111-1111-1111-111111111111"])
+	assert.Equal(t, adapterTestPodKeyA, snapshot.IPOwners[cniImportPrimaryIPID])
 	assert.Equal(t, "if-b", snapshot.IPOwners["33333333-3333-3333-3333-333333333333"])
 	assert.Equal(t, []string{
-		"11111111-1111-1111-1111-111111111111",
-		"22222222-2222-2222-2222-222222222222",
-	}, snapshot.Assignments["if-a"].IPIDs)
-	assert.Equal(t, "10.0.0.4", service.EndpointState["container-a"].IfnameToIPMap["eth0"].IPv4[0].IP.String())
-	assert.Equal(t, "2001:db8::4", service.EndpointState["container-a"].IfnameToIPMap["eth0"].IPv6[0].IP.String())
+		cniImportPrimaryIPID,
+		cniImportIPv6ID,
+	}, snapshot.Assignments[adapterTestPodKeyA].IPIDs)
+	assert.Equal(t, adapterTestIPv4, service.EndpointState[cniImportContainerA].IfnameToIPMap[InfraInterfaceName].IPv4[0].IP.String())
+	assert.Equal(t, "2001:db8::4", service.EndpointState[cniImportContainerA].IfnameToIPMap[InfraInterfaceName].IPv6[0].IP.String())
 	assert.Equal(t, []string{
-		"11111111-1111-1111-1111-111111111111",
-		"22222222-2222-2222-2222-222222222222",
-	}, service.PodIPIDByPodInterfaceKey["if-a"])
-	assert.Equal(t, "nc-1", snapshot.IPs["11111111-1111-1111-1111-111111111111"].NCID)
+		cniImportPrimaryIPID,
+		cniImportIPv6ID,
+	}, service.PodIPIDByPodInterfaceKey[adapterTestPodKeyA])
+	assert.Equal(t, adapterTestNCID, snapshot.IPs[cniImportPrimaryIPID].NCID)
 	assert.Contains(t, snapshot.Networks, "network-1")
 
 	_, err = provider(context.Background())
@@ -75,13 +90,12 @@ func TestCNIEndpointImportAdapterProjectionFailures(t *testing.T) {
 		beforeSnapshot, err := db.Snapshot(context.Background())
 		require.NoError(t, err)
 		beforeCache := durableCacheFingerprint(service, adapter)
-		injected := errors.New("projection failure")
 		adapter.buildProjection = func(state.Snapshot) (durableCacheProjection, error) {
-			return durableCacheProjection{}, injected
+			return durableCacheProjection{}, errCNIImportProjection
 		}
 
 		err = adapter.importCNIEndpointState(context.Background(), records, plan)
-		require.ErrorIs(t, err, injected)
+		require.ErrorIs(t, err, errCNIImportProjection)
 		afterSnapshot, snapshotErr := db.Snapshot(context.Background())
 		require.NoError(t, snapshotErr)
 		assert.Equal(t, beforeSnapshot, afterSnapshot)
@@ -100,14 +114,13 @@ func TestCNIEndpointImportAdapterProjectionFailures(t *testing.T) {
 		plan, err := adapter.preflightCNIEndpointImport(context.Background(), records)
 		require.NoError(t, err)
 		originalStatus := adapter.store.status
-		injected := errors.New("status failure")
 		adapter.store.status = func(context.Context) (state.Status, error) {
-			return state.Status{}, injected
+			return state.Status{}, errCNIImportStatus
 		}
 
 		err = adapter.importCNIEndpointState(context.Background(), records, plan)
-		require.ErrorIs(t, err, injected)
-		assert.Contains(t, service.EndpointState, "container-a")
+		require.ErrorIs(t, err, errCNIImportStatus)
+		assert.Contains(t, service.EndpointState, cniImportContainerA)
 		snapshot, snapshotErr := db.Snapshot(context.Background())
 		require.NoError(t, snapshotErr)
 		generation, projected := adapter.cacheGeneration()
@@ -128,7 +141,7 @@ func openAdapterImportDB(t *testing.T) *state.DB {
 func seedAdapterImportInventory(t *testing.T, db *state.DB) {
 	t.Helper()
 	snapshot := completeAdapterSnapshot(0)
-	for _, ncID := range []string{"nc-1", "nc-2"} {
+	for _, ncID := range []string{adapterTestNCID, adapterTestNCID2} {
 		ips := make([]state.IPRecord, 0)
 		for _, ip := range snapshot.IPs {
 			if ip.NCID == ncID {
@@ -152,24 +165,24 @@ func adapterImportRecords(t *testing.T) []cns.CNIEndpointState {
 	t.Helper()
 	return []cns.CNIEndpointState{
 		{
-			InfraContainerID: "container-a",
-			PodEndpointID:    "if-a",
-			PodName:          "pod-a",
-			PodNamespace:     "namespace-a",
+			InfraContainerID: cniImportContainerA,
+			PodEndpointID:    adapterTestPodKeyA,
+			PodName:          cniImportPodA,
+			PodNamespace:     cniImportNamespaceA,
 			InterfaceKey:     "container-a-eth0",
-			InterfaceName:    "eth0",
+			InterfaceName:    InfraInterfaceName,
 			IPAddresses: []net.IPNet{
 				testIPNet("10.0.0.4/24"),
 				testIPNet("2001:db8::4/64"),
 			},
 		},
 		{
-			InfraContainerID: "container-a",
+			InfraContainerID: cniImportContainerA,
 			PodEndpointID:    "if-b",
-			PodName:          "pod-a",
-			PodNamespace:     "namespace-a",
+			PodName:          cniImportPodA,
+			PodNamespace:     cniImportNamespaceA,
 			InterfaceKey:     "container-a-eth1",
-			InterfaceName:    "eth1",
+			InterfaceName:    cniImportSecondaryIF,
 			IPAddresses:      []net.IPNet{testIPNet("10.0.1.4/32")},
 		},
 	}

--- a/cns/restserver/durable_state_adapter.go
+++ b/cns/restserver/durable_state_adapter.go
@@ -52,6 +52,8 @@ type durableStateOperations struct {
 	snapshot       func(context.Context) (state.Snapshot, error)
 	replace        func(context.Context, uint64, state.DurableState) (bool, error)
 	updateMetadata func(context.Context, uint64, state.Metadata) (bool, error)
+	preflightCNI   func(context.Context, []cns.CNIEndpointState, bool) (state.CNIImportPreflight, error)
+	importCNI      func(context.Context, []cns.CNIEndpointState, state.CNIImportPreflight) (bool, error)
 	status         func(context.Context) (state.Status, error)
 	close          func() error
 }
@@ -64,8 +66,10 @@ type durableStateAdapter struct {
 	// service lock; the adapter applies complete projections under that lock.
 	mu                   sync.Mutex
 	projectEndpointState bool
+	buildProjection      func(state.Snapshot) (durableCacheProjection, error)
 	projected            bool
 	generation           uint64
+	cniImportActive      bool
 	closeOnce            sync.Once
 	closeErr             error
 }
@@ -106,6 +110,30 @@ func NewDurableStateLifecycle(
 	return adapter.restore, adapter.Close, nil
 }
 
+// NewCNIEndpointImportLifecycle creates an import-only adapter for transferring
+// live stateful CNI ownership into Bolt. It does not install, configure, or
+// select stateless CNI.
+func NewCNIEndpointImportLifecycle(
+	service *HTTPRestService,
+	db *state.DB,
+) (
+	restore func(context.Context) error,
+	preflight func(context.Context, []cns.CNIEndpointState) (state.CNIImportPreflight, error),
+	importState func(context.Context, []cns.CNIEndpointState, state.CNIImportPreflight) error,
+	close func() error,
+	err error,
+) {
+	adapter, err := newDurableStateAdapter(service, db, true)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	return adapter.restore,
+		adapter.preflightCNIEndpointImport,
+		adapter.importCNIEndpointState,
+		adapter.Close,
+		nil
+}
+
 func newDurableStateAdapter(
 	service *HTTPRestService,
 	db *state.DB,
@@ -138,8 +166,10 @@ func newDurableStateAdapter(
 			}
 			return true, nil
 		},
-		status: db.Status,
-		close:  db.Close,
+		preflightCNI: db.PreflightCNIEndpointImport,
+		importCNI:    db.ImportCNIEndpointState,
+		status:       db.Status,
+		close:        db.Close,
 	}, projectEndpointState)
 }
 
@@ -168,7 +198,90 @@ func newDurableStateAdapterWithOperations(
 		service:              service,
 		store:                operations,
 		projectEndpointState: projectEndpointState,
+		buildProjection:      buildDurableCacheProjection,
 	}, nil
+}
+
+func (a *durableStateAdapter) preflightCNIEndpointImport(
+	ctx context.Context,
+	records []cns.CNIEndpointState,
+) (state.CNIImportPreflight, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.store.preflightCNI == nil {
+		return state.CNIImportPreflight{}, errors.New("CNI endpoint preflight operation is nil")
+	}
+	current, err := a.currentSnapshot(ctx)
+	if err != nil {
+		return state.CNIImportPreflight{}, err
+	}
+	plan, err := a.store.preflightCNI(ctx, records, a.cniImportActive)
+	if err != nil {
+		return state.CNIImportPreflight{}, err
+	}
+	candidate, err := plan.SnapshotForProjection(current)
+	if err != nil {
+		return state.CNIImportPreflight{}, err
+	}
+	if _, err := a.buildProjection(candidate); err != nil {
+		return state.CNIImportPreflight{}, err
+	}
+	return plan, nil
+}
+
+func (a *durableStateAdapter) importCNIEndpointState(
+	ctx context.Context,
+	records []cns.CNIEndpointState,
+	plan state.CNIImportPreflight,
+) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.store.importCNI == nil {
+		return errors.New("CNI endpoint import operation is nil")
+	}
+	current, err := a.currentSnapshot(ctx)
+	if err != nil {
+		return err
+	}
+	candidate, err := plan.SnapshotForProjection(current)
+	if err != nil {
+		return err
+	}
+	projection, err := a.buildProjection(candidate)
+	if err != nil {
+		return err
+	}
+	changed, err := a.store.importCNI(ctx, records, plan)
+	if err != nil {
+		return err
+	}
+	expectedGeneration := current.Metadata.Generation
+	if changed {
+		expectedGeneration++
+	}
+	projection.generation = expectedGeneration
+	if err := a.verifyStatus(ctx, expectedGeneration); err != nil {
+		return a.restoreCommittedProjection(ctx, err)
+	}
+	a.applyProjection(projection)
+	a.cniImportActive = true
+	return nil
+}
+
+func (a *durableStateAdapter) restoreCommittedProjection(ctx context.Context, importErr error) error {
+	snapshot, err := a.store.snapshot(context.WithoutCancel(ctx))
+	if err != nil {
+		return errors.Join(importErr, fmt.Errorf("restoring committed CNI import projection: %w", err))
+	}
+	projection, err := a.buildProjection(snapshot)
+	if err != nil {
+		return errors.Join(importErr, fmt.Errorf("restoring committed CNI import projection: %w", err))
+	}
+	a.applyProjection(projection)
+	a.cniImportActive = true
+	return importErr
 }
 
 func (a *durableStateAdapter) restore(ctx context.Context) error {

--- a/cns/restserver/durable_state_adapter.go
+++ b/cns/restserver/durable_state_adapter.go
@@ -46,6 +46,8 @@ var (
 	errMissingProjectedAssignment   = errors.New("missing projected assignment")
 	errProjectedAssignmentMissingIP = errors.New("projected assignment does not contain owned IP")
 	errNilProjectedInterface        = errors.New("projected endpoint interface is nil")
+	errNilCNIEndpointPreflight      = errors.New("CNI endpoint preflight operation is nil")
+	errNilCNIEndpointImport         = errors.New("CNI endpoint import operation is nil")
 )
 
 type durableStateOperations struct {
@@ -120,7 +122,7 @@ func NewCNIEndpointImportLifecycle(
 	restore func(context.Context) error,
 	preflight func(context.Context, []cns.CNIEndpointState) (state.CNIImportPreflight, error),
 	importState func(context.Context, []cns.CNIEndpointState, state.CNIImportPreflight) error,
-	close func() error,
+	closeFn func() error,
 	err error,
 ) {
 	adapter, err := newDurableStateAdapter(service, db, true)
@@ -210,7 +212,7 @@ func (a *durableStateAdapter) preflightCNIEndpointImport(
 	defer a.mu.Unlock()
 
 	if a.store.preflightCNI == nil {
-		return state.CNIImportPreflight{}, errors.New("CNI endpoint preflight operation is nil")
+		return state.CNIImportPreflight{}, errNilCNIEndpointPreflight
 	}
 	current, err := a.currentSnapshot(ctx)
 	if err != nil {
@@ -222,7 +224,7 @@ func (a *durableStateAdapter) preflightCNIEndpointImport(
 	}
 	candidate, err := plan.SnapshotForProjection(current)
 	if err != nil {
-		return state.CNIImportPreflight{}, err
+		return state.CNIImportPreflight{}, fmt.Errorf("building CNI endpoint preflight projection: %w", err)
 	}
 	if _, err := a.buildProjection(candidate); err != nil {
 		return state.CNIImportPreflight{}, err
@@ -239,7 +241,7 @@ func (a *durableStateAdapter) importCNIEndpointState(
 	defer a.mu.Unlock()
 
 	if a.store.importCNI == nil {
-		return errors.New("CNI endpoint import operation is nil")
+		return errNilCNIEndpointImport
 	}
 	current, err := a.currentSnapshot(ctx)
 	if err != nil {
@@ -247,7 +249,7 @@ func (a *durableStateAdapter) importCNIEndpointState(
 	}
 	candidate, err := plan.SnapshotForProjection(current)
 	if err != nil {
-		return err
+		return fmt.Errorf("building CNI endpoint import projection: %w", err)
 	}
 	projection, err := a.buildProjection(candidate)
 	if err != nil {

--- a/cns/state/cni_import.go
+++ b/cns/state/cni_import.go
@@ -1,0 +1,625 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package state
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"net"
+	"net/netip"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/Azure/azure-container-networking/cns"
+)
+
+var ErrCNIImportConflict = errors.New("cns state: CNI import conflicts with session state")
+
+type CNIImportCounts struct {
+	Containers  uint32
+	Interfaces  uint32
+	Assignments uint32
+	IPs         uint32
+}
+
+// CNIImportPreflight is an immutable plan for importing live stateful CNI
+// ownership. It contains no source path or raw CNI response.
+type CNIImportPreflight struct {
+	ExpectedGeneration uint64
+	Counts             CNIImportCounts
+	IdentityDigest     string
+
+	allowReplacement bool
+	identities       []string
+	endpoints        map[string]EndpointRecord
+	assignments      map[string]AssignmentRecord
+	owners           map[string]string
+	seal             [sha256.Size]byte
+}
+
+type cniImportSession struct {
+	Endpoints   map[string]EndpointRecord   `json:"endpoints"`
+	Assignments map[string]AssignmentRecord `json:"assignments"`
+	Owners      map[string]string           `json:"owners"`
+}
+
+type normalizedCNIEndpoint struct {
+	InfraContainerID string         `json:"infraContainerID"`
+	PodEndpointID    string         `json:"podEndpointID"`
+	PodName          string         `json:"podName"`
+	PodNamespace     string         `json:"podNamespace"`
+	InterfaceKey     string         `json:"interfaceKey"`
+	InterfaceName    string         `json:"interfaceName"`
+	Prefixes         []netip.Prefix `json:"prefixes"`
+}
+
+func (s *DB) PreflightCNIEndpointImport(
+	ctx context.Context,
+	records []cns.CNIEndpointState,
+	allowSessionReplacement bool,
+) (CNIImportPreflight, error) {
+	if ctx == nil {
+		return CNIImportPreflight{}, errors.New("preflighting CNI endpoint import: context is nil")
+	}
+	snapshot, err := s.Snapshot(ctx)
+	if err != nil {
+		return CNIImportPreflight{}, fmt.Errorf("preflighting CNI endpoint import: %w", err)
+	}
+	plan, _, err := buildCNIImportPreflight(ctx, snapshot, records, allowSessionReplacement)
+	if err != nil {
+		return CNIImportPreflight{}, fmt.Errorf("preflighting CNI endpoint import: %w", err)
+	}
+	return plan, nil
+}
+
+func (s *DB) ImportCNIEndpointState(
+	ctx context.Context,
+	records []cns.CNIEndpointState,
+	plan CNIImportPreflight,
+) (bool, error) {
+	if ctx == nil {
+		return false, errors.New("importing CNI endpoint state: context is nil")
+	}
+	if err := validateCNIImportPlan(plan); err != nil {
+		return false, fmt.Errorf("importing CNI endpoint state: %w", err)
+	}
+	changed, err := s.update(ctx, func(tx *WriteTx) (bool, error) {
+		current, err := tx.validSnapshot()
+		if err != nil {
+			return false, err
+		}
+		if current.Metadata.Generation != plan.ExpectedGeneration {
+			return false, fmt.Errorf(
+				"%w: expected=%d actual=%d",
+				ErrStaleGeneration,
+				plan.ExpectedGeneration,
+				current.Metadata.Generation,
+			)
+		}
+		recomputed, candidate, err := buildCNIImportPreflight(
+			ctx,
+			current,
+			records,
+			plan.allowReplacement,
+		)
+		if err != nil {
+			return false, err
+		}
+		if !sameCNIImportPlan(plan, recomputed) {
+			return false, invalidInput("CNI import preflight identity changed", nil)
+		}
+		if sessionEqual(current, candidate) {
+			return false, nil
+		}
+
+		encoded, err := encodeCNIImportSession(candidate)
+		if err != nil {
+			return false, err
+		}
+		for _, replacement := range encoded {
+			if err := replaceJSONBucket(tx.tx, replacement.name, replacement.values); err != nil {
+				return false, err
+			}
+		}
+		if s.cniImportBeforeCommit != nil {
+			if err := s.cniImportBeforeCommit(); err != nil {
+				return false, err
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("importing CNI endpoint state: %w", err)
+	}
+	return changed, nil
+}
+
+// SnapshotForProjection applies this preflight's session candidate to a fresh
+// copy of base. The plan seal and generation are checked before any data is
+// returned.
+func (p CNIImportPreflight) SnapshotForProjection(base Snapshot) (Snapshot, error) {
+	if err := validateCNIImportPlan(p); err != nil {
+		return Snapshot{}, err
+	}
+	if base.Metadata.Generation != p.ExpectedGeneration {
+		return Snapshot{}, fmt.Errorf(
+			"%w: expected=%d actual=%d",
+			ErrStaleGeneration,
+			p.ExpectedGeneration,
+			base.Metadata.Generation,
+		)
+	}
+	candidate := cloneSnapshot(base)
+	candidate.Endpoints = cloneCNIEndpoints(p.endpoints)
+	candidate.Assignments = cloneCNIAssignments(p.assignments)
+	candidate.IPOwners = cloneMap(p.owners)
+	if err := candidate.Validate(); err != nil {
+		return Snapshot{}, err
+	}
+	return candidate, nil
+}
+
+func buildCNIImportPreflight(
+	ctx context.Context,
+	snapshot Snapshot,
+	records []cns.CNIEndpointState,
+	allowReplacement bool,
+) (CNIImportPreflight, Snapshot, error) {
+	if err := snapshot.Validate(); err != nil {
+		return CNIImportPreflight{}, Snapshot{}, err
+	}
+	if len(snapshot.DeleteIntents) != 0 {
+		return CNIImportPreflight{}, Snapshot{}, fmt.Errorf("%w: endpoint import is blocked", ErrDeleteIntent)
+	}
+	normalized, err := normalizeCNIEndpointRecords(ctx, records)
+	if err != nil {
+		return CNIImportPreflight{}, Snapshot{}, err
+	}
+	inventory, err := cniImportInventory(snapshot)
+	if err != nil {
+		return CNIImportPreflight{}, Snapshot{}, err
+	}
+	candidate := cloneSnapshot(snapshot)
+	candidate.Endpoints = make(map[string]EndpointRecord)
+	candidate.Assignments = make(map[string]AssignmentRecord)
+	candidate.IPOwners = make(map[string]string)
+	identities := make([]string, 0, len(normalized))
+	pods := make(map[string]string)
+
+	for _, record := range normalized {
+		if err := ctx.Err(); err != nil {
+			return CNIImportPreflight{}, Snapshot{}, err
+		}
+		podIdentity := record.PodNamespace + "\x00" + record.PodName
+		if other, ok := pods[podIdentity]; ok && other != record.InfraContainerID {
+			return CNIImportPreflight{}, Snapshot{}, invalidInput(
+				fmt.Sprintf("pod is associated with containers %q and %q", other, record.InfraContainerID),
+				nil,
+			)
+		}
+		pods[podIdentity] = record.InfraContainerID
+
+		endpoint, ok := candidate.Endpoints[record.InfraContainerID]
+		if ok && (endpoint.PodName != record.PodName || endpoint.PodNamespace != record.PodNamespace) {
+			return CNIImportPreflight{}, Snapshot{}, invalidInput(
+				fmt.Sprintf("infra container %q has conflicting pod identity", record.InfraContainerID),
+				nil,
+			)
+		}
+		if !ok {
+			endpoint = EndpointRecord{
+				PodName:       record.PodName,
+				PodNamespace:  record.PodNamespace,
+				IfnameToIPMap: make(map[string]*IPInfoRecord),
+			}
+		}
+		if _, ok := endpoint.IfnameToIPMap[record.InterfaceName]; ok {
+			return CNIImportPreflight{}, Snapshot{}, invalidInput(
+				fmt.Sprintf(
+					"infra container %q has duplicate interface %q",
+					record.InfraContainerID,
+					record.InterfaceName,
+				),
+				nil,
+			)
+		}
+		info := IPInfoRecord{
+			IPv4: make([]net.IPNet, 0),
+			IPv6: make([]net.IPNet, 0),
+		}
+		ipIDs := make([]string, 0, len(record.Prefixes))
+		for _, prefix := range record.Prefixes {
+			ip, ok := inventory[prefix.Addr()]
+			if !ok {
+				return CNIImportPreflight{}, Snapshot{}, invalidInput("CNI address is missing from IP inventory", nil)
+			}
+			if info.NetworkContainerID == "" {
+				info.NetworkContainerID = ip.NCID
+			} else if info.NetworkContainerID != ip.NCID {
+				return CNIImportPreflight{}, Snapshot{}, invalidInput(
+					fmt.Sprintf("interface %q spans network containers", record.InterfaceName),
+					nil,
+				)
+			}
+			ipIDs = append(ipIDs, ip.ID)
+			value := net.IPNet{
+				IP:   net.IP(prefix.Addr().AsSlice()),
+				Mask: net.CIDRMask(prefix.Bits(), prefix.Addr().BitLen()),
+			}
+			if prefix.Addr().Is4() {
+				info.IPv4 = append(info.IPv4, value)
+			} else {
+				info.IPv6 = append(info.IPv6, value)
+			}
+		}
+		sort.Strings(ipIDs)
+		endpoint.IfnameToIPMap[record.InterfaceName] = &info
+		candidate.Endpoints[record.InfraContainerID] = endpoint
+
+		if _, ok := candidate.Assignments[record.PodEndpointID]; ok {
+			return CNIImportPreflight{}, Snapshot{}, invalidInput(
+				fmt.Sprintf("duplicate assignment identity %q", record.PodEndpointID),
+				nil,
+			)
+		}
+		assignment := AssignmentRecord{
+			Pod: PodIdentity{
+				PodKey:           record.PodEndpointID,
+				InfraContainerID: record.InfraContainerID,
+				InterfaceID:      record.PodEndpointID,
+				PodName:          record.PodName,
+				PodNamespace:     record.PodNamespace,
+			},
+			IPIDs: ipIDs,
+		}
+		candidate.Assignments[record.PodEndpointID] = assignment
+		for _, ipID := range ipIDs {
+			if other, ok := candidate.IPOwners[ipID]; ok {
+				return CNIImportPreflight{}, Snapshot{}, invalidInput(
+					fmt.Sprintf("IP inventory ID is assigned to %q and %q", other, record.PodEndpointID),
+					nil,
+				)
+			}
+			candidate.IPOwners[ipID] = record.PodEndpointID
+		}
+		identity, err := json.Marshal(record)
+		if err != nil {
+			return CNIImportPreflight{}, Snapshot{}, invalidInput("encoding CNI identity", err)
+		}
+		identities = append(identities, string(identity))
+	}
+	if err := candidate.Validate(); err != nil {
+		return CNIImportPreflight{}, Snapshot{}, fmt.Errorf("%w: candidate CNI import: %v", ErrInvalidInput, err)
+	}
+	if !allowReplacement && !sessionEmpty(snapshot) && !sessionEqual(snapshot, candidate) {
+		return CNIImportPreflight{}, Snapshot{}, ErrCNIImportConflict
+	}
+	counts, err := cniImportCounts(candidate, len(normalized))
+	if err != nil {
+		return CNIImportPreflight{}, Snapshot{}, err
+	}
+	digest, err := cniImportDigest(normalized, candidate)
+	if err != nil {
+		return CNIImportPreflight{}, Snapshot{}, err
+	}
+	plan := CNIImportPreflight{
+		ExpectedGeneration: snapshot.Metadata.Generation,
+		Counts:             counts,
+		IdentityDigest:     digest,
+		allowReplacement:   allowReplacement,
+		identities:         append([]string{}, identities...),
+		endpoints:          cloneCNIEndpoints(candidate.Endpoints),
+		assignments:        cloneCNIAssignments(candidate.Assignments),
+		owners:             cloneMap(candidate.IPOwners),
+	}
+	plan.seal = sealCNIImportPlan(plan)
+	return plan, candidate, nil
+}
+
+func normalizeCNIEndpointRecords(
+	ctx context.Context,
+	records []cns.CNIEndpointState,
+) ([]normalizedCNIEndpoint, error) {
+	normalized := make([]normalizedCNIEndpoint, 0, len(records))
+	seenAddresses := make(map[netip.Addr]string)
+	seenEndpointIDs := make(map[string]string)
+	seenKeys := make(map[string]string)
+	seenInterfaces := make(map[string]string)
+	for index, input := range records {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		record := normalizedCNIEndpoint{
+			InfraContainerID: strings.TrimSpace(input.InfraContainerID),
+			PodEndpointID:    strings.TrimSpace(input.PodEndpointID),
+			PodName:          strings.TrimSpace(input.PodName),
+			PodNamespace:     strings.TrimSpace(input.PodNamespace),
+			InterfaceKey:     strings.TrimSpace(input.InterfaceKey),
+			InterfaceName:    strings.TrimSpace(input.InterfaceName),
+			Prefixes:         make([]netip.Prefix, 0, len(input.IPAddresses)),
+		}
+		switch {
+		case record.InfraContainerID == "":
+			return nil, invalidInput(fmt.Sprintf("CNI record %d has empty infra container ID", index), nil)
+		case record.PodEndpointID == "":
+			return nil, invalidInput(fmt.Sprintf("CNI record %d has empty pod endpoint ID", index), nil)
+		case record.PodName == "":
+			return nil, invalidInput(fmt.Sprintf("CNI record %d has empty pod name", index), nil)
+		case record.PodNamespace == "":
+			return nil, invalidInput(fmt.Sprintf("CNI record %d has empty pod namespace", index), nil)
+		case record.InterfaceKey == "":
+			return nil, invalidInput(fmt.Sprintf("CNI record %d has empty interface key", index), nil)
+		case record.InterfaceName == "":
+			return nil, invalidInput(fmt.Sprintf("CNI record %d has empty interface name", index), nil)
+		case len(input.IPAddresses) == 0:
+			return nil, invalidInput(fmt.Sprintf("CNI record %d has no IPs", index), nil)
+		}
+		if other, ok := seenEndpointIDs[record.PodEndpointID]; ok {
+			return nil, invalidInput(
+				fmt.Sprintf("CNI records %q and %q have duplicate pod endpoint identity", other, record.InterfaceKey),
+				nil,
+			)
+		}
+		if other, ok := seenKeys[record.InterfaceKey]; ok {
+			return nil, invalidInput(
+				fmt.Sprintf("CNI records %q and %q have duplicate interface key", other, record.InterfaceKey),
+				nil,
+			)
+		}
+		interfaceIdentity := record.InfraContainerID + "\x00" + record.InterfaceName
+		if other, ok := seenInterfaces[interfaceIdentity]; ok {
+			return nil, invalidInput(
+				fmt.Sprintf("CNI records %q and %q have duplicate interface identity", other, record.InterfaceKey),
+				nil,
+			)
+		}
+		for ipIndex, value := range input.IPAddresses {
+			address, prefix, err := canonicalCNIIPNet(value)
+			if err != nil {
+				return nil, invalidInput(
+					fmt.Sprintf("CNI record %q IP %d", record.InterfaceKey, ipIndex),
+					err,
+				)
+			}
+			if other, ok := seenAddresses[address]; ok {
+				return nil, invalidInput(
+					fmt.Sprintf("CNI records %q and %q contain duplicate address", other, record.InterfaceKey),
+					nil,
+				)
+			}
+			seenAddresses[address] = record.InterfaceKey
+			record.Prefixes = append(record.Prefixes, prefix)
+		}
+		sort.Slice(record.Prefixes, func(i, j int) bool {
+			return record.Prefixes[i].Addr().Compare(record.Prefixes[j].Addr()) < 0
+		})
+		seenEndpointIDs[record.PodEndpointID] = record.InterfaceKey
+		seenKeys[record.InterfaceKey] = record.InterfaceKey
+		seenInterfaces[interfaceIdentity] = record.InterfaceKey
+		normalized = append(normalized, record)
+	}
+	sort.Slice(normalized, func(i, j int) bool {
+		left := normalized[i]
+		right := normalized[j]
+		if left.InfraContainerID != right.InfraContainerID {
+			return left.InfraContainerID < right.InfraContainerID
+		}
+		if left.PodEndpointID != right.PodEndpointID {
+			return left.PodEndpointID < right.PodEndpointID
+		}
+		return left.InterfaceKey < right.InterfaceKey
+	})
+	return normalized, nil
+}
+
+func canonicalCNIIPNet(value net.IPNet) (netip.Addr, netip.Prefix, error) {
+	address, ok := netip.AddrFromSlice(value.IP)
+	if !ok {
+		return netip.Addr{}, netip.Prefix{}, errors.New("invalid IP address")
+	}
+	address = address.Unmap()
+	ones, bits := value.Mask.Size()
+	if bits != address.BitLen() || ones < 0 {
+		return netip.Addr{}, netip.Prefix{}, errors.New("invalid IP mask")
+	}
+	prefix := netip.PrefixFrom(address, ones)
+	if !prefix.IsValid() {
+		return netip.Addr{}, netip.Prefix{}, errors.New("invalid IP prefix")
+	}
+	return address, prefix, nil
+}
+
+func cniImportInventory(snapshot Snapshot) (map[netip.Addr]IPRecord, error) {
+	inventory := make(map[netip.Addr]IPRecord, len(snapshot.IPs))
+	for _, id := range sortedKeys(snapshot.IPs) {
+		ip := snapshot.IPs[id]
+		address, err := netip.ParseAddr(ip.IPAddress)
+		if err != nil {
+			return nil, corruptValue(bucketIPs, id, "invalid address", err)
+		}
+		address = address.Unmap()
+		if other, ok := inventory[address]; ok {
+			return nil, invalidInput(
+				fmt.Sprintf("IP inventory IDs %q and %q contain duplicate address", other.ID, id),
+				nil,
+			)
+		}
+		inventory[address] = ip
+	}
+	return inventory, nil
+}
+
+func cniImportCounts(candidate Snapshot, interfaceCount int) (CNIImportCounts, error) {
+	values := []int{
+		len(candidate.Endpoints),
+		interfaceCount,
+		len(candidate.Assignments),
+		len(candidate.IPOwners),
+	}
+	for _, value := range values {
+		if uint64(value) > math.MaxUint32 {
+			return CNIImportCounts{}, invalidInput("CNI import count exceeds uint32", nil)
+		}
+	}
+	return CNIImportCounts{
+		Containers:  uint32(values[0]),
+		Interfaces:  uint32(values[1]),
+		Assignments: uint32(values[2]),
+		IPs:         uint32(values[3]),
+	}, nil
+}
+
+func cniImportDigest(records []normalizedCNIEndpoint, candidate Snapshot) (string, error) {
+	data, err := json.Marshal(struct {
+		Records []normalizedCNIEndpoint `json:"records"`
+		Session cniImportSession        `json:"session"`
+	}{
+		Records: records,
+		Session: cniImportSession{
+			Endpoints:   candidate.Endpoints,
+			Assignments: candidate.Assignments,
+			Owners:      candidate.IPOwners,
+		},
+	})
+	if err != nil {
+		return "", invalidInput("encoding CNI import identity", err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func sealCNIImportPlan(plan CNIImportPreflight) [sha256.Size]byte {
+	hash := sha256.New()
+	var generation [8]byte
+	binary.LittleEndian.PutUint64(generation[:], plan.ExpectedGeneration)
+	_, _ = hash.Write(generation[:])
+	_, _ = hash.Write([]byte(plan.IdentityDigest))
+	if plan.allowReplacement {
+		_, _ = hash.Write([]byte{1})
+	} else {
+		_, _ = hash.Write([]byte{0})
+	}
+	countData, _ := json.Marshal(plan.Counts)
+	_, _ = hash.Write(countData)
+	identityData, _ := json.Marshal(plan.identities)
+	_, _ = hash.Write(identityData)
+	sessionData, _ := json.Marshal(cniImportSession{
+		Endpoints:   plan.endpoints,
+		Assignments: plan.assignments,
+		Owners:      plan.owners,
+	})
+	_, _ = hash.Write(sessionData)
+	var seal [sha256.Size]byte
+	copy(seal[:], hash.Sum(nil))
+	return seal
+}
+
+func validateCNIImportPlan(plan CNIImportPreflight) error {
+	if plan.IdentityDigest == "" {
+		return invalidInput("CNI import preflight digest is empty", nil)
+	}
+	expectedSeal := sealCNIImportPlan(plan)
+	if !bytes.Equal(plan.seal[:], expectedSeal[:]) {
+		return invalidInput("CNI import preflight was modified", nil)
+	}
+	return nil
+}
+
+func sameCNIImportPlan(left, right CNIImportPreflight) bool {
+	return left.ExpectedGeneration == right.ExpectedGeneration &&
+		left.Counts == right.Counts &&
+		left.IdentityDigest == right.IdentityDigest &&
+		left.allowReplacement == right.allowReplacement &&
+		slices.Equal(left.identities, right.identities) &&
+		bytes.Equal(left.seal[:], right.seal[:])
+}
+
+func sessionEmpty(snapshot Snapshot) bool {
+	return len(snapshot.Endpoints) == 0 && len(snapshot.Assignments) == 0 && len(snapshot.IPOwners) == 0
+}
+
+func sessionEqual(left, right Snapshot) bool {
+	leftData, leftErr := json.Marshal(cniImportSession{
+		Endpoints:   left.Endpoints,
+		Assignments: left.Assignments,
+		Owners:      left.IPOwners,
+	})
+	rightData, rightErr := json.Marshal(cniImportSession{
+		Endpoints:   right.Endpoints,
+		Assignments: right.Assignments,
+		Owners:      right.IPOwners,
+	})
+	return leftErr == nil && rightErr == nil && bytes.Equal(leftData, rightData)
+}
+
+func encodeCNIImportSession(candidate Snapshot) ([]encodedBucket, error) {
+	endpoints, err := encodeJSONMap(candidate.Endpoints)
+	if err != nil {
+		return nil, err
+	}
+	assignments, err := encodeJSONMap(candidate.Assignments)
+	if err != nil {
+		return nil, err
+	}
+	owners, err := encodeJSONMap(candidate.IPOwners)
+	if err != nil {
+		return nil, err
+	}
+	return []encodedBucket{
+		{name: bucketEndpoints, values: endpoints},
+		{name: bucketAssignments, values: assignments},
+		{name: bucketIPOwners, values: owners},
+	}, nil
+}
+
+func cloneCNIEndpoints(input map[string]EndpointRecord) map[string]EndpointRecord {
+	cloned := make(map[string]EndpointRecord, len(input))
+	for key, endpoint := range input {
+		value := EndpointRecord{
+			PodName:       endpoint.PodName,
+			PodNamespace:  endpoint.PodNamespace,
+			IfnameToIPMap: make(map[string]*IPInfoRecord, len(endpoint.IfnameToIPMap)),
+		}
+		for ifname, info := range endpoint.IfnameToIPMap {
+			if info == nil {
+				value.IfnameToIPMap[ifname] = nil
+				continue
+			}
+			clonedInfo := *info
+			clonedInfo.IPv4 = cloneIPNets(info.IPv4)
+			clonedInfo.IPv6 = cloneIPNets(info.IPv6)
+			value.IfnameToIPMap[ifname] = &clonedInfo
+		}
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func cloneCNIAssignments(input map[string]AssignmentRecord) map[string]AssignmentRecord {
+	cloned := make(map[string]AssignmentRecord, len(input))
+	for key, assignment := range input {
+		assignment.IPIDs = append([]string{}, assignment.IPIDs...)
+		cloned[key] = assignment
+	}
+	return cloned
+}
+
+func cloneIPNets(input []net.IPNet) []net.IPNet {
+	cloned := make([]net.IPNet, 0, len(input))
+	for _, value := range input {
+		cloned = append(cloned, net.IPNet{
+			IP:   append(net.IP{}, value.IP...),
+			Mask: append(net.IPMask{}, value.Mask...),
+		})
+	}
+	return cloned
+}

--- a/cns/state/cni_import.go
+++ b/cns/state/cni_import.go
@@ -86,6 +86,15 @@ func (s *DB) ImportCNIEndpointState(
 	records []cns.CNIEndpointState,
 	plan CNIImportPreflight,
 ) (bool, error) {
+	return s.importCNIEndpointState(ctx, records, plan, nil)
+}
+
+func (s *DB) importCNIEndpointState(
+	ctx context.Context,
+	records []cns.CNIEndpointState,
+	plan CNIImportPreflight,
+	beforeCommit func() error,
+) (bool, error) {
 	if ctx == nil {
 		return false, errors.New("importing CNI endpoint state: context is nil")
 	}
@@ -130,8 +139,8 @@ func (s *DB) ImportCNIEndpointState(
 				return false, err
 			}
 		}
-		if s.cniImportBeforeCommit != nil {
-			if err := s.cniImportBeforeCommit(); err != nil {
+		if beforeCommit != nil {
+			if err := beforeCommit(); err != nil {
 				return false, err
 			}
 		}

--- a/cns/state/cni_import.go
+++ b/cns/state/cni_import.go
@@ -22,13 +22,21 @@ import (
 	"github.com/Azure/azure-container-networking/cns"
 )
 
-var ErrCNIImportConflict = errors.New("cns state: CNI import conflicts with session state")
+var (
+	ErrCNIImportConflict = errors.New("cns state: CNI import conflicts with session state")
+
+	errNilCNIPreflightContext = errors.New("preflighting CNI endpoint import: context is nil")
+	errNilCNIImportContext    = errors.New("importing CNI endpoint state: context is nil")
+	errInvalidCNIIPAddress    = errors.New("invalid CNI IP address")
+	errInvalidCNIIPMask       = errors.New("invalid CNI IP mask")
+	errInvalidCNIIPPrefix     = errors.New("invalid CNI IP prefix")
+)
 
 type CNIImportCounts struct {
-	Containers  uint32
-	Interfaces  uint32
-	Assignments uint32
-	IPs         uint32
+	Containers  uint32 `json:"Containers"`
+	Interfaces  uint32 `json:"Interfaces"`
+	Assignments uint32 `json:"Assignments"`
+	IPs         uint32 `json:"IPs"`
 }
 
 // CNIImportPreflight is an immutable plan for importing live stateful CNI
@@ -68,7 +76,7 @@ func (s *DB) PreflightCNIEndpointImport(
 	allowSessionReplacement bool,
 ) (CNIImportPreflight, error) {
 	if ctx == nil {
-		return CNIImportPreflight{}, errors.New("preflighting CNI endpoint import: context is nil")
+		return CNIImportPreflight{}, errNilCNIPreflightContext
 	}
 	snapshot, err := s.Snapshot(ctx)
 	if err != nil {
@@ -96,7 +104,7 @@ func (s *DB) importCNIEndpointState(
 	beforeCommit func() error,
 ) (bool, error) {
 	if ctx == nil {
-		return false, errors.New("importing CNI endpoint state: context is nil")
+		return false, errNilCNIImportContext
 	}
 	if err := validateCNIImportPlan(plan); err != nil {
 		return false, fmt.Errorf("importing CNI endpoint state: %w", err)
@@ -205,8 +213,8 @@ func buildCNIImportPreflight(
 	pods := make(map[string]string)
 
 	for _, record := range normalized {
-		if err := ctx.Err(); err != nil {
-			return CNIImportPreflight{}, Snapshot{}, err
+		if contextErr := ctx.Err(); contextErr != nil {
+			return CNIImportPreflight{}, Snapshot{}, fmt.Errorf("building CNI endpoint import preflight: %w", contextErr)
 		}
 		podIdentity := record.PodNamespace + "\x00" + record.PodName
 		if other, ok := pods[podIdentity]; ok && other != record.InfraContainerID {
@@ -300,14 +308,18 @@ func buildCNIImportPreflight(
 			}
 			candidate.IPOwners[ipID] = record.PodEndpointID
 		}
-		identity, err := json.Marshal(record)
-		if err != nil {
-			return CNIImportPreflight{}, Snapshot{}, invalidInput("encoding CNI identity", err)
+		identity, identityErr := json.Marshal(record)
+		if identityErr != nil {
+			return CNIImportPreflight{}, Snapshot{}, invalidInput("encoding CNI identity", identityErr)
 		}
 		identities = append(identities, string(identity))
 	}
-	if err := candidate.Validate(); err != nil {
-		return CNIImportPreflight{}, Snapshot{}, fmt.Errorf("%w: candidate CNI import: %v", ErrInvalidInput, err)
+	if validationErr := candidate.Validate(); validationErr != nil {
+		return CNIImportPreflight{}, Snapshot{}, fmt.Errorf(
+			"%w: candidate CNI import: %w",
+			ErrInvalidInput,
+			validationErr,
+		)
 	}
 	if !allowReplacement && !sessionEmpty(snapshot) && !sessionEqual(snapshot, candidate) {
 		return CNIImportPreflight{}, Snapshot{}, ErrCNIImportConflict
@@ -330,7 +342,11 @@ func buildCNIImportPreflight(
 		assignments:        cloneCNIAssignments(candidate.Assignments),
 		owners:             cloneMap(candidate.IPOwners),
 	}
-	plan.seal = sealCNIImportPlan(plan)
+	seal, err := sealCNIImportPlan(plan)
+	if err != nil {
+		return CNIImportPreflight{}, Snapshot{}, err
+	}
+	plan.seal = seal
 	return plan, candidate, nil
 }
 
@@ -345,7 +361,7 @@ func normalizeCNIEndpointRecords(
 	seenInterfaces := make(map[string]string)
 	for index, input := range records {
 		if err := ctx.Err(); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("normalizing CNI endpoint record %d: %w", index, err)
 		}
 		record := normalizedCNIEndpoint{
 			InfraContainerID: strings.TrimSpace(input.InfraContainerID),
@@ -433,16 +449,16 @@ func normalizeCNIEndpointRecords(
 func canonicalCNIIPNet(value net.IPNet) (netip.Addr, netip.Prefix, error) {
 	address, ok := netip.AddrFromSlice(value.IP)
 	if !ok {
-		return netip.Addr{}, netip.Prefix{}, errors.New("invalid IP address")
+		return netip.Addr{}, netip.Prefix{}, errInvalidCNIIPAddress
 	}
 	address = address.Unmap()
 	ones, bits := value.Mask.Size()
 	if bits != address.BitLen() || ones < 0 {
-		return netip.Addr{}, netip.Prefix{}, errors.New("invalid IP mask")
+		return netip.Addr{}, netip.Prefix{}, errInvalidCNIIPMask
 	}
 	prefix := netip.PrefixFrom(address, ones)
 	if !prefix.IsValid() {
-		return netip.Addr{}, netip.Prefix{}, errors.New("invalid IP prefix")
+		return netip.Addr{}, netip.Prefix{}, errInvalidCNIIPPrefix
 	}
 	return address, prefix, nil
 }
@@ -475,15 +491,15 @@ func cniImportCounts(candidate Snapshot, interfaceCount int) (CNIImportCounts, e
 		len(candidate.IPOwners),
 	}
 	for _, value := range values {
-		if uint64(value) > math.MaxUint32 {
+		if value < 0 || int64(value) > int64(math.MaxUint32) {
 			return CNIImportCounts{}, invalidInput("CNI import count exceeds uint32", nil)
 		}
 	}
 	return CNIImportCounts{
-		Containers:  uint32(values[0]),
-		Interfaces:  uint32(values[1]),
-		Assignments: uint32(values[2]),
-		IPs:         uint32(values[3]),
+		Containers:  uint32(values[0]), //nolint:gosec // All values are bounds checked above.
+		Interfaces:  uint32(values[1]), //nolint:gosec // All values are bounds checked above.
+		Assignments: uint32(values[2]), //nolint:gosec // All values are bounds checked above.
+		IPs:         uint32(values[3]), //nolint:gosec // All values are bounds checked above.
 	}, nil
 }
 
@@ -506,8 +522,9 @@ func cniImportDigest(records []normalizedCNIEndpoint, candidate Snapshot) (strin
 	return hex.EncodeToString(sum[:]), nil
 }
 
-func sealCNIImportPlan(plan CNIImportPreflight) [sha256.Size]byte {
+func sealCNIImportPlan(plan CNIImportPreflight) ([sha256.Size]byte, error) {
 	hash := sha256.New()
+	var seal [sha256.Size]byte
 	var generation [8]byte
 	binary.LittleEndian.PutUint64(generation[:], plan.ExpectedGeneration)
 	_, _ = hash.Write(generation[:])
@@ -517,26 +534,37 @@ func sealCNIImportPlan(plan CNIImportPreflight) [sha256.Size]byte {
 	} else {
 		_, _ = hash.Write([]byte{0})
 	}
-	countData, _ := json.Marshal(plan.Counts)
+	countData, err := json.Marshal(plan.Counts)
+	if err != nil {
+		return seal, fmt.Errorf("encoding CNI import counts: %w", err)
+	}
 	_, _ = hash.Write(countData)
-	identityData, _ := json.Marshal(plan.identities)
+	identityData, err := json.Marshal(plan.identities)
+	if err != nil {
+		return seal, fmt.Errorf("encoding CNI import identities: %w", err)
+	}
 	_, _ = hash.Write(identityData)
-	sessionData, _ := json.Marshal(cniImportSession{
+	sessionData, err := json.Marshal(cniImportSession{
 		Endpoints:   plan.endpoints,
 		Assignments: plan.assignments,
 		Owners:      plan.owners,
 	})
+	if err != nil {
+		return seal, fmt.Errorf("encoding CNI import session: %w", err)
+	}
 	_, _ = hash.Write(sessionData)
-	var seal [sha256.Size]byte
 	copy(seal[:], hash.Sum(nil))
-	return seal
+	return seal, nil
 }
 
 func validateCNIImportPlan(plan CNIImportPreflight) error {
 	if plan.IdentityDigest == "" {
 		return invalidInput("CNI import preflight digest is empty", nil)
 	}
-	expectedSeal := sealCNIImportPlan(plan)
+	expectedSeal, err := sealCNIImportPlan(plan)
+	if err != nil {
+		return invalidInput("sealing CNI import preflight", err)
+	}
 	if !bytes.Equal(plan.seal[:], expectedSeal[:]) {
 		return invalidInput("CNI import preflight was modified", nil)
 	}

--- a/cns/state/cni_import_test.go
+++ b/cns/state/cni_import_test.go
@@ -18,6 +18,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var errInjectedCNIImport = errors.New("injected commit failure")
+
+const cniImportTestSecondaryInterface = "net1"
+
 func TestCNIEndpointImportPreflightAndAtomicImport(t *testing.T) {
 	db, _ := openTestDB(t)
 	seedCNIImportInventory(t, db)
@@ -34,7 +38,7 @@ func TestCNIEndpointImportPreflightAndAtomicImport(t *testing.T) {
 	}, plan.Counts)
 	require.Len(t, plan.IdentityDigest, 64)
 	assert.True(t, sort.StringsAreSorted(plan.identities))
-	publicPlan, err := json.Marshal(plan)
+	publicPlan, err := json.Marshal(plan) //nolint:musttag // The public preflight intentionally exposes only its exported summary fields.
 	require.NoError(t, err)
 	assert.NotContains(t, string(publicPlan), "10.0.0.4")
 	assert.NotContains(t, string(publicPlan), "pod-1")
@@ -161,9 +165,9 @@ func TestCNIEndpointImportInputErrors(t *testing.T) {
 	db, _ := openTestDB(t)
 	seedCNIImportInventory(t, db)
 	records := cniImportRecords(t)
-	_, err := db.PreflightCNIEndpointImport(nil, records, false)
+	_, err := db.PreflightCNIEndpointImport(nil, records, false) //nolint:staticcheck // Verifies the fail-closed nil-context guard.
 	require.Error(t, err)
-	_, err = db.ImportCNIEndpointState(nil, records, CNIImportPreflight{})
+	_, err = db.ImportCNIEndpointState(nil, records, CNIImportPreflight{}) //nolint:staticcheck // Verifies the fail-closed nil-context guard.
 	require.Error(t, err)
 	_, err = (CNIImportPreflight{}).SnapshotForProjection(NewSnapshot())
 	require.ErrorIs(t, err, ErrInvalidInput)
@@ -237,7 +241,7 @@ func TestCNIEndpointImportReplacementStaleTamperedAndCommitFailure(t *testing.T)
 		require.NoError(t, err)
 
 		changedRecords := cniImportRecords(t)
-		changedRecords[1].InterfaceName = "net1"
+		changedRecords[1].InterfaceName = cniImportTestSecondaryInterface
 		_, err = db.PreflightCNIEndpointImport(context.Background(), changedRecords, false)
 		require.ErrorIs(t, err, ErrCNIImportConflict)
 		fresh, err := db.PreflightCNIEndpointImport(context.Background(), changedRecords, true)
@@ -245,7 +249,11 @@ func TestCNIEndpointImportReplacementStaleTamperedAndCommitFailure(t *testing.T)
 		changed, err := db.ImportCNIEndpointState(context.Background(), changedRecords, fresh)
 		require.NoError(t, err)
 		assert.True(t, changed)
-		assert.Contains(t, requireValidSnapshot(t, db).Endpoints["container-1"].IfnameToIPMap, "net1")
+		assert.Contains(
+			t,
+			requireValidSnapshot(t, db).Endpoints["container-1"].IfnameToIPMap,
+			cniImportTestSecondaryInterface,
+		)
 	})
 
 	t.Run("stale and tampered", func(t *testing.T) {
@@ -260,9 +268,9 @@ func TestCNIEndpointImportReplacementStaleTamperedAndCommitFailure(t *testing.T)
 		require.ErrorIs(t, err, ErrInvalidInput)
 
 		require.NoError(t, db.Update(context.Background(), func(tx *WriteTx) error {
-			meta, err := tx.Metadata()
-			if err != nil {
-				return err
+			meta, metadataErr := tx.Metadata()
+			if metadataErr != nil {
+				return metadataErr
 			}
 			meta.NodeID = "changed"
 			return tx.PutMetadata(meta)
@@ -278,14 +286,13 @@ func TestCNIEndpointImportReplacementStaleTamperedAndCommitFailure(t *testing.T)
 		plan, err := db.PreflightCNIEndpointImport(context.Background(), records, false)
 		require.NoError(t, err)
 		before := requireValidSnapshot(t, db)
-		injected := errors.New("injected commit failure")
 		changed, err := db.importCNIEndpointState(
 			context.Background(),
 			records,
 			plan,
-			func() error { return injected },
+			func() error { return errInjectedCNIImport },
 		)
-		require.ErrorIs(t, err, injected)
+		require.ErrorIs(t, err, errInjectedCNIImport)
 		assert.False(t, changed)
 		assert.Equal(t, before, requireValidSnapshot(t, db))
 	})
@@ -349,8 +356,8 @@ func TestCNIEndpointImportConcurrentCloseReadOnlyCancelAndReopen(t *testing.T) {
 			errs <- importErr
 		}()
 		select {
-		case err := <-errs:
-			t.Fatalf("import returned while writer gate was held: %v", err)
+		case earlyErr := <-errs:
+			t.Fatalf("import returned while writer gate was held: %v", earlyErr)
 		case <-time.After(10 * time.Millisecond):
 		}
 		cancel()

--- a/cns/state/cni_import_test.go
+++ b/cns/state/cni_import_test.go
@@ -279,8 +279,12 @@ func TestCNIEndpointImportReplacementStaleTamperedAndCommitFailure(t *testing.T)
 		require.NoError(t, err)
 		before := requireValidSnapshot(t, db)
 		injected := errors.New("injected commit failure")
-		db.cniImportBeforeCommit = func() error { return injected }
-		changed, err := db.ImportCNIEndpointState(context.Background(), records, plan)
+		changed, err := db.importCNIEndpointState(
+			context.Background(),
+			records,
+			plan,
+			func() error { return injected },
+		)
 		require.ErrorIs(t, err, injected)
 		assert.False(t, changed)
 		assert.Equal(t, before, requireValidSnapshot(t, db))

--- a/cns/state/cni_import_test.go
+++ b/cns/state/cni_import_test.go
@@ -1,0 +1,454 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package state
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCNIEndpointImportPreflightAndAtomicImport(t *testing.T) {
+	db, _ := openTestDB(t)
+	seedCNIImportInventory(t, db)
+	records := cniImportRecords(t)
+
+	plan, err := db.PreflightCNIEndpointImport(context.Background(), records, false)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), plan.ExpectedGeneration)
+	assert.Equal(t, CNIImportCounts{
+		Containers:  1,
+		Interfaces:  2,
+		Assignments: 2,
+		IPs:         3,
+	}, plan.Counts)
+	require.Len(t, plan.IdentityDigest, 64)
+	assert.True(t, sort.StringsAreSorted(plan.identities))
+	publicPlan, err := json.Marshal(plan)
+	require.NoError(t, err)
+	assert.NotContains(t, string(publicPlan), "10.0.0.4")
+	assert.NotContains(t, string(publicPlan), "pod-1")
+	assert.NotContains(t, string(publicPlan), "path")
+
+	reordered := []cns.CNIEndpointState{records[1], records[0]}
+	reorderedPlan, err := db.PreflightCNIEndpointImport(context.Background(), reordered, false)
+	require.NoError(t, err)
+	assert.Equal(t, plan.IdentityDigest, reorderedPlan.IdentityDigest)
+
+	projected, err := plan.SnapshotForProjection(requireValidSnapshot(t, db))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ip-v4", "ip-v6"}, projected.Assignments["iface-primary"].IPIDs)
+	assert.Equal(t, "iface-secondary", projected.IPOwners["ip-secondary"])
+	assert.Equal(t, "nc-1", projected.Endpoints["container-1"].IfnameToIPMap["eth0"].NetworkContainerID)
+	projected.Endpoints["container-1"].IfnameToIPMap["eth0"].IPv4[0].IP[0] = 192
+	fresh, err := plan.SnapshotForProjection(requireValidSnapshot(t, db))
+	require.NoError(t, err)
+	assert.Equal(t, "10.0.0.4", fresh.Endpoints["container-1"].IfnameToIPMap["eth0"].IPv4[0].IP.String())
+
+	before := requireValidSnapshot(t, db)
+	changed, err := db.ImportCNIEndpointState(context.Background(), records, plan)
+	require.NoError(t, err)
+	require.True(t, changed)
+	after := requireValidSnapshot(t, db)
+	assert.Equal(t, before.Metadata.Generation+1, after.Metadata.Generation)
+	assert.Equal(t, before.NetworkContainers, after.NetworkContainers)
+	assert.Equal(t, before.IPs, after.IPs)
+	assert.Equal(t, before.Networks, after.Networks)
+	assert.Equal(t, before.OrchestratorContexts, after.OrchestratorContexts)
+	assert.Equal(t, before.PnPIDByMAC, after.PnPIDByMAC)
+	assert.Equal(t, fresh.Endpoints["container-1"].PodName, after.Endpoints["container-1"].PodName)
+	assert.Equal(t, "10.0.0.4", after.Endpoints["container-1"].IfnameToIPMap["eth0"].IPv4[0].IP.String())
+	assert.Equal(t, "fd00::4", after.Endpoints["container-1"].IfnameToIPMap["eth0"].IPv6[0].IP.String())
+	assert.Equal(t, "10.1.0.4", after.Endpoints["container-1"].IfnameToIPMap["eth1"].IPv4[0].IP.String())
+	assert.Equal(t, fresh.Assignments, after.Assignments)
+	assert.Equal(t, fresh.IPOwners, after.IPOwners)
+	assert.Empty(t, after.DeleteIntents)
+
+	replay, err := db.PreflightCNIEndpointImport(context.Background(), records, false)
+	require.NoError(t, err)
+	changed, err = db.ImportCNIEndpointState(context.Background(), records, replay)
+	require.NoError(t, err)
+	assert.False(t, changed)
+	assert.Equal(t, after.Metadata.Generation, readMetadata(t, db).Generation)
+}
+
+func TestCNIEndpointImportValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		prepare func(*testing.T, *DB, []cns.CNIEndpointState)
+		mutate  func([]cns.CNIEndpointState) []cns.CNIEndpointState
+		want    error
+	}{
+		{
+			name: "missing inventory",
+			mutate: func(records []cns.CNIEndpointState) []cns.CNIEndpointState {
+				records[0].IPAddresses[0] = testCNIIPNet(t, "10.0.0.99/24")
+				return records
+			},
+			want: ErrInvalidInput,
+		},
+		{
+			name: "duplicate inventory",
+			prepare: func(t *testing.T, db *DB, _ []cns.CNIEndpointState) {
+				putRaw(t, db, bucketIPs, []byte("duplicate"), []byte(
+					`{"id":"duplicate","ipAddress":"10.0.0.4","ncID":"nc-1","ncVersion":7}`,
+				))
+			},
+			want: ErrInconsistentState,
+		},
+		{
+			name: "active delete intent",
+			prepare: func(t *testing.T, db *DB, _ []cns.CNIEndpointState) {
+				require.NoError(t, db.Update(context.Background(), func(tx *WriteTx) error {
+					return tx.PutDeleteIntent("old", DeleteIntent{CreatedAt: time.Now()})
+				}))
+			},
+			want: ErrDeleteIntent,
+		},
+		{
+			name: "conflicting container pod",
+			mutate: func(records []cns.CNIEndpointState) []cns.CNIEndpointState {
+				records[1].PodName = "other"
+				return records
+			},
+			want: ErrInvalidInput,
+		},
+		{
+			name: "duplicate interface",
+			mutate: func(records []cns.CNIEndpointState) []cns.CNIEndpointState {
+				records[1].InterfaceName = "eth0"
+				return records
+			},
+			want: ErrInvalidInput,
+		},
+		{
+			name: "duplicate endpoint",
+			mutate: func(records []cns.CNIEndpointState) []cns.CNIEndpointState {
+				records[1].PodEndpointID = records[0].PodEndpointID
+				return records
+			},
+			want: ErrInvalidInput,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, _ := openTestDB(t)
+			seedCNIImportInventory(t, db)
+			records := cniImportRecords(t)
+			if tt.prepare != nil {
+				tt.prepare(t, db, records)
+			}
+			if tt.mutate != nil {
+				records = tt.mutate(records)
+			}
+			_, err := db.PreflightCNIEndpointImport(context.Background(), records, false)
+			require.ErrorIs(t, err, tt.want)
+		})
+	}
+}
+
+func TestCNIEndpointImportInputErrors(t *testing.T) {
+	db, _ := openTestDB(t)
+	seedCNIImportInventory(t, db)
+	records := cniImportRecords(t)
+	_, err := db.PreflightCNIEndpointImport(nil, records, false)
+	require.Error(t, err)
+	_, err = db.ImportCNIEndpointState(nil, records, CNIImportPreflight{})
+	require.Error(t, err)
+	_, err = (CNIImportPreflight{}).SnapshotForProjection(NewSnapshot())
+	require.ErrorIs(t, err, ErrInvalidInput)
+
+	plan, err := db.PreflightCNIEndpointImport(context.Background(), records, false)
+	require.NoError(t, err)
+	base := requireValidSnapshot(t, db)
+	base.Metadata.Generation++
+	_, err = plan.SnapshotForProjection(base)
+	require.ErrorIs(t, err, ErrStaleGeneration)
+
+	tests := []struct {
+		name   string
+		mutate func([]cns.CNIEndpointState)
+	}{
+		{name: "empty container", mutate: func(records []cns.CNIEndpointState) {
+			records[0].InfraContainerID = ""
+		}},
+		{name: "empty endpoint", mutate: func(records []cns.CNIEndpointState) {
+			records[0].PodEndpointID = ""
+		}},
+		{name: "empty pod name", mutate: func(records []cns.CNIEndpointState) {
+			records[0].PodName = ""
+		}},
+		{name: "empty pod namespace", mutate: func(records []cns.CNIEndpointState) {
+			records[0].PodNamespace = ""
+		}},
+		{name: "empty interface key", mutate: func(records []cns.CNIEndpointState) {
+			records[0].InterfaceKey = ""
+		}},
+		{name: "empty interface name", mutate: func(records []cns.CNIEndpointState) {
+			records[0].InterfaceName = ""
+		}},
+		{name: "empty IPs", mutate: func(records []cns.CNIEndpointState) {
+			records[0].IPAddresses = []net.IPNet{}
+		}},
+		{name: "duplicate interface key", mutate: func(records []cns.CNIEndpointState) {
+			records[1].InterfaceKey = records[0].InterfaceKey
+		}},
+		{name: "duplicate address", mutate: func(records []cns.CNIEndpointState) {
+			records[1].IPAddresses = append(records[1].IPAddresses, records[0].IPAddresses[0])
+		}},
+		{name: "invalid address", mutate: func(records []cns.CNIEndpointState) {
+			records[0].IPAddresses[0].IP = net.IP{1, 2}
+		}},
+		{name: "invalid mask", mutate: func(records []cns.CNIEndpointState) {
+			records[0].IPAddresses[0].Mask = net.CIDRMask(24, 32)
+		}},
+		{name: "pod spans containers", mutate: func(records []cns.CNIEndpointState) {
+			records[1].InfraContainerID = "container-2"
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := cniImportRecords(t)
+			tt.mutate(input)
+			_, err := db.PreflightCNIEndpointImport(context.Background(), input, false)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestCNIEndpointImportReplacementStaleTamperedAndCommitFailure(t *testing.T) {
+	t.Run("replacement requires explicit mode", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		seedCNIImportInventory(t, db)
+		records := cniImportRecords(t)
+		plan, err := db.PreflightCNIEndpointImport(context.Background(), records, false)
+		require.NoError(t, err)
+		_, err = db.ImportCNIEndpointState(context.Background(), records, plan)
+		require.NoError(t, err)
+
+		changedRecords := cniImportRecords(t)
+		changedRecords[1].InterfaceName = "net1"
+		_, err = db.PreflightCNIEndpointImport(context.Background(), changedRecords, false)
+		require.ErrorIs(t, err, ErrCNIImportConflict)
+		fresh, err := db.PreflightCNIEndpointImport(context.Background(), changedRecords, true)
+		require.NoError(t, err)
+		changed, err := db.ImportCNIEndpointState(context.Background(), changedRecords, fresh)
+		require.NoError(t, err)
+		assert.True(t, changed)
+		assert.Contains(t, requireValidSnapshot(t, db).Endpoints["container-1"].IfnameToIPMap, "net1")
+	})
+
+	t.Run("stale and tampered", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		seedCNIImportInventory(t, db)
+		records := cniImportRecords(t)
+		plan, err := db.PreflightCNIEndpointImport(context.Background(), records, false)
+		require.NoError(t, err)
+		tampered := plan
+		tampered.IdentityDigest = "modified"
+		_, err = db.ImportCNIEndpointState(context.Background(), records, tampered)
+		require.ErrorIs(t, err, ErrInvalidInput)
+
+		require.NoError(t, db.Update(context.Background(), func(tx *WriteTx) error {
+			meta, err := tx.Metadata()
+			if err != nil {
+				return err
+			}
+			meta.NodeID = "changed"
+			return tx.PutMetadata(meta)
+		}))
+		_, err = db.ImportCNIEndpointState(context.Background(), records, plan)
+		require.ErrorIs(t, err, ErrStaleGeneration)
+	})
+
+	t.Run("commit failure", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		seedCNIImportInventory(t, db)
+		records := cniImportRecords(t)
+		plan, err := db.PreflightCNIEndpointImport(context.Background(), records, false)
+		require.NoError(t, err)
+		before := requireValidSnapshot(t, db)
+		injected := errors.New("injected commit failure")
+		db.cniImportBeforeCommit = func() error { return injected }
+		changed, err := db.ImportCNIEndpointState(context.Background(), records, plan)
+		require.ErrorIs(t, err, injected)
+		assert.False(t, changed)
+		assert.Equal(t, before, requireValidSnapshot(t, db))
+	})
+}
+
+func TestCNIEndpointImportConcurrentCloseReadOnlyCancelAndReopen(t *testing.T) {
+	t.Run("one concurrent import", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		seedCNIImportInventory(t, db)
+		records := cniImportRecords(t)
+		plan, err := db.PreflightCNIEndpointImport(context.Background(), records, false)
+		require.NoError(t, err)
+		var wg sync.WaitGroup
+		results := make(chan error, 8)
+		for range 8 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, err := db.ImportCNIEndpointState(context.Background(), records, plan)
+				results <- err
+			}()
+		}
+		wg.Wait()
+		close(results)
+		successes := 0
+		stale := 0
+		for err := range results {
+			switch {
+			case err == nil:
+				successes++
+			case errors.Is(err, ErrStaleGeneration):
+				stale++
+			default:
+				t.Fatalf("unexpected import error: %v", err)
+			}
+		}
+		assert.Equal(t, 1, successes)
+		assert.Equal(t, 7, stale)
+	})
+
+	t.Run("canceled", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		seedCNIImportInventory(t, db)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := db.PreflightCNIEndpointImport(ctx, cniImportRecords(t), false)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("canceled at writer gate", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		seedCNIImportInventory(t, db)
+		records := cniImportRecords(t)
+		plan, err := db.PreflightCNIEndpointImport(context.Background(), records, false)
+		require.NoError(t, err)
+		db.writeGate <- struct{}{}
+		ctx, cancel := context.WithCancel(context.Background())
+		errs := make(chan error, 1)
+		go func() {
+			_, importErr := db.ImportCNIEndpointState(ctx, records, plan)
+			errs <- importErr
+		}()
+		select {
+		case err := <-errs:
+			t.Fatalf("import returned while writer gate was held: %v", err)
+		case <-time.After(10 * time.Millisecond):
+		}
+		cancel()
+		err = <-errs
+		<-db.writeGate
+		require.ErrorIs(t, err, context.Canceled)
+		assert.Empty(t, requireValidSnapshot(t, db).Endpoints)
+	})
+
+	t.Run("closed", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		seedCNIImportInventory(t, db)
+		records := cniImportRecords(t)
+		plan, err := db.PreflightCNIEndpointImport(context.Background(), records, false)
+		require.NoError(t, err)
+		require.NoError(t, db.Close())
+		_, err = db.ImportCNIEndpointState(context.Background(), records, plan)
+		require.Error(t, err)
+	})
+
+	t.Run("read only", func(t *testing.T) {
+		db, path := openTestDB(t)
+		seedCNIImportInventory(t, db)
+		require.NoError(t, db.Close())
+		readOnly, err := Open(path, Options{ReadOnly: true})
+		require.NoError(t, err)
+		defer readOnly.Close()
+		records := cniImportRecords(t)
+		plan, err := readOnly.PreflightCNIEndpointImport(context.Background(), records, false)
+		require.NoError(t, err)
+		_, err = readOnly.ImportCNIEndpointState(context.Background(), records, plan)
+		require.Error(t, err)
+	})
+
+	t.Run("close reopen", func(t *testing.T) {
+		db, path := openTestDB(t)
+		seedCNIImportInventory(t, db)
+		records := cniImportRecords(t)
+		plan, err := db.PreflightCNIEndpointImport(context.Background(), records, false)
+		require.NoError(t, err)
+		_, err = db.ImportCNIEndpointState(context.Background(), records, plan)
+		require.NoError(t, err)
+		require.NoError(t, db.Close())
+		reopened, err := Open(path, Options{})
+		require.NoError(t, err)
+		defer reopened.Close()
+		snapshot := requireValidSnapshot(t, reopened)
+		assert.Equal(t, "iface-primary", snapshot.IPOwners["ip-v4"])
+	})
+}
+
+func seedCNIImportInventory(t *testing.T, db *DB) {
+	t.Helper()
+	snapshot := completeSnapshot()
+	snapshot.Assignments = map[string]AssignmentRecord{}
+	snapshot.IPOwners = map[string]string{}
+	snapshot.Endpoints = map[string]EndpointRecord{}
+	snapshot.DeleteIntents = map[string]DeleteIntent{}
+	ips := make([]IPRecord, 0, len(snapshot.IPs))
+	for _, id := range sortedKeys(snapshot.IPs) {
+		ips = append(ips, snapshot.IPs[id])
+	}
+	changed, err := db.ApplyNetworkContainer(
+		context.Background(),
+		snapshot.NetworkContainers["nc-1"],
+		ips,
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
+}
+
+func cniImportRecords(t *testing.T) []cns.CNIEndpointState {
+	t.Helper()
+	return []cns.CNIEndpointState{
+		{
+			InfraContainerID: "container-1",
+			PodEndpointID:    "iface-primary",
+			PodName:          "pod-1",
+			PodNamespace:     "ns-1",
+			InterfaceKey:     "container-1-eth0",
+			InterfaceName:    "eth0",
+			IPAddresses: []net.IPNet{
+				testCNIIPNet(t, "fd00::4/64"),
+				testCNIIPNet(t, "10.0.0.4/24"),
+			},
+		},
+		{
+			InfraContainerID: "container-1",
+			PodEndpointID:    "iface-secondary",
+			PodName:          "pod-1",
+			PodNamespace:     "ns-1",
+			InterfaceKey:     "container-1-eth1",
+			InterfaceName:    "eth1",
+			IPAddresses:      []net.IPNet{testCNIIPNet(t, "10.1.0.4/24")},
+		},
+	}
+}
+
+func testCNIIPNet(t *testing.T, value string) net.IPNet {
+	t.Helper()
+	ip, prefix, err := net.ParseCIDR(value)
+	require.NoError(t, err)
+	prefix.IP = ip
+	return *prefix
+}

--- a/cns/stateprovider/cni/endpointstateprovider_test.go
+++ b/cns/stateprovider/cni/endpointstateprovider_test.go
@@ -5,7 +5,6 @@ package cni
 
 import (
 	"context"
-	"errors"
 	"net"
 	"testing"
 
@@ -19,25 +18,32 @@ import (
 	fakeexec "k8s.io/utils/exec/testing"
 )
 
+const (
+	cniProviderTestPod       = "pod"
+	cniProviderTestContainer = "container"
+	cniProviderTestInterface = "if-a"
+	cniProviderTestNamespace = "namespace"
+)
+
 func TestTranslateEndpointState(t *testing.T) {
 	valid := func() *api.AzureCNIState {
 		return &api.AzureCNIState{ContainerInterfaces: map[string]api.PodNetworkInterfaceInfo{
 			"if-b": {
-				PodName:       "pod",
+				PodName:       cniProviderTestPod,
 				PodNamespace:  "ns",
 				PodEndpointId: "if-b",
-				ContainerID:   "container",
+				ContainerID:   cniProviderTestContainer,
 				IfName:        "eth1",
 				IPAddresses: []net.IPNet{
 					mustIPNet(t, "2001:db8::4/64"),
 					mustIPNet(t, "10.0.1.4/24"),
 				},
 			},
-			"if-a": {
-				PodName:       "pod",
+			cniProviderTestInterface: {
+				PodName:       cniProviderTestPod,
 				PodNamespace:  "ns",
-				PodEndpointId: "if-a",
-				ContainerID:   "container",
+				PodEndpointId: cniProviderTestInterface,
+				ContainerID:   cniProviderTestContainer,
 				IfName:        "eth0",
 				IPAddresses:   []net.IPNet{mustIPNet(t, "10.0.0.4/24")},
 			},
@@ -47,7 +53,7 @@ func TestTranslateEndpointState(t *testing.T) {
 	records, err := translateEndpointState(valid())
 	require.NoError(t, err)
 	require.Len(t, records, 2)
-	assert.Equal(t, "if-a", records[0].InterfaceKey)
+	assert.Equal(t, cniProviderTestInterface, records[0].InterfaceKey)
 	assert.Equal(t, "if-b", records[1].InterfaceKey)
 	assert.Equal(t, "10.0.1.4", records[1].IPAddresses[0].IP.String())
 	assert.Equal(t, "2001:db8::4", records[1].IPAddresses[1].IP.String())
@@ -65,24 +71,24 @@ func TestTranslateEndpointState(t *testing.T) {
 	}{
 		{name: "nil state", mutate: func(state *api.AzureCNIState) { *state = api.AzureCNIState{} }},
 		{name: "empty container", mutate: func(state *api.AzureCNIState) {
-			value := state.ContainerInterfaces["if-a"]
+			value := state.ContainerInterfaces[cniProviderTestInterface]
 			value.ContainerID = ""
-			state.ContainerInterfaces["if-a"] = value
+			state.ContainerInterfaces[cniProviderTestInterface] = value
 		}},
 		{name: "empty endpoint", mutate: func(state *api.AzureCNIState) {
-			value := state.ContainerInterfaces["if-a"]
+			value := state.ContainerInterfaces[cniProviderTestInterface]
 			value.PodEndpointId = ""
-			state.ContainerInterfaces["if-a"] = value
+			state.ContainerInterfaces[cniProviderTestInterface] = value
 		}},
 		{name: "malformed IP", mutate: func(state *api.AzureCNIState) {
-			value := state.ContainerInterfaces["if-a"]
+			value := state.ContainerInterfaces[cniProviderTestInterface]
 			value.IPAddresses[0].IP = net.IP{1, 2}
-			state.ContainerInterfaces["if-a"] = value
+			state.ContainerInterfaces[cniProviderTestInterface] = value
 		}},
 		{name: "malformed prefix", mutate: func(state *api.AzureCNIState) {
-			value := state.ContainerInterfaces["if-a"]
+			value := state.ContainerInterfaces[cniProviderTestInterface]
 			value.IPAddresses[0].Mask = net.CIDRMask(64, 128)
-			state.ContainerInterfaces["if-a"] = value
+			state.ContainerInterfaces[cniProviderTestInterface] = value
 		}},
 		{name: "duplicate IP", mutate: func(state *api.AzureCNIState) {
 			value := state.ContainerInterfaces["if-b"]
@@ -91,7 +97,7 @@ func TestTranslateEndpointState(t *testing.T) {
 		}},
 		{name: "duplicate endpoint", mutate: func(state *api.AzureCNIState) {
 			value := state.ContainerInterfaces["if-b"]
-			value.PodEndpointId = "if-a"
+			value.PodEndpointId = cniProviderTestInterface
 			state.ContainerInterfaces["if-b"] = value
 		}},
 		{name: "duplicate interface", mutate: func(state *api.AzureCNIState) {
@@ -147,7 +153,7 @@ func TestEndpointStateProviderContextAndRepeatedReads(t *testing.T) {
 
 	_, err = provider(nil)
 	require.Error(t, err)
-	assert.False(t, errors.Is(err, cns.ErrDuplicateIP))
+	require.NotErrorIs(t, err, cns.ErrDuplicateIP)
 
 	t.Run("canceled after non-cancelable exec", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())

--- a/cns/stateprovider/cni/endpointstateprovider_test.go
+++ b/cns/stateprovider/cni/endpointstateprovider_test.go
@@ -1,0 +1,181 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package cni
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/Azure/azure-container-networking/cni/api"
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/platform"
+	testutils "github.com/Azure/azure-container-networking/test/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	utilexec "k8s.io/utils/exec"
+	fakeexec "k8s.io/utils/exec/testing"
+)
+
+func TestTranslateEndpointState(t *testing.T) {
+	valid := func() *api.AzureCNIState {
+		return &api.AzureCNIState{ContainerInterfaces: map[string]api.PodNetworkInterfaceInfo{
+			"if-b": {
+				PodName:       "pod",
+				PodNamespace:  "ns",
+				PodEndpointId: "if-b",
+				ContainerID:   "container",
+				IfName:        "eth1",
+				IPAddresses: []net.IPNet{
+					mustIPNet(t, "2001:db8::4/64"),
+					mustIPNet(t, "10.0.1.4/24"),
+				},
+			},
+			"if-a": {
+				PodName:       "pod",
+				PodNamespace:  "ns",
+				PodEndpointId: "if-a",
+				ContainerID:   "container",
+				IfName:        "eth0",
+				IPAddresses:   []net.IPNet{mustIPNet(t, "10.0.0.4/24")},
+			},
+		}}
+	}
+
+	records, err := translateEndpointState(valid())
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+	assert.Equal(t, "if-a", records[0].InterfaceKey)
+	assert.Equal(t, "if-b", records[1].InterfaceKey)
+	assert.Equal(t, "10.0.1.4", records[1].IPAddresses[0].IP.String())
+	assert.Equal(t, "2001:db8::4", records[1].IPAddresses[1].IP.String())
+	ones, bits := records[1].IPAddresses[0].Mask.Size()
+	assert.Equal(t, 24, ones)
+	assert.Equal(t, 32, bits)
+
+	second, err := translateEndpointState(valid())
+	require.NoError(t, err)
+	assert.Equal(t, records, second)
+
+	tests := []struct {
+		name   string
+		mutate func(*api.AzureCNIState)
+	}{
+		{name: "nil state", mutate: func(state *api.AzureCNIState) { *state = api.AzureCNIState{} }},
+		{name: "empty container", mutate: func(state *api.AzureCNIState) {
+			value := state.ContainerInterfaces["if-a"]
+			value.ContainerID = ""
+			state.ContainerInterfaces["if-a"] = value
+		}},
+		{name: "empty endpoint", mutate: func(state *api.AzureCNIState) {
+			value := state.ContainerInterfaces["if-a"]
+			value.PodEndpointId = ""
+			state.ContainerInterfaces["if-a"] = value
+		}},
+		{name: "malformed IP", mutate: func(state *api.AzureCNIState) {
+			value := state.ContainerInterfaces["if-a"]
+			value.IPAddresses[0].IP = net.IP{1, 2}
+			state.ContainerInterfaces["if-a"] = value
+		}},
+		{name: "malformed prefix", mutate: func(state *api.AzureCNIState) {
+			value := state.ContainerInterfaces["if-a"]
+			value.IPAddresses[0].Mask = net.CIDRMask(64, 128)
+			state.ContainerInterfaces["if-a"] = value
+		}},
+		{name: "duplicate IP", mutate: func(state *api.AzureCNIState) {
+			value := state.ContainerInterfaces["if-b"]
+			value.IPAddresses = append(value.IPAddresses, mustIPNet(t, "10.0.0.4/32"))
+			state.ContainerInterfaces["if-b"] = value
+		}},
+		{name: "duplicate endpoint", mutate: func(state *api.AzureCNIState) {
+			value := state.ContainerInterfaces["if-b"]
+			value.PodEndpointId = "if-a"
+			state.ContainerInterfaces["if-b"] = value
+		}},
+		{name: "duplicate interface", mutate: func(state *api.AzureCNIState) {
+			value := state.ContainerInterfaces["if-b"]
+			value.IfName = "eth0"
+			state.ContainerInterfaces["if-b"] = value
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := valid()
+			tt.mutate(state)
+			if tt.name == "nil state" {
+				state = nil
+			}
+			_, err := translateEndpointState(state)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestEndpointStateProviderContextAndRepeatedReads(t *testing.T) {
+	calls := []testutils.TestCmd{
+		{
+			Cmd: []string{platform.CNIBinaryPath},
+			Stdout: `{"ContainerInterfaces":{"if-a":{"PodName":"pod","PodNamespace":"ns",
+				"PodEndpointID":"if-a","ContainerID":"container","IfName":"eth0",
+				"IPAddresses":[{"IP":"10.0.0.4","Mask":"////AA=="}]}}}`,
+		},
+		{
+			Cmd: []string{platform.CNIBinaryPath},
+			Stdout: `{"ContainerInterfaces":{"if-a":{"PodName":"pod","PodNamespace":"ns",
+				"PodEndpointID":"if-a","ContainerID":"container","IfName":"eth0",
+				"IPAddresses":[{"IP":"10.0.0.5","Mask":"////AA=="}]}}}`,
+		},
+	}
+	exec := testutils.GetFakeExecWithScripts(calls)
+	provider := endpointStateProvider(exec)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := provider(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Zero(t, exec.CommandCalls)
+
+	first, err := provider(context.Background())
+	require.NoError(t, err)
+	second, err := provider(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "10.0.0.4", first[0].IPAddresses[0].IP.String())
+	require.Equal(t, "10.0.0.5", second[0].IPAddresses[0].IP.String())
+	require.Equal(t, 2, exec.CommandCalls)
+
+	_, err = provider(nil)
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, cns.ErrDuplicateIP))
+
+	t.Run("canceled after non-cancelable exec", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		exec := &fakeexec.FakeExec{
+			ExactOrder: true,
+			CommandScript: []fakeexec.FakeCommandAction{
+				func(cmd string, args ...string) utilexec.Cmd {
+					command := &fakeexec.FakeCmd{
+						CombinedOutputScript: []fakeexec.FakeAction{
+							func() ([]byte, []byte, error) {
+								cancel()
+								return []byte(`{"ContainerInterfaces":{}}`), nil, nil
+							},
+						},
+					}
+					return fakeexec.InitFakeCmd(command, cmd, args...)
+				},
+			},
+		}
+		_, err := endpointStateProvider(exec)(ctx)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+func mustIPNet(t *testing.T, value string) net.IPNet {
+	t.Helper()
+	ip, prefix, err := net.ParseCIDR(value)
+	require.NoError(t, err)
+	prefix.IP = ip
+	return *prefix
+}

--- a/cns/stateprovider/cni/podinfoprovider.go
+++ b/cns/stateprovider/cni/podinfoprovider.go
@@ -1,12 +1,17 @@
 package cni
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"net"
+	"net/netip"
+	"sort"
+	"strings"
 
 	"github.com/Azure/azure-container-networking/cni/api"
 	"github.com/Azure/azure-container-networking/cni/client"
 	"github.com/Azure/azure-container-networking/cns"
-	"github.com/pkg/errors"
 	kexec "k8s.io/utils/exec"
 )
 
@@ -27,23 +32,177 @@ func podInfoProvider(exec kexec.Interface) (cns.PodInfoByIPProvider, error) {
 	}), nil
 }
 
+// NewEndpointStateProvider returns a function that queries stateful Azure CNI
+// on every call. The CNI exec API cannot interrupt a running command, so the
+// context is checked immediately before and after that bounded operation.
+func NewEndpointStateProvider() cns.CNIEndpointStateProvider {
+	return endpointStateProvider(kexec.New())
+}
+
+func endpointStateProvider(exec kexec.Interface) cns.CNIEndpointStateProvider {
+	cli := client.New(exec)
+	return func(ctx context.Context) ([]cns.CNIEndpointState, error) {
+		if ctx == nil {
+			return nil, errors.New("reading CNI endpoint state: context is nil")
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("reading CNI endpoint state: %w", err)
+		}
+		state, err := cli.GetEndpointState()
+		if err != nil {
+			return nil, errors.New("reading CNI endpoint state: CNI query failed")
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("reading CNI endpoint state: %w", err)
+		}
+		return translateEndpointState(state)
+	}
+}
+
 // cniStateToPodInfoByIP converts an AzureCNIState dumped from a CNI exec
 // into a PodInfo map, using the endpoint IPs as keys in the map.
 // for pods with multiple IPs (such as in dualstack cases), this means multiple keys in the map
 // will point to the same pod information.
 func cniStateToPodInfoByIP(state *api.AzureCNIState) (map[string]cns.PodInfo, error) {
-	podInfoByIP := map[string]cns.PodInfo{}
-	for _, endpoint := range state.ContainerInterfaces {
-		for _, epIP := range endpoint.IPAddresses {
-			podInfo := cns.NewPodInfo(endpoint.ContainerID, endpoint.PodEndpointId, endpoint.PodName, endpoint.PodNamespace)
-
-			ipKey := epIP.IP.String()
-			if prevPodInfo, ok := podInfoByIP[ipKey]; ok {
-				return nil, errors.Wrapf(cns.ErrDuplicateIP, "duplicate ip %s found for different pods: pod: %+v, pod: %+v", ipKey, podInfo, prevPodInfo)
-			}
-
-			podInfoByIP[ipKey] = podInfo
+	records, err := translateEndpointState(state)
+	if err != nil {
+		return nil, err
+	}
+	podInfoByIP := make(map[string]cns.PodInfo)
+	for _, record := range records {
+		podInfo := cns.NewPodInfo(
+			record.InfraContainerID,
+			record.PodEndpointID,
+			record.PodName,
+			record.PodNamespace,
+		)
+		for _, prefix := range record.IPAddresses {
+			address, _ := netip.AddrFromSlice(prefix.IP)
+			podInfoByIP[address.Unmap().String()] = podInfo
 		}
 	}
 	return podInfoByIP, nil
+}
+
+func translateEndpointState(state *api.AzureCNIState) ([]cns.CNIEndpointState, error) {
+	if state == nil {
+		return nil, errors.New("CNI endpoint state is nil")
+	}
+	keys := make([]string, 0, len(state.ContainerInterfaces))
+	for key := range state.ContainerInterfaces {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	records := make([]cns.CNIEndpointState, 0, len(keys))
+	seenAddresses := make(map[netip.Addr]string)
+	seenEndpointIDs := make(map[string]string)
+	seenInterfaces := make(map[string]string)
+	for _, rawKey := range keys {
+		key := strings.TrimSpace(rawKey)
+		endpoint := state.ContainerInterfaces[rawKey]
+		containerID := strings.TrimSpace(endpoint.ContainerID)
+		endpointID := strings.TrimSpace(endpoint.PodEndpointId)
+		podName := strings.TrimSpace(endpoint.PodName)
+		podNamespace := strings.TrimSpace(endpoint.PodNamespace)
+		ifName := strings.TrimSpace(endpoint.IfName)
+		if ifName == "" {
+			ifName = interfaceNameFromKey(key)
+		}
+		switch {
+		case key == "":
+			return nil, errors.New("CNI interface key is empty")
+		case containerID == "":
+			return nil, fmt.Errorf("CNI interface %q has empty container ID", key)
+		case endpointID == "":
+			return nil, fmt.Errorf("CNI interface %q has empty pod endpoint ID", key)
+		case podName == "":
+			return nil, fmt.Errorf("CNI interface %q has empty pod name", key)
+		case podNamespace == "":
+			return nil, fmt.Errorf("CNI interface %q has empty pod namespace", key)
+		case ifName == "":
+			return nil, fmt.Errorf("CNI interface %q has empty interface name", key)
+		case len(endpoint.IPAddresses) == 0:
+			return nil, fmt.Errorf("CNI interface %q has no IP addresses", key)
+		}
+		if other, ok := seenEndpointIDs[endpointID]; ok {
+			return nil, fmt.Errorf("CNI interfaces %q and %q have duplicate pod endpoint ID", other, key)
+		}
+		identity := containerID + "\x00" + ifName
+		if other, ok := seenInterfaces[identity]; ok {
+			return nil, fmt.Errorf("CNI interfaces %q and %q have duplicate interface identity", other, key)
+		}
+
+		ipAddresses := make([]net.IPNet, 0, len(endpoint.IPAddresses))
+		for index, value := range endpoint.IPAddresses {
+			address, prefix, err := parseIPNet(value)
+			if err != nil {
+				return nil, fmt.Errorf("CNI interface %q IP %d: %w", key, index, err)
+			}
+			if other, ok := seenAddresses[address]; ok {
+				return nil, fmt.Errorf(
+					"%w: CNI interfaces %q and %q contain duplicate address",
+					cns.ErrDuplicateIP,
+					other,
+					key,
+				)
+			}
+			seenAddresses[address] = key
+			ipAddresses = append(ipAddresses, prefix)
+		}
+		sort.Slice(ipAddresses, func(i, j int) bool {
+			left, _ := netip.AddrFromSlice(ipAddresses[i].IP)
+			right, _ := netip.AddrFromSlice(ipAddresses[j].IP)
+			return left.Unmap().Compare(right.Unmap()) < 0
+		})
+		seenEndpointIDs[endpointID] = key
+		seenInterfaces[identity] = key
+		records = append(records, cns.CNIEndpointState{
+			InfraContainerID: containerID,
+			PodEndpointID:    endpointID,
+			PodName:          podName,
+			PodNamespace:     podNamespace,
+			InterfaceKey:     key,
+			InterfaceName:    ifName,
+			IPAddresses:      ipAddresses,
+		})
+	}
+	return records, nil
+}
+
+func parseIPNet(value net.IPNet) (netip.Addr, net.IPNet, error) {
+	address, ok := netip.AddrFromSlice(value.IP)
+	if !ok {
+		return netip.Addr{}, net.IPNet{}, errors.New("invalid IP address")
+	}
+	address = address.Unmap()
+	ones, bits := value.Mask.Size()
+	expectedBits := 128
+	if address.Is4() {
+		expectedBits = 32
+	}
+	if bits != expectedBits || ones < 0 {
+		return netip.Addr{}, net.IPNet{}, fmt.Errorf("invalid mask for %d-bit address", address.BitLen())
+	}
+	return address, net.IPNet{
+		IP:   net.IP(address.AsSlice()),
+		Mask: net.CIDRMask(ones, expectedBits),
+	}, nil
+}
+
+func interfaceNameFromKey(key string) string {
+	index := strings.LastIndex(key, "-eth")
+	if index < 0 {
+		return "eth0"
+	}
+	name := key[index+1:]
+	for _, value := range strings.TrimPrefix(name, "eth") {
+		if value < '0' || value > '9' {
+			return ""
+		}
+	}
+	if name == "eth" {
+		return ""
+	}
+	return name
 }

--- a/cns/stateprovider/cni/podinfoprovider.go
+++ b/cns/stateprovider/cni/podinfoprovider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-container-networking/cni/api"
 	"github.com/Azure/azure-container-networking/cni/client"
 	"github.com/Azure/azure-container-networking/cns"
+	pkgerrors "github.com/pkg/errors"
 	kexec "k8s.io/utils/exec"
 )
 
@@ -64,21 +65,17 @@ func endpointStateProvider(exec kexec.Interface) cns.CNIEndpointStateProvider {
 // for pods with multiple IPs (such as in dualstack cases), this means multiple keys in the map
 // will point to the same pod information.
 func cniStateToPodInfoByIP(state *api.AzureCNIState) (map[string]cns.PodInfo, error) {
-	records, err := translateEndpointState(state)
-	if err != nil {
-		return nil, err
-	}
-	podInfoByIP := make(map[string]cns.PodInfo)
-	for _, record := range records {
-		podInfo := cns.NewPodInfo(
-			record.InfraContainerID,
-			record.PodEndpointID,
-			record.PodName,
-			record.PodNamespace,
-		)
-		for _, prefix := range record.IPAddresses {
-			address, _ := netip.AddrFromSlice(prefix.IP)
-			podInfoByIP[address.Unmap().String()] = podInfo
+	podInfoByIP := map[string]cns.PodInfo{}
+	for _, endpoint := range state.ContainerInterfaces {
+		for _, epIP := range endpoint.IPAddresses {
+			podInfo := cns.NewPodInfo(endpoint.ContainerID, endpoint.PodEndpointId, endpoint.PodName, endpoint.PodNamespace)
+
+			ipKey := epIP.IP.String()
+			if prevPodInfo, ok := podInfoByIP[ipKey]; ok {
+				return nil, pkgerrors.Wrapf(cns.ErrDuplicateIP, "duplicate ip %s found for different pods: pod: %+v, pod: %+v", ipKey, podInfo, prevPodInfo)
+			}
+
+			podInfoByIP[ipKey] = podInfo
 		}
 	}
 	return podInfoByIP, nil

--- a/cns/stateprovider/cni/podinfoprovider.go
+++ b/cns/stateprovider/cni/podinfoprovider.go
@@ -16,6 +16,23 @@ import (
 	kexec "k8s.io/utils/exec"
 )
 
+var (
+	errNilCNIEndpointContext       = errors.New("reading CNI endpoint state: context is nil")
+	errCNIEndpointQueryFailed      = errors.New("reading CNI endpoint state: CNI query failed")
+	errNilCNIEndpointState         = errors.New("CNI endpoint state is nil")
+	errEmptyCNIInterfaceKey        = errors.New("CNI interface key is empty")
+	errEmptyCNIContainerID         = errors.New("CNI interface container ID is empty")
+	errEmptyCNIPodEndpointID       = errors.New("CNI interface pod endpoint ID is empty")
+	errEmptyCNIPodName             = errors.New("CNI interface pod name is empty")
+	errEmptyCNIPodNamespace        = errors.New("CNI interface pod namespace is empty")
+	errEmptyCNIInterfaceName       = errors.New("CNI interface name is empty")
+	errEmptyCNIIPAddresses         = errors.New("CNI interface has no IP addresses")
+	errDuplicateCNIPodEndpointID   = errors.New("duplicate CNI pod endpoint ID")
+	errDuplicateCNIInterface       = errors.New("duplicate CNI interface identity")
+	errInvalidCNIProviderIPAddress = errors.New("invalid CNI IP address")
+	errInvalidCNIProviderIPMask    = errors.New("invalid CNI IP mask")
+)
+
 // New returns an implementation of cns.PodInfoByIPProvider
 // that execs out to the CNI and uses the response to build the PodInfo map.
 func New() (cns.PodInfoByIPProvider, error) {
@@ -44,14 +61,14 @@ func endpointStateProvider(exec kexec.Interface) cns.CNIEndpointStateProvider {
 	cli := client.New(exec)
 	return func(ctx context.Context) ([]cns.CNIEndpointState, error) {
 		if ctx == nil {
-			return nil, errors.New("reading CNI endpoint state: context is nil")
+			return nil, errNilCNIEndpointContext
 		}
 		if err := ctx.Err(); err != nil {
 			return nil, fmt.Errorf("reading CNI endpoint state: %w", err)
 		}
 		state, err := cli.GetEndpointState()
 		if err != nil {
-			return nil, errors.New("reading CNI endpoint state: CNI query failed")
+			return nil, errCNIEndpointQueryFailed
 		}
 		if err := ctx.Err(); err != nil {
 			return nil, fmt.Errorf("reading CNI endpoint state: %w", err)
@@ -83,7 +100,7 @@ func cniStateToPodInfoByIP(state *api.AzureCNIState) (map[string]cns.PodInfo, er
 
 func translateEndpointState(state *api.AzureCNIState) ([]cns.CNIEndpointState, error) {
 	if state == nil {
-		return nil, errors.New("CNI endpoint state is nil")
+		return nil, errNilCNIEndpointState
 	}
 	keys := make([]string, 0, len(state.ContainerInterfaces))
 	for key := range state.ContainerInterfaces {
@@ -108,26 +125,26 @@ func translateEndpointState(state *api.AzureCNIState) ([]cns.CNIEndpointState, e
 		}
 		switch {
 		case key == "":
-			return nil, errors.New("CNI interface key is empty")
+			return nil, errEmptyCNIInterfaceKey
 		case containerID == "":
-			return nil, fmt.Errorf("CNI interface %q has empty container ID", key)
+			return nil, fmt.Errorf("%w: %q", errEmptyCNIContainerID, key)
 		case endpointID == "":
-			return nil, fmt.Errorf("CNI interface %q has empty pod endpoint ID", key)
+			return nil, fmt.Errorf("%w: %q", errEmptyCNIPodEndpointID, key)
 		case podName == "":
-			return nil, fmt.Errorf("CNI interface %q has empty pod name", key)
+			return nil, fmt.Errorf("%w: %q", errEmptyCNIPodName, key)
 		case podNamespace == "":
-			return nil, fmt.Errorf("CNI interface %q has empty pod namespace", key)
+			return nil, fmt.Errorf("%w: %q", errEmptyCNIPodNamespace, key)
 		case ifName == "":
-			return nil, fmt.Errorf("CNI interface %q has empty interface name", key)
+			return nil, fmt.Errorf("%w: %q", errEmptyCNIInterfaceName, key)
 		case len(endpoint.IPAddresses) == 0:
-			return nil, fmt.Errorf("CNI interface %q has no IP addresses", key)
+			return nil, fmt.Errorf("%w: %q", errEmptyCNIIPAddresses, key)
 		}
 		if other, ok := seenEndpointIDs[endpointID]; ok {
-			return nil, fmt.Errorf("CNI interfaces %q and %q have duplicate pod endpoint ID", other, key)
+			return nil, fmt.Errorf("%w: %q and %q", errDuplicateCNIPodEndpointID, other, key)
 		}
 		identity := containerID + "\x00" + ifName
 		if other, ok := seenInterfaces[identity]; ok {
-			return nil, fmt.Errorf("CNI interfaces %q and %q have duplicate interface identity", other, key)
+			return nil, fmt.Errorf("%w: %q and %q", errDuplicateCNIInterface, other, key)
 		}
 
 		ipAddresses := make([]net.IPNet, 0, len(endpoint.IPAddresses))
@@ -170,7 +187,7 @@ func translateEndpointState(state *api.AzureCNIState) ([]cns.CNIEndpointState, e
 func parseIPNet(value net.IPNet) (netip.Addr, net.IPNet, error) {
 	address, ok := netip.AddrFromSlice(value.IP)
 	if !ok {
-		return netip.Addr{}, net.IPNet{}, errors.New("invalid IP address")
+		return netip.Addr{}, net.IPNet{}, errInvalidCNIProviderIPAddress
 	}
 	address = address.Unmap()
 	ones, bits := value.Mask.Size()
@@ -179,7 +196,7 @@ func parseIPNet(value net.IPNet) (netip.Addr, net.IPNet, error) {
 		expectedBits = 32
 	}
 	if bits != expectedBits || ones < 0 {
-		return netip.Addr{}, net.IPNet{}, fmt.Errorf("invalid mask for %d-bit address", address.BitLen())
+		return netip.Addr{}, net.IPNet{}, fmt.Errorf("%w: %d-bit address", errInvalidCNIProviderIPMask, address.BitLen())
 	}
 	return address, net.IPNet{
 		IP:   net.IP(address.AsSlice()),

--- a/cns/stateprovider/cni/podinfoprovider_test.go
+++ b/cns/stateprovider/cni/podinfoprovider_test.go
@@ -1,8 +1,11 @@
 package cni
 
 import (
+	"errors"
+	"net"
 	"testing"
 
+	"github.com/Azure/azure-container-networking/cni/api"
 	"github.com/Azure/azure-container-networking/cns"
 	"github.com/Azure/azure-container-networking/platform"
 	testutils "github.com/Azure/azure-container-networking/test/utils"
@@ -49,10 +52,10 @@ func TestNewCNIPodInfoProvider(t *testing.T) {
 				`{"ContainerInterfaces":{"3f813b02-eth0":{"PodName":"metrics-server-77c8679d7d-6ksdh","IfName":"eth0",
 				"PodNamespace":"kube-system","PodEndpointID":"3f813b02-eth0",
 				"ContainerID":"3f813b029429b4e41a09ab33b6f6d365d2ed704017524c78d1d0dece33cdaf46",
-				"IPAddresses":[{"IP":"10.241.0.17","Mask":"//8AAA=="},{"IP":"2001:0db8:abcd:0015::0","Mask":"//////////8AAAAAAAAAAA=="}]},
+				"IPAddresses":[{"IP":"10.241.0.17","Mask":"//8AAA=="},{"IP":"2001:0db8:abcd:0015::0","Mask":"//8AAA=="}]},
 				"6e688597-eth0":{"PodName":"tunnelfront-5d96f9b987-65xbn","IfName":"eth0","PodNamespace":"kube-system",
 				"PodEndpointID":"6e688597-eth0","ContainerID":"6e688597eafb97c83c84e402cc72b299bfb8aeb02021e4c99307a037352c0bed",
-				"IPAddresses":[{"IP":"10.241.0.13","Mask":"//8AAA=="},{"IP":"2001:0db8:abcd:0014::0","Mask":"//////////8AAAAAAAAAAA=="}]}}}`,
+				"IPAddresses":[{"IP":"10.241.0.13","Mask":"//8AAA=="},{"IP":"2001:0db8:abcd:0014::0","Mask":"//8AAA=="}]}}}`,
 			),
 			want: map[string]cns.PodInfo{
 				"2001:db8:abcd:15::": cns.NewPodInfo("3f813b029429b4e41a09ab33b6f6d365d2ed704017524c78d1d0dece33cdaf46", "3f813b02-eth0", "metrics-server-77c8679d7d-6ksdh", "kube-system"),
@@ -84,4 +87,58 @@ func TestNewCNIPodInfoProvider(t *testing.T) {
 			assert.Equal(t, tt.want, podInfoByIP)
 		})
 	}
+}
+
+func TestCNIStateToPodInfoByIPLegacyTolerance(t *testing.T) {
+	state := &api.AzureCNIState{ContainerInterfaces: map[string]api.PodNetworkInterfaceInfo{
+		"healthy": {
+			PodName:       "pod",
+			PodNamespace:  "namespace",
+			PodEndpointId: "interface",
+			ContainerID:   "container",
+			IPAddresses: []net.IPNet{{
+				IP:   net.ParseIP("10.0.0.4"),
+				Mask: net.CIDRMask(24, 32),
+			}},
+		},
+		"zero-ip-degenerate": {},
+		"mismatched-mask-degenerate": {
+			IPAddresses: []net.IPNet{{
+				IP:   net.ParseIP("2001:db8::4"),
+				Mask: net.CIDRMask(24, 32),
+			}},
+		},
+	}}
+
+	got, err := cniStateToPodInfoByIP(state)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]cns.PodInfo{
+		"10.0.0.4":    cns.NewPodInfo("container", "interface", "pod", "namespace"),
+		"2001:db8::4": cns.NewPodInfo("", "", "", ""),
+	}, got)
+}
+
+func TestCNIStateToPodInfoByIPDuplicateStillErrors(t *testing.T) {
+	duplicate := net.IPNet{IP: net.ParseIP("10.0.0.4"), Mask: net.CIDRMask(24, 32)}
+	state := &api.AzureCNIState{ContainerInterfaces: map[string]api.PodNetworkInterfaceInfo{
+		"first": {
+			PodName:       "pod-a",
+			PodNamespace:  "namespace",
+			PodEndpointId: "interface-a",
+			ContainerID:   "container-a",
+			IPAddresses:   []net.IPNet{duplicate},
+		},
+		"second": {
+			PodName:       "pod-b",
+			PodNamespace:  "namespace",
+			PodEndpointId: "interface-b",
+			ContainerID:   "container-b",
+			IPAddresses:   []net.IPNet{duplicate},
+		},
+	}}
+
+	got, err := cniStateToPodInfoByIP(state)
+	assert.Nil(t, got)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, cns.ErrDuplicateIP))
 }

--- a/cns/stateprovider/cni/podinfoprovider_test.go
+++ b/cns/stateprovider/cni/podinfoprovider_test.go
@@ -1,7 +1,6 @@
 package cni
 
 import (
-	"errors"
 	"net"
 	"testing"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/Azure/azure-container-networking/platform"
 	testutils "github.com/Azure/azure-container-networking/test/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/utils/exec"
 )
 
@@ -82,7 +82,7 @@ func TestNewCNIPodInfoProvider(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			podInfoByIP, _ := got.PodInfoByIP()
 			assert.Equal(t, tt.want, podInfoByIP)
 		})
@@ -92,10 +92,10 @@ func TestNewCNIPodInfoProvider(t *testing.T) {
 func TestCNIStateToPodInfoByIPLegacyTolerance(t *testing.T) {
 	state := &api.AzureCNIState{ContainerInterfaces: map[string]api.PodNetworkInterfaceInfo{
 		"healthy": {
-			PodName:       "pod",
-			PodNamespace:  "namespace",
+			PodName:       cniProviderTestPod,
+			PodNamespace:  cniProviderTestNamespace,
 			PodEndpointId: "interface",
-			ContainerID:   "container",
+			ContainerID:   cniProviderTestContainer,
 			IPAddresses: []net.IPNet{{
 				IP:   net.ParseIP("10.0.0.4"),
 				Mask: net.CIDRMask(24, 32),
@@ -111,9 +111,9 @@ func TestCNIStateToPodInfoByIPLegacyTolerance(t *testing.T) {
 	}}
 
 	got, err := cniStateToPodInfoByIP(state)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, map[string]cns.PodInfo{
-		"10.0.0.4":    cns.NewPodInfo("container", "interface", "pod", "namespace"),
+		"10.0.0.4":    cns.NewPodInfo(cniProviderTestContainer, "interface", cniProviderTestPod, cniProviderTestNamespace),
 		"2001:db8::4": cns.NewPodInfo("", "", "", ""),
 	}, got)
 }
@@ -139,6 +139,6 @@ func TestCNIStateToPodInfoByIPDuplicateStillErrors(t *testing.T) {
 
 	got, err := cniStateToPodInfoByIP(state)
 	assert.Nil(t, got)
-	assert.Error(t, err)
-	assert.True(t, errors.Is(err, cns.ErrDuplicateIP))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, cns.ErrDuplicateIP)
 }

--- a/cns/stateprovider/cni/podinfoprovider_test.go
+++ b/cns/stateprovider/cni/podinfoprovider_test.go
@@ -49,10 +49,10 @@ func TestNewCNIPodInfoProvider(t *testing.T) {
 				`{"ContainerInterfaces":{"3f813b02-eth0":{"PodName":"metrics-server-77c8679d7d-6ksdh","IfName":"eth0",
 				"PodNamespace":"kube-system","PodEndpointID":"3f813b02-eth0",
 				"ContainerID":"3f813b029429b4e41a09ab33b6f6d365d2ed704017524c78d1d0dece33cdaf46",
-				"IPAddresses":[{"IP":"10.241.0.17","Mask":"//8AAA=="},{"IP":"2001:0db8:abcd:0015::0","Mask":"//8AAA=="}]},
+				"IPAddresses":[{"IP":"10.241.0.17","Mask":"//8AAA=="},{"IP":"2001:0db8:abcd:0015::0","Mask":"//////////8AAAAAAAAAAA=="}]},
 				"6e688597-eth0":{"PodName":"tunnelfront-5d96f9b987-65xbn","IfName":"eth0","PodNamespace":"kube-system",
 				"PodEndpointID":"6e688597-eth0","ContainerID":"6e688597eafb97c83c84e402cc72b299bfb8aeb02021e4c99307a037352c0bed",
-				"IPAddresses":[{"IP":"10.241.0.13","Mask":"//8AAA=="},{"IP":"2001:0db8:abcd:0014::0","Mask":"//8AAA=="}]}}}`,
+				"IPAddresses":[{"IP":"10.241.0.13","Mask":"//8AAA=="},{"IP":"2001:0db8:abcd:0014::0","Mask":"//////////8AAAAAAAAAAA=="}]}}}`,
 			),
 			want: map[string]cns.PodInfo{
 				"2001:db8:abcd:15::": cns.NewPodInfo("3f813b029429b4e41a09ab33b6f6d365d2ed704017524c78d1d0dece33cdaf46", "3f813b02-eth0", "metrics-server-77c8679d7d-6ksdh", "kube-system"),


### PR DESCRIPTION
## Scope
Adds two-phase live stateful-CNI ownership preflight/import and the repeated-read CNI state provider.

## Draft dependency caveat
This is one of two independent children of R3 and is opened early for parallel review. **Do not merge until R3 and its temporary-base prerequisites merge.** J1 remains separately blocked on both this PR and transactional PATCH.

## Behavior
Import does not install stateless CNI or activate Bolt. The sealed plan is revalidated in the commit transaction and fails closed on identity/generation changes.

## Evidence
Linux/Windows lint and state/restserver/service/CNI-provider race tests pass.