### PR TITLE
fix(npm): enforce IPBlock.Except on NPM Lite Windows direct-rule path

### DIFF
--- a/npm/pkg/controlplane/translation/translatePolicy.go
+++ b/npm/pkg/controlplane/translation/translatePolicy.go
@@ -395,6 +395,12 @@ func exceptDirectDropRules(npmNetPol *policies.NPMNetworkPolicy, direction polic
 }
 
 func directPeerAndPortAllowRule(npmNetPol *policies.NPMNetworkPolicy, direction policies.Direction, ports []networkingv1.NetworkPolicyPort, cidr string, except []string, npmLiteToggle bool) error {
+	// Match the ipset-based ipBlockRule path and reject non-IPv4 enclosing CIDRs (e.g. IPv6),
+	// which HNS direct-IP ACLs cannot express. Failing closed avoids programming an ACL that
+	// silently ignores the peer.
+	if !util.IsIPV4(cidr) {
+		return ErrUnsupportedIPAddress
+	}
 	if len(ports) == 0 {
 		acl := policies.NewACLPolicy(policies.Allowed, direction)
 		// bypasses ipset creation for /32 cidrs and directly creates an acl with the cidr

--- a/npm/pkg/controlplane/translation/translatePolicy.go
+++ b/npm/pkg/controlplane/translation/translatePolicy.go
@@ -365,17 +365,42 @@ func peerAndPortRule(npmNetPol *policies.NPMNetworkPolicy, direction policies.Di
 	return nil
 }
 
-func directPeerAndPortAllowRule(npmNetPol *policies.NPMNetworkPolicy, direction policies.Direction, ports []networkingv1.NetworkPolicyPort, cidr string, npmLiteToggle bool) error {
+// setDirectIP assigns cidr to the source or destination direct-IP field of acl based on direction.
+func setDirectIP(acl *policies.ACLPolicy, direction policies.Direction, cidr string) {
+	if direction == policies.Ingress {
+		acl.SrcDirectIPs = []string{cidr}
+	} else {
+		acl.DstDirectIPs = []string{cidr}
+	}
+}
+
+// exceptDirectDropRules emits a higher-priority Block ACL for each IPBlock.Except CIDR so an
+// excepted peer is denied even though it falls inside the enclosing CIDR allowed above. It
+// mirrors the port/protocol scope of the Allow it accompanies. Without these rules the Windows
+// direct-rule path would silently ignore Except and allow the full enclosing CIDR.
+func exceptDirectDropRules(npmNetPol *policies.NPMNetworkPolicy, direction policies.Direction, except []string, ports policies.Ports, protocol policies.Protocol) error {
+	for _, exceptCIDR := range deDuplicateExcept(except) {
+		if !util.IsIPV4(exceptCIDR) {
+			// Fail closed: refuse to program an ACL that silently ignores the exclusion.
+			return ErrUnsupportedIPAddress
+		}
+		acl := policies.NewACLPolicy(policies.Dropped, direction)
+		acl.Priority = policies.ExceptBlockPriority
+		setDirectIP(acl, direction, exceptCIDR)
+		acl.DstPorts = ports
+		acl.Protocol = protocol
+		npmNetPol.ACLs = append(npmNetPol.ACLs, acl)
+	}
+	return nil
+}
+
+func directPeerAndPortAllowRule(npmNetPol *policies.NPMNetworkPolicy, direction policies.Direction, ports []networkingv1.NetworkPolicyPort, cidr string, except []string, npmLiteToggle bool) error {
 	if len(ports) == 0 {
 		acl := policies.NewACLPolicy(policies.Allowed, direction)
 		// bypasses ipset creation for /32 cidrs and directly creates an acl with the cidr
-		if direction == policies.Ingress {
-			acl.SrcDirectIPs = []string{cidr}
-		} else {
-			acl.DstDirectIPs = []string{cidr}
-		}
+		setDirectIP(acl, direction, cidr)
 		npmNetPol.ACLs = append(npmNetPol.ACLs, acl)
-		return nil
+		return exceptDirectDropRules(npmNetPol, direction, except, policies.Ports{}, "")
 	}
 	// handle each port separately
 	for i := range ports {
@@ -392,19 +417,25 @@ func directPeerAndPortAllowRule(npmNetPol *policies.NPMNetworkPolicy, direction 
 		acl := policies.NewACLPolicy(policies.Allowed, direction)
 
 		// Set direct IP based on direction
-		if direction == policies.Ingress {
-			acl.SrcDirectIPs = []string{cidr}
-		} else {
-			acl.DstDirectIPs = []string{cidr}
-		}
+		setDirectIP(acl, direction, cidr)
 
 		// Handle ports
+		var portInfo policies.Ports
+		var protocol policies.Protocol
 		if portKind == numericPortType {
-			portInfo, protocol := numericPortRule(&ports[i])
+			var protoStr string
+			portInfo, protoStr = numericPortRule(&ports[i])
+			protocol = policies.Protocol(protoStr)
 			acl.DstPorts = portInfo
-			acl.Protocol = policies.Protocol(protocol)
+			acl.Protocol = protocol
 		}
 		npmNetPol.ACLs = append(npmNetPol.ACLs, acl)
+
+		// Emit the matching higher-priority Block ACLs for each excepted CIDR, scoped to the
+		// same port/protocol as the Allow above.
+		if err := exceptDirectDropRules(npmNetPol, direction, except, portInfo, protocol); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -453,7 +484,7 @@ func translateRule(npmNetPol *policies.NPMNetworkPolicy,
 		if peer.IPBlock != nil {
 			if len(peer.IPBlock.CIDR) > 0 {
 				if npmLiteToggle && util.IsWindowsDP() {
-					err = directPeerAndPortAllowRule(npmNetPol, direction, ports, peer.IPBlock.CIDR, npmLiteToggle)
+					err = directPeerAndPortAllowRule(npmNetPol, direction, ports, peer.IPBlock.CIDR, peer.IPBlock.Except, npmLiteToggle)
 					if err != nil {
 						return err
 					}

--- a/npm/pkg/controlplane/translation/translatePolicy_linux_test.go
+++ b/npm/pkg/controlplane/translation/translatePolicy_linux_test.go
@@ -50,3 +50,38 @@ func TestTranslatePolicyNPMLiteUsesIPSets(t *testing.T) {
 	require.Len(t, translated.ACLs[2].DstList, 1)
 	require.Empty(t, translated.ACLs[2].DstDirectIPs)
 }
+
+// TestTranslatePolicyNPMLiteLinuxExceptUsesNomatch guards that, on Linux, NPM Lite keeps
+// routing IPBlock.Except through the ipset "nomatch" path (never the Windows direct-drop path),
+// so the fix for MSRC 132306 does not change Linux behavior.
+func TestTranslatePolicyNPMLiteLinuxExceptUsesNomatch(t *testing.T) {
+	networkPolicy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "allow-cidr-except",
+			Namespace: "victim",
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "victim"}},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{{
+					IPBlock: &networkingv1.IPBlock{
+						CIDR:   "10.244.1.0/24",
+						Except: []string{"10.244.1.106/32"},
+					},
+				}},
+			}},
+		},
+	}
+
+	translated, err := TranslatePolicy(networkPolicy, true)
+	require.NoError(t, err)
+	require.Len(t, translated.RuleIPSets, 1)
+	require.Equal(t, []string{"10.244.1.0/24", "10.244.1.106/32 nomatch"}, translated.RuleIPSets[0].Members)
+
+	// No direct-IP ACLs on Linux; the CIDR+Except is enforced through the ipset above.
+	for _, acl := range translated.ACLs {
+		require.Empty(t, acl.SrcDirectIPs)
+		require.Empty(t, acl.DstDirectIPs)
+	}
+}

--- a/npm/pkg/controlplane/translation/translatePolicy_linux_test.go
+++ b/npm/pkg/controlplane/translation/translatePolicy_linux_test.go
@@ -13,11 +13,11 @@ func TestTranslatePolicyNPMLiteUsesIPSets(t *testing.T) {
 	networkPolicy := &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "allow-cidrs",
-			Namespace: "victim",
+			Namespace: victimName,
 		},
 		Spec: networkingv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{
-				MatchLabels: map[string]string{"app": "victim"},
+				MatchLabels: map[string]string{appLabelKey: victimName},
 			},
 			PolicyTypes: []networkingv1.PolicyType{
 				networkingv1.PolicyTypeIngress,
@@ -58,16 +58,16 @@ func TestTranslatePolicyNPMLiteLinuxExceptUsesNomatch(t *testing.T) {
 	networkPolicy := &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "allow-cidr-except",
-			Namespace: "victim",
+			Namespace: victimName,
 		},
 		Spec: networkingv1.NetworkPolicySpec{
-			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "victim"}},
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{appLabelKey: victimName}},
 			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 			Ingress: []networkingv1.NetworkPolicyIngressRule{{
 				From: []networkingv1.NetworkPolicyPeer{{
 					IPBlock: &networkingv1.IPBlock{
-						CIDR:   "10.244.1.0/24",
-						Except: []string{"10.244.1.106/32"},
+						CIDR:   enclosingCIDR,
+						Except: []string{exceptedHostBits},
 					},
 				}},
 			}},
@@ -77,7 +77,7 @@ func TestTranslatePolicyNPMLiteLinuxExceptUsesNomatch(t *testing.T) {
 	translated, err := TranslatePolicy(networkPolicy, true)
 	require.NoError(t, err)
 	require.Len(t, translated.RuleIPSets, 1)
-	require.Equal(t, []string{"10.244.1.0/24", "10.244.1.106/32 nomatch"}, translated.RuleIPSets[0].Members)
+	require.Equal(t, []string{enclosingCIDR, "10.244.1.106/32 nomatch"}, translated.RuleIPSets[0].Members)
 
 	// No direct-IP ACLs on Linux; the CIDR+Except is enforced through the ipset above.
 	for _, acl := range translated.ACLs {

--- a/npm/pkg/controlplane/translation/translatePolicy_test.go
+++ b/npm/pkg/controlplane/translation/translatePolicy_test.go
@@ -1848,7 +1848,7 @@ func TestDirectPeerAndPortAllowRule(t *testing.T) {
 				PolicyKey:   namedPortPolicyKey,
 				ACLPolicyID: fmt.Sprintf("azure-acl-%s-%s", defaultNS, namedPortPolicyKey),
 			}
-			err := directPeerAndPortAllowRule(npmNetPol, tt.direction, tt.ports, tt.cidr, npmLiteToggle)
+			err := directPeerAndPortAllowRule(npmNetPol, tt.direction, tt.ports, tt.cidr, nil, npmLiteToggle)
 			if tt.skipWindows {
 				require.Error(t, err)
 			} else {

--- a/npm/pkg/controlplane/translation/translatePolicy_test.go
+++ b/npm/pkg/controlplane/translation/translatePolicy_test.go
@@ -19,6 +19,11 @@ const (
 	nonIncluded  bool   = false
 	namedPortStr string = "serve-tcp"
 	defaultNS    string = "default"
+
+	victimName       string = "victim"
+	appLabelKey      string = "app"
+	enclosingCIDR    string = "10.244.1.0/24"
+	exceptedHostBits string = "10.244.1.106/32"
 )
 
 var namedPortPolicyKey = fmt.Sprintf("%s/%s", defaultNS, namedPortStr)

--- a/npm/pkg/controlplane/translation/translatePolicy_windows_test.go
+++ b/npm/pkg/controlplane/translation/translatePolicy_windows_test.go
@@ -172,3 +172,23 @@ func TestNPMLiteWindowsNonIPv4ExceptFailsClosed(t *testing.T) {
 	_, err := TranslatePolicy(networkPolicy, true)
 	require.ErrorIs(t, err, ErrUnsupportedIPAddress)
 }
+
+func TestNPMLiteWindowsNonIPv4CIDRFailsClosed(t *testing.T) {
+	networkPolicy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "victim-bad-cidr", Namespace: victimName},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{appLabelKey: victimName}},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{{
+					IPBlock: &networkingv1.IPBlock{
+						CIDR: "fd00::/64",
+					},
+				}},
+			}},
+		},
+	}
+
+	_, err := TranslatePolicy(networkPolicy, true)
+	require.ErrorIs(t, err, ErrUnsupportedIPAddress)
+}

