### PR TITLE
ci: fix wireserver and imds test flakes

### DIFF
--- a/test/network/wireserver_metadata_test.sh
+++ b/test/network/wireserver_metadata_test.sh
@@ -11,13 +11,15 @@ if [ -n "$POOL" ]; then
     OVERRIDES=(--overrides="{\"spec\":{\"nodeSelector\":{\"agentpool\":\"${POOL}\"}}}")
 fi
 
-kubectl run "$POD_NAME-wireserver" -it --rm --image busybox --restart Never "${OVERRIDES[@]}" -- wget --timeout=3 --header=Metadata:true "http://168.63.129.16/machine/plugins?comp=nmagent&type=getinterfaceinfov1"
+SUFFIX="${RANDOM}"
+
+kubectl run "$POD_NAME-wireserver-${SUFFIX}" -it --rm --image busybox --restart Never "${OVERRIDES[@]}" -- wget --timeout=3 --header=Metadata:true "http://168.63.129.16/machine/plugins?comp=nmagent&type=getinterfaceinfov1"
 if [ $? -eq 0 ]; then
     echo "wireserver connectivity expected to fail but succeeded"
     exit 1
 fi
 
-kubectl run "$POD_NAME-metadata" -it --rm --image busybox --restart Never "${OVERRIDES[@]}" -- wget --timeout=3 --header=Metadata:true "http://169.254.169.254/metadata/instance?api-version=2021-02-01"
+kubectl run "$POD_NAME-metadata-${SUFFIX}" -it --rm --image busybox --restart Never "${OVERRIDES[@]}" -- wget --timeout=3 --header=Metadata:true "http://169.254.169.254/metadata/instance?api-version=2021-02-01"
 if [ $? -ne 0 ]; then
     echo "metadata server connectivity expected to succeed but failed"
     exit 1

--- a/test/network/wireserver_metadata_test.sh
+++ b/test/network/wireserver_metadata_test.sh
@@ -11,13 +11,13 @@ if [ -n "$POOL" ]; then
     OVERRIDES=(--overrides="{\"spec\":{\"nodeSelector\":{\"agentpool\":\"${POOL}\"}}}")
 fi
 
-kubectl run "$POD_NAME" -it --rm --image busybox --restart Never "${OVERRIDES[@]}" -- wget --timeout=3 --header=Metadata:true "http://168.63.129.16/machine/plugins?comp=nmagent&type=getinterfaceinfov1"
+kubectl run "$POD_NAME-wireserver" -it --rm --image busybox --restart Never "${OVERRIDES[@]}" -- wget --timeout=3 --header=Metadata:true "http://168.63.129.16/machine/plugins?comp=nmagent&type=getinterfaceinfov1"
 if [ $? -eq 0 ]; then
     echo "wireserver connectivity expected to fail but succeeded"
     exit 1
 fi
 
-kubectl run "$POD_NAME" -it --rm --image busybox --restart Never "${OVERRIDES[@]}" -- wget --timeout=3 --header=Metadata:true "http://169.254.169.254/metadata/instance?api-version=2021-02-01"
+kubectl run "$POD_NAME-metadata" -it --rm --image busybox --restart Never "${OVERRIDES[@]}" -- wget --timeout=3 --header=Metadata:true "http://169.254.169.254/metadata/instance?api-version=2021-02-01"
 if [ $? -ne 0 ]; then
     echo "metadata server connectivity expected to succeed but failed"
     exit 1

--- a/test/network/wireserver_metadata_test.sh
+++ b/test/network/wireserver_metadata_test.sh
@@ -13,13 +13,13 @@ fi
 
 SUFFIX="${RANDOM}"
 
-kubectl run "$POD_NAME-wireserver-${SUFFIX}" -it --rm --image busybox --restart Never "${OVERRIDES[@]}" -- wget --timeout=3 --header=Metadata:true "http://168.63.129.16/machine/plugins?comp=nmagent&type=getinterfaceinfov1"
+kubectl run "$POD_NAME-wireserver-${SUFFIX}" -it --rm --image busybox --restart Never --pod-running-timeout=5m "${OVERRIDES[@]}" -- wget --timeout=3 --header=Metadata:true "http://168.63.129.16/machine/plugins?comp=nmagent&type=getinterfaceinfov1"
 if [ $? -eq 0 ]; then
     echo "wireserver connectivity expected to fail but succeeded"
     exit 1
 fi
 
