### PR TITLE
fix: [NPM] restore platform prefix and image revision in reported version

### DIFF
--- a/.pipelines/build/ob-prepare.steps.yaml
+++ b/.pipelines/build/ob-prepare.steps.yaml
@@ -89,6 +89,10 @@ steps:
     echo "##vso[task.setvariable variable=npmVersion;isOutput=true]$NPMVERSION"
     echo "npmVersion: $NPMVERSION"
 
+    NPMIMAGETAG=$(make npm-image-tag)
+    echo "##vso[task.setvariable variable=npmImageTag;isOutput=true]$NPMIMAGETAG"
+    echo "npmImageTag: $NPMIMAGETAG"
+
     cat /etc/os-release
     uname -a
     sudo chown -R $(whoami):$(whoami) .

--- a/.pipelines/build/scripts/npm.sh
+++ b/.pipelines/build/scripts/npm.sh
@@ -17,9 +17,13 @@ mkdir -p "$OUT_DIR"/bin
 mkdir -p "$OUT_DIR"/scripts
 
 pushd "$REPO_ROOT"/npm
+  # Report the platform and the published image revision (e.g. linux-amd64-v1.6.48-0)
+  # so the version a pod reports matches the image tag in the registry.
+  NPM_BUILD_VERSION="$OS-$ARCH-${NPM_IMAGE_TAG:-$NPM_VERSION}"
+
   GOOS="$OS" go build -a -v -trimpath \
     -o "$OUT_DIR"/bin/azure-npm"$FILE_EXT" \
-    -ldflags "-s -w -X main.version="$NPM_VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" \
+    -ldflags "-s -w -X main.version="$NPM_BUILD_VERSION" -X "$NPM_AI_PATH"="$NPM_AI_ID"" \
     -gcflags="-dwarflocationlists=true" \
     ./cmd/*.go
 

--- a/.pipelines/run-pipeline.yaml
+++ b/.pipelines/run-pipeline.yaml
@@ -45,6 +45,7 @@ stages:
     CNS_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.cnsVersion'] ]
     IPV6_HP_BPF_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.ipv6HpBpfVersion'] ]
     NPM_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.npmVersion'] ]
+    NPM_IMAGE_TAG: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.npmImageTag'] ]
   jobs:
   - template: /.pipelines/build/images.jobs.yaml
     parameters:
@@ -224,6 +225,7 @@ stages:
       CNS_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.cnsVersion'] ]
       IPV6_HP_BPF_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.ipv6HpBpfVersion'] ]
       NPM_VERSION: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.npmVersion'] ]
+      NPM_IMAGE_TAG: $[ stageDependencies.setup.env.outputs['EnvironmentalVariables.npmImageTag'] ]
 
       IPAM_LINUX_AMD64_REF: $(IMAGE_REPO_PATH)/linux-amd64/azure-ipam:$(Build.BuildNumber)
       IPAM_LINUX_ARM64_REF: $(IMAGE_REPO_PATH)/linux-arm64/azure-ipam:$(Build.BuildNumber)

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,11 @@ AZURE_IPTABLES_MONITOR_VERSION		?= $(notdir $(shell git describe --match "azure-
 CNI_VERSION							?= $(ACN_VERSION)
 CNS_VERSION							?= $(ACN_VERSION)
 NPM_VERSION							?= $(ACN_VERSION)
+# The published azure-npm image tag carries an extra revision component after the
+# git tag (e.g. v1.6.48-0), so a CVE respin can be republished off the same commit
+# by bumping the revision. Release pipelines override NPM_IMAGE_REVISION.
+NPM_IMAGE_REVISION					?= 0
+NPM_IMAGE_TAG						?= $(NPM_VERSION)-$(NPM_IMAGE_REVISION)
 ZAPAI_VERSION						?= $(notdir $(shell git describe --match "zapai*" --tags --always))
 
 # Build directories.
@@ -181,6 +186,9 @@ cns-version:
 
 npm-version:
 	@echo $(NPM_VERSION)
+
+npm-image-tag: ## prints the published npm image tag (version plus revision).
+	@echo $(NPM_IMAGE_TAG)
 
 zapai-version: ## prints the zapai version
 	@echo $(ZAPAI_VERSION)


### PR DESCRIPTION
## Reason for Change

The signed OneBranch build stamps `main.version` from `NPM_VERSION`, which is the bare `git describe` output. The older unsigned Makefile path stamped `NPM_PLATFORM_TAG` instead (`--build-arg VERSION=$(TAG)`), so images built before the signed path report `linux-amd64-v1.6.42` while newer ones report `v1.6.48`.

That has two consequences for fleet telemetry:

* Version queries that select on the `linux-amd64-` / `windows-amd64-` prefix silently drop **every** pod built by the signed pipeline. A rollout looks like it has not started when in fact it has. This is not hypothetical — the standard `NPMReport` fleet-version query filters on `AppVersion has "linux-amd64-"` and returned zero clusters on the current version.
* `AppVersion` no longer records the platform, and it never recorded the revision component of the published tag. A `-0` image and a `-1` CVE respin of the same version are indistinguishable in telemetry.

## Description of Changes

Build the stamped version from the OS, the architecture and the published image tag, so a pod reports exactly what is in the registry:

```
linux-amd64-v1.6.48-0
```

* `NPM_IMAGE_REVISION` (default `0`) and `NPM_IMAGE_TAG` = `$(NPM_VERSION)-$(NPM_IMAGE_REVISION)` are added to the `Makefile`, with a `npm-image-tag` print target. The revision exists because the published tag carries an extra component after the git tag, letting a CVE respin be republished off the same commit.
* `ob-prepare.steps.yaml` exports `npmImageTag` alongside the existing `npmVersion`, and `run-pipeline.yaml` maps it to `NPM_IMAGE_TAG` for the build and image stages.
* `npm.sh` composes `$OS-$ARCH-${NPM_IMAGE_TAG:-$NPM_VERSION}`. The fallback keeps local and unsigned builds working when `NPM_IMAGE_TAG` is not set.

No change to image contents or behaviour — this only affects the version string reported in telemetry.

## Validation

`make npm-image-tag` on this branch:

```
v1.8.12-42-g12130745c-0
make npm-image-tag NPM_IMAGE_REVISION=3  ->  v1.8.12-42-g12130745c-3
```

Composed version strings:

| OS / arch | stamped version |
| --- | --- |
| linux/amd64 | `linux-amd64-v1.6.49-0` |
| windows/amd64 | `windows-amd64-v1.6.49-0` |
| linux/arm64 | `linux-arm64-v1.6.49-0` |
| `NPM_IMAGE_TAG` unset (fallback) | `linux-amd64-v1.6.49` |

Built the binary with the new ldflags and confirmed the symbol is embedded:

```
$ strings azure-npm | grep linux-amd64-v1.6.49
linux-amd64-v1.6.49-0
```

`bash -n` passes on `npm.sh` (including under `set -u`, via the `:-` fallback) and all three modified YAML files parse.

## Note for reviewers

This intentionally changes the reported version string, so any saved query or dashboard that pins the exact `AppVersion` format will shift once. Suggest landing it with the next tag rather than mid-rollout, so the format moves exactly once. An arch-agnostic way to read the version across both old and new formats:

```kusto
| extend Version = replace_regex(AppVersion, @"^\w+-\w+64-(ltsc\d+-)?", "")
| where Version matches regex @"^v\d+\.\d+\.\d+(-\d+)?$"
```