--- a/npm/pkg/controlplane/translation/translatePolicy_windows_test.go
+++ b/npm/pkg/controlplane/translation/translatePolicy_windows_test.go
@@ -1,0 +1,174 @@
+//go:build windows
+// +build windows
+
+package translation
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-container-networking/npm/pkg/dataplane/policies"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// These tests exercise the NPM Lite Windows direct-rule path (util.IsWindowsDP() is true when
+// GOOS=windows), which the CI Windows job runs natively. They guard against MSRC 132306: an
+// IPBlock.Except CIDR must be denied by a higher-priority Block ACL rather than silently
+// dropped, which previously allowed the full enclosing CIDR.
+
+func TestNPMLiteWindowsIngressExceptEmitsHigherPriorityDrop(t *testing.T) {
+	networkPolicy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "victim-ingress", Namespace: "victim"},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "victim"}},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{{
+					IPBlock: &networkingv1.IPBlock{
+						CIDR:   "10.244.1.0/24",
+						Except: []string{"10.244.1.106/32"},
+					},
+				}},
+			}},
+		},
+	}
+
+	translated, err := TranslatePolicy(networkPolicy, true)
+	require.NoError(t, err)
+	require.Len(t, translated.ACLs, 2)
+
+	allow := translated.ACLs[0]
+	require.Equal(t, policies.Allowed, allow.Target)
+	require.Equal(t, []string{"10.244.1.0/24"}, allow.SrcDirectIPs)
+	require.Zero(t, allow.Priority)
+
+	drop := translated.ACLs[1]
+	require.Equal(t, policies.Dropped, drop.Target)
+	require.Equal(t, []string{"10.244.1.106/32"}, drop.SrcDirectIPs)
+	require.Equal(t, policies.ExceptBlockPriority, drop.Priority)
+	// the excepted-drop must out-prioritize the enclosing-CIDR allow (lower number wins on HNS)
+	require.Less(t, drop.Priority, uint16(222))
+}
+
+func TestNPMLiteWindowsEgressExceptEmitsHigherPriorityDrop(t *testing.T) {
+	networkPolicy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "victim-egress", Namespace: "victim"},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "victim"}},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+			Egress: []networkingv1.NetworkPolicyEgressRule{{
+				To: []networkingv1.NetworkPolicyPeer{{
+					IPBlock: &networkingv1.IPBlock{
+						CIDR:   "192.0.2.0/24",
+						Except: []string{"192.0.2.5/32"},
+					},
+				}},
+			}},
+		},
+	}
+
+	translated, err := TranslatePolicy(networkPolicy, true)
+	require.NoError(t, err)
+	require.Len(t, translated.ACLs, 2)
+
+	allow := translated.ACLs[0]
+	require.Equal(t, policies.Allowed, allow.Target)
+	require.Equal(t, []string{"192.0.2.0/24"}, allow.DstDirectIPs)
+
+	drop := translated.ACLs[1]
+	require.Equal(t, policies.Dropped, drop.Target)
+	require.Equal(t, []string{"192.0.2.5/32"}, drop.DstDirectIPs)
+	require.Equal(t, policies.ExceptBlockPriority, drop.Priority)
+}
+
+func TestNPMLiteWindowsExceptWithPortMirrorsPortScope(t *testing.T) {
+	port := intstr.FromInt(8080)
+	tcp := v1.ProtocolTCP
+	networkPolicy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "victim-port", Namespace: "victim"},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "victim"}},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				Ports: []networkingv1.NetworkPolicyPort{{
+					Protocol: &tcp,
+					Port:     &port,
+				}},
+				From: []networkingv1.NetworkPolicyPeer{{
+					IPBlock: &networkingv1.IPBlock{
+						CIDR:   "10.244.1.0/24",
+						Except: []string{"10.244.1.106/32"},
+					},
+				}},
+			}},
+		},
+	}
+
+	translated, err := TranslatePolicy(networkPolicy, true)
+	require.NoError(t, err)
+	require.Len(t, translated.ACLs, 2)
+
+	allow := translated.ACLs[0]
+	require.Equal(t, policies.Allowed, allow.Target)
+	require.Equal(t, int32(8080), allow.DstPorts.Port)
+	require.Equal(t, policies.Protocol("TCP"), allow.Protocol)
+
+	drop := translated.ACLs[1]
+	require.Equal(t, policies.Dropped, drop.Target)
+	require.Equal(t, []string{"10.244.1.106/32"}, drop.SrcDirectIPs)
+	require.Equal(t, int32(8080), drop.DstPorts.Port)
+	require.Equal(t, policies.Protocol("TCP"), drop.Protocol)
+	require.Equal(t, policies.ExceptBlockPriority, drop.Priority)
+}
+
+func TestNPMLiteWindowsMultipleExceptsDeduplicated(t *testing.T) {
+	networkPolicy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "victim-multi", Namespace: "victim"},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "victim"}},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{{
+					IPBlock: &networkingv1.IPBlock{
+						CIDR:   "10.244.1.0/24",
+						Except: []string{"10.244.1.106/32", "10.244.1.106/32", "10.244.1.200/32"},
+					},
+				}},
+			}},
+		},
+	}
+
+	translated, err := TranslatePolicy(networkPolicy, true)
+	require.NoError(t, err)
+	// 1 allow + 2 unique drops
+	require.Len(t, translated.ACLs, 3)
+	require.Equal(t, policies.Allowed, translated.ACLs[0].Target)
+	require.Equal(t, policies.Dropped, translated.ACLs[1].Target)
+	require.Equal(t, []string{"10.244.1.106/32"}, translated.ACLs[1].SrcDirectIPs)
+	require.Equal(t, policies.Dropped, translated.ACLs[2].Target)
+	require.Equal(t, []string{"10.244.1.200/32"}, translated.ACLs[2].SrcDirectIPs)
+}
+
+func TestNPMLiteWindowsNonIPv4ExceptFailsClosed(t *testing.T) {
+	networkPolicy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "victim-bad", Namespace: "victim"},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "victim"}},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{{
+					IPBlock: &networkingv1.IPBlock{
+						CIDR:   "10.244.1.0/24",
+						Except: []string{"fd00::/64"},
+					},
+				}},
+			}},
+		},
+	}
+
+	_, err := TranslatePolicy(networkPolicy, true)
+	require.ErrorIs(t, err, ErrUnsupportedIPAddress)
+}

