### PR TITLE
fix: add arg to match go mod version bump

### DIFF
--- a/tools/azure-npm-to-cilium-validator/azure-npm-to-cilium-validator.go
+++ b/tools/azure-npm-to-cilium-validator/azure-npm-to-cilium-validator.go
@@ -96,7 +96,7 @@ func main() {
 
 	// Create telemetry handle
 	// Note: npmVersionNum and imageVersion telemetry is not needed for this tool so they are set to abitrary values
-	err = metrics.CreateTelemetryHandle(0, "NPM-script-v0.0.1", "014c22bd-4107-459e-8475-67909e96edcb")
+	err = metrics.CreateTelemetryHandle(0, "NPM-script-v0.0.1", "014c22bd-4107-459e-8475-67909e96edcb", "info")
 
 	if err != nil {
 		klog.Infof("CreateTelemetryHandle failed with error %v. AITelemetry is not initialized.", err)


### PR DESCRIPTION
<!-- Thank you for helping Azure Container Networking with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Container Networking? -->
add missing logLevel arg to CreateTelemetryHandle call in azure-npm-to-cilium-validator so the module compiles against azure-container-networking v1.8.12 (was broken by the v1.6.21->v1.8.12 dependency bump), unblocking the govulncheck workflow.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [X] relevant PR labels added

**Notes**:
https://github.com/Azure/azure-container-networking/actions/runs/33694014959