### PR TITLE
ci: fix false-positive issue dedup in go-version-check

### DIFF
--- a/.github/workflows/go-version-check.yaml
+++ b/.github/workflows/go-version-check.yaml
@@ -320,8 +320,13 @@ jobs:
           "
           fi
 
-          # Dedup: skip if an open issue already exists for this update
-          EXISTING_ISSUE=$(gh issue list --repo "$REPO" --state open --search "$MARKER" --json number --jq '.[0].number // empty')
+          # Dedup: skip if an open issue already exists for this update.
+          # Match the marker as an exact substring of the body. Do NOT use
+          # `gh issue list --search`: GitHub's full-text index tokenizes markers
+          # like `go-patch-update:1.26.8` on `-`, `:` and `.`, so it returns
+          # false positives (unrelated issues) and silently suppresses creation.
+          EXISTING_ISSUE=$(gh issue list --repo "$REPO" --state open --limit 200 --json number,body \
+            | jq -r --arg m "$MARKER" 'map(select((.body // "") | contains($m))) | .[0].number // empty')
           if [ -n "$EXISTING_ISSUE" ]; then
             echo "::notice::Issue #$EXISTING_ISSUE already exists for this update — skipping"
             exit 0
@@ -445,7 +450,9 @@ jobs:
           GOEXP_CGO0: ${{ steps.prereqs.outputs.goexp_cgo0 }}
         run: |
           MARKER="fips-prereq:${MATRIX_BRANCH}"
-          EXISTING_ISSUE=$(gh issue list --repo "$REPO" --state open --search "$MARKER" --json number --jq '.[0].number // empty')
+          # Exact substring match — see note on dedup in the auto-bump job.
+          EXISTING_ISSUE=$(gh issue list --repo "$REPO" --state open --limit 200 --json number,body \
+            | jq -r --arg m "$MARKER" 'map(select((.body // "") | contains($m))) | .[0].number // empty')
           if [ -n "$EXISTING_ISSUE" ]; then
             echo "::notice::Prerequisite issue #$EXISTING_ISSUE already exists — skipping"
             exit 0
@@ -496,7 +503,9 @@ jobs:
 
           # Dedup
           MARKER="go-backport:${MATRIX_BRANCH}:${UPDATE_TYPE}"
-          EXISTING_ISSUE=$(gh issue list --repo "$REPO" --state open --search "$MARKER" --json number --jq '.[0].number // empty')
+          # Exact substring match — see note on dedup in the auto-bump job.
+          EXISTING_ISSUE=$(gh issue list --repo "$REPO" --state open --limit 200 --json number,body \
+            | jq -r --arg m "$MARKER" 'map(select((.body // "") | contains($m))) | .[0].number // empty')
           if [ -n "$EXISTING_ISSUE" ]; then
             echo "::notice::Backport issue #$EXISTING_ISSUE already exists — skipping"
             exit 0
@@ -573,13 +582,17 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           MARKER="go-minor-update:${LATEST_MINOR}"
+          # Exact substring match — see note on dedup in the auto-bump job.
+          # The previous `--search "in:body $MARKER"` matched unrelated issues
+          # (e.g. "Release Tracking" issues) and blocked issue creation entirely.
           EXISTING=$(gh issue list \
             --repo "$REPO" \
             --state open \
-            --search "in:body $MARKER" \
-            --json number \
-            --jq 'length')
+            --limit 200 \
+            --json number,body \
+            | jq --arg m "$MARKER" 'map(select((.body // "") | contains($m))) | length')
           echo "existing_count=$EXISTING" >> "$GITHUB_OUTPUT"
+          echo "::notice::Existing open issues matching '${MARKER}': ${EXISTING}"
 
       - name: Fetch MS Go FIPS requirements
         id: msgo_fips_tier3


### PR DESCRIPTION
## Problem

All four issue-dedup checks in `go-version-check.yaml` used:

```bash
gh issue list --repo "$REPO" --state open --search "$MARKER" ...
```

`--search` goes through GitHub's **full-text index**, which tokenizes markers like `go-minor-update:1.27.1` on `-`, `:` and `.` and returns results by *relevance*, not exact content. So it matches unrelated issues.

### Observed failure

In run [33692611337](https://github.com/Azure/azure-container-networking/actions/runs/33692611337) the Tier 3 job searched for `go-minor-update:1.27.1` and matched two **Release Tracking** issues that do not contain the marker anywhere:

```
#4667  🔄 Release Tracking: v1.8.12   -> contains marker: 0
#4541  🔄 Release Tracking: v1.8.11   -> contains marker: 0
```

`existing_count` became `2`, so the gate `if: steps.existing.outputs.existing_count == '0'` failed and the **"Create issue and assign Copilot agent"** step never ran.

The job still reported **success** — skipping a step is not a failure — so the Go 1.27 upgrade issue was silently never created. It had to be created by hand (#4832).

## Fix

Match the marker as an **exact substring** of the issue body:

```bash
EXISTING=$(gh issue list --repo "$REPO" --state open --limit 200 --json number,body \
  | jq --arg m "$MARKER" 'map(select((.body // "") | contains($m))) | length')
```

Applied to all four dedup sites:

| Job | Marker |
|---|---|
| `auto-bump` | `go-patch-update:*` / `go-digest-update:*` |
| `backport-release` (prereq) | `fips-prereq:*` |
| `backport-release` | `go-backport:*` |
| `minor-upgrade-agent` | `go-minor-update:*` |

Also added a `::notice::` with the match count so a suppressed creation is visible in the logs rather than silent.

## Verification

Run against the live repo, old vs new:

| Marker | old (`--search`) | new (exact) | Correct |
|---|:---:|:---:|---|
| `go-minor-update:1.27.1` | 3 | **1** | ✅ only #4832 contains it |
| `go-minor-update:1.27.0` | 1 | **0** | ✅ #4748 is closed |
| `go-patch-update:1.26.8` | 0 | 0 | ✅ |

YAML parses cleanly (`yaml.safe_load`).

## Impact

Without this, any tier (digest refresh, patch bump, backport, minor upgrade) can silently fail to create its issue whenever the marker happens to score against an unrelated open issue — with a green check mark.

## Related
- #4832 — Go 1.27.1 upgrade issue that had to be created manually
- #4758 — copilot-setup-steps fix (merged)