--- a/npm/pkg/controlplane/translation/translatePolicy_windows_test.go
+++ b/npm/pkg/controlplane/translation/translatePolicy_windows_test.go
@@ -21,15 +21,15 @@ import (
 
 func TestNPMLiteWindowsIngressExceptEmitsHigherPriorityDrop(t *testing.T) {
 	networkPolicy := &networkingv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{Name: "victim-ingress", Namespace: "victim"},
+		ObjectMeta: metav1.ObjectMeta{Name: "victim-ingress", Namespace: victimName},
 		Spec: networkingv1.NetworkPolicySpec{
-			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "victim"}},
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{appLabelKey: victimName}},
 			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 			Ingress: []networkingv1.NetworkPolicyIngressRule{{
 				From: []networkingv1.NetworkPolicyPeer{{
 					IPBlock: &networkingv1.IPBlock{
-						CIDR:   "10.244.1.0/24",
-						Except: []string{"10.244.1.106/32"},
+						CIDR:   enclosingCIDR,
+						Except: []string{exceptedHostBits},
 					},
 				}},
 			}},
@@ -42,12 +42,12 @@ func TestNPMLiteWindowsIngressExceptEmitsHigherPriorityDrop(t *testing.T) {
 
 	allow := translated.ACLs[0]
 	require.Equal(t, policies.Allowed, allow.Target)
-	require.Equal(t, []string{"10.244.1.0/24"}, allow.SrcDirectIPs)
+	require.Equal(t, []string{enclosingCIDR}, allow.SrcDirectIPs)
 	require.Zero(t, allow.Priority)
 
 	drop := translated.ACLs[1]
 	require.Equal(t, policies.Dropped, drop.Target)
-	require.Equal(t, []string{"10.244.1.106/32"}, drop.SrcDirectIPs)
+	require.Equal(t, []string{exceptedHostBits}, drop.SrcDirectIPs)
 	require.Equal(t, policies.ExceptBlockPriority, drop.Priority)
 	// the excepted-drop must out-prioritize the enclosing-CIDR allow (lower number wins on HNS)
 	require.Less(t, drop.Priority, uint16(222))
@@ -55,9 +55,9 @@ func TestNPMLiteWindowsIngressExceptEmitsHigherPriorityDrop(t *testing.T) {
 
 func TestNPMLiteWindowsEgressExceptEmitsHigherPriorityDrop(t *testing.T) {
 	networkPolicy := &networkingv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{Name: "victim-egress", Namespace: "victim"},
+		ObjectMeta: metav1.ObjectMeta{Name: "victim-egress", Namespace: victimName},
 		Spec: networkingv1.NetworkPolicySpec{
-			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "victim"}},
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{appLabelKey: victimName}},
 			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
 			Egress: []networkingv1.NetworkPolicyEgressRule{{
 				To: []networkingv1.NetworkPolicyPeer{{
@@ -88,9 +88,9 @@ func TestNPMLiteWindowsExceptWithPortMirrorsPortScope(t *testing.T) {
 	port := intstr.FromInt(8080)
 	tcp := v1.ProtocolTCP
 	networkPolicy := &networkingv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{Name: "victim-port", Namespace: "victim"},
+		ObjectMeta: metav1.ObjectMeta{Name: "victim-port", Namespace: victimName},
 		Spec: networkingv1.NetworkPolicySpec{
-			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "victim"}},
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{appLabelKey: victimName}},
 			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 			Ingress: []networkingv1.NetworkPolicyIngressRule{{
 				Ports: []networkingv1.NetworkPolicyPort{{
@@ -99,8 +99,8 @@ func TestNPMLiteWindowsExceptWithPortMirrorsPortScope(t *testing.T) {
 				}},
 				From: []networkingv1.NetworkPolicyPeer{{
 					IPBlock: &networkingv1.IPBlock{
-						CIDR:   "10.244.1.0/24",
-						Except: []string{"10.244.1.106/32"},
+						CIDR:   enclosingCIDR,
+						Except: []string{exceptedHostBits},
 					},
 				}},
 			}},
@@ -118,7 +118,7 @@ func TestNPMLiteWindowsExceptWithPortMirrorsPortScope(t *testing.T) {
 
 	drop := translated.ACLs[1]
 	require.Equal(t, policies.Dropped, drop.Target)
-	require.Equal(t, []string{"10.244.1.106/32"}, drop.SrcDirectIPs)
+	require.Equal(t, []string{exceptedHostBits}, drop.SrcDirectIPs)
 	require.Equal(t, int32(8080), drop.DstPorts.Port)
 	require.Equal(t, policies.Protocol("TCP"), drop.Protocol)
 	require.Equal(t, policies.ExceptBlockPriority, drop.Priority)
@@ -126,15 +126,15 @@ func TestNPMLiteWindowsExceptWithPortMirrorsPortScope(t *testing.T) {
 
 func TestNPMLiteWindowsMultipleExceptsDeduplicated(t *testing.T) {
 	networkPolicy := &networkingv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{Name: "victim-multi", Namespace: "victim"},
+		ObjectMeta: metav1.ObjectMeta{Name: "victim-multi", Namespace: victimName},
 		Spec: networkingv1.NetworkPolicySpec{
-			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "victim"}},
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{appLabelKey: victimName}},
 			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 			Ingress: []networkingv1.NetworkPolicyIngressRule{{
 				From: []networkingv1.NetworkPolicyPeer{{
 					IPBlock: &networkingv1.IPBlock{
-						CIDR:   "10.244.1.0/24",
-						Except: []string{"10.244.1.106/32", "10.244.1.106/32", "10.244.1.200/32"},
+						CIDR:   enclosingCIDR,
+						Except: []string{exceptedHostBits, exceptedHostBits, "10.244.1.200/32"},
 					},
 				}},
 			}},
@@ -147,21 +147,21 @@ func TestNPMLiteWindowsMultipleExceptsDeduplicated(t *testing.T) {
 	require.Len(t, translated.ACLs, 3)
 	require.Equal(t, policies.Allowed, translated.ACLs[0].Target)
 	require.Equal(t, policies.Dropped, translated.ACLs[1].Target)
-	require.Equal(t, []string{"10.244.1.106/32"}, translated.ACLs[1].SrcDirectIPs)
+	require.Equal(t, []string{exceptedHostBits}, translated.ACLs[1].SrcDirectIPs)
 	require.Equal(t, policies.Dropped, translated.ACLs[2].Target)
 	require.Equal(t, []string{"10.244.1.200/32"}, translated.ACLs[2].SrcDirectIPs)
 }
 
 func TestNPMLiteWindowsNonIPv4ExceptFailsClosed(t *testing.T) {
 	networkPolicy := &networkingv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{Name: "victim-bad", Namespace: "victim"},
+		ObjectMeta: metav1.ObjectMeta{Name: "victim-bad", Namespace: victimName},
 		Spec: networkingv1.NetworkPolicySpec{
-			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "victim"}},
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{appLabelKey: victimName}},
 			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 			Ingress: []networkingv1.NetworkPolicyIngressRule{{
 				From: []networkingv1.NetworkPolicyPeer{{
 					IPBlock: &networkingv1.IPBlock{
-						CIDR:   "10.244.1.0/24",
+						CIDR:   enclosingCIDR,
 						Except: []string{"fd00::/64"},
 					},
 				}},

--- a/npm/pkg/dataplane/policies/policy.go
+++ b/npm/pkg/dataplane/policies/policy.go
@@ -134,6 +134,11 @@ type ACLPolicy struct {
 	// Target defines a target in iptables for linux. i,e, Mark, Accept, Drop
 	// in windows, this is either ALLOW or DENY
 	Target Verdict
+	// Priority optionally overrides the HNS ACL priority on Windows. When zero, the priority is
+	// derived from Target (allow vs. block). It is used to emit higher-precedence Block ACLs for
+	// IPBlock.Except CIDRs on the NPM Lite Windows direct-rule path so they out-prioritize the
+	// enclosing-CIDR Allow. Ignored on Linux.
+	Priority uint16
 	// Direction defines the flow of traffic
 	Direction Direction
 	// DstPorts always holds the destination port information.
@@ -359,6 +364,14 @@ const (
 	// Dropped is denying a flow
 	Dropped Verdict = "DROP"
 )
+
+// ExceptBlockPriority is the HNS ACL priority assigned to Block ACLs generated from an
+// IPBlock.Except CIDR on the NPM Lite Windows direct-rule path. HNS treats a lower number as
+// higher precedence, so this sits below the Allow priority (222) to out-prioritize the
+// enclosing-CIDR Allow, and above the base wireserver block (200) and readiness-probe allow
+// (201) so it never shadows them. It is set on ACLPolicy.Priority and honored by the Windows
+// renderer; it has no effect on Linux.
+const ExceptBlockPriority uint16 = 221
 
 // Protocol can be TCP, UDP, SCTP, or unspecified since they are currently supported in networkpolicy.
 // Protocol value is case-sensitive (Capital now).

--- a/npm/pkg/dataplane/policies/policy_windows.go
+++ b/npm/pkg/dataplane/policies/policy_windows.go
@@ -88,6 +88,11 @@ func (acl *ACLPolicy) convertToAclSettings(aclID string) (*NPMACLPolSettings, er
 	if policySettings.Action == hcn.ActionTypeBlock {
 		policySettings.Priority = uint16(blockRulePriotity)
 	}
+	// An explicit per-ACL priority (e.g. higher-precedence Block ACLs for IPBlock.Except CIDRs)
+	// overrides the Target-derived default.
+	if acl.Priority != 0 {
+		policySettings.Priority = acl.Priority
+	}
 	protoNum, ok := protocolNumMap[acl.Protocol]
 	if !ok {
 		return policySettings, ErrProtocolNotSupported

--- a/npm/pkg/dataplane/policies/policymanager_windows_test.go
+++ b/npm/pkg/dataplane/policies/policymanager_windows_test.go
@@ -329,6 +329,30 @@ func TestGetSettingsFromACLNodeEgressPorts(t *testing.T) {
 
 // Helper functions for UTS
 
+// TestConvertToAclSettingsExceptBlockPriority verifies that an IPBlock.Except Block ACL renders
+// at its higher-precedence priority (below the enclosing-CIDR Allow) with the excepted CIDR in
+// RemoteAddresses, so HNS actually denies the excepted peer (MSRC 132306).
+func TestConvertToAclSettingsExceptBlockPriority(t *testing.T) {
+	allow := NewACLPolicy(Allowed, Ingress)
+	allow.SrcDirectIPs = []string{"10.244.1.0/24"}
+	allowSettings, err := allow.convertToAclSettings("azure-acl-victim-ingress")
+	require.NoError(t, err)
+	assert.Equal(t, hcn.ActionTypeAllow, allowSettings.Action)
+	assert.Equal(t, "10.244.1.0/24", allowSettings.RemoteAddresses)
+	assert.Equal(t, uint16(allowRulePriotity), allowSettings.Priority)
+
+	drop := NewACLPolicy(Dropped, Ingress)
+	drop.SrcDirectIPs = []string{"10.244.1.106/32"}
+	drop.Priority = ExceptBlockPriority
+	dropSettings, err := drop.convertToAclSettings("azure-acl-victim-ingress")
+	require.NoError(t, err)
+	assert.Equal(t, hcn.ActionTypeBlock, dropSettings.Action)
+	assert.Equal(t, "10.244.1.106/32", dropSettings.RemoteAddresses)
+	assert.Equal(t, ExceptBlockPriority, dropSettings.Priority)
+	// lower number wins on HNS: the excepted drop must out-prioritize the enclosing allow
+	assert.Less(t, dropSettings.Priority, allowSettings.Priority)
+}
+
 func getPMgr(t *testing.T) (*PolicyManager, *hnswrapper.Hnsv2wrapperFake) {
 	hns := ipsets.GetHNSFake(t, "azure")
 	io := common.NewMockIOShimWithFakeHNS(hns)

--- a/npm/pkg/dataplane/policies/policymanager_windows_test.go
+++ b/npm/pkg/dataplane/policies/policymanager_windows_test.go
@@ -335,6 +335,7 @@ func TestGetSettingsFromACLNodeEgressPorts(t *testing.T) {
 func TestConvertToAclSettingsExceptBlockPriority(t *testing.T) {
 	allow := NewACLPolicy(Allowed, Ingress)
 	allow.SrcDirectIPs = []string{"10.244.1.0/24"}
+	allow.Protocol = UnspecifiedProtocol
 	allowSettings, err := allow.convertToAclSettings("azure-acl-victim-ingress")
 	require.NoError(t, err)
 	assert.Equal(t, hcn.ActionTypeAllow, allowSettings.Action)
@@ -344,6 +345,7 @@ func TestConvertToAclSettingsExceptBlockPriority(t *testing.T) {
 	drop := NewACLPolicy(Dropped, Ingress)
 	drop.SrcDirectIPs = []string{"10.244.1.106/32"}
 	drop.Priority = ExceptBlockPriority
+	drop.Protocol = UnspecifiedProtocol
 	dropSettings, err := drop.convertToAclSettings("azure-acl-victim-ingress")
 	require.NoError(t, err)
 	assert.Equal(t, hcn.ActionTypeBlock, dropSettings.Action)


### PR DESCRIPTION
Human summary:
_in the case_ that a customer of NPM-lite specified an _except_ range in their policy, we were ignoring that (and only programming the "allow" part)

AI summary:
NPM Lite on Windows forwarded only IPBlock.CIDR to the HNS direct ACL and silently dropped IPBlock.Except, so a pod IP explicitly excluded by a victim NetworkPolicy was still allowed through the enclosing CIDR

Forward IPBlock.Except into directPeerAndPortAllowRule and emit a higher-precedence Block ACL for each excepted CIDR alongside the enclosing-CIDR Allow, for both ingress and egress. HNS treats a lower priority number as higher precedence, so except-block ACLs render at priority 221 (below the 222 Allow, above the base wireserver/readiness rules) via a new ACLPolicy.Priority override honored by the Windows renderer. Non-IPv4 excepts fail closed with ErrUnsupportedIPAddress. Linux behavior is unchanged (Except still uses the ipset nomatch path).