-kubectl run "$POD_NAME-metadata-${SUFFIX}" -it --rm --image busybox --restart Never "${OVERRIDES[@]}" -- wget --timeout=3 --header=Metadata:true "http://169.254.169.254/metadata/instance?api-version=2021-02-01"
+kubectl run "$POD_NAME-metadata-${SUFFIX}" -it --rm --image busybox --restart Never --pod-running-timeout=5m "${OVERRIDES[@]}" -- wget --timeout=3 --header=Metadata:true "http://169.254.169.254/metadata/instance?api-version=2021-02-01"
 if [ $? -ne 0 ]; then
     echo "metadata server connectivity expected to succeed but failed"
     exit 1

--- a/test/network/wireserver_metadata_test.sh
+++ b/test/network/wireserver_metadata_test.sh
@@ -1,25 +1,29 @@
 #!/bin/bash
-# Optional per-pool parameterization: when POOL is set the throwaway pods are
-# named "wget-${POOL}" and pinned to that agent pool via nodeSelector, so this
-# test can run per-pool in parallel. When POOL is empty the behavior is
-# unchanged (pod name "wget", no node selector).
+# The two connectivity checks each run a throwaway busybox pod named
+# "${POD_NAME}-wireserver-${SUFFIX}" / "${POD_NAME}-metadata-${SUFFIX}", where
+# POD_NAME is "wget" (or "wget-${POOL}" when POOL is set) and SUFFIX is a random
+# value for uniqueness across retries. When POOL is set the pods are also pinned
+# to that agent pool. The pods always target Linux nodes (kubernetes.io/os=linux)
+# so the Linux busybox image is never scheduled onto a Windows node, where it
+# cannot be pulled/run and the check would time out.
 POOL="${POOL:-}"
 POD_NAME="wget"
-OVERRIDES=()
+NODE_SELECTOR='"kubernetes.io/os":"linux"'
 if [ -n "$POOL" ]; then
     POD_NAME="wget-${POOL}"
-    OVERRIDES=(--overrides="{\"spec\":{\"nodeSelector\":{\"agentpool\":\"${POOL}\"}}}")
+    NODE_SELECTOR="${NODE_SELECTOR},\"agentpool\":\"${POOL}\""
 fi
+OVERRIDES=(--overrides="{\"spec\":{\"nodeSelector\":{${NODE_SELECTOR}}}}")
 
 SUFFIX="${RANDOM}"
 
-kubectl run "$POD_NAME-wireserver-${SUFFIX}" -it --rm --image busybox --restart Never --pod-running-timeout=5m "${OVERRIDES[@]}" -- wget --timeout=3 --header=Metadata:true "http://168.63.129.16/machine/plugins?comp=nmagent&type=getinterfaceinfov1"
+kubectl run "$POD_NAME-wireserver-${SUFFIX}" -it --rm --image busybox --restart Never --pod-running-timeout=1m "${OVERRIDES[@]}" -- wget --timeout=3 --header=Metadata:true "http://168.63.129.16/machine/plugins?comp=nmagent&type=getinterfaceinfov1"
 if [ $? -eq 0 ]; then
     echo "wireserver connectivity expected to fail but succeeded"
     exit 1
 fi
 
-kubectl run "$POD_NAME-metadata-${SUFFIX}" -it --rm --image busybox --restart Never --pod-running-timeout=5m "${OVERRIDES[@]}" -- wget --timeout=3 --header=Metadata:true "http://169.254.169.254/metadata/instance?api-version=2021-02-01"
+kubectl run "$POD_NAME-metadata-${SUFFIX}" -it --rm --image busybox --restart Never --pod-running-timeout=1m "${OVERRIDES[@]}" -- wget --timeout=3 --header=Metadata:true "http://169.254.169.254/metadata/instance?api-version=2021-02-01"
 if [ $? -ne 0 ]; then
     echo "metadata server connectivity expected to succeed but failed"
     exit 1


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
On azure stateless e2e, we have windows nodes and run the imds metadata server sh test. Busybox, the image we use, only runs on linux, but the pod can get scheduled onto a windows node and fails to start up. This PR adds a selector so we only target linux, and also makes the run pod names unique.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
