### PR TITLE
feat(cns): make unified ADD transactional

### DIFF
--- a/cns/restserver/durable_state_adapter.go
+++ b/cns/restserver/durable_state_adapter.go
@@ -52,6 +52,16 @@ type durableStateOperations struct {
 	snapshot       func(context.Context) (state.Snapshot, error)
 	replace        func(context.Context, uint64, state.DurableState) (bool, error)
 	updateMetadata func(context.Context, uint64, state.Metadata) (bool, error)
+	assignEndpoint func(
+		context.Context,
+		uint64,
+		state.AssignmentRecord,
+		state.EndpointRecord,
+		time.Time,
+		time.Duration,
+		func(state.Snapshot) error,
+	) (bool, error)
+	refreshMetrics func(context.Context) (state.Status, error)
 	status         func(context.Context) (state.Status, error)
 	close          func() error
 }
@@ -64,6 +74,9 @@ type durableStateAdapter struct {
 	// service lock; the adapter applies complete projections under that lock.
 	mu                   sync.Mutex
 	projectEndpointState bool
+	buildProjection      func(state.Snapshot) (durableCacheProjection, error)
+	applyAddProjection   func(durableCacheProjection) error
+	now                  func() time.Time
 	projected            bool
 	generation           uint64
 	closeOnce            sync.Once
@@ -103,6 +116,15 @@ func NewDurableStateLifecycle(
 	if err != nil {
 		return nil, nil, err
 	}
+	if projectEndpointState {
+		return func(ctx context.Context) error {
+			if err := adapter.restore(ctx); err != nil {
+				return err
+			}
+			service.setUnifiedStateAdapter(adapter)
+			return nil
+		}, adapter.Close, nil
+	}
 	return adapter.restore, adapter.Close, nil
 }
 
@@ -115,8 +137,10 @@ func newDurableStateAdapter(
 		return nil, errNilDurableStateDB
 	}
 	return newDurableStateAdapterWithOperations(service, durableStateOperations{
-		snapshot: db.Snapshot,
-		replace:  db.ReplaceDurableState,
+		snapshot:       db.Snapshot,
+		replace:        db.ReplaceDurableState,
+		assignEndpoint: db.AssignEndpointIfGeneration,
+		refreshMetrics: db.RefreshMetrics,
 		updateMetadata: func(ctx context.Context, expectedGeneration uint64, metadata state.Metadata) (bool, error) {
 			err := db.Update(ctx, func(tx *state.WriteTx) error {
 				current, err := tx.Metadata()
@@ -168,6 +192,8 @@ func newDurableStateAdapterWithOperations(
 		service:              service,
 		store:                operations,
 		projectEndpointState: projectEndpointState,
+		buildProjection:      buildDurableCacheProjection,
+		now:                  time.Now,
 	}, nil
 }
 
@@ -486,6 +512,10 @@ func (a *durableStateAdapter) applyProjection(projection durableCacheProjection)
 	a.service.Lock()
 	defer a.service.Unlock()
 
+	a.applyProjectionLocked(projection)
+}
+
+func (a *durableStateAdapter) applyProjectionLocked(projection durableCacheProjection) {
 	a.service.state.OrchestratorType = projection.metadata.OrchestratorType
 	a.service.state.NodeID = projection.metadata.NodeID
 	a.service.state.Location = projection.metadata.Location

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -73,11 +73,22 @@ func (service *HTTPRestService) requestIPConfigHandlerHelper(ctx context.Context
 
 	// record a pod requesting an IP
 	service.podsPendingIPAssignment.Push(podInfo.Key())
-	podIPInfo, err := requestIPConfigsHelper(service, ipconfigsRequest) //nolint:contextcheck // appease linter for revert PR
+	unifiedAdapter := service.selectedUnifiedStateAdapter()
+	var podIPInfo []cns.PodIpInfo
+	var err error
+	if unifiedAdapter != nil {
+		podIPInfo, err = unifiedAdapter.requestIPConfigs(ctx, ipconfigsRequest, podInfo)
+	} else {
+		podIPInfo, err = requestIPConfigsHelper(service, ipconfigsRequest) //nolint:contextcheck // appease linter for revert PR
+	}
 	if err != nil {
+		returnCode := types.FailedToAllocateIPConfig
+		if unifiedAdapter != nil {
+			returnCode = unifiedAddResponseCode(err)
+		}
 		return &cns.IPConfigsResponse{
 			Response: cns.Response{
-				ReturnCode: types.FailedToAllocateIPConfig,
+				ReturnCode: returnCode,
 				Message:    fmt.Sprintf("AllocateIPConfig failed: %v, IP config request is %v", err, ipconfigsRequest),
 			},
 			PodIPInfo: podIPInfo,
@@ -93,7 +104,7 @@ func (service *HTTPRestService) requestIPConfigHandlerHelper(ctx context.Context
 	}()
 
 	// Check if http rest service managed endpoint state is set
-	if service.Options[common.OptManageEndpointState] == true {
+	if unifiedAdapter == nil && service.Options[common.OptManageEndpointState] == true {
 		err = service.updateEndpointState(ipconfigsRequest, podInfo, podIPInfo)
 		if err != nil {
 			return &cns.IPConfigsResponse{

--- a/cns/restserver/restserver.go
+++ b/cns/restserver/restserver.go
@@ -128,6 +128,7 @@ type HTTPRestService struct {
 	nodeinfoClient             nodeinfoClient
 	nodeName                   string
 	stateRestoreLogger         stateRestoreLogger
+	unifiedStateAdapter        *durableStateAdapter
 }
 
 type CNIConflistGenerator interface {

--- a/cns/restserver/unified_add.go
+++ b/cns/restserver/unified_add.go
@@ -1,0 +1,489 @@
+// Copyright 2026 Microsoft. All rights reserved.
+// MIT License
+
+package restserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/state"
+	"github.com/Azure/azure-container-networking/cns/types"
+)
+
+const unifiedDeleteIntentTTL = 10 * time.Minute
+
+var errUnifiedIPUnavailable = errors.New("unified ADD: IP unavailable")
+
+type unifiedAddPlan struct {
+	assignment state.AssignmentRecord
+	endpoint   state.EndpointRecord
+	podIPInfo  []cns.PodIpInfo
+	replay     bool
+}
+
+type unifiedIPCandidate struct {
+	record  state.IPRecord
+	status  cns.IPConfigurationStatus
+	address netip.Addr
+}
+
+type unifiedAddCommittedError struct {
+	err error
+}
+
+func (e *unifiedAddCommittedError) Error() string {
+	return fmt.Sprintf("unified ADD committed but cache projection failed: %v", e.err)
+}
+
+func (e *unifiedAddCommittedError) Unwrap() error {
+	return e.err
+}
+
+func (service *HTTPRestService) setUnifiedStateAdapter(adapter *durableStateAdapter) {
+	service.Lock()
+	defer service.Unlock()
+	service.unifiedStateAdapter = adapter
+}
+
+func (service *HTTPRestService) selectedUnifiedStateAdapter() *durableStateAdapter {
+	service.RLock()
+	defer service.RUnlock()
+	return service.unifiedStateAdapter
+}
+
+func (a *durableStateAdapter) requestIPConfigs(
+	ctx context.Context,
+	request cns.IPConfigsRequest,
+	podInfo cns.PodInfo,
+) ([]cns.PodIpInfo, error) {
+	if a.store.assignEndpoint == nil {
+		return nil, errors.New("durable state endpoint assignment operation is nil")
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.service.Lock()
+	defer a.service.Unlock()
+
+	snapshot, err := a.currentSnapshot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	plan, err := a.service.requestIPConfigsUnifiedLocked(ctx, request, podInfo, snapshot)
+	if err != nil {
+		return nil, err
+	}
+	if plan.replay {
+		return plan.podIPInfo, nil
+	}
+
+	var projection durableCacheProjection
+	changed, err := a.store.assignEndpoint(
+		ctx,
+		a.generation,
+		plan.assignment,
+		plan.endpoint,
+		a.now(),
+		unifiedDeleteIntentTTL,
+		func(candidate state.Snapshot) error {
+			var buildErr error
+			projection, buildErr = a.buildProjection(candidate)
+			return buildErr
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if !changed {
+		return nil, fmt.Errorf("%w: endpoint assignment unexpectedly made no change", state.ErrStaleGeneration)
+	}
+
+	apply := a.applyAddProjection
+	if apply == nil {
+		apply = func(value durableCacheProjection) error {
+			a.applyProjectionLocked(value)
+			return nil
+		}
+	}
+	var postCommitErr error
+	if err := apply(projection); err != nil {
+		postCommitErr = a.restoreCommittedAddProjectionLocked(ctx, projection, err)
+	}
+	if a.store.refreshMetrics != nil {
+		if _, err := a.store.refreshMetrics(context.WithoutCancel(ctx)); err != nil {
+			postCommitErr = errors.Join(postCommitErr, fmt.Errorf("refreshing persistent state metrics: %w", err))
+		}
+	}
+	if postCommitErr != nil {
+		return nil, &unifiedAddCommittedError{err: postCommitErr}
+	}
+	return plan.podIPInfo, nil
+}
+
+func (a *durableStateAdapter) restoreCommittedAddProjectionLocked(
+	ctx context.Context,
+	committed durableCacheProjection,
+	applyErr error,
+) error {
+	restoreErr := error(nil)
+	snapshot, err := a.store.snapshot(context.WithoutCancel(ctx))
+	if err != nil {
+		restoreErr = fmt.Errorf("reading committed endpoint assignment: %w", err)
+	} else {
+		projection, buildErr := a.buildProjection(snapshot)
+		if buildErr != nil {
+			restoreErr = fmt.Errorf("building committed endpoint assignment projection: %w", buildErr)
+		} else {
+			committed = projection
+		}
+	}
+	a.applyProjectionLocked(committed)
+	return errors.Join(applyErr, restoreErr)
+}
+
+// requestIPConfigsUnifiedLocked builds and preflights a complete ADD without
+// mutating service state. The caller owns the service lock.
+func (service *HTTPRestService) requestIPConfigsUnifiedLocked(
+	ctx context.Context,
+	request cns.IPConfigsRequest,
+	podInfo cns.PodInfo,
+	snapshot state.Snapshot,
+) (unifiedAddPlan, error) {
+	if err := ctx.Err(); err != nil {
+		return unifiedAddPlan{}, err
+	}
+	requestedPod := state.PodIdentity{
+		PodKey:           podInfo.Key(),
+		InfraContainerID: podInfo.InfraContainerID(),
+		InterfaceID:      podInfo.InterfaceID(),
+		PodName:          podInfo.Name(),
+		PodNamespace:     podInfo.Namespace(),
+	}
+	if existing, ok := snapshot.Assignments[requestedPod.PodKey]; ok {
+		if existing.Pod != requestedPod {
+			return unifiedAddPlan{}, fmt.Errorf(
+				"%w: existing assignment identity does not match request",
+				state.ErrInvalidInput,
+			)
+		}
+		endpoint, ok := snapshot.Endpoints[requestedPod.InfraContainerID]
+		if !ok {
+			return unifiedAddPlan{}, fmt.Errorf(
+				"%w: existing assignment endpoint is missing",
+				state.ErrStaleGeneration,
+			)
+		}
+		if request.Ifname != "" {
+			if _, ok := endpoint.IfnameToIPMap[strings.TrimSpace(request.Ifname)]; !ok {
+				return unifiedAddPlan{}, fmt.Errorf(
+					"%w: existing assignment interface does not match request",
+					state.ErrInvalidInput,
+				)
+			}
+		}
+		responses, err := service.podIPInfoForAssignmentLocked(ctx, snapshot, existing)
+		if err != nil {
+			return unifiedAddPlan{}, err
+		}
+		return unifiedAddPlan{
+			assignment: existing,
+			endpoint:   endpoint,
+			podIPInfo:  responses,
+			replay:     true,
+		}, nil
+	}
+
+	ifname := strings.TrimSpace(request.Ifname)
+	if ifname == "" {
+		return unifiedAddPlan{}, fmt.Errorf("%w: interface name is empty", state.ErrInvalidInput)
+	}
+	candidates, err := service.selectUnifiedIPCandidatesLocked(request, snapshot)
+	if err != nil {
+		return unifiedAddPlan{}, err
+	}
+	responses := make([]cns.PodIpInfo, 0, len(candidates))
+	ipIDs := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		response, err := service.podIPInfoForCandidateLocked(ctx, candidate)
+		if err != nil {
+			return unifiedAddPlan{}, err
+		}
+		responses = append(responses, response)
+		ipIDs = append(ipIDs, candidate.record.ID)
+	}
+
+	endpoint, err := buildUnifiedEndpoint(snapshot, requestedPod, ifname, candidates, responses)
+	if err != nil {
+		return unifiedAddPlan{}, err
+	}
+	return unifiedAddPlan{
+		assignment: state.AssignmentRecord{Pod: requestedPod, IPIDs: ipIDs},
+		endpoint:   endpoint,
+		podIPInfo:  responses,
+	}, nil
+}
+
+func (service *HTTPRestService) selectUnifiedIPCandidatesLocked(
+	request cns.IPConfigsRequest,
+	snapshot state.Snapshot,
+) ([]unifiedIPCandidate, error) {
+	inventory, byAddress, err := service.unifiedIPInventoryLocked(snapshot)
+	if err != nil {
+		return nil, err
+	}
+	if len(request.DesiredIPAddresses) != 0 {
+		selected := make([]unifiedIPCandidate, 0, len(request.DesiredIPAddresses))
+		seen := make(map[netip.Addr]struct{}, len(request.DesiredIPAddresses))
+		for _, rawAddress := range request.DesiredIPAddresses {
+			address, err := netip.ParseAddr(rawAddress)
+			if err != nil {
+				return nil, fmt.Errorf("%w: invalid desired IP address", state.ErrInvalidInput)
+			}
+			address = address.Unmap()
+			if _, ok := seen[address]; ok {
+				return nil, fmt.Errorf("%w: duplicate desired IP address", state.ErrInvalidInput)
+			}
+			seen[address] = struct{}{}
+			candidate, ok := byAddress[address]
+			if !ok {
+				return nil, fmt.Errorf("%w: desired IP was not found", errUnifiedIPUnavailable)
+			}
+			if owner, ok := snapshot.IPOwners[candidate.record.ID]; ok {
+				return nil, fmt.Errorf("%w: desired IP is owned by %q", state.ErrIPAlreadyAssigned, owner)
+			}
+			switch candidate.status.GetState() {
+			case types.Available, types.PendingProgramming:
+				selected = append(selected, candidate)
+			default:
+				return nil, fmt.Errorf("%w: desired IP is not available", errUnifiedIPUnavailable)
+			}
+		}
+		return selected, nil
+	}
+
+	if len(service.state.ContainerStatus) == 0 {
+		return nil, ErrNoNCs
+	}
+	families := service.getIPFamiliesMap()
+	selectedByFamily := make(map[cns.IPFamily]unifiedIPCandidate, len(families))
+	for _, candidate := range inventory {
+		if candidate.status.GetState() != types.Available {
+			continue
+		}
+		if _, owned := snapshot.IPOwners[candidate.record.ID]; owned {
+			continue
+		}
+		family := cns.IPv6
+		if candidate.address.Is4() {
+			family = cns.IPv4
+		}
+		if _, wanted := families[family]; !wanted {
+			continue
+		}
+		if _, exists := selectedByFamily[family]; !exists {
+			selectedByFamily[family] = candidate
+		}
+	}
+	selected := make([]unifiedIPCandidate, 0, len(families))
+	for _, family := range []cns.IPFamily{cns.IPv4, cns.IPv6} {
+		if _, wanted := families[family]; !wanted {
+			continue
+		}
+		candidate, ok := selectedByFamily[family]
+		if !ok {
+			return nil, fmt.Errorf("%w: not enough %s IPs are available", errUnifiedIPUnavailable, family)
+		}
+		selected = append(selected, candidate)
+	}
+	if len(selected) == 0 {
+		return nil, fmt.Errorf("%w: no IP families are available", errUnifiedIPUnavailable)
+	}
+	return selected, nil
+}
+
+func (service *HTTPRestService) unifiedIPInventoryLocked(
+	snapshot state.Snapshot,
+) ([]unifiedIPCandidate, map[netip.Addr]unifiedIPCandidate, error) {
+	ids := make([]string, 0, len(service.PodIPConfigState))
+	for id := range service.PodIPConfigState {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	inventory := make([]unifiedIPCandidate, 0, len(ids))
+	byAddress := make(map[netip.Addr]unifiedIPCandidate, len(ids))
+	for _, id := range ids {
+		status := service.PodIPConfigState[id]
+		record, ok := snapshot.IPs[id]
+		if !ok || status.ID != record.ID || status.IPAddress != record.IPAddress || status.NCID != record.NCID {
+			return nil, nil, fmt.Errorf("%w: projected IP inventory does not match database", state.ErrStaleGeneration)
+		}
+		address, err := netip.ParseAddr(record.IPAddress)
+		if err != nil {
+			return nil, nil, fmt.Errorf("%w: projected IP address is invalid", state.ErrInvalidInput)
+		}
+		candidate := unifiedIPCandidate{record: record, status: status, address: address.Unmap()}
+		if previous, exists := byAddress[candidate.address]; exists && previous.record.ID != candidate.record.ID {
+			return nil, nil, fmt.Errorf("%w: projected IP inventory contains a duplicate address", state.ErrStaleGeneration)
+		}
+		inventory = append(inventory, candidate)
+		byAddress[candidate.address] = candidate
+	}
+	return inventory, byAddress, nil
+}
+
+func (service *HTTPRestService) podIPInfoForAssignmentLocked(
+	ctx context.Context,
+	snapshot state.Snapshot,
+	assignment state.AssignmentRecord,
+) ([]cns.PodIpInfo, error) {
+	responses := make([]cns.PodIpInfo, 0, len(assignment.IPIDs))
+	for _, ipID := range assignment.IPIDs {
+		record, ok := snapshot.IPs[ipID]
+		if !ok {
+			return nil, fmt.Errorf("%w: assignment IP is missing", state.ErrStaleGeneration)
+		}
+		status, ok := service.PodIPConfigState[ipID]
+		if !ok || status.GetState() != types.Assigned || status.PodInfo == nil ||
+			status.PodInfo.Key() != assignment.Pod.PodKey {
+			return nil, fmt.Errorf("%w: projected assignment does not match database", state.ErrStaleGeneration)
+		}
+		address, err := netip.ParseAddr(record.IPAddress)
+		if err != nil {
+			return nil, fmt.Errorf("%w: assignment IP address is invalid", state.ErrInvalidInput)
+		}
+		response, err := service.podIPInfoForCandidateLocked(ctx, unifiedIPCandidate{
+			record: record, status: status, address: address.Unmap(),
+		})
+		if err != nil {
+			return nil, err
+		}
+		responses = append(responses, response)
+	}
+	return responses, nil
+}
+
+func (service *HTTPRestService) podIPInfoForCandidateLocked(
+	ctx context.Context,
+	candidate unifiedIPCandidate,
+) (cns.PodIpInfo, error) {
+	ncStatus, ok := service.state.ContainerStatus[candidate.record.NCID]
+	if !ok {
+		return cns.PodIpInfo{}, fmt.Errorf("%w: selected IP references a missing NC", state.ErrInvalidInput)
+	}
+	primaryIPConfig := ncStatus.CreateNetworkContainerRequest.IPConfiguration
+	primaryHostInterface, err := service.getPrimaryHostInterface(ctx)
+	if err != nil {
+		return cns.PodIpInfo{}, err
+	}
+	return cns.PodIpInfo{
+		PodIPConfig: cns.IPSubnet{
+			IPAddress:    candidate.record.IPAddress,
+			PrefixLength: primaryIPConfig.IPSubnet.PrefixLength,
+		},
+		NetworkContainerPrimaryIPConfig: primaryIPConfig,
+		HostPrimaryIPInfo: cns.HostIPInfo{
+			PrimaryIP: primaryHostInterface.PrimaryIP,
+			Subnet:    primaryHostInterface.Subnet,
+			Gateway:   primaryHostInterface.Gateway,
+		},
+		MacAddress:        ncStatus.CreateNetworkContainerRequest.NetworkInterfaceInfo.MACAddress,
+		NICType:           cns.InfraNIC,
+		SkipDefaultRoutes: ncStatus.CreateNetworkContainerRequest.SkipDefaultRoutes,
+	}, nil
+}
+
+func buildUnifiedEndpoint(
+	snapshot state.Snapshot,
+	pod state.PodIdentity,
+	ifname string,
+	candidates []unifiedIPCandidate,
+	responses []cns.PodIpInfo,
+) (state.EndpointRecord, error) {
+	endpoint := state.EndpointRecord{
+		PodName:       pod.PodName,
+		PodNamespace:  pod.PodNamespace,
+		IfnameToIPMap: map[string]*state.IPInfoRecord{},
+	}
+	if existing, ok := snapshot.Endpoints[pod.InfraContainerID]; ok {
+		if existing.PodName != pod.PodName || existing.PodNamespace != pod.PodNamespace {
+			return state.EndpointRecord{}, fmt.Errorf(
+				"%w: existing endpoint identity does not match request",
+				state.ErrInvalidInput,
+			)
+		}
+		var err error
+		endpoint, err = cloneJSON(existing)
+		if err != nil {
+			return state.EndpointRecord{}, fmt.Errorf("%w: cloning endpoint: %v", state.ErrInvalidInput, err)
+		}
+	}
+	if _, exists := endpoint.IfnameToIPMap[ifname]; exists {
+		return state.EndpointRecord{}, fmt.Errorf(
+			"%w: endpoint interface is already assigned",
+			state.ErrInvalidInput,
+		)
+	}
+	info := &state.IPInfoRecord{NICType: cns.InfraNIC}
+	commonNCID := ""
+	for index, candidate := range candidates {
+		if index == 0 {
+			commonNCID = candidate.record.NCID
+		} else if commonNCID != candidate.record.NCID {
+			commonNCID = ""
+		}
+		prefixLength := int(responses[index].PodIPConfig.PrefixLength)
+		bits := 128
+		target := &info.IPv6
+		if candidate.address.Is4() {
+			bits = 32
+			target = &info.IPv4
+		}
+		prefix := net.IPNet{
+			IP:   net.IP(candidate.address.AsSlice()),
+			Mask: net.CIDRMask(prefixLength, bits),
+		}
+		if !containsIPNet(*target, prefix) {
+			*target = append(*target, prefix)
+		}
+	}
+	if info.NetworkContainerID == "" {
+		info.NetworkContainerID = commonNCID
+	}
+	endpoint.IfnameToIPMap[ifname] = info
+	return endpoint, nil
+}
+
+func containsIPNet(values []net.IPNet, target net.IPNet) bool {
+	targetOnes, targetBits := target.Mask.Size()
+	for _, value := range values {
+		ones, bits := value.Mask.Size()
+		if value.IP.Equal(target.IP) && ones == targetOnes && bits == targetBits {
+			return true
+		}
+	}
+	return false
+}
+
+func unifiedAddResponseCode(err error) types.ResponseCode {
+	switch {
+	case errors.Is(err, state.ErrIPAlreadyAssigned),
+		errors.Is(err, state.ErrDeleteIntent),
+		errors.Is(err, errUnifiedIPUnavailable):
+		return types.AddressUnavailable
+	case errors.Is(err, state.ErrStaleGeneration):
+		return types.InconsistentIPConfigState
+	case errors.Is(err, state.ErrInvalidInput):
+		return types.InvalidRequest
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return types.FailedToAllocateIPConfig
+	default:
+		return types.UnexpectedError
+	}
+}

--- a/cns/restserver/unified_add.go
+++ b/cns/restserver/unified_add.go
@@ -20,7 +20,10 @@ import (
 
 const unifiedDeleteIntentTTL = 10 * time.Minute
 
-var errUnifiedIPUnavailable = errors.New("unified ADD: IP unavailable")
+var (
+	errUnifiedIPUnavailable       = errors.New("unified ADD: IP unavailable")
+	errNilEndpointAssignOperation = errors.New("durable state endpoint assignment operation is nil")
+)
 
 type unifiedAddPlan struct {
 	assignment state.AssignmentRecord
@@ -65,7 +68,7 @@ func (a *durableStateAdapter) requestIPConfigs(
 	podInfo cns.PodInfo,
 ) ([]cns.PodIpInfo, error) {
 	if a.store.assignEndpoint == nil {
-		return nil, errors.New("durable state endpoint assignment operation is nil")
+		return nil, errNilEndpointAssignOperation
 	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -132,7 +135,7 @@ func (a *durableStateAdapter) restoreCommittedAddProjectionLocked(
 	committed durableCacheProjection,
 	applyErr error,
 ) error {
-	restoreErr := error(nil)
+	var restoreErr error
 	snapshot, err := a.store.snapshot(context.WithoutCancel(ctx))
 	if err != nil {
 		restoreErr = fmt.Errorf("reading committed endpoint assignment: %w", err)
@@ -157,7 +160,7 @@ func (service *HTTPRestService) requestIPConfigsUnifiedLocked(
 	snapshot state.Snapshot,
 ) (unifiedAddPlan, error) {
 	if err := ctx.Err(); err != nil {
-		return unifiedAddPlan{}, err
+		return unifiedAddPlan{}, fmt.Errorf("planning unified endpoint assignment: %w", err)
 	}
 	requestedPod := state.PodIdentity{
 		PodKey:           podInfo.Key(),
@@ -210,13 +213,13 @@ func (service *HTTPRestService) requestIPConfigsUnifiedLocked(
 	}
 	responses := make([]cns.PodIpInfo, 0, len(candidates))
 	ipIDs := make([]string, 0, len(candidates))
-	for _, candidate := range candidates {
-		response, err := service.podIPInfoForCandidateLocked(ctx, candidate)
-		if err != nil {
-			return unifiedAddPlan{}, err
+	for i := range candidates {
+		response, responseErr := service.podIPInfoForCandidateLocked(ctx, candidates[i])
+		if responseErr != nil {
+			return unifiedAddPlan{}, responseErr
 		}
 		responses = append(responses, response)
-		ipIDs = append(ipIDs, candidate.record.ID)
+		ipIDs = append(ipIDs, candidates[i].record.ID)
 	}
 
 	endpoint, err := buildUnifiedEndpoint(snapshot, requestedPod, ifname, candidates, responses)
@@ -261,8 +264,14 @@ func (service *HTTPRestService) selectUnifiedIPCandidatesLocked(
 			switch candidate.status.GetState() {
 			case types.Available, types.PendingProgramming:
 				selected = append(selected, candidate)
-			default:
+			case types.Assigned, types.PendingRelease:
 				return nil, fmt.Errorf("%w: desired IP is not available", errUnifiedIPUnavailable)
+			default:
+				return nil, fmt.Errorf(
+					"%w: desired IP has unknown state %q",
+					state.ErrInvalidInput,
+					candidate.status.GetState(),
+				)
 			}
 		}
 		return selected, nil
@@ -273,7 +282,8 @@ func (service *HTTPRestService) selectUnifiedIPCandidatesLocked(
 	}
 	families := service.getIPFamiliesMap()
 	selectedByFamily := make(map[cns.IPFamily]unifiedIPCandidate, len(families))
-	for _, candidate := range inventory {
+	for i := range inventory {
+		candidate := inventory[i]
 		if candidate.status.GetState() != types.Available {
 			continue
 		}
@@ -421,7 +431,7 @@ func buildUnifiedEndpoint(
 		var err error
 		endpoint, err = cloneJSON(existing)
 		if err != nil {
-			return state.EndpointRecord{}, fmt.Errorf("%w: cloning endpoint: %v", state.ErrInvalidInput, err)
+			return state.EndpointRecord{}, fmt.Errorf("%w: cloning endpoint: %w", state.ErrInvalidInput, err)
 		}
 	}
 	if _, exists := endpoint.IfnameToIPMap[ifname]; exists {
@@ -432,7 +442,8 @@ func buildUnifiedEndpoint(
 	}
 	info := &state.IPInfoRecord{NICType: cns.InfraNIC}
 	commonNCID := ""
-	for index, candidate := range candidates {
+	for index := range candidates {
+		candidate := candidates[index]
 		if index == 0 {
 			commonNCID = candidate.record.NCID
 		} else if commonNCID != candidate.record.NCID {

--- a/cns/restserver/unified_add_test.go
+++ b/cns/restserver/unified_add_test.go
@@ -23,6 +23,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	errUnifiedAddCommitFailure     = errors.New("injected commit failure")
+	errUnifiedAddProjectionFailure = errors.New("injected projection build failure")
+	errUnifiedAddCacheFailure      = errors.New("injected cache application failure")
+)
+
+const (
+	unifiedTestIPv6        = "2001:db8::4"
+	unifiedTestIPID1       = "ip-1"
+	unifiedTestIPv6Network = "2001:db8::"
+	unifiedTestIPv4ID      = "ip-v4"
+	unifiedTestIPv6ID      = "ip-v6"
+	unifiedTestNCIPv4      = "nc-v4"
+	unifiedTestNCIPv6      = "nc-v6"
+)
+
 func TestUnifiedAddSingleAndDualStack(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -33,18 +49,18 @@ func TestUnifiedAddSingleAndDualStack(t *testing.T) {
 		{
 			name: "single",
 			containers: map[string][]state.IPRecord{
-				"nc-v4": {{ID: "ip-v4", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+				unifiedTestNCIPv4: {{ID: unifiedTestIPv4ID, IPAddress: adapterTestIPv4, NCID: unifiedTestNCIPv4, NCVersion: 1}},
 			},
-			want: []string{"10.0.0.4"},
+			want: []string{adapterTestIPv4},
 		},
 		{
 			name: "dual stack desired order",
 			containers: map[string][]state.IPRecord{
-				"nc-v4": {{ID: "ip-v4", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
-				"nc-v6": {{ID: "ip-v6", IPAddress: "2001:db8::4", NCID: "nc-v6", NCVersion: 1}},
+				unifiedTestNCIPv4: {{ID: unifiedTestIPv4ID, IPAddress: adapterTestIPv4, NCID: unifiedTestNCIPv4, NCVersion: 1}},
+				unifiedTestNCIPv6: {{ID: unifiedTestIPv6ID, IPAddress: unifiedTestIPv6, NCID: unifiedTestNCIPv6, NCVersion: 1}},
 			},
-			desired: []string{"2001:db8::4", "10.0.0.4"},
-			want:    []string{"2001:db8::4", "10.0.0.4"},
+			desired: []string{unifiedTestIPv6, adapterTestIPv4},
+			want:    []string{unifiedTestIPv6, adapterTestIPv4},
 		},
 	}
 	for _, tt := range tests {
@@ -56,7 +72,7 @@ func TestUnifiedAddSingleAndDualStack(t *testing.T) {
 				refreshCalls++
 				return refreshMetrics(ctx)
 			}
-			request := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
+			request := unifiedAddRequest(adapterTestContainerID, "interface-1", InfraInterfaceName, "pod-1", "namespace-1")
 			request.DesiredIPAddresses = tt.desired
 			before := requireUnifiedSnapshot(t, db)
 
@@ -72,10 +88,10 @@ func TestUnifiedAddSingleAndDualStack(t *testing.T) {
 			assert.Equal(t, before.Metadata.Generation+1, after.Metadata.Generation)
 			assignment := after.Assignments["interface-1"]
 			require.Len(t, assignment.IPIDs, len(tt.want))
-			assert.Equal(t, "container-1", assignment.Pod.InfraContainerID)
+			assert.Equal(t, adapterTestContainerID, assignment.Pod.InfraContainerID)
 			assert.Equal(t, "interface-1", assignment.Pod.InterfaceID)
-			require.Contains(t, after.Endpoints, "container-1")
-			endpointInfo := after.Endpoints["container-1"].IfnameToIPMap["eth0"]
+			require.Contains(t, after.Endpoints, adapterTestContainerID)
+			endpointInfo := after.Endpoints[adapterTestContainerID].IfnameToIPMap[InfraInterfaceName]
 			assert.Len(t, endpointInfo.IPv4, 1)
 			assert.Len(t, endpointInfo.IPv6, len(tt.want)-1)
 			for _, ipID := range assignment.IPIDs {
@@ -94,22 +110,22 @@ func TestUnifiedAddSingleAndDualStack(t *testing.T) {
 
 func TestUnifiedAddMultiNICAndReplayIdentity(t *testing.T) {
 	service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
-		"nc-v4": {
-			{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1},
-			{ID: "ip-2", IPAddress: "10.0.0.5", NCID: "nc-v4", NCVersion: 1},
+		unifiedTestNCIPv4: {
+			{ID: unifiedTestIPID1, IPAddress: adapterTestIPv4, NCID: unifiedTestNCIPv4, NCVersion: 1},
+			{ID: "ip-2", IPAddress: primaryIP, NCID: unifiedTestNCIPv4, NCVersion: 1},
 		},
 	}, nil)
-	primary := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
-	primary.DesiredIPAddresses = []string{"10.0.0.4"}
-	secondary := unifiedAddRequest("container-1", "interface-2", "net1", "pod-1", "namespace-1")
-	secondary.DesiredIPAddresses = []string{"10.0.0.5"}
+	primary := unifiedAddRequest(adapterTestContainerID, "interface-1", InfraInterfaceName, "pod-1", "namespace-1")
+	primary.DesiredIPAddresses = []string{adapterTestIPv4}
+	secondary := unifiedAddRequest(adapterTestContainerID, "interface-2", "net1", "pod-1", "namespace-1")
+	secondary.DesiredIPAddresses = []string{primaryIP}
 	secondary.SecondaryInterfacesExist = true
 
 	_, err := service.requestIPConfigHandlerHelper(context.Background(), primary)
 	require.NoError(t, err)
 	afterPrimary := requireUnifiedSnapshot(t, db)
 	conflictingInterface := secondary
-	conflictingInterface.Ifname = "eth0"
+	conflictingInterface.Ifname = InfraInterfaceName
 	response, err := service.requestIPConfigHandlerHelper(context.Background(), conflictingInterface)
 	require.ErrorIs(t, err, state.ErrInvalidInput)
 	assert.Equal(t, types.InvalidRequest, response.Response.ReturnCode)
@@ -119,14 +135,14 @@ func TestUnifiedAddMultiNICAndReplayIdentity(t *testing.T) {
 	require.NoError(t, err)
 	afterAdds := requireUnifiedSnapshot(t, db)
 	require.Len(t, afterAdds.Assignments, 2)
-	require.Len(t, afterAdds.Endpoints["container-1"].IfnameToIPMap, 2)
-	assert.Contains(t, afterAdds.Endpoints["container-1"].IfnameToIPMap, "eth0")
-	assert.Contains(t, afterAdds.Endpoints["container-1"].IfnameToIPMap, "net1")
+	require.Len(t, afterAdds.Endpoints[adapterTestContainerID].IfnameToIPMap, 2)
+	assert.Contains(t, afterAdds.Endpoints[adapterTestContainerID].IfnameToIPMap, InfraInterfaceName)
+	assert.Contains(t, afterAdds.Endpoints[adapterTestContainerID].IfnameToIPMap, "net1")
 
 	replay, err := service.requestIPConfigHandlerHelper(context.Background(), secondary)
 	require.NoError(t, err)
 	require.Len(t, replay.PodIPInfo, 1)
-	assert.Equal(t, "10.0.0.5", replay.PodIPInfo[0].PodIPConfig.IPAddress)
+	assert.Equal(t, primaryIP, replay.PodIPInfo[0].PodIPConfig.IPAddress)
 	assert.Equal(t, afterAdds.Metadata.Generation, requireUnifiedSnapshot(t, db).Metadata.Generation)
 	generation, _ := adapter.cacheGeneration()
 	assert.Equal(t, afterAdds.Metadata.Generation, generation)
@@ -134,22 +150,21 @@ func TestUnifiedAddMultiNICAndReplayIdentity(t *testing.T) {
 	changed := secondary
 	changed.OrchestratorContext = mustPodContext(t, "other-pod", "namespace-1")
 	response, err = service.requestIPConfigHandlerHelper(context.Background(), changed)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, state.ErrInvalidInput)
+	require.ErrorIs(t, err, state.ErrInvalidInput)
 	assert.Equal(t, types.InvalidRequest, response.Response.ReturnCode)
 	assert.Equal(t, afterAdds.Metadata.Generation, requireUnifiedSnapshot(t, db).Metadata.Generation)
 }
 
 func TestUnifiedAddDuplicateConcurrencyIsAtomic(t *testing.T) {
 	service, _, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
-		"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+		unifiedTestNCIPv4: {{ID: unifiedTestIPID1, IPAddress: adapterTestIPv4, NCID: unifiedTestNCIPv4, NCVersion: 1}},
 	}, nil)
 	requests := []cns.IPConfigsRequest{
-		unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1"),
-		unifiedAddRequest("container-2", "interface-2", "eth0", "pod-2", "namespace-1"),
+		unifiedAddRequest(adapterTestContainerID, "interface-1", InfraInterfaceName, "pod-1", "namespace-1"),
+		unifiedAddRequest("container-2", "interface-2", InfraInterfaceName, "pod-2", "namespace-1"),
 	}
 	for index := range requests {
-		requests[index].DesiredIPAddresses = []string{"10.0.0.4"}
+		requests[index].DesiredIPAddresses = []string{adapterTestIPv4}
 	}
 
 	start := make(chan struct{})
@@ -213,10 +228,10 @@ func TestUnifiedAddDeleteIntentAndExpiry(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
-				"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+				unifiedTestNCIPv4: {{ID: unifiedTestIPID1, IPAddress: adapterTestIPv4, NCID: unifiedTestNCIPv4, NCVersion: 1}},
 			}, func(db *state.DB) {
 				require.NoError(t, db.Update(context.Background(), func(tx *state.WriteTx) error {
-					return tx.PutDeleteIntent("container-1", state.DeleteIntent{CreatedAt: tt.createdAt})
+					return tx.PutDeleteIntent(adapterTestContainerID, state.DeleteIntent{CreatedAt: tt.createdAt})
 				}))
 			})
 			adapter.now = func() time.Time { return now }
@@ -224,14 +239,14 @@ func TestUnifiedAddDeleteIntentAndExpiry(t *testing.T) {
 
 			response, err := service.requestIPConfigHandlerHelper(
 				context.Background(),
-				unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1"),
+				unifiedAddRequest(adapterTestContainerID, "interface-1", InfraInterfaceName, "pod-1", "namespace-1"),
 			)
 			assert.Equal(t, tt.wantCode, response.Response.ReturnCode)
 			after := requireUnifiedSnapshot(t, db)
 			if tt.wantSuccess {
 				require.NoError(t, err)
 				assert.Equal(t, before.Metadata.Generation+1, after.Metadata.Generation)
-				assert.NotContains(t, after.DeleteIntents, "container-1")
+				assert.NotContains(t, after.DeleteIntents, adapterTestContainerID)
 				assert.Contains(t, after.Assignments, "interface-1")
 			} else {
 				require.ErrorIs(t, err, state.ErrDeleteIntent)
@@ -245,11 +260,10 @@ func TestUnifiedAddDeleteIntentAndExpiry(t *testing.T) {
 func TestUnifiedAddFailuresDoNotPartiallyAllocate(t *testing.T) {
 	t.Run("commit", func(t *testing.T) {
 		service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
-			"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+			unifiedTestNCIPv4: {{ID: unifiedTestIPID1, IPAddress: adapterTestIPv4, NCID: unifiedTestNCIPv4, NCVersion: 1}},
 		}, nil)
 		beforeSnapshot := requireUnifiedSnapshot(t, db)
 		beforeCache := durableCacheFingerprint(service, adapter)
-		injected := errors.New("injected commit failure")
 		adapter.store.assignEndpoint = func(
 			context.Context,
 			uint64,
@@ -259,14 +273,14 @@ func TestUnifiedAddFailuresDoNotPartiallyAllocate(t *testing.T) {
 			time.Duration,
 			func(state.Snapshot) error,
 		) (bool, error) {
-			return false, injected
+			return false, errUnifiedAddCommitFailure
 		}
 
 		response, err := service.requestIPConfigHandlerHelper(
 			context.Background(),
-			unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1"),
+			unifiedAddRequest(adapterTestContainerID, "interface-1", InfraInterfaceName, "pod-1", "namespace-1"),
 		)
-		require.ErrorIs(t, err, injected)
+		require.ErrorIs(t, err, errUnifiedAddCommitFailure)
 		assert.Equal(t, types.UnexpectedError, response.Response.ReturnCode)
 		assert.Equal(t, beforeSnapshot, requireUnifiedSnapshot(t, db))
 		assert.Equal(t, beforeCache, durableCacheFingerprint(service, adapter))
@@ -274,20 +288,19 @@ func TestUnifiedAddFailuresDoNotPartiallyAllocate(t *testing.T) {
 
 	t.Run("projection prebuild callback", func(t *testing.T) {
 		service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
-			"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+			unifiedTestNCIPv4: {{ID: unifiedTestIPID1, IPAddress: adapterTestIPv4, NCID: unifiedTestNCIPv4, NCVersion: 1}},
 		}, nil)
 		beforeSnapshot := requireUnifiedSnapshot(t, db)
 		beforeCache := durableCacheFingerprint(service, adapter)
-		injected := errors.New("injected projection build failure")
 		adapter.buildProjection = func(state.Snapshot) (durableCacheProjection, error) {
-			return durableCacheProjection{}, injected
+			return durableCacheProjection{}, errUnifiedAddProjectionFailure
 		}
 
 		response, err := service.requestIPConfigHandlerHelper(
 			context.Background(),
-			unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1"),
+			unifiedAddRequest(adapterTestContainerID, "interface-1", InfraInterfaceName, "pod-1", "namespace-1"),
 		)
-		require.ErrorIs(t, err, injected)
+		require.ErrorIs(t, err, errUnifiedAddProjectionFailure)
 		assert.Equal(t, types.UnexpectedError, response.Response.ReturnCode)
 		assert.Equal(t, beforeSnapshot, requireUnifiedSnapshot(t, db))
 		assert.Equal(t, beforeCache, durableCacheFingerprint(service, adapter))
@@ -295,16 +308,16 @@ func TestUnifiedAddFailuresDoNotPartiallyAllocate(t *testing.T) {
 
 	t.Run("later invalid multi-IP candidate", func(t *testing.T) {
 		service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
-			"nc-v4": {{ID: "ip-v4", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
-			"nc-v6": {{ID: "ip-v6", IPAddress: "2001:db8::4", NCID: "nc-v6", NCVersion: 1}},
+			unifiedTestNCIPv4: {{ID: unifiedTestIPv4ID, IPAddress: adapterTestIPv4, NCID: unifiedTestNCIPv4, NCVersion: 1}},
+			unifiedTestNCIPv6: {{ID: unifiedTestIPv6ID, IPAddress: unifiedTestIPv6, NCID: unifiedTestNCIPv6, NCVersion: 1}},
 		}, nil)
-		nc := service.state.ContainerStatus["nc-v6"]
+		nc := service.state.ContainerStatus[unifiedTestNCIPv6]
 		nc.CreateNetworkContainerRequest.IPConfiguration.IPSubnet.PrefixLength = 200
-		service.state.ContainerStatus["nc-v6"] = nc
+		service.state.ContainerStatus[unifiedTestNCIPv6] = nc
 		beforeSnapshot := requireUnifiedSnapshot(t, db)
 		beforeCache := durableCacheFingerprint(service, adapter)
-		request := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
-		request.DesiredIPAddresses = []string{"10.0.0.4", "2001:db8::4"}
+		request := unifiedAddRequest(adapterTestContainerID, "interface-1", InfraInterfaceName, "pod-1", "namespace-1")
+		request.DesiredIPAddresses = []string{adapterTestIPv4, unifiedTestIPv6}
 
 		response, err := service.requestIPConfigHandlerHelper(context.Background(), request)
 		require.Error(t, err)
@@ -315,7 +328,7 @@ func TestUnifiedAddFailuresDoNotPartiallyAllocate(t *testing.T) {
 
 	t.Run("canceled before transaction", func(t *testing.T) {
 		service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
-			"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+			unifiedTestNCIPv4: {{ID: unifiedTestIPID1, IPAddress: adapterTestIPv4, NCID: unifiedTestNCIPv4, NCVersion: 1}},
 		}, nil)
 		beforeSnapshot := requireUnifiedSnapshot(t, db)
 		beforeCache := durableCacheFingerprint(service, adapter)
@@ -324,7 +337,7 @@ func TestUnifiedAddFailuresDoNotPartiallyAllocate(t *testing.T) {
 
 		response, err := service.requestIPConfigHandlerHelper(
 			ctx,
-			unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1"),
+			unifiedAddRequest(adapterTestContainerID, "interface-1", InfraInterfaceName, "pod-1", "namespace-1"),
 		)
 		require.ErrorIs(t, err, context.Canceled)
 		assert.Equal(t, types.FailedToAllocateIPConfig, response.Response.ReturnCode)
@@ -334,7 +347,7 @@ func TestUnifiedAddFailuresDoNotPartiallyAllocate(t *testing.T) {
 
 	t.Run("deadline before transaction", func(t *testing.T) {
 		service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
-			"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+			unifiedTestNCIPv4: {{ID: unifiedTestIPID1, IPAddress: adapterTestIPv4, NCID: unifiedTestNCIPv4, NCVersion: 1}},
 		}, nil)
 		beforeSnapshot := requireUnifiedSnapshot(t, db)
 		beforeCache := durableCacheFingerprint(service, adapter)
@@ -343,7 +356,7 @@ func TestUnifiedAddFailuresDoNotPartiallyAllocate(t *testing.T) {
 
 		response, err := service.requestIPConfigHandlerHelper(
 			ctx,
-			unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1"),
+			unifiedAddRequest(adapterTestContainerID, "interface-1", InfraInterfaceName, "pod-1", "namespace-1"),
 		)
 		require.ErrorIs(t, err, context.DeadlineExceeded)
 		assert.Equal(t, types.FailedToAllocateIPConfig, response.Response.ReturnCode)
@@ -354,10 +367,9 @@ func TestUnifiedAddFailuresDoNotPartiallyAllocate(t *testing.T) {
 
 func TestUnifiedAddProjectionFailureRestoresCommittedState(t *testing.T) {
 	service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
-		"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+		unifiedTestNCIPv4: {{ID: unifiedTestIPID1, IPAddress: adapterTestIPv4, NCID: unifiedTestNCIPv4, NCVersion: 1}},
 	}, nil)
 	beforeGeneration := requireUnifiedSnapshot(t, db).Metadata.Generation
-	injected := errors.New("injected cache application failure")
 	refreshMetrics := adapter.store.refreshMetrics
 	refreshCalls := 0
 	adapter.store.refreshMetrics = func(ctx context.Context) (state.Status, error) {
@@ -366,24 +378,24 @@ func TestUnifiedAddProjectionFailureRestoresCommittedState(t *testing.T) {
 	}
 	adapter.applyAddProjection = func(durableCacheProjection) error {
 		service.PodIPConfigState = map[string]cns.IPConfigurationStatus{}
-		return injected
+		return errUnifiedAddCacheFailure
 	}
 
 	response, err := service.requestIPConfigHandlerHelper(
 		context.Background(),
-		unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1"),
+		unifiedAddRequest(adapterTestContainerID, "interface-1", InfraInterfaceName, "pod-1", "namespace-1"),
 	)
 	var committedErr *unifiedAddCommittedError
 	require.ErrorAs(t, err, &committedErr)
-	require.ErrorIs(t, err, injected)
+	require.ErrorIs(t, err, errUnifiedAddCacheFailure)
 	assert.Equal(t, types.UnexpectedError, response.Response.ReturnCode)
 
 	snapshot := requireUnifiedSnapshot(t, db)
 	assert.Equal(t, beforeGeneration+1, snapshot.Metadata.Generation)
 	assert.Contains(t, snapshot.Assignments, "interface-1")
-	status := service.PodIPConfigState["ip-1"]
+	status := service.PodIPConfigState[unifiedTestIPID1]
 	assert.Equal(t, types.Assigned, status.GetState())
-	assert.Equal(t, []string{"ip-1"}, service.PodIPIDByPodInterfaceKey["interface-1"])
+	assert.Equal(t, []string{unifiedTestIPID1}, service.PodIPIDByPodInterfaceKey["interface-1"])
 	generation, projected := adapter.cacheGeneration()
 	assert.True(t, projected)
 	assert.Equal(t, snapshot.Metadata.Generation, generation)
@@ -393,7 +405,7 @@ func TestUnifiedAddProjectionFailureRestoresCommittedState(t *testing.T) {
 func TestUnifiedAddStaleGenerationAndClosedDatabase(t *testing.T) {
 	t.Run("stale adapter", func(t *testing.T) {
 		service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
-			"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+			unifiedTestNCIPv4: {{ID: unifiedTestIPID1, IPAddress: adapterTestIPv4, NCID: unifiedTestNCIPv4, NCVersion: 1}},
 		}, nil)
 		beforeCache := durableCacheFingerprint(service, adapter)
 		_, err := db.ApplyNetworkContainer(
@@ -406,7 +418,7 @@ func TestUnifiedAddStaleGenerationAndClosedDatabase(t *testing.T) {
 
 		response, err := service.requestIPConfigHandlerHelper(
 			context.Background(),
-			unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1"),
+			unifiedAddRequest(adapterTestContainerID, "interface-1", InfraInterfaceName, "pod-1", "namespace-1"),
 		)
 		require.ErrorIs(t, err, state.ErrStaleGeneration)
 		assert.Equal(t, types.InconsistentIPConfigState, response.Response.ReturnCode)
@@ -417,14 +429,14 @@ func TestUnifiedAddStaleGenerationAndClosedDatabase(t *testing.T) {
 
 	t.Run("closed", func(t *testing.T) {
 		service, adapter, db, closeState := newUnifiedAddFixture(t, map[string][]state.IPRecord{
-			"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+			unifiedTestNCIPv4: {{ID: unifiedTestIPID1, IPAddress: adapterTestIPv4, NCID: unifiedTestNCIPv4, NCVersion: 1}},
 		}, nil)
 		beforeCache := durableCacheFingerprint(service, adapter)
 		require.NoError(t, closeState())
 
 		response, err := service.requestIPConfigHandlerHelper(
 			context.Background(),
-			unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1"),
+			unifiedAddRequest(adapterTestContainerID, "interface-1", InfraInterfaceName, "pod-1", "namespace-1"),
 		)
 		require.Error(t, err)
 		assert.Equal(t, types.UnexpectedError, response.Response.ReturnCode)
@@ -435,29 +447,29 @@ func TestUnifiedAddStaleGenerationAndClosedDatabase(t *testing.T) {
 }
 
 func TestUnifiedAddImportedOwnershipReplayAndConflict(t *testing.T) {
-	request := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
+	request := unifiedAddRequest(adapterTestContainerID, "interface-1", InfraInterfaceName, "pod-1", "namespace-1")
 	service, _, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
-		"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+		unifiedTestNCIPv4: {{ID: unifiedTestIPID1, IPAddress: adapterTestIPv4, NCID: unifiedTestNCIPv4, NCVersion: 1}},
 	}, func(db *state.DB) {
 		_, err := db.AssignEndpoint(
 			context.Background(),
 			state.AssignmentRecord{
 				Pod: state.PodIdentity{
 					PodKey:           "interface-1",
-					InfraContainerID: "container-1",
+					InfraContainerID: adapterTestContainerID,
 					InterfaceID:      "interface-1",
 					PodName:          "pod-1",
 					PodNamespace:     "namespace-1",
 				},
-				IPIDs: []string{"ip-1"},
+				IPIDs: []string{unifiedTestIPID1},
 			},
 			state.EndpointRecord{
 				PodName:      "pod-1",
 				PodNamespace: "namespace-1",
 				IfnameToIPMap: map[string]*state.IPInfoRecord{
-					"eth0": {
+					InfraInterfaceName: {
 						IPv4:               []net.IPNet{testIPNet("10.0.0.4/24")},
-						NetworkContainerID: "nc-v4",
+						NetworkContainerID: unifiedTestNCIPv4,
 						NICType:            cns.InfraNIC,
 					},
 				},
@@ -485,16 +497,16 @@ func TestUnifiedAddImportedOwnershipReplayAndConflict(t *testing.T) {
 func TestJSONAddPathDoesNotSelectUnifiedState(t *testing.T) {
 	service := newUnifiedAddTestService(t)
 	assert.Nil(t, service.selectedUnifiedStateAdapter())
-	service.state.ContainerStatus["nc-v4"] = containerstatus{
-		ID:                            "nc-v4",
+	service.state.ContainerStatus[unifiedTestNCIPv4] = containerstatus{
+		ID:                            unifiedTestNCIPv4,
 		HostVersion:                   "1",
-		CreateNetworkContainerRequest: r18NetworkContainer("nc-v4").Request,
+		CreateNetworkContainerRequest: r18NetworkContainer(unifiedTestNCIPv4).Request,
 	}
-	status := cns.IPConfigurationStatus{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4"}
+	status := cns.IPConfigurationStatus{ID: unifiedTestIPID1, IPAddress: adapterTestIPv4, NCID: unifiedTestNCIPv4}
 	status.SetState(types.Available)
-	service.PodIPConfigState["ip-1"] = status
-	request := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
-	request.DesiredIPAddresses = []string{"10.0.0.4"}
+	service.PodIPConfigState[unifiedTestIPID1] = status
+	request := unifiedAddRequest(adapterTestContainerID, "interface-1", InfraInterfaceName, "pod-1", "namespace-1")
+	request.DesiredIPAddresses = []string{adapterTestIPv4}
 
 	beforeAdapter := service.unifiedStateAdapter
 	response, err := service.requestIPConfigHandlerHelper(context.Background(), request)
@@ -502,27 +514,27 @@ func TestJSONAddPathDoesNotSelectUnifiedState(t *testing.T) {
 	expected := &cns.IPConfigsResponse{
 		Response: cns.Response{ReturnCode: types.Success},
 		PodIPInfo: []cns.PodIpInfo{{
-			PodIPConfig: cns.IPSubnet{IPAddress: "10.0.0.4", PrefixLength: 24},
-			NetworkContainerPrimaryIPConfig: service.state.ContainerStatus["nc-v4"].
+			PodIPConfig: cns.IPSubnet{IPAddress: adapterTestIPv4, PrefixLength: 24},
+			NetworkContainerPrimaryIPConfig: service.state.ContainerStatus[unifiedTestNCIPv4].
 				CreateNetworkContainerRequest.IPConfiguration,
 			HostPrimaryIPInfo: cns.HostIPInfo{
 				PrimaryIP: "192.0.2.10",
 				Subnet:    "192.0.2.0/24",
 				Gateway:   "192.0.2.1",
 			},
-			MacAddress: "00:11:22:33:44:55",
+			MacAddress: adapterTestMAC,
 			NICType:    cns.InfraNIC,
 		}},
 	}
 	assert.Equal(t, expected, response)
-	gotJSON, err := json.Marshal(response)
+	gotJSON, err := json.Marshal(response) //nolint:musttag // IPConfigsResponse is the existing CNS API wire type.
 	require.NoError(t, err)
-	wantJSON, err := json.Marshal(expected)
+	wantJSON, err := json.Marshal(expected) //nolint:musttag // IPConfigsResponse is the existing CNS API wire type.
 	require.NoError(t, err)
-	assert.Equal(t, wantJSON, gotJSON)
+	assert.JSONEq(t, string(wantJSON), string(gotJSON))
 	assert.Same(t, beforeAdapter, service.unifiedStateAdapter)
-	assert.Equal(t, []string{"ip-1"}, service.PodIPIDByPodInterfaceKey["interface-1"])
-	assigned := service.PodIPConfigState["ip-1"]
+	assert.Equal(t, []string{unifiedTestIPID1}, service.PodIPIDByPodInterfaceKey["interface-1"])
+	assigned := service.PodIPConfigState[unifiedTestIPID1]
 	assert.Equal(t, types.Assigned, assigned.GetState())
 }
 
@@ -535,8 +547,8 @@ func newUnifiedAddFixture(
 	db, err := state.Open(filepath.Join(t.TempDir(), "state.db"), state.Options{})
 	require.NoError(t, err)
 	for id, ips := range containers {
-		_, err := db.ApplyNetworkContainer(context.Background(), r18NetworkContainer(id), ips)
-		require.NoError(t, err)
+		_, applyErr := db.ApplyNetworkContainer(context.Background(), r18NetworkContainer(id), ips)
+		require.NoError(t, applyErr)
 	}
 	if beforeAttach != nil {
 		beforeAttach(db)
@@ -575,9 +587,9 @@ func newUnifiedAddTestService(t *testing.T) *HTTPRestService {
 }
 
 func r18NetworkContainer(id string) state.NetworkContainerRecord {
-	prefix := cns.IPSubnet{IPAddress: "10.0.0.0", PrefixLength: 24}
+	prefix := cns.IPSubnet{IPAddress: adapterTestNetwork, PrefixLength: 24}
 	if strings.Contains(id, "v6") {
-		prefix = cns.IPSubnet{IPAddress: "2001:db8::", PrefixLength: 64}
+		prefix = cns.IPSubnet{IPAddress: unifiedTestIPv6Network, PrefixLength: 64}
 	}
 	return state.NewNetworkContainerRecord(id, "1", "1", true, cns.CreateNetworkContainerRequest{
 		NetworkContainerid: id,
@@ -587,12 +599,13 @@ func r18NetworkContainer(id string) state.NetworkContainerRecord {
 			GatewayIPAddress: "10.0.0.1",
 			DNSServers:       []string{"168.63.129.16"},
 		},
-		NetworkInterfaceInfo: cns.NetworkInterfaceInfo{MACAddress: "00:11:22:33:44:55"},
+		NetworkInterfaceInfo: cns.NetworkInterfaceInfo{MACAddress: adapterTestMAC},
 	})
 }
 
+//nolint:unparam // Downstream DEL and PATCH slices exercise distinct namespaces.
 func unifiedAddRequest(containerID, interfaceID, ifname, podName, namespace string) cns.IPConfigsRequest {
-	context, err := json.Marshal(cns.KubernetesPodInfo{PodName: podName, PodNamespace: namespace})
+	orchestratorContext, err := json.Marshal(cns.KubernetesPodInfo{PodName: podName, PodNamespace: namespace})
 	if err != nil {
 		panic(err)
 	}
@@ -600,7 +613,7 @@ func unifiedAddRequest(containerID, interfaceID, ifname, podName, namespace stri
 		PodInterfaceID:      interfaceID,
 		InfraContainerID:    containerID,
 		Ifname:              ifname,
-		OrchestratorContext: context,
+		OrchestratorContext: orchestratorContext,
 	}
 }
 

--- a/cns/restserver/unified_add_test.go
+++ b/cns/restserver/unified_add_test.go
@@ -1,0 +1,619 @@
+// Copyright 2026 Microsoft. All rights reserved.
+// MIT License
+
+package restserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/state"
+	"github.com/Azure/azure-container-networking/cns/types"
+	"github.com/Azure/azure-container-networking/cns/types/bounded"
+	"github.com/Azure/azure-container-networking/cns/wireserver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnifiedAddSingleAndDualStack(t *testing.T) {
+	tests := []struct {
+		name       string
+		containers map[string][]state.IPRecord
+		desired    []string
+		want       []string
+	}{
+		{
+			name: "single",
+			containers: map[string][]state.IPRecord{
+				"nc-v4": {{ID: "ip-v4", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+			},
+			want: []string{"10.0.0.4"},
+		},
+		{
+			name: "dual stack desired order",
+			containers: map[string][]state.IPRecord{
+				"nc-v4": {{ID: "ip-v4", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+				"nc-v6": {{ID: "ip-v6", IPAddress: "2001:db8::4", NCID: "nc-v6", NCVersion: 1}},
+			},
+			desired: []string{"2001:db8::4", "10.0.0.4"},
+			want:    []string{"2001:db8::4", "10.0.0.4"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service, adapter, db, _ := newUnifiedAddFixture(t, tt.containers, nil)
+			refreshMetrics := adapter.store.refreshMetrics
+			refreshCalls := 0
+			adapter.store.refreshMetrics = func(ctx context.Context) (state.Status, error) {
+				refreshCalls++
+				return refreshMetrics(ctx)
+			}
+			request := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
+			request.DesiredIPAddresses = tt.desired
+			before := requireUnifiedSnapshot(t, db)
+
+			response, err := service.requestIPConfigHandlerHelper(context.Background(), request)
+			require.NoError(t, err)
+			require.Equal(t, types.Success, response.Response.ReturnCode)
+			require.Len(t, response.PodIPInfo, len(tt.want))
+			for index, address := range tt.want {
+				assert.Equal(t, address, response.PodIPInfo[index].PodIPConfig.IPAddress)
+			}
+
+			after := requireUnifiedSnapshot(t, db)
+			assert.Equal(t, before.Metadata.Generation+1, after.Metadata.Generation)
+			assignment := after.Assignments["interface-1"]
+			require.Len(t, assignment.IPIDs, len(tt.want))
+			assert.Equal(t, "container-1", assignment.Pod.InfraContainerID)
+			assert.Equal(t, "interface-1", assignment.Pod.InterfaceID)
+			require.Contains(t, after.Endpoints, "container-1")
+			endpointInfo := after.Endpoints["container-1"].IfnameToIPMap["eth0"]
+			assert.Len(t, endpointInfo.IPv4, 1)
+			assert.Len(t, endpointInfo.IPv6, len(tt.want)-1)
+			for _, ipID := range assignment.IPIDs {
+				assert.Equal(t, "interface-1", after.IPOwners[ipID])
+				status := service.PodIPConfigState[ipID]
+				assert.Equal(t, types.Assigned, status.GetState())
+			}
+			generation, projected := adapter.cacheGeneration()
+			assert.True(t, projected)
+			assert.Equal(t, after.Metadata.Generation, generation)
+			assert.Equal(t, assignment.IPIDs, service.PodIPIDByPodInterfaceKey["interface-1"])
+			assert.Equal(t, 1, refreshCalls)
+		})
+	}
+}
+
+func TestUnifiedAddMultiNICAndReplayIdentity(t *testing.T) {
+	service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
+		"nc-v4": {
+			{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1},
+			{ID: "ip-2", IPAddress: "10.0.0.5", NCID: "nc-v4", NCVersion: 1},
+		},
+	}, nil)
+	primary := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
+	primary.DesiredIPAddresses = []string{"10.0.0.4"}
+	secondary := unifiedAddRequest("container-1", "interface-2", "net1", "pod-1", "namespace-1")
+	secondary.DesiredIPAddresses = []string{"10.0.0.5"}
+	secondary.SecondaryInterfacesExist = true
+
+	_, err := service.requestIPConfigHandlerHelper(context.Background(), primary)
+	require.NoError(t, err)
+	afterPrimary := requireUnifiedSnapshot(t, db)
+	conflictingInterface := secondary
+	conflictingInterface.Ifname = "eth0"
+	response, err := service.requestIPConfigHandlerHelper(context.Background(), conflictingInterface)
+	require.ErrorIs(t, err, state.ErrInvalidInput)
+	assert.Equal(t, types.InvalidRequest, response.Response.ReturnCode)
+	assert.Equal(t, afterPrimary, requireUnifiedSnapshot(t, db))
+
+	_, err = service.requestIPConfigHandlerHelper(context.Background(), secondary)
+	require.NoError(t, err)
+	afterAdds := requireUnifiedSnapshot(t, db)
+	require.Len(t, afterAdds.Assignments, 2)
+	require.Len(t, afterAdds.Endpoints["container-1"].IfnameToIPMap, 2)
+	assert.Contains(t, afterAdds.Endpoints["container-1"].IfnameToIPMap, "eth0")
+	assert.Contains(t, afterAdds.Endpoints["container-1"].IfnameToIPMap, "net1")
+
+	replay, err := service.requestIPConfigHandlerHelper(context.Background(), secondary)
+	require.NoError(t, err)
+	require.Len(t, replay.PodIPInfo, 1)
+	assert.Equal(t, "10.0.0.5", replay.PodIPInfo[0].PodIPConfig.IPAddress)
+	assert.Equal(t, afterAdds.Metadata.Generation, requireUnifiedSnapshot(t, db).Metadata.Generation)
+	generation, _ := adapter.cacheGeneration()
+	assert.Equal(t, afterAdds.Metadata.Generation, generation)
+
+	changed := secondary
+	changed.OrchestratorContext = mustPodContext(t, "other-pod", "namespace-1")
+	response, err = service.requestIPConfigHandlerHelper(context.Background(), changed)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, state.ErrInvalidInput)
+	assert.Equal(t, types.InvalidRequest, response.Response.ReturnCode)
+	assert.Equal(t, afterAdds.Metadata.Generation, requireUnifiedSnapshot(t, db).Metadata.Generation)
+}
+
+func TestUnifiedAddDuplicateConcurrencyIsAtomic(t *testing.T) {
+	service, _, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
+		"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+	}, nil)
+	requests := []cns.IPConfigsRequest{
+		unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1"),
+		unifiedAddRequest("container-2", "interface-2", "eth0", "pod-2", "namespace-1"),
+	}
+	for index := range requests {
+		requests[index].DesiredIPAddresses = []string{"10.0.0.4"}
+	}
+
+	start := make(chan struct{})
+	results := make(chan *cns.IPConfigsResponse, len(requests))
+	errs := make(chan error, len(requests))
+	var ready sync.WaitGroup
+	ready.Add(len(requests))
+	for _, request := range requests {
+		go func() {
+			ready.Done()
+			<-start
+			response, err := service.requestIPConfigHandlerHelper(context.Background(), request)
+			results <- response
+			errs <- err
+		}()
+	}
+	ready.Wait()
+	close(start)
+
+	successes := 0
+	conflicts := 0
+	for range requests {
+		response := <-results
+		err := <-errs
+		if err == nil {
+			successes++
+			assert.Equal(t, types.Success, response.Response.ReturnCode)
+			continue
+		}
+		conflicts++
+		assert.Equal(t, types.AddressUnavailable, response.Response.ReturnCode)
+	}
+	assert.Equal(t, 1, successes)
+	assert.Equal(t, 1, conflicts)
+	snapshot := requireUnifiedSnapshot(t, db)
+	assert.Len(t, snapshot.Assignments, 1)
+	assert.Len(t, snapshot.IPOwners, 1)
+	assert.Len(t, snapshot.Endpoints, 1)
+}
+
+func TestUnifiedAddDeleteIntentAndExpiry(t *testing.T) {
+	now := time.Date(2026, time.July, 24, 1, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name        string
+		createdAt   time.Time
+		wantCode    types.ResponseCode
+		wantSuccess bool
+	}{
+		{
+			name:      "active",
+			createdAt: now.Add(-unifiedDeleteIntentTTL + time.Nanosecond),
+			wantCode:  types.AddressUnavailable,
+		},
+		{
+			name:        "expired",
+			createdAt:   now.Add(-unifiedDeleteIntentTTL),
+			wantCode:    types.Success,
+			wantSuccess: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
+				"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+			}, func(db *state.DB) {
+				require.NoError(t, db.Update(context.Background(), func(tx *state.WriteTx) error {
+					return tx.PutDeleteIntent("container-1", state.DeleteIntent{CreatedAt: tt.createdAt})
+				}))
+			})
+			adapter.now = func() time.Time { return now }
+			before := requireUnifiedSnapshot(t, db)
+
+			response, err := service.requestIPConfigHandlerHelper(
+				context.Background(),
+				unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1"),
+			)
+			assert.Equal(t, tt.wantCode, response.Response.ReturnCode)
+			after := requireUnifiedSnapshot(t, db)
+			if tt.wantSuccess {
+				require.NoError(t, err)
+				assert.Equal(t, before.Metadata.Generation+1, after.Metadata.Generation)
+				assert.NotContains(t, after.DeleteIntents, "container-1")
+				assert.Contains(t, after.Assignments, "interface-1")
+			} else {
+				require.ErrorIs(t, err, state.ErrDeleteIntent)
+				assert.Equal(t, before, after)
+				assert.Empty(t, service.PodIPIDByPodInterfaceKey)
+			}
+		})
+	}
+}
+
+func TestUnifiedAddFailuresDoNotPartiallyAllocate(t *testing.T) {
+	t.Run("commit", func(t *testing.T) {
+		service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
+			"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+		}, nil)
+		beforeSnapshot := requireUnifiedSnapshot(t, db)
+		beforeCache := durableCacheFingerprint(service, adapter)
+		injected := errors.New("injected commit failure")
+		adapter.store.assignEndpoint = func(
+			context.Context,
+			uint64,
+			state.AssignmentRecord,
+			state.EndpointRecord,
+			time.Time,
+			time.Duration,
+			func(state.Snapshot) error,
+		) (bool, error) {
+			return false, injected
+		}
+
+		response, err := service.requestIPConfigHandlerHelper(
+			context.Background(),
+			unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1"),
+		)
+		require.ErrorIs(t, err, injected)
+		assert.Equal(t, types.UnexpectedError, response.Response.ReturnCode)
+		assert.Equal(t, beforeSnapshot, requireUnifiedSnapshot(t, db))
+		assert.Equal(t, beforeCache, durableCacheFingerprint(service, adapter))
+	})
+
+	t.Run("projection prebuild callback", func(t *testing.T) {
+		service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
+			"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+		}, nil)
+		beforeSnapshot := requireUnifiedSnapshot(t, db)
+		beforeCache := durableCacheFingerprint(service, adapter)
+		injected := errors.New("injected projection build failure")
+		adapter.buildProjection = func(state.Snapshot) (durableCacheProjection, error) {
+			return durableCacheProjection{}, injected
+		}
+
+		response, err := service.requestIPConfigHandlerHelper(
+			context.Background(),
+			unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1"),
+		)
+		require.ErrorIs(t, err, injected)
+		assert.Equal(t, types.UnexpectedError, response.Response.ReturnCode)
+		assert.Equal(t, beforeSnapshot, requireUnifiedSnapshot(t, db))
+		assert.Equal(t, beforeCache, durableCacheFingerprint(service, adapter))
+	})
+
+	t.Run("later invalid multi-IP candidate", func(t *testing.T) {
+		service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
+			"nc-v4": {{ID: "ip-v4", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+			"nc-v6": {{ID: "ip-v6", IPAddress: "2001:db8::4", NCID: "nc-v6", NCVersion: 1}},
+		}, nil)
+		nc := service.state.ContainerStatus["nc-v6"]
+		nc.CreateNetworkContainerRequest.IPConfiguration.IPSubnet.PrefixLength = 200
+		service.state.ContainerStatus["nc-v6"] = nc
+		beforeSnapshot := requireUnifiedSnapshot(t, db)
+		beforeCache := durableCacheFingerprint(service, adapter)
+		request := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
+		request.DesiredIPAddresses = []string{"10.0.0.4", "2001:db8::4"}
+
+		response, err := service.requestIPConfigHandlerHelper(context.Background(), request)
+		require.Error(t, err)
+		assert.Equal(t, types.InvalidRequest, response.Response.ReturnCode)
+		assert.Equal(t, beforeSnapshot, requireUnifiedSnapshot(t, db))
+		assert.Equal(t, beforeCache, durableCacheFingerprint(service, adapter))
+	})
+
+	t.Run("canceled before transaction", func(t *testing.T) {
+		service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
+			"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+		}, nil)
+		beforeSnapshot := requireUnifiedSnapshot(t, db)
+		beforeCache := durableCacheFingerprint(service, adapter)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		response, err := service.requestIPConfigHandlerHelper(
+			ctx,
+			unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1"),
+		)
+		require.ErrorIs(t, err, context.Canceled)
+		assert.Equal(t, types.FailedToAllocateIPConfig, response.Response.ReturnCode)
+		assert.Equal(t, beforeSnapshot, requireUnifiedSnapshot(t, db))
+		assert.Equal(t, beforeCache, durableCacheFingerprint(service, adapter))
+	})
+
+	t.Run("deadline before transaction", func(t *testing.T) {
+		service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
+			"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+		}, nil)
+		beforeSnapshot := requireUnifiedSnapshot(t, db)
+		beforeCache := durableCacheFingerprint(service, adapter)
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		defer cancel()
+
+		response, err := service.requestIPConfigHandlerHelper(
+			ctx,
+			unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1"),
+		)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.Equal(t, types.FailedToAllocateIPConfig, response.Response.ReturnCode)
+		assert.Equal(t, beforeSnapshot, requireUnifiedSnapshot(t, db))
+		assert.Equal(t, beforeCache, durableCacheFingerprint(service, adapter))
+	})
+}
+
+func TestUnifiedAddProjectionFailureRestoresCommittedState(t *testing.T) {
+	service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
+		"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+	}, nil)
+	beforeGeneration := requireUnifiedSnapshot(t, db).Metadata.Generation
+	injected := errors.New("injected cache application failure")
+	refreshMetrics := adapter.store.refreshMetrics
+	refreshCalls := 0
+	adapter.store.refreshMetrics = func(ctx context.Context) (state.Status, error) {
+		refreshCalls++
+		return refreshMetrics(ctx)
+	}
+	adapter.applyAddProjection = func(durableCacheProjection) error {
+		service.PodIPConfigState = map[string]cns.IPConfigurationStatus{}
+		return injected
+	}
+
+	response, err := service.requestIPConfigHandlerHelper(
+		context.Background(),
+		unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1"),
+	)
+	var committedErr *unifiedAddCommittedError
+	require.ErrorAs(t, err, &committedErr)
+	require.ErrorIs(t, err, injected)
+	assert.Equal(t, types.UnexpectedError, response.Response.ReturnCode)
+
+	snapshot := requireUnifiedSnapshot(t, db)
+	assert.Equal(t, beforeGeneration+1, snapshot.Metadata.Generation)
+	assert.Contains(t, snapshot.Assignments, "interface-1")
+	status := service.PodIPConfigState["ip-1"]
+	assert.Equal(t, types.Assigned, status.GetState())
+	assert.Equal(t, []string{"ip-1"}, service.PodIPIDByPodInterfaceKey["interface-1"])
+	generation, projected := adapter.cacheGeneration()
+	assert.True(t, projected)
+	assert.Equal(t, snapshot.Metadata.Generation, generation)
+	assert.Equal(t, 1, refreshCalls)
+}
+
+func TestUnifiedAddStaleGenerationAndClosedDatabase(t *testing.T) {
+	t.Run("stale adapter", func(t *testing.T) {
+		service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
+			"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+		}, nil)
+		beforeCache := durableCacheFingerprint(service, adapter)
+		_, err := db.ApplyNetworkContainer(
+			context.Background(),
+			r18NetworkContainer("external"),
+			[]state.IPRecord{{ID: "external-ip", IPAddress: "10.1.0.4", NCID: "external", NCVersion: 1}},
+		)
+		require.NoError(t, err)
+		external := requireUnifiedSnapshot(t, db)
+
+		response, err := service.requestIPConfigHandlerHelper(
+			context.Background(),
+			unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1"),
+		)
+		require.ErrorIs(t, err, state.ErrStaleGeneration)
+		assert.Equal(t, types.InconsistentIPConfigState, response.Response.ReturnCode)
+		assert.Empty(t, external.Assignments)
+		assert.Equal(t, external, requireUnifiedSnapshot(t, db))
+		assert.Equal(t, beforeCache, durableCacheFingerprint(service, adapter))
+	})
+
+	t.Run("closed", func(t *testing.T) {
+		service, adapter, db, closeState := newUnifiedAddFixture(t, map[string][]state.IPRecord{
+			"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+		}, nil)
+		beforeCache := durableCacheFingerprint(service, adapter)
+		require.NoError(t, closeState())
+
+		response, err := service.requestIPConfigHandlerHelper(
+			context.Background(),
+			unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1"),
+		)
+		require.Error(t, err)
+		assert.Equal(t, types.UnexpectedError, response.Response.ReturnCode)
+		assert.Equal(t, beforeCache, durableCacheFingerprint(service, adapter))
+		_, snapshotErr := db.Snapshot(context.Background())
+		require.Error(t, snapshotErr)
+	})
+}
+
+func TestUnifiedAddImportedOwnershipReplayAndConflict(t *testing.T) {
+	request := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
+	service, _, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
+		"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+	}, func(db *state.DB) {
+		_, err := db.AssignEndpoint(
+			context.Background(),
+			state.AssignmentRecord{
+				Pod: state.PodIdentity{
+					PodKey:           "interface-1",
+					InfraContainerID: "container-1",
+					InterfaceID:      "interface-1",
+					PodName:          "pod-1",
+					PodNamespace:     "namespace-1",
+				},
+				IPIDs: []string{"ip-1"},
+			},
+			state.EndpointRecord{
+				PodName:      "pod-1",
+				PodNamespace: "namespace-1",
+				IfnameToIPMap: map[string]*state.IPInfoRecord{
+					"eth0": {
+						IPv4:               []net.IPNet{testIPNet("10.0.0.4/24")},
+						NetworkContainerID: "nc-v4",
+						NICType:            cns.InfraNIC,
+					},
+				},
+			},
+			time.Date(2026, time.July, 24, 0, 0, 0, 0, time.UTC),
+			unifiedDeleteIntentTTL,
+		)
+		require.NoError(t, err)
+	})
+	before := requireUnifiedSnapshot(t, db)
+
+	response, err := service.requestIPConfigHandlerHelper(context.Background(), request)
+	require.NoError(t, err)
+	assert.Equal(t, types.Success, response.Response.ReturnCode)
+	assert.Equal(t, before.Metadata.Generation, requireUnifiedSnapshot(t, db).Metadata.Generation)
+
+	conflict := request
+	conflict.InfraContainerID = "container-2"
+	response, err = service.requestIPConfigHandlerHelper(context.Background(), conflict)
+	require.ErrorIs(t, err, state.ErrInvalidInput)
+	assert.Equal(t, types.InvalidRequest, response.Response.ReturnCode)
+	assert.Equal(t, before, requireUnifiedSnapshot(t, db))
+}
+
+func TestJSONAddPathDoesNotSelectUnifiedState(t *testing.T) {
+	service := newUnifiedAddTestService(t)
+	assert.Nil(t, service.selectedUnifiedStateAdapter())
+	service.state.ContainerStatus["nc-v4"] = containerstatus{
+		ID:                            "nc-v4",
+		HostVersion:                   "1",
+		CreateNetworkContainerRequest: r18NetworkContainer("nc-v4").Request,
+	}
+	status := cns.IPConfigurationStatus{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4"}
+	status.SetState(types.Available)
+	service.PodIPConfigState["ip-1"] = status
+	request := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
+	request.DesiredIPAddresses = []string{"10.0.0.4"}
+
+	beforeAdapter := service.unifiedStateAdapter
+	response, err := service.requestIPConfigHandlerHelper(context.Background(), request)
+	require.NoError(t, err)
+	expected := &cns.IPConfigsResponse{
+		Response: cns.Response{ReturnCode: types.Success},
+		PodIPInfo: []cns.PodIpInfo{{
+			PodIPConfig: cns.IPSubnet{IPAddress: "10.0.0.4", PrefixLength: 24},
+			NetworkContainerPrimaryIPConfig: service.state.ContainerStatus["nc-v4"].
+				CreateNetworkContainerRequest.IPConfiguration,
+			HostPrimaryIPInfo: cns.HostIPInfo{
+				PrimaryIP: "192.0.2.10",
+				Subnet:    "192.0.2.0/24",
+				Gateway:   "192.0.2.1",
+			},
+			MacAddress: "00:11:22:33:44:55",
+			NICType:    cns.InfraNIC,
+		}},
+	}
+	assert.Equal(t, expected, response)
+	gotJSON, err := json.Marshal(response)
+	require.NoError(t, err)
+	wantJSON, err := json.Marshal(expected)
+	require.NoError(t, err)
+	assert.Equal(t, wantJSON, gotJSON)
+	assert.Same(t, beforeAdapter, service.unifiedStateAdapter)
+	assert.Equal(t, []string{"ip-1"}, service.PodIPIDByPodInterfaceKey["interface-1"])
+	assigned := service.PodIPConfigState["ip-1"]
+	assert.Equal(t, types.Assigned, assigned.GetState())
+}
+
+func newUnifiedAddFixture(
+	t *testing.T,
+	containers map[string][]state.IPRecord,
+	beforeAttach func(*state.DB),
+) (*HTTPRestService, *durableStateAdapter, *state.DB, func() error) {
+	t.Helper()
+	db, err := state.Open(filepath.Join(t.TempDir(), "state.db"), state.Options{})
+	require.NoError(t, err)
+	for id, ips := range containers {
+		_, err := db.ApplyNetworkContainer(context.Background(), r18NetworkContainer(id), ips)
+		require.NoError(t, err)
+	}
+	if beforeAttach != nil {
+		beforeAttach(db)
+	}
+	service := newUnifiedAddTestService(t)
+	restore, closeState, err := NewDurableStateLifecycle(service, db, true)
+	require.NoError(t, err)
+	require.NoError(t, restore(context.Background()))
+	t.Cleanup(func() { require.NoError(t, closeState()) })
+	return service, service.unifiedStateAdapter, db, closeState
+}
+
+func newUnifiedAddTestService(t *testing.T) *HTTPRestService {
+	t.Helper()
+	base, err := cns.NewService("test", "test", cns.Managed, nil)
+	require.NoError(t, err)
+	return &HTTPRestService{
+		Service: base,
+		state: &httpRestServiceState{
+			ContainerStatus:                  map[string]containerstatus{},
+			ContainerIDByOrchestratorContext: map[string]*ncList{},
+			Networks:                         map[string]*networkInfo{},
+			joinedNetworks:                   map[string]struct{}{},
+			PnpIDByMacAddress:                map[string]string{},
+			primaryInterface: &wireserver.InterfaceInfo{
+				PrimaryIP: "192.0.2.10",
+				Subnet:    "192.0.2.0/24",
+				Gateway:   "192.0.2.1",
+			},
+		},
+		PodIPConfigState:         map[string]cns.IPConfigurationStatus{},
+		PodIPIDByPodInterfaceKey: map[string][]string{},
+		EndpointState:            map[string]*EndpointInfo{},
+		podsPendingIPAssignment:  bounded.NewTimedSet(10),
+	}
+}
+
+func r18NetworkContainer(id string) state.NetworkContainerRecord {
+	prefix := cns.IPSubnet{IPAddress: "10.0.0.0", PrefixLength: 24}
+	if strings.Contains(id, "v6") {
+		prefix = cns.IPSubnet{IPAddress: "2001:db8::", PrefixLength: 64}
+	}
+	return state.NewNetworkContainerRecord(id, "1", "1", true, cns.CreateNetworkContainerRequest{
+		NetworkContainerid: id,
+		Version:            "1",
+		IPConfiguration: cns.IPConfiguration{
+			IPSubnet:         prefix,
+			GatewayIPAddress: "10.0.0.1",
+			DNSServers:       []string{"168.63.129.16"},
+		},
+		NetworkInterfaceInfo: cns.NetworkInterfaceInfo{MACAddress: "00:11:22:33:44:55"},
+	})
+}
+
+func unifiedAddRequest(containerID, interfaceID, ifname, podName, namespace string) cns.IPConfigsRequest {
+	context, err := json.Marshal(cns.KubernetesPodInfo{PodName: podName, PodNamespace: namespace})
+	if err != nil {
+		panic(err)
+	}
+	return cns.IPConfigsRequest{
+		PodInterfaceID:      interfaceID,
+		InfraContainerID:    containerID,
+		Ifname:              ifname,
+		OrchestratorContext: context,
+	}
+}
+
+func mustPodContext(t *testing.T, podName, namespace string) json.RawMessage {
+	t.Helper()
+	value, err := json.Marshal(cns.KubernetesPodInfo{PodName: podName, PodNamespace: namespace})
+	require.NoError(t, err)
+	return value
+}
+
+func requireUnifiedSnapshot(t *testing.T, db *state.DB) state.Snapshot {
+	t.Helper()
+	snapshot, err := db.Snapshot(context.Background())
+	require.NoError(t, err)
+	return snapshot
+}

--- a/cns/state/metrics.go
+++ b/cns/state/metrics.go
@@ -300,7 +300,9 @@ func classifyResult(changed bool, err error) OperationResult {
 	switch {
 	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
 		return ResultCanceled
-	case errors.Is(err, ErrStaleGeneration):
+	case errors.Is(err, ErrStaleGeneration),
+		errors.Is(err, ErrIPAlreadyAssigned),
+		errors.Is(err, ErrDeleteIntent):
 		return ResultConflict
 	case err != nil:
 		return ResultError

--- a/cns/state/observability_test.go
+++ b/cns/state/observability_test.go
@@ -51,6 +51,7 @@ func TestNewMetricsRegistration(t *testing.T) {
 			"cns_persistent_state_database_bytes":               "Current persistent state database size in bytes.",
 			"cns_persistent_state_records":                      "Current persistent state record count by bounded record type.",
 		}
+
 		wantLabels := map[string][]string{
 			"cns_persistent_state_transactions_total":           {metricLabelOperation, metricLabelResult},
 			"cns_persistent_state_transaction_duration_seconds": {metricLabelOperation, metricLabelResult},
@@ -107,6 +108,19 @@ func TestNewMetricsRegistration(t *testing.T) {
 		_, err := NewMetrics(registerer)
 		require.ErrorContains(t, err, "collector rollback incomplete")
 	})
+}
+
+func TestClassifyOwnershipConflictResult(t *testing.T) {
+	tests := map[string]error{
+		"stale generation": ErrStaleGeneration,
+		"IP owner":         ErrIPAlreadyAssigned,
+		"delete intent":    ErrDeleteIntent,
+	}
+	for name, err := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, ResultConflict, classifyResult(false, err))
+		})
+	}
 }
 
 func TestMetricsValidateBoundedInputs(t *testing.T) {

--- a/cns/state/observability_test.go
+++ b/cns/state/observability_test.go
@@ -25,6 +25,11 @@ var errMetricRegistration = errors.New("register failure")
 
 const metricTestDelta = 1e-9
 
+const (
+	metricTestIPOwner      = "IP owner"
+	metricTestDeleteIntent = "delete intent"
+)
+
 func TestNewMetricsRegistration(t *testing.T) {
 	t.Run("descriptors", func(t *testing.T) {
 		registry := prometheus.NewRegistry()
@@ -112,9 +117,9 @@ func TestNewMetricsRegistration(t *testing.T) {
 
 func TestClassifyOwnershipConflictResult(t *testing.T) {
 	tests := map[string]error{
-		"stale generation": ErrStaleGeneration,
-		"IP owner":         ErrIPAlreadyAssigned,
-		"delete intent":    ErrDeleteIntent,
+		"stale generation":     ErrStaleGeneration,
+		metricTestIPOwner:      ErrIPAlreadyAssigned,
+		metricTestDeleteIntent: ErrDeleteIntent,
 	}
 	for name, err := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/cns/state/ownership_operations.go
+++ b/cns/state/ownership_operations.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net"
 	"net/netip"
 	"slices"
@@ -32,6 +33,41 @@ func (s *DB) AssignEndpoint(
 	now time.Time,
 	deleteIntentTTL time.Duration,
 ) (bool, error) {
+	return s.assignEndpoint(ctx, nil, assignment, endpoint, now, deleteIntentTTL, nil)
+}
+
+// AssignEndpointIfGeneration atomically assigns an endpoint only when the
+// database is at expectedGeneration. beforeCommit may validate the complete
+// candidate snapshot before any records are written.
+func (s *DB) AssignEndpointIfGeneration(
+	ctx context.Context,
+	expectedGeneration uint64,
+	assignment AssignmentRecord,
+	endpoint EndpointRecord,
+	now time.Time,
+	deleteIntentTTL time.Duration,
+	beforeCommit func(Snapshot) error,
+) (bool, error) {
+	return s.assignEndpoint(
+		ctx,
+		&expectedGeneration,
+		assignment,
+		endpoint,
+		now,
+		deleteIntentTTL,
+		beforeCommit,
+	)
+}
+
+func (s *DB) assignEndpoint(
+	ctx context.Context,
+	expectedGeneration *uint64,
+	assignment AssignmentRecord,
+	endpoint EndpointRecord,
+	now time.Time,
+	deleteIntentTTL time.Duration,
+	beforeCommit func(Snapshot) error,
+) (bool, error) {
 	normalizedAssignment, err := normalizeAssignment(assignment, true)
 	if err != nil {
 		return false, err
@@ -52,6 +88,14 @@ func (s *DB) AssignEndpoint(
 		current, snapshotErr := tx.validSnapshot()
 		if snapshotErr != nil {
 			return false, snapshotErr
+		}
+		if expectedGeneration != nil && current.Metadata.Generation != *expectedGeneration {
+			return false, fmt.Errorf(
+				"%w: expected=%d actual=%d",
+				ErrStaleGeneration,
+				*expectedGeneration,
+				current.Metadata.Generation,
+			)
 		}
 		plan, planErr := buildEndpointAssignmentPlan(
 			current,
@@ -78,7 +122,22 @@ func (s *DB) AssignEndpoint(
 		}
 
 		if plan.assignmentExists && !plan.endpointChanged && !plan.removeExpiredIntent {
+			if beforeCommit != nil {
+				if err := beforeCommit(current); err != nil {
+					return false, fmt.Errorf("validating endpoint assignment candidate: %w", err)
+				}
+			}
 			return false, nil
+		}
+		candidate := plan.candidate
+		if candidate.Metadata.Generation == math.MaxUint64 {
+			return false, corrupt("generation overflow", nil)
+		}
+		candidate.Metadata.Generation++
+		if beforeCommit != nil {
+			if err := beforeCommit(candidate); err != nil {
+				return false, fmt.Errorf("validating endpoint assignment candidate: %w", err)
+			}
 		}
 
 		if plan.removeExpiredIntent {

--- a/cns/state/ownership_operations_test.go
+++ b/cns/state/ownership_operations_test.go
@@ -241,6 +241,182 @@ func TestAssignEndpoint(t *testing.T) {
 	})
 }
 
+func TestAssignEndpointIfGenerationPrecommitAndCancellation(t *testing.T) {
+	t.Run("candidate callback failure rolls back", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		assignment, endpoint := seedOwnershipInventory(t, db)
+		before := requireValidSnapshot(t, db)
+		injected := errors.New("injected candidate failure")
+		callbackCalled := false
+
+		changed, err := db.AssignEndpointIfGeneration(
+			context.Background(),
+			before.Metadata.Generation,
+			assignment,
+			endpoint,
+			testNow,
+			testDeleteIntentTTL,
+			func(candidate Snapshot) error {
+				callbackCalled = true
+				assert.Equal(t, before.Metadata.Generation+1, candidate.Metadata.Generation)
+				assert.Contains(t, candidate.Assignments, assignment.Pod.PodKey)
+				assert.Contains(t, candidate.Endpoints, assignment.Pod.InfraContainerID)
+				assert.Len(t, candidate.IPOwners, len(assignment.IPIDs))
+				return injected
+			},
+		)
+		require.ErrorIs(t, err, injected)
+		assert.False(t, changed)
+		assert.True(t, callbackCalled)
+		assert.Equal(t, before, requireValidSnapshot(t, db))
+	})
+
+	t.Run("stale generation does not invoke callback", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		assignment, endpoint := seedOwnershipInventory(t, db)
+		before := requireValidSnapshot(t, db)
+
+		changed, err := db.AssignEndpointIfGeneration(
+			context.Background(),
+			before.Metadata.Generation+1,
+			assignment,
+			endpoint,
+			testNow,
+			testDeleteIntentTTL,
+			func(Snapshot) error {
+				t.Fatal("stale generation invoked candidate callback")
+				return nil
+			},
+		)
+		require.ErrorIs(t, err, ErrStaleGeneration)
+		assert.False(t, changed)
+		assert.Equal(t, before, requireValidSnapshot(t, db))
+	})
+
+	t.Run("canceled while waiting for writer gate", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		assignment, endpoint := seedOwnershipInventory(t, db)
+		before := requireValidSnapshot(t, db)
+		db.writeGate <- struct{}{}
+		t.Cleanup(func() {
+			select {
+			case <-db.writeGate:
+			default:
+			}
+		})
+		ctx, cancel := context.WithCancel(context.Background())
+		started := make(chan struct{})
+		result := make(chan error, 1)
+		go func() {
+			close(started)
+			_, err := db.AssignEndpointIfGeneration(
+				ctx,
+				before.Metadata.Generation,
+				assignment,
+				endpoint,
+				testNow,
+				testDeleteIntentTTL,
+				nil,
+			)
+			result <- err
+		}()
+		<-started
+		cancel()
+		require.ErrorIs(t, <-result, context.Canceled)
+		<-db.writeGate
+		assert.Equal(t, before, requireValidSnapshot(t, db))
+	})
+
+	t.Run("read only", func(t *testing.T) {
+		db, path := openTestDB(t)
+		assignment, endpoint := seedOwnershipInventory(t, db)
+		before := requireValidSnapshot(t, db)
+		require.NoError(t, db.Close())
+		readOnly, err := Open(path, Options{ReadOnly: true})
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, readOnly.Close()) })
+
+		changed, err := readOnly.AssignEndpointIfGeneration(
+			context.Background(),
+			before.Metadata.Generation,
+			assignment,
+			endpoint,
+			testNow,
+			testDeleteIntentTTL,
+			nil,
+		)
+		require.ErrorIs(t, err, bolterrors.ErrDatabaseReadOnly)
+		assert.False(t, changed)
+		assert.Equal(t, before, requireValidSnapshot(t, readOnly))
+	})
+}
+
+func TestAssignEndpointRejectsIdentityConflicts(t *testing.T) {
+	tests := []struct {
+		name          string
+		retainFirst   bool
+		changeRequest func(*AssignmentRecord, *EndpointRecord)
+	}{
+		{
+			name: "container already belongs to another pod",
+			changeRequest: func(assignment *AssignmentRecord, endpoint *EndpointRecord) {
+				assignment.Pod.PodName = "other-pod"
+				endpoint.PodName = "other-pod"
+			},
+		},
+		{
+			name: "pod changes containers before release",
+			changeRequest: func(assignment *AssignmentRecord, _ *EndpointRecord) {
+				assignment.Pod.PodKey = "container-2"
+				assignment.Pod.InfraContainerID = "container-2"
+			},
+		},
+		{
+			name:        "pod changes containers while endpoint retained",
+			retainFirst: true,
+			changeRequest: func(assignment *AssignmentRecord, _ *EndpointRecord) {
+				assignment.Pod.PodKey = "container-2"
+				assignment.Pod.InfraContainerID = "container-2"
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, _ := openTestDB(t)
+			assignment, endpoint := seedOwnershipInventory(t, db)
+			changed, err := db.AssignEndpoint(
+				context.Background(),
+				assignment,
+				endpoint,
+				testNow,
+				testDeleteIntentTTL,
+			)
+			require.NoError(t, err)
+			require.True(t, changed)
+
+			if tt.retainFirst {
+				changed, err = db.ReleaseEndpoint(context.Background(), assignment.Pod, testNow)
+				require.NoError(t, err)
+				require.True(t, changed)
+			}
+			before := readMetadata(t, db).Generation
+			requestedEndpoint := deepCloneEndpoint(t, endpoint)
+			tt.changeRequest(&assignment, &requestedEndpoint)
+
+			_, err = db.AssignEndpoint(
+				context.Background(),
+				assignment,
+				requestedEndpoint,
+				testNow,
+				testDeleteIntentTTL,
+			)
+			require.ErrorIs(t, err, ErrInvalidInput)
+			assert.Equal(t, before, readMetadata(t, db).Generation)
+			requireValidSnapshot(t, db)
+		})
+	}
+}
+
 func TestConcurrentDuplicateOwnership(t *testing.T) {
 	db, _ := openTestDB(t)
 	ip := IPRecord{ID: testIPID1, IPAddress: testIPv4Address, NCID: testNCID}

--- a/cns/state/ownership_operations_test.go
+++ b/cns/state/ownership_operations_test.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net"
 	"sync"
@@ -1078,6 +1079,15 @@ func testEndpoint(podName, address string) EndpointRecord {
 			},
 		},
 	}
+}
+
+func deepCloneEndpoint(t *testing.T, endpoint EndpointRecord) EndpointRecord {
+	t.Helper()
+	data, err := json.Marshal(endpoint)
+	require.NoError(t, err)
+	var cloned EndpointRecord
+	require.NoError(t, json.Unmarshal(data, &cloned))
+	return cloned
 }
 
 func requireValidSnapshot(t *testing.T, db *DB) Snapshot {

--- a/cns/state/ownership_operations_test.go
+++ b/cns/state/ownership_operations_test.go
@@ -22,7 +22,12 @@ const testDeleteIntentTTL = 10 * time.Minute
 
 var testNow = time.Date(2026, time.July, 24, 0, 0, 0, 0, time.UTC)
 
-const testIPv4Address2 = "10.0.0.5"
+var errAssignmentCandidate = errors.New("injected candidate failure")
+
+const (
+	testIPv4Address2 = "10.0.0.5"
+	testContainerID2 = "container-2"
+)
 
 func TestOwnershipTransactions(t *testing.T) {
 	db, _ := openTestDB(t)
@@ -247,7 +252,6 @@ func TestAssignEndpointIfGenerationPrecommitAndCancellation(t *testing.T) {
 		db, _ := openTestDB(t)
 		assignment, endpoint := seedOwnershipInventory(t, db)
 		before := requireValidSnapshot(t, db)
-		injected := errors.New("injected candidate failure")
 		callbackCalled := false
 
 		changed, err := db.AssignEndpointIfGeneration(
@@ -263,10 +267,10 @@ func TestAssignEndpointIfGenerationPrecommitAndCancellation(t *testing.T) {
 				assert.Contains(t, candidate.Assignments, assignment.Pod.PodKey)
 				assert.Contains(t, candidate.Endpoints, assignment.Pod.InfraContainerID)
 				assert.Len(t, candidate.IPOwners, len(assignment.IPIDs))
-				return injected
+				return errAssignmentCandidate
 			},
 		)
-		require.ErrorIs(t, err, injected)
+		require.ErrorIs(t, err, errAssignmentCandidate)
 		assert.False(t, changed)
 		assert.True(t, callbackCalled)
 		assert.Equal(t, before, requireValidSnapshot(t, db))
@@ -368,16 +372,16 @@ func TestAssignEndpointRejectsIdentityConflicts(t *testing.T) {
 		{
 			name: "pod changes containers before release",
 			changeRequest: func(assignment *AssignmentRecord, _ *EndpointRecord) {
-				assignment.Pod.PodKey = "container-2"
-				assignment.Pod.InfraContainerID = "container-2"
+				assignment.Pod.PodKey = testContainerID2
+				assignment.Pod.InfraContainerID = testContainerID2
 			},
 		},
 		{
 			name:        "pod changes containers while endpoint retained",
 			retainFirst: true,
 			changeRequest: func(assignment *AssignmentRecord, _ *EndpointRecord) {
-				assignment.Pod.PodKey = "container-2"
-				assignment.Pod.InfraContainerID = "container-2"
+				assignment.Pod.PodKey = testContainerID2
+				assignment.Pod.InfraContainerID = testContainerID2
 			},
 		},
 	}


### PR DESCRIPTION
## Scope
Routes CNS-owned ADD through one generation-gated Bolt transaction with candidate projection and post-commit cache recovery.

## Draft dependency caveat
This is the second independent child of R3 and is opened early for parallel review. **Do not merge until R3 and its temporary-base prerequisites merge.** DEL additionally depends on #4502 through a temporary join base.

## Behavior
The path remains externally dark. Duplicate ownership, delete intents, cancellation, and projection failures are fail-closed and atomic.

## Evidence
Linux/Windows lint and state/restserver/service race tests pass.