### PR TITLE
[Backport release/v1.7] fix: key async delete watcher by container ID, not full path

### DIFF
--- a/cns/fsnotify/fsnotify.go
+++ b/cns/fsnotify/fsnotify.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -56,15 +57,20 @@ func (w *watcher) releaseAll(ctx context.Context) {
 	defer w.lock.Unlock()
 	for containerID := range w.pendingDelete {
 		// read file contents
-		filepath := w.path + "/" + containerID
-		file, err := os.Open(filepath)
+		filePath := w.path + "/" + containerID
+		file, err := os.Open(filePath)
 		if err != nil {
-			w.log.Error("failed to open file", zap.Error(err))
+			// Without the file we cannot know the pod interface ID, and a
+			// release without it cannot match the assignment in CNS.
+			w.log.Error("failed to open file", zap.String("containerID", containerID), zap.String("path", filePath), zap.Error(err))
+			continue
 		}
 
 		data, errReadingFile := io.ReadAll(file)
 		if errReadingFile != nil {
-			w.log.Error("failed to read file content", zap.Error(errReadingFile))
+			w.log.Error("failed to read file content", zap.String("containerID", containerID), zap.String("path", filePath), zap.Error(errReadingFile))
+			file.Close()
+			continue
 		}
 		file.Close()
 		podInterfaceID := string(data)
@@ -92,7 +98,9 @@ func (w *watcher) watchPendingDelete(ctx context.Context) error {
 		case <-ctx.Done():
 			return errors.Wrap(ctx.Err(), "exiting watchPendingDelete")
 		case <-ticker.C:
+			w.lock.Lock()
 			n := len(w.pendingDelete)
+			w.lock.Unlock()
 			if n == 0 {
 				continue
 			}
@@ -153,7 +161,9 @@ func (w *watcher) watchFS(ctx context.Context) error {
 			}
 			w.log.Info("received create event", zap.String("event", event.Name))
 			w.lock.Lock()
-			w.pendingDelete[event.Name] = struct{}{}
+			// event.Name is the full path; the map is keyed by container ID
+			// (the file name), because releaseAll rebuilds the path from it.
+			w.pendingDelete[filepath.Base(event.Name)] = struct{}{}
 			w.lock.Unlock()
 		case watcherErr := <-watcher.Errors:
 			w.log.Error("fsnotify watcher error", zap.Error(watcherErr))
@@ -177,8 +187,8 @@ func (w *watcher) Start(ctx context.Context) error {
 
 // AddFile creates new file using the containerID as name
 func AddFile(podInterfaceID, containerID, path string) error {
-	filepath := path + "/" + containerID
-	f, err := os.Create(filepath)
+	filePath := path + "/" + containerID
+	f, err := os.Create(filePath)
 	if err != nil {
 		return errors.Wrap(err, "error creating file")
 	}
@@ -191,8 +201,8 @@ func AddFile(podInterfaceID, containerID, path string) error {
 
 // removeFile removes the file based on containerID
 func removeFile(containerID, path string) error {
-	filepath := path + "/" + containerID
-	if err := os.Remove(filepath); err != nil {
+	filePath := path + "/" + containerID
+	if err := os.Remove(filePath); err != nil {
 		return errors.Wrap(err, "error deleting file")
 	}
 	return nil

--- a/cns/fsnotify/pendingdelete_key_test.go
+++ b/cns/fsnotify/pendingdelete_key_test.go
@@ -1,0 +1,148 @@
+package fsnotify
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-container-networking/cns"
+	"go.uber.org/zap"
+)
+
+const (
+	testContainerID    = "56dba5daf3ed3aaab57f13047b0abbebfe2bdb05156896e2531beb6a2a0b15ae"
+	testPodInterfaceID = "56dba5da-eth0"
+)
+
+type recordingReleaseClient struct {
+	mu   sync.Mutex
+	reqs []cns.IPConfigsRequest
+}
+
+func (c *recordingReleaseClient) ReleaseIPs(_ context.Context, req cns.IPConfigsRequest) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.reqs = append(c.reqs, req)
+	return nil
+}
+
+func (c *recordingReleaseClient) snapshot() []cns.IPConfigsRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]cns.IPConfigsRequest(nil), c.reqs...)
+}
+
+func hasKey(w *watcher, key string) bool {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+	_, ok := w.pendingDelete[key]
+	return ok
+}
+
+func waitForKey(t *testing.T, w *watcher, key string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for !hasKey(w, key) {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for pending key %q", key)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestLiveCreateEventReleasesWithRealKeys guards the async-delete leak.
+//
+// fsnotify sets event.Name to the full path of the new file, but releaseAll
+// rebuilds the path as w.path + "/" + key. A map keyed by the full path made
+// every live-enqueued file unreadable, so the release reached CNS with an
+// empty PodInterfaceID and the pod IP stayed Assigned until the next CNS
+// restart. The map must be keyed by the container ID: the file's base name.
+func TestLiveCreateEventReleasesWithRealKeys(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "deleteIDs")
+	cli := &recordingReleaseClient{}
+	w, err := New(cli, dir, zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A pre-seeded file marks the end of the startup scan. watchFS attaches
+	// the inotify watch first and lists the directory second, so once this
+	// key appears, every later file reaches the map through a create event
+	// only. Without this handshake the test file could be picked up by the
+	// startup scan, which keys correctly even on the broken code.
+	const preseed = "preseed-scan-marker"
+	if err := AddFile("preseed-eth0", preseed, dir); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = w.watchFS(ctx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Error("watchFS did not exit after cancellation")
+		}
+	})
+	waitForKey(t, w, preseed)
+
+	// The CNI enqueues a missed delete exactly as invoker_cns.go does. Only
+	// the create event can deliver this key now. On the broken code the key
+	// is the full path and this wait times out.
+	if err := AddFile(testPodInterfaceID, testContainerID, dir); err != nil {
+		t.Fatal(err)
+	}
+	waitForKey(t, w, testContainerID)
+
+	// Drop the preseed entry so the release assertions see one request.
+	w.lock.Lock()
+	delete(w.pendingDelete, preseed)
+	w.lock.Unlock()
+	if err := os.Remove(filepath.Join(dir, preseed)); err != nil {
+		t.Fatal(err)
+	}
+
+	w.releaseAll(ctx)
+
+	reqs := cli.snapshot()
+	if len(reqs) != 1 {
+		t.Fatalf("want 1 release request, got %+v", reqs)
+	}
+	if reqs[0].PodInterfaceID != testPodInterfaceID || reqs[0].InfraContainerID != testContainerID {
+		t.Errorf("LEAK: CNS got PodInterfaceID=%q InfraContainerID=%q, want %q and %q",
+			reqs[0].PodInterfaceID, reqs[0].InfraContainerID, testPodInterfaceID, testContainerID)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, testContainerID)); statErr == nil {
+		t.Errorf("LEAK: pending delete file was left on disk")
+	}
+	if hasKey(w, testContainerID) {
+		t.Errorf("released entry must be dropped from pendingDelete")
+	}
+}
+
+// TestReleaseAllSkipsEntryWithoutFile checks the guard: an entry whose file
+// cannot be read must not produce a release, because the request would carry
+// an empty pod interface ID and can never match an assignment.
+func TestReleaseAllSkipsEntryWithoutFile(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "deleteIDs")
+	cli := &recordingReleaseClient{}
+	w, err := New(cli, dir, zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.pendingDelete["no-such-file"] = struct{}{}
+
+	w.releaseAll(context.Background())
+
+	if reqs := cli.snapshot(); len(reqs) != 0 {
+		t.Errorf("no release must be sent for an unreadable entry, got %+v", reqs)
+	}
+}


### PR DESCRIPTION
**Reason for Change**:

Backport of #4768 to `release/v1.7`. The cherry-pick from `5c160f8a0f9e1d5d803c1bae8f4dcbc4beea30f3` applies with no conflicts.

CNS keys the async-delete watcher map by the full file path from the fsnotify event, but `releaseAll` rebuilds the path as `w.path + "/" + key`. Every missed delete enqueued while CNS runs is read through a doubled path and released with an empty pod interface ID. CNS cannot match that request, so the pod IP stays `Assigned` until the next CNS restart. The fix keys the map by `filepath.Base(event.Name)` — the container ID — the same key the startup scan uses. Full failure timeline in #4768.

**Issue Fixed**:

N/A — see #4768.

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [x] adds unit tests
- [x] relevant PR labels added

**Notes**:

`go test ./cns/fsnotify/...` passes on the backport branch.
