### PR TITLE
feat(cns): make unified PATCH transactional

### DIFF
--- a/cns/restserver/durable_state_adapter.go
+++ b/cns/restserver/durable_state_adapter.go
@@ -61,6 +61,15 @@ type durableStateOperations struct {
 		time.Duration,
 		func(state.Snapshot) error,
 	) (bool, error)
+	patchEndpoint func(
+		context.Context,
+		uint64,
+		state.PodIdentity,
+		state.EndpointRecord,
+		time.Time,
+		time.Duration,
+		func(state.Snapshot) error,
+	) (bool, error)
 	releaseEndpoint func(
 		context.Context,
 		uint64,
@@ -96,6 +105,7 @@ type durableStateAdapter struct {
 	projectEndpointState  bool
 	buildProjection       func(state.Snapshot) (durableCacheProjection, error)
 	applyAddProjection    func(durableCacheProjection) error
+	applyPatchProjection  func(durableCacheProjection) error
 	applyDeleteProjection func(durableCacheProjection) error
 	now                   func() time.Time
 	projected             bool
@@ -161,6 +171,7 @@ func newDurableStateAdapter(
 		snapshot:           db.Snapshot,
 		replace:            db.ReplaceDurableState,
 		assignEndpoint:     db.AssignEndpointIfGeneration,
+		patchEndpoint:      db.PatchEndpointIfGeneration,
 		releaseEndpoint:    db.ReleaseEndpointIfGeneration,
 		deleteEndpoint:     db.DeleteEndpointRecordIfGeneration,
 		pruneDeleteIntents: db.PruneDeleteIntentsIfGeneration,

--- a/cns/restserver/ipam.go
+++ b/cns/restserver/ipam.go
@@ -1231,7 +1231,13 @@ func validateDesiredIPAddresses(desiredIPs []string) error {
 func (service *HTTPRestService) EndpointHandlerAPI(w http.ResponseWriter, r *http.Request) {
 	opName := "endpointHandler"
 	logger.Printf("[EndpointHandlerAPI] EndpointHandlerAPI received request with http Method %s", r.Method)
-	if r.Method == http.MethodDelete {
+	switch r.Method {
+	case http.MethodPatch:
+		if adapter := service.selectedUnifiedStateAdapter(); adapter != nil {
+			service.updateEndpointHandler(w, r, adapter)
+			return
+		}
+	case http.MethodDelete:
 		if adapter := service.selectedUnifiedStateAdapter(); adapter != nil {
 			service.deleteEndpointStateHandler(w, r, adapter)
 			return
@@ -1253,7 +1259,7 @@ func (service *HTTPRestService) EndpointHandlerAPI(w http.ResponseWriter, r *htt
 	case http.MethodGet:
 		service.GetEndpointHandler(w, r)
 	case http.MethodPatch:
-		service.UpdateEndpointHandler(w, r)
+		service.updateEndpointHandler(w, r, nil)
 	case http.MethodDelete:
 		service.deleteEndpointStateHandler(w, r, nil)
 	default:
@@ -1422,6 +1428,14 @@ func (service *HTTPRestService) GetEndpointHelper(endpointID string) (*EndpointI
 
 // UpdateEndpointHandler handles the incoming UpdateEndpoint requests with http Patch method
 func (service *HTTPRestService) UpdateEndpointHandler(w http.ResponseWriter, r *http.Request) {
+	service.updateEndpointHandler(w, r, service.selectedUnifiedStateAdapter())
+}
+
+func (service *HTTPRestService) updateEndpointHandler(
+	w http.ResponseWriter,
+	r *http.Request,
+	adapter *durableStateAdapter,
+) {
 	opName := "UpdateEndpointHandler"
 	logger.Printf("[updateEndpoint] updateEndpoint for %s", r.URL.Path)
 
@@ -1451,10 +1465,10 @@ func (service *HTTPRestService) UpdateEndpointHandler(w http.ResponseWriter, r *
 		return
 	}
 	// Update the endpoint state
-	err = service.UpdateEndpointHelper(endpointID, req)
+	err = service.updateEndpoint(r.Context(), endpointID, req, adapter)
 	if err != nil {
 		response := cns.Response{
-			ReturnCode: types.UnexpectedError,
+			ReturnCode: unifiedPatchResponseCode(err),
 			Message:    fmt.Sprintf("[updateEndpoint] updateEndpoint failed with error: %s", err.Error()),
 		}
 		w.Header().Set(cnsReturnCode, response.ReturnCode.String())
@@ -1469,6 +1483,18 @@ func (service *HTTPRestService) UpdateEndpointHandler(w http.ResponseWriter, r *
 	w.Header().Set(cnsReturnCode, response.ReturnCode.String())
 	err = common.Encode(w, &response)
 	logger.Response(opName, response, response.ReturnCode, err)
+}
+
+func (service *HTTPRestService) updateEndpoint(
+	ctx context.Context,
+	endpointID string,
+	req map[string]*IPInfo,
+	adapter *durableStateAdapter,
+) error {
+	if adapter != nil {
+		return adapter.patchEndpoint(ctx, endpointID, req)
+	}
+	return service.UpdateEndpointHelper(endpointID, req)
 }
 
 // UpdateEndpointHelper updates the state of the given endpointId with HNSId, VethName or other InterfaceInfo fields
@@ -1556,6 +1582,9 @@ func updateIPInfoMap(iPInfo map[string]*IPInfo, interfaceInfo *IPInfo, ifName, e
 // verifyUpdateEndpointStateRequest verify the CNI request body for the UpdateENdpointState API
 func verifyUpdateEndpointStateRequest(req map[string]*IPInfo) error {
 	for ifName, InterfaceInfo := range req {
+		if InterfaceInfo == nil {
+			return errors.New("[updateEndpoint] Interface info must not be null")
+		}
 		if InterfaceInfo.HostVethName == "" && InterfaceInfo.HnsEndpointID == "" && InterfaceInfo.NICType == "" && InterfaceInfo.MacAddress == "" {
 			return errors.New("[updateEndpoint] No NicType, MacAddress, HnsEndpointID or HostVethName has been provided")
 		}

--- a/cns/restserver/unified_patch.go
+++ b/cns/restserver/unified_patch.go
@@ -1,0 +1,492 @@
+// Copyright 2026 Microsoft. All rights reserved.
+// MIT License
+
+package restserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"sort"
+	"strings"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/state"
+	"github.com/Azure/azure-container-networking/cns/types"
+)
+
+type unifiedPatchPlan struct {
+	pod      state.PodIdentity
+	endpoint state.EndpointRecord
+}
+
+type unifiedPatchCommittedError struct {
+	err error
+}
+
+func (e *unifiedPatchCommittedError) Error() string {
+	return fmt.Sprintf("unified PATCH committed but cache projection failed: %v", e.err)
+}
+
+func (e *unifiedPatchCommittedError) Unwrap() error {
+	return e.err
+}
+
+func (a *durableStateAdapter) patchEndpoint(
+	ctx context.Context,
+	infraContainerID string,
+	request map[string]*IPInfo,
+) error {
+	if a.store.patchEndpoint == nil {
+		return errors.New("durable state endpoint patch operation is nil")
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.service.Lock()
+	defer a.service.Unlock()
+
+	snapshot, err := a.currentSnapshot(ctx)
+	if err != nil {
+		return err
+	}
+	now := a.now()
+	if intent, ok := snapshot.DeleteIntents[strings.TrimSpace(infraContainerID)]; ok &&
+		now.Before(intent.CreatedAt.Add(unifiedDeleteIntentTTL)) {
+		return fmt.Errorf("%w: infra container %q", state.ErrDeleteIntent, strings.TrimSpace(infraContainerID))
+	}
+	if err := a.service.validateUnifiedPatchProjectionLocked(snapshot, strings.TrimSpace(infraContainerID)); err != nil {
+		return err
+	}
+	plan, err := buildUnifiedPatchPlan(ctx, infraContainerID, request, snapshot)
+	if err != nil {
+		return err
+	}
+
+	var projection durableCacheProjection
+	changed, err := a.store.patchEndpoint(
+		ctx,
+		a.generation,
+		plan.pod,
+		plan.endpoint,
+		now,
+		unifiedDeleteIntentTTL,
+		func(candidate state.Snapshot) error {
+			var buildErr error
+			projection, buildErr = a.buildProjection(candidate)
+			return buildErr
+		},
+	)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return nil
+	}
+
+	apply := a.applyPatchProjection
+	if apply == nil {
+		apply = func(value durableCacheProjection) error {
+			a.applyProjectionLocked(value)
+			return nil
+		}
+	}
+	var postCommitErr error
+	if err := apply(projection); err != nil {
+		postCommitErr = a.restoreCommittedPatchProjectionLocked(ctx, projection, err)
+	}
+	if a.store.refreshMetrics != nil {
+		if _, err := a.store.refreshMetrics(context.WithoutCancel(ctx)); err != nil {
+			postCommitErr = errors.Join(postCommitErr, fmt.Errorf("refreshing persistent state metrics: %w", err))
+		}
+	}
+	if postCommitErr != nil {
+		return &unifiedPatchCommittedError{err: postCommitErr}
+	}
+	return nil
+}
+
+func (a *durableStateAdapter) restoreCommittedPatchProjectionLocked(
+	ctx context.Context,
+	committed durableCacheProjection,
+	applyErr error,
+) error {
+	restoreErr := error(nil)
+	snapshot, err := a.store.snapshot(context.WithoutCancel(ctx))
+	if err != nil {
+		restoreErr = fmt.Errorf("reading committed endpoint patch: %w", err)
+	} else {
+		projection, buildErr := a.buildProjection(snapshot)
+		if buildErr != nil {
+			restoreErr = fmt.Errorf("building committed endpoint patch projection: %w", buildErr)
+		} else {
+			committed = projection
+		}
+	}
+	a.applyProjectionLocked(committed)
+	return errors.Join(applyErr, restoreErr)
+}
+
+func (service *HTTPRestService) validateUnifiedPatchProjectionLocked(
+	snapshot state.Snapshot,
+	infraContainerID string,
+) error {
+	record, ok := snapshot.Endpoints[infraContainerID]
+	if !ok {
+		return nil
+	}
+	projected, err := projectEndpoint(record)
+	if err != nil {
+		return fmt.Errorf("%w: projecting endpoint cache: %v", state.ErrInvalidInput, err)
+	}
+	cached, ok := service.EndpointState[infraContainerID]
+	if !ok {
+		return fmt.Errorf("%w: projected endpoint is missing from cache", state.ErrStaleGeneration)
+	}
+	projectedData, err := json.Marshal(projected)
+	if err != nil {
+		return fmt.Errorf("%w: encoding projected endpoint cache: %v", state.ErrInvalidInput, err)
+	}
+	cachedData, err := json.Marshal(cached)
+	if err != nil {
+		return fmt.Errorf("%w: encoding endpoint cache: %v", state.ErrInvalidInput, err)
+	}
+	if !bytes.Equal(projectedData, cachedData) {
+		return fmt.Errorf("%w: projected endpoint cache does not match database", state.ErrStaleGeneration)
+	}
+	return nil
+}
+
+func buildUnifiedPatchPlan(
+	ctx context.Context,
+	infraContainerID string,
+	request map[string]*IPInfo,
+	snapshot state.Snapshot,
+) (unifiedPatchPlan, error) {
+	if err := ctx.Err(); err != nil {
+		return unifiedPatchPlan{}, err
+	}
+	infraContainerID = strings.TrimSpace(infraContainerID)
+	if infraContainerID == "" {
+		return unifiedPatchPlan{}, fmt.Errorf("%w: infra container ID is empty", state.ErrInvalidInput)
+	}
+	existing, ok := snapshot.Endpoints[infraContainerID]
+	if !ok {
+		return unifiedPatchPlan{}, fmt.Errorf("%w: endpoint %q", state.ErrNotFound, infraContainerID)
+	}
+	if len(request) == 0 {
+		return unifiedPatchPlan{}, fmt.Errorf("%w: endpoint patch has no interfaces", state.ErrInvalidInput)
+	}
+	candidate, err := cloneJSON(existing)
+	if err != nil {
+		return unifiedPatchPlan{}, fmt.Errorf("%w: cloning endpoint: %v", state.ErrInvalidInput, err)
+	}
+
+	ifnames := make([]string, 0, len(request))
+	for ifname := range request {
+		ifnames = append(ifnames, ifname)
+	}
+	sort.Strings(ifnames)
+	var pod state.PodIdentity
+	for _, rawIfname := range ifnames {
+		if err := ctx.Err(); err != nil {
+			return unifiedPatchPlan{}, err
+		}
+		ifname := strings.TrimSpace(rawIfname)
+		if ifname == "" || ifname != rawIfname {
+			return unifiedPatchPlan{}, fmt.Errorf("%w: endpoint interface name is invalid", state.ErrInvalidInput)
+		}
+		patch := request[rawIfname]
+		if patch == nil {
+			return unifiedPatchPlan{}, fmt.Errorf("%w: interface %q is null", state.ErrInvalidInput, ifname)
+		}
+		current, ok := existing.IfnameToIPMap[ifname]
+		if !ok || current == nil {
+			return unifiedPatchPlan{}, fmt.Errorf(
+				"%w: endpoint %q interface %q does not exist",
+				state.ErrInvalidInput,
+				infraContainerID,
+				ifname,
+			)
+		}
+		interfacePod, err := validateUnifiedPatchOwnership(snapshot, infraContainerID, existing, *current)
+		if err != nil {
+			return unifiedPatchPlan{}, err
+		}
+		if pod.PodKey == "" {
+			pod = interfacePod
+		}
+		updated, err := applyUnifiedIPInfoPatch(snapshot, ifname, *current, *patch)
+		if err != nil {
+			return unifiedPatchPlan{}, err
+		}
+		candidate.IfnameToIPMap[ifname] = &updated
+	}
+	if pod.PodKey == "" {
+		return unifiedPatchPlan{}, fmt.Errorf("%w: endpoint ownership is missing", state.ErrNotFound)
+	}
+	return unifiedPatchPlan{pod: pod, endpoint: candidate}, nil
+}
+
+func validateUnifiedPatchOwnership(
+	snapshot state.Snapshot,
+	infraContainerID string,
+	endpoint state.EndpointRecord,
+	info state.IPInfoRecord,
+) (state.PodIdentity, error) {
+	recordsByAddress := make(map[netip.Addr]state.IPRecord, len(snapshot.IPs))
+	for _, record := range snapshot.IPs {
+		address, err := netip.ParseAddr(record.IPAddress)
+		if err != nil {
+			return state.PodIdentity{}, fmt.Errorf("%w: endpoint IP inventory is invalid", state.ErrInvalidInput)
+		}
+		recordsByAddress[address.Unmap()] = record
+	}
+	var ownerPod state.PodIdentity
+	for _, family := range []struct {
+		bits     int
+		prefixes []net.IPNet
+	}{
+		{bits: 32, prefixes: info.IPv4},
+		{bits: 128, prefixes: info.IPv6},
+	} {
+		for _, prefix := range family.prefixes {
+			address, _, err := parseUnifiedPatchPrefix(prefix, family.bits)
+			if err != nil {
+				return state.PodIdentity{}, err
+			}
+			record, ok := recordsByAddress[address]
+			if !ok {
+				return state.PodIdentity{}, fmt.Errorf("%w: endpoint IP is missing", state.ErrNotFound)
+			}
+			owner, ok := snapshot.IPOwners[record.ID]
+			if !ok {
+				return state.PodIdentity{}, fmt.Errorf("%w: endpoint IP owner is missing", state.ErrNotFound)
+			}
+			assignment, ok := snapshot.Assignments[owner]
+			if !ok {
+				return state.PodIdentity{}, fmt.Errorf("%w: endpoint assignment is missing", state.ErrNotFound)
+			}
+			if assignment.Pod.InfraContainerID != infraContainerID ||
+				assignment.Pod.PodName != endpoint.PodName ||
+				assignment.Pod.PodNamespace != endpoint.PodNamespace {
+				return state.PodIdentity{}, fmt.Errorf(
+					"%w: endpoint ownership identity does not match",
+					state.ErrInvalidInput,
+				)
+			}
+			if ownerPod.PodKey == "" {
+				ownerPod = assignment.Pod
+			} else if ownerPod != assignment.Pod {
+				return state.PodIdentity{}, fmt.Errorf(
+					"%w: endpoint interface spans assignments",
+					state.ErrInvalidInput,
+				)
+			}
+		}
+	}
+	if ownerPod.PodKey == "" {
+		return state.PodIdentity{}, fmt.Errorf("%w: endpoint interface owner is missing", state.ErrNotFound)
+	}
+	return ownerPod, nil
+}
+
+func applyUnifiedIPInfoPatch(
+	snapshot state.Snapshot,
+	ifname string,
+	current state.IPInfoRecord,
+	patch IPInfo,
+) (state.IPInfoRecord, error) {
+	updated, err := cloneJSON(current)
+	if err != nil {
+		return state.IPInfoRecord{}, fmt.Errorf("%w: cloning interface %q: %v", state.ErrInvalidInput, ifname, err)
+	}
+	for _, family := range []struct {
+		name     string
+		bits     int
+		request  []net.IPNet
+		existing []net.IPNet
+	}{
+		{name: "IPv4", bits: 32, request: patch.IPv4, existing: current.IPv4},
+		{name: "IPv6", bits: 128, request: patch.IPv6, existing: current.IPv6},
+	} {
+		if len(family.request) == 0 {
+			continue
+		}
+		equal, err := equalUnifiedPatchPrefixes(family.request, family.existing, family.bits)
+		if err != nil {
+			return state.IPInfoRecord{}, fmt.Errorf(
+				"%w: interface %q %s prefixes are invalid: %v",
+				state.ErrInvalidInput,
+				ifname,
+				family.name,
+				err,
+			)
+		}
+		if !equal {
+			return state.IPInfoRecord{}, fmt.Errorf(
+				"%w: interface %q cannot change assigned %s addresses",
+				state.ErrInvalidInput,
+				ifname,
+				family.name,
+			)
+		}
+	}
+
+	if patch.HnsEndpointID != "" {
+		updated.HNSEndpointID, err = normalizedUnifiedPatchValue(patch.HnsEndpointID, "HNS endpoint ID")
+		if err != nil {
+			return state.IPInfoRecord{}, err
+		}
+	}
+	if patch.HnsNetworkID != "" {
+		updated.HNSNetworkID, err = normalizedUnifiedPatchValue(patch.HnsNetworkID, "HNS network ID")
+		if err != nil {
+			return state.IPInfoRecord{}, err
+		}
+	}
+	if patch.HostVethName != "" {
+		updated.HostVethName, err = normalizedUnifiedPatchValue(patch.HostVethName, "host veth name")
+		if err != nil {
+			return state.IPInfoRecord{}, err
+		}
+	}
+	if patch.MacAddress != "" {
+		mac, parseErr := net.ParseMAC(strings.TrimSpace(patch.MacAddress))
+		if parseErr != nil {
+			return state.IPInfoRecord{}, fmt.Errorf("%w: interface %q MAC address is invalid", state.ErrInvalidInput, ifname)
+		}
+		updated.MACAddress = mac.String()
+	}
+	if patch.NetworkContainerID != "" {
+		networkContainerID, valueErr := normalizedUnifiedPatchValue(
+			patch.NetworkContainerID,
+			"network container ID",
+		)
+		if valueErr != nil {
+			return state.IPInfoRecord{}, valueErr
+		}
+		if _, ok := snapshot.NetworkContainers[networkContainerID]; !ok {
+			return state.IPInfoRecord{}, fmt.Errorf(
+				"%w: interface %q network container %q does not exist",
+				state.ErrInvalidInput,
+				ifname,
+				networkContainerID,
+			)
+		}
+		updated.NetworkContainerID = networkContainerID
+	}
+	if patch.NICType != "" {
+		if !validUnifiedPatchNICType(patch.NICType) {
+			return state.IPInfoRecord{}, fmt.Errorf("%w: interface %q NIC type is invalid", state.ErrInvalidInput, ifname)
+		}
+		updated.NICType = patch.NICType
+	}
+	return updated, nil
+}
+
+func normalizedUnifiedPatchValue(value, name string) (string, error) {
+	normalized := strings.TrimSpace(value)
+	if normalized == "" {
+		return "", fmt.Errorf("%w: %s is empty", state.ErrInvalidInput, name)
+	}
+	return normalized, nil
+}
+
+func validUnifiedPatchNICType(value cns.NICType) bool {
+	switch value {
+	case cns.InfraNIC,
+		cns.DelegatedVMNIC,
+		cns.BackendNIC,
+		cns.NodeNetworkInterfaceAccelnetFrontendNIC,
+		cns.ApipaNIC:
+		return true
+	default:
+		return false
+	}
+}
+
+type unifiedPatchPrefix struct {
+	address netip.Addr
+	bits    int
+}
+
+func equalUnifiedPatchPrefixes(left, right []net.IPNet, expectedBits int) (bool, error) {
+	leftSet, err := unifiedPatchPrefixSet(left, expectedBits)
+	if err != nil {
+		return false, err
+	}
+	rightSet, err := unifiedPatchPrefixSet(right, expectedBits)
+	if err != nil {
+		return false, err
+	}
+	if len(leftSet) != len(rightSet) {
+		return false, nil
+	}
+	for prefix := range leftSet {
+		if _, ok := rightSet[prefix]; !ok {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func unifiedPatchPrefixSet(values []net.IPNet, expectedBits int) (map[unifiedPatchPrefix]struct{}, error) {
+	result := make(map[unifiedPatchPrefix]struct{}, len(values))
+	for _, value := range values {
+		address, bits, err := parseUnifiedPatchPrefix(value, expectedBits)
+		if err != nil {
+			return nil, err
+		}
+		prefix := unifiedPatchPrefix{address: address, bits: bits}
+		if _, ok := result[prefix]; ok {
+			return nil, errors.New("duplicate prefix")
+		}
+		result[prefix] = struct{}{}
+	}
+	return result, nil
+}
+
+func parseUnifiedPatchPrefix(value net.IPNet, expectedBits int) (netip.Addr, int, error) {
+	address, ok := netip.AddrFromSlice(value.IP)
+	if !ok {
+		return netip.Addr{}, 0, errors.New("invalid IP")
+	}
+	address = address.Unmap()
+	ones, bits := value.Mask.Size()
+	if bits != expectedBits {
+		return netip.Addr{}, 0, fmt.Errorf("mask has %d bits, expected %d", bits, expectedBits)
+	}
+	if expectedBits == 32 && !address.Is4() {
+		return netip.Addr{}, 0, errors.New("IPv6 address in IPv4 prefixes")
+	}
+	if expectedBits == 128 && !address.Is6() {
+		return netip.Addr{}, 0, errors.New("IPv4 address in IPv6 prefixes")
+	}
+	if !netip.PrefixFrom(address, ones).IsValid() {
+		return netip.Addr{}, 0, errors.New("invalid prefix length")
+	}
+	return address, ones, nil
+}
+
+func unifiedPatchResponseCode(err error) types.ResponseCode {
+	var committedErr *unifiedPatchCommittedError
+	switch {
+	case errors.Is(err, state.ErrNotFound):
+		return types.NotFound
+	case errors.Is(err, state.ErrStaleGeneration):
+		return types.InconsistentIPConfigState
+	case errors.Is(err, state.ErrInvalidInput):
+		return types.InvalidRequest
+	case errors.Is(err, state.ErrDeleteIntent),
+		errors.Is(err, context.Canceled),
+		errors.Is(err, context.DeadlineExceeded),
+		errors.As(err, &committedErr):
+		return types.UnexpectedError
+	default:
+		return types.UnexpectedError
+	}
+}

--- a/cns/restserver/unified_patch.go
+++ b/cns/restserver/unified_patch.go
@@ -19,6 +19,16 @@ import (
 	"github.com/Azure/azure-container-networking/cns/types"
 )
 
+var (
+	errNilEndpointPatchOperation = errors.New("durable state endpoint patch operation is nil")
+	errDuplicatePatchPrefix      = errors.New("duplicate endpoint patch prefix")
+	errInvalidPatchIP            = errors.New("invalid endpoint patch IP")
+	errInvalidPatchMaskSize      = errors.New("invalid endpoint patch mask size")
+	errIPv6InIPv4Patch           = errors.New("ipv6 address in ipv4 endpoint patch")
+	errIPv4InIPv6Patch           = errors.New("ipv4 address in ipv6 endpoint patch")
+	errInvalidPatchPrefixLength  = errors.New("invalid endpoint patch prefix length")
+)
+
 type unifiedPatchPlan struct {
 	pod      state.PodIdentity
 	endpoint state.EndpointRecord
@@ -42,7 +52,7 @@ func (a *durableStateAdapter) patchEndpoint(
 	request map[string]*IPInfo,
 ) error {
 	if a.store.patchEndpoint == nil {
-		return errors.New("durable state endpoint patch operation is nil")
+		return errNilEndpointPatchOperation
 	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -58,8 +68,11 @@ func (a *durableStateAdapter) patchEndpoint(
 		now.Before(intent.CreatedAt.Add(unifiedDeleteIntentTTL)) {
 		return fmt.Errorf("%w: infra container %q", state.ErrDeleteIntent, strings.TrimSpace(infraContainerID))
 	}
-	if err := a.service.validateUnifiedPatchProjectionLocked(snapshot, strings.TrimSpace(infraContainerID)); err != nil {
-		return err
+	if projectionErr := a.service.validateUnifiedPatchProjectionLocked(
+		snapshot,
+		strings.TrimSpace(infraContainerID),
+	); projectionErr != nil {
+		return projectionErr
 	}
 	plan, err := buildUnifiedPatchPlan(ctx, infraContainerID, request, snapshot)
 	if err != nil {
@@ -114,7 +127,7 @@ func (a *durableStateAdapter) restoreCommittedPatchProjectionLocked(
 	committed durableCacheProjection,
 	applyErr error,
 ) error {
-	restoreErr := error(nil)
+	var restoreErr error
 	snapshot, err := a.store.snapshot(context.WithoutCancel(ctx))
 	if err != nil {
 		restoreErr = fmt.Errorf("reading committed endpoint patch: %w", err)
@@ -140,19 +153,19 @@ func (service *HTTPRestService) validateUnifiedPatchProjectionLocked(
 	}
 	projected, err := projectEndpoint(record)
 	if err != nil {
-		return fmt.Errorf("%w: projecting endpoint cache: %v", state.ErrInvalidInput, err)
+		return fmt.Errorf("%w: projecting endpoint cache: %w", state.ErrInvalidInput, err)
 	}
 	cached, ok := service.EndpointState[infraContainerID]
 	if !ok {
 		return fmt.Errorf("%w: projected endpoint is missing from cache", state.ErrStaleGeneration)
 	}
-	projectedData, err := json.Marshal(projected)
+	projectedData, err := json.Marshal(projected) //nolint:musttag // EndpointInfo is the existing endpoint API wire type.
 	if err != nil {
-		return fmt.Errorf("%w: encoding projected endpoint cache: %v", state.ErrInvalidInput, err)
+		return fmt.Errorf("%w: encoding projected endpoint cache: %w", state.ErrInvalidInput, err)
 	}
-	cachedData, err := json.Marshal(cached)
+	cachedData, err := json.Marshal(cached) //nolint:musttag // EndpointInfo is the existing endpoint API wire type.
 	if err != nil {
-		return fmt.Errorf("%w: encoding endpoint cache: %v", state.ErrInvalidInput, err)
+		return fmt.Errorf("%w: encoding endpoint cache: %w", state.ErrInvalidInput, err)
 	}
 	if !bytes.Equal(projectedData, cachedData) {
 		return fmt.Errorf("%w: projected endpoint cache does not match database", state.ErrStaleGeneration)
@@ -167,7 +180,7 @@ func buildUnifiedPatchPlan(
 	snapshot state.Snapshot,
 ) (unifiedPatchPlan, error) {
 	if err := ctx.Err(); err != nil {
-		return unifiedPatchPlan{}, err
+		return unifiedPatchPlan{}, fmt.Errorf("planning endpoint patch: %w", err)
 	}
 	infraContainerID = strings.TrimSpace(infraContainerID)
 	if infraContainerID == "" {
@@ -182,7 +195,7 @@ func buildUnifiedPatchPlan(
 	}
 	candidate, err := cloneJSON(existing)
 	if err != nil {
-		return unifiedPatchPlan{}, fmt.Errorf("%w: cloning endpoint: %v", state.ErrInvalidInput, err)
+		return unifiedPatchPlan{}, fmt.Errorf("%w: cloning endpoint: %w", state.ErrInvalidInput, err)
 	}
 
 	ifnames := make([]string, 0, len(request))
@@ -193,7 +206,7 @@ func buildUnifiedPatchPlan(
 	var pod state.PodIdentity
 	for _, rawIfname := range ifnames {
 		if err := ctx.Err(); err != nil {
-			return unifiedPatchPlan{}, err
+			return unifiedPatchPlan{}, fmt.Errorf("planning endpoint interface %q patch: %w", rawIfname, err)
 		}
 		ifname := strings.TrimSpace(rawIfname)
 		if ifname == "" || ifname != rawIfname {
@@ -302,7 +315,7 @@ func applyUnifiedIPInfoPatch(
 ) (state.IPInfoRecord, error) {
 	updated, err := cloneJSON(current)
 	if err != nil {
-		return state.IPInfoRecord{}, fmt.Errorf("%w: cloning interface %q: %v", state.ErrInvalidInput, ifname, err)
+		return state.IPInfoRecord{}, fmt.Errorf("%w: cloning interface %q: %w", state.ErrInvalidInput, ifname, err)
 	}
 	for _, family := range []struct {
 		name     string
@@ -316,14 +329,14 @@ func applyUnifiedIPInfoPatch(
 		if len(family.request) == 0 {
 			continue
 		}
-		equal, err := equalUnifiedPatchPrefixes(family.request, family.existing, family.bits)
-		if err != nil {
+		equal, compareErr := equalUnifiedPatchPrefixes(family.request, family.existing, family.bits)
+		if compareErr != nil {
 			return state.IPInfoRecord{}, fmt.Errorf(
-				"%w: interface %q %s prefixes are invalid: %v",
+				"%w: interface %q %s prefixes are invalid: %w",
 				state.ErrInvalidInput,
 				ifname,
 				family.name,
-				err,
+				compareErr,
 			)
 		}
 		if !equal {
@@ -443,7 +456,7 @@ func unifiedPatchPrefixSet(values []net.IPNet, expectedBits int) (map[unifiedPat
 		}
 		prefix := unifiedPatchPrefix{address: address, bits: bits}
 		if _, ok := result[prefix]; ok {
-			return nil, errors.New("duplicate prefix")
+			return nil, errDuplicatePatchPrefix
 		}
 		result[prefix] = struct{}{}
 	}
@@ -453,27 +466,26 @@ func unifiedPatchPrefixSet(values []net.IPNet, expectedBits int) (map[unifiedPat
 func parseUnifiedPatchPrefix(value net.IPNet, expectedBits int) (netip.Addr, int, error) {
 	address, ok := netip.AddrFromSlice(value.IP)
 	if !ok {
-		return netip.Addr{}, 0, errors.New("invalid IP")
+		return netip.Addr{}, 0, errInvalidPatchIP
 	}
 	address = address.Unmap()
 	ones, bits := value.Mask.Size()
 	if bits != expectedBits {
-		return netip.Addr{}, 0, fmt.Errorf("mask has %d bits, expected %d", bits, expectedBits)
+		return netip.Addr{}, 0, fmt.Errorf("%w: got %d bits, expected %d", errInvalidPatchMaskSize, bits, expectedBits)
 	}
 	if expectedBits == 32 && !address.Is4() {
-		return netip.Addr{}, 0, errors.New("IPv6 address in IPv4 prefixes")
+		return netip.Addr{}, 0, errIPv6InIPv4Patch
 	}
 	if expectedBits == 128 && !address.Is6() {
-		return netip.Addr{}, 0, errors.New("IPv4 address in IPv6 prefixes")
+		return netip.Addr{}, 0, errIPv4InIPv6Patch
 	}
 	if !netip.PrefixFrom(address, ones).IsValid() {
-		return netip.Addr{}, 0, errors.New("invalid prefix length")
+		return netip.Addr{}, 0, errInvalidPatchPrefixLength
 	}
 	return address, ones, nil
 }
 
 func unifiedPatchResponseCode(err error) types.ResponseCode {
-	var committedErr *unifiedPatchCommittedError
 	switch {
 	case errors.Is(err, state.ErrNotFound):
 		return types.NotFound
@@ -481,11 +493,6 @@ func unifiedPatchResponseCode(err error) types.ResponseCode {
 		return types.InconsistentIPConfigState
 	case errors.Is(err, state.ErrInvalidInput):
 		return types.InvalidRequest
-	case errors.Is(err, state.ErrDeleteIntent),
-		errors.Is(err, context.Canceled),
-		errors.Is(err, context.DeadlineExceeded),
-		errors.As(err, &committedErr):
-		return types.UnexpectedError
 	default:
 		return types.UnexpectedError
 	}

--- a/cns/restserver/unified_patch_test.go
+++ b/cns/restserver/unified_patch_test.go
@@ -1,0 +1,650 @@
+// Copyright 2026 Microsoft. All rights reserved.
+// MIT License
+
+package restserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"github.com/Azure/azure-container-networking/cns/state"
+	"github.com/Azure/azure-container-networking/cns/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	bolterrors "go.etcd.io/bbolt/errors"
+)
+
+func TestUnifiedPatchPersistsPlatformDetailsAndReplay(t *testing.T) {
+	service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
+		"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+	}, nil)
+	add := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
+	add.DesiredIPAddresses = []string{"10.0.0.4"}
+	_, err := service.requestIPConfigHandlerHelper(context.Background(), add)
+	require.NoError(t, err)
+	before := requireUnifiedSnapshot(t, db)
+	beforeAssignments := before.Assignments
+	beforeOwners := before.IPOwners
+	beforeIntents := before.DeleteIntents
+	refresh := adapter.store.refreshMetrics
+	refreshCalls := 0
+	adapter.store.refreshMetrics = func(ctx context.Context) (state.Status, error) {
+		refreshCalls++
+		return refresh(ctx)
+	}
+	patch := map[string]*IPInfo{
+		"eth0": {
+			IPv4:               []net.IPNet{testIPNet("10.0.0.4/24")},
+			HnsEndpointID:      "hns-endpoint-1",
+			HnsNetworkID:       "hns-network-1",
+			HostVethName:       "veth-1",
+			MacAddress:         "AA-BB-CC-DD-EE-FF",
+			NetworkContainerID: "nc-v4",
+			NICType:            cns.DelegatedVMNIC,
+		},
+	}
+
+	response, recorder := invokeEndpointPatch(t, service, context.Background(), "container-1", patch)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Equal(t, types.Success, response.ReturnCode)
+	assert.Equal(t, "[updateEndpoint] updateEndpoint retruned successfully", response.Message)
+	assert.Equal(t, types.Success.String(), recorder.Header().Get(cnsReturnCode))
+
+	after := requireUnifiedSnapshot(t, db)
+	assert.Equal(t, before.Metadata.Generation+1, after.Metadata.Generation)
+	assert.Equal(t, beforeAssignments, after.Assignments)
+	assert.Equal(t, beforeOwners, after.IPOwners)
+	assert.Equal(t, beforeIntents, after.DeleteIntents)
+	info := after.Endpoints["container-1"].IfnameToIPMap["eth0"]
+	assert.Equal(t, "hns-endpoint-1", info.HNSEndpointID)
+	assert.Equal(t, "hns-network-1", info.HNSNetworkID)
+	assert.Equal(t, "veth-1", info.HostVethName)
+	assert.Equal(t, "aa:bb:cc:dd:ee:ff", info.MACAddress)
+	assert.Equal(t, "nc-v4", info.NetworkContainerID)
+	assert.Equal(t, cns.DelegatedVMNIC, info.NICType)
+	require.Len(t, info.IPv4, 1)
+	assert.Equal(t, "10.0.0.4", info.IPv4[0].IP.String())
+	cacheInfo := service.EndpointState["container-1"].IfnameToIPMap["eth0"]
+	assert.Equal(t, info.HNSEndpointID, cacheInfo.HnsEndpointID)
+	assert.Equal(t, info.HNSNetworkID, cacheInfo.HnsNetworkID)
+	assert.Equal(t, info.HostVethName, cacheInfo.HostVethName)
+	assert.Equal(t, info.MACAddress, cacheInfo.MacAddress)
+	assert.Equal(t, info.NetworkContainerID, cacheInfo.NetworkContainerID)
+	assert.Equal(t, info.NICType, cacheInfo.NICType)
+	generation, projected := adapter.cacheGeneration()
+	assert.True(t, projected)
+	assert.Equal(t, after.Metadata.Generation, generation)
+	assert.Equal(t, 1, refreshCalls)
+
+	response, _ = invokeEndpointPatch(t, service, context.Background(), "container-1", patch)
+	assert.Equal(t, types.Success, response.ReturnCode)
+	assert.Equal(t, after, requireUnifiedSnapshot(t, db))
+	assert.Equal(t, 1, refreshCalls)
+}
+
+func TestUnifiedPatchMultiNICConcurrencyPreservesAssignments(t *testing.T) {
+	service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
+		"nc-v4": {
+			{ID: "ip-primary", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1},
+			{ID: "ip-secondary", IPAddress: "10.0.0.5", NCID: "nc-v4", NCVersion: 1},
+		},
+		"nc-v6": {{ID: "ip-v6", IPAddress: "2001:db8::4", NCID: "nc-v6", NCVersion: 1}},
+	}, nil)
+	primary := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
+	primary.DesiredIPAddresses = []string{"10.0.0.4", "2001:db8::4"}
+	secondary := unifiedAddRequest("container-1", "interface-2", "net1", "pod-1", "namespace-1")
+	secondary.DesiredIPAddresses = []string{"10.0.0.5"}
+	secondary.SecondaryInterfacesExist = true
+	_, err := service.requestIPConfigHandlerHelper(context.Background(), primary)
+	require.NoError(t, err)
+	_, err = service.requestIPConfigHandlerHelper(context.Background(), secondary)
+	require.NoError(t, err)
+	before := requireUnifiedSnapshot(t, db)
+
+	patches := []map[string]*IPInfo{
+		{"eth0": {
+			HnsEndpointID: "primary-hns",
+			IPv4:          []net.IPNet{testIPNet("10.0.0.4/24")},
+			IPv6:          []net.IPNet{testIPNet("2001:db8::4/64")},
+		}},
+		{"net1": {
+			HostVethName: "secondary-veth",
+			MacAddress:   "00:11:22:33:44:66",
+			IPv4:         []net.IPNet{testIPNet("10.0.0.5/24")},
+		}},
+	}
+	start := make(chan struct{})
+	results := make(chan cns.Response, len(patches))
+	var ready sync.WaitGroup
+	ready.Add(len(patches))
+	for _, patch := range patches {
+		go func() {
+			ready.Done()
+			<-start
+			response, _ := invokeEndpointPatch(t, service, context.Background(), "container-1", patch)
+			results <- response
+		}()
+	}
+	ready.Wait()
+	close(start)
+	for range patches {
+		assert.Equal(t, types.Success, (<-results).ReturnCode)
+	}
+
+	after := requireUnifiedSnapshot(t, db)
+	assert.Equal(t, before.Metadata.Generation+2, after.Metadata.Generation)
+	assert.Equal(t, before.Assignments, after.Assignments)
+	assert.Equal(t, before.IPOwners, after.IPOwners)
+	assert.Equal(t, before.DeleteIntents, after.DeleteIntents)
+	assert.Equal(t, "primary-hns", after.Endpoints["container-1"].IfnameToIPMap["eth0"].HNSEndpointID)
+	assert.Equal(t, "secondary-veth", after.Endpoints["container-1"].IfnameToIPMap["net1"].HostVethName)
+	require.Len(t, after.Endpoints["container-1"].IfnameToIPMap["eth0"].IPv4, 1)
+	require.Len(t, after.Endpoints["container-1"].IfnameToIPMap["eth0"].IPv6, 1)
+	require.Len(t, after.Endpoints["container-1"].IfnameToIPMap["net1"].IPv4, 1)
+
+	duplicate := map[string]*IPInfo{"net1": {
+		HnsNetworkID: "network-once",
+		NICType:      cns.InfraNIC,
+	}}
+	start = make(chan struct{})
+	for range 2 {
+		go func() {
+			<-start
+			response, _ := invokeEndpointPatch(t, service, context.Background(), "container-1", duplicate)
+			results <- response
+		}()
+	}
+	close(start)
+	assert.Equal(t, types.Success, (<-results).ReturnCode)
+	assert.Equal(t, types.Success, (<-results).ReturnCode)
+	replayed := requireUnifiedSnapshot(t, db)
+	assert.Equal(t, after.Metadata.Generation+1, replayed.Metadata.Generation)
+	assert.Equal(t, "network-once", replayed.Endpoints["container-1"].IfnameToIPMap["net1"].HNSNetworkID)
+	generation, _ := adapter.cacheGeneration()
+	assert.Equal(t, replayed.Metadata.Generation, generation)
+}
+
+func TestUnifiedPatchValidationFailuresAreAtomic(t *testing.T) {
+	tests := []struct {
+		name       string
+		endpointID string
+		request    map[string]*IPInfo
+		wantCode   types.ResponseCode
+	}{
+		{
+			name:       "absent endpoint",
+			endpointID: "missing",
+			request:    map[string]*IPInfo{"eth0": {HostVethName: "veth"}},
+			wantCode:   types.NotFound,
+		},
+		{
+			name:       "mismatched interface",
+			endpointID: "container-1",
+			request:    map[string]*IPInfo{"net1": {HostVethName: "veth"}},
+			wantCode:   types.InvalidRequest,
+		},
+		{
+			name:       "assigned IP change",
+			endpointID: "container-1",
+			request: map[string]*IPInfo{"eth0": {
+				HostVethName: "veth",
+				IPv4:         []net.IPNet{testIPNet("10.0.0.99/24")},
+			}},
+			wantCode: types.InvalidRequest,
+		},
+		{
+			name:       "malformed prefix",
+			endpointID: "container-1",
+			request: map[string]*IPInfo{"eth0": {
+				HostVethName: "veth",
+				IPv4: []net.IPNet{{
+					IP: net.ParseIP("10.0.0.4"), Mask: net.IPMask{255, 0, 255, 0},
+				}},
+			}},
+			wantCode: types.InvalidRequest,
+		},
+		{
+			name:       "wrong prefix family",
+			endpointID: "container-1",
+			request: map[string]*IPInfo{"eth0": {
+				HostVethName: "veth",
+				IPv4:         []net.IPNet{testIPNet("2001:db8::4/64")},
+			}},
+			wantCode: types.InvalidRequest,
+		},
+		{
+			name:       "malformed MAC",
+			endpointID: "container-1",
+			request:    map[string]*IPInfo{"eth0": {MacAddress: "not-a-mac"}},
+			wantCode:   types.InvalidRequest,
+		},
+		{
+			name:       "missing network container",
+			endpointID: "container-1",
+			request: map[string]*IPInfo{"eth0": {
+				HostVethName:       "veth",
+				NetworkContainerID: "missing-nc",
+			}},
+			wantCode: types.InvalidRequest,
+		},
+		{
+			name:       "invalid NIC type",
+			endpointID: "container-1",
+			request:    map[string]*IPInfo{"eth0": {NICType: cns.NICType("invalid")}},
+			wantCode:   types.InvalidRequest,
+		},
+		{
+			name:       "null interface",
+			endpointID: "container-1",
+			request:    map[string]*IPInfo{"eth0": nil},
+			wantCode:   types.InvalidRequest,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
+				"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+			}, nil)
+			add := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
+			add.DesiredIPAddresses = []string{"10.0.0.4"}
+			_, err := service.requestIPConfigHandlerHelper(context.Background(), add)
+			require.NoError(t, err)
+			before := requireUnifiedSnapshot(t, db)
+			beforeCache := durableCacheFingerprint(service, adapter)
+
+			response, _ := invokeEndpointPatch(t, service, context.Background(), tt.endpointID, tt.request)
+			assert.Equal(t, tt.wantCode, response.ReturnCode)
+			assert.Equal(t, before, requireUnifiedSnapshot(t, db))
+			assert.Equal(t, beforeCache, durableCacheFingerprint(service, adapter))
+		})
+	}
+}
+
+func TestUnifiedPatchDeleteOrderingAndExpiry(t *testing.T) {
+	t.Run("patch then delete retains details", func(t *testing.T) {
+		service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
+			"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+		}, nil)
+		add := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
+		add.DesiredIPAddresses = []string{"10.0.0.4"}
+		_, err := service.requestIPConfigHandlerHelper(context.Background(), add)
+		require.NoError(t, err)
+		response, _ := invokeEndpointPatch(
+			t,
+			service,
+			context.Background(),
+			"container-1",
+			map[string]*IPInfo{"eth0": {HostVethName: "patched-before-delete"}},
+		)
+		require.Equal(t, types.Success, response.ReturnCode)
+		now := time.Date(2026, time.July, 24, 7, 0, 0, 0, time.UTC)
+		adapter.now = func() time.Time { return now }
+		_, err = service.ReleaseIPConfigHandlerHelper(context.Background(), add)
+		require.NoError(t, err)
+		after := requireUnifiedSnapshot(t, db)
+		assert.Equal(t, "patched-before-delete", after.Endpoints["container-1"].IfnameToIPMap["eth0"].HostVethName)
+		assert.Contains(t, after.DeleteIntents, "container-1")
+		assert.Empty(t, after.Assignments)
+		assert.Empty(t, after.IPOwners)
+	})
+
+	t.Run("delete then patch is blocked through expiry boundary", func(t *testing.T) {
+		service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
+			"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+		}, nil)
+		add := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
+		add.DesiredIPAddresses = []string{"10.0.0.4"}
+		_, err := service.requestIPConfigHandlerHelper(context.Background(), add)
+		require.NoError(t, err)
+		now := time.Date(2026, time.July, 24, 8, 0, 0, 0, time.UTC)
+		adapter.now = func() time.Time { return now }
+		_, err = service.ReleaseIPConfigHandlerHelper(context.Background(), add)
+		require.NoError(t, err)
+		before := requireUnifiedSnapshot(t, db)
+		patch := map[string]*IPInfo{"eth0": {HostVethName: "must-not-apply"}}
+
+		response, _ := invokeEndpointPatch(t, service, context.Background(), "container-1", patch)
+		assert.Equal(t, types.UnexpectedError, response.ReturnCode)
+		assert.Equal(t, before, requireUnifiedSnapshot(t, db))
+
+		adapter.now = func() time.Time { return now.Add(unifiedDeleteIntentTTL) }
+		response, _ = invokeEndpointPatch(t, service, context.Background(), "container-1", patch)
+		assert.Equal(t, types.NotFound, response.ReturnCode)
+		after := requireUnifiedSnapshot(t, db)
+		assert.Equal(t, before, after)
+		assert.Equal(t, now, after.DeleteIntents["container-1"].CreatedAt)
+	})
+}
+
+func TestUnifiedPatchFailuresAndPostcommitRestore(t *testing.T) {
+	injected := errors.New("injected patch failure")
+	tests := []struct {
+		name     string
+		inject   func(*durableStateAdapter)
+		ctx      func() context.Context
+		wantCode types.ResponseCode
+	}{
+		{
+			name: "commit",
+			inject: func(adapter *durableStateAdapter) {
+				adapter.store.patchEndpoint = func(
+					context.Context,
+					uint64,
+					state.PodIdentity,
+					state.EndpointRecord,
+					time.Time,
+					time.Duration,
+					func(state.Snapshot) error,
+				) (bool, error) {
+					return false, injected
+				}
+			},
+			wantCode: types.UnexpectedError,
+		},
+		{
+			name: "stale generation",
+			inject: func(adapter *durableStateAdapter) {
+				adapter.store.patchEndpoint = func(
+					context.Context,
+					uint64,
+					state.PodIdentity,
+					state.EndpointRecord,
+					time.Time,
+					time.Duration,
+					func(state.Snapshot) error,
+				) (bool, error) {
+					return false, state.ErrStaleGeneration
+				}
+			},
+			wantCode: types.InconsistentIPConfigState,
+		},
+		{
+			name: "candidate callback",
+			inject: func(adapter *durableStateAdapter) {
+				adapter.buildProjection = func(state.Snapshot) (durableCacheProjection, error) {
+					return durableCacheProjection{}, injected
+				}
+			},
+			wantCode: types.UnexpectedError,
+		},
+		{
+			name:   "canceled",
+			inject: func(*durableStateAdapter) {},
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			wantCode: types.UnexpectedError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
+				"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+			}, nil)
+			add := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
+			add.DesiredIPAddresses = []string{"10.0.0.4"}
+			_, err := service.requestIPConfigHandlerHelper(context.Background(), add)
+			require.NoError(t, err)
+			before := requireUnifiedSnapshot(t, db)
+			beforeCache := durableCacheFingerprint(service, adapter)
+			tt.inject(adapter)
+			ctx := context.Background()
+			if tt.ctx != nil {
+				ctx = tt.ctx()
+			}
+
+			response, _ := invokeEndpointPatch(
+				t,
+				service,
+				ctx,
+				"container-1",
+				map[string]*IPInfo{"eth0": {HostVethName: "patched"}},
+			)
+			assert.Equal(t, tt.wantCode, response.ReturnCode)
+			assert.Equal(t, before, requireUnifiedSnapshot(t, db))
+			assert.Equal(t, beforeCache, durableCacheFingerprint(service, adapter))
+		})
+	}
+
+	t.Run("cache does not match database", func(t *testing.T) {
+		service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
+			"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+		}, nil)
+		add := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
+		add.DesiredIPAddresses = []string{"10.0.0.4"}
+		_, err := service.requestIPConfigHandlerHelper(context.Background(), add)
+		require.NoError(t, err)
+		before := requireUnifiedSnapshot(t, db)
+		service.EndpointState["container-1"].IfnameToIPMap["eth0"].HostVethName = "stale-cache-value"
+		beforeCache := durableCacheFingerprint(service, adapter)
+
+		response, _ := invokeEndpointPatch(
+			t,
+			service,
+			context.Background(),
+			"container-1",
+			map[string]*IPInfo{"eth0": {HostVethName: "patched"}},
+		)
+		assert.Equal(t, types.InconsistentIPConfigState, response.ReturnCode)
+		assert.Equal(t, before, requireUnifiedSnapshot(t, db))
+		assert.Equal(t, beforeCache, durableCacheFingerprint(service, adapter))
+	})
+
+	t.Run("postcommit cache restore", func(t *testing.T) {
+		service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
+			"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+		}, nil)
+		add := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
+		add.DesiredIPAddresses = []string{"10.0.0.4"}
+		_, err := service.requestIPConfigHandlerHelper(context.Background(), add)
+		require.NoError(t, err)
+		before := requireUnifiedSnapshot(t, db)
+		adapter.applyPatchProjection = func(durableCacheProjection) error { return injected }
+
+		response, _ := invokeEndpointPatch(
+			t,
+			service,
+			context.Background(),
+			"container-1",
+			map[string]*IPInfo{"eth0": {HostVethName: "committed"}},
+		)
+		assert.Equal(t, types.UnexpectedError, response.ReturnCode)
+		after := requireUnifiedSnapshot(t, db)
+		assert.Equal(t, before.Metadata.Generation+1, after.Metadata.Generation)
+		assert.Equal(t, "committed", after.Endpoints["container-1"].IfnameToIPMap["eth0"].HostVethName)
+		assert.Equal(t, "committed", service.EndpointState["container-1"].IfnameToIPMap["eth0"].HostVethName)
+		generation, projected := adapter.cacheGeneration()
+		assert.True(t, projected)
+		assert.Equal(t, after.Metadata.Generation, generation)
+	})
+}
+
+func TestUnifiedPatchReadOnlyClosedAndRestart(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	db, err := state.Open(path, state.Options{})
+	require.NoError(t, err)
+	_, err = db.ApplyNetworkContainer(context.Background(), r18NetworkContainer("nc-v4"), []state.IPRecord{{
+		ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1,
+	}})
+	require.NoError(t, err)
+	service := newUnifiedAddTestService(t)
+	restore, closeState, err := NewDurableStateLifecycle(service, db, true)
+	require.NoError(t, err)
+	require.NoError(t, restore(context.Background()))
+	add := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
+	add.DesiredIPAddresses = []string{"10.0.0.4"}
+	_, err = service.requestIPConfigHandlerHelper(context.Background(), add)
+	require.NoError(t, err)
+	response, _ := invokeEndpointPatch(
+		t,
+		service,
+		context.Background(),
+		"container-1",
+		map[string]*IPInfo{"eth0": {
+			HnsEndpointID: "restart-hns",
+			HnsNetworkID:  "restart-network",
+			HostVethName:  "restart-veth",
+			MacAddress:    "00:11:22:33:44:77",
+			NICType:       cns.ApipaNIC,
+		}},
+	)
+	require.Equal(t, types.Success, response.ReturnCode)
+	require.NoError(t, closeState())
+
+	response, _ = invokeEndpointPatch(
+		t,
+		service,
+		context.Background(),
+		"container-1",
+		map[string]*IPInfo{"eth0": {HostVethName: "closed"}},
+	)
+	assert.Equal(t, types.UnexpectedError, response.ReturnCode)
+
+	reopened, err := state.Open(path, state.Options{})
+	require.NoError(t, err)
+	restarted := newUnifiedAddTestService(t)
+	restore, closeRestarted, err := NewDurableStateLifecycle(restarted, reopened, true)
+	require.NoError(t, err)
+	require.NoError(t, restore(context.Background()))
+	t.Cleanup(func() { require.NoError(t, closeRestarted()) })
+	info := restarted.EndpointState["container-1"].IfnameToIPMap["eth0"]
+	assert.Equal(t, "restart-hns", info.HnsEndpointID)
+	assert.Equal(t, "restart-network", info.HnsNetworkID)
+	assert.Equal(t, "restart-veth", info.HostVethName)
+	assert.Equal(t, "00:11:22:33:44:77", info.MacAddress)
+	assert.Equal(t, cns.ApipaNIC, info.NICType)
+
+	require.NoError(t, closeRestarted())
+	readOnly, err := state.Open(path, state.Options{ReadOnly: true})
+	require.NoError(t, err)
+	readOnlyService := newUnifiedAddTestService(t)
+	restore, closeReadOnly, err := NewDurableStateLifecycle(readOnlyService, readOnly, true)
+	require.NoError(t, err)
+	require.NoError(t, restore(context.Background()))
+	t.Cleanup(func() { require.NoError(t, closeReadOnly()) })
+	response, _ = invokeEndpointPatch(
+		t,
+		readOnlyService,
+		context.Background(),
+		"container-1",
+		map[string]*IPInfo{"eth0": {HostVethName: "read-only"}},
+	)
+	assert.Equal(t, types.UnexpectedError, response.ReturnCode)
+	assert.Equal(t, "restart-veth", readOnlyService.EndpointState["container-1"].IfnameToIPMap["eth0"].HostVethName)
+}
+
+func TestUnifiedPatchImportedEndpointPreservesOwnership(t *testing.T) {
+	db, err := state.Open(filepath.Join(t.TempDir(), "state.db"), state.Options{})
+	require.NoError(t, err)
+	_, err = db.ApplyNetworkContainer(context.Background(), r18NetworkContainer("nc-v4"), []state.IPRecord{{
+		ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1,
+	}})
+	require.NoError(t, err)
+	records := []cns.CNIEndpointState{{
+		InfraContainerID: "container-1",
+		PodEndpointID:    "interface-1",
+		PodName:          "pod-1",
+		PodNamespace:     "namespace-1",
+		InterfaceKey:     "container-1-eth0",
+		InterfaceName:    "eth0",
+		IPAddresses:      []net.IPNet{testIPNet("10.0.0.4/24")},
+	}}
+	plan, err := db.PreflightCNIEndpointImport(context.Background(), records, false)
+	require.NoError(t, err)
+	changed, err := db.ImportCNIEndpointState(context.Background(), records, plan)
+	require.NoError(t, err)
+	require.True(t, changed)
+	before := requireUnifiedSnapshot(t, db)
+	service := newUnifiedAddTestService(t)
+	restore, closeState, err := NewDurableStateLifecycle(service, db, true)
+	require.NoError(t, err)
+	require.NoError(t, restore(context.Background()))
+	t.Cleanup(func() { require.NoError(t, closeState()) })
+
+	response, _ := invokeEndpointPatch(
+		t,
+		service,
+		context.Background(),
+		"container-1",
+		map[string]*IPInfo{"eth0": {
+			HnsEndpointID:      "imported-hns",
+			NetworkContainerID: "nc-v4",
+			NICType:            cns.InfraNIC,
+		}},
+	)
+	require.Equal(t, types.Success, response.ReturnCode)
+	after := requireUnifiedSnapshot(t, db)
+	assert.Equal(t, before.Assignments, after.Assignments)
+	assert.Equal(t, before.IPOwners, after.IPOwners)
+	assert.Equal(t, before.DeleteIntents, after.DeleteIntents)
+	assert.Equal(t, "imported-hns", after.Endpoints["container-1"].IfnameToIPMap["eth0"].HNSEndpointID)
+	assert.Equal(t, "nc-v4", after.Endpoints["container-1"].IfnameToIPMap["eth0"].NetworkContainerID)
+}
+
+func TestJSONPatchPathRemainsIsolated(t *testing.T) {
+	service := getTestService(cns.KubernetesCRD)
+	enableManagedEndpointState(service)
+	service.EndpointState["container-1"] = &EndpointInfo{
+		PodName:      "pod-1",
+		PodNamespace: "namespace-1",
+		IfnameToIPMap: map[string]*IPInfo{
+			"eth0": {IPv4: []net.IPNet{testIPNet("10.0.0.4/24")}},
+		},
+	}
+	require.NoError(t, service.EndpointStateStore.Write(EndpointStoreKey, service.EndpointState))
+	require.Nil(t, service.selectedUnifiedStateAdapter())
+
+	response, _ := invokeEndpointPatch(
+		t,
+		service,
+		context.Background(),
+		"container-1",
+		map[string]*IPInfo{"eth0": {HostVethName: "json-veth"}},
+	)
+	require.Equal(t, types.Success, response.ReturnCode)
+	assert.Equal(t, "json-veth", service.EndpointState["container-1"].IfnameToIPMap["eth0"].HostVethName)
+	var persisted map[string]*EndpointInfo
+	require.NoError(t, service.EndpointStateStore.Read(EndpointStoreKey, &persisted))
+	assert.Equal(t, "json-veth", persisted["container-1"].IfnameToIPMap["eth0"].HostVethName)
+	assert.Nil(t, service.selectedUnifiedStateAdapter())
+}
+
+func invokeEndpointPatch(
+	t *testing.T,
+	service *HTTPRestService,
+	ctx context.Context,
+	endpointID string,
+	request map[string]*IPInfo,
+) (cns.Response, *httptest.ResponseRecorder) {
+	t.Helper()
+	body, err := json.Marshal(request)
+	require.NoError(t, err)
+	httpRequest := httptest.NewRequest(
+		http.MethodPatch,
+		cns.EndpointPath+endpointID,
+		bytes.NewReader(body),
+	).WithContext(ctx)
+	recorder := httptest.NewRecorder()
+	service.EndpointHandlerAPI(recorder, httpRequest)
+	var response cns.Response
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	return response, recorder
+}
+
+func TestUnifiedPatchReadOnlyErrorIdentity(t *testing.T) {
+	assert.Equal(t, types.UnexpectedError, unifiedPatchResponseCode(bolterrors.ErrDatabaseReadOnly))
+	assert.Equal(t, types.UnexpectedError, unifiedPatchResponseCode(context.Canceled))
+	assert.Equal(t, types.UnexpectedError, unifiedPatchResponseCode(state.ErrDeleteIntent))
+}

--- a/cns/restserver/unified_patch_test.go
+++ b/cns/restserver/unified_patch_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -24,12 +25,20 @@ import (
 	bolterrors "go.etcd.io/bbolt/errors"
 )
 
+var errInjectedPatchFailure = errors.New("injected patch failure")
+
+const (
+	patchTestSecondaryInterface = "net1"
+	patchTestVeth               = "veth"
+	patchTestCommit             = "commit"
+)
+
 func TestUnifiedPatchPersistsPlatformDetailsAndReplay(t *testing.T) {
 	service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
-		"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+		delTestNCIPv4: {{ID: delTestIPID1, IPAddress: delTestIPv4Address, NCID: delTestNCIPv4, NCVersion: 1}},
 	}, nil)
-	add := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
-	add.DesiredIPAddresses = []string{"10.0.0.4"}
+	add := unifiedAddRequest(delTestContainerID, delTestInterfaceID, InfraInterfaceName, delTestPodName, delTestNamespace)
+	add.DesiredIPAddresses = []string{delTestIPv4Address}
 	_, err := service.requestIPConfigHandlerHelper(context.Background(), add)
 	require.NoError(t, err)
 	before := requireUnifiedSnapshot(t, db)
@@ -43,18 +52,19 @@ func TestUnifiedPatchPersistsPlatformDetailsAndReplay(t *testing.T) {
 		return refresh(ctx)
 	}
 	patch := map[string]*IPInfo{
-		"eth0": {
-			IPv4:               []net.IPNet{testIPNet("10.0.0.4/24")},
+		InfraInterfaceName: {
+			IPv4:               []net.IPNet{testIPNet(delTestIPv4Address + "/24")},
 			HnsEndpointID:      "hns-endpoint-1",
 			HnsNetworkID:       "hns-network-1",
 			HostVethName:       "veth-1",
 			MacAddress:         "AA-BB-CC-DD-EE-FF",
-			NetworkContainerID: "nc-v4",
+			NetworkContainerID: delTestNCIPv4,
 			NICType:            cns.DelegatedVMNIC,
 		},
 	}
 
-	response, recorder := invokeEndpointPatch(t, service, context.Background(), "container-1", patch)
+	response, recorder, err := invokeEndpointPatch(context.Background(), service, delTestContainerID, patch)
+	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, recorder.Code)
 	assert.Equal(t, types.Success, response.ReturnCode)
 	assert.Equal(t, "[updateEndpoint] updateEndpoint retruned successfully", response.Message)
@@ -65,16 +75,16 @@ func TestUnifiedPatchPersistsPlatformDetailsAndReplay(t *testing.T) {
 	assert.Equal(t, beforeAssignments, after.Assignments)
 	assert.Equal(t, beforeOwners, after.IPOwners)
 	assert.Equal(t, beforeIntents, after.DeleteIntents)
-	info := after.Endpoints["container-1"].IfnameToIPMap["eth0"]
+	info := after.Endpoints[delTestContainerID].IfnameToIPMap[InfraInterfaceName]
 	assert.Equal(t, "hns-endpoint-1", info.HNSEndpointID)
 	assert.Equal(t, "hns-network-1", info.HNSNetworkID)
 	assert.Equal(t, "veth-1", info.HostVethName)
 	assert.Equal(t, "aa:bb:cc:dd:ee:ff", info.MACAddress)
-	assert.Equal(t, "nc-v4", info.NetworkContainerID)
+	assert.Equal(t, delTestNCIPv4, info.NetworkContainerID)
 	assert.Equal(t, cns.DelegatedVMNIC, info.NICType)
 	require.Len(t, info.IPv4, 1)
-	assert.Equal(t, "10.0.0.4", info.IPv4[0].IP.String())
-	cacheInfo := service.EndpointState["container-1"].IfnameToIPMap["eth0"]
+	assert.Equal(t, delTestIPv4Address, info.IPv4[0].IP.String())
+	cacheInfo := service.EndpointState[delTestContainerID].IfnameToIPMap[InfraInterfaceName]
 	assert.Equal(t, info.HNSEndpointID, cacheInfo.HnsEndpointID)
 	assert.Equal(t, info.HNSNetworkID, cacheInfo.HnsNetworkID)
 	assert.Equal(t, info.HostVethName, cacheInfo.HostVethName)
@@ -86,7 +96,8 @@ func TestUnifiedPatchPersistsPlatformDetailsAndReplay(t *testing.T) {
 	assert.Equal(t, after.Metadata.Generation, generation)
 	assert.Equal(t, 1, refreshCalls)
 
-	response, _ = invokeEndpointPatch(t, service, context.Background(), "container-1", patch)
+	response, _, err = invokeEndpointPatch(context.Background(), service, delTestContainerID, patch)
+	require.NoError(t, err)
 	assert.Equal(t, types.Success, response.ReturnCode)
 	assert.Equal(t, after, requireUnifiedSnapshot(t, db))
 	assert.Equal(t, 1, refreshCalls)
@@ -94,16 +105,16 @@ func TestUnifiedPatchPersistsPlatformDetailsAndReplay(t *testing.T) {
 
 func TestUnifiedPatchMultiNICConcurrencyPreservesAssignments(t *testing.T) {
 	service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
-		"nc-v4": {
-			{ID: "ip-primary", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1},
-			{ID: "ip-secondary", IPAddress: "10.0.0.5", NCID: "nc-v4", NCVersion: 1},
+		delTestNCIPv4: {
+			{ID: "ip-primary", IPAddress: delTestIPv4Address, NCID: delTestNCIPv4, NCVersion: 1},
+			{ID: "ip-secondary", IPAddress: primaryIP, NCID: delTestNCIPv4, NCVersion: 1},
 		},
-		"nc-v6": {{ID: "ip-v6", IPAddress: "2001:db8::4", NCID: "nc-v6", NCVersion: 1}},
+		delTestNCIPv6: {{ID: delTestIPv6ID, IPAddress: delTestIPv6Address, NCID: delTestNCIPv6, NCVersion: 1}},
 	}, nil)
-	primary := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
-	primary.DesiredIPAddresses = []string{"10.0.0.4", "2001:db8::4"}
-	secondary := unifiedAddRequest("container-1", "interface-2", "net1", "pod-1", "namespace-1")
-	secondary.DesiredIPAddresses = []string{"10.0.0.5"}
+	primary := unifiedAddRequest(delTestContainerID, delTestInterfaceID, InfraInterfaceName, delTestPodName, delTestNamespace)
+	primary.DesiredIPAddresses = []string{delTestIPv4Address, delTestIPv6Address}
+	secondary := unifiedAddRequest(delTestContainerID, "interface-2", patchTestSecondaryInterface, delTestPodName, delTestNamespace)
+	secondary.DesiredIPAddresses = []string{primaryIP}
 	secondary.SecondaryInterfacesExist = true
 	_, err := service.requestIPConfigHandlerHelper(context.Background(), primary)
 	require.NoError(t, err)
@@ -112,33 +123,39 @@ func TestUnifiedPatchMultiNICConcurrencyPreservesAssignments(t *testing.T) {
 	before := requireUnifiedSnapshot(t, db)
 
 	patches := []map[string]*IPInfo{
-		{"eth0": {
+		{InfraInterfaceName: {
 			HnsEndpointID: "primary-hns",
-			IPv4:          []net.IPNet{testIPNet("10.0.0.4/24")},
-			IPv6:          []net.IPNet{testIPNet("2001:db8::4/64")},
+			IPv4:          []net.IPNet{testIPNet(delTestIPv4Address + "/24")},
+			IPv6:          []net.IPNet{testIPNet(delTestIPv6Address + "/64")},
 		}},
-		{"net1": {
+		{patchTestSecondaryInterface: {
 			HostVethName: "secondary-veth",
 			MacAddress:   "00:11:22:33:44:66",
-			IPv4:         []net.IPNet{testIPNet("10.0.0.5/24")},
+			IPv4:         []net.IPNet{testIPNet(primaryIP + "/24")},
 		}},
 	}
+	type patchResult struct {
+		response cns.Response
+		err      error
+	}
 	start := make(chan struct{})
-	results := make(chan cns.Response, len(patches))
+	results := make(chan patchResult, len(patches))
 	var ready sync.WaitGroup
 	ready.Add(len(patches))
 	for _, patch := range patches {
 		go func() {
 			ready.Done()
 			<-start
-			response, _ := invokeEndpointPatch(t, service, context.Background(), "container-1", patch)
-			results <- response
+			response, _, err := invokeEndpointPatch(context.Background(), service, delTestContainerID, patch)
+			results <- patchResult{response: response, err: err}
 		}()
 	}
 	ready.Wait()
 	close(start)
 	for range patches {
-		assert.Equal(t, types.Success, (<-results).ReturnCode)
+		result := <-results
+		require.NoError(t, result.err)
+		assert.Equal(t, types.Success, result.response.ReturnCode)
 	}
 
 	after := requireUnifiedSnapshot(t, db)
@@ -146,13 +163,13 @@ func TestUnifiedPatchMultiNICConcurrencyPreservesAssignments(t *testing.T) {
 	assert.Equal(t, before.Assignments, after.Assignments)
 	assert.Equal(t, before.IPOwners, after.IPOwners)
 	assert.Equal(t, before.DeleteIntents, after.DeleteIntents)
-	assert.Equal(t, "primary-hns", after.Endpoints["container-1"].IfnameToIPMap["eth0"].HNSEndpointID)
-	assert.Equal(t, "secondary-veth", after.Endpoints["container-1"].IfnameToIPMap["net1"].HostVethName)
-	require.Len(t, after.Endpoints["container-1"].IfnameToIPMap["eth0"].IPv4, 1)
-	require.Len(t, after.Endpoints["container-1"].IfnameToIPMap["eth0"].IPv6, 1)
-	require.Len(t, after.Endpoints["container-1"].IfnameToIPMap["net1"].IPv4, 1)
+	assert.Equal(t, "primary-hns", after.Endpoints[delTestContainerID].IfnameToIPMap[InfraInterfaceName].HNSEndpointID)
+	assert.Equal(t, "secondary-veth", after.Endpoints[delTestContainerID].IfnameToIPMap[patchTestSecondaryInterface].HostVethName)
+	require.Len(t, after.Endpoints[delTestContainerID].IfnameToIPMap[InfraInterfaceName].IPv4, 1)
+	require.Len(t, after.Endpoints[delTestContainerID].IfnameToIPMap[InfraInterfaceName].IPv6, 1)
+	require.Len(t, after.Endpoints[delTestContainerID].IfnameToIPMap[patchTestSecondaryInterface].IPv4, 1)
 
-	duplicate := map[string]*IPInfo{"net1": {
+	duplicate := map[string]*IPInfo{patchTestSecondaryInterface: {
 		HnsNetworkID: "network-once",
 		NICType:      cns.InfraNIC,
 	}}
@@ -160,16 +177,20 @@ func TestUnifiedPatchMultiNICConcurrencyPreservesAssignments(t *testing.T) {
 	for range 2 {
 		go func() {
 			<-start
-			response, _ := invokeEndpointPatch(t, service, context.Background(), "container-1", duplicate)
-			results <- response
+			response, _, err := invokeEndpointPatch(context.Background(), service, delTestContainerID, duplicate)
+			results <- patchResult{response: response, err: err}
 		}()
 	}
 	close(start)
-	assert.Equal(t, types.Success, (<-results).ReturnCode)
-	assert.Equal(t, types.Success, (<-results).ReturnCode)
+	first := <-results
+	require.NoError(t, first.err)
+	assert.Equal(t, types.Success, first.response.ReturnCode)
+	second := <-results
+	require.NoError(t, second.err)
+	assert.Equal(t, types.Success, second.response.ReturnCode)
 	replayed := requireUnifiedSnapshot(t, db)
 	assert.Equal(t, after.Metadata.Generation+1, replayed.Metadata.Generation)
-	assert.Equal(t, "network-once", replayed.Endpoints["container-1"].IfnameToIPMap["net1"].HNSNetworkID)
+	assert.Equal(t, "network-once", replayed.Endpoints[delTestContainerID].IfnameToIPMap[patchTestSecondaryInterface].HNSNetworkID)
 	generation, _ := adapter.cacheGeneration()
 	assert.Equal(t, replayed.Metadata.Generation, generation)
 }
@@ -184,85 +205,92 @@ func TestUnifiedPatchValidationFailuresAreAtomic(t *testing.T) {
 		{
 			name:       "absent endpoint",
 			endpointID: "missing",
-			request:    map[string]*IPInfo{"eth0": {HostVethName: "veth"}},
+			request:    map[string]*IPInfo{InfraInterfaceName: {HostVethName: patchTestVeth}},
 			wantCode:   types.NotFound,
 		},
 		{
 			name:       "mismatched interface",
-			endpointID: "container-1",
-			request:    map[string]*IPInfo{"net1": {HostVethName: "veth"}},
+			endpointID: delTestContainerID,
+			request:    map[string]*IPInfo{patchTestSecondaryInterface: {HostVethName: patchTestVeth}},
 			wantCode:   types.InvalidRequest,
 		},
 		{
 			name:       "assigned IP change",
-			endpointID: "container-1",
-			request: map[string]*IPInfo{"eth0": {
-				HostVethName: "veth",
+			endpointID: delTestContainerID,
+			request: map[string]*IPInfo{InfraInterfaceName: {
+				HostVethName: patchTestVeth,
 				IPv4:         []net.IPNet{testIPNet("10.0.0.99/24")},
 			}},
 			wantCode: types.InvalidRequest,
 		},
 		{
 			name:       "malformed prefix",
-			endpointID: "container-1",
-			request: map[string]*IPInfo{"eth0": {
-				HostVethName: "veth",
+			endpointID: delTestContainerID,
+			request: map[string]*IPInfo{InfraInterfaceName: {
+				HostVethName: patchTestVeth,
 				IPv4: []net.IPNet{{
-					IP: net.ParseIP("10.0.0.4"), Mask: net.IPMask{255, 0, 255, 0},
+					IP: net.ParseIP(delTestIPv4Address), Mask: net.IPMask{255, 0, 255, 0},
 				}},
 			}},
 			wantCode: types.InvalidRequest,
 		},
 		{
 			name:       "wrong prefix family",
-			endpointID: "container-1",
-			request: map[string]*IPInfo{"eth0": {
-				HostVethName: "veth",
-				IPv4:         []net.IPNet{testIPNet("2001:db8::4/64")},
+			endpointID: delTestContainerID,
+			request: map[string]*IPInfo{InfraInterfaceName: {
+				HostVethName: patchTestVeth,
+				IPv4:         []net.IPNet{testIPNet(delTestIPv6Address + "/64")},
 			}},
 			wantCode: types.InvalidRequest,
 		},
 		{
 			name:       "malformed MAC",
-			endpointID: "container-1",
-			request:    map[string]*IPInfo{"eth0": {MacAddress: "not-a-mac"}},
+			endpointID: delTestContainerID,
+			request:    map[string]*IPInfo{InfraInterfaceName: {MacAddress: "not-a-mac"}},
 			wantCode:   types.InvalidRequest,
 		},
 		{
 			name:       "missing network container",
-			endpointID: "container-1",
-			request: map[string]*IPInfo{"eth0": {
-				HostVethName:       "veth",
+			endpointID: delTestContainerID,
+			request: map[string]*IPInfo{InfraInterfaceName: {
+				HostVethName:       patchTestVeth,
 				NetworkContainerID: "missing-nc",
 			}},
 			wantCode: types.InvalidRequest,
 		},
 		{
 			name:       "invalid NIC type",
-			endpointID: "container-1",
-			request:    map[string]*IPInfo{"eth0": {NICType: cns.NICType("invalid")}},
+			endpointID: delTestContainerID,
+			request:    map[string]*IPInfo{InfraInterfaceName: {NICType: cns.NICType("invalid")}},
 			wantCode:   types.InvalidRequest,
 		},
 		{
 			name:       "null interface",
-			endpointID: "container-1",
-			request:    map[string]*IPInfo{"eth0": nil},
+			endpointID: delTestContainerID,
+			request:    map[string]*IPInfo{InfraInterfaceName: nil},
 			wantCode:   types.InvalidRequest,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
-				"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+				delTestNCIPv4: {{ID: delTestIPID1, IPAddress: delTestIPv4Address, NCID: delTestNCIPv4, NCVersion: 1}},
 			}, nil)
-			add := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
-			add.DesiredIPAddresses = []string{"10.0.0.4"}
+			add := unifiedAddRequest(
+				delTestContainerID,
+				delTestInterfaceID,
+				InfraInterfaceName,
+				delTestPodName,
+				delTestNamespace,
+			)
+			add.DesiredIPAddresses = []string{delTestIPv4Address}
 			_, err := service.requestIPConfigHandlerHelper(context.Background(), add)
 			require.NoError(t, err)
 			before := requireUnifiedSnapshot(t, db)
 			beforeCache := durableCacheFingerprint(service, adapter)
 
-			response, _ := invokeEndpointPatch(t, service, context.Background(), tt.endpointID, tt.request)
+			response, _, err := invokeEndpointPatch(context.Background(), service, tt.endpointID, tt.request)
+			require.NoError(t, err)
 			assert.Equal(t, tt.wantCode, response.ReturnCode)
 			assert.Equal(t, before, requireUnifiedSnapshot(t, db))
 			assert.Equal(t, beforeCache, durableCacheFingerprint(service, adapter))
@@ -273,37 +301,41 @@ func TestUnifiedPatchValidationFailuresAreAtomic(t *testing.T) {
 func TestUnifiedPatchDeleteOrderingAndExpiry(t *testing.T) {
 	t.Run("patch then delete retains details", func(t *testing.T) {
 		service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
-			"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+			delTestNCIPv4: {{ID: delTestIPID1, IPAddress: delTestIPv4Address, NCID: delTestNCIPv4, NCVersion: 1}},
 		}, nil)
-		add := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
-		add.DesiredIPAddresses = []string{"10.0.0.4"}
+		add := unifiedAddRequest(delTestContainerID, delTestInterfaceID, InfraInterfaceName, delTestPodName, delTestNamespace)
+		add.DesiredIPAddresses = []string{delTestIPv4Address}
 		_, err := service.requestIPConfigHandlerHelper(context.Background(), add)
 		require.NoError(t, err)
-		response, _ := invokeEndpointPatch(
-			t,
-			service,
+		response, _, err := invokeEndpointPatch(
 			context.Background(),
-			"container-1",
-			map[string]*IPInfo{"eth0": {HostVethName: "patched-before-delete"}},
+			service,
+			delTestContainerID,
+			map[string]*IPInfo{InfraInterfaceName: {HostVethName: "patched-before-delete"}},
 		)
+		require.NoError(t, err)
 		require.Equal(t, types.Success, response.ReturnCode)
 		now := time.Date(2026, time.July, 24, 7, 0, 0, 0, time.UTC)
 		adapter.now = func() time.Time { return now }
 		_, err = service.ReleaseIPConfigHandlerHelper(context.Background(), add)
 		require.NoError(t, err)
 		after := requireUnifiedSnapshot(t, db)
-		assert.Equal(t, "patched-before-delete", after.Endpoints["container-1"].IfnameToIPMap["eth0"].HostVethName)
-		assert.Contains(t, after.DeleteIntents, "container-1")
+		assert.Equal(
+			t,
+			"patched-before-delete",
+			after.Endpoints[delTestContainerID].IfnameToIPMap[InfraInterfaceName].HostVethName,
+		)
+		assert.Contains(t, after.DeleteIntents, delTestContainerID)
 		assert.Empty(t, after.Assignments)
 		assert.Empty(t, after.IPOwners)
 	})
 
 	t.Run("delete then patch is blocked through expiry boundary", func(t *testing.T) {
 		service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
-			"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+			delTestNCIPv4: {{ID: delTestIPID1, IPAddress: delTestIPv4Address, NCID: delTestNCIPv4, NCVersion: 1}},
 		}, nil)
-		add := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
-		add.DesiredIPAddresses = []string{"10.0.0.4"}
+		add := unifiedAddRequest(delTestContainerID, delTestInterfaceID, InfraInterfaceName, delTestPodName, delTestNamespace)
+		add.DesiredIPAddresses = []string{delTestIPv4Address}
 		_, err := service.requestIPConfigHandlerHelper(context.Background(), add)
 		require.NoError(t, err)
 		now := time.Date(2026, time.July, 24, 8, 0, 0, 0, time.UTC)
@@ -311,23 +343,24 @@ func TestUnifiedPatchDeleteOrderingAndExpiry(t *testing.T) {
 		_, err = service.ReleaseIPConfigHandlerHelper(context.Background(), add)
 		require.NoError(t, err)
 		before := requireUnifiedSnapshot(t, db)
-		patch := map[string]*IPInfo{"eth0": {HostVethName: "must-not-apply"}}
+		patch := map[string]*IPInfo{InfraInterfaceName: {HostVethName: "must-not-apply"}}
 
-		response, _ := invokeEndpointPatch(t, service, context.Background(), "container-1", patch)
+		response, _, err := invokeEndpointPatch(context.Background(), service, delTestContainerID, patch)
+		require.NoError(t, err)
 		assert.Equal(t, types.UnexpectedError, response.ReturnCode)
 		assert.Equal(t, before, requireUnifiedSnapshot(t, db))
 
 		adapter.now = func() time.Time { return now.Add(unifiedDeleteIntentTTL) }
-		response, _ = invokeEndpointPatch(t, service, context.Background(), "container-1", patch)
+		response, _, err = invokeEndpointPatch(context.Background(), service, delTestContainerID, patch)
+		require.NoError(t, err)
 		assert.Equal(t, types.NotFound, response.ReturnCode)
 		after := requireUnifiedSnapshot(t, db)
 		assert.Equal(t, before, after)
-		assert.Equal(t, now, after.DeleteIntents["container-1"].CreatedAt)
+		assert.Equal(t, now, after.DeleteIntents[delTestContainerID].CreatedAt)
 	})
 }
 
 func TestUnifiedPatchFailuresAndPostcommitRestore(t *testing.T) {
-	injected := errors.New("injected patch failure")
 	tests := []struct {
 		name     string
 		inject   func(*durableStateAdapter)
@@ -335,7 +368,7 @@ func TestUnifiedPatchFailuresAndPostcommitRestore(t *testing.T) {
 		wantCode types.ResponseCode
 	}{
 		{
-			name: "commit",
+			name: patchTestCommit,
 			inject: func(adapter *durableStateAdapter) {
 				adapter.store.patchEndpoint = func(
 					context.Context,
@@ -346,7 +379,7 @@ func TestUnifiedPatchFailuresAndPostcommitRestore(t *testing.T) {
 					time.Duration,
 					func(state.Snapshot) error,
 				) (bool, error) {
-					return false, injected
+					return false, errInjectedPatchFailure
 				}
 			},
 			wantCode: types.UnexpectedError,
@@ -372,13 +405,13 @@ func TestUnifiedPatchFailuresAndPostcommitRestore(t *testing.T) {
 			name: "candidate callback",
 			inject: func(adapter *durableStateAdapter) {
 				adapter.buildProjection = func(state.Snapshot) (durableCacheProjection, error) {
-					return durableCacheProjection{}, injected
+					return durableCacheProjection{}, errInjectedPatchFailure
 				}
 			},
 			wantCode: types.UnexpectedError,
 		},
 		{
-			name:   "canceled",
+			name:   delTestCanceled,
 			inject: func(*durableStateAdapter) {},
 			ctx: func() context.Context {
 				ctx, cancel := context.WithCancel(context.Background())
@@ -391,10 +424,16 @@ func TestUnifiedPatchFailuresAndPostcommitRestore(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
-				"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+				delTestNCIPv4: {{ID: delTestIPID1, IPAddress: delTestIPv4Address, NCID: delTestNCIPv4, NCVersion: 1}},
 			}, nil)
-			add := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
-			add.DesiredIPAddresses = []string{"10.0.0.4"}
+			add := unifiedAddRequest(
+				delTestContainerID,
+				delTestInterfaceID,
+				InfraInterfaceName,
+				delTestPodName,
+				delTestNamespace,
+			)
+			add.DesiredIPAddresses = []string{delTestIPv4Address}
 			_, err := service.requestIPConfigHandlerHelper(context.Background(), add)
 			require.NoError(t, err)
 			before := requireUnifiedSnapshot(t, db)
@@ -405,13 +444,13 @@ func TestUnifiedPatchFailuresAndPostcommitRestore(t *testing.T) {
 				ctx = tt.ctx()
 			}
 
-			response, _ := invokeEndpointPatch(
-				t,
-				service,
+			response, _, err := invokeEndpointPatch(
 				ctx,
-				"container-1",
-				map[string]*IPInfo{"eth0": {HostVethName: "patched"}},
+				service,
+				delTestContainerID,
+				map[string]*IPInfo{InfraInterfaceName: {HostVethName: "patched"}},
 			)
+			require.NoError(t, err)
 			assert.Equal(t, tt.wantCode, response.ReturnCode)
 			assert.Equal(t, before, requireUnifiedSnapshot(t, db))
 			assert.Equal(t, beforeCache, durableCacheFingerprint(service, adapter))
@@ -420,23 +459,23 @@ func TestUnifiedPatchFailuresAndPostcommitRestore(t *testing.T) {
 
 	t.Run("cache does not match database", func(t *testing.T) {
 		service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
-			"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+			delTestNCIPv4: {{ID: delTestIPID1, IPAddress: delTestIPv4Address, NCID: delTestNCIPv4, NCVersion: 1}},
 		}, nil)
-		add := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
-		add.DesiredIPAddresses = []string{"10.0.0.4"}
+		add := unifiedAddRequest(delTestContainerID, delTestInterfaceID, InfraInterfaceName, delTestPodName, delTestNamespace)
+		add.DesiredIPAddresses = []string{delTestIPv4Address}
 		_, err := service.requestIPConfigHandlerHelper(context.Background(), add)
 		require.NoError(t, err)
 		before := requireUnifiedSnapshot(t, db)
-		service.EndpointState["container-1"].IfnameToIPMap["eth0"].HostVethName = "stale-cache-value"
+		service.EndpointState[delTestContainerID].IfnameToIPMap[InfraInterfaceName].HostVethName = "stale-cache-value"
 		beforeCache := durableCacheFingerprint(service, adapter)
 
-		response, _ := invokeEndpointPatch(
-			t,
-			service,
+		response, _, err := invokeEndpointPatch(
 			context.Background(),
-			"container-1",
-			map[string]*IPInfo{"eth0": {HostVethName: "patched"}},
+			service,
+			delTestContainerID,
+			map[string]*IPInfo{InfraInterfaceName: {HostVethName: "patched"}},
 		)
+		require.NoError(t, err)
 		assert.Equal(t, types.InconsistentIPConfigState, response.ReturnCode)
 		assert.Equal(t, before, requireUnifiedSnapshot(t, db))
 		assert.Equal(t, beforeCache, durableCacheFingerprint(service, adapter))
@@ -444,27 +483,27 @@ func TestUnifiedPatchFailuresAndPostcommitRestore(t *testing.T) {
 
 	t.Run("postcommit cache restore", func(t *testing.T) {
 		service, adapter, db, _ := newUnifiedAddFixture(t, map[string][]state.IPRecord{
-			"nc-v4": {{ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1}},
+			delTestNCIPv4: {{ID: delTestIPID1, IPAddress: delTestIPv4Address, NCID: delTestNCIPv4, NCVersion: 1}},
 		}, nil)
-		add := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
-		add.DesiredIPAddresses = []string{"10.0.0.4"}
+		add := unifiedAddRequest(delTestContainerID, delTestInterfaceID, InfraInterfaceName, delTestPodName, delTestNamespace)
+		add.DesiredIPAddresses = []string{delTestIPv4Address}
 		_, err := service.requestIPConfigHandlerHelper(context.Background(), add)
 		require.NoError(t, err)
 		before := requireUnifiedSnapshot(t, db)
-		adapter.applyPatchProjection = func(durableCacheProjection) error { return injected }
+		adapter.applyPatchProjection = func(durableCacheProjection) error { return errInjectedPatchFailure }
 
-		response, _ := invokeEndpointPatch(
-			t,
-			service,
+		response, _, err := invokeEndpointPatch(
 			context.Background(),
-			"container-1",
-			map[string]*IPInfo{"eth0": {HostVethName: "committed"}},
+			service,
+			delTestContainerID,
+			map[string]*IPInfo{InfraInterfaceName: {HostVethName: "committed"}},
 		)
+		require.NoError(t, err)
 		assert.Equal(t, types.UnexpectedError, response.ReturnCode)
 		after := requireUnifiedSnapshot(t, db)
 		assert.Equal(t, before.Metadata.Generation+1, after.Metadata.Generation)
-		assert.Equal(t, "committed", after.Endpoints["container-1"].IfnameToIPMap["eth0"].HostVethName)
-		assert.Equal(t, "committed", service.EndpointState["container-1"].IfnameToIPMap["eth0"].HostVethName)
+		assert.Equal(t, "committed", after.Endpoints[delTestContainerID].IfnameToIPMap[InfraInterfaceName].HostVethName)
+		assert.Equal(t, "committed", service.EndpointState[delTestContainerID].IfnameToIPMap[InfraInterfaceName].HostVethName)
 		generation, projected := adapter.cacheGeneration()
 		assert.True(t, projected)
 		assert.Equal(t, after.Metadata.Generation, generation)
@@ -475,24 +514,23 @@ func TestUnifiedPatchReadOnlyClosedAndRestart(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "state.db")
 	db, err := state.Open(path, state.Options{})
 	require.NoError(t, err)
-	_, err = db.ApplyNetworkContainer(context.Background(), r18NetworkContainer("nc-v4"), []state.IPRecord{{
-		ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1,
+	_, err = db.ApplyNetworkContainer(context.Background(), r18NetworkContainer(delTestNCIPv4), []state.IPRecord{{
+		ID: delTestIPID1, IPAddress: delTestIPv4Address, NCID: delTestNCIPv4, NCVersion: 1,
 	}})
 	require.NoError(t, err)
 	service := newUnifiedAddTestService(t)
 	restore, closeState, err := NewDurableStateLifecycle(service, db, true)
 	require.NoError(t, err)
 	require.NoError(t, restore(context.Background()))
-	add := unifiedAddRequest("container-1", "interface-1", "eth0", "pod-1", "namespace-1")
-	add.DesiredIPAddresses = []string{"10.0.0.4"}
+	add := unifiedAddRequest(delTestContainerID, delTestInterfaceID, InfraInterfaceName, delTestPodName, delTestNamespace)
+	add.DesiredIPAddresses = []string{delTestIPv4Address}
 	_, err = service.requestIPConfigHandlerHelper(context.Background(), add)
 	require.NoError(t, err)
-	response, _ := invokeEndpointPatch(
-		t,
-		service,
+	response, _, err := invokeEndpointPatch(
 		context.Background(),
-		"container-1",
-		map[string]*IPInfo{"eth0": {
+		service,
+		delTestContainerID,
+		map[string]*IPInfo{InfraInterfaceName: {
 			HnsEndpointID: "restart-hns",
 			HnsNetworkID:  "restart-network",
 			HostVethName:  "restart-veth",
@@ -500,16 +538,17 @@ func TestUnifiedPatchReadOnlyClosedAndRestart(t *testing.T) {
 			NICType:       cns.ApipaNIC,
 		}},
 	)
+	require.NoError(t, err)
 	require.Equal(t, types.Success, response.ReturnCode)
 	require.NoError(t, closeState())
 
-	response, _ = invokeEndpointPatch(
-		t,
-		service,
+	response, _, err = invokeEndpointPatch(
 		context.Background(),
-		"container-1",
-		map[string]*IPInfo{"eth0": {HostVethName: "closed"}},
+		service,
+		delTestContainerID,
+		map[string]*IPInfo{InfraInterfaceName: {HostVethName: "closed"}},
 	)
+	require.NoError(t, err)
 	assert.Equal(t, types.UnexpectedError, response.ReturnCode)
 
 	reopened, err := state.Open(path, state.Options{})
@@ -519,7 +558,7 @@ func TestUnifiedPatchReadOnlyClosedAndRestart(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, restore(context.Background()))
 	t.Cleanup(func() { require.NoError(t, closeRestarted()) })
-	info := restarted.EndpointState["container-1"].IfnameToIPMap["eth0"]
+	info := restarted.EndpointState[delTestContainerID].IfnameToIPMap[InfraInterfaceName]
 	assert.Equal(t, "restart-hns", info.HnsEndpointID)
 	assert.Equal(t, "restart-network", info.HnsNetworkID)
 	assert.Equal(t, "restart-veth", info.HostVethName)
@@ -534,65 +573,72 @@ func TestUnifiedPatchReadOnlyClosedAndRestart(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, restore(context.Background()))
 	t.Cleanup(func() { require.NoError(t, closeReadOnly()) })
-	response, _ = invokeEndpointPatch(
-		t,
-		readOnlyService,
+	response, _, err = invokeEndpointPatch(
 		context.Background(),
-		"container-1",
-		map[string]*IPInfo{"eth0": {HostVethName: "read-only"}},
+		readOnlyService,
+		delTestContainerID,
+		map[string]*IPInfo{InfraInterfaceName: {HostVethName: "read-only"}},
 	)
+	require.NoError(t, err)
 	assert.Equal(t, types.UnexpectedError, response.ReturnCode)
-	assert.Equal(t, "restart-veth", readOnlyService.EndpointState["container-1"].IfnameToIPMap["eth0"].HostVethName)
+	assert.Equal(
+		t,
+		"restart-veth",
+		readOnlyService.EndpointState[delTestContainerID].IfnameToIPMap[InfraInterfaceName].HostVethName,
+	)
 }
 
 func TestJSONPatchPathRemainsIsolated(t *testing.T) {
 	service := getTestService(cns.KubernetesCRD)
 	enableManagedEndpointState(service)
-	service.EndpointState["container-1"] = &EndpointInfo{
-		PodName:      "pod-1",
-		PodNamespace: "namespace-1",
+	service.EndpointState[delTestContainerID] = &EndpointInfo{
+		PodName:      delTestPodName,
+		PodNamespace: delTestNamespace,
 		IfnameToIPMap: map[string]*IPInfo{
-			"eth0": {IPv4: []net.IPNet{testIPNet("10.0.0.4/24")}},
+			InfraInterfaceName: {IPv4: []net.IPNet{testIPNet(delTestIPv4Address + "/24")}},
 		},
 	}
 	require.NoError(t, service.EndpointStateStore.Write(EndpointStoreKey, service.EndpointState))
 	require.Nil(t, service.selectedUnifiedStateAdapter())
 
-	response, _ := invokeEndpointPatch(
-		t,
-		service,
+	response, _, err := invokeEndpointPatch(
 		context.Background(),
-		"container-1",
-		map[string]*IPInfo{"eth0": {HostVethName: "json-veth"}},
+		service,
+		delTestContainerID,
+		map[string]*IPInfo{InfraInterfaceName: {HostVethName: "json-veth"}},
 	)
+	require.NoError(t, err)
 	require.Equal(t, types.Success, response.ReturnCode)
-	assert.Equal(t, "json-veth", service.EndpointState["container-1"].IfnameToIPMap["eth0"].HostVethName)
+	assert.Equal(t, "json-veth", service.EndpointState[delTestContainerID].IfnameToIPMap[InfraInterfaceName].HostVethName)
 	var persisted map[string]*EndpointInfo
 	require.NoError(t, service.EndpointStateStore.Read(EndpointStoreKey, &persisted))
-	assert.Equal(t, "json-veth", persisted["container-1"].IfnameToIPMap["eth0"].HostVethName)
+	assert.Equal(t, "json-veth", persisted[delTestContainerID].IfnameToIPMap[InfraInterfaceName].HostVethName)
 	assert.Nil(t, service.selectedUnifiedStateAdapter())
 }
 
 func invokeEndpointPatch(
-	t *testing.T,
-	service *HTTPRestService,
 	ctx context.Context,
+	service *HTTPRestService,
 	endpointID string,
 	request map[string]*IPInfo,
-) (cns.Response, *httptest.ResponseRecorder) {
-	t.Helper()
-	body, err := json.Marshal(request)
-	require.NoError(t, err)
-	httpRequest := httptest.NewRequest(
+) (cns.Response, *httptest.ResponseRecorder, error) {
+	body, err := json.Marshal(request) //nolint:musttag // IPInfo is the existing endpoint API wire type.
+	if err != nil {
+		return cns.Response{}, nil, fmt.Errorf("encoding endpoint patch request: %w", err)
+	}
+	httpRequest := httptest.NewRequestWithContext(
+		ctx,
 		http.MethodPatch,
 		cns.EndpointPath+endpointID,
 		bytes.NewReader(body),
-	).WithContext(ctx)
+	)
 	recorder := httptest.NewRecorder()
 	service.EndpointHandlerAPI(recorder, httpRequest)
 	var response cns.Response
-	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
-	return response, recorder
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		return cns.Response{}, recorder, fmt.Errorf("decoding endpoint patch response: %w", err)
+	}
+	return response, recorder, nil
 }
 
 func TestUnifiedPatchReadOnlyErrorIdentity(t *testing.T) {

--- a/cns/restserver/unified_patch_test.go
+++ b/cns/restserver/unified_patch_test.go
@@ -545,54 +545,6 @@ func TestUnifiedPatchReadOnlyClosedAndRestart(t *testing.T) {
 	assert.Equal(t, "restart-veth", readOnlyService.EndpointState["container-1"].IfnameToIPMap["eth0"].HostVethName)
 }
 
-func TestUnifiedPatchImportedEndpointPreservesOwnership(t *testing.T) {
-	db, err := state.Open(filepath.Join(t.TempDir(), "state.db"), state.Options{})
-	require.NoError(t, err)
-	_, err = db.ApplyNetworkContainer(context.Background(), r18NetworkContainer("nc-v4"), []state.IPRecord{{
-		ID: "ip-1", IPAddress: "10.0.0.4", NCID: "nc-v4", NCVersion: 1,
-	}})
-	require.NoError(t, err)
-	records := []cns.CNIEndpointState{{
-		InfraContainerID: "container-1",
-		PodEndpointID:    "interface-1",
-		PodName:          "pod-1",
-		PodNamespace:     "namespace-1",
-		InterfaceKey:     "container-1-eth0",
-		InterfaceName:    "eth0",
-		IPAddresses:      []net.IPNet{testIPNet("10.0.0.4/24")},
-	}}
-	plan, err := db.PreflightCNIEndpointImport(context.Background(), records, false)
-	require.NoError(t, err)
-	changed, err := db.ImportCNIEndpointState(context.Background(), records, plan)
-	require.NoError(t, err)
-	require.True(t, changed)
-	before := requireUnifiedSnapshot(t, db)
-	service := newUnifiedAddTestService(t)
-	restore, closeState, err := NewDurableStateLifecycle(service, db, true)
-	require.NoError(t, err)
-	require.NoError(t, restore(context.Background()))
-	t.Cleanup(func() { require.NoError(t, closeState()) })
-
-	response, _ := invokeEndpointPatch(
-		t,
-		service,
-		context.Background(),
-		"container-1",
-		map[string]*IPInfo{"eth0": {
-			HnsEndpointID:      "imported-hns",
-			NetworkContainerID: "nc-v4",
-			NICType:            cns.InfraNIC,
-		}},
-	)
-	require.Equal(t, types.Success, response.ReturnCode)
-	after := requireUnifiedSnapshot(t, db)
-	assert.Equal(t, before.Assignments, after.Assignments)
-	assert.Equal(t, before.IPOwners, after.IPOwners)
-	assert.Equal(t, before.DeleteIntents, after.DeleteIntents)
-	assert.Equal(t, "imported-hns", after.Endpoints["container-1"].IfnameToIPMap["eth0"].HNSEndpointID)
-	assert.Equal(t, "nc-v4", after.Endpoints["container-1"].IfnameToIPMap["eth0"].NetworkContainerID)
-}
-
 func TestJSONPatchPathRemainsIsolated(t *testing.T) {
 	service := getTestService(cns.KubernetesCRD)
 	enableManagedEndpointState(service)

--- a/cns/state/ownership_operations.go
+++ b/cns/state/ownership_operations.go
@@ -369,6 +369,41 @@ func (s *DB) PatchEndpoint(
 	now time.Time,
 	deleteIntentTTL time.Duration,
 ) (bool, error) {
+	return s.patchEndpoint(ctx, nil, pod, endpoint, now, deleteIntentTTL, nil)
+}
+
+// PatchEndpointIfGeneration atomically replaces endpoint details only at
+// expectedGeneration. beforeCommit may validate the complete candidate
+// snapshot before the endpoint is written.
+func (s *DB) PatchEndpointIfGeneration(
+	ctx context.Context,
+	expectedGeneration uint64,
+	pod PodIdentity,
+	endpoint EndpointRecord,
+	now time.Time,
+	deleteIntentTTL time.Duration,
+	beforeCommit func(Snapshot) error,
+) (bool, error) {
+	return s.patchEndpoint(
+		ctx,
+		&expectedGeneration,
+		pod,
+		endpoint,
+		now,
+		deleteIntentTTL,
+		beforeCommit,
+	)
+}
+
+func (s *DB) patchEndpoint(
+	ctx context.Context,
+	expectedGeneration *uint64,
+	pod PodIdentity,
+	endpoint EndpointRecord,
+	now time.Time,
+	deleteIntentTTL time.Duration,
+	beforeCommit func(Snapshot) error,
+) (bool, error) {
 	normalizedPod, err := normalizePodIdentity(pod, true)
 	if err != nil {
 		return false, err
@@ -389,6 +424,14 @@ func (s *DB) PatchEndpoint(
 		current, snapshotErr := tx.validSnapshot()
 		if snapshotErr != nil {
 			return false, snapshotErr
+		}
+		if expectedGeneration != nil && current.Metadata.Generation != *expectedGeneration {
+			return false, fmt.Errorf(
+				"%w: expected=%d actual=%d",
+				ErrStaleGeneration,
+				*expectedGeneration,
+				current.Metadata.Generation,
+			)
 		}
 		if intent, ok := current.DeleteIntents[normalizedPod.InfraContainerID]; ok &&
 			deleteIntentLive(intent, now, deleteIntentTTL) {
@@ -415,7 +458,24 @@ func (s *DB) PatchEndpoint(
 			return false, equalErr
 		}
 		if equal {
+			if beforeCommit != nil {
+				if err := beforeCommit(current); err != nil {
+					return false, fmt.Errorf("validating endpoint patch candidate: %w", err)
+				}
+			}
 			return false, nil
+		}
+		if candidate.Metadata.Generation == math.MaxUint64 {
+			return false, corrupt("generation overflow", nil)
+		}
+		candidate.Metadata.Generation++
+		if beforeCommit != nil {
+			if callbackErr := beforeCommit(candidate); callbackErr != nil {
+				return false, fmt.Errorf("validating endpoint patch candidate: %w", callbackErr)
+			}
+		}
+		if contextErr := ctx.Err(); contextErr != nil {
+			return false, fmt.Errorf("committing endpoint patch: %w", contextErr)
 		}
 		data, encodeErr := encodeJSONInput(normalizedEndpoint)
 		if encodeErr != nil {

--- a/cns/state/ownership_operations_test.go
+++ b/cns/state/ownership_operations_test.go
@@ -676,6 +676,398 @@ func TestPatchAndDeleteEndpoint(t *testing.T) {
 	assert.Equal(t, deleteGeneration, readMetadata(t, db).Generation)
 }
 
+func TestPatchEndpointIfGeneration(t *testing.T) {
+	t.Run("commit callback and replay", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		assignment, endpoint := seedOwnershipInventory(t, db)
+		_, err := db.AssignEndpoint(
+			context.Background(),
+			assignment,
+			endpoint,
+			testNow,
+			testDeleteIntentTTL,
+		)
+		require.NoError(t, err)
+		before := requireValidSnapshot(t, db)
+		patched := deepCloneEndpoint(t, endpoint)
+		patched.IfnameToIPMap["eth0"].HNSEndpointID = "patched-hns"
+		callbacks := 0
+
+		changed, err := db.PatchEndpointIfGeneration(
+			context.Background(),
+			before.Metadata.Generation,
+			assignment.Pod,
+			patched,
+			testNow,
+			testDeleteIntentTTL,
+			func(candidate Snapshot) error {
+				callbacks++
+				assert.Equal(t, before.Metadata.Generation+1, candidate.Metadata.Generation)
+				equal, equalErr := endpointsEqual(
+					patched,
+					candidate.Endpoints[assignment.Pod.InfraContainerID],
+				)
+				require.NoError(t, equalErr)
+				assert.True(t, equal)
+				assert.Equal(t, before.Assignments, candidate.Assignments)
+				assert.Equal(t, before.IPOwners, candidate.IPOwners)
+				assert.Equal(t, before.DeleteIntents, candidate.DeleteIntents)
+				return nil
+			},
+		)
+		require.NoError(t, err)
+		assert.True(t, changed)
+		committed := requireValidSnapshot(t, db)
+		assert.Equal(t, before.Metadata.Generation+1, committed.Metadata.Generation)
+		equal, err := endpointsEqual(patched, committed.Endpoints[assignment.Pod.InfraContainerID])
+		require.NoError(t, err)
+		assert.True(t, equal)
+
+		changed, err = db.PatchEndpointIfGeneration(
+			context.Background(),
+			committed.Metadata.Generation,
+			assignment.Pod,
+			patched,
+			testNow,
+			testDeleteIntentTTL,
+			func(candidate Snapshot) error {
+				callbacks++
+				assert.Equal(t, committed, candidate)
+				return nil
+			},
+		)
+		require.NoError(t, err)
+		assert.False(t, changed)
+		assert.Equal(t, 2, callbacks)
+		assert.Equal(t, committed, requireValidSnapshot(t, db))
+
+		changed, err = db.PatchEndpointIfGeneration(
+			context.Background(),
+			committed.Metadata.Generation,
+			assignment.Pod,
+			patched,
+			testNow,
+			testDeleteIntentTTL,
+			func(Snapshot) error { return errAbort },
+		)
+		require.ErrorIs(t, err, errAbort)
+		assert.False(t, changed)
+		assert.Equal(t, committed, requireValidSnapshot(t, db))
+	})
+
+	t.Run("stale and callback failures are atomic", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		assignment, endpoint := seedOwnershipInventory(t, db)
+		_, err := db.AssignEndpoint(
+			context.Background(),
+			assignment,
+			endpoint,
+			testNow,
+			testDeleteIntentTTL,
+		)
+		require.NoError(t, err)
+		before := requireValidSnapshot(t, db)
+		patched := deepCloneEndpoint(t, endpoint)
+		patched.IfnameToIPMap["eth0"].HostVethName = "patched-veth"
+
+		changed, err := db.PatchEndpointIfGeneration(
+			context.Background(),
+			before.Metadata.Generation-1,
+			assignment.Pod,
+			patched,
+			testNow,
+			testDeleteIntentTTL,
+			nil,
+		)
+		require.ErrorIs(t, err, ErrStaleGeneration)
+		assert.False(t, changed)
+		assert.Equal(t, before, requireValidSnapshot(t, db))
+
+		changed, err = db.PatchEndpointIfGeneration(
+			context.Background(),
+			before.Metadata.Generation,
+			assignment.Pod,
+			patched,
+			testNow,
+			testDeleteIntentTTL,
+			func(Snapshot) error { return errAbort },
+		)
+		require.ErrorIs(t, err, errAbort)
+		assert.False(t, changed)
+		assert.Equal(t, before, requireValidSnapshot(t, db))
+	})
+
+	t.Run("contract failures", func(t *testing.T) {
+		t.Run("invalid time", func(t *testing.T) {
+			db, _ := openTestDB(t)
+			assignment, endpoint := seedOwnershipInventory(t, db)
+			changed, err := db.PatchEndpointIfGeneration(
+				context.Background(),
+				0,
+				assignment.Pod,
+				endpoint,
+				time.Time{},
+				testDeleteIntentTTL,
+				nil,
+			)
+			require.ErrorIs(t, err, ErrInvalidInput)
+			assert.False(t, changed)
+		})
+
+		t.Run("expired released assignment is absent", func(t *testing.T) {
+			db, _ := openTestDB(t)
+			assignment, endpoint := seedOwnershipInventory(t, db)
+			_, err := db.AssignEndpoint(
+				context.Background(),
+				assignment,
+				endpoint,
+				testNow,
+				testDeleteIntentTTL,
+			)
+			require.NoError(t, err)
+			_, err = db.ReleaseEndpoint(context.Background(), assignment.Pod, testNow)
+			require.NoError(t, err)
+			before := requireValidSnapshot(t, db)
+
+			changed, err := db.PatchEndpointIfGeneration(
+				context.Background(),
+				before.Metadata.Generation,
+				assignment.Pod,
+				endpoint,
+				testNow.Add(testDeleteIntentTTL),
+				testDeleteIntentTTL,
+				nil,
+			)
+			require.ErrorIs(t, err, ErrNotFound)
+			assert.False(t, changed)
+			assert.Equal(t, before, requireValidSnapshot(t, db))
+		})
+
+		t.Run("assignment identity mismatch", func(t *testing.T) {
+			db, _ := openTestDB(t)
+			assignment, endpoint := seedOwnershipInventory(t, db)
+			_, err := db.AssignEndpoint(
+				context.Background(),
+				assignment,
+				endpoint,
+				testNow,
+				testDeleteIntentTTL,
+			)
+			require.NoError(t, err)
+			before := requireValidSnapshot(t, db)
+			wrongPod := assignment.Pod
+			wrongPod.InfraContainerID = "other-container"
+
+			changed, err := db.PatchEndpointIfGeneration(
+				context.Background(),
+				before.Metadata.Generation,
+				wrongPod,
+				endpoint,
+				testNow,
+				testDeleteIntentTTL,
+				nil,
+			)
+			require.ErrorIs(t, err, ErrInvalidInput)
+			assert.False(t, changed)
+			assert.Equal(t, before, requireValidSnapshot(t, db))
+		})
+
+		t.Run("generation overflow", func(t *testing.T) {
+			db, _ := openTestDB(t)
+			assignment, endpoint := seedOwnershipInventory(t, db)
+			_, err := db.AssignEndpoint(
+				context.Background(),
+				assignment,
+				endpoint,
+				testNow,
+				testDeleteIntentTTL,
+			)
+			require.NoError(t, err)
+			require.NoError(t, db.db.Update(func(tx *bolt.Tx) error {
+				return tx.Bucket(bucketMetadata).Put(metaKeyGeneration, encodeUint64(^uint64(0)))
+			}))
+			before := requireValidSnapshot(t, db)
+			patched := deepCloneEndpoint(t, endpoint)
+			patched.IfnameToIPMap["eth0"].HostVethName = "patched-veth"
+
+			changed, err := db.PatchEndpointIfGeneration(
+				context.Background(),
+				before.Metadata.Generation,
+				assignment.Pod,
+				patched,
+				testNow,
+				testDeleteIntentTTL,
+				nil,
+			)
+			require.ErrorIs(t, err, ErrCorrupt)
+			assert.False(t, changed)
+			assert.Equal(t, before, requireValidSnapshot(t, db))
+		})
+
+		t.Run("callback cancellation", func(t *testing.T) {
+			db, _ := openTestDB(t)
+			assignment, endpoint := seedOwnershipInventory(t, db)
+			_, err := db.AssignEndpoint(
+				context.Background(),
+				assignment,
+				endpoint,
+				testNow,
+				testDeleteIntentTTL,
+			)
+			require.NoError(t, err)
+			before := requireValidSnapshot(t, db)
+			patched := deepCloneEndpoint(t, endpoint)
+			patched.IfnameToIPMap["eth0"].HostVethName = "patched-veth"
+			ctx, cancel := context.WithCancel(context.Background())
+
+			changed, err := db.PatchEndpointIfGeneration(
+				ctx,
+				before.Metadata.Generation,
+				assignment.Pod,
+				patched,
+				testNow,
+				testDeleteIntentTTL,
+				func(Snapshot) error {
+					cancel()
+					return nil
+				},
+			)
+			require.ErrorIs(t, err, context.Canceled)
+			assert.False(t, changed)
+			assert.Equal(t, before, requireValidSnapshot(t, db))
+		})
+	})
+
+	t.Run("expired intent is retained", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		assignment, endpoint := seedOwnershipInventory(t, db)
+		_, err := db.AssignEndpoint(
+			context.Background(),
+			assignment,
+			endpoint,
+			testNow,
+			testDeleteIntentTTL,
+		)
+		require.NoError(t, err)
+		createdAt := testNow.Add(-testDeleteIntentTTL)
+		require.NoError(t, db.Update(context.Background(), func(tx *WriteTx) error {
+			return tx.PutDeleteIntent(assignment.Pod.InfraContainerID, DeleteIntent{CreatedAt: createdAt})
+		}))
+		before := requireValidSnapshot(t, db)
+		beforeAssignment := rawValue(t, db, bucketAssignments, []byte(assignment.Pod.PodKey))
+		beforeIntent := rawValue(t, db, bucketDeleteIntents, []byte(assignment.Pod.InfraContainerID))
+		beforeOwners := map[string][]byte{}
+		for _, ipID := range assignment.IPIDs {
+			beforeOwners[ipID] = rawValue(t, db, bucketIPOwners, []byte(ipID))
+		}
+		patched := deepCloneEndpoint(t, endpoint)
+		patched.IfnameToIPMap["eth0"].HNSNetworkID = "patched-network"
+
+		changed, err := db.PatchEndpointIfGeneration(
+			context.Background(),
+			before.Metadata.Generation,
+			assignment.Pod,
+			patched,
+			testNow,
+			testDeleteIntentTTL,
+			nil,
+		)
+		require.NoError(t, err)
+		assert.True(t, changed)
+		after := requireValidSnapshot(t, db)
+		assert.Equal(t, DeleteIntent{CreatedAt: createdAt}, after.DeleteIntents[assignment.Pod.InfraContainerID])
+		assert.Equal(t, beforeAssignment, rawValue(t, db, bucketAssignments, []byte(assignment.Pod.PodKey)))
+		assert.Equal(t, beforeIntent, rawValue(t, db, bucketDeleteIntents, []byte(assignment.Pod.InfraContainerID)))
+		for _, ipID := range assignment.IPIDs {
+			assert.Equal(t, beforeOwners[ipID], rawValue(t, db, bucketIPOwners, []byte(ipID)))
+		}
+	})
+
+	t.Run("canceled while waiting for writer gate", func(t *testing.T) {
+		db, _ := openTestDB(t)
+		assignment, endpoint := seedOwnershipInventory(t, db)
+		_, err := db.AssignEndpoint(
+			context.Background(),
+			assignment,
+			endpoint,
+			testNow,
+			testDeleteIntentTTL,
+		)
+		require.NoError(t, err)
+		before := requireValidSnapshot(t, db)
+		patched := deepCloneEndpoint(t, endpoint)
+		patched.IfnameToIPMap["eth0"].MACAddress = "00:11:22:33:44:66"
+		db.writeGate <- struct{}{}
+		t.Cleanup(func() {
+			select {
+			case <-db.writeGate:
+			default:
+			}
+		})
+		ctx, cancel := context.WithCancel(context.Background())
+		result := make(chan error, 1)
+		go func() {
+			_, patchErr := db.PatchEndpointIfGeneration(
+				ctx,
+				before.Metadata.Generation,
+				assignment.Pod,
+				patched,
+				testNow,
+				testDeleteIntentTTL,
+				nil,
+			)
+			result <- patchErr
+		}()
+		cancel()
+		require.ErrorIs(t, <-result, context.Canceled)
+		<-db.writeGate
+		assert.Equal(t, before, requireValidSnapshot(t, db))
+	})
+
+	t.Run("read only and closed", func(t *testing.T) {
+		db, path := openTestDB(t)
+		assignment, endpoint := seedOwnershipInventory(t, db)
+		_, err := db.AssignEndpoint(
+			context.Background(),
+			assignment,
+			endpoint,
+			testNow,
+			testDeleteIntentTTL,
+		)
+		require.NoError(t, err)
+		before := requireValidSnapshot(t, db)
+		require.NoError(t, db.Close())
+
+		_, err = db.PatchEndpointIfGeneration(
+			context.Background(),
+			before.Metadata.Generation,
+			assignment.Pod,
+			endpoint,
+			testNow,
+			testDeleteIntentTTL,
+			nil,
+		)
+		require.ErrorIs(t, err, bolterrors.ErrDatabaseNotOpen)
+
+		readOnly, err := Open(path, Options{ReadOnly: true})
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, readOnly.Close()) })
+		patched := deepCloneEndpoint(t, endpoint)
+		patched.IfnameToIPMap["eth0"].HostVethName = "patched-veth"
+		_, err = readOnly.PatchEndpointIfGeneration(
+			context.Background(),
+			before.Metadata.Generation,
+			assignment.Pod,
+			patched,
+			testNow,
+			testDeleteIntentTTL,
+			nil,
+		)
+		require.ErrorIs(t, err, bolterrors.ErrDatabaseReadOnly)
+		assert.Equal(t, before, requireValidSnapshot(t, readOnly))
+	})
+}
+
 func TestPruneDeleteIntents(t *testing.T) {
 	db, _ := openTestDB(t)
 	require.NoError(t, db.Update(context.Background(), func(tx *WriteTx) error {

--- a/cns/state/ownership_operations_test.go
+++ b/cns/state/ownership_operations_test.go
@@ -27,6 +27,7 @@ var errAssignmentCandidate = errors.New("injected candidate failure")
 const (
 	testIPv4Address2 = "10.0.0.5"
 	testContainerID2 = "container-2"
+	testPatchedVeth  = "patched-veth"
 )
 
 func TestOwnershipTransactions(t *testing.T) {
@@ -768,7 +769,7 @@ func TestPatchEndpointIfGeneration(t *testing.T) {
 		require.NoError(t, err)
 		before := requireValidSnapshot(t, db)
 		patched := deepCloneEndpoint(t, endpoint)
-		patched.IfnameToIPMap["eth0"].HostVethName = "patched-veth"
+		patched.IfnameToIPMap["eth0"].HostVethName = testPatchedVeth
 
 		changed, err := db.PatchEndpointIfGeneration(
 			context.Background(),
@@ -888,7 +889,7 @@ func TestPatchEndpointIfGeneration(t *testing.T) {
 			}))
 			before := requireValidSnapshot(t, db)
 			patched := deepCloneEndpoint(t, endpoint)
-			patched.IfnameToIPMap["eth0"].HostVethName = "patched-veth"
+			patched.IfnameToIPMap["eth0"].HostVethName = testPatchedVeth
 
 			changed, err := db.PatchEndpointIfGeneration(
 				context.Background(),
@@ -917,7 +918,7 @@ func TestPatchEndpointIfGeneration(t *testing.T) {
 			require.NoError(t, err)
 			before := requireValidSnapshot(t, db)
 			patched := deepCloneEndpoint(t, endpoint)
-			patched.IfnameToIPMap["eth0"].HostVethName = "patched-veth"
+			patched.IfnameToIPMap["eth0"].HostVethName = testPatchedVeth
 			ctx, cancel := context.WithCancel(context.Background())
 
 			changed, err := db.PatchEndpointIfGeneration(
@@ -1053,7 +1054,7 @@ func TestPatchEndpointIfGeneration(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, readOnly.Close()) })
 		patched := deepCloneEndpoint(t, endpoint)
-		patched.IfnameToIPMap["eth0"].HostVethName = "patched-veth"
+		patched.IfnameToIPMap["eth0"].HostVethName = testPatchedVeth
 		_, err = readOnly.PatchEndpointIfGeneration(
 			context.Background(),
 			before.Metadata.Generation,


### PR DESCRIPTION
## Scope
Routes endpoint platform-detail PATCH through one generation-gated Bolt transaction with candidate projection and committed-state recovery.

## Draft dependency caveat
This PR is opened early for review and CI on top of transactional DEL, whose base is a temporary T1 + #4502 join. **Do not merge until T2 and all inherited prerequisites merge.**

## Behavior
PATCH cannot change assigned addresses, cannot bypass delete intents, and preserves assignment/owner identity. PATCH/DELETE dispatch captures the adapter before handler execution to avoid races and lock recursion.

## Evidence
Whole restserver race tests pass; the previously hanging JSON PATCH path completes in 8.6 seconds.