### PR TITLE
test(cns): cover CNI import and request integration

### DIFF
--- a/cns/restserver/unified_patch_test.go
+++ b/cns/restserver/unified_patch_test.go
@@ -591,18 +591,18 @@ func TestUnifiedPatchReadOnlyClosedAndRestart(t *testing.T) {
 func TestUnifiedPatchImportedEndpointPreservesOwnership(t *testing.T) {
 	db, err := state.Open(filepath.Join(t.TempDir(), "state.db"), state.Options{})
 	require.NoError(t, err)
-	_, err = db.ApplyNetworkContainer(context.Background(), r18NetworkContainer("nc-v4"), []state.IPRecord{{
-		ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1,
+	_, err = db.ApplyNetworkContainer(context.Background(), r18NetworkContainer(unifiedTestNCIPv4), []state.IPRecord{{
+		ID: unifiedTestIPID1, IPAddress: adapterTestIPv4, NCID: unifiedTestNCIPv4, NCVersion: 1,
 	}})
 	require.NoError(t, err)
 	records := []cns.CNIEndpointState{{
-		InfraContainerID: "container-1",
-		PodEndpointID:    "interface-1",
-		PodName:          "pod-1",
-		PodNamespace:     "namespace-1",
+		InfraContainerID: adapterTestContainerID,
+		PodEndpointID:    delTestInterfaceID,
+		PodName:          delTestPodName,
+		PodNamespace:     delTestNamespace,
 		InterfaceKey:     "container-1-eth0",
-		InterfaceName:    "eth0",
-		IPAddresses:      []net.IPNet{testIPNet("10.0.0.4/24")},
+		InterfaceName:    InfraInterfaceName,
+		IPAddresses:      []net.IPNet{testIPNet(adapterTestIPv4 + "/24")},
 	}}
 	plan, err := db.PreflightCNIEndpointImport(context.Background(), records, false)
 	require.NoError(t, err)
@@ -616,24 +616,28 @@ func TestUnifiedPatchImportedEndpointPreservesOwnership(t *testing.T) {
 	require.NoError(t, restore(context.Background()))
 	t.Cleanup(func() { require.NoError(t, closeState()) })
 
-	response, _ := invokeEndpointPatch(
-		t,
-		service,
+	response, _, err := invokeEndpointPatch(
 		context.Background(),
-		"container-1",
-		map[string]*IPInfo{"eth0": {
+		service,
+		adapterTestContainerID,
+		map[string]*IPInfo{InfraInterfaceName: {
 			HnsEndpointID:      "imported-hns",
-			NetworkContainerID: "nc-v4",
+			NetworkContainerID: unifiedTestNCIPv4,
 			NICType:            cns.InfraNIC,
 		}},
 	)
+	require.NoError(t, err)
 	require.Equal(t, types.Success, response.ReturnCode)
 	after := requireUnifiedSnapshot(t, db)
 	assert.Equal(t, before.Assignments, after.Assignments)
 	assert.Equal(t, before.IPOwners, after.IPOwners)
 	assert.Equal(t, before.DeleteIntents, after.DeleteIntents)
-	assert.Equal(t, "imported-hns", after.Endpoints["container-1"].IfnameToIPMap["eth0"].HNSEndpointID)
-	assert.Equal(t, "nc-v4", after.Endpoints["container-1"].IfnameToIPMap["eth0"].NetworkContainerID)
+	assert.Equal(t, "imported-hns", after.Endpoints[adapterTestContainerID].IfnameToIPMap[InfraInterfaceName].HNSEndpointID)
+	assert.Equal(
+		t,
+		unifiedTestNCIPv4,
+		after.Endpoints[adapterTestContainerID].IfnameToIPMap[InfraInterfaceName].NetworkContainerID,
+	)
 }
 
 func TestJSONPatchPathRemainsIsolated(t *testing.T) {

--- a/cns/restserver/unified_patch_test.go
+++ b/cns/restserver/unified_patch_test.go
@@ -588,6 +588,54 @@ func TestUnifiedPatchReadOnlyClosedAndRestart(t *testing.T) {
 	)
 }
 
+func TestUnifiedPatchImportedEndpointPreservesOwnership(t *testing.T) {
+	db, err := state.Open(filepath.Join(t.TempDir(), "state.db"), state.Options{})
+	require.NoError(t, err)
+	_, err = db.ApplyNetworkContainer(context.Background(), r18NetworkContainer("nc-v4"), []state.IPRecord{{
+		ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1,
+	}})
+	require.NoError(t, err)
+	records := []cns.CNIEndpointState{{
+		InfraContainerID: "container-1",
+		PodEndpointID:    "interface-1",
+		PodName:          "pod-1",
+		PodNamespace:     "namespace-1",
+		InterfaceKey:     "container-1-eth0",
+		InterfaceName:    "eth0",
+		IPAddresses:      []net.IPNet{testIPNet("10.0.0.4/24")},
+	}}
+	plan, err := db.PreflightCNIEndpointImport(context.Background(), records, false)
+	require.NoError(t, err)
+	changed, err := db.ImportCNIEndpointState(context.Background(), records, plan)
+	require.NoError(t, err)
+	require.True(t, changed)
+	before := requireUnifiedSnapshot(t, db)
+	service := newUnifiedAddTestService(t)
+	restore, closeState, err := NewDurableStateLifecycle(service, db, true)
+	require.NoError(t, err)
+	require.NoError(t, restore(context.Background()))
+	t.Cleanup(func() { require.NoError(t, closeState()) })
+
+	response, _ := invokeEndpointPatch(
+		t,
+		service,
+		context.Background(),
+		"container-1",
+		map[string]*IPInfo{"eth0": {
+			HnsEndpointID:      "imported-hns",
+			NetworkContainerID: "nc-v4",
+			NICType:            cns.InfraNIC,
+		}},
+	)
+	require.Equal(t, types.Success, response.ReturnCode)
+	after := requireUnifiedSnapshot(t, db)
+	assert.Equal(t, before.Assignments, after.Assignments)
+	assert.Equal(t, before.IPOwners, after.IPOwners)
+	assert.Equal(t, before.DeleteIntents, after.DeleteIntents)
+	assert.Equal(t, "imported-hns", after.Endpoints["container-1"].IfnameToIPMap["eth0"].HNSEndpointID)
+	assert.Equal(t, "nc-v4", after.Endpoints["container-1"].IfnameToIPMap["eth0"].NetworkContainerID)
+}
+
 func TestJSONPatchPathRemainsIsolated(t *testing.T) {
 	service := getTestService(cns.KubernetesCRD)
 	enableManagedEndpointState(service)


### PR DESCRIPTION
## Scope
Adds cross-facet coverage for PATCH after live CNI ownership import and validates the joined runtime adapter operation surface.

## Draft dependency caveat
This PR is opened early for review and CI. Its base, `users/rbtr/bolt-runtime-join-base-v4`, is a temporary integration branch joining R4 and T3. **Do not merge until both sibling branches and their prerequisites merge.**

## Behavior
Test-only integration; no activation or shipped default changes.

## Evidence
Linux/Windows whole-diff lint and state/restserver/service race tests pass.